### PR TITLE
[Epic] Inbound Webhook Infrastructure

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -227,7 +227,18 @@ app.use(
     credentials: true,
   })
 );
-app.use(express.json({ limit: '50mb' }));
+
+// Preserve raw body for webhook signature verification
+// This middleware must be before express.json()
+app.use(
+  express.json({
+    limit: '50mb',
+    verify: (req: any, _res, buf) => {
+      // Store raw body for routes that need it (e.g., webhook signature verification)
+      req.rawBody = buf;
+    },
+  })
+);
 app.use(cookieParser());
 
 // Create shared event emitter for streaming

--- a/apps/server/src/routes/github/index.ts
+++ b/apps/server/src/routes/github/index.ts
@@ -18,6 +18,7 @@ import {
   createMarkViewedHandler,
 } from './routes/validation-endpoints.js';
 import { createProcessCodeRabbitFeedbackHandler } from './routes/process-coderabbit-feedback.js';
+import { createWebhookHandler } from './routes/webhook.js';
 import type { SettingsService } from '../../services/settings-service.js';
 
 export function createGitHubRoutes(
@@ -25,6 +26,12 @@ export function createGitHubRoutes(
   settingsService?: SettingsService
 ): Router {
   const router = Router();
+
+  // Webhook endpoint - must be first (no validatePathParams middleware)
+  // Uses query parameter for project path to support GitHub webhook configuration
+  if (settingsService) {
+    router.post('/webhook', createWebhookHandler(settingsService, events));
+  }
 
   router.post('/check-remote', validatePathParams('projectPath'), createCheckGitHubRemoteHandler());
   router.post('/issues', validatePathParams('projectPath'), createListIssuesHandler());

--- a/apps/server/src/routes/github/routes/webhook.ts
+++ b/apps/server/src/routes/github/routes/webhook.ts
@@ -1,0 +1,308 @@
+/**
+ * GitHub Webhook Handler - Receives and processes inbound webhook events
+ *
+ * Handles GitHub webhook events (issues, PRs, pushes) with HMAC-SHA256 signature verification.
+ * Supports automatic feature creation from GitHub issues when configured.
+ */
+
+import { createHmac, timingSafeEqual } from 'crypto';
+import type { Request, Response, NextFunction } from 'express';
+import { createLogger } from '@automaker/utils';
+import type {
+  GitHubWebhookPayload,
+  GitHubIssueWebhookPayload,
+  GitHubPullRequestWebhookPayload,
+  GitHubPushWebhookPayload,
+  GitHubPingWebhookPayload,
+  WebhookVerificationResult,
+} from '@automaker/types';
+import type { SettingsService } from '../../../services/settings-service.js';
+import type { EventEmitter } from '../../../lib/events.js';
+
+const logger = createLogger('GitHubWebhook');
+
+/**
+ * Verify GitHub webhook signature using HMAC-SHA256
+ *
+ * @param payload - Raw request body (string or Buffer)
+ * @param signature - GitHub signature from X-Hub-Signature-256 header
+ * @param secret - Webhook secret configured in GitHub and project settings
+ * @returns Verification result with valid flag and optional error
+ */
+function verifyWebhookSignature(
+  payload: string | Buffer,
+  signature: string | undefined,
+  secret: string
+): WebhookVerificationResult {
+  if (!signature) {
+    return {
+      valid: false,
+      error: 'Missing X-Hub-Signature-256 header',
+    };
+  }
+
+  if (!signature.startsWith('sha256=')) {
+    return {
+      valid: false,
+      error: 'Invalid signature format (expected sha256=...)',
+    };
+  }
+
+  // Compute expected signature
+  const hmac = createHmac('sha256', secret);
+  hmac.update(payload);
+  const expectedSignature = `sha256=${hmac.digest('hex')}`;
+
+  // Timing-safe comparison to prevent timing attacks
+  try {
+    const signatureBuffer = Buffer.from(signature);
+    const expectedBuffer = Buffer.from(expectedSignature);
+
+    if (signatureBuffer.length !== expectedBuffer.length) {
+      return {
+        valid: false,
+        error: 'Invalid signature',
+      };
+    }
+
+    const isValid = timingSafeEqual(signatureBuffer, expectedBuffer);
+
+    return {
+      valid: isValid,
+      error: isValid ? undefined : 'Invalid signature',
+    };
+  } catch (error) {
+    logger.error('Error verifying webhook signature:', error);
+    return {
+      valid: false,
+      error: 'Signature verification failed',
+    };
+  }
+}
+
+/**
+ * Handle GitHub ping event (webhook test)
+ */
+async function handlePingEvent(payload: GitHubPingWebhookPayload): Promise<void> {
+  logger.info(
+    `Received ping event for repository ${payload.repository.full_name} (hook_id: ${payload.hook_id})`
+  );
+  logger.debug(`Zen message: ${payload.zen}`);
+}
+
+/**
+ * Handle GitHub issue event
+ */
+async function handleIssueEvent(
+  payload: GitHubIssueWebhookPayload,
+  projectPath: string,
+  events: EventEmitter
+): Promise<void> {
+  const { action, issue, repository } = payload;
+
+  logger.info(
+    `Received issue event: ${action} on ${repository.full_name}#${issue.number} - ${issue.title}`
+  );
+
+  // Emit event for logging and potential auto-creation
+  events.emit('webhook:github:issue', {
+    action,
+    issueNumber: issue.number,
+    issueTitle: issue.title,
+    issueBody: issue.body,
+    issueUrl: issue.html_url,
+    repository: repository.full_name,
+    projectPath,
+    labels: issue.labels?.map((l) => l.name) || [],
+  });
+
+  // Future: Auto-create features from issues when webhookSettings.autoCreateFromIssues is enabled
+  // This would integrate with the feature creation logic
+}
+
+/**
+ * Handle GitHub pull request event
+ */
+async function handlePullRequestEvent(
+  payload: GitHubPullRequestWebhookPayload,
+  projectPath: string,
+  events: EventEmitter
+): Promise<void> {
+  const { action, pull_request, repository } = payload;
+
+  logger.info(
+    `Received PR event: ${action} on ${repository.full_name}#${pull_request.number} - ${pull_request.title}`
+  );
+
+  // Emit event for logging
+  events.emit('webhook:github:pull_request', {
+    action,
+    prNumber: pull_request.number,
+    prTitle: pull_request.title,
+    prUrl: pull_request.html_url,
+    repository: repository.full_name,
+    projectPath,
+    merged: pull_request.merged,
+    headBranch: pull_request.head.ref,
+    baseBranch: pull_request.base.ref,
+  });
+
+  // Future: Update feature status when PR is merged/closed
+}
+
+/**
+ * Handle GitHub push event
+ */
+async function handlePushEvent(
+  payload: GitHubPushWebhookPayload,
+  projectPath: string,
+  events: EventEmitter
+): Promise<void> {
+  const { ref, repository, commits } = payload;
+
+  logger.info(
+    `Received push event on ${repository.full_name} (${ref}): ${commits.length} commits`
+  );
+
+  // Emit event for logging
+  events.emit('webhook:github:push', {
+    ref,
+    repository: repository.full_name,
+    projectPath,
+    commitCount: commits.length,
+    commits: commits.map((c) => ({
+      sha: c.id,
+      message: c.message,
+    })),
+  });
+
+  // Future: Trigger builds or update feature status based on commits
+}
+
+/**
+ * Create webhook handler
+ *
+ * Receives GitHub webhook events, verifies signatures, and processes the payload.
+ * Requires raw body for signature verification.
+ */
+export function createWebhookHandler(
+  settingsService: SettingsService,
+  events: EventEmitter
+): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      // Extract project path from query parameter
+      const projectPath = req.query.project as string | undefined;
+
+      if (!projectPath) {
+        res.status(400).json({
+          error: 'Missing project query parameter',
+          message: 'Webhook URL must include ?project=/path/to/project',
+        });
+        return;
+      }
+
+      // Load project settings to get webhook secret
+      const projectSettings = await settingsService.getProjectSettings(projectPath);
+      const webhookSettings = projectSettings.webhookSettings;
+
+      // Check if webhooks are enabled
+      if (!webhookSettings?.webhookEnabled) {
+        res.status(403).json({
+          error: 'Webhooks disabled',
+          message: 'Webhooks are not enabled for this project',
+        });
+        return;
+      }
+
+      // Verify webhook secret is configured
+      if (!webhookSettings.webhookSecret) {
+        logger.error('Webhook secret not configured for project:', projectPath);
+        res.status(500).json({
+          error: 'Configuration error',
+          message: 'Webhook secret not configured',
+        });
+        return;
+      }
+
+      // Get raw body for signature verification
+      // Express should preserve rawBody when using express.json({ verify: ... })
+      const rawBody = (req as any).rawBody as Buffer | undefined;
+
+      if (!rawBody) {
+        logger.error('Raw body not available for signature verification');
+        res.status(500).json({
+          error: 'Server error',
+          message: 'Unable to verify webhook signature (raw body missing)',
+        });
+        return;
+      }
+
+      // Verify signature
+      const signature = req.headers['x-hub-signature-256'] as string | undefined;
+      const verification = verifyWebhookSignature(rawBody, signature, webhookSettings.webhookSecret);
+
+      if (!verification.valid) {
+        logger.warn(`Webhook signature verification failed: ${verification.error}`);
+        res.status(401).json({
+          error: 'Unauthorized',
+          message: verification.error,
+        });
+        return;
+      }
+
+      // Get event type from header
+      const eventType = req.headers['x-github-event'] as string | undefined;
+
+      if (!eventType) {
+        res.status(400).json({
+          error: 'Missing X-GitHub-Event header',
+        });
+        return;
+      }
+
+      logger.info(`Processing GitHub ${eventType} event for project: ${projectPath}`);
+
+      // Process event based on type
+      const payload = req.body as GitHubWebhookPayload;
+
+      switch (eventType) {
+        case 'ping':
+          await handlePingEvent(payload as GitHubPingWebhookPayload);
+          break;
+
+        case 'issues':
+          await handleIssueEvent(payload as GitHubIssueWebhookPayload, projectPath, events);
+          break;
+
+        case 'pull_request':
+          await handlePullRequestEvent(
+            payload as GitHubPullRequestWebhookPayload,
+            projectPath,
+            events
+          );
+          break;
+
+        case 'push':
+          await handlePushEvent(payload as GitHubPushWebhookPayload, projectPath, events);
+          break;
+
+        default:
+          logger.info(`Ignoring unsupported event type: ${eventType}`);
+          res.status(200).json({
+            message: `Event type ${eventType} not supported`,
+          });
+          return;
+      }
+
+      // Success response
+      res.status(200).json({
+        message: 'Webhook processed successfully',
+        event: eventType,
+      });
+    } catch (error) {
+      logger.error('Error processing webhook:', error);
+      next(error);
+    }
+  };
+}

