### PR TITLE
feat: add AgentFactoryService for template-based agent config

### DIFF
--- a/apps/server/src/services/agent-factory-service.ts
+++ b/apps/server/src/services/agent-factory-service.ts
@@ -1,0 +1,273 @@
+/**
+ * AgentFactoryService - Creates configured agent instances from templates.
+ *
+ * Resolves templates from the RoleRegistry, applies overrides, merges
+ * inherited capabilities, and returns fully configured agent configs
+ * ready for execution. Does NOT execute agents.
+ */
+
+import { AgentTemplateSchema, type AgentTemplate } from '@automaker/types';
+import { createLogger } from '@automaker/utils';
+import { resolveModelString } from '@automaker/model-resolver';
+import type { RoleRegistryService } from './role-registry-service.js';
+import type { EventEmitter } from '../lib/events.js';
+
+const logger = createLogger('AgentFactory');
+
+/**
+ * The resolved agent configuration returned by the factory.
+ * Contains everything needed to execute an agent.
+ */
+export interface AgentConfig {
+  /** Template name used to create this config */
+  templateName: string;
+  /** Resolved Claude model ID (e.g., "claude-sonnet-4-5-20250929") */
+  resolvedModel: string;
+  /** Model alias (e.g., "sonnet") */
+  modelAlias: string;
+  /** Allowed tools for this agent */
+  tools: string[];
+  /** Denied tools (overrides allowlist) */
+  disallowedTools: string[];
+  /** Maximum turns before stopping */
+  maxTurns: number;
+  /** System prompt template path (if using file) */
+  systemPromptTemplate?: string;
+  /** Inline system prompt (if provided) */
+  systemPrompt?: string;
+  /** Agent role */
+  role: string;
+  /** Display name */
+  displayName: string;
+  /** Trust level (0-3) */
+  trustLevel: number;
+  /** Capability flags */
+  capabilities: {
+    canUseBash: boolean;
+    canModifyFiles: boolean;
+    canCommit: boolean;
+    canCreatePRs: boolean;
+    canSpawnAgents: boolean;
+  };
+  /** Allowed sub-agent roles (if canSpawnAgents) */
+  allowedSubagentRoles: string[];
+  /** Headsdown loop config */
+  headsdownConfig?: AgentTemplate['headsdownConfig'];
+  /** Routing assignments */
+  assignments?: AgentTemplate['assignments'];
+  /** Project path this agent is configured for */
+  projectPath: string;
+}
+
+/** Overrides that can be applied when creating from template */
+export type AgentOverrides = Partial<
+  Pick<
+    AgentTemplate,
+    | 'model'
+    | 'tools'
+    | 'disallowedTools'
+    | 'maxTurns'
+    | 'systemPrompt'
+    | 'trustLevel'
+    | 'maxRiskAllowed'
+    | 'canUseBash'
+    | 'canModifyFiles'
+    | 'canCommit'
+    | 'canCreatePRs'
+  >
+>;
+
+const DEFAULT_MAX_TURNS = 100;
+const DEFAULT_TRUST_LEVEL = 1;
+
+export class AgentFactoryService {
+  private registry: RoleRegistryService;
+  private events?: EventEmitter;
+
+  constructor(registry: RoleRegistryService, events?: EventEmitter) {
+    this.registry = registry;
+    this.events = events;
+  }
+
+  /**
+   * Create a fully resolved agent config from a registered template.
+   *
+   * @param templateName - The template name in the registry
+   * @param projectPath - The project this agent will work on
+   * @param overrides - Optional field-level overrides
+   * @returns Fully resolved AgentConfig ready for execution
+   * @throws Error if template not found or validation fails
+   */
+  createFromTemplate(
+    templateName: string,
+    projectPath: string,
+    overrides?: AgentOverrides
+  ): AgentConfig {
+    const template = this.registry.get(templateName);
+    if (!template) {
+      const available = this.registry
+        .list()
+        .map((t) => t.name)
+        .join(', ');
+      throw new Error(
+        `Template "${templateName}" not found in registry. Available: ${available || 'none'}`
+      );
+    }
+
+    const merged = this.applyOverrides(template, overrides);
+    const config = this.resolveConfig(merged, projectPath);
+
+    logger.info(
+      `Created agent config from "${templateName}" for ${projectPath} (model: ${config.modelAlias}, turns: ${config.maxTurns})`
+    );
+
+    this.events?.emit('authority:agent-registered', {
+      name: templateName,
+      role: config.role,
+      tier: template.tier ?? 1,
+      action: 'factory-create',
+      projectPath,
+    });
+
+    return config;
+  }
+
+  /**
+   * Create from template with inheritance — custom template extends a base.
+   * The child template's fields override the parent's. Tools are merged additively.
+   *
+   * @param parentName - Base template name
+   * @param childTemplate - Partial template to overlay
+   * @param projectPath - The project this agent will work on
+   * @returns Fully resolved AgentConfig
+   */
+  createWithInheritance(
+    parentName: string,
+    childTemplate: Partial<AgentTemplate> & { name: string },
+    projectPath: string
+  ): AgentConfig {
+    const parent = this.registry.get(parentName);
+    if (!parent) {
+      throw new Error(`Parent template "${parentName}" not found in registry`);
+    }
+
+    // Merge: child overrides parent, tools are additive
+    const merged: AgentTemplate = {
+      ...parent,
+      ...childTemplate,
+      // Additive tool merge: parent tools + child tools (deduped)
+      tools: this.mergeTools(parent.tools, childTemplate.tools),
+      // Disallowed tools: child replaces parent entirely
+      disallowedTools: childTemplate.disallowedTools ?? parent.disallowedTools,
+      // Assignments: deep merge
+      assignments: childTemplate.assignments
+        ? {
+            ...parent.assignments,
+            ...childTemplate.assignments,
+          }
+        : parent.assignments,
+      // Headsdown: child replaces parent entirely
+      headsdownConfig: childTemplate.headsdownConfig ?? parent.headsdownConfig,
+    };
+
+    // Validate the merged template
+    const result = AgentTemplateSchema.safeParse(merged);
+    if (!result.success) {
+      const errors = result.error.issues.map((i) => i.message).join(', ');
+      throw new Error(`Inherited template "${childTemplate.name}" failed validation: ${errors}`);
+    }
+
+    const config = this.resolveConfig(result.data as AgentTemplate, projectPath);
+
+    logger.info(
+      `Created inherited agent config "${childTemplate.name}" (parent: "${parentName}") for ${projectPath}`
+    );
+
+    this.events?.emit('authority:agent-registered', {
+      name: childTemplate.name,
+      role: config.role,
+      tier: childTemplate.tier ?? parent.tier ?? 1,
+      action: 'factory-inherit',
+      parentName,
+      projectPath,
+    });
+
+    return config;
+  }
+
+  /**
+   * List all available template names in the registry.
+   */
+  getAvailableTemplates(): Array<{ name: string; displayName: string; role: string }> {
+    return this.registry.list().map((t) => ({
+      name: t.name,
+      displayName: t.displayName,
+      role: t.role,
+    }));
+  }
+
+  /**
+   * Apply overrides to a template. Tools are additive, other fields replace.
+   */
+  private applyOverrides(template: AgentTemplate, overrides?: AgentOverrides): AgentTemplate {
+    if (!overrides) return template;
+
+    return {
+      ...template,
+      model: overrides.model ?? template.model,
+      tools: overrides.tools ? this.mergeTools(template.tools, overrides.tools) : template.tools,
+      disallowedTools: overrides.disallowedTools ?? template.disallowedTools,
+      maxTurns: overrides.maxTurns ?? template.maxTurns,
+      systemPrompt: overrides.systemPrompt ?? template.systemPrompt,
+      trustLevel: overrides.trustLevel ?? template.trustLevel,
+      maxRiskAllowed: overrides.maxRiskAllowed ?? template.maxRiskAllowed,
+      canUseBash: overrides.canUseBash ?? template.canUseBash,
+      canModifyFiles: overrides.canModifyFiles ?? template.canModifyFiles,
+      canCommit: overrides.canCommit ?? template.canCommit,
+      canCreatePRs: overrides.canCreatePRs ?? template.canCreatePRs,
+    };
+  }
+
+  /**
+   * Merge tool arrays additively, deduplicating.
+   */
+  private mergeTools(base?: string[], additional?: string[]): string[] | undefined {
+    if (!base && !additional) return undefined;
+    if (!additional) return base;
+    if (!base) return additional;
+    return [...new Set([...base, ...additional])];
+  }
+
+  /**
+   * Resolve a template into a concrete AgentConfig.
+   */
+  private resolveConfig(template: AgentTemplate, projectPath: string): AgentConfig {
+    const modelAlias = template.model ?? 'sonnet';
+    const resolvedModel = resolveModelString(modelAlias);
+
+    return {
+      templateName: template.name,
+      resolvedModel,
+      modelAlias,
+      tools: template.tools ?? [],
+      disallowedTools: template.disallowedTools ?? [],
+      maxTurns: template.maxTurns ?? DEFAULT_MAX_TURNS,
+      systemPromptTemplate: template.systemPromptTemplate,
+      systemPrompt: template.systemPrompt,
+      role: template.role,
+      displayName: template.displayName,
+      trustLevel: template.trustLevel ?? DEFAULT_TRUST_LEVEL,
+      capabilities: {
+        canUseBash: template.canUseBash ?? true,
+        canModifyFiles: template.canModifyFiles ?? true,
+        canCommit: template.canCommit ?? true,
+        canCreatePRs: template.canCreatePRs ?? true,
+        canSpawnAgents: template.canSpawnAgents ?? false,
+      },
+      allowedSubagentRoles: template.allowedSubagentRoles ?? [],
+      headsdownConfig: template.headsdownConfig,
+      assignments: template.assignments,
+      projectPath,
+    };
+  }
+}

