### PR TITLE
fix(e2e): skip splash screen in CI/test environments

### DIFF
--- a/apps/ui/src/app.tsx
+++ b/apps/ui/src/app.tsx
@@ -14,6 +14,10 @@ const logger = createLogger('App');
 
 export default function App() {
   const [showSplash, setShowSplash] = useState(() => {
+    // Skip splash in CI/test environments
+    if (import.meta.env.VITE_SKIP_SETUP === 'true') {
+      return false;
+    }
     // Only show splash once per session
     if (sessionStorage.getItem('automaker-splash-shown')) {
       return false;


### PR DESCRIPTION
## Summary
- The 2.3s splash screen animation (`z-[9999]`) intercepts all Playwright pointer events, causing 16/23 E2E tests to fail on the self-hosted runner (since PR #585)
- Skip the splash when `VITE_SKIP_SETUP=true` — this env var is already set in the E2E workflow
- One-line fix in `app.tsx` initial state

## Test plan
- [ ] E2E tests pass on self-hosted runner (was 16/23 failing, should be 0)
- [ ] Splash screen still works in dev/production (no `VITE_SKIP_SETUP` set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added environment-driven configuration to skip the splash screen in CI and test environments for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->