### PR TITLE
feat: PreCompact and SessionEnd hooks with state persistence

### DIFF
--- a/packages/mcp-server/plugins/automaker/hooks/hooks.json
+++ b/packages/mcp-server/plugins/automaker/hooks/hooks.json
@@ -8,11 +8,24 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/compaction-prime-directive.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-context.sh\""
           }
         ]
       },
       {
         "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-context.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "resume",
         "hooks": [
           {
             "type": "command",
@@ -49,6 +62,26 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/continue-work.sh\""
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact-save-state.sh\""
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-end-save.sh\""
           }
         ]
       }

--- a/packages/mcp-server/plugins/automaker/hooks/pre-compact-save-state.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/pre-compact-save-state.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Hook: pre-compact-save-state.sh
+# Event: PreCompact
+# Purpose: Save board state, current task, and PR pipeline before compaction
+# to preserve operational context across context window compression.
+# Reads directly from feature.json files on disk (no MCP access in hooks).
+
+set -euo pipefail
+
+PROJECT_ROOT="${AUTOMAKER_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+FEATURES_DIR="$PROJECT_ROOT/.automaker/features"
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DATA_DIR="${PLUGIN_DIR}/data"
+STATE_FILE="${DATA_DIR}/ava-session-state.json"
+
+mkdir -p "$DATA_DIR"
+
+if [ ! -d "$FEATURES_DIR" ]; then
+  exit 0
+fi
+
+# Count features by status
+BACKLOG=0; IN_PROGRESS=0; REVIEW=0; DONE=0; BLOCKED=0; TOTAL=0
+IN_PROGRESS_TITLES=""
+REVIEW_TITLES=""
+
+for dir in "$FEATURES_DIR"/*/; do
+  [ -d "$dir" ] || continue
+  feature_file="$dir/feature.json"
+  [ -f "$feature_file" ] || continue
+
+  TOTAL=$((TOTAL + 1))
+  status=$(jq -r '.status // empty' "$feature_file" 2>/dev/null)
+  title=$(jq -r '.title // "untitled"' "$feature_file" 2>/dev/null)
+  case "$status" in
+    backlog) BACKLOG=$((BACKLOG + 1)) ;;
+    in_progress)
+      IN_PROGRESS=$((IN_PROGRESS + 1))
+      IN_PROGRESS_TITLES="${IN_PROGRESS_TITLES}$(jq -c '{id: .id, title: .title}' "$feature_file" 2>/dev/null),"
+      ;;
+    review)
+      REVIEW=$((REVIEW + 1))
+      REVIEW_TITLES="${REVIEW_TITLES}$(jq -c '{id: .id, title: .title}' "$feature_file" 2>/dev/null),"
+      ;;
+    done|verified) DONE=$((DONE + 1)) ;;
+    blocked) BLOCKED=$((BLOCKED + 1)) ;;
+  esac
+done
+
+# Clean trailing commas and wrap in arrays
+IN_PROGRESS_TITLES="[${IN_PROGRESS_TITLES%,}]"
+REVIEW_TITLES="[${REVIEW_TITLES%,}]"
+
+BRANCH=$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || echo "unknown")
+
+# Count open PRs via gh if available
+PR_COUNT=0
+PR_LIST="[]"
+if command -v gh &>/dev/null; then
+  PR_LIST=$(gh pr list --state open --json number,title --limit 10 2>/dev/null || echo "[]")
+  PR_COUNT=$(echo "$PR_LIST" | jq 'length' 2>/dev/null || echo 0)
+fi
+
+cat > "$STATE_FILE" <<EOJSON
+{
+  "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "event": "PreCompact",
+  "branch": "$BRANCH",
+  "board": {
+    "total": $TOTAL,
+    "backlog": $BACKLOG,
+    "in_progress": $IN_PROGRESS,
+    "review": $REVIEW,
+    "done": $DONE,
+    "blocked": $BLOCKED
+  },
+  "currentWork": $IN_PROGRESS_TITLES,
+  "inReview": $REVIEW_TITLES,
+  "prPipeline": {
+    "count": $PR_COUNT,
+    "prs": $PR_LIST
+  }
+}
+EOJSON
+
+echo "Session state saved before compaction: ${TOTAL} features (${BACKLOG} backlog, ${IN_PROGRESS} active, ${REVIEW} review, ${BLOCKED} blocked)"

--- a/packages/mcp-server/plugins/automaker/hooks/session-context.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/session-context.sh
@@ -6,6 +6,10 @@
 PROJECT_ROOT="${AUTOMAKER_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}"
 FEATURES_DIR="$PROJECT_ROOT/.automaker/features"
 
+# Get the plugin directory to access saved state
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE_FILE="${PLUGIN_DIR}/data/ava-session-state.json"
+
 if [ ! -d "$FEATURES_DIR" ]; then
   exit 0
 fi
@@ -15,6 +19,7 @@ BACKLOG=0
 IN_PROGRESS=0
 REVIEW=0
 DONE=0
+BLOCKED=0
 TOTAL=0
 
 for dir in "$FEATURES_DIR"/*/; do
