### PR TITLE
fix: stop auto-mode loop after idle event to prevent spam

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -945,10 +945,13 @@ export class AutoModeService {
             logger.info(
               `[AutoLoop] No pending features available, ${projectRunningCount} still running, waiting...`
             );
-          } else {
-            logger.warn(
-              `[AutoLoop] No pending features found for ${worktreeDesc} (branchName: ${branchName === null ? 'null (main)' : branchName}). Check server logs for filtering details.`
+          } else if (projectState.hasEmittedIdleEvent) {
+            // Already emitted idle event and still no work — stop the loop to prevent spam
+            logger.info(
+              `[AutoLoop] No pending features and idle already reported. Stopping loop for ${worktreeDesc}.`
             );
+            projectState.isRunning = false;
+            break;
           }
           await this.sleep(10000);
           continue;
@@ -1314,8 +1317,11 @@ export class AutoModeService {
             logger.debug(
               `[AutoLoop] No pending features, ${runningCount} still running, waiting...`
             );
-          } else {
-            logger.debug(`[AutoLoop] No pending features, waiting for new items...`);
+          } else if (this.hasEmittedIdleEvent) {
+            // Already emitted idle event and still no work — stop the loop to prevent spam
+            logger.info(`[AutoLoop] No pending features and idle already reported. Stopping loop.`);
+            this.autoLoopRunning = false;
+            break;
           }
           await this.sleep(10000);
           continue;

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -208,7 +208,10 @@ export type EventType =
   | 'beads:dependency-added'
   // Ceremony events (milestone updates and project retrospectives)
   | 'ceremony:milestone-update'
-  | 'ceremony:project-retro';
+  | 'ceremony:project-retro'
+  | 'ceremony:triggered'
+  // Feature lifecycle events
+  | 'feature:status-changed';
 
 export type EventCallback = (type: EventType, payload: unknown) => void;
 


### PR DESCRIPTION
## Summary

- When backlog is empty and idle event already emitted, break out of the auto-mode loop instead of continuing to spin every 10 seconds
- Fixes both per-project (`runAutoLoopForProject`) and legacy (`runAutoLoop`) paths
- Adds missing `ceremony:triggered` and `feature:status-changed` entries to `EventType` union that were causing build failures

## Problem

Circuit breaker auto-resume creates fresh state every 5 minutes with `hasEmittedIdleEvent: false`, causing 190+ duplicate `auto_mode_complete` events on an empty board. Even without the circuit breaker, the loop continued spinning every 10s doing nothing after emitting the idle event.

## Test plan

- [x] Build clean (`npm run build:packages && npm run build:server`)
- [x] 1602 tests passing (`npm run test:server`)
- [x] Verify auto-mode stops cleanly when board is empty
- [x] No pre-existing build errors remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended event system with additional event types for enhanced workflow capabilities
  * Introduced event severity classification system with four severity levels

* **Improvements**
  * Optimized auto-mode idle state handling to reduce redundant logging and improve system efficiency during idle periods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->