### PR TITLE
fix(e2e): bump edit-feature timeout, use forceClick for confirm

### DIFF
--- a/apps/ui/tests/features/edit-feature.spec.ts
+++ b/apps/ui/tests/features/edit-feature.spec.ts
@@ -16,7 +16,7 @@ import {
   clickAddFeature,
   fillAddFeatureDialog,
   confirmAddFeature,
-  clickElement,
+  forceClick,
   authenticateForTests,
   handleLoginScreenIfPresent,
 } from '../utils';
@@ -60,7 +60,9 @@ test.describe('Edit Feature', () => {
     cleanupTempDir(TEST_TEMP_DIR);
   });
 
-  test('should edit an existing feature description', async ({ page }) => {
+  // This test creates a feature AND edits it — double the work of other tests.
+  // CI shared runners need more than the default 30s for the full flow.
+  test('should edit an existing feature description', { timeout: 60_000 }, async ({ page }) => {
     const originalDescription = `Original feature ${Date.now()}`;
     const updatedDescription = `Updated feature ${Date.now()}`;
 
@@ -126,8 +128,10 @@ test.describe('Edit Feature', () => {
     await expect(descriptionInput).toBeVisible({ timeout: 5000 });
     await descriptionInput.fill(updatedDescription);
 
-    // Save changes
-    await clickElement(page, 'confirm-edit-feature');
+    // Save changes — use forceClick to bypass Playwright's viewport check
+    // on position:fixed dialogs (avoids wasting actionTimeout on the try/catch path)
+    const confirmButton = page.locator('[data-testid="confirm-edit-feature"]');
+    await forceClick(confirmButton);
 
     // Wait for dialog to close
     await page.waitForFunction(


### PR DESCRIPTION
## Summary

- Fixes the last failing e2e test (`edit-feature.spec.ts`) after PR #584 fixed 5/6
- Root cause: the edit-feature test creates AND edits a feature in one test (double the work) — the 30s default timeout is too tight on CI shared runners
- Uses `forceClick()` (from #584) directly for the confirm button to skip the try/catch overhead
- Bumps this specific test's timeout to 60s

## Test plan

- [ ] All 21+ e2e tests pass in CI (0 failures)
- [ ] No regressions in passing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability for the feature editing workflow by improving test interaction methods and adding explicit timeout handling to ensure consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->