### PR TITLE
feat(mcp): add skills MCP tools for self-learning

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -90,6 +90,7 @@ import { createEventHistoryRoutes } from './routes/event-history/index.js';
 import { getEventHistoryService } from './services/event-history-service.js';
 import { createRalphRoutes } from './routes/ralph/index.js';
 import { RalphLoopService } from './services/ralph-loop-service.js';
+import { createSkillsRoutes } from './routes/skills/index.js';
 
 const PORT = parseInt(process.env.PORT || '3008', 10);
 const HOST = process.env.HOST || '0.0.0.0';
@@ -350,6 +351,7 @@ app.use('/api/pipeline', createPipelineRoutes(pipelineService));
 app.use('/api/ideation', createIdeationRoutes(events, ideationService, featureLoader));
 app.use('/api/notifications', createNotificationsRoutes(notificationService));
 app.use('/api/ralph', createRalphRoutes(ralphLoopService));
+app.use('/api/skills', createSkillsRoutes());
 app.use('/api/event-history', createEventHistoryRoutes(eventHistoryService, settingsService));
 app.use('/api/projects', createProjectsRoutes(featureLoader));
 

--- a/apps/server/src/routes/skills/index.ts
+++ b/apps/server/src/routes/skills/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Skills routes - HTTP API for skill management
+ *
+ * Provides endpoints for managing self-learning skills including
+ * CRUD operations and usage tracking.
+ */
+
+import { Router } from 'express';
+import { createListHandler } from './routes/list.js';
+import { createGetHandler } from './routes/get.js';
+import { createCreateHandler } from './routes/create.js';
+import { createUpdateHandler } from './routes/update.js';
+import { createDeleteHandler } from './routes/delete.js';
+import { createRecordUsageHandler } from './routes/record-usage.js';
+
+/**
+ * Create the skills router
+ *
+ * @returns Express router with skills endpoints
+ */
+export function createSkillsRoutes(): Router {
+  const router = Router();
+
+  router.post('/list', createListHandler());
+  router.post('/get', createGetHandler());
+  router.post('/create', createCreateHandler());
+  router.post('/update', createUpdateHandler());
+  router.post('/delete', createDeleteHandler());
+  router.post('/record-usage', createRecordUsageHandler());
+
+  return router;
+}

