### PR TITLE
feat: add Linear comment webhook handler for HITL deepening

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -480,6 +480,22 @@ linearApprovalHandler.initialize(settingsService, events);
 const approvalBridge = new LinearApprovalBridge(events, featureLoader);
 approvalBridge.start();
 
+// Listen for Linear comment follow-up events and route to agent
+events.subscribe((type, payload) => {
+  if (type === 'linear:comment:followup') {
+    const { featureId, projectPath, commentBody, userName } = payload as any;
+    logger.info(`Routing Linear comment to agent for feature ${featureId}`, {
+      userName,
+    });
+
+    autoModeService
+      .followUpFeature(projectPath, featureId, commentBody, undefined, true)
+      .catch((error) => {
+        logger.error(`Failed to send Linear comment to agent for feature ${featureId}:`, error);
+      });
+  }
+});
+
 // Initialize PR Feedback Service (monitors open PRs for review comments)
 const prFeedbackService = new PRFeedbackService(events, featureLoader);
 // Wire up AutoModeService for automatic agent restart on PR feedback

--- a/apps/server/src/routes/linear/webhook.ts
+++ b/apps/server/src/routes/linear/webhook.ts
@@ -24,7 +24,7 @@ const logger = createLogger('linear:webhook');
 
 /** Linear webhook event types we handle */
 type LinearWebhookAction = 'create' | 'update' | 'remove';
-type LinearWebhookType = 'AgentSession' | 'Issue' | 'Project';
+type LinearWebhookType = 'AgentSession' | 'Issue' | 'Project' | 'Comment';
 
 /** Agent session trigger types */
 type AgentSessionTrigger = 'mention' | 'delegation' | 'prompt';
@@ -122,6 +122,27 @@ interface LinearProjectWebhookPayload extends LinearWebhookPayload {
   };
 }
 
+/** Linear Comment webhook payload */
+interface LinearCommentWebhookPayload extends LinearWebhookPayload {
+  type: 'Comment';
+  data: {
+    id: string;
+    /** Comment body (markdown) */
+    body: string;
+    /** The issue this comment is on */
+    issueId?: string;
+    /** The user who created the comment */
+    user?: {
+      id: string;
+      name: string;
+      email?: string;
+    };
+    /** Timestamps */
+    createdAt: string;
+    updatedAt: string;
+  };
+}
+
 /**
  * Verify webhook signature from Linear
  */
