### PR TITLE
feat(deploy): zero-downtime staging deploy with agent drain

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -49,6 +49,16 @@ jobs:
             exit 1
           fi
 
+      - name: Drain running agents
+        run: |
+          # Gracefully stop auto-mode and wait for agents to finish.
+          # Uses the API key from .env (same machine as staging server).
+          AUTOMAKER_API_KEY=$(grep -oP 'AUTOMAKER_API_KEY=\K.*' "$ENV_SOURCE" || echo "")
+          curl -sf -X POST http://localhost:3008/api/deploy/drain \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $AUTOMAKER_API_KEY" \
+            --max-time 180 || echo "Drain skipped (server not running or no agents)"
+
       - name: Rebuild and restart staging
         working-directory: /home/josh/staging-deploy/automaker
         run: |

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -176,6 +176,7 @@ import {
 import { createCrewRoutes } from './routes/crew/index.js';
 import { linearApprovalHandler } from './services/linear-approval-handler.js';
 import { LinearApprovalBridge } from './services/linear-approval-bridge.js';
+import { createDeployRoutes } from './routes/deploy/index.js';
 
 const PORT = parseInt(process.env.PORT || '3008', 10);
 const HOST = process.env.HOST || '0.0.0.0';
@@ -966,6 +967,7 @@ app.use(
 app.use('/api/ceremonies', createCeremoniesRoutes(events, featureLoader, projectService));
 app.use('/api/issues', createIssuesRoutes(events));
 app.use('/api/crew', createCrewRoutes(crewLoopService));
+app.use('/api/deploy', createDeployRoutes(autoModeService));
 
 // Create HTTP server
 const server = createServer(app);

--- a/apps/server/src/routes/deploy/index.ts
+++ b/apps/server/src/routes/deploy/index.ts
@@ -1,0 +1,121 @@
+/**
+ * Deploy routes - Pre-deploy drain and status endpoints
+ *
+ * Provides graceful agent shutdown before container restarts.
+ * Called by deploy-staging.yml before rebuilding Docker images.
+ */
+
+import { Router } from 'express';
+import type { AutoModeService } from '../../services/auto-mode-service.js';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('DeployRoute');
+
+const DRAIN_POLL_INTERVAL_MS = 5_000;
+const DRAIN_TIMEOUT_MS = 120_000;
+
+let drainInProgress = false;
+
+export function createDeployRoutes(autoModeService: AutoModeService): Router {
+  const router = Router();
+
+  /**
+   * POST /api/deploy/drain
+   *
+   * Gracefully drain all running agents before a deploy:
+   * 1. Stop auto-mode for all projects (prevents new agents from starting)
+   * 2. Wait up to 2 minutes for running agents to finish
+   * 3. Force-stop any remaining agents after timeout
+   */
+  router.post('/drain', async (_req, res) => {
+    if (drainInProgress) {
+      res.status(409).json({ success: false, error: 'Drain already in progress' });
+      return;
+    }
+
+    drainInProgress = true;
+    const startTime = Date.now();
+
+    try {
+      // 1. Stop auto-mode for all active worktrees
+      const activeWorktrees = autoModeService.getActiveAutoLoopWorktrees();
+      logger.info(`[DRAIN] Stopping auto-mode for ${activeWorktrees.length} worktree(s)`);
+
+      for (const { projectPath, branchName } of activeWorktrees) {
+        try {
+          await autoModeService.stopAutoLoopForProject(projectPath, branchName);
+          const desc = branchName ? `${projectPath} (${branchName})` : projectPath;
+          logger.info(`[DRAIN] Stopped auto-mode for ${desc}`);
+        } catch (err) {
+          logger.warn(`[DRAIN] Failed to stop auto-mode for ${projectPath}:`, err);
+        }
+      }
+
+      // 2. Poll for running agents to finish
+      let agents = await autoModeService.getRunningAgents();
+      logger.info(`[DRAIN] Waiting for ${agents.length} running agent(s) to finish...`);
+
+      while (agents.length > 0 && Date.now() - startTime < DRAIN_TIMEOUT_MS) {
+        await new Promise((resolve) => setTimeout(resolve, DRAIN_POLL_INTERVAL_MS));
+        agents = await autoModeService.getRunningAgents();
+        logger.info(
+          `[DRAIN] ${agents.length} agent(s) still running (${Math.round((Date.now() - startTime) / 1000)}s elapsed)`
+        );
+      }
+
+      // 3. Force-stop remaining agents
+      let forceStoppedCount = 0;
+      if (agents.length > 0) {
+        logger.warn(`[DRAIN] Timeout reached, force-stopping ${agents.length} agent(s)`);
+        for (const agent of agents) {
+          try {
+            await autoModeService.stopFeature(agent.featureId);
+            forceStoppedCount++;
+            logger.info(`[DRAIN] Force-stopped agent for feature ${agent.featureId}`);
+          } catch (err) {
+            logger.warn(`[DRAIN] Failed to force-stop feature ${agent.featureId}:`, err);
+          }
+        }
+      }
+
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      logger.info(
+        `[DRAIN] Drain complete in ${elapsed}s — ${activeWorktrees.length} worktree(s) stopped, ${forceStoppedCount} agent(s) force-stopped`
+      );
+
+      res.json({
+        success: true,
+        drained: true,
+        worktreesStopped: activeWorktrees.length,
+        agentsForceStopped: forceStoppedCount,
+        elapsedSeconds: elapsed,
+      });
+    } catch (err) {
+      logger.error('[DRAIN] Drain failed:', err);
+      res.status(500).json({
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      drainInProgress = false;
+    }
+  });
+
+  /**
+   * GET /api/deploy/status
+   *
+   * Check if a drain is currently in progress.
+   */
+  router.get('/status', async (_req, res) => {
+    const agents = await autoModeService.getRunningAgents();
+    const activeWorktrees = autoModeService.getActiveAutoLoopWorktrees();
+
+    res.json({
+      drainInProgress,
+      runningAgents: agents.length,
+      activeWorktrees: activeWorktrees.length,
+    });
+  });
+
+  return router;
+}

--- a/docs/infra/staging-deployment.md
+++ b/docs/infra/staging-deployment.md
@@ -650,9 +650,44 @@ Staging auto-deploys from `main` via a GitHub Actions self-hosted runner.
 2. `.github/workflows/deploy-staging.yml` triggers on the self-hosted runner
 3. Workflow clones/pulls into a **persistent deploy directory** (`/home/josh/staging-deploy/automaker`) — not the runner's `_work/` workspace (which gets cleaned by cron)
 4. `.env` is copied from `/home/josh/dev/ava/.env` (persistent credentials)
-5. `setup-staging.sh --build` builds all Docker images, `--start` restarts containers
-6. Health check verifies deployment, smoke tests run
-7. Discord notification posted to `#deployments`
+5. **Drain step** calls `POST /api/deploy/drain` to gracefully stop auto-mode and wait for running agents to finish (up to 2 minutes, then force-stops)
+6. `setup-staging.sh --build` builds all Docker images, `--start` restarts containers
+7. On startup, auto-mode auto-resumes from `autoModeAlwaysOn` settings and orphaned features are reset to `backlog`
+8. Health check verifies deployment, smoke tests run
+9. Discord notification posted to `#deployments`
+
+### Zero-Downtime Deploy (Agent Drain)
+
+Previous deploys killed running agents by restarting Docker containers immediately. The drain system prevents this:
+
+```
+push to main → drain API → agents finish/stop → build → restart → auto-resume
+```
+
+**Drain endpoint:** `POST /api/deploy/drain`
+
+- Stops auto-mode for all active worktrees (prevents new agents)
+- Polls every 5s for running agents to finish (up to 2 min timeout)
+- Force-stops any agents still running after timeout
+- Returns `{ success, drained, worktreesStopped, agentsForceStopped, elapsedSeconds }`
+
+**Status endpoint:** `GET /api/deploy/status`
+
+- Returns `{ drainInProgress, runningAgents, activeWorktrees }`
+
+**Manual drain:**
+
+```bash
+# Via setup script
+./scripts/setup-staging.sh --drain
+
+# Via curl
+curl -X POST http://localhost:3008/api/deploy/drain \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $AUTOMAKER_API_KEY"
+```
+
+**Auto-resume:** The server automatically restarts auto-mode on startup using `autoModeAlwaysOn` settings. Features stuck in `in_progress` are reset to `backlog`.
 
 ### Setup
 

--- a/scripts/setup-staging.sh
+++ b/scripts/setup-staging.sh
@@ -6,6 +6,7 @@
 #   ./scripts/setup-staging.sh              # Full setup (build + start)
 #   ./scripts/setup-staging.sh --build      # Rebuild images only
 #   ./scripts/setup-staging.sh --start      # Start without rebuilding
+#   ./scripts/setup-staging.sh --drain      # Gracefully stop agents before deploy
 #   ./scripts/setup-staging.sh --stop       # Stop services
 #   ./scripts/setup-staging.sh --status     # Show status
 #   ./scripts/setup-staging.sh --teardown   # Stop and remove volumes
@@ -288,6 +289,31 @@ show_status() {
   echo ""
 }
 
+# ─── Drain ────────────────────────────────────────────────────────────────────
+
+drain_agents() {
+  info "Draining running agents before deploy..."
+
+  local api_port="${API_PORT:-3008}"
+  local api_key="${AUTOMAKER_API_KEY:-}"
+
+  if [ -z "$api_key" ]; then
+    warn "AUTOMAKER_API_KEY not set, skipping drain"
+    return 0
+  fi
+
+  local response
+  response=$(curl -sf -X POST "http://localhost:${api_port}/api/deploy/drain" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${api_key}" \
+    --max-time 180 2>&1) || {
+    warn "Drain failed or server not running — continuing with deploy"
+    return 0
+  }
+
+  ok "Drain complete: $response"
+}
+
 # ─── Main ────────────────────────────────────────────────────────────────────
 
 # Source env file if it exists (for port vars)
@@ -311,6 +337,9 @@ case "${1:-}" in
     check_prereqs
     start_services
     ;;
+  --drain)
+    drain_agents
+    ;;
   --stop)
     stop_services
     ;;
@@ -321,11 +350,12 @@ case "${1:-}" in
     teardown
     ;;
   --help|-h)
-    echo "Usage: $0 [--build|--start|--stop|--status|--teardown|--help]"
+    echo "Usage: $0 [--build|--start|--drain|--stop|--status|--teardown|--help]"
     echo ""
     echo "  (no args)   Full setup: check prereqs, build images, start services"
     echo "  --build     Rebuild images only"
     echo "  --start     Start without rebuilding"
+    echo "  --drain     Gracefully stop agents before deploy"
     echo "  --stop      Stop services"
     echo "  --status    Show status"
     echo "  --teardown  Stop and remove all volumes"


### PR DESCRIPTION
## Summary
- Add `POST /api/deploy/drain` endpoint that gracefully stops auto-mode and waits for running agents to finish (2min timeout, then force-stop)
- Add `GET /api/deploy/status` to check drain progress
- Deploy workflow calls drain API before rebuilding Docker images
- `setup-staging.sh --drain` for manual use
- Auto-resume on startup via `autoModeAlwaysOn` settings (unchanged)

## Test plan
- [ ] Start auto-mode with agents running
- [ ] Call `POST /api/deploy/drain` — verify agents stop, auto-mode saves state
- [ ] Restart server — verify auto-mode resumes automatically
- [ ] Run `./scripts/setup-staging.sh --drain` — verify it calls the API
- [ ] Full deploy test (push to main) — verify drain → build → restart → resume flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deployment drain functionality to gracefully manage agent shutdown during staging deployments.
  * Introduced new deployment APIs for monitoring agent status and controlling drain operations.

* **Documentation**
  * Updated staging deployment documentation with zero-downtime deploy flow and updated workflow examples.

* **Chores**
  * Updated CI deployment workflow with pre-deployment agent drain step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->