### PR TITLE
fix: repair broken MCP tool namespaces across 15 skills and harden hooks

### DIFF
--- a/packages/mcp-server/plugins/automaker/commands/auto-mode.md
+++ b/packages/mcp-server/plugins/automaker/commands/auto-mode.md
@@ -5,15 +5,15 @@ argument-hint: (start|stop|status) [project-path]
 allowed-tools:
   - AskUserQuestion
   # Auto-mode Control
-  - mcp__automaker__start_auto_mode
-  - mcp__automaker__stop_auto_mode
-  - mcp__automaker__get_auto_mode_status
+  - mcp__plugin_automaker_automaker__start_auto_mode
+  - mcp__plugin_automaker_automaker__stop_auto_mode
+  - mcp__plugin_automaker_automaker__get_auto_mode_status
   # Supporting tools
-  - mcp__automaker__list_features
-  - mcp__automaker__get_board_summary
-  - mcp__automaker__list_running_agents
-  - mcp__automaker__get_execution_order
-  - mcp__automaker__health_check
+  - mcp__plugin_automaker_automaker__list_features
+  - mcp__plugin_automaker_automaker__get_board_summary
+  - mcp__plugin_automaker_automaker__list_running_agents
+  - mcp__plugin_automaker_automaker__get_execution_order
+  - mcp__plugin_automaker_automaker__health_check
 ---
 
 # Automaker Auto-Mode Controller
@@ -56,7 +56,7 @@ options:
 Then start:
 
 ```
-mcp__automaker__start_auto_mode({
+mcp__plugin_automaker_automaker__start_auto_mode({
   projectPath: "<path>",
   maxConcurrency: <chosen-value>
 })
@@ -71,7 +71,7 @@ When user says "stop", "halt", "pause auto-mode":
 3. Show what was in progress (agents will complete their current feature)
 
 ```
-mcp__automaker__stop_auto_mode({ projectPath: "<path>" })
+mcp__plugin_automaker_automaker__stop_auto_mode({ projectPath: "<path>" })
 ```
 
 ### Check Status
@@ -79,7 +79,7 @@ mcp__automaker__stop_auto_mode({ projectPath: "<path>" })
 When user says "status", "check", "is auto-mode running":
 
 ```
-mcp__automaker__get_auto_mode_status({ projectPath: "<path>" })
+mcp__plugin_automaker_automaker__get_auto_mode_status({ projectPath: "<path>" })
 ```
 
 Display:
@@ -105,11 +105,11 @@ Display:
 User: "start auto-mode"
 
 You:
-1. mcp__automaker__health_check()
-2. mcp__automaker__get_board_summary({ projectPath })
-3. mcp__automaker__get_execution_order({ projectPath })
+1. mcp__plugin_automaker_automaker__health_check()
+2. mcp__plugin_automaker_automaker__get_board_summary({ projectPath })
+3. mcp__plugin_automaker_automaker__get_execution_order({ projectPath })
 4. Ask about concurrency
-5. mcp__automaker__start_auto_mode({ projectPath, maxConcurrency })
+5. mcp__plugin_automaker_automaker__start_auto_mode({ projectPath, maxConcurrency })
 6. Confirm started and show first features being processed
 ```
 

--- a/packages/mcp-server/plugins/automaker/commands/board.md
+++ b/packages/mcp-server/plugins/automaker/commands/board.md
@@ -6,21 +6,21 @@ allowed-tools:
   - AskUserQuestion
   - Task
   # Feature Management
-  - mcp__automaker__list_features
-  - mcp__automaker__get_feature
-  - mcp__automaker__create_feature
-  - mcp__automaker__update_feature
-  - mcp__automaker__delete_feature
-  - mcp__automaker__move_feature
+  - mcp__plugin_automaker_automaker__list_features
+  - mcp__plugin_automaker_automaker__get_feature
+  - mcp__plugin_automaker_automaker__create_feature
+  - mcp__plugin_automaker_automaker__update_feature
+  - mcp__plugin_automaker_automaker__delete_feature
+  - mcp__plugin_automaker_automaker__move_feature
   # Agent Control
-  - mcp__automaker__start_agent
-  - mcp__automaker__stop_agent
-  - mcp__automaker__list_running_agents
-  - mcp__automaker__get_agent_output
-  - mcp__automaker__send_message_to_agent
+  - mcp__plugin_automaker_automaker__start_agent
+  - mcp__plugin_automaker_automaker__stop_agent
+  - mcp__plugin_automaker_automaker__list_running_agents
+  - mcp__plugin_automaker_automaker__get_agent_output
+  - mcp__plugin_automaker_automaker__send_message_to_agent
   # Utilities
