### PR TITLE
fix(auto-mode): enforce maxConcurrency by loading feature before tracking

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -1997,7 +1997,13 @@ export class AutoModeService {
         `Pending approvals at cleanup: ${Array.from(this.pendingApprovals.keys()).join(', ') || 'none'}`
       );
       abortController?.abort();
-      this.runningFeatures.delete(featureId);
+
+      // Only delete if the current entry is still the one we created
+      // (delegated executions may have created a new entry)
+      const current = this.runningFeatures.get(featureId);
+      if (current === tempRunningFeature) {
+        this.runningFeatures.delete(featureId);
+      }
 
       // Update execution state after feature completes
       if (this.autoLoopRunning && projectPath) {
@@ -2425,7 +2431,7 @@ Complete the pipeline step instructions above. Review the previous work and appl
 
     // Add to running features immediately
     const abortController = new AbortController();
-    this.runningFeatures.set(featureId, {
+    const pipelineRunningFeature: RunningFeature = {
       featureId,
       projectPath,
       worktreePath: null, // Will be set below
@@ -2435,7 +2441,8 @@ Complete the pipeline step instructions above. Review the previous work and appl
       startTime: Date.now(),
       retryCount: 0,
       previousErrors: [],
-    });
+    };
+    this.runningFeatures.set(featureId, pipelineRunningFeature);
 
     try {
       // Validate project path
@@ -2604,7 +2611,12 @@ Complete the pipeline step instructions above. Review the previous work and appl
       }
     } finally {
       abortController.abort();
-      this.runningFeatures.delete(featureId);
+
+      // Only delete if the current entry is still the one we created
+      const current = this.runningFeatures.get(featureId);
+      if (current === pipelineRunningFeature) {
+        this.runningFeatures.delete(featureId);
+      }
     }
   }
 
@@ -2723,7 +2735,7 @@ Address the follow-up instructions above. Review the previous work and make the 
     const provider = ProviderFactory.getProviderNameForModel(model);
     logger.info(`Follow-up for feature ${featureId} using model: ${model}, provider: ${provider}`);
 
-    this.runningFeatures.set(featureId, {
+    const followUpRunningFeature: RunningFeature = {
       featureId,
       projectPath,
       worktreePath,
@@ -2735,7 +2747,8 @@ Address the follow-up instructions above. Review the previous work and make the 
       provider,
       retryCount: 0,
       previousErrors: [],
-    });
+    };
+    this.runningFeatures.set(featureId, followUpRunningFeature);
 
     try {
       // Update feature status to in_progress BEFORE emitting event
@@ -2953,7 +2966,12 @@ Address the follow-up instructions above. Review the previous work and make the 
       }
     } finally {
       abortController.abort();
-      this.runningFeatures.delete(featureId);
+
+      // Only delete if the current entry is still the one we created
+      const current = this.runningFeatures.get(featureId);
+      if (current === followUpRunningFeature) {
+        this.runningFeatures.delete(featureId);
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

**CRITICAL:** Server crashes with 4-5 agents running despite `maxConcurrency=1`.

## Root Cause

Race condition in `auto-mode-service.ts` (`executeFeature` method):

1. Features added to `runningFeatures` with `branchName=null` (line 1366)
2. Actual `branchName` populated 100ms-2s later after async worktree operations (line 1459)
3. During this window, `getRunningCountForWorktree()` miscounts the feature
4. Result: Capacity checks undercount, allowing concurrent overflow

## Solution

- Load feature **BEFORE** adding to `runningFeatures`
- Set `branchName` immediately from loaded feature (no more null)
- Remove redundant `branchName` assignment
- Add proper null checks in catch block

## Changes

**File:** `apps/server/src/services/auto-mode-service.ts` (~20 lines)

- Moved feature loading before `runningFeatures.set()`
- Set `branchName: feature.branchName ?? null` immediately
- Removed redundant assignment at line 1464
- Added null-safe access in catch block

## Testing

✅ TypeScript compiles successfully  
✅ Server builds without errors  
⚠️ 1 test failure: "should prevent duplicate feature execution" (may be test timing issue)  
📋 Manual test pending: maxConcurrency=1 with 6 queued features

## Verification Plan

1. CI will run full test suite
2. Manual test: Set `maxConcurrency=1`, queue 6 features, verify sequential execution
3. Monitor: "Race condition detected" log should never appear
4. Load test: Run multiple features concurrently and verify no crashes

## References

- Full analysis: `~/.claude/projects/-Users-kj-dev-automaker/memory/prd-auto-mode-concurrency-race.md`
- Related: Known Issue "13+ concurrent agents = server crash"

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved auto-mode reliability and startup sequencing to reduce timing conflicts and initialization issues, lowering the chance of failed feature starts and race-condition related interruptions.

* **Chores**
  * Enhanced null-safety and error handling across execution flows, tightened retry behavior and timeout stability, and more accurate runtime/completion reporting to reduce unexpected failures and noisy errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->