### PR TITLE
Add PR Feedback Event Hook Trigger

### DIFF
--- a/apps/server/src/services/event-hook-service.ts
+++ b/apps/server/src/services/event-hook-service.ts
@@ -18,6 +18,7 @@
  * - auto_mode_health_check: Periodic health status check
  * - skill_created: An agent created a new reusable skill
  * - memory_learning: A new learning was recorded from agent execution
+ * - pr:review-feedback: PR review feedback received from webhook
  */
 
 import { exec } from 'child_process';
@@ -67,6 +68,11 @@ interface HookContext {
   // Health check specific fields
   healthStatus?: string;
   healthDetails?: string;
+  // PR review feedback specific fields
+  prNumber?: number;
+  prUrl?: string;
+  reviewData?: string;
+  reviewer?: string;
 }
 
 /**
@@ -146,6 +152,19 @@ export interface HealthCheckPayload {
 }
 
 /**
+ * PR review feedback event payload structure
+ */
+export interface PRReviewFeedbackPayload {
+  featureId?: string;
+  featureName?: string;
+  projectPath: string;
+  prNumber: number;
+  prUrl: string;
+  reviewData: string;
+  reviewer?: string;
+}
+
+/**
  * Event Hook Service
  *
  * Manages execution of user-configured event hooks in response to system events.
@@ -188,6 +207,8 @@ export class EventHookService {
         this.handleMemoryLearningEvent(payload as MemoryLearningPayload);
       } else if (type === 'auto-mode:health-check') {
         this.handleHealthCheckEvent(payload as HealthCheckPayload);
+      } else if (type === 'pr:review-feedback') {
+        this.handlePRReviewFeedbackEvent(payload as PRReviewFeedbackPayload);
       }
     });
 
@@ -366,6 +387,26 @@ export class EventHookService {
     };
 
     await this.executeHooksForTrigger('auto_mode_health_check', context);
+  }
+
+  /**
+   * Handle pr:review-feedback events and trigger matching hooks
+   */
+  private async handlePRReviewFeedbackEvent(payload: PRReviewFeedbackPayload): Promise<void> {
+    const context: HookContext = {
+      featureId: payload.featureId,
+      featureName: payload.featureName,
+      projectPath: payload.projectPath,
+      projectName: this.extractProjectName(payload.projectPath),
+      prNumber: payload.prNumber,
+      prUrl: payload.prUrl,
+      reviewData: payload.reviewData,
+      reviewer: payload.reviewer,
+      timestamp: new Date().toISOString(),
+      eventType: 'pr:review-feedback',
+    };
+
+    await this.executeHooksForTrigger('pr:review-feedback', context);
   }
 
   /**
@@ -603,6 +644,15 @@ export class EventHookService {
   emitHealthCheck(payload: HealthCheckPayload): void {
     if (this.emitter) {
       this.emitter.emit('auto-mode:health-check', payload);
+    }
+  }
+
+  /**
+   * Emit a PR review feedback event
+   */
+  emitPRReviewFeedback(payload: PRReviewFeedbackPayload): void {
+    if (this.emitter) {
+      this.emitter.emit('pr:review-feedback', payload);
     }
   }
 }

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -56,6 +56,7 @@ export type EventType =
   | 'dev-server:stopped'
   | 'skill:created'
   | 'memory:learning'
+  | 'pr:review-feedback'
   | 'notification:created'
   | 'health:check-completed'
   | 'health:issue-detected'

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -456,6 +456,7 @@ export const CLAUDE_API_PROFILE_TEMPLATES: ClaudeApiProfileTemplate[] = [
  * - skill_created: An agent created a new reusable skill
  * - memory_learning: A new learning was recorded from agent execution
  * - pr_feedback_received: Pull request received feedback that needs addressing
+ * - pr:review-feedback: PR review feedback received from webhook
  */
 export type EventHookTrigger =
   | 'feature_created'
@@ -468,7 +469,8 @@ export type EventHookTrigger =
   | 'auto_mode_health_check'
   | 'skill_created'
   | 'memory_learning'
-  | 'pr_feedback_received';
+  | 'pr_feedback_received'
+  | 'pr:review-feedback';
 
 // ============================================================================
 // Git Workflow Settings - Auto commit/push/PR after feature completion
@@ -631,6 +633,7 @@ export const EVENT_HOOK_TRIGGER_LABELS: Record<EventHookTrigger, string> = {
   skill_created: 'New skill created by agent',
   memory_learning: 'New learning recorded',
   pr_feedback_received: 'PR feedback received',
+  'pr:review-feedback': 'PR review feedback received',
 };
 
 const DEFAULT_CODEX_AUTO_LOAD_AGENTS = false;


### PR DESCRIPTION
## Summary

**Milestone:** Agent Resume Integration

Register pr:review-feedback as valid event hook trigger. When webhook receives CodeRabbit review, emit event that triggers configured hooks.

**Files to Modify:**
- apps/server/src/services/event-hook-service.ts
- libs/types/src/settings.ts

**Acceptance Criteria:**
- [ ] pr:review-feedback in EVENT_TYPES
- [ ] Hook can trigger on PR feedback
- [ ] Hook receives review data in payload
- [ ] Can configure shell or HTTP action

**Complexity:** small

---
*Created automatically by Automaker*