### PR TITLE
Add scheduler status endpoint

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -95,6 +95,7 @@ import { getSchedulerService } from './services/scheduler-service.js';
 import { GraphiteSyncScheduler } from './services/graphite-sync-scheduler.js';
 import { graphiteService } from './services/graphite-service.js';
 import { createWebhooksRoutes } from './routes/webhooks/index.js';
+import { createSchedulerRoutes } from './routes/scheduler/index.js';
 
 const PORT = parseInt(process.env.PORT || '3008', 10);
 const HOST = process.env.HOST || '0.0.0.0';
@@ -424,6 +425,7 @@ app.use('/api/ralph', createRalphRoutes(ralphLoopService));
 app.use('/api/skills', createSkillsRoutes());
 app.use('/api/event-history', createEventHistoryRoutes(eventHistoryService, settingsService));
 app.use('/api/projects', createProjectsRoutes(featureLoader));
+app.use('/api/scheduler', createSchedulerRoutes(schedulerService));
 
 // Create HTTP server
 const server = createServer(app);

--- a/apps/server/src/routes/scheduler/index.ts
+++ b/apps/server/src/routes/scheduler/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Scheduler routes - HTTP API for scheduler service
+ */
+
+import { Router } from 'express';
+import type { SchedulerService } from '../../services/scheduler-service.js';
+import { createGetStatusHandler } from './routes/get-status.js';
+
+export function createSchedulerRoutes(schedulerService: SchedulerService): Router {
+  const router = Router();
+
+  router.get('/status', createGetStatusHandler(schedulerService));
+
+  return router;
+}

--- a/apps/server/src/routes/scheduler/routes/get-status.ts
+++ b/apps/server/src/routes/scheduler/routes/get-status.ts
@@ -1,0 +1,27 @@
+/**
+ * GET /api/scheduler/status endpoint - Get scheduler status
+ *
+ * Returns all registered tasks, their schedules, next run times, and execution history.
+ * Useful for monitoring and debugging scheduled tasks.
+ */
+
+import type { Request, Response } from 'express';
+import type { SchedulerService } from '../../../services/scheduler-service.js';
+
+export function createGetStatusHandler(schedulerService: SchedulerService) {
+  return async (_req: Request, res: Response): Promise<void> => {
+    try {
+      const status = schedulerService.getStatus();
+      res.json({
+        success: true,
+        ...status,
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      res.status(500).json({
+        success: false,
+        error: errorMessage
+      });
+    }
+  };
+}

--- a/apps/ui/tests/scheduler-status-verification.spec.ts
+++ b/apps/ui/tests/scheduler-status-verification.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Scheduler Status Endpoint Verification Test
+ *
+ * This test verifies that the GET /api/scheduler/status endpoint works correctly
+ * and returns all required scheduler information including:
+ * - All registered tasks
+ * - Next run times
+ * - Execution counts
+ * - Task status information
+ */
+
+import { test, expect } from '@playwright/test';
+import { authenticateForTests, API_BASE_URL } from './utils';
+
+test.describe('Scheduler Status Endpoint', () => {
+  test('GET /api/scheduler/status should return scheduler status', async ({ page }) => {
+    await authenticateForTests(page);
+
+    // Call the scheduler status endpoint
+    const response = await page.request.get(`${API_BASE_URL}/api/scheduler/status`);
+
+    expect(response.ok()).toBe(true);
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+
+    // Verify response structure
+    expect(data).toHaveProperty('success');
+    expect(data.success).toBe(true);
+
+    // Verify scheduler status fields
+    expect(data).toHaveProperty('running');
+    expect(data).toHaveProperty('taskCount');
+    expect(data).toHaveProperty('enabledTaskCount');
+    expect(data).toHaveProperty('tasks');
+
+    // Verify running is a boolean
+    expect(typeof data.running).toBe('boolean');
+
+    // Verify task counts are numbers
+    expect(typeof data.taskCount).toBe('number');
+    expect(typeof data.enabledTaskCount).toBe('number');
+
+    // Verify tasks is an array
+    expect(Array.isArray(data.tasks)).toBe(true);
+
+    // If there are tasks, verify their structure
+    if (data.tasks.length > 0) {
+      const task = data.tasks[0];
+
+      // Verify required task fields
+      expect(task).toHaveProperty('id');
+      expect(task).toHaveProperty('name');
+      expect(task).toHaveProperty('enabled');
+      expect(task).toHaveProperty('failureCount');
+      expect(task).toHaveProperty('executionCount');
+
+      // Verify types
+      expect(typeof task.id).toBe('string');
+      expect(typeof task.name).toBe('string');
+      expect(typeof task.enabled).toBe('boolean');
+      expect(typeof task.failureCount).toBe('number');
+      expect(typeof task.executionCount).toBe('number');
+
+      // Optional fields (should be strings if present)
+      if (task.lastRun !== undefined) {
+        expect(typeof task.lastRun).toBe('string');
+      }
+      if (task.nextRun !== undefined) {
+        expect(typeof task.nextRun).toBe('string');
+      }
+    }
+  });
+
+  test('GET /api/scheduler/status should include Graphite sync task', async ({ page }) => {
+    await authenticateForTests(page);
+
+    const response = await page.request.get(`${API_BASE_URL}/api/scheduler/status`);
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(Array.isArray(data.tasks)).toBe(true);
+
+    // Look for the Graphite sync task (if scheduler has been initialized)
+    // This verifies that the scheduler is actually tracking tasks
+    const graphiteSyncTask = data.tasks.find((task: any) =>
+      task.name.toLowerCase().includes('graphite')
+    );
+
+    // If the graphite sync task exists, verify its structure
+    if (graphiteSyncTask) {
+      expect(graphiteSyncTask).toHaveProperty('id');
+      expect(graphiteSyncTask).toHaveProperty('name');
+      expect(graphiteSyncTask).toHaveProperty('enabled');
+      expect(graphiteSyncTask.enabled).toBe(true);
+
+      // Verify it has a next run time (since it's enabled)
+      expect(graphiteSyncTask).toHaveProperty('nextRun');
+      expect(typeof graphiteSyncTask.nextRun).toBe('string');
+    }
+  });
+
+  test('GET /api/scheduler/status should be accessible without authentication errors', async ({
+    page,
+  }) => {
+    await authenticateForTests(page);
+
+    // Make multiple requests to ensure the endpoint is stable
+    for (let i = 0; i < 3; i++) {
+      const response = await page.request.get(`${API_BASE_URL}/api/scheduler/status`);
+
+      expect(response.ok()).toBe(true);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      // Brief delay between requests
+      await page.waitForTimeout(100);
+    }
+  });
+});


### PR DESCRIPTION
Adds GET /api/scheduler/status endpoint for monitoring scheduled tasks.

## Changes
- Created `apps/server/src/routes/scheduler/routes/get-status.ts`
- Registered route in scheduler router
- Returns task list, schedules, and execution history

## Testing
```bash
curl http://localhost:3008/api/scheduler/status
```

## Related
- Part of Graphite Sync Scheduler Integration
- Enables monitoring of scheduled tasks

🤖 Generated with Automaker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduler status API at /api/scheduler/status to return scheduler state, task counts, and per-task details (id, name, enabled, execution/failure counts, last/next run).

* **Tests**
  * Added automated tests validating response shape, per-task fields, example task expectations, and stability across repeated requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->