### PR TITLE
fix(server): dynamic import CopilotKit to prevent crash when dep missing

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -183,9 +183,8 @@ import { LinearApprovalBridge } from './services/linear-approval-bridge.js';
 import { createDeployRoutes } from './routes/deploy/index.js';
 import { createAnalyticsRoutes } from './routes/analytics.js';
 import { AntagonisticReviewService } from './services/antagonistic-review-service.js';
-import { createCopilotKitEndpoint } from './routes/copilotkit/index.js';
-import { createCopilotKitThreadRoutes } from './routes/copilotkit/threads.js';
-import { CopilotKitThreadService } from './services/copilotkit-thread-service.js';
+// CopilotKit imports are dynamic — @copilotkit/runtime may not be installed (e.g. Docker)
+// See conditional registration below at /api/copilotkit routes
 
 const PORT = parseInt(process.env.PORT || '3008', 10);
 const HOST = process.env.HOST || '0.0.0.0';
@@ -1034,9 +1033,19 @@ app.use('/api/escalation', createEscalationRoutes(escalationRouter));
 app.use('/api/analytics', createAnalyticsRoutes(events));
 app.use('/api/flows', createFlowsRoutes(antagonisticReviewService));
 if (process.env.ANTHROPIC_API_KEY) {
-  app.use('/api/copilotkit', createCopilotKitEndpoint({ featureLoader, autoModeService }));
-  const copilotKitThreadService = new CopilotKitThreadService(DATA_DIR);
-  app.use('/api/copilotkit/threads', createCopilotKitThreadRoutes(copilotKitThreadService));
+  try {
+    const { createCopilotKitEndpoint } = await import('./routes/copilotkit/index.js');
+    const { createCopilotKitThreadRoutes } = await import('./routes/copilotkit/threads.js');
+    const { CopilotKitThreadService } = await import('./services/copilotkit-thread-service.js');
+    app.use('/api/copilotkit', createCopilotKitEndpoint({ featureLoader, autoModeService }));
+    const copilotKitThreadService = new CopilotKitThreadService(DATA_DIR);
+    app.use('/api/copilotkit/threads', createCopilotKitThreadRoutes(copilotKitThreadService));
+  } catch (err) {
+    logger.warn(
+      'CopilotKit routes disabled — @copilotkit/runtime not installed:',
+      (err as Error).message
+    );
+  }
 } else {
   logger.warn('CopilotKit routes disabled — ANTHROPIC_API_KEY not set');
 }


### PR DESCRIPTION
## Summary
- Server crashes in restart loop because `@copilotkit/runtime` is not installed in Docker image
- Converts static top-level imports to dynamic `await import()` inside the `ANTHROPIC_API_KEY` conditional block
- Adds try-catch fallback — CopilotKit routes gracefully disabled with warning log instead of crashing

## Root Cause
CopilotKit PRs (#513-518) added `@copilotkit/runtime` as a server dependency, but the Docker build doesn't install it. The static `import` at module load time throws `ERR_MODULE_NOT_FOUND` before any server code runs.

## Test plan
- [ ] Server starts without `@copilotkit/runtime` installed — logs warning, all other routes work
- [ ] Server starts with `@copilotkit/runtime` installed — CopilotKit routes registered normally
- [ ] Docker container stops restart-looping after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved server initialization robustness by gracefully handling missing API key configurations and optional dependency availability, ensuring the application continues running with appropriate warning logs when CopilotKit features are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->