### PR TITLE
rebrand: Automaker → protoLabs Studio

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
-# Contributing to Automaker
+# Contributing to protoLabs Studio
 
-Thank you for your interest in contributing to Automaker! We're excited to have you join our community of developers building the future of autonomous AI development.
+Thank you for your interest in contributing to protoLabs Studio! We're excited to have you join our community of developers building the future of autonomous AI development.
 
-Automaker is an autonomous AI development studio that provides a Kanban-based workflow where AI agents implement features in isolated git worktrees. Whether you're fixing bugs, adding features, improving documentation, or suggesting ideas, your contributions help make this project better for everyone.
+protoLabs Studio is an autonomous AI development studio that provides a Kanban-based workflow where AI agents implement features in isolated git worktrees. Whether you're fixing bugs, adding features, improving documentation, or suggesting ideas, your contributions help make this project better for everyone.
 
-This guide will help you get started with contributing to Automaker. Please take a moment to read through these guidelines to ensure a smooth contribution process.
+This guide will help you get started with contributing to protoLabs Studio. Please take a moment to read through these guidelines to ensure a smooth contribution process.
 
 ## Contribution License Agreement
 
-**Important:** By submitting, pushing, or contributing any code, documentation, pull requests, issues, or other materials to the Automaker project, you agree to assign all right, title, and interest in and to your contributions, including all copyrights, patents, and other intellectual property rights, to the Core Contributors of Automaker. This assignment is irrevocable and includes the right to use, modify, distribute, and monetize your contributions in any manner.
+**Important:** By submitting, pushing, or contributing any code, documentation, pull requests, issues, or other materials to the protoLabs Studio project, you agree to assign all right, title, and interest in and to your contributions, including all copyrights, patents, and other intellectual property rights, to the Core Contributors of protoLabs Studio. This assignment is irrevocable and includes the right to use, modify, distribute, and monetize your contributions in any manner.
 
 **You understand and agree that you will have no right to receive any royalties, compensation, or other financial benefits from any revenue, income, or commercial use generated from your contributed code or any derivative works thereof.** All contributions are made without expectation of payment or financial return.
 
@@ -16,7 +16,7 @@ For complete details on contribution terms and rights assignment, please review 
 
 ## Table of Contents
 
