### PR TITLE
fix(copilotkit): pass auth headers to CopilotKit provider

### DIFF
--- a/apps/ui/src/components/copilotkit/provider.tsx
+++ b/apps/ui/src/components/copilotkit/provider.tsx
@@ -13,6 +13,7 @@ import '@copilotkit/react-ui/styles.css';
 import { getCopilotKitThemeStyles } from './theme-bridge';
 import { useCopilotKitContext } from '@/hooks/use-copilotkit-context';
 import { useCopilotKitSuggestions } from '@/hooks/use-copilotkit-suggestions';
+import { getAuthHeaders } from '@/lib/api-fetch';
 
 const CopilotAvailableContext = createContext(false);
 
@@ -38,11 +39,12 @@ export function CopilotKitProvider({ children }: { children: ReactNode }) {
     fetch('/api/copilotkit', {
       method: 'HEAD',
       signal: controller.signal,
+      credentials: 'include',
+      headers: getAuthHeaders(),
     })
       .then((res) => {
-        // Only enable if the route actually exists and responds.
-        // 401 = auth middleware caught it but route may not be registered (disabled).
-        // 404 = route not found. Both mean CopilotKit is unavailable.
+        // 2xx or 405 = route exists and CopilotKit is available.
+        // 401 = auth failed or route not registered. 404 = route not found.
         setAvailable(res.ok || res.status === 405);
       })
       .catch(() => {
@@ -61,7 +63,12 @@ export function CopilotKitProvider({ children }: { children: ReactNode }) {
 
   return (
     <CopilotAvailableContext.Provider value={true}>
-      <CopilotKit runtimeUrl="/api/copilotkit" agent="default">
+      <CopilotKit
+        runtimeUrl="/api/copilotkit"
+        agent="default"
+        headers={getAuthHeaders()}
+        credentials="include"
+      >
         <CopilotKitHooks>{children}</CopilotKitHooks>
       </CopilotKit>
     </CopilotAvailableContext.Provider>


### PR DESCRIPTION
## Summary

- Pass `credentials: 'include'` and `getAuthHeaders()` to CopilotKit availability check and `<CopilotKit>` provider
- Without auth, the HEAD check gets 401 from `authMiddleware`, the UI treats CopilotKit as unavailable, and the sidebar never enables
- Follows the same auth pattern as all other UI API calls (`api-fetch.ts`)

## Context

After PR #530 fixed the `serviceAdapter` crash, the CopilotKit runtime initializes correctly in Docker. However, the UI availability check still fails because `/api/copilotkit` sits behind the global `authMiddleware` (line 922 of `index.ts`). The plain `fetch` without credentials gets a 401.

## Test plan

- [ ] Deploy to staging, verify CopilotKit availability check passes (no 401)
- [ ] Open UI, press `\` — sidebar should load
- [ ] Test sidebar interaction with board tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication support for CopilotKit by ensuring credentials and authorization headers are properly included in API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->