### PR TITLE
fix(copilotkit): switch to Express-native runtime endpoint

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -36,7 +36,7 @@
     "@automaker/types": "1.0.0",
     "@automaker/utils": "1.0.0",
     "@copilotkitnext/agent": "^1.51.3",
-    "@copilotkit/runtime": "^1.51.3",
+    "@copilotkitnext/runtime": "^1.51.3",
     "@langchain/anthropic": "^0.3.34",
     "@langchain/core": "^0.3.80",
     "@modelcontextprotocol/sdk": "^1.26.0",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -183,7 +183,7 @@ import { LinearApprovalBridge } from './services/linear-approval-bridge.js';
 import { createDeployRoutes } from './routes/deploy/index.js';
 import { createAnalyticsRoutes } from './routes/analytics.js';
 import { AntagonisticReviewService } from './services/antagonistic-review-service.js';
-// CopilotKit imports are dynamic — @copilotkit/runtime may not be installed (e.g. Docker)
+// CopilotKit imports are dynamic — @copilotkitnext/runtime may not be installed
 // See conditional registration below at /api/copilotkit routes
 
 const PORT = parseInt(process.env.PORT || '3008', 10);
@@ -1042,7 +1042,7 @@ if (process.env.ANTHROPIC_API_KEY) {
     app.use('/api/copilotkit/threads', createCopilotKitThreadRoutes(copilotKitThreadService));
   } catch (err) {
     logger.warn(
-      'CopilotKit routes disabled — @copilotkit/runtime not installed:',
+      'CopilotKit routes disabled — @copilotkitnext/runtime not installed:',
       (err as Error).message
     );
   }

--- a/apps/server/src/routes/copilotkit/index.ts
+++ b/apps/server/src/routes/copilotkit/index.ts
@@ -6,11 +6,8 @@
  * can find the "default" agent on /api/copilotkit/info.
  */
 
-import {
-  CopilotRuntime,
-  copilotRuntimeNodeExpressEndpoint,
-  EmptyAdapter,
-} from '@copilotkit/runtime';
+import { CopilotRuntime } from '@copilotkitnext/runtime';
+import { createCopilotEndpointExpress } from '@copilotkitnext/runtime/express';
 import { BuiltInAgent, defineTool } from '@copilotkitnext/agent';
 import { z } from 'zod';
 import { createLogger } from '@automaker/utils';
