### PR TITLE
feat: Add documentation checklist to /ava skill

### DIFF
--- a/packages/mcp-server/plugins/automaker/commands/ava.md
+++ b/packages/mcp-server/plugins/automaker/commands/ava.md
@@ -313,6 +313,13 @@ On exit: update memory with decisions/changes, `bd sync`
 
 Monitor board, check agents, watch for work. Only sign off at max backoff with zero pending work.
 
+**Pre-backoff checklist (run before entering monitoring loop):**
+
+- [ ] **Document progress** - Update `~/.claude/projects/-Users-kj-dev-automaker/memory/MEMORY.md` with completed work
+- [ ] **Check PRs** - Address CodeRabbit feedback, ensure no stale PRs
+- [ ] **Verify CI** - All recent PRs passing CI checks
+- [ ] **Clean up** - Stage/commit any uncommitted changes
+
 ```
 while true:
   sleep(backoff)


### PR DESCRIPTION
## Summary
Adds pre-backoff documentation checklist to /ava skill to ensure progress is documented before entering monitoring mode.

## Changes
- **Pre-backoff checklist** added to /ava skill:
  - Document progress in MEMORY.md
  - Check PRs for CodeRabbit feedback
  - Verify CI passing
  - Clean up uncommitted changes

## Context
Per Josh's requirement: "make sure we are documenting as we go so we don't have to play catchup after all this work. this should be one of your responsibilities to check in on before going into backoff mode."

## Plugin Update Note
After merging, users may need to restart Claude Code to pick up the updated /ava skill, or the MCP server will auto-reload on file changes (TBD - needs testing/automation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a pre-backoff checklist guide outlining steps to complete before the monitoring loop begins, including documentation updates, pull request reviews, CI verification, and cleanup tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->