### PR TITLE
fix: increase dev heap to 8GB and make memory thresholds configurable

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "dev": "NODE_OPTIONS='--max-old-space-size=4096' tsx watch --ignore '**/.automaker/**' --ignore '**/.worktrees/**' --ignore 'data/**' --ignore '**/*.log' src/index.ts",
+    "dev": "NODE_OPTIONS='--max-old-space-size=8192' tsx watch --ignore '**/.automaker/**' --ignore '**/.worktrees/**' --ignore 'data/**' --ignore '**/*.log' src/index.ts",
     "dev:test": "tsx src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -443,9 +443,13 @@ export class AutoModeService {
   // Rate-limiting for auto_mode_progress events (per feature)
   private lastProgressEventTime = new Map<string, number>();
   private readonly PROGRESS_EVENT_MIN_INTERVAL_MS = 100; // Max 1 event per 100ms per feature
-  // Memory management thresholds
-  private readonly HEAP_USAGE_STOP_NEW_AGENTS_THRESHOLD = 0.8; // 80%
-  private readonly HEAP_USAGE_ABORT_AGENTS_THRESHOLD = 0.9; // 90%
+  // Memory management thresholds (configurable via env vars)
+  private readonly HEAP_USAGE_STOP_NEW_AGENTS_THRESHOLD = parseFloat(
+    process.env.HEAP_STOP_THRESHOLD || '0.8'
+  ); // Default 80%
+  private readonly HEAP_USAGE_ABORT_AGENTS_THRESHOLD = parseFloat(
+    process.env.HEAP_ABORT_THRESHOLD || '0.9'
+  ); // Default 90%
 
   constructor(events: EventEmitter, settingsService?: SettingsService) {
     this.events = events;


### PR DESCRIPTION
## Summary
- Bumps dev server `--max-old-space-size` from 4096 (4GB) to 8192 (8GB). 4GB was too small for even a single Sonnet agent (~4-5GB per agent), causing immediate 95% heap usage and abort loops.
- Makes memory thresholds configurable via `HEAP_STOP_THRESHOLD` and `HEAP_ABORT_THRESHOLD` env vars (defaults remain 0.8 and 0.9).

## Test plan
- [ ] Restart dev server — verify 8GB heap via `process.memoryUsage()`
- [ ] Run single agent — verify it doesn't hit 80% threshold
- [ ] Optionally set `HEAP_STOP_THRESHOLD=0.7` in `.env` and verify lower threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased default Node.js memory allocation from 4 GB to 8 GB in the development environment.
  * Server heap usage thresholds are now configurable via environment variables, enabling fine-tuning of memory management behavior without code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->