### PR TITLE
feat: extend handleMessage with user message routing

### DIFF
--- a/apps/server/src/services/discord-bot-service.ts
+++ b/apps/server/src/services/discord-bot-service.ts
@@ -1006,6 +1006,7 @@ export class DiscordBotService {
           // Emit routed message event
           this.events.emit('discord:user-message:routed', {
             projectPath: this.projectPath,
+            userId,
             username: message.author.username,
             agentId,
             messages,
@@ -1013,10 +1014,13 @@ export class DiscordBotService {
           });
 
           logger.info(
-            `Routed ${messages.length} message(s) from ${message.author.username} to agent ${agentId}`
+            `Routed ${messages.length} message(s) from ${userId} (${message.author.username}) to agent ${agentId}`
           );
         } catch (error) {
-          logger.error(`Failed to route buffered messages for ${message.author.username}:`, error);
+          logger.error(
+            `Failed to route buffered messages for ${userId} (${message.author.username}):`,
+            error
+          );
         }
       })();
     }, 3000);


### PR DESCRIPTION
## Summary

- Adds user message routing to `DiscordBotService.handleMessage()` as a fallback after existing handlers (agent commands, authority agents)
- Implements 3-second debounce buffer that batches rapid-fire messages before routing to assigned agents
- Emits `discord:user-message:routed` events with full message content, attachments, and metadata
- Adds `userRouting` map for per-user agent assignments and `messageBuffer` for debounce state

## Test plan

- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Verify prettier formatting passes
- [ ] Verify existing Discord bot functionality (agent commands, authority agent routing) is unaffected
- [ ] Verify messages from users with routing enabled are buffered and emitted after 3s debounce
- [ ] Verify messages from users without routing fall through to default behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user routing to designated AI agents with configurable assignment and enable/disable.
  * Debounced message batching (~3s) to group rapid user inputs for more efficient processing.
  * Aggregated handling of attachments and text, delivering batched payloads to assigned agents.
  * Routed-messages flow integrated into the existing message handling pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->