### PR TITLE
fix: pass REPO_ROOT to WorldStateMonitor for correct project path det…

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -383,7 +383,8 @@ const worldStateMonitor = new WorldStateMonitor(
       github: true,
       git: true,
     },
-  }
+  },
+  REPO_ROOT
 );
 
 // Register the main project for GitHub state checking


### PR DESCRIPTION
…ection

WorldStateMonitor was using process.cwd() internally which resolves to apps/server directory instead of the repo root. This caused the monitor to find zero features and fail to detect drift.

Fix: Pass REPO_ROOT as the projectPath parameter to WorldStateMonitor constructor. The monitor already supports this parameter and falls back through: projectPath ?? process.env.REPO_ROOT ?? path.resolve(process.cwd(), '../..')

Testing:
- Monitor now detects features correctly
- Drift detection works for epic-not-decomposed scenarios

Related: feature-1770583282070-izd4y82af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-visible changes.** This release includes internal updates to system architecture with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->