### PR TITLE
fix(deploy): add legacy-peer-deps for Docker npm ci

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -9,6 +9,9 @@
 # In CI/CD: Use "npm install" instead of "npm ci" to allow npm to resolve
 # the correct platform-specific binaries at install time.
 
+# Allow overrides that cross peer-dep ranges (e.g. langsmith 0.3→0.4 security fix)
+legacy-peer-deps=true
+
 # Include bindings for all platforms in package-lock.json to support CI/CD
 # This ensures Linux, macOS, and Windows bindings are all present
 # NOTE: Only enable when regenerating package-lock.json, then comment out to keep installs fast


### PR DESCRIPTION
## Summary
- Add `legacy-peer-deps=true` to project `.npmrc` so Docker `npm ci` succeeds
- Fixes deploy failure from #525 where langsmith 0.3→0.4 override crosses `@langchain/core`'s peer dep range

## Test plan
- [ ] Deploy workflow should pass after merge
- [x] Local `npm install` works fine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm configuration to improve dependency installation compatibility and resolution across package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->