### PR TITLE
feat: extract built-in agent templates to JSON files

### DIFF
--- a/.automaker/templates/built-in/backend-engineer.json
+++ b/.automaker/templates/built-in/backend-engineer.json
@@ -1,0 +1,48 @@
+{
+  "name": "backend-engineer",
+  "displayName": "Backend Engineer",
+  "description": "Implement APIs, services, database logic, backend features",
+  "role": "backend-engineer",
+  "tier": 0,
+  "model": "sonnet",
+  "tools": [
+    "Read",
+    "Write",
+    "Edit",
+    "Glob",
+    "Grep",
+    "Bash"
+  ],
+  "canUseBash": true,
+  "canModifyFiles": true,
+  "canCommit": true,
+  "canCreatePRs": true,
+  "maxTurns": 150,
+  "systemPromptTemplate": "agents/backend-engineer-prompt.ts",
+  "trustLevel": 1,
+  "maxRiskAllowed": "medium",
+  "headsdownConfig": {
+    "model": "sonnet",
+    "maxTurns": 150,
+    "loop": {
+      "enabled": true,
+      "checkInterval": 30000,
+      "maxConsecutiveErrors": 5,
+      "workTimeout": 7200000
+    },
+    "idleTasks": {
+      "enabled": true,
+      "tasks": [
+        "review_prs",
+        "run_cleanup",
+        "check_tests",
+        "update_docs"
+      ]
+    }
+  },
+  "tags": [
+    "built-in",
+    "implementation",
+    "backend"
+  ]
+}

--- a/.automaker/templates/built-in/chief-of-staff.json
+++ b/.automaker/templates/built-in/chief-of-staff.json
@@ -1,0 +1,61 @@
+{
+  "name": "chief-of-staff",
+  "displayName": "Chief of Staff (Ava)",
+  "description": "Operational leadership, project orchestration, team coordination, autonomous decision-making",
+  "role": "chief-of-staff",
+  "tier": 0,
+  "model": "opus",
+  "tools": [
+    "Read",
+    "Write",
+    "Edit",
+    "Glob",
+    "Grep",
+    "Bash",
+    "WebSearch",
+    "WebFetch",
+    "Task"
+  ],
+  "canUseBash": true,
+  "canModifyFiles": true,
+  "canCommit": true,
+  "canCreatePRs": true,
+  "maxTurns": 500,
+  "canSpawnAgents": true,
+  "allowedSubagentRoles": [
+    "product-manager",
+    "engineering-manager",
+    "frontend-engineer",
+    "backend-engineer",
+    "devops-engineer",
+    "qa-engineer",
+    "docs-engineer",
+    "gtm-specialist"
+  ],
+  "trustLevel": 3,
+  "maxRiskAllowed": "high",
+  "headsdownConfig": {
+    "model": "opus",
+    "maxTurns": 500,
+    "loop": {
+      "enabled": true,
+      "checkInterval": 30000,
+      "maxConsecutiveErrors": 10,
+      "workTimeout": 14400000
+    },
+    "idleTasks": {
+      "enabled": true,
+      "tasks": [
+        "review_prs",
+        "run_cleanup",
+        "update_docs",
+        "check_tests"
+      ]
+    }
+  },
+  "tags": [
+    "built-in",
+    "leadership",
+    "autonomous"
+  ]
+}

--- a/.automaker/templates/built-in/devops-engineer.json
+++ b/.automaker/templates/built-in/devops-engineer.json
@@ -1,0 +1,46 @@
+{
+  "name": "devops-engineer",
+  "displayName": "DevOps Engineer",
+  "description": "Setup CI/CD, infrastructure, deployment, build configuration",
+  "role": "devops-engineer",
+  "tier": 0,
+  "model": "sonnet",
+  "tools": [
+    "Read",
+    "Write",
+    "Edit",
+    "Glob",
+    "Grep",
+    "Bash"
+  ],
+  "canUseBash": true,
+  "canModifyFiles": true,
+  "canCommit": true,
+  "canCreatePRs": true,
+  "maxTurns": 150,
+  "systemPromptTemplate": "agents/devops-engineer-prompt.ts",
+  "trustLevel": 1,
+  "maxRiskAllowed": "high",
+  "headsdownConfig": {
+    "model": "sonnet",
+    "maxTurns": 150,
+    "loop": {
+      "enabled": true,
+      "checkInterval": 30000,
+      "maxConsecutiveErrors": 5,
+      "workTimeout": 7200000
+    },
+    "idleTasks": {
+      "enabled": true,
+      "tasks": [
+        "check_tests",
+        "run_cleanup"
+      ]
+    }
+  },
+  "tags": [
+    "built-in",
+    "implementation",
+    "infrastructure"
+  ]
+}

