### PR TITLE
fix: reduce MCP tool context window consumption

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -185,6 +185,11 @@ const tools: Tool[] = [
           type: 'string',
           description: 'The feature ID (UUID)',
         },
+        includeHistory: {
+          type: 'boolean',
+          description:
+            'Include full executionHistory, descriptionHistory, statusHistory, and planSpec (default: false to save context)',
+        },
       },
       required: ['projectPath', 'featureId'],
     },
@@ -467,6 +472,11 @@ const tools: Tool[] = [
         featureId: {
           type: 'string',
           description: 'The feature ID',
+        },
+        maxLines: {
+          type: 'number',
+          description:
+            'Maximum lines to return (default: 200). Use -1 for unlimited. Returns the last N lines.',
         },
       },
       required: ['projectPath', 'featureId'],
@@ -1560,11 +1570,29 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         compact: true, // Use compact mode to reduce response size
       });
 
-    case 'get_feature':
-      return apiCall('/features/get', {
+    case 'get_feature': {
+      const featureResult = (await apiCall('/features/get', {
         projectPath: args.projectPath,
         featureId: args.featureId,
-      });
+      })) as { success?: boolean; feature?: Record<string, unknown> };
+      // Strip heavy history fields to reduce context usage unless explicitly requested
+      if (featureResult.feature && !args.includeHistory) {
+        const f = featureResult.feature;
+        const execHistory = f.executionHistory as unknown[] | undefined;
+        const descHistory = f.descriptionHistory as unknown[] | undefined;
+        if (execHistory?.length) {
+          f.executionCount = execHistory.length;
+          delete f.executionHistory;
+        }
+        if (descHistory?.length) {
+          f.descriptionRevisions = descHistory.length;
+          delete f.descriptionHistory;
+        }
+        delete f.statusHistory;
+        delete f.planSpec;
+      }
+      return featureResult;
+    }
 
     case 'create_feature': {
       const featureData: Record<string, unknown> = {
@@ -1647,11 +1675,25 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
     case 'list_running_agents':
       return apiCall('/running-agents', {}, 'GET');
 
-    case 'get_agent_output':
-      return apiCall('/features/agent-output', {
+    case 'get_agent_output': {
+      const agentOutput = (await apiCall('/features/agent-output', {
         projectPath: args.projectPath,
         featureId: args.featureId,
-      });
+      })) as { success?: boolean; content?: string };
+      // Truncate to last N lines to prevent context window bloat
+      const maxLines = (args.maxLines as number) ?? 200;
+      if (agentOutput.content && maxLines > 0) {
+        const lines = agentOutput.content.split('\n');
+        if (lines.length > maxLines) {
+          agentOutput.content = [
+            `[Truncated: showing last ${maxLines} of ${lines.length} lines. Use maxLines: -1 for full output]`,
+            '',
+            ...lines.slice(-maxLines),
+          ].join('\n');
+        }
+      }
+      return agentOutput;
+    }
 
     case 'send_message_to_agent':
       return apiCall('/auto-mode/follow-up-feature', {


### PR DESCRIPTION
## Summary
- **`get_agent_output`**: Truncate to last 200 lines by default (was unlimited, 60KB+ responses). New `maxLines` param; use `-1` for full output.
- **`get_feature`**: Strip `executionHistory`, `descriptionHistory`, `statusHistory`, `planSpec` by default (replaced with `executionCount`/`descriptionRevisions` counts). New `includeHistory` param for full data.

## Context
Research from Ofer's question about MCP context window management.

## Test plan
- [ ] Build passes
- [ ] Truncation and history stripping work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature retrieval now supports `includeHistory` parameter to exclude heavy history fields, reducing payload size.
  * Agent output retrieval now supports `maxLines` parameter to limit returned output lines (default 200).
  * When history is excluded, execution and revision counts are provided instead of full history data.
  * Truncation notifications added for limited output results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->