### PR TITLE
fix(docker): copy server node_modules for non-hoisted deps + harden CopilotKit check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,6 +155,10 @@ COPY --from=server-builder /app/apps/server/package*.json ./apps/server/
 # Copy node_modules (includes symlinks to libs)
 COPY --from=server-builder /app/node_modules ./node_modules
 
+# Copy server-local node_modules (packages not hoisted to root due to workspace conflicts)
+# e.g. @copilotkit/runtime lives here because the UI has a conflicting transitive version
+COPY --from=server-builder /app/apps/server/node_modules ./apps/server/node_modules
+
 # Create data and projects directories
 RUN mkdir -p /data /projects && chown automaker:automaker /data /projects
 

--- a/apps/ui/src/components/copilotkit/provider.tsx
+++ b/apps/ui/src/components/copilotkit/provider.tsx
@@ -40,8 +40,10 @@ export function CopilotKitProvider({ children }: { children: ReactNode }) {
       signal: controller.signal,
     })
       .then((res) => {
-        // 2xx or 4xx means the route exists (CopilotKit returns 405 for HEAD)
-        setAvailable(res.status !== 404);
+        // Only enable if the route actually exists and responds.
+        // 401 = auth middleware caught it but route may not be registered (disabled).
+        // 404 = route not found. Both mean CopilotKit is unavailable.
+        setAvailable(res.ok || res.status === 405);
       })
       .catch(() => {
         setAvailable(false);


### PR DESCRIPTION
## Summary
- **Root cause**: `@copilotkit/runtime` lives in `apps/server/node_modules/` (not hoisted to root due to workspace conflicts with the UI's transitive dep). The Dockerfile only copied root `node_modules/`, so the package was missing in Docker, disabling CopilotKit routes.
- The UI's availability check treated 401 (auth middleware) as "CopilotKit available" (only checked `!== 404`). This enabled the CopilotKit provider against a non-existent runtime, causing React crashes and page resets.
- **Fix**: Copy `apps/server/node_modules/` in Dockerfile + tighten availability check to only enable on 2xx/405

## Test plan
- [ ] `npm run build` succeeds
- [ ] Deploy to staging — CopilotKit routes should be enabled (no "routes disabled" warning in server logs)
- [ ] UI loads without freezing or resetting when navigating to the board
- [ ] CopilotKit sidebar opens with `\` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced CopilotKit endpoint availability detection with improved status verification logic to more accurately determine service accessibility and overall system health status based on API responses.
  * Optimized deployment packaging to ensure all required server-side dependencies are properly included and available in the final production application image for consistent functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->