### PR TITLE
feat(server): add AI-powered feature classifier using Haiku

### DIFF
--- a/apps/server/src/services/feature-classifier.ts
+++ b/apps/server/src/services/feature-classifier.ts
@@ -1,0 +1,134 @@
+/**
+ * Feature Classifier Service
+ *
+ * Uses Haiku to classify features into agent roles based on description.
+ * Single-turn query with <2s timeout, fallback to backend-engineer on low confidence.
+ */
+
+import { createLogger } from '@automaker/utils';
+import { simpleQuery } from '../providers/simple-query-service.js';
+import type { AgentRole } from '@automaker/types';
+
+const logger = createLogger('FeatureClassifier');
+
+/** Valid roles for classification */
+const VALID_ROLES: AgentRole[] = [
+  'frontend-engineer',
+  'backend-engineer',
+  'devops-engineer',
+  'gtm-specialist',
+];
+
+const DEFAULT_ROLE: AgentRole = 'backend-engineer';
+const CONFIDENCE_THRESHOLD = 0.6;
+const TIMEOUT_MS = 5000;
+
+/**
+ * Classification result from the AI
+ */
+export interface ClassificationResult {
+  role: AgentRole;
+  confidence: number;
+  reasoning: string;
+}
+
+const SYSTEM_PROMPT = `You are a feature classifier for an AI development studio. Given a feature title and description, classify it into exactly one agent role.
+
+Available roles:
+- frontend-engineer: React components, UI/UX, Tailwind CSS, Storybook, design systems, theming, user-facing visuals
+- backend-engineer: Express routes, services, database, API endpoints, WebSocket, server logic, TypeScript types
+- devops-engineer: CI/CD pipelines, Docker, deployment, infrastructure, monitoring, staging environments
+- gtm-specialist: Marketing content, social media, documentation for external users, competitive analysis
+
+Respond with ONLY valid JSON (no markdown, no code fences):
+{"role": "<role>", "confidence": <0.0-1.0>, "reasoning": "<brief explanation>"}
+
+Rules:
+- confidence should reflect how clearly the feature fits one role
+- If the feature spans multiple roles, pick the PRIMARY role and lower confidence
+- If unclear, default to backend-engineer with low confidence`;
+
+/**
+ * Classify a feature into an agent role using Haiku
+ */
+export async function classifyFeature(
+  title: string,
+  description: string,
+  cwd: string
+): Promise<ClassificationResult> {
+  const prompt = `Classify this feature:
+
+Title: ${title}
+Description: ${description}`;
+
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => abortController.abort(), TIMEOUT_MS);
+
+  try {
+    const result = await simpleQuery({
+      prompt,
+      systemPrompt: SYSTEM_PROMPT,
+      model: 'claude-haiku',
+      cwd,
+      maxTurns: 1,
+      allowedTools: [],
+      abortController,
+    });
+
+    clearTimeout(timeoutId);
+
+    return parseClassification(result.text);
+  } catch (error) {
+    clearTimeout(timeoutId);
+
+    if (error instanceof Error && error.name === 'AbortError') {
+      logger.warn('Feature classification timed out, using default role');
+    } else {
+      logger.error('Feature classification failed:', error);
+    }
+
+    return {
+      role: DEFAULT_ROLE,
+      confidence: 0,
+      reasoning: `Classification failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    };
+  }
+}
+
+/**
+ * Parse and validate the AI response into a ClassificationResult
+ */
+function parseClassification(text: string): ClassificationResult {
+  try {
+    // Strip markdown code fences if present
+    const cleaned = text.replace(/```(?:json)?\n?/g, '').trim();
+    const parsed = JSON.parse(cleaned);
+
+    const role = parsed.role as AgentRole;
+    const confidence = typeof parsed.confidence === 'number' ? parsed.confidence : 0;
+    const reasoning = typeof parsed.reasoning === 'string' ? parsed.reasoning : '';
+
+    // Validate role
+    if (!VALID_ROLES.includes(role)) {
+      logger.warn(`Invalid role "${role}" from classifier, falling back to ${DEFAULT_ROLE}`);
+      return { role: DEFAULT_ROLE, confidence: 0, reasoning: `Invalid role: ${role}` };
+    }
+
+    // Apply confidence threshold
+    if (confidence < CONFIDENCE_THRESHOLD) {
+      logger.info(
+        `Low confidence (${confidence}) for role "${role}", falling back to ${DEFAULT_ROLE}`
+      );
+      return { role: DEFAULT_ROLE, confidence, reasoning };
+    }
+
+    return { role, confidence, reasoning };
+  } catch (error) {
+    logger.error('Failed to parse classification response:', text);
+    return {
+      role: DEFAULT_ROLE,
+      confidence: 0,
+      reasoning: `Parse error: ${error instanceof Error ? error.message : 'Invalid JSON'}`,
+    };
+  }
+}

