### PR TITLE
fix: prettier worktree ignore-path + docs cleanup

### DIFF
--- a/apps/server/src/services/built-in-templates.ts
+++ b/apps/server/src/services/built-in-templates.ts
@@ -41,8 +41,9 @@ const BUILT_IN_TEMPLATES: AgentTemplate[] = [
 
 ## Operating Rules
 
-- Always run prettier from INSIDE the worktree: \`cd <worktree> && npx prettier --write $(git diff --name-only --diff-filter=ACMR)\`
-- Never run prettier from the main repo root — config resolution differences cause false passes
+- Always pass \`--ignore-path .prettierignore\` to prettier: \`npx prettier --ignore-path .prettierignore --write <files>\`
+- This prevents prettier from using .gitignore which silently skips files in .worktrees/
+- Can run from worktree (\`git -C <worktree> ...\`) or main repo — both work with --ignore-path flag
 - After formatting, commit and push before enabling auto-merge
 - Use \`gh pr merge <number> --auto --squash\` for auto-merge
 - Use resolve_review_threads MCP tool for batch CodeRabbit resolution

--- a/apps/server/src/services/crew-members/pr-maintainer-check.ts
+++ b/apps/server/src/services/crew-members/pr-maintainer-check.ts
@@ -311,7 +311,7 @@ Please:
 1. For critical-threads: use \`resolve_review_threads\` to address unresolved critical-severity feedback
 2. For stale PRs: check PR status with \`check_pr_status\`, resolve threads with \`resolve_review_threads\`, enable auto-merge
 3. For orphaned worktrees: check for uncommitted work, create PR with \`create_pr_from_worktree\` if needed
-4. For format failures: fix from inside the worktree (\`cd <worktree> && npx prettier --write $(git diff --name-only --diff-filter=ACMR)\`)
+4. For format failures: run \`npx prettier --ignore-path .prettierignore --write <files>\` (the --ignore-path flag is critical — without it, prettier silently skips .worktrees/ files via .gitignore)
 5. For branches behind main: rebase and force-push
 
 This is an automated triage request triggered by the crew loop system.`;

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -700,10 +700,13 @@ export class GitWorkflowService {
       );
       const files = stagedFiles.trim().split('\n').filter(Boolean);
       if (files.length > 0) {
-        await execAsync(`npx prettier --write ${files.map((f) => `"${f}"`).join(' ')}`, {
-          cwd: workDir,
-          env: execEnv,
-        });
+        await execAsync(
+          `npx prettier --ignore-path .prettierignore --write ${files.map((f) => `"${f}"`).join(' ')}`,
+          {
+            cwd: workDir,
+            env: execEnv,
+          }
+        );
         // Re-stage after formatting
         await execAsync("git add -A -- ':!.automaker/'", { cwd: workDir, env: execEnv });
         logger.debug(`Auto-formatted ${files.length} staged files`);

--- a/apps/server/src/templates/cicd/github-actions/format-check.yml
+++ b/apps/server/src/templates/cicd/github-actions/format-check.yml
@@ -22,4 +22,4 @@ jobs:
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm exec prettier --check .
+      - run: pnpm exec prettier --ignore-path .prettierignore --check .

--- a/docs/architecture/agent-flows.md
+++ b/docs/architecture/agent-flows.md
@@ -1,0 +1,225 @@
+# Agent Flows
+
+End-to-end pipeline diagrams documenting how work moves through Automaker's autonomous development system.
+
+## Automaker Dev Cycle — Idea to Merged PR
+
+The complete lifecycle from an idea entering the system through to code merged on main. This is the core pipeline that Automaker automates.
+
+### Full Pipeline Diagram
+
+```mermaid
+flowchart TD
+    subgraph Intake["1. Intake"]
+        A[Idea / Signal] --> B{Source?}
+        B -->|Human| C[Josh creates PRD via CLI]
+        B -->|CoS| D["Ava submits PRD via submit_prd MCP"]
+        B -->|External| E[Linear webhook / Discord signal]
+        C --> F[SPARC PRD Document]
+        D --> F
+        E --> F
+    end
+
+    subgraph Planning["2. Planning & Decomposition"]
+        F --> G[ProjM Agent receives PRD]
+        G --> H[Deep research — codebase scan]
+        H --> I[Decompose into milestones + phases]
+        I --> J["Scaffold .automaker/projects/"]
+        J --> K["create_project_features()"]
+        K --> L[Epic features per milestone]
+        K --> M[Implementation features per phase]
+        K --> N[Dependency chain set]
+    end
+
+    subgraph Execution["3. Autonomous Execution"]
+        N --> O{Auto-mode running?}
+        O -->|No| P["start_auto_mode(concurrency=1)"]
+        O -->|Yes| Q[Tick loop]
+        P --> Q
+        Q --> R[Load pending features]
+        R --> S[Topological sort by dependencies]
+        S --> T[Filter: deps satisfied + not blocked]
+        T --> U[Pick highest priority unblocked feature]
+        U --> V[Create git worktree]
+        V --> W["Agent starts (Sonnet default)"]
+    end
+
+    subgraph AgentWork["4. Agent Implementation"]
+        W --> X[Read feature description + context files]
+        X --> Y[Ava sends context message]
+        Y --> Z[Agent implements in worktree]
+        Z --> AA[Agent runs tests]
+        AA --> AB{Tests pass?}
+        AB -->|Yes| AC[Agent marks verified]
+        AB -->|No| AD[Agent iterates / fixes]
+        AD --> Z
+        AC --> AE{Hit turn limit?}
+        AE -->|No| AF[Clean completion]
+        AE -->|Yes| AG[Partial work in worktree]
+    end
+
+    subgraph PostFlight["5. Post-Flight PR Pipeline"]
+        AF --> AH[Ava: Check worktree commits]
+        AG --> AH
+        AH --> AI[Rebase on origin/main]
+        AI --> AJ[Prettier format fix]
+        AJ --> AK[Push branch to origin]
+        AK --> AL["gh pr create"]
+        AL --> AM["gh pr merge --auto --squash"]
+        AM --> AN[Move feature to review]
+    end
+
+    subgraph CIReview["6. CI & Review"]
+        AN --> AO[GitHub Actions CI]
+        AO --> AP{All checks pass?}
+        AP -->|build| AQ[TypeScript build]
+        AP -->|test| AR[Vitest unit tests]
+        AP -->|format| AS[Prettier check]
+        AP -->|audit| AT[Security audit]
+        AP -->|e2e| AU[Playwright E2E]
+        AQ & AR & AS & AT & AU --> AV{CodeRabbit review}
+        AV --> AW{Critical threads?}
+        AW -->|Yes| AX["Resolve threads (GraphQL mutation)"]
+        AW -->|No| AY[All clear]
+        AX --> AY
+    end
+
+    subgraph Completion["7. Merge & Completion"]
+        AY --> AZ[Auto-merge executes]
+        AZ --> BA[PR squash-merged to main]
+        BA --> BB[Move feature to done]
+        BB --> BC{All epic children done?}
+        BC -->|Yes| BD[Close epic]
+        BC -->|No| BE[Continue with next feature]
+        BD --> BF{All epics in milestone done?}
+        BE --> Q
+        BF -->|Yes| BG[Milestone retro ceremony]
+        BF -->|No| BE
+        BG --> BH{More milestones?}
+        BH -->|Yes| BE
+        BH -->|No| BI[Project complete]
+    end
+
+    subgraph Escalation["Recovery & Escalation"]
+        AP -->|Failure| BJ[CI failure detected]
+        BJ --> BK{Fixable?}
+        BK -->|Format| AJ
+        BK -->|Build error| BL[Escalate complexity]
+        BL --> BM["Retry: haiku→sonnet→opus"]
+        BM --> W
+        BK -->|Blocked| BN[Create blocking issue]
+        BN --> BO[Alert via EscalationRouter]
+    end
+
+    style Intake fill:#1e293b,color:#e2e8f0
+    style Planning fill:#1e3a5f,color:#e2e8f0
+    style Execution fill:#1a3a2a,color:#e2e8f0
+    style AgentWork fill:#3a2a1a,color:#e2e8f0
+    style PostFlight fill:#2a1a3a,color:#e2e8f0
+    style CIReview fill:#3a1a1a,color:#e2e8f0
+    style Completion fill:#1a2a3a,color:#e2e8f0
+    style Escalation fill:#4a1a1a,color:#e2e8f0
+```
+
+### ProjM Decomposition Flow (Detail)
+
+The Project Manager agent's internal flow when receiving a PRD from the Chief of Staff.
+
+```mermaid
+sequenceDiagram
+    participant CoS as Ava (Chief of Staff)
+    participant API as Server API
+    participant ProjM as ProjM Agent
+    participant Board as Automaker Board
+    participant Git as Git / Worktrees
+
+    CoS->>API: POST /api/cos/submit-prd
+    API->>Board: Create epic feature
+    API-->>CoS: Epic ID returned
+
+    API->>ProjM: Trigger decomposition
+    ProjM->>ProjM: Deep research (codebase scan)
+    ProjM->>ProjM: Identify affected files
+    ProjM->>ProjM: Design milestone breakdown
+
+    loop For each milestone
+        ProjM->>Board: Create milestone epic
+        loop For each phase in milestone
+            ProjM->>Board: Create implementation feature
+            ProjM->>Board: Set dependencies (previous phase)
+            ProjM->>Board: Set epicId (parent milestone)
+        end
+    end
+
+    ProjM->>Board: Scaffold .automaker/projects/
+    ProjM-->>CoS: Decomposition complete event
+
+    CoS->>Board: Review features + deps
+    CoS->>Board: start_auto_mode()
+
+    loop Auto-mode tick
+        Board->>Board: Pick next unblocked feature
+        Board->>Git: Create worktree
+        Board->>ProjM: Start agent (Sonnet)
+        Note over ProjM,Git: Agent implements in isolation
+        ProjM-->>Board: Feature verified
+        CoS->>Git: Post-flight (rebase, format, push)
+        CoS->>Board: Create PR, enable auto-merge
+    end
+```
+
+### Crew Loop Monitoring (Parallel to Execution)
+
+While agents execute, crew members run on cron schedules to maintain system health.
+
+```mermaid
+flowchart LR
+    subgraph Cron["Cron Scheduler"]
+        T1["*/10 min"] --> PR[PR Maintainer]
+        T1 --> FK[Frank]
+        T2["*/15 min"] --> BJ[Board Janitor]
+    end
+
+    subgraph PRMaint["PR Maintainer"]
+        PR --> PR1[Stale PRs > 24h?]
+        PR --> PR2[Auto-merge stuck?]
+        PR --> PR3[CodeRabbit unresolved?]
+        PR --> PR4[Orphaned worktrees?]
+    end
+
+    subgraph Frank["Frank (DevOps)"]
+        FK --> FK1[V8 heap usage]
+        FK --> FK2[RSS memory]
+        FK --> FK3[Agent capacity]
+    end
+
+    subgraph BoardJ["Board Janitor"]
+        BJ --> BJ1[Merged but not done?]
+        BJ --> BJ2[Orphaned in-progress?]
+        BJ --> BJ3[Broken dependency chain?]
+    end
+
+    PR1 & PR2 & PR3 & PR4 --> E1{Needs escalation?}
+    FK1 & FK2 & FK3 --> E2{Critical?}
+    BJ1 & BJ2 & BJ3 --> E3{Needs fix?}
+
+    E1 -->|Yes| A1[Escalate to Ava]
+    E2 -->|Yes| A2[Alert #infra]
+    E3 -->|Yes| A3[Auto-fix board state]
+
+    style Cron fill:#1e293b,color:#e2e8f0
+    style PRMaint fill:#2a1a3a,color:#e2e8f0
+    style Frank fill:#1a3a2a,color:#e2e8f0
+    style BoardJ fill:#3a2a1a,color:#e2e8f0
+```
+
+### Key Metrics
+
+| Metric                              | Typical Value         |
+| ----------------------------------- | --------------------- |
+| Agent implementation time           | 3-6 min (Sonnet)      |
+| PR pipeline (post-flight → merge)   | 2-5 min               |
+| Full feature cycle (backlog → done) | 8-15 min              |
+| Agent cost per feature              | $1.15-1.70 (Sonnet)   |
+| Escalation rate                     | ~15% (format fixes)   |
+| Auto-merge success rate             | >95% after format fix |

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,0 +1,7 @@
+# Architecture
+
+System architecture documentation for Automaker's autonomous development pipeline.
+
+## Pages
+
+- [Agent Flows](./agent-flows.md) — End-to-end pipeline diagrams for how work flows through the system

--- a/docs/protolabs/agency-architecture.md
+++ b/docs/protolabs/agency-architecture.md
@@ -1,0 +1,249 @@
+# ProtoLabs Agency System — Architecture
+
+## System Architecture Diagram
+
+```mermaid
+graph TB
+    subgraph INTAKE["1. SIGNAL INTAKE"]
+        D_MSG[Discord Message]
+        L_ISS[Linear Issue]
+        GH_ISS[GitHub Issue]
+        HUMAN[Human CLI/Chat]
+        AGENT_SIG[Agent Signal<br/>retro findings, escalations]
+    end
+
+    subgraph TRIAGE["2. TRIAGE & ROUTING"]
+        AVA_TRIAGE["Ava (CoS)<br/>Signal Classification"]
+        AVA_TRIAGE -->|idea| PRD_PIPE
+        AVA_TRIAGE -->|bug| BUG_FAST["Fast-track:<br/>Create feature → Agent"]
+        AVA_TRIAGE -->|ops improvement| BEADS_CREATE["Create Bead<br/>→ Self-improvement"]
+        AVA_TRIAGE -->|gtm/content| JON_ROUTE["Route to Jon"]
+    end
+
+    subgraph PRD_REVIEW["3. PRD PIPELINE"]
+        PRD_PIPE["SPARC PRD<br/>Creation"]
+        PRD_PIPE --> ANTAG["Antagonistic Review"]
+        AVA_REV["Ava: Feasibility<br/>Risk, Capacity"]
+        JON_REV["Jon: Market Value<br/>Positioning, ROI"]
+        AVA_REV <-->|Challenge| JON_REV
+        ANTAG --> AVA_REV
+        ANTAG --> JON_REV
+        AVA_REV --> CONSOLIDATED["Consolidated PRD"]
+        JON_REV --> CONSOLIDATED
+    end
+
+    subgraph APPROVAL["4. APPROVAL GATE"]
+        CONSOLIDATED --> GATE{Approval?}
+        GATE -->|preApproved<br/>small/ops| AUTO_APPROVE["Auto-approve"]
+        GATE -->|standard| JOSH_REVIEW["Josh reviews<br/>in Linear"]
+        JOSH_REVIEW -->|approved| APPROVED
+        JOSH_REVIEW -->|changes| CONSOLIDATED
+        AUTO_APPROVE --> APPROVED["Approved PRD"]
+    end
+
+    subgraph PLANNING["5. PLANNING"]
+        APPROVED --> PROJM["ProjM Agent<br/>Deep Research"]
+        PROJM --> MILESTONES["Milestones + Phases<br/>+ Dependencies"]
+        MILESTONES --> LINEAR_POST["Post to Linear<br/>Project + Issues"]
+        LINEAR_POST --> HITL_CHECK{HITL<br/>Scope Review?}
+        HITL_CHECK -->|adjust| MILESTONES
+        HITL_CHECK -->|proceed| BOARD_CREATE["Create Features<br/>on Automaker Board"]
+    end
+
+    subgraph SYNC["6. SYSTEM OF RECORD"]
+        LINEAR_SOT["Linear<br/>(Source of Truth)"]
+        AUTOMAKER_BOARD["Automaker Board<br/>(Execution)"]
+        GITHUB_REPO["GitHub<br/>(Code + PRs)"]
+        LINEAR_SOT <-->|Bidirectional Sync| AUTOMAKER_BOARD
+        AUTOMAKER_BOARD <-->|Branches + PRs| GITHUB_REPO
+        GITHUB_REPO <-->|Issue Sync| LINEAR_SOT
+    end
+
+    subgraph EXECUTION["7. EXECUTION LOOP"]
+        AUTO_MODE["Auto-Mode<br/>Tick Loop"]
+        AUTO_MODE --> PICK["Pick Unblocked<br/>Feature"]
+        PICK --> WORKTREE["Create Worktree"]
+        WORKTREE --> AGENT["Agent Implements<br/>(Sonnet/Opus)"]
+        AGENT --> TESTS{Tests Pass?}
+        TESTS -->|no| ITERATE["Iterate / Escalate"]
+        ITERATE --> AGENT
+        TESTS -->|yes| VERIFIED["Verified"]
+    end
+
+    subgraph PR_PIPELINE["8. PR PIPELINE"]
+        VERIFIED --> REBASE["Rebase + Format"]
+        REBASE --> PR_CREATE["Push + PR"]
+        PR_CREATE --> CI["CI Checks<br/>build, test, format, audit"]
+        CI --> CODERABBIT["CodeRabbit Review"]
+        CODERABBIT --> RESOLVE["Resolve Threads"]
+        RESOLVE --> MERGE["Squash-Merge<br/>to Main"]
+        MERGE --> DONE["Feature → Done"]
+    end
+
+    subgraph REFLECTION["9. REFLECTION LOOP"]
+        DONE --> EPIC_CHECK{Epic Done?}
+        EPIC_CHECK -->|no| AUTO_MODE
+        EPIC_CHECK -->|yes| RETRO["Milestone Retro"]
+        RETRO --> METRICS["Impact Metrics<br/>cost, duration, quality"]
+        RETRO --> KNOWLEDGE["Update Memory<br/>+ Knowledge Base"]
+        RETRO --> IMPROVEMENTS["Spawn Improvement<br/>Tickets"]
+        RETRO --> CHANGELOG["Generate Changelog"]
+        METRICS --> STRATEGY["Strategy Regroup"]
+        IMPROVEMENTS --> INTAKE
+        STRATEGY --> INTAKE
+    end
+
+    %% Cross-cutting connections
+    INTAKE --> AVA_TRIAGE
+    BOARD_CREATE --> AUTO_MODE
+    BOARD_CREATE --> SYNC
+    DONE --> SYNC
+```
+
+## Component Inventory
+
+### Exists and Working
+
+| Component                    | Location                                            | Status  | Notes                               |
+| ---------------------------- | --------------------------------------------------- | ------- | ----------------------------------- |
+| **submit_prd MCP tool**      | `packages/mcp-server/src/index.ts`                  | Working | Creates epic, ProjM decomposes      |
+| **SPARC PRD skill**          | `plugins/automaker/commands/sparc-prd.md`           | Working | Interactive PRD creation            |
+| **ProjM deep research**      | `apps/server/src/services/authority-agents/`        | Working | Milestone/phase decomposition       |
+| **Auto-mode execution**      | `apps/server/src/services/auto-mode-service.ts`     | Working | Dependency-aware, model escalation  |
+| **Agent factory + registry** | `apps/server/src/services/agent-factory-service.ts` | Working | Template-based agent creation       |
+| **Worktree isolation**       | `apps/server/src/services/agent-service.ts`         | Working | Per-feature branches                |
+| **PR pipeline**              | `apps/server/src/services/git-workflow-service.ts`  | Working | Create, push, merge                 |
+| **CodeRabbit integration**   | Branch protection + resolve_review_threads          | Working | Required check                      |
+| **CI/CD**                    | `.github/workflows/`                                | Working | Build, test, format, audit          |
+| **Linear sync (features)**   | `apps/server/src/services/linear-sync-service.ts`   | Working | Feature → Linear issue push         |
+| **Linear webhook**           | `apps/server/src/routes/linear/webhook.ts`          | Working | Receives mentions/delegations       |
+| **Ceremony service**         | `apps/server/src/services/ceremony-service.ts`      | Working | Standup, retro, project-retro       |
+| **Crew loops**               | `apps/server/src/services/crew-loop-service.ts`     | Working | PR Maintainer, Board Janitor, Frank |
+| **Escalation pipeline**      | `apps/server/src/services/escalation-router.ts`     | Working | 5 channels, SLA engine              |
+| **Signal accumulator**       | `apps/server/src/services/`                         | Working | Severity classification + briefing  |
+| **Agent memory**             | `.automaker/memory/*.md`                            | Working | Per-agent learning files            |
+| **Beads task tracking**      | `.beads/issues.jsonl`                               | Working | Operational task queue              |
+| **Discord MCP**              | `packages/mcp-server/plugins/automaker/`            | Working | Send, read, channels, webhooks      |
+| **Conflict resolution UI**   | `apps/ui/src/`                                      | Working | Linear sync conflict handling       |
+
+### Partially Built
+
+| Component               | What Exists                              | What's Missing                                                           |
+| ----------------------- | ---------------------------------------- | ------------------------------------------------------------------------ |
+| **Signal intake**       | Discord/Linear/GitHub receive messages   | No auto-triage pipeline. Messages don't auto-trigger PRD creation.       |
+| **Jon GTM agent**       | Template registered, `/gtm` skill exists | Not wired into PRD review pipeline. Only does standalone content work.   |
+| **Linear project sync** | Feature-level sync works                 | Can't create Linear projects or documents programmatically. Only issues. |
+| **Ceremonies**          | Discord posts on milestone events        | Don't spawn improvement tickets. Don't capture learnings systematically. |
+| **HITL approval**       | Linear agent sessions, elicitation tools | No structured approval gate for milestones/scope in Linear.              |
+| **preApproved flag**    | submit_prd creates features directly     | No trust-boundary logic for auto-approval vs. human review.              |
+
+### Doesn't Exist Yet
+
+| Component                            | Purpose                                                   | Priority                                                 |
+| ------------------------------------ | --------------------------------------------------------- | -------------------------------------------------------- |
+| **Antagonistic review**              | Ava + Jon cross-challenge PRDs before approval            | Critical — prevents garbage-in                           |
+| **Unified signal router**            | Any signal source → classification → correct pipeline     | Critical — intake bottleneck                             |
+| **Retro → improvement tickets**      | Ceremony retros auto-create Beads/Linear items            | High — closes the loop                                   |
+| **Linear project/document creation** | Programmatic project + doc creation in Linear             | High — can't be automation agency with manual Linear ops |
+| **Automated changelog**              | Generate changelog from merged features per epic/project  | Medium — visibility                                      |
+| **Metrics-driven impact analysis**   | "Was this project worth it?" automated analysis           | Medium — accountability                                  |
+| **Knowledge synthesis**              | Project-level learning rollup (not just per-agent memory) | Medium — organizational learning                         |
+| **preApproved trust boundaries**     | Rules: complexity ≤ small + category = ops → auto-approve | Medium — removes bottleneck                              |
+
+## Data Flow
+
+### Signal → Production
+
+```
+Signal (Discord/Linear/GitHub)
+  ↓
+Ava classifies signal type and urgency
+  ↓
+[idea] → SPARC PRD created
+  ↓
+Antagonistic review: Ava ↔ Jon
+  ↓
+Consolidated PRD → Linear document
+  ↓
+Approval gate (Josh or preApproved)
+  ↓
+ProjM: deep research → milestones → phases
+  ↓
+Linear project + Automaker board features
+  ↓
+Auto-mode picks features in dependency order
+  ↓
+Agent implements in worktree → tests → verified
+  ↓
+PR pipeline: rebase → push → CI → CodeRabbit → merge
+  ↓
+Feature → done, sync to Linear
+  ↓
+Epic complete → ceremony (retro + metrics)
+  ↓
+Improvement tickets + knowledge update → REPEAT
+```
+
+### System of Record Boundaries
+
+```
+┌──────────────────────────────────────────────────────┐
+│                    LINEAR (Strategic)                  │
+│  Projects, Milestones, Roadmap, Human Reviews         │
+│  ↕ Bidirectional sync (issue status, labels, fields)  │
+├──────────────────────────────────────────────────────┤
+│                 AUTOMAKER BOARD (Tactical)             │
+│  Features, Agents, Worktrees, Dependencies, Auto-mode │
+│  ↕ Git operations (branches, PRs, merges)             │
+├──────────────────────────────────────────────────────┤
+│                    GITHUB (Code)                       │
+│  Repository, Branches, PRs, CI, CodeRabbit            │
+│  ↕ Webhooks + API (status updates, PR events)         │
+├──────────────────────────────────────────────────────┤
+│                   DISCORD (Comms)                      │
+│  Status updates, Ceremonies, Alerts, Conversations    │
+│  Read-only state — no persistent data                 │
+└──────────────────────────────────────────────────────┘
+```
+
+### Agent Communication Topology
+
+```
+                    Josh (Human)
+                    ↕ Discord / Linear
+                   Ava (CoS)
+                 ↙    ↓    ↘
+              Jon    ProjM    Frank
+             (GTM)  (Plan)   (DevOps)
+                      ↓
+                   Features
+                 ↙    ↓    ↘
+            Agent₁  Agent₂  Agent₃
+            (Sonnet) (Sonnet) (Haiku)
+                 ↘    ↓    ↙
+               PR Maintainer (Crew)
+               Board Janitor (Crew)
+```
+
+Ava is the hub. All strategic decisions flow through her. Agents communicate via:
+
+- **MCP tools** for system operations
+- **Discord** for human-facing updates
+- **Events** for system-to-system (feature:completed, milestone:started, etc.)
+- **Agent memory** for persistent cross-session learning
+
+## Scalability Considerations
+
+### Current Limits
+
+- 2-3 concurrent agents on dev hardware (8GB heap)
+- 6-10 concurrent agents on staging (32GB heap, 125GB RAM)
+- Linear MCP has basic CRUD only (no project/doc creation)
+- Agent turns limited (hit turn limit = uncommitted work)
+
+### Scaling Strategy
+
+- **Vertical**: Staging hardware handles more concurrent agents
+- **Horizontal**: Multiple Automaker instances per project (future)
+- **Efficiency**: Model routing (Haiku for mechanical work, Opus only for architectural decisions)
+- **Automation**: Every manual step today becomes automated tomorrow — this is the self-improvement loop

--- a/docs/protolabs/agency-overview.md
+++ b/docs/protolabs/agency-overview.md
@@ -1,0 +1,158 @@
+# ProtoLabs Agency System — Overview
+
+## What It Is
+
+ProtoLabs is a fully autonomous software development agency powered by AI agents. It takes ideas from any source — human conversation, Discord messages, Linear issues, GitHub — and transforms them into shipped, tested, merged code through a repeatable, measurable loop.
+
+The system doesn't just execute. It plans, challenges its own plans, breaks work into measurable pieces, delegates to specialized agents, monitors quality, and — critically — reflects on what it learned and feeds that back into better future work.
+
+**The loop: IDEA → RESEARCH → EXPAND → EXECUTE → REFLECT → REPEAT**
+
+## Why It Matters
+
+### The Problem With AI-Assisted Development Today
+
+Most AI coding tools operate at the wrong altitude. They help you write a function or fix a bug. ProtoLabs operates at the **organizational** level — it's not a tool, it's a **team**.
+
+The gap between "AI can write code" and "AI can run a development organization" is:
+
+- **Planning**: Who decides what to build and why?
+- **Quality gates**: Who challenges bad ideas before they waste execution cycles?
+- **Coordination**: How do parallel workstreams avoid conflicts?
+- **Accountability**: How do you know if the work was worth doing?
+- **Learning**: How does the org get smarter over time?
+
+### The ProtoLabs Answer
+
+Every human development org has these roles: product (what), engineering (how), QA (quality), PM (when), and leadership (why). ProtoLabs fills these with specialized AI agents that communicate through well-defined interfaces:
+
+| Role                | Agent           | Responsibilities                                            |
+| ------------------- | --------------- | ----------------------------------------------------------- |
+| CEO / Visionary     | Josh (human)    | Ideas, direction, final approval                            |
+| Chief of Staff      | Ava             | Triage, orchestration, quality gates, antagonistic review   |
+| GTM / Strategy      | Jon             | Market perspective, customer value, content, positioning    |
+| Project Manager     | ProjM           | Deep research, milestone decomposition, dependency planning |
+| Engineering Manager | EM              | PR pipeline, merge strategy, build health                   |
+| Backend Engineer    | Agents (Sonnet) | Feature implementation in worktrees                         |
+| Frontend Engineer   | Matt            | UI components, design systems, Storybook                    |
+| DevOps              | Frank           | Infrastructure health, deploys, monitoring                  |
+| PR Maintainer       | Crew (Haiku)    | Auto-merge, format fixes, CodeRabbit resolution             |
+| Board Janitor       | Crew (Haiku)    | Board consistency, orphaned features, stale deps            |
+
+## Three Surfaces, Clear Separation
+
+ProtoLabs operates across three systems that each own a distinct layer:
+
+### Linear — Strategic Layer (Source of Truth)
+
+- Vision, goals, initiatives, projects, roadmap
+- Human reviews happen here
+- Clients see progress here
+- The "exec team" view
+
+### Automaker Board — Tactical Layer
+
+- Features, agents, branches, PRs, task execution
+- Where code actually gets written
+- Agent worktrees, auto-mode, dependency chains
+- The "dev team" view
+
+### Discord — Communication Layer
+
+- Async team coordination
+- Status updates, alerts, ceremonies
+- Josh ↔ Ava primary channel
+- The "office" view
+
+**Rule: Never mix the layers.** Linear doesn't track individual PRs. Automaker doesn't own roadmap vision. Discord doesn't store state.
+
+## The Flow
+
+### 1. Idea Intake
+
+Ideas arrive from anywhere:
+
+- Josh types in Discord or creates a Linear issue
+- Ava identifies operational improvements during execution
+- Jon identifies market opportunities from content/social
+- External stakeholders file GitHub issues
+- Agents surface improvement opportunities from retros
+
+All signals funnel through communication channels into the planning pipeline.
+
+### 2. PRD Consolidation + Antagonistic Review
+
+Every idea gets a SPARC PRD (Situation, Problem, Approach, Results, Constraints). Two agents review it from opposing perspectives:
+
+- **Ava (CoS)**: Is this operationally feasible? Does it align with current capacity? What's the risk?
+- **Jon (GTM)**: Does this create customer value? Can we sell this? Does it strengthen our positioning?
+
+They challenge each other. The output is a consolidated plan that has survived cross-functional scrutiny.
+
+### 3. Approval Gate
+
+Josh reviews the PRD in Linear. Two modes:
+
+- **Standard**: Josh reviews, comments, approves or requests changes
+- **preApproved**: Low-risk items (small scope, operational improvements) auto-pass based on trust boundaries
+
+### 4. Planning & Research
+
+ProjM takes the approved PRD and does deep research:
+
+- Analyzes the codebase for relevant patterns
+- Identifies files that need modification
+- Designs milestones and phases
+- Sets acceptance criteria
+- Estimates complexity
+
+Output: Milestones with ordered phases, posted to Linear for visibility.
+
+### 5. Execution
+
+Auto-mode processes features in dependency order:
+
+- Creates isolated git worktrees
+- Routes to appropriate agent model (Haiku for small, Sonnet for medium, Opus for architectural)
+- Agent implements, tests, verifies
+- On failure: iterate with more context, escalate model, or flag for human help
+
+### 6. PR Pipeline
+
+Automated quality assurance:
+
+- Rebase on latest main
+- Format fixes (Prettier)
+- Push + create PR
+- CI checks (build, test, format, audit)
+- CodeRabbit AI review
+- Thread resolution
+- Auto-merge (squash to main)
+
+### 7. Reflection
+
+When an epic completes:
+
+- **Retro**: What worked, what didn't, what to change
+- **Metrics**: Cost, duration, failure rate, agent model distribution
+- **Knowledge capture**: Update memory files with lessons learned
+- **Improvement tickets**: Auto-create tasks from identified friction points
+- **Changelog**: Generate human-readable summary of what shipped
+
+The reflection loop is what makes this a **learning system**, not just an execution engine. Every project makes the next project better.
+
+## The Revenue Model
+
+1. **Content/Social Media**: Every project we run generates content about how autonomous AI development works
+2. **Consulting (setupLab)**: We teach other organizations to set up their own proto labs using our gold standard
+3. **Template Repos**: Standardized project scaffolding that embodies our patterns
+
+The system is both the product and the factory that makes the product.
+
+## What Makes This Different
+
+- **Not a copilot** — it's a team. Multiple specialized agents with defined roles and communication protocols.
+- **Not one-shot** — it's a loop. Continuous improvement feeds learning back into planning.
+- **Not just code** — it's organizational. Planning, review, execution, reflection, knowledge management.
+- **Not a black box** — it's observable. Linear for strategy, Automaker board for tactics, Discord for communication. Full audit trail.
+- **Not static** — it's self-improving. The system upgrades itself through the same pipeline it uses for customer work.

--- a/docs/protolabs/agency-prd.md
+++ b/docs/protolabs/agency-prd.md
@@ -1,0 +1,255 @@
+# PRD: ProtoLabs Agency System — Full-Loop Automation
+
+## Situation
+
+Automaker has a strong execution engine: auto-mode processes features through dependency-ordered agent implementation, PR pipelines merge code with CI checks and CodeRabbit review, and Linear sync keeps the strategic layer informed. Over 40 sessions and 400+ PRs, we've proven the execution loop works.
+
+But the system has critical gaps at the **boundaries** — intake and reflection. Ideas arrive ad-hoc through Discord/Linear/GitHub with no automated triage. PRDs are created by one agent without cross-functional challenge. Ceremonies post to Discord but don't close the loop by creating improvement tickets. There's no mechanism for the system to recognize its own friction points and auto-generate the work to fix them.
+
+The execution middle is mature. The intake beginning and reflection end are manual. This means the system can't run autonomously end-to-end — it still requires Josh as the bottleneck for triage, PRD review, and improvement identification.
+
+## Problem
+
+**The IDEA → PRODUCTION → LEARNING loop is broken at two points:**
+
+1. **Intake**: Signals arrive from 4+ sources (Discord, Linear, GitHub, agent observations) but nothing auto-triages them into PRDs. Ava manually reads Discord. Josh manually creates Linear issues. No automated classification, no priority routing, no cross-functional review.
+
+2. **Reflection**: Ceremonies generate Discord posts but don't create actionable improvement tickets. Agent memory captures per-file gotchas but not project-level organizational learning. There's no "was this project worth it?" analysis that feeds into the next planning cycle.
+
+**Secondary gaps:**
+
+3. **Linear is strategic SOT but we can't programmatically create projects or documents** — the team manually copy-pastes. An "automation agency" that requires manual data entry in its planning tool is a contradiction.
+
+4. **No antagonistic review** — PRDs go from creation to execution without being challenged. This is how bad ideas become expensive mistakes. We need Ava (ops) and Jon (GTM) to cross-examine every plan before committing resources.
+
+5. **No preApproved trust boundaries** — Every PRD needs Josh's approval, including trivial operational improvements. This bottleneck prevents true autonomy for low-risk work.
+
+6. **No automated changelog** — Stakeholders can't see what shipped without reading PR titles. Need human-readable summaries per project/milestone.
+
+## Approach
+
+### Milestone 1: Signal Intake Pipeline (Critical)
+
+Build a unified signal router that classifies incoming signals and routes them to the correct pipeline.
+
+**Phase 1.1: Signal Classification Service**
+
+- New service: `SignalClassificationService`
+- Receives raw signals from Discord messages, Linear issue creation webhooks, GitHub issue webhooks, and internal agent events
+- Classifies each signal into: `idea`, `bug`, `improvement`, `question`, `gtm`, `ops`
+- Assigns urgency: `critical`, `high`, `normal`, `low`
+- Uses lightweight heuristic classification first (keyword matching, source context), with Claude fallback for ambiguous signals
+- Files to modify: `apps/server/src/services/`, new service
+- Acceptance criteria: Signals from all 4 sources classified with >80% accuracy on test corpus
+
+**Phase 1.2: Signal → PRD Auto-Trigger**
+
+- When a signal is classified as `idea` with urgency >= `normal`:
+  - Auto-create a SPARC PRD draft using signal content as seed
+  - Route to antagonistic review pipeline (Milestone 2)
+- When classified as `bug`:
+  - Fast-track: create Automaker feature directly, skip PRD
+- When classified as `improvement` or `ops`:
+  - Create Bead for operational tracking
+  - If complexity > small, trigger PRD pipeline
+- Files to modify: `apps/server/src/services/signal-classification-service.ts`, integration with existing event system
+- Acceptance criteria: Discord message "we need a user dashboard" auto-generates PRD draft within 60 seconds
+
+**Phase 1.3: Discord Signal Listener**
+
+- Listen to configured Discord channels for signal patterns
+- Detect when Josh or team members post ideas vs. casual conversation
+- Parse @mentions, thread context, and channel semantics
+- Files to modify: Integration service, Discord webhook handling
+- Acceptance criteria: Message in #ava-josh with idea keywords triggers signal classification
+
+### Milestone 2: Antagonistic Review Pipeline (Critical)
+
+Build the cross-functional PRD review where Ava and Jon challenge each other.
+
+**Phase 2.1: Review Protocol**
+
+- Define the antagonistic review process:
+  1. PRD enters review state
+  2. Ava reviews for operational feasibility (capacity, risk, technical debt, timeline)
+  3. Jon reviews for market value (customer impact, competitive positioning, content opportunity, ROI)
+  4. Each produces a structured critique with: `approve`, `concern`, `block` verdicts per section
+  5. If any `block`: the blocker must justify and the other must respond
+  6. After resolution: consolidated PRD with both perspectives merged
+- New types in `@automaker/types`: `ReviewVerdict`, `AntagonisticReviewResult`
+- Files to modify: `libs/types/src/`, new review types
+- Acceptance criteria: Type definitions compile, review protocol documented
+
+**Phase 2.2: Review Execution Service**
+
+- New service: `AntagonisticReviewService`
+- Orchestrates the Ava + Jon review as sequential agent executions
+- Ava review runs first (using `execute_dynamic_agent` with ava template + review-specific prompt)
+- Jon review runs second with access to Ava's critique
+- Resolution agent (Ava as CoS) merges verdicts into final consolidated PRD
+- Emits `prd:review:started`, `prd:review:completed` events
+- Files to modify: `apps/server/src/services/`, new service
+- Acceptance criteria: Given a PRD, produces consolidated review with both perspectives in < 3 minutes
+
+**Phase 2.3: Review UI + Linear Integration**
+
+- Post review summary to Linear as a document attached to the project
+- Post review summary to Discord
+- If any `block` verdicts remain after resolution: flag for Josh's attention in Linear
+- Files to modify: Integration service, Linear sync, ceremony service
+- Acceptance criteria: Review results visible in Linear and Discord within 1 minute of completion
+
+### Milestone 3: Approval Gate + Trust Boundaries (High)
+
+**Phase 3.1: preApproved Trust Rules**
+
+- Define trust boundary rules in project settings:
+  ```
+  trustBoundaries:
+    autoApprove:
+      maxComplexity: "small"
+      categories: ["ops", "improvement", "bug"]
+      maxEstimatedCost: 5.00
+    requireReview:
+      categories: ["idea", "architectural"]
+      minComplexity: "large"
+  ```
+- When a PRD passes antagonistic review and matches autoApprove rules → skip Josh review
+- When it matches requireReview rules → create Linear issue with review request
+- Emit events: `prd:auto-approved`, `prd:review-requested`
+- Files to modify: `libs/types/src/settings.ts`, settings service, PRD pipeline
+- Acceptance criteria: Small ops improvement auto-approved, large architectural feature requires Josh
+
+**Phase 3.2: Linear Approval Workflow**
+
+- When PRD needs human review:
+  1. Create Linear issue with PRD content, review summary, and recommended action
+  2. Set issue status to "In Review"
+  3. Josh changes status to "Approved" or "Changes Requested" in Linear
+  4. Webhook fires → triggers next pipeline stage or returns to PRD revision
+- Files to modify: Linear webhook handler, Linear sync service
+- Acceptance criteria: Status change in Linear triggers automated response within 30 seconds
+
+### Milestone 4: Linear Project & Document API (High)
+
+**Phase 4.1: Linear GraphQL Project Operations**
+
+- Extend `LinearMCPClient` with project operations:
+  - `createProject(teamId, name, description, icon)`
+  - `updateProject(projectId, fields)`
+  - `createDocument(projectId, title, content)`
+  - `updateDocument(documentId, content)`
+- Use Linear GraphQL API (mutations: `projectCreate`, `documentCreate`)
+- Files to modify: `apps/server/src/services/linear-mcp-client.ts`
+- Acceptance criteria: Can programmatically create a Linear project with 3 documents
+
+**Phase 4.2: MCP Tools for Linear Projects**
+
+- New MCP tools: `linear_create_project`, `linear_create_document`, `linear_update_document`
+- Wire through to the server API
+- Files to modify: `packages/mcp-server/src/index.ts`, new route handlers
+- Acceptance criteria: Ava can create a Linear project via MCP tool
+
+**Phase 4.3: Auto-Sync Projects to Linear**
+
+- When `create_project` is called on Automaker board:
+  - Auto-create corresponding Linear project
+  - Attach PRD as Linear document
+  - Create milestone sub-issues
+- When project status changes in Automaker:
+  - Sync to Linear project status
+- Files to modify: Integration service, project service
+- Acceptance criteria: `create_project` MCP call creates both Automaker project and Linear project
+
+### Milestone 5: Reflection Loop (High)
+
+**Phase 5.1: Retro → Improvement Tickets**
+
+- Extend `CeremonyService` retro generation:
+  - After generating retro content, analyze it for actionable improvements
+  - Use lightweight Claude query: "Given this retro, list 1-3 specific improvement tickets"
+  - Auto-create Beads items for each improvement
+  - If improvement is code-related, also create Automaker feature
+- Emit `retro:improvements:created` event
+- Files to modify: `apps/server/src/services/ceremony-service.ts`
+- Acceptance criteria: Milestone retro generates 1-3 Beads improvement items
+
+**Phase 5.2: Automated Changelog**
+
+- New service: `ChangelogService`
+- On project completion or milestone completion:
+  - Gather all merged features with PR titles, descriptions, and impact
+  - Generate human-readable changelog grouped by category
+  - Post to Discord
+  - Attach as Linear document
+- Files to modify: New service, ceremony integration
+- Acceptance criteria: Project completion generates changelog with all features listed
+
+**Phase 5.3: Metrics-Driven Impact Analysis**
+
+- Extend `get_project_metrics` to include:
+  - Cost per feature (API spend)
+  - Average cycle time (creation → merged)
+  - Failure rate and escalation count
+  - Agent model distribution (what % was Haiku/Sonnet/Opus)
+  - Comparison to historical averages
+- Generate "Project Impact Report" as part of project retro
+- Files to modify: Metrics routes, ceremony service
+- Acceptance criteria: Project retro includes cost, time, quality metrics with historical comparison
+
+**Phase 5.4: Knowledge Synthesis**
+
+- On project completion:
+  - Collect all `.automaker/memory/*.md` entries created during the project
+  - Synthesize into a project-level learning summary
+  - Update organizational MEMORY.md with key patterns
+  - Archive project-specific memory entries
+- Files to modify: Ceremony service, memory management
+- Acceptance criteria: Project completion produces a 1-page learning summary
+
+### Milestone 6: End-to-End Integration (Medium)
+
+**Phase 6.1: Wire It All Together**
+
+- Signal intake → PRD → antagonistic review → approval gate → planning → execution → PR → reflection → repeat
+- Full pipeline test: Post a message in Discord → watch it become a merged PR → see retro generate improvement ticket
+- Files to modify: Integration testing, event wiring
+- Acceptance criteria: E2E flow completes without manual intervention for a preApproved signal
+
+**Phase 6.2: Dashboard & Observability**
+
+- Add ProtoLabs pipeline view to Automaker UI:
+  - Current signals being triaged
+  - PRDs in review
+  - Projects in execution
+  - Recent retros and improvement tickets
+- Files to modify: `apps/ui/src/`, new dashboard route/components
+- Acceptance criteria: Single view shows full pipeline state
+
+## Results
+
+When complete, the ProtoLabs agency system will:
+
+1. **Accept ideas from any source** (Discord, Linear, GitHub, agent observations) and auto-triage them into the correct pipeline
+2. **Challenge every plan** through antagonistic cross-functional review before committing resources
+3. **Auto-approve low-risk work** while routing high-impact decisions to Josh
+4. **Execute autonomously** through the proven auto-mode → agent → PR → merge pipeline
+5. **Reflect and improve** by auto-generating improvement tickets from retros and feeding them back into the intake pipeline
+6. **Keep Linear as the strategic source of truth** with programmatic project and document creation
+7. **Generate changelogs and impact reports** so stakeholders see what shipped and whether it was worth doing
+
+The system becomes a **self-improving loop**: every project it runs makes it better at running the next project.
+
+## Constraints
+
+- Must not break existing execution pipeline — this is additive infrastructure
+- Signal classification must work without expensive Claude calls for common cases (heuristic-first)
+- Antagonistic review must complete in < 5 minutes to avoid blocking the pipeline
+- Linear API operations must handle rate limits gracefully (Linear has strict GraphQL rate limits)
+- preApproved auto-gate must be conservative at launch — false approval of a bad idea is worse than a Josh bottleneck
+- All new services must emit events to the existing event system for observability
+- Must work on both dev hardware (2-3 concurrent agents) and staging (6-10)
+- Discord listener must not create noise — only process signals from configured channels
+- Changelog generation must not expose internal details (agent names, cost, failure counts) in client-facing output
+- Every new MCP tool must be built into `build:packages` (lesson from MCP server build gap)
+- No Express 5 wildcard routes (`/:param(*)`) — use POST with body (lesson from session 39)

--- a/docs/protolabs/flow-builder-agent-spec.md
+++ b/docs/protolabs/flow-builder-agent-spec.md
@@ -1,0 +1,131 @@
+# Flow Builder Agent Specification
+
+## Overview
+
+The Flow Builder is a specialized agent template that scaffolds LangGraph workflows using test-driven flow development. Given a flow specification, it generates all 5 layers of the pipeline pattern with tests at each layer.
+
+## Agent Template
+
+```yaml
+name: flow-builder
+displayName: Flow Builder
+description: Scaffolds LangGraph workflows using the 5-layer test-driven pipeline pattern
+role: backend-engineer
+tier: 1 # Project-level, not protected
+model: sonnet
+tags: [flows, langgraph, scaffolding, test-driven]
+```
+
+## Trigger
+
+Invoked via `execute_dynamic_agent` when:
+
+- A feature description mentions "flow", "pipeline", "graph", or "LangGraph"
+- A Beads item is categorized as a flow-building task
+- Manually via MCP: `execute_dynamic_agent({ templateName: 'flow-builder', prompt: '...' })`
+
+## What It Does
+
+Given a natural language flow specification, the agent generates:
+
+### 1. State Schema (`libs/flows/src/{flow-name}/state.ts`)
+
+- Zod schemas for inputs, outputs, and intermediate state
+- LangGraph `Annotation.Root()` with appropriate reducers
+- Type exports for consumers
+
+### 2. Node Implementations (`libs/flows/src/{flow-name}/nodes/`)
+
+- One file per node function
+- Each node: `(state) => Partial<state>` pattern
+- Model fallback via `executeWithFallback()`
+- Zod validation of LLM responses
+- Graceful error handling (return errors, never crash)
+
+### 3. Graph Composition (`libs/flows/src/{flow-name}/graph.ts`)
+
+- `GraphBuilder` or manual `StateGraph` construction
+- Entry/finish points
+- Conditional edges for routing
+- Subgraph isolation where needed
+- HITL interrupts if human review is required
+
+### 4. Test Suite (`libs/flows/src/{flow-name}/__tests__/`)
+
+- Unit tests for each node with `TestChatModel`
+- Integration test for full graph with mock data
+- Edge case tests (model failure, invalid JSON, timeout)
+- No real API calls in any test
+
+### 5. Barrel Export (`libs/flows/src/{flow-name}/index.ts`)
+
+- Re-export graph, state types, and node functions
+- Add to `libs/flows/src/index.ts` barrel
+
+## System Prompt Additions
+
+```
+You are the Flow Builder agent. You scaffold LangGraph workflows following
+the 5-layer test-driven pipeline pattern.
+
+CRITICAL RULES:
+1. Every node is a pure function: state in, partial state out
+2. Always use Zod schemas for LLM response validation
+3. Always include TestChatModel-based tests — no real API calls in tests
+4. Use appendReducer for arrays, replaceReducer for scalars
+5. Use executeWithFallback() for model fallback chains
+6. Use wrapSubgraph() for subgraph isolation
+7. Follow existing patterns in libs/flows/src/content/ as reference
+8. Run npm run build:packages after creating files to verify compilation
+9. Run npm run test:packages to verify tests pass
+
+PACKAGE IMPORTS:
+- State primitives: import from '@automaker/flows'
+- LLM models: import { BaseChatModel } from '@langchain/core/language_models/chat_models'
+- Testing: import { createTestModels } from research-workers or create local TestChatModel
+- Observability: import from '@automaker/observability' (production layer only)
+```
+
+## Tools Required
+
+- `Read`, `Write`, `Edit` — File operations
+- `Bash` — Running build:packages and test:packages
+- `Glob`, `Grep` — Finding existing patterns
+
+## Example Invocation
+
+```typescript
+execute_dynamic_agent({
+  templateName: 'flow-builder',
+  projectPath: '/Users/kj/dev/automaker',
+  prompt: `Build a "code-review" flow that:
+    - Takes a diff string and file paths as input
+    - Research node: analyzes the diff for patterns and potential issues
+    - Review node: generates review comments with severity levels
+    - Summary node: aggregates comments into a structured review
+    - Output: ReviewResult with comments[], overallSeverity, summary
+
+    Include HITL interrupt before the summary node for human override.
+    Use parallel research workers for large diffs (>500 lines).`,
+});
+```
+
+## Implementation Plan
+
+1. **Register template** — Add `flow-builder` to built-in templates in `apps/server/src/services/agent-templates/`
+2. **System prompt** — Create detailed prompt in `@automaker/prompts` with the 5-layer pattern reference
+3. **Crew integration** — Optional: add as a crew member that watches for flow-related features and auto-activates
+
+## Dependencies
+
+- `@automaker/flows` — Core graph primitives (already built)
+- `@automaker/llm-providers` — Model abstraction (already built)
+- `@automaker/observability` — Tracing (already built)
+- Content pipeline in `libs/flows/src/content/` — Reference implementation (already built)
+
+## Success Criteria
+
+- Agent generates compilable TypeScript that passes `npm run build:packages`
+- All generated tests pass with `npm run test:packages`
+- Generated flows follow the exact same patterns as the content pipeline
+- No real API calls in any test file

--- a/docs/protolabs/flow-development-pattern.md
+++ b/docs/protolabs/flow-development-pattern.md
@@ -1,0 +1,189 @@
+# Test-Driven Flow Development Pattern
+
+## The 5-Layer Pipeline
+
+Every LangGraph flow follows the same progression from prompt to production. Each layer is independently testable.
+
+```
+Layer 1: Prompt        Define data I/O contract (Zod schema)
+Layer 2: Tool          Inference call + JSON parse
+Layer 3: API           Express endpoint for isolated testing
+Layer 4: StateGraph    Compose nodes with mock data (FakeChatModel)
+Layer 5: Production    Swap real models, add observability, fine-tune
+```
+
+### Layer 1: Prompt — Define the Contract
+
+Start with a Zod schema defining what goes in and what comes out.
+
+```typescript
+import { z } from 'zod';
+import { Annotation } from '@langchain/langgraph';
+import { appendReducer } from '@automaker/flows';
+
+// Define the shape of your data
+const FindingSchema = z.object({
+  source: z.enum(['web', 'codebase', 'existing_content']),
+  topic: z.string(),
+  content: z.string(),
+  relevance: z.enum(['high', 'medium', 'low']),
+});
+
+// Create state annotation with reducers
+const ResearchState = Annotation.Root({
+  topic: Annotation<string>(),
+  findings: Annotation<z.infer<typeof FindingSchema>[]>({
+    reducer: appendReducer,
+    default: () => [],
+  }),
+  errors: Annotation<string[]>({
+    reducer: appendReducer,
+    default: () => [],
+  }),
+});
+```
+
+**Test**: Schema validates, annotation compiles, defaults work.
+
+### Layer 2: Tool — Inference + Parse
+
+Each node is a pure function: state in, partial state out. The LLM call is wrapped with model fallback.
+
+```typescript
+import { BaseChatModel } from '@langchain/core/language_models/chat_models';
+
+async function researchNode(
+  state: typeof ResearchState.State
+): Promise<Partial<typeof ResearchState.State>> {
+  const { topic, smartModel, fastModel } = state;
+
+  const result = await executeWithFallback(
+    { primary: smartModel, fallback: fastModel },
+    async (model) => {
+      const response = await model.invoke([
+        { role: 'user', content: `Research: "${topic}". Return JSON array of findings.` },
+      ]);
+      return FindingSchema.array().parse(JSON.parse(response.content.toString()));
+    },
+    'ResearchNode'
+  );
+
+  return { findings: result };
+}
+```
+
+**Test**: Mock model returns valid JSON, schema validates, fallback triggers on error.
+
+### Layer 3: API — Isolated Testing
+
+Expose the node as an Express endpoint for manual testing and integration.
+
+```typescript
+// apps/server/src/routes/flows/research.ts
+router.post('/research', async (req, res) => {
+  const { topic } = req.body;
+  const result = await researchNode({
+    topic,
+    smartModel: getModel('sonnet'),
+    fastModel: getModel('haiku'),
+    findings: [],
+    errors: [],
+  });
+  res.json(result);
+});
+```
+
+**Test**: `curl -X POST localhost:3008/api/flows/research -d '{"topic":"LangGraph"}'`
+
+### Layer 4: StateGraph — Compose with Mocks
+
+Wire nodes into a graph using `GraphBuilder`. Use `TestChatModel` for deterministic testing.
+
+```typescript
+import { GraphBuilder, createTestModels } from '@automaker/flows';
+
+const graph = new GraphBuilder(ResearchState)
+  .setEntryPoint('research')
+  .addNode('research', researchNode)
+  .addNode('analyze', analyzeNode)
+  .addNode('summarize', summarizeNode)
+  .addEdge('research', 'analyze')
+  .addEdge('analyze', 'summarize')
+  .setFinishPoint('summarize')
+  .compile();
+
+// Test with mock models
+const { smartModel, fastModel } = createTestModels();
+const result = await graph.invoke({
+  topic: 'Test topic',
+  smartModel,
+  fastModel,
+});
+```
+
+**Test**: Full graph executes with mock data, state flows correctly, no API calls.
+
+### Layer 5: Production — Real Models + Observability
+
+Swap mocks for real models, add Langfuse tracing, configure fallbacks.
+
+```typescript
+import { LangfuseClient, executeTrackedPrompt } from '@automaker/observability';
+import { ProviderFactory } from '@automaker/llm-providers';
+
+const langfuse = new LangfuseClient();
+const smartModel = ProviderFactory.create('anthropic', {
+  modelId: 'claude-sonnet-4-5-20250929',
+});
+
+// Wrap node with tracing
+async function tracedResearchNode(state) {
+  return executeTrackedPrompt(langfuse, 'research-node', {
+    fallbackPrompt: 'Research: {{TOPIC}}',
+    variables: { TOPIC: state.topic },
+    executor: async (prompt) => researchNode({ ...state, smartModel }),
+  });
+}
+```
+
+**Test**: Real API calls, Langfuse traces visible, latency/cost tracking active.
+
+## Key Patterns
+
+### Model Fallback Chain
+
+Always provide smart (expensive/capable) and fast (cheap/quick) models. The `executeWithFallback()` utility handles retry logic.
+
+### Subgraph Isolation
+
+Use `wrapSubgraph()` when composing flows to prevent state leakage between parent and child graphs.
+
+### Dynamic Parallelism
+
+Use `Send()` for fan-out to variable numbers of workers (e.g., one research worker per topic).
+
+### HITL Interrupts
+
+Use `interruptBefore: ['node_name']` with `MemorySaver` checkpointer for human review gates.
+
+### Graceful Degradation
+
+Workers should return error objects, never crash. The aggregator handles partial results.
+
+## Package Map
+
+| Package                    | Role                                 | Key Exports                                                              |
+| -------------------------- | ------------------------------------ | ------------------------------------------------------------------------ |
+| `@automaker/flows`         | State graphs, reducers, builders     | `GraphBuilder`, `createStateAnnotation`, `appendReducer`, `wrapSubgraph` |
+| `@automaker/llm-providers` | Multi-provider LLM abstraction       | `ProviderFactory`, `BaseLLMProvider`                                     |
+| `@automaker/observability` | Langfuse tracing + prompt versioning | `LangfuseClient`, `executeTrackedPrompt`                                 |
+
+## Existing Implementations
+
+The content pipeline in `libs/flows/src/content/` demonstrates all 5 layers:
+
+- **State**: `ContentPipelineState` annotation with typed reducers
+- **Nodes**: Research workers, section writer, assembler, output generators
+- **Subgraphs**: SectionWriter (retry + validation), Research (parallel workers + HITL)
+- **Parallelism**: `Send()` for research workers and output formats
+- **Testing**: `TestChatModel` + `createTestModels()` factory

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
-    "format": "prettier --write .",
-    "format:check": "prettier --check .",
+    "format": "prettier --ignore-path .prettierignore --write .",
+    "format:check": "prettier --ignore-path .prettierignore --check .",
     "rebuild": "rm -rf node_modules apps/*/node_modules libs/*/node_modules && npm install",
     "prepare": "husky && npm run build:packages",
     "plugin:reload": "claude plugin uninstall automaker && claude plugin install automaker",
@@ -67,7 +67,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mts,cts,json,css,md,html,yml,yaml}": [
-      "prettier --write"
+      "prettier --ignore-path .prettierignore --write"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- **Prettier worktree fix**: `.worktrees/` is in `.gitignore`. Prettier 3.x respects `.gitignore` by default, so `prettier --write` on worktree files **silently skips them** — no formatting, no error. This was the root cause of repeated CI format failures on agent PRs. Fix: pass `--ignore-path .prettierignore` everywhere prettier runs.
- **Docs**: Add agency architecture, flow patterns, and graph flow development guides

## Changes

| Area | Change |
|------|--------|
| `package.json` | lint-staged + format scripts use `--ignore-path .prettierignore` |
| `git-workflow-service.ts` | Auto-format step uses `--ignore-path` |
| `built-in-templates.ts` | PR Maintainer template updated |
| `pr-maintainer-check.ts` | Format failure instructions updated |
| `format-check.yml` template | CI template for new projects updated |
| `docs/architecture/` | Agent flows documentation |
| `docs/protolabs/` | Agency architecture, overview, PRD, flow specs |

## Test plan

- [x] Reproduced: `prettier --write` silently skips `.worktrees/` files (no output, no formatting)
- [x] Verified fix: `prettier --ignore-path .prettierignore --write` correctly formats worktree files
- [x] Confirmed `.prettierignore` still excludes `node_modules/`, `dist/`, etc.
- [x] Pre-commit hook tested: lint-staged ran with new flag during this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Prettier formatting workflow to properly respect .prettierignore, ensuring consistent file handling across CI/CD and development environments.

* **Documentation**
  * Added comprehensive architecture documentation with agent flow diagrams and system component details.
  * Added ProtoLabs Agency System documentation covering operational overview, system architecture, and implementation roadmap.
  * Added Flow development patterns and agent specification guides for development reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->