### PR TITLE
fix: correct Stop hook JSON schema

### DIFF
--- a/packages/mcp-server/plugins/automaker/hooks/continue-work.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/continue-work.sh
@@ -48,13 +48,13 @@ TOTAL=$((BACKLOG + IN_PROGRESS + REVIEW))
 # Check for escalation case: all remaining features are blocked
 if [ "$TOTAL" -eq 0 ] && [ "$BLOCKED" -gt 0 ]; then
   jq -n --arg reason "All $BLOCKED remaining features are blocked. Manual intervention required for dependency resolution or unblocking." \
-    '{hookSpecificOutput: {decision: "block", reason: $reason}}'
+    '{decision: "block", reason: $reason}'
   exit 0
 fi
 
 if [ "$TOTAL" -gt 0 ]; then
   jq -n --arg reason "Board has active work: ${BACKLOG} backlog, ${IN_PROGRESS} in-progress, ${REVIEW} in review. Continue processing." \
-    '{hookSpecificOutput: {decision: "block", reason: $reason}}'
+    '{decision: "block", reason: $reason}'
   exit 0
 fi
 
@@ -86,5 +86,5 @@ EOF
 )
 
 jq -n --arg reason "$IDLE_TASKS" \
-  '{hookSpecificOutput: {decision: "block", reason: $reason}}'
+  '{decision: "block", reason: $reason}'
 exit 0


### PR DESCRIPTION
## Summary
- Moves `decision` and `reason` fields from nested `hookSpecificOutput` to root level in Stop hook JSON output
- `hookSpecificOutput` wrapper is only valid for PreToolUse/PostToolUse/UserPromptSubmit hooks
- Fixes JSON validation error on every stop cycle: "Invalid input"

## Test plan
- [ ] Verify stop hook no longer throws JSON validation errors
- [ ] Verify board-clear idle cycle triggers correctly
- [ ] Verify active-work continuation triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal output structure formatting to improve code maintainability. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->