### PR TITLE
fix: resolve TypeScript build errors for Docker production build

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -543,11 +543,11 @@ export class AutoModeService {
 
     // Restart auto-mode with the same configuration
     try {
-      await this.startAutoMode({
+      await this.startAutoLoopForProject(
         projectPath,
-        maxConcurrency: projectState.config.maxConcurrency,
-        branchName: projectState.branchName ?? undefined,
-      });
+        projectState.branchName ?? null,
+        projectState.config.maxConcurrency
+      );
     } catch (error) {
       logger.error('Failed to auto-resume after cooldown:', error);
       this.emitAutoModeEvent('auto_mode_error', {

--- a/apps/server/src/services/discord-service.ts
+++ b/apps/server/src/services/discord-service.ts
@@ -125,10 +125,10 @@ function parseDiscordError(error: unknown): {
  * All methods return DiscordOperationResult with success/error states.
  */
 export class DiscordService {
-  private provider: ClaudeProvider;
+  private provider: ClaudeProvider | null;
 
-  constructor(provider: ClaudeProvider) {
-    this.provider = provider;
+  constructor(provider?: ClaudeProvider) {
+    this.provider = provider ?? null;
   }
 
   /**
@@ -658,7 +658,7 @@ let discordServiceInstance: DiscordService | null = null;
  * Get or create the singleton Discord service instance
  * @param provider - Claude provider for MCP tool execution
  */
-export function getDiscordService(provider: ClaudeProvider): DiscordService {
+export function getDiscordService(provider?: ClaudeProvider): DiscordService {
   if (!discordServiceInstance) {
     discordServiceInstance = new DiscordService(provider);
   }

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -237,6 +237,9 @@ export {
   DEFAULT_GRAPHITE_SETTINGS,
   // Discord integration defaults
   DEFAULT_DISCORD_SETTINGS,
+  // Integration config defaults
+  DEFAULT_LINEAR_INTEGRATION,
+  DEFAULT_DISCORD_INTEGRATION,
   // Claude-compatible provider templates (new)
   CLAUDE_PROVIDER_TEMPLATES,
   // Claude API profile constants (deprecated)


### PR DESCRIPTION
## Summary
- Add missing `project:scaffolded` and `project:deleted` event types to the `EventType` union
- Export missing types from `@automaker/types` (`EventHookDiscordAction`, `LinearIntegrationConfig`, `DiscordIntegrationConfig`, `ProjectIntegrations`)
- Fix `startAutoMode()` → `startAutoLoopForProject()` with correct positional args in auto-mode cooldown resume
- Make `DiscordService` constructor parameter optional since it's used without a provider in routes

## Test plan
- [x] Docker production build compiles successfully
- [x] Server container starts and passes health check
- [ ] Verify auto-mode cooldown resume works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added default configuration support for Discord and Linear integrations.

* **Bug Fixes**
  * Improved auto-mode restart behavior for better multi-project handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->