### PR TITLE
feat: add Linear agent OAuth flow and webhook handler

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -141,6 +141,7 @@ import { getAvaGatewayService } from './services/ava-gateway-service.js';
 import { getDiscordService } from './services/discord-service.js';
 import { createDiscordRoutes } from './routes/discord/index.js';
 import { createAvaRoutes } from './routes/ava/index.js';
+import { createLinearRoutes } from './routes/linear/index.js';
 import { MAX_SYSTEM_CONCURRENCY } from '@automaker/types';
 
 const PORT = parseInt(process.env.PORT || '3008', 10);
@@ -759,6 +760,8 @@ app.use('/api/setup', createSetupRoutes(settingsService));
 
 // Mount webhooks at root level (unauthenticated - uses signature verification)
 app.use('/webhooks', createWebhooksRoutes(events, settingsService));
+// Linear agent routes (OAuth + webhook)
+app.use('/api/linear', createLinearRoutes(settingsService, events));
 
 // Apply authentication to all /api/* routes
 app.use('/api', authMiddleware);

--- a/apps/server/src/routes/linear/index.ts
+++ b/apps/server/src/routes/linear/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Linear Agent Routes
+ *
+ * OAuth flow for registering as a Linear agent (actor=app)
+ * and webhook handler for AgentSessionEvent.
+ */
+
+import { Router } from 'express';
+import { createOAuthRoutes } from './oauth.js';
+import { createWebhookHandler } from './webhook.js';
+import type { SettingsService } from '../../services/settings-service.js';
+import type { EventEmitter } from '../../lib/events.js';
+
+export function createLinearRoutes(settingsService: SettingsService, events: EventEmitter): Router {
+  const router = Router();
+
+  // OAuth authorize + callback (actor=app flow)
+  router.use('/oauth', createOAuthRoutes(settingsService));
+
+  // Webhook for AgentSessionEvent (mentions, delegations)
+  router.post('/webhook', createWebhookHandler(settingsService, events));
+
+  return router;
+}

