### PR TITLE
docs: align GTM docs and Jon prompt with $49 lifetime Pro strategy

### DIFF
--- a/docs/protolabs/agency-overview.md
+++ b/docs/protolabs/agency-overview.md
@@ -143,11 +143,13 @@ The reflection loop is what makes this a **learning system**, not just an execut
 
 ## The Revenue Model
 
-1. **Content/Social Media**: Every project we run generates content about how autonomous AI development works
-2. **Consulting (setupLab)**: We teach other organizations to set up their own proto labs using our gold standard
-3. **Template Repos**: Standardized project scaffolding that embodies our patterns
+No SaaS, no subscriptions, no obligations. Indie maker, not startup.
 
-The system is both the product and the factory that makes the product.
+1. **Free tool**: protoMaker is source-available. Builds community trust and distribution.
+2. **$49 lifetime Pro**: Written tutorials, agent templates, prompt library, methodology guide. One-time payment, lifetime access.
+3. **Consulting (setupLab)**: Help organizations set up their own proto labs. Organic inbound from community trust, not outbound sales.
+
+The system is both the product and the factory that makes the product. Every project generates content and proves the methodology.
 
 ## What Makes This Different
 

--- a/docs/protolabs/brand.md
+++ b/docs/protolabs/brand.md
@@ -12,8 +12,9 @@ This is the living brand bible for protoLabs. All agents, content, and external 
 | **proto-labs-ai**     | GitHub organization                   | `github.com/proto-labs-ai`                                                                       |
 | **Automaker**         | Internal codename / upstream origin   | Used in code (`@automaker/*` packages, `.automaker/` directory). NOT used in external marketing. |
 | **create-protolab**   | npx CLI tool                          | Scaffolds new projects with protoLabs methodology                                                |
-| **rabbit-hole**       | AI-powered TTRPG                      | Built with protoMaker. Proof of concept product.                                                 |
-| **proto-ux**          | UX automation toolkit                 | Proof of concept product.                                                                        |
+| **MythXEngine**       | AI-powered TTRPG engine               | Built with protoMaker. Portfolio proof of methodology.                                           |
+| **SVGVal**            | SVG validation toolkit                | Built with protoMaker. Portfolio proof of methodology.                                           |
+| **rabbit-hole**       | AI-powered TTRPG (legacy name)        | Now MythXEngine. Built with protoMaker.                                                          |
 | **Agentic Jumpstart** | Community Discord / educational brand | Community-facing, not the agency brand                                                           |
 
 ### Naming Rules
@@ -70,11 +71,9 @@ This is the living brand bible for protoLabs. All agents, content, and external 
 
 ### Platforms (Priority Order)
 
-1. **Twitter/X** — Daily. 40% show work, 30% insights, 20% threads, 10% engagement
-2. **Twitch** — 2-3x/week. Live building sessions, architecture discussions
-3. **YouTube** — VODs from Twitch streams, edited tutorials
-4. **Instagram** — Visual brand moments, studio aesthetics
-5. **TikTok** — Short clips from streams, hot takes
+1. **Twitter/X** — Primary. Show the work, insights, threads, engagement.
+2. **Twitch** — Live building sessions when it makes sense. Not a fixed schedule.
+3. **YouTube** — VODs from Twitch streams, edited tutorials.
 
 ### Content Pillars
 
@@ -85,17 +84,19 @@ This is the living brand bible for protoLabs. All agents, content, and external 
 
 ### Core Principle
 
-"One effort, many surfaces." Every work session generates content that flows to all channels.
+"One effort, many surfaces." Content generation is automated — Cindi writes, Jon strategizes, schedulers distribute. Josh's role is to engage with people, not produce content manually.
 
 ### Pipeline
 
-Work -> Capture -> Source Content -> Repurpose -> All Channels Fed
+Work -> AI generates content -> Schedule across platforms -> Josh engages with responses
 
 ## Revenue Model
 
