### PR TITLE
fix: increase dev server heap to 16GB

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "dev": "NODE_OPTIONS='--max-old-space-size=8192' tsx watch --ignore '**/.automaker/**' --ignore '**/.worktrees/**' --ignore 'data/**' --ignore '**/*.log' src/index.ts",
+    "dev": "NODE_OPTIONS='--max-old-space-size=16384' tsx watch --ignore '**/.automaker/**' --ignore '**/.worktrees/**' --ignore 'data/**' --ignore '**/*.log' src/index.ts",
     "dev:test": "tsx src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",


### PR DESCRIPTION
## Summary

- Bumps `--max-old-space-size` from 8192 to 16384 in dev script
- 8GB was still marginal — Sonnet agents need ~4-5GB each, and server overhead takes another 2-3GB
- Prevents OOM crashes during agent execution

## Test plan

- [x] One-line change in package.json dev script
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation in the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->