### PR TITLE
chore: add agent memory from CopilotKit sessions

### DIFF
--- a/.automaker/context/copilotkit-conventions.md
+++ b/.automaker/context/copilotkit-conventions.md
@@ -1,0 +1,114 @@
+# CopilotKit Conventions
+
+**CRITICAL: Use `@copilotkitnext` packages (AG-UI protocol). NEVER use `@copilotkit`.**
+
+## Package Imports
+
+```typescript
+// UI layer
+import { CopilotKitProvider, CopilotSidebar } from '@copilotkitnext/react';
+import '@copilotkitnext/react/styles.css';
+
+// Server layer
+import { CopilotRuntime, createCopilotEndpointExpress } from '@copilotkitnext/runtime/express';
+import { BuiltInAgent, defineTool } from '@copilotkitnext/agent';
+```
+
+## Server: Registering Agents
+
+Location: `apps/server/src/routes/copilotkit/index.ts`
+
+```typescript
+const runtime = new CopilotRuntime({
+  agents: {
+    default: avaAgent,                        // BuiltInAgent (tool-based)
+    'content-pipeline': contentPipelineGraph,  // LangGraph flow (registered directly)
+    'antagonistic-review': antagonisticReviewAgent, // BuiltInAgent
+  },
+});
+```
+
+- **BuiltInAgent**: For tool-based agents. Uses `defineTool()` with Zod schemas.
+- **LangGraph graphs**: Register directly in `agents` object (they implement the agent interface).
+- Model format: `'anthropic/claude-sonnet-4-5-20250929'`
+- Endpoint: `createCopilotEndpointExpress({ runtime, basePath: '/' })`
+
+## LangGraph State Annotations
+
+Every LangGraph flow that integrates with CopilotKit must include:
+
+```typescript
+const CopilotKitStateAnnotation = {
+  sessionId: Annotation<string | undefined>,
+  userId: Annotation<string | undefined>,
+  threadMetadata: Annotation<Record<string, unknown> | undefined>,
+  currentActivity: Annotation<string | undefined>,
+  progress: Annotation<number | undefined>,
+};
+```
+
+Spread into your root annotation: `...CopilotKitStateAnnotation`
+
+## State Emission in Nodes
+
+```typescript
+import { copilotkitEmitState, emitHeartbeat } from '../copilotkit-utils';
+
+// At node entry
+await copilotkitEmitState(config, { currentActivity: 'Generating outline', progress: 0 });
+// During I/O
+await emitHeartbeat(config, 'Invoking LLM');
+// At node exit
+await copilotkitEmitState(config, { currentActivity: 'Outline complete', progress: 100 });
+```
+
+Both functions gracefully no-op when CopilotKit is unavailable.
+
+## UI: Context Injection
+
+Use `useAgentContext` to inject readable context into CopilotKit agents:
+
+```typescript
+import { useAgentContext } from '@copilotkitnext/react';
+
+// Inside a component rendered within CKProvider
+useAgentContext({
+  description: 'Current project path',
+  value: currentProject?.path || null,
+});
+```
+
+**NOTE:** `useCopilotReadable` does NOT exist in `@copilotkitnext/react` v1.51.3. Use `useAgentContext` instead.
+
+## UI: Existing Components
+
+Location: `apps/ui/src/components/copilotkit/`
+
+- **provider.tsx** — Root CopilotKit provider with auth, error boundary, availability check, project context injection
+- **theme-bridge.tsx** — Maps Automaker CSS vars to CopilotKit CSS vars (use HSL format)
+- **agent-state-display.tsx** — Displays LangGraph agent state (activity, progress) streamed via AG-UI protocol
+- **workflow-selector.tsx** — Dropdown to choose which LangGraph agent to invoke, with WorkflowProvider context
+- **use-sidebar-state.ts** — Persists sidebar state (open/closed, workflow, model) to localStorage
+- **execution-list.tsx** — Active workflow executions with status/progress
+- **model-selector.tsx** — Haiku/Sonnet/Opus model chooser
+- **generic-dialog.tsx** — Fallback yes/no dialog for LangGraph interrupts
+- **workflow-abort.tsx** — Cancel running workflows
+- **workflow-history.tsx** — Execution history viewer
+
+## LangGraph Interrupts (HITL)
+
+For human-in-the-loop approval flows:
+- Import `interrupt` from `@langchain/langgraph`
+- Call `interrupt({ type: 'review_approval', ...payload })` in graph nodes
+- CopilotKit AG-UI runtime surfaces interrupts in the sidebar automatically
+- UI routes interrupt types to components via discriminated union
+- Resume with `resolve()` containing user response
+
+## Key Rules
+
+1. All `@copilotkitnext` packages are at v1.51.3 — verify new APIs exist before using
+2. Wrap CopilotKit UI in error boundaries (provider already does this)
+3. Use `getCopilotKitThemeStyles()` from theme-bridge for consistent styling
+4. Check `/api/copilotkit/info` for endpoint availability before assuming CopilotKit is live
+5. Tool parameters MUST be Zod schemas
+6. `maxSteps` on BuiltInAgent prevents infinite tool loops

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,9 +5,9 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 42
-  referenced: 24
-  successfulFeatures: 24
+  loaded: 46
+  referenced: 27
+  successfulFeatures: 27
 ---
 # api
 
@@ -287,3 +287,52 @@ usageStats:
 - **Rejected:** Only exporting the flow - forces users to write boilerplate execution code. Only exporting executor - prevents customization.
 - **Trade-offs:** Adds two exports instead of one. But eliminates duplicated initialization code across callers.
 - **Breaking if changed:** If the underlying StateGraph changes, both exports might need updates. The executor hides state graph details, so it must be kept in sync with flow structure.
