### PR TITLE
feat(server): add Linear approval detection handler

### DIFF
--- a/apps/server/src/routes/linear/webhook.ts
+++ b/apps/server/src/routes/linear/webhook.ts
@@ -17,6 +17,7 @@ import { createLogger } from '@automaker/utils';
 import type { SettingsService } from '../../services/settings-service.js';
 import type { EventEmitter } from '../../lib/events.js';
 import type { FeatureLoader } from '../../services/feature-loader.js';
+import { linearApprovalHandler } from '../../services/linear-approval-handler.js';
 
 const logger = createLogger('linear:webhook');
 
@@ -352,6 +353,16 @@ async function handleIssueUpdated(
     });
   } else {
     logger.debug(`No relevant changes detected for issue ${data.id}`);
+  }
+
+  // Check for approval state transitions
+  if (data.state?.name) {
+    await linearApprovalHandler.onIssueStateChange(data.id, data.state.name, projectPath, {
+      title: data.title,
+      description: data.description,
+      priority: data.priority,
+      team: data.team,
+    });
   }
 }
 

--- a/apps/server/src/services/linear-approval-handler.ts
+++ b/apps/server/src/services/linear-approval-handler.ts
@@ -1,0 +1,132 @@
+/**
+ * LinearApprovalHandler
+ *
+ * Detects when a Linear issue transitions to an "approved" workflow state
+ * and emits a linear:approval:detected event with full issue context.
+ *
+ * Approval states are configurable via settings.integrations.linear.approvalStates
+ * (default: ['Approved', 'Ready for Planning']).
+ */
+
+import { createLogger } from '@automaker/utils';
+import type { EventEmitter } from '../lib/events.js';
+import type { SettingsService } from './settings-service.js';
+
+const logger = createLogger('linear:approval');
+
+const DEFAULT_APPROVAL_STATES = ['Approved', 'Ready for Planning'];
+
+export interface ApprovalContext {
+  /** Linear issue ID */
+  issueId: string;
+  /** Linear issue identifier (e.g., ENG-123) */
+  identifier?: string;
+  /** Issue title */
+  title: string;
+  /** Issue description */
+  description?: string;
+  /** The workflow state that triggered approval */
+  approvalState: string;
+  /** Priority (0-4) */
+  priority?: number;
+  /** Team info */
+  team?: { id: string; name: string };
+  /** Labels */
+  labels?: string[];
+  /** Timestamp of approval detection */
+  detectedAt: string;
+}
+
+export class LinearApprovalHandler {
+  private settingsService: SettingsService | null = null;
+  private emitter: EventEmitter | null = null;
+  private running = false;
+
+  initialize(settingsService: SettingsService, emitter: EventEmitter): void {
+    this.settingsService = settingsService;
+    this.emitter = emitter;
+    this.running = true;
+    logger.info('LinearApprovalHandler initialized');
+  }
+
+  stop(): void {
+    this.running = false;
+    logger.info('LinearApprovalHandler stopped');
+  }
+
+  /**
+   * Get configured approval states from project settings
+   */
+  private async getApprovalStates(projectPath: string): Promise<string[]> {
+    if (!this.settingsService) {
+      return DEFAULT_APPROVAL_STATES;
+    }
+
+    try {
+      const settings = await this.settingsService.getProjectSettings(projectPath);
+      return settings?.integrations?.linear?.approvalStates || DEFAULT_APPROVAL_STATES;
+    } catch {
+      return DEFAULT_APPROVAL_STATES;
+    }
+  }
+
+  /**
+   * Check if a Linear workflow state name indicates approval
+   */
+  async isApprovalState(stateName: string, projectPath: string): Promise<boolean> {
+    const approvalStates = await this.getApprovalStates(projectPath);
+    return approvalStates.some((s) => s.toLowerCase() === stateName.toLowerCase());
+  }
+
+  /**
+   * Handle a Linear issue state change and detect approval transitions.
+   * Called from the webhook handler or sync service when a Linear issue updates.
+   *
+   * @param issueId - Linear issue ID
+   * @param stateName - New workflow state name
+   * @param projectPath - Project path for settings lookup
+   * @param issueContext - Additional issue context from the webhook payload
+   */
+  async onIssueStateChange(
+    issueId: string,
+    stateName: string,
+    projectPath: string,
+    issueContext?: {
+      identifier?: string;
+      title?: string;
+      description?: string;
+      priority?: number;
+      team?: { id: string; name: string };
+      labels?: string[];
+    }
+  ): Promise<void> {
+    if (!this.running) return;
+
+    const isApproval = await this.isApprovalState(stateName, projectPath);
+    if (!isApproval) return;
+
+    const approvalContext: ApprovalContext = {
+      issueId,
+      identifier: issueContext?.identifier,
+      title: issueContext?.title || 'Unknown',
+      description: issueContext?.description,
+      approvalState: stateName,
+      priority: issueContext?.priority,
+      team: issueContext?.team,
+      labels: issueContext?.labels,
+      detectedAt: new Date().toISOString(),
+    };
+
+    logger.info(`Approval detected for issue ${issueId}: state "${stateName}"`, {
+      identifier: approvalContext.identifier,
+      title: approvalContext.title,
+    });
+
+    if (this.emitter) {
+      this.emitter.emit('linear:approval:detected', approvalContext);
+    }
+  }
+}
+
+// Singleton instance
+export const linearApprovalHandler = new LinearApprovalHandler();

