### PR TITLE
feat: PR lifecycle timestamps

### DIFF
--- a/apps/server/src/services/authority-agents/em-agent.ts
+++ b/apps/server/src/services/authority-agents/em-agent.ts
@@ -311,10 +311,21 @@ export class EMAuthorityAgent {
           },
         });
 
-        // Update feature status to done
-        await this.featureLoader.update(projectPath, featureId, {
+        // Update feature status to done and set merge timestamps
+        const prMergedAt = new Date().toISOString();
+        const updates: Partial<Feature> = {
           status: 'done',
-        });
+          prMergedAt,
+        };
+
+        // Calculate review duration if prCreatedAt is available
+        if (feature.prCreatedAt) {
+          const createdAt = new Date(feature.prCreatedAt);
+          const mergedAt = new Date(prMergedAt);
+          updates.prReviewDurationMs = mergedAt.getTime() - createdAt.getTime();
+        }
+
+        await this.featureLoader.update(projectPath, featureId, updates);
 
         // Emit event for UI notification
         this.events.emit('feature:pr-merged', {

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -1876,13 +1876,35 @@ export class AutoModeService {
               projectPath,
             });
 
-            // Transition feature to 'review' so the merge webhook can move it to 'done'
+            // Transition feature to 'review' or 'done' based on merge status
             if (gitWorkflowResult.prUrl) {
-              await this.featureLoader.update(projectPath, featureId, {
-                status: 'review',
+              const updates: Record<string, unknown> = {
                 prUrl: gitWorkflowResult.prUrl,
                 prNumber: gitWorkflowResult.prNumber,
-              });
+              };
+
+              // Set PR creation timestamp
+              if (gitWorkflowResult.prCreatedAt) {
+                updates.prCreatedAt = gitWorkflowResult.prCreatedAt;
+              }
+
+              // If PR was auto-merged, set merge timestamp and status to 'done'
+              if (gitWorkflowResult.merged && gitWorkflowResult.prMergedAt) {
+                updates.status = 'done';
+                updates.prMergedAt = gitWorkflowResult.prMergedAt;
+
+                // Calculate review duration if prCreatedAt is available
+                if (gitWorkflowResult.prCreatedAt) {
+                  const createdAt = new Date(gitWorkflowResult.prCreatedAt);
+                  const mergedAt = new Date(gitWorkflowResult.prMergedAt);
+                  updates.prReviewDurationMs = mergedAt.getTime() - createdAt.getTime();
+                }
+              } else {
+                // PR created but not merged - transition to 'review'
+                updates.status = 'review';
+              }
+
+              await this.featureLoader.update(projectPath, featureId, updates);
             }
           }
         } catch (gitError) {
@@ -3048,13 +3070,35 @@ Address the follow-up instructions above. Review the previous work and make the 
               projectPath,
             });
 
