### PR TITLE
fix(copilotkit): wire PhaseApprovalDialog to HITL handler

### DIFF
--- a/apps/ui/src/components/copilotkit/use-langgraph-interrupt.tsx
+++ b/apps/ui/src/components/copilotkit/use-langgraph-interrupt.tsx
@@ -21,6 +21,7 @@ import { useHumanInTheLoop } from '@copilotkitnext/react';
 import { z } from 'zod';
 import { GenericApprovalDialog } from './generic-dialog';
 import { EntityWizard } from './entity-wizard';
+import { PhaseApprovalDialog } from './phase-approval';
 
 /**
  * Registers all HITL interrupt handlers with CopilotKit.
@@ -99,17 +100,36 @@ export function useLangGraphInterrupt() {
         type: z.literal('phase-approval'),
         phaseTitle: z.string(),
         phaseDescription: z.string(),
+        phaseType: z.string().optional(),
+        completedTasks: z.array(z.string()).optional(),
+        customFields: z
+          .array(
+            z.object({
+              name: z.string(),
+              label: z.string(),
+              type: z.enum(['text', 'textarea', 'number', 'checkbox']),
+              required: z.boolean().optional(),
+              placeholder: z.string().optional(),
+              defaultValue: z.union([z.string(), z.number(), z.boolean()]).optional(),
+            })
+          )
+          .optional(),
       }),
       render: ({ args, respond }) => {
         if (!respond) {
           return <div className="p-4 text-sm text-muted-foreground">Loading phase approval...</div>;
         }
         return (
-          <GenericApprovalDialog
+          <PhaseApprovalDialog
             open={true}
-            title={args.phaseTitle}
-            message={args.phaseDescription}
-            onResolve={(approved) => respond({ approved })}
+            phaseDetails={{
+              phaseName: args.phaseTitle,
+              phaseType: args.phaseType,
+              description: args.phaseDescription,
+              completedTasks: args.completedTasks,
+              customFields: args.customFields,
+            }}
+            onResolve={(approved, data) => respond({ approved, ...data })}
           />
         );
       },


### PR DESCRIPTION
## Summary
- Wire `PhaseApprovalDialog` component (added in #575) to the `approve_phase` useHumanInTheLoop handler
- Replace `GenericApprovalDialog` with the rich form that supports custom fields, completed tasks, and rejection reasons
- Expand zod schema to accept optional `phaseType`, `completedTasks`, and `customFields` from LangGraph interrupts

## Context
PR #575 added the `PhaseApprovalDialog` component but merged from a stale worktree that didn't include the HITL wiring. This PR completes the integration.

## Test plan
- [ ] Verify `approve_phase` interrupt renders PhaseApprovalDialog
- [ ] Verify approve/reject flows work with custom fields
- [ ] TypeScript compiles

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Phase-approval workflow now includes an improved dialog with expanded capabilities: specify phase type, track completed tasks, and define custom fields for more comprehensive approval context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->