+
+#### [Pattern] New endpoint added via Express Router composition instead of single exported route handler (2026-02-15)
+- **Problem solved:** Existing pattern was `createCopilotKitEndpoint()` returning single router/endpoint. Now need both `/workflows` metadata endpoint AND the existing CopilotKit runtime endpoint from same logical module.
+- **Why this works:** Express Router allows multiple endpoint handlers under same prefix. Avoids duplicating auth middleware or creating separate route files. Maintains cohesion - all copilotkit routes in one module.
+- **Trade-offs:** Easier: single logical mount point, shared auth. Harder: callers must understand router composition pattern, not immediately obvious that `createCopilotKitEndpoint()` now returns composite router.
+
+#### [Gotcha] Workflow metadata uses hardcoded `supportedModels: ['haiku', 'sonnet', 'opus']` for all workflows - no per-workflow model filtering (2026-02-15)
+- **Situation:** Future workflows may only support specific models (e.g., content-pipeline might require opus). Currently all three workflows list identical models.
+- **Root cause:** Simplest initial implementation - all agents are Claude, all support same models. No visibility into model requirements yet.
+- **How to avoid:** Easier: predictable, static. Harder: frontend cannot warn user when selecting workflow+model combo that won't work.
+
+#### [Gotcha] CopilotKit exports useAgentContext hook, not useCopilotReadable. Feature specs may reference older/incorrect hook names. Always verify against actual package exports. (2026-02-15)
+- **Situation:** Feature description mentioned useCopilotReadable but @copilotkitnext/react package only exports useAgentContext for context injection.
+- **Root cause:** CopilotKit API evolved. Documentation/specs can lag behind actual implementation. Direct source inspection prevents wasted implementation time.
+- **How to avoid:** Takes extra 5min to verify exports, saves hours of debugging non-existent APIs.
+
+### Interrupt payload includes both structured review data (reviewResult with dimensions/scores/verdicts) AND rendered content for display, rather than just one or the other (2026-02-15)
+- **Context:** HITL nodes need to communicate review findings to CopilotKit AG-UI while also showing the actual content being reviewed
+- **Why:** Human reviewers need both the analytic review breakdown (why it was flagged) AND the actual content (what to approve/reject). CopilotKit sidebar displays the full payload; redundancy is feature, not waste.
+- **Rejected:** Including only reviewResult (no content) would force sidebar to request content separately; including only content (no review) would hide the reasoning for the interrupt
+- **Trade-offs:** Larger payload per interrupt, but eliminates round-trip to fetch context and provides complete decision context to human
+- **Breaking if changed:** If content is removed from payload, human loses critical context for approval decision; if reviewResult is removed, human sees content but not why it was flagged
+
+### Model passed via X-Copilotkit-Model HTTP header rather than as CopilotKit AG-UI runtime property (2026-02-15)
+- **Context:** CopilotKit SDK doesn't expose a clean TypeScript API for per-request model override via runtime properties, despite AG-UI protocol supporting it in theory
+- **Why:** Headers are simpler to implement, require no modifications to CopilotKit SDK, and can be read server-side immediately. Avoids dependency on CopilotKit SDK improvements
+- **Rejected:** Alternative was to implement model override via AG-UI protocol properties once CopilotKit TypeScript API matures, but this blocks feature implementation on external SDK changes
+- **Trade-offs:** Header approach is pragmatic short-term solution but creates technical debt. Server must parse headers instead of receiving strongly-typed model config. Future AG-UI API improvements could obsolete this pattern
+- **Breaking if changed:** Server-side getModelFromRequest() relies on header presence. If header is omitted, code falls back to defaults silently. Should add validation to catch missing model headers in requests
+
+#### [Gotcha] @copilotkitnext/react does not expose UseAgentUpdate.OnInterrupt. Interrupt data flows through agent state mutations (state.interrupt, state.waitingForInput) instead. (2026-02-15)
+- **Situation:** Attempted to subscribe to interrupt events directly via CopilotKit's documented interrupt API. API does not exist in the current version.
+- **Root cause:** CopilotKit AG-UI protocol uses state-driven communication rather than event-driven for interrupts. Monitoring state changes is the only available surface.
+- **How to avoid:** State-based polling is less explicit than event-driven, requires watching for state mutations rather than subscribing to named events. More brittle if internal state shape changes.
+
+#### [Gotcha] Resume implementation uses agent.sendMessage() with type-casted any, exact AG-UI protocol for resuming from interrupts is undocumented. (2026-02-15)
+- **Situation:** CopilotKit/LangGraph interrupt resume mechanism not exposed in public API docs. Implemented placeholder that may not match actual protocol.
+- **Root cause:** Best guess based on available APIs. sendMessage() is known to exist and accepts messages. Typed as any to allow runtime protocol adaptation.
+- **How to avoid:** Gains: Feature doesn't silently fail to resume. Loses: May send wrong message format to agent, requiring debugging against real LangGraph flow.
+
+#### [Gotcha] LangGraph interrupt/resume with CopilotKit: when resolve() is called from frontend with updated state, the graph automatically resumes at the exact node where it interrupted. State updates are merged, not replaced. (2026-02-15)
+- **Situation:** Initial assumption was that graph would skip the HITL node and resume downstream. Actually, the HITL node runs again with the new state, allowing it to validate/process edits before continuing.
+- **Root cause:** LangGraph by design re-enters the interrupted node with merged state. This is a feature: it gives the HITL node a chance to validate and apply edits before the flow continues. The alternative (skip HITL node) would bypass crucial validation.
+- **How to avoid:** Easier: validation/edit handling happens in the same HITL node code. Harder: must account for the HITL node running twice (once to interrupt, once to resume with edits).
+
+#### [Gotcha] CopilotKit AG-UI interrupt protocol expects resolve() callback to receive decision payload, not boolean confirmation (2026-02-15)
+- **Situation:** Initial assumption was interrupt resolution = approve/reject boolean. Actual protocol requires passing decision object back to graph.
+- **Root cause:** Agent needs to process decisions (merge targets, corrections, specific entity IDs). Simple boolean loses this context.
+- **How to avoid:** Richer payload enables complex workflows but requires careful serialization. Type safety becomes critical.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -1444,3 +1444,117 @@ usageStats:
 - **Problem solved:** review-quality node checks if report meets quality standards. Could have been implemented as always-execute node that sets a flag, but conditional edges are cleaner.
 - **Why this works:** Conditional edges make the graph structure match the decision logic. Approval path and revision path are explicit in the graph, not hidden in node logic. Graph visualization shows the real flow.
 - **Trade-offs:** Requires registering conditional_edges instead of linear node chains. But produces clearer state graphs and easier reasoning about paths.
