### PR TITLE
fix: track consecutive_errors and idle_duration_ms in world state

### DIFF
--- a/apps/server/src/services/headsdown-service.ts
+++ b/apps/server/src/services/headsdown-service.ts
@@ -73,6 +73,12 @@ export class HeadsdownService {
   /** Loop intervals for cleanup */
   private loopIntervals = new Map<string, NodeJS.Timeout>();
 
+  /** Consecutive error counts per agent */
+  private consecutiveErrors = new Map<string, number>();
+
+  /** Last work timestamp per agent (milliseconds) */
+  private lastWorkTimestamp = new Map<string, number>();
+
   /** Discord monitor for detecting user messages */
   private discordMonitor: DiscordMonitor;
 
@@ -239,6 +245,8 @@ export class HeadsdownService {
 
     // Remove from active agents
     this.agents.delete(agentId);
+    this.consecutiveErrors.delete(agentId);
+    this.lastWorkTimestamp.delete(agentId);
 
     // Emit stop event
     this.events.emit('headsdown:agent:stopped', {
@@ -320,6 +328,8 @@ export class HeadsdownService {
     };
 
     this.agents.set(agent.id, agent);
+    this.consecutiveErrors.set(agent.id, 0);
+    this.lastWorkTimestamp.set(agent.id, Date.now());
 
     return agent;
   }
@@ -380,10 +390,15 @@ export class HeadsdownService {
     } catch (error) {
       logger.error(`Work loop error for agent ${agentId}:`, error);
 
+      // Increment consecutive error count
+      const errorCount = (this.consecutiveErrors.get(agentId) ?? 0) + 1;
+      this.consecutiveErrors.set(agentId, errorCount);
+
       // Emit error event
       this.events.emit('headsdown:agent:error', {
         agentId,
         error: error instanceof Error ? error.message : String(error),
+        consecutiveErrors: errorCount,
       });
 
       // Continue loop after error
@@ -525,13 +540,17 @@ export class HeadsdownService {
    * Build world state for work evaluation
    */
   private async buildWorldState(agent: AgentInstance): Promise<WorldState> {
+    const lastWorkTime = this.lastWorkTimestamp.get(agent.id) ?? Date.now();
+    const idleDurationMs = Date.now() - lastWorkTime;
+    const consecutiveErrorCount = this.consecutiveErrors.get(agent.id) ?? 0;
+
     const state: WorldState = {
       // Agent state
       agent_role: agent.role,
       agent_idle: agent.status === 'idle',
       total_turns: agent.stats.totalTurns,
-      consecutive_errors: 0, // TODO: track from loop errors
-      idle_duration_ms: 0, // TODO: track from last work timestamp
+      consecutive_errors: consecutiveErrorCount,
+      idle_duration_ms: idleDurationMs,
 
       // Monitoring state
       discord_monitoring_active: !!agent.monitoring.discord,
@@ -793,6 +812,12 @@ export class HeadsdownService {
 
       // Update stats
       agent.stats.totalTurns++;
+
+      // Reset consecutive errors on successful work execution
+      this.consecutiveErrors.set(agent.id, 0);
+
+      // Update last work timestamp
+      this.lastWorkTimestamp.set(agent.id, Date.now());
     } catch (error) {
       logger.error(`Work execution failed for agent ${agent.id}:`, error);
       throw error;
@@ -830,11 +855,13 @@ export class HeadsdownService {
       await mkdir(stateDir, { recursive: true });
     }
 
+    const consecutiveErrorCount = this.consecutiveErrors.get(agentId) ?? 0;
+
     const state: HeadsdownState = {
       agentId: agent.id,
       status: agent.status,
       currentTurns: agent.stats.totalTurns,
-      consecutiveErrors: 0, // TODO: Track errors properly
+      consecutiveErrors: consecutiveErrorCount,
       updatedAt: new Date().toISOString(),
     };
 


### PR DESCRIPTION
## Summary
- Replaces hardcoded `consecutive_errors: 0` and `idle_duration_ms: 0` in `buildWorldState()` with actual tracked values
- Adds `consecutiveErrors` and `lastWorkTimestamp` Maps for per-agent tracking
- Fixes `saveAgentState()` to use real error counts instead of hardcoded 0

## Test plan
- [ ] `npm run build:server` compiles clean
- [ ] Induce error → `consecutive_errors` increments
- [ ] Idle period → `idle_duration_ms` grows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved tracking of agent idle time and consecutive errors throughout the system.
  * More accurate persistence and recovery of agent state information.
  * Enhanced reliability in monitoring agent health and performance metrics during normal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->