### PR TITLE
feat: add gtm-specialist role and capabilities

### DIFF
--- a/libs/types/src/agent-roles.ts
+++ b/libs/types/src/agent-roles.ts
@@ -23,7 +23,8 @@ export type AgentRole =
   | 'backend-engineer'
   | 'devops-engineer'
   | 'qa-engineer'
-  | 'docs-engineer';
+  | 'docs-engineer'
+  | 'gtm-specialist';
 
 /**
  * Agent task types
@@ -303,5 +304,16 @@ export const ROLE_CAPABILITIES: Record<AgentRole, RoleCapabilities> = {
     canCommit: true,
     canCreatePRs: true,
     description: 'Update documentation, generate changelogs, maintain project docs',
+  },
+  'gtm-specialist': {
+    role: 'gtm-specialist',
+    tools: ['Read', 'Grep', 'Glob', 'WebSearch', 'WebFetch', 'Write', 'Edit'],
+    maxTurns: 250,
+    canUseBash: false,
+    canModifyFiles: true,
+    canCommit: false,
+    canCreatePRs: false,
+    description:
+      'Content strategy, marketing, competitive research, brand positioning, social media coordination',
   },
 };

--- a/libs/types/src/headsdown.ts
+++ b/libs/types/src/headsdown.ts
@@ -158,6 +158,20 @@ export const DEFAULT_HEADSDOWN_CONFIGS: Record<AgentRole, Partial<HeadsdownConfi
       tasks: ['update_docs', 'update_changelog'],
     },
   },
+  'gtm-specialist': {
+    model: 'sonnet',
+    maxTurns: 250,
+    loop: {
+      enabled: true,
+      checkInterval: 30000,
+      maxConsecutiveErrors: 5,
+      workTimeout: 7200000,
+    },
+    idleTasks: {
+      enabled: false,
+      tasks: [],
+    },
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary
- Adds `gtm-specialist` to `AgentRole` union type
- Adds `ROLE_CAPABILITIES` entry: Read, Grep, Glob, WebSearch, WebFetch, Write, Edit (no Bash, no commits, no PRs)
- Adds `DEFAULT_HEADSDOWN_CONFIGS` entry: sonnet model, 250 max turns, 2hr timeout

Part of Multi-Agent GTM System project (M1 Phase 2).

## Test plan
- [ ] `npm run build:packages` succeeds
- [ ] `ROLE_CAPABILITIES['gtm-specialist']` has correct tools
- [ ] `DEFAULT_HEADSDOWN_CONFIGS['gtm-specialist']` has correct model/turns
- [ ] No TypeScript errors in dependent packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the GTM Specialist agent role with associated capabilities and default configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->