### PR TITLE
feat: persist PR tracking state to feature.json

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -764,6 +764,9 @@ specGenerationMonitor.startMonitoring();
           logger.info(
             `[AUTO-START] Auto-mode started successfully for ${worktreeDesc} in ${projectPath} with maxConcurrency: ${resolvedMaxConcurrency}`
           );
+
+          // Restore tracked PRs for this project
+          await prFeedbackService.restoreTrackedPRsForProject(projectPath);
         } catch (err) {
           // If auto-mode is already running, that's OK (might have been restored from state)
           const errorMsg = err instanceof Error ? err.message : String(err);

--- a/apps/server/src/services/pr-feedback-service.ts
+++ b/apps/server/src/services/pr-feedback-service.ts
@@ -122,6 +122,51 @@ export class PRFeedbackService {
   }
 
   /**
+   * Restore tracked PRs from features with status=review and prNumber set for a specific project.
+   * This ensures PR tracking survives server restarts.
+   *
+   * @param projectPath - Path to the project to restore PRs for
+   */
+  async restoreTrackedPRsForProject(projectPath: string): Promise<void> {
+    try {
+      const features = await this.featureLoader.getAll(projectPath);
+
+      let restoredCount = 0;
+      for (const feature of features) {
+        // Only restore tracking for features in review with an open PR
+        if (feature.status === 'review' && feature.prNumber && feature.prUrl) {
+          const lastPolledAt =
+            feature.prLastPolledAt && typeof feature.prLastPolledAt === 'string'
+              ? new Date(feature.prLastPolledAt).getTime()
+              : 0;
+
+          this.trackedPRs.set(feature.id, {
+            featureId: feature.id,
+            projectPath,
+            prNumber: feature.prNumber,
+            prUrl: feature.prUrl,
+            branchName: feature.branchName || '',
+            lastCheckedAt: lastPolledAt,
+            reviewState: 'pending',
+            iterationCount: feature.prIterationCount || 0,
+          });
+
+          logger.info(
+            `Restored tracking for PR #${feature.prNumber} (feature ${feature.id}) from persisted state`
+          );
+          restoredCount++;
+        }
+      }
+
+      if (restoredCount > 0) {
+        logger.info(`Restored ${restoredCount} tracked PRs for project ${projectPath}`);
+      }
+    } catch (error) {
+      logger.error(`Failed to restore tracked PRs for project ${projectPath}:`, error);
+    }
+  }
+
+  /**
    * Start tracking a newly created PR.
    */
   private trackPR(data: Record<string, unknown>): void {
@@ -134,6 +179,7 @@ export class PRFeedbackService {
 
     // Check if we're already tracking this feature's PR
     const existing = this.trackedPRs.get(featureId);
+    const now = new Date().toISOString();
 
     this.trackedPRs.set(featureId, {
       featureId,
@@ -146,10 +192,12 @@ export class PRFeedbackService {
       iterationCount: existing?.iterationCount || 0,
     });
 
-    // Save PR info to feature
+    // Save PR info and tracking metadata to feature
     void this.featureLoader.update(projectPath, featureId, {
       prUrl,
       prNumber,
+      prTrackedSince: existing ? undefined : now, // Only set on first track
+      prLastPolledAt: now,
     });
 
     logger.info(`Tracking PR #${prNumber} for feature ${featureId}`);
@@ -165,7 +213,13 @@ export class PRFeedbackService {
 
       try {
         const reviewInfo = await this.fetchPRReviewStatus(pr);
-        pr.lastCheckedAt = Date.now();
+        const now = Date.now();
+        pr.lastCheckedAt = now;
+
+        // Persist poll timestamp to feature.json
+        await this.featureLoader.update(pr.projectPath, featureId, {
+          prLastPolledAt: new Date(now).toISOString(),
+        });
 
         if (!reviewInfo) continue;
 

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -249,6 +249,16 @@ export interface Feature {
    */
   lastReviewFeedback?: string;
   /**
+   * Timestamp when PR tracking started (ISO 8601).
+   * Set by PRFeedbackService when a PR is first tracked.
+   */
+  prTrackedSince?: string;
+  /**
+   * Timestamp of the last PR polling check (ISO 8601).
+   * Updated by PRFeedbackService after each GitHub API poll.
+   */
+  prLastPolledAt?: string;
+  /**
    * GitHub issue number (if an issue was auto-created for this feature).
    * Set by IssueCreationService when a feature exceeds max retries or is escalated.
    */


### PR DESCRIPTION
## Summary
- Add prTrackedSince and prLastPolledAt to Feature type
- Save tracking metadata to feature.json on PR creation
- Restore tracking on service init for features in review with prNumber

Part of: Autonomous PR Feedback Remediation Loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PR tracking state now automatically restores after service restart, preserving feedback history.
  * Enhanced code review feedback integration and analysis capabilities.
  * Automatic agent retry when code review changes are requested, with built-in escalation for excessive iterations.

* **Improvements**
  * Better tracking and persistence of PR polling activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->