-            // Transition feature to 'review' so the merge webhook can move it to 'done'
+            // Transition feature to 'review' or 'done' based on merge status
             if (gitWorkflowResult.prUrl) {
-              await this.featureLoader.update(projectPath, featureId, {
-                status: 'review',
+              const updates: Record<string, unknown> = {
                 prUrl: gitWorkflowResult.prUrl,
                 prNumber: gitWorkflowResult.prNumber,
-              });
+              };
+
+              // Set PR creation timestamp
+              if (gitWorkflowResult.prCreatedAt) {
+                updates.prCreatedAt = gitWorkflowResult.prCreatedAt;
+              }
+
+              // If PR was auto-merged, set merge timestamp and status to 'done'
+              if (gitWorkflowResult.merged && gitWorkflowResult.prMergedAt) {
+                updates.status = 'done';
+                updates.prMergedAt = gitWorkflowResult.prMergedAt;
+
+                // Calculate review duration if prCreatedAt is available
+                if (gitWorkflowResult.prCreatedAt) {
+                  const createdAt = new Date(gitWorkflowResult.prCreatedAt);
+                  const mergedAt = new Date(gitWorkflowResult.prMergedAt);
+                  updates.prReviewDurationMs = mergedAt.getTime() - createdAt.getTime();
+                }
+              } else {
+                // PR created but not merged - transition to 'review'
+                updates.status = 'review';
+              }
+
+              await this.featureLoader.update(projectPath, featureId, updates);
             }
           }
         } catch (gitError) {

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -423,6 +423,7 @@ export class GitWorkflowService {
             if (mergeResult.success) {
               result.merged = true;
               result.mergeCommitSha = mergeResult.mergeCommitSha;
+              result.prMergedAt = new Date().toISOString();
               logger.info(
                 `Successfully merged PR #${result.prNumber}${mergeResult.mergeCommitSha ? ` (commit: ${mergeResult.mergeCommitSha})` : ''}`
               );
@@ -472,26 +473,34 @@ export class GitWorkflowService {
     projectPath: string,
     feature: Feature,
     branchName: string
-  ): Promise<{ prUrl: string | null; prNumber?: number; prAlreadyExisted?: boolean }> {
+  ): Promise<{
+    prUrl: string | null;
+    prNumber?: number;
+    prAlreadyExisted?: boolean;
+    prCreatedAt?: string;
+  }> {
     const title = feature.title || extractTitleFromDescription(feature.description);
     const body = `## Summary\n\n${feature.description.substring(0, 500)}${feature.description.length > 500 ? '...' : ''}\n\n---\n*Created automatically by Automaker*`;
 
     const submitResult = await graphiteService.submit(workDir, title, body);
 
     if (submitResult.success && submitResult.prUrl) {
+      const prCreatedAt = new Date().toISOString();
+
       // Store PR info in metadata
       await updateWorktreePRInfo(projectPath, branchName, {
         number: submitResult.prNumber!,
         url: submitResult.prUrl,
         title,
         state: 'OPEN',
-        createdAt: new Date().toISOString(),
+        createdAt: prCreatedAt,
       });
 
       return {
         prUrl: submitResult.prUrl,
         prNumber: submitResult.prNumber,
         prAlreadyExisted: false, // Graphite submit handles existing PRs internally
+        prCreatedAt,
       };
     }
 
@@ -590,7 +599,12 @@ export class GitWorkflowService {
     feature: Feature,
     branchName: string,
     baseBranch: string
-  ): Promise<{ prUrl: string | null; prNumber?: number; prAlreadyExisted?: boolean }> {
+  ): Promise<{
+    prUrl: string | null;
+    prNumber?: number;
+    prAlreadyExisted?: boolean;
+    prCreatedAt?: string;
+  }> {
     // Check if gh CLI is available
     const ghAvailable = await isGhCliAvailable();
     if (!ghAvailable) {
@@ -692,6 +706,7 @@ export class GitWorkflowService {
 
       // Extract PR number and store metadata
       let prNumber: number | undefined;
+      const prCreatedAt = new Date().toISOString();
       const prMatch = prUrl.match(/\/pull\/(\d+)/);
       if (prMatch) {
         prNumber = parseInt(prMatch[1], 10);
@@ -701,11 +716,11 @@ export class GitWorkflowService {
           url: prUrl,
           title,
           state: 'OPEN',
-          createdAt: new Date().toISOString(),
+          createdAt: prCreatedAt,
         });
       }
 
-      return { prUrl, prNumber, prAlreadyExisted: false };
+      return { prUrl, prNumber, prAlreadyExisted: false, prCreatedAt };
     } catch (error) {
       // Check if error indicates PR already exists
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/apps/server/src/services/reconciliation-service.ts
+++ b/apps/server/src/services/reconciliation-service.ts
@@ -228,9 +228,21 @@ export class ReconciliationService {
 
     logger.info(`Moving feature ${drift.featureId} to 'done' - PR merged`);
 
-    await this.featureLoader.update(drift.projectPath, drift.featureId, {
+    const feature = await this.featureLoader.get(drift.projectPath, drift.featureId);
+    const prMergedAt = new Date().toISOString();
+    const updates: Record<string, unknown> = {
       status: 'done',
-    });
+      prMergedAt,
+    };
+
+    // Calculate review duration if prCreatedAt is available
+    if (feature?.prCreatedAt) {
+      const createdAt = new Date(feature.prCreatedAt);
+      const mergedAt = new Date(prMergedAt);
+      updates.prReviewDurationMs = mergedAt.getTime() - createdAt.getTime();
+    }
+
+    await this.featureLoader.update(drift.projectPath, drift.featureId, updates);
 
     return 'feature-marked-done';
   }

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -254,6 +254,21 @@ export interface Feature {
    */
   beadsTaskId?: string;
   /**
+   * Timestamp when the PR was created (ISO 8601).
+   * Set by git-workflow-service when auto-creating a PR.
+   */
+  prCreatedAt?: string;
+  /**
+   * Timestamp when the PR was merged (ISO 8601).
+   * Set by git-workflow-service after successful merge.
+   */
+  prMergedAt?: string;
+  /**
+   * Duration of PR review in milliseconds.
+   * Computed as: prMergedAt - prCreatedAt
+   */
+  prReviewDurationMs?: number;
+  /**
    * Lifecycle timestamps for tracking feature progression through statuses.
    * All timestamps are ISO 8601 strings.
    */

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -657,6 +657,10 @@ export interface GitWorkflowResult {
   merged?: boolean;
   /** Commit SHA of the merge commit (if merged) */
   mergeCommitSha?: string;
+  /** Timestamp when the PR was created (ISO 8601) */
+  prCreatedAt?: string;
+  /** Timestamp when the PR was merged (ISO 8601) */
+  prMergedAt?: string;
   /** Error message if any step failed (workflow continues best-effort) */
   error?: string;
 }


### PR DESCRIPTION
## Summary

- Adds `prCreatedAt`, `prMergedAt`, and `prReviewDurationMs` fields to the `Feature` interface
- Adds `prCreatedAt` and `prMergedAt` to `GitWorkflowResult` for propagating timestamps
- Sets `prCreatedAt` at PR creation time in both Graphite and gh CLI paths
- Sets `prMergedAt` and computes `prReviewDurationMs` at merge time in auto-mode, reconciliation, and EM agent
- When auto-merge succeeds immediately, transitions feature directly to `done` instead of `review`

## Test plan

- [ ] Create a feature via auto-mode — verify `prCreatedAt` is set when PR is created
- [ ] When PR is merged — verify `prMergedAt` and `prReviewDurationMs` are set
- [ ] Verify build passes with `npm run build:server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic tracking of pull request creation and merge timestamps across workflow services, capturing precise timing data at each PR lifecycle event.
  * Added automatic calculation of pull request review duration metrics, computed as the time elapsed between PR creation and merge completion.
  * Extended feature records and workflow results to persistently store PR lifecycle timestamps and computed review duration metrics for enhanced tracking and analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->