### PR TITLE
feat: add Discord DM escalation channel for emergency/critical alerts

### DIFF
--- a/apps/server/src/services/escalation-channels/discord-dm-channel.ts
+++ b/apps/server/src/services/escalation-channels/discord-dm-channel.ts
@@ -12,11 +12,7 @@
  * - Configurable recipient list
  */
 
-import type {
-  EscalationSignal,
-  EscalationChannel,
-  EscalationSeverity,
-} from '@automaker/types';
+import type { EscalationSignal, EscalationChannel, EscalationSeverity } from '@automaker/types';
 import { EscalationSeverity as Severity } from '@automaker/types';
 import { createLogger } from '@automaker/utils';
 import type { DiscordBotService } from '../discord-bot-service.js';
@@ -107,9 +103,7 @@ export class DiscordDMChannel implements EscalationChannel {
    * Only handles emergency and critical severity
    */
   canHandle(signal: EscalationSignal): boolean {
-    return (
-      signal.severity === Severity.emergency || signal.severity === Severity.critical
-    );
+    return signal.severity === Severity.emergency || signal.severity === Severity.critical;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Implements `DiscordDMChannel` as an `EscalationChannel` plugin for the EscalationRouter
- Sends DMs for emergency and critical severity signals to configurable recipients (default: chukz)
- Rate limited to 1 DM per 15min window (router-enforced)
- Rich message format with severity badges, source context, action URLs
- Acknowledgment infrastructure via reaction tracking (reaction events TBD)

## Files Changed
- `apps/server/src/services/escalation-channels/discord-dm-channel.ts` (new)

## Test plan
- [x] Unit tests: 6 tests covering severity filtering, message formatting, multi-recipient, error handling, config updates
- [ ] Integration: Wire up in `index.ts` and test with real Discord bot (separate feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord Direct Message escalation channel now available for sending notifications
  * Configurable recipient list with adjustable rate limiting (default 1 message per 15 minutes)
  * Rich message formatting with severity indicators and action links
  * Acknowledgment tracking for sent notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->