### PR TITLE
feat: Fix AbortController Cleanup

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -1662,6 +1662,7 @@ export class AutoModeService {
       logger.info(
         `Pending approvals at cleanup: ${Array.from(this.pendingApprovals.keys()).join(', ') || 'none'}`
       );
+      abortController.abort();
       this.runningFeatures.delete(featureId);
 
       // Update execution state after feature completes
@@ -2212,6 +2213,7 @@ Complete the pipeline step instructions above. Review the previous work and appl
         });
       }
     } finally {
+      abortController.abort();
       this.runningFeatures.delete(featureId);
     }
   }
@@ -2543,6 +2545,7 @@ Address the follow-up instructions above. Review the previous work and make the 
         }
       }
     } finally {
+      abortController.abort();
       this.runningFeatures.delete(featureId);
     }
   }
@@ -2836,6 +2839,8 @@ Format your response as a structured markdown document.`;
         errorType: errorInfo.type,
         projectPath,
       });
+    } finally {
+      abortController.abort();
     }
   }
 


### PR DESCRIPTION
## Summary
Ensure AbortController.abort() is called in all execution paths to prevent memory leaks when running concurrent agents.

## Changes
- Add `abort()` calls to finally blocks in `followUpFeature` method
- Add `abort()` calls to finally blocks in `resumeFromPipelineStep` method  
- Add `abort()` calls to finally blocks in `analyzeProject` method
- Ensure `runningFeatures` Map cleanup is guaranteed

## Problem Solved
Prevents memory leaks and resource exhaustion after 10+ agent runs by ensuring AbortController instances are always cleaned up, even when execution fails or is interrupted.

## Test Plan
- [x] Package builds successfully
- [x] All finally blocks contain abort() calls
- [ ] Manual test: Run 10 agents sequentially and verify no memory leaks
- [ ] Manual test: Stop an agent mid-execution and verify cleanup occurs

## Related
Part of Critical Fixes epic (feature-1770314282843-iv1dfb519)
Depends on: Enforce System MaxConcurrency (#PR_NUMBER)

🤖 Generated with [Claude Code](https://claude.com/claude-code)