@@ -160,7 +181,8 @@ export function createWebhookHandler(
     const payload = req.body as
       | LinearAgentSessionPayload
       | LinearIssueWebhookPayload
-      | LinearProjectWebhookPayload;
+      | LinearProjectWebhookPayload
+      | LinearCommentWebhookPayload;
 
     // Must respond within 5 seconds (Linear requirement)
     // Acknowledge immediately, process async
@@ -181,7 +203,11 @@ export function createWebhookHandler(
 }
 
 async function processWebhookEvent(
-  payload: LinearAgentSessionPayload | LinearIssueWebhookPayload | LinearProjectWebhookPayload,
+  payload:
+    | LinearAgentSessionPayload
+    | LinearIssueWebhookPayload
+    | LinearProjectWebhookPayload
+    | LinearCommentWebhookPayload,
   settingsService: SettingsService,
   events: EventEmitter,
   featureLoader: FeatureLoader
@@ -202,6 +228,9 @@ async function processWebhookEvent(
       break;
     case 'Project':
       await handleProjectEvent(payload as LinearProjectWebhookPayload, action, events);
+      break;
+    case 'Comment':
+      await handleCommentEvent(payload as LinearCommentWebhookPayload, action, events);
       break;
     default:
       logger.debug(`Unhandled event type: ${type}`);
@@ -419,5 +448,56 @@ async function handleSessionUpdated(
     issueId: data.issueId,
     prompt: data.prompt,
     status: data.status,
+  });
+}
+
+/**
+ * Handle Comment webhook events
+ */
+async function handleCommentEvent(
+  payload: LinearCommentWebhookPayload,
+  action: LinearWebhookAction,
+  events: EventEmitter
+): Promise<void> {
+  const { data } = payload;
+
+  switch (action) {
+    case 'create':
+      await handleCommentCreated(data, events);
+      break;
+    case 'update':
+      logger.debug(`Comment updated: ${data.id}`);
+      // Future: handle comment updates if needed
+      break;
+    case 'remove':
+      logger.debug(`Comment removed: ${data.id}`);
+      // Future: handle comment removal if needed
+      break;
+    default:
+      logger.debug(`Unhandled action: ${action}`);
+  }
+}
+
+/**
+ * Handle new comment creation
+ * Routes comment to LinearSyncService for parsing and routing
+ */
+async function handleCommentCreated(
+  data: LinearCommentWebhookPayload['data'],
+  events: EventEmitter
+): Promise<void> {
+  logger.info(`Comment created: ${data.id}`, {
+    issueId: data.issueId,
+    userName: data.user?.name,
+    bodyPreview: data.body?.substring(0, 100),
+  });
+
+  // Emit comment event for LinearSyncService to handle
+  events.emit('linear:comment:created', {
+    commentId: data.id,
+    issueId: data.issueId,
+    body: data.body,
+    user: data.user,
+    createdAt: data.createdAt,
   });
 }

--- a/apps/server/src/services/linear-sync-service.ts
+++ b/apps/server/src/services/linear-sync-service.ts
@@ -93,6 +93,21 @@ interface ProjectScaffoldedPayload {
 }
 
 /**
+ * Comment created event payload structure
+ */
+interface CommentCreatedPayload {
+  commentId: string;
+  issueId?: string;
+  body: string;
+  user?: {
+    id: string;
+    name: string;
+    email?: string;
+  };
+  createdAt: string;
+}
+
+/**
  * Debounce time window in milliseconds (5 seconds)
  */
 const DEBOUNCE_WINDOW_MS = 5000;
@@ -183,6 +198,8 @@ export class LinearSyncService {
         this.handleFeaturePRMerged(payload as FeatureEventPayload);
       } else if (type === 'project:scaffolded') {
         this.handleProjectScaffolded(payload as ProjectScaffoldedPayload);
+      } else if (type === 'linear:comment:created') {
+        this.handleCommentCreated(payload as CommentCreatedPayload);
       }
     });
 