+
+### Workflow metadata exposed as static HTTP endpoint instead of extracted from runtime agent registry (2026-02-15)
+- **Context:** CopilotKit runtime has registered agents (Ava, content-pipeline, antagonistic-review). Could either extract metadata from runtime dynamically or define statically in HTTP response.
+- **Why:** Static definitions provide predictable API contract, enable versioning independently of agent registration, and don't require exposing internal runtime structure. Simpler initial implementation.
+- **Rejected:** Dynamic extraction from runtime.agents would require introspection API, coupling HTTP contract to runtime impl details, risk of agents being registered/unregistered changing API responses mid-session.
+- **Trade-offs:** Easier: stable API, clear schema. Harder: metadata sync required when agents change, requires manual update in two places.
+- **Breaking if changed:** If metadata endpoint is removed, frontend components relying on `/api/copilotkit/workflows` fail silently (loading state persists). If schema changes (add/remove field), frontend selector breaks unless it handles gracefully.
+
+#### [Pattern] useAgentContext must be called inside CopilotKitProvider component tree. Calling it outside provider causes undefined behavior. Create intermediate wrapper component (ProjectContextInjector) that lives inside provider and calls the hook. (2026-02-15)
+- **Problem solved:** CopilotKit hooks have provider dependency similar to React Context. App provider structure needed adjustment to place hook consumer inside correct scope.
+- **Why this works:** Hook-provider coupling is enforced by CopilotKit's internal state management. Intermediate component pattern avoids restructuring entire provider tree while satisfying hook constraints.
+- **Trade-offs:** Adds small wrapper component but keeps provider logic clean and decoupled. Alternative (monolithic provider) would couple unrelated concerns.
+
+### Conditionally inject context values (only if data exists) rather than always injecting null/undefined. Prevents noisy context, reduces cognitive load on agents. (2026-02-15)
+- **Context:** App store may not have loaded currentProject, features, or spec yet during initial render. Injecting null/undefined for unavailable data clutters agent context.
+- **Why:** Agents should only see relevant, available data. Injecting undefined forces them to handle null checks they don't need. Conditional injection keeps context clean and focused.
+- **Rejected:** Always injecting all values (including null) would work but create noise. Agents must then write defensive code to check for undefined on every use.
+- **Trade-offs:** Cleaner agent context, less defensive coding needed. Cost is conditional checks in ProjectContextInjector (minimal).
+- **Breaking if changed:** If agents assume context values always exist, missing values will cause errors. Agents should always check value existence before using (defensive pattern).
+
+#### [Pattern] HITL (Human-In-The-Loop) interrupt gates use dual-trigger pattern: config flag AND content condition. Interrupts only fire when enableHITL=true AND criticalIssues.length > 0. (2026-02-15)
+- **Problem solved:** Implementing HITL approval gates in content pipeline that should respect both user configuration and actual content review findings
+- **Why this works:** Prevents spurious interrupts on clean reviews (enableHITL alone) and prevents interrupts when disabled (criticalIssues alone). Both conditions must align for human review to trigger.
+- **Trade-offs:** Slightly more complex conditional logic, but catches edge cases where config disagrees with content quality
+
+#### [Pattern] HITL phases (research/outline/final) are explicitly named in interrupt payload type, not inferred from node name. Payload includes 'phase: research|outline|final' as discrete value. (2026-02-15)
+- **Problem solved:** Three different HITL gates in a pipeline all use similar interrupt mechanics but need to be distinguished in downstream processing
+- **Why this works:** Explicit phase field makes payload self-describing and eliminates need for downstream code to parse node names or maintain phase ordering. CopilotKit runtime and UI can instantly know which stage failed without inference.
+- **Trade-offs:** Slightly more verbose payload, but decouples phase semantics from implementation details (node names). Phase is semantic; node name is implementation.
+
+### Interrupt calls are placed INSIDE HITL node functions (after review logic), not at graph compilation level. Uses LangGraph's interruptBefore=[nodeNames] for pause points, but interrupt(payload) for data injection. (2026-02-15)
+- **Context:** Distinguishing between where execution pauses (graph structure) vs. where human context is injected (node logic)
+- **Why:** interruptBefore is a graph-level directive that marks nodes as interrupt candidates; interrupt() is called inside the node when the condition is met. This allows selective interrupts within a node (only on critical issues) rather than pausing unconditionally.
+- **Rejected:** Could pause all HITL nodes unconditionally via interruptBefore and let downstream decide to interrupt, but that wastes resources pausing clean reviews
+- **Trade-offs:** Requires condition logic in node code (not declarative at graph level), but enables smart filtering and only passes data when actually needed
+- **Breaking if changed:** If interrupt() is removed and only interruptBefore is used, system pauses on clean reviews (empty/null reviewResult), forcing UI to handle 'no-op' interrupts
+
+### ModelProvider context created as intermediate provider that depends on WorkflowProvider context, requiring specific nesting order in provider tree (2026-02-15)
+- **Context:** Model selection needs to read from WorkflowProvider (selectedAgent) and provide model state to CopilotKitInnerProvider, but CKProvider was already nested inside WorkflowProvider
+- **Why:** Allows ModelProvider to hook into WorkflowProvider's selectedAgent via useWorkflowSelection(). Alternative of flattening providers would require prop drilling or context merging, losing composition benefits
+- **Rejected:** Could have merged ModelProvider logic into CopilotKitInnerProvider directly, but this violates separation of concerns and makes state management less reusable
+- **Trade-offs:** Provider nesting depth increased by one level (slight performance cost from extra context consumer) but gained isolated, reusable model selection logic that other components can independently consume
+- **Breaking if changed:** Provider nesting order is now critical - ModelProvider MUST be inside WorkflowProvider. Reversing order breaks useWorkflowSelection() call in ModelProvider
+
+#### [Pattern] Setter function pattern for persistence: setSelectedModel(model, workflowId) both updates state AND persists to localStorage in single call (2026-02-15)
+- **Problem solved:** Model selection needs to update UI state and persist preference without requiring separate effect hooks or manual save calls from consumers
+- **Why this works:** Encapsulates state and persistence logic together, preventing accidental state-only updates that forget to persist. Single source of truth for how model changes are handled. Consumer code (SidebarControls) doesn't need to know about localStorage
+- **Trade-offs:** Setter must take both model AND workflowId parameter (more complex signature) but prevents silent bugs where model changes but doesn't persist across page reloads. Forces explicit intent on every change
+
+#### [Pattern] Factory function pattern for creating agents with model injection: agentFactories.get(selectedModel)(agentConfig) returns model-specific agent instance (2026-02-15)
+- **Problem solved:** Need to support dynamic model selection without hardcoding model strings in agent implementations or creating separate agent classes per model
+- **Why this works:** Factory pattern decouples model selection (runtime/UI) from agent instantiation (server logic). Allows swapping model implementation without changing agent code. Scales to future models without proliferating agent variants
+- **Trade-offs:** Factory registry pattern requires registration step for each model, but gained flexibility and avoided class explosion. Makes model behavior testable via mock factories
+
+#### [Pattern] Component structure follows existing CopilotKit UI patterns (Dialog composition, state reset on props change, Tailwind styling consistent with shadcn/ui) (2026-02-15)
+- **Problem solved:** Codebase has established patterns in copilotkit/agent-state-display.tsx and other CopilotKit-related components. New HITL component must integrate cohesively.
+- **Why this works:** Consistency reduces cognitive load for future maintainers. Uses already-proven patterns from codebase (Dialog wrapper, useEffect cleanup for state, Tailwind + shadcn/ui). Reduces chance of unexpected behavior from ad-hoc patterns.
+- **Trade-offs:** Following established patterns means some constraints (must use Dialog, Tailwind classes, specific file locations). Upside: immediate familiarity for Josh/team, easier to find/modify, integrates with existing design system.
+
+### Created separate TipTapEditor component instead of inline TipTap setup inside PRDEditorModal (2026-02-15)
+- **Context:** TipTap editor setup is complex: extension configuration, event handlers, content state management. Could have written it inline inside modal.
+- **Why:** Separation of concerns: TipTapEditor encapsulates all TipTap-specific logic (useEditor hook, extension setup, toolbar rendering). PRDEditorModal focuses on modal UX (approve/reject, content display). Makes both components testable/reusable independently.
+- **Rejected:** Inline TipTap in PRDEditorModal: simpler initially but mixes concerns. If future features need TipTap elsewhere (inline editing in grid, comment threads), code duplication or tight coupling. Harder to unit test TipTap behavior without modal context.
+- **Trade-offs:** Component split adds one extra file and prop drilling (editorRef, onContentChange callbacks). Benefit: TipTapEditor can be reused in other contexts, easier to test TipTap features in isolation, PRDEditorModal stays focused on modal/approval logic.
+- **Breaking if changed:** Merging TipTapEditor back into PRDEditorModal removes reusability and mixes concerns, making future TipTap usage elsewhere require code duplication or refactoring.
+
+#### [Gotcha] Hook returns JSX (InterruptRouter component) directly. This violates traditional hook naming conventions where hooks return values, not UI. (2026-02-15)
+- **Situation:** useLangGraphInterrupt both manages interrupt state AND renders UI. Standard React pattern would return state + handlers, separate component would render.
+- **Root cause:** Encapsulation: hook owns complete interrupt lifecycle (detect, route, resume). Returning JSX keeps related logic together. Caller just imports hook and renders result.
+- **How to avoid:** Gains: Single import, cleaner provider code. Loses: Violates hook naming convention (naming suggests it returns state, not UI). Hook harder to test in isolation.
+
+#### [Pattern] Discriminated union routing pattern for payload.type determines which UI component renders. Type system enforces exhaustive checking. (2026-02-15)
+- **Problem solved:** Four different interrupt types need different handling logic and UI. Need to ensure new types added in future are handled.
+- **Why this works:** Discriminated unions with switch statements allow TypeScript to prove exhaustiveness at compile time. If new interrupt type added to union, compiler errors until all cases handled.
+- **Trade-offs:** Gains: Type safety, prevents silent failures on new interrupt types. Loses: Must update union type + switch case + test coverage when adding new types.
+
+#### [Pattern] Graceful fallback in interrupt resume: attempt to parse userEditedContent as structured JSON (ResearchResult[], Outline) first, then fall back to treating it as feedback text if parsing fails (2026-02-15)
+- **Problem solved:** researchHitlNode needs to handle both structured edits (researcher modified results array) and unstructured feedback (text comments). Can't assume the frontend always sends valid JSON.
+- **Why this works:** Prevents graph interruption on invalid JSON from user edits. Gives users freedom to edit content freely without strict serialization requirements. Maintains robustness when frontend passes unexpected data types.
+- **Trade-offs:** Easier: flexible user edits, resilient resume. Harder: ambiguity between 'valid JSON that happens to be feedback' vs 'actual structured data'. Added logging becomes critical for debugging.
+
+### Clear userEditedContent from state after processing in each HITL node to prevent stale edited data from affecting subsequent resume cycles (2026-02-15)
+- **Context:** When graph resumes multiple times (e.g., research approved but then outline rejected and re-edited), old userEditedContent from previous resume could contaminate later phases.
+- **Why:** State hygiene. If userEditedContent persists after being consumed, a second interrupt/resume cycle would reapply old edits from a previous phase. Each phase only cares about edits relevant to that phase.
+- **Rejected:** Keep userEditedContent throughout graph execution to allow downstream nodes to inspect edit history. Would require careful ordering and phase-checking to avoid cross-phase contamination.
+- **Trade-offs:** Easier: clear semantics, no stale data bugs. Harder: can't retrospectively audit what edits were made in earlier phases once they're cleared.
+- **Breaking if changed:** If any downstream node (beyond the HITL gate) tries to access userEditedContent for audit/logging, it will be empty. Must capture/log edits before clearing, or store them in a separate audit field.
+
+#### [Pattern] Consistent HITL gate pattern across three phases (research, outline, final review): each gate uses the same interrupt/resume flow, parses phase-specific edited content from userEditedContent, and applies it to state before continuing (2026-02-15)
+- **Problem solved:** Rather than unique interrupt logic per phase, all three gates follow the same schema: check approval flag, parse edited content, update state, clear field, continue.
+- **Why this works:** Predictability and maintainability. Future developers see 'HITL gate pattern' and know exactly how resume works in any phase. Reduces cognitive load and bug surface. Makes it easy to add a fourth gate.
+- **Trade-offs:** Easier: consistent code, clear mental model. Harder: the pattern is opinionated and constrains how future gates can work. If a future phase needs async validation on resume, the pattern may not fit.
+
+### ErrorDisplay placed in SidebarControls below AgentStateDisplay, reusing existing sidebar integration pattern (2026-02-15)
+- **Context:** Error display needs to be visible in UI; must integrate without requiring new UI structure or layout changes
+- **Why:** Reusing sidebar pattern follows established convention in codebase; AgentStateDisplay already proven to work in that location. Reduces layout refactoring
+- **Rejected:** Placing error display in modal or toast would require new integration points; inline in main content area would obscure workflow visualization
+- **Trade-offs:** Error display shares sidebar real estate with other controls (spacing constraints) but integrates seamlessly without new structure
+- **Breaking if changed:** Moving to different location requires updating provider.tsx imports/placement and potentially breaking layout assumptions if error info becomes critical for navigation
+
+#### [Pattern] CopilotKit interrupt routing via useAgent hook with OnStateChanged subscription pattern (2026-02-15)
+- **Problem solved:** Need to receive LangGraph interrupts from agent execution and route them to appropriate UI components
+- **Why this works:** useAgent hook provides reactive state updates when agent execution encounters interrupts. OnStateChanged subscription mode efficiently listens for interrupt events without polling. Separating router from specific dialog implementations allows multiple interrupt types to coexist.
+- **Trade-offs:** Router pattern adds one component layer but enables extensibility. Alternative of direct callbacks would be simpler for one interrupt type but brittles as types multiply.
+
+#### [Pattern] Dialog components follow controlled component pattern (open prop + onResolve callback) rather than imperative show/hide methods (2026-02-15)
+- **Problem solved:** EntityWizard and InterruptRouter both use Dialog with controlled visibility
+- **Why this works:** React best practice: declarative state management makes interrupt lifecycle predictable. Component renders when interrupt exists, closes when resolved. Callback-based resolution ensures parent can handle completion.
+- **Trade-offs:** Controlled pattern requires parent to manage open state, but prevents dialog from getting orphaned. Parent can add loading spinners, error handling, retry logic.
+
+#### [Gotcha] InterruptRouter requires placement in component tree where CopilotKit context exists. Cannot work in arbitrary location. (2026-02-15)
+- **Situation:** Implementation creates router component but integration point is not specified
+- **Root cause:** useAgent hook depends on CopilotKit provider being ancestor. Router only receives interrupts if within that tree.
+- **How to avoid:** Context dependency ensures proper lifecycle management but restricts placement flexibility.

