### PR TITLE
feat: wire CompletionDetectorService and ceremony routes

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -124,6 +124,8 @@ import { createIntegrationRoutes } from './routes/integrations/index.js';
 import { AuthorityService } from './services/authority-service.js';
 import { createAuthorityRoutes } from './routes/authority/index.js';
 import { createCosRoutes } from './routes/cos/index.js';
+import { CompletionDetectorService } from './services/completion-detector-service.js';
+import { createCeremoniesRoutes } from './routes/ceremonies/index.js';
 import { PMAuthorityAgent } from './services/authority-agents/pm-agent.js';
 import { ProjMAuthorityAgent } from './services/authority-agents/projm-agent.js';
 import { EMAuthorityAgent } from './services/authority-agents/em-agent.js';
@@ -425,6 +427,10 @@ const projectService = new ProjectService(featureLoader);
 // Initialize Ceremony Service for milestone completion ceremonies
 const { ceremonyService } = await import('./services/ceremony-service.js');
 ceremonyService.initialize(events, settingsService, featureLoader, projectService);
+
+// Initialize Completion Detector Service — cascades feature done → epic → milestone → project
+const completionDetectorService = new CompletionDetectorService();
+completionDetectorService.initialize(events, featureLoader, projectService);
 
 const projmAgent = new ProjMAuthorityAgent(events, authorityService, featureLoader, projectService);
 const emAgent = new EMAuthorityAgent(
@@ -897,6 +903,7 @@ app.use(
   '/api/agents',
   createAgentManagementRoutes(roleRegistryService, agentFactoryService, dynamicAgentExecutor)
 );
+app.use('/api/ceremonies', createCeremoniesRoutes(events, featureLoader, projectService));
 
 // Create HTTP server
 const server = createServer(app);


### PR DESCRIPTION
## Summary

- Initialize `CompletionDetectorService` in server startup after `CeremonyService`
- Mount ceremony routes at `/api/ceremonies` for manual ceremony triggers
- Enables automatic completion cascade: feature done → epic done → milestone completed → project completed

## Context

PR #273 added the `CompletionDetectorService` and ceremony routes but didn't wire them into `index.ts`. This PR completes the integration.

## Test plan

- [x] Build clean
- [x] 1602 tests passing
- [ ] Manual: move feature to done → verify completion cascade events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Ceremonies API endpoint at `/api/ceremonies` for ceremony management operations.
  * Integrated Completion Detector service for enhanced event processing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->