### PR TITLE
fix(docker): skip vite-plugin-electron in Storybook Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -260,6 +260,8 @@ COPY libs ./libs
 COPY apps/ui ./apps/ui
 
 # Build packages in dependency order, then build Storybook static site
+# VITE_SKIP_ELECTRON prevents vite-plugin-electron from loading (no Electron in Docker)
+ENV VITE_SKIP_ELECTRON=true
 RUN npm run build:libs \
     && npx storybook build --config-dir apps/ui/.storybook --output-dir apps/ui/storybook-static
 

--- a/apps/ui/vite.config.mts
+++ b/apps/ui/vite.config.mts
@@ -14,10 +14,11 @@ const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'package.
 const appVersion = packageJson.version;
 
 export default defineConfig(({ command }) => {
-  // Only skip electron plugin during dev server in CI (no display available for Electron)
-  // Always include it during build - we need dist-electron/main.js for electron-builder
+  // Skip electron plugin when VITE_SKIP_ELECTRON is set (Docker web/storybook builds)
+  // or during dev server in CI (no display available for Electron).
+  // Electron desktop builds (build:electron) don't set this env var.
   const skipElectron =
-    command === 'serve' && (process.env.CI === 'true' || process.env.VITE_SKIP_ELECTRON === 'true');
+    process.env.VITE_SKIP_ELECTRON === 'true' || (command === 'serve' && process.env.CI === 'true');
 
   return {
     plugins: [


### PR DESCRIPTION
## Summary
- Storybook Docker build failed because `vite-plugin-electron` tried to resolve `src/preload.ts` during Vite's build phase
- The `skipElectron` condition only worked for `serve` mode — changed to also respect `VITE_SKIP_ELECTRON=true` during builds
- Added `ENV VITE_SKIP_ELECTRON=true` to storybook-builder Dockerfile stage

## Root Cause
`vite.config.mts` had:
```js
const skipElectron = command === 'serve' && (process.env.CI === 'true' || process.env.VITE_SKIP_ELECTRON === 'true');
```
This only skipped the plugin during dev server, not during `vite build` (which Storybook uses internally).

## Fix
```js
const skipElectron = process.env.VITE_SKIP_ELECTRON === 'true' || (command === 'serve' && process.env.CI === 'true');
```
Now `VITE_SKIP_ELECTRON=true` works for all Vite commands. Electron desktop builds (`build:electron`) are unaffected — they don't set this env var.

## Test plan
- [ ] `docker build --target storybook .` builds successfully (was failing)
- [ ] `npm run dev:web` still works (uses VITE_SKIP_ELECTRON)
- [ ] `npm run build:electron` still includes electron plugin (no env var set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Docker build environment configuration and optimized build tool initialization logic across development, continuous integration, and Storybook builds. These changes reduce build overhead by refining how components are loaded in specific scenarios, enabling faster feedback during active development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->