-- [Contributing to Automaker](#contributing-to-automaker)
+- [Contributing to protoLabs Studio](#contributing-to-protolabs-studio)
   - [Table of Contents](#table-of-contents)
   - [Getting Started](#getting-started)
     - [Prerequisites](#prerequisites)
@@ -68,7 +68,7 @@ For complete details on contribution terms and rights assignment, please review 
 
 ### Prerequisites
 
-Before contributing to Automaker, ensure you have the following installed on your system:
+Before contributing to protoLabs Studio, ensure you have the following installed on your system:
 
 - **Node.js 18+** (tested with Node.js 22)
   - Download from [nodejs.org](https://nodejs.org/)
@@ -88,31 +88,31 @@ Before contributing to Automaker, ensure you have the following installed on you
 ### Fork and Clone
 
 1. **Fork the repository** on GitHub
-   - Navigate to [https://github.com/AutoMaker-Org/automaker](https://github.com/AutoMaker-Org/automaker)
+   - Navigate to [https://github.com/proto-labs-ai/protolabs-studio](https://github.com/proto-labs-ai/protolabs-studio)
    - Click the "Fork" button in the top-right corner
    - This creates your own copy of the repository
 
 2. **Clone your fork locally**
 
    ```bash
-   git clone https://github.com/YOUR_USERNAME/automaker.git
-   cd automaker
+   git clone https://github.com/YOUR_USERNAME/protolabs-studio.git
+   cd protolabs-studio
    ```
 
 3. **Add the upstream remote** to keep your fork in sync
 
    ```bash
-   git remote add upstream https://github.com/AutoMaker-Org/automaker.git
+   git remote add upstream https://github.com/proto-labs-ai/protolabs-studio.git
    ```
 
 4. **Verify remotes**
    ```bash
    git remote -v
    # Should show:
-   # origin    https://github.com/YOUR_USERNAME/automaker.git (fetch)
-   # origin    https://github.com/YOUR_USERNAME/automaker.git (push)
-   # upstream  https://github.com/AutoMaker-Org/automaker.git (fetch)
-   # upstream  https://github.com/AutoMaker-Org/automaker.git (push)
+   # origin    https://github.com/YOUR_USERNAME/protolabs-studio.git (fetch)
+   # origin    https://github.com/YOUR_USERNAME/protolabs-studio.git (push)
+   # upstream  https://github.com/proto-labs-ai/protolabs-studio.git (fetch)
+   # upstream  https://github.com/proto-labs-ai/protolabs-studio.git (push)
    ```
 
 ### Development Setup
@@ -165,10 +165,10 @@ This sets up the merge driver so `.beads/issues.jsonl` merges correctly. See `.b
 
 ### Project Structure
 
-Automaker is organized as an npm workspace monorepo:
+protoLabs Studio is organized as an npm workspace monorepo:
 
 ```
-automaker/
+protolabs-studio/
 ├── apps/
 │   ├── ui/              # React + Vite + Electron frontend
 │   └── server/          # Express + WebSocket backend
@@ -199,7 +199,7 @@ This section covers everything you need to know about contributing changes throu
 
 ### Branching Strategy (RC Branches)
 
-Automaker uses **Release Candidate (RC) branches** for all development work. Understanding this workflow is essential before contributing.
+protoLabs Studio uses **Release Candidate (RC) branches** for all development work. Understanding this workflow is essential before contributing.
 
 **How it works:**
 
@@ -378,7 +378,7 @@ git push origin feature/your-feature-name
 
 1. Go to your fork on GitHub
 2. Click "Compare & pull request" for your branch
-3. **Important:** Set the base repository to `AutoMaker-Org/automaker` and the base branch to the **current RC branch** (e.g., `v0.11.0rc`), not `main`
+3. **Important:** Set the base repository to `proto-labs-ai/protolabs-studio` and the base branch to the **current RC branch** (e.g., `v0.11.0rc`), not `main`
 4. Fill out the PR template completely
 
 #### PR Requirements Checklist
@@ -399,7 +399,7 @@ Your PR should include:
 ```markdown
 ## Summary
 
-This PR adds dark mode support to the Automaker UI.
+This PR adds dark mode support to the protoLabs Studio UI.
 
 - Implements theme toggle in settings panel
 - Adds CSS custom properties for theme colors
@@ -470,13 +470,13 @@ If your PR seems stuck:
 
 ## Code Style Guidelines
 
-Automaker uses automated tooling to enforce code style. Run `npm run format` to format code and `npm run lint` to check for issues. Pre-commit hooks automatically format staged files before committing.
+protoLabs Studio uses automated tooling to enforce code style. Run `npm run format` to format code and `npm run lint` to check for issues. Pre-commit hooks automatically format staged files before committing.
 
 ---
 
 ## Testing Requirements
 
-Testing helps prevent regressions. Automaker uses **Playwright** for end-to-end testing and **Vitest** for unit tests.
+Testing helps prevent regressions. protoLabs Studio uses **Playwright** for end-to-end testing and **Vitest** for unit tests.
 
 ### Running Tests
 
@@ -569,7 +569,7 @@ npx vitest --watch
 
 ### CI/CD Pipeline
 
-Automaker uses **GitHub Actions** for continuous integration. Every pull request triggers automated checks.
+protoLabs Studio uses **GitHub Actions** for continuous integration. Every pull request triggers automated checks.
 
 #### CI Checks
 
@@ -584,7 +584,7 @@ The following checks must pass before your PR can be merged:
 
 #### CI Testing Environment
 
-For CI environments, Automaker supports a mock agent mode:
+For CI environments, protoLabs Studio supports a mock agent mode:
 
 ```bash
 # Enable mock agent mode for CI testing
@@ -638,7 +638,7 @@ When reporting a bug, please provide as much information as possible to help us 
 #### Before Reporting
 
 1. **Search existing issues** - Check if the bug has already been reported
-2. **Try the latest version** - Make sure you're running the latest version of Automaker
+2. **Try the latest version** - Make sure you're running the latest version of protoLabs Studio
 3. **Reproduce the issue** - Verify you can consistently reproduce the bug
 
 #### Bug Report Template
@@ -649,7 +649,7 @@ When creating a bug report, include:
 - **Environment:**
   - Operating System and version
   - Node.js version (`node --version`)
-  - Automaker version or commit hash
+  - protoLabs Studio version or commit hash
 - **Steps to Reproduce:** Numbered list of steps to reproduce the bug
 - **Expected Behavior:** What you expected to happen
 - **Actual Behavior:** What actually happened
@@ -664,7 +664,7 @@ When creating a bug report, include:
 
 - OS: Windows 11
 - Node.js: 22.11.0
-- Automaker: commit abc1234
+- protoLabs Studio: commit abc1234
 
 ### Steps to Reproduce
 
@@ -688,12 +688,12 @@ The UI shows "Connection lost" and the card doesn't move.
 
 ### Feature Requests
 
-We welcome ideas for improving Automaker! Here's how to submit a feature request:
+We welcome ideas for improving protoLabs Studio! Here's how to submit a feature request:
 
 #### Before Requesting
 
 1. **Check existing issues** - Your idea may already be proposed or in development
-2. **Consider scope** - Think about whether the feature fits Automaker's mission as an autonomous AI development studio
+2. **Consider scope** - Think about whether the feature fits protoLabs Studio's mission as an autonomous AI development studio
 
 #### Feature Request Template
 
@@ -747,4 +747,4 @@ For license and contribution terms, see the [LICENSE](LICENSE) file in the repos
 
 ---
 
-Thank you for contributing to Automaker!
+Thank you for contributing to protoLabs Studio!

--- a/README.md
+++ b/README.md
@@ -1,27 +1,29 @@
 <p align="center">
-  <img src="apps/ui/public/readme_logo.svg" alt="ProtoMaker Logo" height="80" />
+  <img src="apps/ui/public/readme_logo.svg" alt="protoLabs Studio Logo" height="80" />
 </p>
 
 > **[!NOTE]**
 >
-> **ProtoMaker** is a fork of [Automaker](https://github.com/AutoMaker-Org/automaker) by Proto Labs AI, evolved to support **multi-agent swarm management** across teams and projects. We're grateful to the original Automaker team for the foundation that made this possible.
+> **protoLabs Studio** is a fork of [Automaker](https://github.com/AutoMaker-Org/automaker) by Proto Labs AI, evolved to support **multi-agent swarm management** across teams and projects. We're grateful to the original Automaker team for the foundation that made this possible.
 
 > **[!TIP]**
 >
 > **Learn more about Agentic Coding!**
 >
-> ProtoMaker was built using AI and agentic coding techniques, leveraging tools like Cursor IDE and Claude Code CLI to orchestrate AI agents that implement complex functionality in days instead of weeks.
+> protoLabs Studio was built using AI and agentic coding techniques, leveraging tools like Cursor IDE and Claude Code CLI to orchestrate AI agents that implement complex functionality in days instead of weeks.
 >
 > **Learn how:** Master these same techniques and workflows in the [Agentic Jumpstart course](https://agenticjumpstart.com/?utm=protomaker-gh).
 
-# ProtoMaker
+# protoLabs Studio
+
+_made by automaker_
 
 **From solo agents to swarm intelligence. Build software at team scale with AI.**
 
 <details open>
 <summary><h2>Table of Contents</h2></summary>
 
-- [What Makes Automaker Different?](#what-makes-automaker-different)
+- [What Makes protoLabs Studio Different?](#what-makes-protolabs-studio-different)
   - [The Workflow](#the-workflow)
   - [Powered by Claude Agent SDK](#powered-by-claude-agent-sdk)
   - [Why This Matters](#why-this-matters)
@@ -62,22 +64,22 @@
 
 </details>
 
-ProtoMaker is an **autonomous AI development studio** that transforms how teams build software at scale. Instead of manually writing code, you orchestrate **swarms of AI agents** across multiple projects, teams, and communication channels. Agents collaborate through Linear (planning) and Discord (communication), working together like an agile development team—but fully autonomous.
+protoLabs Studio is an **autonomous AI development studio** that transforms how teams build software at scale. Instead of manually writing code, you orchestrate **swarms of AI agents** across multiple projects, teams, and communication channels. Agents collaborate through Linear (planning) and Discord (communication), working together like an agile development team—but fully autonomous.
 
-Built with React, Vite, Electron, Express, and powered by Claude Agent SDK, ProtoMaker provides enterprise-grade workflow orchestration for managing multiple AI agents through a desktop application (or web browser), with features like real-time streaming, git worktree isolation, Linear project sync, Discord thread management, and cross-team collaboration.
+Built with React, Vite, Electron, Express, and powered by Claude Agent SDK, protoLabs Studio provides enterprise-grade workflow orchestration for managing multiple AI agents through a desktop application (or web browser), with features like real-time streaming, git worktree isolation, Linear project sync, Discord thread management, and cross-team collaboration.
 
-![ProtoMaker UI](https://i.imgur.com/jdwKydM.png)
+![protoLabs Studio UI](https://i.imgur.com/jdwKydM.png)
 
-## What Makes ProtoMaker Different?
+## What Makes protoLabs Studio Different?
 
-Traditional development tools help you write code. **ProtoMaker orchestrates swarms of AI agents** across your entire organization. Think of it as having multiple AI development teams working simultaneously—you define projects in Linear, agents implement features autonomously, and teams collaborate through Discord threads. It's **swarm management, agile style.**
+Traditional development tools help you write code. **protoLabs Studio orchestrates swarms of AI agents** across your entire organization. Think of it as having multiple AI development teams working simultaneously—you define projects in Linear, agents implement features autonomously, and teams collaborate through Discord threads. It's **swarm management, agile style.**
 
 ### The Evolution from Automaker
 
-ProtoMaker extends the original Automaker concept with:
+protoLabs Studio extends the original Automaker concept with:
 
 - **Multi-project orchestration**: Manage agents across multiple codebases simultaneously
-- **Linear integration**: Planning and project management in Linear, execution in ProtoMaker
+- **Linear integration**: Planning and project management in Linear, execution in protoLabs Studio
 - **Discord collaboration**: Real-time updates, threaded discussions, and team communication
 - **Swarm intelligence**: Agents can collaborate across teams and projects
 - **Enterprise scale**: Built for organizations with multiple products and teams
@@ -85,7 +87,7 @@ ProtoMaker extends the original Automaker concept with:
 ### The Workflow
 
 1. **Plan in Linear** - Create issues and projects in Linear for your team's work
-2. **Sync to ProtoMaker** - Features automatically sync to the ProtoMaker board
+2. **Sync to protoLabs Studio** - Features automatically sync to the protoLabs Studio board
 3. **Agents Execute** - AI agents pick up features and implement them autonomously
 4. **Collaborate in Discord** - Watch real-time updates, discuss progress in threads
 5. **Ship at Scale** - Multiple agents working across multiple projects simultaneously
@@ -93,18 +95,18 @@ ProtoMaker extends the original Automaker concept with:
 ### Core Workflow
 
 1. **Add Features** - Describe features you want built (with text, images, or screenshots)
-2. **Move to "In Progress"** - ProtoMaker automatically assigns an AI agent to implement the feature
+2. **Move to "In Progress"** - protoLabs Studio automatically assigns an AI agent to implement the feature
 3. **Watch It Build** - See real-time progress as the agent writes code, runs tests, and makes changes
 4. **Review & Verify** - Review the changes, run tests, and approve when ready
 5. **Ship Faster** - Build entire applications in days, not weeks
 
 ### Powered by Claude Agent SDK
 
-ProtoMaker leverages the [Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk) to give AI agents full access to your codebase. Agents can read files, write code, execute commands, run tests, and make git commits—all while working in isolated git worktrees to keep your main branch safe. The SDK provides autonomous AI agents that can use tools, make decisions, and complete complex multi-step tasks without constant human intervention.
+protoLabs Studio leverages the [Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk) to give AI agents full access to your codebase. Agents can read files, write code, execute commands, run tests, and make git commits—all while working in isolated git worktrees to keep your main branch safe. The SDK provides autonomous AI agents that can use tools, make decisions, and complete complex multi-step tasks without constant human intervention.
 
 ### Integrated with Linear & Discord via MCP
 
-ProtoMaker uses the [Model Context Protocol (MCP)](https://modelcontextprotocol.io) to integrate with:
+protoLabs Studio uses the [Model Context Protocol (MCP)](https://modelcontextprotocol.io) to integrate with:
 
 - **Linear**: Project management, issue tracking, roadmap planning
 - **Discord**: Real-time communication, threaded discussions, team updates
@@ -112,7 +114,7 @@ ProtoMaker uses the [Model Context Protocol (MCP)](https://modelcontextprotocol.
 
 ### Why This Matters
 
-The future of software development is **swarm intelligence**—where multiple AI agents collaborate like an agile team, coordinating through shared context and communication channels. ProtoMaker brings this future to your organization today, letting you scale from a single agent to a full AI development team working across multiple projects simultaneously. You focus on strategy and architecture; the swarm handles implementation.
+The future of software development is **swarm intelligence**—where multiple AI agents collaborate like an agile team, coordinating through shared context and communication channels. protoLabs Studio brings this future to your organization today, letting you scale from a single agent to a full AI development team working across multiple projects simultaneously. You focus on strategy and architecture; the swarm handles implementation.
 
 ## Community & Support
 
@@ -122,7 +124,7 @@ In the Discord, you can:
 
 - 💬 Discuss agentic coding patterns and best practices
 - 🧠 Share ideas for AI-driven development workflows
-- 🛠️ Get help setting up or extending Automaker
+- 🛠️ Get help setting up or extending protoLabs Studio
 - 🚀 Show off projects built with AI agents
 - 🤝 Collaborate with other developers and contributors
 
@@ -136,26 +138,26 @@ In the Discord, you can:
 
 - **Node.js 22+** (required: >=22.0.0 <23.0.0)
 - **npm** (comes with Node.js)
-- **[Claude Code CLI](https://code.claude.com/docs/en/overview)** - Install and authenticate with your Anthropic subscription. Automaker integrates with your authenticated Claude Code CLI to access Claude models.
+- **[Claude Code CLI](https://code.claude.com/docs/en/overview)** - Install and authenticate with your Anthropic subscription. protoLabs Studio integrates with your authenticated Claude Code CLI to access Claude models.
 
 ### Quick Start
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/proto-labs-ai/protomaker.git
-cd protomaker
+git clone https://github.com/proto-labs-ai/protolabs-studio.git
+cd protolabs-studio
 
 # 2. Install dependencies
 npm install
 
-# 3. Start ProtoMaker
+# 3. Start protoLabs Studio
 npm run dev
 # Choose between:
 #   1. Web Application (browser at localhost:3007)
 #   2. Desktop Application (Electron - recommended)
 ```
 
-**Authentication:** ProtoMaker integrates with your authenticated Claude Code CLI. Make sure you have [installed and authenticated](https://code.claude.com/docs/en/quickstart) the Claude Code CLI before running ProtoMaker. Your CLI credentials will be detected automatically.
+**Authentication:** protoLabs Studio integrates with your authenticated Claude Code CLI. Make sure you have [installed and authenticated](https://code.claude.com/docs/en/quickstart) the Claude Code CLI before running protoLabs Studio. Your CLI credentials will be detected automatically.
 
 **For Development:** `npm run dev` starts the development server with Vite live reload and hot module replacement for fast refresh and instant updates as you make changes.
 
@@ -163,7 +165,7 @@ npm run dev
 
 ### Development Mode
 
-Start Automaker in development mode:
+Start protoLabs Studio in development mode:
 
 ```bash
 npm run dev
@@ -273,7 +275,7 @@ npm run build:electron:linux   # Linux (AppImage + DEB + RPM, x64)
 
 ```bash
 # Download the RPM package
-wget https://github.com/AutoMaker-Org/automaker/releases/latest/download/Automaker-<version>-x86_64.rpm
+wget https://github.com/proto-labs-ai/protolabs-studio/releases/latest/download/Automaker-<version>-x86_64.rpm
 
 # Install with dnf (Fedora)
 sudo dnf install ./Automaker-<version>-x86_64.rpm
@@ -284,7 +286,7 @@ sudo yum localinstall ./Automaker-<version>-x86_64.rpm
 
 #### Docker Deployment
 
-Docker provides the most secure way to run Automaker by isolating it from your host filesystem.
+Docker provides the most secure way to run protoLabs Studio by isolating it from your host filesystem.
 
 ```bash
 # Build and run with Docker Compose
@@ -302,7 +304,7 @@ docker-compose down
 
 ##### Authentication
 
-Automaker integrates with your authenticated Claude Code CLI. To use CLI authentication in Docker, mount your Claude CLI config directory (see [Claude CLI Authentication](#claude-cli-authentication) below).
+protoLabs Studio integrates with your authenticated Claude Code CLI. To use CLI authentication in Docker, mount your Claude CLI config directory (see [Claude CLI Authentication](#claude-cli-authentication) below).
 
 ##### Working with Projects (Host Directory Access)
 
@@ -437,11 +439,11 @@ npm run lint
 
 ### Authentication Setup
 
-Automaker integrates with your authenticated Claude Code CLI and uses your Anthropic subscription.
+protoLabs Studio integrates with your authenticated Claude Code CLI and uses your Anthropic subscription.
 
 Install and authenticate the Claude Code CLI following the [official quickstart guide](https://code.claude.com/docs/en/quickstart).
 
-Once authenticated, Automaker will automatically detect and use your CLI credentials. No additional configuration needed!
+Once authenticated, protoLabs Studio will automatically detect and use your CLI credentials. No additional configuration needed!
 
 ## Features
 
@@ -498,7 +500,7 @@ Once authenticated, Automaker will automatically detect and use your CLI credent
 
 ### Claude Code Integration
 
-Automaker includes a Claude Code plugin and MCP server for programmatic control directly from your terminal.
+protoLabs Studio includes a Claude Code plugin and MCP server for programmatic control directly from your terminal.
 
 - 🔌 **MCP Server** - 32 tools for managing features, agents, and orchestration
 - ⚡ **Slash Commands** - `/board`, `/auto-mode`, `/orchestrate`, `/context`, `/create-project`
@@ -509,11 +511,11 @@ Automaker includes a Claude Code plugin and MCP server for programmatic control 
 
 ```bash
 # 1. Install the plugin from GitHub
-claude plugin marketplace add https://github.com/proto-labs-ai/automaker/tree/main/packages/mcp-server/plugins
+claude plugin marketplace add https://github.com/proto-labs-ai/protolabs-studio/tree/main/packages/mcp-server/plugins
 claude plugin install automaker
 
-# 2. Start Automaker (in a separate terminal)
-git clone https://github.com/proto-labs-ai/automaker.git && cd automaker
+# 2. Start protoLabs Studio (in a separate terminal)
+git clone https://github.com/proto-labs-ai/protolabs-studio.git && cd protolabs-studio
 npm install && npm run dev:web
 
 # 3. Use slash commands in Claude Code
@@ -589,7 +591,7 @@ claude
 
 ## Available Views
 
-Automaker provides several specialized views accessible via the sidebar or keyboard shortcuts:
+protoLabs Studio provides several specialized views accessible via the sidebar or keyboard shortcuts:
 
 | View               | Shortcut | Description                                                                                      |
 | ------------------ | -------- | ------------------------------------------------------------------------------------------------ |
@@ -620,10 +622,10 @@ All shortcuts are customizable in Settings. Default shortcuts:
 
 ### Monorepo Structure
 
-Automaker is built as an npm workspace monorepo with two main applications and seven shared packages:
+protoLabs Studio is built as an npm workspace monorepo with two main applications and seven shared packages:
 
 ```text
-automaker/
+protolabs-studio/
 ├── apps/
 │   ├── ui/          # React + Vite + Electron frontend
 │   └── server/      # Express + WebSocket backend
@@ -665,7 +667,7 @@ automaker/
 
 ### Data Storage
 
-Automaker uses a file-based storage system (no database required):
+protoLabs Studio uses a file-based storage system (no database required):
 
 #### Per-Project Data
 
@@ -714,7 +716,7 @@ data/
 >
 > We have reviewed this codebase for security vulnerabilities, but you assume all risk when running this software. You should review the code yourself before running it.
 >
-> **We do not recommend running Automaker directly on your local computer** due to the risk of AI agents having access to your entire file system. Please sandbox this application using Docker or a virtual machine.
+> **We do not recommend running protoLabs Studio directly on your local computer** due to the risk of AI agents having access to your entire file system. Please sandbox this application using Docker or a virtual machine.
 >
 > **[Read the full disclaimer](./DISCLAIMER.md)**
 
@@ -724,7 +726,7 @@ data/
 
 ### Documentation
 
-- [Contributing Guide](./CONTRIBUTING.md) - How to contribute to Automaker
+- [Contributing Guide](./CONTRIBUTING.md) - How to contribute to protoLabs Studio
 - [Project Documentation](./docs/) - Architecture guides, patterns, and developer docs
 - [Shared Packages Guide](./docs/llm-shared-packages.md) - Using monorepo packages
 

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en" suppressHydrationWarning>
   <head>
     <meta charset="UTF-8" />
-    <title>Automaker - Autonomous AI Development Studio</title>
+    <title>protoLabs Studio - Autonomous AI Development Studio</title>
     <meta name="description" content="Build software autonomously with AI agents" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,12 @@
-# Automaker Documentation
+# protoLabs Studio Documentation
 
 ## Quick Links
 
-| Service  | URL                                                                         | Description              |
-| -------- | --------------------------------------------------------------------------- | ------------------------ |
-| GitHub   | [proto-labs-ai/automaker](https://github.com/proto-labs-ai/automaker)       | Source code, issues, PRs |
-| Graphite | [proto-labs-ai](https://app.graphite.dev/github/pr/proto-labs-ai/automaker) | Stacked PR dashboard     |
-| Discord  | [Agentic Jumpstart](https://discord.gg/jjem7aEDKU)                          | Community and team chat  |
+| Service  | URL                                                                                 | Description              |
+| -------- | ----------------------------------------------------------------------------------- | ------------------------ |
+| GitHub   | [proto-labs-ai/protolabs-studio](https://github.com/proto-labs-ai/protolabs-studio) | Source code, issues, PRs |
+| Graphite | [proto-labs-ai](https://app.graphite.dev/github/pr/proto-labs-ai/protolabs-studio)  | Stacked PR dashboard     |
+| Discord  | [Agentic Jumpstart](https://discord.gg/jjem7aEDKU)                                  | Community and team chat  |
 
 ## Getting Started
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,13 +36,13 @@ features:
 
 ## Quick Links
 
-| Service  | URL                                                                         | Description                       |
-| -------- | --------------------------------------------------------------------------- | --------------------------------- |
-| GitHub   | [proto-labs-ai/automaker](https://github.com/proto-labs-ai/automaker)       | Source code, issues, PRs          |
-| Linear   | [protolabsai](https://linear.app/protolabsai)                               | Strategic roadmap and initiatives |
-| Graphite | [proto-labs-ai](https://app.graphite.dev/github/pr/proto-labs-ai/automaker) | Stacked PR dashboard              |
-| Discord  | [Agentic Jumpstart](https://discord.gg/jjem7aEDKU)                          | Community and team chat           |
+| Service  | URL                                                                                 | Description                       |
+| -------- | ----------------------------------------------------------------------------------- | --------------------------------- |
+| GitHub   | [proto-labs-ai/protolabs-studio](https://github.com/proto-labs-ai/protolabs-studio) | Source code, issues, PRs          |
+| Linear   | [protolabsai](https://linear.app/protolabsai)                                       | Strategic roadmap and initiatives |
+| Graphite | [proto-labs-ai](https://app.graphite.dev/github/pr/proto-labs-ai/protolabs-studio)  | Stacked PR dashboard              |
+| Discord  | [Agentic Jumpstart](https://discord.gg/jjem7aEDKU)                                  | Community and team chat           |
 
 ---
 
-<small>Built with <a href="https://github.com/proto-labs-ai/automaker">Automaker</a> — the open-source autonomous AI development studio that powers protoLabs.</small>
+<small>Built with <a href="https://github.com/proto-labs-ai/protolabs-studio">Automaker</a> — the open-source autonomous AI development studio that powers protoLabs.</small>

--- a/libs/dependency-resolver/package.json
+++ b/libs/dependency-resolver/package.json
@@ -23,6 +23,9 @@
     "dependency",
     "resolver"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "AutoMaker Team",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/libs/flows/package.json
+++ b/libs/flows/package.json
@@ -26,6 +26,9 @@
     "state-graphs",
     "flows"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "AutoMaker Team",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/libs/git-utils/package.json
+++ b/libs/git-utils/package.json
@@ -16,6 +16,9 @@
     "git",
     "utils"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "AutoMaker Team",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/libs/llm-providers/package.json
+++ b/libs/llm-providers/package.json
@@ -26,6 +26,9 @@
     "ollama",
     "bedrock"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "AutoMaker Team",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/libs/model-resolver/package.json
+++ b/libs/model-resolver/package.json
@@ -16,6 +16,9 @@
     "model",
     "resolver"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "AutoMaker Team",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/libs/observability/package.json
+++ b/libs/observability/package.json
@@ -23,6 +23,9 @@
     "langfuse",
     "tracing"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "AutoMaker Team",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/libs/platform/package.json
+++ b/libs/platform/package.json
@@ -15,6 +15,9 @@
     "automaker",
     "platform"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "AutoMaker Team",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/libs/policy-engine/package.json
+++ b/libs/policy-engine/package.json
@@ -17,6 +17,9 @@
     "authorization",
     "trust"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "AutoMaker Team",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/libs/prompts/package.json
+++ b/libs/prompts/package.json
@@ -16,6 +16,9 @@
     "prompts",
     "ai"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "AutoMaker Team",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/libs/spec-parser/package.json
+++ b/libs/spec-parser/package.json
@@ -22,6 +22,9 @@
     "spec-parser",
     "xml"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "AutoMaker Team",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -13,6 +13,9 @@
     "automaker",
     "types"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "AutoMaker Team",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -25,6 +25,9 @@
     "automaker",
     "utils"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "AutoMaker Team",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "automaker",
+  "name": "protolabs-studio",
   "version": "0.13.0",
   "private": true,
   "engines": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -15,6 +15,9 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "mcp",
     "automaker",


### PR DESCRIPTION
## Summary
- Superficial rebrand for external-facing docs and package publishing
- Product name references: Automaker/ProtoMaker → protoLabs Studio
- GitHub URLs → proto-labs-ai/protolabs-studio
- Root package.json name → protolabs-studio
- Added `publishConfig.access: public` to all 13 lib/package.json files
- UI title tag updated

## What does NOT change
- `@automaker/*` internal package names
- `.automaker/` directory name
- `AUTOMAKER_*` environment variables
- MCP plugin name/tools
- Electron productName/appId
- Docker paths
- License text
- Any functional code

## Test plan
- [x] `npm run build:packages` passes
- [x] `npm run format:check` passes (1 pre-existing violation in unrelated file)
- [x] Remaining "Automaker" in README = engine attribution, RPM filenames, license only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rebranded project from Automaker to protoLabs Studio across all documentation, contributing guides, readme files, repository references, and user-facing elements including page titles.

* **Chores**
  * Enabled public availability for multiple internal libraries and packages, allowing external developers to access and integrate them within the ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->