-1. **Open source** — protoMaker is source-available (Automaker License). Builds community trust and distribution.
-2. **Paid content** — Methodology, tutorials, tips & tricks behind paywalls. The tool is free; the knowledge of how to orchestrate it is the product.
-3. **Consulting** — setupLab offering. Help companies set up their own proto labs. Template repos and guided onboarding.
+**Philosophy: No SaaS, no subscriptions, no obligations.** Build cool things, share how, let people pay once for the knowledge. Indie maker, not startup.
+
+1. **Free tool** — protoMaker is source-available. Builds community trust and distribution.
+2. **$49 lifetime Pro** — Written tutorials, agent templates, prompt library, methodology guide. One-time payment, lifetime access. No recurring obligations on either side.
+3. **Consulting** — setupLab offering. Happens organically when people see the work and want help. Not outbound sales — inbound from community trust.
 
 ## Operating Principles
 
@@ -107,10 +108,11 @@ Work -> Capture -> Source Content -> Repurpose -> All Channels Fed
 
 ## License
 
-The Automaker License is source-available, NOT open source by OSI standards. Users can:
+Source-available under the Automaker License (FSL-style). NOT open source by OSI standards. Users can:
 
 - Use the tool internally
 - Build products USING the tool
+- View and learn from the source code
 
 Users cannot:
 
@@ -118,4 +120,4 @@ Users cannot:
 - Host it as SaaS for others
 - Extract and resell prompts or instructional content
 
-This will be revisited when the product is ready for full open source release.
+License decision pending: evaluating Functional Source License (FSL) which auto-converts to Apache 2.0 after 2 years. See PRO-128 and PRO-159 in Linear.

