### PR TITLE
feat: add epic delivery ceremony to CeremonyService

### DIFF
--- a/apps/server/src/services/ceremony-service.ts
+++ b/apps/server/src/services/ceremony-service.ts
@@ -29,6 +29,16 @@ interface MilestoneEventPayload {
 }
 
 /**
+ * Epic completion payload from the event system
+ */
+interface EpicCompletedPayload {
+  projectPath: string;
+  featureId: string;
+  featureTitle: string;
+  isEpic: true;
+}
+
+/**
  * Project completion payload from the event system
  */
 interface ProjectCompletedPayload {
@@ -83,6 +93,11 @@ export class CeremonyService {
         this.handleMilestoneStarted(payload as MilestoneEventPayload);
       } else if (type === 'milestone:completed') {
         this.handleMilestoneCompleted(payload as MilestoneEventPayload);
+      } else if (type === 'feature:completed') {
+        const data = payload as EpicCompletedPayload;
+        if (data.isEpic) {
+          this.handleEpicCompleted(data);
+        }
       } else if (type === 'project:completed') {
         this.handleProjectCompleted(payload as ProjectCompletedPayload);
       }
@@ -186,6 +201,50 @@ export class CeremonyService {
       );
     } catch (error) {
       logger.error('Failed to generate milestone ceremony:', error);
+    }
+  }
+
+  /**
+   * Handle feature:completed event for epics
+   * Generate an epic delivery announcement with child features, PRs, cost, and duration
+   */
+  private async handleEpicCompleted(payload: EpicCompletedPayload): Promise<void> {
+    const { projectPath, featureId, featureTitle } = payload;
+
+    // Check if ceremonies are enabled
+    const ceremonySettings = await this.getCeremonySettings(projectPath);
+    if (!ceremonySettings?.enabled || !ceremonySettings?.enableEpicDelivery) {
+      logger.debug('Epic delivery ceremonies disabled, skipping announcement');
+      return;
+    }
+
+    try {
+      // Load the epic feature to get full details
+      const epic = await this.featureLoader!.get(projectPath, featureId);
+      if (!epic) {
+        logger.warn(`Epic ${featureId} not found for announcement`);
+        return;
+      }
+
+      // Generate the epic delivery announcement
+      const content = await this.generateEpicDeliveryAnnouncement(projectPath, epic);
+
+      // Split into chunks if needed (Discord limit: 2000 chars)
+      const messages = this.splitMessage(content, 2000);
+
+      // Emit Discord events for each message chunk
+      for (const message of messages) {
+        await this.emitDiscordEvent(
+          projectPath,
+          ceremonySettings.discordChannelId,
+          message,
+          `Epic Delivered: ${featureTitle}`
+        );
+      }
+
+      logger.info(`Posted epic delivery announcement for "${featureTitle}"`);
+    } catch (error) {
+      logger.error('Failed to generate epic delivery announcement:', error);
     }
   }
 
