### PR TITLE
feat: add launchd deployment for Ava headless monitor

### DIFF
--- a/scripts/infra/com.automaker.ava-monitor.plist
+++ b/scripts/infra/com.automaker.ava-monitor.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.automaker.ava-monitor</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__AUTOMAKER_ROOT__/scripts/ava-monitor.sh</string>
+    </array>
+
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>WorkingDirectory</key>
+    <string>__AUTOMAKER_ROOT__</string>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/automaker/ava-monitor.stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/automaker/ava-monitor.stderr.log</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <false/>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:__HOME__/.npm-global/bin</string>
+        <key>HOME</key>
+        <string>__HOME__</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/install-ava-monitor.sh
+++ b/scripts/install-ava-monitor.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# install-ava-monitor.sh — Install Ava monitor as a macOS launchd service
+#
+# Runs ava-monitor.sh every 5 minutes in the background.
+# Logs to ~/Library/Logs/automaker/
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLIST_TEMPLATE="$SCRIPT_DIR/infra/com.automaker.ava-monitor.plist"
+PLIST_NAME="com.automaker.ava-monitor"
+PLIST_DEST="$HOME/Library/LaunchAgents/$PLIST_NAME.plist"
+LOG_DIR="$HOME/Library/Logs/automaker"
+
+# Check prerequisites
+if ! command -v claude &>/dev/null; then
+  echo "Error: 'claude' CLI not found. Install it first."
+  exit 1
+fi
+
+if [ ! -f "$PLIST_TEMPLATE" ]; then
+  echo "Error: Plist template not found at $PLIST_TEMPLATE"
+  exit 1
+fi
+
+# Unload existing service if running
+if launchctl list "$PLIST_NAME" &>/dev/null; then
+  echo "Stopping existing service..."
+  launchctl unload "$PLIST_DEST" 2>/dev/null || true
+fi
+
+# Create log directory
+mkdir -p "$LOG_DIR"
+
+# Create LaunchAgents directory if needed
+mkdir -p "$HOME/Library/LaunchAgents"
+
+# Generate plist from template with path substitution
+sed \
+  -e "s|__AUTOMAKER_ROOT__|$PROJECT_DIR|g" \
+  -e "s|__HOME__|$HOME|g" \
+  "$PLIST_TEMPLATE" > "$PLIST_DEST"
+
+# Make monitor script executable
+chmod +x "$SCRIPT_DIR/ava-monitor.sh"
+
+# Load the service
+launchctl load "$PLIST_DEST"
+
+echo "Ava monitor installed and started."
+echo "  Service: $PLIST_NAME"
+echo "  Interval: every 5 minutes"
+echo "  Logs: $LOG_DIR/"
+echo ""
+echo "Commands:"
+echo "  Check status:  launchctl list $PLIST_NAME"
+echo "  Stop:          launchctl unload $PLIST_DEST"
+echo "  Start:         launchctl load $PLIST_DEST"
+echo "  Uninstall:     ./scripts/uninstall-ava-monitor.sh"

--- a/scripts/uninstall-ava-monitor.sh
+++ b/scripts/uninstall-ava-monitor.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# uninstall-ava-monitor.sh — Remove Ava monitor launchd service
+
+set -euo pipefail
+
+PLIST_NAME="com.automaker.ava-monitor"
+PLIST_DEST="$HOME/Library/LaunchAgents/$PLIST_NAME.plist"
+
+if [ -f "$PLIST_DEST" ]; then
+  echo "Stopping and removing service..."
+  launchctl unload "$PLIST_DEST" 2>/dev/null || true
+  rm -f "$PLIST_DEST"
+  echo "Ava monitor uninstalled."
+else
+  echo "Service not installed (no plist at $PLIST_DEST)."
+fi
+
+echo ""
+echo "Note: Logs are preserved at ~/Library/Logs/automaker/"
+echo "To remove logs: rm -rf ~/Library/Logs/automaker/"


### PR DESCRIPTION
## Summary
- Add macOS launchd plist template for running Ava monitor every 5 minutes in the background
- Install script (`scripts/install-ava-monitor.sh`) handles path substitution, log directory, launchctl
- Uninstall script cleanly removes the service
- Logs to `~/Library/Logs/automaker/`

## Test plan
- [ ] Run `./scripts/install-ava-monitor.sh` — service loads
- [ ] `launchctl list com.automaker.ava-monitor` shows running
- [ ] Check logs appear in `~/Library/Logs/automaker/`
- [ ] `./scripts/uninstall-ava-monitor.sh` cleanly removes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ava monitor can now be configured as an automated macOS background service that starts at system startup and runs at regular intervals
  * Installation script handles service setup, validates dependencies, creates necessary directories, and configures logging
  * Uninstallation script allows clean removal of the service while maintaining logs for troubleshooting and reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->