### PR TITLE
feat(server): implement Automaker → Linear status change sync

### DIFF
--- a/apps/server/src/services/linear-sync-service.ts
+++ b/apps/server/src/services/linear-sync-service.ts
@@ -449,14 +449,385 @@ export class LinearSyncService {
   /**
    * Handle feature:status-changed events
    */
-  private handleFeatureStatusChanged(payload: FeatureEventPayload): void {
+  private async handleFeatureStatusChanged(payload: FeatureEventPayload): Promise<void> {
     logger.debug('Received feature:status-changed event', {
       featureId: payload.featureId,
       status: payload.status,
     });
 
-    // No actual sync logic yet - just structure and guards
-    // Future implementation will check guards and perform sync
+    // Call the async implementation
+    await this.onFeatureStatusChanged(payload);
+  }
+
+  /**
+   * Sync feature status changes to Linear
+   */
+  private async onFeatureStatusChanged(payload: FeatureEventPayload): Promise<void> {
+    const { featureId, projectPath, status } = payload;
+
+    // Guard: Check if service is running and sync is enabled
+    if (!this.shouldSync(featureId)) {
+      return;
+    }
+
+    // Check if sync is enabled for this project
+    const syncEnabled = await this.isProjectSyncEnabled(projectPath);
+    if (!syncEnabled) {
+      logger.debug(`Linear sync not enabled for project ${projectPath}`);
+      return;
+    }
+
+    // Check if status change sync is enabled
+    if (!this.settingsService) {
+      logger.error('SettingsService not initialized');
+      return;
+    }
+
+    const settings = await this.settingsService.getProjectSettings(projectPath);
+    if (settings.integrations?.linear?.syncOnStatusChange === false) {
+      logger.debug(`Status change sync disabled for project ${projectPath}`);
+      return;
+    }
+
+    if (!this.featureLoader) {
+      logger.error('FeatureLoader not initialized');
+      return;
+    }
+
+    // Mark as syncing to prevent duplicates
+    this.markSyncing(featureId);
+
+    try {
+      // Get the feature details
+      const feature = await this.featureLoader.get(projectPath, featureId);
+      if (!feature) {
+        logger.error(`Feature ${featureId} not found`);
+        return;
+      }
+
+      // Skip if feature has no Linear issue ID
+      if (!feature.linearIssueId) {
+        logger.debug(`Feature ${featureId} has no Linear issue ID, skipping status sync`);
+        return;
+      }
+
+      // Skip if status is unchanged from last sync
+      const lastMetadata = this.getSyncMetadata(featureId);
+      if (lastMetadata?.linearIssueId === feature.linearIssueId) {
+        // Check if status is the same
+        const currentLinearState = await this.getIssueState(projectPath, feature.linearIssueId);
+        const newLinearState = this.mapAutomakerStatusToLinear(
+          status || feature.status || 'backlog'
+        );
+
+        if (currentLinearState === newLinearState) {
+          logger.debug(`Status unchanged for feature ${featureId}, skipping sync`);
+          return;
+        }
+      }
+
+      // Update Linear issue status
+      await this.updateIssueStatus(
+        projectPath,
+        feature.linearIssueId,
+        status || feature.status || 'backlog'
+      );
+
+      // Update sync metadata
+      const existingMetadata = this.getSyncMetadata(featureId);
+      const metadata: SyncMetadata = {
+        featureId,
+        lastSyncTimestamp: Date.now(),
+        lastSyncStatus: 'success',
+        linearIssueId: feature.linearIssueId,
+        syncCount: (existingMetadata?.syncCount || 0) + 1,
+        syncSource: 'automaker',
+        syncDirection: 'push',
+      };
+      this.updateSyncMetadata(metadata);
+
+      // Emit completion event
+      if (this.emitter) {
+        this.emitter.emit('linear:sync:completed', {
+          featureId,
+          direction: 'push',
+          conflictDetected: false,
+          timestamp: new Date().toISOString(),
+        });
+      }
+
+      logger.info(
+        `Successfully synced status change for feature ${featureId} to Linear issue ${feature.linearIssueId}`
+      );
+    } catch (error) {
+      logger.error(`Failed to sync status change for feature ${featureId}:`, error);
+
+      // Update sync metadata with error
+      const metadata: SyncMetadata = {
+        featureId,
+        lastSyncTimestamp: Date.now(),
+        lastSyncStatus: 'error',
+        errorMessage: error instanceof Error ? error.message : 'Unknown error',
+        syncCount: 0,
+      };
+      this.updateSyncMetadata(metadata);
+
+      // Emit error event
+      if (this.emitter) {
+        this.emitter.emit('linear:sync:error', {
+          featureId,
+          direction: 'push',
+          error: error instanceof Error ? error.message : 'Unknown error',
+          timestamp: new Date().toISOString(),
+        });
+      }
+    } finally {
+      // Unmark syncing
+      this.unmarkSyncing(featureId);
+    }
+  }
+
+  /**
+   * Map Automaker status to Linear workflow state name
+   */
+  private mapAutomakerStatusToLinear(status: string): string {
+    switch (status) {
+      case 'backlog':
+        return 'Backlog';
+      case 'in_progress':
+        return 'In Progress';
+      case 'review':
+        return 'In Review';
+      case 'done':
+        return 'Done';
+      case 'blocked':
+        return 'Blocked';
+      case 'verified':
+        return 'Done'; // Map verified to Done
+      default:
+        logger.warn(`Unknown Automaker status: ${status}, defaulting to Backlog`);
+        return 'Backlog';
+    }
+  }
+
+  /**
+   * Get current Linear issue state
+   */
+  private async getIssueState(projectPath: string, issueId: string): Promise<string> {
+    if (!this.settingsService) {
+      throw new Error('SettingsService not initialized');
+    }
+
+    const settings = await this.settingsService.getProjectSettings(projectPath);
+    const linearAccessToken = settings.integrations?.linear?.agentToken;
+
+    if (!linearAccessToken) {
+      throw new Error('No Linear OAuth token found in settings');
+    }
+
+    // GraphQL query to get issue state
+    const query = `
+      query GetIssue($id: String!) {
+        issue(id: $id) {
+          id
+          state {
+            name
+          }
+        }
+      }
+    `;
+
+    const variables = {
+      id: issueId,
+    };
+
+    const response = await fetch('https://api.linear.app/graphql', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${linearAccessToken}`,
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Linear API error: ${response.status} ${response.statusText}`);
+    }
+
+    const result = (await response.json()) as {
+      data?: {
+        issue?: {
+          state?: { name: string };
+        };
+      };
+      errors?: Array<{ message: string }>;
+    };
+
+    if (result.errors) {
+      throw new Error(`Linear GraphQL error: ${result.errors.map((e) => e.message).join(', ')}`);
+    }
+
+    return result.data?.issue?.state?.name || 'Backlog';
+  }
+
+  /**
+   * Update Linear issue status
+   */
+  private async updateIssueStatus(
+    projectPath: string,
+    issueId: string,
+    status: string
+  ): Promise<void> {
+    if (!this.settingsService) {
+      throw new Error('SettingsService not initialized');
+    }
+
+    const settings = await this.settingsService.getProjectSettings(projectPath);
+    const linearAccessToken = settings.integrations?.linear?.agentToken;
+    const teamId = settings.integrations?.linear?.teamId;
+
+    if (!linearAccessToken) {
+      throw new Error('No Linear OAuth token found in settings');
+    }
+
+    if (!teamId) {
+      throw new Error('No Linear team ID found in settings');
+    }
+
+    // Map status to Linear state name
+    const linearStateName = this.mapAutomakerStatusToLinear(status);
+
+    // Get workflow state ID from Linear
+    const stateId = await this.getWorkflowStateId(projectPath, teamId, linearStateName);
+
+    // GraphQL mutation to update issue
+    const mutation = `
+      mutation UpdateIssue($id: String!, $stateId: String!) {
+        issueUpdate(id: $id, input: { stateId: $stateId }) {
+          success
+          issue {
+            id
+            state {
+              name
+            }
+          }
+        }
+      }
+    `;
+
+    const variables = {
+      id: issueId,
+      stateId,
+    };
+
+    const response = await fetch('https://api.linear.app/graphql', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${linearAccessToken}`,
+      },
+      body: JSON.stringify({ query: mutation, variables }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Linear API error: ${response.status} ${response.statusText}`);
+    }
+
+    const result = (await response.json()) as {
+      data?: {
+        issueUpdate?: {
+          success: boolean;
+          issue?: { id: string; state?: { name: string } };
+        };
+      };
+      errors?: Array<{ message: string }>;
+    };
+
+    if (result.errors) {
+      throw new Error(`Linear GraphQL error: ${result.errors.map((e) => e.message).join(', ')}`);
+    }
+
+    if (!result.data?.issueUpdate?.success) {
+      throw new Error('Failed to update Linear issue status');
+    }
+
+    logger.info(`Updated Linear issue ${issueId} to state: ${linearStateName}`);
+  }
+
+  /**
+   * Get workflow state ID from Linear by state name
+   */
+  private async getWorkflowStateId(
+    projectPath: string,
+    teamId: string,
+    stateName: string
+  ): Promise<string> {
+    if (!this.settingsService) {
+      throw new Error('SettingsService not initialized');
+    }
+
+    const settings = await this.settingsService.getProjectSettings(projectPath);
+    const linearAccessToken = settings.integrations?.linear?.agentToken;
+
+    if (!linearAccessToken) {
+      throw new Error('No Linear OAuth token found in settings');
+    }
+
+    // GraphQL query to fetch workflow states
+    const query = `
+      query GetWorkflowStates($teamId: String!) {
+        team(id: $teamId) {
+          id
+          states {
+            nodes {
+              id
+              name
+            }
+          }
+        }
+      }
+    `;
+
+    const variables = {
+      teamId,
+    };
+
+    const response = await fetch('https://api.linear.app/graphql', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${linearAccessToken}`,
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Linear API error: ${response.status} ${response.statusText}`);
+    }
+
+    const result = (await response.json()) as {
+      data?: {
+        team?: {
+          states?: {
+            nodes: Array<{ id: string; name: string }>;
+          };
+        };
+      };
+      errors?: Array<{ message: string }>;
+    };
+
+    if (result.errors) {
+      throw new Error(`Linear GraphQL error: ${result.errors.map((e) => e.message).join(', ')}`);
+    }
+
+    const states = result.data?.team?.states?.nodes || [];
+    const state = states.find((s) => s.name === stateName);
+
+    if (!state) {
+      throw new Error(`Workflow state "${stateName}" not found in Linear team ${teamId}`);
+    }
+
+    return state.id;
   }
 
   /**

--- a/apps/server/tests/unit/services/linear-sync-service.test.ts
+++ b/apps/server/tests/unit/services/linear-sync-service.test.ts
@@ -494,4 +494,307 @@ describe('LinearSyncService', () => {
       expect(service.shouldSync('feature-2')).toBe(true);
     });
   });
+
+  describe('Status Change Sync', () => {
+    let mockFetch: any;
+
+    beforeEach(() => {
+      service.initialize(emitter, mockSettingsService, mockFeatureLoader);
+      service.start();
+
+      // Mock fetch globally
+      mockFetch = vi.fn();
+      global.fetch = mockFetch;
+
+      // Default mock settings
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue({
+        integrations: {
+          linear: {
+            enabled: true,
+            agentToken: 'test-token-123',
+            teamId: 'team-123',
+            syncOnStatusChange: true,
+          },
+        },
+      } as any);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    describe('Status Mapping', () => {
+      it('should map backlog status to Backlog state', () => {
+        const result = (service as any).mapAutomakerStatusToLinear('backlog');
+        expect(result).toBe('Backlog');
+      });
+
+      it('should map in_progress status to In Progress state', () => {
+        const result = (service as any).mapAutomakerStatusToLinear('in_progress');
+        expect(result).toBe('In Progress');
+      });
+
+      it('should map review status to In Review state', () => {
+        const result = (service as any).mapAutomakerStatusToLinear('review');
+        expect(result).toBe('In Review');
+      });
+
+      it('should map done status to Done state', () => {
+        const result = (service as any).mapAutomakerStatusToLinear('done');
+        expect(result).toBe('Done');
+      });
+
+      it('should map blocked status to Blocked state', () => {
+        const result = (service as any).mapAutomakerStatusToLinear('blocked');
+        expect(result).toBe('Blocked');
+      });
+
+      it('should map verified status to Done state', () => {
+        const result = (service as any).mapAutomakerStatusToLinear('verified');
+        expect(result).toBe('Done');
+      });
+
+      it('should default unknown status to Backlog', () => {
+        const result = (service as any).mapAutomakerStatusToLinear('unknown-status');
+        expect(result).toBe('Backlog');
+      });
+    });
+
+    describe('Status Change Handling', () => {
+      it('should skip sync when feature has no linearIssueId', async () => {
+        const feature = {
+          id: 'test-feature-1',
+          description: 'Test feature',
+          category: 'test',
+          status: 'in_progress',
+          // No linearIssueId
+        };
+
+        vi.mocked(mockFeatureLoader.get).mockResolvedValue(feature as any);
+
+        await emitter.emit('feature:status-changed', {
+          featureId: 'test-feature-1',
+          projectPath: '/test/path',
+          status: 'in_progress',
+        });
+
+        // Allow async handlers to complete
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        // Should not have called fetch since no linearIssueId
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      it('should skip sync when syncOnStatusChange is disabled', async () => {
+        vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue({
+          integrations: {
+            linear: {
+              enabled: true,
+              agentToken: 'test-token-123',
+              teamId: 'team-123',
+              syncOnStatusChange: false, // Disabled
+            },
+          },
+        } as any);
+
+        const feature = {
+          id: 'test-feature-2',
+          description: 'Test feature',
+          category: 'test',
+          status: 'in_progress',
+          linearIssueId: 'issue-999',
+        };
+
+        vi.mocked(mockFeatureLoader.get).mockResolvedValue(feature as any);
+
+        await emitter.emit('feature:status-changed', {
+          featureId: 'test-feature-2',
+          projectPath: '/test/path',
+          status: 'in_progress',
+        });
+
+        // Allow async handlers to complete
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        // Should not have called fetch since syncOnStatusChange is disabled
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      it('should update Linear issue status on status change', async () => {
+        const feature = {
+          id: 'test-feature-3',
+          description: 'Test feature',
+          category: 'test',
+          status: 'in_progress',
+          linearIssueId: 'issue-123',
+        };
+
+        vi.mocked(mockFeatureLoader.get).mockResolvedValue(feature as any);
+
+        // Mock workflow states fetch (first call)
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: {
+              team: {
+                states: {
+                  nodes: [
+                    { id: 'state-in-progress', name: 'In Progress' },
+                    { id: 'state-backlog', name: 'Backlog' },
+                  ],
+                },
+              },
+            },
+          }),
+        });
+
+        // Mock issue update (second call)
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: {
+              issueUpdate: {
+                success: true,
+                issue: { id: 'issue-123', state: { name: 'In Progress' } },
+              },
+            },
+          }),
+        });
+
+        await emitter.emit('feature:status-changed', {
+          featureId: 'test-feature-3',
+          projectPath: '/test/path',
+          status: 'in_progress',
+        });
+
+        // Allow async handlers to complete
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        // Should have called fetch twice (workflow states + issue update)
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+
+        // Verify sync metadata was updated
+        const metadata = service.getSyncMetadata('test-feature-3');
+        expect(metadata).toBeDefined();
+        expect(metadata?.lastSyncStatus).toBe('success');
+        expect(metadata?.linearIssueId).toBe('issue-123');
+        expect(metadata?.syncSource).toBe('automaker');
+        expect(metadata?.syncDirection).toBe('push');
+      });
+
+      it('should update sync metadata on error', async () => {
+        const feature = {
+          id: 'test-feature-4',
+          description: 'Test feature',
+          category: 'test',
+          status: 'in_progress',
+          linearIssueId: 'issue-456',
+        };
+
+        vi.mocked(mockFeatureLoader.get).mockResolvedValue(feature as any);
+
+        // Mock fetch to fail
+        mockFetch.mockRejectedValue(new Error('Linear API error'));
+
+        await emitter.emit('feature:status-changed', {
+          featureId: 'test-feature-4',
+          projectPath: '/test/path',
+          status: 'in_progress',
+        });
+
+        // Allow async handlers to complete
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        const metadata = service.getSyncMetadata('test-feature-4');
+        expect(metadata).toBeDefined();
+        expect(metadata?.lastSyncStatus).toBe('error');
+        expect(metadata?.errorMessage).toContain('Linear API error');
+      });
+
+      it('should handle missing feature gracefully', async () => {
+        vi.mocked(mockFeatureLoader.get).mockResolvedValue(null);
+
+        await emitter.emit('feature:status-changed', {
+          featureId: 'non-existent-feature',
+          projectPath: '/test/path',
+          status: 'in_progress',
+        });
+
+        // Allow async handlers to complete
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        // Should not throw and should not call fetch
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Workflow State Fetching', () => {
+      it('should fetch workflow states from Linear API', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: {
+              team: {
+                states: {
+                  nodes: [
+                    { id: 'state-1', name: 'Backlog' },
+                    { id: 'state-2', name: 'In Progress' },
+                    { id: 'state-3', name: 'Done' },
+                  ],
+                },
+              },
+            },
+          }),
+        });
+
+        const stateId = await (service as any).getWorkflowStateId(
+          '/test/path',
+          'team-123',
+          'In Progress'
+        );
+
+        expect(stateId).toBe('state-2');
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://api.linear.app/graphql',
+          expect.objectContaining({
+            method: 'POST',
+            headers: expect.objectContaining({
+              Authorization: 'Bearer test-token-123',
+            }),
+          })
+        );
+      });
+
+      it('should throw error when workflow state not found', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: {
+              team: {
+                states: {
+                  nodes: [{ id: 'state-1', name: 'Backlog' }],
+                },
+              },
+            },
+          }),
+        });
+
+        await expect(
+          (service as any).getWorkflowStateId('/test/path', 'team-123', 'Non-existent State')
+        ).rejects.toThrow('Workflow state "Non-existent State" not found');
+      });
+
+      it('should throw error when Linear API fails', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+        });
+
+        await expect(
+          (service as any).getWorkflowStateId('/test/path', 'team-123', 'In Progress')
+        ).rejects.toThrow('Linear API error: 500 Internal Server Error');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Implements `onFeatureStatusChanged()` in LinearSyncService for bidirectional status sync
- Maps all 6 Automaker statuses to Linear workflow states (backlog→Backlog, in_progress→In Progress, review→In Review, done/verified→Done, blocked→Blocked)
- Fetches Linear team workflow states via GraphQL to get correct stateId
- Skips sync when feature has no linearIssueId or status is unchanged
- Updates sync metadata with timestamps and direction tracking
- Emits `linear:sync:completed` and `linear:sync:error` events

## Changes
- `apps/server/src/services/linear-sync-service.ts` — Added `onFeatureStatusChanged()`, `mapAutomakerStatusToLinear()`, `getIssueState()`, `updateIssueStatus()`, `getWorkflowStateId()` methods
- `apps/server/tests/unit/services/linear-sync-service.test.ts` — 303 lines of tests for status change sync

## Test plan
- [ ] Status mapping covers all 6 Automaker statuses
- [ ] Features without linearIssueId are skipped gracefully
- [ ] Unchanged status doesn't trigger unnecessary API calls
- [ ] Sync metadata updated on success and error
- [ ] Events emitted for sync completion and errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)