--- a/.automaker/templates/built-in/docs-engineer.json
+++ b/.automaker/templates/built-in/docs-engineer.json
@@ -1,0 +1,44 @@
+{
+  "name": "docs-engineer",
+  "displayName": "Docs Engineer",
+  "description": "Update documentation, generate changelogs, maintain project docs",
+  "role": "docs-engineer",
+  "tier": 0,
+  "model": "haiku",
+  "tools": [
+    "Read",
+    "Write",
+    "Edit",
+    "Glob",
+    "Grep"
+  ],
+  "canUseBash": false,
+  "canModifyFiles": true,
+  "canCommit": true,
+  "canCreatePRs": true,
+  "maxTurns": 50,
+  "systemPromptTemplate": "agents/docs-engineer-prompt.ts",
+  "trustLevel": 1,
+  "maxRiskAllowed": "low",
+  "headsdownConfig": {
+    "model": "haiku",
+    "maxTurns": 50,
+    "loop": {
+      "enabled": true,
+      "checkInterval": 30000,
+      "maxConsecutiveErrors": 5,
+      "workTimeout": 1800000
+    },
+    "idleTasks": {
+      "enabled": true,
+      "tasks": [
+        "update_docs",
+        "update_changelog"
+      ]
+    }
+  },
+  "tags": [
+    "built-in",
+    "documentation"
+  ]
+}

--- a/.automaker/templates/built-in/engineering-manager.json
+++ b/.automaker/templates/built-in/engineering-manager.json
@@ -1,0 +1,49 @@
+{
+  "name": "engineering-manager",
+  "displayName": "Engineering Manager",
+  "description": "Break down projects into features, assign to roles, manage PRs, trigger releases",
+  "role": "engineering-manager",
+  "tier": 0,
+  "model": "sonnet",
+  "tools": [
+    "Read",
+    "Grep",
+    "Glob",
+    "Task"
+  ],
+  "canUseBash": false,
+  "canModifyFiles": false,
+  "canCommit": false,
+  "canCreatePRs": false,
+  "maxTurns": 100,
+  "systemPromptTemplate": "agents/engineering-manager-prompt.ts",
+  "canSpawnAgents": true,
+  "allowedSubagentRoles": [
+    "frontend-engineer",
+    "backend-engineer",
+    "devops-engineer",
+    "qa-engineer",
+    "docs-engineer"
+  ],
+  "trustLevel": 2,
+  "maxRiskAllowed": "medium",
+  "headsdownConfig": {
+    "model": "sonnet",
+    "maxTurns": 100,
+    "loop": {
+      "enabled": true,
+      "checkInterval": 30000,
+      "maxConsecutiveErrors": 5,
+      "workTimeout": 3600000
+    },
+    "idleTasks": {
+      "enabled": false,
+      "tasks": []
+    }
+  },
+  "tags": [
+    "built-in",
+    "leadership",
+    "management"
+  ]
+}

--- a/.automaker/templates/built-in/frontend-engineer.json
+++ b/.automaker/templates/built-in/frontend-engineer.json
@@ -1,0 +1,47 @@
+{
+  "name": "frontend-engineer",
+  "displayName": "Frontend Engineer",
+  "description": "Implement React components, UI/UX features, frontend logic",
+  "role": "frontend-engineer",
+  "tier": 0,
+  "model": "sonnet",
+  "tools": [
+    "Read",
+    "Write",
+    "Edit",
+    "Glob",
+    "Grep"
+  ],
+  "canUseBash": false,
+  "canModifyFiles": true,
+  "canCommit": true,
+  "canCreatePRs": true,
+  "maxTurns": 150,
+  "systemPromptTemplate": "agents/frontend-engineer-prompt.ts",
+  "trustLevel": 1,
+  "maxRiskAllowed": "medium",
+  "headsdownConfig": {
+    "model": "sonnet",
+    "maxTurns": 150,
+    "loop": {
+      "enabled": true,
+      "checkInterval": 30000,
+      "maxConsecutiveErrors": 5,
+      "workTimeout": 7200000
+    },
+    "idleTasks": {
+      "enabled": true,
+      "tasks": [
+        "review_prs",
+        "update_docs",
+        "run_cleanup",
+        "check_tests"
+      ]
+    }
+  },
+  "tags": [
+    "built-in",
+    "implementation",
+    "frontend"
+  ]
+}

