### PR TITLE
feat: add ProjectHealthCard component for dashboard

### DIFF
--- a/apps/ui/src/components/views/dashboard-view/project-health-card.tsx
+++ b/apps/ui/src/components/views/dashboard-view/project-health-card.tsx
@@ -1,0 +1,132 @@
+/**
+ * ProjectHealthCard Component
+ *
+ * Displays a compact overview of project health including:
+ * - Board state (backlog/in-progress/review/done counts)
+ * - Running agents count
+ * - Auto-mode status
+ *
+ * Updates via polling (30s) and WebSocket events
+ */
+
+import { Card, CardContent } from '@/components/ui/card';
+import { useProjectHealth } from '@/hooks/use-project-health';
+import { useAppStore } from '@/store/app-store';
+import { Activity, CheckCircle2, Clock, ListTodo, PlayCircle, StopCircle } from 'lucide-react';
+import { useShallow } from 'zustand/react/shallow';
+
+interface StatusBadgeProps {
+  status: 'running' | 'stopped' | 'idle';
+}
+
+function StatusBadge({ status }: StatusBadgeProps) {
+  const config = {
+    running: {
+      label: 'Running',
+      icon: PlayCircle,
+      className: 'bg-green-500/10 text-green-500',
+    },
+    idle: {
+      label: 'Idle',
+      icon: Clock,
+      className: 'bg-yellow-500/10 text-yellow-500',
+    },
+    stopped: {
+      label: 'Stopped',
+      icon: StopCircle,
+      className: 'bg-gray-500/10 text-gray-500',
+    },
+  };
+
+  const { label, icon: Icon, className } = config[status];
+
+  return (
+    <div
+      className={`flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium ${className}`}
+    >
+      <Icon className="h-3 w-3" />
+      {label}
+    </div>
+  );
+}
+
+interface MetricProps {
+  label: string;
+  value: string | number;
+  icon: React.ComponentType<{ className?: string }>;
+}
+
+function Metric({ label, value, icon: Icon }: MetricProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="rounded-md bg-primary/10 p-1.5">
+        <Icon className="h-3.5 w-3.5 text-primary" />
+      </div>
+      <div className="flex flex-col">
+        <span className="text-xs text-muted-foreground">{label}</span>
+        <span className="text-sm font-semibold">{value}</span>
+      </div>
+    </div>
+  );
+}
+
+export function ProjectHealthCard() {
+  const { currentProject } = useAppStore(
+    useShallow((state) => ({
+      currentProject: state.currentProject,
+    }))
+  );
+
+  const { boardCounts, runningAgentsCount, autoModeStatus, isLoading } = useProjectHealth(
+    currentProject?.path
+  );
+
+  // Loading skeleton
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="pt-4 pb-3">
+          <div className="flex items-center justify-between gap-4">
+            <div className="h-12 w-full animate-pulse rounded bg-muted" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardContent className="pt-4 pb-3">
+        <div className="flex items-center justify-between gap-6">
+          {/* Board Counts */}
+          <div className="flex items-center gap-4">
+            <Metric label="Backlog" value={boardCounts.backlog} icon={ListTodo} />
+            <div className="h-6 w-px bg-border" />
+            <Metric label="In Progress" value={boardCounts.inProgress} icon={Activity} />
+            <div className="h-6 w-px bg-border" />
+            <Metric label="Review" value={boardCounts.review} icon={Clock} />
+            <div className="h-6 w-px bg-border" />
+            <Metric label="Done" value={boardCounts.done} icon={CheckCircle2} />
+          </div>
+
+          {/* Right side: Running Agents & Auto-mode Status */}
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <div className="rounded-md bg-primary/10 p-1.5">
+                <Activity className="h-3.5 w-3.5 text-primary" />
+              </div>
+              <div className="flex flex-col">
+                <span className="text-xs text-muted-foreground">Agents</span>
+                <span className="text-sm font-semibold">{runningAgentsCount}</span>
+              </div>
+            </div>
+
+            <div className="h-6 w-px bg-border" />
+
+            <StatusBadge status={autoModeStatus} />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/ui/src/hooks/use-project-health.ts
+++ b/apps/ui/src/hooks/use-project-health.ts
@@ -1,0 +1,195 @@
+/**
+ * Project Health Hook
+ *
+ * Fetches and manages project health data including:
+ * - Board state (feature counts by status)
+ * - Running agents count
+ * - Auto-mode status
+ *
+ * Data refreshes via polling and WebSocket events
+ */
+
+import { useEffect, useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getElectronAPI } from '@/lib/electron';
+import { queryKeys } from '@/lib/query-keys';
+import type { AutoModeEvent } from '@/types/electron';
+import type { Feature } from '@/store/app-store';
+
+const POLL_INTERVAL = 30000; // 30 seconds
+
+export interface BoardCounts {
+  backlog: number;
+  inProgress: number;
+  review: number;
+  done: number;
+  total: number;
+}
+
+export interface ProjectHealthData {
+  boardCounts: BoardCounts;
+  runningAgentsCount: number;
+  autoModeStatus: 'running' | 'stopped' | 'idle';
+  isLoading: boolean;
+  error?: Error;
+}
+
+/**
+ * Custom hook to fetch and manage project health data
+ *
+ * @param projectPath - The current project path
+ * @returns Project health data with board counts, running agents, and auto-mode status
+ */
+export function useProjectHealth(projectPath: string | undefined): ProjectHealthData {
+  const queryClient = useQueryClient();
+
+  // Fetch features summary for board counts
+  const {
+    data: features,
+    isLoading: featuresLoading,
+    error: featuresError,
+  } = useQuery({
+    queryKey: queryKeys.features.all(projectPath || ''),
+    queryFn: async (): Promise<Feature[]> => {
+      if (!projectPath) return [];
+      const api = getElectronAPI();
+      const result = await api.features?.getAll(projectPath);
+      if (!result?.success) {
+        throw new Error(result?.error || 'Failed to fetch features');
+      }
+      return (result.features ?? []) as Feature[];
+    },
+    enabled: !!projectPath,
+    refetchInterval: POLL_INTERVAL,
+    staleTime: 10000, // Consider data stale after 10s
+  });
+
+  // Fetch running agents count
+  const {
+    data: runningAgentsData,
+    isLoading: agentsLoading,
+    error: agentsError,
+  } = useQuery({
+    queryKey: queryKeys.runningAgents.all(),
+    queryFn: async () => {
+      const api = getElectronAPI();
+      const result = await api.runningAgents?.getAll();
+      if (!result?.success) {
+        throw new Error(result?.error || 'Failed to fetch running agents');
+      }
+      return {
+        agents: result.runningAgents ?? [],
+        count: result.totalCount ?? 0,
+      };
+    },
+    refetchInterval: POLL_INTERVAL,
+    staleTime: 10000,
+  });
+
+  // Fetch auto-mode status
+  const {
+    data: autoModeStatus,
+    isLoading: statusLoading,
+    error: statusError,
+  } = useQuery({
+    queryKey: queryKeys.autoMode.status(projectPath),
+    queryFn: async () => {
+      if (!projectPath) return { isAutoLoopRunning: false };
+      const api = getElectronAPI();
+      const result = await api.autoMode?.status(projectPath, null);
+      if (!result?.success) {
+        throw new Error(result?.error || 'Failed to fetch auto-mode status');
+      }
+      return {
+        isAutoLoopRunning: result.isAutoLoopRunning || false,
+      };
+    },
+    enabled: !!projectPath,
+    refetchInterval: POLL_INTERVAL,
+    staleTime: 10000,
+  });
+
+  // Subscribe to WebSocket events to invalidate queries
+  useEffect(() => {
+    if (!projectPath) return;
+
+    const api = getElectronAPI();
+    const unsubscribe = api.autoMode?.onEvent((event: AutoModeEvent) => {
+      // Invalidate features when they change
+      if (
+        event.type === 'auto_mode_feature_complete' ||
+        event.type === 'auto_mode_feature_start' ||
+        event.type === 'auto_mode_error'
+      ) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.features.all(projectPath),
+        });
+      }
+
+      // Invalidate running agents on status changes
+      if (
+        event.type === 'auto_mode_feature_start' ||
+        event.type === 'auto_mode_feature_complete' ||
+        event.type === 'auto_mode_error' ||
+        event.type === 'auto_mode_resuming_features'
+      ) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.runningAgents.all(),
+        });
+      }
+
+      // Invalidate auto-mode status on start/stop
+      if (event.type === 'auto_mode_started' || event.type === 'auto_mode_stopped') {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.autoMode.status(projectPath),
+        });
+      }
+    });
+
+    return unsubscribe;
+  }, [projectPath, queryClient]);
+
+  // Calculate board counts from features
+  const boardCounts: BoardCounts = useMemo(() => {
+    if (!features) {
+      return { backlog: 0, inProgress: 0, review: 0, done: 0, total: 0 };
+    }
+
+    return features.reduce(
+      (acc: BoardCounts, feature: Feature) => {
+        const status = feature.status?.toLowerCase() || 'backlog';
+        if (status === 'backlog') acc.backlog++;
+        else if (status === 'in-progress') acc.inProgress++;
+        else if (status === 'review') acc.review++;
+        else if (status === 'done') acc.done++;
+        acc.total++;
+        return acc;
+      },
+      { backlog: 0, inProgress: 0, review: 0, done: 0, total: 0 }
+    );
+  }, [features]);
+
+  // Determine auto-mode status
+  const runningAgentsCount = runningAgentsData?.count || 0;
+  const isAutoLoopRunning = autoModeStatus?.isAutoLoopRunning || false;
+
+  let autoModeStatusValue: 'running' | 'stopped' | 'idle';
+  if (isAutoLoopRunning && runningAgentsCount > 0) {
+    autoModeStatusValue = 'running';
+  } else if (isAutoLoopRunning && runningAgentsCount === 0) {
+    autoModeStatusValue = 'idle';
+  } else {
+    autoModeStatusValue = 'stopped';
+  }
+
+  const isLoading = featuresLoading || agentsLoading || statusLoading;
+  const error = (featuresError || agentsError || statusError) as Error | undefined;
+
+  return {
+    boardCounts,
+    runningAgentsCount,
+    autoModeStatus: autoModeStatusValue,
+    isLoading,
+    error,
+  };
+}


### PR DESCRIPTION
## Summary
- New ProjectHealthCard component showing board counts, running agents, and auto-mode status
- New useProjectHealth hook using React Query + WebSocket events for real-time updates
- Compact card layout with loading skeleton and 30s polling fallback

## Files Changed
- `apps/ui/src/components/views/dashboard-view/project-health-card.tsx` — New component
- `apps/ui/src/hooks/use-project-health.ts` — New hook (React Query + WS events)

## Test plan
- [ ] Shows board counts (backlog/in-progress/review/done)
- [ ] Shows running agent count
- [ ] Shows auto-mode status (running/stopped/idle)
- [ ] Loading skeleton while fetching
- [ ] Refreshes on WebSocket events

🤖 Generated with [Claude Code](https://claude.com/claude-code)