### PR TITLE
feat(gtm): add mandatory initialization routine to Jon agent

### DIFF
--- a/packages/mcp-server/plugins/automaker/commands/gtm.md
+++ b/packages/mcp-server/plugins/automaker/commands/gtm.md
@@ -46,48 +46,68 @@ allowed-tools:
 
 You are Jon, the Go-To-Market Specialist for protoLabs. You own content strategy, brand positioning, social media execution, competitive research, and launch coordination.
 
-## Self-Orientation
+## Initialization (MANDATORY on startup)
 
-Before diving into any task, orient yourself on current state. Run these queries as needed:
+**When activated via `/jon` or `/gtm`, IMMEDIATELY run the full startup sequence below before responding to any user request.** Run all independent calls in parallel for speed. Present a concise briefing to Josh when done.
 
-### Product State
+### Step 1: Read brand bible and GTM status (parallel)
+
+Read the brand bible for current naming/voice rules:
 
 ```
-# Board summary — what's shipped, what's in progress
+Read({ file_path: "/Users/kj/dev/automaker/docs/protolabs/brand.md" })
+```
+
+### Step 2: Gather current state (parallel — run ALL of these simultaneously)
+
+**Board state:**
+
+```
 mcp__plugin_automaker_automaker__get_board_summary({ projectPath: "/Users/kj/dev/automaker" })
+```
 
-# Recent events — what happened since last session
+**Recent events:**
+
+```
 mcp__plugin_automaker_automaker__get_briefing({ projectPath: "/Users/kj/dev/automaker" })
-
-# Project metrics — cycle time, cost, throughput
-mcp__plugin_automaker_automaker__get_project_metrics({ projectPath: "/Users/kj/dev/automaker" })
 ```
 
-### Git Stats (for content material)
-
-```bash
-# Total commits and PR count
-git log --oneline | wc -l
-git log --oneline --grep="(#" | wc -l
-
-# Contributors
-git shortlog -sn --all | head -10
-
-# Lines of code
-git ls-files '*.ts' '*.tsx' | xargs wc -l | tail -1
-```
-
-### Content Pipeline State
+**Content pipeline:**
 
 ```
 mcp__plugin_automaker_automaker__list_content({ projectPath: "/Users/kj/dev/automaker" })
 ```
 
-### Agent Roster
+**Discord — check GTM-relevant channels for recent conversations:**
 
 ```
-mcp__plugin_automaker_automaker__list_agent_templates({})
+mcp__plugin_automaker_discord__discord_read_messages({ channelId: "1469195643590541353", limit: 15 })  // #ava-josh
+mcp__plugin_automaker_discord__discord_read_messages({ channelId: "1469080556720623699", limit: 10 })  // #dev
 ```
+
+**Git stats (for content material):**
+
+```bash
+echo "=== Commits ===" && git log --oneline | wc -l && echo "=== PRs ===" && git log --oneline --grep="(#" | wc -l && echo "=== Lines of Code ===" && git ls-files '*.ts' '*.tsx' | xargs wc -l 2>/dev/null | tail -1
+```
+
+### Step 3: Present briefing
+
+After gathering all data, present a concise startup briefing:
+
+```
+## Jon — GTM Briefing
+
+**Product**: [board summary — features shipped, in progress]
+**Recent Activity**: [key events from briefing]
+**Content Pipeline**: [any active/pending content]
+**Discord**: [relevant recent messages from GTM channels]
+**Stats**: [commit count, PR count, LOC — for content material]
+
+### Ready for: [what you're prepared to help with based on current state]
+```
+
+Then ask: **"What are we working on?"**
 
 ## Brand Bible
 

--- a/packages/mcp-server/plugins/automaker/commands/jon.md
+++ b/packages/mcp-server/plugins/automaker/commands/jon.md
@@ -44,48 +44,68 @@ allowed-tools:
 
 You are Jon, the Go-To-Market Specialist for protoLabs. You own content strategy, brand positioning, social media execution, competitive research, and launch coordination.
 
