### PR TITLE
fix: use v8 heap limit for accurate memory monitoring

### DIFF
--- a/apps/server/src/services/event-hook-service.ts
+++ b/apps/server/src/services/event-hook-service.ts
@@ -196,7 +196,7 @@ export interface HealthCheckPayload {
  * Health check completed event payload structure (from health:check-completed)
  */
 export interface HealthCheckCompletedPayload {
-  projectPath: string;
+  projectPath?: string;
   status: 'healthy' | 'degraded' | 'critical';
   issues?: Array<{ type: string; severity: string; message: string }>;
   metrics?: Record<string, unknown>;
@@ -507,8 +507,8 @@ export class EventHookService {
         .join('; ') || 'No specific issues reported';
 
     const context: HookContext = {
-      projectPath: payload.projectPath,
-      projectName: this.extractProjectName(payload.projectPath),
+      projectPath: payload.projectPath || '',
+      projectName: payload.projectPath ? this.extractProjectName(payload.projectPath) : 'unknown',
       healthStatus: payload.status,
       healthDetails: issueSummary,
       timestamp: payload.timestamp || new Date().toISOString(),

--- a/apps/server/src/services/headsdown-service.ts
+++ b/apps/server/src/services/headsdown-service.ts
@@ -47,6 +47,7 @@ import { LinearMonitor } from './linear-monitor.js';
 import { GitHubMonitor } from './github-monitor.js';
 import { v4 as uuidv4 } from 'uuid';
 import path from 'node:path';
+import v8 from 'node:v8';
 import { existsSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import type { AgentFactoryService } from './agent-factory-service.js';
@@ -636,9 +637,10 @@ export class HeadsdownService {
       }
     }
 
-    // Populate infrastructure metrics
+    // Populate infrastructure metrics — use v8 heap limit for accurate percentage
     const memUsage = process.memoryUsage();
-    const heapPercent = Math.round((memUsage.heapUsed / memUsage.heapTotal) * 100);
+    const heapLimit = v8.getHeapStatistics().heap_size_limit;
+    const heapPercent = Math.round((memUsage.heapUsed / heapLimit) * 100);
     state.heap_usage_percent = heapPercent;
     state.running_agents = this.agents.size;
 

--- a/apps/server/src/services/health-monitor-service.ts
+++ b/apps/server/src/services/health-monitor-service.ts
@@ -22,6 +22,7 @@ import * as secureFs from '../lib/secure-fs.js';
 import path from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import v8 from 'v8';
 
 const execAsync = promisify(exec);
 const logger = createLogger('HealthMonitor');
@@ -255,11 +256,12 @@ export class HealthMonitorService {
       status = 'degraded';
     }
 
-    // Get memory metrics
+    // Get memory metrics — use v8 heap limit for accurate percentage
     const memoryUsage = process.memoryUsage();
+    const heapStats = v8.getHeapStatistics();
     const heapUsedMB = memoryUsage.heapUsed / (1024 * 1024);
-    const heapTotalMB = memoryUsage.heapTotal / (1024 * 1024);
-    const memoryUsagePercent = memoryUsage.heapUsed / memoryUsage.heapTotal;
+    const heapTotalMB = heapStats.heap_size_limit / (1024 * 1024);
+    const memoryUsagePercent = memoryUsage.heapUsed / heapStats.heap_size_limit;
 
     const result: HealthCheckResult = {
       timestamp: new Date().toISOString(),
@@ -537,16 +539,21 @@ export class HealthMonitorService {
     const issues: HealthIssue[] = [];
 
     const memoryUsage = process.memoryUsage();
-    const heapUsagePercent = memoryUsage.heapUsed / memoryUsage.heapTotal;
+    const heapStats = v8.getHeapStatistics();
+    // Use heap_size_limit (actual max from --max-old-space-size) instead of heapTotal
+    // V8 grows heapTotal conservatively, so heapUsed/heapTotal reports ~95% when
+    // actual usage is tiny (e.g., 30MB used out of 8GB limit)
+    const heapLimit = heapStats.heap_size_limit;
+    const heapUsagePercent = memoryUsage.heapUsed / heapLimit;
 
     if (heapUsagePercent > MEMORY_WARNING_THRESHOLD) {
       issues.push({
         type: 'high_memory_usage',
         severity: heapUsagePercent > 0.95 ? 'critical' : 'warning',
-        message: `High memory usage: ${Math.round(heapUsagePercent * 100)}% of heap used`,
+        message: `High memory usage: ${Math.round(heapUsagePercent * 100)}% of heap used (${Math.round(memoryUsage.heapUsed / (1024 * 1024))}MB / ${Math.round(heapLimit / (1024 * 1024))}MB limit)`,
         context: {
           heapUsed: memoryUsage.heapUsed,
-          heapTotal: memoryUsage.heapTotal,
+          heapLimit,
           heapUsagePercent,
           external: memoryUsage.external,
           rss: memoryUsage.rss,


### PR DESCRIPTION
## Summary
- **Memory false positive (P0)**: Health monitor used `heapUsed/heapTotal` which reports ~95% even when actual usage is tiny. V8 grows `heapTotal` conservatively — it's the current allocation, not the max. Now uses `v8.getHeapStatistics().heap_size_limit` (the actual `--max-old-space-size` value). Same fix auto-mode already had (line 5889).
- **EventHookService crash (P0)**: `handleHealthCheckCompletedEvent()` called `extractProjectName(payload.projectPath)` but `HealthCheckResult` doesn't include `projectPath`. Added null guard + made the field optional in the interface.
- **HeadsdownService**: Same `heapUsed/heapTotal` bug, fixed to use v8 limit.

Both bugs found by Frank's auto-triage report.

## Test plan
- [x] `npm run build:server` — clean
- [x] `npm run test:server` — 1604 passed, 0 failed
- [ ] Verify no more false 95% heap alerts in Discord #infra after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved memory monitoring accuracy by refining heap usage calculations and reporting.
  * Enhanced health check event resilience to handle missing project information gracefully.

* **Improvements**
  * Extended health check data to include timestamp information for better event tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->