### PR TITLE
feat: add severity routing to PR feedback and merge blocking

### DIFF
--- a/apps/server/src/services/coderabbit-resolver-service.ts
+++ b/apps/server/src/services/coderabbit-resolver-service.ts
@@ -74,6 +74,8 @@ interface ReviewThread {
   };
   /** Whether this thread was created by a bot */
   isBot: boolean;
+  /** Severity level parsed from the comment (critical threads should not be auto-resolved) */
+  severity?: 'critical' | 'warning' | 'suggestion' | 'info';
 }
 
 /**
@@ -112,6 +114,28 @@ export class CodeRabbitResolverService {
   private isBotAccount(login: string): boolean {
     const lowerLogin = login.toLowerCase();
     return KNOWN_BOT_ACCOUNTS.some((bot) => lowerLogin.includes(bot.toLowerCase()));
+  }
+
+  /**
+   * Parse severity from comment body
+   * Looks for severity markers like **Severity**: critical or emoji indicators
+   */
+  private parseSeverity(body: string): 'critical' | 'warning' | 'suggestion' | 'info' {
+    // Extract severity from explicit marker
+    const severityMatch = body.match(/\*\*Severity\*\*:\s*(\w+)/i);
+    if (severityMatch) {
+      const sev = severityMatch[1].toLowerCase();
+      if (sev === 'critical' || sev === 'high') return 'critical';
+      if (sev === 'warning' || sev === 'medium') return 'warning';
+      if (sev === 'suggestion' || sev === 'low') return 'suggestion';
+    }
+
+    // Infer from emoji
+    if (body.includes('🚨')) return 'critical';
+    if (body.includes('⚠️')) return 'warning';
+    if (body.includes('💡')) return 'suggestion';
+
+    return 'info';
   }
 
   /**
@@ -167,6 +191,7 @@ export class CodeRabbitResolverService {
                       author {
                         login
                       }
+                      body
                     }
                   }
                 }
@@ -188,16 +213,24 @@ export class CodeRabbitResolverService {
         (thread: {
           id: string;
           isResolved: boolean;
-          comments: { nodes: Array<{ author: { login: string } }> };
+          comments: { nodes: Array<{ author: { login: string }; body?: string }> };
         }) => {
-          const author = thread.comments?.nodes?.[0]?.author;
+          const firstComment = thread.comments?.nodes?.[0];
+          const author = firstComment?.author;
           const isBot = author ? this.isBotAccount(author.login) : false;
+
+          // Parse severity from comment body
+          let severity: 'critical' | 'warning' | 'suggestion' | 'info' = 'info';
+          if (firstComment?.body) {
+            severity = this.parseSeverity(firstComment.body);
+          }
 
           return {
             id: thread.id,
             isResolved: thread.isResolved,
             author,
             isBot,
+            severity,
           };
         }
       );
@@ -395,39 +428,56 @@ export class CodeRabbitResolverService {
       const unresolvedBotThreads = threads.filter((thread) => !thread.isResolved && thread.isBot);
       const humanThreads = threads.filter((thread) => !thread.isBot);
 
-      logger.info(
-        `Found ${unresolvedBotThreads.length} unresolved bot threads and ${humanThreads.length} human threads`
+      // Filter out critical bot threads - they must NOT be auto-resolved
+      const criticalBotThreads = unresolvedBotThreads.filter(
+        (thread) => thread.severity === 'critical'
+      );
+      const resolvableBotThreads = unresolvedBotThreads.filter(
+        (thread) => thread.severity !== 'critical'
       );
 
-      if (unresolvedBotThreads.length === 0) {
+      logger.info(
+        `Found ${unresolvedBotThreads.length} unresolved bot threads ` +
+          `(${criticalBotThreads.length} critical, ${resolvableBotThreads.length} resolvable) ` +
+          `and ${humanThreads.length} human threads`
+      );
+
+      if (criticalBotThreads.length > 0) {
+        logger.warn(
+          `Skipping ${criticalBotThreads.length} critical bot threads that require manual review`
+        );
+      }
+
+      if (resolvableBotThreads.length === 0) {
         return {
           success: true,
           resolvedCount: 0,
-          skippedCount: humanThreads.length,
+          skippedCount: humanThreads.length + criticalBotThreads.length,
           totalThreads,
         };
       }
 
-      // Resolve bot threads
+      // Resolve non-critical bot threads only
       let resolvedCount = 0;
-      for (const thread of unresolvedBotThreads) {
+      for (const thread of resolvableBotThreads) {
         const resolved = await this.resolveThread(thread.id);
         if (resolved) {
           resolvedCount++;
           logger.debug(
-            `Resolved bot thread from ${thread.author?.login || 'unknown'}: ${thread.id}`
+            `Resolved ${thread.severity} bot thread from ${thread.author?.login || 'unknown'}: ${thread.id}`
           );
         }
       }
 
       logger.info(
-        `Resolved ${resolvedCount}/${unresolvedBotThreads.length} bot review threads for PR #${prNumber}`
+        `Resolved ${resolvedCount}/${resolvableBotThreads.length} resolvable bot review threads for PR #${prNumber} ` +
+          `(${criticalBotThreads.length} critical threads skipped)`
       );
 
       return {
         success: true,
         resolvedCount,
-        skippedCount: humanThreads.length,
+        skippedCount: humanThreads.length + criticalBotThreads.length,
         totalThreads,
       };
     } catch (error) {

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -387,12 +387,43 @@ export class GitWorkflowService {
               `Auto-merging PR #${result.prNumber} with strategy: ${mergeStrategy}, waitForCI: ${waitForCI}`
             );
 
-            // Step 5a: Resolve bot review threads before merge attempt
+            // Step 5a: Check for critical threads and resolve non-critical bot threads before merge
             // This runs after CI passes (checked by mergePR) but before the actual merge
-            // Only resolve threads if waitForCI is true (we're checking CI status)
+            // Only check/resolve threads if waitForCI is true (we're checking CI status)
             if (waitForCI) {
               try {
-                logger.info(`Resolving bot review threads for PR #${result.prNumber}`);
+                logger.info(`Checking review threads for PR #${result.prNumber}`);
+
+                // First check for critical threads that would block merge
+                const hasCriticalThreads = await this.checkForCriticalThreads(
+                  workDir,
+                  result.prNumber
+                );
+
+                if (hasCriticalThreads) {
+                  logger.warn(
+                    `PR #${result.prNumber} has unresolved critical review threads, blocking merge`
+                  );
+                  result.merged = false;
+                  const blockError = 'Merge blocked: unresolved critical review threads exist';
+                  result.error = result.error ? `${result.error}; ${blockError}` : blockError;
+
+                  // Emit event for monitoring
+                  if (events) {
+                    events.emit('pr:merge-blocked-critical-threads', {
+                      featureId,
+                      projectPath,
+                      prNumber: result.prNumber,
+                      prUrl: result.prUrl,
+                    });
+                  }
+
+                  // Don't attempt merge if critical threads exist
+                  return result;
+                }
+
+                // No critical threads - proceed with resolving non-critical bot threads
+                logger.info(`Resolving non-critical bot review threads for PR #${result.prNumber}`);
                 const resolveResult = await codeRabbitResolverService.resolveThreads(
                   workDir,
                   result.prNumber
@@ -411,8 +442,8 @@ export class GitWorkflowService {
               } catch (resolveError) {
                 const resolveErrorMsg =
                   resolveError instanceof Error ? resolveError.message : String(resolveError);
-                logger.warn(`Error resolving bot review threads: ${resolveErrorMsg}`);
-                // Continue with merge attempt even if thread resolution fails
+                logger.warn(`Error checking/resolving review threads: ${resolveErrorMsg}`);
+                // Continue with merge attempt even if thread check/resolution fails
               }
             }
 
@@ -477,6 +508,103 @@ export class GitWorkflowService {
       result.error = errorMsg;
       return result;
     }
+  }
+
+  /**
+   * Check if PR has unresolved critical review threads.
+   * Critical threads must be manually reviewed and block auto-merge.
+   *
+   * @param workDir - Working directory containing the repository
+   * @param prNumber - PR number to check
+   * @returns true if critical threads exist, false otherwise
+   */
+  private async checkForCriticalThreads(workDir: string, prNumber: number): Promise<boolean> {
+    try {
+      // Extract owner/repo from git remote
+      const { stdout: remoteOutput } = await execAsync('git remote get-url origin', {
+        cwd: workDir,
+        env: execEnv,
+      });
+
+      const remoteUrl = remoteOutput.trim();
+      const match =
+        remoteUrl.match(/github\.com[:/]([^/]+)\/([^/\s]+?)(?:\.git)?$/) ||
+        remoteUrl.match(/^([^/]+)\/([^/\s]+)$/);
+
+      if (!match) {
+        logger.warn(`Could not parse GitHub owner/repo from remote: ${remoteUrl}`);
+        return false;
+      }
+
+      const [, owner, repoName] = match;
+
+      // Query review threads using GraphQL
+      const query = `
+        query {
+          repository(owner: "${owner}", name: "${repoName}") {
+            pullRequest(number: ${prNumber}) {
+              reviewThreads(first: 100) {
+                nodes {
+                  id
+                  isResolved
+                  comments(first: 1) {
+                    nodes {
+                      body
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `;
+
+      const { stdout } = await execAsync(`gh api graphql -f query='${query.replace(/\n/g, ' ')}'`, {
+        cwd: workDir,
+        env: execEnv,
+      });
+
+      const data = JSON.parse(stdout);
+      const threads = data.data?.repository?.pullRequest?.reviewThreads?.nodes || [];
+
+      // Check for unresolved threads with critical severity
+      for (const thread of threads) {
+        if (thread.isResolved) continue;
+
+        const body = thread.comments?.nodes?.[0]?.body || '';
+        const severity = this.parseSeverityFromBody(body);
+
+        if (severity === 'critical') {
+          logger.warn(`Found unresolved critical thread: ${thread.id}`);
+          return true;
+        }
+      }
+
+      return false;
+    } catch (error) {
+      logger.error(`Failed to check for critical threads on PR #${prNumber}:`, error);
+      // On error, don't block merge - assume no critical threads
+      return false;
+    }
+  }
+
+  /**
+   * Parse severity from comment body (same logic as codeRabbitResolverService)
+   */
+  private parseSeverityFromBody(body: string): 'critical' | 'warning' | 'suggestion' | 'info' {
+    const severityMatch = body.match(/\*\*Severity\*\*:\s*(\w+)/i);
+    if (severityMatch) {
+      const sev = severityMatch[1].toLowerCase();
+      if (sev === 'critical' || sev === 'high') return 'critical';
+      if (sev === 'warning' || sev === 'medium') return 'warning';
+      if (sev === 'suggestion' || sev === 'low') return 'suggestion';
+    }
+
+    if (body.includes('🚨')) return 'critical';
+    if (body.includes('⚠️')) return 'warning';
+    if (body.includes('💡')) return 'suggestion';
+
+    return 'info';
   }
 
   /**

--- a/apps/server/src/services/pr-feedback-service.ts
+++ b/apps/server/src/services/pr-feedback-service.ts
@@ -26,6 +26,7 @@ import type {
   FeedbackThreadDecision,
   PendingFeedback,
 } from '@automaker/types';
+import { EscalationSeverity, EscalationSource } from '@automaker/types';
 import { codeRabbitParserService } from './coderabbit-parser-service.js';
 import { codeRabbitResolverService } from './coderabbit-resolver-service.js';
 
@@ -648,6 +649,9 @@ export class PRFeedbackService {
               // Fetch review threads for structured remediation prompt
               const threads = await this.fetchReviewThreads(pr);
 
+              // Classify threads by severity and emit escalation signals for critical/warning findings
+              this.classifyAndEmitEscalations(threads, pr, featureId);
+
               // Build the remediation prompt with structured evaluation instructions
               const continuationPrompt = await this.buildRemediationPrompt(
                 threads,
@@ -831,6 +835,10 @@ export class PRFeedbackService {
               );
 
               try {
+                // Fetch threads to classify severity and emit escalations
+                const threads = await this.fetchReviewThreads(pr);
+                this.classifyAndEmitEscalations(threads, pr, featureId);
+
                 const continuationPrompt = await this.buildFeedbackPrompt(
                   feedbackSummary,
                   pr.prNumber,
@@ -2055,6 +2063,88 @@ This is CI fix iteration ${iteration}.`;
     } catch (error) {
       logger.error(`Failed to process thread feedback for PR #${prNumber}:`, error);
     }
+  }
+
+  /**
+   * Classify threads by severity and emit EscalationSignal for critical/warning findings.
+   * This routes critical feedback to the EscalationRouter for appropriate handling.
+   *
+   * @param threads - The review threads to classify
+   * @param pr - The tracked PR
+   * @param featureId - The feature ID
+   */
+  private classifyAndEmitEscalations(
+    threads: ThreadFeedbackItem[],
+    pr: TrackedPR,
+    featureId: string
+  ): void {
+    const criticalThreads = threads.filter((t) => t.severity === 'critical');
+    const warningThreads = threads.filter((t) => t.severity === 'warning');
+
+    // Emit escalation signal for critical findings
+    if (criticalThreads.length > 0) {
+      logger.warn(
+        `PR #${pr.prNumber} has ${criticalThreads.length} critical findings, emitting escalation signal`
+      );
+
+      this.events.emit('escalation:signal-received', {
+        source: EscalationSource.pr_feedback,
+        severity: EscalationSeverity.critical,
+        type: 'pr_critical_feedback',
+        context: {
+          featureId,
+          prNumber: pr.prNumber,
+          prUrl: pr.prUrl,
+          projectPath: pr.projectPath,
+          criticalCount: criticalThreads.length,
+          criticalThreads: criticalThreads.map((t) => ({
+            threadId: t.threadId,
+            message: t.message,
+            location: t.location,
+            isBot: t.isBot,
+          })),
+          iterationCount: pr.iterationCount,
+        },
+        deduplicationKey: `pr_critical_${pr.prNumber}_${pr.iterationCount}`,
+        timestamp: new Date().toISOString(),
+      });
+    }
+
+    // Emit escalation signal for warning findings (lower severity)
+    if (warningThreads.length > 0) {
+      logger.info(
+        `PR #${pr.prNumber} has ${warningThreads.length} warning findings, emitting escalation signal`
+      );
+
+      this.events.emit('escalation:signal-received', {
+        source: EscalationSource.pr_feedback,
+        severity: EscalationSeverity.high,
+        type: 'pr_warning_feedback',
+        context: {
+          featureId,
+          prNumber: pr.prNumber,
+          prUrl: pr.prUrl,
+          projectPath: pr.projectPath,
+          warningCount: warningThreads.length,
+          warningThreads: warningThreads.map((t) => ({
+            threadId: t.threadId,
+            message: t.message,
+            location: t.location,
+            isBot: t.isBot,
+          })),
+          iterationCount: pr.iterationCount,
+        },
+        deduplicationKey: `pr_warning_${pr.prNumber}_${pr.iterationCount}`,
+        timestamp: new Date().toISOString(),
+      });
+    }
+
+    logger.info(
+      `Severity classification for PR #${pr.prNumber}: ` +
+        `${criticalThreads.length} critical, ${warningThreads.length} warning, ` +
+        `${threads.filter((t) => t.severity === 'suggestion').length} suggestion, ` +
+        `${threads.filter((t) => t.severity === 'info').length} info`
+    );
   }
 
   /**

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -210,6 +210,7 @@ export type EventType =
   | 'pr:remediation-failed' // Fired when PR remediation workflow fails
   | 'pr:thread-evaluated' // Fired when a single PR review thread is evaluated for resolution status
   | 'pr:threads-resolved' // Fired when all PR review threads are marked as resolved
+  | 'pr:merge-blocked-critical-threads' // Fired when merge is blocked due to critical review threads
   // Worktree recovery events
   | 'worktree:drift-detected'
   | 'worktree:phantom-pruned'


### PR DESCRIPTION
## Summary
- PRFeedbackService now classifies thread severity and emits EscalationSignals for critical/warning findings
- CodeRabbitResolverService skips auto-resolution of critical bot threads
- GitWorkflowService blocks merge when unresolved critical threads exist
- Added `pr:merge-blocked-critical-threads` event type

## Test plan
- [ ] Critical findings emit escalation signals to registered channels
- [ ] Bot threads with critical severity are preserved (not auto-resolved)
- [ ] Merge blocked when critical threads exist
- [ ] Warning findings enter normal remediation path
- [ ] Existing happy path (no critical threads) works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added severity classification for review threads (critical, warning, suggestion, info).
  * Critical review threads now block automatic merge and resolution processes, requiring manual attention.
  * System emits alerts when merges are prevented due to unresolved critical threads.
  * Enhanced escalation tracking to notify on critical and warning-level review feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->