### PR TITLE
feat: add DM types and capability interfaces

### DIFF
--- a/libs/types/src/discord.ts
+++ b/libs/types/src/discord.ts
@@ -72,6 +72,27 @@ export interface DiscordUser {
 }
 
 /**
+ * Discord DM message
+ *
+ * Represents a direct message that can be sent or received by agents.
+ * Agents can send DMs to their assigned human by username lookup.
+ */
+export interface DiscordDMMessage {
+  /** Message ID (if received) */
+  id?: string;
+  /** Username to send to or username of sender */
+  username: string;
+  /** Message content */
+  content: string;
+  /** ISO timestamp when message was sent/received */
+  timestamp: string;
+  /** Direction of the message */
+  direction: 'sent' | 'received';
+  /** Agent role that sent the message (if sent by agent) */
+  agentRole?: string;
+}
+
+/**
  * Options for creating a text channel
  */
 export interface CreateChannelOptions {

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -137,6 +137,9 @@ export type EventType =
   | 'prd:status:updated'
   // Discord monitoring events
   | 'discord:message:detected'
+  // Discord DM events
+  | 'discord:dm:received'
+  | 'discord:dm:sent'
   // Linear monitoring events
   | 'linear:project:updated'
   | 'linear:issue:detected'

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -202,6 +202,7 @@ export type {
   GraphiteSettings,
   // Discord integration types
   DiscordSettings,
+  DiscordUserDMConfig,
   // Ceremony types
   CeremonySettings,
   // Project integration types
@@ -462,6 +463,7 @@ export type {
   DiscordMessage,
   DiscordWebhook,
   DiscordUser,
+  DiscordDMMessage,
   CreateChannelOptions,
   CreateCategoryOptions,
   DiscordSendMessageOptions,

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -451,6 +451,21 @@ export { DEFAULT_WEBHOOK_SETTINGS } from './webhook.js';
 // ============================================================================
 
 /**
+ * DiscordUserDMConfig - Configuration for user-specific Discord DM functionality
+ *
+ * Maps a human user to their Discord username for agent DM capabilities.
+ * Agents can send DMs to their assigned human using this configuration.
+ */
+export interface DiscordUserDMConfig {
+  /** Human's identifier/email/name (used internally) */
+  userId: string;
+  /** Discord username to send DMs to */
+  discordUsername: string;
+  /** Whether this user has opted in to receive DMs from agents */
+  dmEnabled: boolean;
+}
+
+/**
  * DiscordSettings - Configuration for Discord MCP integration
  *
  * Supports Discord bot integration via the discord-mcp server for:
@@ -458,6 +473,7 @@ export { DEFAULT_WEBHOOK_SETTINGS } from './webhook.js';
  * - Announcing feature completion
  * - Headsdown mode status updates
  * - Team communication automation
+ * - Direct messages between agents and their assigned humans
  */
 export interface DiscordSettings {
   /** Whether Discord integration is enabled */
@@ -482,6 +498,8 @@ export interface DiscordSettings {
   notifyOnProjectComplete?: boolean;
   /** Notify on agent errors/failures */
   notifyOnError?: boolean;
+  /** User DM configurations (maps users to Discord usernames) */
+  userDMConfig?: DiscordUserDMConfig[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `DiscordDMMessage` interface for agent-human direct messaging
- Add `discord:dm:received` and `discord:dm:sent` event types
- Add `DiscordUserDMConfig` for opt-in DM settings per user
- Export all new types from `@automaker/types`

## Context
Part of Discord Agent Router project (Phase 3 - DM types and capability interfaces).

## Test plan
- [ ] Types compile with `npm run build:packages`
- [ ] No breaking changes to existing Discord types
- [ ] New exports accessible from `@automaker/types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced Discord direct messaging functionality with support for message tracking, event types for sent and received messages, and configuration for managing which users can receive direct messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->