@@ -1546,6 +1563,160 @@ export class LinearSyncService {
    */
   protected unmarkSyncing(featureId: string): void {
     this.syncingFeatures.delete(featureId);
+  }
+
+  /**
+   * Handle comment:created events
+   */
+  private async handleCommentCreated(payload: CommentCreatedPayload): Promise<void> {
+    logger.debug('Received linear:comment:created event', {
+      commentId: payload.commentId,
+      issueId: payload.issueId,
+      userName: payload.user?.name,
+    });
+
+    // Call the async implementation
+    await this.onCommentCreated(payload);
+  }
+
+  /**
+   * Handle Linear comment creation
+   * Parses comment and routes it based on content:
+   * 1. Reply to agent elicitation -> forward to running agent
+   * 2. New instructions -> update feature description
+   * 3. Approval language -> trigger approval bridge
+   *
+   * @param payload - Comment creation payload
+   */
+  private async onCommentCreated(payload: CommentCreatedPayload): Promise<void> {
+    const { commentId, issueId, body, user } = payload;
+
+    if (!issueId) {
+      logger.debug(`Comment ${commentId} has no issueId, skipping`);
+      return;
+    }
+
+    if (!this.running) {
+      logger.debug(`Sync service not running, skipping comment ${commentId}`);
+      return;
+    }
+
+    if (!this.featureLoader) {
+      logger.error('FeatureLoader not initialized');
+      return;
+    }
+
+    try {
+      // Find the feature associated with this Linear issue
+      // We need to search across all projects since we don't have projectPath in the webhook
+      // For now, we'll use process.cwd() as the project path
+      const projectPath = process.cwd();
+      const feature = await this.featureLoader.findByLinearIssueId(projectPath, issueId);
+
+      if (!feature) {
+        logger.debug(`No feature found for Linear issue ${issueId}, skipping comment routing`);
+        return;
+      }
+
+      logger.info(`Processing comment for feature ${feature.id}`, {
+        commentId,
+        issueId,
+        userName: user?.name,
+      });
+
+      // Parse comment to determine routing
+      const commentLower = body.toLowerCase().trim();
+
+      // Check for approval language
+      if (this.isApprovalComment(commentLower)) {
+        logger.info(`Approval comment detected on issue ${issueId}`);
+        // Emit approval event for approval bridge to handle
+        if (this.emitter) {
+          this.emitter.emit('linear:approval:detected', {
+            issueId,
+            title: feature.title,
+            description: feature.description,
+            approvalState: 'Comment Approval',
+            detectedAt: new Date().toISOString(),
+          });
+        }
+        return;
+      }
+
+      // Check for new instructions (contains action words)
+      if (this.isInstructionComment(commentLower)) {
+        logger.info(`Instruction comment detected for feature ${feature.id}`);
+        // Update feature description with new instructions
+        const updatedDescription = `${feature.description}\n\n---\n\n**Additional Instructions from ${user?.name || 'Linear'}:**\n${body}`;
+        await this.featureLoader.update(projectPath, feature.id, {
+          description: updatedDescription,
+        });
+
+        // Emit event for potential signal creation
+        if (this.emitter) {
+          this.emitter.emit('linear:comment:instruction', {
+            featureId: feature.id,
+            issueId,
+            commentBody: body,
+            userName: user?.name,
+          });
+        }
+        return;
+      }
+
+      // Default: treat as agent follow-up reply
+      logger.info(`Treating comment as agent follow-up for feature ${feature.id}`);
+      if (this.emitter) {
+        this.emitter.emit('linear:comment:followup', {
+          featureId: feature.id,
+          projectPath,
+          commentBody: body,
+          userName: user?.name,
+          issueId,
+        });
+      }
+    } catch (error) {
+      logger.error(`Failed to process comment ${commentId}:`, error);
+    }
+  }
+
+  /**
+   * Check if comment contains approval language
+   */
+  private isApprovalComment(commentLower: string): boolean {
+    const approvalKeywords = [
+      'approve',
+      'approved',
+      'looks good',
+      'lgtm',
+      'ship it',
+      'go ahead',
+      'proceed',
+      'green light',
+    ];
+    return approvalKeywords.some((keyword) => commentLower.includes(keyword));
+  }
+
+  /**
+   * Check if comment contains instruction language
+   */
+  private isInstructionComment(commentLower: string): boolean {
+    const instructionKeywords = [
+      'please',
+      'can you',
+      'could you',
+      'make sure',
+      'also',
+      'additionally',
+      'instead',
+      'change',
+      'update',
+      'modify',
+      'add',
+      'remove',
+      'fix',
+    ];
+    return instructionKeywords.some((keyword) => commentLower.includes(keyword));
   }
 
   /**

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -147,6 +147,10 @@ export type EventType =
   | 'linear:agent-session:created'
   | 'linear:agent-session:updated'
   | 'linear:agent-session:removed'
+  // Linear comment events (webhook-driven)
+  | 'linear:comment:created'
+  | 'linear:comment:instruction'
+  | 'linear:comment:followup'
   // GitHub monitoring events
   | 'github:pr:detected'
   // Linear monitor events


### PR DESCRIPTION
## Summary
- Handle Comment webhook events in the Linear webhook route
- Parse human comments on linked Linear issues and route back to Automaker
- Forward agent replies to running agents via `send_message_to_agent`
- Detect new instructions and update feature descriptions
- Detect approval language and trigger the approval bridge
- Enables bidirectional agent-human dialogue through Linear

## Test plan
- [ ] Comment webhooks properly processed and routed
- [ ] Human replies forwarded to running agents
- [ ] New instructions update feature descriptions
- [ ] Approval language triggers approval bridge
- [ ] Non-linked comments gracefully ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)