### PR TITLE
fix(server): add startup cooldown and crash guard to auto-mode

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -21,6 +21,8 @@ const __dirname = dirname(__filename);
 dotenv.config({ path: resolve(__dirname, '../../../.env') });
 
 import { execSync } from 'node:child_process';
+import { access, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import express from 'express';
 import cors from 'cors';
 import morgan from 'morgan';
@@ -739,6 +741,27 @@ specGenerationMonitor.startMonitoring();
     logger.warn('[STARTUP-RECOVERY] Failed to run startup recovery:', err);
   }
 
+  // Crash detection: check for clean shutdown marker
+  const cleanShutdownMarker = join(DATA_DIR, '.clean-shutdown');
+  let wasCleanShutdown = false;
+  try {
+    await access(cleanShutdownMarker);
+    wasCleanShutdown = true;
+    await unlink(cleanShutdownMarker); // Remove it — next crash won't have it
+    logger.info('[AUTO-START] Clean shutdown marker found — previous shutdown was graceful');
+  } catch {
+    // No marker = crash recovery
+  }
+
+  if (!wasCleanShutdown) {
+    const crashDelayMs = process.env.AUTO_MODE_CRASH_DELAY_MS || '30000';
+    logger.warn(
+      `[AUTO-START] Previous shutdown was not clean (crash detected). Using ${crashDelayMs}ms cooldown for auto-mode.`
+    );
+    // Override startup delay with longer crash delay
+    process.env.AUTO_MODE_STARTUP_DELAY_MS = crashDelayMs;
+  }
+
   // Auto-start auto-mode if enabled in settings
   try {
     const settings = await settingsService.getGlobalSettings();
@@ -1394,6 +1417,13 @@ process.on('uncaughtException', (error: Error) => {
 // Graceful shutdown
 async function gracefulShutdown() {
   logger.info('Shutting down gracefully...');
+
+  // Write clean shutdown marker so next startup knows this wasn't a crash
+  try {
+    await writeFile(join(DATA_DIR, '.clean-shutdown'), Date.now().toString());
+  } catch (err) {
+    logger.warn('[SHUTDOWN] Failed to write clean shutdown marker:', err);
+  }
 
   await autoModeService.shutdown();
   healthMonitorService.stopMonitoring();

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -900,11 +900,43 @@ export class AutoModeService {
     );
     let iterationCount = 0;
 
+    // Configurable startup delay before first agent launch (default 10s, 0 to disable)
+    const startupDelayMs = parseInt(process.env.AUTO_MODE_STARTUP_DELAY_MS || '10000', 10);
+    if (startupDelayMs > 0) {
+      logger.info(
+        `[AutoLoop] Startup cooldown: waiting ${startupDelayMs}ms before first agent launch`
+      );
+      await this.sleep(startupDelayMs, projectState.abortController.signal);
+      if (!projectState.isRunning || projectState.abortController.signal.aborted) {
+        logger.info(`[AutoLoop] Auto-mode stopped during startup cooldown for ${worktreeDesc}`);
+        return;
+      }
+      const heapUsage = this.getHeapUsagePercent();
+      if (heapUsage >= this.HEAP_USAGE_STOP_NEW_AGENTS_THRESHOLD) {
+        logger.warn(
+          `[AutoLoop] Heap at ${Math.round(heapUsage * 100)}% after cooldown, stopping auto-mode for ${worktreeDesc}`
+        );
+        projectState.isRunning = false;
+        return;
+      }
+    }
+
     while (projectState.isRunning && !projectState.abortController.signal.aborted) {
       iterationCount++;
       logger.debug(
         `[AutoLoop] 💓 Heartbeat - Iteration ${iterationCount} for ${worktreeDesc} in ${projectPath}`
       );
+
+      // Early heap check — prevent any work when memory is critical
+      const earlyHeapUsage = this.getHeapUsagePercent();
+      if (earlyHeapUsage >= this.HEAP_USAGE_STOP_NEW_AGENTS_THRESHOLD) {
+        logger.warn(
+          `[AutoLoop] High heap (${Math.round(earlyHeapUsage * 100)}%), deferring iteration for ${worktreeDesc}`
+        );
+        await this.sleep(10000, projectState.abortController.signal);
+        continue;
+      }
+
       try {
         // Count running features for THIS project/worktree only
         const projectRunningCount = await this.getRunningCountForWorktree(projectPath, branchName);


### PR DESCRIPTION
## Summary
- Adds configurable startup delay (`AUTO_MODE_STARTUP_DELAY_MS`, default 10s) before auto-mode spawns first agent
- Moves heap check to top of loop iteration, before feature loading
- Writes `.clean-shutdown` marker on graceful shutdown; if missing on next boot (crash), uses longer delay (`AUTO_MODE_CRASH_DELAY_MS`, default 30s)

Prevents the OOM crash-restart loop on dev machines (8GB heap) where `autoModeAlwaysOn` immediately spawns Sonnet agents after a crash.

## Test plan
- [x] TypeScript compiles clean
- [x] 1718 server tests pass, 0 failures
- [x] Prettier passes
- [ ] Manual: verify 10s delay on normal startup
- [ ] Manual: verify 30s delay after kill -9 (crash simulation)
- [ ] Staging unaffected (32GB heap, delay is harmless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server now detects previous crashes at startup and adjusts recovery behavior accordingly.
  * Graceful shutdown handling with clean shutdown detection.
  * Memory usage monitoring for auto-mode to prevent agent creation when system memory is constrained.
  * Configurable startup delay for auto-mode operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->