### PR TITLE
feat: add per-thread feedback tracking types

### DIFF
--- a/libs/types/src/coderabbit.ts
+++ b/libs/types/src/coderabbit.ts
@@ -71,3 +71,18 @@ export interface CodeRabbitParseResult {
   review?: CodeRabbitReview;
   error?: string;
 }
+
+/**
+ * Review thread feedback status
+ */
+export type ReviewThreadStatus = 'pending' | 'accepted' | 'denied';
+
+/**
+ * Individual review thread with agent decision tracking
+ */
+export interface ReviewThreadFeedback {
+  threadId: string;
+  status: ReviewThreadStatus;
+  agentReasoning?: string;
+  resolvedAt?: string;
+}

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -7,6 +7,7 @@ import type { ReasoningEffort } from './provider.js';
 import type { FeatureRalphConfig } from './ralph.js';
 import type { AgentRole } from './agent-roles.js';
 import type { WorkItemState } from './authority.js';
+import type { ReviewThreadFeedback } from './coderabbit.js';
 
 /**
  * A single entry in the description history
@@ -79,6 +80,27 @@ export interface ExecutionRecord {
   turnCount?: number;
   /** What triggered this execution (auto-mode, manual, retry) */
   trigger: 'auto' | 'manual' | 'retry';
+}
+
+/**
+ * Records a remediation attempt in response to PR review feedback.
+ * Tracks each iteration with timing and metadata.
+ */
+export interface RemediationHistoryEntry {
+  /** Unique identifier for this remediation attempt */
+  id: string;
+  /** ISO 8601 timestamp when remediation started */
+  timestamp: string;
+  /** Which iteration this represents (1-indexed) */
+  iteration: number;
+  /** Model used for this remediation attempt */
+  model?: string;
+  /** Whether the remediation completed successfully */
+  success?: boolean;
+  /** Error message if remediation failed */
+  error?: string;
+  /** Summary of changes made during this remediation */
+  changesSummary?: string;
 }
 
 export interface Feature {
@@ -262,6 +284,16 @@ export interface Feature {
    * Links feature to Ava's operational task manager.
    */
   beadsTaskId?: string;
+  /**
+   * Per-thread review feedback tracking with agent decisions.
+   * Each thread can be accepted, denied, or pending with reasoning.
+   */
+  threadFeedback?: ReviewThreadFeedback[];
+  /**
+   * History of remediation attempts for PR review feedback.
+   * Tracks iterations with timestamps and metadata.
+   */
+  remediationHistory?: RemediationHistoryEntry[];
   /**
    * Timestamp when the PR was created (ISO 8601).
    * Set by git-workflow-service when auto-creating a PR.

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -61,6 +61,7 @@ export type {
   DescriptionHistoryEntry,
   StatusTransition,
   ExecutionRecord,
+  RemediationHistoryEntry,
 } from './feature.js';
 export { normalizeFeatureStatus } from './feature.js';
 
@@ -442,6 +443,8 @@ export type {
   FeatureBranchLink,
   FeatureCodeRabbitFeedback,
   CodeRabbitParseResult,
+  ReviewThreadStatus,
+  ReviewThreadFeedback,
 } from './coderabbit.js';
 
 // Webhook types


### PR DESCRIPTION
## Summary
- Add ReviewThreadFeedback interface (threadId, status, agentReasoning, resolvedAt)
- Add threadFeedback and remediationHistory fields to Feature type

Part of: Autonomous PR Feedback Remediation Loop (Foundation types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced internal data structures to support tracking of review thread feedback with status information.
  * Added support for recording remediation attempt history with detailed metadata including timestamps and outcomes.
  * Expanded public type system to enable thread-level feedback and remediation tracking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->