### PR TITLE
feat: implement branch protection setup via GitHub rulesets

### DIFF
--- a/packages/create-protolab/package-lock.json
+++ b/packages/create-protolab/package-lock.json
@@ -1,0 +1,48 @@
+{
+  "name": "@protolab/create-protolab",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@protolab/create-protolab",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
+      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/create-protolab/package.json
+++ b/packages/create-protolab/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@protolab/create-protolab",
+  "version": "0.1.0",
+  "description": "Protolab project scaffolding and setup utilities",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "protolab",
+    "scaffolding",
+    "setup"
+  ],
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/create-protolab/src/phases/branch-protection.ts
+++ b/packages/create-protolab/src/phases/branch-protection.ts
@@ -1,0 +1,189 @@
+import { execSync } from 'child_process';
+import { readFileSync, writeFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+interface BranchProtectionStatus {
+  success: boolean;
+  rulesetId?: number;
+  error?: string;
+}
+
+interface BranchProtectionOptions {
+  defaultBranch?: string;
+  owner?: string;
+  repo?: string;
+}
+
+/**
+ * Checks if gh CLI is available and authenticated
+ */
+function checkGhCli(): { available: boolean; authenticated: boolean; error?: string } {
+  try {
+    // Check if gh CLI is installed
+    execSync('which gh', { stdio: 'pipe' });
+  } catch {
+    return { available: false, authenticated: false, error: 'gh CLI not found in PATH' };
+  }
+
+  try {
+    // Check if gh CLI is authenticated
+    execSync('gh auth status', { stdio: 'pipe' });
+    return { available: true, authenticated: true };
+  } catch {
+    return { available: true, authenticated: false, error: 'gh CLI not authenticated' };
+  }
+}
+
+/**
+ * Gets the current repository owner and name
+ */
+function getRepoInfo(): { owner: string; repo: string } | null {
+  try {
+    const remoteUrl = execSync('git config --get remote.origin.url', {
+      encoding: 'utf-8',
+      stdio: 'pipe'
+    }).trim();
+
+    // Parse GitHub URL (supports both HTTPS and SSH)
+    // HTTPS: https://github.com/owner/repo.git
+    // SSH: git@github.com:owner/repo.git
+    const httpsMatch = remoteUrl.match(/github\.com[/:]([\w-]+)\/([\w-]+?)(\.git)?$/);
+    if (httpsMatch) {
+      return { owner: httpsMatch[1], repo: httpsMatch[2] };
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Interpolates template variables in the ruleset JSON
+ */
+function interpolateTemplate(templateContent: string, variables: Record<string, string>): string {
+  let result = templateContent;
+  for (const [key, value] of Object.entries(variables)) {
+    const regex = new RegExp(`{{${key}}}`, 'g');
+    result = result.replace(regex, value);
+  }
+  return result;
+}
+
+/**
+ * Creates a GitHub branch protection ruleset using gh CLI
+ */
+export async function createBranchProtectionRuleset(
+  options: BranchProtectionOptions = {}
+): Promise<BranchProtectionStatus> {
+  // Step 1: Check gh CLI availability
+  const ghStatus = checkGhCli();
+
+  if (!ghStatus.available) {
+    console.warn('⚠️  gh CLI not available, skipping branch protection setup');
+    console.warn(`   Reason: ${ghStatus.error}`);
+    return { success: false, error: ghStatus.error };
+  }
+
+  if (!ghStatus.authenticated) {
+    console.warn('⚠️  gh CLI not authenticated, skipping branch protection setup');
+    console.warn('   Run: gh auth login');
+    return { success: false, error: ghStatus.error };
+  }
+
+  // Step 2: Get repository information
+  const repoInfo = options.owner && options.repo
+    ? { owner: options.owner, repo: options.repo }
+    : getRepoInfo();
+
+  if (!repoInfo) {
+    const error = 'Could not determine repository owner and name';
+    console.warn(`⚠️  ${error}`);
+    return { success: false, error };
+  }
+
+  // Step 3: Determine default branch
+  let defaultBranch = options.defaultBranch || 'main';
+
+  try {
+    // Try to get the actual default branch from git
+    const branch = execSync('git symbolic-ref refs/remotes/origin/HEAD', {
+      encoding: 'utf-8',
+      stdio: 'pipe'
+    }).trim().replace('refs/remotes/origin/', '');
+
+    if (branch) {
+      defaultBranch = branch;
+    }
+  } catch {
+    // Fall back to 'main' if we can't determine it
+    console.log(`   Using default branch: ${defaultBranch}`);
+  }
+
+  // Step 4: Load and interpolate template
+  const templatePath = join(process.cwd(), 'templates/cicd/branch-protection/main.json');
+
+  let templateContent: string;
+  try {
+    templateContent = readFileSync(templatePath, 'utf-8');
+  } catch (error) {
+    const errorMsg = `Could not read template file: ${templatePath}`;
+    console.error(`❌ ${errorMsg}`);
+    return { success: false, error: errorMsg };
+  }
+
+  const interpolatedContent = interpolateTemplate(templateContent, { defaultBranch });
+
+  // Step 5: Create temporary file for the ruleset
+  const tempFile = join(tmpdir(), `ruleset-${Date.now()}.json`);
+
+  try {
+    writeFileSync(tempFile, interpolatedContent, 'utf-8');
+
+    // Step 6: Create ruleset via gh CLI
+    console.log(`📋 Creating branch protection ruleset for ${repoInfo.owner}/${repoInfo.repo}...`);
+
+    const result = execSync(
+      `gh api repos/${repoInfo.owner}/${repoInfo.repo}/rulesets --method POST --input "${tempFile}"`,
+      { encoding: 'utf-8', stdio: 'pipe' }
+    );
+
+    // Parse the response to get the ruleset ID
+    const response = JSON.parse(result);
+    const rulesetId = response.id;
+
+    console.log(`✅ Branch protection ruleset created successfully (ID: ${rulesetId})`);
+
+    return { success: true, rulesetId };
+  } catch (error: any) {
+    // Handle errors gracefully
+    const errorMessage = error.stderr?.toString() || error.message || 'Unknown error';
+
+    if (errorMessage.includes('404') || errorMessage.includes('Not Found')) {
+      console.warn('⚠️  Repository not found or insufficient permissions');
+      return { success: false, error: 'Repository not found or insufficient permissions' };
+    }
+
+    if (errorMessage.includes('already exists')) {
+      console.log('ℹ️  Branch protection ruleset already exists');
+      return { success: false, error: 'Ruleset already exists' };
+    }
+
+    console.error('❌ Failed to create branch protection ruleset');
+    console.error(`   ${errorMessage}`);
+    return { success: false, error: errorMessage };
+  } finally {
+    // Clean up temporary file
+    try {
+      unlinkSync(tempFile);
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+/**
+ * Main export for the phase
+ */
+export default createBranchProtectionRuleset;

--- a/packages/create-protolab/tsconfig.json
+++ b/packages/create-protolab/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/templates/cicd/branch-protection/main.json
+++ b/templates/cicd/branch-protection/main.json
@@ -1,0 +1,33 @@
+{
+  "name": "Protect {{defaultBranch}}",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/{{defaultBranch}}"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    }
+  ],
+  "bypass_actors": []
+}


### PR DESCRIPTION
Phase Implementations milestone: Branch protection

- Created packages/create-protolab/src/phases/branch-protection.ts
- Uses gh CLI to create rulesets from templates
- Gracefully skips if gh CLI unavailable or not authenticated
- Interpolates default branch name from research
- Returns detailed status (success, rulesetId, error)
- Verification tests passing

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>