### PR TITLE
feat: Phase 10 - Tiered Health Check API

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -39,7 +39,13 @@ import { authMiddleware, validateWsConnectionToken, checkRawAuthentication } fro
 import { requireJsonContentType } from './middleware/require-json-content-type.js';
 import { createAuthRoutes } from './routes/auth/index.js';
 import { createFsRoutes } from './routes/fs/index.js';
-import { createHealthRoutes, createDetailedHandler } from './routes/health/index.js';
+import {
+  createHealthRoutes,
+  createDetailedHandler,
+  createQuickHandler,
+  createStandardHandler,
+  createDeepHandler,
+} from './routes/health/index.js';
 import { createAgentRoutes } from './routes/agent/index.js';
 import { createSessionsRoutes } from './routes/sessions/index.js';
 import { createFeaturesRoutes } from './routes/features/index.js';
@@ -771,8 +777,17 @@ app.use('/webhooks', createWebhooksRoutes(events, settingsService));
 // Apply authentication to all /api/* routes
 app.use('/api', authMiddleware);
 
-// Protected health endpoint with detailed info
+// Protected health endpoints with detailed info
 app.get('/api/health/detailed', createDetailedHandler());
+app.get('/api/health/quick', createQuickHandler());
+app.get(
+  '/api/health/standard',
+  createStandardHandler(agentService, featureLoader, autoModeService, REPO_ROOT)
+);
+app.get(
+  '/api/health/deep',
+  createDeepHandler(agentService, featureLoader, autoModeService, REPO_ROOT, worldStateMonitor)
+);
 
 app.use('/api/fs', createFsRoutes(events));
 app.use('/api/agent', createAgentRoutes(agentService, events));

--- a/apps/server/src/routes/health/index.ts
+++ b/apps/server/src/routes/health/index.ts
@@ -2,7 +2,7 @@
  * Health check routes
  *
  * NOTE: Only the basic health check (/) and environment check are unauthenticated.
- * The /detailed endpoint requires authentication.
+ * The /detailed, /quick, /standard, and /deep endpoints require authentication.
  */
 
 import { Router } from 'express';
@@ -26,5 +26,8 @@ export function createHealthRoutes(): Router {
   return router;
 }
 
-// Re-export detailed handler for use in authenticated routes
+// Re-export handlers for use in authenticated routes
 export { createDetailedHandler } from './routes/detailed.js';
+export { createQuickHandler } from './routes/quick.js';
+export { createStandardHandler } from './routes/standard.js';
+export { createDeepHandler } from './routes/deep.js';

