### PR TITLE
fix: add decomposition anti-patterns to project breakdown prompts

### DIFF
--- a/apps/server/src/services/authority-agents/projm-agent.ts
+++ b/apps/server/src/services/authority-agents/projm-agent.ts
@@ -393,11 +393,20 @@ Each phase should be a concrete, implementable unit of work. Respond with valid 
 }
 
 Guidelines:
-- Each phase should take 1-4 hours of focused work
-- Phases should be ordered by dependency (earlier phases first)
+- Each phase should take 30-60 minutes of focused AI agent work
+- Phases should be ordered by dependency — critical-path blockers FIRST
 - Be specific about what files to modify and what changes to make
-- Include clear acceptance criteria
-- Aim for 2-6 phases per milestone`;
+- Include clear acceptance criteria that are machine-verifiable (build passes, tests pass)
+
+Anti-patterns to AVOID:
+- NEVER create multiple phases that modify the same file — this causes merge conflicts when agents work in parallel
+- NEVER decompose type definitions, interfaces, or config into a separate phase from the code that uses them — combine them into one phase
+- NEVER create phases smaller than ~100 lines of meaningful code changes — merge them with adjacent phases
+- NEVER put critical-path fixes (race conditions, blockers) late in the plan — they must be Phase 1
+- Aim for 3-5 phases per milestone, not 6+. Fewer, larger phases are better than many tiny ones.
+
+File contention rule: Before finalizing, check if any file appears in filesToModify for 2+ phases.
+If so, consolidate those phases or sequence them strictly. Parallel agents on the same file = guaranteed merge conflicts.`;
 
     const prompt = `Project: ${project.title}
 Goal: ${project.goal}

--- a/libs/prompts/src/agents/product-manager-prompt.ts
+++ b/libs/prompts/src/agents/product-manager-prompt.ts
@@ -112,14 +112,19 @@ Post the PRD to the Discord thread for user review and approval.
 
 Once the PRD is approved:
 1. Break down the approach into logical milestones (Foundation, Features, Polish)
-2. Each milestone has phases (implementable units)
+2. Each milestone has 3-5 phases (implementable units)
 3. Each phase specifies:
    - Title and description
-   - Files to modify
-   - Acceptance criteria
+   - Files to modify (no file should appear in multiple phases)
+   - Acceptance criteria (machine-verifiable: build passes, tests pass)
    - Complexity (small/medium/large/architectural)
-4. Create the Linear project using MCP tools
-5. Post the Linear project URL to Discord for final review
+4. Validate before creating:
+   - Critical-path work (deconfliction, blockers) is in the earliest milestone
+   - No two phases modify the same file (merge conflict risk)
+   - No phase is smaller than ~50 lines of real code changes
+   - Total features proportional to actual work (not ceremony)
+5. Create the Linear project using MCP tools
+6. Post the Linear project URL to Discord for final review
 
 ## Available Tools
 

--- a/packages/mcp-server/plugins/automaker/agents/sparc-prd.md
+++ b/packages/mcp-server/plugins/automaker/agents/sparc-prd.md
@@ -252,9 +252,11 @@ Produce a complete PRD:
 
 ### Phase Sizing
 
-- **Small**: ~30 minutes, 1-2 files
-- **Medium**: ~1 hour, 3-5 files
-- **Large**: ~2 hours, 5+ files
+- **Small**: ~30 minutes, 1-2 files, ~50-150 lines changed
+- **Medium**: ~1 hour, 2-4 files, ~150-400 lines changed
+- **Large**: ~2 hours, 4-8 files, ~400+ lines changed
+
+A phase with fewer than 50 lines of real code changes should be merged into an adjacent phase.
 
 ### Acceptance Criteria
 
@@ -269,3 +271,34 @@ Each phase should have:
 - Explicit is better than implicit
 - Early phases should have fewer dependencies
 - Avoid circular dependencies
+
+### Decomposition Anti-Patterns (AVOID THESE)
+
+These patterns cause real failures in autonomous execution:
+
+1. **Over-decomposition**: If a milestone has 6+ phases, you've probably sliced too thin.
+   The overhead of branching, PR creation, CI, review, and merge for each feature means
+   tiny features waste more time on ceremony than on code. Aim for 3-5 phases per milestone.
+
+2. **File contention**: If multiple phases modify the same file, agents running in parallel
+   will produce merge conflicts. Either consolidate into one phase, or make them strictly
+   sequential with explicit dependencies.
+
+3. **Wrong critical path**: If Phase 5 fixes a bug that Phase 1-4 all depend on, the plan
+   is backwards. Always identify blockers and deconfliction work FIRST.
+
+4. **Type-only phases**: Don't create a separate phase just for TypeScript types or interfaces.
+   Types are meaningless without the code that uses them. Include types in the phase that
+   implements the corresponding logic.
+
+5. **Redundant phases**: If two phases cover the same conceptual change (e.g., "add webhook type"
+   and "add webhook handler"), they should be one phase. The handler needs the type —
+   splitting them just adds overhead.
+
+### Quality Checklist (verify before finalizing)
+
+- [ ] No file appears in filesToModify for more than one phase (unless strictly sequenced)
+- [ ] Critical-path blockers are in the earliest milestone
+- [ ] No phase has fewer than 50 lines of meaningful code changes
+- [ ] Each phase can be tested independently (build passes, tests pass)
+- [ ] Total phase count is proportional to actual work (~1 phase per 100-400 lines of real code)

--- a/packages/mcp-server/plugins/automaker/commands/create-project.md
+++ b/packages/mcp-server/plugins/automaker/commands/create-project.md
@@ -101,8 +101,16 @@ For each milestone, define phases:
 Each phase should be:
 
 - Completable in ~30-60 minutes by an AI agent
-- Independently testable
+- Independently testable (build + tests must pass)
 - Have clear acceptance criteria
+- Touch distinct files (no two phases modifying the same file unless sequenced)
+
+Phase sizing guide:
+
+- If a phase is < 50 lines of code, merge it with an adjacent phase
+- If a milestone has > 5 phases, consolidate — you've over-decomposed
+- Types/interfaces go in the same phase as the code that uses them
+- Critical-path fixes (race conditions, blockers) are always Phase 1
 
 ### Step 6: Scaffold Project
 


### PR DESCRIPTION
## Summary

- Encodes lessons from antagonistic review of an over-decomposed project plan (22 features for ~5 real units of work)
- Adds file contention rules, phase sizing minimums (~50-100 line floors), critical-path-first ordering, and a quality checklist
- Updates 4 prompt sources: ProjM agent, SPARC PRD agent, create-project command, and PM agent prompt

## Test plan

- [x] `npm run build:packages && npm run build:server` passes
- [ ] Next project created via `/create-project` produces 3-8 features instead of 20+

🤖 Generated with [Claude Code](https://claude.com/claude-code)