### PR TITLE
fix: Discord thread routing event payload mismatch

### DIFF
--- a/apps/server/src/services/discord-bot-service.ts
+++ b/apps/server/src/services/discord-bot-service.ts
@@ -731,18 +731,11 @@ export class DiscordBotService {
 
       // Emit routed event so AgentDiscordRouter picks it up
       this.events.emit('discord:user-message:routed', {
-        projectPath: this.projectPath,
+        channelId: thread.id,
         userId: interaction.user.id,
         username,
-        agentId: agentName,
-        messages: [
-          {
-            content: userMessage,
-            attachments: {},
-            timestamp: Date.now(),
-          },
-        ],
-        channelId: thread.id,
+        content: userMessage,
+        routedToAgent: agentName,
       });
 
       logger.info(`Created agent thread for /${agentName}`, {
@@ -871,18 +864,11 @@ export class DiscordBotService {
       const agentThread = this.agentThreads.get(message.channelId);
       if (agentThread) {
         this.events.emit('discord:user-message:routed', {
-          projectPath: this.projectPath,
+          channelId: message.channelId,
           userId: message.author.id,
           username: message.author.username,
-          agentId: agentThread.agentType,
-          messages: [
-            {
-              content: message.content,
-              attachments: {},
-              timestamp: message.createdTimestamp,
-            },
-          ],
-          channelId: message.channelId,
+          content: message.content,
+          routedToAgent: agentThread.agentType,
         });
         return;
       }


### PR DESCRIPTION
## Summary
- Fix two locations in `discord-bot-service.ts` emitting `discord:user-message:routed` with wrong payload shape
- `handleAgentCommand()`: `agentId` → `routedToAgent`, `messages[]` → `content`
- Thread handler in `messageCreate`: same fix
- Both now match `DiscordUserMessageRoutedPayload` type: `{ channelId, userId, username, content, routedToAgent }`

## Context
After PR #271 shipped Discord slash commands, the thread routing was broken because the emitted event payload didn't match what `agent-discord-router.ts` expected. `content` and `routedToAgent` were always `undefined`.

## Test plan
- [ ] Build passes: `npm run build:server`
- [ ] `/ava` slash command creates thread and routes message to Ava
- [ ] Follow-up messages in thread get agent responses
- [ ] `/gtm` slash command routes to GTM specialist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined Discord message routing event structure for improved efficiency. Message content is now transmitted as a single string with simplified routing identifiers, removing unnecessary batch processing and optimizing data transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->