--- a/apps/server/tests/unit/services/feature-classifier.test.ts
+++ b/apps/server/tests/unit/services/feature-classifier.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for FeatureClassifier
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the simple-query-service before importing
+vi.mock('@/providers/simple-query-service.js', () => ({
+  simpleQuery: vi.fn(),
+}));
+
+import { classifyFeature } from '@/services/feature-classifier.js';
+import { simpleQuery } from '@/providers/simple-query-service.js';
+
+const mockSimpleQuery = vi.mocked(simpleQuery);
+
+describe('FeatureClassifier', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('classifyFeature', () => {
+    it('classifies frontend features correctly', async () => {
+      mockSimpleQuery.mockResolvedValueOnce({
+        text: '{"role": "frontend-engineer", "confidence": 0.95, "reasoning": "React component work with Tailwind CSS"}',
+      });
+
+      const result = await classifyFeature(
+        'Add user profile card component',
+        'Create a React component for displaying user profiles with avatar, name, and stats',
+        '/test'
+      );
+
+      expect(result.role).toBe('frontend-engineer');
+      expect(result.confidence).toBe(0.95);
+      expect(result.reasoning).toContain('React');
+    });
+
+    it('classifies backend features correctly', async () => {
+      mockSimpleQuery.mockResolvedValueOnce({
+        text: '{"role": "backend-engineer", "confidence": 0.9, "reasoning": "API endpoint and service logic"}',
+      });
+
+      const result = await classifyFeature(
+        'Add webhook handler for Linear events',
+        'Create Express route to receive and process Linear webhook payloads',
+        '/test'
+      );
+
+      expect(result.role).toBe('backend-engineer');
+      expect(result.confidence).toBe(0.9);
+    });
+
+    it('classifies devops features correctly', async () => {
+      mockSimpleQuery.mockResolvedValueOnce({
+        text: '{"role": "devops-engineer", "confidence": 0.85, "reasoning": "CI/CD pipeline configuration"}',
+      });
+
+      const result = await classifyFeature(
+        'Set up GitHub Actions for staging deployment',
+        'Configure automated deployment pipeline for staging environment',
+        '/test'
+      );
+
+      expect(result.role).toBe('devops-engineer');
+      expect(result.confidence).toBe(0.85);
+    });
+
+    it('classifies GTM features correctly', async () => {
+      mockSimpleQuery.mockResolvedValueOnce({
+        text: '{"role": "gtm-specialist", "confidence": 0.88, "reasoning": "Marketing and content creation"}',
+      });
+
+      const result = await classifyFeature(
+        'Create launch blog post',
+        'Write a blog post announcing the new feature with screenshots and examples',
+        '/test'
+      );
+
+      expect(result.role).toBe('gtm-specialist');
+      expect(result.confidence).toBe(0.88);
+    });
+
+    it('falls back to backend-engineer on low confidence', async () => {
+      mockSimpleQuery.mockResolvedValueOnce({
+        text: '{"role": "frontend-engineer", "confidence": 0.4, "reasoning": "Could be either frontend or backend"}',
+      });
+
+      const result = await classifyFeature(
+        'Add data display feature',
+        'Show some data to the user in a table format',
+        '/test'
+      );
+
+      expect(result.role).toBe('backend-engineer');
+      expect(result.confidence).toBe(0.4);
+    });
+
+    it('falls back to backend-engineer on invalid role', async () => {
+      mockSimpleQuery.mockResolvedValueOnce({
+        text: '{"role": "unknown-role", "confidence": 0.9, "reasoning": "Some reasoning"}',
+      });
+
+      const result = await classifyFeature('Test', 'Test description', '/test');
+
+      expect(result.role).toBe('backend-engineer');
+      expect(result.confidence).toBe(0);
+    });
+
+    it('handles JSON wrapped in code fences', async () => {
+      mockSimpleQuery.mockResolvedValueOnce({
+        text: '```json\n{"role": "frontend-engineer", "confidence": 0.85, "reasoning": "UI work"}\n```',
+      });
+
+      const result = await classifyFeature('UI component', 'Build a button', '/test');
+
+      expect(result.role).toBe('frontend-engineer');
+      expect(result.confidence).toBe(0.85);
+    });
+
+    it('falls back on invalid JSON response', async () => {
+      mockSimpleQuery.mockResolvedValueOnce({
+        text: 'This is not JSON at all',
+      });
+
+      const result = await classifyFeature('Test', 'Test', '/test');
+
+      expect(result.role).toBe('backend-engineer');
+      expect(result.confidence).toBe(0);
+      expect(result.reasoning).toContain('Parse error');
+    });
+
+    it('falls back on simpleQuery error', async () => {
+      mockSimpleQuery.mockRejectedValueOnce(new Error('API rate limit exceeded'));
+
+      const result = await classifyFeature('Test', 'Test', '/test');
+
+      expect(result.role).toBe('backend-engineer');
+      expect(result.confidence).toBe(0);
+      expect(result.reasoning).toContain('API rate limit exceeded');
+    });
+
+    it('falls back on timeout (AbortError)', async () => {
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      mockSimpleQuery.mockRejectedValueOnce(abortError);
+
+      const result = await classifyFeature('Test', 'Test', '/test');
+
+      expect(result.role).toBe('backend-engineer');
+      expect(result.confidence).toBe(0);
+      expect(result.reasoning).toContain('The operation was aborted');
+    });
+
+    it('passes correct options to simpleQuery', async () => {
+      mockSimpleQuery.mockResolvedValueOnce({
+        text: '{"role": "backend-engineer", "confidence": 0.9, "reasoning": "test"}',
+      });
+
+      await classifyFeature('My Feature', 'Feature description', '/my/project');
+
+      expect(mockSimpleQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'claude-haiku',
+          cwd: '/my/project',
+          maxTurns: 1,
+          allowedTools: [],
+        })
+      );
+
+      // Check that prompt includes the feature info
+      const callArgs = mockSimpleQuery.mock.calls[0][0];
+      expect(callArgs.prompt).toContain('My Feature');
+      expect(callArgs.prompt).toContain('Feature description');
+      expect(callArgs.systemPrompt).toContain('feature classifier');
+    });
+
+    it('handles missing confidence field', async () => {
+      mockSimpleQuery.mockResolvedValueOnce({
+        text: '{"role": "backend-engineer", "reasoning": "test"}',
+      });
+
+      const result = await classifyFeature('Test', 'Test', '/test');
+
+      // confidence defaults to 0, which is below threshold
+      expect(result.role).toBe('backend-engineer');
+      expect(result.confidence).toBe(0);
+    });
+
+    it('handles missing reasoning field', async () => {
+      mockSimpleQuery.mockResolvedValueOnce({
+        text: '{"role": "frontend-engineer", "confidence": 0.9}',
+      });
+
+      const result = await classifyFeature('Test', 'Test', '/test');
+
+      expect(result.role).toBe('frontend-engineer');
+      expect(result.confidence).toBe(0.9);
+      expect(result.reasoning).toBe('');
+    });
+
+    it('handles confidence at exact threshold (0.6)', async () => {
+      mockSimpleQuery.mockResolvedValueOnce({
+        text: '{"role": "devops-engineer", "confidence": 0.6, "reasoning": "borderline case"}',
+      });
+
+      const result = await classifyFeature('Test', 'Test', '/test');
+
+      expect(result.role).toBe('devops-engineer');
+      expect(result.confidence).toBe(0.6);
+    });
+
+    it('falls back when confidence is just below threshold (0.59)', async () => {
+      mockSimpleQuery.mockResolvedValueOnce({
+        text: '{"role": "devops-engineer", "confidence": 0.59, "reasoning": "borderline case"}',
+      });
+
+      const result = await classifyFeature('Test', 'Test', '/test');
+
+      expect(result.role).toBe('backend-engineer');
+      expect(result.confidence).toBe(0.59);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `FeatureClassifier` service that classifies features into agent roles using a single Haiku query
- Roles: `frontend-engineer`, `backend-engineer`, `devops-engineer`, `gtm-specialist`
- 5s timeout with graceful fallback to `backend-engineer` on low confidence (<0.6), timeout, or error
- Parses JSON responses including code-fenced output

## Test plan
- [x] 15 unit tests with mocked AI responses covering all classification paths
- [x] Full server suite passes (1770 tests, 69 files)
- [x] TypeScript build clean
- [x] Prettier formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)