### PR TITLE
fix: add CodeRabbit config and make template tests resilient

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,13 @@
+# CodeRabbit configuration
+# https://docs.coderabbit.ai/configuration
+reviews:
+  # Don't review operational data files — they generate noise threads
+  # that block PR merges via required_review_thread_resolution
+  path_filters:
+    - '!.beads/**'
+    - '!.automaker/memory/**'
+    - '!.automaker/projects/**'
+    - '!data/**'
+  auto_review:
+    enabled: true
+    drafts: false

--- a/apps/server/tests/integration/services/agent-template-flow.test.ts
+++ b/apps/server/tests/integration/services/agent-template-flow.test.ts
@@ -52,11 +52,11 @@ describe('Agent Template Flow (integration)', () => {
       expect(config.trustLevel).toBe(3);
     });
 
-    it('creates config for all 12 built-in templates without errors', () => {
-      registerBuiltInTemplates(registry);
+    it('creates config for all built-in templates without errors', () => {
+      const count = registerBuiltInTemplates(registry);
       const templates = registry.list();
 
-      expect(templates).toHaveLength(12);
+      expect(templates).toHaveLength(count);
 
       for (const template of templates) {
         const config = factory.createFromTemplate(template.name, '/test/project');
@@ -162,7 +162,7 @@ describe('Agent Template Flow (integration)', () => {
 
   describe('mixed built-in and custom', () => {
     it('built-in and custom templates coexist', () => {
-      registerBuiltInTemplates(registry);
+      const builtInCount = registerBuiltInTemplates(registry);
 
       const custom: AgentTemplate = {
         name: 'data-analyst',
@@ -177,8 +177,8 @@ describe('Agent Template Flow (integration)', () => {
 
       registry.register(custom);
 
-      // Total should be 13 (12 built-in + 1 custom)
-      expect(registry.size).toBe(13);
+      // Total should be built-in + 1 custom
+      expect(registry.size).toBe(builtInCount + 1);
 
       // Both resolve correctly
       const builtIn = factory.createFromTemplate('backend-engineer', '/test/project');

--- a/apps/server/tests/unit/services/built-in-templates.test.ts
+++ b/apps/server/tests/unit/services/built-in-templates.test.ts
@@ -11,10 +11,11 @@ describe('registerBuiltInTemplates', () => {
     registry = new RoleRegistryService(events);
   });
 
-  it('registers all 12 built-in templates', () => {
+  it('registers all built-in templates', () => {
     const count = registerBuiltInTemplates(registry);
-    expect(count).toBe(12);
-    expect(registry.size).toBe(12);
+    // Use dynamic count — adding a team member shouldn't break tests
+    expect(count).toBeGreaterThanOrEqual(12);
+    expect(registry.size).toBe(count);
   });
 
   it('registers templates as tier 0 (protected)', () => {
@@ -93,10 +94,10 @@ describe('registerBuiltInTemplates', () => {
   });
 
   it('is idempotent — calling twice does not duplicate', () => {
+    const count1 = registerBuiltInTemplates(registry);
     registerBuiltInTemplates(registry);
-    const count2 = registerBuiltInTemplates(registry);
-    // Second call may succeed (overwrite) or fail, but total should still be 12
-    expect(registry.size).toBe(12);
+    // Second call may succeed (overwrite) or fail, but total should stay the same
+    expect(registry.size).toBe(count1);
   });
 
   it('ava has systemPrompt for Discord routing', () => {


### PR DESCRIPTION
## Summary
- Add `.coderabbit.yaml` excluding operational files (`.beads/`, `.automaker/memory/`, `.automaker/projects/`) from review — these generated noise threads that blocked PR #400 for 30+ minutes
- Replace hardcoded template count assertions (`toBe(12)`) with dynamic checks — adding a team member no longer breaks 4 tests

## Context
Sprint retro identified two process bottlenecks:
1. CodeRabbit reviewing operational data files creates threads that must be resolved before merge (ruleset: `required_review_thread_resolution: true`), and each branch update triggers re-review with new threads
2. Template tests used magic numbers that broke whenever a new agent was added to `built-in-templates.ts`

## Test plan
- [x] All 26 template tests pass locally
- [ ] CI passes (build, test, format, audit)
- [ ] Verify CodeRabbit does NOT review `.beads/` or `.automaker/` files on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)