### PR TITLE
feat: emit health:issue-detected events from HealthMonitorService

### DIFF
--- a/apps/server/src/services/health-monitor-service.ts
+++ b/apps/server/src/services/health-monitor-service.ts
@@ -278,6 +278,21 @@ export class HealthMonitorService {
 
     this.lastCheckResult = result;
 
+    // Emit health:issue-detected for critical and warning issues BEFORE auto-remediation
+    if (this.events) {
+      for (const issue of issues) {
+        if (issue.severity === 'critical' || issue.severity === 'warning') {
+          this.events.emit('health:issue-detected', {
+            type: issue.type,
+            severity: issue.severity,
+            message: issue.message,
+            featureId: issue.context.featureId as string | undefined,
+            metrics: result.metrics,
+          });
+        }
+      }
+    }
+
     // Auto-remediate if enabled
     if (this.config.autoRemediate) {
       await this.autoRemediate(issues);


### PR DESCRIPTION
## Summary
- Emit `health:issue-detected` event for each critical/warning issue detected by HealthMonitorService
- Events are emitted BEFORE auto-remediation so AvaGatewayService can post to Discord immediately
- Includes issue type, severity, message, featureId (if applicable), and current metrics

## Context
The `health:issue-detected` event was defined in `event.ts` and subscribed to by `AvaGatewayService`, but was never emitted. This was one of three critical breaks preventing the health → Discord notification pipeline from working.

## Test plan
- [ ] Build passes: `npm run build:server`
- [ ] Health events with critical/warning severity emit `health:issue-detected`
- [ ] Non-severe issues (info) do NOT emit `health:issue-detected`
- [ ] `health:check-completed` still emits as before (backward compatible)
- [ ] No duplicate emissions — each issue emits exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health monitoring now emits issue-detected events when critical or warning-level problems are identified, providing better visibility into system health status with detailed issue information (type, severity, message, and associated metrics).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->