### PR TITLE
feat: extract Button and Badge atoms to @automaker/ui-components

### DIFF
--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -41,6 +41,7 @@
     "node": ">=22.0.0 <23.0.0"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "1.2.4",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "tailwind-merge": "3.4.0",

--- a/libs/ui/src/atoms/badge.tsx
+++ b/libs/ui/src/atoms/badge.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '../lib/utils.js';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 shadow-sm',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive: 'border-transparent bg-destructive text-white hover:bg-destructive/90',
+        outline: 'text-foreground border-border bg-background/50 backdrop-blur-sm',
+        // Semantic status variants using CSS variables
+        success:
+          'border-transparent bg-[var(--status-success-bg)] text-[var(--status-success)] border border-[var(--status-success)]/30',
+        warning:
+          'border-transparent bg-[var(--status-warning-bg)] text-[var(--status-warning)] border border-[var(--status-warning)]/30',
+        error:
+          'border-transparent bg-[var(--status-error-bg)] text-[var(--status-error)] border border-[var(--status-error)]/30',
+        info: 'border-transparent bg-[var(--status-info-bg)] text-[var(--status-info)] border border-[var(--status-info)]/30',
+        // Muted variants for subtle indication
+        muted: 'border-border/50 bg-muted/50 text-muted-foreground',
+        brand: 'border-transparent bg-brand-500/15 text-brand-500 border border-brand-500/30',
+      },
+      size: {
+        default: 'px-2.5 py-0.5 text-xs',
+        sm: 'px-2 py-0.5 text-[10px]',
+        lg: 'px-3 py-1 text-sm',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, size, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant, size }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/libs/ui/src/atoms/button.tsx
+++ b/libs/ui/src/atoms/button.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { Loader2 } from 'lucide-react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '../lib/utils.js';
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 cursor-pointer disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive active:scale-[0.98]",
+  {
+    variants: {
+      variant: {
+        default:
+          'bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md hover:shadow-primary/25',
+        destructive:
+          'bg-destructive text-white shadow-sm hover:bg-destructive/90 hover:shadow-md hover:shadow-destructive/25 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline:
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+        secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline active:scale-100',
+        'animated-outline': 'relative overflow-hidden rounded-xl hover:bg-transparent shadow-none',
+      },
+      size: {
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9',
+        'icon-sm': 'size-8',
+        'icon-lg': 'size-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+// Loading spinner component
+function ButtonSpinner({ className }: { className?: string }) {
+  return <Loader2 className={cn('h-4 w-4 animate-spin', className)} aria-hidden="true" />;
+}
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  loading = false,
+  disabled,
+  children,
+  ...props
+}: React.ComponentProps<'button'> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+    loading?: boolean;
+  }) {
+  const isDisabled = disabled || loading;
+
+  // Special handling for animated-outline variant
+  if (variant === 'animated-outline' && !asChild) {
+    return (
+      <button
+        className={cn(
+          buttonVariants({ variant, size }),
+          'group p-[1px]', // Force 1px padding for the gradient border, group for hover animation
+          className
+        )}
+        data-slot="button"
+        disabled={isDisabled}
+        {...props}
+      >
+        {/* Animated rotating gradient border - only animates on hover for GPU efficiency */}
+        <span className="absolute inset-[-1000%] animated-outline-gradient opacity-75 transition-opacity duration-300 group-hover:animate-[spin_3s_linear_infinite] group-hover:opacity-100" />
+
+        {/* Inner content container */}
+        <span
+          className={cn(
+            'animated-outline-inner inline-flex h-full w-full cursor-pointer items-center justify-center gap-2 rounded-[10px] px-4 py-1 text-sm font-medium backdrop-blur-3xl transition-all duration-200',
+            size === 'sm' && 'px-3 text-xs gap-1.5',
+            size === 'lg' && 'px-8',
+            size === 'icon' && 'p-0 gap-0'
+          )}
+        >
+          {loading && <ButtonSpinner />}
+          {children}
+        </span>
+      </button>
+    );
+  }
+
+  const Comp = asChild ? Slot : 'button';
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      disabled={isDisabled}
+      {...props}
+    >
+      {loading && <ButtonSpinner />}
+      {children}
+    </Comp>
+  );
+}
+
+export { Button, buttonVariants };

--- a/libs/ui/src/atoms/index.ts
+++ b/libs/ui/src/atoms/index.ts
@@ -1,4 +1,5 @@
-// Atoms will be populated by subsequent features
+export { Button, buttonVariants } from './button.js';
+export { Badge, badgeVariants } from './badge.js';
 export { Checkbox } from './checkbox.js';
 export { RadioGroup, RadioGroupItem } from './radio-group.js';
 export {


### PR DESCRIPTION
## Summary
- Extracts Button (with buttonVariants, loading state, animated-outline variant) and Badge (with badgeVariants) from `apps/ui/src/components/ui/` to `libs/ui/src/atoms/`
- Replaces app-level Spinner dependency with lucide-react Loader2 for self-contained Button
- Adds `@radix-ui/react-slot` dependency for Button's asChild pattern
- Updates cn() imports to relative `.js` paths for NodeNext resolution

## Test plan
- [ ] `npm run build -w @automaker/ui-components` compiles without errors
- [ ] Button and Badge exports accessible from `@automaker/ui-components/atoms`
- [ ] buttonVariants and badgeVariants properly typed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Badge component with multiple visual variants and configurable sizes.
  * Added a Button component with variant and size options, loading state, and an animated-outline style for richer interactions.
  * Exposed the new components in the UI library index for easier import.

* **Chores**
  * Updated package manifest to include a UI slot dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->