### PR TITLE
fix: remove duplicate roleRegistryService on main

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -440,9 +440,6 @@ const discordBotService = new DiscordBotService(
 );
 void discordBotService.initialize();
 
-// Initialize Role Registry (shared agent template registry)
-const roleRegistryService = new RoleRegistryService(events);
-
 // Initialize Agent Discord Router for agent-to-Discord message routing
 // Must be imported after DiscordBotService is initialized
 const { AgentDiscordRouter } = await import('./services/agent-discord-router.js');


### PR DESCRIPTION
## Summary
- Removes duplicate `const roleRegistryService` declaration that broke the build (TS2451)
- Root cause: PR #253 merge introduced a second declaration at line 444, conflicting with the existing one at line 339
- This is a critical fix — main build is broken until this merges

## Test plan
- [x] TypeScript build clean (`tsc --noEmit`)
- [x] Unit tests pass (role-registry + agent-factory)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified server initialization process by removing redundant configuration setup steps to enhance code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->