### PR TITLE
feat(utils): add skills loader for self-learning skills

### DIFF
--- a/apps/server/tests/unit/utils/skills-loader.test.ts
+++ b/apps/server/tests/unit/utils/skills-loader.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Skills Loader Tests
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getSkillsDir,
+  parseSkillFrontmatter,
+  serializeSkill,
+  checkRequirements,
+  listSkills,
+  getSkill,
+  loadRelevantSkills,
+  createSkill,
+  updateSkill,
+  deleteSkill,
+  recordSkillUsage,
+  type SkillsFsModule,
+} from '@automaker/utils';
+import type { Skill, CreateSkillOptions } from '@automaker/types';
+
+// Mock file system
+function createMockFs(files: Record<string, string> = {}): SkillsFsModule {
+  const fileSystem = { ...files };
+
+  return {
+    readFile: vi.fn(async (path: string) => {
+      if (fileSystem[path]) return fileSystem[path];
+      throw new Error(`ENOENT: ${path}`);
+    }),
+    writeFile: vi.fn(async (path: string, content: string) => {
+      fileSystem[path] = content;
+    }),
+    readdir: vi.fn(async (dirPath: string) => {
+      const prefix = dirPath.endsWith('/') ? dirPath : dirPath + '/';
+      const entries = new Set<string>();
+      for (const path of Object.keys(fileSystem)) {
+        if (path.startsWith(prefix)) {
+          const relative = path.slice(prefix.length);
+          const firstPart = relative.split('/')[0];
+          if (firstPart) entries.add(firstPart);
+        }
+      }
+      return Array.from(entries);
+    }),
+    stat: vi.fn(async (path: string) => {
+      if (fileSystem[path]) return { isFile: () => true };
+      throw new Error(`ENOENT: ${path}`);
+    }),
+    mkdir: vi.fn(async () => {}),
+    unlink: vi.fn(async (path: string) => {
+      if (fileSystem[path]) {
+        delete fileSystem[path];
+      } else {
+        throw new Error(`ENOENT: ${path}`);
+      }
+    }),
+    access: vi.fn(async (path: string) => {
+      if (!fileSystem[path]) throw new Error(`ENOENT: ${path}`);
+    }),
+  };
+}
+
+describe('getSkillsDir', () => {
+  it('returns correct skills directory path', () => {
+    expect(getSkillsDir('/project')).toBe('/project/.automaker/skills');
+    expect(getSkillsDir('/home/user/myproject')).toBe('/home/user/myproject/.automaker/skills');
+  });
+});
+
+describe('parseSkillFrontmatter', () => {
+  it('parses valid frontmatter', () => {
+    const content = `---
+name: test-skill
+emoji: 🧪
+description: A test skill
+requires:
+  bins: [git, npm]
+  files: [package.json]
+  env: [API_KEY]
+metadata:
+  author: tester
+  created: 2026-01-01T00:00:00Z
+  usageCount: 10
+  successRate: 0.9
+  tags: [test, example]
+  source: learned
+---
+
+# Test Skill
+
+This is the skill content.
+`;
+
+    const { frontmatter, body } = parseSkillFrontmatter(content);
+
+    expect(frontmatter).not.toBeNull();
+    expect(frontmatter?.name).toBe('test-skill');
+    expect(frontmatter?.emoji).toBe('🧪');
+    expect(frontmatter?.description).toBe('A test skill');
+    expect(frontmatter?.requires?.bins).toEqual(['git', 'npm']);
+    expect(frontmatter?.requires?.files).toEqual(['package.json']);
+    expect(frontmatter?.requires?.env).toEqual(['API_KEY']);
+    expect(frontmatter?.metadata?.author).toBe('tester');
+    expect(frontmatter?.metadata?.usageCount).toBe(10);
+    expect(frontmatter?.metadata?.successRate).toBe(0.9);
+    expect(frontmatter?.metadata?.tags).toEqual(['test', 'example']);
+    expect(frontmatter?.metadata?.source).toBe('learned');
+    expect(body).toBe('# Test Skill\n\nThis is the skill content.');
+  });
+
+  it('returns null frontmatter for content without frontmatter', () => {
+    const content = '# Just Content\n\nNo frontmatter here.';
+    const { frontmatter, body } = parseSkillFrontmatter(content);
+
+    expect(frontmatter).toBeNull();
+    expect(body).toBe(content);
+  });
+
+  it('handles empty arrays', () => {
+    const content = `---
+name: minimal
+description: Minimal skill
+requires:
+  bins: []
+metadata:
+  created: 2026-01-01T00:00:00Z
+  usageCount: 0
+  successRate: 0
+---
+
+Content`;
+
+    const { frontmatter } = parseSkillFrontmatter(content);
+    expect(frontmatter?.requires?.bins).toEqual([]);
+  });
+});
+
+describe('serializeSkill', () => {
+  it('serializes skill to markdown with frontmatter', () => {
+    const skill: Skill = {
+      name: 'my-skill',
+      emoji: '🚀',
+      description: 'A great skill',
+      requires: {
+        bins: ['node'],
+        files: ['package.json'],
+      },
+      content: '# My Skill\n\nDo the thing.',
+      metadata: {
+        author: 'dev',
+        created: '2026-01-01T00:00:00Z',
+        usageCount: 5,
+        successRate: 0.8,
+        tags: ['useful'],
+        source: 'learned',
+      },
+    };
+
+    const serialized = serializeSkill(skill);
+
+    expect(serialized).toContain('name: my-skill');
+    expect(serialized).toContain('emoji: 🚀');
+    expect(serialized).toContain('description: A great skill');
+    expect(serialized).toContain('bins: [node]');
+    expect(serialized).toContain('files: [package.json]');
+    expect(serialized).toContain('author: dev');
+    expect(serialized).toContain('usageCount: 5');
+    expect(serialized).toContain('successRate: 0.8');
+    expect(serialized).toContain('tags: [useful]');
+    expect(serialized).toContain('source: learned');
+    expect(serialized).toContain('# My Skill');
+  });
+
+  it('omits optional fields when not present', () => {
+    const skill: Skill = {
+      name: 'minimal',
+      description: 'Minimal skill',
+      content: 'Content',
+      metadata: {
+        created: '2026-01-01T00:00:00Z',
+        usageCount: 0,
+        successRate: 0,
+      },
+    };
+
+    const serialized = serializeSkill(skill);
+
+    expect(serialized).toContain('name: minimal');
+    expect(serialized).not.toContain('emoji:');
+    expect(serialized).not.toContain('requires:');
+    expect(serialized).not.toContain('tags:');
+  });
+});
+
+describe('checkRequirements', () => {
+  it('returns satisfied when no requirements', async () => {
+    const fs = createMockFs();
+    const result = await checkRequirements(undefined, '/project', fs);
+    expect(result.satisfied).toBe(true);
+    expect(result.missing).toEqual([]);
+  });
+
+  it('checks file requirements', async () => {
+    const fs = createMockFs({
+      '/project/package.json': '{}',
+    });
+
+    const result = await checkRequirements(
+      { files: ['package.json', 'missing.txt'] },
+      '/project',
+      fs
+    );
+
+    expect(result.satisfied).toBe(false);
+    expect(result.missing).toContain('file:missing.txt');
+    expect(result.missing).not.toContain('file:package.json');
+  });
+
+  it('checks env requirements', async () => {
+    const fs = createMockFs();
+    const originalEnv = process.env.TEST_VAR;
+    process.env.TEST_VAR = 'value';
+
+    const result = await checkRequirements({ env: ['TEST_VAR', 'MISSING_VAR'] }, '/project', fs);
+
+    expect(result.satisfied).toBe(false);
+    expect(result.missing).toContain('env:MISSING_VAR');
+    expect(result.missing).not.toContain('env:TEST_VAR');
+
+    // Cleanup
+    if (originalEnv === undefined) {
+      delete process.env.TEST_VAR;
+    } else {
+      process.env.TEST_VAR = originalEnv;
+    }
+  });
+});
+
+describe('createSkill', () => {
+  it('creates a new skill file', async () => {
+    const fs = createMockFs();
+
+    const options: CreateSkillOptions = {
+      name: 'new-skill',
+      emoji: '✨',
+      description: 'A brand new skill',
+      content: '# New Skill\n\nInstructions here.',
+      author: 'tester',
+      tags: ['new'],
+      source: 'learned',
+    };
+
+    const skill = await createSkill('/project', options, fs);
+
+    expect(skill.name).toBe('new-skill');
+    expect(skill.emoji).toBe('✨');
+    expect(skill.description).toBe('A brand new skill');
+    expect(skill.metadata.author).toBe('tester');
+    expect(skill.metadata.tags).toEqual(['new']);
+    expect(fs.writeFile).toHaveBeenCalled();
+  });
+});
+
+describe('listSkills', () => {
+  it('lists all skills in directory', async () => {
+    const skillContent = `---
+name: skill-one
+description: First skill
+metadata:
+  created: 2026-01-01T00:00:00Z
+  usageCount: 0
+  successRate: 0
+---
+
+Content`;
+
+    const fs = createMockFs({
+      '/project/.automaker/skills/skill-one.md': skillContent,
+      '/project/.automaker/skills/not-a-skill.txt': 'ignored',
+    });
+
+    const skills = await listSkills('/project', fs);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('skill-one');
+  });
+
+  it('returns empty array when no skills', async () => {
+    const fs = createMockFs();
+    const skills = await listSkills('/project', fs);
+    expect(skills).toEqual([]);
+  });
+});
+
+describe('getSkill', () => {
+  it('gets a specific skill by name', async () => {
+    const skillContent = `---
+name: target-skill
+description: The target
+metadata:
+  created: 2026-01-01T00:00:00Z
+  usageCount: 5
+  successRate: 0.8
+---
+
+Target content`;
+
+    const fs = createMockFs({
+      '/project/.automaker/skills/target-skill.md': skillContent,
+    });
+
+    const skill = await getSkill('/project', 'target-skill', fs);
+
+    expect(skill).not.toBeNull();
+    expect(skill?.name).toBe('target-skill');
+    expect(skill?.metadata.usageCount).toBe(5);
+  });
+
+  it('returns null for non-existent skill', async () => {
+    const fs = createMockFs();
+    const skill = await getSkill('/project', 'missing', fs);
+    expect(skill).toBeNull();
+  });
+});
+
+describe('loadRelevantSkills', () => {
+  it('loads skills relevant to context', async () => {
+    const skill1 = `---
+name: git-skill
+description: Git operations
+metadata:
+  created: 2026-01-01T00:00:00Z
+  usageCount: 10
+  successRate: 0.9
+  tags: [git, version-control]
+---
+
+Git content`;
+
+    const skill2 = `---
+name: test-skill
+description: Testing utilities
+metadata:
+  created: 2026-01-01T00:00:00Z
+  usageCount: 5
+  successRate: 0.7
+  tags: [testing, jest]
+---
+
+Test content`;
+
+    const fs = createMockFs({
+      '/project/.automaker/skills/git-skill.md': skill1,
+      '/project/.automaker/skills/test-skill.md': skill2,
+    });
+
+    const result = await loadRelevantSkills(
+      '/project',
+      { tags: ['git'], featureTitle: 'Add git commit feature' },
+      fs
+    );
+
+    expect(result.skills.length).toBeGreaterThan(0);
+    // Git skill should be ranked higher due to tag match
+    expect(result.skills[0].name).toBe('git-skill');
+    expect(result.formattedPrompt).toContain('Available Skills');
+  });
+
+  it('returns empty when no skills exist', async () => {
+    const fs = createMockFs();
+    const result = await loadRelevantSkills('/project', {}, fs);
+
+    expect(result.skills).toEqual([]);
+    expect(result.totalLoaded).toBe(0);
+    expect(result.formattedPrompt).toBe('');
+  });
+});
+
+describe('updateSkill', () => {
+  it('updates an existing skill', async () => {
+    const originalContent = `---
+name: updatable
+description: Original description
+metadata:
+  created: 2026-01-01T00:00:00Z
+  usageCount: 0
+  successRate: 0
+---
+
+Original content`;
+
+    const fs = createMockFs({
+      '/project/.automaker/skills/updatable.md': originalContent,
+    });
+
+    const updated = await updateSkill(
+      '/project',
+      'updatable',
+      { description: 'Updated description', content: 'Updated content' },
+      fs
+    );
+
+    expect(updated).not.toBeNull();
+    expect(updated?.description).toBe('Updated description');
+    expect(updated?.content).toBe('Updated content');
+    expect(updated?.metadata.updated).toBeDefined();
+  });
+
+  it('returns null for non-existent skill', async () => {
+    const fs = createMockFs();
+    const result = await updateSkill('/project', 'missing', { description: 'test' }, fs);
+    expect(result).toBeNull();
+  });
+});
+
+describe('deleteSkill', () => {
+  it('deletes an existing skill', async () => {
+    const fs = createMockFs({
+      '/project/.automaker/skills/to-delete.md': 'content',
+    });
+
+    const result = await deleteSkill('/project', 'to-delete', fs);
+
+    expect(result).toBe(true);
+    expect(fs.unlink).toHaveBeenCalledWith('/project/.automaker/skills/to-delete.md');
+  });
+
+  it('returns false for non-existent skill', async () => {
+    const fs = createMockFs();
+    const result = await deleteSkill('/project', 'missing', fs);
+    expect(result).toBe(false);
+  });
+});
+
+describe('recordSkillUsage', () => {
+  it('updates usage statistics on success', async () => {
+    const skillContent = `---
+name: tracked
+description: Tracked skill
+metadata:
+  created: 2026-01-01T00:00:00Z
+  usageCount: 10
+  successRate: 0.8
+---
+
+Content`;
+
+    const fs = createMockFs({
+      '/project/.automaker/skills/tracked.md': skillContent,
+    });
+
+    await recordSkillUsage('/project', 'tracked', true, fs);
+
+    // Verify writeFile was called with updated stats
+    expect(fs.writeFile).toHaveBeenCalled();
+    const writeCall = (fs.writeFile as ReturnType<typeof vi.fn>).mock.calls[0];
+    const writtenContent = writeCall[1] as string;
+
+    expect(writtenContent).toContain('usageCount: 11');
+    // New success rate: (10 * 0.8 + 1) / 11 = 9 / 11 ≈ 0.818
+    expect(writtenContent).toMatch(/successRate: 0\.8\d+/);
+  });
+
+  it('updates usage statistics on failure', async () => {
+    const skillContent = `---
+name: tracked
+description: Tracked skill
+metadata:
+  created: 2026-01-01T00:00:00Z
+  usageCount: 10
+  successRate: 0.8
+---
+
+Content`;
+
+    const fs = createMockFs({
+      '/project/.automaker/skills/tracked.md': skillContent,
+    });
+
+    await recordSkillUsage('/project', 'tracked', false, fs);
+
+    const writeCall = (fs.writeFile as ReturnType<typeof vi.fn>).mock.calls[0];
+    const writtenContent = writeCall[1] as string;
+
+    expect(writtenContent).toContain('usageCount: 11');
+    // New success rate: (10 * 0.8 + 0) / 11 = 8 / 11 ≈ 0.727
+    expect(writtenContent).toMatch(/successRate: 0\.7\d+/);
+  });
+});

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -138,3 +138,21 @@ export {
   resolveMilestoneDependencies,
   resolvePhaseDependencies,
 } from './project-parser.js';
