### PR TITLE
feat(server): add Linear sync observability metrics and status endpoint

### DIFF
--- a/apps/server/src/routes/linear/index.ts
+++ b/apps/server/src/routes/linear/index.ts
@@ -1,13 +1,14 @@
 /**
  * Linear Agent Routes
  *
- * OAuth flow for registering as a Linear agent (actor=app)
- * and webhook handler for AgentSessionEvent.
+ * OAuth flow for registering as a Linear agent (actor=app),
+ * webhook handler for AgentSessionEvent, and sync status endpoint.
  */
 
 import { Router } from 'express';
 import { createOAuthRoutes } from './oauth.js';
 import { createWebhookHandler } from './webhook.js';
+import { getSyncStatus } from './sync-status.js';
 import type { SettingsService } from '../../services/settings-service.js';
 import type { EventEmitter } from '../../lib/events.js';
 import type { FeatureLoader } from '../../services/feature-loader.js';
@@ -24,6 +25,9 @@ export function createLinearRoutes(
 
   // Webhook for AgentSessionEvent, Issue, and Project events
   router.post('/webhook', createWebhookHandler(settingsService, events, featureLoader));
+
+  // Sync status and metrics
+  router.get('/sync-status', getSyncStatus);
 
   return router;
 }

--- a/apps/server/src/routes/linear/sync-status.ts
+++ b/apps/server/src/routes/linear/sync-status.ts
@@ -1,0 +1,25 @@
+/**
+ * Linear Sync Status Endpoint
+ *
+ * GET /api/linear/sync-status
+ *
+ * Returns the current state of Linear sync including:
+ * - Whether sync is enabled
+ * - Metrics (operations, errors, conflicts, durations)
+ * - Recent sync activity
+ * - Per-feature sync state
+ */
+
+import type { RequestHandler } from 'express';
+import { linearSyncService } from '../../services/linear-sync-service.js';
+
+export const getSyncStatus: RequestHandler = (_req, res) => {
+  const metrics = linearSyncService.getMetrics();
+  const recentActivity = linearSyncService.getRecentActivity(20);
+
+  res.json({
+    enabled: linearSyncService.isRunning(),
+    metrics,
+    recentActivity,
+  });
+};

