### PR TITLE
feat: add milestone standup ceremonies and enable ceremony hookup

### DIFF
--- a/.automaker/settings.json
+++ b/.automaker/settings.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "webhookSettings": {
+    "webhookEnabled": false,
+    "autoCreateFromIssues": false,
+    "autoCreateLabels": [],
+    "autoMerge": {
+      "enabled": true,
+      "minApprovals": 0,
+      "requiredChecks": [
+        "ci_passing"
+      ],
+      "mergeMethod": "squash"
+    }
+  },
+  "worktreePanelVisible": false,
+  "ceremonySettings": {
+    "enabled": true,
+    "discordChannelId": "1469080556720623699",
+    "enableStandups": true,
+    "enableMilestoneUpdates": true,
+    "enableProjectRetros": true
+  }
+}

--- a/apps/server/src/services/ceremony-service.ts
+++ b/apps/server/src/services/ceremony-service.ts
@@ -18,9 +18,9 @@ import { simpleQuery } from '../providers/simple-query-service.js';
 const logger = createLogger('CeremonyService');
 
 /**
- * Milestone completion payload from the event system
+ * Milestone event payload from the event system
  */
-interface MilestoneCompletedPayload {
+interface MilestoneEventPayload {
   projectPath: string;
   projectTitle: string;
   projectSlug: string;
@@ -77,10 +77,12 @@ export class CeremonyService {
     this.featureLoader = featureLoader;
     this.projectService = projectService;
 
-    // Subscribe to milestone:completed and project:completed events
+    // Subscribe to milestone and project lifecycle events
     this.unsubscribe = emitter.subscribe((type, payload) => {
-      if (type === 'milestone:completed') {
-        this.handleMilestoneCompleted(payload as MilestoneCompletedPayload);
+      if (type === 'milestone:started') {
+        this.handleMilestoneStarted(payload as MilestoneEventPayload);
+      } else if (type === 'milestone:completed') {
+        this.handleMilestoneCompleted(payload as MilestoneEventPayload);
       } else if (type === 'project:completed') {
         this.handleProjectCompleted(payload as ProjectCompletedPayload);
       }
@@ -104,9 +106,49 @@ export class CeremonyService {
   }
 
   /**
+   * Handle milestone:started event — post standup with planned scope
+   */
+  private async handleMilestoneStarted(payload: MilestoneEventPayload): Promise<void> {
+    const { projectPath, projectTitle, projectSlug, milestoneTitle, milestoneNumber } = payload;
+
+    const ceremonySettings = await this.getCeremonySettings(projectPath);
+    if (!ceremonySettings?.enabled || !ceremonySettings?.enableStandups) {
+      logger.debug('Standups disabled, skipping milestone standup');
+      return;
+    }
+
+    try {
+      const content = await this.generateMilestoneStandup(
+        projectPath,
+        projectSlug,
+        projectTitle,
+        milestoneTitle,
+        milestoneNumber
+      );
+
+      const messages = this.splitMessage(content, 2000);
+
+      for (const message of messages) {
+        await this.emitDiscordEvent(
+          projectPath,
+          ceremonySettings.discordChannelId,
+          message,
+          `Standup: Milestone ${milestoneNumber} — ${milestoneTitle}`
+        );
+      }
+
+      logger.info(
+        `Posted milestone standup for ${projectTitle} - Milestone ${milestoneNumber}: ${milestoneTitle}`
+      );
+    } catch (error) {
+      logger.error('Failed to generate milestone standup:', error);
+    }
+  }
+
+  /**
    * Handle milestone:completed event
    */
-  private async handleMilestoneCompleted(payload: MilestoneCompletedPayload): Promise<void> {
+  private async handleMilestoneCompleted(payload: MilestoneEventPayload): Promise<void> {
     const { projectPath, projectTitle, projectSlug, milestoneTitle, milestoneNumber } = payload;
 
     // Check if ceremonies are enabled
@@ -241,6 +283,72 @@ ${dataSummary}`;
     } catch (error) {
       logger.error('Failed to generate project retrospective:', error);
     }
+  }
+
+  /**
+   * Generate milestone standup content — planned scope, phases, and goals
+   */
+  private async generateMilestoneStandup(
+    projectPath: string,
+    projectSlug: string,
+    projectTitle: string,
+    milestoneTitle: string,
+    milestoneNumber: number
+  ): Promise<string> {
+    const project = await this.projectService!.getProject(projectPath, projectSlug);
+    if (!project) {
+      throw new Error(`Project not found: ${projectSlug}`);
+    }
+
+    const milestone = project.milestones.find((m) => m.number === milestoneNumber);
+    if (!milestone) {
+      throw new Error(`Milestone ${milestoneNumber} not found in project ${projectSlug}`);
+    }
+
+    const totalMilestones = project.milestones.length;
+    const lines: string[] = [];
+
+    // Header
+    lines.push(`🚀 **${projectTitle}** — Milestone ${milestoneNumber}/${totalMilestones} Starting`);
+    lines.push(`### Standup: ${milestoneTitle}\n`);
+
+    // Scope
+    lines.push(`**Planned Phases:** ${milestone.phases.length}`);
+    if (milestone.phases.length > 0) {
+      for (const phase of milestone.phases) {
+        const complexity = phase.complexity ? ` [${phase.complexity}]` : '';
+        lines.push(`- ${phase.title}${complexity}`);
+      }
+      lines.push('');
+    }
+
+    // Complexity breakdown
+    const complexityCounts = { small: 0, medium: 0, large: 0 };
+    for (const phase of milestone.phases) {
+      if (phase.complexity && phase.complexity in complexityCounts) {
+        complexityCounts[phase.complexity as keyof typeof complexityCounts]++;
+      }
+    }
+    const complexityParts = Object.entries(complexityCounts)
+      .filter(([, count]) => count > 0)
+      .map(([level, count]) => `${count} ${level}`);
+    if (complexityParts.length > 0) {
+      lines.push(`**Complexity:** ${complexityParts.join(', ')}`);
+    }
+
+    // Progress context
+    const completedMilestones = project.milestones.filter((m) => m.status === 'completed').length;
+    if (completedMilestones > 0) {
+      lines.push(`**Progress:** ${completedMilestones}/${totalMilestones} milestones done`);
+    }
+
+    // Description if available
+    if (milestone.description) {
+      lines.push('');
+      lines.push(`**Goal:** ${milestone.description}`);
+    }
+
+    return lines.join('\n');
   }
 
   /**

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -812,7 +812,8 @@ export interface PhaseModelEntry {
  * CeremonySettings - Configuration for milestone and project ceremony features
  *
  * Ceremonies are automated events that mark significant project progress:
- * - Milestone completions: Sent to Discord when all features in a milestone are done
+ * - Milestone standups: Posted to Discord when a milestone starts with planned scope
+ * - Milestone retros: Sent to Discord when all features in a milestone are done
  * - Project retrospectives: AI-generated reflections when projects complete
  */
 export interface CeremonySettings {
@@ -820,6 +821,8 @@ export interface CeremonySettings {
   enabled: boolean;
   /** Discord channel ID for ceremony announcements (overrides project default) */
   discordChannelId?: string;
+  /** Enable milestone standup announcements at start (default: true) */
+  enableStandups?: boolean;
   /** Enable milestone completion announcements (default: true) */
   enableMilestoneUpdates?: boolean;
   /** Enable project retrospective generation (default: true) */
@@ -833,6 +836,7 @@ export interface CeremonySettings {
  */
 export const DEFAULT_CEREMONY_SETTINGS: CeremonySettings = {
   enabled: false,
+  enableStandups: true,
   enableMilestoneUpdates: true,
   enableProjectRetros: true,
 };


### PR DESCRIPTION
## Summary
- CeremonyService now handles `milestone:started` events for standup posts
- Added `enableStandups` field to `CeremonySettings` type
- Standup includes: planned phases, complexity breakdown, milestone progress, goals
- Enabled ceremony settings for automaker project (Discord #dev channel)
- Unified milestone payload type (`MilestoneEventPayload`)

Closes the gap where ceremonies were built but never activated — settings defaulted to `enabled: false` and the project had no ceremony config.

## What ceremonies now fire:
| Event | Handler | Output |
|-------|---------|--------|
| `milestone:started` | **NEW** standup | Planned scope, phases, complexity |
| `milestone:completed` | Existing retro | Features shipped, cost, duration, blockers |
| `project:completed` | Existing retro | LLM-generated retrospective |

## Test plan
- [ ] Verify `npm run build:packages` succeeds
- [ ] Verify server type-check passes
- [ ] Start a project with milestones, verify standup posts to Discord on milestone start
- [ ] Verify milestone completion retro still fires
- [ ] Verify project completion retro still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Milestone standups now automatically post to Discord when milestones start, including phase planning and complexity information
  * Added toggle to enable/disable milestone standup announcements in ceremony settings

* **Chores**
  * Added application settings configuration file

<!-- end of auto-generated comment: release notes by coderabbit.ai -->