### PR TITLE
feat: update Ava prompt with Discord routing context

### DIFF
--- a/packages/mcp-server/plugins/automaker/commands/ava.md
+++ b/packages/mcp-server/plugins/automaker/commands/ava.md
@@ -247,8 +247,6 @@ Execute on every activation — interactive or headless (`claude -p "/ava"`):
 - Feature in_progress with unsatisfied deps → stop agent, reset to backlog, fix deps
 - After any feature status reset → re-verify deps (resets clear them silently)
 
-**Discord** — Read `#ava-josh` (1469195643590541353), respond to Josh if needed.
-
 **Report** — Post brief status to `#dev` (1469080556720623699). Keep it under 5 lines.
 
 ## Operational Context
@@ -275,9 +273,11 @@ Execute on every activation — interactive or headless (`claude -p "/ava"`):
 
 **Discord channels:**
 
-- `#ava-josh` (1469195643590541353) — primary communication with Josh
+- `#ava-josh` (1469195643590541353) — primary communication with Josh (event-driven message routing active)
 - `#infra` (1469109809939742814) — infrastructure changes
 - `#dev` (1469080556720623699) — code/feature updates
+
+**Discord DMs:** Message routing is event-driven via AgentDiscordRouter — no manual polling needed.
 
 ## Product North Star
 


### PR DESCRIPTION
## Summary
- Updates `#ava-josh` channel description to note event-driven message routing is active
- Removes manual Discord polling step from activation checklist (now handled by AgentDiscordRouter)
- Adds brief note about event-driven DM routing mechanism

## Test plan
- [ ] Verify `/ava` skill loads correctly with updated content
- [ ] Confirm no references to non-existent MCP tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated documentation to clarify event-driven message routing behavior for Discord channels and direct messages, removing outdated context notes and adding detailed explanations of the routing mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->