### PR TITLE
feat(discord): Add channel mapping storage and updates

### DIFF
--- a/apps/server/src/routes/settings/index.ts
+++ b/apps/server/src/routes/settings/index.ts
@@ -21,6 +21,7 @@ import { createGetCredentialsHandler } from './routes/get-credentials.js';
 import { createUpdateCredentialsHandler } from './routes/update-credentials.js';
 import { createGetProjectHandler } from './routes/get-project.js';
 import { createUpdateProjectHandler } from './routes/update-project.js';
+import { createUpdateDiscordChannelsHandler } from './routes/update-discord-channels.js';
 import { createMigrateHandler } from './routes/migrate.js';
 import { createStatusHandler } from './routes/status.js';
 import { createDiscoverAgentsHandler } from './routes/discover-agents.js';
@@ -39,6 +40,7 @@ import { createDiscoverAgentsHandler } from './routes/discover-agents.js';
  * - PUT /credentials - Update API keys
  * - POST /project - Get project settings (requires projectPath in body)
  * - PUT /project - Update project settings
+ * - PUT /project/discord-channels - Update Discord channel mappings
  * - POST /migrate - Migrate settings from localStorage
  * - POST /agents/discover - Discover filesystem agents from .claude/agents/ (read-only)
  *
@@ -69,6 +71,13 @@ export function createSettingsRoutes(settingsService: SettingsService): Router {
     '/project',
     validatePathParams('projectPath'),
     createUpdateProjectHandler(settingsService)
+  );
+
+  // Discord channel mappings
+  router.put(
+    '/project/discord-channels',
+    validatePathParams('projectPath'),
+    createUpdateDiscordChannelsHandler(settingsService)
   );
 
   // Migration from localStorage

--- a/apps/server/src/routes/settings/routes/update-discord-channels.ts
+++ b/apps/server/src/routes/settings/routes/update-discord-channels.ts
@@ -1,0 +1,84 @@
+/**
+ * PUT /api/settings/project/discord-channels - Update Discord channel mappings
+ *
+ * Dedicated endpoint for updating Discord channel mappings without affecting
+ * other project settings. Performs a deep merge to preserve existing mappings.
+ *
+ * Request body: `{ projectPath: string, channelMappings: Partial<DiscordChannelMappings> }`
+ * Response: `{ "success": true, "settings": ProjectSettings }`
+ */
+
+import type { Request, Response } from 'express';
+import type { SettingsService } from '../../../services/settings-service.js';
+import type { ProjectSettings } from '../../../types/settings.js';
+import { getErrorMessage, logError } from '../common.js';
+
+interface DiscordChannelMappings {
+  featureCreated?: string;
+  featureCompleted?: string;
+  featureError?: string;
+  prCreated?: string;
+  prMerged?: string;
+  autoModeStatus?: string;
+  general?: string;
+}
+
+/**
+ * Create handler factory for PUT /api/settings/project/discord-channels
+ *
+ * @param settingsService - Instance of SettingsService for file I/O
+ * @returns Express request handler
+ */
+export function createUpdateDiscordChannelsHandler(settingsService: SettingsService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, channelMappings } = req.body as {
+        projectPath?: string;
+        channelMappings?: Partial<DiscordChannelMappings>;
+      };
+
+      if (!projectPath || typeof projectPath !== 'string') {
+        res.status(400).json({
+          success: false,
+          error: 'projectPath is required',
+        });
+        return;
+      }
+
+      if (!channelMappings || typeof channelMappings !== 'object') {
+        res.status(400).json({
+          success: false,
+          error: 'channelMappings object is required',
+        });
+        return;
+      }
+
+      // Validate channel IDs are strings or undefined
+      for (const [key, value] of Object.entries(channelMappings)) {
+        if (value !== undefined && typeof value !== 'string') {
+          res.status(400).json({
+            success: false,
+            error: `Invalid channel ID for ${key}: must be a string`,
+          });
+          return;
+        }
+      }
+
+      // Update only the Discord channel mappings
+      const updates: Partial<ProjectSettings> = {
+        discordChannelMappings: channelMappings,
+      };
+
+      const settings = await settingsService.updateProjectSettings(projectPath, updates);
+
+      res.json({
+        success: true,
+        settings,
+        discordChannelMappings: settings.discordChannelMappings,
+      });
+    } catch (error) {
+      logError(error, 'Update Discord channel mappings failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/apps/server/src/services/settings-service.ts
+++ b/apps/server/src/services/settings-service.ts
@@ -771,6 +771,10 @@ export class SettingsService {
     return {
       ...DEFAULT_PROJECT_SETTINGS,
       ...settings,
+      // Preserve Discord channel mappings from loaded settings
+      discordChannelMappings: settings.discordChannelMappings
+        ? { ...settings.discordChannelMappings }
+        : undefined,
     };
   }
 
@@ -803,6 +807,15 @@ export class SettingsService {
       updated.boardBackground = {
         ...current.boardBackground,
         ...updates.boardBackground,
+      };
+    }
+
+    // Deep merge Discord channel mappings if provided
+    // This ensures partial updates don't overwrite existing channel mappings
+    if (updates.discordChannelMappings) {
+      updated.discordChannelMappings = {
+        ...current.discordChannelMappings,
+        ...updates.discordChannelMappings,
       };
     }
 

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -1287,6 +1287,29 @@ export interface WorktreeInfo {
 }
 
 /**
+ * DiscordChannelMappings - Discord channel IDs for project lifecycle events
+ *
+ * Maps project lifecycle events to Discord channel IDs for notifications.
+ * Channel IDs are Discord snowflake IDs (e.g., "1234567890123456789").
+ */
+export interface DiscordChannelMappings {
+  /** Channel ID for feature creation notifications */
+  featureCreated?: string;
+  /** Channel ID for feature completion notifications */
+  featureCompleted?: string;
+  /** Channel ID for feature error notifications */
+  featureError?: string;
+  /** Channel ID for PR creation notifications */
+  prCreated?: string;
+  /** Channel ID for PR merge notifications */
+  prMerged?: string;
+  /** Channel ID for auto-mode status updates */
+  autoModeStatus?: string;
+  /** Channel ID for general project updates */
+  general?: string;
+}
+
+/**
  * ProjectSettings - Project-specific overrides stored in {projectPath}/.automaker/settings.json
  *
  * Allows per-project customization without affecting global settings.
@@ -1372,6 +1395,13 @@ export interface ProjectSettings {
    * @see WebhookSettings in webhook.ts
    */
   webhookSettings?: import('./webhook.js').WebhookSettings;
+
+  // Discord Integration (per-project)
+  /**
+   * Discord channel mappings for project lifecycle notifications.
+   * Maps lifecycle events to specific Discord channels for notifications.
+   */
+  discordChannelMappings?: DiscordChannelMappings;
 
   // Deprecated Claude API Profile Override
   /**


### PR DESCRIPTION
## Summary
- Create update-discord-channels route
- Store channel ID mappings in project settings
- Support updating existing channel configurations

## Test Plan
- [x] Channel mappings save correctly
- [x] Updates preserve existing data

🤖 Generated with [Claude Code](https://claude.ai/claude-code)