--- a/.automaker/templates/built-in/gtm-specialist.json
+++ b/.automaker/templates/built-in/gtm-specialist.json
@@ -1,0 +1,44 @@
+{
+  "name": "gtm-specialist",
+  "displayName": "GTM Specialist",
+  "description": "Content strategy, marketing, competitive research, brand positioning, social media coordination",
+  "role": "gtm-specialist",
+  "tier": 1,
+  "model": "sonnet",
+  "tools": [
+    "Read",
+    "Grep",
+    "Glob",
+    "WebSearch",
+    "WebFetch",
+    "Write",
+    "Edit"
+  ],
+  "canUseBash": false,
+  "canModifyFiles": true,
+  "canCommit": false,
+  "canCreatePRs": false,
+  "maxTurns": 250,
+  "systemPromptTemplate": "agents/gtm-specialist-prompt.ts",
+  "trustLevel": 1,
+  "maxRiskAllowed": "low",
+  "headsdownConfig": {
+    "model": "sonnet",
+    "maxTurns": 250,
+    "loop": {
+      "enabled": true,
+      "checkInterval": 30000,
+      "maxConsecutiveErrors": 5,
+      "workTimeout": 7200000
+    },
+    "idleTasks": {
+      "enabled": false,
+      "tasks": []
+    }
+  },
+  "tags": [
+    "extensible",
+    "marketing",
+    "gtm"
+  ]
+}

--- a/.automaker/templates/built-in/product-manager.json
+++ b/.automaker/templates/built-in/product-manager.json
@@ -1,0 +1,47 @@
+{
+  "name": "product-manager",
+  "displayName": "Product Manager",
+  "description": "Research codebase, engage with users, create SPARC PRDs, create Linear projects",
+  "role": "product-manager",
+  "tier": 0,
+  "model": "opus",
+  "tools": [
+    "Read",
+    "Grep",
+    "Glob",
+    "WebSearch",
+    "WebFetch",
+    "Task"
+  ],
+  "canUseBash": false,
+  "canModifyFiles": false,
+  "canCommit": false,
+  "canCreatePRs": false,
+  "maxTurns": 250,
+  "systemPromptTemplate": "agents/product-manager-prompt.ts",
+  "canSpawnAgents": true,
+  "allowedSubagentRoles": [
+    "engineering-manager"
+  ],
+  "trustLevel": 2,
+  "maxRiskAllowed": "low",
+  "headsdownConfig": {
+    "model": "opus",
+    "maxTurns": 250,
+    "loop": {
+      "enabled": true,
+      "checkInterval": 30000,
+      "maxConsecutiveErrors": 5,
+      "workTimeout": 7200000
+    },
+    "idleTasks": {
+      "enabled": false,
+      "tasks": []
+    }
+  },
+  "tags": [
+    "built-in",
+    "leadership",
+    "planning"
+  ]
+}

--- a/.automaker/templates/built-in/qa-engineer.json
+++ b/.automaker/templates/built-in/qa-engineer.json
@@ -1,0 +1,44 @@
+{
+  "name": "qa-engineer",
+  "displayName": "QA Engineer",
+  "description": "Review PRs, run tests, check quality, provide feedback",
+  "role": "qa-engineer",
+  "tier": 0,
+  "model": "haiku",
+  "tools": [
+    "Read",
+    "Bash",
+    "Grep",
+    "Glob"
+  ],
+  "canUseBash": true,
+  "canModifyFiles": false,
+  "canCommit": false,
+  "canCreatePRs": false,
+  "maxTurns": 50,
+  "systemPromptTemplate": "agents/qa-engineer-prompt.ts",
+  "trustLevel": 1,
+  "maxRiskAllowed": "low",
+  "headsdownConfig": {
+    "model": "haiku",
+    "maxTurns": 50,
+    "loop": {
+      "enabled": true,
+      "checkInterval": 30000,
+      "maxConsecutiveErrors": 5,
+      "workTimeout": 1800000
+    },
+    "idleTasks": {
+      "enabled": true,
+      "tasks": [
+        "review_prs",
+        "check_tests"
+      ]
+    }
+  },
+  "tags": [
+    "built-in",
+    "quality",
+    "review"
+  ]
+}


### PR DESCRIPTION
## Summary

- Extracts all 8 existing agent roles + chief-of-staff into JSON template files
- Templates at `.automaker/templates/built-in/{role-name}.json`
- All validated against `AgentTemplateSchema` from PR #237
- Capabilities match existing `ROLE_CAPABILITIES` exactly
- Headsdown configs match `DEFAULT_HEADSDOWN_CONFIGS`
- Tier 0 for core roles, tier 1 for gtm-specialist

Agent Architect M1P3 — depends on M1P1 (PR #237, merged) and M1P2 (PR #240).

## Test plan

- [x] All 9 templates validate against AgentTemplateSchema
- [x] Capability parity with ROLE_CAPABILITIES
- [x] Headsdown config parity with DEFAULT_HEADSDOWN_CONFIGS
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced nine new specialized agent templates: Backend Engineer, Frontend Engineer, DevOps Engineer, QA Engineer, Docs Engineer, Engineering Manager, Product Manager, Chief of Staff, and GTM Specialist. Each template provides pre-configured capabilities, operational constraints, and automated task execution settings for its respective domain, enabling more efficient workflow automation across development, infrastructure, testing, documentation, management, and go-to-market functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->