--- a/apps/server/src/routes/health/routes/deep.ts
+++ b/apps/server/src/routes/health/routes/deep.ts
@@ -1,0 +1,196 @@
+/**
+ * GET /deep endpoint - Deep health check (<2s target, 10s timeout)
+ * Returns comprehensive diagnostics: probes agents, world state, full system status
+ * Timeout protection ensures response even if checks are slow
+ */
+
+import type { Request, Response } from 'express';
+import { getVersion } from '../../../lib/version.js';
+import type { AgentService } from '../../../services/agent-service.js';
+import type { FeatureLoader } from '../../../services/feature-loader.js';
+import type { AutoModeService } from '../../../services/auto-mode-service.js';
+import type { WorldStateMonitor } from '../../../services/world-state-monitor.js';
+
+interface DeepHealthResponse {
+  status: 'ok' | 'degraded' | 'unhealthy';
+  uptime: number;
+  version: string;
+  board: {
+    totalFeatures: number;
+    byStatus: Record<string, number>;
+    features: Array<{
+      id: string;
+      title: string;
+      status: string;
+      branchName?: string;
+    }>;
+  };
+  agents: {
+    running: number;
+    total: number;
+    sessions: Array<{
+      id: string;
+      name: string;
+      workingDirectory: string;
+      model?: string;
+      createdAt: string;
+    }>;
+  };
+  autoMode: {
+    enabled: boolean;
+    queueLength: number;
+    queue: Array<{
+      featureId: string;
+      title: string;
+    }>;
+  };
+  worldState?: {
+    monitored: boolean;
+    lastUpdate?: string;
+    [key: string]: unknown;
+  };
+  performance: {
+    responseTime: number;
+    timedOut: boolean;
+  };
+}
+
+const DEEP_CHECK_TIMEOUT = 10000; // 10s timeout
+const TARGET_TIME = 2000; // 2s target
+
+export function createDeepHandler(
+  agentService: AgentService,
+  featureLoader: FeatureLoader,
+  autoModeService: AutoModeService,
+  projectPath: string,
+  worldStateMonitor?: WorldStateMonitor
+) {
+  return async (_req: Request, res: Response): Promise<void> => {
+    const startTime = Date.now();
+    let timedOut = false;
+
+    // Set up timeout protection
+    const timeoutId = setTimeout(() => {
+      timedOut = true;
+      res.status(503).json({
+        status: 'unhealthy',
+        error: 'Health check timed out',
+        uptime: process.uptime(),
+        version: getVersion(),
+        performance: {
+          responseTime: Date.now() - startTime,
+          timedOut: true,
+        },
+      });
+    }, DEEP_CHECK_TIMEOUT);
+
+    try {
+      // Get comprehensive board data
+      const features = await featureLoader.getAll(projectPath);
+      const byStatus: Record<string, number> = {};
+      for (const feature of features) {
+        const status = feature.status || 'unknown';
+        byStatus[status] = (byStatus[status] || 0) + 1;
+      }
+
+      // Get detailed agent information
+      const sessions = await agentService.listSessions();
+
+      // Get auto-mode full status (Note: getRunningAgents would be better but this is simpler)
+      const autoModeStatus = autoModeService.getStatus();
+
+      // Get world state if monitor exists
+      let worldState: DeepHealthResponse['worldState'] | undefined;
+      if (worldStateMonitor) {
+        try {
+          const metrics = worldStateMonitor.getMetrics();
+          worldState = {
+            monitored: true,
+            lastUpdate: new Date(metrics.lastTickTimestamp).toISOString(),
+            ...metrics,
+          };
+        } catch (error) {
+          worldState = {
+            monitored: false,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          };
+        }
+      }
+
+      const duration = Date.now() - startTime;
+
+      // Determine overall health status
+      let status: 'ok' | 'degraded' | 'unhealthy' = 'ok';
+      if (duration > TARGET_TIME) {
+        status = 'degraded';
+      }
+      if (timedOut) {
+        status = 'unhealthy';
+      }
+
+      const response: DeepHealthResponse = {
+        status,
+        uptime: process.uptime(),
+        version: getVersion(),
+        board: {
+          totalFeatures: features.length,
+          byStatus,
+          features: features.map((f) => ({
+            id: f.id,
+            title: f.title || 'Untitled',
+            status: f.status || 'unknown',
+            branchName: f.branchName,
+          })),
+        },
+        agents: {
+          running: sessions.filter((s) => !s.archived).length,
+          total: sessions.length,
+          sessions: sessions.map((s) => ({
+            id: s.id,
+            name: s.name,
+            workingDirectory: s.workingDirectory,
+            model: s.model,
+            createdAt: s.createdAt,
+          })),
+        },
+        autoMode: {
+          enabled: autoModeStatus.isRunning,
+          queueLength: autoModeStatus.runningCount,
+          queue: autoModeStatus.runningFeatures.map((featureId) => ({
+            featureId,
+            title: features.find((f) => f.id === featureId)?.title || 'Unknown',
+          })),
+        },
+        worldState,
+        performance: {
+          responseTime: duration,
+          timedOut: false,
+        },
+      };
+
+      clearTimeout(timeoutId);
+
+      if (!timedOut) {
+        res.setHeader('X-Response-Time', `${duration}ms`);
+        res.json(response);
+      }
+    } catch (error) {
+      clearTimeout(timeoutId);
+
+      if (!timedOut) {
+        const duration = Date.now() - startTime;
+        res.setHeader('X-Response-Time', `${duration}ms`);
+        res.status(503).json({
+          status: 'unhealthy',
+          error: error instanceof Error ? error.message : 'Unknown error',
+          uptime: process.uptime(),
+          version: getVersion(),
+          performance: {
+            responseTime: duration,
+            timedOut: false,
+          },
+        });
+      }
+    }
+  };
+}

--- a/apps/server/src/routes/health/routes/quick.ts
+++ b/apps/server/src/routes/health/routes/quick.ts
@@ -1,0 +1,18 @@
+/**
+ * GET /quick endpoint - Quick health check (<10ms target)
+ * Returns minimal information: uptime and version
+ * No database or service checks - instant response
+ */
+
+import type { Request, Response } from 'express';
+import { getVersion } from '../../../lib/version.js';
+
+export function createQuickHandler() {
+  return (_req: Request, res: Response): void => {
+    res.json({
+      status: 'ok',
+      uptime: process.uptime(),
+      version: getVersion(),
+    });
+  };
+}

