### PR TITLE
fix: make Linear calls best-effort in lifecycle launch/approve

### DIFF
--- a/apps/server/src/services/project-lifecycle-service.ts
+++ b/apps/server/src/services/project-lifecycle-service.ts
@@ -164,36 +164,41 @@ export class ProjectLifecycleService {
       this.events
     );
 
-    // Sync milestones to Linear if project has a Linear ID
+    // Sync milestones to Linear if project has a Linear ID (best-effort)
     const linearMilestones: Array<{ id: string; name: string }> = [];
     if (project.linearProjectId) {
-      const client = this.getLinearClient(projectPath);
-      const updatedMilestones: Milestone[] = [...project.milestones];
+      try {
+        const client = this.getLinearClient(projectPath);
+        const updatedMilestones: Milestone[] = [...project.milestones];
 
-      for (let i = 0; i < project.milestones.length; i++) {
-        const milestone = project.milestones[i];
-        try {
-          const msResult = await client.createProjectMilestone({
-            projectId: project.linearProjectId,
-            name: milestone.title,
-            description: milestone.description,
-            sortOrder: milestone.number,
-          });
-          linearMilestones.push({ id: msResult.id, name: msResult.name });
-          // Persist the Linear milestone ID back
-          updatedMilestones[i] = { ...milestone, linearMilestoneId: msResult.id };
-        } catch (error) {
-          logger.warn(`Failed to create Linear milestone: ${milestone.title}`, error);
+        for (let i = 0; i < project.milestones.length; i++) {
+          const milestone = project.milestones[i];
+          try {
+            const msResult = await client.createProjectMilestone({
+              projectId: project.linearProjectId,
+              name: milestone.title,
+              description: milestone.description,
+              sortOrder: milestone.number,
+            });
+            linearMilestones.push({ id: msResult.id, name: msResult.name });
+            updatedMilestones[i] = { ...milestone, linearMilestoneId: msResult.id };
+          } catch (error) {
+            logger.warn(`Failed to create Linear milestone: ${milestone.title}`, error);
+          }
         }
-      }
 
-      // Persist milestone IDs to project.json
-      await this.projectService.updateProject(projectPath, projectSlug, {
-        status: 'active',
-        milestones: updatedMilestones,
-      });
+        // Persist milestone IDs to project.json
+        await this.projectService.updateProject(projectPath, projectSlug, {
+          status: 'active',
+          milestones: updatedMilestones,
+        });
+      } catch (error) {
+        logger.warn('Failed to sync milestones to Linear:', error);
+        await this.projectService.updateProject(projectPath, projectSlug, {
+          status: 'active',
+        });
+      }
     } else {
-      // Update project status without milestone changes
       await this.projectService.updateProject(projectPath, projectSlug, {
         status: 'active',
       });
@@ -238,10 +243,14 @@ export class ProjectLifecycleService {
       throw new Error('No features in backlog. Approve the PRD first to create features.');
     }
 
-    // Update Linear project status to started
+    // Update Linear project status to started (best-effort)
     if (project.linearProjectId) {
-      const client = this.getLinearClient(projectPath);
-      await client.updateProject(project.linearProjectId, { status: 'started' });
+      try {
+        const client = this.getLinearClient(projectPath);
+        await client.updateProject(project.linearProjectId, { status: 'started' });
+      } catch (error) {
+        logger.warn('Failed to update Linear project status:', error);
+      }
     }
 
     // Start auto-mode


### PR DESCRIPTION
## Summary
- Wrap Linear API calls in `launch()` and `approvePrd()` with try/catch so the lifecycle flow works even when LINEAR_API_KEY is not configured
- Discovered during CopilotKit launch test: the launch endpoint failed because Linear token wasn't available in the dev environment

## Test plan
- [x] `npm run build:server` — clean
- [x] Verified `approve_project_prd` creates 39 features successfully without Linear token
- [x] Auto-mode starts correctly via direct endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in project lifecycle operations to ensure PRD approval and project launch continue successfully even when external integrations encounter issues, while maintaining visibility through warning logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->