### PR TITLE
fix(copilotkit): add error boundary to prevent app crashes

### DIFF
--- a/apps/ui/src/components/copilotkit/provider.tsx
+++ b/apps/ui/src/components/copilotkit/provider.tsx
@@ -4,9 +4,11 @@
  * Wraps the app with CopilotKit context, but only when the runtime
  * endpoint is available. Falls through to children without CopilotKit
  * when the endpoint is unreachable (e.g. CI/E2E tests without API key).
+ *
+ * Wrapped in an error boundary so CopilotKit failures never crash the app.
  */
 
-import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { Component, createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 import { CopilotKit } from '@copilotkit/react-core';
 import { CopilotSidebar } from '@copilotkit/react-ui';
 import '@copilotkit/react-ui/styles.css';
@@ -16,6 +18,35 @@ import { useCopilotKitSuggestions } from '@/hooks/use-copilotkit-suggestions';
 import { getAuthHeaders } from '@/lib/api-fetch';
 
 const CopilotAvailableContext = createContext(false);
+
+/**
+ * Error boundary that catches CopilotKit crashes and falls through
+ * to rendering children without CopilotKit features.
+ */
+class CopilotErrorBoundary extends Component<
+  { children: ReactNode; fallback: ReactNode },
+  { hasError: boolean }
+> {
+  constructor(props: { children: ReactNode; fallback: ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    console.warn('[CopilotKit] Error caught by boundary, disabling sidebar:', error.message);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}
 
 /**
  * Injects CopilotKit hooks when provider is active.
@@ -30,6 +61,7 @@ function CopilotKitHooks({ children }: { children: ReactNode }) {
 /**
  * Conditionally wraps children with CopilotKit provider.
  * Checks if the /api/copilotkit endpoint responds before enabling.
+ * Wrapped in error boundary so CopilotKit can never crash the app.
  */
 export function CopilotKitProvider({ children }: { children: ReactNode }) {
   const [available, setAvailable] = useState<boolean | null>(null);
@@ -53,24 +85,27 @@ export function CopilotKitProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const isAvailable = available === true;
+  const unavailableFallback = (
+    <CopilotAvailableContext.Provider value={false}>{children}</CopilotAvailableContext.Provider>
+  );
 
   if (!isAvailable) {
-    return (
-      <CopilotAvailableContext.Provider value={false}>{children}</CopilotAvailableContext.Provider>
-    );
+    return unavailableFallback;
   }
 
   return (
-    <CopilotAvailableContext.Provider value={true}>
-      <CopilotKit
-        runtimeUrl="/api/copilotkit"
-        agent="default"
-        headers={getAuthHeaders()}
-        credentials="include"
-      >
-        <CopilotKitHooks>{children}</CopilotKitHooks>
-      </CopilotKit>
-    </CopilotAvailableContext.Provider>
+    <CopilotErrorBoundary fallback={unavailableFallback}>
+      <CopilotAvailableContext.Provider value={true}>
+        <CopilotKit
+          runtimeUrl="/api/copilotkit"
+          agent="default"
+          headers={getAuthHeaders()}
+          credentials="include"
+        >
+          <CopilotKitHooks>{children}</CopilotKitHooks>
+        </CopilotKit>
+      </CopilotAvailableContext.Provider>
+    </CopilotErrorBoundary>
   );
 }
 


### PR DESCRIPTION
## Summary

- Add `CopilotErrorBoundary` around CopilotKit provider so failures never crash the entire app
- When CopilotKit throws, the boundary catches it and falls through to rendering the app without CopilotKit features
- Logs the error to console for debugging

## Root cause

`CopilotKitProvider` wraps the entire React tree in `__root.tsx`. If any CopilotKit component throws during render (connection error, protocol mismatch, AG-UI runtime issues), React unmounts the entire tree — the user sees the page "crashing" or "resetting itself."

## Test plan

- [x] `npm run build --workspace=apps/ui` compiles clean
- [ ] Deploy to staging — app should load without freezing
- [ ] If CopilotKit has issues, app continues working (sidebar just won't appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved application stability by preventing crashes when CopilotKit encounters runtime errors; the app will continue functioning normally without CopilotKit features.
  * Enhanced fallback handling when CopilotKit is unavailable, ensuring graceful degradation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->