### PR TITLE
feat: add ExecutionRecord type for agent execution tracking

### DIFF
--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -50,6 +50,37 @@ export interface StatusTransition {
   reason?: string;
 }
 
+/**
+ * Records a single agent execution on a feature.
+ * Pushed to executionHistory array for each agent run (success or failure).
+ */
+export interface ExecutionRecord {
+  /** Unique identifier for this execution */
+  id: string;
+  /** ISO 8601 timestamp when the agent started */
+  startedAt: string;
+  /** ISO 8601 timestamp when the agent finished (success or failure) */
+  completedAt?: string;
+  /** Duration of the execution in milliseconds */
+  durationMs?: number;
+  /** Total cost in USD for this execution */
+  costUsd?: number;
+  /** Number of input tokens consumed */
+  inputTokens?: number;
+  /** Number of output tokens produced */
+  outputTokens?: number;
+  /** Model used for this execution */
+  model: string;
+  /** Whether the execution completed successfully */
+  success: boolean;
+  /** Error message if the execution failed */
+  error?: string;
+  /** Number of turns the agent took */
+  turnCount?: number;
+  /** What triggered this execution (auto-mode, manual, retry) */
+  trigger: 'auto' | 'manual' | 'retry';
+}
+
 export interface Feature {
   id: string;
   title?: string;
@@ -132,6 +163,11 @@ export interface Feature {
    * Populated from SDK's total_cost_usd in the result message.
    */
   costUsd?: number;
+  /**
+   * History of all agent executions on this feature.
+   * Each record captures timing, cost, tokens, model, and outcome.
+   */
+  executionHistory?: ExecutionRecord[];
   /**
    * Override max turns for this feature's agent execution.
    * If not set, turns are derived from complexity:

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -60,6 +60,7 @@ export type {
   LegacyFeatureStatus,
   DescriptionHistoryEntry,
   StatusTransition,
+  ExecutionRecord,
 } from './feature.js';
 export { normalizeFeatureStatus } from './feature.js';
 


### PR DESCRIPTION
## Summary
- Adds `ExecutionRecord` interface to `@automaker/types` for tracking individual agent executions
- Each record captures: timing (startedAt, completedAt, durationMs), cost (costUsd), tokens (input/output), model, success/failure, turn count, and trigger type
- Adds `executionHistory?: ExecutionRecord[]` field to the `Feature` interface
- Exports `ExecutionRecord` from the package barrel

Part of Agent Metrics & Forecasting project (M2P1 - Add ExecutionRecord type).

## Test plan
- [x] `npm run build:packages` passes — all packages compile cleanly
- [ ] CI build + test checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking agent execution history with comprehensive metrics including execution timing, cost analysis, token usage, model information, and execution status/trigger type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->