### PR TITLE
feat: add idle work mode to stop hook

### DIFF
--- a/packages/mcp-server/plugins/automaker/hooks/continue-work.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/continue-work.sh
@@ -47,5 +47,20 @@ if [ "$TOTAL" -gt 0 ]; then
   exit 2  # Block stop, continue working
 fi
 
-# Board is clear
-exit 0
+# Board is clear — check if we should run idle tasks
+IDLE_COOLDOWN_FILE="/tmp/ava-idle-cooldown"
+IDLE_COOLDOWN_SECONDS=600  # 10 minutes between idle cycles
+
+if [ -f "$IDLE_COOLDOWN_FILE" ]; then
+  LAST_IDLE=$(cat "$IDLE_COOLDOWN_FILE" 2>/dev/null || echo "0")
+  NOW=$(date +%s)
+  ELAPSED=$((NOW - LAST_IDLE))
+  if [ "$ELAPSED" -lt "$IDLE_COOLDOWN_SECONDS" ]; then
+    exit 0  # Cooldown active, allow stop
+  fi
+fi
+
+# Set cooldown timestamp and trigger idle work
+date +%s > "$IDLE_COOLDOWN_FILE"
+echo "Board is clear. Running idle work cycle (cleanup, health checks). Next idle in ${IDLE_COOLDOWN_SECONDS}s." >&2
+exit 2  # Block stop, run idle tasks


### PR DESCRIPTION
## Summary
- When board is clear, stop hook triggers idle work cycle instead of stopping
- 10-minute cooldown via `/tmp/ava-idle-cooldown` prevents rapid cycling
- Idle work includes cleanup, health checks, and proactive maintenance

## Test plan
- [ ] When board has work: hook continues as before (blocks stop)
- [ ] When board is empty + no cooldown: triggers idle cycle
- [ ] When board is empty + cooldown active: allows stop
- [ ] Cooldown resets after 10 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added automatic idle task scheduling: when no active work exists, the system now periodically triggers maintenance operations (cleanup and health checks) with a 10-minute cooldown between cycles to optimize resource efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->