-  - mcp__automaker__health_check
-  - mcp__automaker__get_board_summary
+  - mcp__plugin_automaker_automaker__health_check
+  - mcp__plugin_automaker_automaker__get_board_summary
 ---
 
 # Automaker Board Manager
@@ -45,7 +45,7 @@ You can:
 1. First, check if the Automaker server is running:
 
    ```
-   mcp__automaker__health_check()
+   mcp__plugin_automaker_automaker__health_check()
    ```
 
    If it fails, inform the user: "Automaker server is not running. Start it with `npm run dev` in the automaker directory."
@@ -56,7 +56,7 @@ You can:
 
 ### Board Overview
 
-When showing the board, use `mcp__automaker__get_board_summary()` first for counts, then `mcp__automaker__list_features()` for details.
+When showing the board, use `mcp__plugin_automaker_automaker__get_board_summary()` first for counts, then `mcp__plugin_automaker_automaker__list_features()` for details.
 
 Display format:
 

--- a/packages/mcp-server/plugins/automaker/commands/context.md
+++ b/packages/mcp-server/plugins/automaker/commands/context.md
@@ -7,14 +7,14 @@ allowed-tools:
   - Read
   - Write
   # Context File Management
-  - mcp__automaker__list_context_files
-  - mcp__automaker__get_context_file
-  - mcp__automaker__create_context_file
-  - mcp__automaker__delete_context_file
+  - mcp__plugin_automaker_automaker__list_context_files
+  - mcp__plugin_automaker_automaker__get_context_file
+  - mcp__plugin_automaker_automaker__create_context_file
+  - mcp__plugin_automaker_automaker__delete_context_file
   # Project Spec
-  - mcp__automaker__get_project_spec
-  - mcp__automaker__update_project_spec
-  - mcp__automaker__health_check
+  - mcp__plugin_automaker_automaker__get_project_spec
+  - mcp__plugin_automaker_automaker__update_project_spec
+  - mcp__plugin_automaker_automaker__health_check
 ---
 
 # Automaker Context Manager
@@ -38,7 +38,7 @@ Every time an agent starts working on a feature, ALL context files are loaded in
 ### List Context Files
 
 ```
-mcp__automaker__list_context_files({ projectPath })
+mcp__plugin_automaker_automaker__list_context_files({ projectPath })
 ```
 
 Display:
@@ -56,7 +56,7 @@ Display:
 ### View a Context File
 
 ```
-mcp__automaker__get_context_file({ projectPath, filename: "coding-standards.md" })
+mcp__plugin_automaker_automaker__get_context_file({ projectPath, filename: "coding-standards.md" })
 ```
 
 ### Create a Context File
@@ -84,7 +84,7 @@ options:
 Then create:
 
 ```
-mcp__automaker__create_context_file({
+mcp__plugin_automaker_automaker__create_context_file({
   projectPath,
   filename: "my-rules.md",
   content: "<markdown content>"
@@ -94,7 +94,7 @@ mcp__automaker__create_context_file({
 ### Delete a Context File
 
 ```
-mcp__automaker__delete_context_file({ projectPath, filename: "old-rules.md" })
+mcp__plugin_automaker_automaker__delete_context_file({ projectPath, filename: "old-rules.md" })
 ```
 
 ## Project Spec
@@ -104,13 +104,13 @@ The project spec (`.automaker/spec.md`) is a special context file that describes
 ### View Project Spec
 
 ```
-mcp__automaker__get_project_spec({ projectPath })
+mcp__plugin_automaker_automaker__get_project_spec({ projectPath })
 ```
 
 ### Update Project Spec
 
 ```
-mcp__automaker__update_project_spec({ projectPath, content: "<new content>" })
+mcp__plugin_automaker_automaker__update_project_spec({ projectPath, content: "<new content>" })
 ```
 
 ## Writing Effective Context Files

--- a/packages/mcp-server/plugins/automaker/commands/create-project-features.md
+++ b/packages/mcp-server/plugins/automaker/commands/create-project-features.md
@@ -5,10 +5,10 @@ argument-hint: <project slug>
 allowed-tools:
   - Read
   - AskUserQuestion
-  - mcp__automaker__list_features
-  - mcp__automaker__create_feature
-  - mcp__automaker__set_feature_dependencies
-  - mcp__automaker__health_check
+  - mcp__plugin_automaker_automaker__list_features
+  - mcp__plugin_automaker_automaker__create_feature
+  - mcp__plugin_automaker_automaker__set_feature_dependencies
+  - mcp__plugin_automaker_automaker__health_check
 model: haiku
 ---
 
@@ -62,7 +62,7 @@ Dependencies are translated:
 ### Step 1: Verify Server
 
 ```