--- a/apps/server/tests/unit/services/agent-factory-service.test.ts
+++ b/apps/server/tests/unit/services/agent-factory-service.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AgentFactoryService } from '../../../src/services/agent-factory-service.js';
+import { RoleRegistryService } from '../../../src/services/role-registry-service.js';
+import type { AgentTemplate } from '@automaker/types';
+
+function makeTemplate(overrides: Partial<AgentTemplate> = {}): AgentTemplate {
+  return {
+    name: 'test-agent',
+    displayName: 'Test Agent',
+    description: 'A test agent template',
+    role: 'backend-engineer',
+    tier: 1,
+    model: 'sonnet',
+    tools: ['Read', 'Write', 'Bash'],
+    maxTurns: 50,
+    trustLevel: 1,
+    canUseBash: true,
+    canModifyFiles: true,
+    canCommit: true,
+    canCreatePRs: false,
+    ...overrides,
+  };
+}
+
+describe('AgentFactoryService', () => {
+  let registry: RoleRegistryService;
+  let factory: AgentFactoryService;
+
+  beforeEach(() => {
+    registry = new RoleRegistryService();
+    factory = new AgentFactoryService(registry);
+  });
+
+  describe('createFromTemplate', () => {
+    it('creates config from a registered template', () => {
+      const template = makeTemplate();
+      registry.register(template);
+
+      const config = factory.createFromTemplate('test-agent', '/project');
+
+      expect(config.templateName).toBe('test-agent');
+      expect(config.modelAlias).toBe('sonnet');
+      expect(config.resolvedModel).toContain('sonnet');
+      expect(config.tools).toEqual(['Read', 'Write', 'Bash']);
+      expect(config.maxTurns).toBe(50);
+      expect(config.role).toBe('backend-engineer');
+      expect(config.displayName).toBe('Test Agent');
+      expect(config.trustLevel).toBe(1);
+      expect(config.projectPath).toBe('/project');
+      expect(config.capabilities.canUseBash).toBe(true);
+      expect(config.capabilities.canCreatePRs).toBe(false);
+    });
+
+    it('throws when template not found', () => {
+      expect(() => factory.createFromTemplate('nonexistent', '/project')).toThrow(
+        'Template "nonexistent" not found'
+      );
+    });
+
+    it('applies model override', () => {
+      registry.register(makeTemplate());
+
+      const config = factory.createFromTemplate('test-agent', '/project', {
+        model: 'opus',
+      });
+
+      expect(config.modelAlias).toBe('opus');
+      expect(config.resolvedModel).toContain('opus');
+    });
+
+    it('applies maxTurns override', () => {
+      registry.register(makeTemplate());
+
+      const config = factory.createFromTemplate('test-agent', '/project', {
+        maxTurns: 200,
+      });
+
+      expect(config.maxTurns).toBe(200);
+    });
+
+    it('merges tools additively', () => {
+      registry.register(makeTemplate({ tools: ['Read', 'Write'] }));
+
+      const config = factory.createFromTemplate('test-agent', '/project', {
+        tools: ['Bash', 'Grep'],
+      });
+
+      expect(config.tools).toContain('Read');
+      expect(config.tools).toContain('Write');
+      expect(config.tools).toContain('Bash');
+      expect(config.tools).toContain('Grep');
+    });
+
+    it('deduplicates tools on merge', () => {
+      registry.register(makeTemplate({ tools: ['Read', 'Write'] }));
+
+      const config = factory.createFromTemplate('test-agent', '/project', {
+        tools: ['Read', 'Bash'],
+      });
+
+      const readCount = config.tools.filter((t) => t === 'Read').length;
+      expect(readCount).toBe(1);
+    });
+
+    it('applies capability overrides', () => {
+      registry.register(makeTemplate({ canUseBash: false }));
+
+      const config = factory.createFromTemplate('test-agent', '/project', {
+        canUseBash: true,
+      });
+
+      expect(config.capabilities.canUseBash).toBe(true);
+    });
+
+    it('uses defaults when template fields are missing', () => {
+      registry.register(
+        makeTemplate({
+          model: undefined,
+          maxTurns: undefined,
+          trustLevel: undefined,
+          tools: undefined,
+        })
+      );
+
+      const config = factory.createFromTemplate('test-agent', '/project');
+
+      expect(config.modelAlias).toBe('sonnet');
+      expect(config.maxTurns).toBe(100);
+      expect(config.trustLevel).toBe(1);
+      expect(config.tools).toEqual([]);
+    });
+  });
+
+  describe('createWithInheritance', () => {
+    it('inherits from parent template', () => {
+      const parent = makeTemplate({
+        name: 'parent-agent',
+        model: 'sonnet',
+        tools: ['Read', 'Write'],
+        maxTurns: 100,
+      });
+      registry.register(parent);
+
+      const config = factory.createWithInheritance(
+        'parent-agent',
+        {
+          name: 'child-agent',
+          displayName: 'Child Agent',
+          description: 'Extended from parent',
+          role: 'backend-engineer',
+          model: 'opus',
+        },
+        '/project'
+      );
+
+      expect(config.modelAlias).toBe('opus');
+      expect(config.tools).toContain('Read');
+      expect(config.tools).toContain('Write');
+      expect(config.maxTurns).toBe(100);
+      expect(config.displayName).toBe('Child Agent');
+    });
+
+    it('merges tools additively from parent and child', () => {
+      registry.register(makeTemplate({ name: 'parent-agent', tools: ['Read'] }));
+
+      const config = factory.createWithInheritance(
+        'parent-agent',
+        {
+          name: 'child-agent',
+          displayName: 'Child',
+          description: 'Test',
+          role: 'backend-engineer',
+          tools: ['Bash'],
+        },
+        '/project'
+      );
+
+      expect(config.tools).toContain('Read');
+      expect(config.tools).toContain('Bash');
+    });
+
+    it('throws when parent not found', () => {
+      expect(() =>
+        factory.createWithInheritance(
+          'nonexistent',
+          {
+            name: 'child-agent',
+            displayName: 'Child',
+            description: 'Test',
+            role: 'backend-engineer',
+          },
+          '/project'
+        )
+      ).toThrow('Parent template "nonexistent" not found');
+    });
+
+    it('validates the merged template', () => {
+      registry.register(makeTemplate({ name: 'parent-agent' }));
+
+      expect(() =>
+        factory.createWithInheritance(
+          'parent-agent',
+          {
+            name: 'INVALID NAME', // kebab-case violation
+            displayName: 'Child',
+            description: 'Test',
+            role: 'backend-engineer',
+          },
+          '/project'
+        )
+      ).toThrow('failed validation');
+    });
+  });
+
+  describe('getAvailableTemplates', () => {
+    it('returns empty list when no templates', () => {
+      expect(factory.getAvailableTemplates()).toEqual([]);
+    });
+
+    it('returns all registered templates', () => {
+      registry.register(makeTemplate({ name: 'agent-aa' }));
+      registry.register(
+        makeTemplate({
+          name: 'agent-bb',
+          displayName: 'Agent BB',
+          role: 'frontend-engineer',
+        })
+      );
+
+      const available = factory.getAvailableTemplates();
+      expect(available).toHaveLength(2);
+      expect(available[0]).toEqual({
+        name: 'agent-aa',
+        displayName: 'Test Agent',
+        role: 'backend-engineer',
+      });
+      expect(available[1]).toEqual({
+        name: 'agent-bb',
+        displayName: 'Agent BB',
+        role: 'frontend-engineer',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Creates `AgentFactoryService` that resolves templates from `RoleRegistryService` into fully configured `AgentConfig` objects
- `createFromTemplate(name, projectPath, overrides?)` — standard creation with optional field overrides
- `createWithInheritance(parentName, childTemplate, projectPath)` — child extends parent, tools merge additively
- Model aliases resolved via `@automaker/model-resolver`
- 14 unit tests covering normal flow, overrides, inheritance, validation, and error cases

Part of Agent Architect M2: Agent Factory & Execution. Depends on M1 (Schema + Registry + Templates, all merged).

## Test plan
- [x] 14 unit tests pass (`vitest run agent-factory-service.test.ts`)
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent template factory for creating fully resolved agent configurations from registered templates
  * Agent template inheritance system allowing child templates to extend and override parent configurations
  * Template override capabilities for customizing agent properties including models, tools, and system prompts
  * Template availability listing showing registered agent templates with metadata

* **Tests**
  * Comprehensive unit test coverage for agent factory operations including template creation, inheritance, and overrides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->