### PR TITLE
fix(cors): allow 'ava' hostname for local network access

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -316,6 +316,7 @@ app.use(
           hostname === '127.0.0.1' ||
           hostname === '::1' ||
           hostname === '0.0.0.0' ||
+          hostname === 'ava' ||
           hostname.startsWith('192.168.') ||
           hostname.startsWith('10.') ||
           hostname.startsWith('172.')


### PR DESCRIPTION
## Summary

- Add `ava` to the CORS hostname allowlist so the UI works when accessed via `http://ava:3007`

## Test plan

- [ ] Login works at `http://ava:3007/login`
- [ ] No CORS errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded CORS configuration to support an additional local development origin hostname alongside existing localhost and private network ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->