### PR TITLE
feat(copilotkit): remaining UI features + graph resume logic

### DIFF
--- a/apps/server/src/services/content-flow-service.ts
+++ b/apps/server/src/services/content-flow-service.ts
@@ -111,6 +111,7 @@ export interface HITLReview {
   gate: 'research_hitl' | 'outline_hitl' | 'final_review_hitl';
   decision: 'approve' | 'revise' | 'reject';
   feedback?: string;
+  editedContent?: string;
 }
 
 /**
@@ -216,7 +217,7 @@ export class ContentFlowService {
 
     this.activeRuns.set(runId, status);
 
-    const flow = createContentCreationFlow();
+    const flow = createContentCreationFlow({ enableHITL: config.enableHITL });
 
     this.executeFlow(runId, projectPath, flow, config).catch((error: unknown) => {
       const message = error instanceof Error ? error.message : String(error);
@@ -402,7 +403,7 @@ export class ContentFlowService {
 
     logger.info(`Resuming flow ${runId} at gate ${review.gate} with decision: ${review.decision}`);
 
-    const flow = createContentCreationFlow();
+    const flow = createContentCreationFlow({ enableHITL: true });
 
     const resumeState: Record<string, unknown> = {};
 
@@ -421,6 +422,11 @@ export class ContentFlowService {
       if (review.feedback) {
         resumeState.finalReviewFeedback = review.feedback;
       }
+    }
+
+    // Pass user-edited content through to the HITL node for merging
+    if (review.editedContent) {
+      resumeState.userEditedContent = review.editedContent;
     }
 
     status.status = 'running';

--- a/apps/ui/src/components/copilotkit/generic-dialog.tsx
+++ b/apps/ui/src/components/copilotkit/generic-dialog.tsx
@@ -1,0 +1,57 @@
+/**
+ * Generic Approval Dialog
+ *
+ * Simple yes/no dialog as fallback for untyped LangGraph interrupts.
+ * Shows a message from the interrupt payload and two action buttons.
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { CheckCircle, XCircle } from 'lucide-react';
+
+interface GenericApprovalDialogProps {
+  open: boolean;
+  title?: string;
+  message: string;
+  onResolve: (approved: boolean) => void;
+}
+
+export function GenericApprovalDialog({
+  open,
+  title = 'Approval Required',
+  message,
+  onResolve,
+}: GenericApprovalDialogProps) {
+  return (
+    <Dialog open={open}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{message}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <button
+            onClick={() => onResolve(false)}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md border border-border bg-background text-foreground hover:bg-muted transition-colors"
+          >
+            <XCircle className="w-4 h-4" />
+            Reject
+          </button>
+          <button
+            onClick={() => onResolve(true)}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity"
+          >
+            <CheckCircle className="w-4 h-4" />
+            Approve
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/ui/src/components/copilotkit/model-selector.tsx
+++ b/apps/ui/src/components/copilotkit/model-selector.tsx
@@ -1,0 +1,114 @@
+/**
+ * Model Selector for CopilotKit Sidebar
+ *
+ * Dropdown to choose between haiku, sonnet, and opus for workflow execution.
+ * Selection persists per-workflow in localStorage.
+ */
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Zap, Gauge, Brain } from 'lucide-react';
+
+export type ModelTier = 'haiku' | 'sonnet' | 'opus';
+
+interface ModelOption {
+  value: ModelTier;
+  label: string;
+  description: string;
+  icon: typeof Zap;
+  tier: string;
+}
+
+const MODEL_OPTIONS: ModelOption[] = [
+  {
+    value: 'haiku',
+    label: 'Haiku',
+    description: 'Fast & affordable',
+    icon: Zap,
+    tier: 'Speed',
+  },
+  {
+    value: 'sonnet',
+    label: 'Sonnet',
+    description: 'Balanced performance',
+    icon: Gauge,
+    tier: 'Balanced',
+  },
+  {
+    value: 'opus',
+    label: 'Opus',
+    description: 'Maximum capability',
+    icon: Brain,
+    tier: 'Power',
+  },
+];
+
+const STORAGE_KEY_PREFIX = 'copilotkit-model-';
+
+function getStoredModel(workflowId: string): ModelTier {
+  try {
+    const stored = localStorage.getItem(`${STORAGE_KEY_PREFIX}${workflowId}`);
+    if (stored === 'haiku' || stored === 'sonnet' || stored === 'opus') {
+      return stored;
+    }
+  } catch {
+    // localStorage unavailable
+  }
+  return 'sonnet';
+}
+
+function storeModel(workflowId: string, model: ModelTier) {
+  try {
+    localStorage.setItem(`${STORAGE_KEY_PREFIX}${workflowId}`, model);
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+interface ModelSelectorProps {
+  workflowId: string;
+  value: ModelTier;
+  onChange: (model: ModelTier) => void;
+  disabled?: boolean;
+}
+
+export function ModelSelector({ workflowId, value, onChange, disabled }: ModelSelectorProps) {
+  const handleChange = (newValue: string) => {
+    const model = newValue as ModelTier;
+    storeModel(workflowId, model);
+    onChange(model);
+  };
+
+  const selected = MODEL_OPTIONS.find((m) => m.value === value);
+
+  return (
+    <div className="flex items-center gap-2">
+      <Select value={value} onValueChange={handleChange} disabled={disabled}>
+        <SelectTrigger className="h-8 w-[140px] text-xs">
+          <div className="flex items-center gap-1.5">
+            {selected && <selected.icon className="w-3.5 h-3.5" />}
+            <SelectValue />
+          </div>
+        </SelectTrigger>
+        <SelectContent>
+          {MODEL_OPTIONS.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              <div className="flex items-center gap-2">
+                <option.icon className="w-3.5 h-3.5" />
+                <span>{option.label}</span>
+                <span className="text-muted-foreground text-[10px] ml-1">{option.tier}</span>
+              </div>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+export { getStoredModel, storeModel };

--- a/apps/ui/src/components/copilotkit/workflow-abort.tsx
+++ b/apps/ui/src/components/copilotkit/workflow-abort.tsx
@@ -1,0 +1,78 @@
+/**
+ * Workflow Abort Button
+ *
+ * Stop/cancel button for running workflows. Shows a confirmation dialog
+ * before aborting the current execution.
+ */
+
+import { useState } from 'react';
+import { Square, AlertTriangle } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface WorkflowAbortProps {
+  isRunning: boolean;
+  workflowName?: string;
+  onAbort: () => void;
+}
+
+export function WorkflowAbortButton({ isRunning, workflowName, onAbort }: WorkflowAbortProps) {
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  if (!isRunning) return null;
+
+  const handleAbort = () => {
+    setShowConfirm(false);
+    onAbort();
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => setShowConfirm(true)}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors"
+        title="Stop workflow"
+      >
+        <Square className="w-3 h-3 fill-current" />
+        Stop
+      </button>
+
+      <Dialog open={showConfirm} onOpenChange={setShowConfirm}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="w-5 h-5 text-destructive" />
+              Abort Workflow
+            </DialogTitle>
+            <DialogDescription>
+              {workflowName
+                ? `Are you sure you want to abort "${workflowName}"? This action cannot be undone.`
+                : 'Are you sure you want to abort the current workflow? This action cannot be undone.'}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <button
+              onClick={() => setShowConfirm(false)}
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md border border-border bg-background text-foreground hover:bg-muted transition-colors"
+            >
+              Continue Running
+            </button>
+            <button
+              onClick={handleAbort}
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md bg-destructive text-destructive-foreground hover:opacity-90 transition-opacity"
+            >
+              <Square className="w-3.5 h-3.5 fill-current" />
+              Abort
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/libs/flows/src/content/content-creation-flow.ts
+++ b/libs/flows/src/content/content-creation-flow.ts
@@ -146,6 +146,9 @@ export const ContentCreationState = Annotation.Root({
 
   // Error handling
   error: Annotation<string | undefined>,
+
+  // User-edited content from HITL resume
+  userEditedContent: Annotation<string | undefined>,
 });
 
 export type ContentCreationStateType = typeof ContentCreationState.State;
@@ -319,16 +322,20 @@ ${r.findings.references.map((ref) => `- ${ref}`).join('\n')}
 
 /**
  * HITL interrupt #1 - optional human review of research (only if enableHITL=true)
+ *
+ * When the graph resumes after interrupt, the state will contain
+ * researchApproved and optionally researchFeedback, set by the caller.
+ * This node is a passthrough — routing logic happens in routeAfterResearchReview.
  */
 async function researchHitlNode(
   state: ContentCreationStateType
 ): Promise<Partial<ContentCreationStateType>> {
-  const { researchReview } = state;
+  const { researchReview, researchApproved } = state;
 
-  logger.info(`Research HITL: Review score ${researchReview?.percentage.toFixed(1)}%`);
+  logger.info(
+    `Research HITL: Review score ${researchReview?.percentage.toFixed(1)}%, approved=${researchApproved}`
+  );
 
-  // This node will interrupt and wait for user input
-  // User provides: researchApproved, researchFeedback
   return {};
 }
 
@@ -491,17 +498,34 @@ ${s.description}
 
 /**
  * HITL interrupt #2 - optional human review of outline (only if enableHITL=true)
+ *
+ * On resume, state contains outlineApproved and optionally outlineFeedback.
+ * If userEditedContent is set, the outline is replaced with the user's edits.
  */
 async function outlineHitlNode(
   state: ContentCreationStateType
 ): Promise<Partial<ContentCreationStateType>> {
-  const { outlineReview } = state;
+  const { outlineReview, outlineApproved, userEditedContent } = state;
 
-  logger.info(`Outline HITL: Review score ${outlineReview?.percentage.toFixed(1)}%`);
+  logger.info(
+    `Outline HITL: Review score ${outlineReview?.percentage.toFixed(1)}%, approved=${outlineApproved}`
+  );
 
-  // This node will interrupt and wait for user input
-  // User provides: outlineApproved, outlineFeedback
-  return {};
+  // If user provided edited content, attempt to parse it as an updated outline
+  if (userEditedContent && outlineApproved) {
+    try {
+      const edited = JSON.parse(userEditedContent) as Outline;
+      logger.info(
+        `Outline HITL: Using user-edited outline with ${edited.sections.length} sections`
+      );
+      return { outline: edited, userEditedContent: undefined };
+    } catch {
+      // Not valid JSON — treat as feedback text, keep existing outline
+      logger.info('Outline HITL: User edit is not valid outline JSON, treating as feedback');
+    }
+  }
+
+  return { userEditedContent: undefined };
 }
 
 /**
@@ -789,17 +813,26 @@ async function finalContentReviewNode(
 
 /**
  * HITL interrupt #3 - optional human review of final content (only if enableHITL=true)
+ *
+ * On resume, state contains reviewApproved and optionally finalReviewFeedback.
+ * If userEditedContent is set and approved, the assembled content is replaced.
  */
 async function finalReviewHitlNode(
   state: ContentCreationStateType
 ): Promise<Partial<ContentCreationStateType>> {
-  const { finalReview } = state;
+  const { finalReview, reviewApproved, userEditedContent } = state;
 
-  logger.info(`Final content HITL: Review score ${finalReview?.percentage.toFixed(1)}%`);
+  logger.info(
+    `Final content HITL: Review score ${finalReview?.percentage.toFixed(1)}%, approved=${reviewApproved}`
+  );
 
-  // This node will interrupt and wait for user input
-  // User provides: reviewApproved, finalReviewFeedback
-  return {};
+  // If user provided edited content, replace the assembled content
+  if (userEditedContent && reviewApproved) {
+    logger.info(`Final HITL: Using user-edited content (${userEditedContent.length} chars)`);
+    return { assembledContent: userEditedContent, userEditedContent: undefined };
+  }
+
+  return { userEditedContent: undefined };
 }
 
 /**
@@ -935,9 +968,18 @@ async function completeNode(
 // ============================================================================
 
 /**
+ * Options for creating the content creation flow
+ */
+export interface ContentCreationFlowOptions {
+  /** Enable HITL interrupt gates. When true, the graph pauses at review nodes. */
+  enableHITL?: boolean;
+}
+
+/**
  * Creates the Content Creation Flow graph
  */
-export function createContentCreationFlow() {
+export function createContentCreationFlow(options?: ContentCreationFlowOptions) {
+  const { enableHITL = false } = options ?? {};
   const graph = new StateGraph(ContentCreationState);
 
   // Phase 1: Research (parallel)
@@ -1033,7 +1075,15 @@ export function createContentCreationFlow() {
   g.addEdge('output_delegate', 'complete');
   g.setFinishPoint('complete');
 
-  // Compile without checkpointer or interrupts - runs end-to-end by default
-  // HITL nodes are in the flow but won't interrupt unless explicitly configured
+  // When HITL is enabled, compile with interruptBefore on HITL gate nodes
+  // so the graph pauses and waits for user input via resolve()
+  if (enableHITL) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (graph as any).compile({
+      interruptBefore: ['research_hitl', 'outline_hitl', 'final_review_hitl'],
+    });
+  }
+
+  // Default: compile without interrupts — runs end-to-end autonomously
   return graph.compile();
 }

--- a/libs/flows/src/index.ts
+++ b/libs/flows/src/index.ts
@@ -138,6 +138,7 @@ export {
   createContentCreationFlow,
   ContentCreationState,
   type ContentCreationStateType,
+  type ContentCreationFlowOptions,
   type ContentConfig as ContentCreationConfig,
   type Outline as ContentOutline,
   type ResearchResult,


### PR DESCRIPTION
## Summary
- Generic approval dialog for untyped LangGraph interrupts (yes/no fallback)
- Model selector UI (haiku/sonnet/opus dropdown with localStorage persistence per-workflow)
- Workflow abort button with confirmation dialog
- Graph resume logic for edited content in HITL flows (interruptBefore compilation, user-edited content passthrough)

## Changes
- **New UI**: `generic-dialog.tsx`, `model-selector.tsx`, `workflow-abort.tsx`
- **Backend**: Content creation flow now compiles with `interruptBefore` when `enableHITL=true`
- **State**: Added `userEditedContent` field for HITL resume with user edits
- **Service**: `ContentFlowService.resumeFlow()` passes `editedContent` through to HITL nodes

## Test plan
- [ ] `npm run build:packages` compiles clean
- [ ] `npm run build:server` compiles clean
- [ ] UI components render with correct theme styles
- [ ] Model selector persists selection in localStorage
- [ ] Abort button shows confirmation dialog before stopping
- [ ] HITL flow interrupts at review gates when `enableHITL=true`
- [ ] User edits are applied to outline/content on resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model selection dropdown for choosing between different AI model variants with automatic preference saving.
  * Added workflow abort button with confirmation dialog to stop running processes.
  * Enhanced approval workflows to preserve and integrate user-edited content when resuming after human review.
  * New approval dialog component for user confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->