### PR TITLE
fix(copilotkit): pass EmptyAdapter to prevent serviceAdapter null crash

### DIFF
--- a/apps/server/src/routes/copilotkit/index.ts
+++ b/apps/server/src/routes/copilotkit/index.ts
@@ -6,7 +6,11 @@
  * can find the "default" agent on /api/copilotkit/info.
  */
 
-import { CopilotRuntime, copilotRuntimeNodeExpressEndpoint } from '@copilotkit/runtime';
+import {
+  CopilotRuntime,
+  copilotRuntimeNodeExpressEndpoint,
+  EmptyAdapter,
+} from '@copilotkit/runtime';
 import { BuiltInAgent, defineTool } from '@copilotkitnext/agent';
 import { z } from 'zod';
 import { createLogger } from '@automaker/utils';
@@ -177,5 +181,6 @@ export function createCopilotKitEndpoint(deps: CopilotKitDependencies) {
   return copilotRuntimeNodeExpressEndpoint({
     runtime,
     endpoint: '/api/copilotkit',
+    serviceAdapter: new EmptyAdapter(),
   });
 }


### PR DESCRIPTION
## Summary

- Pass `EmptyAdapter` to `copilotRuntimeNodeExpressEndpoint` to fix null crash in CopilotKit v1.51 telemetry
- `getCommonConfig` reads `options.serviceAdapter.constructor.name` without null-check — crashes when no adapter is provided
- `EmptyAdapter` is CopilotKit's recommended no-op adapter for BuiltInAgent workflows

## Root cause

After PR #529 deployed `@copilotkit/runtime` into Docker successfully, the server log showed:
```
[CopilotKit] CopilotKit runtime initialized with Ava agent (6 tools)
[Server] CopilotKit routes disabled — Cannot read properties of undefined (reading 'constructor')
```

The crash occurs at `@copilotkit/runtime/dist/index.js:4674` in `getCommonConfig` where telemetry tries to read `serviceAdapter.constructor.name` on the undefined `serviceAdapter` option.

## Test plan

- [x] `npm run build --workspace=apps/server` compiles clean
- [ ] Deploy to staging, verify server log shows "CopilotKit runtime initialized" without crash
- [ ] Open UI, press `\` to open sidebar — loads without error
- [ ] Test "What's on the board?" in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced adapter configuration support for the CopilotKit runtime endpoint, enabling custom runtime adapter setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->