### PR TITLE
feat: create @automaker/ui-components shared package scaffold

### DIFF
--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@automaker/ui-components",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Shared UI components for AutoMaker",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./atoms": {
+      "types": "./dist/atoms/index.d.ts",
+      "default": "./dist/atoms/index.js"
+    },
+    "./molecules": {
+      "types": "./dist/molecules/index.d.ts",
+      "default": "./dist/molecules/index.js"
+    },
+    "./organisms": {
+      "types": "./dist/organisms/index.d.ts",
+      "default": "./dist/organisms/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch"
+  },
+  "keywords": [
+    "automaker",
+    "ui",
+    "components"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "AutoMaker Team",
+  "license": "SEE LICENSE IN LICENSE",
+  "engines": {
+    "node": ">=22.0.0 <23.0.0"
+  },
+  "dependencies": {
+    "class-variance-authority": "0.7.1",
+    "clsx": "2.1.1",
+    "tailwind-merge": "3.4.0",
+    "lucide-react": "0.562.0"
+  },
+  "peerDependencies": {
+    "react": ">=19",
+    "tailwindcss": ">=4"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.3",
+    "@types/react": "^19.0.10",
+    "typescript": "5.9.3"
+  }
+}

--- a/libs/ui/src/atoms/index.ts
+++ b/libs/ui/src/atoms/index.ts
@@ -1,0 +1,1 @@
+// Atoms will be populated by subsequent features

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -1,0 +1,1 @@
+export * from './atoms/index.js';

--- a/libs/ui/src/lib/utils.ts
+++ b/libs/ui/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/libs/ui/src/molecules/index.ts
+++ b/libs/ui/src/molecules/index.ts
@@ -1,0 +1,1 @@
+// Molecules will be populated by subsequent features

--- a/libs/ui/src/organisms/index.ts
+++ b/libs/ui/src/organisms/index.ts
@@ -1,0 +1,1 @@
+// Organisms will be populated by subsequent features

--- a/libs/ui/tsconfig.json
+++ b/libs/ui/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1653,6 +1653,29 @@
         "node": ">=22.0.0 <23.0.0"
       }
     },
+    "libs/ui": {
+      "name": "@automaker/ui-components",
+      "version": "1.0.0",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "class-variance-authority": "0.7.1",
+        "clsx": "2.1.1",
+        "lucide-react": "0.562.0",
+        "tailwind-merge": "3.4.0"
+      },
+      "devDependencies": {
+        "@types/node": "22.19.3",
+        "@types/react": "^19.0.10",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=22.0.0 <23.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=19",
+        "tailwindcss": ">=4"
+      }
+    },
     "libs/utils": {
       "name": "@automaker/utils",
       "version": "1.0.0",
@@ -2186,6 +2209,10 @@
     },
     "node_modules/@automaker/ui": {
       "resolved": "apps/ui",
+      "link": true
+    },
+    "node_modules/@automaker/ui-components": {
+      "resolved": "libs/ui",
       "link": true
     },
     "node_modules/@automaker/utils": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev:docker:rebuild": "docker compose build --no-cache && docker compose up",
     "dev:full": "npm run build:packages && concurrently \"npm run _dev:server\" \"npm run _dev:web\"",
     "build": "npm run build:packages && npm run build --workspace=apps/ui",
-    "build:libs": "npm run build -w @automaker/types && npm run build -w @automaker/platform && npm run build -w @automaker/utils -w @automaker/spec-parser && npm run build -w @automaker/prompts -w @automaker/model-resolver -w @automaker/dependency-resolver -w @automaker/policy-engine -w @automaker/llm-providers -w @automaker/observability -w @automaker/flows && npm run build -w @automaker/git-utils",
+    "build:libs": "npm run build -w @automaker/types && npm run build -w @automaker/platform && npm run build -w @automaker/utils -w @automaker/spec-parser && npm run build -w @automaker/prompts -w @automaker/model-resolver -w @automaker/dependency-resolver -w @automaker/policy-engine -w @automaker/llm-providers -w @automaker/observability -w @automaker/flows && npm run build -w @automaker/git-utils && npm run build -w @automaker/ui-components",
     "build:packages": "npm run build:libs && tsc --project packages/mcp-server/tsconfig.json",
     "build:server": "npm run build:packages && npm run build --workspace=apps/server",
     "build:electron": "npm run build:packages && npm run build:electron --workspace=apps/ui",


### PR DESCRIPTION
## Summary
- Creates `libs/ui/` package (`@automaker/ui-components`) — foundation for shared component library
- Exports map with subpaths: `./atoms`, `./molecules`, `./organisms`
- Dependencies: class-variance-authority, clsx, tailwind-merge, lucide-react
- Peer deps: react >=19, tailwindcss >=4
- `cn()` utility helper (clsx + tailwind-merge)
- Added to `build:libs` pipeline in root package.json
- Empty barrel exports for atoms/molecules/organisms (populated by subsequent features)

**Note:** Named `@automaker/ui-components` (not `@automaker/ui`) because `apps/ui` already claims that package name.

## Test plan
- [x] `npm run build:packages` succeeds
- [x] All export paths resolve: main, ./atoms, ./molecules, ./organisms
- [x] Package imports work from apps/ui workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Established new UI components library with modular architecture supporting atoms, molecules, and organisms component layers
  * Integrated new library into project build pipeline
  * Added TypeScript configuration and CSS class composition utility for component styling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->