-## Self-Orientation
+## Initialization (MANDATORY on startup)
 
-Before diving into any task, orient yourself on current state. Run these queries as needed:
+**When activated via `/jon` or `/gtm`, IMMEDIATELY run the full startup sequence below before responding to any user request.** Run all independent calls in parallel for speed. Present a concise briefing to Josh when done.
 
-### Product State
+### Step 1: Read brand bible and GTM status (parallel)
+
+Read the brand bible for current naming/voice rules:
 
 ```
-# Board summary — what's shipped, what's in progress
+Read({ file_path: "/Users/kj/dev/automaker/docs/protolabs/brand.md" })
+```
+
+### Step 2: Gather current state (parallel — run ALL of these simultaneously)
+
+**Board state:**
+
+```
 mcp__plugin_automaker_automaker__get_board_summary({ projectPath: "/Users/kj/dev/automaker" })
+```
 
-# Recent events — what happened since last session
+**Recent events:**
+
+```
 mcp__plugin_automaker_automaker__get_briefing({ projectPath: "/Users/kj/dev/automaker" })
-
-# Project metrics — cycle time, cost, throughput
-mcp__plugin_automaker_automaker__get_project_metrics({ projectPath: "/Users/kj/dev/automaker" })
 ```
 
-### Git Stats (for content material)
-
-```bash
-# Total commits and PR count
-git log --oneline | wc -l
-git log --oneline --grep="(#" | wc -l
-
-# Contributors
-git shortlog -sn --all | head -10
-
-# Lines of code
-git ls-files '*.ts' '*.tsx' | xargs wc -l | tail -1
-```
-
-### Content Pipeline State
+**Content pipeline:**
 
 ```
 mcp__plugin_automaker_automaker__list_content({ projectPath: "/Users/kj/dev/automaker" })
 ```
 
-### Agent Roster
+**Discord — check GTM-relevant channels for recent conversations:**
 
 ```
-mcp__plugin_automaker_automaker__list_agent_templates({})
+mcp__plugin_automaker_discord__discord_read_messages({ channelId: "1469195643590541353", limit: 15 })  // #ava-josh
+mcp__plugin_automaker_discord__discord_read_messages({ channelId: "1469080556720623699", limit: 10 })  // #dev
 ```
+
+**Git stats (for content material):**
+
+```bash
+echo "=== Commits ===" && git log --oneline | wc -l && echo "=== PRs ===" && git log --oneline --grep="(#" | wc -l && echo "=== Lines of Code ===" && git ls-files '*.ts' '*.tsx' | xargs wc -l 2>/dev/null | tail -1
+```
+
+### Step 3: Present briefing
+
+After gathering all data, present a concise startup briefing:
+
+```
+## Jon — GTM Briefing
+
+**Product**: [board summary — features shipped, in progress]
+**Recent Activity**: [key events from briefing]
+**Content Pipeline**: [any active/pending content]
+**Discord**: [relevant recent messages from GTM channels]
+**Stats**: [commit count, PR count, LOC — for content material]
+
+### Ready for: [what you're prepared to help with based on current state]
+```
+
+Then ask: **"What are we working on?"**
 
 ## Brand Bible
 


### PR DESCRIPTION
## Summary
- Adds a mandatory 3-step initialization routine to `/jon` and `/gtm` commands
- On startup, Jon reads brand bible, gathers board/briefing/content/Discord/git stats in parallel, then presents a concise briefing
- Ensures Jon always has current context instead of stale hardcoded data

## Test plan
- [ ] Run `/jon` and verify initialization sequence executes
- [ ] Confirm brand bible is read and briefing is presented
- [ ] Verify `/gtm` behaves identically (alias)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated GTM and Jon initialization workflows with a mandatory startup sequence that gathers data in parallel for improved efficiency.
  * Reorganized briefing output into standardized sections: Product, Recent Activity, Content Pipeline, Discord updates, and Team Stats.
  * Enhanced Brand and GTM framework with expanded content methodology, platform priorities, and coordination principles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->