### PR TITLE
feat: add MCP tools for project metrics

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1519,6 +1519,62 @@ const tools: Tool[] = [
       required: ['projectPath'],
     },
   },
+  // ========== Metrics ==========
+  {
+    name: 'get_project_metrics',
+    description:
+      'Get aggregated project metrics including cycle time, cost, throughput, success rate, and token usage.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+  {
+    name: 'get_capacity_metrics',
+    description:
+      'Get capacity utilization metrics including concurrency, backlog size, and estimated backlog clearance time.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        maxConcurrency: {
+          type: 'number',
+          description: 'Maximum concurrent features for utilization calculation (default: 3)',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+  {
+    name: 'get_forecast',
+    description:
+      'Estimate duration and cost for a new feature based on historical averages scaled by complexity.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        complexity: {
+          type: 'string',
+          enum: ['small', 'medium', 'large', 'architectural'],
+          description: 'Feature complexity level for forecast scaling (default: medium)',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+
   {
     name: 'start_goap_loop',
     description:
@@ -2098,6 +2154,24 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
     case 'list_notifications':
       return apiCall('/notifications/list', {
         projectPath: args.projectPath,
+      });
+
+    // Metrics
+    case 'get_project_metrics':
+      return apiCall('/metrics/summary', {
+        projectPath: args.projectPath,
+      });
+
+    case 'get_capacity_metrics':
+      return apiCall('/metrics/capacity', {
+        projectPath: args.projectPath,
+        maxConcurrency: args.maxConcurrency,
+      });
+
+    case 'get_forecast':
+      return apiCall('/metrics/forecast', {
+        projectPath: args.projectPath,
+        complexity: args.complexity || 'medium',
       });
 
     case 'start_goap_loop':


### PR DESCRIPTION
## Summary
- Adds 3 new MCP tools: `get_project_metrics`, `get_capacity_metrics`, `get_forecast`
- Tools delegate to the metrics API endpoints added in PR #218
- Enables Ava to query project analytics (cycle time, cost, throughput, capacity, forecasting) programmatically

## Test plan
- [ ] Verify `get_project_metrics` returns aggregated project metrics
- [ ] Verify `get_capacity_metrics` returns capacity utilization data
- [ ] Verify `get_forecast` returns duration/cost estimates by complexity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project metrics summary tool providing comprehensive insights into overall project performance, health, and current status throughout the development lifecycle.
  * Added capacity metrics analysis tool with customizable concurrency limits for improved resource planning and team optimization.
  * Added forecasting tool featuring multiple complexity levels (small, medium, large, architectural) enabling tailored predictions and detailed scenario planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->