-mcp__automaker__health_check()
+mcp__plugin_automaker_automaker__health_check()
 ```
 
 ### Step 2: Load Project

--- a/packages/mcp-server/plugins/automaker/commands/create-project.md
+++ b/packages/mcp-server/plugins/automaker/commands/create-project.md
@@ -9,13 +9,13 @@ allowed-tools:
   - Task
   - AskUserQuestion
   - Write
-  - mcp__automaker__get_project_spec
-  - mcp__automaker__list_context_files
-  - mcp__automaker__get_context_file
-  - mcp__automaker__list_features
-  - mcp__automaker__create_feature
-  - mcp__automaker__set_feature_dependencies
-  - mcp__automaker__health_check
+  - mcp__plugin_automaker_automaker__get_project_spec
+  - mcp__plugin_automaker_automaker__list_context_files
+  - mcp__plugin_automaker_automaker__get_context_file
+  - mcp__plugin_automaker_automaker__list_features
+  - mcp__plugin_automaker_automaker__create_feature
+  - mcp__plugin_automaker_automaker__set_feature_dependencies
+  - mcp__plugin_automaker_automaker__health_check
 model: sonnet
 ---
 
@@ -36,7 +36,7 @@ Complete project orchestration pipeline:
 Check Automaker server health:
 
 ```
-mcp__automaker__health_check()
+mcp__plugin_automaker_automaker__health_check()
 ```
 
 Get project path confirmation:

--- a/packages/mcp-server/plugins/automaker/commands/deep-research.md
+++ b/packages/mcp-server/plugins/automaker/commands/deep-research.md
@@ -8,10 +8,10 @@ allowed-tools:
   - Grep
   - Task
   - AskUserQuestion
-  - mcp__automaker__get_project_spec
-  - mcp__automaker__list_context_files
-  - mcp__automaker__get_context_file
-  - mcp__automaker__list_features
+  - mcp__plugin_automaker_automaker__get_project_spec
+  - mcp__plugin_automaker_automaker__list_context_files
+  - mcp__plugin_automaker_automaker__get_context_file
+  - mcp__plugin_automaker_automaker__list_features
 model: haiku
 ---
 
@@ -50,18 +50,18 @@ options:
 1. Get the project specification:
 
    ```
-   mcp__automaker__get_project_spec({ projectPath })
+   mcp__plugin_automaker_automaker__get_project_spec({ projectPath })
    ```
 
 2. Check context files for coding standards:
 
    ```
-   mcp__automaker__list_context_files({ projectPath })
+   mcp__plugin_automaker_automaker__list_context_files({ projectPath })
    ```
 
 3. Review existing features for related work:
    ```
-   mcp__automaker__list_features({ projectPath })
+   mcp__plugin_automaker_automaker__list_features({ projectPath })
    ```
 
 ### Step 3: Explore the Codebase

--- a/packages/mcp-server/plugins/automaker/commands/devops.md
+++ b/packages/mcp-server/plugins/automaker/commands/devops.md
@@ -9,7 +9,7 @@ allowed-tools:
   - Glob
   - AskUserQuestion
   - Task
-  - mcp__automaker__health_check
+  - mcp__plugin_automaker_automaker__health_check
 ---
 
 # Automaker DevOps Manager
@@ -117,7 +117,7 @@ Quick health check:
 curl -s http://localhost:3008/api/health | jq .
 
 # Or use MCP tool
-mcp__automaker__health_check()
+mcp__plugin_automaker_automaker__health_check()
 ```
 
 ### Action: Backup

--- a/packages/mcp-server/plugins/automaker/commands/discord.md
+++ b/packages/mcp-server/plugins/automaker/commands/discord.md
@@ -8,36 +8,36 @@ allowed-tools:
   - Bash
   - Read
   # Channel Management
