### PR TITLE
feat: add Discord and GitHub signal listeners for simplified intake

### DIFF
--- a/apps/server/src/routes/linear/webhook.ts
+++ b/apps/server/src/routes/linear/webhook.ts
@@ -293,7 +293,14 @@ async function handleIssueEvent(
         title: data.title,
         state: data.state?.name,
       });
-      // Future: handle issue creation if needed
+      // Emit issue detected event for signal intake
+      events.emit('linear:issue:detected', {
+        issueId: data.id,
+        title: data.title,
+        description: data.description,
+        state: data.state,
+        createdAt: data.createdAt,
+      });
       break;
     case 'update':
       await handleIssueUpdated(data, events, featureLoader);

--- a/apps/server/src/routes/webhooks/routes/github.ts
+++ b/apps/server/src/routes/webhooks/routes/github.ts
@@ -34,6 +34,23 @@ interface GitHubPullRequestPayload {
   };
 }
 
+interface GitHubIssuePayload {
+  action: string;
+  issue: {
+    number: number;
+    title: string;
+    body: string | null;
+    state: string;
+    created_at: string;
+    user: {
+      login: string;
+    };
+  };
+  repository: {
+    full_name: string;
+  };
+}
+
 /**
  * Verify GitHub webhook signature
  */
@@ -122,9 +139,38 @@ export function createGitHubWebhookHandler(events: EventEmitter, settingsService
 
       // Check event type
       const eventType = req.headers['x-github-event'] as string | undefined;
-      if (eventType !== 'pull_request' && eventType !== 'pull_request_review') {
+      if (
+        eventType !== 'pull_request' &&
+        eventType !== 'pull_request_review' &&
+        eventType !== 'issues'
+      ) {
         logger.debug(`Ignoring event: ${eventType}`);
         res.json({ success: true, message: 'Event type not handled' });
+        return;
+      }
+
+      // Handle issues events (created)
+      if (eventType === 'issues') {
+        const issuePayload = req.body as GitHubIssuePayload;
+
+        if (issuePayload.action === 'opened') {
+          logger.info(
+            `GitHub issue #${issuePayload.issue.number} created: ${issuePayload.issue.title}`
+          );
+
+          // Emit issue detected event for signal intake
+          events.emit('webhook:github:issue', {
+            action: 'opened',
+            issueNumber: issuePayload.issue.number,
+            title: issuePayload.issue.title,
+            body: issuePayload.issue.body || '',
+            author: issuePayload.issue.user.login,
+            createdAt: issuePayload.issue.created_at,
+            repository: issuePayload.repository.full_name,
+          });
+        }
+
+        res.json({ success: true, message: 'Issue event processed' });
         return;
       }
 

--- a/apps/server/src/services/integration-service.ts
+++ b/apps/server/src/services/integration-service.ts
@@ -178,6 +178,42 @@ export class IntegrationService {
             type
           );
           break;
+        case 'discord:message:detected':
+          this.handleDiscordMessage(
+            payload as {
+              channelId: string;
+              channelName?: string;
+              userId: string;
+              username: string;
+              content: string;
+              timestamp: string;
+            }
+          );
+          break;
+        case 'linear:issue:detected':
+          this.handleLinearIssue(
+            payload as {
+              issueId: string;
+              title: string;
+              description?: string;
+              state?: { name: string };
+              createdAt: string;
+            }
+          );
+          break;
+        case 'webhook:github:issue':
+          this.handleGitHubIssue(
+            payload as {
+              action: string;
+              issueNumber: number;
+              title: string;
+              body: string;
+              author: string;
+              createdAt: string;
+              repository: string;
+            }
+          );
+          break;
       }
     });
 
