### PR TITLE
feat: add Linear MCP server to plugin

### DIFF
--- a/packages/mcp-server/plugins/automaker/.claude-plugin/plugin.json
+++ b/packages/mcp-server/plugins/automaker/.claude-plugin/plugin.json
@@ -22,6 +22,13 @@
       "env": {
         "DISCORD_BOT_TOKEN": "${DISCORD_BOT_TOKEN}"
       }
+    },
+    "linear": {
+      "command": "npx",
+      "args": ["-y", "linear-mcp-server"],
+      "env": {
+        "LINEAR_API_KEY": "${LINEAR_API_KEY}"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `linear-mcp-server` to plugin's `mcpServers` config
- All protoLab environments now get Linear tools alongside Discord and Automaker MCP
- Uses `LINEAR_API_KEY` env var from plugin `.env`
- Enables searching, creating, and updating Linear issues/comments from Claude Code

Part of the Multi-Agent GTM System project (M1: Foundation).

## Test plan
- [ ] Plugin reinstall picks up Linear MCP server
- [ ] `linear_search_issues` tool available in Claude Code session
- [ ] Can create and comment on Linear issues via MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linear integration to the automaker Claude plugin, enabling users to authenticate and access Linear workspace functionality with API key authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->