### PR TITLE
Fix auto-mode dependency enforcement

### DIFF
--- a/libs/dependency-resolver/src/resolver.ts
+++ b/libs/dependency-resolver/src/resolver.ts
@@ -56,7 +56,12 @@ export function resolveDependencies(features: Feature[]): DependencyResolutionRe
 
         // Check if dependency is incomplete (blocking)
         const depFeature = featureMap.get(depId)!;
-        if (depFeature.status !== 'completed' && depFeature.status !== 'verified') {
+        if (
+          depFeature.status !== 'completed' &&
+          depFeature.status !== 'verified' &&
+          depFeature.status !== 'done' &&
+          depFeature.status !== 'review'
+        ) {
           if (!blockedFeatures.has(feature.id)) {
             blockedFeatures.set(feature.id, []);
           }
@@ -206,8 +211,17 @@ export function areDependenciesSatisfied(
       // When skipping verification, only block if dependency is currently running
       return dep.status !== 'running';
     }
-    // Default: require 'completed' or 'verified'
-    return dep.status === 'completed' || dep.status === 'verified';
+    // Default: require 'completed', 'verified', 'done' (PR merged), or 'review' (PR open)
+    // 'done' = PR merged, final state
+    // 'review' = PR created and under review, work is complete
+    // 'completed' = agent finished, no PR workflow
+    // 'verified' = manually verified by user
+    return (
+      dep.status === 'completed' ||
+      dep.status === 'verified' ||
+      dep.status === 'done' ||
+      dep.status === 'review'
+    );
   });
 }
 
@@ -225,7 +239,13 @@ export function getBlockingDependencies(feature: Feature, allFeatures: Feature[]
 
   return feature.dependencies.filter((depId: string) => {
     const dep = allFeatures.find((f) => f.id === depId);
-    return dep && dep.status !== 'completed' && dep.status !== 'verified';
+    return (
+      dep &&
+      dep.status !== 'completed' &&
+      dep.status !== 'verified' &&
+      dep.status !== 'done' &&
+      dep.status !== 'review'
+    );
   });
 }
 
@@ -264,7 +284,13 @@ export function getBlockingDependenciesFromMap(
   const blockingDependencies: string[] = [];
   for (const depId of dependencies) {
     const dep = featureMap.get(depId);
-    if (dep && dep.status !== 'completed' && dep.status !== 'verified') {
+    if (
+      dep &&
+      dep.status !== 'completed' &&
+      dep.status !== 'verified' &&
+      dep.status !== 'done' &&
+      dep.status !== 'review'
+    ) {
       blockingDependencies.push(depId);
     }
   }

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -41,7 +41,7 @@ export interface Feature {
   description: string;
   passes?: boolean;
   priority?: number;
-  status?: string;
+  status?: FeatureStatus | string; // Allow string for extensibility
   dependencies?: string[];
   spec?: string;
   model?: string;
@@ -99,4 +99,14 @@ export interface Feature {
   [key: string]: unknown; // Keep catch-all for extensibility
 }
 
-export type FeatureStatus = 'pending' | 'running' | 'completed' | 'failed' | 'verified';
+export type FeatureStatus =
+  | 'pending' // Initial state, not yet started
+  | 'backlog' // Queued for auto-mode
+  | 'ready' // Ready to be picked up
+  | 'running' // Currently being executed by agent
+  | 'completed' // Agent finished successfully
+  | 'failed' // Agent execution failed
+  | 'verified' // Manually verified by user
+  | 'waiting_approval' // Agent completed, waiting for user review
+  | 'review' // PR created, under review
+  | 'done'; // PR merged, final state


### PR DESCRIPTION
## Summary

## Bug Report

Auto-mode started M3 features in parallel despite having sequential dependencies:
- M3 depends on M0 (not yet done)
- M3-P1 → P2 → P3 → P4 → P5 (sequential chain)
- All 6 features started simultaneously

## Root Cause Investigation Needed

Check AutoModeService for:
1. **Dependency checking before starting features**
   - Are dependencies loaded from feature.json?
   - Is status checked (must be "done" not just "verified")?
   - Are epic dependencies checked?

2. **Race conditions...

---
*Created automatically by Automaker*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Dependency resolution now recognizes additional feature completion states (review, done) as valid for unblocking dependent features.
  * Expanded feature lifecycle with new status options: backlog, ready, waiting_approval, review, and done for more granular progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->