### PR TITLE
Integrate Graphite restack into automated git workflow

### DIFF
--- a/apps/server/src/routes/worktree/index.ts
+++ b/apps/server/src/routes/worktree/index.ts
@@ -52,6 +52,7 @@ import { createDiscardChangesHandler } from './routes/discard-changes.js';
 import { createListRemotesHandler } from './routes/list-remotes.js';
 import { createGraphiteStatusHandler } from './routes/graphite-status.js';
 import { createGraphiteSyncHandler } from './routes/graphite-sync.js';
+import { createGraphiteRestackHandler } from './routes/graphite-restack.js';
 import type { SettingsService } from '../../services/settings-service.js';
 
 export function createWorktreeRoutes(
@@ -180,6 +181,12 @@ export function createWorktreeRoutes(
     validatePathParams('worktreePath'),
     requireGitRepoOnly,
     createGraphiteSyncHandler()
+  );
+  router.post(
+    '/graphite-restack',
+    validatePathParams('worktreePath'),
+    requireGitRepoOnly,
+    createGraphiteRestackHandler()
   );
 
   return router;

--- a/apps/server/src/routes/worktree/routes/graphite-restack.ts
+++ b/apps/server/src/routes/worktree/routes/graphite-restack.ts
@@ -1,0 +1,93 @@
+/**
+ * POST /graphite-restack endpoint - Restack entire branch stack on trunk
+ *
+ * Uses Graphite's restack command to rebase all branches in the stack when trunk changes.
+ * This is more aggressive than sync - it updates all branches in the stack to be based on
+ * the latest trunk, preventing merge conflicts during PR creation.
+ */
+
+import type { Request, Response } from 'express';
+import { getErrorMessage, logError } from '../common.js';
+import { graphiteService } from '../../../services/graphite-service.js';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('GraphiteRestack');
+
+export function createGraphiteRestackHandler() {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { worktreePath } = req.body as {
+        worktreePath: string;
+      };
+
+      if (!worktreePath) {
+        res.status(400).json({
+          success: false,
+          error: 'worktreePath required',
+        });
+        return;
+      }
+
+      // Check if Graphite CLI is available
+      const available = await graphiteService.isAvailable();
+      if (!available) {
+        res.status(400).json({
+          success: false,
+          error: 'Graphite CLI (gt) is not installed or not in PATH',
+        });
+        return;
+      }
+
+      // Check if repo is initialized
+      const initialized = await graphiteService.isRepoInitialized(worktreePath);
+      if (!initialized) {
+        res.status(400).json({
+          success: false,
+          error: 'Repository is not initialized for Graphite. Run: gt repo init',
+        });
+        return;
+      }
+
+      // Run restack
+      logger.info(`Restacking Graphite stack at ${worktreePath}`);
+      const result = await graphiteService.restack(worktreePath);
+
+      if (result.conflicts) {
+        res.status(409).json({
+          success: false,
+          error: 'Restack encountered merge conflicts that need to be resolved manually',
+          result: {
+            rebased: false,
+            conflicts: true,
+          },
+        });
+        return;
+      }
+
+      if (!result.success) {
+        res.status(500).json({
+          success: false,
+          error: result.error || 'Graphite restack failed',
+          result: {
+            rebased: false,
+            conflicts: false,
+          },
+        });
+        return;
+      }
+
+      logger.info(`Graphite restack successful at ${worktreePath}`);
+      res.json({
+        success: true,
+        result: {
+          rebased: result.rebased,
+          conflicts: false,
+          message: 'Stack restacked successfully on trunk',
+        },
+      });
+    } catch (error) {
+      logError(error, 'Graphite restack failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3230,6 +3230,62 @@ Format your response as a structured markdown document.`;
   }
 
   /**
+   * Attempt to restack the worktree using Graphite to sync with main/trunk
+   * This helps prevent merge conflicts by keeping the branch up to date
+   *
+   * @param worktreePath - Path to the worktree
+   * @param branchName - Name of the branch being worked on
+   * @returns true if restack succeeded or wasn't needed, false if conflicts occurred
+   */
+  private async attemptGraphiteRestack(
+    worktreePath: string,
+    branchName: string
+  ): Promise<boolean> {
+    try {
+      // Check if Graphite should be used
+      const settings = await this.settingsService?.getGlobalSettings();
+      const useGraphite = await graphiteService.shouldUseGraphite(settings?.graphite);
+
+      if (!useGraphite) {
+        logger.debug('Graphite not enabled, skipping restack');
+        return true; // Not an error, just not using Graphite
+      }
+
+      // Check if repo is initialized for Graphite
+      const initialized = await graphiteService.isRepoInitialized(worktreePath);
+      if (!initialized) {
+        logger.debug('Graphite not initialized for this repo, skipping restack');
+        return true; // Not an error, just not initialized
+      }
+
+      // Perform restack to sync with trunk
+      logger.info(`Restacking branch "${branchName}" to sync with trunk`);
+      const result = await graphiteService.restack(worktreePath);
+
+      if (result.conflicts) {
+        logger.warn(
+          `Restack encountered conflicts for branch "${branchName}". Manual resolution required.`
+        );
+        return false; // Conflicts need manual resolution
+      }
+
+      if (!result.success) {
+        logger.warn(`Restack failed for branch "${branchName}": ${result.error}`);
+        // Non-conflict failures are logged but don't block execution
+        return true;
+      }
+
+      logger.info(`Successfully restacked branch "${branchName}"`);
+      return true;
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      logger.warn(`Error attempting Graphite restack for "${branchName}": ${errorMsg}`);
+      // Don't block execution on restack errors
+      return true;
+    }
+  }
+
+  /**
    * Create a new worktree for a given branch
    * Returns the worktree path on success, null on failure
    */
@@ -3281,6 +3337,17 @@ Format your response as a structured markdown document.`;
       }
 
       logger.info(`Created worktree for branch "${branchName}" at: ${worktreePath}`);
+
+      // Attempt to restack with Graphite to sync with trunk
+      const restackSuccess = await this.attemptGraphiteRestack(worktreePath, branchName);
+      if (!restackSuccess) {
+        logger.warn(
+          `Branch "${branchName}" has merge conflicts after restack. Agent may encounter issues.`
+        );
+        // Note: We don't fail worktree creation, but log the warning
+        // The agent will discover conflicts when it tries to commit
+      }
+
       return path.resolve(worktreePath);
     } catch (error) {
       logger.error(`Failed to create worktree for branch "${branchName}":`, error);

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -195,6 +195,33 @@ export class GitWorkflowService {
       result.commitHash = commitHash;
       logger.info(`Committed changes for feature ${featureId}: ${commitHash}`);
 
+      // Step 1.5: Restack with Graphite before pushing (if enabled)
+      // This ensures the branch is up to date with trunk/main to prevent merge conflicts
+      if (useGraphite && gitSettings.autoPush) {
+        try {
+          logger.info(`Restacking branch ${branchName} before push`);
+          const restackResult = await graphiteService.restack(workDir);
+
+          if (restackResult.conflicts) {
+            logger.warn(`Restack encountered conflicts for branch ${branchName}`);
+            result.error = 'Restack conflicts detected - manual resolution required';
+            // Don't proceed with push/PR if conflicts exist
+            return result;
+          }
+
+          if (!restackResult.success) {
+            logger.warn(`Restack failed for branch ${branchName}: ${restackResult.error}`);
+            // Log but continue - non-conflict failures shouldn't block PR creation
+          } else {
+            logger.info(`Successfully restacked branch ${branchName}`);
+          }
+        } catch (restackError) {
+          const errorMsg = restackError instanceof Error ? restackError.message : String(restackError);
+          logger.warn(`Error during restack for branch ${branchName}: ${errorMsg}`);
+          // Log but continue - restack errors shouldn't block PR creation
+        }
+      }
+
       // Step 2: Push to remote (if enabled)
       if (gitSettings.autoPush) {
         try {

--- a/apps/server/src/services/graphite-service.ts
+++ b/apps/server/src/services/graphite-service.ts
@@ -408,6 +408,33 @@ export class GraphiteService {
   }
 
   /**
+   * Restack the entire branch stack on top of the trunk
+   * This rebases all branches in the stack when the trunk (main) has changed
+   * Use this to keep feature branches up to date with main and prevent merge conflicts
+   *
+   * @param workDir - Working directory (worktree path)
+   * @returns Result indicating success, conflicts, or other errors
+   */
+  async restack(workDir: string): Promise<GraphiteSyncResult> {
+    try {
+      await execAsync('gt restack', { cwd: workDir, env: execEnv });
+      logger.info('Graphite restack successful');
+      return { success: true, rebased: true, conflicts: false };
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+
+      // Check for merge conflicts
+      if (errorMsg.includes('conflict') || errorMsg.includes('CONFLICT')) {
+        logger.warn('Graphite restack encountered conflicts');
+        return { success: false, rebased: false, conflicts: true, error: errorMsg };
+      }
+
+      logger.warn(`Graphite restack failed: ${errorMsg}`);
+      return { success: false, rebased: false, conflicts: false, error: errorMsg };
+    }
+  }
+
+  /**
    * Get stack information for the current branch
    * Returns information about the branch's position in the stack
    */

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1107,6 +1107,21 @@ const tools: Tool[] = [
       required: ['projectPath'],
     },
   },
+  {
+    name: 'graphite_restack',
+    description:
+      'Restack the entire branch stack on trunk using Graphite CLI. This rebases all branches in the stack when trunk (main) has changed, preventing merge conflicts during PR creation. Use this to sync feature branches with the latest main branch.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        worktreePath: {
+          type: 'string',
+          description: 'Absolute path to the worktree directory',
+        },
+      },
+      required: ['worktreePath'],
+    },
+  },
 ];
 
 // Tool implementations
@@ -1478,6 +1493,11 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
       };
       return summary;
     }
+
+    case 'graphite_restack':
+      return apiCall('/worktree/graphite-restack', {
+        worktreePath: args.worktreePath,
+      });
 
     default:
       throw new Error(`Unknown tool: ${name}`);


### PR DESCRIPTION
## Summary

**Problem:** Feature branches get out of sync with main, causing merge conflicts during PR creation. Currently requires manual intervention to restack.

**Goal:** Fully automate branch synchronization using Graphite CLI as part of the Automaker workflow.

**Integration Points to Consider:**
1. Before agent starts on a feature (auto-mode)
2. Before PR creation (git-workflow-service)
3. Periodic scheduled sync (scheduler-service)
4. Recovery flow when conflicts occur

**Files Likely Involved:**
- ...

---
*Created automatically by Automaker*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Graphite restack functionality integrated throughout the workflow—available as an API endpoint and automatically triggered when creating worktrees and before auto-push operations, with graceful conflict handling that logs warnings without blocking operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->