@@ -29,6 +34,7 @@ for dir in "$FEATURES_DIR"/*/; do
     in_progress) IN_PROGRESS=$((IN_PROGRESS + 1)) ;;
     review) REVIEW=$((REVIEW + 1)) ;;
     done|verified) DONE=$((DONE + 1)) ;;
+    blocked) BLOCKED=$((BLOCKED + 1)) ;;
   esac
 done
 
@@ -36,10 +42,48 @@ BRANCH=$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || echo "unkno
 
 echo "## Session Context"
 echo "Project: $PROJECT_ROOT | Branch: $BRANCH"
-echo "Board: ${TOTAL} features — ${BACKLOG} backlog, ${IN_PROGRESS} in-progress, ${REVIEW} review, ${DONE} done"
+echo "Board: ${TOTAL} features — ${BACKLOG} backlog, ${IN_PROGRESS} in-progress, ${REVIEW} review, ${BLOCKED} blocked, ${DONE} done"
 
 if [ "$IN_PROGRESS" -gt 0 ] || [ "$REVIEW" -gt 0 ]; then
   echo "Active work detected — check agents and PRs."
+fi
+
+# Inject saved state from pre-compact hook if available
+if [ -f "$STATE_FILE" ]; then
+  SAVED_TS=$(jq -r '.timestamp // "unknown"' "$STATE_FILE" 2>/dev/null)
+  CURRENT_WORK=$(jq -r '.currentWork // "[]"' "$STATE_FILE" 2>/dev/null)
+  CURRENT_TASK=$(jq -r '.currentTask // "null"' "$STATE_FILE" 2>/dev/null)
+  IN_REVIEW=$(jq -r '.inReview // "[]"' "$STATE_FILE" 2>/dev/null)
+  PR_COUNT=$(jq -r '.prPipeline.count // 0' "$STATE_FILE" 2>/dev/null)
+  PR_TITLES=$(jq -r '[.prPipeline.prs[]? | "#\(.number) \(.title)"] | join(", ")' "$STATE_FILE" 2>/dev/null)
+
+  WORK_COUNT=$(echo "$CURRENT_WORK" | jq 'length' 2>/dev/null || echo 0)
+  REVIEW_COUNT=$(echo "$IN_REVIEW" | jq 'length' 2>/dev/null || echo 0)
+  HAS_TASK=$([ "$CURRENT_TASK" != "null" ] && [ "$CURRENT_TASK" != "[]" ] && echo 1 || echo 0)
+
+  if [ "$WORK_COUNT" -gt 0 ] || [ "$REVIEW_COUNT" -gt 0 ] || [ "$PR_COUNT" -gt 0 ] || [ "$HAS_TASK" -eq 1 ]; then
+    echo ""
+    echo "## Restored State (pre-compaction: $SAVED_TS)"
+    if [ "$WORK_COUNT" -gt 0 ]; then
+      WORK_TITLES=$(echo "$CURRENT_WORK" | jq -r '[.[].title] | join(", ")' 2>/dev/null)
+      echo "Was working on: $WORK_TITLES"
+    fi
+    if [ "$HAS_TASK" -eq 1 ]; then
+      TASK_FEATURE=$(echo "$CURRENT_TASK" | jq -r '.feature // empty' 2>/dev/null)
+      TASK_DESC=$(echo "$CURRENT_TASK" | jq -r '.description // empty' 2>/dev/null)
+      if [ -n "$TASK_FEATURE" ]; then
+        echo "Current task: $TASK_FEATURE"
+        [ -n "$TASK_DESC" ] && echo "  Description: $TASK_DESC"
+      fi
+    fi
+    if [ "$REVIEW_COUNT" -gt 0 ]; then
+      REV_TITLES=$(echo "$IN_REVIEW" | jq -r '[.[].title] | join(", ")' 2>/dev/null)
+      echo "In review: $REV_TITLES"
+    fi
+    if [ "$PR_COUNT" -gt 0 ] && [ -n "$PR_TITLES" ]; then
+      echo "Open PRs: $PR_TITLES"
+    fi
+  fi
 fi
 
 exit 0

--- a/packages/mcp-server/plugins/automaker/hooks/session-end-save.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/session-end-save.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Hook: session-end-save.sh
+# Event: SessionEnd
+# Purpose: Persist session summary when a session ends.
+# Appends to JSONL log with board state snapshot for continuity tracking.
+
+set -euo pipefail
+
+PROJECT_ROOT="${AUTOMAKER_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+FEATURES_DIR="$PROJECT_ROOT/.automaker/features"
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DATA_DIR="${PLUGIN_DIR}/data"
+STATE_FILE="${DATA_DIR}/ava-session-state.json"
+SESSION_LOG="${DATA_DIR}/session-history.jsonl"
+
+mkdir -p "$DATA_DIR"
+
+# Quick board count
+BACKLOG=0; IN_PROGRESS=0; REVIEW=0; DONE=0; TOTAL=0
+if [ -d "$FEATURES_DIR" ]; then
+  for dir in "$FEATURES_DIR"/*/; do
+    [ -d "$dir" ] || continue
+    feature_file="$dir/feature.json"
+    [ -f "$feature_file" ] || continue
+    TOTAL=$((TOTAL + 1))
+    status=$(jq -r '.status // empty' "$feature_file" 2>/dev/null)
+    case "$status" in
+      backlog) BACKLOG=$((BACKLOG + 1)) ;;
+      in_progress) IN_PROGRESS=$((IN_PROGRESS + 1)) ;;
+      review) REVIEW=$((REVIEW + 1)) ;;
+      done|verified) DONE=$((DONE + 1)) ;;
+    esac
+  done
+fi
+
+BRANCH=$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || echo "unknown")
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+# Write to main state file (overwrite, for reading on next session start)
+cat > "$STATE_FILE" <<EOF
+{
+  "timestamp": "$TIMESTAMP",
+  "event": "SessionEnd",
+  "branch": "$BRANCH",
+  "sessionSummary": "Session completed. Board: ${TOTAL} features (${BACKLOG} backlog, ${IN_PROGRESS} active, ${REVIEW} review, ${DONE} done)",
+  "board": {
+    "total": $TOTAL,
+    "backlog": $BACKLOG,
+    "inProgress": $IN_PROGRESS,
+    "review": $REVIEW,
+    "done": $DONE
+  }
+}
+EOF
+
+# Also append session record to JSONL history (one line per session)
+echo "{\"timestamp\":\"$TIMESTAMP\",\"event\":\"SessionEnd\",\"branch\":\"$BRANCH\",\"board\":{\"total\":$TOTAL,\"backlog\":$BACKLOG,\"in_progress\":$IN_PROGRESS,\"review\":$REVIEW,\"done\":$DONE}}" >> "$SESSION_LOG"
+
+# Keep log from growing unbounded — retain last 100 entries
+if [ -f "$SESSION_LOG" ] && [ "$(wc -l < "$SESSION_LOG")" -gt 100 ]; then
+  tail -100 "$SESSION_LOG" > "${SESSION_LOG}.tmp" && mv "${SESSION_LOG}.tmp" "$SESSION_LOG"
+fi
+
+echo "Session ended. Board: ${TOTAL} features (${BACKLOG} backlog, ${IN_PROGRESS} active, ${REVIEW} review, ${DONE} done)"


### PR DESCRIPTION
## Summary
- **PreCompact hook** saves board state, active features, and PR pipeline to JSON before context compaction wipes memory. Reads feature.json files directly (no MCP access in hooks).
- **SessionEnd hook** captures board snapshot to JSONL history with auto-rotation (100 entries max).
- **session-context.sh** now restores pre-compaction state on startup/compact/resume, including active work titles and PR pipeline.
- **hooks.json** updated with PreCompact, SessionEnd, and resume event matchers.
- Added blocked feature counting to session-context.sh.

## Test plan
- [ ] Verify PreCompact hook creates `data/ava-session-state.json` with correct board counts
- [ ] Verify SessionEnd hook appends to `data/session-history.jsonl`
- [ ] Verify session-context.sh displays restored state after compaction
- [ ] Verify hooks.json registers all events correctly
- [ ] Test that log rotation keeps file under 100 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic session state preservation before context window compression, capturing board status, active work items, and pull request data.
  * Added session state restoration that displays previously saved work context, current tasks, in-review items, and open pull requests.
  * Added session history logging to track board state and work progress across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->