### PR TITLE
fix: include MCP server in build:packages script

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev:docker:rebuild": "docker compose build --no-cache && docker compose up",
     "dev:full": "npm run build:packages && concurrently \"npm run _dev:server\" \"npm run _dev:web\"",
     "build": "npm run build:packages && npm run build --workspace=apps/ui",
-    "build:packages": "npm run build -w @automaker/types && npm run build -w @automaker/platform && npm run build -w @automaker/utils -w @automaker/spec-parser && npm run build -w @automaker/prompts -w @automaker/model-resolver -w @automaker/dependency-resolver -w @automaker/policy-engine && npm run build -w @automaker/git-utils",
+    "build:packages": "npm run build -w @automaker/types && npm run build -w @automaker/platform && npm run build -w @automaker/utils -w @automaker/spec-parser && npm run build -w @automaker/prompts -w @automaker/model-resolver -w @automaker/dependency-resolver -w @automaker/policy-engine && npm run build -w @automaker/git-utils && tsc --project packages/mcp-server/tsconfig.json",
     "build:server": "npm run build:packages && npm run build --workspace=apps/server",
     "build:electron": "npm run build:packages && npm run build:electron --workspace=apps/ui",
     "build:electron:dir": "npm run build:packages && npm run build:electron:dir --workspace=apps/ui",


### PR DESCRIPTION
## Summary
- `@automaker/mcp-server` lives in `packages/` not `libs/`, so it's not an npm workspace member
- `build:packages` never built it — new MCP tools existed in source but not in `dist/`, making them invisible to Claude Code plugins
- Appends `tsc --project packages/mcp-server/tsconfig.json` to the end of the `build:packages` script

## Test plan
- [ ] Run `npm run build:packages` and verify `packages/mcp-server/dist/index.js` contains recent tools (e.g. `send_discord_dm`)
- [ ] Reinstall plugin and verify new tools appear in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to include TypeScript compilation as part of the package build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->