### PR TITLE
fix(copilotkit): fix Hono basePath mismatch and use /info endpoint

### DIFF
--- a/apps/server/src/routes/copilotkit/index.ts
+++ b/apps/server/src/routes/copilotkit/index.ts
@@ -178,9 +178,12 @@ export function createCopilotKitEndpoint(deps: CopilotKitDependencies) {
 
   logger.info(`CopilotKit runtime initialized with Ava agent (${tools.length} tools)`);
 
+  // endpoint '/' because Express strips the mount prefix (/api/copilotkit)
+  // before passing req.url to the handler — Hono basePath must match the
+  // stripped path, not the original URL.
   return copilotRuntimeNodeExpressEndpoint({
     runtime,
-    endpoint: '/api/copilotkit',
+    endpoint: '/',
     serviceAdapter: new EmptyAdapter(),
   });
 }

--- a/apps/ui/src/components/copilotkit/provider.tsx
+++ b/apps/ui/src/components/copilotkit/provider.tsx
@@ -36,16 +36,15 @@ export function CopilotKitProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetch('/api/copilotkit', {
-      method: 'HEAD',
+    fetch('/api/copilotkit/info', {
       signal: controller.signal,
       credentials: 'include',
       headers: getAuthHeaders(),
     })
       .then((res) => {
-        // 2xx or 405 = route exists and CopilotKit is available.
-        // 401 = auth failed or route not registered. 404 = route not found.
-        setAvailable(res.ok || res.status === 405);
+        // 2xx = CopilotKit route exists and responds with agent info.
+        // 404 = route not registered (CopilotKit disabled).
+        setAvailable(res.ok);
       })
       .catch(() => {
         setAvailable(false);


### PR DESCRIPTION
## Summary

- Fix Express/Hono routing mismatch: `endpoint: '/'` instead of `'/api/copilotkit'` since Express strips the mount prefix from `req.url`
- Change UI availability check from `HEAD /api/copilotkit` to `GET /api/copilotkit/info` (CopilotKit only handles POST/GET, not HEAD)

## Root cause

After PRs #530 and #531 fixed the serviceAdapter crash and added auth headers, CopilotKit routes still returned 404. The issue:

1. `app.use('/api/copilotkit', handler)` strips `/api/copilotkit` from `req.url`
2. Handler sees `req.url = '/info'` but Hono's `basePath` was `/api/copilotkit`
3. Hono expected paths starting with `/api/copilotkit/info` — never matched

## Test plan

- [ ] Deploy to staging
- [ ] `curl http://localhost:3008/api/copilotkit/info -H "X-API-Key: ..."` returns agent metadata
- [ ] Open UI, press `\` — sidebar loads and responds to queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CopilotKit endpoint configuration and availability detection mechanism to ensure proper server communication and feature initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->