### PR TITLE
feat: add PR remediation event types

### DIFF
--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -191,6 +191,10 @@ export type EventType =
   | 'pr:agent-restart-failed'
   | 'feature:reassigned-for-fixes'
   | 'feature:worktree-cleaned'
+  // PR remediation events (automated PR maintenance and thread resolution)
+  | 'pr:remediation-started' // Fired when PR remediation workflow begins (agent spawned to address feedback)
+  | 'pr:thread-evaluated' // Fired when a single PR review thread is evaluated for resolution status
+  | 'pr:threads-resolved' // Fired when all PR review threads are marked as resolved
   // Worktree recovery events
   | 'worktree:drift-detected'
   | 'worktree:phantom-pruned'
@@ -229,3 +233,61 @@ export type EventCallback = (type: EventType, payload: unknown) => void;
  * Event severity levels for classification and filtering
  */
 export type EventSeverity = 'critical' | 'high' | 'medium' | 'low';
+
+/**
+ * PR Remediation Event Payloads
+ * Used by the PR maintenance workflow to track thread resolution and feedback processing
+ */
+
+/**
+ * pr:remediation-started - Fired when PR remediation workflow begins
+ * Triggered when an agent is spawned to address PR feedback or review comments
+ */
+export interface PRRemediationStartedPayload {
+  /** Feature ID being remediated */
+  featureId: string;
+  /** PR number in GitHub */
+  prNumber: number;
+  /** Number of review threads requiring attention */
+  threadCount: number;
+  /** Agent ID spawned for remediation */
+  agentId?: string;
+  /** Timestamp when remediation started */
+  timestamp: string;
+}
+
+/**
+ * pr:thread-evaluated - Fired when a single PR review thread is evaluated
+ * Indicates whether a thread has been addressed and can be resolved
+ */
+export interface PRThreadEvaluatedPayload {
+  /** Feature ID being remediated */
+  featureId: string;
+  /** PR number in GitHub */
+  prNumber: number;
+  /** Thread/comment ID being evaluated */
+  threadId: string;
+  /** Whether the thread is ready to be resolved */
+  canResolve: boolean;
+  /** Reason for resolution status (e.g., "changes committed", "not addressed yet") */
+  reason?: string;
+  /** Timestamp of evaluation */
+  timestamp: string;
+}
+
+/**
+ * pr:threads-resolved - Fired when all PR review threads are marked as resolved
+ * Signals that PR is ready for re-review or approval
+ */
+export interface PRThreadsResolvedPayload {
+  /** Feature ID being remediated */
+  featureId: string;
+  /** PR number in GitHub */
+  prNumber: number;
+  /** Total number of threads resolved */
+  resolvedCount: number;
+  /** Whether PR is now ready for approval */
+  readyForReview: boolean;
+  /** Timestamp when all threads were resolved */
+  timestamp: string;
+}

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -127,7 +127,14 @@ export {
 } from './model.js';
 
 // Event types
-export type { EventType, EventCallback, EventSeverity } from './event.js';
+export type {
+  EventType,
+  EventCallback,
+  EventSeverity,
+  PRRemediationStartedPayload,
+  PRThreadEvaluatedPayload,
+  PRThreadsResolvedPayload,
+} from './event.js';
 
 // Spec types
 export type { SpecOutput } from './spec.js';


### PR DESCRIPTION
## Summary
- Add pr:remediation-started, pr:thread-evaluated, pr:threads-resolved event types

Part of: Autonomous PR Feedback Remediation Loop (Foundation types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for PR remediation event tracking with three new events: pr:remediation-started captures initial remediation launch details, pr:thread-evaluated tracks individual thread evaluation results, and pr:threads-resolved confirms completion status and review readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->