### PR TITLE
feat(ui): add AgentStateDisplay for LangGraph state streaming

### DIFF
--- a/apps/ui/src/components/copilotkit/agent-state-display.tsx
+++ b/apps/ui/src/components/copilotkit/agent-state-display.tsx
@@ -1,0 +1,68 @@
+/**
+ * Agent State Display
+ *
+ * Displays the current LangGraph agent state (currentActivity, progress)
+ * from the CopilotKit AG-UI protocol. State is automatically streamed via
+ * StateDeltaEvent/StateSnapshotEvent and available on the AbstractAgent instance.
+ *
+ * Gracefully handles when no agent is running.
+ */
+
+import { useAgent, UseAgentUpdate } from '@copilotkitnext/react';
+import { Activity, Loader2 } from 'lucide-react';
+
+export function AgentStateDisplay() {
+  try {
+    // Subscribe to agent state changes via AG-UI protocol.
+    // State is streamed from LangGraph via copilotkitEmitState() calls
+    // and arrives as StateDeltaEvent/StateSnapshotEvent.
+    const { agent } = useAgent({
+      updates: [UseAgentUpdate.OnStateChanged],
+    });
+
+    const currentActivity = agent.state?.currentActivity as string | undefined;
+    const progress = agent.state?.progress as number | undefined;
+
+    // Only show when agent is running and has activity to display
+    if (!agent.isRunning || !currentActivity) {
+      return null;
+    }
+
+    const progressPercent = Math.round((progress ?? 0) * 100);
+
+    return (
+      <div className="border-t border-border bg-muted/50 p-3">
+        <div className="flex items-start gap-3">
+          <div className="flex-shrink-0 mt-0.5">
+            <Loader2 className="size-4 text-primary animate-spin" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1.5">
+              <Activity className="size-3.5 text-muted-foreground" />
+              <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Agent Activity
+              </span>
+            </div>
+            <p className="text-sm text-foreground mb-2 break-words">{currentActivity}</p>
+            {progress != null && (
+              <div className="flex items-center gap-2">
+                <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-primary transition-all duration-300 ease-out"
+                    style={{ width: `${progressPercent}%` }}
+                  />
+                </div>
+                <span className="text-xs text-muted-foreground font-mono min-w-[3ch]">
+                  {progressPercent}%
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  } catch {
+    // Gracefully handle when CopilotKit context is not available
+    return null;
+  }
+}

--- a/apps/ui/src/components/copilotkit/provider.tsx
+++ b/apps/ui/src/components/copilotkit/provider.tsx
@@ -14,6 +14,7 @@ import '@copilotkitnext/react/styles.css';
 import { getCopilotKitThemeStyles } from './theme-bridge';
 import { getAuthHeaders } from '@/lib/api-fetch';
 import { useAuthStore } from '@/store/auth-store';
+import { AgentStateDisplay } from './agent-state-display';
 
 const CopilotAvailableContext = createContext(false);
 
@@ -119,6 +120,7 @@ export function CopilotSidebarWrapper({ children }: { children: ReactNode }) {
             welcomeMessageText: 'How can I help with your project?',
           }}
         />
+        <AgentStateDisplay />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- New `AgentStateDisplay` component that renders LangGraph agent state (`currentActivity`, `progress`) from the CopilotKit AG-UI protocol
- Uses `useAgent` hook with `UseAgentUpdate.OnStateChanged` to subscribe to state snapshots streamed via `StateDeltaEvent`/`StateSnapshotEvent`
- Graceful fallback: returns null when no agent is running or CopilotKit context unavailable
- Integrated into `CopilotSidebarWrapper` as sibling to `CopilotSidebar`

## Files Changed
- `apps/ui/src/components/copilotkit/agent-state-display.tsx` (new — 68 lines)
- `apps/ui/src/components/copilotkit/provider.tsx` (import + render)

## Test plan
- [ ] Build passes (verified locally)
- [ ] Component renders activity text + progress bar when agent is running
- [ ] Component hidden when no agent is active
- [ ] No crash when CopilotKit context unavailable (try/catch fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added agent activity status display with real-time progress tracking. Users can now view what the agent is currently doing and monitor task completion through a visual progress bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->