--- a/.automaker/memory/auth.md
+++ b/.automaker/memory/auth.md
@@ -15,3 +15,8 @@ usageStats:
 - **Situation:** Implementation reads token from settings using exact path string. Easy to mistype the path or assume different structure.
 - **Root cause:** Project settings use dot-notation path strings for nested configuration values. This is consistent with settings service implementation pattern
 - **How to avoid:** String-based paths are error-prone (typos break silently) but consistent with existing settings service pattern across codebase
+
+#### [Gotcha] HTTP endpoint mounted after global auth middleware - ALL endpoints in that router require authentication, cannot be overridden at endpoint level (2026-02-15)
+- **Situation:** Tried to verify `/api/copilotkit/workflows` endpoint exists without auth. Got 401 as expected, but couldn't quickly test endpoint without setting up auth token.
+- **Root cause:** CopilotKit routes mounted at line 922 in server index.ts, AFTER `app.use(authenticate)` middleware (line ~900). Express middleware chains apply to all subsequent routes unless explicitly skipped.
+- **How to avoid:** Easier: consistent auth for all copilotkit endpoints, no accidental public endpoints. Harder: cannot create public metadata endpoint without refactoring middleware chain.

--- a/.automaker/memory/database.md
+++ b/.automaker/memory/database.md
@@ -22,3 +22,8 @@ usageStats:
 - **Rejected:** Could have hardcoded string literals in each service but loses type safety and makes refactoring dangerous
 - **Trade-offs:** Requires updating shared type library (more coordination) but enables type-safe event subscriptions everywhere
 - **Breaking if changed:** Services subscribing to 'github-state-drift' events will have type errors if event type not in union; type checking would prevent misnamed events
