### PR TITLE
fix: add dist/** to tsx watch ignore list

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "dev": "NODE_OPTIONS='--max-old-space-size=16384' tsx watch --ignore '**/.automaker/**' --ignore '**/.worktrees/**' --ignore 'data/**' --ignore '**/*.log' src/index.ts",
+    "dev": "NODE_OPTIONS='--max-old-space-size=16384' tsx watch --ignore '**/.automaker/**' --ignore '**/.worktrees/**' --ignore '**/dist/**' --ignore 'data/**' --ignore '**/*.log' src/index.ts",
     "dev:test": "tsx src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",


### PR DESCRIPTION
## Summary
- Adds `**/dist/**` to tsx watch ignore patterns in the dev server script
- Prevents zombie process loop when `build:packages` modifies `libs/*/dist/` while dev server is running
- Previously caused EventEmitter memory leak, unresponsive terminal, and required manual `kill -9`

## Test plan
- [x] Start dev server with `npm run dev:server`
- [x] Run `npm run build:packages` in another terminal
- [x] Verify dev server doesn't enter zombie kill loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development performance by excluding the dist folder from the file watcher, reducing unnecessary build triggers during local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->