+
+// Skills loading
+export {
+  getSkillsDir,
+  parseSkillFrontmatter,
+  serializeSkill,
+  checkRequirements,
+  listSkills,
+  getSkill,
+  loadRelevantSkills,
+  createSkill,
+  updateSkill,
+  deleteSkill,
+  recordSkillUsage,
+  initializeSkillsFolder,
+  type SkillsFsModule,
+  type SkillsLoadResult,
+} from './skills-loader.js';

--- a/libs/utils/src/skills-loader.ts
+++ b/libs/utils/src/skills-loader.ts
@@ -1,0 +1,699 @@
+/**
+ * Skills Loader
+ *
+ * Manages loading, creating, and tracking reusable skills for AI agents.
+ * Skills are stored as markdown files with YAML frontmatter in .automaker/skills/
+ */
+
+import * as path from 'path';
+import type {
+  Skill,
+  SkillFrontmatter,
+  SkillMetadata,
+  SkillRequirements,
+  CreateSkillOptions,
+  UpdateSkillOptions,
+} from '@automaker/types';
+
+/**
+ * File system module interface for dependency injection
+ */
+export interface SkillsFsModule {
+  readFile: (path: string, encoding: string) => Promise<string>;
+  writeFile: (path: string, content: string) => Promise<void>;
+  readdir: (path: string) => Promise<string[]>;
+  stat: (path: string) => Promise<{ isFile: () => boolean }>;
+  mkdir: (path: string, options?: { recursive?: boolean }) => Promise<void>;
+  unlink: (path: string) => Promise<void>;
+  access: (path: string) => Promise<void>;
+}
+
+/**
+ * Result of loading relevant skills
+ */
+export interface SkillsLoadResult {
+  skills: Skill[];
+  formattedPrompt: string;
+  totalLoaded: number;
+}
+
+/**
+ * Get the skills directory path for a project
+ */
+export function getSkillsDir(projectPath: string): string {
+  return path.join(projectPath, '.automaker', 'skills');
+}
+
+/**
+ * Create default metadata for a new skill
+ */
+function createDefaultMetadata(
+  author?: string,
+  source?: 'learned' | 'imported' | 'built-in'
+): SkillMetadata {
+  return {
+    author: author || 'agent',
+    created: new Date().toISOString(),
+    usageCount: 0,
+    successRate: 0,
+    source: source || 'learned',
+  };
+}
+
+/**
+ * Escape a string for safe YAML output
+ */
+function escapeYamlString(str: string): string {
+  if (typeof str !== 'string') return String(str);
+  if (/[:\[\]{}#&*!|>'"%@`\n\r]/.test(str) || str.trim() !== str) {
+    return `"${str.replace(/"/g, '\\"')}"`;
+  }
+  return str;
+}
+
+/**
+ * Parse YAML frontmatter from skill markdown content
+ */
+export function parseSkillFrontmatter(content: string): {
+  frontmatter: SkillFrontmatter | null;
+  body: string;
+} {
+  const frontmatterRegex = /^---\s*\r?\n([\s\S]*?)\r?\n---\s*\r?\n?/;
+  const match = content.match(frontmatterRegex);
+
+  if (!match) {
+    return { frontmatter: null, body: content };
+  }
+
+  const yamlContent = match[1];
+  const body = content.slice(match[0].length).trim();
+
+  try {
+    // Simple YAML parser for skill frontmatter
+    const frontmatter: SkillFrontmatter = {
+      name: '',
+      description: '',
+    };
+
+    const lines = yamlContent.split(/\r?\n/);
+    let currentKey: string | null = null;
+    let currentIndent = 0;
+    let inRequires = false;
+    let inMetadata = false;
+    const requires: SkillRequirements = {};
+    const metadata: Partial<SkillMetadata> = {};
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+
+      const indent = line.search(/\S/);
+
+      // Check for top-level keys
+      const keyMatch = trimmed.match(/^([a-zA-Z_]+):\s*(.*)$/);
+      if (keyMatch && indent === 0) {
+        currentKey = keyMatch[1];
+        const value = keyMatch[2].trim();
+        currentIndent = indent;
+        inRequires = currentKey === 'requires';
+        inMetadata = currentKey === 'metadata';
+
+        if (!inRequires && !inMetadata && value) {
+          // Simple value
+          const parsedValue = parseYamlValue(value);
+          if (currentKey === 'name') frontmatter.name = String(parsedValue);
+          else if (currentKey === 'emoji') frontmatter.emoji = String(parsedValue);
+          else if (currentKey === 'description') frontmatter.description = String(parsedValue);
+        }
+        continue;
+      }
+
+      // Handle nested keys in requires
+      if (inRequires && indent > 0) {
+        const nestedMatch = trimmed.match(/^([a-zA-Z_]+):\s*(.*)$/);
+        if (nestedMatch) {
+          const nestedKey = nestedMatch[1] as keyof SkillRequirements;
+          const nestedValue = nestedMatch[2].trim();
+          if (nestedValue) {
+            const parsed = parseYamlValue(nestedValue);
+            if (Array.isArray(parsed)) {
+              requires[nestedKey] = parsed as string[];
+            }
+          }
+        }
+      }
+
+      // Handle nested keys in metadata
+      if (inMetadata && indent > 0) {
+        const nestedMatch = trimmed.match(/^([a-zA-Z_]+):\s*(.*)$/);
+        if (nestedMatch) {
+          const nestedKey = nestedMatch[1];
+          const nestedValue = nestedMatch[2].trim();
+          if (nestedValue) {
+            const parsed = parseYamlValue(nestedValue);
+            if (nestedKey === 'author') metadata.author = String(parsed);
+            else if (nestedKey === 'created') metadata.created = String(parsed);
+            else if (nestedKey === 'updated') metadata.updated = String(parsed);
+            else if (nestedKey === 'usageCount') metadata.usageCount = Number(parsed);
+            else if (nestedKey === 'successRate') metadata.successRate = Number(parsed);
+            else if (nestedKey === 'version') metadata.version = String(parsed);
+            else if (nestedKey === 'source')
+              metadata.source = parsed as 'learned' | 'imported' | 'built-in';
+            else if (nestedKey === 'tags' && Array.isArray(parsed))
+              metadata.tags = parsed as string[];
+          }
+        }
+      }
+    }
+
+    if (Object.keys(requires).length > 0) {
+      frontmatter.requires = requires;
+    }
+    if (Object.keys(metadata).length > 0) {
+      frontmatter.metadata = metadata;
+    }
+
+    return { frontmatter, body };
+  } catch {
+    return { frontmatter: null, body: content };
+  }
+}
+
+/**
+ * Parse a simple YAML value (string, number, boolean, array)
+ */
+function parseYamlValue(value: string): string | number | boolean | string[] {
+  // Handle arrays [a, b, c]
+  if (value.startsWith('[') && value.endsWith(']')) {
+    const inner = value.slice(1, -1);
+    if (!inner.trim()) return [];
+    return inner.split(',').map((s) => {
+      const trimmed = s.trim();
+      // Remove quotes if present
+      if (
+        (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+        (trimmed.startsWith("'") && trimmed.endsWith("'"))
+      ) {
+        return trimmed.slice(1, -1);
+      }
+      return trimmed;
+    });
+  }
+
+  // Handle quoted strings
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+
+  // Handle booleans
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+
+  // Handle numbers
+  const num = Number(value);
+  if (!isNaN(num) && value !== '') return num;
+
+  return value;
+}
+
+/**
+ * Serialize skill to markdown with YAML frontmatter
+ */
+export function serializeSkill(skill: Skill): string {
+  const lines: string[] = ['---'];
+
+  lines.push(`name: ${escapeYamlString(skill.name)}`);
+  if (skill.emoji) {
+    lines.push(`emoji: ${skill.emoji}`);
+  }
+  lines.push(`description: ${escapeYamlString(skill.description)}`);
+
+  if (skill.requires && Object.keys(skill.requires).length > 0) {
+    lines.push('requires:');
+    if (skill.requires.bins?.length) {
+      lines.push(`  bins: [${skill.requires.bins.map(escapeYamlString).join(', ')}]`);
+    }
+    if (skill.requires.files?.length) {
+      lines.push(`  files: [${skill.requires.files.map(escapeYamlString).join(', ')}]`);
+    }
+    if (skill.requires.env?.length) {
+      lines.push(`  env: [${skill.requires.env.map(escapeYamlString).join(', ')}]`);
+    }
+  }
+
+  lines.push('metadata:');
+  if (skill.metadata.author) {
+    lines.push(`  author: ${escapeYamlString(skill.metadata.author)}`);
+  }
+  lines.push(`  created: ${skill.metadata.created}`);
+  if (skill.metadata.updated) {
+    lines.push(`  updated: ${skill.metadata.updated}`);
+  }
+  lines.push(`  usageCount: ${skill.metadata.usageCount}`);
+  lines.push(`  successRate: ${skill.metadata.successRate}`);
+  if (skill.metadata.version) {
+    lines.push(`  version: ${escapeYamlString(skill.metadata.version)}`);
+  }
+  if (skill.metadata.tags?.length) {
+    lines.push(`  tags: [${skill.metadata.tags.map(escapeYamlString).join(', ')}]`);
+  }
+  if (skill.metadata.source) {
+    lines.push(`  source: ${skill.metadata.source}`);
+  }
+
+  lines.push('---');
+  lines.push('');
+  lines.push(skill.content);
+
+  return lines.join('\n');
+}
+
+/**
+ * Convert frontmatter to full Skill object
+ */
+function frontmatterToSkill(frontmatter: SkillFrontmatter, body: string): Skill {
+  return {
+    name: frontmatter.name,
+    emoji: frontmatter.emoji,
+    description: frontmatter.description,
+    requires: frontmatter.requires,
+    content: body,
+    metadata: {
+      author: frontmatter.metadata?.author,
+      created: frontmatter.metadata?.created || new Date().toISOString(),
+      updated: frontmatter.metadata?.updated,
+      usageCount: frontmatter.metadata?.usageCount || 0,
+      successRate: frontmatter.metadata?.successRate || 0,
+      version: frontmatter.metadata?.version,
+      tags: frontmatter.metadata?.tags,
+      source: frontmatter.metadata?.source,
+    },
+  };
+}
+
+/**
+ * Check if requirements are satisfied
+ */
+export async function checkRequirements(
+  requires: SkillRequirements | undefined,
+  projectPath: string,
+  fsModule: SkillsFsModule
+): Promise<{ satisfied: boolean; missing: string[] }> {
+  if (!requires) {
+    return { satisfied: true, missing: [] };
+  }
+
+  const missing: string[] = [];
+
+  // Check required files
+  if (requires.files) {
+    for (const file of requires.files) {
+      const filePath = path.join(projectPath, file);
+      try {
+        await fsModule.access(filePath);
+      } catch {
+        missing.push(`file:${file}`);
+      }
+    }
+  }
+
+  // Check required environment variables
+  if (requires.env) {
+    for (const envVar of requires.env) {
+      if (!process.env[envVar]) {
+        missing.push(`env:${envVar}`);
+      }
+    }
+  }
+
+  // Note: bin checking would require executing 'which' or similar
+  // For simplicity, we skip bin checking here (agents can handle it)
+
+  return {
+    satisfied: missing.length === 0,
+    missing,
+  };
+}
+
+/**
+ * Load all skills from the skills directory
+ */
+export async function listSkills(projectPath: string, fsModule: SkillsFsModule): Promise<Skill[]> {
+  const skillsDir = getSkillsDir(projectPath);
+  const skills: Skill[] = [];
+
+  try {
+    const files = await fsModule.readdir(skillsDir);
+
+    for (const file of files) {
+      if (!file.endsWith('.md')) continue;
+
+      const filePath = path.join(skillsDir, file);
+      try {
+        const stat = await fsModule.stat(filePath);
+        if (!stat.isFile()) continue;
+
+        const content = await fsModule.readFile(filePath, 'utf-8');
+        const { frontmatter, body } = parseSkillFrontmatter(content);
+
+        if (frontmatter && frontmatter.name) {
+          skills.push(frontmatterToSkill(frontmatter, body));
+        }
+      } catch {
+        // Skip files that can't be read
+      }
+    }
+  } catch {
+    // Skills directory doesn't exist yet
+  }
+
+  return skills;
+}
+
+/**
+ * Get a specific skill by name
+ */
+export async function getSkill(
+  projectPath: string,
+  skillName: string,
+  fsModule: SkillsFsModule
+): Promise<Skill | null> {
+  const skillsDir = getSkillsDir(projectPath);
+  const filePath = path.join(skillsDir, `${skillName}.md`);
+
+  try {
+    const content = await fsModule.readFile(filePath, 'utf-8');
+    const { frontmatter, body } = parseSkillFrontmatter(content);
+
+    if (frontmatter && frontmatter.name) {
+      return frontmatterToSkill(frontmatter, body);
+    }
+  } catch {
+    // Skill not found
+  }
+
+  return null;
+}
+
+/**
+ * Load skills relevant to a feature/task
+ * Filters by tags, requirements satisfaction, and sorts by success rate
+ */
+export async function loadRelevantSkills(
+  projectPath: string,
+  context: {
+    tags?: string[];
+    featureTitle?: string;
+    featureDescription?: string;
+  },
+  fsModule: SkillsFsModule,
+  maxSkills: number = 5
+): Promise<SkillsLoadResult> {
+  const allSkills = await listSkills(projectPath, fsModule);
+
+  // Extract terms from context for matching
+  const contextTerms = new Set<string>();
+  if (context.tags) {
+    context.tags.forEach((tag) => contextTerms.add(tag.toLowerCase()));
+  }
+  if (context.featureTitle) {
+    context.featureTitle
+      .toLowerCase()
+      .split(/\W+/)
+      .filter(Boolean)
+      .forEach((term) => contextTerms.add(term));
+  }
+  if (context.featureDescription) {
+    context.featureDescription
+      .toLowerCase()
+      .split(/\W+/)
+      .filter(Boolean)
+      .forEach((term) => contextTerms.add(term));
+  }
+
+  // Score and filter skills
+  const scored: Array<{ skill: Skill; score: number }> = [];
+
+  for (const skill of allSkills) {
+    // Check requirements
+    const { satisfied } = await checkRequirements(skill.requires, projectPath, fsModule);
+    if (!satisfied) continue;
+
+    // Calculate relevance score
+    let score = 0;
+
+    // Tag matching
+    if (skill.metadata.tags) {
+      for (const tag of skill.metadata.tags) {
+        if (contextTerms.has(tag.toLowerCase())) {
+          score += 3;
+        }
+      }
+    }
+
+    // Name/description matching
+    const skillTerms = [
+      ...skill.name.toLowerCase().split(/\W+/),
+      ...skill.description.toLowerCase().split(/\W+/),
+    ].filter(Boolean);
+
+    for (const term of skillTerms) {
+      if (contextTerms.has(term)) {
+        score += 1;
+      }
+    }
+
+    // Boost by success rate and usage
+    score += skill.metadata.successRate * 2;
+    score += Math.min(skill.metadata.usageCount / 10, 1);
+
+    scored.push({ skill, score });
+  }
+
+  // Sort by score and take top N
+  scored.sort((a, b) => b.score - a.score);
+  const topSkills = scored.slice(0, maxSkills).map((s) => s.skill);
+
+  // Build formatted prompt
+  const formattedPrompt = buildSkillsPrompt(topSkills);
+
+  return {
+    skills: topSkills,
+    formattedPrompt,
+    totalLoaded: topSkills.length,
+  };
+}
+
+/**
+ * Build a prompt section for loaded skills
+ */
+function buildSkillsPrompt(skills: Skill[]): string {
+  if (skills.length === 0) {
+    return '';
+  }
+
+  const lines: string[] = [
+    '## Available Skills',
+    '',
+    'The following skills have been learned from previous work and may be relevant:',
+    '',
+  ];
+
+  for (const skill of skills) {
+    const emoji = skill.emoji ? `${skill.emoji} ` : '';
+    lines.push(`### ${emoji}${skill.name}`);
+    lines.push(`> ${skill.description}`);
+    if (skill.metadata.successRate > 0) {
+      lines.push(`> Success rate: ${Math.round(skill.metadata.successRate * 100)}%`);
+    }
+    lines.push('');
+    lines.push(skill.content);
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Create a new skill
+ */
+export async function createSkill(
+  projectPath: string,
+  options: CreateSkillOptions,
+  fsModule: SkillsFsModule
+): Promise<Skill> {
+  const skillsDir = getSkillsDir(projectPath);
+
+  // Ensure skills directory exists
+  try {
+    await fsModule.mkdir(skillsDir, { recursive: true });
+  } catch {
+    // Directory may already exist
+  }
+
+  const skill: Skill = {
+    name: options.name,
+    emoji: options.emoji,
+    description: options.description,
+    requires: options.requires,
+    content: options.content,
+    metadata: createDefaultMetadata(options.author, options.source),
+  };
+
+  if (options.tags) {
+    skill.metadata.tags = options.tags;
+  }
+
+  const filePath = path.join(skillsDir, `${options.name}.md`);
+  const content = serializeSkill(skill);
+  await fsModule.writeFile(filePath, content);
+
+  return skill;
+}
+
+/**
+ * Update an existing skill
+ */
+export async function updateSkill(
+  projectPath: string,
+  skillName: string,
+  updates: UpdateSkillOptions,
+  fsModule: SkillsFsModule
+): Promise<Skill | null> {
+  const existing = await getSkill(projectPath, skillName, fsModule);
+  if (!existing) {
+    return null;
+  }
+
+  const updated: Skill = {
+    ...existing,
+    emoji: updates.emoji ?? existing.emoji,
+    description: updates.description ?? existing.description,
+    content: updates.content ?? existing.content,
+    requires: updates.requires ?? existing.requires,
+    metadata: {
+      ...existing.metadata,
+      updated: new Date().toISOString(),
+      tags: updates.tags ?? existing.metadata.tags,
+    },
+  };
+
+  const skillsDir = getSkillsDir(projectPath);
+  const filePath = path.join(skillsDir, `${skillName}.md`);
+  const content = serializeSkill(updated);
+  await fsModule.writeFile(filePath, content);
+
+  return updated;
+}
+
+/**
+ * Delete a skill
+ */
+export async function deleteSkill(
+  projectPath: string,
+  skillName: string,
+  fsModule: SkillsFsModule
+): Promise<boolean> {
+  const skillsDir = getSkillsDir(projectPath);
+  const filePath = path.join(skillsDir, `${skillName}.md`);
+
+  try {
+    await fsModule.unlink(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Record skill usage (success or failure)
+ */
+export async function recordSkillUsage(
+  projectPath: string,
+  skillName: string,
+  success: boolean,
+  fsModule: SkillsFsModule
+): Promise<void> {
+  const skill = await getSkill(projectPath, skillName, fsModule);
+  if (!skill) return;
+
+  const totalUses = skill.metadata.usageCount + 1;
+  const successCount = skill.metadata.usageCount * skill.metadata.successRate + (success ? 1 : 0);
+  const newSuccessRate = successCount / totalUses;
+
+  const updated: Skill = {
+    ...skill,
+    metadata: {
+      ...skill.metadata,
+      usageCount: totalUses,
+      successRate: newSuccessRate,
+      updated: new Date().toISOString(),
+    },
+  };
+
+  const skillsDir = getSkillsDir(projectPath);
+  const filePath = path.join(skillsDir, `${skillName}.md`);
+  const content = serializeSkill(updated);
+  await fsModule.writeFile(filePath, content);
+}
+
+/**
+ * Initialize the skills folder with example skills
+ */
+export async function initializeSkillsFolder(
+  projectPath: string,
+  fsModule: SkillsFsModule
+): Promise<void> {
+  const skillsDir = getSkillsDir(projectPath);
+
+  try {
+    await fsModule.mkdir(skillsDir, { recursive: true });
+  } catch {
+    // Already exists
+  }
+
+  // Create an example skill if the folder is empty
+  try {
+    const files = await fsModule.readdir(skillsDir);
+    if (files.filter((f) => f.endsWith('.md')).length === 0) {
+      await createSkill(
+        projectPath,
+        {
+          name: 'example-skill',
+          emoji: '📝',
+          description: 'An example skill showing the format',
+          content: `# Example Skill
+
+This is an example skill file showing the expected format.
+
+## When to Use
+
+Use this as a template for creating new skills.
+
+## Instructions
+
+1. Create a new .md file in .automaker/skills/
+2. Add YAML frontmatter with name, description, and optional metadata
+3. Write the skill content in markdown
+
+## Notes
+
+- Skills are automatically loaded based on relevance to the current task
+- Usage statistics are tracked to improve recommendations
+`,
+          author: 'automaker',
+          source: 'built-in',
+          tags: ['example', 'template'],
+        },
+        fsModule
+      );
+    }
+  } catch {
+    // Couldn't list or create
+  }
+}


### PR DESCRIPTION
Implements the skills loading system that enables agents to create
and reuse learned skills stored in .automaker/skills/ as markdown
files with YAML frontmatter.

Key features:
- parseSkillFrontmatter() / serializeSkill() - YAML frontmatter handling
- listSkills() / getSkill() - Load skills from directory
- loadRelevantSkills() - Context-aware skill loading with scoring
- createSkill() / updateSkill() / deleteSkill() - CRUD operations
- recordSkillUsage() - Track success/failure for recommendations
- checkRequirements() - Verify skill requirements (files, env vars)
- initializeSkillsFolder() - Create skills directory with example

Skills format supports:
- name, emoji, description
- requires: bins, files, env
- metadata: author, created, usageCount, successRate, tags, source

22 tests covering all functionality.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive Skills system for managing reusable skill templates.
  * Added capabilities to create, update, delete, and track skill usage and success metrics.
  * Implemented skill relevance filtering based on context to load the most applicable skills.
  * Included requirement validation and YAML/markdown serialization for skill data.

* **Tests**
  * Added extensive test coverage for all Skills system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->