### PR TITLE
feat: capture ExecutionRecord for agent runs in AutoModeService

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -1456,6 +1456,7 @@ export class AutoModeService {
     // Execution tracking — declared outside try for catch block access
     const executionId = randomUUID();
     const executionStartedAt = new Date().toISOString();
+    let startingCostUsd = 0;
 
     try {
       // Validate that project path is allowed using centralized validation
@@ -1467,6 +1468,9 @@ export class AutoModeService {
       if (!feature) {
         throw new Error(`Feature ${featureId} not found`);
       }
+
+      // Capture starting cost for execution-specific cost tracking
+      startingCostUsd = feature.costUsd ?? 0;
 
       // Update branchName immediately after loading
       tempRunningFeature.branchName = feature.branchName ?? null;
@@ -1775,15 +1779,17 @@ export class AutoModeService {
         const completedAt = new Date().toISOString();
         const durationMs = Date.now() - tempRunningFeature.startTime;
         const currentFeature = await this.featureLoader.get(projectPath, featureId);
+        // Calculate execution-specific cost delta (not cumulative cost)
+        const executionCostUsd = Math.max(0, (currentFeature?.costUsd ?? 0) - startingCostUsd);
         const record: ExecutionRecord = {
           id: executionId,
           startedAt: executionStartedAt,
           completedAt,
           durationMs,
-          costUsd: currentFeature?.costUsd,
+          costUsd: executionCostUsd,
           model,
           success: true,
-          trigger: isAutoMode ? 'auto' : 'manual',
+          trigger: isAutoMode ? (tempRunningFeature.retryCount > 0 ? 'retry' : 'auto') : 'manual',
         };
         const history = currentFeature?.executionHistory ?? [];
         await this.featureLoader.update(projectPath, featureId, {
@@ -1911,12 +1917,14 @@ export class AutoModeService {
           const completedAt = new Date().toISOString();
           const durationMs = Date.now() - tempRunningFeature.startTime;
           const currentFeature = await this.featureLoader.get(projectPath, featureId);
+          // Calculate execution-specific cost delta (not cumulative cost)
+          const executionCostUsd = Math.max(0, (currentFeature?.costUsd ?? 0) - startingCostUsd);
           const record: ExecutionRecord = {
             id: executionId,
             startedAt: executionStartedAt,
             completedAt,
             durationMs,
-            costUsd: currentFeature?.costUsd,
+            costUsd: executionCostUsd,
             model: tempRunningFeature.model || 'unknown',
             success: false,
             error: errorInfo.message,


### PR DESCRIPTION
## Summary
- Wires `ExecutionRecord` into `AutoModeService.executeFeature()` to track every agent run
- Records timing (start, completion, duration), cost, model, success/failure, and trigger type
- Success records captured after feature verified; failure records captured in catch block
- Abort events (user stops) are excluded — they're not real execution attempts
- Records persist to `feature.executionHistory` array in feature.json

Part of Agent Metrics & Forecasting project (M2P2 - Capture execution records in AutoModeService).

## Test plan
- [x] `npm run build:server` compiles cleanly
- [ ] CI build + test checks pass
- [ ] Manual verification: start a feature, check executionHistory in feature.json after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced execution tracking: every run now records a unique execution identifier, start/end timestamps, duration, estimated cost, model used, success status, error details (when applicable), and trigger type (auto, manual, retry).
  * Execution records are appended to and persistently stored in each feature’s execution history; aborted executions are intentionally not recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->