### PR TITLE
feat(flows): handle resume after interrupt with edited PRD content

### DIFF
--- a/libs/flows/src/content/content-creation-flow.ts
+++ b/libs/flows/src/content/content-creation-flow.ts
@@ -325,12 +325,13 @@ ${r.findings.references.map((ref) => `- ${ref}`).join('\n')}
  *
  * When the graph resumes after interrupt, the state will contain
  * researchApproved and optionally researchFeedback, set by the caller.
+ * If userEditedContent is set, the research findings are updated with user edits.
  * This node triggers an interrupt when critical issues are found.
  */
 async function researchHitlNode(
   state: ContentCreationStateType
 ): Promise<Partial<ContentCreationStateType>> {
-  const { researchReview, researchApproved, researchResults, config } = state;
+  const { researchReview, researchApproved, userEditedContent, researchResults, config } = state;
 
   logger.info(
     `Research HITL: Review score ${researchReview?.percentage.toFixed(1)}%, approved=${researchApproved}`
@@ -365,7 +366,19 @@ ${r.findings.references.map((ref) => `- ${ref}`).join('\n')}
     });
   }
 
-  return {};
+  // If user provided edited content, attempt to parse it as updated research results
+  if (userEditedContent && researchApproved) {
+    try {
+      const edited = JSON.parse(userEditedContent) as ResearchResult[];
+      logger.info(`Research HITL: Using user-edited research with ${edited.length} results`);
+      return { researchResults: edited, userEditedContent: undefined };
+    } catch {
+      // Not valid JSON — treat as feedback text, keep existing research
+      logger.info('Research HITL: User edit is not valid research JSON, treating as feedback');
+    }
+  }
+
+  return { userEditedContent: undefined };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Enhances `researchHitlNode` in content creation flow to handle `userEditedContent` during graph resume
- When user edits research results in the HITL approval modal and resumes, the flow now parses and applies those edits
- Consistent pattern across all three HITL gates (research, outline, final review)

## Changes
- `libs/flows/src/content/content-creation-flow.ts` — Added userEditedContent parsing for research phase, graceful JSON fallback

## Test plan
- [ ] Content pipeline compiles with `npx tsc --noEmit`
- [ ] Resume with edited JSON content applies edits to graph state
- [ ] Resume with non-JSON content falls back to feedback text
- [ ] All three HITL gates (research, outline, final review) handle edited content consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now directly edit research results within the content creation flow, enabling quick refinements and corrections.
  * When an edit is approved, the changes are applied to the research data.
  * Invalid edits are preserved as feedback for review rather than being discarded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->