--- a/libs/prompts/src/agents/jon.ts
+++ b/libs/prompts/src/agents/jon.ts
@@ -12,7 +12,7 @@ export function getJonPrompt(config?: PromptConfig): string {
 
 ## Josh Mabry — Positioning
 
-**Who Josh is:** Architect, founder, technical leader, consultant. NOT a developer — an orchestrator who designs systems and directs AI agents to build them.
+**Who Josh is:** Architect, founder, technical leader. NOT a developer — an orchestrator who designs systems and directs AI agents to build them.
 
 **Language Guide:**
 - USE: "architect, orchestrate, ship, design, direct"
@@ -21,34 +21,42 @@ export function getJonPrompt(config?: PromptConfig): string {
 
 **Josh's background:** Former Principal Application Architect at Vizient, now building protoLabs — the first AI-native development agency. He doesn't write code; he designs what gets built and directs agents to build it.
 
-## Ecosystem
+## Revenue Model
 
-- **protoLabs** — The AI-native development agency (the org)
+No SaaS, no subscriptions, no obligations. Indie maker, not startup.
+- **Free tool** — protoMaker source-available. Community trust and distribution.
+- **$49 lifetime Pro** — Written tutorials, agent templates, prompt library, methodology guide. One-time, forever.
+- **Consulting** — setupLab. Organic inbound from community, not outbound sales.
+
+## Portfolio Proof Points
+
 - **protoMaker** — AI development studio product (Kanban + autonomous agents)
-- **rabbit-hole** — AI-powered TTRPG built with protoMaker
-- **mythΞengine** — AI RPG engine powering rabbit-hole
-- **proto-ux** — UX automation toolkit
+- **MythXEngine** — AI-powered TTRPG engine built with protoMaker
+- **SVGVal** — SVG validation toolkit built with protoMaker
 
-These products are proof of concept — every one demonstrates the protoLabs methodology.
+No competitor ships finished products built with their own tool. This IS the differentiator.
+
+## Team Capacity
+
+This is NOT a human org. AI agents generate, schedule, and distribute content at 10x human capacity. Josh's only role is to engage with people. Everything else is delegated.
 
 ## Team Context
 
-- **Abdellah** — Strategy partner, personal branding, visual identity. NOT content creation. Helps Josh look like the architect he is. Handles brand strategy and positioning refinement.
-- **Ava Loveland (AI)** — Chief of Staff, operational automation, agent management. The proof that AI teammates work.
+- **Abdellah** — Strategy partner, personal branding, visual identity. NOT content creation.
+- **Ava Loveland (AI)** — Chief of Staff, operational automation, agent management.
+- **Cindi (AI)** — Content writing execution. Jon provides strategy and briefs.
 
 ## Platform Priority
 
-1. **Twitter/X** — Daily. 40% show work, 30% insights, 20% threads, 10% engagement
-2. **Twitch** — 2-3x/week. Live building sessions, thinking out loud, architecture discussions
-3. **YouTube** — VODs from Twitch streams, edited tutorials
-4. **Instagram** — Visual brand moments, studio aesthetics
-5. **TikTok** — Short clips from streams, hot takes
+1. **Twitter/X** — Primary. Show the work, insights, threads, engagement.
+2. **Twitch** — Live building sessions when it makes sense. Not a fixed schedule.
+3. **YouTube** — VODs from Twitch streams, edited tutorials.
 
 ## Content Strategy
 
-**Core principle:** "One effort, many surfaces." Every work session generates content that flows to all channels.
+**Core principle:** "One effort, many surfaces." Content generation is automated — Cindi writes, Jon strategizes, schedulers distribute. Josh engages.
 
-**Pipeline:** Work → Capture → Source Content → Repurpose → All Channels Fed
+**Pipeline:** Work → AI generates content → Schedule across platforms → Josh engages with responses
 
 **Content pillars:**
 - **Show the work** — Architecture decisions, agent orchestration, system design
@@ -61,13 +69,14 @@ These products are proof of concept — every one demonstrates the protoLabs met
 - "Look what I coded" (Josh doesn't code, agents do)
 - Feature lists without context
 - Marketing speak that doesn't match Josh's direct, pragmatic voice
+- SaaS language ("subscribe", "plans", "tiers") — we sell one-time, forever
 
 ## Operating Principles
 
 1. **Proof through products** — No claim without a working demo
 2. **Build in public** — Share decisions, tradeoffs, failures, and wins
 3. **Orchestration over implementation** — Demonstrate the methodology in everything
-4. **Community first** — Open source, transparent process, enable others
+4. **Community first** — Open process, enable others
 5. **Ship fast** — MVPs over perfection, iterate based on feedback
 
 ## Your Mission

--- a/packages/mcp-server/plugins/automaker/commands/jon.md
+++ b/packages/mcp-server/plugins/automaker/commands/jon.md
@@ -118,17 +118,44 @@ Then ask: **"What are we working on?"**
 - **Voice**: Technical, direct, pragmatic, authentic, opinionated
 - **Josh**: Architect, NOT developer. "Orchestrate" not "code."
 
+## Strategic Context
+
+### Revenue Model
+
+- **Free tool** — protoMaker is source-available. Builds community trust.
+- **$49 lifetime Pro** — Written tutorials, agent templates, prompt library, methodology guide. One-time, no obligations.
+- **Consulting** — setupLab. Organic inbound from community, not outbound sales.
+- **Philosophy**: No SaaS, no subscriptions. Indie maker, not startup. Josh needs sustainable income to prototype and research, not a billion-dollar company.
+
+### Portfolio Proof Points
+
+Three products built with protoMaker prove the methodology works:
+
+- **protoMaker** — The AI dev studio itself (the tool)
+- **MythXEngine** — AI-powered TTRPG engine
+- **SVGVal** — SVG validation toolkit
+
+No competitor ships finished products built with their own tool. This IS the differentiator.
+
+### Team Capacity
+
+This is NOT a human org. Stop thinking in human hours. The AI team generates, schedules, and distributes content at 10x human capacity. Josh's only role is to engage with people. Everything else is delegated to AI agents.
+
+### Linear Projects
+
+- **GTM Strategy** — Strategic foundations (brand, infrastructure, content engine, revenue)
+- **Begin Media Blitz** — Tactical launch execution (tease → launch → post-launch)
+
 ## Content Methodology
 
-### Pipeline: One Effort, Many Surfaces
+### Pipeline: AI-Powered, Not Manual
 
-Every work session generates content that flows to all channels:
+Content generation is automated. Cindi writes, Jon strategizes, schedulers distribute.
 
-1. **Capture** — Screenshots, terminal output, architecture decisions, anecdotes
-2. **Source** — Write the primary content piece (blog post, thread, video script)
-3. **Repurpose** — Adapt for each platform (tweet, clip, reel, post)
-4. **Schedule** — Queue across platforms with appropriate timing
-5. **Measure** — Track engagement, adjust strategy
+1. **Work happens** — Features ship, architecture decisions are made, agents produce output
+2. **AI generates content** — Cindi produces written pieces from the work
+3. **Schedule across platforms** — Automated scheduling and distribution
+4. **Josh engages** — Responds to comments, builds relationships. The only human step.
 
 ### Content Pillars
 
@@ -139,11 +166,9 @@ Every work session generates content that flows to all channels:
 
 ### Platform Priorities
 
-1. **Twitter/X** — Daily. 40% show work, 30% insights, 20% threads, 10% engagement
-2. **Twitch** — 2-3x/week. Live building, architecture discussions
-3. **YouTube** — VODs from Twitch, edited tutorials
-4. **Instagram** — Visual brand moments, studio aesthetics
-5. **TikTok** — Short clips from streams, hot takes
+1. **Twitter/X** — Primary. Show the work, insights, threads, engagement.
+2. **Twitch** — Live building sessions when it makes sense. Not a fixed schedule.
+3. **YouTube** — VODs from Twitch streams, edited tutorials.
 
 ### What to Avoid
 
@@ -152,6 +177,7 @@ Every work session generates content that flows to all channels:
 - Feature lists without context or proof
 - Marketing speak that doesn't match Josh's voice
 - Comparisons that punch down at competitors
+- SaaS language ("subscribe", "plans", "tiers") — we sell one-time, forever
 
 ## Coordination
 
@@ -180,17 +206,19 @@ Abdellah owns visual identity and brand strategy refinement. Coordinate on visua
 
 **You own:**
 
-- Content calendar and execution
+- Content strategy and automated pipeline direction
 - Competitive research and market positioning
-- Social media strategy and analytics
+- Social media strategy (what to say, when, where)
 - Brand voice consistency
 - Launch planning and coordination
+- Briefing Cindi with content topics and direction
 
 **You do NOT own:**
 
 - Engineering features, infrastructure, agent development (other roles)
 - Visual identity (Abdellah)
-- Content writing execution (Cindi — you provide the brief)
+- Content writing execution (Cindi writes — you provide the brief and editorial direction)
+- Manual content production (the pipeline is automated)
 
 ## Mission
 


### PR DESCRIPTION
## Summary
- Update brand bible, agency overview, Jon command, and Jon prompt with new revenue model
- $49 lifetime Pro, no SaaS, automated content pipeline, indie maker philosophy
- Updated portfolio products (MythXEngine + SVGVal), removed Instagram/TikTok from priorities
- Resolved conflict with Josh's `getJonPrompt()` refactor — updated the prompt source in `libs/prompts/`

## Test plan
- [ ] Verify Jon template loads correctly after server restart
- [ ] Verify brand.md renders correctly in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product branding and naming for clarity.
  * Revised pricing model: free tier, $49 lifetime Pro access, and consulting services available.
  * Clarified platform presence across Twitter/X, Twitch, and YouTube.
  * Updated license information to reflect source-available terms.
  * Refined content strategy and team role descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->