### PR TITLE
chore: fix qs DoS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13666,9 +13666,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
## Summary
- `npm audit fix` to address GHSA-w7fw-mjwx-w883 (qs <=6.14.1 arrayLimit bypass → DoS)
- Low severity, minimal lock file change (3 lines)

## Test plan
- [x] `npm run build:server` — clean
- [x] `npm audit` — 0 vulnerabilities
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)