### PR TITLE
fix: enforce maxConcurrency with startingFeatures tracking

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -944,12 +944,7 @@ export class AutoModeService {
           }, 30000);
 
           // Start feature execution in background
-          this.executeFeature(
-            projectPath,
-            nextFeature.id,
-            projectState.config.useWorktrees,
-            true
-          )
+          this.executeFeature(projectPath, nextFeature.id, projectState.config.useWorktrees, true)
             .then(() => {
               // Remove from starting set once executeFeature completes (successfully or not)
               clearTimeout(startingTimeout);
@@ -965,9 +960,7 @@ export class AutoModeService {
           // Brief sleep to ensure proper sequencing
           await this.sleep(100);
         } else {
-          logger.debug(
-            `[AutoLoop] All pending features are already running or being started`
-          );
+          logger.debug(`[AutoLoop] All pending features are already running or being started`);
         }
 
         await this.sleep(2000);


### PR DESCRIPTION
Fixes critical race condition where multiple features could start simultaneously despite maxConcurrency=1.

## Problem
TOCTOU (time-of-check-to-time-of-use) race condition in auto-mode loop allowed multiple agents to start before any registered as running.

## Changes
- Add `startingFeatures` Set to ProjectAutoLoopState to track features being started
- Count both running + starting features when checking capacity
- Mark features as starting BEFORE calling executeFeature to claim slot
- Add 30s safety timeout to prevent features stuck in starting state
- Add `cleanupStartingFeature()` helper to prevent leaks
- Clean up starting features in stopFeature and shutdown

## Testing
- Added verification tests (11 tests passing)
- Verified proper capacity checking with maxConcurrency=1 and N
- Confirmed no features stuck in starting state

## Impact
Prevents server crashes from agent storms when >2-3 agents run concurrently.

Fixes: automaker-53w (Beads issue)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened race-condition protection in auto-loop to safely handle concurrent feature execution.
  * Enhanced capacity accounting to track both running and starting features for improved concurrency management.
  * Implemented automatic timeout-based cleanup mechanisms for feature startup state management and resource leak prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->