### PR TITLE
fix: load root .env when server runs via npm workspace

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,7 +9,16 @@
 // Load environment variables FIRST, before any imports that depend on them
 // (auth.ts reads AUTOMAKER_API_KEY at module load time)
 import dotenv from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// Load .env from CWD (works with combined launcher from monorepo root)
 dotenv.config();
+// Also load from monorepo root as fallback (for workspace-based dev scripts
+// where CWD is apps/server/ and the root .env isn't found by default)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+dotenv.config({ path: resolve(__dirname, '../../../.env') });
 
 import { execSync } from 'node:child_process';
 import express from 'express';


### PR DESCRIPTION
## Summary
- Fixes auto-login and project loading when running `npm run dev:server` separately from the combined launcher
- `dotenv.config()` only loads `.env` from CWD, but npm workspace changes CWD to `apps/server/` where no `.env` exists
- Added fallback `dotenv.config()` call that loads from monorepo root via `__dirname`
- `dotenv` doesn't overwrite existing vars, so both calls are safe together

## Test plan
- [ ] Run `npm run dev:server` and `npm run dev:web` separately
- [ ] Verify auto-login works (no login prompt)
- [ ] Verify project data loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved environment variable loading with fallback support for monorepo configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->