--- a/apps/server/src/routes/health/routes/standard.ts
+++ b/apps/server/src/routes/health/routes/standard.ts
@@ -1,0 +1,92 @@
+/**
+ * GET /standard endpoint - Standard health check (<100ms target)
+ * Returns system overview: uptime, version, board summary, agent counts
+ * Lightweight service checks without deep probing
+ */
+
+import type { Request, Response } from 'express';
+import { getVersion } from '../../../lib/version.js';
+import type { AgentService } from '../../../services/agent-service.js';
+import type { FeatureLoader } from '../../../services/feature-loader.js';
+import type { AutoModeService } from '../../../services/auto-mode-service.js';
+
+interface StandardHealthResponse {
+  status: 'ok' | 'degraded';
+  uptime: number;
+  version: string;
+  board: {
+    totalFeatures: number;
+    byStatus: Record<string, number>;
+  };
+  agents: {
+    running: number;
+    total: number;
+  };
+  autoMode: {
+    enabled: boolean;
+    queueLength?: number;
+  };
+}
+
+export function createStandardHandler(
+  agentService: AgentService,
+  featureLoader: FeatureLoader,
+  autoModeService: AutoModeService,
+  projectPath: string
+) {
+  return async (_req: Request, res: Response): Promise<void> => {
+    const startTime = Date.now();
+
+    try {
+      // Get board summary
+      const features = await featureLoader.getAll(projectPath);
+      const byStatus: Record<string, number> = {};
+      for (const feature of features) {
+        const status = feature.status || 'unknown';
+        byStatus[status] = (byStatus[status] || 0) + 1;
+      }
+
+      // Get agent counts
+      const sessions = await agentService.listSessions();
+      const runningSessions = sessions.filter((s) => {
+        // Sessions are running if they have active agent conversations
+        // We approximate this by checking if they're not archived
+        return !s.archived;
+      });
+
+      // Get auto-mode status
+      const autoModeStatus = autoModeService.getStatus();
+
+      const response: StandardHealthResponse = {
+        status: 'ok',
+        uptime: process.uptime(),
+        version: getVersion(),
+        board: {
+          totalFeatures: features.length,
+          byStatus,
+        },
+        agents: {
+          running: runningSessions.length,
+          total: sessions.length,
+        },
+        autoMode: {
+          enabled: autoModeStatus.isRunning,
+          queueLength: autoModeStatus.runningCount,
+        },
+      };
+
+      const duration = Date.now() - startTime;
+      res.setHeader('X-Response-Time', `${duration}ms`);
+      res.json(response);
+    } catch (error) {
+      const duration = Date.now() - startTime;
+      res.setHeader('X-Response-Time', `${duration}ms`);
+      res.status(503).json({
+        status: 'degraded',
+        error: error instanceof Error ? error.message : 'Unknown error',
+        uptime: process.uptime(),
+        version: getVersion(),
+      });
+    }
+  };
+}


### PR DESCRIPTION
## Summary
Implements 3-tier health check endpoints for system monitoring and diagnostics.

## Endpoints Created
- **`/api/health/quick`** - Instant (<10ms target)
  - Returns: uptime, version
  - Use case: Load balancer health checks
  
- **`/api/health/standard`** - Fast (<100ms target)
  - Returns: board summary, agent counts, auto-mode status
  - Use case: Dashboard status display
  
- **`/api/health/deep`** - Thorough (<2s target, 10s timeout)
  - Returns: Full diagnostics including all features, agent details, world state
  - Use case: Detailed troubleshooting and monitoring

## Implementation Details
- All endpoints require authentication (behind `/api/*`)
- Response time headers (`X-Response-Time`) included
- Deep endpoint has timeout protection to prevent hanging
- Proper error handling with degraded/unhealthy status codes

## Testing
- ✅ Build passes (TypeScript validation)
- ✅ Format passes
- 🧪 Manual endpoint testing pending (requires auth token)

## Notes
- Agent crashed 3x during automated implementation
- Completed manually to avoid further server instability

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new health check endpoints: `/api/health/quick` (lightweight status check), `/api/health/standard` (aggregated system health), and `/api/health/deep` (comprehensive diagnostics). These endpoints provide server uptime, version, feature status counts, agent session metrics, and auto-mode queue information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->