### PR TITLE
feat: wire agentConfig (maxTurns, systemPrompt) to API

### DIFF
--- a/apps/ui/src/components/views/agent-view.tsx
+++ b/apps/ui/src/components/views/agent-view.tsx
@@ -44,7 +44,6 @@ export function AgentView() {
   }, []);
 
   const [modelSelection, setModelSelection] = useState<PhaseModelEntry>({ model: 'claude-sonnet' });
-  // TODO: Wire agentConfig to useElectronAgent so maxTurns and systemPromptOverride take effect
   const [agentConfig, setAgentConfig] = useState<AgentConfig>({
     maxTurns: DEFAULT_MAX_TURNS,
     systemPromptOverride: '',
@@ -79,6 +78,8 @@ export function AgentView() {
     model: modelSelection.model,
     thinkingLevel: modelSelection.thinkingLevel,
     role: agentConfig.role,
+    maxTurns: agentConfig.maxTurns,
+    systemPromptOverride: agentConfig.systemPromptOverride,
     onToolUse: (toolName) => {
       setCurrentTool(toolName);
       setTimeout(() => setCurrentTool(null), 2000);

--- a/apps/ui/src/hooks/use-electron-agent.ts
+++ b/apps/ui/src/hooks/use-electron-agent.ts
@@ -15,6 +15,8 @@ interface UseElectronAgentOptions {
   model?: string;
   thinkingLevel?: string;
   role?: string;
+  maxTurns?: number;
+  systemPromptOverride?: string;
   onToolUse?: (toolName: string, toolInput: unknown) => void;
 }
 
@@ -73,6 +75,8 @@ export function useElectronAgent({
   model,
   thinkingLevel,
   role,
+  maxTurns,
+  systemPromptOverride,
   onToolUse,
 }: UseElectronAgentOptions): UseElectronAgentResult {
   const [messages, setMessages] = useState<Message[]>([]);
@@ -144,7 +148,9 @@ export function useElectronAgent({
           imagePaths,
           model,
           thinkingLevel,
-          role
+          role,
+          maxTurns,
+          systemPromptOverride
         );
 
         if (!result.success) {
@@ -160,7 +166,16 @@ export function useElectronAgent({
         throw err;
       }
     },
-    [sessionId, workingDirectory, model, thinkingLevel, role, isProcessing]
+    [
+      sessionId,
+      workingDirectory,
+      model,
+      thinkingLevel,
+      role,
+      maxTurns,
+      systemPromptOverride,
+      isProcessing,
+    ]
   );
 
   // Message queue for queuing messages when agent is busy
@@ -434,7 +449,9 @@ export function useElectronAgent({
           imagePaths,
           model,
           thinkingLevel,
-          role
+          role,
+          maxTurns,
+          systemPromptOverride
         );
 
         if (!result.success) {
@@ -449,7 +466,16 @@ export function useElectronAgent({
         setIsProcessing(false);
       }
     },
-    [sessionId, workingDirectory, model, thinkingLevel, role, isProcessing]
+    [
+      sessionId,
+      workingDirectory,
+      model,
+      thinkingLevel,
+      role,
+      maxTurns,
+      systemPromptOverride,
+      isProcessing,
+    ]
   );
 
   // Stop current execution
@@ -542,7 +568,10 @@ export function useElectronAgent({
           messageContent,
           imagePaths,
           model,
-          thinkingLevel
+          thinkingLevel,
+          role,
+          maxTurns,
+          systemPromptOverride
         );
 
         if (!result.success) {
@@ -553,7 +582,7 @@ export function useElectronAgent({
         setError(err instanceof Error ? err.message : 'Failed to add to queue');
       }
     },
-    [sessionId, workingDirectory, model, thinkingLevel]
+    [sessionId, workingDirectory, model, thinkingLevel, role, maxTurns, systemPromptOverride]
   );
 
   // Remove a prompt from the server queue

--- a/apps/ui/src/lib/electron.ts
+++ b/apps/ui/src/lib/electron.ts
@@ -813,7 +813,11 @@ export interface ElectronAPI {
       message: string,
       workingDirectory?: string,
       imagePaths?: string[],
-      model?: string
+      model?: string,
+      thinkingLevel?: string,
+      role?: string,
+      maxTurns?: number,
+      systemPromptOverride?: string
     ) => Promise<{ success: boolean; error?: string }>;
     getHistory: (sessionId: string) => Promise<{
       success: boolean;
@@ -824,6 +828,16 @@ export interface ElectronAPI {
     stop: (sessionId: string) => Promise<{ success: boolean; error?: string }>;
     clear: (sessionId: string) => Promise<{ success: boolean; error?: string }>;
     onStream: (callback: (data: unknown) => void) => () => void;
+    queueAdd?: (
+      sessionId: string,
+      message: string,
+      imagePaths?: string[],
+      model?: string,
+      thinkingLevel?: string,
+      role?: string,
+      maxTurns?: number,
+      systemPromptOverride?: string
+    ) => Promise<{ success: boolean; error?: string }>;
   };
   sessions?: {
     list: (includeArchived?: boolean) => Promise<{

--- a/apps/ui/src/lib/http-api-client.ts
+++ b/apps/ui/src/lib/http-api-client.ts
@@ -2042,7 +2042,9 @@ export class HttpApiClient implements ElectronAPI {
       imagePaths?: string[],
       model?: string,
       thinkingLevel?: string,
-      role?: string
+      role?: string,
+      maxTurns?: number,
+      systemPromptOverride?: string
     ): Promise<{ success: boolean; error?: string }> =>
       this.post('/api/agent/send', {
         sessionId,
@@ -2052,6 +2054,8 @@ export class HttpApiClient implements ElectronAPI {
         model,
         thinkingLevel,
         role,
+        maxTurns,
+        systemPromptOverride,
       }),
 
     getHistory: (
@@ -2079,7 +2083,10 @@ export class HttpApiClient implements ElectronAPI {
       message: string,
       imagePaths?: string[],
       model?: string,
-      thinkingLevel?: string
+      thinkingLevel?: string,
+      role?: string,
+      maxTurns?: number,
+      systemPromptOverride?: string
     ): Promise<{
       success: boolean;
       queuedPrompt?: {
@@ -2092,7 +2099,16 @@ export class HttpApiClient implements ElectronAPI {
       };
       error?: string;
     }> =>
-      this.post('/api/agent/queue/add', { sessionId, message, imagePaths, model, thinkingLevel }),
+      this.post('/api/agent/queue/add', {
+        sessionId,
+        message,
+        imagePaths,
+        model,
+        thinkingLevel,
+        role,
+        maxTurns,
+        systemPromptOverride,
+      }),
 
     queueList: (
       sessionId: string

--- a/apps/ui/src/types/electron.d.ts
+++ b/apps/ui/src/types/electron.d.ts
@@ -89,7 +89,9 @@ export interface AgentAPI {
     imagePaths?: string[],
     model?: string,
     thinkingLevel?: string,
-    role?: string
+    role?: string,
+    maxTurns?: number,
+    systemPromptOverride?: string
   ) => Promise<{
     success: boolean;
     error?: string;
@@ -108,6 +110,20 @@ export interface AgentAPI {
   }>;
 
   clear: (sessionId: string) => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+
+  queueAdd: (
+    sessionId: string,
+    message: string,
+    imagePaths?: string[],
+    model?: string,
+    thinkingLevel?: string,
+    role?: string,
+    maxTurns?: number,
+    systemPromptOverride?: string
+  ) => Promise<{
     success: boolean;
     error?: string;
   }>;


### PR DESCRIPTION
## Summary
- Extends useElectronAgent hook with `maxTurns` and `systemPromptOverride` params
- Wires these through http-api-client, electron IPC, and agent-view
- Enables the agent config popover settings to actually reach the server

## Files Changed
- `apps/ui/src/hooks/use-electron-agent.ts` — Add maxTurns/systemPromptOverride to options, send/queue calls, dependency arrays
- `apps/ui/src/lib/http-api-client.ts` — Add params to agent.send()
- `apps/ui/src/lib/electron.ts` — Add params to IPC send/queue
- `apps/ui/src/types/electron.d.ts` — Update AgentAPI.send signature
- `apps/ui/src/components/views/agent-view.tsx` — Pass agentConfig params to hook

## Test plan
- [ ] Agent config popover maxTurns value reaches server
- [ ] System prompt override is sent in API call
- [ ] Server queue also receives new params
- [ ] No regressions in existing agent send flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)