### PR TITLE
chore: ignore .env files in prettier config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -29,6 +29,12 @@ apps/ui/src/routeTree.gen.ts
 # Template files (contain placeholders)
 packages/create-protolab/src/templates/
 
+# Environment files (can't be parsed by prettier)
+.env
+.env.example
+.env.local
+.env.*.local
+
 # Test artifacts
 test-results/
 coverage/


### PR DESCRIPTION
Environment files (.env, .env.example) cannot be parsed by prettier. This PR adds them to `.prettierignore` to prevent format check failures.

**Why**: PR #385 modified `.env.example` and CI format check failed because prettier can't infer a parser for `.env` files.

**Impact**: This fix unblocks PRs #385 and #386 format checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration to exclude environment files from code formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->