### PR TITLE
fix(deploy): copy .npmrc into Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Copy root package files
-COPY package*.json ./
+# Copy root package files and npm config
+COPY package*.json .npmrc ./
 
 # Copy all libs package.json files (centralized - add new libs here)
 COPY libs/types/package*.json ./libs/types/


### PR DESCRIPTION
## Summary
- Copy `.npmrc` into Docker base stage so `npm ci` inherits `legacy-peer-deps=true`
- Fixes deploy failures from #525/#526 where langsmith override crosses peer dep range

## Test plan
- [ ] Deploy workflow should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to include npm settings during image creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->