### PR TITLE
fix: tsx watch ignore parent dist/ during build:packages

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "dev": "NODE_OPTIONS='--max-old-space-size=16384' tsx watch --ignore '**/.automaker/**' --ignore '**/.worktrees/**' --ignore '**/dist/**' --ignore 'data/**' --ignore '**/*.log' src/index.ts",
+    "dev": "NODE_OPTIONS='--max-old-space-size=16384' tsx watch --ignore '**/.automaker/**' --ignore '**/.worktrees/**' --ignore '**/dist/**' --ignore '../../libs/**/dist/**' --ignore '../../packages/**/dist/**' --ignore 'data/**' --ignore '**/*.log' src/index.ts",
     "dev:test": "tsx src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",


### PR DESCRIPTION
## Summary
- Fix tsx watch restart storm during `build:packages` — tsx's `**/dist/**` glob doesn't match `../../libs/types/dist/index.js` paths
- Added explicit `../../libs/**/dist/**` and `../../packages/**/dist/**` ignores
- This is the root cause of the "Process hasn't exited. Killing process..." spam and port 3008 conflicts on startup

## Test plan
- [ ] Run `npm run dev:web` — build:packages should complete without tsx restart spam
- [ ] Server starts cleanly on port 3008 without "Port already in use" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized development build process to reduce unnecessary rebuilds and improve development experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->