### PR TITLE
style: sharpen border radius to Linear-inspired 6px

### DIFF
--- a/apps/ui/src/styles/global.css
+++ b/apps/ui/src/styles/global.css
@@ -92,16 +92,16 @@
   --color-status-blocked: var(--status-blocked);
   --color-status-done: var(--status-done);
 
-  /* Border radius */
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  /* Border radius — Linear-inspired: tight, geometric */
+  --radius-sm: calc(var(--radius) - 2px);
+  --radius-md: var(--radius);
+  --radius-lg: calc(var(--radius) + 2px);
+  --radius-xl: calc(var(--radius) + 6px);
 }
 
 :root {
   /* Default to Studio Light */
-  --radius: 0.5rem;
+  --radius: 0.375rem;
   --perf-contain-intrinsic-size: 500px;
 
   /* Surfaces */
@@ -568,7 +568,7 @@
 
   .animated-border-wrapper {
     position: relative;
-    border-radius: 0.75rem;
+    border-radius: var(--radius-lg);
     padding: 2px;
     background: linear-gradient(
       135deg,
@@ -588,7 +588,7 @@
   }
 
   .animated-border-wrapper > * {
-    border-radius: calc(0.75rem - 2px);
+    border-radius: calc(var(--radius-lg) - 2px);
   }
 }
 
@@ -723,7 +723,7 @@
   --xy-background-color: transparent;
   --xy-node-background-color: var(--card);
   --xy-node-border-color: var(--border);
-  --xy-node-border-radius: 0.75rem;
+  --xy-node-border-radius: var(--radius-lg);
   --xy-edge-stroke-default: var(--border);
   --xy-edge-stroke-selected: var(--brand-500);
   --xy-minimap-background-color: var(--popover);
@@ -736,7 +736,7 @@
 .graph-canvas .react-flow__minimap {
   background-color: var(--popover) !important;
   border: 1px solid var(--border) !important;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-md);
 }
 
 .graph-canvas .react-flow__minimap-mask {


### PR DESCRIPTION
## Summary
- Drop `--radius` from `0.5rem` (8px) to `0.375rem` (6px) for Linear-sharp borders
- Rework radius scale: sm=4px, md=6px, lg=8px, xl=12px (tighter increments)
- Replace hardcoded `0.75rem` border-radius values with `var(--radius-lg)` tokens
- Scrollbar thumb radius (3-4px) left as-is — intentionally small

## Context
Follow-up to PR #539 (design system overhaul). Josh's feedback: "ultra round border radius" needed sharpening. Linear uses ~6px for most elements.

## Test plan
- [ ] Cards, buttons, inputs all visually sharper
- [ ] Animated border wrapper still renders correctly
- [ ] React Flow graph nodes use consistent radius
- [ ] Minimap uses consistent radius


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refactored border radius styling to use a scalable token-based system
  * Adjusted default base radius value for tighter, more consistent design
  * Updated UI components to use unified border radius tokens instead of hard-coded values
  * Enhanced design consistency across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->