### PR TITLE
fix: add missing libs to Dockerfile and fix implicit any types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ COPY libs/dependency-resolver/package*.json ./libs/dependency-resolver/
 COPY libs/git-utils/package*.json ./libs/git-utils/
 COPY libs/spec-parser/package*.json ./libs/spec-parser/
 COPY libs/policy-engine/package*.json ./libs/policy-engine/
+COPY libs/flows/package*.json ./libs/flows/
+COPY libs/llm-providers/package*.json ./libs/llm-providers/
+COPY libs/observability/package*.json ./libs/observability/
 
 # Copy scripts (needed by npm workspace)
 COPY scripts ./scripts

--- a/libs/flows/src/graphs/coordinator-flow.ts
+++ b/libs/flows/src/graphs/coordinator-flow.ts
@@ -36,11 +36,11 @@ export const CoordinatorState = Annotation.Root({
   researchQueries: Annotation<string[]>,
   analysisData: Annotation<string[]>,
   researchResults: Annotation<string[]>({
-    reducer: (left, right) => [...left, ...right],
+    reducer: (left: string[], right: string[]) => [...left, ...right],
     default: () => [],
   }),
   analysisResults: Annotation<string[]>({
-    reducer: (left, right) => [...left, ...right],
+    reducer: (left: string[], right: string[]) => [...left, ...right],
     default: () => [],
   }),
   finalReport: Annotation<string | undefined>,
@@ -196,10 +196,10 @@ async function aggregationNode(
 === Final Report for: ${task} ===
 
 Research Results (${researchResults.length}):
-${researchResults.map((r, i) => `\n${i + 1}. ${r}`).join('')}
+${researchResults.map((r: string, i: number) => `\n${i + 1}. ${r}`).join('')}
 
 Analysis Results (${analysisResults.length}):
-${analysisResults.map((r, i) => `\n${i + 1}. ${r}`).join('')}
+${analysisResults.map((r: string, i: number) => `\n${i + 1}. ${r}`).join('')}
 
 === End Report ===
 `.trim();


### PR DESCRIPTION
## Summary
- Adds `libs/flows/`, `libs/llm-providers/`, and `libs/observability/` package.json copies to Dockerfile base stage so `npm ci` installs their dependencies (`@langchain/langgraph`, `@langchain/core`, etc.)
- Fixes implicit `any` type annotations in `coordinator-flow.ts` reducer and map callbacks

## Context
Deploy to staging has been failing since the LangGraph integration (#394) and content pipeline work (#442-#445) merged — the Dockerfile was never updated to include the new packages.

## Test plan
- [ ] Deploy workflow succeeds (Docker build completes)
- [ ] Staging server starts and responds to health check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dependency resolution for newly integrated libraries during the build process.

* **Refactor**
  * Enhanced type annotations in coordinator flow logic for improved type safety and code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->