+
+#### [Pattern] Model preference stored per-workflow in localStorage (keys like 'copilotkit-model-default'), not globally (2026-02-15)
+- **Problem solved:** Different workflows (agents) may have different optimal models. User might want Haiku for lightweight operations but Opus for complex reasoning
+- **Why this works:** Per-workflow storage allows user to maintain separate model preferences for different use cases without constant switching. Respects the fact that workflow context changes optimal model choice
+- **Trade-offs:** Slight increase in localStorage entries (one per workflow instead of one global) but gained better UX and workflow-specific optimization capability. Makes migration harder if workflow IDs ever change

--- a/.automaker/memory/documentation.md
+++ b/.automaker/memory/documentation.md
@@ -5,9 +5,9 @@ relevantTo: [documentation]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 9
-  referenced: 6
-  successfulFeatures: 6
+  loaded: 10
+  referenced: 7
+  successfulFeatures: 7
 ---
 # documentation
 

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 181
-  referenced: 81
-  successfulFeatures: 81
+  loaded: 195
+  referenced: 91
+  successfulFeatures: 91
 ---
 # gotchas
 
@@ -120,3 +120,18 @@ usageStats:
 - **Situation:** Implemented review-quality node with approve/revise routing. Without max_iterations, a single revision request could loop indefinitely.
 - **Root cause:** The quality gate uses `conditional_edges` to route back to generateReport if revision needed. Without iteration limits, this becomes unbounded. The state graph doesn't automatically prevent looping.
 - **How to avoid:** Adding max_iterations limits review quality (can't endlessly refine). But prevents hang/timeout. Need to balance thoroughness vs practicality.
+
+#### [Gotcha] TipTap packages installed at monorepo root node_modules (v2.27.2 latest) rather than workspace-scoped, following npm workspace hoisting rules. (2026-02-15)
+- **Situation:** Attempted to install TipTap but packages didn't appear in node_modules/@tiptap initially. Later discovered they were installed in root (../..) not in apps/ui/node_modules.
+- **Root cause:** npm workspaces use symlink hoisting: dependencies listed in workspace package.json are resolved from workspace root node_modules, not individual workspace. This is by design to avoid duplication across workspaces.
+- **How to avoid:** Root hoisting means one copy of TipTap shared across entire monorepo (good: saves disk/memory). Risk: if two workspaces need different TipTap versions, hoisting forces a choice (usually latest wins). Debugging requires understanding ../.../node_modules path navigation.
+
+#### [Gotcha] File path confusion: created files in nested apps/ui/apps/ui/src structure before realizing working directory was already apps/ui. (2026-02-15)
+- **Situation:** Mistakenly copied files to wrong location, then corrected course by checking pwd and file listing.
+- **Root cause:** Initial uncertainty about Bash context (pwd). Assumed needs to create full path structure.
+- **How to avoid:** Extra file copy operation, but caught and fixed during implementation rather than in review.
+
+#### [Gotcha] Error state structure assumed to have message, stack, type, timestamp properties based on JavaScript error patterns, but actual CopilotKit error structure may vary (2026-02-15)
+- **Situation:** CopilotKit agent state stores errors with unknown shape; component accesses error properties without knowing definitive structure
+- **Root cause:** No TypeScript interface definition available for CopilotKit error objects; reasonable inference from standard error patterns
+- **How to avoid:** Defensive null checks and optional chaining prevent crashes but silently hide error details if structure differs from assumption

--- a/.automaker/memory/pattern.md
+++ b/.automaker/memory/pattern.md
@@ -5,9 +5,9 @@ relevantTo: [pattern]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 0
-  referenced: 0
-  successfulFeatures: 0
+  loaded: 3
+  referenced: 3
+  successfulFeatures: 3
 ---
 # pattern
 

--- a/.automaker/memory/performance.md
+++ b/.automaker/memory/performance.md
@@ -55,3 +55,10 @@ usageStats:
 - **Rejected:** No timeout would risk blocking webhook handlers. Promise.race with setTimeout would require manual cleanup.
 - **Trade-offs:** Easier: Native API, clean error handling. Harder: Must manually clear timeout in success path (existing code does this).
 - **Breaking if changed:** If timeout is removed, slow Linear API responses could block webhook processing for other issues.
+
+### Lazy-load TipTap editor via React.lazy() with Suspense boundary to defer ~200KB bundle until modal is opened (2026-02-15)
+- **Context:** TipTap is a large library (~200KB) that's only needed when user opens PRDEditorModal. Including it in main bundle would impact initial page load for all users.
+- **Why:** Monorepo UI has many features competing for bundle space. Code-splitting HITL approval flow avoids shipping unused TipTap code to users who never trigger interrupts. The modal is opened on-demand during HITL approval, making lazy loading the optimal trade-off.
+- **Rejected:** Direct import of TipTap at top-level: simpler code but forces all users to download 200KB unused in happy path. Dynamic import without Suspense: requires manual loading state management.
+- **Trade-offs:** Lazy loading adds slight UX delay (~500ms-1s) when modal first opens while TipTap bundle loads, but saves 200KB on initial pageload for 95%+ of users. Suspense boundary provides fallback UI (spinner) during load.
+- **Breaking if changed:** Removing lazy loading restores immediate modal rendering but bloats main bundle by 200KB. Removing Suspense boundary causes render error if chunk fails to load. Moving TipTap import to top level defeats lazy load benefit and increases initial JS payload.

--- a/.automaker/memory/security.md
+++ b/.automaker/memory/security.md
@@ -5,9 +5,9 @@ relevantTo: [security]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 17
-  referenced: 11
-  successfulFeatures: 11
+  loaded: 18
+  referenced: 12
+  successfulFeatures: 12
 ---
 # security
 

--- a/.automaker/memory/testing.md
+++ b/.automaker/memory/testing.md
@@ -5,9 +5,9 @@ relevantTo: [testing]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 22
-  referenced: 14
-  successfulFeatures: 14
+  loaded: 23
+  referenced: 15
+  successfulFeatures: 15
 ---
 # testing
 
@@ -481,3 +481,30 @@ usageStats:
 - **Problem solved:** E2E Playwright test failed due to unrelated ESM module issues in flows package. Standalone verification script identified actual flow issues in minutes.
 - **Why this works:** Playwright tests have setup overhead and dependency complications. A simple Node.js script that imports and executes the flow cuts through noise. Tests the happy path before complexity of test harness.
 - **Trade-offs:** Standalone script only tests happy path, doesn't validate browser/UI integration. But catches real problems much faster. Use both approaches.
+
+### Verification test was structure-only, not integration test - verified schema in code rather than testing live endpoint response (2026-02-15)
+- **Context:** Could write Playwright test to authenticate, call endpoint, verify full response. Instead, created test that verifies endpoint exists (401 check) and structure is correct in code.
+- **Why:** Live integration test would require auth setup, environment config, potentially fragile. Structure test ensures types are correct and catches refactoring errors. 401 check confirms router is registered without needing full auth flow.
+- **Rejected:** Could skip testing entirely - endpoint is simple passthrough. Could require full auth integration test, but adds setup overhead. Could use unit test mocking, but same verification value as structure test.
+- **Trade-offs:** Easier: fast, no auth setup, catches structure drift. Harder: doesn't verify actual response shape at runtime, doesn't catch auth bypass.
+- **Breaking if changed:** If schema is removed/changed without updating code test, test fails (catches drift). If endpoint auth is accidentally removed, test passes but endpoint becomes public (test didn't catch it). If endpoint returns unexpected shape at runtime, test doesn't catch it.
+
+#### [Gotcha] Playwright config with reuseExistingServer: false will spawn new server instance even if one is already running. Don't use Playwright for integration tests of already-running dev servers. Use direct build verification + component structure checks instead. (2026-02-15)
+- **Situation:** Dev server was already running (port 3007). Playwright attempted to spawn another instance, created port conflict and test hang.
+- **Root cause:** Playwright's reuseExistingServer: false is aggressive. Running tests against running dev servers requires either: (1) explicit reuseExistingServer: true, or (2) skip Playwright entirely and verify at build/import level.
+- **How to avoid:** Build verification is faster, doesn't depend on running server, but catches fewer runtime errors. Tradeoff acceptable for feature verification (structure is deterministic at build time).
+
+#### [Gotcha] Substring-based test matching fails when function boundaries span multiple lines. The pattern 'indexOf(functionName)' to 'indexOf(nextFunctionName)' captures wrong slice when definitions wrap. (2026-02-15)
+- **Situation:** Verification test tried to extract function bodies using substring() with indexOf() for start/end, but function signatures and closing braces span multiple lines causing off-by-one slices
+- **Root cause:** Direct string matching for multi-line code structures requires exact context. indexOf() finds the first character match, not the logical block boundary.
+- **How to avoid:** Switched to direct string containment checks ('expect(source).toContain(exactString)') which is less precise (doesn't verify placement in function) but more reliable
+
+#### [Gotcha] Per codebase instructions, did NOT write Playwright tests despite it being obvious practice. Verified component syntax/structure via static analysis instead. (2026-02-15)
+- **Situation:** Instruction explicitly stated 'DO NOT write Playwright tests'. Instinct was to write tests but instruction took precedence.
+- **Root cause:** Codebase has specific testing guidance: components verified through static analysis first (syntax check, bracket matching, import presence). Full Playwright tests likely written separately in established test suite. Respecting project guidance prevents test duplication and maintains test architecture consistency.
+- **How to avoid:** Static analysis verification is faster (no test framework setup) but less comprehensive than runtime tests. Trade-off accepted because codebase architecture isolates testing responsibility elsewhere (likely centralised test suite).
+
+#### [Gotcha] Playwright test verification test file must be deleted after verification to avoid contaminating test suite with temporary checks (2026-02-15)
+- **Situation:** Created error-display-verification.spec.ts to validate implementation but instructions require cleanup
+- **Root cause:** Temporary verification tests can become stale, mislead future developers, and clutter the test suite; one-off validation should not persist in version control
+- **How to avoid:** Deleting test means no permanent verification record (harder to debug if feature regresses) but keeps test suite focused on production behavior

--- a/.automaker/memory/ui.md
+++ b/.automaker/memory/ui.md
@@ -76,3 +76,73 @@ usageStats:
 - **Rejected:** Alternative 1: Automatically run all phases without prompt. Breaks workflows where user wants selective setup. Alternative 2: Single-select radio buttons instead of multi-select. Rejected because users may want mixed critical+optional (skip recommended for speed)
 - **Trade-offs:** Easier: User confidence (visual feedback, sensible defaults). Harder: CLI code complexity (+50 lines for prompt logic), interactive mode blocked for JSON/automation
 - **Breaking if changed:** If default selection is removed (all phases deselected), users hit the prompt with nothing selected and must manually check boxes—UX regression. If spinner is removed during research phase, users assume CLI hung
+
+#### [Pattern] Map store features to lightweight summary format {id, title, status, complexity, milestone} instead of passing full feature objects. Reduces context payload, avoids serialization issues with complex objects. (2026-02-15)
+- **Problem solved:** App store features contain nested objects, circular refs, or non-serializable properties. Sending raw features to agents bloats context and may cause serialization errors.
+- **Why this works:** Agents only need enough info to reference features, not internal implementation details. Summary format is JSON-serializable, reduces token usage, improves agent decision-making by hiding implementation noise.
+- **Trade-offs:** Minimal data loss (agents get what they need), smaller context window usage, guaranteed serializability. Cost is mapping logic.
+
+#### [Gotcha] CKProvider does not automatically react to header prop changes. Passing new headers via prop alone does not update active connections (2026-02-15)
+- **Situation:** Initial attempt to update headers reactively via CKProvider props failed - selected model changed but requests still used old model
+- **Root cause:** CopilotKit initializes connection handlers at mount time using headers snapshot. Prop updates don't trigger reconnection or header refresh. Root cause is that CopilotKit SDK initialization is one-shot, not reactive to prop changes
+- **How to avoid:** Solution uses React key prop to force CKProvider remount on model change. Gained reliable header updates but lost connection continuity (brief reconnection lag when model changes). WebSocket-based message passing would preserve connection but requires modifying CopilotKit runtime itself
+
+### All interrupt payload types route to GenericApprovalDialog as a working baseline, with specialized UIs (PRD editor modal) marked as TODOs. (2026-02-15)
+- **Context:** Four interrupt types (prd-review, entity-review, phase-approval, generic) need to be routed to UI components. Only generic dialog exists and is fully available.
+- **Why:** Pragmatic approach: implement discriminated union routing infrastructure now, defer specialized UI integration until those components are ready. Unblocks testing of interrupt flow with working baseline.
+- **Rejected:** Blocking implementation on PRD editor modal availability. Would delay entire feature.
+- **Trade-offs:** Gains: Feature ships with working interrupt routing. Loses: Type-specific UIs are not realized yet. Risk: developers may forget to update router when specialized UIs land.
+- **Breaking if changed:** When prd-review modal is integrated, the router switch case must be updated to use it instead of GenericApprovalDialog. If not updated, all PRD reviews will show wrong UI.
+
+#### [Gotcha] CopilotKit's CopilotSidebar component uses uncontrolled state pattern (defaultOpen prop only), not controlled state (open/onOpenChange props). Cannot directly manage sidebar visibility from parent component. (2026-02-15)
+- **Situation:** Attempted to toggle sidebar via state passed to CopilotSidebar component, but discovered component doesn't expose controlled state API
+- **Root cause:** CopilotKit's sidebar implementation is internally managed. This is a library limitation, not a configuration option.
+- **How to avoid:** Using key-based re-mounting forces component reset on each toggle (loses internal sidebar state like scroll position), but ensures clean open/closed state transitions without stale internal state
+
+#### [Pattern] Use React component key prop to force full re-mount and re-initialization when a child component doesn't support controlled state. Pair with defaultOpen/defaultValue props to set initial state on each mount. (2026-02-15)
+- **Problem solved:** Need to toggle CopilotSidebar open/closed from parent, but component only accepts defaultOpen (uncontrolled)
+- **Why this works:** React's key prop is the documented way to reset component state without managing internal state from parent. Changing key unmounts and remounts component, running all initialization logic again.
+- **Trade-offs:** Cost: component remounts on every toggle (slightly higher CPU). Benefit: zero coupling to CopilotSidebar's internal implementation, automatically compatible with library updates
+
+### Keyboard shortcut uses metaKey (macOS) OR ctrlKey (Windows/Linux), not AND. Single condition checks both platforms in one listener. (2026-02-15)
+- **Context:** Cmd+K on macOS, Ctrl+K on Windows/Linux - two different modifier keys, same logical intent
+- **Why:** JavaScript KeyboardEvent.metaKey is true only on macOS (Cmd), ctrlKey is true only on Windows/Linux (Ctrl). Using OR means one listener handles both platforms without branching or multiple listeners.
+- **Rejected:** Separate listeners for metaKey and ctrlKey (code duplication), user-agent detection (fragile), checking platform at listener registration time (doesn't adapt if user remaps keys)
+- **Trade-offs:** Single listener is simpler but relies on browser consistency. If a user remaps Ctrl→Cmd on Windows, it won't work (acceptable since remapping is intentional user config)
+- **Breaking if changed:** If event.metaKey or event.ctrlKey API changes (extremely unlikely), listener stops working. If browser stops sending these properties, shortcut breaks silently.
+
+#### [Gotcha] preventDefault() must be called immediately on keyboard event to prevent browser default behavior (Cmd+K opens browser search). Late or conditional preventDefault() doesn't work due to event propagation timing. (2026-02-15)
+- **Situation:** Without preventDefault(), browser's native Cmd+K handler (URL bar focus) runs alongside sidebar toggle, causing UI interference
+- **Root cause:** Browser's KeyboardEvent default handlers are registered at the capturing/bubbling phases. preventDefault() only works when called synchronously during event dispatch, before default handlers execute.
+- **How to avoid:** Must call preventDefault() at the start of the listener. If future code adds async validation before toggle, must move preventDefault() outside the async path.
+
+#### [Pattern] Error display component wraps CopilotKit context usage in try-catch to prevent crashes when context unavailable, following existing AgentStateDisplay pattern (2026-02-15)
+- **Problem solved:** CopilotKit provider context may not be available in all render contexts; component must gracefully degrade rather than crash
+- **Why this works:** CopilotKit agents are optional/conditional features. Wrapping prevents entire UI from breaking if agent context is missing or uninitialized
+- **Trade-offs:** Graceful degradation means error display silently doesn't render if context missing (good for resilience, harder to debug if context should exist)
+
+### Retry button attempts agent.restart() first, falls back to window.location.reload() if method unavailable (2026-02-15)
+- **Context:** Uncertain whether CopilotKit agent instance has a restart() method for checkpoint resumption vs requiring full page reload
+- **Why:** Two-tier fallback allows graceful degradation: attempt smart restart if available, fall back to crude full reload rather than fail silently
+- **Rejected:** Hard-coding single approach (either restart or reload) would break if method availability differs from assumption
+- **Trade-offs:** Page reload loses in-memory state but guarantees recovery; smart restart preserves state but may not exist in all CopilotKit versions
+- **Breaking if changed:** Removing fallback chain means retry fails silently if agent.restart() doesn't exist; page becomes unresponsive to user retry attempts
+
+#### [Pattern] Stack trace visibility toggled via local component state with ChevronUp/ChevronDown icons, hidden by default (2026-02-15)
+- **Problem solved:** Long stack traces clutter UI; most users don't need them until debugging; need to balance visibility with UI cleanliness
+- **Why this works:** Default-hidden pattern reduces cognitive load for normal operation; users can opt-in to debug details when needed. Chevron icons provide clear affordance
+- **Trade-offs:** Extra click to see stack trace (worse for rapid debugging) but cleaner default UX for non-technical users
+
+### EntityWizard uses local Map<entityId, EntityDecision> to accumulate decisions across steps rather than submitting individually (2026-02-15)
+- **Context:** Multi-step wizard needs to collect user decisions on many entities before sending back to graph
+- **Why:** Batch submission prevents partial state on graph. Individual submissions would require complex recovery if user cancels mid-wizard. Map structure allows decision override (user can change decision on later review).
+- **Rejected:** Submit-on-step pattern (loses decisions if user cancels), Redux/Context state (overkill for component scope), array accumulation (can't override previous decisions easily)
+- **Trade-offs:** Map-based approach uses more memory but prevents bad UX states. Could add 'undo' feature easily with this structure.
+- **Breaking if changed:** Changing to submit-on-step breaks cancellation semantics. Graph expects single batch of decisions.
+
+### EntityWizard decision actions (approve, reject, correct, merge) are defined as discriminated union type (action + optional mergeWith/newName fields) (2026-02-15)
+- **Context:** Wizard supports 4 different decision types with different required fields
+- **Why:** Discriminated union (action: 'merge' + mergeWith field) provides type safety. Compiler verifies mergeWith exists only for merge actions. Prevents invalid states like reject-with-correction.
+- **Rejected:** Four separate decision types (verbose), open string+object (no type safety), boolean flags (unclear semantics)
+- **Trade-offs:** Slightly more verbose type definition but eliminates entire class of runtime bugs. Graph validation becomes simpler.
+- **Breaking if changed:** Adding new action type requires updating EntityDecision union AND all places that pattern-match on action field.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,20 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Planning & Approach
+
+- When creating plans, start with the minimal viable scope. Do NOT propose multi-phase plans unless explicitly asked. Default to the smallest, lowest-risk approach first.
+- Do not exit plan mode or transition away from planning until the user explicitly confirms the plan is complete and approved. Wait for user signal before proceeding to implementation.
+
+## Git Workflow
+
+- Never push directly to main. Always create a feature branch and open a PR, even for small changes. Assume branch protection is enabled on all repositories.
+- Before committing, run `git status` and verify that only intended files are staged. Watch for accidentally staged deletions from previously merged PRs.
+
+## Session Continuation
+
+- When continuing a previous session or autonomous loop, always check MCP server connectivity and board status FIRST before attempting any agent launches or API calls.
+
 ## Project Overview
 
 Automaker is an autonomous AI development studio built as an npm workspace monorepo. It provides a Kanban-based workflow where AI agents (powered by Claude Agent SDK) implement features in isolated git worktrees.


### PR DESCRIPTION
## Summary
- Adds 446 lines of agent-learned patterns from CopilotKit integration sessions 54-55
- Covers HITL API patterns, content pipeline conventions, LangGraph interrupts, and UI component architecture
- New context file: `copilotkit-conventions.md` for future CopilotKit agent work

## Test plan
- [ ] Verify memory files parse correctly (markdown lint)
- [ ] Confirm no secrets or sensitive data in committed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for CopilotKit conventions, including package imports, server-side agent registration, state management, and UI integration patterns.
  * Enhanced development guidance with planning approach, git workflow requirements, and session continuation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->