### PR TITLE
fix: auto-mode concurrency tracking loses count of running agents

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -1018,23 +1018,22 @@ export class AutoModeService {
     projectPath: string,
     branchName: string | null
   ): Promise<number> {
-    // Get the actual primary branch name for the project
-    const primaryBranch = await getCurrentBranch(projectPath);
-
     let count = 0;
     for (const [, feature] of this.runningFeatures) {
-      // Filter by project path AND branchName to get accurate worktree-specific count
-      const featureBranch = feature.branchName ?? null;
+      if (feature.projectPath !== projectPath) continue;
+
       if (branchName === null) {
-        // Main worktree: match features with branchName === null OR branchName matching primary branch
-        const isPrimaryBranch =
-          featureBranch === null || (primaryBranch && featureBranch === primaryBranch);
-        if (feature.projectPath === projectPath && isPrimaryBranch) {
-          count++;
-        }
+        // Main worktree auto-loop: count ALL running features for this project.
+        // Features start with branchName null but get assigned feature-specific branches
+        // (e.g., feature/concurrency-auto-mode-lane) when their worktree is created.
+        // The old logic only matched null/primary-branch, missing all features that had
+        // migrated to their own worktrees - causing the count to return 0 when 9+ agents
+        // were actually running, which broke concurrency enforcement.
+        count++;
       } else {
         // Feature worktree: exact match
-        if (feature.projectPath === projectPath && featureBranch === branchName) {
+        const featureBranch = feature.branchName ?? null;
+        if (featureBranch === branchName) {
           count++;
         }
       }
@@ -3315,9 +3314,17 @@ Format your response as a structured markdown document.`;
     const runningFeatures: string[] = [];
 
     for (const [featureId, feature] of this.runningFeatures) {
-      // Filter by project path AND branchName to get worktree-specific features
-      if (feature.projectPath === projectPath && feature.branchName === branchName) {
+      if (feature.projectPath !== projectPath) continue;
+
+      if (branchName === null) {
+        // Main worktree: include ALL project features (they migrate to their own branches
+        // once worktrees are created, so exact branch matching would miss them)
         runningFeatures.push(featureId);
+      } else {
+        // Feature worktree: exact match
+        if (feature.branchName === branchName) {
+          runningFeatures.push(featureId);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- **Critical bug fix**: `getRunningCountForWorktree()` and `getStatusForProject()` returned 0 running agents when 9+ were actually active
- Features get assigned their own branch names when worktrees are created, but the count methods only matched `null`/primary branch - missing all migrated features
- This bypassed `maxConcurrency` enforcement, causing unlimited agent spawning and server crashes
- Fix: when counting for main worktree (`branchName: null`), count ALL running features for the project

## Root Cause
Auto-mode starts features from the main worktree loop. On start, features have `branchName: null`. But `executeFeature()` assigns a feature-specific branch (e.g., `feature/concurrency-auto-mode-lane`) when the worktree is created. After that, the old counting logic (`featureBranch === null || featureBranch === primaryBranch`) no longer matched, so the count dropped to 0.

The auto-loop saw `0/1 running`, thought it had capacity, and kept starting more agents. Server reached 11 concurrent agents and crashed.

## Test plan
- [x] All 1488 server tests pass
- [x] Pre-commit hooks (prettier) pass
- [ ] After merge, restart auto-mode with `maxConcurrency: 1` and verify log shows `1/1 running` (not `0/1`)
- [ ] Verify status API returns `isRunning: true` and correct `runningCount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed worktree concurrency counting to accurately track all running features for the main worktree, regardless of which branch they are on, rather than only counting features on the primary branch.

* **Refactor**
  * Simplified internal feature counting logic to improve consistency across worktree operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->