### PR TITLE
Create GitHub Webhook Route

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -94,6 +94,7 @@ import { createSkillsRoutes } from './routes/skills/index.js';
 import { getSchedulerService } from './services/scheduler-service.js';
 import { GraphiteSyncScheduler } from './services/graphite-sync-scheduler.js';
 import { graphiteService } from './services/graphite-service.js';
+import { createWebhooksRoutes } from './routes/webhooks/index.js';
 
 const PORT = parseInt(process.env.PORT || '3008', 10);
 const HOST = process.env.HOST || '0.0.0.0';
@@ -368,10 +369,11 @@ function calculateNextSyncDelay(): number {
 // This helps prevent CSRF and content-type confusion attacks
 app.use('/api', requireJsonContentType);
 
-// Mount API routes - health, auth, and setup are unauthenticated
+// Mount API routes - health, auth, setup, and webhooks are unauthenticated
 app.use('/api/health', createHealthRoutes());
 app.use('/api/auth', createAuthRoutes());
 app.use('/api/setup', createSetupRoutes());
+app.use('/api/webhooks', createWebhooksRoutes());
 
 // Apply authentication to all other routes
 app.use('/api', authMiddleware);

--- a/apps/server/src/routes/webhooks/index.ts
+++ b/apps/server/src/routes/webhooks/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Webhooks routes - Inbound webhook endpoints
+ */
+
+import { Router } from 'express';
+import express from 'express';
+import { createGitHubWebhookHandler } from './routes/github.js';
+
+export function createWebhooksRoutes(): Router {
+  const router = Router();
+
+  // GitHub webhook endpoint with raw body parsing for signature verification
+  // We need the raw body to verify the HMAC signature
+  router.post(
+    '/github',
+    express.raw({ type: 'application/json', limit: '10mb' }),
+    createGitHubWebhookHandler()
+  );
+
+  return router;
+}

--- a/apps/server/src/routes/webhooks/routes/github.ts
+++ b/apps/server/src/routes/webhooks/routes/github.ts
@@ -1,0 +1,120 @@
+/**
+ * GitHub webhook handler
+ *
+ * Receives and validates GitHub webhook events
+ * Implements HMAC-SHA256 signature verification per GitHub's webhook security
+ * https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+ */
+
+import type { Request, Response } from 'express';
+import crypto from 'crypto';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('WebhookGitHub');
+
+/**
+ * Verify GitHub webhook signature using HMAC-SHA256
+ *
+ * @param payload - Raw request body as string
+ * @param signature - X-Hub-Signature-256 header value
+ * @param secret - Webhook secret configured in GitHub
+ * @returns true if signature is valid, false otherwise
+ */
+function verifyGitHubSignature(payload: string, signature: string, secret: string): boolean {
+  if (!signature || !signature.startsWith('sha256=')) {
+    return false;
+  }
+
+  // Extract the signature hash (remove 'sha256=' prefix)
+  const signatureHash = signature.substring(7);
+
+  // Calculate expected signature
+  const hmac = crypto.createHmac('sha256', secret);
+  hmac.update(payload);
+  const expectedHash = hmac.digest('hex');
+
+  // Use timing-safe comparison to prevent timing attacks
+  try {
+    return crypto.timingSafeEqual(Buffer.from(signatureHash), Buffer.from(expectedHash));
+  } catch {
+    // Lengths don't match or other error
+    return false;
+  }
+}
+
+/**
+ * Create GitHub webhook handler
+ */
+export function createGitHubWebhookHandler() {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      // Get webhook secret from environment
+      const webhookSecret = process.env.GITHUB_WEBHOOK_SECRET;
+
+      if (!webhookSecret) {
+        logger.error('GITHUB_WEBHOOK_SECRET not configured');
+        res.status(500).json({
+          success: false,
+          error: 'Webhook secret not configured',
+        });
+        return;
+      }
+
+      // Get signature from header
+      const signature = req.headers['x-hub-signature-256'] as string | undefined;
+
+      if (!signature) {
+        logger.warn('Webhook received without signature');
+        res.status(401).json({
+          success: false,
+          error: 'Missing signature',
+        });
+        return;
+      }
+
+      // Get raw body for signature verification
+      // express.raw() middleware stores the body as a Buffer in req.body
+      const rawBody = req.body as Buffer;
+      const rawBodyString = rawBody.toString('utf8');
+
+      // Verify signature
+      if (!verifyGitHubSignature(rawBodyString, signature, webhookSecret)) {
+        logger.warn('Invalid webhook signature');
+        res.status(401).json({
+          success: false,
+          error: 'Invalid signature',
+        });
+        return;
+      }
+
+      // Parse the JSON payload after signature verification
+      const payload = JSON.parse(rawBodyString);
+
+      // Extract event type and delivery ID
+      const eventType = req.headers['x-github-event'] as string | undefined;
+      const deliveryId = req.headers['x-github-delivery'] as string | undefined;
+
+      // Log webhook event
+      logger.info('GitHub webhook received', {
+        event: eventType,
+        deliveryId,
+        action: payload?.action,
+        repository: payload?.repository?.full_name,
+      });
+
+      // TODO: Process webhook payload based on event type
+      // For now, just acknowledge receipt
+
+      res.status(200).json({
+        success: true,
+        message: 'Webhook received',
+      });
+    } catch (error) {
+      logger.error('Error processing webhook:', error);
+      res.status(500).json({
+        success: false,
+        error: 'Internal server error',
+      });
+    }
+  };
+}

