### PR TITLE
Auto-rebase stale PRs

### DIFF
--- a/apps/server/src/services/maintenance-tasks.ts
+++ b/apps/server/src/services/maintenance-tasks.ts
@@ -978,9 +978,7 @@ async function autoRebaseStalePRs(
       const allFeatures = await featureLoader.getAll(projectPath);
       const reviewFeatures = allFeatures.filter((f) => f.status === 'review');
 
-      logger.debug(
-        `Found ${reviewFeatures.length} features in review status for ${projectPath}`
-      );
+      logger.debug(`Found ${reviewFeatures.length} features in review status for ${projectPath}`);
 
       for (const feature of reviewFeatures) {
         if (!feature.prNumber || !feature.branchName) {
@@ -1005,9 +1003,7 @@ async function autoRebaseStalePRs(
         }
 
         if (!behindStatus.isBehind) {
-          logger.debug(
-            `PR #${feature.prNumber} (${feature.title}) is up to date with base branch`
-          );
+          logger.debug(`PR #${feature.prNumber} (${feature.title}) is up to date with base branch`);
           continue;
         }
 


### PR DESCRIPTION
## Summary

**Milestone:** Proactive Maintenance

Detect PRs behind their base branch. Auto-rebase via gt restack (Graphite) or gh pr rebase. If conflicts detected, escalate to human via Discord notification instead of force-pushing.

**Files to Modify:**
- apps/server/src/services/maintenance-tasks.ts
- apps/server/src/services/graphite-service.ts

**Acceptance Criteria:**
- [ ] Stale PRs auto-rebased
- [ ] Conflicts escalate to Discord
- [ ] Uses Graphite when available

**Complexity:** medium

---
*Created automatically by Automaker*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic rebase of stale pull requests every 30 minutes to keep them current with base branches
  * Conflict detection with Discord notifications when rebase issues occur
  * Flexible rebase methods supporting both Graphite restacking and GitHub CLI fallback options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->