### PR TITLE
feat(copilotkit): add Cmd+K / Ctrl+K keyboard shortcut to toggle sidebar

### DIFF
--- a/apps/ui/src/components/copilotkit/provider.tsx
+++ b/apps/ui/src/components/copilotkit/provider.tsx
@@ -215,13 +215,32 @@ export function CopilotSidebarWrapper({ children }: { children: ReactNode }) {
  */
 function SidebarControls() {
   const { selectedWorkflow, setSelectedWorkflow } = useModelSelection();
+  const [sidebarKey, setSidebarKey] = useState(0);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Check for Cmd+K (macOS) or Ctrl+K (other platforms)
+      const isModifierPressed = event.metaKey || event.ctrlKey;
+      if (isModifierPressed && event.key === 'k') {
+        event.preventDefault(); // Prevent browser's default Cmd+K behavior
+        setIsSidebarOpen((prev) => !prev);
+        // Force re-render of CopilotSidebar by changing the key
+        setSidebarKey((prev) => prev + 1);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   return (
     <div style={getCopilotKitThemeStyles()}>
       <WorkflowSelector value={selectedWorkflow} onChange={setSelectedWorkflow} />
       <SidebarModelSelector workflowId={selectedWorkflow} />
       <CopilotSidebar
-        defaultOpen={false}
+        key={sidebarKey}
+        defaultOpen={isSidebarOpen}
         labels={{
           modalHeaderTitle: 'Ava',
           welcomeMessageText: 'How can I help with your project?',


### PR DESCRIPTION
## Summary
- Adds global keyboard shortcut (Cmd+K on macOS, Ctrl+K on other platforms) to toggle the CopilotKit sidebar
- Uses `preventDefault` to avoid conflicts with browser's default Cmd+K behavior (URL bar)
- Works around CopilotSidebar's uncontrolled `defaultOpen` prop by using React `key` to force re-mount

## Changes
- `apps/ui/src/components/copilotkit/provider.tsx` — Added keyboard event handler in `SidebarControls` component

## Test plan
- [ ] Cmd+K toggles sidebar on macOS
- [ ] Ctrl+K toggles sidebar on Windows/Linux
- [ ] No conflict with browser URL bar shortcut
- [ ] TypeScript compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)