@@ -796,6 +832,150 @@ export class IntegrationService {
       webhookToken: integrations.discord.webhookToken,
       action: 'send_message',
       content: message,
+    });
+  }
+
+  // ============================================================================
+  // Signal Intake - Simplified keyword detection for Ava triage
+  // ============================================================================
+
+  /**
+   * Keywords that indicate a message is a signal (idea or request)
+   */
+  private readonly SIGNAL_KEYWORDS = [
+    'we need',
+    'let us build',
+    'lets build',
+    "let's build",
+    'feature request',
+    'idea:',
+    'what if',
+    'could we',
+    'can we build',
+    'we should',
+    'it would be cool',
+    'request:',
+    'proposal:',
+  ];
+
+  /**
+   * Detect if a message contains signal keywords
+   */
+  private detectSignal(content: string): boolean {
+    const lowerContent = content.toLowerCase();
+    return this.SIGNAL_KEYWORDS.some((keyword) => lowerContent.includes(keyword));
+  }
+
+  /**
+   * Handle Discord message events and detect signals
+   */
+  private async handleDiscordMessage(payload: {
+    channelId: string;
+    channelName?: string;
+    userId: string;
+    username: string;
+    content: string;
+    timestamp: string;
+  }): Promise<void> {
+    // Simple keyword detection - not a classification engine
+    if (!this.detectSignal(payload.content)) {
+      // Casual conversation, let it pass through
+      return;
+    }
+
+    // Signal detected - route to Ava triage
+    logger.info(`Signal detected in Discord message from ${payload.username}`, {
+      channelId: payload.channelId,
+      channelName: payload.channelName,
+      contentPreview: payload.content.slice(0, 100),
+    });
+
+    if (!this.emitter) return;
+
+    this.emitter.emit('signal:received', {
+      source: 'discord',
+      content: payload.content,
+      author: {
+        id: payload.userId,
+        name: payload.username,
+      },
+      channelContext: {
+        channelId: payload.channelId,
+        channelName: payload.channelName,
+      },
+      timestamp: payload.timestamp,
+    });
+  }
+
+  /**
+   * Handle Linear issue creation events and detect signals
+   */
+  private async handleLinearIssue(payload: {
+    issueId: string;
+    title: string;
+    description?: string;
+    state?: { name: string };
+    createdAt: string;
+  }): Promise<void> {
+    // All new Linear issues are treated as signals
+    logger.info(`Signal detected from Linear issue: ${payload.title}`, {
+      issueId: payload.issueId,
+    });
+
+    if (!this.emitter) return;
+
+    this.emitter.emit('signal:received', {
+      source: 'linear',
+      content: `${payload.title}\n\n${payload.description || ''}`,
+      author: {
+        id: payload.issueId,
+        name: 'Linear Issue',
+      },
+      channelContext: {
+        issueId: payload.issueId,
+        state: payload.state?.name,
+      },
+      timestamp: payload.createdAt,
+    });
+  }
+
+  /**
+   * Handle GitHub issue creation events and detect signals
+   */
+  private async handleGitHubIssue(payload: {
+    action: string;
+    issueNumber: number;
+    title: string;
+    body: string;
+    author: string;
+    createdAt: string;
+    repository: string;
+  }): Promise<void> {
+    // Only handle newly opened issues
+    if (payload.action !== 'opened') {
+      return;
+    }
+
+    // All new GitHub issues are treated as signals
+    logger.info(`Signal detected from GitHub issue #${payload.issueNumber}: ${payload.title}`, {
+      repository: payload.repository,
+      author: payload.author,
+    });
+
+    if (!this.emitter) return;
+
+    this.emitter.emit('signal:received', {
+      source: 'github',
+      content: `${payload.title}\n\n${payload.body}`,
+      author: {
+        id: payload.author,
+        name: payload.author,
+      },
+      channelContext: {
+        issueNumber: payload.issueNumber,
+        repository: payload.repository,
+      },
+      timestamp: payload.createdAt,
     });
   }
 }

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -259,7 +259,9 @@ export type EventType =
   | 'escalation:signal-deduplicated'
   | 'escalation:ui-notification'
   // Feedback analytics events (pattern detection and metrics)
-  | 'feedback:pattern-detected';
+  | 'feedback:pattern-detected'
+  // Signal intake events (Ava triage routing)
+  | 'signal:received';
 
 export type EventCallback = (type: EventType, payload: unknown) => void;
 


### PR DESCRIPTION
## Summary
- Adds signal detection to  for Discord messages with keyword matching
- Extends GitHub webhook to emit  for new issue creation
- Extends Linear webhook to emit  for new issue detection
- Keywords: 'we need', 'let us build', 'feature request', 'idea:', etc.
- Signals include source, content, author, and channel context

## Test plan
- [ ] Verify Discord message keyword detection triggers signal:received
- [ ] Verify GitHub issue webhook triggers signal:received
- [ ] Verify Linear issue webhook triggers signal:received
- [ ] Verify casual conversation is not triggered
- [ ] Verify build passes