### PR TITLE
Add Webhook Secret to Settings

### DIFF
--- a/apps/ui/src/components/views/settings-view.tsx
+++ b/apps/ui/src/components/views/settings-view.tsx
@@ -62,6 +62,8 @@ export function SettingsView() {
     setPromptCustomization,
     skipSandboxWarning,
     setSkipSandboxWarning,
+    githubWebhookSecret,
+    setGithubWebhookSecret,
   } = useAppStore();
 
   // Global theme (project-specific themes are managed in Project Settings)
@@ -186,6 +188,8 @@ export function SettingsView() {
           <SecuritySection
             skipSandboxWarning={skipSandboxWarning}
             onSkipSandboxWarningChange={setSkipSandboxWarning}
+            githubWebhookSecret={githubWebhookSecret}
+            onGithubWebhookSecretChange={setGithubWebhookSecret}
           />
         );
       case 'developer':

--- a/apps/ui/src/components/views/settings-view/security/security-section.tsx
+++ b/apps/ui/src/components/views/settings-view/security/security-section.tsx
@@ -1,17 +1,43 @@
-import { Shield, AlertTriangle } from 'lucide-react';
+import { useState } from 'react';
+import { Shield, AlertTriangle, Key, Eye, EyeOff, Copy, Check } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
 
 interface SecuritySectionProps {
   skipSandboxWarning: boolean;
   onSkipSandboxWarningChange: (skip: boolean) => void;
+  githubWebhookSecret: string;
+  onGithubWebhookSecretChange: (secret: string) => void;
 }
 
 export function SecuritySection({
   skipSandboxWarning,
   onSkipSandboxWarningChange,
+  githubWebhookSecret,
+  onGithubWebhookSecretChange,
 }: SecuritySectionProps) {
+  const [showSecret, setShowSecret] = useState(false);
+  const [copiedSecret, setCopiedSecret] = useState(false);
+  const [copiedUrl, setCopiedUrl] = useState(false);
+
+  const handleCopySecret = async () => {
+    if (githubWebhookSecret) {
+      await navigator.clipboard.writeText(githubWebhookSecret);
+      setCopiedSecret(true);
+      setTimeout(() => setCopiedSecret(false), 2000);
+    }
+  };
+
+  const handleCopyWebhookUrl = async () => {
+    const webhookUrl = `${window.location.protocol}//${window.location.hostname}:3008/api/webhooks/github`;
+    await navigator.clipboard.writeText(webhookUrl);
+    setCopiedUrl(true);
+    setTimeout(() => setCopiedUrl(false), 2000);
+  };
+
   return (
     <div
       className={cn(
@@ -65,6 +91,106 @@ export function SecuritySection({
           containerized environment (like Docker). This helps remind you to use proper isolation
           when running AI agents.
         </p>
+
+        {/* GitHub Webhook Secret */}
+        <div className="space-y-3 mt-6">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-blue-500/20 to-blue-600/10 flex items-center justify-center border border-blue-500/20">
+              <Key className="w-5 h-5 text-blue-500" />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-foreground tracking-tight">
+                GitHub Webhook Secret
+              </h3>
+              <p className="text-xs text-muted-foreground/80">
+                Secret for validating inbound GitHub webhook requests
+              </p>
+            </div>
+          </div>
+
+          {/* Secret Input Field */}
+          <div className="p-4 rounded-xl bg-muted/30 border border-border/30 space-y-3">
+            <div className="space-y-2">
+              <Label htmlFor="webhook-secret" className="text-sm font-medium text-foreground">
+                Webhook Secret
+              </Label>
+              <div className="flex gap-2">
+                <div className="relative flex-1">
+                  <Input
+                    id="webhook-secret"
+                    type={showSecret ? 'text' : 'password'}
+                    value={githubWebhookSecret}
+                    onChange={(e) => onGithubWebhookSecretChange(e.target.value)}
+                    placeholder="Enter webhook secret..."
+                    className="pr-10"
+                    data-testid="webhook-secret-input"
+                  />
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="absolute right-0 top-0 h-full w-10 hover:bg-transparent"
+                    onClick={() => setShowSecret(!showSecret)}
+                    data-testid="toggle-secret-visibility"
+                  >
+                    {showSecret ? (
+                      <EyeOff className="w-4 h-4 text-muted-foreground" />
+                    ) : (
+                      <Eye className="w-4 h-4 text-muted-foreground" />
+                    )}
+                  </Button>
+                </div>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={handleCopySecret}
+                  disabled={!githubWebhookSecret}
+                  data-testid="copy-secret-button"
+                >
+                  {copiedSecret ? (
+                    <Check className="w-4 h-4 text-green-500" />
+                  ) : (
+                    <Copy className="w-4 h-4" />
+                  )}
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground/60">
+                This secret is used to verify that webhook payloads are coming from GitHub
+              </p>
+            </div>
+
+            {/* Webhook URL */}
+            <div className="space-y-2">
+              <Label htmlFor="webhook-url" className="text-sm font-medium text-foreground">
+                Webhook URL
+              </Label>
+              <div className="flex gap-2">
+                <Input
+                  id="webhook-url"
+                  type="text"
+                  value={`${window.location.protocol}//${window.location.hostname}:3008/api/webhooks/github`}
+                  readOnly
+                  className="font-mono text-xs"
+                  data-testid="webhook-url-input"
+                />
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={handleCopyWebhookUrl}
+                  data-testid="copy-url-button"
+                >
+                  {copiedUrl ? (
+                    <Check className="w-4 h-4 text-green-500" />
+                  ) : (
+                    <Copy className="w-4 h-4" />
+                  )}
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground/60">
+                Configure this URL in your GitHub repository webhook settings
+              </p>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/ui/src/store/app-store.ts
+++ b/apps/ui/src/store/app-store.ts
@@ -732,6 +732,9 @@ export interface AppState {
   autoLoadClaudeMd: boolean; // Auto-load CLAUDE.md files using SDK's settingSources option
   skipSandboxWarning: boolean; // Skip the sandbox environment warning dialog on startup
 
+  // GitHub Webhook Settings
+  githubWebhookSecret: string; // GitHub webhook secret for validating inbound webhook requests
+
   // MCP Servers
   mcpServers: MCPServerConfig[]; // List of configured MCP servers for agent use
 
@@ -1216,6 +1219,9 @@ export interface AppActions {
   setAutoLoadClaudeMd: (enabled: boolean) => Promise<void>;
   setSkipSandboxWarning: (skip: boolean) => Promise<void>;
 
+  // GitHub Webhook Configuration actions
+  setGithubWebhookSecret: (secret: string) => Promise<void>;
+
   // Editor Configuration actions
   setDefaultEditorCommand: (command: string | null) => void;
 
@@ -1495,6 +1501,7 @@ const initialState: AppState = {
   disabledProviders: [], // No providers disabled by default
   autoLoadClaudeMd: false, // Default to disabled (user must opt-in)
   skipSandboxWarning: false, // Default to disabled (show sandbox warning dialog)
+  githubWebhookSecret: '', // No webhook secret by default
   mcpServers: [], // No MCP servers configured by default
   defaultEditorCommand: null, // Auto-detect: Cursor > VS Code > first available
   defaultTerminalId: null, // Integrated terminal by default
@@ -2718,6 +2725,18 @@ export const useAppStore = create<AppState & AppActions>()((set, get) => ({
     if (!ok) {
       logger.error('Failed to sync skipSandboxWarning setting to server - reverting');
       set({ skipSandboxWarning: previous });
+    }
+  },
+
+  setGithubWebhookSecret: async (secret) => {
+    const previous = get().githubWebhookSecret;
+    set({ githubWebhookSecret: secret });
+    // Sync to server settings file
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    const ok = await syncSettingsToServer();
+    if (!ok) {
+      logger.error('Failed to sync githubWebhookSecret setting to server - reverting');
+      set({ githubWebhookSecret: previous });
     }
   },
 

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -1154,6 +1154,12 @@ export interface GlobalSettings {
    * @see GraphiteSettings
    */
   graphite?: GraphiteSettings;
+
+  /**
+   * GitHub webhook secret for validating inbound webhook requests.
+   * Used to verify that webhook payloads are coming from GitHub.
+   */
+  githubWebhookSecret?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

**Milestone:** Inbound Webhook Infrastructure

Add githubWebhookSecret to GlobalSettings. Add UI in settings to configure secret.

**Files to Modify:**
- libs/types/src/settings.ts
- apps/ui/src/components/views/settings-view.tsx

**Acceptance Criteria:**
- [ ] githubWebhookSecret in GlobalSettings
- [ ] Settings UI shows webhook secret field
- [ ] Secret is masked in UI
- [ ] Can copy webhook URL from UI

**Complexity:** small

---
*Created automatically by Automaker*