### PR TITLE
fix: include backlog features with stale worktrees in auto-mode

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -4348,13 +4348,26 @@ Format your response as a structured markdown document.`;
                 featureBranch === null || (primaryBranch && featureBranch === primaryBranch);
               // Orphaned = has branchName but no corresponding worktree exists
               const isOrphaned = featureBranch !== null && !worktreeBranches.has(featureBranch);
+              // Stale worktree = has branchName with existing worktree BUT feature is in backlog
+              // This happens when a previous agent attempt created the worktree but failed before starting.
+              // The agent service will reuse the existing worktree, so we should include these.
+              const hasStaleWorktree =
+                featureBranch !== null &&
+                worktreeBranches.has(featureBranch) &&
+                (feature.status === 'backlog' ||
+                  feature.status === 'pending' ||
+                  feature.status === 'ready');
 
               logger.debug(
-                `[loadPendingFeatures] Feature ${feature.id} branch filter - featureBranch: ${featureBranch}, primaryBranch: ${primaryBranch}, isPrimaryOrUnassigned: ${isPrimaryOrUnassigned}, isOrphaned: ${isOrphaned}`
+                `[loadPendingFeatures] Feature ${feature.id} branch filter - featureBranch: ${featureBranch}, primaryBranch: ${primaryBranch}, isPrimaryOrUnassigned: ${isPrimaryOrUnassigned}, isOrphaned: ${isOrphaned}, hasStaleWorktree: ${hasStaleWorktree}`
               );
 
-              if (isPrimaryOrUnassigned || isOrphaned) {
-                if (isOrphaned) {
+              if (isPrimaryOrUnassigned || isOrphaned || hasStaleWorktree) {
+                if (hasStaleWorktree) {
+                  logger.info(
+                    `[loadPendingFeatures] ✅ Including feature ${feature.id} with stale worktree (branchName: ${featureBranch}, status: ${feature.status}) for main worktree`
+                  );
+                } else if (isOrphaned) {
                   logger.info(
                     `[loadPendingFeatures] ✅ Including orphaned feature ${feature.id} (branchName: ${featureBranch} has no worktree) for main worktree`
                   );
@@ -4365,9 +4378,9 @@ Format your response as a structured markdown document.`;
                 }
                 pendingFeatures.push(feature);
               } else {
-                // Feature belongs to a specific worktree (has branchName with existing worktree)
+                // Feature belongs to a specific worktree AND is actively being worked on (in_progress)
                 logger.info(
-                  `[loadPendingFeatures] ❌ Filtering out feature ${feature.id} (branchName: ${featureBranch} has worktree) for main worktree`
+                  `[loadPendingFeatures] ❌ Filtering out feature ${feature.id} (branchName: ${featureBranch} has worktree, status: ${feature.status}) for main worktree`
                 );
               }
             } else {


### PR DESCRIPTION
## Summary
- Features with existing worktrees were unconditionally skipped by auto-mode on the main worktree
- This caused features to get permanently stuck when a previous agent attempt created the worktree but failed before starting
- The feature sat in backlog but auto-mode skipped it, then the idle-stop logic killed the loop after 2 iterations

## Root Cause
`loadPendingFeatures()` filtered out any feature where `worktreeBranches.has(featureBranch)` was true, regardless of feature status. A failed agent start creates a worktree but resets the feature to backlog — creating a dead zone where the feature can't be picked up.

## Fix
Added "stale worktree" detection: if a feature has a worktree but is in `backlog`/`pending`/`ready` status, the worktree is from a failed previous attempt. The agent service will reuse it, so we include these features as candidates.

## Test plan
- [x] `npm run build:server` passes
- [ ] Manual: create feature with worktree, reset to backlog → auto-mode picks it up
- [ ] Existing behavior: in_progress features with worktrees still filtered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)