### PR TITLE
refactor: add domain slice stores for app-store extraction (Phase 1)

### DIFF
--- a/apps/ui/src/store/ai-models-store.ts
+++ b/apps/ui/src/store/ai-models-store.ts
@@ -1,0 +1,801 @@
+/**
+ * AI Models Store - State management for all model-related configuration
+ *
+ * Manages:
+ * - Phase models and enhancement/validation model selection
+ * - Cursor, Codex, and OpenCode CLI model settings
+ * - Claude-compatible providers and API profiles
+ * - API keys and usage tracking
+ * - Provider visibility settings
+ */
+
+import { create } from 'zustand';
+import { createLogger } from '@automaker/utils/logger';
+import { getElectronAPI } from '@/lib/electron';
+import type {
+  ModelAlias,
+  PlanningMode,
+  ModelProvider,
+  CursorModelId,
+  CodexModelId,
+  OpencodeModelId,
+  PhaseModelConfig,
+  PhaseModelKey,
+  PhaseModelEntry,
+  ModelDefinition,
+  ClaudeApiProfile,
+  ClaudeCompatibleProvider,
+} from '@automaker/types';
+import {
+  getAllCursorModelIds,
+  getAllCodexModelIds,
+  getAllOpencodeModelIds,
+  DEFAULT_PHASE_MODELS,
+  DEFAULT_OPENCODE_MODEL,
+} from '@automaker/types';
+
+const logger = createLogger('AiModelsStore');
+const OPENCODE_BEDROCK_PROVIDER_ID = 'amazon-bedrock';
+const OPENCODE_BEDROCK_MODEL_PREFIX = `${OPENCODE_BEDROCK_PROVIDER_ID}/`;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ApiKeys {
+  anthropic: string;
+  google: string;
+  openai: string;
+}
+
+// Claude Usage interface matching the server response
+export type ClaudeUsage = {
+  sessionTokensUsed: number;
+  sessionLimit: number;
+  sessionPercentage: number;
+  sessionResetTime: string;
+  sessionResetText: string;
+
+  weeklyTokensUsed: number;
+  weeklyLimit: number;
+  weeklyPercentage: number;
+  weeklyResetTime: string;
+  weeklyResetText: string;
+
+  sonnetWeeklyTokensUsed: number;
+  sonnetWeeklyPercentage: number;
+  sonnetResetText: string;
+
+  costUsed: number | null;
+  costLimit: number | null;
+  costCurrency: string | null;
+
+  lastUpdated: string;
+  userTimezone: string;
+};
+
+// Response type for Claude usage API (can be success or error)
+export type ClaudeUsageResponse = ClaudeUsage | { error: string; message?: string };
+
+// Codex Usage types
+export type CodexPlanType =
+  | 'free'
+  | 'plus'
+  | 'pro'
+  | 'team'
+  | 'business'
+  | 'enterprise'
+  | 'edu'
+  | 'unknown';
+
+export interface CodexRateLimitWindow {
+  limit: number;
+  used: number;
+  remaining: number;
+  usedPercent: number; // Percentage used (0-100)
+  windowDurationMins: number; // Duration in minutes
+  resetsAt: number; // Unix timestamp in seconds
+}
+
+export interface CodexUsage {
+  rateLimits: {
+    primary?: CodexRateLimitWindow;
+    secondary?: CodexRateLimitWindow;
+    planType?: CodexPlanType;
+  } | null;
+  lastUpdated: string;
+}
+
+// Response type for Codex usage API (can be success or error)
+export type CodexUsageResponse = CodexUsage | { error: string; message?: string };
+
+/**
+ * Check if Claude usage is at its limit (any of: session >= 100%, weekly >= 100%, OR cost >= limit)
+ * Returns true if any limit is reached, meaning auto mode should pause feature pickup.
+ */
+export function isClaudeUsageAtLimit(claudeUsage: ClaudeUsage | null): boolean {
+  if (!claudeUsage) {
+    // No usage data available - don't block
+    return false;
+  }
+
+  // Check session limit (5-hour window)
+  if (claudeUsage.sessionPercentage >= 100) {
+    return true;
+  }
+
+  // Check weekly limit
+  if (claudeUsage.weeklyPercentage >= 100) {
+    return true;
+  }
+
+  // Check cost limit (if configured)
+  if (
+    claudeUsage.costLimit !== null &&
+    claudeUsage.costLimit > 0 &&
+    claudeUsage.costUsed !== null &&
+    claudeUsage.costUsed >= claudeUsage.costLimit
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+// ============================================================================
+// State Interface
+// ============================================================================
+
+interface AiModelsStoreState {
+  // API Keys
+  apiKeys: ApiKeys;
+
+  // Enhancement Model Settings
+  enhancementModel: ModelAlias; // Model used for feature enhancement (default: sonnet)
+
+  // Validation Model Settings
+  validationModel: ModelAlias; // Model used for GitHub issue validation (default: opus)
+
+  // Phase Model Settings - per-phase AI model configuration
+  phaseModels: PhaseModelConfig;
+  favoriteModels: string[];
+
+  // Default Planning Settings
+  defaultPlanningMode: PlanningMode;
+  defaultRequirePlanApproval: boolean;
+  defaultFeatureModel: PhaseModelEntry;
+
+  // Cursor CLI Settings (global)
+  enabledCursorModels: CursorModelId[]; // Which Cursor models are available in feature modal
+  cursorDefaultModel: CursorModelId; // Default Cursor model selection
+
+  // Codex CLI Settings (global)
+  enabledCodexModels: CodexModelId[]; // Which Codex models are available in feature modal
+  codexDefaultModel: CodexModelId; // Default Codex model selection
+  codexAutoLoadAgents: boolean; // Auto-load .codex/AGENTS.md files
+  codexSandboxMode: 'read-only' | 'workspace-write' | 'danger-full-access'; // Sandbox policy
+  codexApprovalPolicy: 'untrusted' | 'on-failure' | 'on-request' | 'never'; // Approval policy
+  codexEnableWebSearch: boolean; // Enable web search capability
+  codexEnableImages: boolean; // Enable image processing
+
+  // OpenCode CLI Settings (global)
+  // Static OpenCode settings are persisted via SETTINGS_FIELDS_TO_SYNC
+  enabledOpencodeModels: OpencodeModelId[]; // Which static OpenCode models are available
+  opencodeDefaultModel: OpencodeModelId; // Default OpenCode model selection
+  // Dynamic models are session-only (not persisted) because they're discovered at runtime
+  // from `opencode models` CLI and depend on current provider authentication state
+  dynamicOpencodeModels: ModelDefinition[]; // Dynamically discovered models from OpenCode CLI
+  enabledDynamicModelIds: string[]; // Which dynamic models are enabled
+  cachedOpencodeProviders: Array<{
+    id: string;
+    name: string;
+    authenticated: boolean;
+    authMethod?: string;
+  }>; // Cached providers
+  opencodeModelsLoading: boolean; // Whether OpenCode models are being fetched
+  opencodeModelsError: string | null; // Error message if fetch failed
+  opencodeModelsLastFetched: number | null; // Timestamp of last successful fetch
+  opencodeModelsLastFailedAt: number | null; // Timestamp of last failed fetch
+
+  // Provider Visibility Settings
+  disabledProviders: ModelProvider[]; // Providers that are disabled and hidden from dropdowns
+
+  // Claude-Compatible Providers (new system)
+  claudeCompatibleProviders: ClaudeCompatibleProvider[]; // Providers that expose models to dropdowns
+
+  // Claude API Profiles (deprecated - kept for backward compatibility)
+  claudeApiProfiles: ClaudeApiProfile[]; // Claude-compatible API endpoint profiles
+  activeClaudeApiProfileId: string | null; // Active profile ID (null = use direct Anthropic API)
+
+  // Claude Usage Tracking
+  claudeRefreshInterval: number; // Refresh interval in seconds (default: 60)
+  claudeUsage: ClaudeUsage | null;
+  claudeUsageLastUpdated: number | null;
+
+  // Codex Usage Tracking
+  codexUsage: CodexUsage | null;
+  codexUsageLastUpdated: number | null;
+
+  // Codex Models (dynamically fetched)
+  codexModels: Array<{
+    id: string;
+    label: string;
+    description: string;
+    hasThinking: boolean;
+    supportsVision: boolean;
+    tier: 'premium' | 'standard' | 'basic';
+    isDefault: boolean;
+  }>;
+  codexModelsLoading: boolean;
+  codexModelsError: string | null;
+  codexModelsLastFetched: number | null;
+  codexModelsLastFailedAt: number | null;
+}
+
+// ============================================================================
+// Actions Interface
+// ============================================================================
+
+interface AiModelsActions {
+  // Enhancement Model actions
+  setEnhancementModel: (model: ModelAlias) => void;
+
+  // Validation Model actions
+  setValidationModel: (model: ModelAlias) => void;
+
+  // Phase Model actions
+  setPhaseModel: (phase: PhaseModelKey, entry: PhaseModelEntry) => Promise<void>;
+  setPhaseModels: (models: Partial<PhaseModelConfig>) => Promise<void>;
+  resetPhaseModels: () => Promise<void>;
+  toggleFavoriteModel: (modelId: string) => void;
+
+  // Default Planning actions
+  setDefaultPlanningMode: (mode: PlanningMode) => void;
+  setDefaultRequirePlanApproval: (require: boolean) => void;
+  setDefaultFeatureModel: (entry: PhaseModelEntry) => void;
+
+  // Cursor CLI Settings actions
+  setEnabledCursorModels: (models: CursorModelId[]) => void;
+  setCursorDefaultModel: (model: CursorModelId) => void;
+  toggleCursorModel: (model: CursorModelId, enabled: boolean) => void;
+
+  // Codex CLI Settings actions
+  setEnabledCodexModels: (models: CodexModelId[]) => void;
+  setCodexDefaultModel: (model: CodexModelId) => void;
+  toggleCodexModel: (model: CodexModelId, enabled: boolean) => void;
+  setCodexAutoLoadAgents: (enabled: boolean) => Promise<void>;
+  setCodexSandboxMode: (
+    mode: 'read-only' | 'workspace-write' | 'danger-full-access'
+  ) => Promise<void>;
+  setCodexApprovalPolicy: (
+    policy: 'untrusted' | 'on-failure' | 'on-request' | 'never'
+  ) => Promise<void>;
+  setCodexEnableWebSearch: (enabled: boolean) => Promise<void>;
+  setCodexEnableImages: (enabled: boolean) => Promise<void>;
+
+  // OpenCode CLI Settings actions
+  setEnabledOpencodeModels: (models: OpencodeModelId[]) => void;
+  setOpencodeDefaultModel: (model: OpencodeModelId) => void;
+  toggleOpencodeModel: (model: OpencodeModelId, enabled: boolean) => void;
+  setDynamicOpencodeModels: (models: ModelDefinition[]) => void;
+  setEnabledDynamicModelIds: (ids: string[]) => void;
+  toggleDynamicModel: (modelId: string, enabled: boolean) => void;
+  setCachedOpencodeProviders: (
+    providers: Array<{ id: string; name: string; authenticated: boolean; authMethod?: string }>
+  ) => void;
+
+  // Provider Visibility Settings actions
+  setDisabledProviders: (providers: ModelProvider[]) => void;
+  toggleProviderDisabled: (provider: ModelProvider, disabled: boolean) => void;
+  isProviderDisabled: (provider: ModelProvider) => boolean;
+
+  // Claude-Compatible Provider actions (new system)
+  addClaudeCompatibleProvider: (provider: ClaudeCompatibleProvider) => Promise<void>;
+  updateClaudeCompatibleProvider: (
+    id: string,
+    updates: Partial<ClaudeCompatibleProvider>
+  ) => Promise<void>;
+  deleteClaudeCompatibleProvider: (id: string) => Promise<void>;
+  setClaudeCompatibleProviders: (providers: ClaudeCompatibleProvider[]) => Promise<void>;
+  toggleClaudeCompatibleProviderEnabled: (id: string) => Promise<void>;
+
+  // Claude API Profile actions (deprecated - kept for backward compatibility)
+  addClaudeApiProfile: (profile: ClaudeApiProfile) => Promise<void>;
+  updateClaudeApiProfile: (id: string, updates: Partial<ClaudeApiProfile>) => Promise<void>;
+  deleteClaudeApiProfile: (id: string) => Promise<void>;
+  setActiveClaudeApiProfile: (id: string | null) => Promise<void>;
+  setClaudeApiProfiles: (profiles: ClaudeApiProfile[]) => Promise<void>;
+
+  // Claude Usage Tracking actions
+  setClaudeRefreshInterval: (interval: number) => void;
+  setClaudeUsageLastUpdated: (timestamp: number) => void;
+  setClaudeUsage: (usage: ClaudeUsage | null) => void;
+
+  // Codex Usage Tracking actions
+  setCodexUsage: (usage: CodexUsage | null) => void;
+
+  // Codex Models actions
+  fetchCodexModels: (forceRefresh?: boolean) => Promise<void>;
+  setCodexModels: (
+    models: Array<{
+      id: string;
+      label: string;
+      description: string;
+      hasThinking: boolean;
+      supportsVision: boolean;
+      tier: 'premium' | 'standard' | 'basic';
+      isDefault: boolean;
+    }>
+  ) => void;
+
+  // OpenCode Models actions
+  fetchOpencodeModels: (forceRefresh?: boolean) => Promise<void>;
+
+  // API Keys actions
+  setApiKeys: (keys: ApiKeys) => void;
+}
+
+// ============================================================================
+// Initial State
+// ============================================================================
+
+const initialState: AiModelsStoreState = {
+  apiKeys: {
+    anthropic: '',
+    google: '',
+    openai: '',
+  },
+
+  enhancementModel: 'sonnet' as ModelAlias,
+  validationModel: 'opus' as ModelAlias,
+
+  phaseModels: DEFAULT_PHASE_MODELS,
+  favoriteModels: [],
+
+  defaultPlanningMode: 'spec' as PlanningMode,
+  defaultRequirePlanApproval: false,
+  defaultFeatureModel: DEFAULT_PHASE_MODELS.featureGenerationModel,
+
+  enabledCursorModels: getAllCursorModelIds(),
+  cursorDefaultModel: 'claude-3-5-sonnet' as CursorModelId,
+
+  enabledCodexModels: getAllCodexModelIds(),
+  codexDefaultModel: 'claude-3-5-sonnet' as CodexModelId,
+  codexAutoLoadAgents: false,
+  codexSandboxMode: 'read-only',
+  codexApprovalPolicy: 'on-failure',
+  codexEnableWebSearch: false,
+  codexEnableImages: false,
+
+  enabledOpencodeModels: getAllOpencodeModelIds(),
+  opencodeDefaultModel: DEFAULT_OPENCODE_MODEL,
+  dynamicOpencodeModels: [],
+  enabledDynamicModelIds: [],
+  cachedOpencodeProviders: [],
+  opencodeModelsLoading: false,
+  opencodeModelsError: null,
+  opencodeModelsLastFetched: null,
+  opencodeModelsLastFailedAt: null,
+
+  disabledProviders: [],
+
+  claudeCompatibleProviders: [],
+  claudeApiProfiles: [],
+  activeClaudeApiProfileId: null,
+
+  claudeRefreshInterval: 60,
+  claudeUsage: null,
+  claudeUsageLastUpdated: null,
+
+  codexUsage: null,
+  codexUsageLastUpdated: null,
+
+  codexModels: [],
+  codexModelsLoading: false,
+  codexModelsError: null,
+  codexModelsLastFetched: null,
+  codexModelsLastFailedAt: null,
+};
+
+// ============================================================================
+// Store
+// ============================================================================
+
+export const useAiModelsStore = create<AiModelsStoreState & AiModelsActions>((set, get) => ({
+  ...initialState,
+
+  // Enhancement Model actions
+  setEnhancementModel: (model) => set({ enhancementModel: model }),
+
+  // Validation Model actions
+  setValidationModel: (model) => set({ validationModel: model }),
+
+  // Phase Model actions
+  setPhaseModel: async (phase, entry) => {
+    set((state) => ({
+      phaseModels: {
+        ...state.phaseModels,
+        [phase]: entry,
+      },
+    }));
+    // Sync to server settings file
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  setPhaseModels: async (models) => {
+    set((state) => ({
+      phaseModels: {
+        ...state.phaseModels,
+        ...models,
+      },
+    }));
+    // Sync to server settings file
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  resetPhaseModels: async () => {
+    set({ phaseModels: DEFAULT_PHASE_MODELS });
+    // Sync to server settings file
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  toggleFavoriteModel: (modelId) => {
+    const current = get().favoriteModels;
+    if (current.includes(modelId)) {
+      set({ favoriteModels: current.filter((id) => id !== modelId) });
+    } else {
+      set({ favoriteModels: [...current, modelId] });
+    }
+  },
+
+  // Default Planning actions
+  setDefaultPlanningMode: (mode) => set({ defaultPlanningMode: mode }),
+  setDefaultRequirePlanApproval: (require) => set({ defaultRequirePlanApproval: require }),
+  setDefaultFeatureModel: (entry) => set({ defaultFeatureModel: entry }),
+
+  // Cursor CLI Settings actions
+  setEnabledCursorModels: (models) => set({ enabledCursorModels: models }),
+  setCursorDefaultModel: (model) => set({ cursorDefaultModel: model }),
+  toggleCursorModel: (model, enabled) =>
+    set((state) => ({
+      enabledCursorModels: enabled
+        ? [...state.enabledCursorModels, model]
+        : state.enabledCursorModels.filter((m) => m !== model),
+    })),
+
+  // Codex CLI Settings actions
+  setEnabledCodexModels: (models) => set({ enabledCodexModels: models }),
+  setCodexDefaultModel: (model) => set({ codexDefaultModel: model }),
+  toggleCodexModel: (model, enabled) =>
+    set((state) => ({
+      enabledCodexModels: enabled
+        ? [...state.enabledCodexModels, model]
+        : state.enabledCodexModels.filter((m) => m !== model),
+    })),
+
+  setCodexAutoLoadAgents: async (enabled) => {
+    set({ codexAutoLoadAgents: enabled });
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  setCodexSandboxMode: async (mode) => {
+    set({ codexSandboxMode: mode });
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  setCodexApprovalPolicy: async (policy) => {
+    set({ codexApprovalPolicy: policy });
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  setCodexEnableWebSearch: async (enabled) => {
+    set({ codexEnableWebSearch: enabled });
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  setCodexEnableImages: async (enabled) => {
+    set({ codexEnableImages: enabled });
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  // OpenCode CLI Settings actions
+  setEnabledOpencodeModels: (models) => set({ enabledOpencodeModels: models }),
+  setOpencodeDefaultModel: (model) => set({ opencodeDefaultModel: model }),
+  toggleOpencodeModel: (model, enabled) =>
+    set((state) => ({
+      enabledOpencodeModels: enabled
+        ? [...state.enabledOpencodeModels, model]
+        : state.enabledOpencodeModels.filter((m) => m !== model),
+    })),
+
+  setDynamicOpencodeModels: (models) => {
+    // Dynamic models depend on CLI authentication state and are re-discovered each session.
+    // Persist enabled model IDs, but do not auto-enable new models.
+    const filteredModels = models.filter(
+      (model) =>
+        model.provider !== OPENCODE_BEDROCK_PROVIDER_ID &&
+        !model.id.startsWith(OPENCODE_BEDROCK_MODEL_PREFIX)
+    );
+    const currentEnabled = get().enabledDynamicModelIds;
+    const newModelIds = filteredModels.map((m) => m.id);
+    const filteredEnabled = currentEnabled.filter((modelId) => newModelIds.includes(modelId));
+
+    const nextEnabled = currentEnabled.length === 0 ? [] : filteredEnabled;
+    set({ dynamicOpencodeModels: filteredModels, enabledDynamicModelIds: nextEnabled });
+  },
+
+  setEnabledDynamicModelIds: (ids) => set({ enabledDynamicModelIds: ids }),
+
+  toggleDynamicModel: (modelId, enabled) =>
+    set((state) => ({
+      enabledDynamicModelIds: enabled
+        ? [...state.enabledDynamicModelIds, modelId]
+        : state.enabledDynamicModelIds.filter((id) => id !== modelId),
+    })),
+
+  setCachedOpencodeProviders: (providers) =>
+    set({
+      cachedOpencodeProviders: providers.filter(
+        (provider) => provider.id !== OPENCODE_BEDROCK_PROVIDER_ID
+      ),
+    }),
+
+  // Provider Visibility Settings actions
+  setDisabledProviders: (providers) => set({ disabledProviders: providers }),
+
+  toggleProviderDisabled: (provider, disabled) =>
+    set((state) => ({
+      disabledProviders: disabled
+        ? [...state.disabledProviders, provider]
+        : state.disabledProviders.filter((p) => p !== provider),
+    })),
+
+  isProviderDisabled: (provider) => get().disabledProviders.includes(provider),
+
+  // Claude-Compatible Provider actions (new system)
+  addClaudeCompatibleProvider: async (provider) => {
+    set({ claudeCompatibleProviders: [...get().claudeCompatibleProviders, provider] });
+    // Sync immediately to persist provider
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  updateClaudeCompatibleProvider: async (id, updates) => {
+    set({
+      claudeCompatibleProviders: get().claudeCompatibleProviders.map((p) =>
+        p.id === id ? { ...p, ...updates } : p
+      ),
+    });
+    // Sync immediately to persist changes
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  deleteClaudeCompatibleProvider: async (id) => {
+    set({
+      claudeCompatibleProviders: get().claudeCompatibleProviders.filter((p) => p.id !== id),
+    });
+    // Sync immediately to persist deletion
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  setClaudeCompatibleProviders: async (providers) => {
+    set({ claudeCompatibleProviders: providers });
+    // Sync immediately to persist providers
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  toggleClaudeCompatibleProviderEnabled: async (id) => {
+    set({
+      claudeCompatibleProviders: get().claudeCompatibleProviders.map((p) =>
+        p.id === id ? { ...p, enabled: p.enabled === false ? true : false } : p
+      ),
+    });
+    // Sync immediately to persist change
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  // Claude API Profile actions (deprecated - kept for backward compatibility)
+  addClaudeApiProfile: async (profile) => {
+    set({ claudeApiProfiles: [...get().claudeApiProfiles, profile] });
+    // Sync immediately to persist profile
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  updateClaudeApiProfile: async (id, updates) => {
+    set({
+      claudeApiProfiles: get().claudeApiProfiles.map((p) =>
+        p.id === id ? { ...p, ...updates } : p
+      ),
+    });
+    // Sync immediately to persist changes
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  deleteClaudeApiProfile: async (id) => {
+    const currentActiveId = get().activeClaudeApiProfileId;
+
+    // Update state: remove profile and clear references
+    set({
+      claudeApiProfiles: get().claudeApiProfiles.filter((p) => p.id !== id),
+      // Clear global active if the deleted profile was active
+      activeClaudeApiProfileId: currentActiveId === id ? null : currentActiveId,
+    });
+
+    // Sync global settings to persist deletion
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  setActiveClaudeApiProfile: async (id) => {
+    set({ activeClaudeApiProfileId: id });
+    // Sync immediately to persist active profile change
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  setClaudeApiProfiles: async (profiles) => {
+    set({ claudeApiProfiles: profiles });
+    // Sync immediately to persist profiles
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  // Claude Usage Tracking actions
+  setClaudeRefreshInterval: (interval: number) => set({ claudeRefreshInterval: interval }),
+  setClaudeUsageLastUpdated: (timestamp: number) => set({ claudeUsageLastUpdated: timestamp }),
+  setClaudeUsage: (usage: ClaudeUsage | null) =>
+    set({
+      claudeUsage: usage,
+      claudeUsageLastUpdated: usage ? Date.now() : null,
+    }),
+
+  // Codex Usage Tracking actions
+  setCodexUsage: (usage: CodexUsage | null) =>
+    set({
+      codexUsage: usage,
+      codexUsageLastUpdated: usage ? Date.now() : null,
+    }),
+
+  // Codex Models actions
+  fetchCodexModels: async (forceRefresh = false) => {
+    const FAILURE_COOLDOWN_MS = 30 * 1000; // 30 seconds
+    const SUCCESS_CACHE_MS = 5 * 60 * 1000; // 5 minutes
+
+    const { codexModelsLastFetched, codexModelsLoading, codexModelsLastFailedAt } = get();
+
+    // Skip if already loading
+    if (codexModelsLoading) return;
+
+    // Skip if recently failed and not forcing refresh
+    if (
+      !forceRefresh &&
+      codexModelsLastFailedAt &&
+      Date.now() - codexModelsLastFailedAt < FAILURE_COOLDOWN_MS
+    ) {
+      return;
+    }
+
+    // Skip if recently fetched successfully and not forcing refresh
+    if (
+      !forceRefresh &&
+      codexModelsLastFetched &&
+      Date.now() - codexModelsLastFetched < SUCCESS_CACHE_MS
+    ) {
+      return;
+    }
+
+    set({ codexModelsLoading: true, codexModelsError: null });
+
+    try {
+      const api = getElectronAPI();
+      if (!api.codex) {
+        throw new Error('Codex API not available');
+      }
+
+      const result = await api.codex.getModels(forceRefresh);
+
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to fetch Codex models');
+      }
+
+      set({
+        codexModels: result.models || [],
+        codexModelsLastFetched: Date.now(),
+        codexModelsLoading: false,
+        codexModelsError: null,
+        codexModelsLastFailedAt: null, // Clear failure on success
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      set({
+        codexModelsError: errorMessage,
+        codexModelsLoading: false,
+        codexModelsLastFailedAt: Date.now(), // Record failure time for cooldown
+      });
+    }
+  },
+
+  setCodexModels: (models) =>
+    set({
+      codexModels: models,
+      codexModelsLastFetched: Date.now(),
+    }),
+
+  // OpenCode Models actions
+  fetchOpencodeModels: async (forceRefresh = false) => {
+    const FAILURE_COOLDOWN_MS = 30 * 1000; // 30 seconds
+    const SUCCESS_CACHE_MS = 5 * 60 * 1000; // 5 minutes
+
+    const { opencodeModelsLastFetched, opencodeModelsLoading, opencodeModelsLastFailedAt } = get();
+
+    // Skip if already loading
+    if (opencodeModelsLoading) return;
+
+    // Skip if recently failed and not forcing refresh
+    if (
+      !forceRefresh &&
+      opencodeModelsLastFailedAt &&
+      Date.now() - opencodeModelsLastFailedAt < FAILURE_COOLDOWN_MS
+    ) {
+      return;
+    }
+
+    // Skip if recently fetched successfully and not forcing refresh
+    if (
+      !forceRefresh &&
+      opencodeModelsLastFetched &&
+      Date.now() - opencodeModelsLastFetched < SUCCESS_CACHE_MS
+    ) {
+      return;
+    }
+
+    set({ opencodeModelsLoading: true, opencodeModelsError: null });
+
+    try {
+      const api = getElectronAPI() as Record<string, any>;
+      if (!api.opencode) {
+        throw new Error('OpenCode API not available');
+      }
+
+      const result = await api.opencode.getModels(forceRefresh);
+
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to fetch OpenCode models');
+      }
+
+      // Call setDynamicOpencodeModels which filters Bedrock models and handles enabled state
+      get().setDynamicOpencodeModels(result.models || []);
+
+      set({
+        opencodeModelsLastFetched: Date.now(),
+        opencodeModelsLoading: false,
+        opencodeModelsError: null,
+        opencodeModelsLastFailedAt: null, // Clear failure on success
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      set({
+        opencodeModelsError: errorMessage,
+        opencodeModelsLoading: false,
+        opencodeModelsLastFailedAt: Date.now(), // Record failure time for cooldown
+      });
+    }
+  },
+
+  // API Keys actions
+  setApiKeys: (keys) => set({ apiKeys: keys }),
+}));

--- a/apps/ui/src/store/chat-store.ts
+++ b/apps/ui/src/store/chat-store.ts
@@ -1,0 +1,184 @@
+/**
+ * Chat Store - State management for chat sessions and messages
+ */
+
+import { create } from 'zustand';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ImageAttachment {
+  id?: string; // Optional - may not be present in messages loaded from server
+  data: string; // base64 encoded image data
+  mimeType: string; // e.g., "image/png", "image/jpeg"
+  filename: string;
+  size?: number; // file size in bytes - optional for messages from server
+}
+
+export interface TextFileAttachment {
+  id: string;
+  content: string; // text content of the file
+  mimeType: string; // e.g., "text/plain", "text/markdown"
+  filename: string;
+  size: number; // file size in bytes
+}
+
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: Date;
+  images?: ImageAttachment[];
+  textFiles?: TextFileAttachment[];
+}
+
+export interface ChatSession {
+  id: string;
+  title: string;
+  projectId: string;
+  messages: ChatMessage[];
+  createdAt: Date;
+  updatedAt: Date;
+  archived: boolean;
+}
+
+// ============================================================================
+// State Interface
+// ============================================================================
+
+interface ChatStoreState {
+  chatSessions: ChatSession[];
+  currentChatSession: ChatSession | null;
+  chatHistoryOpen: boolean;
+}
+
+// ============================================================================
+// Actions Interface
+// ============================================================================
+
+interface ChatActions {
+  createChatSession: (title?: string) => ChatSession;
+  updateChatSession: (sessionId: string, updates: Partial<ChatSession>) => void;
+  addMessageToSession: (sessionId: string, message: ChatMessage) => void;
+  setCurrentChatSession: (session: ChatSession | null) => void;
+  archiveChatSession: (sessionId: string) => void;
+  unarchiveChatSession: (sessionId: string) => void;
+  deleteChatSession: (sessionId: string) => void;
+  setChatHistoryOpen: (open: boolean) => void;
+  toggleChatHistory: () => void;
+}
+
+// ============================================================================
+// Initial State
+// ============================================================================
+
+const initialState: ChatStoreState = {
+  chatSessions: [],
+  currentChatSession: null,
+  chatHistoryOpen: false,
+};
+
+// ============================================================================
+// Store
+// ============================================================================
+
+export const useChatStore = create<ChatStoreState & ChatActions>((set, get) => ({
+  ...initialState,
+
+  createChatSession: (title) => {
+    const now = new Date();
+    const session: ChatSession = {
+      id: `chat-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      title: title || `Chat ${new Date().toLocaleDateString()} ${new Date().toLocaleTimeString()}`,
+      projectId: '', // Will be set by the caller if needed
+      messages: [
+        {
+          id: 'welcome',
+          role: 'assistant',
+          content:
+            "Hello! I'm the Automaker Agent. I can help you build software autonomously. What would you like to create today?",
+          timestamp: now,
+        },
+      ],
+      createdAt: now,
+      updatedAt: now,
+      archived: false,
+    };
+
+    set({
+      chatSessions: [...get().chatSessions, session],
+      currentChatSession: session,
+    });
+
+    return session;
+  },
+
+  updateChatSession: (sessionId, updates) => {
+    set({
+      chatSessions: get().chatSessions.map((session) =>
+        session.id === sessionId ? { ...session, ...updates, updatedAt: new Date() } : session
+      ),
+    });
+
+    // Update current session if it's the one being updated
+    const currentSession = get().currentChatSession;
+    if (currentSession && currentSession.id === sessionId) {
+      set({
+        currentChatSession: {
+          ...currentSession,
+          ...updates,
+          updatedAt: new Date(),
+        },
+      });
+    }
+  },
+
+  addMessageToSession: (sessionId, message) => {
+    const sessions = get().chatSessions;
+    const sessionIndex = sessions.findIndex((s) => s.id === sessionId);
+
+    if (sessionIndex >= 0) {
+      const updatedSessions = [...sessions];
+      updatedSessions[sessionIndex] = {
+        ...updatedSessions[sessionIndex],
+        messages: [...updatedSessions[sessionIndex].messages, message],
+        updatedAt: new Date(),
+      };
+
+      set({ chatSessions: updatedSessions });
+
+      // Update current session if it's the one being updated
+      const currentSession = get().currentChatSession;
+      if (currentSession && currentSession.id === sessionId) {
+        set({
+          currentChatSession: updatedSessions[sessionIndex],
+        });
+      }
+    }
+  },
+
+  setCurrentChatSession: (session) => {
+    set({ currentChatSession: session });
+  },
+
+  archiveChatSession: (sessionId) => {
+    get().updateChatSession(sessionId, { archived: true });
+  },
+
+  unarchiveChatSession: (sessionId) => {
+    get().updateChatSession(sessionId, { archived: false });
+  },
+
+  deleteChatSession: (sessionId) => {
+    const currentSession = get().currentChatSession;
+    set({
+      chatSessions: get().chatSessions.filter((s) => s.id !== sessionId),
+      currentChatSession: currentSession?.id === sessionId ? null : currentSession,
+    });
+  },
+
+  setChatHistoryOpen: (open) => set({ chatHistoryOpen: open }),
+
+  toggleChatHistory: () => set({ chatHistoryOpen: !get().chatHistoryOpen }),
+}));

--- a/apps/ui/src/store/settings-store.ts
+++ b/apps/ui/src/store/settings-store.ts
@@ -1,0 +1,477 @@
+/**
+ * Settings Store - State management for application settings and preferences
+ * Contains non-model-related settings extracted from app-store
+ */
+
+import { create } from 'zustand';
+import type {
+  MCPServerConfig,
+  PromptCustomization,
+  EventHook,
+  ServerLogLevel,
+} from '@automaker/types';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+// Parsed shortcut key structure
+export interface ShortcutKey {
+  key: string; // The main key (e.g., "K", "N", "1")
+  shift?: boolean; // Shift key modifier
+  cmdCtrl?: boolean; // Cmd on Mac, Ctrl on Windows/Linux
+  alt?: boolean; // Alt/Option key modifier
+}
+
+/**
+ * Parse a shortcut string (e.g., "Cmd+K", "Shift+N") into its components
+ */
+export function parseShortcut(shortcut: string | undefined | null): ShortcutKey {
+  if (!shortcut) return { key: '' };
+  const parts = shortcut.split('+').map((p) => p.trim());
+  const result: ShortcutKey = { key: parts[parts.length - 1] };
+
+  // Normalize common OS-specific modifiers (Cmd/Ctrl/Win/Super symbols) into cmdCtrl
+  for (let i = 0; i < parts.length - 1; i++) {
+    const modifier = parts[i].toLowerCase();
+    if (modifier === 'shift') result.shift = true;
+    else if (
+      modifier === 'cmd' ||
+      modifier === 'ctrl' ||
+      modifier === 'win' ||
+      modifier === 'super' ||
+      modifier === '⌘' ||
+      modifier === '^' ||
+      modifier === '⊞' ||
+      modifier === '◆'
+    )
+      result.cmdCtrl = true;
+    else if (modifier === 'alt' || modifier === 'opt' || modifier === 'option' || modifier === '⌥')
+      result.alt = true;
+  }
+
+  return result;
+}
+
+/**
+ * Format a shortcut string for display (e.g., "⌘ K" on Mac, "Win+K" on Windows)
+ */
+export function formatShortcut(shortcut: string | undefined | null, forDisplay = false): string {
+  if (!shortcut) return '';
+  const parsed = parseShortcut(shortcut);
+  const parts: string[] = [];
+
+  // Prefer User-Agent Client Hints when available; fall back to legacy
+  const platform: 'darwin' | 'win32' | 'linux' = (() => {
+    if (typeof navigator === 'undefined') return 'linux';
+
+    const uaPlatform = (
+      navigator as Navigator & { userAgentData?: { platform?: string } }
+    ).userAgentData?.platform?.toLowerCase?.();
+    const legacyPlatform = navigator.platform?.toLowerCase?.();
+    const platformString = uaPlatform || legacyPlatform || '';
+
+    if (platformString.includes('mac')) return 'darwin';
+    if (platformString.includes('win')) return 'win32';
+    return 'linux';
+  })();
+
+  // Primary modifier - OS-specific
+  if (parsed.cmdCtrl) {
+    if (forDisplay) {
+      parts.push(platform === 'darwin' ? '⌘' : platform === 'win32' ? '⊞' : '◆');
+    } else {
+      parts.push(platform === 'darwin' ? 'Cmd' : platform === 'win32' ? 'Win' : 'Super');
+    }
+  }
+
+  // Alt/Option
+  if (parsed.alt) {
+    parts.push(
+      forDisplay ? (platform === 'darwin' ? '⌥' : 'Alt') : platform === 'darwin' ? 'Opt' : 'Alt'
+    );
+  }
+
+  // Shift
+  if (parsed.shift) {
+    parts.push(forDisplay ? '⇧' : 'Shift');
+  }
+
+  parts.push(parsed.key.toUpperCase());
+
+  // Add spacing when displaying symbols
+  return parts.join(forDisplay ? ' ' : '+');
+}
+
+// Keyboard Shortcuts - stored as strings like "K", "Shift+N", "Cmd+K"
+export interface KeyboardShortcuts {
+  // Navigation shortcuts
+  board: string;
+  graph: string;
+  agent: string;
+  spec: string;
+  context: string;
+  memory: string;
+  settings: string;
+  projectSettings: string;
+  terminal: string;
+  ideation: string;
+  notifications: string;
+  githubIssues: string;
+  githubPrs: string;
+
+  // UI shortcuts
+  toggleSidebar: string;
+
+  // Action shortcuts
+  addFeature: string;
+  addContextFile: string;
+  startNext: string;
+  newSession: string;
+  openProject: string;
+  projectPicker: string;
+  cyclePrevProject: string;
+  cycleNextProject: string;
+
+  // Terminal shortcuts
+  splitTerminalRight: string;
+  splitTerminalDown: string;
+  closeTerminal: string;
+  newTerminalTab: string;
+}
+
+// Default keyboard shortcuts
+export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcuts = {
+  // Navigation
+  board: 'K',
+  graph: 'H',
+  agent: 'A',
+  spec: 'D',
+  context: 'C',
+  memory: 'Y',
+  settings: 'S',
+  projectSettings: 'Shift+S',
+  terminal: 'T',
+  ideation: 'I',
+  notifications: 'X',
+  githubIssues: 'G',
+  githubPrs: 'R',
+
+  // UI
+  toggleSidebar: '`',
+
+  // Actions
+  // Note: Some shortcuts share the same key (e.g., "N" for addFeature, newSession)
+  // This is intentional as they are context-specific and only active in their respective views
+  addFeature: 'N', // Only active in board view
+  addContextFile: 'N', // Only active in context view
+  startNext: 'G', // Only active in board view
+  newSession: 'N', // Only active in agent view
+  openProject: 'O', // Global shortcut
+  projectPicker: 'P', // Global shortcut
+  cyclePrevProject: 'Q', // Global shortcut
+  cycleNextProject: 'E', // Global shortcut
+
+  // Terminal shortcuts (only active in terminal view)
+  // Using Alt modifier to avoid conflicts with both terminal signals AND browser shortcuts
+  splitTerminalRight: 'Alt+D',
+  splitTerminalDown: 'Alt+S',
+  closeTerminal: 'Alt+W',
+  newTerminalTab: 'Alt+T',
+};
+
+// ============================================================================
+// State Interface
+// ============================================================================
+
+export interface SettingsState {
+  // Keyboard Shortcuts
+  keyboardShortcuts: KeyboardShortcuts;
+
+  // Audio Settings
+  muteDoneSound: boolean;
+
+  // Server Log Level Settings
+  serverLogLevel: ServerLogLevel;
+  enableRequestLogging: boolean;
+
+  // MCP Servers
+  mcpServers: MCPServerConfig[];
+
+  // Editor Configuration
+  defaultEditorCommand: string | null;
+
+  // Terminal Configuration
+  defaultTerminalId: string | null;
+
+  // Skills Configuration
+  enableSkills: boolean;
+  skillsSources: Array<'user' | 'project'>;
+
+  // Subagents Configuration
+  enableSubagents: boolean;
+  subagentsSources: Array<'user' | 'project'>;
+
+  // Prompt Customization
+  promptCustomization: PromptCustomization;
+
+  // Event Hooks
+  eventHooks: EventHook[];
+
+  // Claude SDK Settings
+  autoLoadClaudeMd: boolean;
+  skipSandboxWarning: boolean;
+
+  // Feature Defaults
+  defaultSkipTests: boolean;
+  enableDependencyBlocking: boolean;
+  skipVerificationInAutoMode: boolean;
+  enableAiCommitMessages: boolean;
+  planUseSelectedWorktreeBranch: boolean;
+  addFeatureUseSelectedWorktreeBranch: boolean;
+}
+
+// ============================================================================
+// Actions Interface
+// ============================================================================
+
+interface SettingsActions {
+  // Keyboard Shortcuts actions
+  setKeyboardShortcut: (key: keyof KeyboardShortcuts, value: string) => void;
+  setKeyboardShortcuts: (shortcuts: Partial<KeyboardShortcuts>) => void;
+  resetKeyboardShortcuts: () => void;
+
+  // Audio Settings actions
+  setMuteDoneSound: (muted: boolean) => void;
+
+  // Server Log Level actions
+  setServerLogLevel: (level: ServerLogLevel) => void;
+  setEnableRequestLogging: (enabled: boolean) => void;
+
+  // MCP Servers actions
+  setMcpServers: (servers: MCPServerConfig[]) => void;
+  addMcpServer: (server: MCPServerConfig) => void;
+  removeMcpServer: (serverId: string) => void;
+  updateMcpServer: (serverId: string, server: Partial<MCPServerConfig>) => void;
+
+  // Editor Configuration actions
+  setDefaultEditorCommand: (command: string | null) => void;
+
+  // Terminal Configuration actions
+  setDefaultTerminalId: (terminalId: string | null) => void;
+
+  // Skills Configuration actions
+  setEnableSkills: (enabled: boolean) => void;
+  setSkillsSources: (sources: Array<'user' | 'project'>) => void;
+
+  // Subagents Configuration actions
+  setEnableSubagents: (enabled: boolean) => void;
+  setSubagentsSources: (sources: Array<'user' | 'project'>) => void;
+
+  // Prompt Customization actions
+  setPromptCustomization: (customization: PromptCustomization) => void;
+
+  // Event Hooks actions
+  setEventHooks: (hooks: EventHook[]) => void;
+  addEventHook: (hook: EventHook) => void;
+  removeEventHook: (hookId: string) => void;
+  updateEventHook: (hookId: string, hook: Partial<EventHook>) => void;
+
+  // Claude SDK Settings actions
+  setAutoLoadClaudeMd: (enabled: boolean) => void;
+  setSkipSandboxWarning: (skip: boolean) => void;
+
+  // Feature Defaults actions
+  setDefaultSkipTests: (skip: boolean) => void;
+  setEnableDependencyBlocking: (enabled: boolean) => void;
+  setSkipVerificationInAutoMode: (skip: boolean) => void;
+  setEnableAiCommitMessages: (enabled: boolean) => void;
+  setPlanUseSelectedWorktreeBranch: (use: boolean) => void;
+  setAddFeatureUseSelectedWorktreeBranch: (use: boolean) => void;
+}
+
+// ============================================================================
+// Initial State
+// ============================================================================
+
+const initialState: SettingsState = {
+  keyboardShortcuts: DEFAULT_KEYBOARD_SHORTCUTS,
+  muteDoneSound: false,
+  serverLogLevel: 'info',
+  enableRequestLogging: true,
+  mcpServers: [],
+  defaultEditorCommand: null,
+  defaultTerminalId: null,
+  enableSkills: true,
+  skillsSources: ['user', 'project'],
+  enableSubagents: true,
+  subagentsSources: ['user', 'project'],
+  promptCustomization: {},
+  eventHooks: [],
+  autoLoadClaudeMd: false,
+  skipSandboxWarning: false,
+  defaultSkipTests: true,
+  enableDependencyBlocking: true,
+  skipVerificationInAutoMode: false,
+  enableAiCommitMessages: true,
+  planUseSelectedWorktreeBranch: true,
+  addFeatureUseSelectedWorktreeBranch: false,
+};
+
+// ============================================================================
+// Store
+// ============================================================================
+
+export const useSettingsStore = create<SettingsState & SettingsActions>((set, get) => ({
+  ...initialState,
+
+  // Keyboard Shortcuts actions
+  setKeyboardShortcut: (key, value) => {
+    set({
+      keyboardShortcuts: {
+        ...get().keyboardShortcuts,
+        [key]: value,
+      },
+    });
+  },
+
+  setKeyboardShortcuts: (shortcuts) => {
+    set({
+      keyboardShortcuts: {
+        ...get().keyboardShortcuts,
+        ...shortcuts,
+      },
+    });
+  },
+
+  resetKeyboardShortcuts: () => {
+    set({ keyboardShortcuts: DEFAULT_KEYBOARD_SHORTCUTS });
+  },
+
+  // Audio Settings actions
+  setMuteDoneSound: (muted) => {
+    set({ muteDoneSound: muted });
+  },
+
+  // Server Log Level actions
+  setServerLogLevel: (level) => {
+    set({ serverLogLevel: level });
+  },
+
+  setEnableRequestLogging: (enabled) => {
+    set({ enableRequestLogging: enabled });
+  },
+
+  // MCP Servers actions
+  setMcpServers: (servers) => {
+    set({ mcpServers: servers });
+  },
+
+  addMcpServer: (server) => {
+    set({
+      mcpServers: [...get().mcpServers, server],
+    });
+  },
+
+  removeMcpServer: (serverId) => {
+    set({
+      mcpServers: get().mcpServers.filter((server) => server.id !== serverId),
+    });
+  },
+
+  updateMcpServer: (serverId, server) => {
+    set({
+      mcpServers: get().mcpServers.map((s) => (s.id === serverId ? { ...s, ...server } : s)),
+    });
+  },
+
+  // Editor Configuration actions
+  setDefaultEditorCommand: (command) => {
+    set({ defaultEditorCommand: command });
+  },
+
+  // Terminal Configuration actions
+  setDefaultTerminalId: (terminalId) => {
+    set({ defaultTerminalId: terminalId });
+  },
+
+  // Skills Configuration actions
+  setEnableSkills: (enabled) => {
+    set({ enableSkills: enabled });
+  },
+
+  setSkillsSources: (sources) => {
+    set({ skillsSources: sources });
+  },
+
+  // Subagents Configuration actions
+  setEnableSubagents: (enabled) => {
+    set({ enableSubagents: enabled });
+  },
+
+  setSubagentsSources: (sources) => {
+    set({ subagentsSources: sources });
+  },
+
+  // Prompt Customization actions
+  setPromptCustomization: (customization) => {
+    set({ promptCustomization: customization });
+  },
+
+  // Event Hooks actions
+  setEventHooks: (hooks) => {
+    set({ eventHooks: hooks });
+  },
+
+  addEventHook: (hook) => {
+    set({
+      eventHooks: [...get().eventHooks, hook],
+    });
+  },
+
+  removeEventHook: (hookId) => {
+    set({
+      eventHooks: get().eventHooks.filter((hook) => hook.id !== hookId),
+    });
+  },
+
+  updateEventHook: (hookId, hook) => {
+    set({
+      eventHooks: get().eventHooks.map((h) => (h.id === hookId ? { ...h, ...hook } : h)),
+    });
+  },
+
+  // Claude SDK Settings actions
+  setAutoLoadClaudeMd: (enabled) => {
+    set({ autoLoadClaudeMd: enabled });
+  },
+
+  setSkipSandboxWarning: (skip) => {
+    set({ skipSandboxWarning: skip });
+  },
+
+  // Feature Defaults actions
+  setDefaultSkipTests: (skip) => {
+    set({ defaultSkipTests: skip });
+  },
+
+  setEnableDependencyBlocking: (enabled) => {
+    set({ enableDependencyBlocking: enabled });
+  },
+
+  setSkipVerificationInAutoMode: (skip) => {
+    set({ skipVerificationInAutoMode: skip });
+  },
+
+  setEnableAiCommitMessages: (enabled) => {
+    set({ enableAiCommitMessages: enabled });
+  },
+
+  setPlanUseSelectedWorktreeBranch: (use) => {
+    set({ planUseSelectedWorktreeBranch: use });
+  },
+
+  setAddFeatureUseSelectedWorktreeBranch: (use) => {
+    set({ addFeatureUseSelectedWorktreeBranch: use });
+  },
+}));

--- a/apps/ui/src/store/terminal-store.ts
+++ b/apps/ui/src/store/terminal-store.ts
@@ -1,0 +1,901 @@
+/**
+ * Terminal Store - State management for integrated terminal
+ */
+
+import { create } from 'zustand';
+import { DEFAULT_FONT_VALUE } from '@/config/ui-font-options';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type TerminalPanelContent =
+  | { type: 'terminal'; sessionId: string; size?: number; fontSize?: number; branchName?: string }
+  | {
+      type: 'split';
+      id: string; // Stable ID for React key stability
+      direction: 'horizontal' | 'vertical';
+      panels: TerminalPanelContent[];
+      size?: number;
+    };
+
+// Terminal tab - each tab has its own layout
+export interface TerminalTab {
+  id: string;
+  name: string;
+  layout: TerminalPanelContent | null;
+}
+
+export interface TerminalState {
+  isUnlocked: boolean;
+  authToken: string | null;
+  tabs: TerminalTab[];
+  activeTabId: string | null;
+  activeSessionId: string | null;
+  maximizedSessionId: string | null; // Session ID of the maximized terminal pane (null if none)
+  defaultFontSize: number; // Default font size for new terminals
+  defaultRunScript: string; // Script to run when a new terminal is created (e.g., "claude" to start Claude Code)
+  screenReaderMode: boolean; // Enable screen reader accessibility mode
+  fontFamily: string; // Font family for terminal text
+  scrollbackLines: number; // Number of lines to keep in scrollback buffer
+  lineHeight: number; // Line height multiplier for terminal text
+  maxSessions: number; // Maximum concurrent terminal sessions (server setting)
+  lastActiveProjectPath: string | null; // Last project path to detect route changes vs project switches
+  openTerminalMode: 'newTab' | 'split'; // How to open terminals from "Open in Terminal" action
+}
+
+// Persisted terminal layout - now includes sessionIds for reconnection
+// Used to restore terminal layout structure when switching projects
+export type PersistedTerminalPanel =
+  | { type: 'terminal'; size?: number; fontSize?: number; sessionId?: string; branchName?: string }
+  | {
+      type: 'split';
+      id?: string; // Optional for backwards compatibility with older persisted layouts
+      direction: 'horizontal' | 'vertical';
+      panels: PersistedTerminalPanel[];
+      size?: number;
+    };
+
+// Helper to generate unique split IDs
+const generateSplitId = () => `split-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+
+export interface PersistedTerminalTab {
+  id: string;
+  name: string;
+  layout: PersistedTerminalPanel | null;
+}
+
+export interface PersistedTerminalState {
+  tabs: PersistedTerminalTab[];
+  activeTabIndex: number; // Use index instead of ID since IDs are regenerated
+  defaultFontSize: number;
+  defaultRunScript?: string; // Optional to support existing persisted data
+  screenReaderMode?: boolean; // Optional to support existing persisted data
+  fontFamily?: string; // Optional to support existing persisted data
+  scrollbackLines?: number; // Optional to support existing persisted data
+  lineHeight?: number; // Optional to support existing persisted data
+}
+
+// Persisted terminal settings - stored globally (not per-project)
+export interface PersistedTerminalSettings {
+  defaultFontSize: number;
+  defaultRunScript: string;
+  screenReaderMode: boolean;
+  fontFamily: string;
+  scrollbackLines: number;
+  lineHeight: number;
+  maxSessions: number;
+  openTerminalMode: 'newTab' | 'split';
+}
+
+// ============================================================================
+// State Interface
+// ============================================================================
+
+interface TerminalStoreState {
+  terminalState: TerminalState;
+  // Terminal layout persistence (per-project, keyed by project path)
+  // Stores the tab/split structure so it can be restored when switching projects
+  terminalLayoutByProject: Record<string, PersistedTerminalState>;
+}
+
+// ============================================================================
+// Actions Interface
+// ============================================================================
+
+interface TerminalActions {
+  setTerminalUnlocked: (unlocked: boolean, token?: string) => void;
+  setActiveTerminalSession: (sessionId: string | null) => void;
+  toggleTerminalMaximized: (sessionId: string) => void;
+  addTerminalToLayout: (
+    sessionId: string,
+    direction?: 'horizontal' | 'vertical',
+    targetSessionId?: string,
+    branchName?: string
+  ) => void;
+  removeTerminalFromLayout: (sessionId: string) => void;
+  clearTerminalState: (keepAuth?: boolean) => void;
+  setTerminalPanelFontSize: (sessionId: string, fontSize: number) => void;
+  setTerminalDefaultFontSize: (fontSize: number) => void;
+  setTerminalDefaultRunScript: (script: string) => void;
+  setTerminalScreenReaderMode: (enabled: boolean) => void;
+  setTerminalFontFamily: (fontFamily: string) => void;
+  setTerminalScrollbackLines: (lines: number) => void;
+  setTerminalLineHeight: (lineHeight: number) => void;
+  setTerminalMaxSessions: (maxSessions: number) => void;
+  setTerminalLastActiveProjectPath: (projectPath: string | null) => void;
+  setOpenTerminalMode: (mode: 'newTab' | 'split') => void;
+  addTerminalTab: (name?: string) => string;
+  removeTerminalTab: (tabId: string) => void;
+  setActiveTerminalTab: (tabId: string) => void;
+  renameTerminalTab: (tabId: string, newName: string) => void;
+  reorderTerminalTabs: (oldIndex: number, newIndex: number) => void;
+  moveTerminalToTab: (sessionId: string, targetTabId: string) => void;
+  addTerminalToTab: (
+    sessionId: string,
+    tabId: string,
+    direction?: 'horizontal' | 'vertical',
+    branchName?: string
+  ) => void;
+  setTerminalTabLayout: (
+    tabId: string,
+    layout: TerminalPanelContent | null,
+    activeSessionId?: string | null
+  ) => void;
+  updateTerminalPanelSizes: (tabId: string, panelKeys: string[], sizes: number[]) => void;
+  saveTerminalLayout: (projectPath: string) => void;
+  getPersistedTerminalLayout: (projectPath: string) => PersistedTerminalState | undefined;
+  clearPersistedTerminalLayout: (projectPath: string) => void;
+}
+
+// ============================================================================
+// Initial State
+// ============================================================================
+
+const initialState: TerminalStoreState = {
+  terminalState: {
+    isUnlocked: false,
+    authToken: null,
+    tabs: [],
+    activeTabId: null,
+    activeSessionId: null,
+    maximizedSessionId: null,
+    defaultFontSize: 14,
+    defaultRunScript: '',
+    screenReaderMode: false,
+    fontFamily: DEFAULT_FONT_VALUE,
+    scrollbackLines: 5000,
+    lineHeight: 1.0,
+    maxSessions: 100,
+    lastActiveProjectPath: null,
+    openTerminalMode: 'newTab',
+  },
+  terminalLayoutByProject: {},
+};
+
+// ============================================================================
+// Store
+// ============================================================================
+
+export const useTerminalStore = create<TerminalStoreState & TerminalActions>((set, get) => ({
+  ...initialState,
+
+  setTerminalUnlocked: (unlocked, token) => {
+    set({
+      terminalState: {
+        ...get().terminalState,
+        isUnlocked: unlocked,
+        authToken: token || null,
+      },
+    });
+  },
+
+  setActiveTerminalSession: (sessionId) => {
+    set({
+      terminalState: {
+        ...get().terminalState,
+        activeSessionId: sessionId,
+      },
+    });
+  },
+
+  toggleTerminalMaximized: (sessionId) => {
+    const current = get().terminalState;
+    const newMaximized = current.maximizedSessionId === sessionId ? null : sessionId;
+    set({
+      terminalState: {
+        ...current,
+        maximizedSessionId: newMaximized,
+        // Also set as active when maximizing
+        activeSessionId: newMaximized ?? current.activeSessionId,
+      },
+    });
+  },
+
+  addTerminalToLayout: (sessionId, direction = 'horizontal', targetSessionId, branchName) => {
+    const current = get().terminalState;
+    const newTerminal: TerminalPanelContent = {
+      type: 'terminal',
+      sessionId,
+      size: 50,
+      branchName,
+    };
+
+    // If no tabs, create first tab
+    if (current.tabs.length === 0) {
+      const newTabId = `tab-${Date.now()}`;
+      set({
+        terminalState: {
+          ...current,
+          tabs: [
+            {
+              id: newTabId,
+              name: 'Terminal 1',
+              layout: { type: 'terminal', sessionId, size: 100, branchName },
+            },
+          ],
+          activeTabId: newTabId,
+          activeSessionId: sessionId,
+        },
+      });
+      return;
+    }
+
+    // Add to active tab's layout
+    const activeTab = current.tabs.find((t) => t.id === current.activeTabId);
+    if (!activeTab) return;
+
+    // If targetSessionId is provided, find and split that specific terminal
+    const splitTargetTerminal = (
+      node: TerminalPanelContent,
+      targetId: string,
+      targetDirection: 'horizontal' | 'vertical'
+    ): TerminalPanelContent => {
+      if (node.type === 'terminal') {
+        if (node.sessionId === targetId) {
+          // Found the target - split it
+          return {
+            type: 'split',
+            id: generateSplitId(),
+            direction: targetDirection,
+            panels: [{ ...node, size: 50 }, newTerminal],
+          };
+        }
+        // Not the target, return unchanged
+        return node;
+      }
+      // It's a split - recurse into panels
+      return {
+        ...node,
+        panels: node.panels.map((p) => splitTargetTerminal(p, targetId, targetDirection)),
+      };
+    };
+
+    // Legacy behavior: add to root layout (when no targetSessionId)
+    const addToRootLayout = (
+      node: TerminalPanelContent,
+      targetDirection: 'horizontal' | 'vertical'
+    ): TerminalPanelContent => {
+      if (node.type === 'terminal') {
+        return {
+          type: 'split',
+          id: generateSplitId(),
+          direction: targetDirection,
+          panels: [{ ...node, size: 50 }, newTerminal],
+        };
+      }
+      // If same direction, add to existing split
+      if (node.direction === targetDirection) {
+        const newSize = 100 / (node.panels.length + 1);
+        return {
+          ...node,
+          panels: [
+            ...node.panels.map((p) => ({ ...p, size: newSize })),
+            { ...newTerminal, size: newSize },
+          ],
+        };
+      }
+      // Different direction, wrap in new split
+      return {
+        type: 'split',
+        id: generateSplitId(),
+        direction: targetDirection,
+        panels: [{ ...node, size: 50 }, newTerminal],
+      };
+    };
+
+    let newLayout: TerminalPanelContent;
+    if (!activeTab.layout) {
+      newLayout = { type: 'terminal', sessionId, size: 100, branchName };
+    } else if (targetSessionId) {
+      newLayout = splitTargetTerminal(activeTab.layout, targetSessionId, direction);
+    } else {
+      newLayout = addToRootLayout(activeTab.layout, direction);
+    }
+
+    const newTabs = current.tabs.map((t) =>
+      t.id === current.activeTabId ? { ...t, layout: newLayout } : t
+    );
+
+    set({
+      terminalState: {
+        ...current,
+        tabs: newTabs,
+        activeSessionId: sessionId,
+      },
+    });
+  },
+
+  removeTerminalFromLayout: (sessionId) => {
+    const current = get().terminalState;
+    if (current.tabs.length === 0) return;
+
+    // Find which tab contains this session
+    const findFirstTerminal = (node: TerminalPanelContent | null): string | null => {
+      if (!node) return null;
+      if (node.type === 'terminal') return node.sessionId;
+      for (const panel of node.panels) {
+        const found = findFirstTerminal(panel);
+        if (found) return found;
+      }
+      return null;
+    };
+
+    const removeAndCollapse = (node: TerminalPanelContent): TerminalPanelContent | null => {
+      if (node.type === 'terminal') {
+        return node.sessionId === sessionId ? null : node;
+      }
+      const newPanels: TerminalPanelContent[] = [];
+      for (const panel of node.panels) {
+        const result = removeAndCollapse(panel);
+        if (result !== null) newPanels.push(result);
+      }
+      if (newPanels.length === 0) return null;
+      if (newPanels.length === 1) return newPanels[0];
+      // Normalize sizes to sum to 100%
+      const totalSize = newPanels.reduce((sum, p) => sum + (p.size || 0), 0);
+      const normalizedPanels =
+        totalSize > 0
+          ? newPanels.map((p) => ({ ...p, size: ((p.size || 0) / totalSize) * 100 }))
+          : newPanels.map((p) => ({ ...p, size: 100 / newPanels.length }));
+      return { ...node, panels: normalizedPanels };
+    };
+
+    let newTabs = current.tabs.map((tab) => {
+      if (!tab.layout) return tab;
+      const newLayout = removeAndCollapse(tab.layout);
+      return { ...tab, layout: newLayout };
+    });
+
+    // Remove empty tabs
+    newTabs = newTabs.filter((tab) => tab.layout !== null);
+
+    // Determine new active session
+    const newActiveTabId =
+      newTabs.length > 0
+        ? current.activeTabId && newTabs.find((t) => t.id === current.activeTabId)
+          ? current.activeTabId
+          : newTabs[0].id
+        : null;
+    const newActiveSessionId = newActiveTabId
+      ? findFirstTerminal(newTabs.find((t) => t.id === newActiveTabId)?.layout || null)
+      : null;
+
+    // Clear maximized if it was the removed session
+    const newMaximizedSessionId =
+      current.maximizedSessionId === sessionId ? null : current.maximizedSessionId;
+
+    set({
+      terminalState: {
+        ...current,
+        tabs: newTabs,
+        activeTabId: newActiveTabId,
+        activeSessionId: newActiveSessionId,
+        maximizedSessionId: newMaximizedSessionId,
+      },
+    });
+  },
+
+  clearTerminalState: (keepAuth = false) => {
+    const current = get().terminalState;
+    set({
+      terminalState: {
+        ...current,
+        isUnlocked: keepAuth ? current.isUnlocked : false,
+        authToken: keepAuth ? current.authToken : null,
+        tabs: [],
+        activeTabId: null,
+        activeSessionId: null,
+        maximizedSessionId: null,
+      },
+    });
+  },
+
+  setTerminalPanelFontSize: (sessionId, fontSize) => {
+    const current = get().terminalState;
+    const updateFontSize = (node: TerminalPanelContent): TerminalPanelContent => {
+      if (node.type === 'terminal') {
+        return node.sessionId === sessionId ? { ...node, fontSize } : node;
+      }
+      return { ...node, panels: node.panels.map(updateFontSize) };
+    };
+
+    const newTabs = current.tabs.map((tab) =>
+      tab.layout ? { ...tab, layout: updateFontSize(tab.layout) } : tab
+    );
+
+    set({
+      terminalState: {
+        ...current,
+        tabs: newTabs,
+      },
+    });
+  },
+
+  setTerminalDefaultFontSize: (fontSize) => {
+    set({
+      terminalState: {
+        ...get().terminalState,
+        defaultFontSize: fontSize,
+      },
+    });
+  },
+
+  setTerminalDefaultRunScript: (script) => {
+    set({
+      terminalState: {
+        ...get().terminalState,
+        defaultRunScript: script,
+      },
+    });
+  },
+
+  setTerminalScreenReaderMode: (enabled) => {
+    set({
+      terminalState: {
+        ...get().terminalState,
+        screenReaderMode: enabled,
+      },
+    });
+  },
+
+  setTerminalFontFamily: (fontFamily) => {
+    set({
+      terminalState: {
+        ...get().terminalState,
+        fontFamily,
+      },
+    });
+  },
+
+  setTerminalScrollbackLines: (lines) => {
+    // Clamp to reasonable values (1000-50000)
+    const clampedLines = Math.max(1000, Math.min(50000, lines));
+    set({
+      terminalState: {
+        ...get().terminalState,
+        scrollbackLines: clampedLines,
+      },
+    });
+  },
+
+  setTerminalLineHeight: (lineHeight) => {
+    // Clamp to reasonable values (0.5-2.0)
+    const clampedLineHeight = Math.max(0.5, Math.min(2.0, lineHeight));
+    set({
+      terminalState: {
+        ...get().terminalState,
+        lineHeight: clampedLineHeight,
+      },
+    });
+  },
+
+  setTerminalMaxSessions: (maxSessions) => {
+    set({
+      terminalState: {
+        ...get().terminalState,
+        maxSessions,
+      },
+    });
+  },
+
+  setTerminalLastActiveProjectPath: (projectPath) => {
+    set({
+      terminalState: {
+        ...get().terminalState,
+        lastActiveProjectPath: projectPath,
+      },
+    });
+  },
+
+  setOpenTerminalMode: (mode) => {
+    set({
+      terminalState: {
+        ...get().terminalState,
+        openTerminalMode: mode,
+      },
+    });
+  },
+
+  addTerminalTab: (name) => {
+    const current = get().terminalState;
+    const tabCount = current.tabs.length;
+    const newTabId = `tab-${Date.now()}`;
+    const tabName = name || `Terminal ${tabCount + 1}`;
+
+    set({
+      terminalState: {
+        ...current,
+        tabs: [
+          ...current.tabs,
+          {
+            id: newTabId,
+            name: tabName,
+            layout: null,
+          },
+        ],
+        activeTabId: newTabId,
+      },
+    });
+
+    return newTabId;
+  },
+
+  removeTerminalTab: (tabId) => {
+    const current = get().terminalState;
+    const tabIndex = current.tabs.findIndex((t) => t.id === tabId);
+    if (tabIndex === -1) return;
+
+    const newTabs = current.tabs.filter((t) => t.id !== tabId);
+    let newActiveTabId = current.activeTabId;
+    let newActiveSessionId = current.activeSessionId;
+
+    // If we're removing the active tab, switch to another tab
+    if (current.activeTabId === tabId && newTabs.length > 0) {
+      // Try to activate the next tab, or fall back to the previous one
+      const nextTab = newTabs[Math.min(tabIndex, newTabs.length - 1)];
+      newActiveTabId = nextTab.id;
+
+      // Find the first terminal in the new active tab
+      const findFirstTerminal = (node: TerminalPanelContent | null): string | null => {
+        if (!node) return null;
+        if (node.type === 'terminal') return node.sessionId;
+        for (const panel of node.panels) {
+          const found = findFirstTerminal(panel);
+          if (found) return found;
+        }
+        return null;
+      };
+      newActiveSessionId = findFirstTerminal(nextTab.layout);
+    } else if (newTabs.length === 0) {
+      newActiveTabId = null;
+      newActiveSessionId = null;
+    }
+
+    set({
+      terminalState: {
+        ...current,
+        tabs: newTabs,
+        activeTabId: newActiveTabId,
+        activeSessionId: newActiveSessionId,
+      },
+    });
+  },
+
+  setActiveTerminalTab: (tabId) => {
+    const current = get().terminalState;
+    const tab = current.tabs.find((t) => t.id === tabId);
+    if (!tab) return;
+
+    // Find the first terminal in this tab to set as active
+    const findFirstTerminal = (node: TerminalPanelContent | null): string | null => {
+      if (!node) return null;
+      if (node.type === 'terminal') return node.sessionId;
+      for (const panel of node.panels) {
+        const found = findFirstTerminal(panel);
+        if (found) return found;
+      }
+      return null;
+    };
+
+    const newActiveSessionId = findFirstTerminal(tab.layout);
+
+    set({
+      terminalState: {
+        ...current,
+        activeTabId: tabId,
+        activeSessionId: newActiveSessionId,
+      },
+    });
+  },
+
+  renameTerminalTab: (tabId, newName) => {
+    const current = get().terminalState;
+    set({
+      terminalState: {
+        ...current,
+        tabs: current.tabs.map((tab) => (tab.id === tabId ? { ...tab, name: newName } : tab)),
+      },
+    });
+  },
+
+  reorderTerminalTabs: (oldIndex, newIndex) => {
+    const current = get().terminalState;
+    const newTabs = [...current.tabs];
+    const [movedTab] = newTabs.splice(oldIndex, 1);
+    newTabs.splice(newIndex, 0, movedTab);
+
+    set({
+      terminalState: {
+        ...current,
+        tabs: newTabs,
+      },
+    });
+  },
+
+  moveTerminalToTab: (sessionId, targetTabId) => {
+    const current = get().terminalState;
+
+    // Find the terminal panel in the current layout
+    const findAndRemove = (
+      node: TerminalPanelContent,
+      targetSessionId: string
+    ): {
+      found: TerminalPanelContent | null;
+      remaining: TerminalPanelContent | null;
+    } => {
+      if (node.type === 'terminal') {
+        if (node.sessionId === targetSessionId) {
+          return { found: node, remaining: null };
+        }
+        return { found: null, remaining: node };
+      }
+
+      const results = node.panels.map((p) => findAndRemove(p, targetSessionId));
+      const found = results.find((r) => r.found !== null);
+
+      if (found) {
+        const remainingPanels = results
+          .map((r) => r.remaining)
+          .filter((r): r is TerminalPanelContent => r !== null);
+
+        if (remainingPanels.length === 0) {
+          return { found: found.found, remaining: null };
+        }
+        if (remainingPanels.length === 1) {
+          return { found: found.found, remaining: remainingPanels[0] };
+        }
+
+        return {
+          found: found.found,
+          remaining: { ...node, panels: remainingPanels },
+        };
+      }
+
+      return { found: null, remaining: node };
+    };
+
+    let terminalPanel: TerminalPanelContent | null = null;
+    const newTabs = current.tabs.map((tab) => {
+      if (!tab.layout) return tab;
+
+      const result = findAndRemove(tab.layout, sessionId);
+      if (result.found) {
+        terminalPanel = result.found;
+      }
+
+      return { ...tab, layout: result.remaining };
+    });
+
+    if (!terminalPanel) return; // Terminal not found
+
+    // Add the terminal to the target tab
+    const finalTabs = newTabs.map((tab) => {
+      if (tab.id !== targetTabId) return tab;
+
+      if (!tab.layout) {
+        return { ...tab, layout: terminalPanel };
+      }
+
+      // Add to the tab's layout (default horizontal split)
+      const newLayout: TerminalPanelContent = {
+        type: 'split',
+        id: generateSplitId(),
+        direction: 'horizontal',
+        panels: [tab.layout, terminalPanel as TerminalPanelContent],
+      };
+
+      return { ...tab, layout: newLayout };
+    });
+
+    set({
+      terminalState: {
+        ...current,
+        tabs: finalTabs.filter((tab) => tab.layout !== null),
+        activeTabId: targetTabId,
+        activeSessionId: sessionId,
+      },
+    });
+  },
+
+  addTerminalToTab: (sessionId, tabId, direction = 'horizontal', branchName) => {
+    const current = get().terminalState;
+    const tab = current.tabs.find((t) => t.id === tabId);
+    if (!tab) return;
+
+    const newTerminal: TerminalPanelContent = {
+      type: 'terminal',
+      sessionId,
+      size: 50,
+      branchName,
+    };
+
+    let newLayout: TerminalPanelContent;
+    if (!tab.layout) {
+      newLayout = { type: 'terminal', sessionId, size: 100, branchName };
+    } else if (tab.layout.type === 'terminal') {
+      newLayout = {
+        type: 'split',
+        id: generateSplitId(),
+        direction,
+        panels: [{ ...tab.layout, size: 50 }, newTerminal],
+      };
+    } else if (tab.layout.direction === direction) {
+      const newSize = 100 / (tab.layout.panels.length + 1);
+      newLayout = {
+        ...tab.layout,
+        panels: [
+          ...tab.layout.panels.map((p) => ({ ...p, size: newSize })),
+          { ...newTerminal, size: newSize },
+        ],
+      };
+    } else {
+      newLayout = {
+        type: 'split',
+        id: generateSplitId(),
+        direction,
+        panels: [{ ...tab.layout, size: 50 }, newTerminal],
+      };
+    }
+
+    set({
+      terminalState: {
+        ...current,
+        tabs: current.tabs.map((t) => (t.id === tabId ? { ...t, layout: newLayout } : t)),
+        activeTabId: tabId,
+        activeSessionId: sessionId,
+      },
+    });
+  },
+
+  setTerminalTabLayout: (tabId, layout, activeSessionId) => {
+    const current = get().terminalState;
+    const newTabs = current.tabs.map((tab) => (tab.id === tabId ? { ...tab, layout } : tab));
+
+    // Find first terminal if activeSessionId not provided
+    const findFirstTerminal = (node: TerminalPanelContent | null): string | null => {
+      if (!node) return null;
+      if (node.type === 'terminal') return node.sessionId;
+      for (const panel of node.panels) {
+        const found = findFirstTerminal(panel);
+        if (found) return found;
+      }
+      return null;
+    };
+
+    const newActiveSessionId =
+      activeSessionId !== undefined
+        ? activeSessionId
+        : tabId === current.activeTabId
+          ? findFirstTerminal(layout)
+          : current.activeSessionId;
+
+    set({
+      terminalState: {
+        ...current,
+        tabs: newTabs,
+        activeSessionId: newActiveSessionId,
+      },
+    });
+  },
+
+  updateTerminalPanelSizes: (tabId, panelKeys, sizes) => {
+    const current = get().terminalState;
+    const tab = current.tabs.find((t) => t.id === tabId);
+    if (!tab || !tab.layout) return;
+
+    const updateSizes = (node: TerminalPanelContent, path: string): TerminalPanelContent => {
+      const currentKey =
+        node.type === 'terminal' ? `terminal-${node.sessionId}` : `split-${node.id}`;
+
+      const pathWithCurrent = path ? `${path}.${currentKey}` : currentKey;
+
+      // Check if this node's size should be updated
+      const sizeIndex = panelKeys.indexOf(pathWithCurrent);
+      if (sizeIndex !== -1) {
+        return { ...node, size: sizes[sizeIndex] };
+      }
+
+      // Recurse for splits
+      if (node.type === 'split') {
+        return {
+          ...node,
+          panels: node.panels.map((panel) => updateSizes(panel, pathWithCurrent)),
+        };
+      }
+
+      return node;
+    };
+
+    const newLayout = updateSizes(tab.layout, '');
+
+    set({
+      terminalState: {
+        ...current,
+        tabs: current.tabs.map((t) => (t.id === tabId ? { ...t, layout: newLayout } : t)),
+      },
+    });
+  },
+
+  saveTerminalLayout: (projectPath) => {
+    const current = get().terminalState;
+
+    // Convert runtime layout to persisted format (strip sessionIds from active terminals)
+    const convertToPersistedPanel = (node: TerminalPanelContent): PersistedTerminalPanel => {
+      if (node.type === 'terminal') {
+        return {
+          type: 'terminal',
+          size: node.size,
+          fontSize: node.fontSize,
+          sessionId: node.sessionId, // Keep sessionId for reconnection
+          branchName: node.branchName,
+        };
+      }
+      return {
+        type: 'split',
+        id: node.id,
+        direction: node.direction,
+        panels: node.panels.map(convertToPersistedPanel),
+        size: node.size,
+      };
+    };
+
+    const persistedTabs: PersistedTerminalTab[] = current.tabs.map((tab) => ({
+      id: tab.id,
+      name: tab.name,
+      layout: tab.layout ? convertToPersistedPanel(tab.layout) : null,
+    }));
+
+    const activeTabIndex = current.activeTabId
+      ? current.tabs.findIndex((t) => t.id === current.activeTabId)
+      : 0;
+
+    const persistedState: PersistedTerminalState = {
+      tabs: persistedTabs,
+      activeTabIndex: Math.max(0, activeTabIndex),
+      defaultFontSize: current.defaultFontSize,
+      defaultRunScript: current.defaultRunScript,
+      screenReaderMode: current.screenReaderMode,
+      fontFamily: current.fontFamily,
+      scrollbackLines: current.scrollbackLines,
+      lineHeight: current.lineHeight,
+    };
+
+    set({
+      terminalLayoutByProject: {
+        ...get().terminalLayoutByProject,
+        [projectPath]: persistedState,
+      },
+    });
+  },
+
+  getPersistedTerminalLayout: (projectPath) => {
+    return get().terminalLayoutByProject[projectPath];
+  },
+
+  clearPersistedTerminalLayout: (projectPath) => {
+    const layouts = { ...get().terminalLayoutByProject };
+    delete layouts[projectPath];
+    set({ terminalLayoutByProject: layouts });
+  },
+}));

--- a/apps/ui/src/store/worktree-store.ts
+++ b/apps/ui/src/store/worktree-store.ts
@@ -1,0 +1,599 @@
+/**
+ * Worktree Store - State management for git worktree isolation
+ */
+
+import { create } from 'zustand';
+import { DEFAULT_MAX_CONCURRENCY } from '@automaker/types';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** State for worktree init script execution */
+export interface InitScriptState {
+  status: 'idle' | 'running' | 'success' | 'failed';
+  branch: string;
+  output: string[];
+  error?: string;
+}
+
+/** Activity log entry for auto mode operations */
+export interface AutoModeActivity {
+  id: string;
+  featureId: string;
+  timestamp: Date;
+  type:
+    | 'start'
+    | 'progress'
+    | 'tool'
+    | 'complete'
+    | 'error'
+    | 'planning'
+    | 'action'
+    | 'verification';
+  message: string;
+  tool?: string;
+  passes?: boolean;
+  phase?: 'planning' | 'action' | 'verification';
+  errorType?: 'authentication' | 'execution';
+}
+
+// ============================================================================
+// State Interface
+// ============================================================================
+
+interface WorktreeStoreState {
+  // Auto Mode (per-worktree state, keyed by "${projectId}::${branchName ?? '__main__'}")
+  autoModeByWorktree: Record<
+    string,
+    {
+      isRunning: boolean;
+      runningTasks: string[]; // Feature IDs being worked on
+      branchName: string | null; // null = main worktree
+      maxConcurrency?: number; // Maximum concurrent features for this worktree (defaults to 3)
+    }
+  >;
+  autoModeActivityLog: AutoModeActivity[];
+  maxConcurrency: number; // Legacy: Maximum number of concurrent agent tasks (deprecated, use per-worktree maxConcurrency)
+
+  // Worktree Settings
+  useWorktrees: boolean; // Whether to use git worktree isolation for features (default: true)
+
+  // User-managed Worktrees (per-project)
+  // projectPath -> { path: worktreePath or null for main, branch: branch name }
+  currentWorktreeByProject: Record<string, { path: string | null; branch: string }>;
+  worktreesByProject: Record<
+    string,
+    Array<{
+      path: string;
+      branch: string;
+      isMain: boolean;
+      hasChanges?: boolean;
+      changedFilesCount?: number;
+    }>
+  >;
+  // Track loading state for worktrees per project
+  worktreesLoadingByProject: Record<string, boolean>;
+
+  // Worktree Panel Visibility (per-project, keyed by project path)
+  // Whether the worktree panel row is visible (default: true)
+  worktreePanelVisibleByProject: Record<string, boolean>;
+
+  // Init Script Indicator Visibility (per-project, keyed by project path)
+  // Whether to show the floating init script indicator panel (default: true)
+  showInitScriptIndicatorByProject: Record<string, boolean>;
+
+  // Default Delete Branch With Worktree (per-project, keyed by project path)
+  // Whether to default the "delete branch" checkbox when deleting a worktree (default: false)
+  defaultDeleteBranchByProject: Record<string, boolean>;
+
+  // Auto-dismiss Init Script Indicator (per-project, keyed by project path)
+  // Whether to auto-dismiss the indicator after completion (default: true)
+  autoDismissInitScriptIndicatorByProject: Record<string, boolean>;
+
+  // Use Worktrees Override (per-project, keyed by project path)
+  // undefined = use global setting, true/false = project-specific override
+  useWorktreesByProject: Record<string, boolean | undefined>;
+
+  // Init Script State (keyed by "projectPath::branch" to support concurrent scripts)
+  initScriptState: Record<string, InitScriptState>;
+
+  // UI State
+  /** Whether worktree panel is collapsed in board view */
+  worktreePanelCollapsed: boolean;
+}
+
+// ============================================================================
+// Actions Interface
+// ============================================================================
+
+interface WorktreeActions {
+  // Auto Mode actions (per-worktree)
+  /** Helper to generate worktree key from projectId and branchName */
+  getWorktreeKey: (projectId: string, branchName: string | null) => string;
+  setAutoModeState: (
+    projectId: string,
+    branchName: string | null,
+    running: boolean,
+    maxConcurrency?: number,
+    runningTasks?: string[]
+  ) => {
+    isRunning: boolean;
+    runningTasks: string[];
+    branchName: string | null;
+    maxConcurrency?: number;
+  };
+  addRunningTask: (projectId: string, branchName: string | null, taskId: string) => void;
+  removeRunningTask: (projectId: string, branchName: string | null, taskId: string) => void;
+  clearRunningTasks: (projectId: string, branchName: string | null) => void;
+  getAutoModeState: (
+    projectId: string,
+    branchName: string | null
+  ) => {
+    isRunning: boolean;
+    runningTasks: string[];
+    branchName: string | null;
+    maxConcurrency?: number;
+  };
+  addAutoModeActivity: (activity: Omit<AutoModeActivity, 'id' | 'timestamp'>) => void;
+  clearAutoModeActivity: () => void;
+  setMaxConcurrency: (max: number) => void; // Legacy: kept for backward compatibility
+  getMaxConcurrencyForWorktree: (projectId: string, branchName: string | null) => number;
+  setMaxConcurrencyForWorktree: (
+    projectId: string,
+    branchName: string | null,
+    maxConcurrency: number
+  ) => void;
+
+  // Worktree Settings actions
+  setUseWorktrees: (enabled: boolean) => void;
+  setCurrentWorktree: (projectPath: string, worktreePath: string | null, branch: string) => void;
+  setWorktrees: (
+    projectPath: string,
+    worktrees: Array<{
+      path: string;
+      branch: string;
+      isMain: boolean;
+      hasChanges?: boolean;
+      changedFilesCount?: number;
+    }>
+  ) => void;
+  setWorktreesLoading: (projectPath: string, isLoading: boolean) => void;
+  getWorktreesLoading: (projectPath: string) => boolean;
+  getCurrentWorktree: (projectPath: string) => { path: string | null; branch: string } | null;
+  getWorktrees: (projectPath: string) => Array<{
+    path: string;
+    branch: string;
+    isMain: boolean;
+    hasChanges?: boolean;
+    changedFilesCount?: number;
+  }>;
+  isPrimaryWorktreeBranch: (projectPath: string, branchName: string) => boolean;
+  getPrimaryWorktreeBranch: (projectPath: string) => string | null;
+
+  // Worktree Panel Visibility actions (per-project)
+  setWorktreePanelVisible: (projectPath: string, visible: boolean) => void;
+  getWorktreePanelVisible: (projectPath: string) => boolean;
+
+  // Init Script Indicator Visibility actions (per-project)
+  setShowInitScriptIndicator: (projectPath: string, visible: boolean) => void;
+  getShowInitScriptIndicator: (projectPath: string) => boolean;
+
+  // Default Delete Branch actions (per-project)
+  setDefaultDeleteBranch: (projectPath: string, deleteBranch: boolean) => void;
+  getDefaultDeleteBranch: (projectPath: string) => boolean;
+
+  // Auto-dismiss Init Script Indicator actions (per-project)
+  setAutoDismissInitScriptIndicator: (projectPath: string, autoDismiss: boolean) => void;
+  getAutoDismissInitScriptIndicator: (projectPath: string) => boolean;
+
+  // Use Worktrees Override actions (per-project)
+  setProjectUseWorktrees: (projectPath: string, useWorktrees: boolean | null) => void; // null = use global
+  getProjectUseWorktrees: (projectPath: string) => boolean | undefined; // undefined = using global
+  getEffectiveUseWorktrees: (projectPath: string) => boolean; // Returns actual value (project or global fallback)
+
+  // UI State actions
+  setWorktreePanelCollapsed: (collapsed: boolean) => void;
+
+  // Init Script State actions (keyed by "projectPath::branch" to support concurrent scripts)
+  setInitScriptState: (
+    projectPath: string,
+    branch: string,
+    state: Partial<InitScriptState>
+  ) => void;
+  appendInitScriptOutput: (projectPath: string, branch: string, content: string) => void;
+  clearInitScriptState: (projectPath: string, branch: string) => void;
+  getInitScriptState: (projectPath: string, branch: string) => InitScriptState | null;
+  getInitScriptStatesForProject: (
+    projectPath: string
+  ) => Array<{ key: string; state: InitScriptState }>;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const MAX_INIT_OUTPUT_LINES = 1000; // Maximum lines to keep in init script output buffer
+
+// ============================================================================
+// Initial State
+// ============================================================================
+
+const initialState: WorktreeStoreState = {
+  autoModeByWorktree: {},
+  autoModeActivityLog: [],
+  maxConcurrency: DEFAULT_MAX_CONCURRENCY, // Default concurrent agents
+  useWorktrees: true, // Default to enabled (git worktree isolation)
+  currentWorktreeByProject: {},
+  worktreesByProject: {},
+  worktreesLoadingByProject: {}, // Track loading state per project (default=true via getter)
+  worktreePanelVisibleByProject: {},
+  showInitScriptIndicatorByProject: {},
+  defaultDeleteBranchByProject: {},
+  autoDismissInitScriptIndicatorByProject: {},
+  useWorktreesByProject: {},
+  initScriptState: {},
+  worktreePanelCollapsed: false,
+};
+
+// ============================================================================
+// Store
+// ============================================================================
+
+export const useWorktreeStore = create<WorktreeStoreState & WorktreeActions>()((set, get) => ({
+  ...initialState,
+
+  // Auto Mode actions (per-worktree)
+  getWorktreeKey: (projectId, branchName) => {
+    // Normalize 'main' to null so it matches the main worktree key
+    // The backend sometimes sends 'main' while the UI uses null for the main worktree
+    const normalizedBranch = branchName === 'main' ? null : branchName;
+    return `${projectId}::${normalizedBranch ?? '__main__'}`;
+  },
+
+  setAutoModeState: (projectId, branchName, running, maxConcurrency, runningTasks) => {
+    const worktreeKey = get().getWorktreeKey(projectId, branchName);
+    const current = get().autoModeByWorktree;
+    const worktreeState = current[worktreeKey] || {
+      isRunning: false,
+      runningTasks: [],
+      branchName,
+    };
+
+    const newState = {
+      isRunning: running,
+      runningTasks: runningTasks ?? worktreeState.runningTasks,
+      branchName,
+      maxConcurrency: maxConcurrency ?? worktreeState.maxConcurrency,
+    };
+
+    set({
+      autoModeByWorktree: {
+        ...current,
+        [worktreeKey]: newState,
+      },
+    });
+
+    return newState;
+  },
+
+  addRunningTask: (projectId, branchName, taskId) => {
+    const worktreeKey = get().getWorktreeKey(projectId, branchName);
+    const current = get().autoModeByWorktree;
+    const worktreeState = current[worktreeKey] || {
+      isRunning: false,
+      runningTasks: [],
+      branchName,
+    };
+
+    if (!worktreeState.runningTasks.includes(taskId)) {
+      set({
+        autoModeByWorktree: {
+          ...current,
+          [worktreeKey]: {
+            ...worktreeState,
+            runningTasks: [...worktreeState.runningTasks, taskId],
+          },
+        },
+      });
+    }
+  },
+
+  removeRunningTask: (projectId, branchName, taskId) => {
+    const worktreeKey = get().getWorktreeKey(projectId, branchName);
+    const current = get().autoModeByWorktree;
+    const worktreeState = current[worktreeKey] || {
+      isRunning: false,
+      runningTasks: [],
+      branchName,
+    };
+
+    set({
+      autoModeByWorktree: {
+        ...current,
+        [worktreeKey]: {
+          ...worktreeState,
+          runningTasks: worktreeState.runningTasks.filter((t) => t !== taskId),
+        },
+      },
+    });
+  },
+
+  clearRunningTasks: (projectId, branchName) => {
+    const worktreeKey = get().getWorktreeKey(projectId, branchName);
+    const current = get().autoModeByWorktree;
+    const worktreeState = current[worktreeKey] || {
+      isRunning: false,
+      runningTasks: [],
+      branchName,
+    };
+
+    set({
+      autoModeByWorktree: {
+        ...current,
+        [worktreeKey]: {
+          ...worktreeState,
+          runningTasks: [],
+        },
+      },
+    });
+  },
+
+  getAutoModeState: (projectId, branchName) => {
+    const worktreeKey = get().getWorktreeKey(projectId, branchName);
+    const worktreeState = get().autoModeByWorktree[worktreeKey];
+    return (
+      worktreeState || {
+        isRunning: false,
+        runningTasks: [],
+        branchName,
+      }
+    );
+  },
+
+  getMaxConcurrencyForWorktree: (projectId, branchName) => {
+    const worktreeKey = get().getWorktreeKey(projectId, branchName);
+    const worktreeState = get().autoModeByWorktree[worktreeKey];
+    return worktreeState?.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY;
+  },
+
+  setMaxConcurrencyForWorktree: (projectId, branchName, maxConcurrency) => {
+    const worktreeKey = get().getWorktreeKey(projectId, branchName);
+    const current = get().autoModeByWorktree;
+    const worktreeState = current[worktreeKey] || {
+      isRunning: false,
+      runningTasks: [],
+      branchName,
+    };
+
+    set({
+      autoModeByWorktree: {
+        ...current,
+        [worktreeKey]: { ...worktreeState, maxConcurrency, branchName },
+      },
+    });
+  },
+
+  addAutoModeActivity: (activity) => {
+    const id = `activity-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const newActivity: AutoModeActivity = {
+      ...activity,
+      id,
+      timestamp: new Date(),
+    };
+
+    // Keep only last 1000 activities to prevent unbounded growth
+    const updatedLog = [...get().autoModeActivityLog, newActivity].slice(-1000);
+
+    set({ autoModeActivityLog: updatedLog });
+  },
+
+  clearAutoModeActivity: () => set({ autoModeActivityLog: [] }),
+
+  setMaxConcurrency: (max) => set({ maxConcurrency: max }),
+
+  // Worktree Settings actions
+  setUseWorktrees: (enabled) => set({ useWorktrees: enabled }),
+
+  setCurrentWorktree: (projectPath, worktreePath, branch) => {
+    const current = get().currentWorktreeByProject;
+    set({
+      currentWorktreeByProject: {
+        ...current,
+        [projectPath]: { path: worktreePath, branch },
+      },
+    });
+  },
+
+  setWorktrees: (projectPath, worktrees) => {
+    const current = get().worktreesByProject;
+    set({
+      worktreesByProject: {
+        ...current,
+        [projectPath]: worktrees,
+      },
+    });
+  },
+
+  setWorktreesLoading: (projectPath, isLoading) => {
+    const current = get().worktreesLoadingByProject;
+    set({
+      worktreesLoadingByProject: {
+        ...current,
+        [projectPath]: isLoading,
+      },
+    });
+  },
+
+  getWorktreesLoading: (projectPath) => {
+    return get().worktreesLoadingByProject[projectPath] ?? true; // Default to loading=true for safety
+  },
+
+  getCurrentWorktree: (projectPath) => {
+    return get().currentWorktreeByProject[projectPath] ?? null;
+  },
+
+  getWorktrees: (projectPath) => {
+    return get().worktreesByProject[projectPath] ?? [];
+  },
+
+  isPrimaryWorktreeBranch: (projectPath, branchName) => {
+    const worktrees = get().worktreesByProject[projectPath] ?? [];
+    const primary = worktrees.find((w) => w.isMain);
+    return primary?.branch === branchName;
+  },
+
+  getPrimaryWorktreeBranch: (projectPath) => {
+    const worktrees = get().worktreesByProject[projectPath] ?? [];
+    const primary = worktrees.find((w) => w.isMain);
+    return primary?.branch ?? null;
+  },
+
+  // Worktree Panel Visibility actions (per-project)
+  setWorktreePanelVisible: (projectPath, visible) => {
+    set({
+      worktreePanelVisibleByProject: {
+        ...get().worktreePanelVisibleByProject,
+        [projectPath]: visible,
+      },
+    });
+  },
+
+  getWorktreePanelVisible: (projectPath) => {
+    // Default to true (visible) if not set
+    return get().worktreePanelVisibleByProject[projectPath] ?? true;
+  },
+
+  // Init Script Indicator Visibility actions (per-project)
+  setShowInitScriptIndicator: (projectPath, visible) => {
+    set({
+      showInitScriptIndicatorByProject: {
+        ...get().showInitScriptIndicatorByProject,
+        [projectPath]: visible,
+      },
+    });
+  },
+
+  getShowInitScriptIndicator: (projectPath) => {
+    // Default to true (visible) if not set
+    return get().showInitScriptIndicatorByProject[projectPath] ?? true;
+  },
+
+  // Default Delete Branch actions (per-project)
+  setDefaultDeleteBranch: (projectPath, deleteBranch) => {
+    set({
+      defaultDeleteBranchByProject: {
+        ...get().defaultDeleteBranchByProject,
+        [projectPath]: deleteBranch,
+      },
+    });
+  },
+
+  getDefaultDeleteBranch: (projectPath) => {
+    // Default to false (don't delete branch) if not set
+    return get().defaultDeleteBranchByProject[projectPath] ?? false;
+  },
+
+  // Auto-dismiss Init Script Indicator actions (per-project)
+  setAutoDismissInitScriptIndicator: (projectPath, autoDismiss) => {
+    set({
+      autoDismissInitScriptIndicatorByProject: {
+        ...get().autoDismissInitScriptIndicatorByProject,
+        [projectPath]: autoDismiss,
+      },
+    });
+  },
+
+  getAutoDismissInitScriptIndicator: (projectPath) => {
+    // Default to true (auto-dismiss enabled) if not set
+    return get().autoDismissInitScriptIndicatorByProject[projectPath] ?? true;
+  },
+
+  // Use Worktrees Override actions (per-project)
+  setProjectUseWorktrees: (projectPath, useWorktrees) => {
+    const newValue = useWorktrees === null ? undefined : useWorktrees;
+    set({
+      useWorktreesByProject: {
+        ...get().useWorktreesByProject,
+        [projectPath]: newValue,
+      },
+    });
+  },
+
+  getProjectUseWorktrees: (projectPath) => {
+    // Returns undefined if using global setting, true/false if project-specific
+    return get().useWorktreesByProject[projectPath];
+  },
+
+  getEffectiveUseWorktrees: (projectPath) => {
+    // Returns the actual value to use (project override or global fallback)
+    const projectSetting = get().useWorktreesByProject[projectPath];
+    if (projectSetting !== undefined) {
+      return projectSetting;
+    }
+    return get().useWorktrees;
+  },
+
+  // UI State actions
+  setWorktreePanelCollapsed: (collapsed) => set({ worktreePanelCollapsed: collapsed }),
+
+  // Init Script State actions (keyed by "projectPath::branch")
+  setInitScriptState: (projectPath, branch, state) => {
+    const key = `${projectPath}::${branch}`;
+    const current = get().initScriptState[key] || {
+      status: 'idle',
+      branch,
+      output: [],
+    };
+    set({
+      initScriptState: {
+        ...get().initScriptState,
+        [key]: { ...current, ...state },
+      },
+    });
+  },
+
+  appendInitScriptOutput: (projectPath, branch, content) => {
+    const key = `${projectPath}::${branch}`;
+    // Initialize state if absent to avoid dropping output due to event-order races
+    const current = get().initScriptState[key] || {
+      status: 'idle' as const,
+      branch,
+      output: [],
+    };
+    // Append new content and enforce fixed-size buffer to prevent memory bloat
+    const newOutput = [...current.output, content].slice(-MAX_INIT_OUTPUT_LINES);
+    set({
+      initScriptState: {
+        ...get().initScriptState,
+        [key]: {
+          ...current,
+          output: newOutput,
+        },
+      },
+    });
+  },
+
+  clearInitScriptState: (projectPath, branch) => {
+    const key = `${projectPath}::${branch}`;
+
+    const { [key]: _, ...rest } = get().initScriptState;
+    set({ initScriptState: rest });
+  },
+
+  getInitScriptState: (projectPath, branch) => {
+    const key = `${projectPath}::${branch}`;
+    return get().initScriptState[key] || null;
+  },
+
+  getInitScriptStatesForProject: (projectPath) => {
+    const prefix = `${projectPath}::`;
+    const states = get().initScriptState;
+    return Object.entries(states)
+      .filter(([key]) => key.startsWith(prefix))
+      .map(([key, state]) => ({ key, state }));
+  },
+}));
+
+// Export types for convenience
+export type WorktreeStore = typeof useWorktreeStore;


### PR DESCRIPTION
## Summary

Add 5 independent Zustand stores that mirror domain slices from the monolithic `app-store.ts` (4,268 lines). **No consumers migrated yet** — this is additive-only to establish the stores for Phase 2 migration.

### New Stores
- **terminal-store.ts** (901 lines) — terminal tabs, layout, splits, xterm config
- **ai-models-store.ts** (801 lines) — Claude/Codex/OpenCode models, API profiles, usage tracking
- **worktree-store.ts** (599 lines) — worktree management, auto-mode state per project
- **settings-store.ts** (477 lines) — keyboard shortcuts, audio, MCP servers, editor config
- **chat-store.ts** (184 lines) — chat sessions, messaging, history

### Phase 2 Plan
Migrate consumers one domain at a time (separate PRs per domain) and remove duplicated state from `app-store.ts`.

## Test plan
- [ ] `npm run build` passes (additive-only, no breaking changes)
- [ ] E2E tests pass (no consumers modified)
- [ ] No new TypeScript errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced state management infrastructure for chat sessions, AI model configurations, application settings, terminal operations, and worktree management, enabling improved user experience across multiple application areas with better data persistence and performance optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->