-  - mcp__discord__list_channels
-  - mcp__discord__create_text_channel
-  - mcp__discord__delete_channel
-  - mcp__discord__find_channel
+  - mcp__plugin_automaker_discord__list_channels
+  - mcp__plugin_automaker_discord__create_text_channel
+  - mcp__plugin_automaker_discord__delete_channel
+  - mcp__plugin_automaker_discord__find_channel
   # Category Management
-  - mcp__discord__create_category
-  - mcp__discord__find_category
-  - mcp__discord__delete_category
-  - mcp__discord__list_channels_in_category
+  - mcp__plugin_automaker_discord__create_category
+  - mcp__plugin_automaker_discord__find_category
+  - mcp__plugin_automaker_discord__delete_category
+  - mcp__plugin_automaker_discord__list_channels_in_category
   # Message Management
-  - mcp__discord__send_message
-  - mcp__discord__read_messages
-  - mcp__discord__edit_message
-  - mcp__discord__delete_message
+  - mcp__plugin_automaker_discord__send_message
+  - mcp__plugin_automaker_discord__read_messages
+  - mcp__plugin_automaker_discord__edit_message
+  - mcp__plugin_automaker_discord__delete_message
   # Webhook Management
-  - mcp__discord__create_webhook
-  - mcp__discord__list_webhooks
-  - mcp__discord__send_webhook_message
-  - mcp__discord__delete_webhook
+  - mcp__plugin_automaker_discord__create_webhook
+  - mcp__plugin_automaker_discord__list_webhooks
+  - mcp__plugin_automaker_discord__send_webhook_message
+  - mcp__plugin_automaker_discord__delete_webhook
   # Reactions
-  - mcp__discord__add_reaction
-  - mcp__discord__remove_reaction
+  - mcp__plugin_automaker_discord__add_reaction
+  - mcp__plugin_automaker_discord__remove_reaction
   # Private Messages
-  - mcp__discord__send_private_message
-  - mcp__discord__read_private_messages
-  - mcp__discord__edit_private_message
-  - mcp__discord__delete_private_message
+  - mcp__plugin_automaker_discord__send_private_message
+  - mcp__plugin_automaker_discord__read_private_messages
+  - mcp__plugin_automaker_discord__edit_private_message
+  - mcp__plugin_automaker_discord__delete_private_message
   # User & Server
-  - mcp__discord__get_user_id_by_name
-  - mcp__discord__get_server_info
+  - mcp__plugin_automaker_discord__get_user_id_by_name
+  - mcp__plugin_automaker_discord__get_server_info
 ---
 
 # Discord Manager
@@ -77,8 +77,8 @@ Based on the user's input, determine the action:
 Show a comprehensive server overview:
 
 ```
-mcp__discord__get_server_info()
-mcp__discord__list_channels()
+mcp__plugin_automaker_discord__get_server_info()
+mcp__plugin_automaker_discord__list_channels()
 ```
 
 Display format:
@@ -129,7 +129,7 @@ options:
 ### Send the announcement:
 
 ```
-mcp__discord__send_message({
+mcp__plugin_automaker_discord__send_message({
   channelId: "<selected_channel_id>",
   message: "<announcement_content>"
 })
@@ -184,7 +184,7 @@ Agenda:
 ### List Channels
 
 ```
-mcp__discord__list_channels()
+mcp__plugin_automaker_discord__list_channels()
 ```
 
 Display organized by category:
@@ -224,9 +224,9 @@ options:
 Then:
 
 ```
-mcp__discord__create_text_channel({ name: "channel-name", categoryId: "optional" })
+mcp__plugin_automaker_discord__create_text_channel({ name: "channel-name", categoryId: "optional" })
 # or
-mcp__discord__create_category({ name: "Category Name" })
+mcp__plugin_automaker_discord__create_category({ name: "Category Name" })
 ```
 
 ### Delete Channel
@@ -250,7 +250,7 @@ options:
 ### Lookup Member by Username
 
 ```
-mcp__discord__get_user_id_by_name({ username: "username" })
+mcp__plugin_automaker_discord__get_user_id_by_name({ username: "username" })
 ```
 
 Display:
@@ -271,7 +271,7 @@ Display:
 ### Send Direct Message
 
 ```