@@ -178,12 +175,8 @@ export function createCopilotKitEndpoint(deps: CopilotKitDependencies) {
 
   logger.info(`CopilotKit runtime initialized with Ava agent (${tools.length} tools)`);
 
-  // endpoint '/' because Express strips the mount prefix (/api/copilotkit)
-  // before passing req.url to the handler — Hono basePath must match the
-  // stripped path, not the original URL.
-  return copilotRuntimeNodeExpressEndpoint({
-    runtime,
-    endpoint: '/',
-    serviceAdapter: new EmptyAdapter(),
-  });
+  // Use @copilotkitnext/runtime's Express-native endpoint (proper Express Router)
+  // instead of @copilotkit/runtime's Hono-based adapter which has path mismatch issues.
+  // basePath '/' because Express strips the mount prefix (/api/copilotkit) from req.url.
+  return createCopilotEndpointExpress({ runtime, basePath: '/' });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,8 +51,8 @@
         "@automaker/prompts": "1.0.0",
         "@automaker/types": "1.0.0",
         "@automaker/utils": "1.0.0",
-        "@copilotkit/runtime": "^1.51.3",
         "@copilotkitnext/agent": "^1.51.3",
+        "@copilotkitnext/runtime": "^1.51.3",
         "@langchain/anthropic": "^0.3.34",
         "@langchain/core": "^0.3.80",
         "@modelcontextprotocol/sdk": "^1.26.0",
@@ -90,81 +90,6 @@
       },
       "engines": {
         "node": ">=22.0.0 <23.0.0"
-      }
-    },
-    "apps/server/node_modules/@copilotkit/runtime": {
-      "version": "1.51.3",
-      "resolved": "https://registry.npmjs.org/@copilotkit/runtime/-/runtime-1.51.3.tgz",
-      "integrity": "sha512-VHhe3gZLWhEhHwYiyrPC971B7Hvcxsoo25bQBM0A6783GrZlpG/2s9a+6Fl33g5CU4OvPrfDmkX4vQCZDDEUxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ag-ui/client": "^0.0.43",
-        "@ag-ui/core": "^0.0.43",
-        "@ag-ui/langgraph": "^0.0.23",
-        "@copilotkit/shared": "1.51.3",
-        "@copilotkitnext/agent": "1.51.3",
-        "@copilotkitnext/runtime": "1.51.3",
-        "@graphql-yoga/plugin-defer-stream": "^3.3.1",
-        "@hono/node-server": "^1.13.5",
-        "@scarf/scarf": "^1.3.0",
-        "class-transformer": "^0.5.1",
-        "class-validator": "^0.14.1",
-        "graphql": "^16.8.1",
-        "graphql-scalars": "^1.23.0",
-        "graphql-yoga": "^5.3.1",
-        "hono": "^4.11.4",
-        "openai": "^4.85.1",
-        "partial-json": "^0.1.7",
-        "pino": "^9.2.0",
-        "pino-pretty": "^11.2.1",
-        "reflect-metadata": "^0.2.2",
-        "rxjs": "7.8.1",
-        "type-graphql": "2.0.0-rc.1",
-        "zod": "^3.23.3"
-      },
-      "peerDependencies": {
-        "@anthropic-ai/sdk": "^0.57.0",
-        "@copilotkit/shared": "1.51.3",
-        "@copilotkitnext/agent": "1.51.3",
-        "@copilotkitnext/runtime": "1.51.3",
-        "@langchain/aws": ">=0.1.9",
-        "@langchain/community": ">=0.3.58",
-        "@langchain/core": ">=0.3.66",
-        "@langchain/google-gauth": ">=0.1.0",
-        "@langchain/langgraph-sdk": ">=0.1.2",
-        "@langchain/openai": ">=0.4.2",
-        "groq-sdk": ">=0.3.0 <1.0.0",
-        "langchain": ">=0.3.3",
-        "openai": "^4.85.1"
-      },
-      "peerDependenciesMeta": {
-        "@anthropic-ai/sdk": {
-          "optional": true
-        },
-        "@langchain/aws": {
-          "optional": true
-        },
-        "@langchain/community": {
-          "optional": true
-        },
-        "@langchain/google-gauth": {
-          "optional": true
-        },
-        "@langchain/langgraph-sdk": {
-          "optional": true
-        },
-        "@langchain/openai": {
-          "optional": true
-        },
-        "groq-sdk": {
-          "optional": true
-        },
-        "langchain": {
-          "optional": true
-        },
-        "openai": {
-          "optional": true
-        }
       }
     },
     "apps/server/node_modules/@eslint/config-array": {


### PR DESCRIPTION
## Summary

- Switch from `@copilotkit/runtime` (Hono-based) to `@copilotkitnext/runtime/express` (Express Router)
- The old package wraps Hono internally which doesn't interop with Express's `app.use()` prefix stripping — all routes returned 404
- `createCopilotEndpointExpress` returns a proper Express Router with correct route registration

## Changes

- `apps/server/src/routes/copilotkit/index.ts`: Import from `@copilotkitnext/runtime` and `@copilotkitnext/runtime/express`
- `apps/server/package.json`: Replace `@copilotkit/runtime` with `@copilotkitnext/runtime`
- `apps/server/src/index.ts`: Update comments

## Context

PRs #529-532 progressively fixed CopilotKit in Docker:
- #529: Copy server node_modules for non-hoisted deps
- #530: Pass EmptyAdapter for serviceAdapter null crash
- #531: Add auth headers to CopilotKit provider
- #532: Fix endpoint basePath (still 404 due to Hono/Express mismatch)

This PR is the final fix — switching to the Express-native endpoint that CopilotKit provides.

## Test plan

- [x] `npm run build --workspace=apps/server` compiles clean
- [x] `npm run lint --workspace=apps/server` no new warnings
- [ ] Deploy: `GET /api/copilotkit/info` returns agent metadata
- [ ] UI sidebar loads and responds to queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CopilotKit runtime integration to resolve endpoint configuration and improve compatibility with the backend service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->