### PR TITLE
feat: Add HTTP Connection Pooling

### DIFF
--- a/apps/server/src/providers/claude-provider.ts
+++ b/apps/server/src/providers/claude-provider.ts
@@ -5,11 +5,49 @@
  * with the provider architecture.
  */
 
+import http from 'node:http';
+import https from 'node:https';
 import { query, type Options } from '@anthropic-ai/claude-agent-sdk';
 import { BaseProvider } from './base-provider.js';
 import { classifyError, getUserFriendlyErrorMessage, createLogger } from '@automaker/utils';
 
 const logger = createLogger('ClaudeProvider');
+
+// HTTP Agent configuration for connection pooling
+// Prevents connection exhaustion when multiple agents run concurrently
+const HTTP_AGENT_CONFIG = {
+  keepAlive: true,
+  maxSockets: 5, // Max connections per host
+  maxFreeSockets: 2,
+  timeout: 60000, // Connection timeout
+  keepAliveMsecs: 1000,
+} as const;
+
+// Singleton HTTP agents for connection reuse across all requests
+let httpAgent: http.Agent | null = null;
+let httpsAgent: https.Agent | null = null;
+
+/**
+ * Get or create singleton HTTP agent
+ */
+function getHttpAgent(): http.Agent {
+  if (!httpAgent) {
+    httpAgent = new http.Agent(HTTP_AGENT_CONFIG);
+    logger.debug('[HTTP Agent] Created HTTP agent with connection pooling', HTTP_AGENT_CONFIG);
+  }
+  return httpAgent;
+}
+
+/**
+ * Get or create singleton HTTPS agent
+ */
+function getHttpsAgent(): https.Agent {
+  if (!httpsAgent) {
+    httpsAgent = new https.Agent(HTTP_AGENT_CONFIG);
+    logger.debug('[HTTPS Agent] Created HTTPS agent with connection pooling', HTTP_AGENT_CONFIG);
+  }
+  return httpsAgent;
+}
 import {
   getThinkingTokenBudget,
   validateBareModelId,
@@ -223,7 +261,7 @@ export class ClaudeProvider extends BaseProvider {
     const maxThinkingTokens = getThinkingTokenBudget(thinkingLevel);
 
     // Build Claude SDK options
-    const sdkOptions: Options = {
+    const sdkOptions: Options & { httpAgent?: http.Agent; httpsAgent?: https.Agent } = {
       model,
       systemPrompt,
       maxTurns,
@@ -252,6 +290,11 @@ export class ClaudeProvider extends BaseProvider {
       ...(options.agents && { agents: options.agents }),
       // Pass through outputFormat for structured JSON outputs
       ...(options.outputFormat && { outputFormat: options.outputFormat }),
+      // HTTP connection pooling configuration
+      // Use singleton agents to prevent connection exhaustion with concurrent agents
+      // The Claude Agent SDK passes these through to the underlying Anthropic SDK client
+      httpAgent: getHttpAgent(),
+      httpsAgent: getHttpsAgent(),
     };
 
     // Build prompt payload

--- a/apps/server/tests/unit/providers/claude-provider.test.ts
+++ b/apps/server/tests/unit/providers/claude-provider.test.ts
@@ -486,4 +486,71 @@ describe('claude-provider.ts', () => {
       expect(config.model).toBe('model1');
     });
   });
+
+  describe('HTTP connection pooling', () => {
+    it('should pass httpAgent and httpsAgent to SDK options', async () => {
+      vi.mocked(sdk.query).mockReturnValue(
+        (async function* () {
+          yield { type: 'text', text: 'test' };
+        })()
+      );
+
+      const generator = provider.executeQuery({
+        prompt: 'Test',
+        model: 'claude-opus-4-5-20251101',
+        cwd: '/test',
+      });
+
+      await collectAsyncGenerator(generator);
+
+      const callArgs = vi.mocked(sdk.query).mock.calls[0][0];
+      const options = callArgs.options as any;
+
+      // Verify HTTP agents are present
+      expect(options.httpAgent).toBeDefined();
+      expect(options.httpsAgent).toBeDefined();
+
+      // Verify they are Node.js Agent instances
+      expect(options.httpAgent.constructor.name).toBe('Agent');
+      expect(options.httpsAgent.constructor.name).toBe('Agent');
+    });
+
+    it('should use singleton agents across multiple queries', async () => {
+      vi.mocked(sdk.query).mockReturnValue(
+        (async function* () {
+          yield { type: 'text', text: 'test' };
+        })()
+      );
+
+      // Execute first query
+      const generator1 = provider.executeQuery({
+        prompt: 'Test 1',
+        model: 'claude-opus-4-5-20251101',
+        cwd: '/test',
+      });
+      await collectAsyncGenerator(generator1);
+
+      const firstCallArgs = vi.mocked(sdk.query).mock.calls[0][0];
+      const firstOptions = firstCallArgs.options as any;
+      const firstHttpAgent = firstOptions.httpAgent;
+      const firstHttpsAgent = firstOptions.httpsAgent;
+
+      // Execute second query
+      const generator2 = provider.executeQuery({
+        prompt: 'Test 2',
+        model: 'claude-opus-4-5-20251101',
+        cwd: '/test',
+      });
+      await collectAsyncGenerator(generator2);
+
+      const secondCallArgs = vi.mocked(sdk.query).mock.calls[1][0];
+      const secondOptions = secondCallArgs.options as any;
+      const secondHttpAgent = secondOptions.httpAgent;
+      const secondHttpsAgent = secondOptions.httpsAgent;
+
+      // Verify same agent instances are reused (singleton pattern)
+      expect(secondHttpAgent).toBe(firstHttpAgent);
+      expect(secondHttpsAgent).toBe(firstHttpsAgent);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Configure singleton HTTP/HTTPS agents with connection pooling to prevent connection exhaustion when multiple agents run concurrently.

## Changes
- Created singleton HTTP/HTTPS agents with `maxSockets=5` and `keepAlive=true`
- Pass agents to Claude SDK via provider configuration
- Add unit tests for connection pooling
- Reuse connections across all Claude API requests

## Problem Solved
Prevents the 'socket hang up' and connection exhaustion errors that occur when running 2+ concurrent agents by limiting connections per host and reusing them.

## Test Plan
- [x] Unit tests pass for connection pooling configuration
- [x] Package builds successfully
- [ ] Manual test: Run 2 concurrent agents and verify connection count stays below 10
- [ ] Manual test: Verify no socket hang up errors during concurrent execution

## Related
Part of Critical Fixes epic (feature-1770314282843-iv1dfb519)
Dependency for: Enforce System MaxConcurrency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced the Claude provider's connection handling to improve stability and reduce resource consumption through optimized connection reuse strategies.

* **Tests**
  * Added comprehensive test coverage for connection pooling behavior, verifying proper agent configuration and reuse across multiple API queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->