--- a/apps/ui/src/components/views/project-settings-view/config/navigation.ts
+++ b/apps/ui/src/components/views/project-settings-view/config/navigation.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-react';
-import { User, GitBranch, Palette, AlertTriangle, Workflow } from 'lucide-react';
+import { User, GitBranch, Palette, AlertTriangle, Workflow, Webhook } from 'lucide-react';
 import type { ProjectSettingsViewId } from '../hooks/use-project-settings-view';
 
 export interface ProjectNavigationItem {
@@ -13,5 +13,6 @@ export const PROJECT_SETTINGS_NAV_ITEMS: ProjectNavigationItem[] = [
   { id: 'worktrees', label: 'Worktrees', icon: GitBranch },
   { id: 'theme', label: 'Theme', icon: Palette },
   { id: 'claude', label: 'Models', icon: Workflow },
+  { id: 'webhooks', label: 'Webhooks', icon: Webhook },
   { id: 'danger', label: 'Danger Zone', icon: AlertTriangle },
 ];

--- a/apps/ui/src/components/views/project-settings-view/hooks/use-project-settings-view.ts
+++ b/apps/ui/src/components/views/project-settings-view/hooks/use-project-settings-view.ts
@@ -1,6 +1,12 @@
 import { useState, useCallback } from 'react';
 
-export type ProjectSettingsViewId = 'identity' | 'theme' | 'worktrees' | 'claude' | 'danger';
+export type ProjectSettingsViewId =
+  | 'identity'
+  | 'theme'
+  | 'worktrees'
+  | 'claude'
+  | 'webhooks'
+  | 'danger';
 
 interface UseProjectSettingsViewOptions {
   initialView?: ProjectSettingsViewId;

--- a/apps/ui/src/components/views/project-settings-view/project-settings-view.tsx
+++ b/apps/ui/src/components/views/project-settings-view/project-settings-view.tsx
@@ -6,6 +6,7 @@ import { ProjectIdentitySection } from './project-identity-section';
 import { ProjectThemeSection } from './project-theme-section';
 import { WorktreePreferencesSection } from './worktree-preferences-section';
 import { ProjectModelsSection } from './project-models-section';
+import { ProjectWebhooksSection } from './project-webhooks-section';
 import { DangerZoneSection } from '../settings-view/danger-zone/danger-zone-section';
 import { DeleteProjectDialog } from '../settings-view/components/delete-project-dialog';
 import { ProjectSettingsNavigation } from './components/project-settings-navigation';
@@ -87,6 +88,8 @@ export function ProjectSettingsView() {
         return <WorktreePreferencesSection project={currentProject} />;
       case 'claude':
         return <ProjectModelsSection project={currentProject} />;
+      case 'webhooks':
+        return <ProjectWebhooksSection project={currentProject} />;
       case 'danger':
         return (
           <DangerZoneSection

--- a/apps/ui/src/components/views/project-settings-view/project-webhooks-section.tsx
+++ b/apps/ui/src/components/views/project-settings-view/project-webhooks-section.tsx
@@ -1,0 +1,278 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Webhook, Copy, CheckCircle2, Eye, EyeOff } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { useToast } from '@/hooks/use-toast';
+import { api } from '@/lib/api';
+import type { Project } from '@/lib/electron';
+import type { WebhookSettings } from '@automaker/types';
+
+interface ProjectWebhooksSectionProps {
+  project: Project;
+}
+
+interface WebhookFormData {
+  webhookEnabled: boolean;
+  webhookSecret: string;
+  autoCreateFromIssues: boolean;
+  autoCreateLabels: string;
+}
+
+export function ProjectWebhooksSection({ project }: ProjectWebhooksSectionProps) {
+  const { toast } = useToast();
+  const [isSaving, setIsSaving] = useState(false);
+  const [showSecret, setShowSecret] = useState(false);
+  const [copiedWebhookUrl, setCopiedWebhookUrl] = useState(false);
+
+  // Load webhook settings from project settings
+  const [webhookSettings, setWebhookSettings] = useState<WebhookSettings>(() => {
+    return (project.settings?.webhookSettings as WebhookSettings) || {
+      webhookEnabled: false,
+      webhookSecret: '',
+      autoCreateFromIssues: false,
+      autoCreateLabels: [],
+    };
+  });
+
+  const { register, handleSubmit, watch, setValue } = useForm<WebhookFormData>({
+    defaultValues: {
+      webhookEnabled: webhookSettings.webhookEnabled || false,
+      webhookSecret: webhookSettings.webhookSecret || '',
+      autoCreateFromIssues: webhookSettings.autoCreateFromIssues || false,
+      autoCreateLabels: webhookSettings.autoCreateLabels?.join(', ') || '',
+    },
+  });
+
+  const webhookEnabled = watch('webhookEnabled');
+
+  const onSubmit = async (data: WebhookFormData) => {
+    setIsSaving(true);
+
+    try {
+      // Parse comma-separated labels into array
+      const labels = data.autoCreateLabels
+        .split(',')
+        .map((label) => label.trim())
+        .filter((label) => label.length > 0);
+
+      const newWebhookSettings: WebhookSettings = {
+        webhookEnabled: data.webhookEnabled,
+        webhookSecret: data.webhookSecret,
+        autoCreateFromIssues: data.autoCreateFromIssues,
+        autoCreateLabels: labels,
+      };
+
+      // Update project settings
+      await api.updateProjectSettings(project.path, {
+        webhookSettings: newWebhookSettings,
+      });
+
+      setWebhookSettings(newWebhookSettings);
+
+      toast({
+        title: 'Webhook settings saved',
+        description: 'Your webhook configuration has been updated.',
+      });
+    } catch (error) {
+      console.error('Error saving webhook settings:', error);
+      toast({
+        title: 'Failed to save settings',
+        description: error instanceof Error ? error.message : 'An unknown error occurred',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const generateSecret = () => {
+    // Generate a random 32-byte hex string
+    const array = new Uint8Array(32);
+    crypto.getRandomValues(array);
+    const secret = Array.from(array)
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+    setValue('webhookSecret', secret);
+  };
+
+  const copyWebhookUrl = async () => {
+    const webhookUrl = `${window.location.protocol}//${window.location.hostname}:3008/api/github/webhook?project=${encodeURIComponent(project.path)}`;
+
+    try {
+      await navigator.clipboard.writeText(webhookUrl);
+      setCopiedWebhookUrl(true);
+      toast({
+        title: 'Webhook URL copied',
+        description: 'The webhook URL has been copied to your clipboard.',
+      });
+      setTimeout(() => setCopiedWebhookUrl(false), 2000);
+    } catch (error) {
+      toast({
+        title: 'Failed to copy URL',
+        description: 'Could not copy webhook URL to clipboard.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="flex items-center gap-2 mb-2">
+          <Webhook className="w-5 h-5 text-muted-foreground" />
+          <h2 className="text-2xl font-bold">Webhooks</h2>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Configure GitHub webhooks to automatically receive events and create features from issues.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        {/* Enable Webhooks */}
+        <div className="flex items-center justify-between rounded-lg border border-border bg-card p-4">
+          <div className="space-y-0.5 flex-1">
+            <Label htmlFor="webhookEnabled" className="text-base font-medium">
+              Enable Webhooks
+            </Label>
+            <p className="text-sm text-muted-foreground">
+              Accept incoming webhook events from GitHub for this project.
+            </p>
+          </div>
+          <Switch
+            id="webhookEnabled"
+            {...register('webhookEnabled')}
+            checked={watch('webhookEnabled')}
+            onCheckedChange={(checked) => setValue('webhookEnabled', checked)}
+          />
+        </div>
+
+        {/* Webhook Secret */}
+        {webhookEnabled && (
+          <>
+            <div className="space-y-2">
+              <Label htmlFor="webhookSecret">Webhook Secret</Label>
+              <div className="flex gap-2">
+                <div className="relative flex-1">
+                  <Input
+                    id="webhookSecret"
+                    type={showSecret ? 'text' : 'password'}
+                    placeholder="Enter or generate a webhook secret"
+                    {...register('webhookSecret', {
+                      required: webhookEnabled,
+                    })}
+                    className="pr-10"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowSecret(!showSecret)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 p-1 hover:bg-accent rounded-md transition-colors"
+                    tabIndex={-1}
+                  >
+                    {showSecret ? (
+                      <EyeOff className="w-4 h-4 text-muted-foreground" />
+                    ) : (
+                      <Eye className="w-4 h-4 text-muted-foreground" />
+                    )}
+                  </button>
+                </div>
+                <Button type="button" onClick={generateSecret} variant="outline">
+                  Generate
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                This secret is used to verify webhook signatures from GitHub. Copy this value and
+                add it to your GitHub webhook configuration.
+              </p>
+            </div>
+
+            {/* Webhook URL */}
+            <div className="space-y-2">
+              <Label>Webhook URL</Label>
+              <div className="flex gap-2">
+                <Input
+                  value={`${window.location.protocol}//${window.location.hostname}:3008/api/github/webhook?project=${encodeURIComponent(project.path)}`}
+                  readOnly
+                  className="flex-1 font-mono text-xs"
+                />
+                <Button type="button" onClick={copyWebhookUrl} variant="outline" size="sm">
+                  {copiedWebhookUrl ? (
+                    <CheckCircle2 className="w-4 h-4 text-green-500" />
+                  ) : (
+                    <Copy className="w-4 h-4" />
+                  )}
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Use this URL when configuring the webhook in your GitHub repository settings.
+              </p>
+            </div>
+
+            {/* Auto-Create Features */}
+            <div className="space-y-4 rounded-lg border border-border bg-card p-4">
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5 flex-1">
+                  <Label htmlFor="autoCreateFromIssues" className="text-base font-medium">
+                    Auto-Create Features from Issues
+                  </Label>
+                  <p className="text-sm text-muted-foreground">
+                    Automatically create board features when GitHub issues are opened.
+                  </p>
+                </div>
+                <Switch
+                  id="autoCreateFromIssues"
+                  {...register('autoCreateFromIssues')}
+                  checked={watch('autoCreateFromIssues')}
+                  onCheckedChange={(checked) => setValue('autoCreateFromIssues', checked)}
+                />
+              </div>
+
+              {watch('autoCreateFromIssues') && (
+                <div className="space-y-2 pt-2">
+                  <Label htmlFor="autoCreateLabels">Required Labels (Optional)</Label>
+                  <Input
+                    id="autoCreateLabels"
+                    placeholder="feature, enhancement (comma-separated)"
+                    {...register('autoCreateLabels')}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Only create features for issues with these labels. Leave empty to create
+                    features for all issues.
+                  </p>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+
+        {/* Save Button */}
+        <div className="flex justify-end">
+          <Button type="submit" disabled={isSaving}>
+            {isSaving ? 'Saving...' : 'Save Settings'}
+          </Button>
+        </div>
+      </form>
+
+      {/* Documentation */}
+      <div className="rounded-lg border border-border bg-muted/50 p-4 space-y-2">
+        <h3 className="font-medium text-sm">Setting up GitHub Webhooks</h3>
+        <ol className="text-xs text-muted-foreground space-y-1 list-decimal list-inside">
+          <li>Enable webhooks and generate a secret above</li>
+          <li>Copy the webhook URL and secret</li>
+          <li>
+            Go to your GitHub repository → Settings → Webhooks → Add webhook
+          </li>
+          <li>Paste the webhook URL in the "Payload URL" field</li>
+          <li>Set "Content type" to "application/json"</li>
+          <li>Paste the secret in the "Secret" field</li>
+          <li>
+            Select individual events: Issues, Pull requests, Pushes (or "Send me everything")
+          </li>
+          <li>Click "Add webhook"</li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -90,6 +90,10 @@ export type EventType =
   // CodeRabbit review events
   | 'coderabbit:review-received'
   | 'coderabbit:feedback-processed'
-  | 'coderabbit:link-created';
+  | 'coderabbit:link-created'
+  // Webhook events
+  | 'webhook:github:issue'
+  | 'webhook:github:pull_request'
+  | 'webhook:github:push';
 
 export type EventCallback = (type: EventType, payload: unknown) => void;

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -404,3 +404,22 @@ export type {
   FeatureCodeRabbitFeedback,
   CodeRabbitParseResult,
 } from './coderabbit.js';
+
+// Webhook types
+export type {
+  GitHubWebhookEvent,
+  GitHubIssueAction,
+  GitHubPullRequestAction,
+  GitHubUser,
+  GitHubRepository,
+  GitHubIssue,
+  GitHubPullRequest,
+  GitHubIssueWebhookPayload,
+  GitHubPullRequestWebhookPayload,
+  GitHubPushWebhookPayload,
+  GitHubPingWebhookPayload,
+  GitHubWebhookPayload,
+  WebhookVerificationResult,
+  WebhookSettings,
+} from './webhook.js';
+export { DEFAULT_WEBHOOK_SETTINGS } from './webhook.js';

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -439,6 +439,13 @@ export const CLAUDE_API_PROFILE_TEMPLATES: ClaudeApiProfileTemplate[] = [
 ];
 
 // ============================================================================
+// Webhook Settings - Re-export from webhook.ts for convenience
+// ============================================================================
+
+export type { WebhookSettings } from './webhook.js';
+export { DEFAULT_WEBHOOK_SETTINGS } from './webhook.js';
+
+// ============================================================================
 // Event Hooks - Custom actions triggered by system events
 // ============================================================================
 
@@ -1317,6 +1324,14 @@ export interface ProjectSettings {
    * Allows per-project customization of which models are used for each task.
    */
   phaseModelOverrides?: Partial<PhaseModelConfig>;
+
+  // Webhook Settings (per-project)
+  /**
+   * Webhook configuration for receiving GitHub events.
+   * Allows external services to trigger actions in this project.
+   * @see WebhookSettings in webhook.ts
+   */
+  webhookSettings?: import('./webhook.js').WebhookSettings;
 
   // Deprecated Claude API Profile Override
   /**

--- a/libs/types/src/webhook.ts
+++ b/libs/types/src/webhook.ts
@@ -1,0 +1,207 @@
+/**
+ * Webhook Types - Inbound webhook handling for GitHub events
+ *
+ * Defines the structure for receiving and processing webhooks from external services.
+ * Currently focused on GitHub webhook events for automated feature creation and updates.
+ */
+
+/**
+ * GitHubWebhookEvent - The type of GitHub event received
+ *
+ * Supported events:
+ * - issues: Issue created, updated, or commented
+ * - pull_request: PR opened, updated, merged, or closed
+ * - push: Code pushed to repository
+ * - ping: GitHub webhook test event
+ */
+export type GitHubWebhookEvent = 'issues' | 'pull_request' | 'push' | 'ping';
+
+/**
+ * GitHubIssueAction - Actions that can occur on issues
+ */
+export type GitHubIssueAction =
+  | 'opened'
+  | 'edited'
+  | 'deleted'
+  | 'closed'
+  | 'reopened'
+  | 'assigned'
+  | 'unassigned'
+  | 'labeled'
+  | 'unlabeled';
+
+/**
+ * GitHubPullRequestAction - Actions that can occur on pull requests
+ */
+export type GitHubPullRequestAction =
+  | 'opened'
+  | 'edited'
+  | 'closed'
+  | 'reopened'
+  | 'assigned'
+  | 'unassigned'
+  | 'review_requested'
+  | 'review_request_removed'
+  | 'labeled'
+  | 'unlabeled'
+  | 'synchronize';
+
+/**
+ * GitHubUser - Simplified GitHub user object
+ */
+export interface GitHubUser {
+  login: string;
+  id: number;
+  avatar_url?: string;
+  type: string;
+}
+
+/**
+ * GitHubRepository - Simplified GitHub repository object
+ */
+export interface GitHubRepository {
+  id: number;
+  name: string;
+  full_name: string;
+  owner: GitHubUser;
+  private: boolean;
+  html_url: string;
+  description?: string;
+  default_branch: string;
+}
+
+/**
+ * GitHubIssue - Simplified GitHub issue object
+ */
+export interface GitHubIssue {
+  id: number;
+  number: number;
+  title: string;
+  user: GitHubUser;
+  state: 'open' | 'closed';
+  body?: string;
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+  labels?: Array<{ name: string; color: string }>;
+}
+
+/**
+ * GitHubPullRequest - Simplified GitHub pull request object
+ */
+export interface GitHubPullRequest {
+  id: number;
+  number: number;
+  title: string;
+  user: GitHubUser;
+  state: 'open' | 'closed';
+  body?: string;
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+  merged: boolean;
+  head: {
+    ref: string;
+    sha: string;
+  };
+  base: {
+    ref: string;
+    sha: string;
+  };
+}
+
+/**
+ * GitHubIssueWebhookPayload - Webhook payload for issue events
+ */
+export interface GitHubIssueWebhookPayload {
+  action: GitHubIssueAction;
+  issue: GitHubIssue;
+  repository: GitHubRepository;
+  sender: GitHubUser;
+}
+
+/**
+ * GitHubPullRequestWebhookPayload - Webhook payload for pull request events
+ */
+export interface GitHubPullRequestWebhookPayload {
+  action: GitHubPullRequestAction;
+  pull_request: GitHubPullRequest;
+  repository: GitHubRepository;
+  sender: GitHubUser;
+}
+
+/**
+ * GitHubPushWebhookPayload - Webhook payload for push events
+ */
+export interface GitHubPushWebhookPayload {
+  ref: string;
+  before: string;
+  after: string;
+  repository: GitHubRepository;
+  pusher: {
+    name: string;
+    email: string;
+  };
+  sender: GitHubUser;
+  commits: Array<{
+    id: string;
+    message: string;
+    author: {
+      name: string;
+      email: string;
+    };
+  }>;
+}
+
+/**
+ * GitHubPingWebhookPayload - Webhook payload for ping events (webhook test)
+ */
+export interface GitHubPingWebhookPayload {
+  zen: string;
+  hook_id: number;
+  repository: GitHubRepository;
+  sender: GitHubUser;
+}
+
+/**
+ * GitHubWebhookPayload - Union type of all webhook payloads
+ */
+export type GitHubWebhookPayload =
+  | GitHubIssueWebhookPayload
+  | GitHubPullRequestWebhookPayload
+  | GitHubPushWebhookPayload
+  | GitHubPingWebhookPayload;
+
+/**
+ * WebhookVerificationResult - Result of webhook signature verification
+ */
+export interface WebhookVerificationResult {
+  /** Whether the webhook signature is valid */
+  valid: boolean;
+  /** Error message if verification failed */
+  error?: string;
+}
+
+/**
+ * WebhookSettings - Configuration for webhook handling
+ */
+export interface WebhookSettings {
+  /** Secret used to verify webhook signatures (HMAC-SHA256) */
+  webhookSecret?: string;
+  /** Whether webhook endpoint is enabled */
+  webhookEnabled?: boolean;
+  /** Auto-create features from GitHub issues (default: false) */
+  autoCreateFromIssues?: boolean;
+  /** Issue labels that trigger auto-creation (empty = all issues) */
+  autoCreateLabels?: string[];
+}
+
+/**
+ * Default webhook settings
+ */
+export const DEFAULT_WEBHOOK_SETTINGS: Required<WebhookSettings> = {
+  webhookSecret: '',
+  webhookEnabled: false,
+  autoCreateFromIssues: false,
+  autoCreateLabels: [],
+};


### PR DESCRIPTION
## Summary

# Inbound Webhook Infrastructure

Add secure inbound webhook endpoint for receiving GitHub events

## Phases
1. Add Inbound Webhook Types
2. Create GitHub Webhook Route
3. Add Webhook Secret to Settings

---
*Created automatically by Automaker*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub webhook support to receive and verify inbound events and emit structured webhook events.
  * Project settings: new Webhooks section to enable/disable webhooks, manage secret, view/copy webhook URL, and configure auto-create from issues with label filtering.
  * Settings UI and app store: persistent webhook secret management with copy/visibility controls and server sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->