--- a/apps/server/src/routes/linear/oauth.ts
+++ b/apps/server/src/routes/linear/oauth.ts
@@ -1,0 +1,269 @@
+/**
+ * Linear OAuth Routes (actor=app)
+ *
+ * Implements the OAuth 2.0 flow for registering Automaker as a Linear agent.
+ * Uses actor=app to create a dedicated agent user in the workspace.
+ *
+ * Flow:
+ * 1. GET /authorize → redirects to Linear OAuth with actor=app
+ * 2. GET /callback  → exchanges code for token, stores per-workspace
+ * 3. POST /status   → checks if OAuth is configured
+ * 4. POST /revoke   → revokes token
+ *
+ * Required env vars:
+ *   LINEAR_CLIENT_ID, LINEAR_CLIENT_SECRET, LINEAR_REDIRECT_URI
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { randomBytes } from 'node:crypto';
+import { createLogger } from '@automaker/utils';
+import type { SettingsService } from '../../services/settings-service.js';
+
+const logger = createLogger('linear:oauth');
+
+/** Scopes needed for agent functionality */
+const AGENT_SCOPES = [
+  'read',
+  'write',
+  'issues:create',
+  'comments:create',
+  'app:assignable',
+  'app:mentionable',
+];
+
+/** In-memory state store for CSRF protection (short-lived) */
+const pendingStates = new Map<string, { projectPath: string; createdAt: number }>();
+
+/** Clean up expired states older than 10 minutes */
+function cleanExpiredStates(): void {
+  const now = Date.now();
+  for (const [state, data] of pendingStates) {
+    if (now - data.createdAt > 10 * 60 * 1000) {
+      pendingStates.delete(state);
+    }
+  }
+}
+
+export function createOAuthRoutes(settingsService: SettingsService): Router {
+  const router = Router();
+
+  /**
+   * GET /api/linear/oauth/authorize
+   * Initiates the OAuth flow — redirects to Linear's consent screen.
+   * Query params: ?projectPath=/path/to/project
+   */
+  router.get('/authorize', (req: Request, res: Response) => {
+    const projectPath = req.query.projectPath as string;
+    const clientId = process.env.LINEAR_CLIENT_ID;
+    const redirectUri = process.env.LINEAR_REDIRECT_URI;
+
+    if (!clientId || !redirectUri) {
+      res.status(500).json({
+        error: 'LINEAR_CLIENT_ID and LINEAR_REDIRECT_URI must be set in environment',
+      });
+      return;
+    }
+
+    if (!projectPath) {
+      res.status(400).json({ error: 'projectPath query parameter is required' });
+      return;
+    }
+
+    // Generate CSRF state
+    cleanExpiredStates();
+    const state = randomBytes(32).toString('hex');
+    pendingStates.set(state, { projectPath, createdAt: Date.now() });
+
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: 'code',
+      scope: AGENT_SCOPES.join(','),
+      state,
+      actor: 'app',
+      prompt: 'consent',
+    });
+
+    const authorizeUrl = `https://linear.app/oauth/authorize?${params.toString()}`;
+
+    logger.info('Redirecting to Linear OAuth', { projectPath });
+    res.redirect(authorizeUrl);
+  });
+
+  /**
+   * GET /api/linear/oauth/callback
+   * Handles the OAuth callback — exchanges code for token.
+   */
+  router.get('/callback', async (req: Request, res: Response) => {
+    const { code, state, error: oauthError } = req.query;
+
+    if (oauthError) {
+      logger.error('OAuth error from Linear', { error: oauthError });
+      res.status(400).json({ error: `Linear OAuth error: ${oauthError}` });
+      return;
+    }
+
+    if (!code || !state) {
+      res.status(400).json({ error: 'Missing code or state parameter' });
+      return;
+    }
+
+    // Validate CSRF state
+    const stateData = pendingStates.get(state as string);
+    if (!stateData) {
+      res.status(400).json({ error: 'Invalid or expired state parameter' });
+      return;
+    }
+    pendingStates.delete(state as string);
+
+    const clientId = process.env.LINEAR_CLIENT_ID;
+    const clientSecret = process.env.LINEAR_CLIENT_SECRET;
+    const redirectUri = process.env.LINEAR_REDIRECT_URI;
+
+    if (!clientId || !clientSecret || !redirectUri) {
+      res.status(500).json({ error: 'OAuth env vars not configured' });
+      return;
+    }
+
+    try {
+      // Exchange code for token
+      const tokenResponse = await fetch('https://api.linear.app/oauth/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          code: code as string,
+          redirect_uri: redirectUri,
+          client_id: clientId,
+          client_secret: clientSecret,
+          grant_type: 'authorization_code',
+        }),
+      });
+
+      if (!tokenResponse.ok) {
+        const errorText = await tokenResponse.text();
+        logger.error('Token exchange failed', { status: tokenResponse.status, error: errorText });
+        res.status(500).json({ error: 'Failed to exchange authorization code' });
+        return;
+      }
+
+      const tokenData = (await tokenResponse.json()) as {
+        access_token: string;
+        token_type: string;
+        expires_in: number;
+        scope: string;
+        refresh_token?: string;
+      };
+
+      // Store token in project settings
+      const { projectPath } = stateData;
+      await settingsService.updateProjectSettings(projectPath, {
+        integrations: {
+          linear: {
+            enabled: true,
+            agentToken: tokenData.access_token,
+            refreshToken: tokenData.refresh_token,
+            tokenExpiresAt: new Date(Date.now() + tokenData.expires_in * 1000).toISOString(),
+            scopes: tokenData.scope.split(',').map((s) => s.trim()),
+          },
+        },
+      });
+
+      logger.info('Linear OAuth completed successfully', { projectPath });
+
+      // Return success page
+      res.send(`
+        <!DOCTYPE html>
+        <html>
+        <head><title>Automaker - Linear Connected</title></head>
+        <body style="font-family: system-ui; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #0a0a0a; color: #fff;">
+          <div style="text-align: center;">
+            <h1>Linear Agent Connected</h1>
+            <p>Automaker is now registered as an agent in your Linear workspace.</p>
+            <p style="color: #888;">You can close this window.</p>
+          </div>
+        </body>
+        </html>
+      `);
+    } catch (error) {
+      logger.error('OAuth callback failed', { error });
+      res.status(500).json({ error: 'OAuth callback failed' });
+    }
+  });
+
+  /**
+   * POST /api/linear/oauth/status
+   * Check if Linear OAuth is configured for a project.
+   */
+  router.post('/status', async (req: Request, res: Response) => {
+    try {
+      const { projectPath } = req.body;
+      if (!projectPath) {
+        res.status(400).json({ error: 'projectPath is required' });
+        return;
+      }
+
+      const settings = await settingsService.getProjectSettings(projectPath);
+      const linear = settings.integrations?.linear;
+
+      const configured = !!(linear?.enabled && linear?.agentToken);
+      const expired = linear?.tokenExpiresAt ? new Date(linear.tokenExpiresAt) < new Date() : true;
+
+      res.json({
+        configured,
+        expired: configured ? expired : undefined,
+        scopes: configured ? linear?.scopes : undefined,
+        hasClientCredentials: !!(process.env.LINEAR_CLIENT_ID && process.env.LINEAR_CLIENT_SECRET),
+      });
+    } catch (error) {
+      logger.error('Failed to check OAuth status', { error });
+      res.status(500).json({ error: 'Failed to check OAuth status' });
+    }
+  });
+
+  /**
+   * POST /api/linear/oauth/revoke
+   * Revoke the Linear agent token.
+   */
+  router.post('/revoke', async (req: Request, res: Response) => {
+    try {
+      const { projectPath } = req.body;
+      if (!projectPath) {
+        res.status(400).json({ error: 'projectPath is required' });
+        return;
+      }
+
+      const settings = await settingsService.getProjectSettings(projectPath);
+      const token = settings.integrations?.linear?.agentToken;
+
+      if (token) {
+        // Revoke at Linear
+        await fetch('https://api.linear.app/oauth/revoke', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({ token }),
+        });
+      }
+
+      // Clear from settings
+      await settingsService.updateProjectSettings(projectPath, {
+        integrations: {
+          linear: {
+            enabled: false,
+            agentToken: undefined,
+            refreshToken: undefined,
+            tokenExpiresAt: undefined,
+            scopes: undefined,
+          },
+        },
+      });
+
+      logger.info('Linear OAuth token revoked', { projectPath });
+      res.json({ success: true });
+    } catch (error) {
+      logger.error('Failed to revoke token', { error });
+      res.status(500).json({ error: 'Failed to revoke token' });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/routes/linear/webhook.ts
+++ b/apps/server/src/routes/linear/webhook.ts
@@ -1,0 +1,193 @@
+/**
+ * Linear Webhook Handler
+ *
+ * Receives AgentSessionEvent webhooks from Linear.
+ * Routes mentions and delegations to the appropriate agent.
+ *
+ * Events:
+ * - agent_session.created: Agent mentioned or assigned
+ * - agent_session.updated: User provided additional prompt
+ *
+ * Must respond within 5 seconds (Linear requirement).
+ */
+
+import type { RequestHandler, Request, Response } from 'express';
+import { createHmac } from 'node:crypto';
+import { createLogger } from '@automaker/utils';
+import type { SettingsService } from '../../services/settings-service.js';
+import type { EventEmitter } from '../../lib/events.js';
+
+const logger = createLogger('linear:webhook');
+
+/** Linear webhook event types we handle */
+type LinearWebhookAction = 'create' | 'update' | 'remove';
+
+/** Agent session trigger types */
+type AgentSessionTrigger = 'mention' | 'delegation' | 'prompt';
+
+/** Linear AgentSessionEvent webhook payload */
+interface LinearAgentSessionPayload {
+  action: LinearWebhookAction;
+  type: 'AgentSession';
+  data: {
+    id: string;
+    /** The issue this session is associated with */
+    issueId?: string;
+    /** The comment that triggered this session (for mentions) */
+    commentId?: string;
+    /** How this session was triggered */
+    trigger?: AgentSessionTrigger;
+    /** The user's prompt/message to the agent */
+    prompt?: string;
+    /** Current session status */
+    status?: string;
+    /** Workspace ID */
+    organizationId?: string;
+    /** Timestamps */
+    createdAt?: string;
+    updatedAt?: string;
+  };
+  /** URL to respond to (for acknowledging) */
+  url?: string;
+  /** Webhook signature for verification */
+  webhookId?: string;
+  /** Timestamp of the event */
+  createdAt?: string;
+}
+
+/**
+ * Verify webhook signature from Linear
+ */
+function verifyWebhookSignature(
+  body: string,
+  signature: string | undefined,
+  secret: string
+): boolean {
+  if (!signature) return false;
+  const hmac = createHmac('sha256', secret);
+  hmac.update(body);
+  const expected = hmac.digest('hex');
+  return signature === expected;
+}
+
+export function createWebhookHandler(
+  settingsService: SettingsService,
+  events: EventEmitter
+): RequestHandler {
+  return async (req: Request, res: Response) => {
+    const webhookSecret = process.env.LINEAR_WEBHOOK_SECRET;
+
+    // Verify signature if secret is configured
+    if (webhookSecret) {
+      const signature = req.headers['linear-signature'] as string | undefined;
+      const rawBody = JSON.stringify(req.body);
+
+      if (!verifyWebhookSignature(rawBody, signature, webhookSecret)) {
+        logger.warn('Invalid webhook signature');
+        res.status(401).json({ error: 'Invalid signature' });
+        return;
+      }
+    }
+
+    const payload = req.body as LinearAgentSessionPayload;
+
+    // Must respond within 5 seconds (Linear requirement)
+    // Acknowledge immediately, process async
+    res.status(200).json({ ok: true });
+
+    // Process asynchronously after responding
+    try {
+      await processWebhookEvent(payload, settingsService, events);
+    } catch (error) {
+      logger.error('Failed to process webhook event', {
+        error: error instanceof Error ? error.message : String(error),
+        action: payload.action,
+        sessionId: payload.data?.id,
+      });
+    }
+  };
+}
+
+async function processWebhookEvent(
+  payload: LinearAgentSessionPayload,
+  settingsService: SettingsService,
+  events: EventEmitter
+): Promise<void> {
+  const { action, type, data } = payload;
+
+  if (type !== 'AgentSession') {
+    logger.debug(`Ignoring non-AgentSession event: ${type}`);
+    return;
+  }
+
+  logger.info(`Processing AgentSession ${action}`, {
+    sessionId: data.id,
+    trigger: data.trigger,
+    issueId: data.issueId,
+  });
+
+  switch (action) {
+    case 'create':
+      await handleSessionCreated(data, events);
+      break;
+    case 'update':
+      await handleSessionUpdated(data, events);
+      break;
+    case 'remove':
+      logger.info(`Agent session removed: ${data.id}`);
+      events.emit('linear:agent-session:removed', { sessionId: data.id });
+      break;
+    default:
+      logger.debug(`Unhandled action: ${action}`);
+  }
+}
+
+/**
+ * Handle new agent session (mention or delegation)
+ */
+async function handleSessionCreated(
+  data: LinearAgentSessionPayload['data'],
+  events: EventEmitter
+): Promise<void> {
+  const trigger = data.trigger || 'mention';
+
+  logger.info(`Agent session created via ${trigger}`, {
+    sessionId: data.id,
+    issueId: data.issueId,
+    prompt: data.prompt?.substring(0, 100),
+  });
+
+  // Determine agent type based on context
+  // Default routing: delegations go to Ava, mentions are context-dependent
+  const agentType = trigger === 'delegation' ? 'ava' : 'ava';
+
+  events.emit('linear:agent-session:created', {
+    sessionId: data.id,
+    issueId: data.issueId,
+    commentId: data.commentId,
+    trigger,
+    prompt: data.prompt,
+    agentType,
+    organizationId: data.organizationId,
+  });
+}
+
+/**
+ * Handle session update (user provided additional prompt)
+ */
+async function handleSessionUpdated(
+  data: LinearAgentSessionPayload['data'],
+  events: EventEmitter
+): Promise<void> {
+  logger.info(`Agent session updated`, {
+    sessionId: data.id,
+    prompt: data.prompt?.substring(0, 100),
+  });
+
+  events.emit('linear:agent-session:updated', {
+    sessionId: data.id,
+    issueId: data.issueId,
+    prompt: data.prompt,
+    status: data.status,
+  });
+}

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -128,6 +128,10 @@ export type EventType =
   // Linear monitoring events
   | 'linear:project:updated'
   | 'linear:issue:detected'
+  // Linear agent session events (webhook-driven)
+  | 'linear:agent-session:created'
+  | 'linear:agent-session:updated'
+  | 'linear:agent-session:removed'
   // GitHub monitoring events
   | 'github:pr:detected'
   // Linear monitor events

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -1556,6 +1556,16 @@ export interface LinearIntegrationConfig {
   };
   /** Custom label to apply to all synced issues */
   labelName?: string;
+
+  // Agent OAuth (actor=app) fields
+  /** OAuth access token for agent (actor=app) */
+  agentToken?: string;
+  /** OAuth refresh token */
+  refreshToken?: string;
+  /** Token expiration timestamp (ISO 8601) */
+  tokenExpiresAt?: string;
+  /** Granted OAuth scopes */
+  scopes?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Implements Linear OAuth 2.0 `actor=app` flow for registering Automaker as an agent in Linear workspaces
- Adds `AgentSessionEvent` webhook handler for mentions, delegations, and prompts from Linear
- Adds agent OAuth fields (`agentToken`, `refreshToken`, `tokenExpiresAt`, `scopes`) to `LinearIntegrationConfig` in types
- Adds `linear:agent-session:created/updated/removed` event types

## New Files

- `apps/server/src/routes/linear/oauth.ts` — OAuth authorize, callback, status, revoke endpoints
- `apps/server/src/routes/linear/webhook.ts` — Webhook handler with HMAC signature verification
- `apps/server/src/routes/linear/index.ts` — Route index

## Test plan

- [ ] Verify server builds cleanly (`npm run build:server`)
- [ ] Verify OAuth redirect works with LINEAR_CLIENT_ID configured
- [ ] Verify webhook signature verification rejects invalid signatures
- [ ] Verify webhook processes AgentSessionEvent create/update/remove

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linear integration with OAuth 2.0 authentication flow
  * Webhook support for Linear agent session events (create, update, remove actions)
  * Per-project Linear integration settings with secure credential and token management
<!-- end of auto-generated comment: release notes by coderabbit.ai -->