### PR TITLE
feat: add metrics API endpoints

### DIFF
--- a/apps/server/src/routes/metrics/index.ts
+++ b/apps/server/src/routes/metrics/index.ts
@@ -1,0 +1,89 @@
+/**
+ * Metrics routes - HTTP API for project metrics and analytics
+ */
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import type { MetricsService } from '../../services/metrics-service.js';
+import { validatePathParams } from '../../middleware/validate-paths.js';
+
+export function createMetricsRoutes(metricsService: MetricsService): Router {
+  const router = Router();
+
+  /**
+   * POST /summary - Project-level aggregated metrics
+   */
+  router.post(
+    '/summary',
+    validatePathParams('projectPath'),
+    async (req: Request, res: Response) => {
+      try {
+        const { projectPath } = req.body;
+        const metrics = await metricsService.getProjectMetrics(projectPath);
+        res.json({ success: true, ...metrics });
+      } catch (err) {
+        res.status(500).json({ success: false, error: (err as Error).message });
+      }
+    }
+  );
+
+  /**
+   * POST /capacity - Capacity utilization metrics
+   */
+  router.post(
+    '/capacity',
+    validatePathParams('projectPath'),
+    async (req: Request, res: Response) => {
+      try {
+        const { projectPath, maxConcurrency } = req.body;
+        const metrics = await metricsService.getCapacityMetrics(projectPath, maxConcurrency);
+        res.json({ success: true, ...metrics });
+      } catch (err) {
+        res.status(500).json({ success: false, error: (err as Error).message });
+      }
+    }
+  );
+
+  /**
+   * POST /forecast - Estimate duration and cost for a new feature
+   * Uses historical averages scaled by complexity multiplier
+   */
+  router.post(
+    '/forecast',
+    validatePathParams('projectPath'),
+    async (req: Request, res: Response) => {
+      try {
+        const { projectPath, complexity = 'medium' } = req.body;
+
+        const metrics = await metricsService.getProjectMetrics(projectPath);
+
+        // Scale historical averages by complexity
+        const multipliers: Record<string, number> = {
+          small: 0.5,
+          medium: 1.0,
+          large: 1.5,
+          architectural: 2.5,
+        };
+        const multiplier = multipliers[complexity] ?? 1.0;
+
+        // Estimate cost per feature from historical data
+        const avgCostPerFeature =
+          metrics.completedFeatures > 0 ? metrics.totalCostUsd / metrics.completedFeatures : 0;
+
+        res.json({
+          success: true,
+          complexity,
+          estimatedDurationMs: Math.round(metrics.avgCycleTimeMs * multiplier),
+          estimatedAgentTimeMs: Math.round(metrics.avgAgentTimeMs * multiplier),
+          estimatedCostUsd: Number((avgCostPerFeature * multiplier).toFixed(4)),
+          basedOnFeatures: metrics.completedFeatures,
+          multiplier,
+        });
+      } catch (err) {
+        res.status(500).json({ success: false, error: (err as Error).message });
+      }
+    }
+  );
+
+  return router;
+}


### PR DESCRIPTION
## Summary
- Add metrics route module with 3 POST endpoints (`/summary`, `/capacity`, `/forecast`)
- Routes delegate to MetricsService (from PR #217)
- Forecast endpoint estimates duration/cost by scaling historical averages with complexity multiplier
- Does NOT wire into server index.ts (separate feature)

## Test plan
- [ ] Build passes (`npm run build:server`)
- [ ] Format check passes
- [ ] Endpoints accept `{ projectPath }` body params
- [ ] Forecast returns scaled estimates based on complexity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project summary metrics endpoint to retrieve project statistics
  * Added capacity metrics endpoint to analyze resource utilization
  * Added forecasting endpoint with complexity-based cost estimation for feature development

<!-- end of auto-generated comment: release notes by coderabbit.ai -->