### PR TITLE
feat: add agent template support to header and welcome message

### DIFF
--- a/apps/ui/src/components/views/agent-view.tsx
+++ b/apps/ui/src/components/views/agent-view.tsx
@@ -20,6 +20,12 @@ import { AgentInputArea } from './agent-view/input-area';
 /** Tailwind lg breakpoint in pixels */
 const LG_BREAKPOINT = 1024;
 
+interface SelectedAgentTemplate {
+  displayName: string;
+  role: string;
+  description?: string;
+}
+
 export function AgentView() {
   const { currentProject } = useAppStore();
   const [input, setInput] = useState('');
@@ -27,6 +33,10 @@ export function AgentView() {
   // Initialize session manager state - starts as true to match SSR
   // Then updates on mount based on actual screen size to prevent hydration mismatch
   const [showSessionManager, setShowSessionManager] = useState(true);
+  // State for selected agent template (null means no template selected, use defaults)
+  const [selectedAgentTemplate, setSelectedAgentTemplate] = useState<SelectedAgentTemplate | null>(
+    null
+  );
 
   // Update session manager visibility based on screen size after mount and on resize
   useEffect(() => {
@@ -154,14 +164,21 @@ export function AgentView() {
   }, [currentSessionId]);
 
   // Show welcome message if no messages yet
+  // Use template description if available, otherwise use default message
+  const getWelcomeMessage = () => {
+    if (selectedAgentTemplate?.description) {
+      return selectedAgentTemplate.description;
+    }
+    return "Hello! I'm the Automaker Agent. I can help you build software autonomously. I can read and modify files in this project, run commands, and execute tests. What would you like to create today?";
+  };
+
   const displayMessages =
     messages.length === 0
       ? [
           {
             id: 'welcome',
             role: 'assistant' as const,
-            content:
-              "Hello! I'm the Automaker Agent. I can help you build software autonomously. I can read and modify files in this project, run commands, and execute tests. What would you like to create today?",
+            content: getWelcomeMessage(),
             timestamp: new Date().toISOString(),
           },
         ]
@@ -210,6 +227,7 @@ export function AgentView() {
           onClearChat={handleClearChat}
           agentConfig={agentConfig}
           onAgentConfigChange={setAgentConfig}
+          selectedAgentTemplate={selectedAgentTemplate}
         />
 
         {/* Messages */}

--- a/apps/ui/src/components/views/agent-view/components/agent-header.tsx
+++ b/apps/ui/src/components/views/agent-view/components/agent-header.tsx
@@ -2,6 +2,11 @@ import { Bot, PanelLeftClose, PanelLeft, Wrench, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { AgentConfigPopover, type AgentConfig } from './agent-config-popover';
 
+interface SelectedAgentTemplate {
+  displayName: string;
+  role: string;
+}
+
 interface AgentHeaderProps {
   projectName: string;
   currentSessionId: string | null;
@@ -14,6 +19,7 @@ interface AgentHeaderProps {
   onClearChat: () => void;
   agentConfig?: AgentConfig;
   onAgentConfigChange?: (config: AgentConfig) => void;
+  selectedAgentTemplate?: SelectedAgentTemplate | null;
 }
 
 export function AgentHeader({
@@ -28,7 +34,12 @@ export function AgentHeader({
   onClearChat,
   agentConfig,
   onAgentConfigChange,
+  selectedAgentTemplate,
 }: AgentHeaderProps) {
+  // Determine the agent title based on selected template
+  const agentTitle = selectedAgentTemplate
+    ? `${selectedAgentTemplate.displayName} - ${selectedAgentTemplate.role}`
+    : 'AI Agent';
   return (
     <div className="flex items-center justify-between px-6 py-4 border-b border-border bg-card/50 backdrop-blur-sm">
       <div className="flex items-center gap-4">
@@ -36,7 +47,7 @@ export function AgentHeader({
           <Bot className="w-5 h-5 text-primary" />
         </div>
         <div>
-          <h1 className="text-lg font-semibold text-foreground">AI Agent</h1>
+          <h1 className="text-lg font-semibold text-foreground">{agentTitle}</h1>
           <p className="text-sm text-muted-foreground">
             {projectName}
             {currentSessionId && !isConnected && ' - Connecting...'}


### PR DESCRIPTION
## Summary
- AgentHeader shows selected agent's displayName and role instead of generic "AI Agent"
- Welcome message updates per-agent using template description
- Falls back to default "AI Agent" when no template selected

## Files Changed
- `apps/ui/src/components/views/agent-view/components/agent-header.tsx` — Display agent identity
- `apps/ui/src/components/views/agent-view.tsx` — Pass selectedAgentTemplate, agent-specific welcome

## Test plan
- [ ] Header shows agent name and role when template selected
- [ ] Welcome message changes per agent
- [ ] Falls back to "AI Agent" with no template
- [ ] Config popover still accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)