### PR TITLE
fix(docs): remove dead links blocking staging deploy

### DIFF
--- a/docs/dev/pr-remediation-loop.md
+++ b/docs/dev/pr-remediation-loop.md
@@ -557,6 +557,5 @@ This provides:
 ## Related Documentation
 
 - [Crew Loops](./crew-loops.md) - PR Maintainer crew member
-- [Authority System](./authority-system.md) - Escalation and approval flow
-- [Git Workflow](./git-workflow.md) - PR creation and merging
-- [Feature Status System](../feature-status-system.md) - Status transitions
+- [Authority System](../authority/index.md) - Escalation and approval flow
+- [Feature Status System](./feature-status-system.md) - Status transitions


### PR DESCRIPTION
## Summary
- Fixes 3 dead links in `docs/dev/pr-remediation-loop.md` that cause VitePress build to fail
- This has been blocking **all staging deploys** since commit `0831d0d4` (6 consecutive failures)
- Fixed `./authority-system.md` → `../authority/index.md`, `../feature-status-system.md` → `./feature-status-system.md`, removed non-existent `./git-workflow.md`

## Test plan
- [ ] VitePress docs build succeeds in Docker
- [ ] Staging deploy workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated related documentation cross-references in developer guides to reflect current reference paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->