### PR TITLE
feat(flows): add CopilotKit state annotations to content pipeline

### DIFF
--- a/libs/flows/src/content/content-flow.ts
+++ b/libs/flows/src/content/content-flow.ts
@@ -31,6 +31,10 @@ export interface ContentState {
   userId?: string;
   /** CopilotKit thread metadata */
   threadMetadata?: Record<string, unknown>;
+  /** Current activity description streamed to CopilotKit sidebar */
+  currentActivity?: string;
+  /** Progress indicator (0-1) streamed to CopilotKit sidebar */
+  progress?: number;
   /** Research summary input */
   researchSummary?: ResearchSummary;
   /** Content configuration (type, audience, tone, length) */

--- a/libs/flows/src/content/state.ts
+++ b/libs/flows/src/content/state.ts
@@ -26,6 +26,12 @@ export const CopilotKitStateAnnotation = {
 
   /** Thread metadata for CopilotKit thread management */
   threadMetadata: Annotation<Record<string, unknown> | undefined>,
+
+  /** Current activity description streamed to CopilotKit sidebar */
+  currentActivity: Annotation<string | undefined>,
+
+  /** Progress indicator (0-1) streamed to CopilotKit sidebar */
+  progress: Annotation<number | undefined>,
 };
 
 /**
@@ -115,6 +121,8 @@ export interface ContentState {
   sessionId?: string;
   userId?: string;
   threadMetadata?: Record<string, unknown>;
+  currentActivity?: string;
+  progress?: number;
 
   // Research results - parallel collection
   researchFindings: ResearchFinding[];


### PR DESCRIPTION
## Summary
- Add `CopilotKitStateAnnotation` with `sessionId`, `userId`, `threadMetadata`, `currentActivity`, and `progress` fields to `libs/flows/src/content/state.ts`
- Spread into both `ContentStateAnnotation` definitions (state.ts and content-flow.ts)
- AG-UI protocol streams graph state automatically — nodes return `currentActivity`/`progress` and CopilotKit sidebar picks them up

## Test plan
- [ ] `tsc --noEmit` passes for `@automaker/flows`
- [ ] Existing content pipeline tests still pass
- [ ] Fields are optional — no breaking changes to existing node implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new state tracking fields for session management, user identification, thread metadata, activity monitoring, and progress tracking to enhance system observability and context management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->