### PR TITLE
fix(e2e): increase viewport to 1080px, add reducedMotion

### DIFF
--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -24,11 +24,17 @@ export default defineConfig({
     baseURL: `http://localhost:${port}`,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    // 720px default is too short — modals with inputs push confirm buttons
-    // below the fold causing "element is outside of the viewport" failures
-    viewport: { width: 1280, height: 900 },
+    // Desktop Chrome default is 720px. Position:fixed dialogs use
+    // top:50%/translateY(-50%) centering — if the dialog is taller than
+    // expected (Ubuntu CI fonts render taller than macOS), footer buttons
+    // land outside the viewport. scrollIntoView() cannot fix fixed-position
+    // elements. 1080px gives enough headroom for any dialog content.
+    viewport: { width: 1280, height: 1080 },
     // Give CI actions (click, fill, etc.) more time on slow shared runners
     actionTimeout: process.env.CI ? 10_000 : 0,
+    // Disable CSS animations for deterministic rendering on CI.
+    // Prevents "element not stable" from in-flight dialog transitions.
+    reducedMotion: 'reduce',
   },
   // Global setup - authenticate before each test
   globalSetup: require.resolve('./tests/global-setup.ts'),
@@ -37,8 +43,8 @@ export default defineConfig({
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
-        // Override Desktop Chrome's 720px height — keep the user agent and other device props
-        viewport: { width: 1280, height: 900 },
+        // Override Desktop Chrome's 720px — see use.viewport comment above
+        viewport: { width: 1280, height: 1080 },
       },
     },
   ],


### PR DESCRIPTION
## Summary

Follow-up to #580 — 900px viewport still fails the same 6 tests deterministically on CI. This is NOT flaky; retries confirmed it fails 3/3 times.

**Root cause**: `position: fixed` dialogs with `top: 50%; transform: translateY(-50%)` centering. Ubuntu CI renders text with larger font metrics than macOS. Dialog footer buttons land past the viewport edge. `scrollIntoView()` has no effect on fixed-position elements.

**Changes**:
- **viewport**: 1280x1080 (from 900) — enough headroom for any dialog layout regardless of font metrics
- **reducedMotion**: `'reduce'` — disables CSS transitions/animations, prevents "element not stable" errors from in-flight dialog open animations

## Test plan

- [ ] CI e2e on this PR is the test — if the 6 previously-failing tests pass, the fix works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated viewport configuration and disabled CSS animations in test environment for more consistent and reliable test rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->