### PR TITLE
fix(prompts): register Kai in prompt registry

### DIFF
--- a/libs/prompts/src/prompt-registry.ts
+++ b/libs/prompts/src/prompt-registry.ts
@@ -27,6 +27,7 @@ import { getLinearSpecialistPrompt } from './agents/linear-specialist.js';
 import { getPrMaintainerPrompt } from './agents/pr-maintainer.js';
 import { getBoardJanitorPrompt } from './agents/board-janitor.js';
 import { getFrankPrompt } from './agents/frank.js';
+import { getKaiPrompt } from './agents/kai.js';
 
 /** Base config that all prompt functions accept */
 export interface BasePromptConfig {
@@ -168,3 +169,4 @@ registerPrompt('linear-specialist', () => getLinearSpecialistPrompt());
 registerPrompt('pr-maintainer', () => getPrMaintainerPrompt());
 registerPrompt('board-janitor', () => getBoardJanitorPrompt());
 registerPrompt('frank', () => getFrankPrompt());
+registerPrompt('kai', () => getKaiPrompt());


### PR DESCRIPTION
## Summary
- Kai was missing from prompt-registry.ts import and registration
- The role 'kai' would fall back to a generic prompt instead of Kai's personified prompt
- 2-line fix: add import + add registration

## Test plan
- [ ] `npm run build:packages` passes
- [ ] `getPromptForRole('kai', config)` returns Kai's prompt, not generic fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kai prompt as an available option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->