### PR TITLE
feat: extract Card, Input, Label atoms to @automaker/ui-components

### DIFF
--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -41,6 +41,7 @@
     "node": ">=22.0.0 <23.0.0"
   },
   "dependencies": {
+    "@radix-ui/react-label": "2.0.2",
     "@radix-ui/react-slot": "1.2.4",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/libs/ui/src/atoms/card.tsx
+++ b/libs/ui/src/atoms/card.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+
+import { cn } from '../lib/utils.js';
+
+interface CardProps extends React.ComponentProps<'div'> {
+  gradient?: boolean;
+}
+
+function Card({ className, gradient = false, ...props }: CardProps) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        'bg-card text-card-foreground flex flex-col gap-1 rounded-xl border border-white/10 backdrop-blur-md py-6',
+        // Premium layered shadow
+        'shadow-[0_1px_2px_rgba(0,0,0,0.05),0_4px_6px_rgba(0,0,0,0.05),0_10px_20px_rgba(0,0,0,0.04)]',
+        // Gradient border option
+        gradient &&
+          'relative before:absolute before:inset-0 before:rounded-xl before:p-[1px] before:bg-gradient-to-br before:from-white/20 before:to-transparent before:pointer-events-none before:-z-10',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn('leading-none font-semibold tracking-tight', className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn('text-muted-foreground text-sm leading-relaxed', className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-content" className={cn('px-6', className)} {...props} />;
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn('flex items-center gap-3 px-6 [.border-t]:pt-6', className)}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };

--- a/libs/ui/src/atoms/index.ts
+++ b/libs/ui/src/atoms/index.ts
@@ -1,5 +1,8 @@
 export { Button, buttonVariants } from './button.js';
 export { Badge, badgeVariants } from './badge.js';
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent } from './card.js';
+export { Input } from './input.js';
+export { Label } from './label.js';
 export { Checkbox } from './checkbox.js';
 export { RadioGroup, RadioGroupItem } from './radio-group.js';
 export {

--- a/libs/ui/src/atoms/input.tsx
+++ b/libs/ui/src/atoms/input.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+
+import { cn } from '../lib/utils.js';
+
+interface InputProps extends React.ComponentProps<'input'> {
+  startAddon?: React.ReactNode;
+  endAddon?: React.ReactNode;
+}
+
+function Input({ className, type, startAddon, endAddon, ...props }: InputProps) {
+  const hasAddons = startAddon || endAddon;
+
+  const inputElement = (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'file:text-foreground placeholder:text-muted-foreground/60 selection:bg-primary selection:text-primary-foreground bg-input border-border h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base shadow-xs outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        // Inner shadow for depth
+        'shadow-[inset_0_1px_2px_rgba(0,0,0,0.05)]',
+        // Animated focus ring
+        'transition-[color,box-shadow,border-color] duration-200 ease-out',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:ring-destructive/20 aria-invalid:border-destructive',
+        // Adjust padding for addons
+        startAddon && 'pl-0',
+        endAddon && 'pr-0',
+        hasAddons && 'border-0 shadow-none focus-visible:ring-0',
+        className
+      )}
+      {...props}
+    />
+  );
+
+  if (!hasAddons) {
+    return inputElement;
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex items-center h-9 w-full rounded-md border border-border bg-input shadow-xs',
+        'shadow-[inset_0_1px_2px_rgba(0,0,0,0.05)]',
+        'transition-[box-shadow,border-color] duration-200 ease-out',
+        'focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px]',
+        'has-[input:disabled]:opacity-50 has-[input:disabled]:cursor-not-allowed',
+        'has-[input[aria-invalid]]:ring-destructive/20 has-[input[aria-invalid]]:border-destructive'
+      )}
+    >
+      {startAddon && (
+        <span className="flex items-center justify-center px-3 text-muted-foreground text-sm">
+          {startAddon}
+        </span>
+      )}
+      {inputElement}
+      {endAddon && (
+        <span className="flex items-center justify-center px-3 text-muted-foreground text-sm">
+          {endAddon}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export { Input };

--- a/libs/ui/src/atoms/label.tsx
+++ b/libs/ui/src/atoms/label.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import * as LabelPrimitive from '@radix-ui/react-label';
+
+import { cn } from '../lib/utils.js';
+
+function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };


### PR DESCRIPTION
## Summary
- Extracts Card (Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent), Input, and Label components from `apps/ui/src/components/ui/` to `libs/ui/src/atoms/`
- Updates cn() imports to relative paths with `.js` extensions for NodeNext resolution
- Adds `@radix-ui/react-label` dependency to `libs/ui/package.json`
- Updates `libs/ui/src/atoms/index.ts` barrel exports

## Test plan
- [ ] `npm run build -w @automaker/ui-components` compiles without errors
- [ ] Type definitions generated correctly in `dist/atoms/`
- [ ] All component exports accessible from `@automaker/ui-components/atoms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Card component with optional gradient border and composable header/title/description/action/content/footer sections
  * Added Input component with optional start/end addon slots for enhanced field layouts
  * Added Label component to improve form accessibility and styling; components are now publicly exported

* **Chores**
  * Added Radix label dependency to the UI package.json
<!-- end of auto-generated comment: release notes by coderabbit.ai -->