### PR TITLE
feat: wire Langfuse tracing into all LLM execution paths + MCP query tools

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -183,6 +183,9 @@ import { LinearApprovalBridge } from './services/linear-approval-bridge.js';
 import { createDeployRoutes } from './routes/deploy/index.js';
 import { createAnalyticsRoutes } from './routes/analytics.js';
 import { AntagonisticReviewService } from './services/antagonistic-review-service.js';
+import { createLangfuseRoutes } from './routes/langfuse/index.js';
+import { shutdownLangfuse } from './lib/langfuse-singleton.js';
+import { AgentScoringService } from './services/agent-scoring-service.js';
 // CopilotKit imports are dynamic — @copilotkitnext/runtime may not be installed
 // See conditional registration below at /api/copilotkit routes
 
@@ -412,6 +415,9 @@ const antagonisticReviewService = AntagonisticReviewService.getInstance(
   events,
   settingsService
 );
+
+// Initialize Agent Scoring Service (auto-scores agent traces based on feature lifecycle)
+const _agentScoringService = new AgentScoringService(events, featureLoader);
 
 // Initialize HeadsdownService for autonomous agent management
 const headsdownService = HeadsdownService.getInstance(
@@ -1054,6 +1060,7 @@ app.use('/api/crew', createCrewRoutes(crewLoopService));
 app.use('/api/deploy', createDeployRoutes(autoModeService));
 app.use('/api/escalation', createEscalationRoutes(escalationRouter));
 app.use('/api/analytics', createAnalyticsRoutes(events));
+app.use('/api/langfuse', createLangfuseRoutes());
 app.use('/api/flows', createFlowsRoutes(antagonisticReviewService));
 if (process.env.ANTHROPIC_API_KEY) {
   try {
@@ -1551,6 +1558,7 @@ async function gracefulShutdown() {
   issueCreationService.shutdown();
   linearAgentRouter.stop();
   agentDiscordRouter.stop();
+  await shutdownLangfuse();
 
   server.close(() => {
     logger.info('Server closed');

--- a/apps/server/src/lib/langfuse-singleton.ts
+++ b/apps/server/src/lib/langfuse-singleton.ts
@@ -1,0 +1,49 @@
+/**
+ * Langfuse Singleton
+ *
+ * Provides a single shared LangfuseClient instance for the entire server.
+ * Lazy-initialized on first access. Gracefully degrades when credentials
+ * are missing — callers should check isAvailable() before relying on tracing.
+ */
+
+import { LangfuseClient } from '@automaker/observability';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('LangfuseSingleton');
+
+let instance: LangfuseClient | null = null;
+
+/**
+ * Get the shared LangfuseClient instance.
+ * Creates one on first call using env vars. Returns a disabled client
+ * if credentials are missing (isAvailable() will return false).
+ */
+export function getLangfuseInstance(): LangfuseClient {
+  if (!instance) {
+    instance = new LangfuseClient({
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+      secretKey: process.env.LANGFUSE_SECRET_KEY,
+      baseUrl: process.env.LANGFUSE_BASE_URL,
+      enabled: true,
+    });
+
+    if (instance.isAvailable()) {
+      logger.info('Langfuse singleton initialized (tracing enabled)');
+    } else {
+      logger.info('Langfuse singleton initialized (tracing disabled — missing credentials)');
+    }
+  }
+  return instance;
+}
+
+/**
+ * Shutdown the Langfuse client and flush pending events.
+ * Called during server graceful shutdown.
+ */
+export async function shutdownLangfuse(): Promise<void> {
+  if (instance) {
+    await instance.shutdown();
+    instance = null;
+    logger.info('Langfuse singleton shut down');
+  }
+}

--- a/apps/server/src/providers/provider-factory.ts
+++ b/apps/server/src/providers/provider-factory.ts
@@ -6,8 +6,10 @@
  */
 
 import { BaseProvider } from './base-provider.js';
+import { TracedProvider } from './traced-provider.js';
 import type { InstallationStatus, ModelDefinition } from './types.js';
 import { isCursorModel, isCodexModel, isOpencodeModel, type ModelProvider } from '@automaker/types';
+import { getLangfuseInstance } from '../lib/langfuse-singleton.js';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -121,12 +123,12 @@ export class ProviderFactory {
       // Fallback to claude if provider not found
       const claudeReg = providerRegistry.get('claude');
       if (claudeReg) {
-        return claudeReg.factory();
+        return this.wrapWithTracing(claudeReg.factory());
       }
       throw new Error(`No provider found for model: ${modelId}`);
     }
 
-    return provider;
+    return this.wrapWithTracing(provider);
   }
 
   /**
@@ -156,6 +158,26 @@ export class ProviderFactory {
 
     // Default to claude (first registered provider or claude)
     return 'claude';
+  }
+
+  /**
+   * Wrap a provider with Langfuse tracing if available.
+   * Returns the original provider unchanged if Langfuse is not configured.
+   */
+  private static wrapWithTracing(provider: BaseProvider): BaseProvider {
+    try {
+      const langfuse = getLangfuseInstance();
+      if (langfuse.isAvailable()) {
+        return new TracedProvider(provider, {
+          enabled: true,
+          client: langfuse,
+          defaultTags: ['automaker'],
+        });
+      }
+    } catch {
+      // Langfuse initialization failed — return unwrapped provider
+    }
+    return provider;
   }
 
   /**

--- a/apps/server/src/providers/traced-provider.ts
+++ b/apps/server/src/providers/traced-provider.ts
@@ -12,6 +12,13 @@ import type {
 } from './types.js';
 import { wrapProviderWithTracing, type TracingConfig } from '@automaker/observability';
 
+/** Feature context for enriching traces */
+export interface TracedProviderContext {
+  featureId?: string;
+  featureName?: string;
+  agentRole?: string;
+}
+
 /**
  * Wrapper that adds tracing to any provider
  */
@@ -25,6 +32,30 @@ export class TracedProvider extends BaseProvider {
     this.tracingConfig = tracingConfig;
     // Override the name property set by BaseProvider constructor
     this.name = wrapped.getName();
+  }
+
+  /**
+   * Set feature context for trace enrichment.
+   * Call after provider creation to correlate traces with board features.
+   */
+  setContext(ctx: TracedProviderContext): void {
+    this.tracingConfig.defaultMetadata = {
+      ...this.tracingConfig.defaultMetadata,
+      ...ctx,
+    };
+    // Also add feature-specific tags
+    if (ctx.featureId) {
+      this.tracingConfig.defaultTags = [
+        ...(this.tracingConfig.defaultTags ?? []),
+        `feature:${ctx.featureId}`,
+      ];
+    }
+    if (ctx.agentRole) {
+      this.tracingConfig.defaultTags = [
+        ...(this.tracingConfig.defaultTags ?? []),
+        `role:${ctx.agentRole}`,
+      ];
+    }
   }
 
   getName(): string {

--- a/apps/server/src/routes/langfuse/index.ts
+++ b/apps/server/src/routes/langfuse/index.ts
@@ -1,0 +1,258 @@
+/**
+ * Langfuse Routes — Proxy to Langfuse REST API
+ *
+ * All routes use POST (Express 5 convention). Each route proxies to
+ * the corresponding Langfuse public API endpoint using Basic Auth
+ * (publicKey:secretKey).
+ */
+
+import { Router } from 'express';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('LangfuseRoutes');
+
+/**
+ * Build Basic Auth header for Langfuse API.
+ * Returns null if credentials are missing.
+ */
+function getLangfuseAuth(): { baseUrl: string; headers: Record<string, string> } | null {
+  const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
+  const secretKey = process.env.LANGFUSE_SECRET_KEY;
+  const baseUrl = process.env.LANGFUSE_BASE_URL;
+
+  if (!publicKey || !secretKey || !baseUrl) {
+    return null;
+  }
+
+  const credentials = Buffer.from(`${publicKey}:${secretKey}`).toString('base64');
+  return {
+    baseUrl,
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      'Content-Type': 'application/json',
+    },
+  };
+}
+
+/**
+ * Generic proxy helper — forwards to Langfuse API and returns the response.
+ */
+async function langfuseProxy(
+  method: 'GET' | 'POST',
+  path: string,
+  queryParams?: Record<string, string | number | undefined>,
+  body?: unknown
+): Promise<{ ok: boolean; status: number; data: unknown }> {
+  const auth = getLangfuseAuth();
+  if (!auth) {
+    return { ok: false, status: 503, data: { error: 'Langfuse not configured' } };
+  }
+
+  const url = new URL(`${auth.baseUrl}${path}`);
+  if (queryParams) {
+    for (const [key, value] of Object.entries(queryParams)) {
+      if (value !== undefined && value !== null) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+
+  const options: RequestInit = {
+    method,
+    headers: auth.headers,
+  };
+  if (method === 'POST' && body) {
+    options.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(url.toString(), options);
+  const data = await response.json().catch(() => ({ error: 'Failed to parse response' }));
+
+  return { ok: response.ok, status: response.status, data };
+}
+
+export function createLangfuseRoutes(): Router {
+  const router = Router();
+
+  /**
+   * POST /api/langfuse/traces
+   * List traces with optional filters.
+   * Body: { page?, limit?, name?, tags?, userId?, sessionId?, fromTimestamp?, toTimestamp? }
+   */
+  router.post('/traces', async (req, res) => {
+    try {
+      const { page, limit, name, tags, userId, sessionId, fromTimestamp, toTimestamp } = req.body;
+
+      const queryParams: Record<string, string | number | undefined> = {
+        page: page ?? 1,
+        limit: limit ?? 20,
+      };
+      if (name) queryParams.name = name;
+      if (userId) queryParams.userId = userId;
+      if (sessionId) queryParams.sessionId = sessionId;
+      if (fromTimestamp) queryParams.fromTimestamp = fromTimestamp;
+      if (toTimestamp) queryParams.toTimestamp = toTimestamp;
+
+      // Tags are passed as repeated query params
+      let path = '/api/public/traces';
+      if (tags && Array.isArray(tags) && tags.length > 0) {
+        const tagParams = tags.map((t: string) => `tags=${encodeURIComponent(t)}`).join('&');
+        path += `?${tagParams}`;
+      }
+
+      const result = await langfuseProxy('GET', path, queryParams);
+      res.status(result.status).json(result.data);
+    } catch (error) {
+      logger.error('Failed to list traces:', error);
+      res.status(500).json({ error: 'Failed to list traces' });
+    }
+  });
+
+  /**
+   * POST /api/langfuse/traces/detail
+   * Get a single trace with all observations.
+   * Body: { traceId }
+   */
+  router.post('/traces/detail', async (req, res) => {
+    try {
+      const { traceId } = req.body;
+      if (!traceId) {
+        res.status(400).json({ error: 'traceId is required' });
+        return;
+      }
+
+      const result = await langfuseProxy('GET', `/api/public/traces/${traceId}`);
+      res.status(result.status).json(result.data);
+    } catch (error) {
+      logger.error('Failed to get trace detail:', error);
+      res.status(500).json({ error: 'Failed to get trace detail' });
+    }
+  });
+
+  /**
+   * POST /api/langfuse/costs
+   * Get observations for cost aggregation.
+   * Body: { page?, limit?, name?, type?, model?, fromStartTime?, toStartTime? }
+   */
+  router.post('/costs', async (req, res) => {
+    try {
+      const { page, limit, name, type, model, fromStartTime, toStartTime } = req.body;
+
+      const result = await langfuseProxy('GET', '/api/public/observations', {
+        page: page ?? 1,
+        limit: limit ?? 50,
+        name,
+        type: type ?? 'GENERATION',
+        model,
+        fromStartTime,
+        toStartTime,
+      });
+      res.status(result.status).json(result.data);
+    } catch (error) {
+      logger.error('Failed to get costs:', error);
+      res.status(500).json({ error: 'Failed to get costs' });
+    }
+  });
+
+  /**
+   * POST /api/langfuse/prompts
+   * List all managed prompts.
+   * Body: { page?, limit?, name?, label? }
+   */
+  router.post('/prompts', async (req, res) => {
+    try {
+      const { page, limit, name, label } = req.body;
+
+      const result = await langfuseProxy('GET', '/api/public/v2/prompts', {
+        page: page ?? 1,
+        limit: limit ?? 50,
+        name,
+        label,
+      });
+      res.status(result.status).json(result.data);
+    } catch (error) {
+      logger.error('Failed to list prompts:', error);
+      res.status(500).json({ error: 'Failed to list prompts' });
+    }
+  });
+
+  /**
+   * POST /api/langfuse/scores
+   * Create a score on a trace.
+   * Body: { traceId, name, value, comment? }
+   */
+  router.post('/scores', async (req, res) => {
+    try {
+      const { traceId, name, value, comment } = req.body;
+      if (!traceId || !name || value === undefined) {
+        res.status(400).json({ error: 'traceId, name, and value are required' });
+        return;
+      }
+
+      const result = await langfuseProxy('POST', '/api/public/scores', undefined, {
+        traceId,
+        name,
+        value,
+        comment,
+      });
+      res.status(result.status).json(result.data);
+    } catch (error) {
+      logger.error('Failed to create score:', error);
+      res.status(500).json({ error: 'Failed to create score' });
+    }
+  });
+
+  /**
+   * POST /api/langfuse/datasets
+   * List datasets.
+   * Body: { page?, limit? }
+   */
+  router.post('/datasets', async (req, res) => {
+    try {
+      const { page, limit } = req.body;
+
+      const result = await langfuseProxy('GET', '/api/public/v2/datasets', {
+        page: page ?? 1,
+        limit: limit ?? 50,
+      });
+      res.status(result.status).json(result.data);
+    } catch (error) {
+      logger.error('Failed to list datasets:', error);
+      res.status(500).json({ error: 'Failed to list datasets' });
+    }
+  });
+
+  /**
+   * POST /api/langfuse/datasets/items
+   * Add a trace to a dataset. Creates dataset if it doesn't exist.
+   * Body: { datasetName, traceId, observationId?, metadata? }
+   */
+  router.post('/datasets/items', async (req, res) => {
+    try {
+      const { datasetName, traceId, observationId, metadata } = req.body;
+      if (!datasetName || !traceId) {
+        res.status(400).json({ error: 'datasetName and traceId are required' });
+        return;
+      }
+
+      // Ensure dataset exists first
+      await langfuseProxy('POST', '/api/public/v2/datasets', undefined, {
+        name: datasetName,
+      });
+
+      // Add item to dataset
+      const result = await langfuseProxy('POST', '/api/public/dataset-items', undefined, {
+        datasetName,
+        sourceTraceId: traceId,
+        sourceObservationId: observationId,
+        metadata,
+      });
+      res.status(result.status).json(result.data);
+    } catch (error) {
+      logger.error('Failed to add dataset item:', error);
+      res.status(500).json({ error: 'Failed to add dataset item' });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/services/agent-scoring-service.ts
+++ b/apps/server/src/services/agent-scoring-service.ts
@@ -1,0 +1,137 @@
+/**
+ * AgentScoringService — Automatically scores agent traces based on feature lifecycle events.
+ *
+ * Listens to feature:status-changed events and creates Langfuse scores:
+ * - agent.success: 1.0 (done), 0.7 (review), 0.0 (reset to backlog/blocked)
+ * - agent.efficiency: turnsUsed / maxTurns (lower ratio = more efficient)
+ * - agent.quality: based on CodeRabbit review thread count
+ */
+
+import { createLogger } from '@automaker/utils';
+import type { Feature } from '@automaker/types';
+import { getLangfuseInstance } from '../lib/langfuse-singleton.js';
+import type { LangfuseClient } from '@automaker/observability';
+import type { EventEmitter } from '../lib/events.js';
+import type { FeatureLoader } from './feature-loader.js';
+
+const logger = createLogger('AgentScoringService');
+
+export class AgentScoringService {
+  private events: EventEmitter;
+  private featureLoader: FeatureLoader;
+
+  constructor(events: EventEmitter, featureLoader: FeatureLoader) {
+    this.events = events;
+    this.featureLoader = featureLoader;
+    this.registerListeners();
+  }
+
+  private registerListeners(): void {
+    this.events.subscribe((type, payload) => {
+      if (type === 'feature:status-changed') {
+        const data = payload as {
+          featureId: string;
+          oldStatus?: string;
+          newStatus?: string;
+          projectPath?: string;
+        };
+        if (data.projectPath && data.featureId) {
+          void this.handleStatusChanged(
+            data.projectPath,
+            data.featureId,
+            data.oldStatus,
+            data.newStatus
+          );
+        }
+      }
+    });
+
+    logger.info('Agent scoring service initialized');
+  }
+
+  private async handleStatusChanged(
+    projectPath: string,
+    featureId: string,
+    oldStatus?: string,
+    newStatus?: string
+  ): Promise<void> {
+    try {
+      const feature = await this.featureLoader.get(projectPath, featureId);
+      if (!feature) return;
+
+      const traceId = feature.lastTraceId;
+      if (!traceId) return;
+
+      const langfuse = getLangfuseInstance();
+      if (!langfuse.isAvailable()) return;
+
+      // Score based on status transition
+      if (newStatus === 'done' && oldStatus !== 'done') {
+        this.scoreSuccess(langfuse, traceId, 1.0, 'Feature completed — PR merged');
+        this.scoreEfficiency(langfuse, traceId, feature);
+        this.scoreQuality(langfuse, traceId, feature);
+      } else if (newStatus === 'review' && oldStatus === 'in_progress') {
+        this.scoreSuccess(langfuse, traceId, 0.7, 'Feature in review — PR created');
+        this.scoreEfficiency(langfuse, traceId, feature);
+      } else if (newStatus === 'backlog' && oldStatus === 'in_progress') {
+        this.scoreSuccess(langfuse, traceId, 0.0, 'Feature reset to backlog — agent failed');
+      } else if (newStatus === 'blocked' && oldStatus === 'in_progress') {
+        this.scoreSuccess(langfuse, traceId, 0.0, 'Feature blocked — agent failed');
+      }
+
+      // Flush after scoring
+      await langfuse.flush();
+    } catch (error) {
+      logger.error(`Failed to score feature ${featureId}:`, error);
+    }
+  }
+
+  private scoreSuccess(
+    langfuse: LangfuseClient,
+    traceId: string,
+    value: number,
+    comment: string
+  ): void {
+    langfuse.createScore({ traceId, name: 'agent.success', value, comment });
+    logger.debug(`Scored agent.success=${value} for trace ${traceId}`);
+  }
+
+  private scoreEfficiency(langfuse: LangfuseClient, traceId: string, feature: Feature): void {
+    const lastExecution = feature.executionHistory?.[feature.executionHistory.length - 1];
+    if (!lastExecution?.turnCount) return;
+
+    const maxTurns = feature.maxTurns ?? this.getDefaultMaxTurns(feature.complexity);
+    // Lower ratio = more efficient (used fewer turns)
+    const efficiency = 1 - Math.min(lastExecution.turnCount / maxTurns, 1);
+    const comment = `Used ${lastExecution.turnCount}/${maxTurns} turns`;
+
+    langfuse.createScore({ traceId, name: 'agent.efficiency', value: efficiency, comment });
+    logger.debug(`Scored agent.efficiency=${efficiency.toFixed(2)} for trace ${traceId}`);
+  }
+
+  private scoreQuality(langfuse: LangfuseClient, traceId: string, feature: Feature): void {
+    const threadCount = feature.threadFeedback?.length ?? 0;
+    // 0 issues = 1.0, scale down by 0.1 per issue, min 0
+    const quality = Math.max(0, 1 - threadCount * 0.1);
+    const comment =
+      threadCount === 0 ? 'Clean PR — no review issues' : `${threadCount} review thread(s) on PR`;
+
+    langfuse.createScore({ traceId, name: 'agent.quality', value: quality, comment });
+    logger.debug(`Scored agent.quality=${quality.toFixed(2)} for trace ${traceId}`);
+  }
+
+  private getDefaultMaxTurns(complexity?: string): number {
+    switch (complexity) {
+      case 'small':
+        return 200;
+      case 'medium':
+        return 500;
+      case 'large':
+        return 750;
+      case 'architectural':
+        return 1000;
+      default:
+        return 500;
+    }
+  }
+}

--- a/apps/server/src/services/antagonistic-review-service.ts
+++ b/apps/server/src/services/antagonistic-review-service.ts
@@ -15,7 +15,7 @@ import type { AgentFactoryService } from './agent-factory-service.js';
 import { DynamicAgentExecutor } from './dynamic-agent-executor.js';
 import type { SPARCPrd } from '@automaker/types';
 import { AntagonisticReviewAdapter } from './antagonistic-review-adapter.js';
-import { LangfuseClient } from '@automaker/observability';
+import { getLangfuseInstance } from '../lib/langfuse-singleton.js';
 import type { SettingsService } from './settings-service.js';
 
 const logger = createLogger('AntagonisticReview');
@@ -92,19 +92,9 @@ export class AntagonisticReviewService {
    */
   private async initializeLangfuse(): Promise<void> {
     try {
-      // Check if Langfuse credentials are configured
-      const langfusePublicKey = process.env.LANGFUSE_PUBLIC_KEY;
-      const langfuseSecretKey = process.env.LANGFUSE_SECRET_KEY;
-      const langfuseBaseUrl = process.env.LANGFUSE_BASE_URL;
+      const langfuseClient = getLangfuseInstance();
 
-      if (langfusePublicKey && langfuseSecretKey) {
-        const langfuseClient = new LangfuseClient({
-          publicKey: langfusePublicKey,
-          secretKey: langfuseSecretKey,
-          baseUrl: langfuseBaseUrl,
-          enabled: true,
-        });
-
+      if (langfuseClient.isAvailable()) {
         this.adapter = new AntagonisticReviewAdapter({
           smartModel: 'claude-3-5-sonnet-20241022',
           enableHITL: false,
@@ -113,7 +103,7 @@ export class AntagonisticReviewService {
 
         logger.info('Langfuse tracing initialized for antagonistic reviews');
       } else {
-        logger.info('Langfuse credentials not found, tracing disabled');
+        logger.info('Langfuse not available, tracing disabled for antagonistic reviews');
       }
     } catch (error) {
       logger.error('Failed to initialize Langfuse:', error);

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -397,6 +397,12 @@ export interface Feature {
    */
   statusHistory?: StatusTransition[];
 
+  /**
+   * Last Langfuse trace ID from the most recent agent execution.
+   * Used to correlate agent runs with observability data for scoring and analysis.
+   */
+  lastTraceId?: string;
+
   // Hivemind fields
   /** Domain this feature belongs to (e.g. "frontend", "server") for mesh routing */
   domain?: string;

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -2506,6 +2506,108 @@ const tools: Tool[] = [
       required: ['clientRepoUrl'],
     },
   },
+  // ========== Langfuse Observability ==========
+  {
+    name: 'langfuse_list_traces',
+    description:
+      'List recent Langfuse traces. Filter by name, tags, userId, sessionId, date range. Returns traceId, name, model, cost, latency, timestamp.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        page: { type: 'number', description: 'Page number (default: 1)' },
+        limit: { type: 'number', description: 'Results per page (default: 20)' },
+        name: { type: 'string', description: 'Filter by trace name' },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Filter by tags (e.g., ["automaker", "feature:abc123"])',
+        },
+        userId: { type: 'string', description: 'Filter by user ID' },
+        sessionId: { type: 'string', description: 'Filter by session ID' },
+        fromTimestamp: { type: 'string', description: 'Start date (ISO 8601)' },
+        toTimestamp: { type: 'string', description: 'End date (ISO 8601)' },
+      },
+    },
+  },
+  {
+    name: 'langfuse_get_trace',
+    description:
+      'Get full trace detail: all generations, spans, scores, token usage, cost breakdown.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        traceId: { type: 'string', description: 'The trace ID to retrieve' },
+      },
+      required: ['traceId'],
+    },
+  },
+  {
+    name: 'langfuse_get_costs',
+    description:
+      'Get observations/generations for cost analysis. Filter by model, time range. Returns token usage and costs per generation.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        page: { type: 'number', description: 'Page number (default: 1)' },
+        limit: { type: 'number', description: 'Results per page (default: 50)' },
+        model: { type: 'string', description: 'Filter by model name' },
+        fromStartTime: { type: 'string', description: 'Start date (ISO 8601)' },
+        toStartTime: { type: 'string', description: 'End date (ISO 8601)' },
+      },
+    },
+  },
+  {
+    name: 'langfuse_list_prompts',
+    description: 'List all managed prompts in Langfuse with versions and labels.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        page: { type: 'number', description: 'Page number (default: 1)' },
+        limit: { type: 'number', description: 'Results per page (default: 50)' },
+        name: { type: 'string', description: 'Filter by prompt name' },
+        label: { type: 'string', description: 'Filter by label (e.g., "production")' },
+      },
+    },
+  },
+  {
+    name: 'langfuse_score_trace',
+    description:
+      'Score a trace (name, value 0-1, optional comment). Use for manual quality review of agent outputs.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        traceId: { type: 'string', description: 'The trace ID to score' },
+        name: {
+          type: 'string',
+          description: 'Score name (e.g., "quality", "accuracy", "helpfulness")',
+        },
+        value: { type: 'number', description: 'Score value (0 to 1)' },
+        comment: { type: 'string', description: 'Optional comment explaining the score' },
+      },
+      required: ['traceId', 'name', 'value'],
+    },
+  },
+  {
+    name: 'langfuse_add_to_dataset',
+    description:
+      'Add a trace to a named dataset for evaluation. Creates the dataset if it does not exist.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        datasetName: {
+          type: 'string',
+          description: 'Name of the dataset (created if it does not exist)',
+        },
+        traceId: { type: 'string', description: 'Trace ID to add to the dataset' },
+        observationId: {
+          type: 'string',
+          description: 'Optional observation ID within the trace',
+        },
+        metadata: { type: 'object', description: 'Optional metadata for the dataset item' },
+      },
+      required: ['datasetName', 'traceId'],
+    },
+  },
 ];
 
 // Tool implementations
@@ -3488,6 +3590,57 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         gapsSummary: args.gapsSummary,
         changesMade: args.changesMade,
         alignmentPerformed: args.alignmentPerformed ?? false,
+      });
+
+    // Langfuse Observability
+    case 'langfuse_list_traces':
+      return apiCall('/langfuse/traces', {
+        page: args.page,
+        limit: args.limit,
+        name: args.name,
+        tags: args.tags,
+        userId: args.userId,
+        sessionId: args.sessionId,
+        fromTimestamp: args.fromTimestamp,
+        toTimestamp: args.toTimestamp,
+      });
+
+    case 'langfuse_get_trace':
+      return apiCall('/langfuse/traces/detail', {
+        traceId: args.traceId,
+      });
+
+    case 'langfuse_get_costs':
+      return apiCall('/langfuse/costs', {
+        page: args.page,
+        limit: args.limit,
+        model: args.model,
+        fromStartTime: args.fromStartTime,
+        toStartTime: args.toStartTime,
+      });
+
+    case 'langfuse_list_prompts':
+      return apiCall('/langfuse/prompts', {
+        page: args.page,
+        limit: args.limit,
+        name: args.name,
+        label: args.label,
+      });
+
+    case 'langfuse_score_trace':
+      return apiCall('/langfuse/scores', {
+        traceId: args.traceId,
+        name: args.name,
+        value: args.value,
+        comment: args.comment,
+      });
+
+    case 'langfuse_add_to_dataset':
+      return apiCall('/langfuse/datasets/items', {
+        datasetName: args.datasetName,
+        traceId: args.traceId,
+        observationId: args.observationId,
+        metadata: args.metadata,
       });
 
     default:


### PR DESCRIPTION
## Summary

- **M1: Wire Tracing** — Created `langfuse-singleton.ts`, auto-wrap all providers with `TracedProvider` in `ProviderFactory`, added `setContext()` for feature/agent enrichment, replaced manual client in antagonistic-review-service
- **M2: MCP Tools** — 7 Langfuse REST API proxy routes + 6 MCP tools (`langfuse_list_traces`, `langfuse_get_trace`, `langfuse_get_costs`, `langfuse_list_prompts`, `langfuse_score_trace`, `langfuse_add_to_dataset`)
- **M3: Auto-Scoring** — `AgentScoringService` listens to `feature:status-changed` events, auto-scores `agent.success`, `agent.efficiency`, `agent.quality` on Langfuse traces

## Key Changes

| File | Change |
|------|--------|
| `apps/server/src/lib/langfuse-singleton.ts` | **New** — Singleton LangfuseClient with shutdown |
| `apps/server/src/providers/provider-factory.ts` | Auto-wrap providers with TracedProvider |
| `apps/server/src/providers/traced-provider.ts` | Add `setContext()` for feature enrichment |
| `apps/server/src/routes/langfuse/index.ts` | **New** — 7 proxy routes to Langfuse REST API |
| `apps/server/src/services/agent-scoring-service.ts` | **New** — Auto-score agent traces |
| `apps/server/src/services/antagonistic-review-service.ts` | Use singleton instead of manual client |
| `libs/types/src/feature.ts` | Add `lastTraceId` field |
| `packages/mcp-server/src/index.ts` | 6 new MCP tool definitions + handlers |
| `apps/server/src/index.ts` | Register routes, scoring service, shutdown |

## Test plan

- [x] `npm run build:packages` — clean
- [x] `npm run build:server` — clean  
- [x] `npm run test:packages` — 943 tests pass
- [x] `npm run test:server` — 1874 tests pass
- [ ] Start server with Langfuse env vars, verify traces appear at langfuse.proto-labs.ai
- [ ] Test MCP tools via Claude Code CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Langfuse observability integration for tracing LLM executions
  * Introduced automatic agent performance scoring with success, efficiency, and quality metrics
  * Added APIs for accessing traces, scores, costs, and datasets
  * Integrated observability tools in MCP server for trace analysis
  * Enhanced features to track associated trace IDs for correlation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->