### PR TITLE
feat: add metrics-driven project impact report

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -455,7 +455,7 @@ linearSyncService.start();
 
 // Initialize Ceremony Service for milestone completion ceremonies
 const { ceremonyService } = await import('./services/ceremony-service.js');
-ceremonyService.initialize(events, settingsService, featureLoader, projectService);
+ceremonyService.initialize(events, settingsService, featureLoader, projectService, metricsService);
 
 // Initialize Completion Detector Service — cascades feature done → epic → milestone → project
 const completionDetectorService = new CompletionDetectorService();

--- a/apps/server/src/routes/metrics/index.ts
+++ b/apps/server/src/routes/metrics/index.ts
@@ -66,19 +66,33 @@ export function createMetricsRoutes(metricsService: MetricsService): Router {
         };
         const multiplier = multipliers[complexity] ?? 1.0;
 
-        // Estimate cost per feature from historical data
-        const avgCostPerFeature =
-          metrics.completedFeatures > 0 ? metrics.totalCostUsd / metrics.completedFeatures : 0;
-
         res.json({
           success: true,
           complexity,
           estimatedDurationMs: Math.round(metrics.avgCycleTimeMs * multiplier),
           estimatedAgentTimeMs: Math.round(metrics.avgAgentTimeMs * multiplier),
-          estimatedCostUsd: Number((avgCostPerFeature * multiplier).toFixed(4)),
+          estimatedCostUsd: Number((metrics.costPerFeature * multiplier).toFixed(4)),
           basedOnFeatures: metrics.completedFeatures,
           multiplier,
         });
