### PR TITLE
feat: add Graphite-first git workflow to /ava skill

### DIFF
--- a/packages/mcp-server/plugins/automaker/commands/ava.md
+++ b/packages/mcp-server/plugins/automaker/commands/ava.md
@@ -155,6 +155,14 @@ Gather situational awareness fast:
 
 ## Operational Context
 
+**Git workflow: Graphite-first.** Use `gt` over `gh` for all branch and PR operations:
+
+- `gt create <branch>` — create branch (tracks parent automatically)
+- `gt submit --stack` — push and create/update PRs for the entire stack
+- `gt sync` — sync with remote
+- `gt restack` — rebase stack when main changes (one command fixes all branches)
+- Fall back to `gh` only if Graphite errors. Epic branches especially benefit from stacking.
+
 **Beads** (`bd` CLI) — Your task tracker. `bd ready` for what's unblocked. `bd sync` before signing off.
 
 **Subagents** — Use Task tool aggressively. Delegate research, monitoring, and exploration to subagents to keep your main context clean. Run them in parallel when possible.


### PR DESCRIPTION
## Summary
- Adds `gt` over `gh` as default for branch and PR operations in /ava skill
- Includes key `gt` commands: create, submit --stack, sync, restack
- Epic branches benefit from Graphite stacking to avoid cascade rebases

## Test plan
- [ ] /ava skill loads and includes Graphite guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operational context documentation with enhanced Git workflow guidance and command references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->