### PR TITLE
fix: prettier format violation in vitepress config

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -39,7 +39,10 @@ export default defineConfig({
   srcExclude: ['archived/**'],
 
   // Only allow dead links to files outside docs/ (CLAUDE.md, CONTRIBUTING, etc.)
-  ignoreDeadLinks: [/^\.\.\//, /^\/(?!getting-started|agents|infra|server|authority|dev|protolabs|integrations)/],
+  ignoreDeadLinks: [
+    /^\.\.\//,
+    /^\/(?!getting-started|agents|infra|server|authority|dev|protolabs|integrations)/,
+  ],
 
   themeConfig: {
     logo: '/logo.svg',


### PR DESCRIPTION
## Summary
- Fix pre-existing prettier violation in `docs/.vitepress/config.mts` that blocks all PR CI format checks

## Test plan
- [ ] `npx prettier --check .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)