### PR TITLE
feat: deployment environment concept, factory updates, and unit tests

### DIFF
--- a/apps/server/src/services/agent-factory-service.ts
+++ b/apps/server/src/services/agent-factory-service.ts
@@ -6,7 +6,11 @@
  * ready for execution. Does NOT execute agents.
  */
 
-import { AgentTemplateSchema, type AgentTemplate } from '@automaker/types';
+import {
+  AgentTemplateSchema,
+  type AgentTemplate,
+  type DeploymentEnvironment,
+} from '@automaker/types';
 import { createLogger } from '@automaker/utils';
 import { resolveModelString } from '@automaker/model-resolver';
 import type { RoleRegistryService } from './role-registry-service.js';
@@ -55,6 +59,16 @@ export interface AgentConfig {
   headsdownConfig?: AgentTemplate['headsdownConfig'];
   /** Routing assignments */
   assignments?: AgentTemplate['assignments'];
+  /** Desired state conditions for reactive activation (from AgentTemplate.desiredState) */
+  desiredState?: Array<{
+    key: string;
+    operator: string;
+    value: string | number | boolean;
+    description?: string;
+    priority?: number;
+  }>;
+  /** Deployment environment (dev/staging/prod) */
+  environment: DeploymentEnvironment;
   /** Project path this agent is configured for */
   projectPath: string;
 }
