### PR TITLE
feat: add escalation router core types and channel interface

### DIFF
--- a/libs/types/src/escalation.ts
+++ b/libs/types/src/escalation.ts
@@ -1,0 +1,97 @@
+/**
+ * Escalation types for AutoMaker escalation router
+ * Defines core types for routing critical signals to appropriate channels
+ */
+
+/**
+ * Escalation severity levels
+ * Determines urgency and routing strategy for signals
+ */
+export enum EscalationSeverity {
+  /** Critical emergency requiring immediate DM notification */
+  emergency = 'emergency',
+  /** Critical issue requiring urgent attention */
+  critical = 'critical',
+  /** High priority issue */
+  high = 'high',
+  /** Medium priority issue */
+  medium = 'medium',
+  /** Low priority issue */
+  low = 'low',
+}
+
+/**
+ * Source of escalation signal
+ * Identifies where the signal originated
+ */
+export enum EscalationSource {
+  /** PR feedback requiring attention */
+  pr_feedback = 'pr_feedback',
+  /** Agent execution failure */
+  agent_failure = 'agent_failure',
+  /** CI/CD pipeline failure */
+  ci_failure = 'ci_failure',
+  /** Health check failure or degradation */
+  health_check = 'health_check',
+  /** Crew member escalation */
+  crew_escalation = 'crew_escalation',
+  /** SLA breach detected */
+  sla_breach = 'sla_breach',
+  /** Board state anomaly detected */
+  board_anomaly = 'board_anomaly',
+  /** Human explicitly mentioned in a comment */
+  human_mention = 'human_mention',
+}
+
+/**
+ * Escalation signal metadata
+ * Contains all information needed to route and process an escalation
+ */
+export interface EscalationSignal {
+  /** Source of the escalation */
+  source: EscalationSource;
+  /** Severity level determining urgency */
+  severity: EscalationSeverity;
+  /** Type identifier for the signal */
+  type: string;
+  /** Additional context data for the signal */
+  context: Record<string, unknown>;
+  /** Key for deduplication to prevent spam */
+  deduplicationKey: string;
+  /** Timestamp when signal was created */
+  timestamp?: string;
+}
+
+/**
+ * Escalation channel interface
+ * Implemented by all output channels (Discord DM, channel, Linear, etc.)
+ */
+export interface EscalationChannel {
+  /** Unique name for this channel */
+  name: string;
+
+  /**
+   * Determines if this channel can handle the given signal
+   * @param signal The escalation signal to check
+   * @returns true if this channel should process the signal
+   */
+  canHandle(signal: EscalationSignal): boolean;
+
+  /**
+   * Sends the escalation signal through this channel
+   * @param signal The escalation signal to send
+   * @returns Promise resolving when send is complete
+   */
+  send(signal: EscalationSignal): Promise<void>;
+
+  /**
+   * Rate limiting configuration for this channel
+   * @returns Rate limit configuration or undefined if no limit
+   */
+  rateLimit?: {
+    /** Maximum number of signals within the window */
+    maxSignals: number;
+    /** Time window in milliseconds */
+    windowMs: number;
+  };
+}

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -240,7 +240,13 @@ export type EventType =
   | 'crew:check-started'
   | 'crew:check-completed'
   | 'crew:escalation-started'
-  | 'crew:escalation-completed';
+  | 'crew:escalation-completed'
+  // Escalation router events (signal routing to channels)
+  | 'escalation:signal-received'
+  | 'escalation:signal-routed'
+  | 'escalation:signal-sent'
+  | 'escalation:signal-failed'
+  | 'escalation:signal-deduplicated';
 
 export type EventCallback = (type: EventType, payload: unknown) => void;
 

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -630,3 +630,7 @@ export type {
   DesiredStateCondition,
   StateOperator,
 } from './agent-templates.js';
+
+// Escalation router types (signal routing to channels)
+export { EscalationSeverity, EscalationSource } from './escalation.js';
+export type { EscalationSignal, EscalationChannel } from './escalation.js';


### PR DESCRIPTION
## Summary
- Add `EscalationSeverity` enum (emergency, critical, high, medium, low)
- Add `EscalationSource` enum (pr_feedback, agent_failure, ci_failure, health_check, crew_escalation, sla_breach, board_anomaly, human_mention)
- Add `EscalationSignal` interface with deduplication key support
- Add `EscalationChannel` interface for pluggable output channels
- Add escalation event types to `event.ts`
- Export all from `@automaker/types` barrel

Part of the Escalation Pipeline project (M1: Escalation Router Core).

## Test plan
- [ ] Types compile with `npm run build:packages`
- [ ] No breaking changes to existing types
- [ ] Exported correctly from `@automaker/types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added escalation routing system with configurable severity levels (emergency, critical, high, medium, low) and diverse escalation sources including PR feedback, agent failures, CI failures, health checks, crew escalations, SLA breaches, and anomalies.
  * Introduced comprehensive event tracking for escalation signal lifecycle (received, routed, sent, failed, deduplicated).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->