+      } catch (err) {
+        res.status(500).json({ success: false, error: (err as Error).message });
+      }
+    }
+  );
+
+  /**
+   * POST /impact-report - Generate Project Impact Report with historical comparison
+   * Returns markdown report with cost, time, quality metrics and comparison to historical averages
+   */
+  router.post(
+    '/impact-report',
+    validatePathParams('projectPath'),
+    async (req: Request, res: Response) => {
+      try {
+        const { projectPath, historicalBaseline } = req.body;
+        const report = await metricsService.generateImpactReport(projectPath, historicalBaseline);
+        res.json({ success: true, report });
       } catch (err) {
         res.status(500).json({ success: false, error: (err as Error).message });
       }

--- a/apps/server/src/services/ceremony-service.ts
+++ b/apps/server/src/services/ceremony-service.ts
@@ -12,6 +12,7 @@ import type { EventEmitter } from '../lib/events.js';
 import type { SettingsService } from './settings-service.js';
 import type { FeatureLoader } from './feature-loader.js';
 import type { ProjectService } from './project-service.js';
+import type { MetricsService } from './metrics-service.js';
 import type { Feature, CeremonySettings } from '@automaker/types';
 import { simpleQuery } from '../providers/simple-query-service.js';
 
@@ -81,6 +82,7 @@ export class CeremonyService {
   private settingsService: SettingsService | null = null;
   private featureLoader: FeatureLoader | null = null;
   private projectService: ProjectService | null = null;
+  private metricsService: MetricsService | null = null;
   private unsubscribe: (() => void) | null = null;
 
   /**
@@ -90,12 +92,14 @@ export class CeremonyService {
     emitter: EventEmitter,
     settingsService: SettingsService,
     featureLoader: FeatureLoader,
-    projectService: ProjectService
+    projectService: ProjectService,
+    metricsService: MetricsService
   ): void {
     this.emitter = emitter;
     this.settingsService = settingsService;
     this.featureLoader = featureLoader;
     this.projectService = projectService;
+    this.metricsService = metricsService;
 
     // Subscribe to epic, milestone, and project lifecycle events
     this.unsubscribe = emitter.subscribe((type, payload) => {
@@ -151,6 +155,7 @@ export class CeremonyService {
     this.settingsService = null;
     this.featureLoader = null;
     this.projectService = null;
+    this.metricsService = null;
   }
 
   /**
@@ -402,8 +407,22 @@ ${dataSummary}`;
       });
       const retrospective = result.text;
 
-      // Format the retrospective with header
-      const formattedRetro = `🎉 **${projectTitle}** — Project Complete!\n\n${retrospective}`;
+      // Generate Project Impact Report
+      let impactReport = '';
+      if (this.metricsService) {
+        try {
+          impactReport = await this.metricsService.generateImpactReport(projectPath);
+        } catch (error) {
+          logger.error('Failed to generate impact report:', error);
+        }
+      }
+
+      // Format the retrospective with header and impact report
+      let formattedRetro = `🎉 **${projectTitle}** — Project Complete!\n\n${retrospective}`;
+
+      if (impactReport) {
+        formattedRetro += `\n\n---\n\n${impactReport}`;
+      }
 
       // Split into chunks if needed (Discord limit: 2000 chars)
       const messages = this.splitMessage(formattedRetro, 2000);
@@ -418,7 +437,7 @@ ${dataSummary}`;
         );
       }
 
-      logger.info(`Posted project retrospective for ${projectTitle}`);
+      logger.info(`Posted project retrospective with impact report for ${projectTitle}`);
     } catch (error) {
       logger.error('Failed to generate project retrospective:', error);
     }

--- a/apps/server/src/services/metrics-service.ts
+++ b/apps/server/src/services/metrics-service.ts
@@ -32,10 +32,19 @@ export interface ProjectMetrics {
   // Cost metrics
   totalCostUsd: number; // Total cost across all features
   costByModel: Record<string, number>; // Cost breakdown by model
+  costPerFeature: number; // Average cost per completed feature
 
   // Performance metrics
   successRate: number; // Percentage of features that succeeded (0-100)
+  failureRate: number; // Percentage of features that failed (0-100)
   throughputPerDay: number; // Average features completed per day
+
+  // Quality metrics
+  escalationCount: number; // Total number of escalations
+  escalationRate: number; // Percentage of features escalated (0-100)
+
+  // Model distribution (percentage of usage per model)
+  modelDistribution: Record<string, number>; // Percentage by model
 
   // Token usage (aggregated from SDK if available)
   tokenUsage: {
@@ -97,6 +106,7 @@ export class MetricsService {
     let prReviewTimeCount = 0;
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
+    let escalationCount = 0;
     let periodStart: string | undefined;
     let periodEnd: string | undefined;
 
@@ -127,6 +137,12 @@ export class MetricsService {
       // Count failures from executionHistory (blocked is temporary, not a failure)
       if (feature.executionHistory?.some((exec) => !exec.success)) {
         failedCount++;
+      }
+
+      // Track escalations - count features that have failureCount > 0
+      // This indicates the feature required escalation (model upgrade or manual intervention)
+      if (feature.failureCount && feature.failureCount > 0) {
+        escalationCount++;
       }
 
       // Calculate cycle time (createdAt to completedAt)
@@ -168,9 +184,24 @@ export class MetricsService {
     const avgAgentTimeMs = agentTimeCount > 0 ? totalAgentTimeMs / agentTimeCount : 0;
     const avgPrReviewTimeMs = prReviewTimeCount > 0 ? totalPrReviewTimeMs / prReviewTimeCount : 0;
 
-    // Calculate success rate
+    // Calculate cost per feature
+    const costPerFeature = completedCount > 0 ? totalCostUsd / completedCount : 0;
+
+    // Calculate success and failure rates
     const totalAttempted = completedCount + failedCount;
     const successRate = totalAttempted > 0 ? (completedCount / totalAttempted) * 100 : 0;
+    const failureRate = totalAttempted > 0 ? (failedCount / totalAttempted) * 100 : 0;
+
+    // Calculate escalation rate
+    const escalationRate = features.length > 0 ? (escalationCount / features.length) * 100 : 0;
+
+    // Calculate model distribution (percentage of total cost)
+    const modelDistribution: Record<string, number> = {};
+    if (totalCostUsd > 0) {
+      for (const [model, cost] of Object.entries(costByModel)) {
+        modelDistribution[model] = (cost / totalCostUsd) * 100;
+      }
+    }
 
     // Calculate throughput (features per day)
     let throughputPerDay = 0;
@@ -186,8 +217,13 @@ export class MetricsService {
       avgPrReviewTimeMs,
       totalCostUsd,
       costByModel,
+      costPerFeature,
       successRate,
+      failureRate,
       throughputPerDay,
+      escalationCount,
+      escalationRate,
+      modelDistribution,
       tokenUsage: {
         totalInputTokens,
         totalOutputTokens,
@@ -265,5 +301,305 @@ export class MetricsService {
       return new Date(feature.completedAt).getTime();
     }
     return null;
+  }
+
+  /**
+   * Generate Project Impact Report with historical comparison
+   * Returns a markdown-formatted report with cost, time, quality metrics
+   * and comparison to historical baseline if provided
+   */
+  async generateImpactReport(
+    projectPath: string,
+    historicalBaseline?: ProjectMetrics
+  ): Promise<string> {
+    const currentMetrics = await this.getProjectMetrics(projectPath);
+    const lines: string[] = [];
+
+    // Header
+    lines.push('# Project Impact Report');
+    lines.push('');
+    lines.push(`Generated: ${new Date().toISOString()}`);
+    lines.push('');
+
+    // Executive Summary
+    lines.push('## Executive Summary');
+    lines.push('');
+    lines.push(`- **Total Features:** ${currentMetrics.totalFeatures}`);
+    lines.push(`- **Completed:** ${currentMetrics.completedFeatures}`);
+    lines.push(`- **Failed:** ${currentMetrics.failedFeatures}`);
+    lines.push(`- **In Progress:** ${currentMetrics.inProgressFeatures}`);
+    lines.push(`- **Success Rate:** ${currentMetrics.successRate.toFixed(1)}%`);
+    lines.push('');
+
+    // Cost Analysis
+    lines.push('## Cost Analysis');
+    lines.push('');
+    lines.push(`- **Total Cost:** $${currentMetrics.totalCostUsd.toFixed(2)}`);
+    lines.push(`- **Cost per Feature:** $${currentMetrics.costPerFeature.toFixed(2)}`);
+    lines.push('');
+
+    // Cost by Model
+    if (Object.keys(currentMetrics.costByModel).length > 0) {
+      lines.push('### Cost Breakdown by Model');
+      lines.push('');
+      for (const [model, cost] of Object.entries(currentMetrics.costByModel)) {
+        const percentage = currentMetrics.modelDistribution[model] || 0;
+        lines.push(`- **${model}:** $${cost.toFixed(2)} (${percentage.toFixed(1)}%)`);
+      }
+      lines.push('');
+    }
+
+    // Time Analysis
+    lines.push('## Time Analysis');
+    lines.push('');
+    lines.push(`- **Average Cycle Time:** ${this.formatDuration(currentMetrics.avgCycleTimeMs)}`);
+    lines.push(`- **Average Agent Time:** ${this.formatDuration(currentMetrics.avgAgentTimeMs)}`);
+    lines.push(
+      `- **Average PR Review Time:** ${this.formatDuration(currentMetrics.avgPrReviewTimeMs)}`
+    );
+    lines.push(`- **Throughput:** ${currentMetrics.throughputPerDay.toFixed(2)} features/day`);
+    lines.push('');
+
+    // Quality Metrics
+    lines.push('## Quality Metrics');
+    lines.push('');
+    lines.push(`- **Success Rate:** ${currentMetrics.successRate.toFixed(1)}%`);
+    lines.push(`- **Failure Rate:** ${currentMetrics.failureRate.toFixed(1)}%`);
+    lines.push(`- **Escalation Count:** ${currentMetrics.escalationCount}`);
+    lines.push(`- **Escalation Rate:** ${currentMetrics.escalationRate.toFixed(1)}%`);
+    lines.push('');
+
+    // Model Distribution
+    if (Object.keys(currentMetrics.modelDistribution).length > 0) {
+      lines.push('## Agent Model Distribution');
+      lines.push('');
+      for (const [model, percentage] of Object.entries(currentMetrics.modelDistribution)) {
+        lines.push(`- **${model}:** ${percentage.toFixed(1)}%`);
+      }
+      lines.push('');
+    }
+
+    // Historical Comparison
+    if (historicalBaseline) {
+      lines.push('## Historical Comparison');
+      lines.push('');
+
+      // Cost comparison
+      const costDiff = currentMetrics.costPerFeature - historicalBaseline.costPerFeature;
+      const costChange =
+        historicalBaseline.costPerFeature > 0
+          ? ((costDiff / historicalBaseline.costPerFeature) * 100).toFixed(1)
+          : 'N/A';
+      const costTrend = costDiff > 0 ? '📈' : costDiff < 0 ? '📉' : '➡️';
+      lines.push(
+        `- **Cost per Feature:** ${costTrend} ${costChange !== 'N/A' ? `${costChange}%` : costChange} ` +
+          `($${historicalBaseline.costPerFeature.toFixed(2)} → $${currentMetrics.costPerFeature.toFixed(2)})`
+      );
+
+      // Cycle time comparison
+      const cycleTimeDiff = currentMetrics.avgCycleTimeMs - historicalBaseline.avgCycleTimeMs;
+      const cycleTimeChange =
+        historicalBaseline.avgCycleTimeMs > 0
+          ? ((cycleTimeDiff / historicalBaseline.avgCycleTimeMs) * 100).toFixed(1)
+          : 'N/A';
+      const cycleTimeTrend = cycleTimeDiff > 0 ? '📈' : cycleTimeDiff < 0 ? '📉' : '➡️';
+      lines.push(
+        `- **Cycle Time:** ${cycleTimeTrend} ${cycleTimeChange !== 'N/A' ? `${cycleTimeChange}%` : cycleTimeChange} ` +
+          `(${this.formatDuration(historicalBaseline.avgCycleTimeMs)} → ${this.formatDuration(currentMetrics.avgCycleTimeMs)})`
+      );
+
+      // Success rate comparison
+      const successRateDiff = currentMetrics.successRate - historicalBaseline.successRate;
+      const successRateTrend = successRateDiff > 0 ? '📈' : successRateDiff < 0 ? '📉' : '➡️';
+      lines.push(
+        `- **Success Rate:** ${successRateTrend} ${successRateDiff > 0 ? '+' : ''}${successRateDiff.toFixed(1)}% ` +
+          `(${historicalBaseline.successRate.toFixed(1)}% → ${currentMetrics.successRate.toFixed(1)}%)`
+      );
+
+      // Failure rate comparison
+      const failureRateDiff = currentMetrics.failureRate - historicalBaseline.failureRate;
+      const failureRateTrend = failureRateDiff > 0 ? '📈' : failureRateDiff < 0 ? '📉' : '➡️';
+      lines.push(
+        `- **Failure Rate:** ${failureRateTrend} ${failureRateDiff > 0 ? '+' : ''}${failureRateDiff.toFixed(1)}% ` +
+          `(${historicalBaseline.failureRate.toFixed(1)}% → ${currentMetrics.failureRate.toFixed(1)}%)`
+      );
+
+      // Escalation rate comparison
+      const escalationRateDiff = currentMetrics.escalationRate - historicalBaseline.escalationRate;
+      const escalationRateTrend =
+        escalationRateDiff > 0 ? '📈' : escalationRateDiff < 0 ? '📉' : '➡️';
+      lines.push(
+        `- **Escalation Rate:** ${escalationRateTrend} ${escalationRateDiff > 0 ? '+' : ''}${escalationRateDiff.toFixed(1)}% ` +
+          `(${historicalBaseline.escalationRate.toFixed(1)}% → ${currentMetrics.escalationRate.toFixed(1)}%)`
+      );
+      lines.push('');
+    }
+
+    // Token Usage
+    lines.push('## Token Usage');
+    lines.push('');
+    lines.push(`- **Total Tokens:** ${currentMetrics.tokenUsage.totalTokens.toLocaleString()}`);
+    lines.push(
+      `- **Input Tokens:** ${currentMetrics.tokenUsage.totalInputTokens.toLocaleString()}`
+    );
+    lines.push(
+      `- **Output Tokens:** ${currentMetrics.tokenUsage.totalOutputTokens.toLocaleString()}`
+    );
+    lines.push('');
+
+    // Project Period
+    if (currentMetrics.periodStart && currentMetrics.periodEnd) {
+      lines.push('## Project Timeline');
+      lines.push('');
+      lines.push(`- **Start:** ${new Date(currentMetrics.periodStart).toISOString()}`);
+      lines.push(`- **End:** ${new Date(currentMetrics.periodEnd).toISOString()}`);
+      const durationMs =
+        new Date(currentMetrics.periodEnd).getTime() -
+        new Date(currentMetrics.periodStart).getTime();
+      lines.push(`- **Duration:** ${this.formatDuration(durationMs)}`);
+      lines.push('');
+    }
+
+    // Was it worth it?
+    lines.push('## Bottom Line: Was It Worth It?');
+    lines.push('');
+
+    const worthItScore = this.calculateWorthItScore(currentMetrics, historicalBaseline);
+    lines.push(`**Worth It Score:** ${worthItScore.score}/100`);
+    lines.push('');
+    lines.push(worthItScore.summary);
+    lines.push('');
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Format duration in milliseconds to human-readable string
+   */
+  private formatDuration(ms: number): string {
+    if (ms === 0) return '0ms';
+
+    const seconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+
+    if (days > 0) {
+      const remainingHours = hours % 24;
+      return remainingHours > 0 ? `${days}d ${remainingHours}h` : `${days}d`;
+    }
+    if (hours > 0) {
+      const remainingMinutes = minutes % 60;
+      return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+    }
+    if (minutes > 0) {
+      const remainingSeconds = seconds % 60;
+      return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
+    }
+    return `${seconds}s`;
+  }
+
+  /**
+   * Calculate a "worth it" score based on project metrics
+   * Returns a score 0-100 and a summary statement
+   */
+  private calculateWorthItScore(
+    current: ProjectMetrics,
+    baseline?: ProjectMetrics
+  ): { score: number; summary: string } {
+    let score = 50; // Start neutral
+    const factors: string[] = [];
+
+    // Success rate impact (0-30 points)
+    if (current.successRate >= 90) {
+      score += 30;
+      factors.push('excellent success rate');
+    } else if (current.successRate >= 75) {
+      score += 20;
+      factors.push('good success rate');
+    } else if (current.successRate >= 50) {
+      score += 10;
+      factors.push('moderate success rate');
+    } else {
+      score -= 10;
+      factors.push('low success rate');
+    }
+
+    // Cost efficiency (0-20 points)
+    if (current.costPerFeature < 1.0) {
+      score += 20;
+      factors.push('highly cost-efficient');
+    } else if (current.costPerFeature < 5.0) {
+      score += 10;
+      factors.push('cost-efficient');
+    } else if (current.costPerFeature > 10.0) {
+      score -= 10;
+      factors.push('high cost per feature');
+    }
+
+    // Escalation rate impact (0-15 points)
+    if (current.escalationRate < 5) {
+      score += 15;
+      factors.push('minimal escalations');
+    } else if (current.escalationRate < 15) {
+      score += 5;
+      factors.push('some escalations');
+    } else {
+      score -= 10;
+      factors.push('high escalation rate');
+    }
+
+    // Historical improvement (0-20 points)
+    if (baseline) {
+      let improvements = 0;
+
+      if (current.costPerFeature < baseline.costPerFeature) {
+        improvements++;
+        factors.push('improved cost efficiency');
+      }
+      if (current.avgCycleTimeMs < baseline.avgCycleTimeMs) {
+        improvements++;
+        factors.push('faster cycle time');
+      }
+      if (current.successRate > baseline.successRate) {
+        improvements++;
+        factors.push('better success rate');
+      }
+      if (current.escalationRate < baseline.escalationRate) {
+        improvements++;
+        factors.push('fewer escalations');
+      }
+
+      score += improvements * 5;
+    }
+
+    // Throughput bonus (0-15 points)
+    if (current.throughputPerDay >= 5) {
+      score += 15;
+      factors.push('high throughput');
+    } else if (current.throughputPerDay >= 2) {
+      score += 10;
+      factors.push('good throughput');
+    } else if (current.throughputPerDay >= 1) {
+      score += 5;
+      factors.push('moderate throughput');
+    }
+
+    // Clamp score to 0-100
+    score = Math.max(0, Math.min(100, score));
+
+    // Generate summary
+    let summary = '';
+    if (score >= 80) {
+      summary = `✅ **Highly Successful** - This project delivered exceptional value with ${factors.join(', ')}.`;
+    } else if (score >= 60) {
+      summary = `👍 **Successful** - This project delivered solid results with ${factors.join(', ')}.`;
+    } else if (score >= 40) {
+      summary = `⚠️ **Mixed Results** - This project had both successes and challenges: ${factors.join(', ')}.`;
+    } else {
+      summary = `❌ **Needs Improvement** - This project faced significant challenges including ${factors.join(', ')}.`;
+    }
+
+    return { score, summary };
   }
 }


### PR DESCRIPTION
## Summary
- Extend `MetricsService` with cost-per-feature, failure rate, escalation count, and model distribution
- Add `generateImpactReport()` producing markdown with executive summary, cost/time/quality analysis
- Include "Worth It" score (0-100) based on success rate, cost efficiency, escalations, and throughput
- Add `/api/metrics/impact-report` route
- Integrate into ceremony service for automatic generation on project completion

## Test plan
- [x] Manual verification of metrics calculation and report structure
- [ ] Verify impact report generated on project retro ceremony
- [ ] Verify historical comparison with baseline data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>