### PR TITLE
feat: antagonistic review flow state schema & types

### DIFF
--- a/libs/flows/src/antagonistic-review/index.ts
+++ b/libs/flows/src/antagonistic-review/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Antagonistic Review Flow
+ *
+ * Dual-perspective review system for milestone deliverables.
+ * Exports state definitions and types for the antagonistic review pipeline.
+ */
+
+export {
+  AntagonisticReviewStateAnnotation,
+  AntagonisticReviewStateSchema,
+  type AntagonisticReviewState,
+  type AntagonisticReviewStateType,
+} from './state.js';

--- a/libs/flows/src/antagonistic-review/state.ts
+++ b/libs/flows/src/antagonistic-review/state.ts
@@ -1,0 +1,126 @@
+/**
+ * Antagonistic Review Flow State
+ *
+ * Defines the LangGraph StateAnnotation for the antagonistic review pipeline.
+ * Follows reducer patterns from existing flows:
+ * - appendReducer for parallel collection (pairReviews)
+ * - Default replace semantics for all scalar fields
+ */
+
+import { Annotation } from '@langchain/langgraph';
+import { z } from 'zod';
+import { appendReducer } from '../graphs/reducers.js';
+import {
+  type SPARCPrd,
+  type ReviewerPerspective,
+  type PairReviewResult,
+  DistillationDepth,
+} from '@automaker/types';
+
+/**
+ * Zod schema for AntagonisticReviewState
+ * Validates the review state structure
+ */
+export const AntagonisticReviewStateSchema = z.object({
+  // Input PRD to review
+  prd: z.custom<SPARCPrd>(),
+
+  // Review configuration
+  topicComplexity: z.enum(['simple', 'moderate', 'complex']).optional(),
+  distillationDepth: z.nativeEnum(DistillationDepth).optional(),
+
+  // Individual reviewer perspectives
+  avaReview: z.custom<ReviewerPerspective>().optional(),
+  jonReview: z.custom<ReviewerPerspective>().optional(),
+
+  // Pair review results (parallel collection)
+  pairReviews: z.array(z.custom<PairReviewResult>()).default([]),
+
+  // Consensus and consolidation
+  consensus: z.boolean().optional(),
+  consolidatedPrd: z.custom<SPARCPrd>().optional(),
+  finalVerdict: z.enum(['approve', 'concern', 'block']).optional(),
+
+  // HITL (Human-in-the-Loop) integration
+  hitlRequired: z.boolean().optional(),
+  hitlFeedback: z.string().optional(),
+});
+
+/**
+ * Antagonistic Review State
+ * State graph for dual-perspective PRD review pipeline
+ */
+export interface AntagonisticReviewState {
+  /** Input: PRD to review */
+  prd: SPARCPrd;
+
+  /** Complexity level of the topic being reviewed */
+  topicComplexity?: 'simple' | 'moderate' | 'complex';
+
+  /** How deeply to analyze the PRD */
+  distillationDepth?: DistillationDepth;
+
+  /** Ava's perspective (optimistic, supportive) */
+  avaReview?: ReviewerPerspective;
+
+  /** Jon's perspective (critical, rigorous) */
+  jonReview?: ReviewerPerspective;
+
+  /** Pair review results (parallel collection with appendReducer) */
+  pairReviews: PairReviewResult[];
+
+  /** Did the reviewers reach consensus? */
+  consensus?: boolean;
+
+  /** Consolidated PRD after review (output) */
+  consolidatedPrd?: SPARCPrd;
+
+  /** Final overall verdict */
+  finalVerdict?: 'approve' | 'concern' | 'block';
+
+  /** Does this review require human approval? */
+  hitlRequired?: boolean;
+
+  /** Feedback from human reviewer if HITL was triggered */
+  hitlFeedback?: string;
+}
+
+/**
+ * State annotation for LangGraph
+ *
+ * Uses appropriate reducers:
+ * - appendReducer: For pairReviews (parallel Send() safety)
+ * - Default (replace): For all scalar fields
+ */
+export const AntagonisticReviewStateAnnotation = Annotation.Root({
+  // Input PRD
+  prd: Annotation<SPARCPrd>,
+
+  // Configuration
+  topicComplexity: Annotation<'simple' | 'moderate' | 'complex' | undefined>,
+  distillationDepth: Annotation<DistillationDepth | undefined>,
+
+  // Individual perspectives (replace semantics)
+  avaReview: Annotation<ReviewerPerspective | undefined>,
+  jonReview: Annotation<ReviewerPerspective | undefined>,
+
+  // Pair reviews (append reducer for parallel collection)
+  pairReviews: Annotation<PairReviewResult[]>({
+    reducer: appendReducer,
+    default: () => [],
+  }),
+
+  // Consensus and consolidation (replace semantics)
+  consensus: Annotation<boolean | undefined>,
+  consolidatedPrd: Annotation<SPARCPrd | undefined>,
+  finalVerdict: Annotation<'approve' | 'concern' | 'block' | undefined>,
+
+  // HITL integration (replace semantics)
+  hitlRequired: Annotation<boolean | undefined>,
+  hitlFeedback: Annotation<string | undefined>,
+});
+
+/**
+ * Type helper to extract state type from annotation
+ */
+export type AntagonisticReviewStateType = typeof AntagonisticReviewStateAnnotation.State;

