### PR TITLE
fix: add GH_TOKEN to MCP server plugin config

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -18,6 +18,10 @@ OPENAI_API_KEY=sk-...
 # Cursor API key for Cursor models
 CURSOR_API_KEY=...
 
+# GitHub token for PR operations (merge, review threads, CodeRabbit)
+# Get from: gh auth token
+GH_TOKEN=
+
 # OAuth credentials for CLI authentication (extracted automatically)
 CLAUDE_OAUTH_CREDENTIALS=
 CURSOR_AUTH_TOKEN=

--- a/docs/integrations/claude-plugin.md
+++ b/docs/integrations/claude-plugin.md
@@ -301,7 +301,8 @@ Edit `packages/mcp-server/plugins/automaker/.claude-plugin/plugin.json` to use a
       "args": ["/absolute/path/to/automaker/packages/mcp-server/dist/index.js"],
       "env": {
         "AUTOMAKER_API_URL": "http://localhost:3008",
-        "AUTOMAKER_API_KEY": "your-secure-api-key"
+        "AUTOMAKER_API_KEY": "your-secure-api-key",
+        "GH_TOKEN": "${GH_TOKEN}"
       }
     }
   }
@@ -1075,6 +1076,15 @@ Claude: Let me check the agent output.
    /orchestrate
    ```
    The graph view will show any cycles.
+
+### GitHub Operations Fail ("gh auth login" Error)
+
+PR-related tools (`merge_pr`, `resolve_review_threads`, `check_pr_status`) require `GH_TOKEN` to be set in the server's environment:
+
+1. Get your token: `gh auth token`
+2. Add to `.env`: `GH_TOKEN=gho_xxxxx`
+3. Add to `plugin.json` env: `"GH_TOKEN": "${GH_TOKEN}"`
+4. Restart the server and reload the plugin: `npm run plugin:reload`
 
 ### Docker-Specific Issues
 

--- a/packages/mcp-server/plugins/automaker/.claude-plugin/plugin.json
+++ b/packages/mcp-server/plugins/automaker/.claude-plugin/plugin.json
@@ -13,6 +13,7 @@
       "env": {
         "AUTOMAKER_API_URL": "http://localhost:3008",
         "AUTOMAKER_API_KEY": "${AUTOMAKER_API_KEY}",
+        "GH_TOKEN": "${GH_TOKEN}",
         "ENABLE_TOOL_SEARCH": "auto:10"
       }
     },

--- a/packages/mcp-server/plugins/automaker/.env.example
+++ b/packages/mcp-server/plugins/automaker/.env.example
@@ -9,6 +9,10 @@ AUTOMAKER_ROOT=/path/to/your/automaker
 # Use "automaker-staging-key-2026" for local dev
 AUTOMAKER_API_KEY=your_automaker_api_key_here
 
+# GitHub Token (for PR operations: merge, review threads, status checks)
+# Get from: gh auth token
+GH_TOKEN=your_github_token_here
+
 # Discord Bot Token
 # Get from: https://discord.com/developers/applications
 DISCORD_BOT_TOKEN=your_discord_bot_token_here


### PR DESCRIPTION
## Summary

- Add `GH_TOKEN` passthrough to MCP server `plugin.json` env config
- Add `GH_TOKEN` to `.env.example` files for both server and MCP plugin
- Add troubleshooting section for GitHub auth errors in plugin docs
- Update Docker plugin config example in docs to include `GH_TOKEN`

**Root cause**: PR tools (`merge_pr`, `resolve_review_threads`, `check_pr_status`) call `gh` CLI via the backend server, but `GH_TOKEN` was never passed through the MCP server plugin config or documented in `.env.example` files.

## Test plan

- [ ] `resolve_review_threads` MCP tool works without "gh auth login" error
- [ ] `merge_pr` and `check_pr_status` tools work with `GH_TOKEN` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Claude plugin integration documentation with expanded configuration guidance and new troubleshooting section.

* **Chores**
  * Added new environment variable to configuration example files across server and plugin packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->