@@ -83,10 +97,16 @@ const DEFAULT_TRUST_LEVEL = 1;
 export class AgentFactoryService {
   private registry: RoleRegistryService;
   private events?: EventEmitter;
+  private environment: DeploymentEnvironment;
 
-  constructor(registry: RoleRegistryService, events?: EventEmitter) {
+  constructor(
+    registry: RoleRegistryService,
+    events?: EventEmitter,
+    environment?: DeploymentEnvironment
+  ) {
     this.registry = registry;
     this.events = events;
+    this.environment = environment ?? 'development';
   }
 
   /**
@@ -267,6 +287,9 @@ export class AgentFactoryService {
       allowedSubagentRoles: template.allowedSubagentRoles ?? [],
       headsdownConfig: template.headsdownConfig,
       assignments: template.assignments,
+      desiredState: (template as Record<string, unknown>)
+        .desiredState as AgentConfig['desiredState'],
+      environment: this.environment,
       projectPath,
     };
   }

--- a/apps/server/src/services/dynamic-agent-executor.ts
+++ b/apps/server/src/services/dynamic-agent-executor.ts
@@ -175,6 +175,18 @@ export class DynamicAgentExecutor {
       parts.push(additional);
     }
 
+    // Environment context
+    if (config.environment) {
+      parts.push(
+        `## Environment\nYou are running in **${config.environment}** mode. ` +
+          (config.environment === 'development'
+            ? 'This is a local development environment — be conservative with resources and concurrency.'
+            : config.environment === 'staging'
+              ? 'This is a staging environment with higher capacity — you can run more agents and use more memory.'
+              : 'This is a production environment — prioritize stability and reliability.')
+      );
+    }
+
     // Capability constraints
     const constraints: string[] = [];
     if (!config.capabilities.canUseBash) {

--- a/apps/server/tests/unit/services/agent-factory-service.test.ts
+++ b/apps/server/tests/unit/services/agent-factory-service.test.ts
@@ -241,4 +241,48 @@ describe('AgentFactoryService', () => {
       });
     });
   });
+
+  describe('environment', () => {
+    it('defaults to development when no environment specified', () => {
+      registry.register(makeTemplate());
+      const config = factory.createFromTemplate('test-agent', '/project');
+      expect(config.environment).toBe('development');
+    });
+
+    it('uses environment from constructor', () => {
+      const stagingFactory = new AgentFactoryService(registry, undefined, 'staging');
+      registry.register(makeTemplate());
+      const config = stagingFactory.createFromTemplate('test-agent', '/project');
+      expect(config.environment).toBe('staging');
+    });
+
+    it('passes production environment through', () => {
+      const prodFactory = new AgentFactoryService(registry, undefined, 'production');
+      registry.register(makeTemplate());
+      const config = prodFactory.createFromTemplate('test-agent', '/project');
+      expect(config.environment).toBe('production');
+    });
+  });
+
+  describe('desiredState pass-through', () => {
+    it('returns undefined when template has no desiredState', () => {
+      registry.register(makeTemplate());
+      const config = factory.createFromTemplate('test-agent', '/project');
+      expect(config.desiredState).toBeUndefined();
+    });
+
+    it('returns undefined when desiredState added but schema strips it (pre-PR #252)', () => {
+      // Until AgentTemplateSchema includes desiredState, Zod strips unknown fields.
+      // This test documents that behavior and will need updating after PR #252 merges.
+      const templateWithState = makeTemplate();
+      (templateWithState as Record<string, unknown>).desiredState = [
+        { key: 'backlog_count', operator: '>', value: 0, priority: 8 },
+      ];
+      registry.register(templateWithState);
+
+      const config = factory.createFromTemplate('test-agent', '/project');
+      // Zod strips unknown fields, so desiredState won't survive registration
+      expect(config.desiredState).toBeUndefined();
+    });
+  });
 });

--- a/apps/server/tests/unit/services/dynamic-agent-executor.test.ts
+++ b/apps/server/tests/unit/services/dynamic-agent-executor.test.ts
@@ -32,6 +32,7 @@ function makeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
       canSpawnAgents: false,
     },
     allowedSubagentRoles: [],
+    environment: 'development',
     projectPath: '/test/project',
     ...overrides,
   };

--- a/apps/server/tests/unit/services/role-registry-service.test.ts
+++ b/apps/server/tests/unit/services/role-registry-service.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { RoleRegistryService } from '../../../src/services/role-registry-service.js';
+import type { AgentTemplate } from '@automaker/types';
+
+function makeTemplate(overrides: Partial<AgentTemplate> = {}): AgentTemplate {
+  return {
+    name: 'test-agent',
+    displayName: 'Test Agent',
+    description: 'A test agent template',
+    role: 'backend-engineer',
+    tier: 1,
+    model: 'sonnet',
+    tools: ['Read', 'Write'],
+    maxTurns: 50,
+    ...overrides,
+  };
+}
+
+describe('RoleRegistryService', () => {
+  let registry: RoleRegistryService;
+
+  beforeEach(() => {
+    registry = new RoleRegistryService();
+  });
+
+  describe('register', () => {
+    it('registers a valid template', () => {
+      const result = registry.register(makeTemplate());
+      expect(result.success).toBe(true);
+      expect(registry.size).toBe(1);
+    });
+
+    it('rejects invalid template (bad name)', () => {
+      const result = registry.register(makeTemplate({ name: 'INVALID NAME' }));
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Validation failed');
+    });
+
+    it('rejects template with single-char name', () => {
+      const result = registry.register(makeTemplate({ name: 'a' }));
+      expect(result.success).toBe(false);
+    });
+
+    it('allows overwriting tier 1 templates', () => {
+      registry.register(makeTemplate({ tier: 1 }));
+      const result = registry.register(makeTemplate({ tier: 1, displayName: 'Updated Agent' }));
+      expect(result.success).toBe(true);
+      expect(registry.get('test-agent')?.displayName).toBe('Updated Agent');
+    });
+
+    it('rejects overwriting tier 0 templates', () => {
+      registry.register(makeTemplate({ tier: 0 }));
+      const result = registry.register(makeTemplate({ tier: 1, displayName: 'Overwrite attempt' }));
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('protected');
+    });
+  });
+
+  describe('get', () => {
+    it('returns template by name', () => {
+      registry.register(makeTemplate());
+      const template = registry.get('test-agent');
+      expect(template).toBeDefined();
+      expect(template?.displayName).toBe('Test Agent');
+    });
+
+    it('returns undefined for unknown name', () => {
+      expect(registry.get('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('has', () => {
+    it('returns true for registered template', () => {
+      registry.register(makeTemplate());
+      expect(registry.has('test-agent')).toBe(true);
+    });
+
+    it('returns false for unregistered template', () => {
+      expect(registry.has('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('list', () => {
+    it('returns empty array when no templates', () => {
+      expect(registry.list()).toEqual([]);
+    });
+
+    it('returns all templates', () => {
+      registry.register(makeTemplate({ name: 'agent-aa' }));
+      registry.register(makeTemplate({ name: 'agent-bb', role: 'frontend-engineer' }));
+      expect(registry.list()).toHaveLength(2);
+    });
+
+    it('filters by role', () => {
+      registry.register(makeTemplate({ name: 'agent-aa', role: 'backend-engineer' }));
+      registry.register(makeTemplate({ name: 'agent-bb', role: 'frontend-engineer' }));
+
+      const backends = registry.list('backend-engineer');
+      expect(backends).toHaveLength(1);
+      expect(backends[0].name).toBe('agent-aa');
+    });
+
+    it('returns empty when role filter has no matches', () => {
+      registry.register(makeTemplate());
+      expect(registry.list('qa-engineer')).toHaveLength(0);
+    });
+  });
+
+  describe('unregister', () => {
+    it('removes a tier 1 template', () => {
+      registry.register(makeTemplate({ tier: 1 }));
+      const result = registry.unregister('test-agent');
+      expect(result.success).toBe(true);
+      expect(registry.size).toBe(0);
+    });
+
+    it('refuses to remove tier 0 template', () => {
+      registry.register(makeTemplate({ tier: 0 }));
+      const result = registry.unregister('test-agent');
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('protected');
+      expect(registry.size).toBe(1);
+    });
+
+    it('returns error for nonexistent template', () => {
+      const result = registry.unregister('nonexistent');
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+  });
+
+  describe('getKnownRoles', () => {
+    it('returns built-in role names', () => {
+      const roles = registry.getKnownRoles();
+      expect(roles).toContain('product-manager');
+      expect(roles).toContain('backend-engineer');
+      expect(roles).toContain('chief-of-staff');
+    });
+  });
+
+  describe('size', () => {
+    it('starts at 0', () => {
+      expect(registry.size).toBe(0);
+    });
+
+    it('tracks registrations', () => {
+      registry.register(makeTemplate({ name: 'agent-aa' }));
+      registry.register(makeTemplate({ name: 'agent-bb' }));
+      expect(registry.size).toBe(2);
+    });
+  });
+});

--- a/libs/prompts/src/index.ts
+++ b/libs/prompts/src/index.ts
@@ -114,6 +114,16 @@ export type {
   ResolvedTaskExecutionPrompts,
 } from '@automaker/types';
 
+// Prompt registry (unified role → prompt mapping)
+export {
+  getPromptForRole,
+  registerPrompt,
+  createPromptFromTemplate,
+  listRegisteredRoles,
+  hasPrompt,
+} from './prompt-registry.js';
+export type { BasePromptConfig } from './prompt-registry.js';
+
 // Agent role prompts
 export { getProductManagerPrompt, getResearchPrompt } from './agents/product-manager-prompt.js';
 export {

--- a/libs/prompts/src/prompt-registry.ts
+++ b/libs/prompts/src/prompt-registry.ts
@@ -1,0 +1,149 @@
+/**
+ * Prompt Registry Adapter
+ *
+ * Maps role names to prompt generation functions with a unified interface.
+ * Built-in prompts register on module import. Custom prompts can be loaded
+ * from template systemPromptTemplate strings.
+ *
+ * Usage:
+ *   import { getPromptForRole } from '@automaker/prompts';
+ *   const prompt = getPromptForRole('product-manager', { projectPath: '/path' });
+ */
+
+import { getProductManagerPrompt } from './agents/product-manager-prompt.js';
+import { getEngineeringManagerPrompt } from './agents/engineering-manager-prompt.js';
+import { getFrontendEngineerPrompt } from './agents/frontend-engineer-prompt.js';
+import { getBackendEngineerPrompt } from './agents/backend-engineer-prompt.js';
+import { getDevOpsEngineerPrompt } from './agents/devops-engineer-prompt.js';
+import { getQAEngineerPrompt } from './agents/qa-engineer-prompt.js';
+import { getDocsEngineerPrompt } from './agents/docs-engineer-prompt.js';
+import { getGTMSpecialistPrompt } from './agents/gtm-specialist-prompt.js';
+
+/** Base config that all prompt functions accept */
+export interface BasePromptConfig {
+  projectPath: string;
+  contextFiles?: string[];
+  [key: string]: unknown;
+}
+
+/** A prompt generator function */
+type PromptGenerator = (config: BasePromptConfig) => string;
+
+/** Registry of role name → prompt generator */
+const promptRegistry = new Map<string, PromptGenerator>();
+
+/**
+ * Register a prompt generator for a role.
+ */
+export function registerPrompt(role: string, generator: PromptGenerator): void {
+  promptRegistry.set(role, generator);
+}
+
+/**
+ * Get the system prompt for a given role.
+ *
+ * Resolution order:
+ * 1. Registered prompt generator (built-in or custom)
+ * 2. Generic fallback prompt
+ */
+export function getPromptForRole(role: string, config: BasePromptConfig): string {
+  const generator = promptRegistry.get(role);
+  if (generator) {
+    return generator(config);
+  }
+
+  // Generic fallback for unknown roles
+  return `You are a ${role} agent working on the project at ${config.projectPath}. Help with tasks related to your role. Be concise and helpful.`;
+}
+
+/**
+ * Create a prompt generator from an inline system prompt template string.
+ * Supports {{projectPath}} and {{contextFiles}} placeholders.
+ */
+export function createPromptFromTemplate(template: string): PromptGenerator {
+  return (config: BasePromptConfig) => {
+    let prompt = template;
+    prompt = prompt.replace(/\{\{projectPath\}\}/g, config.projectPath);
+    prompt = prompt.replace(/\{\{contextFiles\}\}/g, (config.contextFiles ?? []).join(', '));
+    return prompt;
+  };
+}
+
+/**
+ * List all registered role names.
+ */
+export function listRegisteredRoles(): string[] {
+  return Array.from(promptRegistry.keys());
+}
+
+/**
+ * Check if a role has a registered prompt.
+ */
+export function hasPrompt(role: string): boolean {
+  return promptRegistry.has(role);
+}
+
+// --- Register built-in prompts on module import ---
+
+registerPrompt('product-manager', (config) =>
+  getProductManagerPrompt({
+    projectPath: config.projectPath,
+    discordChannels: (config.discordChannels as string[]) ?? [],
+    contextFiles: config.contextFiles,
+  })
+);
+
+registerPrompt('engineering-manager', (config) =>
+  getEngineeringManagerPrompt({
+    projectPath: config.projectPath,
+    linearProjects: (config.linearProjects as string[]) ?? [],
+    contextFiles: config.contextFiles,
+  })
+);
+
+registerPrompt('frontend-engineer', (config) =>
+  getFrontendEngineerPrompt({
+    projectPath: config.projectPath,
+    linearProjects: (config.linearProjects as string[]) ?? [],
+    contextFiles: config.contextFiles,
+  })
+);
+
+registerPrompt('backend-engineer', (config) =>
+  getBackendEngineerPrompt({
+    projectPath: config.projectPath,
+    linearProjects: (config.linearProjects as string[]) ?? [],
+    contextFiles: config.contextFiles,
+  })
+);
+
+registerPrompt('devops-engineer', (config) =>
+  getDevOpsEngineerPrompt({
+    projectPath: config.projectPath,
+    linearProjects: (config.linearProjects as string[]) ?? [],
+    contextFiles: config.contextFiles,
+  })
+);
+
+registerPrompt('qa-engineer', (config) =>
+  getQAEngineerPrompt({
+    projectPath: config.projectPath,
+    contextFiles: config.contextFiles,
+  })
+);
+
+registerPrompt('docs-engineer', (config) =>
+  getDocsEngineerPrompt({
+    projectPath: config.projectPath,
+    linearProjects: (config.linearProjects as string[]) ?? [],
+    contextFiles: config.contextFiles,
+  })
+);
+
+registerPrompt('gtm-specialist', (config) =>
+  getGTMSpecialistPrompt({
+    context: (config.context as string) ?? '',
+    platform: (config.platform as string) ?? 'twitter',
+    focus: (config.focus as string) ?? '',
+  })
+);

--- a/libs/prompts/tests/prompt-registry.test.ts
+++ b/libs/prompts/tests/prompt-registry.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getPromptForRole,
+  registerPrompt,
+  createPromptFromTemplate,
+  listRegisteredRoles,
+  hasPrompt,
+} from '../src/prompt-registry.js';
+
+describe('prompt-registry', () => {
+  describe('built-in registrations', () => {
+    it('registers all 8 built-in roles on import', () => {
+      const roles = listRegisteredRoles();
+      expect(roles).toContain('product-manager');
+      expect(roles).toContain('engineering-manager');
+      expect(roles).toContain('frontend-engineer');
+      expect(roles).toContain('backend-engineer');
+      expect(roles).toContain('devops-engineer');
+      expect(roles).toContain('qa-engineer');
+      expect(roles).toContain('docs-engineer');
+      expect(roles).toContain('gtm-specialist');
+    });
+  });
+
+  describe('getPromptForRole', () => {
+    it('returns prompt for known role', () => {
+      const prompt = getPromptForRole('backend-engineer', {
+        projectPath: '/test/project',
+      });
+      expect(prompt).toBeDefined();
+      expect(typeof prompt).toBe('string');
+      expect(prompt.length).toBeGreaterThan(100);
+    });
+
+    it('returns fallback for unknown role', () => {
+      const prompt = getPromptForRole('alien-researcher', {
+        projectPath: '/test/project',
+      });
+      expect(prompt).toContain('alien-researcher');
+      expect(prompt).toContain('/test/project');
+    });
+
+    it('passes config to generator', () => {
+      const prompt = getPromptForRole('product-manager', {
+        projectPath: '/my/project',
+        discordChannels: ['general', 'dev'],
+      });
+      expect(prompt).toContain('/my/project');
+    });
+  });
+
+  describe('hasPrompt', () => {
+    it('returns true for registered roles', () => {
+      expect(hasPrompt('backend-engineer')).toBe(true);
+      expect(hasPrompt('product-manager')).toBe(true);
+    });
+
+    it('returns false for unknown roles', () => {
+      expect(hasPrompt('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('registerPrompt', () => {
+    it('registers custom prompt generator', () => {
+      registerPrompt('custom-role-test', () => 'Custom prompt output');
+
+      expect(hasPrompt('custom-role-test')).toBe(true);
+      const prompt = getPromptForRole('custom-role-test', { projectPath: '/test' });
+      expect(prompt).toBe('Custom prompt output');
+    });
+
+    it('overrides existing registration', () => {
+      registerPrompt('override-test', () => 'Original');
+      registerPrompt('override-test', () => 'Overridden');
+
+      const prompt = getPromptForRole('override-test', { projectPath: '/test' });
+      expect(prompt).toBe('Overridden');
+    });
+  });
+
+  describe('createPromptFromTemplate', () => {
+    it('replaces {{projectPath}} placeholder', () => {
+      const generator = createPromptFromTemplate('You work on {{projectPath}}. Do your best.');
+      const prompt = generator({ projectPath: '/home/dev/myapp' });
+      expect(prompt).toBe('You work on /home/dev/myapp. Do your best.');
+    });
+
+    it('replaces {{contextFiles}} placeholder', () => {
+      const generator = createPromptFromTemplate('Context: {{contextFiles}}');
+      const prompt = generator({
+        projectPath: '/test',
+        contextFiles: ['CLAUDE.md', 'rules.md'],
+      });
+      expect(prompt).toBe('Context: CLAUDE.md, rules.md');
+    });
+
+    it('handles missing contextFiles gracefully', () => {
+      const generator = createPromptFromTemplate('Context: {{contextFiles}}');
+      const prompt = generator({ projectPath: '/test' });
+      expect(prompt).toBe('Context: ');
+    });
+
+    it('replaces multiple occurrences', () => {
+      const generator = createPromptFromTemplate(
+        '{{projectPath}} is great. Working on {{projectPath}}.'
+      );
+      const prompt = generator({ projectPath: '/app' });
+      expect(prompt).toBe('/app is great. Working on /app.');
+    });
+  });
+
+  describe('listRegisteredRoles', () => {
+    it('returns array of strings', () => {
+      const roles = listRegisteredRoles();
+      expect(Array.isArray(roles)).toBe(true);
+      roles.forEach((role) => {
+        expect(typeof role).toBe('string');
+      });
+    });
+
+    it('includes custom registered roles', () => {
+      registerPrompt('list-test-role', () => 'test');
+      expect(listRegisteredRoles()).toContain('list-test-role');
+    });
+  });
+});

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -174,6 +174,7 @@ export type {
   ThinkingLevel,
   ServerLogLevel,
   ModelProvider,
+  DeploymentEnvironment,
   PhaseModelEntry,
   PhaseModelConfig,
   PhaseModelKey,
@@ -254,6 +255,9 @@ export {
   CLAUDE_PROVIDER_TEMPLATES,
   // Claude API profile constants (deprecated)
   CLAUDE_API_PROFILE_TEMPLATES,
+  // Environment presets
+  ENVIRONMENT_PRESETS,
+  getDeploymentEnvironment,
 } from './settings.js';
 
 // Model display constants

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -102,6 +102,75 @@ export function getThinkingTokenBudget(level: ThinkingLevel | undefined): number
 /** ModelProvider - AI model provider for credentials and API key management */
 export type ModelProvider = 'claude' | 'cursor' | 'codex' | 'opencode';
 
+/**
+ * DeploymentEnvironment - The runtime environment for this Automaker instance.
+ *
+ * Affects concurrency limits, heap thresholds, agent model defaults, and monitoring behavior.
+ * - 'development': Local dev machine. Conservative limits (2-3 agents, 8GB heap).
+ * - 'staging': LAN/VPN test rig. Higher limits (6-10 agents, 32GB+ heap). Used for load testing.
+ * - 'production': Live deployment. Stable limits with full monitoring and alerting.
+ */
+export type DeploymentEnvironment = 'development' | 'staging' | 'production';
+
+/**
+ * Environment-specific capacity presets.
+ * These serve as defaults — individual settings can override.
+ */
+export const ENVIRONMENT_PRESETS: Record<
+  DeploymentEnvironment,
+  {
+    maxConcurrency: number;
+    defaultModel: 'haiku' | 'sonnet' | 'opus';
+    heapLimitMb: number;
+    agentTimeoutMs: number;
+    enableMetrics: boolean;
+  }
+> = {
+  development: {
+    maxConcurrency: 2,
+    defaultModel: 'sonnet',
+    heapLimitMb: 8192,
+    agentTimeoutMs: 10 * 60 * 1000, // 10 min
+    enableMetrics: false,
+  },
+  staging: {
+    maxConcurrency: 6,
+    defaultModel: 'sonnet',
+    heapLimitMb: 32768,
+    agentTimeoutMs: 20 * 60 * 1000, // 20 min
+    enableMetrics: true,
+  },
+  production: {
+    maxConcurrency: 4,
+    defaultModel: 'sonnet',
+    heapLimitMb: 16384,
+    agentTimeoutMs: 15 * 60 * 1000, // 15 min
+    enableMetrics: true,
+  },
+};
+
+/**
+ * Detect the deployment environment from AUTOMAKER_ENV or NODE_ENV.
+ * Falls back to 'development' if not set or invalid.
+ */
+export function getDeploymentEnvironment(): DeploymentEnvironment {
+  // Guard against browser environments
+  const envValue =
+    typeof process !== 'undefined' && process.env
+      ? process.env.AUTOMAKER_ENV || process.env.NODE_ENV
+      : undefined;
+
+  if (!envValue) return 'development';
+
+  // Normalize common values
+  const normalized = envValue.toLowerCase().trim();
+  if (normalized === 'production' || normalized === 'prod') return 'production';
+  if (normalized === 'staging' || normalized === 'stage') return 'staging';
+  if (normalized === 'development' || normalized === 'dev') return 'development';
+
+  return 'development';
+}
+
 // ============================================================================
 // Claude-Compatible Providers - Configuration for Claude-compatible API endpoints
 // ============================================================================
@@ -1077,6 +1146,14 @@ export interface GlobalSettings {
   /** Version number for schema migration */
   version: number;
 
+  // Deployment Environment
+  /**
+   * Which environment this instance is running in.
+   * Affects concurrency defaults, heap limits, model selection, and monitoring.
+   * Auto-detected from AUTOMAKER_ENV env var, or defaults to 'development'.
+   */
+  environment?: DeploymentEnvironment;
+
   // Migration Tracking
   /** Whether localStorage settings have been migrated to API storage (prevents re-migration) */
   localStorageMigrated?: boolean;
@@ -1823,6 +1900,7 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcuts = {
 /** Default global settings used when no settings file exists */
 export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
   version: SETTINGS_VERSION,
+  environment: 'development',
   setupComplete: false,
   isFirstRun: true,
   skipClaudeSetup: false,

--- a/libs/types/tests/environment.test.ts
+++ b/libs/types/tests/environment.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getDeploymentEnvironment, ENVIRONMENT_PRESETS } from '../src/settings.js';
+
+describe('DeploymentEnvironment', () => {
+  const originalEnv = process.env;
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.unstubAllEnvs();
+  });
+
+  describe('ENVIRONMENT_PRESETS', () => {
+    it('has presets for all three environments', () => {
+      expect(ENVIRONMENT_PRESETS.development).toBeDefined();
+      expect(ENVIRONMENT_PRESETS.staging).toBeDefined();
+      expect(ENVIRONMENT_PRESETS.production).toBeDefined();
+    });
+
+    it('development has conservative limits', () => {
+      expect(ENVIRONMENT_PRESETS.development.maxConcurrency).toBe(2);
+      expect(ENVIRONMENT_PRESETS.development.heapLimitMb).toBe(8192);
+      expect(ENVIRONMENT_PRESETS.development.enableMetrics).toBe(false);
+    });
+
+    it('staging has higher limits', () => {
+      expect(ENVIRONMENT_PRESETS.staging.maxConcurrency).toBe(6);
+      expect(ENVIRONMENT_PRESETS.staging.heapLimitMb).toBe(32768);
+      expect(ENVIRONMENT_PRESETS.staging.enableMetrics).toBe(true);
+    });
+
+    it('production has stable limits', () => {
+      expect(ENVIRONMENT_PRESETS.production.maxConcurrency).toBe(4);
+      expect(ENVIRONMENT_PRESETS.production.enableMetrics).toBe(true);
+    });
+  });
+
+  describe('getDeploymentEnvironment', () => {
+    it('defaults to development when no env var set', () => {
+      vi.stubEnv('AUTOMAKER_ENV', '');
+      vi.stubEnv('NODE_ENV', '');
+      expect(getDeploymentEnvironment()).toBe('development');
+    });
+
+    it('reads AUTOMAKER_ENV first', () => {
+      vi.stubEnv('AUTOMAKER_ENV', 'staging');
+      vi.stubEnv('NODE_ENV', 'production');
+      expect(getDeploymentEnvironment()).toBe('staging');
+    });
+
+    it('falls back to NODE_ENV', () => {
+      vi.stubEnv('AUTOMAKER_ENV', '');
+      vi.stubEnv('NODE_ENV', 'production');
+      expect(getDeploymentEnvironment()).toBe('production');
+    });
+
+    it('normalizes "prod" to "production"', () => {
+      vi.stubEnv('AUTOMAKER_ENV', 'prod');
+      expect(getDeploymentEnvironment()).toBe('production');
+    });
+
+    it('normalizes "stage" to "staging"', () => {
+      vi.stubEnv('AUTOMAKER_ENV', 'stage');
+      expect(getDeploymentEnvironment()).toBe('staging');
+    });
+
+    it('normalizes "dev" to "development"', () => {
+      vi.stubEnv('AUTOMAKER_ENV', 'dev');
+      expect(getDeploymentEnvironment()).toBe('development');
+    });
+
+    it('is case insensitive', () => {
+      vi.stubEnv('AUTOMAKER_ENV', 'PRODUCTION');
+      expect(getDeploymentEnvironment()).toBe('production');
+    });
+
+    it('trims whitespace', () => {
+      vi.stubEnv('AUTOMAKER_ENV', '  staging  ');
+      expect(getDeploymentEnvironment()).toBe('staging');
+    });
+
+    it('returns development for unknown values', () => {
+      vi.stubEnv('AUTOMAKER_ENV', 'preview');
+      expect(getDeploymentEnvironment()).toBe('development');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **DeploymentEnvironment type** (`development` | `staging` | `production`) with `ENVIRONMENT_PRESETS` for capacity limits, heap thresholds, and model defaults per environment
- **`getDeploymentEnvironment()`** utility that auto-detects from `AUTOMAKER_ENV` or `NODE_ENV` with normalization (e.g., "prod" → "production")
- **AgentFactoryService** now passes `environment` and `desiredState` through to `AgentConfig`
- **DynamicAgentExecutor** injects environment-specific context into agent system prompts
- **Prompt registry adapter** with unified `getPromptForRole()` interface and 8 built-in role auto-registrations
- **46 new unit tests** across 4 test files:
  - `role-registry-service.test.ts` (19 tests) — register, get, list, unregister, tier protection, validation
  - `prompt-registry.test.ts` (14 tests) — built-in roles, custom registration, template placeholders
  - `environment.test.ts` (13 tests) — presets, detection, normalization, edge cases
  - Extended `agent-factory-service.test.ts` — environment pass-through, desiredState behavior

## Test plan

- [x] `npm run test:all` — 85/85 files pass, 2188/2188 tests pass
- [x] `npm run build:packages` — clean
- [x] `npm run build:server` — clean
- [ ] Verify `AUTOMAKER_ENV=staging` changes agent system prompt content
- [ ] Verify factory creates configs with correct environment field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment environment support (development, staging, production) for agents with environment-aware configuration.
  * Introduced prompt registry system mapping roles to prompt generators with automatic built-in role registration.
  * Environment-specific context now included in system prompts based on deployment setting.

* **Tests**
  * Added comprehensive test coverage for environment handling, prompt registry, and role-based prompt management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->