--- a/apps/server/src/services/linear-sync-service.ts
+++ b/apps/server/src/services/linear-sync-service.ts
@@ -20,6 +20,33 @@ import type { FeatureLoader } from './feature-loader.js';
 const logger = createLogger('LinearSyncService');
 
 /**
+ * Aggregated sync metrics
+ */
+export interface SyncMetrics {
+  totalOperations: number;
+  successfulOperations: number;
+  failedOperations: number;
+  conflictsDetected: number;
+  pushCount: number;
+  pullCount: number;
+  avgDurationMs: number;
+  lastOperationAt: string | null;
+}
+
+/**
+ * A single sync activity entry for the activity log
+ */
+export interface SyncActivity {
+  timestamp: string;
+  featureId: string;
+  direction: 'push' | 'pull';
+  status: 'success' | 'error';
+  durationMs: number;
+  conflictDetected: boolean;
+  error?: string;
+}
+
+/**
  * Metadata stored for each synced feature
  */
 export interface SyncMetadata {
@@ -95,7 +122,27 @@ export class LinearSyncService {
   /**
    * Flag to track if service is running
    */
-  private isRunning = false;
+  private running = false;
+
+  /**
+   * Metrics counters
+   */
+  private metrics: SyncMetrics = {
+    totalOperations: 0,
+    successfulOperations: 0,
+    failedOperations: 0,
+    conflictsDetected: 0,
+    pushCount: 0,
+    pullCount: 0,
+    avgDurationMs: 0,
+    lastOperationAt: null,
+  };
+
+  /**
+   * Circular buffer for recent activity (last 100 operations)
+   */
+  private activityLog: SyncActivity[] = [];
+  private readonly MAX_ACTIVITY_LOG_SIZE = 100;
 
   /**
    * Initialize the service with event emitter, settings service, and feature loader
@@ -127,12 +174,12 @@ export class LinearSyncService {
    * Start the sync service
    */
   start(): void {
-    if (this.isRunning) {
+    if (this.running) {
       logger.warn('LinearSyncService is already running');
       return;
     }
 
-    this.isRunning = true;
+    this.running = true;
     logger.info('LinearSyncService started');
   }
 
@@ -140,12 +187,12 @@ export class LinearSyncService {
    * Stop the sync service
    */
   stop(): void {
-    if (!this.isRunning) {
+    if (!this.running) {
       logger.warn('LinearSyncService is not running');
       return;
     }
 
-    this.isRunning = false;
+    this.running = false;
 
     // Clear any in-progress syncs
     this.syncingFeatures.clear();
@@ -168,8 +215,91 @@ export class LinearSyncService {
     this.settingsService = null;
     this.lastSyncTimes.clear();
     this.syncState.clear();
+    this.activityLog = [];
+    this.metrics = {
+      totalOperations: 0,
+      successfulOperations: 0,
+      failedOperations: 0,
+      conflictsDetected: 0,
+      pushCount: 0,
+      pullCount: 0,
+      avgDurationMs: 0,
+      lastOperationAt: null,
+    };
 
     logger.info('LinearSyncService destroyed');
+  }
+
+  /**
+   * Check if the sync service is currently running
+   */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /**
+   * Get aggregated sync metrics
+   */
+  getMetrics(): SyncMetrics {
+    return { ...this.metrics };
+  }
+
+  /**
+   * Get recent sync activity entries
+   * @param limit Maximum entries to return (default: 20)
+   */
+  getRecentActivity(limit = 20): SyncActivity[] {
+    return this.activityLog.slice(-limit);
+  }
+
+  /**
+   * Record a sync operation result for metrics tracking
+   */
+  private recordOperation(
+    featureId: string,
+    direction: 'push' | 'pull',
+    status: 'success' | 'error',
+    durationMs: number,
+    conflictDetected: boolean,
+    error?: string
+  ): void {
+    // Update counters
+    this.metrics.totalOperations++;
+    if (status === 'success') {
+      this.metrics.successfulOperations++;
+    } else {
+      this.metrics.failedOperations++;
+    }
+    if (conflictDetected) {
+      this.metrics.conflictsDetected++;
+    }
+    if (direction === 'push') {
+      this.metrics.pushCount++;
+    } else {
+      this.metrics.pullCount++;
+    }
+    this.metrics.lastOperationAt = new Date().toISOString();
+
+    // Update rolling average duration (only for successful ops)
+    if (status === 'success' && this.metrics.successfulOperations > 0) {
+      const prevTotal = this.metrics.avgDurationMs * (this.metrics.successfulOperations - 1);
+      this.metrics.avgDurationMs = (prevTotal + durationMs) / this.metrics.successfulOperations;
+    }
+
+    // Add to activity log (circular buffer)
+    const activity: SyncActivity = {
+      timestamp: new Date().toISOString(),
+      featureId,
+      direction,
+      status,
+      durationMs,
+      conflictDetected,
+      ...(error && { error }),
+    };
+    this.activityLog.push(activity);
+    if (this.activityLog.length > this.MAX_ACTIVITY_LOG_SIZE) {
+      this.activityLog.shift();
+    }
   }
 
   /**
@@ -227,7 +357,7 @@ export class LinearSyncService {
    */
   shouldSync(featureId: string): boolean {
     // Guard 1: Service must be running
-    if (!this.isRunning) {
+    if (!this.running) {
       logger.debug(`Sync skipped for ${featureId}: service not running`);
       return false;
     }
@@ -289,6 +419,8 @@ export class LinearSyncService {
       return;
     }
 
+    const startTime = Date.now();
+
     try {
       // Get the feature details
       const feature = await this.featureLoader.get(projectPath, featureId);
@@ -327,6 +459,9 @@ export class LinearSyncService {
       };
       this.updateSyncMetadata(metadata);
 
+      // Record metrics
+      this.recordOperation(featureId, 'push', 'success', Date.now() - startTime, false);
+
       // Emit completion event
       if (this.emitter) {
         this.emitter.emit('linear:sync:completed', {
@@ -343,12 +478,16 @@ export class LinearSyncService {
     } catch (error) {
       logger.error(`Failed to sync feature ${featureId} to Linear:`, error);
 
+      // Record metrics
+      const errorMsg = error instanceof Error ? error.message : 'Unknown error';
+      this.recordOperation(featureId, 'push', 'error', Date.now() - startTime, false, errorMsg);
+
       // Update sync metadata with error
       const metadata: SyncMetadata = {
         featureId,
         lastSyncTimestamp: Date.now(),
         lastSyncStatus: 'error',
-        errorMessage: error instanceof Error ? error.message : 'Unknown error',
+        errorMessage: errorMsg,
         syncCount: 0,
       };
       this.updateSyncMetadata(metadata);
@@ -358,7 +497,7 @@ export class LinearSyncService {
         this.emitter.emit('linear:sync:error', {
           featureId,
           direction: 'push',
-          error: error instanceof Error ? error.message : 'Unknown error',
+          error: errorMsg,
           timestamp: new Date().toISOString(),
         });
       }
@@ -519,6 +658,8 @@ export class LinearSyncService {
       return;
     }
 
+    const startTime = Date.now();
+
     try {
       // Get the feature details
       const feature = await this.featureLoader.get(projectPath, featureId);
@@ -571,6 +712,9 @@ export class LinearSyncService {
       };
       this.updateSyncMetadata(metadata);
 
+      // Record metrics
+      this.recordOperation(featureId, 'push', 'success', Date.now() - startTime, false);
+
       // Emit completion event
       if (this.emitter) {
         this.emitter.emit('linear:sync:completed', {
@@ -587,12 +731,15 @@ export class LinearSyncService {
     } catch (error) {
       logger.error(`Failed to sync status change for feature ${featureId}:`, error);
 
+      const errorMsg = error instanceof Error ? error.message : 'Unknown error';
+      this.recordOperation(featureId, 'push', 'error', Date.now() - startTime, false, errorMsg);
+
       // Update sync metadata with error
       const metadata: SyncMetadata = {
         featureId,
         lastSyncTimestamp: Date.now(),
         lastSyncStatus: 'error',
-        errorMessage: error instanceof Error ? error.message : 'Unknown error',
+        errorMessage: errorMsg,
         syncCount: 0,
       };
       this.updateSyncMetadata(metadata);
@@ -602,7 +749,7 @@ export class LinearSyncService {
         this.emitter.emit('linear:sync:error', {
           featureId,
           direction: 'push',
-          error: error instanceof Error ? error.message : 'Unknown error',
+          error: errorMsg,
           timestamp: new Date().toISOString(),
         });
       }
@@ -968,6 +1115,8 @@ export class LinearSyncService {
     // Mark as syncing to prevent duplicates
     this.markSyncing(featureId);
 
+    const startTime = Date.now();
+
     try {
       // Get the feature details
       const feature = await this.featureLoader.get(projectPath, featureId);
@@ -1010,6 +1159,9 @@ export class LinearSyncService {
       };
       this.updateSyncMetadata(metadata);
 
+      // Record metrics
+      this.recordOperation(featureId, 'push', 'success', Date.now() - startTime, false);
+
       // Emit completion event
       if (this.emitter) {
         this.emitter.emit('linear:sync:completed', {
@@ -1026,12 +1178,15 @@ export class LinearSyncService {
     } catch (error) {
       logger.error(`Failed to sync PR merge for feature ${featureId}:`, error);
 
+      const errorMsg = error instanceof Error ? error.message : 'Unknown error';
+      this.recordOperation(featureId, 'push', 'error', Date.now() - startTime, false, errorMsg);
+
       // Update sync metadata with error
       const metadata: SyncMetadata = {
         featureId,
         lastSyncTimestamp: Date.now(),
         lastSyncStatus: 'error',
-        errorMessage: error instanceof Error ? error.message : 'Unknown error',
+        errorMessage: errorMsg,
         syncCount: 0,
       };
       this.updateSyncMetadata(metadata);
@@ -1041,7 +1196,7 @@ export class LinearSyncService {
         this.emitter.emit('linear:sync:error', {
           featureId,
           direction: 'push',
-          error: error instanceof Error ? error.message : 'Unknown error',
+          error: errorMsg,
           timestamp: new Date().toISOString(),
         });
       }
@@ -1153,6 +1308,9 @@ export class LinearSyncService {
     projectPath: string,
     options?: { title?: string; priority?: number }
   ): Promise<void> {
+    const startTime = Date.now();
+    let featureId = 'unknown';
+
     try {
       // Find the feature by Linear issue ID
       if (!this.featureLoader) {
@@ -1166,7 +1324,7 @@ export class LinearSyncService {
         return;
       }
 
-      const featureId = feature.id;
+      featureId = feature.id;
 
       // Guard: Check if service is running and sync is enabled
       if (!this.shouldSync(featureId)) {
@@ -1279,6 +1437,15 @@ export class LinearSyncService {
         };
         this.updateSyncMetadata(updatedMetadata);
 
+        // Record metrics
+        this.recordOperation(
+          featureId,
+          'pull',
+          'success',
+          Date.now() - startTime,
+          conflictDetected
+        );
+
         // Emit completion event
         if (this.emitter) {
           this.emitter.emit('linear:sync:completed', {
@@ -1300,12 +1467,15 @@ export class LinearSyncService {
     } catch (error) {
       logger.error(`Failed to sync Linear issue ${linearIssueId}:`, error);
 
+      const errorMsg = error instanceof Error ? error.message : 'Unknown error';
+      this.recordOperation(featureId, 'pull', 'error', Date.now() - startTime, false, errorMsg);
+
       // Emit error event
       if (this.emitter) {
         this.emitter.emit('linear:sync:error', {
           linearIssueId,
           direction: 'pull',
-          error: error instanceof Error ? error.message : 'Unknown error',
+          error: errorMsg,
           timestamp: new Date().toISOString(),
         });
       }

--- a/apps/server/tests/unit/services/linear-sync-observability.test.ts
+++ b/apps/server/tests/unit/services/linear-sync-observability.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Unit tests for LinearSyncService observability (metrics, activity log, sync-status endpoint)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LinearSyncService } from '@/services/linear-sync-service.js';
+import type { EventEmitter } from '@/lib/events.js';
+import type { SettingsService } from '@/services/settings-service.js';
+import type { FeatureLoader } from '@/services/feature-loader.js';
+
+function createMockEventEmitter(): EventEmitter {
+  const subscribers: Array<(type: string, payload: unknown) => void> = [];
+  return {
+    emit: vi.fn((type: string, payload: unknown) => {
+      for (const sub of subscribers) {
+        sub(type, payload);
+      }
+    }),
+    subscribe: vi.fn((callback: (type: string, payload: unknown) => void) => {
+      subscribers.push(callback);
+      return () => {
+        const idx = subscribers.indexOf(callback);
+        if (idx >= 0) subscribers.splice(idx, 1);
+      };
+    }),
+  } as any;
+}
+
+function createMockSettingsService(): SettingsService {
+  return {
+    getProjectSettings: vi.fn().mockResolvedValue({
+      integrations: {
+        linear: {
+          enabled: true,
+          agentToken: 'test-token',
+          teamId: 'team-1',
+          syncOnFeatureCreate: true,
+          syncOnStatusChange: true,
+          commentOnCompletion: true,
+        },
+      },
+    }),
+  } as any;
+}
+
+function createMockFeatureLoader(features: Record<string, any> = {}): FeatureLoader {
+  return {
+    get: vi.fn((projectPath: string, featureId: string) => {
+      return Promise.resolve(features[featureId] || null);
+    }),
+    update: vi.fn().mockResolvedValue(undefined),
+    findByLinearIssueId: vi.fn((projectPath: string, linearIssueId: string) => {
+      const found = Object.values(features).find((f: any) => f.linearIssueId === linearIssueId);
+      return Promise.resolve(found || null);
+    }),
+    create: vi.fn(),
+    getAll: vi.fn(),
+    load: vi.fn(),
+  } as any;
+}
+
+describe('LinearSyncService Observability', () => {
+  let service: LinearSyncService;
+  let emitter: EventEmitter;
+  let settingsService: SettingsService;
+  let featureLoader: FeatureLoader;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    service = new LinearSyncService();
+    emitter = createMockEventEmitter();
+    settingsService = createMockSettingsService();
+    featureLoader = createMockFeatureLoader();
+    service.initialize(emitter, settingsService, featureLoader);
+  });
+
+  describe('isRunning()', () => {
+    it('returns false before start', () => {
+      expect(service.isRunning()).toBe(false);
+    });
+
+    it('returns true after start', () => {
+      service.start();
+      expect(service.isRunning()).toBe(true);
+    });
+
+    it('returns false after stop', () => {
+      service.start();
+      service.stop();
+      expect(service.isRunning()).toBe(false);
+    });
+  });
+
+  describe('getMetrics()', () => {
+    it('returns zeroed metrics initially', () => {
+      const metrics = service.getMetrics();
+      expect(metrics).toEqual({
+        totalOperations: 0,
+        successfulOperations: 0,
+        failedOperations: 0,
+        conflictsDetected: 0,
+        pushCount: 0,
+        pullCount: 0,
+        avgDurationMs: 0,
+        lastOperationAt: null,
+      });
+    });
+
+    it('returns a copy (not a reference)', () => {
+      const m1 = service.getMetrics();
+      const m2 = service.getMetrics();
+      expect(m1).not.toBe(m2);
+      expect(m1).toEqual(m2);
+    });
+
+    it('tracks successful push operations', async () => {
+      // Stub fetch to return a successful issue creation
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                issueCreate: {
+                  success: true,
+                  issue: { id: 'lin-1', url: 'https://linear.app/issue/lin-1' },
+                },
+              },
+            }),
+        })
+      );
+
+      featureLoader = createMockFeatureLoader({
+        'feat-1': {
+          id: 'feat-1',
+          title: 'Test Feature',
+          description: 'desc',
+          status: 'backlog',
+        },
+      });
+      service.destroy();
+      service = new LinearSyncService();
+      service.initialize(emitter, settingsService, featureLoader);
+      service.start();
+
+      // Trigger a feature:created event
+      emitter.emit('feature:created', {
+        featureId: 'feat-1',
+        projectPath: '/test',
+      });
+
+      // Wait for async processing
+      await new Promise((r) => setTimeout(r, 50));
+
+      const metrics = service.getMetrics();
+      expect(metrics.totalOperations).toBe(1);
+      expect(metrics.successfulOperations).toBe(1);
+      expect(metrics.failedOperations).toBe(0);
+      expect(metrics.pushCount).toBe(1);
+      expect(metrics.pullCount).toBe(0);
+      expect(metrics.lastOperationAt).toBeTruthy();
+      expect(metrics.avgDurationMs).toBeGreaterThanOrEqual(0);
+
+      vi.unstubAllGlobals();
+    });
+
+    it('tracks failed operations', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+
+      featureLoader = createMockFeatureLoader({
+        'feat-1': {
+          id: 'feat-1',
+          title: 'Test',
+          description: 'desc',
+          status: 'backlog',
+        },
+      });
+      service.destroy();
+      service = new LinearSyncService();
+      service.initialize(emitter, settingsService, featureLoader);
+      service.start();
+
+      emitter.emit('feature:created', {
+        featureId: 'feat-1',
+        projectPath: '/test',
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const metrics = service.getMetrics();
+      expect(metrics.totalOperations).toBe(1);
+      expect(metrics.successfulOperations).toBe(0);
+      expect(metrics.failedOperations).toBe(1);
+
+      vi.unstubAllGlobals();
+    });
+
+    it('tracks pull operations from Linear updates', async () => {
+      featureLoader = createMockFeatureLoader({
+        'feat-1': {
+          id: 'feat-1',
+          title: 'Test',
+          description: 'desc',
+          status: 'backlog',
+          linearIssueId: 'lin-1',
+        },
+      });
+      service.destroy();
+      service = new LinearSyncService();
+      service.initialize(emitter, settingsService, featureLoader);
+      service.start();
+
+      await service.onLinearIssueUpdated('lin-1', 'In Progress', '/test');
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const metrics = service.getMetrics();
+      expect(metrics.totalOperations).toBe(1);
+      expect(metrics.successfulOperations).toBe(1);
+      expect(metrics.pullCount).toBe(1);
+      expect(metrics.pushCount).toBe(0);
+    });
+
+    it('tracks conflict detection count', async () => {
+      featureLoader = createMockFeatureLoader({
+        'feat-1': {
+          id: 'feat-1',
+          title: 'Test',
+          description: 'desc',
+          status: 'backlog',
+          linearIssueId: 'lin-1',
+        },
+      });
+      service.destroy();
+      service = new LinearSyncService();
+      service.initialize(emitter, settingsService, featureLoader);
+      service.start();
+
+      // Set metadata with recent sync (7s ago = past 5s debounce, within 10s conflict window)
+      const sevenSecondsAgo = Date.now() - 7000;
+      service.updateSyncMetadata({
+        featureId: 'feat-1',
+        lastSyncTimestamp: sevenSecondsAgo,
+        lastSyncStatus: 'success',
+        syncCount: 1,
+        syncSource: 'automaker',
+        syncDirection: 'push',
+        lastSyncedAt: sevenSecondsAgo,
+      });
+
+      await service.onLinearIssueUpdated('lin-1', 'In Progress', '/test');
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const metrics = service.getMetrics();
+      expect(metrics.conflictsDetected).toBe(1);
+    });
+
+    it('resets metrics on destroy', async () => {
+      featureLoader = createMockFeatureLoader({
+        'feat-1': {
+          id: 'feat-1',
+          title: 'Test',
+          description: 'desc',
+          status: 'backlog',
+          linearIssueId: 'lin-1',
+        },
+      });
+      service.destroy();
+      service = new LinearSyncService();
+      service.initialize(emitter, settingsService, featureLoader);
+      service.start();
+
+      await service.onLinearIssueUpdated('lin-1', 'In Progress', '/test');
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(service.getMetrics().totalOperations).toBe(1);
+
+      service.destroy();
+
+      expect(service.getMetrics().totalOperations).toBe(0);
+    });
+  });
+
+  describe('getRecentActivity()', () => {
+    it('returns empty array initially', () => {
+      expect(service.getRecentActivity()).toEqual([]);
+    });
+
+    it('returns activity entries after operations', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                issueCreate: {
+                  success: true,
+                  issue: { id: 'lin-1', url: 'https://linear.app/issue/lin-1' },
+                },
+              },
+            }),
+        })
+      );
+
+      featureLoader = createMockFeatureLoader({
+        'feat-1': {
+          id: 'feat-1',
+          title: 'Test',
+          description: 'desc',
+          status: 'backlog',
+        },
+      });
+      service.destroy();
+      service = new LinearSyncService();
+      service.initialize(emitter, settingsService, featureLoader);
+      service.start();
+
+      emitter.emit('feature:created', {
+        featureId: 'feat-1',
+        projectPath: '/test',
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const activity = service.getRecentActivity();
+      expect(activity).toHaveLength(1);
+      expect(activity[0]).toMatchObject({
+        featureId: 'feat-1',
+        direction: 'push',
+        status: 'success',
+        conflictDetected: false,
+      });
+      expect(activity[0].timestamp).toBeTruthy();
+      expect(activity[0].durationMs).toBeGreaterThanOrEqual(0);
+
+      vi.unstubAllGlobals();
+    });
+
+    it('respects limit parameter', async () => {
+      // Use two different features to avoid debounce conflicts
+      featureLoader = createMockFeatureLoader({
+        'feat-1': {
+          id: 'feat-1',
+          title: 'Test A',
+          description: 'desc',
+          status: 'backlog',
+          linearIssueId: 'lin-1',
+        },
+        'feat-2': {
+          id: 'feat-2',
+          title: 'Test B',
+          description: 'desc',
+          status: 'backlog',
+          linearIssueId: 'lin-2',
+        },
+      });
+      service.destroy();
+      service = new LinearSyncService();
+      service.initialize(emitter, settingsService, featureLoader);
+      service.start();
+
+      await service.onLinearIssueUpdated('lin-1', 'In Progress', '/test');
+      await service.onLinearIssueUpdated('lin-2', 'In Progress', '/test');
+      await new Promise((r) => setTimeout(r, 50));
+
+      // All activity
+      expect(service.getRecentActivity(10)).toHaveLength(2);
+
+      // Limited to 1
+      expect(service.getRecentActivity(1)).toHaveLength(1);
+    });
+
+    it('includes error info for failed operations', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('API timeout')));
+
+      featureLoader = createMockFeatureLoader({
+        'feat-1': {
+          id: 'feat-1',
+          title: 'Test',
+          description: 'desc',
+          status: 'backlog',
+        },
+      });
+      service.destroy();
+      service = new LinearSyncService();
+      service.initialize(emitter, settingsService, featureLoader);
+      service.start();
+
+      emitter.emit('feature:created', {
+        featureId: 'feat-1',
+        projectPath: '/test',
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const activity = service.getRecentActivity();
+      expect(activity).toHaveLength(1);
+      expect(activity[0]).toMatchObject({
+        featureId: 'feat-1',
+        direction: 'push',
+        status: 'error',
+        error: 'API timeout',
+      });
+
+      vi.unstubAllGlobals();
+    });
+
+    it('clears activity log on destroy', async () => {
+      featureLoader = createMockFeatureLoader({
+        'feat-1': {
+          id: 'feat-1',
+          title: 'Test',
+          description: 'desc',
+          status: 'backlog',
+          linearIssueId: 'lin-1',
+        },
+      });
+      service.destroy();
+      service = new LinearSyncService();
+      service.initialize(emitter, settingsService, featureLoader);
+      service.start();
+
+      await service.onLinearIssueUpdated('lin-1', 'In Progress', '/test');
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(service.getRecentActivity().length).toBeGreaterThan(0);
+
+      service.destroy();
+
+      expect(service.getRecentActivity()).toEqual([]);
+    });
+  });
+
+  describe('rolling average duration', () => {
+    it('computes average from successful operations', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                issueCreate: {
+                  success: true,
+                  issue: { id: 'lin-1', url: 'https://linear.app/issue/lin-1' },
+                },
+              },
+            }),
+        })
+      );
+
+      featureLoader = createMockFeatureLoader({
+        'feat-1': {
+          id: 'feat-1',
+          title: 'Test 1',
+          description: 'desc',
+          status: 'backlog',
+        },
+      });
+      service.destroy();
+      service = new LinearSyncService();
+      service.initialize(emitter, settingsService, featureLoader);
+      service.start();
+
+      emitter.emit('feature:created', {
+        featureId: 'feat-1',
+        projectPath: '/test',
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      const metrics = service.getMetrics();
+      expect(metrics.avgDurationMs).toBeGreaterThanOrEqual(0);
+      // Duration should be a reasonable value (not NaN or negative)
+      expect(Number.isFinite(metrics.avgDurationMs)).toBe(true);
+
+      vi.unstubAllGlobals();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `GET /api/linear/sync-status` endpoint for monitoring sync health
- Instruments all sync operations (push/pull) with timing, error tracking, and conflict detection
- Adds `SyncMetrics` and `SyncActivity` types with aggregated counters and a 100-entry circular activity log
- Public methods: `isRunning()`, `getMetrics()`, `getRecentActivity(limit)`

## Test plan
- [x] 16 new unit tests covering all observability features
- [x] Full server suite passes (1771 tests, 69 files)
- [x] TypeScript build clean
- [x] Prettier formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sync status endpoint that exposes synchronization metrics, recent activity logs, and operational status.
  * Introduced detailed tracking for sync operations including status outcomes, duration metrics, and conflict detection.

* **Tests**
  * Added comprehensive unit test coverage for sync observability features and metrics collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->