### PR TITLE
Fix 2 flaky E2E tests for CI (increase timeouts)

### DIFF
--- a/apps/ui/tests/features/feature-manual-review-flow.spec.ts
+++ b/apps/ui/tests/features/feature-manual-review-flow.spec.ts
@@ -156,7 +156,7 @@ test.describe('Feature Manual Review Flow', () => {
 
     // Wait for the feature card to appear (features are loaded asynchronously)
     const featureCard = page.locator(`[data-testid="kanban-card-${featureId}"]`);
-    await expect(featureCard).toBeVisible({ timeout: 20000 });
+    await expect(featureCard).toBeVisible({ timeout: 30000 });
 
     // Verify the feature appears in the waiting_approval column
     const waitingApprovalColumn = await getKanbanColumn(page, 'waiting_approval');

--- a/apps/ui/tests/features/feature-skip-tests-toggle.spec.ts
+++ b/apps/ui/tests/features/feature-skip-tests-toggle.spec.ts
@@ -91,7 +91,7 @@ test.describe('Feature Skip Tests Badge', () => {
         hasText: featureDescription,
       });
       expect(await featureCard.count()).toBeGreaterThan(0);
-    }).toPass({ timeout: 10000 });
+    }).toPass({ timeout: 20000 });
 
     // Get the feature ID from the card
     const featureCard = page


### PR DESCRIPTION
## Summary
- Increase kanban card visibility timeout from 20s to 30s in manual review flow test
- Increase feature card `toPass` timeout from 10s to 20s in skip tests toggle test

## Context
Both tests pass locally but consistently fail in CI (GitHub Actions) due to slower runners. 17/19 E2E tests already pass — these 2 just need longer timeouts.

## Test plan
- [x] Changes are minimal (2 timeout values)
- [ ] Verify both tests pass in CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased visible wait timeout for a feature card check (20s → 30s) to reduce flakiness.
  * Increased wait window for the backlog feature count assertion (10s → 20s) to improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->