--- a/apps/server/tests/unit/services/linear-approval-handler.test.ts
+++ b/apps/server/tests/unit/services/linear-approval-handler.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { LinearApprovalHandler } from '../../../src/services/linear-approval-handler.js';
+import type { EventEmitter } from '../../../src/lib/events.js';
+import type { SettingsService } from '../../../src/services/settings-service.js';
+
+describe('LinearApprovalHandler', () => {
+  let handler: LinearApprovalHandler;
+  let mockEmitter: EventEmitter;
+  let mockSettingsService: SettingsService;
+  let emitSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    handler = new LinearApprovalHandler();
+    emitSpy = vi.fn();
+    mockEmitter = { emit: emitSpy, on: vi.fn(), off: vi.fn() } as any;
+    mockSettingsService = {
+      getProjectSettings: vi.fn().mockResolvedValue({
+        integrations: {
+          linear: {
+            approvalStates: ['Approved', 'Ready for Planning'],
+          },
+        },
+      }),
+    } as any;
+
+    handler.initialize(mockSettingsService, mockEmitter);
+  });
+
+  afterEach(() => {
+    handler.stop();
+  });
+
+  describe('isApprovalState', () => {
+    it('should detect configured approval states', async () => {
+      expect(await handler.isApprovalState('Approved', '/test')).toBe(true);
+      expect(await handler.isApprovalState('Ready for Planning', '/test')).toBe(true);
+    });
+
+    it('should be case-insensitive', async () => {
+      expect(await handler.isApprovalState('approved', '/test')).toBe(true);
+      expect(await handler.isApprovalState('APPROVED', '/test')).toBe(true);
+    });
+
+    it('should reject non-approval states', async () => {
+      expect(await handler.isApprovalState('In Progress', '/test')).toBe(false);
+      expect(await handler.isApprovalState('Done', '/test')).toBe(false);
+      expect(await handler.isApprovalState('Backlog', '/test')).toBe(false);
+    });
+
+    it('should use default states when settings unavailable', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(null as any);
+      expect(await handler.isApprovalState('Approved', '/test')).toBe(true);
+      expect(await handler.isApprovalState('Ready for Planning', '/test')).toBe(true);
+    });
+  });
+
+  describe('onIssueStateChange', () => {
+    it('should emit linear:approval:detected for approval states', async () => {
+      await handler.onIssueStateChange('issue-123', 'Approved', '/test', {
+        title: 'Feature Request',
+        description: 'Build this feature',
+        priority: 2,
+        team: { id: 'team-1', name: 'Engineering' },
+      });
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        'linear:approval:detected',
+        expect.objectContaining({
+          issueId: 'issue-123',
+          title: 'Feature Request',
+          description: 'Build this feature',
+          approvalState: 'Approved',
+          priority: 2,
+          team: { id: 'team-1', name: 'Engineering' },
+        })
+      );
+    });
+
+    it('should not emit for non-approval states', async () => {
+      await handler.onIssueStateChange('issue-456', 'In Progress', '/test', {
+        title: 'Some Issue',
+      });
+
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not emit when handler is stopped', async () => {
+      handler.stop();
+
+      await handler.onIssueStateChange('issue-789', 'Approved', '/test', {
+        title: 'Feature',
+      });
+
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
+
+    it('should include detectedAt timestamp', async () => {
+      const before = new Date().toISOString();
+
+      await handler.onIssueStateChange('issue-abc', 'Approved', '/test', {
+        title: 'Feature',
+      });
+
+      const call = emitSpy.mock.calls[0];
+      expect(call[1].detectedAt).toBeDefined();
+      expect(new Date(call[1].detectedAt).getTime()).toBeGreaterThanOrEqual(
+        new Date(before).getTime()
+      );
+    });
+
+    it('should use custom approval states from settings', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue({
+        integrations: {
+          linear: {
+            approvalStates: ['Verified', 'Ship It'],
+          },
+        },
+      } as any);
+
+      await handler.onIssueStateChange('issue-custom', 'Ship It', '/test', {
+        title: 'Custom Approval',
+      });
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        'linear:approval:detected',
+        expect.objectContaining({
+          issueId: 'issue-custom',
+          approvalState: 'Ship It',
+        })
+      );
+
+      // Default states should no longer match
+      emitSpy.mockClear();
+      await handler.onIssueStateChange('issue-default', 'Approved', '/test', {
+        title: 'Default State',
+      });
+
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -1593,6 +1593,8 @@ export interface LinearIntegrationConfig {
   syncEnabled?: boolean;
   /** Conflict resolution strategy: 'linear' (Linear wins), 'automaker' (AutoMaker wins), 'manual' (require user input) */
   conflictResolution?: 'linear' | 'automaker' | 'manual';
+  /** Workflow state names that indicate approval (default: ['Approved', 'Ready for Planning']) */
+  approvalStates?: string[];
 
   // Agent OAuth (actor=app) fields
   /** OAuth access token for agent (actor=app) */


### PR DESCRIPTION
## Summary
- Creates `LinearApprovalHandler` service that detects approval state transitions in Linear
- Configurable approval states via `settings.integrations.linear.approvalStates` (default: `['Approved', 'Ready for Planning']`)
- Emits `linear:approval:detected` event with full issue context for ProjM pipeline
- Wired into webhook Issue update handler
- 9 unit tests

## Test plan
- [x] Unit tests: 9 passing (detection, custom states, case-insensitive, edge cases)
- [ ] Integration: verify webhook emits approval event on state transition
- [ ] E2E: verify ProjM pipeline receives and processes approval event

🤖 Generated with [Claude Code](https://claude.com/claude-code)