### PR TITLE
feat: generate content brief on milestone completion for GTM

### DIFF
--- a/apps/server/src/services/ceremony-service.ts
+++ b/apps/server/src/services/ceremony-service.ts
@@ -298,8 +298,110 @@ export class CeremonyService {
       logger.info(
         `Posted milestone ceremony for ${projectTitle} - Milestone ${milestoneNumber}: ${milestoneTitle}`
       );
+
+      // Load milestone features for content brief
+      const project = await this.projectService!.getProject(projectPath, projectSlug);
+      const milestone = project?.milestones.find((m) => m.number === milestoneNumber);
+      if (milestone) {
+        const milestoneFeatures = await this.getMilestoneFeatures(projectPath, milestone.slug);
+        await this.generateAndPostMilestoneContentBrief(
+          projectPath,
+          projectSlug,
+          projectTitle,
+          milestoneTitle,
+          milestoneNumber,
+          milestoneFeatures,
+          ceremonySettings
+        );
+      }
     } catch (error) {
       logger.error('Failed to generate milestone ceremony:', error);
+    }
+  }
+
+  /**
+   * Generate and post a content brief to the GTM channel when a milestone completes.
+   * Uses LLM to create a structured content brief that Jon/GTM can pick up.
+   */
+  private async generateAndPostMilestoneContentBrief(
+    projectPath: string,
+    projectSlug: string,
+    projectTitle: string,
+    milestoneTitle: string,
+    milestoneNumber: number,
+    features: Feature[],
+    ceremonySettings: CeremonySettings
+  ): Promise<void> {
+    if (!ceremonySettings.enableContentBriefs) {
+      logger.debug('Content briefs disabled, skipping');
+      return;
+    }
+
+    const channelId = ceremonySettings.contentBriefChannelId;
+    if (!channelId) {
+      logger.debug('No contentBriefChannelId configured, skipping content brief');
+      return;
+    }
+
+    try {
+      const shipped = features.filter((f) => f.status === 'done' && f.prUrl);
+      const totalCost = features.reduce((sum, f) => sum + (f.costUsd || 0), 0);
+
+      // Build feature summary for the prompt
+      const featureSummary = shipped
+        .map((f) => `- ${f.title}: ${f.description?.slice(0, 200) || 'No description'}`)
+        .join('\n');
+
+      const prompt = `You are a content strategist creating a content brief for a Go-To-Market team.
+
+A development milestone just completed. Create a structured content brief that a GTM specialist can use to produce blog posts, tweets, or case study material.
+
+**Project:** ${projectTitle}
+**Milestone ${milestoneNumber}:** ${milestoneTitle}
+**Features Shipped:** ${shipped.length}
+**Total Cost:** $${totalCost.toFixed(2)}
+
+**Features:**
+${featureSummary || 'No features with descriptions'}
+
+Generate a content brief with:
+1. **Headline**: A compelling one-liner for this milestone
+2. **Key Message**: The main takeaway in 2-3 sentences
+3. **Audience**: Who cares about this and why
+4. **Content Angles**: 3-4 possible content pieces (blog post, tweet thread, case study section, etc.) with a one-line description of each
+5. **Technical Highlights**: 2-3 notable technical achievements to emphasize
+6. **Suggested Visuals**: What diagrams, screenshots, or graphics would strengthen the content
+
+Keep it concise, actionable, and focused on what makes this milestone interesting to an external audience.`;
+
+      const model = ceremonySettings.retroModel?.model || 'sonnet';
+      logger.info(`Generating content brief for milestone ${milestoneNumber}: ${milestoneTitle}`);
+
+      const result = await simpleQuery({
+        prompt,
+        model,
+        cwd: projectPath,
+        maxTurns: 1,
+        allowedTools: [],
+      });
+
+      const brief = result.text;
+      const formatted = `📝 **Content Brief** — ${projectTitle} / Milestone ${milestoneNumber}: ${milestoneTitle}\n\n${brief}`;
+
+      // Post to the dedicated content-briefs channel
+      const messages = this.splitMessage(formatted, 2000);
+      for (const message of messages) {
+        await this.emitDiscordEvent(
+          projectPath,
+          channelId,
+          message,
+          `Content Brief: ${milestoneTitle}`
+        );
+      }
+
+      logger.info(`Posted content brief to GTM channel for milestone: ${milestoneTitle}`);
+    } catch (error) {
+      logger.error('Failed to generate milestone content brief:', error);
     }
   }
 

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -905,6 +905,10 @@ export interface CeremonySettings {
   enableEpicDelivery?: boolean;
   /** Enable project retrospective generation (default: true) */
   enableProjectRetros?: boolean;
+  /** Enable content brief generation on milestone completion (default: true) */
+  enableContentBriefs?: boolean;
+  /** Discord channel ID for content briefs (separate from ceremony channel) */
+  contentBriefChannelId?: string;
   /** Model configuration for generating retrospectives */
   retroModel?: PhaseModelEntry;
 }
@@ -919,6 +923,7 @@ export const DEFAULT_CEREMONY_SETTINGS: CeremonySettings = {
   enableMilestoneUpdates: true,
   enableEpicDelivery: true,
   enableProjectRetros: true,
+  enableContentBriefs: true,
 };
 
 /**


### PR DESCRIPTION
## Summary
- When a milestone completes, the ceremony service generates a structured content brief via LLM
- Brief is posted to a dedicated `#content-briefs` Discord channel (separate from ceremony announcements)
- Adds `enableContentBriefs` and `contentBriefChannelId` to `CeremonySettings`
- Content brief includes: headline, key message, audience, content angles, technical highlights, suggested visuals

## Configuration
Set in project settings under `ceremonySettings`:
```json
{
  "enableContentBriefs": true,
  "contentBriefChannelId": "1472072098238431342"
}
```

## Discord Setup
- Created GTM category (ID: `1472072076662673542`)
- Created `#content-briefs` channel (ID: `1472072098238431342`)

## Test plan
- [x] TypeScript builds cleanly (`tsc --noEmit`)
- [x] Prettier passes
- [x] New fields are optional with sensible defaults
- [x] Content brief generation is gated behind both `enableContentBriefs` and `contentBriefChannelId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Milestone ceremonies now automatically generate and post content briefs to a designated Discord channel upon completion, summarizing shipped features and associated costs.
  * New settings added: toggle content brief generation on/off and configure the target Discord channel for brief distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->