--- a/libs/flows/src/index.ts
+++ b/libs/flows/src/index.ts
@@ -155,6 +155,14 @@ export {
   type ContentStyleConfig,
 } from './content/subgraphs/section-writer.js';
 
+// Antagonistic review flow (graph-based)
+export {
+  AntagonisticReviewStateAnnotation,
+  AntagonisticReviewStateSchema,
+  type AntagonisticReviewState,
+  type AntagonisticReviewStateType,
+} from './antagonistic-review/index.js';
+
 // XML tag extraction utilities for LLM output parsing
 export {
   extractTag,

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -652,7 +652,10 @@ export type {
   ReviewState,
   ContentBrief,
   DeliverableType,
+  PairReviewResult,
+  FlowReviewConfig,
 } from './review.js';
+export { DistillationDepth } from './review.js';
 
 // Content generation types
 export { SectionSchema, OutlineSchema } from './content.js';

--- a/libs/types/src/review.ts
+++ b/libs/types/src/review.ts
@@ -101,3 +101,42 @@ export type DeliverableType =
   | 'architecture' // Architecture diagrams and decisions
   | 'demo' // Demo or showcase materials
   | 'migration'; // Migration guides or scripts
+
+/**
+ * Depth of PRD distillation - determines review thoroughness
+ */
+export enum DistillationDepth {
+  Surface = 'surface', // Quick scan
+  Standard = 'standard', // Normal depth
+  Deep = 'deep', // Thorough analysis
+}
+
+/**
+ * Result from a pair review (Ava + Jon discussion)
+ */
+export interface PairReviewResult {
+  /** Section being reviewed */
+  section: string;
+  /** Were the reviewers able to reach consensus? */
+  consensus: boolean;
+  /** Agreed-upon verdict if consensus reached */
+  agreedVerdict?: ReviewVerdict;
+  /** Combined/resolved comments */
+  consolidatedComments: string;
+  /** ISO 8601 timestamp when pair review completed */
+  completedAt: string;
+}
+
+/**
+ * Configuration for the antagonistic review flow
+ */
+export interface FlowReviewConfig {
+  /** Complexity level of the topic being reviewed */
+  topicComplexity?: 'simple' | 'moderate' | 'complex';
+  /** How deep to analyze the PRD */
+  distillationDepth?: DistillationDepth;
+  /** Whether to require human-in-the-loop for final approval */
+  requireHITL?: boolean;
+  /** Timeout for each review phase in milliseconds */
+  reviewTimeout?: number;
+}


### PR DESCRIPTION
## Summary
- Add LangGraph `AntagonisticReviewStateAnnotation` with Zod schema for the graph-based antagonistic review flow
- New types: `DistillationDepth` enum, `PairReviewResult`, `FlowReviewConfig`
- `appendReducer` for parallel pair reviews via `Send()`, replace semantics for scalars
- Follows existing content flow patterns from `libs/flows/src/content/state.ts`

## Context
First feature in the **Antagonistic Review Graph Flow** project — replacing the current sequential DynamicAgentExecutor calls with a proper LangGraph state graph. This is the Layer 1 (state schema) work.

## Test plan
- [x] `libs/types` compiles cleanly
- [x] `libs/flows` compiles cleanly
- [x] All new types exported from `@automaker/types` and `@automaker/flows`
- [x] Prettier passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added antagonistic review flow for comprehensive PRD evaluation.
  * Introduced configurable review settings including topic complexity and distillation depth levels.
  * Enabled parallel pair reviews with consensus and verdict consolidation.
  * Added human-in-the-loop support with feedback integration and configurable review timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->