### PR TITLE
feat(prompts): add skill creation instructions to agent prompts

### DIFF
--- a/libs/prompts/src/defaults.ts
+++ b/libs/prompts/src/defaults.ts
@@ -348,6 +348,44 @@ You operate in an isolated git worktree and have access to Claude Code tools:
 - Risk awareness: Flag unclear requirements or potential blockers early
 - Iterative delivery: Complete small increments and verify before moving on
 
+**Self-Learning Skills:**
+When you discover a reusable pattern or technique that could help future tasks, you can create a skill file at \`.automaker/skills/{name}.md\`. Only create skills for truly reusable patterns, not one-off solutions.
+
+Skill file format:
+\`\`\`markdown
+---
+name: skill-name
+emoji: 🔧
+description: Brief description of what the skill does
+requires:
+  bins: [required-cli-tools]
+  files: [required-project-files]
+  env: [REQUIRED_ENV_VARS]
+metadata:
+  author: agent
+  created: 2026-01-01T00:00:00Z
+  usageCount: 0
+  successRate: 0
+  tags: [relevant, tags]
+  source: learned
+---
+
+# Skill Title
+
+Detailed instructions for how to accomplish this task...
+\`\`\`
+
+Good candidates for skills:
+- Project-specific build/test patterns
+- Common error fixes you've solved multiple times
+- Integration patterns (APIs, databases, etc.)
+- Debugging techniques that worked well
+
+Do NOT create skills for:
+- One-time fixes or unique bugs
+- Simple operations already in documentation
+- Anything containing secrets or credentials
+
 **CRITICAL - Port Protection:**
 NEVER kill or terminate processes running on ports ${STATIC_PORT} or ${SERVER_PORT}. These are reserved for the Automaker application itself. Killing these ports will crash Automaker and terminate your session.
 
@@ -861,6 +899,9 @@ Implement this feature by:
 - Flag unclear requirements immediately rather than guessing
 - If a task is taking longer than expected, assess why and document
 - If you encounter a blocker, stop and report it clearly
+
+**Skill Creation:**
+If you discover a reusable pattern during implementation, consider creating a skill file at \`.automaker/skills/{name}.md\`. Good candidates: project-specific build patterns, common error fixes, integration techniques. See the skill format in the system prompt.
 
 When done, wrap your final summary in <summary> tags like this:
 


### PR DESCRIPTION
Updates agent prompts to include self-learning skill creation capability:

1. DEFAULT_AGENT_SYSTEM_PROMPT - Added "Self-Learning Skills" section:
   - Full skill file format with YAML frontmatter example
   - Guidelines for good vs bad skill candidates
   - Requirements specification (bins, files, env)
   - Metadata fields (author, tags, source, usage tracking)

2. DEFAULT_IMPLEMENTATION_INSTRUCTIONS - Added "Skill Creation" reminder:
   - Encourages agents to create skills for reusable patterns
   - References system prompt for full format details

Agents can now create skills at .automaker/skills/{name}.md when they
discover reusable patterns during feature implementation.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced in-context guidance documentation for skill creation workflows and self-learning capabilities with new instructional blocks.
  * Improved user support through expanded reference materials and clearer guidelines for skill development and creation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->