-mcp__discord__send_private_message({
+mcp__plugin_automaker_discord__send_private_message({
   userId: "123456789",
   message: "Your message here"
 })
@@ -284,7 +284,7 @@ mcp__discord__send_private_message({
 ### Read Recent Messages
 
 ```
-mcp__discord__read_messages({
+mcp__plugin_automaker_discord__read_messages({
   channelId: "<channel_id>",
   count: "20"
 })
@@ -307,7 +307,7 @@ _Showing last 20 messages_
 ### Send Message
 
 ```
-mcp__discord__send_message({
+mcp__plugin_automaker_discord__send_message({
   channelId: "<channel_id>",
   message: "Message content"
 })
@@ -316,7 +316,7 @@ mcp__discord__send_message({
 ### React to Message
 
 ```
-mcp__discord__add_reaction({
+mcp__plugin_automaker_discord__add_reaction({
   channelId: "<channel_id>",
   messageId: "<message_id>",
   emoji: "👍"
@@ -330,7 +330,7 @@ mcp__discord__add_reaction({
 ### List Webhooks
 
 ```
-mcp__discord__list_webhooks({ channelId: "<channel_id>" })
+mcp__plugin_automaker_discord__list_webhooks({ channelId: "<channel_id>" })
 ```
 
 Display:
@@ -347,7 +347,7 @@ Display:
 ### Create Webhook
 
 ```
-mcp__discord__create_webhook({
+mcp__plugin_automaker_discord__create_webhook({
   channelId: "<channel_id>",
   name: "Webhook Name"
 })
@@ -358,7 +358,7 @@ mcp__discord__create_webhook({
 ### Send via Webhook
 
 ```
-mcp__discord__send_webhook_message({
+mcp__plugin_automaker_discord__send_webhook_message({
   webhookUrl: "<full_webhook_url>",
   message: "Message content"
 })
@@ -405,7 +405,7 @@ Analyze the server for cleanup opportunities:
 ### Daily Standup Reminder
 
 ```
-mcp__discord__send_message({
+mcp__plugin_automaker_discord__send_message({
   channelId: "<standup_channel>",
   message: "🌅 **Daily Standup**\n\nPlease share:\n1. What you did yesterday\n2. What you're doing today\n3. Any blockers\n\n@everyone"
 })
@@ -414,7 +414,7 @@ mcp__discord__send_message({
 ### PR Notification
 
 ```
-mcp__discord__send_message({
+mcp__plugin_automaker_discord__send_message({
   channelId: "<dev_channel>",
   message: "🚀 **PR Ready for Review**\n\n**Title**: [PR Title]\n**Author**: @[author]\n**Link**: [PR URL]\n\nPlease review when available!"
 })
@@ -423,7 +423,7 @@ mcp__discord__send_message({
 ### Incident Alert
 
 ```
-mcp__discord__send_message({
+mcp__plugin_automaker_discord__send_message({
   channelId: "<alerts_channel>",
   message: "🚨 **Incident Alert**\n\n**Severity**: [High/Medium/Low]\n**Service**: [service name]\n**Status**: Investigating\n\n@oncall"
 })
@@ -508,13 +508,13 @@ Task(subagent_type: "automaker:discord-bulk",
 To get a channel ID:
 
 1. Use `/discord channels` to list with IDs
-2. Or use `mcp__discord__find_channel({ channelName: "channel-name" })`
+2. Or use `mcp__plugin_automaker_discord__find_channel({ channelName: "channel-name" })`
 
 ### User Mentions
 
 To mention a user in a message:
 
-1. Get their ID: `mcp__discord__get_user_id_by_name({ username: "name" })`
+1. Get their ID: `mcp__plugin_automaker_discord__get_user_id_by_name({ username: "name" })`
 2. Use in message: `<@USER_ID>`
 
 ### Emoji Reactions

--- a/packages/mcp-server/plugins/automaker/commands/groom.md
+++ b/packages/mcp-server/plugins/automaker/commands/groom.md
@@ -6,12 +6,12 @@ allowed-tools:
   - AskUserQuestion
   - Task
   # Feature Management
-  - mcp__automaker__list_features
-  - mcp__automaker__get_feature
-  - mcp__automaker__move_feature
-  - mcp__automaker__update_feature
+  - mcp__plugin_automaker_automaker__list_features
+  - mcp__plugin_automaker_automaker__get_feature
+  - mcp__plugin_automaker_automaker__move_feature
+  - mcp__plugin_automaker_automaker__update_feature
   # Utilities
-  - mcp__automaker__get_board_summary
+  - mcp__plugin_automaker_automaker__get_board_summary
 ---
 
 # Automaker Board Groomer
@@ -35,7 +35,7 @@ You can:
 1. First, check if the Automaker server is running:
 
    ```
-   mcp__automaker__health_check()
+   mcp__plugin_automaker_automaker__health_check()
    ```
 
    If it fails, inform the user: "Automaker server is not running. Start it with `npm run dev` in the automaker directory."
@@ -54,7 +54,7 @@ Run the grooming process in this order:
 
 #### 1. Get Board Summary
 
-Use `mcp__automaker__get_board_summary()` to get counts:
+Use `mcp__plugin_automaker_automaker__get_board_summary()` to get counts:
 
 ```
 ## 📊 Board Summary

--- a/packages/mcp-server/plugins/automaker/commands/headsdown.md
+++ b/packages/mcp-server/plugins/automaker/commands/headsdown.md
@@ -31,8 +31,8 @@ allowed-tools:
   - mcp__plugin_automaker_automaker__get_board_summary
   - mcp__plugin_automaker_automaker__get_execution_order
   - mcp__plugin_automaker_automaker__health_check
-  - mcp__discord__send_message
-  - mcp__discord__list_channels
+  - mcp__plugin_automaker_discord__send_message
+  - mcp__plugin_automaker_discord__list_channels
 ---
 
 # Heads Down Mode

--- a/packages/mcp-server/plugins/automaker/commands/orchestrate.md
+++ b/packages/mcp-server/plugins/automaker/commands/orchestrate.md
@@ -6,14 +6,14 @@ allowed-tools:
   - AskUserQuestion
   - Task
   # Orchestration
-  - mcp__automaker__set_feature_dependencies
-  - mcp__automaker__get_dependency_graph
-  - mcp__automaker__get_execution_order
+  - mcp__plugin_automaker_automaker__set_feature_dependencies
+  - mcp__plugin_automaker_automaker__get_dependency_graph
+  - mcp__plugin_automaker_automaker__get_execution_order
   # Feature tools for context
-  - mcp__automaker__list_features
-  - mcp__automaker__get_feature
-  - mcp__automaker__get_board_summary
-  - mcp__automaker__health_check
+  - mcp__plugin_automaker_automaker__list_features
+  - mcp__plugin_automaker_automaker__get_feature
+  - mcp__plugin_automaker_automaker__get_board_summary
+  - mcp__plugin_automaker_automaker__health_check
 ---
 
 # Automaker Orchestrator
@@ -60,7 +60,7 @@ The resolved order features should be processed, respecting dependencies:
 ### View Dependency Graph
 
 ```
-mcp__automaker__get_dependency_graph({ projectPath })
+mcp__plugin_automaker_automaker__get_dependency_graph({ projectPath })
 ```
 
 Display as:
@@ -103,7 +103,7 @@ multiSelect: true
 Then:
 
 ```
-mcp__automaker__set_feature_dependencies({
+mcp__plugin_automaker_automaker__set_feature_dependencies({
   projectPath,
   featureId: "<feature>",
   dependencies: ["abc-123", "def-456"]
@@ -113,7 +113,7 @@ mcp__automaker__set_feature_dependencies({
 ### View Execution Order
 
 ```
-mcp__automaker__get_execution_order({ projectPath, status: "backlog" })
+mcp__plugin_automaker_automaker__get_execution_order({ projectPath, status: "backlog" })
 ```
 
 Display:

--- a/packages/mcp-server/plugins/automaker/commands/pr-review.md
+++ b/packages/mcp-server/plugins/automaker/commands/pr-review.md
@@ -8,11 +8,11 @@ allowed-tools:
   - AskUserQuestion
   - Task
   # Feature Management
-  - mcp__automaker__list_features
-  - mcp__automaker__get_feature
-  - mcp__automaker__get_board_summary
+  - mcp__plugin_automaker_automaker__list_features
+  - mcp__plugin_automaker_automaker__get_feature
+  - mcp__plugin_automaker_automaker__get_board_summary
   # Utilities
-  - mcp__automaker__health_check
+  - mcp__plugin_automaker_automaker__health_check
 ---
 
 # Automaker PR Reviewer
@@ -37,7 +37,7 @@ You can:
 1. First, check if the Automaker server is running:
 
    ```
-   mcp__automaker__health_check()
+   mcp__plugin_automaker_automaker__health_check()
    ```
 
    If it fails, inform the user: "Automaker server is not running. Start it with `npm run dev` in the automaker directory."
@@ -71,7 +71,7 @@ For each PR, extract:
 Query the board to understand epic structure:
 
 ```
-mcp__automaker__list_features()
+mcp__plugin_automaker_automaker__list_features()
 ```
 
 Build a map of:

--- a/packages/mcp-server/plugins/automaker/commands/scaffold-project.md
+++ b/packages/mcp-server/plugins/automaker/commands/scaffold-project.md
@@ -6,8 +6,8 @@ allowed-tools:
   - Read
   - Write
   - AskUserQuestion
-  - mcp__automaker__get_project_spec
-  - mcp__automaker__list_features
+  - mcp__plugin_automaker_automaker__get_project_spec
+  - mcp__plugin_automaker_automaker__list_features
 model: haiku
 ---
 

--- a/packages/mcp-server/plugins/automaker/commands/setuplab.md
+++ b/packages/mcp-server/plugins/automaker/commands/setuplab.md
@@ -5,8 +5,8 @@ argument-hint: <project path (relative or absolute)>
 allowed-tools:
   - AskUserQuestion
   - Task
-  - mcp__automaker__setup_lab
-  - mcp__automaker__health_check
+  - mcp__plugin_automaker_automaker__setup_lab
+  - mcp__plugin_automaker_automaker__health_check
 model: haiku
 ---
 
@@ -32,7 +32,7 @@ You can:
 Check if Automaker server is running:
 
 ```
-mcp__automaker__health_check()
+mcp__plugin_automaker_automaker__health_check()
 ```
 
 If it fails, inform the user: "Automaker server is not running. Start it with `npm run dev` in the automaker directory."
@@ -66,7 +66,7 @@ Resolve relative paths to absolute paths:
 Invoke the setup_lab MCP tool with the resolved path:
 
 ```
-mcp__automaker__setup_lab({
+mcp__plugin_automaker_automaker__setup_lab({
   projectPath: <resolved path>,
 })
 ```

--- a/packages/mcp-server/plugins/automaker/commands/sparc-prd.md
+++ b/packages/mcp-server/plugins/automaker/commands/sparc-prd.md
@@ -9,10 +9,10 @@ allowed-tools:
   - Task
   - AskUserQuestion
   - Write
-  - mcp__automaker__get_project_spec
-  - mcp__automaker__list_context_files
-  - mcp__automaker__get_context_file
-  - mcp__automaker__list_features
+  - mcp__plugin_automaker_automaker__get_project_spec
+  - mcp__plugin_automaker_automaker__list_context_files
+  - mcp__plugin_automaker_automaker__get_context_file
+  - mcp__plugin_automaker_automaker__list_features
 model: sonnet
 ---
 
@@ -39,12 +39,12 @@ Create a structured Product Requirements Document using the SPARC methodology.
 2. Get project specification:
 
    ```
-   mcp__automaker__get_project_spec({ projectPath })
+   mcp__plugin_automaker_automaker__get_project_spec({ projectPath })
    ```
 
 3. Review related features:
    ```
-   mcp__automaker__list_features({ projectPath })
+   mcp__plugin_automaker_automaker__list_features({ projectPath })
    ```
 
 ### Step 2: Clarify Requirements

--- a/packages/mcp-server/plugins/automaker/hooks/auto-update-plugin.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/auto-update-plugin.sh
@@ -8,7 +8,12 @@ FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
 # Check if the edited file is inside the plugin directory
 if [[ "$FILE_PATH" == *"packages/mcp-server/plugins/automaker"* ]]; then
-  echo "Plugin file modified: $FILE_PATH - Remember to run 'claude plugin update automaker' to pick up changes." >&2
+  # Use stdout so Claude sees this in context (stderr is only visible in verbose mode)
+  echo "Plugin file modified: $FILE_PATH — Run 'claude plugin update automaker' to pick up changes."
+  # hooks.json changes require full reinstall: uninstall + install
+  if [[ "$FILE_PATH" == *"hooks.json"* ]] || [[ "$FILE_PATH" == *"hooks/"* ]]; then
+    echo "Hook file modified — requires plugin REINSTALL (uninstall + install), not just update."
+  fi
 fi
 
 exit 0

--- a/packages/mcp-server/plugins/automaker/hooks/block-dangerous.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/block-dangerous.sh
@@ -16,6 +16,18 @@ if echo "$COMMAND" | grep -qE 'rm\s+-rf\s+(/\s|/;|/$|~|"\$HOME"|\$HOME/?\s|\.\.)
   exit 2
 fi
 
+# Block rm -rf with --no-preserve-root
+if echo "$COMMAND" | grep -qE 'rm\s+.*--no-preserve-root'; then
+  echo "Blocked: rm with --no-preserve-root" >&2
+  exit 2
+fi
+
+# Block find with -delete targeting root
+if echo "$COMMAND" | grep -qE 'find\s+/\s.*-delete'; then
+  echo "Blocked: find / -delete targets entire filesystem" >&2
+  exit 2
+fi
+
 # Block force push to main/master
 if echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force.*\s+(main|master)'; then
   echo "Blocked: force push to main/master" >&2
@@ -33,7 +45,8 @@ if echo "$COMMAND" | grep -qE 'git\s+reset\s+--hard'; then
 fi
 
 # Block git checkout . or git restore . (wipes all unstaged changes)
-if echo "$COMMAND" | grep -qE 'git\s+(checkout|restore)\s+\.$'; then
+# Also catches "git checkout -- ." variant
+if echo "$COMMAND" | grep -qE 'git\s+(checkout|restore)\s+(--\s+)?\.$'; then
   echo "Blocked: git checkout/restore . wipes all unstaged changes" >&2
   exit 2
 fi

--- a/packages/mcp-server/plugins/automaker/hooks/hooks.json
+++ b/packages/mcp-server/plugins/automaker/hooks/hooks.json
@@ -8,11 +8,24 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/compaction-prime-directive.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-context.sh\""
           }
         ]
       },
       {
         "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-context.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "resume",
         "hooks": [
           {
             "type": "command",

--- a/packages/mcp-server/plugins/automaker/hooks/session-context.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/session-context.sh
@@ -14,6 +14,7 @@ fi
 BACKLOG=0
 IN_PROGRESS=0
 REVIEW=0
+BLOCKED=0
 DONE=0
 TOTAL=0
 
@@ -28,6 +29,7 @@ for dir in "$FEATURES_DIR"/*/; do
     backlog) BACKLOG=$((BACKLOG + 1)) ;;
     in_progress) IN_PROGRESS=$((IN_PROGRESS + 1)) ;;
     review) REVIEW=$((REVIEW + 1)) ;;
+    blocked) BLOCKED=$((BLOCKED + 1)) ;;
     done|verified) DONE=$((DONE + 1)) ;;
   esac
 done
@@ -36,7 +38,7 @@ BRANCH=$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || echo "unkno
 
 echo "## Session Context"
 echo "Project: $PROJECT_ROOT | Branch: $BRANCH"
-echo "Board: ${TOTAL} features — ${BACKLOG} backlog, ${IN_PROGRESS} in-progress, ${REVIEW} review, ${DONE} done"
+echo "Board: ${TOTAL} features — ${BACKLOG} backlog, ${IN_PROGRESS} in-progress, ${REVIEW} review, ${BLOCKED} blocked, ${DONE} done"
 
 if [ "$IN_PROGRESS" -gt 0 ] || [ "$REVIEW" -gt 0 ]; then
   echo "Active work detected — check agents and PRs."


### PR DESCRIPTION
## Summary
- **145 broken MCP tool references** fixed across 15 skill files — `mcp__automaker__*` → `mcp__plugin_automaker_automaker__*` and `mcp__discord__*` → `mcp__plugin_automaker_discord__*`
- **Session-context hook** now fires on `compact` and `resume` events (not just `startup`), and counts blocked features
- **Safety guard** catches additional dangerous patterns: `find / -delete`, `rm --no-preserve-root`, `git checkout -- .`
- **Plugin update reminder** now visible to Claude (stdout instead of stderr), distinguishes hook changes requiring reinstall

## Context
These are Phase 1 fixes from a comprehensive self-audit of Ava's toolset and autonomous capabilities. The namespace rot was causing silent skill failures since the plugin consolidation — every `/board`, `/groom`, `/auto-mode`, `/orchestrate`, `/context`, `/pr-review` invocation was referencing tools that don't exist.

## Test plan
- [ ] Invoke `/board` and verify MCP tools resolve correctly
- [ ] Invoke `/groom` and verify features are listed
- [ ] Test compaction — verify board state is injected post-compact
- [ ] Test `find / -delete` is blocked by safety guard
- [ ] Edit a plugin file and verify the update reminder appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Automaker documentation to use the new plugin-scoped command names throughout.

* **Bug Fixes**
  * Added guards to block dangerous shell operations and improved plugin modification notices (including reinstall guidance).

* **New Features**
  * Session improvements: added startup/resume hooks and visible "blocked" feature status in session board output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->