### PR TITLE
fix: remove non-standard metadata from Linear MCP tool responses

### DIFF
--- a/packages/mcp-server/vendor/linear-mcp-server.js
+++ b/packages/mcp-server/vendor/linear-mcp-server.js
@@ -803,26 +803,9 @@ async function main() {
       throw new Error(`Prompt not found: ${request.params.name}`);
     });
     server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      let metrics = {
-        totalRequests: 0,
-        requestsInLastHour: 0,
-        averageRequestTime: 0,
-        queueLength: 0,
-        lastRequestTime: Date.now(),
-      };
       try {
         const { name, arguments: args } = request.params;
         if (!args) throw new Error('Missing arguments');
-        metrics = linearClient.rateLimiter.getMetrics();
-        const baseResponse = {
-          apiMetrics: {
-            requestsInLastHour: metrics.requestsInLastHour,
-            remainingRequests:
-              linearClient.rateLimiter.requestsPerHour - metrics.requestsInLastHour,
-            averageRequestTime: `${Math.round(metrics.averageRequestTime)}ms`,
-            queueLength: metrics.queueLength,
-          },
-        };
         switch (name) {
           case 'linear_create_issue': {
             const validatedArgs = CreateIssueArgsSchema.parse(args);
@@ -832,7 +815,6 @@ async function main() {
                 {
                   type: 'text',
                   text: `Created issue ${issue.identifier}: ${issue.title}\nURL: ${issue.url}`,
-                  metadata: baseResponse,
                 },
               ],
             };
@@ -845,7 +827,6 @@ async function main() {
                 {
                   type: 'text',
                   text: `Updated issue ${issue.identifier}\nURL: ${issue.url}`,
-                  metadata: baseResponse,
                 },
               ],
             };
@@ -858,7 +839,6 @@ async function main() {
                 {
                   type: 'text',
                   text: `Found ${issues.length} issues:\n${issues.map((issue) => `- ${issue.identifier}: ${issue.title}\n  Priority: ${issue.priority || 'None'}\n  Status: ${issue.status || 'None'}\n  ${issue.url}`).join('\n')}`,
-                  metadata: baseResponse,
                 },
               ],
             };
@@ -871,7 +851,6 @@ async function main() {
                 {
                   type: 'text',
                   text: `Found ${issues.length} issues:\n${issues.map((issue) => `- ${issue.identifier}: ${issue.title}\n  Priority: ${issue.priority || 'None'}\n  Status: ${issue.stateName}\n  ${issue.url}`).join('\n')}`,
-                  metadata: baseResponse,
                 },
               ],
             };
@@ -884,7 +863,6 @@ async function main() {
                 {
                   type: 'text',
                   text: `Added comment to issue ${issue?.identifier}\nURL: ${comment.url}`,
-                  metadata: baseResponse,
                 },
               ],
             };
@@ -894,15 +872,6 @@ async function main() {
         }
       } catch (error) {
         console.error('Error executing tool:', error);
-        const errorResponse = {
-          apiMetrics: {
-            requestsInLastHour: metrics.requestsInLastHour,
-            remainingRequests:
-              linearClient.rateLimiter.requestsPerHour - metrics.requestsInLastHour,
-            averageRequestTime: `${Math.round(metrics.averageRequestTime)}ms`,
-            queueLength: metrics.queueLength,
-          },
-        };
         // If it's a Zod error, format it nicely
         if (error instanceof z.ZodError) {
           const formattedErrors = error.errors
@@ -913,12 +882,9 @@ async function main() {
               {
                 type: 'text',
                 text: `Validation error: ${formattedErrors}`,
-                metadata: {
-                  error: true,
-                  ...errorResponse,
-                },
               },
             ],
+            isError: true,
           };
         }
         // For Linear API errors, try to extract useful information
@@ -929,12 +895,9 @@ async function main() {
               {
                 type: 'text',
                 text: `Linear API error (${status}): ${error.message}`,
-                metadata: {
-                  error: true,
-                  ...errorResponse,
-                },
               },
             ],
+            isError: true,
           };
         }
         // For all other errors
@@ -943,12 +906,9 @@ async function main() {
             {
               type: 'text',
               text: `Error: ${error instanceof Error ? error.message : String(error)}`,
-              metadata: {
-                error: true,
-                ...errorResponse,
-              },
             },
           ],
+          isError: true,
         };
       }
     });


### PR DESCRIPTION
## Summary
- Remove non-standard `metadata` field from all MCP TextContent items in the vendored Linear MCP server
- The MCP protocol TextContent schema is strictly `{type: "text", text: string}` — the extra `metadata` field caused Claude Code's MCP client to reject responses with "Invalid tools/call result: expected string, received object"
- Add proper `isError: true` to error responses per MCP spec
- Clean up unused `baseResponse`, `errorResponse`, and `metrics` variables

## Test plan
- [ ] Verify Linear MCP tools respond without validation errors (`linear_get_user_issues`, `linear_search_issues`, etc.)
- [ ] Verify error responses include `isError: true`
- [ ] Run `claude plugin update automaker` to pick up vendored file changes

Closes Beads: automaker-3h1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified response payloads by removing metrics metadata from all requests and responses.
  * Streamlined error handling with clearer error signals for improved transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->