### PR TITLE
feat(linear): Linear as project lifecycle control point

### DIFF
--- a/apps/server/src/services/completion-detector-service.ts
+++ b/apps/server/src/services/completion-detector-service.ts
@@ -227,8 +227,14 @@ export class CompletionDetectorService {
     if (project.linearProjectId && this.settingsService) {
       try {
         const client = new LinearMCPClient(this.settingsService, projectPath);
-        await client.updateProject(project.linearProjectId, { status: 'completed' });
-        logger.info(`Updated Linear project "${project.title}" to completed`);
+        // Linear uses workspace-specific status IDs, not string enums
+        const statusId = await client.resolveProjectStatusId('completed');
+        if (statusId) {
+          await client.updateProject(project.linearProjectId, { statusId });
+          logger.info(`Updated Linear project "${project.title}" to completed`);
+        } else {
+          logger.warn('No "completed" project status found in Linear workspace');
+        }
       } catch (error) {
         logger.error('Failed to update Linear project status (non-blocking):', error);
       }

--- a/apps/server/src/services/linear-mcp-client.ts
+++ b/apps/server/src/services/linear-mcp-client.ts
@@ -283,8 +283,10 @@ export interface UpdateProjectOptions {
   name?: string;
   /** New project description (optional) */
   description?: string;
-  /** New project status (optional) */
+  /** New project status string — mapped to GraphQL `state` field (optional) */
   status?: string;
+  /** Workspace-specific project status ID — use getProjectStatuses() to resolve (optional) */
+  statusId?: string;
   /** New project progress percentage (optional, 0-100) */
   progress?: number;
 }
@@ -1320,7 +1322,7 @@ export class LinearMCPClient {
    * @throws {LinearAPIError} On API errors
    */
   async updateProject(projectId: string, options: UpdateProjectOptions): Promise<boolean> {
-    const { name, description, status, progress } = options;
+    const { name, description, status, statusId, progress } = options;
 
     const mutation = `
       mutation UpdateProject(
@@ -1328,6 +1330,7 @@ export class LinearMCPClient {
         $name: String
         $description: String
         $state: String
+        $statusId: String
         $progress: Float
       ) {
         projectUpdate(
@@ -1336,6 +1339,7 @@ export class LinearMCPClient {
             name: $name
             description: $description
             state: $state
+            statusId: $statusId
             progress: $progress
           }
         ) {
@@ -1353,6 +1357,7 @@ export class LinearMCPClient {
       name,
       description,
       state: status,
+      statusId,
       progress: progress !== undefined ? progress / 100 : undefined, // Convert percentage to 0-1
     };
 
@@ -1375,6 +1380,47 @@ export class LinearMCPClient {
     logger.info(`Updated Linear project: ${data.projectUpdate.project.name}`);
 
     return true;
+  }
+
+  /**
+   * Get workspace project statuses (for resolving status IDs).
+   * Linear uses workspace-specific status IDs rather than string enums.
+   */
+  async getProjectStatuses(): Promise<Array<{ id: string; name: string; type: string }>> {
+    const query = `
+      query {
+        projectStatuses {
+          nodes {
+            id
+            name
+            type
+          }
+        }
+      }
+    `;
+
+    interface ProjectStatusesResponse {
+      projectStatuses: {
+        nodes: Array<{ id: string; name: string; type: string }>;
+      };
+    }
+
+    const data = await this.executeGraphQL<ProjectStatusesResponse>(query, {});
+    return data.projectStatuses.nodes;
+  }
+
+  /**
+   * Resolve a project status type (e.g. "completed") to its workspace-specific ID.
+   * Returns undefined if no matching status found.
+   */
+  async resolveProjectStatusId(statusType: string): Promise<string | undefined> {
+    const statuses = await this.getProjectStatuses();
+    const match = statuses.find(
+      (s) =>
+        s.type.toLowerCase() === statusType.toLowerCase() ||
+        s.name.toLowerCase() === statusType.toLowerCase()
+    );
+    return match?.id;
   }
 
   /**

--- a/apps/server/src/services/linear-project-update-service.ts
+++ b/apps/server/src/services/linear-project-update-service.ts
@@ -53,7 +53,8 @@ export class LinearProjectUpdateService {
   /**
    * Get Linear API token from project settings or environment.
    *
-   * Priority: apiKey from settings > LINEAR_API_KEY env var
+   * Priority: OAuth agentToken > settings apiKey > LINEAR_API_KEY env var
+   * (Matches LinearMCPClient.getAccessToken() priority order)
    *
    * @throws {Error} If no token is configured
    */
@@ -61,14 +62,14 @@ export class LinearProjectUpdateService {
     const settings = await this.settingsService.getProjectSettings(this.projectPath);
     const linearConfig = settings.integrations?.linear;
 
-    // Priority 1: API key from project settings
-    if (linearConfig?.apiKey) {
-      return linearConfig.apiKey;
-    }
-
-    // Priority 2: OAuth agent token (legacy path)
+    // Priority 1: OAuth agent token (full delegated permissions)
     if (linearConfig?.agentToken) {
       return linearConfig.agentToken;
+    }
+
+    // Priority 2: Personal API key from project settings
+    if (linearConfig?.apiKey) {
+      return linearConfig.apiKey;
     }
 
     // Priority 3: Environment variable


### PR DESCRIPTION
## Summary

- **ProjectUpdate webhook + auth fix**: Handle `ProjectUpdate` webhooks from Linear, fix 3-tier token fallback in `LinearProjectUpdateService`, add `getProjectUpdate()` and `addProjectUpdateComment()` to MCP client
- **Project update approval service**: Detect approval signals ("approved", "lgtm", "ship it") in Linear project updates → trigger `approvePrd()` + `launch()` to start auto-mode automatically
- **Real Linear issue creator**: Replace mock issue creation in planning flow with dependency-injected `LinearMCPClient` calls that create proper milestone → epic → child issue hierarchy
- **Knowledge loop closure**: Persist structured learnings to `.automaker/memory/` via `appendLearning()` on project completion, post "complete" health update to Linear, update Linear project status to completed

## Test plan

- [ ] Verify `ProjectUpdate` webhook handler emits correct events
- [ ] Verify `LinearProjectUpdateService` auth works with `lin_api_*` keys (no Bearer prefix)
- [ ] Test approval detection: post "approved" in a Linear project update → verify features created + auto-mode starts
- [ ] Test planning flow creates real Linear issues with milestone/epic/phase hierarchy
- [ ] Test project completion persists learnings to `.automaker/memory/` directory
- [ ] Test project completion posts "complete" health update to Linear
- [ ] Verify `npx tsc --noEmit` passes for all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced project completion workflow by resolving workspace-specific status identifiers for more reliable updates.
  * Improved authentication token resolution priority to consistently use OAuth tokens before other fallback sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->