@@ -450,6 +509,83 @@ ${dataSummary}`;
       lines.push(`${nextMilestone.phases.length} phases planned`);
     } else {
       lines.push(`**Project Status:** All milestones complete! 🎉`);
+    }
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Generate epic delivery announcement with child features, PRs, cost, and duration
+   */
+  private async generateEpicDeliveryAnnouncement(
+    projectPath: string,
+    epic: Feature
+  ): Promise<string> {
+    // Load all features to find children
+    const allFeatures = await this.featureLoader!.getAll(projectPath);
+    const childFeatures = allFeatures.filter((f) => f.epicId === epic.id && f.id !== epic.id);
+
+    // Calculate metrics
+    const totalCost = childFeatures.reduce((sum, f) => sum + (f.costUsd || 0), 0);
+    const featureCount = childFeatures.length;
+    const prLinks = childFeatures.filter((f) => f.prUrl && f.prNumber).map((f) => f.prUrl);
+
+    // Calculate duration from earliest start to now
+    let duration = '';
+    if (childFeatures.length > 0 && childFeatures[0].startedAt) {
+      const startTimes = childFeatures
+        .map((f) => (f.startedAt ? new Date(f.startedAt).getTime() : 0))
+        .filter((t) => t > 0);
+      if (startTimes.length > 0) {
+        const earliestStart = Math.min(...startTimes);
+        const durationMs = Date.now() - earliestStart;
+        const durationHours = Math.floor(durationMs / (1000 * 60 * 60));
+        const durationDays = Math.floor(durationHours / 24);
+
+        if (durationDays > 0) {
+          duration = `${durationDays}d ${durationHours % 24}h`;
+        } else {
+          duration = `${durationHours}h`;
+        }
+      }
+    }
+
+    // Build the announcement
+    const lines: string[] = [];
+
+    // Header
+    lines.push(`🎁 **${epic.title}** — Epic Delivered!`);
+    lines.push('');
+
+    // Child features shipped
+    lines.push(`**Features Shipped:** ${featureCount}`);
+    if (childFeatures.length > 0) {
+      for (const feature of childFeatures) {
+        const title = feature.title || 'Untitled';
+        const prLink = feature.prUrl ? `[PR#${feature.prNumber}](${feature.prUrl})` : 'No PR';
+        lines.push(`- ${title} — ${prLink}`);
+      }
+      lines.push('');
+    }
+
+    // Cost metrics
+    if (totalCost > 0) {
+      lines.push(`**Total Cost:** $${totalCost.toFixed(2)}`);
+      const avgCost = featureCount > 0 ? totalCost / featureCount : 0;
+      lines.push(`**Avg per Feature:** $${avgCost.toFixed(2)}`);
+      lines.push('');
+    }
+
+    // Duration
+    if (duration) {
+      lines.push(`**Duration:** ${duration}`);
+      lines.push('');
+    }
+
+    // Cost rollup summary
+    if (childFeatures.length > 0) {
+      const shippedCount = childFeatures.filter((f) => f.status === 'done' && f.prUrl).length;
+      lines.push(`**Shipped:** ${shippedCount}/${featureCount} features with PRs`);
     }
 
     return lines.join('\n');

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -886,6 +886,7 @@ export interface PhaseModelEntry {
  * Ceremonies are automated events that mark significant project progress:
  * - Milestone standups: Posted to Discord when a milestone starts with planned scope
  * - Milestone retros: Sent to Discord when all features in a milestone are done
+ * - Epic delivery announcements: Posted when all child features in an epic are complete
  * - Project retrospectives: AI-generated reflections when projects complete
  */
 export interface CeremonySettings {
@@ -897,6 +898,8 @@ export interface CeremonySettings {
   enableStandups?: boolean;
   /** Enable milestone completion announcements (default: true) */
   enableMilestoneUpdates?: boolean;
+  /** Enable epic delivery announcements (default: true) */
+  enableEpicDelivery?: boolean;
   /** Enable project retrospective generation (default: true) */
   enableProjectRetros?: boolean;
   /** Model configuration for generating retrospectives */
@@ -910,6 +913,7 @@ export const DEFAULT_CEREMONY_SETTINGS: CeremonySettings = {
   enabled: false,
   enableStandups: true,
   enableMilestoneUpdates: true,
+  enableEpicDelivery: true,
   enableProjectRetros: true,
 };
 


### PR DESCRIPTION
## Summary
- Adds `feature:completed` event listener to CeremonyService that filters for `isEpic: true` payloads
- Generates Discord announcement with: epic title, child features shipped, PR links, cost rollup, duration
- Adds `enableEpicDelivery` boolean to CeremonySettings type (default: true)

## Changes
- `ceremony-service.ts`: New `handleEpicCompleted()` method + `generateEpicDeliveryAnnouncement()` (+136 lines)
- `settings.ts`: Added `enableEpicDelivery` to CeremonySettings interface and defaults (+4 lines)

## Test plan
- [ ] Complete all features in an epic → Discord announcement fires
- [ ] Announcement includes child feature names, PR links, total cost, duration
- [ ] Set `enableEpicDelivery: false` → no announcement
- [ ] Existing milestone/project ceremonies still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added epic delivery announcements with metrics reporting (cost, duration, PR count, shipped features)
  * New configurable ceremony setting to enable/disable epic delivery announcements (enabled by default)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->