### PR TITLE
Add Resume-with-Feedback Endpoint

### DIFF
--- a/apps/server/src/routes/auto-mode/index.ts
+++ b/apps/server/src/routes/auto-mode/index.ts
@@ -14,6 +14,7 @@ import { createStartHandler } from './routes/start.js';
 import { createStopHandler } from './routes/stop.js';
 import { createVerifyFeatureHandler } from './routes/verify-feature.js';
 import { createResumeFeatureHandler } from './routes/resume-feature.js';
+import { createResumeWithFeedbackHandler } from './routes/resume-with-feedback.js';
 import { createContextExistsHandler } from './routes/context-exists.js';
 import { createAnalyzeProjectHandler } from './routes/analyze-project.js';
 import { createFollowUpFeatureHandler } from './routes/follow-up-feature.js';
@@ -44,6 +45,11 @@ export function createAutoModeRoutes(autoModeService: AutoModeService): Router {
     '/resume-feature',
     validatePathParams('projectPath'),
     createResumeFeatureHandler(autoModeService)
+  );
+  router.post(
+    '/resume-with-feedback',
+    validatePathParams('projectPath'),
+    createResumeWithFeedbackHandler(autoModeService)
   );
   router.post(
     '/context-exists',

--- a/apps/server/src/routes/auto-mode/routes/resume-with-feedback.ts
+++ b/apps/server/src/routes/auto-mode/routes/resume-with-feedback.ts
@@ -1,0 +1,62 @@
+/**
+ * POST /resume-with-feedback endpoint - Resume or restart agent with feedback
+ */
+
+import type { Request, Response } from 'express';
+import type { AutoModeService } from '../../../services/auto-mode-service.js';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('AgentRoutes');
+
+export function createResumeWithFeedbackHandler(autoModeService: AutoModeService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, featureId, feedback } = req.body as {
+        projectPath: string;
+        featureId: string;
+        feedback: string;
+      };
+
+      if (!projectPath) {
+        res.status(400).json({
+          success: false,
+          error: 'projectPath is required',
+        });
+        return;
+      }
+
+      if (!featureId) {
+        res.status(400).json({
+          success: false,
+          error: 'featureId is required',
+        });
+        return;
+      }
+
+      if (!feedback) {
+        res.status(400).json({
+          success: false,
+          error: 'feedback is required',
+        });
+        return;
+      }
+
+      logger.info(`Resuming feature ${featureId} with feedback`);
+
+      // Start execution in background
+      autoModeService
+        .resumeWithFeedback(projectPath, featureId, feedback)
+        .catch((error) => {
+          logger.error(`Feature ${featureId} resume with feedback error:`, error);
+        });
+
+      res.json({ success: true });
+    } catch (error) {
+      logger.error('Resume with feedback failed:', error);
+      res.status(500).json({
+        success: false,
+        error: (error as Error).message,
+      });
+    }
+  };
+}

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -4715,6 +4715,75 @@ After generating the revised spec, output:
   }
 
   /**
+   * Resume or restart an agent with additional feedback context.
+   * If the agent is already running, this will throw an error.
+   * If not running, it will start execution with the feedback included in the prompt.
+   *
+   * @param projectPath - The main project path
+   * @param featureId - The feature ID to resume
+   * @param feedback - Additional feedback/context to include in the prompt
+   */
+  async resumeWithFeedback(
+    projectPath: string,
+    featureId: string,
+    feedback: string
+  ): Promise<void> {
+    // Check if already running
+    if (this.runningFeatures.has(featureId)) {
+      throw new Error('Feature is already running');
+    }
+
+    // Load feature to check it exists
+    const feature = await this.loadFeature(projectPath, featureId);
+    if (!feature) {
+      throw new Error(`Feature ${featureId} not found`);
+    }
+
+    // Emit follow-up started event
+    this.events.emit('feature:follow-up-started', {
+      featureId,
+      projectPath,
+      feedback,
+    });
+
+    // Get customized prompts from settings
+    const prompts = await getPromptCustomization(this.settingsService, '[AutoMode]');
+
+    // Build the feature prompt
+    const featurePrompt = this.buildFeaturePrompt(feature, prompts.taskExecution);
+
+    // Check if there's existing context
+    const featureDir = getFeatureDir(projectPath, featureId);
+    const contextPath = path.join(featureDir, 'agent-output.md');
+
+    let previousContext = '';
+    try {
+      await secureFs.access(contextPath);
+      previousContext = (await secureFs.readFile(contextPath, 'utf-8')) as string;
+    } catch {
+      // No previous context, that's okay
+    }
+
+    // Build continuation prompt with feedback
+    let prompt: string;
+    if (previousContext) {
+      // Use resume template with feedback added
+      prompt = prompts.taskExecution.resumeFeatureTemplate;
+      prompt = prompt.replace(/\{\{featurePrompt\}\}/g, featurePrompt);
+      prompt = prompt.replace(/\{\{previousContext\}\}/g, previousContext);
+      prompt += `\n\n## Additional Feedback\n\n${feedback}`;
+    } else {
+      // No previous context, start fresh with feedback
+      prompt = `${featurePrompt}\n\n## Additional Feedback\n\n${feedback}`;
+    }
+
+    // Execute with the feedback-enhanced prompt
+    return this.executeFeature(projectPath, featureId, true, false, undefined, {
+      continuationPrompt: prompt,
+    });
+  }
+
+  /**
    * Detect if a feature is stuck in a pipeline step and extract step information.
    * Parses the feature status to determine if it's a pipeline status (e.g., 'pipeline_step_xyz'),
    * loads the pipeline configuration, and validates that the step still exists.


### PR DESCRIPTION
## Summary

**Milestone:** Agent Resume Integration

Add POST /api/agent/resume-with-feedback endpoint. Takes featureId and feedback context. Resumes or restarts agent with feedback in prompt.

**Files to Modify:**
- apps/server/src/routes/agent.ts
- apps/server/src/services/agent-service.ts

**Acceptance Criteria:**
- [ ] Endpoint accepts featureId and feedback
- [ ] Adds feedback to agent context
- [ ] Resumes running agent or starts new one
- [ ] Emits feature:follow-up-started event

**Complexity:** med...

---
*Created automatically by Automaker*