--- a/apps/ui/tests/webhook-verification.spec.ts
+++ b/apps/ui/tests/webhook-verification.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * GitHub Webhook Verification Test
+ *
+ * This test verifies that the GitHub webhook endpoint:
+ * - Accepts POST requests
+ * - Validates HMAC-SHA256 signatures
+ * - Returns 200 for valid webhooks
+ * - Returns 401 for invalid/missing signatures
+ * - Logs webhook events
+ */
+
+import { test, expect } from '@playwright/test';
+import crypto from 'crypto';
+import { API_BASE_URL } from './utils';
+
+const WEBHOOK_PATH = '/api/webhooks/github';
+const TEST_SECRET = 'test-webhook-secret-123';
+
+/**
+ * Create HMAC-SHA256 signature for webhook payload
+ */
+function createSignature(payload: string, secret: string): string {
+  const hmac = crypto.createHmac('sha256', secret);
+  hmac.update(payload);
+  return 'sha256=' + hmac.digest('hex');
+}
+
+test.describe('GitHub Webhook Endpoint', () => {
+  test.beforeAll(() => {
+    // Set webhook secret for testing
+    process.env.GITHUB_WEBHOOK_SECRET = TEST_SECRET;
+  });
+
+  test('accepts valid webhook with correct signature', async ({ request }) => {
+    const payload = {
+      action: 'opened',
+      issue: {
+        number: 1,
+        title: 'Test issue',
+      },
+      repository: {
+        full_name: 'test/repo',
+      },
+    };
+
+    const payloadString = JSON.stringify(payload);
+    const signature = createSignature(payloadString, TEST_SECRET);
+
+    const response = await request.post(`${API_BASE_URL}${WEBHOOK_PATH}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Hub-Signature-256': signature,
+        'X-GitHub-Event': 'issues',
+        'X-GitHub-Delivery': 'test-delivery-123',
+      },
+      data: payloadString,
+    });
+
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.message).toBe('Webhook received');
+  });
+
+  test('rejects webhook with missing signature', async ({ request }) => {
+    const payload = {
+      action: 'opened',
+      issue: { number: 1 },
+    };
+
+    const response = await request.post(`${API_BASE_URL}${WEBHOOK_PATH}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-GitHub-Event': 'issues',
+      },
+      data: JSON.stringify(payload),
+    });
+
+    expect(response.status()).toBe(401);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Missing signature');
+  });
+
+  test('rejects webhook with invalid signature', async ({ request }) => {
+    const payload = {
+      action: 'opened',
+      issue: { number: 1 },
+    };
+
+    const payloadString = JSON.stringify(payload);
+    const invalidSignature = 'sha256=invalidhash123';
+
+    const response = await request.post(`${API_BASE_URL}${WEBHOOK_PATH}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Hub-Signature-256': invalidSignature,
+        'X-GitHub-Event': 'issues',
+      },
+      data: payloadString,
+    });
+
+    expect(response.status()).toBe(401);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Invalid signature');
+  });
+
+  test('rejects webhook with wrong secret', async ({ request }) => {
+    const payload = {
+      action: 'opened',
+      issue: { number: 1 },
+    };
+
+    const payloadString = JSON.stringify(payload);
+    const wrongSecret = 'wrong-secret';
+    const signature = createSignature(payloadString, wrongSecret);
+
+    const response = await request.post(`${API_BASE_URL}${WEBHOOK_PATH}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Hub-Signature-256': signature,
+        'X-GitHub-Event': 'issues',
+      },
+      data: payloadString,
+    });
+
+    expect(response.status()).toBe(401);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Invalid signature');
+  });
+
+  test('handles various webhook event types', async ({ request }) => {
+    const eventTypes = ['issues', 'pull_request', 'push', 'release'];
+
+    for (const eventType of eventTypes) {
+      const payload = {
+        action: 'test',
+        repository: {
+          full_name: 'test/repo',
+        },
+      };
+
+      const payloadString = JSON.stringify(payload);
+      const signature = createSignature(payloadString, TEST_SECRET);
+
+      const response = await request.post(`${API_BASE_URL}${WEBHOOK_PATH}`, {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Hub-Signature-256': signature,
+          'X-GitHub-Event': eventType,
+          'X-GitHub-Delivery': `test-delivery-${eventType}`,
+        },
+        data: payloadString,
+      });
+
+      expect(response.status()).toBe(200);
+      const body = await response.json();
+      expect(body.success).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
**Milestone:** Inbound Webhook Infrastructure

Add POST /api/webhooks/github endpoint. Verify HMAC-SHA256 signature. Parse webhook payload. Return 200 on success.

**Files to Modify:**
- apps/server/src/routes/index.ts
- apps/server/src/routes/webhooks.ts

**Acceptance Criteria:**
- [ ] Route accepts POST requests
- [ ] Signature verification with X-Hub-Signature-256
- [ ] Returns 200 for valid webhooks
- [ ] Returns 401 for invalid signatures
- [ ] Logs webhook events

**Complexity:** medium