### PR TITLE
style(ui): tighten density across top surfaces (Linear-compact)

### DIFF
--- a/apps/ui/src/components/views/board-view/components/kanban-card/kanban-card.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/kanban-card.tsx
@@ -182,13 +182,13 @@ export const KanbanCard = memo(function KanbanCard({
 
   const innerCardClasses = cn(
     'kanban-card-content h-full relative',
-    reduceEffects ? 'shadow-none' : 'shadow-sm',
+    reduceEffects ? 'shadow-none' : 'shadow',
     'transition-all duration-200 ease-out',
     // Disable hover translate for in-progress cards to prevent gap showing gradient
     isInteractive &&
       !reduceEffects &&
       !isCurrentAutoTask &&
-      'hover:-translate-y-0.5 hover:shadow-md hover:shadow-black/10 bg-transparent',
+      'hover:-translate-y-0.5 hover:shadow-sm hover:shadow-black/5 bg-transparent',
     !glassmorphism && 'backdrop-blur-[0px]!',
     !isCurrentAutoTask &&
       cardBorderEnabled &&
@@ -216,7 +216,7 @@ export const KanbanCard = memo(function KanbanCard({
       {(!isDragging || isOverlay) && (
         <div
           className={cn(
-            'absolute inset-0 rounded-xl bg-card -z-10',
+            'absolute inset-0 rounded-lg bg-card -z-10',
             glassmorphism && 'backdrop-blur-sm'
           )}
           style={{ opacity: opacity / 100 }}

--- a/apps/ui/src/components/views/board-view/dialogs/edit-feature-dialog.tsx
+++ b/apps/ui/src/components/views/board-view/dialogs/edit-feature-dialog.tsx
@@ -269,7 +269,7 @@ export function EditFeatureDialog({
   }
 
   // Shared card styling
-  const cardClass = 'rounded-lg border border-border/50 bg-muted/30 p-4 space-y-3';
+  const cardClass = 'rounded-lg border border-border/50 bg-muted/30 p-3 space-y-2.5';
   const sectionHeaderClass = 'flex items-center gap-2 text-sm font-medium text-foreground';
 
   return (

--- a/apps/ui/src/components/views/settings-view/account/account-section.tsx
+++ b/apps/ui/src/components/views/settings-view/account/account-section.tsx
@@ -64,15 +64,15 @@ export function AccountSection() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/80 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm'
       )}
     >
-      <div className="p-6 border-b border-border/30 bg-gradient-to-r from-primary/5 via-transparent to-transparent">
+      <div className="p-4 border-b border-border/30 bg-gradient-to-r from-primary/5 via-transparent to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-primary/20 to-primary/10 flex items-center justify-center border border-primary/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-primary/20 to-primary/10 flex items-center justify-center border border-primary/20">
             <User className="w-5 h-5 text-primary" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">Account</h2>

--- a/apps/ui/src/components/views/settings-view/api-keys/api-keys-section.tsx
+++ b/apps/ui/src/components/views/settings-view/api-keys/api-keys-section.tsx
@@ -87,15 +87,15 @@ export function ApiKeysSection() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
             <Key className="w-5 h-5 text-brand-500" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">API Keys</h2>
@@ -104,7 +104,7 @@ export function ApiKeysSection() {
           Configure your AI provider API keys. Keys are stored locally in your browser.
         </p>
       </div>
-      <div className="p-6 space-y-6">
+      <div className="p-4 space-y-4">
         {/* API Key Fields with contextual info */}
         {providerConfigs.map((provider) => (
           <div key={provider.key}>

--- a/apps/ui/src/components/views/settings-view/api-keys/claude-usage-section.tsx
+++ b/apps/ui/src/components/views/settings-view/api-keys/claude-usage-section.tsx
@@ -105,15 +105,15 @@ export function ClaudeUsageSection() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-indigo-500/20 to-indigo-600/10 flex items-center justify-center border border-indigo-500/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-indigo-500/20 to-indigo-600/10 flex items-center justify-center border border-indigo-500/20">
             <div className="w-5 h-5 rounded-full bg-indigo-500/50" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">

--- a/apps/ui/src/components/views/settings-view/appearance/appearance-section.tsx
+++ b/apps/ui/src/components/views/settings-view/appearance/appearance-section.tsx
@@ -58,15 +58,15 @@ export function AppearanceSection({ effectiveTheme, onThemeChange }: AppearanceS
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
             <Palette className="w-5 h-5 text-brand-500" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">Appearance</h2>
@@ -75,7 +75,7 @@ export function AppearanceSection({ effectiveTheme, onThemeChange }: AppearanceS
           Customize the look and feel of your application.
         </p>
       </div>
-      <div className="p-6 space-y-6">
+      <div className="p-4 space-y-4">
         {/* Theme Section */}
         <div className="space-y-4">
           <div className="flex items-center justify-between">

--- a/apps/ui/src/components/views/settings-view/audio/audio-section.tsx
+++ b/apps/ui/src/components/views/settings-view/audio/audio-section.tsx
@@ -12,15 +12,15 @@ export function AudioSection({ muteDoneSound, onMuteDoneSoundChange }: AudioSect
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
             <Volume2 className="w-5 h-5 text-brand-500" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">Audio</h2>

--- a/apps/ui/src/components/views/settings-view/claude/claude-md-settings.tsx
+++ b/apps/ui/src/components/views/settings-view/claude/claude-md-settings.tsx
@@ -29,16 +29,16 @@ export function ClaudeMdSettings({
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
       data-testid="claude-md-settings"
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
             <FileCode className="w-5 h-5 text-brand-500" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">

--- a/apps/ui/src/components/views/settings-view/cli-status/claude-cli-status.tsx
+++ b/apps/ui/src/components/views/settings-view/cli-status/claude-cli-status.tsx
@@ -40,13 +40,13 @@ function ClaudeCliStatusSkeleton() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-3">
             <SkeletonPulse className="w-9 h-9 rounded-xl" />
@@ -141,16 +141,16 @@ export function ClaudeCliStatus({ status, authStatus, isChecking, onRefresh }: C
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+            <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
               <AnthropicIcon className="w-5 h-5 text-brand-500" />
             </div>
             <h2 className="text-lg font-semibold text-foreground tracking-tight">

--- a/apps/ui/src/components/views/settings-view/cli-status/cli-status-card.tsx
+++ b/apps/ui/src/components/views/settings-view/cli-status/cli-status-card.tsx
@@ -30,16 +30,16 @@ export function CliStatusCard({
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+            <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
               <Icon className="w-5 h-5 text-brand-500" />
             </div>
             <h2 className="text-lg font-semibold text-foreground tracking-tight">{title}</h2>

--- a/apps/ui/src/components/views/settings-view/cli-status/codex-cli-status.tsx
+++ b/apps/ui/src/components/views/settings-view/cli-status/codex-cli-status.tsx
@@ -35,13 +35,13 @@ function CodexCliStatusSkeleton() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-3">
             <SkeletonPulse className="w-9 h-9 rounded-xl" />
@@ -136,16 +136,16 @@ export function CodexCliStatus({ status, authStatus, isChecking, onRefresh }: Cl
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+            <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
               <OpenAIIcon className="w-5 h-5 text-brand-500" />
             </div>
             <h2 className="text-lg font-semibold text-foreground tracking-tight">Codex CLI</h2>

--- a/apps/ui/src/components/views/settings-view/cli-status/cursor-cli-status.tsx
+++ b/apps/ui/src/components/views/settings-view/cli-status/cursor-cli-status.tsx
@@ -25,13 +25,13 @@ export function CursorCliStatusSkeleton() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-3">
             <SkeletonPulse className="w-9 h-9 rounded-xl" />
@@ -69,13 +69,13 @@ export function CursorPermissionsSkeleton() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent flex items-center justify-between">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent flex items-center justify-between">
         <div className="flex items-center gap-3">
           <SkeletonPulse className="w-9 h-9 rounded-xl" />
           <div className="text-left">
@@ -88,7 +88,7 @@ export function CursorPermissionsSkeleton() {
           <SkeletonPulse className="w-5 h-5 rounded" />
         </div>
       </div>
-      <div className="p-6 space-y-6">
+      <div className="p-4 space-y-4">
         {/* Security Warning skeleton */}
         <div className="flex items-start gap-3 p-4 rounded-xl border border-border/30 bg-muted/10">
           <SkeletonPulse className="w-5 h-5 rounded shrink-0 mt-0.5" />
@@ -154,13 +154,13 @@ export function ModelConfigSkeleton() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
           <SkeletonPulse className="w-9 h-9 rounded-xl" />
           <SkeletonPulse className="h-6 w-40" />
@@ -169,7 +169,7 @@ export function ModelConfigSkeleton() {
           <SkeletonPulse className="h-4 w-72" />
         </div>
       </div>
-      <div className="p-6 space-y-6">
+      <div className="p-4 space-y-4">
         {/* Default Model skeleton */}
         <div className="space-y-2">
           <SkeletonPulse className="h-4 w-24" />
@@ -261,16 +261,16 @@ export function CursorCliStatus({ status, isChecking, onRefresh }: CursorCliStat
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+            <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
               <CursorIcon className="w-5 h-5 text-brand-500" />
             </div>
             <h2 className="text-lg font-semibold text-foreground tracking-tight">Cursor CLI</h2>

--- a/apps/ui/src/components/views/settings-view/cli-status/opencode-cli-status.tsx
+++ b/apps/ui/src/components/views/settings-view/cli-status/opencode-cli-status.tsx
@@ -80,13 +80,13 @@ export function OpencodeCliStatusSkeleton() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-3">
             <SkeletonPulse className="w-9 h-9 rounded-xl" />
@@ -125,13 +125,13 @@ export function OpencodeModelConfigSkeleton() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
           <SkeletonPulse className="w-9 h-9 rounded-xl" />
           <SkeletonPulse className="h-6 w-40" />
@@ -140,7 +140,7 @@ export function OpencodeModelConfigSkeleton() {
           <SkeletonPulse className="h-4 w-72" />
         </div>
       </div>
-      <div className="p-6 space-y-6">
+      <div className="p-4 space-y-4">
         {/* Default Model skeleton */}
         <div className="space-y-2">
           <SkeletonPulse className="h-4 w-24" />
@@ -192,16 +192,16 @@ export function OpencodeCliStatus({
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+            <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
               <OpenCodeIcon className="w-5 h-5 text-brand-500" />
             </div>
             <h2 className="text-lg font-semibold text-foreground tracking-tight">OpenCode CLI</h2>

--- a/apps/ui/src/components/views/settings-view/codex/codex-usage-section.tsx
+++ b/apps/ui/src/components/views/settings-view/codex/codex-usage-section.tsx
@@ -102,15 +102,15 @@ export function CodexUsageSection() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
             <OpenAIIcon className="w-5 h-5 text-brand-500" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">

--- a/apps/ui/src/components/views/settings-view/danger-zone/danger-zone-section.tsx
+++ b/apps/ui/src/components/views/settings-view/danger-zone/danger-zone-section.tsx
@@ -12,15 +12,15 @@ export function DangerZoneSection({ project, onDeleteClick }: DangerZoneSectionP
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-destructive/30',
         'bg-gradient-to-br from-destructive/5 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-destructive/5'
       )}
     >
-      <div className="p-6 border-b border-destructive/20 bg-gradient-to-r from-destructive/5 via-transparent to-transparent">
+      <div className="p-4 border-b border-destructive/20 bg-gradient-to-r from-destructive/5 via-transparent to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-destructive/20 to-destructive/10 flex items-center justify-center border border-destructive/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-destructive/20 to-destructive/10 flex items-center justify-center border border-destructive/20">
             <AlertTriangle className="w-5 h-5 text-destructive" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">Danger Zone</h2>

--- a/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
+++ b/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
@@ -19,15 +19,15 @@ export function DeveloperSection() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-purple-500/20 to-purple-600/10 flex items-center justify-center border border-purple-500/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-purple-500/20 to-purple-600/10 flex items-center justify-center border border-purple-500/20">
             <Code2 className="w-5 h-5 text-purple-500" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">Developer</h2>
@@ -36,7 +36,7 @@ export function DeveloperSection() {
           Advanced settings for debugging and development.
         </p>
       </div>
-      <div className="p-6 space-y-6">
+      <div className="p-4 space-y-4">
         {/* Server Log Level */}
         <div className="space-y-3">
           <Label className="text-foreground font-medium">Server Log Level</Label>

--- a/apps/ui/src/components/views/settings-view/event-hooks/event-hooks-section.tsx
+++ b/apps/ui/src/components/views/settings-view/event-hooks/event-hooks-section.tsx
@@ -61,17 +61,17 @@ export function EventHooksSection() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
       {/* Header */}
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+            <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
               <Webhook className="w-5 h-5 text-brand-500" />
             </div>
             <div>

--- a/apps/ui/src/components/views/settings-view/feature-defaults/feature-defaults-section.tsx
+++ b/apps/ui/src/components/views/settings-view/feature-defaults/feature-defaults-section.tsx
@@ -62,15 +62,15 @@ export function FeatureDefaultsSection({
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
             <FlaskConical className="w-5 h-5 text-brand-500" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">Feature Defaults</h2>

--- a/apps/ui/src/components/views/settings-view/health/health-section.tsx
+++ b/apps/ui/src/components/views/settings-view/health/health-section.tsx
@@ -126,17 +126,17 @@ export function HealthSection() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
       {/* Header */}
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3 mb-2">
-            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-emerald-500/20 to-emerald-600/10 flex items-center justify-center border border-emerald-500/20">
+            <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-emerald-500/20 to-emerald-600/10 flex items-center justify-center border border-emerald-500/20">
               <Activity className="w-5 h-5 text-emerald-500" />
             </div>
             <h2 className="text-lg font-semibold text-foreground tracking-tight">System Health</h2>
@@ -163,7 +163,7 @@ export function HealthSection() {
         </p>
       </div>
 
-      <div className="p-6 space-y-6">
+      <div className="p-4 space-y-4">
         {error && (
           <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 text-sm">
             {error}

--- a/apps/ui/src/components/views/settings-view/keyboard-shortcuts/keyboard-shortcuts-section.tsx
+++ b/apps/ui/src/components/views/settings-view/keyboard-shortcuts/keyboard-shortcuts-section.tsx
@@ -10,15 +10,15 @@ export function KeyboardShortcutsSection({ onOpenKeyboardMap }: KeyboardShortcut
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
             <Settings2 className="w-5 h-5 text-brand-500" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">

--- a/apps/ui/src/components/views/settings-view/mcp-servers/mcp-servers-section.tsx
+++ b/apps/ui/src/components/views/settings-view/mcp-servers/mcp-servers-section.tsx
@@ -73,7 +73,7 @@ export function MCPServersSection() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-linear-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'

--- a/apps/ui/src/components/views/settings-view/model-defaults/model-defaults-section.tsx
+++ b/apps/ui/src/components/views/settings-view/model-defaults/model-defaults-section.tsx
@@ -124,17 +124,17 @@ export function ModelDefaultsSection() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
       {/* Header */}
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+            <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
               <Workflow className="w-5 h-5 text-brand-500" />
             </div>
             <div>

--- a/apps/ui/src/components/views/settings-view/prompts/prompt-customization-section.tsx
+++ b/apps/ui/src/components/views/settings-view/prompts/prompt-customization-section.tsx
@@ -58,7 +58,7 @@ export function PromptCustomizationSection({
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
@@ -66,10 +66,10 @@ export function PromptCustomizationSection({
       data-testid="prompt-customization-section"
     >
       {/* Header */}
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+            <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
               <MessageSquareText className="w-5 h-5 text-brand-500" />
             </div>
             <h2 className="text-lg font-semibold text-foreground tracking-tight">

--- a/apps/ui/src/components/views/settings-view/providers/claude-settings-tab/api-profiles-section.tsx
+++ b/apps/ui/src/components/views/settings-view/providers/claude-settings-tab/api-profiles-section.tsx
@@ -310,7 +310,7 @@ export function ApiProfilesSection() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-linear-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'

--- a/apps/ui/src/components/views/settings-view/providers/claude-settings-tab/skills-section.tsx
+++ b/apps/ui/src/components/views/settings-view/providers/claude-settings-tab/skills-section.tsx
@@ -26,7 +26,7 @@ export function SkillsSection() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-linear-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'

--- a/apps/ui/src/components/views/settings-view/providers/claude-settings-tab/subagents-section.tsx
+++ b/apps/ui/src/components/views/settings-view/providers/claude-settings-tab/subagents-section.tsx
@@ -52,7 +52,7 @@ export function SubagentsSection() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-linear-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'

--- a/apps/ui/src/components/views/settings-view/providers/codex-model-configuration.tsx
+++ b/apps/ui/src/components/views/settings-view/providers/codex-model-configuration.tsx
@@ -66,15 +66,15 @@ export function CodexModelConfiguration({
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
             <OpenAIIcon className="w-5 h-5 text-brand-500" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">
@@ -85,7 +85,7 @@ export function CodexModelConfiguration({
           Configure which Codex models are available in the feature modal
         </p>
       </div>
-      <div className="p-6 space-y-6">
+      <div className="p-4 space-y-4">
         <div className="space-y-2">
           <Label>Default Model</Label>
           <Select

--- a/apps/ui/src/components/views/settings-view/providers/cursor-model-configuration.tsx
+++ b/apps/ui/src/components/views/settings-view/providers/cursor-model-configuration.tsx
@@ -34,15 +34,15 @@ export function CursorModelConfiguration({
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
             <Terminal className="w-5 h-5 text-brand-500" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">
@@ -53,7 +53,7 @@ export function CursorModelConfiguration({
           Configure which Cursor models are available in the feature modal
         </p>
       </div>
-      <div className="p-6 space-y-6">
+      <div className="p-4 space-y-4">
         {/* Default Model */}
         <div className="space-y-2">
           <Label>Default Model</Label>

--- a/apps/ui/src/components/views/settings-view/providers/cursor-permissions-section.tsx
+++ b/apps/ui/src/components/views/settings-view/providers/cursor-permissions-section.tsx
@@ -52,16 +52,16 @@ export function CursorPermissionsSection({
     <Collapsible open={permissionsExpanded} onOpenChange={setPermissionsExpanded}>
       <div
         className={cn(
-          'rounded-2xl overflow-hidden',
+          'rounded-lg overflow-hidden',
           'border border-border/50',
           'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
           'shadow-sm shadow-black/5'
         )}
       >
         <CollapsibleTrigger className="w-full">
-          <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent flex items-center justify-between">
+          <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-amber-500/20 to-amber-600/10 flex items-center justify-center border border-amber-500/20">
+              <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-amber-500/20 to-amber-600/10 flex items-center justify-center border border-amber-500/20">
                 <Shield className="w-5 h-5 text-amber-500" />
               </div>
               <div className="text-left">
@@ -103,7 +103,7 @@ export function CursorPermissionsSection({
         </CollapsibleTrigger>
 
         <CollapsibleContent>
-          <div className="p-6 space-y-6">
+          <div className="p-4 space-y-4">
             {/* Security Warning */}
             <div className="flex items-start gap-3 p-4 rounded-xl bg-amber-500/10 border border-amber-500/20">
               <ShieldAlert className="w-5 h-5 text-amber-400 shrink-0 mt-0.5" />

--- a/apps/ui/src/components/views/settings-view/providers/opencode-model-configuration.tsx
+++ b/apps/ui/src/components/views/settings-view/providers/opencode-model-configuration.tsx
@@ -352,15 +352,15 @@ export function OpencodeModelConfiguration({
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
             <OpenCodeIcon className="w-5 h-5 text-brand-500" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">
@@ -371,7 +371,7 @@ export function OpencodeModelConfiguration({
           Configure which OpenCode models are available in the feature modal
         </p>
       </div>
-      <div className="p-6 space-y-6">
+      <div className="p-4 space-y-4">
         {/* Default Model Selection */}
         <div className="space-y-2">
           <Label>Default Model</Label>

--- a/apps/ui/src/components/views/settings-view/security/security-section.tsx
+++ b/apps/ui/src/components/views/settings-view/security/security-section.tsx
@@ -15,15 +15,15 @@ export function SecuritySection({
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/80 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm'
       )}
     >
-      <div className="p-6 border-b border-border/30 bg-gradient-to-r from-primary/5 via-transparent to-transparent">
+      <div className="p-4 border-b border-border/30 bg-gradient-to-r from-primary/5 via-transparent to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-primary/20 to-primary/10 flex items-center justify-center border border-primary/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-primary/20 to-primary/10 flex items-center justify-center border border-primary/20">
             <Shield className="w-5 h-5 text-primary" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">Security</h2>

--- a/apps/ui/src/components/views/settings-view/terminal/terminal-section.tsx
+++ b/apps/ui/src/components/views/settings-view/terminal/terminal-section.tsx
@@ -55,15 +55,15 @@ export function TerminalSection() {
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-green-500/20 to-green-600/10 flex items-center justify-center border border-green-500/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-green-500/20 to-green-600/10 flex items-center justify-center border border-green-500/20">
             <SquareTerminal className="w-5 h-5 text-green-500" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">Terminal</h2>
@@ -73,7 +73,7 @@ export function TerminalSection() {
           settings.
         </p>
       </div>
-      <div className="p-6 space-y-6">
+      <div className="p-4 space-y-4">
         {/* Default External Terminal */}
         <div className="space-y-3">
           <div className="flex items-center justify-between">

--- a/apps/ui/src/components/views/settings-view/worktrees/worktrees-section.tsx
+++ b/apps/ui/src/components/views/settings-view/worktrees/worktrees-section.tsx
@@ -12,15 +12,15 @@ export function WorktreesSection({ useWorktrees, onUseWorktreesChange }: Worktre
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden',
+        'rounded-lg overflow-hidden',
         'border border-border/50',
         'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
         'shadow-sm shadow-black/5'
       )}
     >
-      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+      <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
             <GitBranch className="w-5 h-5 text-brand-500" />
           </div>
           <h2 className="text-lg font-semibold text-foreground tracking-tight">Worktrees</h2>


### PR DESCRIPTION
## Summary
- Systematic density pass across 33 files in the most-viewed surfaces
- Board kanban cards: `rounded-xl` → `rounded-lg`, reduced shadow
- Settings panels: `p-6` → `p-4`, `gap-6` → `gap-4`, `rounded-2xl` → `rounded-lg`  
- Feature dialogs: `p-4 space-y-3` → `p-3 space-y-2.5`
- Icon containers: `rounded-xl` → `rounded-lg`

## Test plan
- [ ] Board view cards render with tighter spacing
- [ ] Settings panels feel compact without crowding
- [ ] Feature add/edit dialogs maintain readability
- [ ] No visual regressions in sidebar, terminal, dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined UI visual consistency across settings panels and board components with tighter spacing and less pronounced rounded corners.
  * Adjusted card padding and border radius for a more compact appearance.
  * Updated hover effects to provide softer visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->