### PR TITLE
feat: add EscalationRouter service with dedup and rate limiting

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -100,6 +100,8 @@ import { createBacklogPlanRoutes } from './routes/backlog-plan/index.js';
 import { cleanupStaleValidations } from './routes/github/routes/validation-common.js';
 import { createMCPRoutes } from './routes/mcp/index.js';
 import { MCPTestService } from './services/mcp-test-service.js';
+import { createEscalationRoutes } from './routes/escalation.js';
+import { getEscalationRouter } from './services/escalation-router.js';
 import { createPipelineRoutes } from './routes/pipeline/index.js';
 import { pipelineService } from './services/pipeline-service.js';
 import { createMetricsRoutes } from './routes/metrics/index.js';
@@ -357,6 +359,10 @@ const mcpTestService = new MCPTestService(settingsService);
 const featureHealthService = new FeatureHealthService(featureLoader, autoModeService);
 const beadsService = new BeadsService('bd', events);
 const discordService = getDiscordService();
+
+// Initialize Escalation Router
+const escalationRouter = getEscalationRouter();
+escalationRouter.setEventEmitter(events);
 
 // Initialize Health Monitor Service early with autoRemediate enabled
 const healthMonitorService = getHealthMonitorService(featureLoader, {
@@ -969,6 +975,7 @@ app.use('/api/ceremonies', createCeremoniesRoutes(events, featureLoader, project
 app.use('/api/issues', createIssuesRoutes(events));
 app.use('/api/crew', createCrewRoutes(crewLoopService));
 app.use('/api/deploy', createDeployRoutes(autoModeService));
+app.use('/api/escalation', createEscalationRoutes(escalationRouter));
 
 // Create HTTP server
 const server = createServer(app);

--- a/apps/server/src/routes/escalation.ts
+++ b/apps/server/src/routes/escalation.ts
@@ -1,0 +1,77 @@
+/**
+ * Escalation routes - HTTP API for escalation router
+ *
+ * Provides endpoints for:
+ * - GET /api/escalation/status - Router status and channel information
+ * - GET /api/escalation/log - Signal audit log
+ */
+
+import { Router, type Request, type Response } from 'express';
+import type { EscalationRouter } from '../services/escalation-router.js';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('EscalationRoutes');
+
+/**
+ * Create escalation router with all endpoints
+ *
+ * @param escalationRouter - Instance of EscalationRouter
+ * @returns Express Router configured with escalation endpoints
+ */
+export function createEscalationRoutes(escalationRouter: EscalationRouter): Router {
+  const router = Router();
+
+  /**
+   * GET /api/escalation/status
+   *
+   * Returns router status including:
+   * - Registered channels with their priorities and rate limits
+   * - Recent send counts per channel
+   * - Signal tracking statistics
+   */
+  router.get('/status', (_req: Request, res: Response) => {
+    try {
+      const status = escalationRouter.getStatus();
+      res.json(status);
+    } catch (error) {
+      logger.error('Error getting escalation status:', error);
+      res.status(500).json({
+        error: 'Failed to get escalation status',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  });
+
+  /**
+   * GET /api/escalation/log
+   *
+   * Returns signal audit log
+   *
+   * Query params:
+   * - limit: Number of entries to return (default: 100)
+   */
+  router.get('/log', (req: Request, res: Response) => {
+    try {
+      const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 100;
+
+      if (isNaN(limit) || limit < 1) {
+        res.status(400).json({ error: 'Invalid limit parameter' });
+        return;
+      }
+
+      const log = escalationRouter.getLog(limit);
+      res.json({
+        entries: log,
+        count: log.length,
+      });
+    } catch (error) {
+      logger.error('Error getting escalation log:', error);
+      res.status(500).json({
+        error: 'Failed to get escalation log',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/services/escalation-router.ts
+++ b/apps/server/src/services/escalation-router.ts
@@ -1,0 +1,351 @@
+/**
+ * Escalation Router Service
+ *
+ * Receives EscalationSignal events, deduplicates by key within time window,
+ * rate-limits per channel, and routes to registered EscalationChannel implementations.
+ *
+ * Features:
+ * - Signal deduplication (30min window by default)
+ * - Per-channel rate limiting (configurable via channel.rateLimit)
+ * - Plug-and-play channel registration via canHandle() pattern
+ * - Audit log for signal history
+ */
+
+import type { EscalationSignal, EscalationChannel } from '@automaker/types';
+import { EscalationSeverity } from '@automaker/types';
+import { createLogger } from '@automaker/utils';
+import type { EventEmitter } from '../lib/events.js';
+
+const logger = createLogger('EscalationRouter');
+
+/**
+ * Audit log entry for signal history
+ */
+export interface EscalationLogEntry {
+  signal: EscalationSignal;
+  timestamp: string;
+  routedTo: string[];
+  deduplicated: boolean;
+  rateLimited: string[];
+}
+
+/**
+ * Channel rate limiting state
+ */
+interface ChannelRateState {
+  timestamps: number[];
+}
+
+/**
+ * Signal deduplication state
+ */
+interface DeduplicationEntry {
+  key: string;
+  timestamp: number;
+}
+
+/**
+ * EscalationRouter manages signal routing and channel orchestration
+ */
+export class EscalationRouter {
+  private channels: Map<string, EscalationChannel> = new Map();
+  private signalLog: EscalationLogEntry[] = [];
+  private rateLimitState: Map<string, ChannelRateState> = new Map();
+  private recentSignals: Map<string, DeduplicationEntry> = new Map();
+  private events: EventEmitter | null = null;
+  private deduplicationWindowMs: number = 30 * 60 * 1000; // 30 minutes
+  private readonly MAX_LOG_ENTRIES = 1000;
+
+  /**
+   * Set event emitter for listening to escalation signals
+   */
+  setEventEmitter(events: EventEmitter): void {
+    this.events = events;
+
+    events.subscribe((type, payload) => {
+      if (type === 'escalation:signal-received') {
+        void this.routeSignal(payload as EscalationSignal);
+      }
+    });
+
+    logger.info('EscalationRouter listening for escalation:signal-received events');
+  }
+
+  /**
+   * Register an escalation channel
+   */
+  registerChannel(channel: EscalationChannel): void {
+    if (this.channels.has(channel.name)) {
+      logger.warn(`Channel ${channel.name} already registered, replacing`);
+    }
+
+    this.channels.set(channel.name, channel);
+    this.rateLimitState.set(channel.name, { timestamps: [] });
+
+    const rateInfo = channel.rateLimit
+      ? `${channel.rateLimit.maxSignals}/${channel.rateLimit.windowMs}ms`
+      : 'unlimited';
+    logger.info(`Registered channel: ${channel.name} (rateLimit: ${rateInfo})`);
+  }
+
+  /**
+   * Unregister a channel
+   */
+  unregisterChannel(channelName: string): void {
+    this.channels.delete(channelName);
+    this.rateLimitState.delete(channelName);
+    logger.info(`Unregistered channel: ${channelName}`);
+  }
+
+  /**
+   * Get all registered channels
+   */
+  getChannels(): EscalationChannel[] {
+    return Array.from(this.channels.values());
+  }
+
+  /**
+   * Route a signal to appropriate channels
+   */
+  async routeSignal(signal: EscalationSignal): Promise<void> {
+    if (!signal.timestamp) {
+      signal.timestamp = new Date().toISOString();
+    }
+
+    // Deduplication check
+    if (this.isDuplicate(signal)) {
+      logger.debug(`Signal deduplicated: ${signal.deduplicationKey}`);
+      this.addToLog({
+        signal,
+        timestamp: signal.timestamp,
+        routedTo: [],
+        deduplicated: true,
+        rateLimited: [],
+      });
+
+      if (this.events) {
+        this.events.emit('escalation:signal-deduplicated', { signal });
+      }
+      return;
+    }
+
+    this.recordSignal(signal);
+
+    // Low severity = log only
+    if (signal.severity === EscalationSeverity.low) {
+      logger.info(`Low severity signal logged: ${signal.type}`);
+      this.addToLog({
+        signal,
+        timestamp: signal.timestamp,
+        routedTo: [],
+        deduplicated: false,
+        rateLimited: [],
+      });
+      return;
+    }
+
+    // Route to channels that can handle this signal
+    const routedTo: string[] = [];
+    const rateLimited: string[] = [];
+
+    for (const [name, channel] of this.channels.entries()) {
+      // Ask channel if it can handle this signal
+      if (!channel.canHandle(signal)) {
+        continue;
+      }
+
+      // Check rate limit
+      if (!this.checkRateLimit(name, channel.rateLimit)) {
+        rateLimited.push(name);
+        logger.debug(`Rate limit exceeded for channel: ${name}`);
+        continue;
+      }
+
+      try {
+        await channel.send(signal);
+        routedTo.push(name);
+        this.recordSend(name);
+        logger.info(`Routed ${signal.severity} signal to ${name}: ${signal.type}`);
+
+        if (this.events) {
+          this.events.emit('escalation:signal-sent', {
+            signal,
+            channel: name,
+          });
+        }
+      } catch (error) {
+        logger.error(`Failed to send to channel ${name}:`, error);
+        if (this.events) {
+          this.events.emit('escalation:signal-failed', {
+            signal,
+            channel: name,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          });
+        }
+      }
+    }
+
+    this.addToLog({
+      signal,
+      timestamp: signal.timestamp,
+      routedTo,
+      deduplicated: false,
+      rateLimited,
+    });
+
+    if (this.events) {
+      this.events.emit('escalation:signal-routed', {
+        signal,
+        routedTo,
+        rateLimited,
+      });
+    }
+  }
+
+  /**
+   * Check if signal is a duplicate within deduplication window
+   */
+  private isDuplicate(signal: EscalationSignal): boolean {
+    const existing = this.recentSignals.get(signal.deduplicationKey);
+    if (!existing) return false;
+
+    const age = Date.now() - existing.timestamp;
+    if (age > this.deduplicationWindowMs) {
+      this.recentSignals.delete(signal.deduplicationKey);
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Record signal for deduplication tracking
+   */
+  private recordSignal(signal: EscalationSignal): void {
+    this.recentSignals.set(signal.deduplicationKey, {
+      key: signal.deduplicationKey,
+      timestamp: Date.now(),
+    });
+    this.cleanupOldSignals();
+  }
+
+  /**
+   * Clean up expired signal entries
+   */
+  private cleanupOldSignals(): void {
+    const now = Date.now();
+    const keysToDelete: string[] = [];
+
+    for (const [key, entry] of this.recentSignals.entries()) {
+      if (now - entry.timestamp > this.deduplicationWindowMs) {
+        keysToDelete.push(key);
+      }
+    }
+
+    for (const key of keysToDelete) {
+      this.recentSignals.delete(key);
+    }
+  }
+
+  /**
+   * Check if channel is within rate limit
+   */
+  private checkRateLimit(channelName: string, rateLimit?: EscalationChannel['rateLimit']): boolean {
+    if (!rateLimit) return true;
+
+    const state = this.rateLimitState.get(channelName);
+    if (!state) return true;
+
+    const windowStart = Date.now() - rateLimit.windowMs;
+    state.timestamps = state.timestamps.filter((t) => t > windowStart);
+
+    return state.timestamps.length < rateLimit.maxSignals;
+  }
+
+  /**
+   * Record a send for rate limiting
+   */
+  private recordSend(channelName: string): void {
+    const state = this.rateLimitState.get(channelName);
+    if (state) {
+      state.timestamps.push(Date.now());
+    }
+  }
+
+  /**
+   * Add entry to audit log
+   */
+  private addToLog(entry: EscalationLogEntry): void {
+    this.signalLog.push(entry);
+    if (this.signalLog.length > this.MAX_LOG_ENTRIES) {
+      this.signalLog = this.signalLog.slice(-this.MAX_LOG_ENTRIES);
+    }
+  }
+
+  /**
+   * Get signal log (most recent first)
+   */
+  getLog(limit?: number): EscalationLogEntry[] {
+    const log = [...this.signalLog].reverse();
+    return limit ? log.slice(0, limit) : log;
+  }
+
+  /**
+   * Get router status
+   */
+  getStatus(): {
+    channelCount: number;
+    channels: Array<{
+      name: string;
+      rateLimit?: { maxSignals: number; windowMs: number };
+      recentSends: number;
+    }>;
+    recentSignalCount: number;
+    logEntryCount: number;
+  } {
+    const channels = Array.from(this.channels.values()).map((channel) => {
+      const state = this.rateLimitState.get(channel.name);
+      const windowMs = channel.rateLimit?.windowMs ?? 3600000;
+      const windowStart = Date.now() - windowMs;
+      const recentSends = state ? state.timestamps.filter((t) => t > windowStart).length : 0;
+
+      return {
+        name: channel.name,
+        rateLimit: channel.rateLimit,
+        recentSends,
+      };
+    });
+
+    return {
+      channelCount: this.channels.size,
+      channels,
+      recentSignalCount: this.recentSignals.size,
+      logEntryCount: this.signalLog.length,
+    };
+  }
+
+  /**
+   * Clear all state (for testing)
+   */
+  clear(): void {
+    this.signalLog = [];
+    this.recentSignals.clear();
+    for (const state of this.rateLimitState.values()) {
+      state.timestamps = [];
+    }
+  }
+}
+
+// Singleton instance
+let routerInstance: EscalationRouter | null = null;
+
+/**
+ * Get or create the singleton escalation router instance
+ */
+export function getEscalationRouter(): EscalationRouter {
+  if (!routerInstance) {
+    routerInstance = new EscalationRouter();
+    logger.info('EscalationRouter instance created');
+  }
+  return routerInstance;
+}


### PR DESCRIPTION
## Summary
- Add `EscalationRouter` service with pluggable channel registration via `canHandle()` pattern
- Signal deduplication within 30min window prevents alert spam
- Per-channel rate limiting (configurable maxSignals/windowMs per channel)
- Audit log with max 1000 entries for signal history
- Event-driven: listens for `escalation:signal-received`, emits `escalation:signal-routed`, `escalation:signal-sent`, `escalation:signal-failed`, `escalation:signal-deduplicated`
- REST API: `GET /api/escalation/status` and `GET /api/escalation/log`
- Imports shared types from `@automaker/types` (EscalationSignal, EscalationChannel, EscalationSeverity)
- Singleton pattern via `getEscalationRouter()`
- Wired into server index.ts with event emitter

Part of Escalation Pipeline project (M1: Escalation Router Core).

Depends on PR #395 (merged).

## Test plan
- [ ] Server builds with `npm run build:server`
- [ ] `/api/escalation/status` returns channel info
- [ ] `/api/escalation/log` returns audit entries
- [ ] Invalid `limit` param returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New escalation API endpoints to view escalation status and retrieve audit logs with adjustable history limits.
  * Added an escalation routing system with automatic deduplication (default 30-minute window), per-channel rate limiting, and comprehensive audit/event logging for escalation activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->