--- a/apps/server/src/routes/skills/routes/create.ts
+++ b/apps/server/src/routes/skills/routes/create.ts
@@ -1,0 +1,80 @@
+/**
+ * POST /skills/create endpoint - Create a new skill
+ */
+
+import type { Request, Response, RequestHandler } from 'express';
+import { promises as fs } from 'fs';
+import { createSkill, type SkillsFsModule } from '@automaker/utils';
+import type { CreateSkillOptions } from '@automaker/types';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('skills:create');
+
+const fsModule: SkillsFsModule = {
+  readFile: (path, encoding) => fs.readFile(path, encoding as BufferEncoding),
+  writeFile: fs.writeFile,
+  readdir: fs.readdir as (path: string) => Promise<string[]>,
+  stat: fs.stat,
+  mkdir: fs.mkdir,
+  unlink: fs.unlink,
+  access: fs.access,
+};
+
+interface CreateRequest {
+  projectPath: string;
+  name: string;
+  description: string;
+  content: string;
+  emoji?: string;
+  requires?: {
+    bins?: string[];
+    files?: string[];
+    env?: string[];
+  };
+  author?: string;
+  tags?: string[];
+  source?: 'learned' | 'imported' | 'built-in';
+}
+
+export function createCreateHandler(): RequestHandler {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, name, description, content, emoji, requires, author, tags, source } =
+        req.body as CreateRequest;
+
+      if (!projectPath || !name || !description || !content) {
+        res.status(400).json({
+          success: false,
+          error: 'projectPath, name, description, and content are required',
+        });
+        return;
+      }
+
+      logger.debug(`Creating skill ${name} for project: ${projectPath}`);
+
+      const options: CreateSkillOptions = {
+        name,
+        description,
+        content,
+        emoji,
+        requires,
+        author,
+        tags,
+        source,
+      };
+
+      const skill = await createSkill(projectPath, options, fsModule);
+
+      res.json({
+        success: true,
+        skill,
+      });
+    } catch (error) {
+      logger.error('Error creating skill:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}

--- a/apps/server/src/routes/skills/routes/delete.ts
+++ b/apps/server/src/routes/skills/routes/delete.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /skills/delete endpoint - Delete a skill
+ */
+
+import type { Request, Response, RequestHandler } from 'express';
+import { promises as fs } from 'fs';
+import { deleteSkill, type SkillsFsModule } from '@automaker/utils';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('skills:delete');
+
+const fsModule: SkillsFsModule = {
+  readFile: (path, encoding) => fs.readFile(path, encoding as BufferEncoding),
+  writeFile: fs.writeFile,
+  readdir: fs.readdir as (path: string) => Promise<string[]>,
+  stat: fs.stat,
+  mkdir: fs.mkdir,
+  unlink: fs.unlink,
+  access: fs.access,
+};
+
+interface DeleteRequest {
+  projectPath: string;
+  skillName: string;
+}
+
+export function createDeleteHandler(): RequestHandler {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, skillName } = req.body as DeleteRequest;
+
+      if (!projectPath || !skillName) {
+        res.status(400).json({
+          success: false,
+          error: 'projectPath and skillName are required',
+        });
+        return;
+      }
+
+      logger.debug(`Deleting skill ${skillName} for project: ${projectPath}`);
+
+      const deleted = await deleteSkill(projectPath, skillName, fsModule);
+
+      if (!deleted) {
+        res.status(404).json({
+          success: false,
+          error: `Skill not found: ${skillName}`,
+        });
+        return;
+      }
+
+      res.json({
+        success: true,
+        message: `Skill ${skillName} deleted successfully`,
+      });
+    } catch (error) {
+      logger.error('Error deleting skill:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}

--- a/apps/server/src/routes/skills/routes/get.ts
+++ b/apps/server/src/routes/skills/routes/get.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /skills/get endpoint - Get a specific skill by name
+ */
+
+import type { Request, Response, RequestHandler } from 'express';
+import { promises as fs } from 'fs';
+import { getSkill, type SkillsFsModule } from '@automaker/utils';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('skills:get');
+
+const fsModule: SkillsFsModule = {
+  readFile: (path, encoding) => fs.readFile(path, encoding as BufferEncoding),
+  writeFile: fs.writeFile,
+  readdir: fs.readdir as (path: string) => Promise<string[]>,
+  stat: fs.stat,
+  mkdir: fs.mkdir,
+  unlink: fs.unlink,
+  access: fs.access,
+};
+
+interface GetRequest {
+  projectPath: string;
+  skillName: string;
+}
+
+export function createGetHandler(): RequestHandler {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, skillName } = req.body as GetRequest;
+
+      if (!projectPath || !skillName) {
+        res.status(400).json({
+          success: false,
+          error: 'projectPath and skillName are required',
+        });
+        return;
+      }
+
+      logger.debug(`Getting skill ${skillName} for project: ${projectPath}`);
+
+      const skill = await getSkill(projectPath, skillName, fsModule);
+
+      if (!skill) {
+        res.status(404).json({
+          success: false,
+          error: `Skill not found: ${skillName}`,
+        });
+        return;
+      }
+
+      res.json({
+        success: true,
+        skill,
+      });
+    } catch (error) {
+      logger.error('Error getting skill:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}

--- a/apps/server/src/routes/skills/routes/list.ts
+++ b/apps/server/src/routes/skills/routes/list.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /skills/list endpoint - List all skills in a project
+ */
+
+import type { Request, Response, RequestHandler } from 'express';
+import { promises as fs } from 'fs';
+import { listSkills, type SkillsFsModule } from '@automaker/utils';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('skills:list');
+
+const fsModule: SkillsFsModule = {
+  readFile: (path, encoding) => fs.readFile(path, encoding as BufferEncoding),
+  writeFile: fs.writeFile,
+  readdir: fs.readdir as (path: string) => Promise<string[]>,
+  stat: fs.stat,
+  mkdir: fs.mkdir,
+  unlink: fs.unlink,
+  access: fs.access,
+};
+
+interface ListRequest {
+  projectPath: string;
+}
+
+export function createListHandler(): RequestHandler {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath } = req.body as ListRequest;
+
+      if (!projectPath) {
+        res.status(400).json({
+          success: false,
+          error: 'projectPath is required',
+        });
+        return;
+      }
+
+      logger.debug(`Listing skills for project: ${projectPath}`);
+
+      const skills = await listSkills(projectPath, fsModule);
+
+      res.json({
+        success: true,
+        skills: skills.map((skill) => ({
+          name: skill.name,
+          emoji: skill.emoji,
+          description: skill.description,
+          tags: skill.metadata.tags,
+          usageCount: skill.metadata.usageCount,
+          successRate: skill.metadata.successRate,
+          source: skill.metadata.source,
+        })),
+        count: skills.length,
+      });
+    } catch (error) {
+      logger.error('Error listing skills:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}

--- a/apps/server/src/routes/skills/routes/record-usage.ts
+++ b/apps/server/src/routes/skills/routes/record-usage.ts
@@ -1,0 +1,57 @@
+/**
+ * POST /skills/record-usage endpoint - Record skill usage (success/failure)
+ */
+
+import type { Request, Response, RequestHandler } from 'express';
+import { promises as fs } from 'fs';
+import { recordSkillUsage, type SkillsFsModule } from '@automaker/utils';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('skills:record-usage');
+
+const fsModule: SkillsFsModule = {
+  readFile: (path, encoding) => fs.readFile(path, encoding as BufferEncoding),
+  writeFile: fs.writeFile,
+  readdir: fs.readdir as (path: string) => Promise<string[]>,
+  stat: fs.stat,
+  mkdir: fs.mkdir,
+  unlink: fs.unlink,
+  access: fs.access,
+};
+
+interface RecordUsageRequest {
+  projectPath: string;
+  skillName: string;
+  success: boolean;
+}
+
+export function createRecordUsageHandler(): RequestHandler {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, skillName, success } = req.body as RecordUsageRequest;
+
+      if (!projectPath || !skillName || typeof success !== 'boolean') {
+        res.status(400).json({
+          success: false,
+          error: 'projectPath, skillName, and success (boolean) are required',
+        });
+        return;
+      }
+
+      logger.debug(`Recording usage for skill ${skillName}: ${success ? 'success' : 'failure'}`);
+
+      await recordSkillUsage(projectPath, skillName, success, fsModule);
+
+      res.json({
+        success: true,
+        message: `Usage recorded for skill ${skillName}`,
+      });
+    } catch (error) {
+      logger.error('Error recording skill usage:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}

--- a/apps/server/src/routes/skills/routes/update.ts
+++ b/apps/server/src/routes/skills/routes/update.ts
@@ -1,0 +1,66 @@
+/**
+ * POST /skills/update endpoint - Update an existing skill
+ */
+
+import type { Request, Response, RequestHandler } from 'express';
+import { promises as fs } from 'fs';
+import { updateSkill, type SkillsFsModule } from '@automaker/utils';
+import type { UpdateSkillOptions } from '@automaker/types';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('skills:update');
+
+const fsModule: SkillsFsModule = {
+  readFile: (path, encoding) => fs.readFile(path, encoding as BufferEncoding),
+  writeFile: fs.writeFile,
+  readdir: fs.readdir as (path: string) => Promise<string[]>,
+  stat: fs.stat,
+  mkdir: fs.mkdir,
+  unlink: fs.unlink,
+  access: fs.access,
+};
+
+interface UpdateRequest {
+  projectPath: string;
+  skillName: string;
+  updates: UpdateSkillOptions;
+}
+
+export function createUpdateHandler(): RequestHandler {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, skillName, updates } = req.body as UpdateRequest;
+
+      if (!projectPath || !skillName || !updates) {
+        res.status(400).json({
+          success: false,
+          error: 'projectPath, skillName, and updates are required',
+        });
+        return;
+      }
+
+      logger.debug(`Updating skill ${skillName} for project: ${projectPath}`);
+
+      const skill = await updateSkill(projectPath, skillName, updates, fsModule);
+
+      if (!skill) {
+        res.status(404).json({
+          success: false,
+          error: `Skill not found: ${skillName}`,
+        });
+        return;
+      }
+
+      res.json({
+        success: true,
+        skill,
+      });
+    } catch (error) {
+      logger.error('Error updating skill:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -522,6 +522,95 @@ const tools: Tool[] = [
     },
   },
 
+  // ========== Skills ==========
+  {
+    name: 'list_skills',
+    description:
+      'List all learned skills in a project. Skills are reusable patterns stored in .automaker/skills/',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+  {
+    name: 'get_skill',
+    description: 'Get the full content and metadata of a specific skill.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        skillName: {
+          type: 'string',
+          description: 'Name of the skill (without .md extension)',
+        },
+      },
+      required: ['projectPath', 'skillName'],
+    },
+  },
+  {
+    name: 'create_skill',
+    description:
+      'Create a new skill from a learned pattern. Skills help agents reuse successful approaches.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        name: {
+          type: 'string',
+          description: 'Unique name for the skill (kebab-case, e.g., "git-commit-workflow")',
+        },
+        description: {
+          type: 'string',
+          description: 'Brief description of what the skill does',
+        },
+        content: {
+          type: 'string',
+          description: 'The skill content/instructions in markdown',
+        },
+        emoji: {
+          type: 'string',
+          description: 'Optional emoji for visual identification',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Tags for categorization and discovery',
+        },
+      },
+      required: ['projectPath', 'name', 'description', 'content'],
+    },
+  },
+  {
+    name: 'delete_skill',
+    description: 'Delete a skill that is no longer needed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        skillName: {
+          type: 'string',
+          description: 'Name of the skill to delete',
+        },
+      },
+      required: ['projectPath', 'skillName'],
+    },
+  },
+
   // ========== Project Spec ==========
   {
     name: 'get_project_spec',
@@ -1145,6 +1234,34 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
       return apiCall('/context/delete', {
         projectPath: args.projectPath,
         filename: args.filename,
+      });
+
+    // Skills
+    case 'list_skills':
+      return apiCall('/skills/list', {
+        projectPath: args.projectPath,
+      });
+
+    case 'get_skill':
+      return apiCall('/skills/get', {
+        projectPath: args.projectPath,
+        skillName: args.skillName,
+      });
+
+    case 'create_skill':
+      return apiCall('/skills/create', {
+        projectPath: args.projectPath,
+        name: args.name,
+        description: args.description,
+        content: args.content,
+        emoji: args.emoji,
+        tags: args.tags,
+      });
+
+    case 'delete_skill':
+      return apiCall('/skills/delete', {
+        projectPath: args.projectPath,
+        skillName: args.skillName,
       });
 
     // Project Spec


### PR DESCRIPTION
## Summary

Adds MCP tools for managing skills in the self-learning system:

- `list_skills` - List all learned skills in a project
- `get_skill` - Get skill content and metadata  
- `create_skill` - Create new skill from learned pattern
- `delete_skill` - Remove unused skill

Also adds corresponding server routes in `/api/skills/` with 6 endpoints.

Part of the Self-Learning Skills epic (feature 4/4).

## Stack
- Depends on PR #27 (skills-loader)
- Depends on PR #28 (agent prompts)

## Test plan

- [ ] Start server and verify `/api/skills/*` endpoints respond
- [ ] Test MCP tools via Claude Code plugin
- [ ] Verify skills CRUD operations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)