### PR TITLE
fix(deploy): isolate storybook from critical deploy path

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -84,6 +84,8 @@ jobs:
         id: rebuild
         working-directory: /home/josh/staging-deploy/automaker
         run: |
+          # setup-staging.sh --build isolates storybook from critical services.
+          # If storybook fails to build, the script continues (non-fatal).
           ./scripts/setup-staging.sh --build
           ./scripts/setup-staging.sh --start
 
@@ -157,9 +159,9 @@ jobs:
         run: |
           echo "Deploy verification failed — rolling back to previous images"
 
-          # Check if rollback images exist
+          # Check if rollback images exist for critical services
           has_rollback=false
-          for svc in server ui docs storybook; do
+          for svc in server ui docs; do
             if docker image inspect "automaker-staging-${svc}:rollback" &>/dev/null; then
               has_rollback=true
               break
@@ -175,6 +177,7 @@ jobs:
           docker compose -f docker-compose.staging.yml down 2>/dev/null || true
 
           # Retag rollback images as latest and collect which services to start
+          # Critical services first, storybook is best-effort
           ROLLBACK_SERVICES=""
           for svc in server ui docs storybook; do
             if docker image inspect "automaker-staging-${svc}:rollback" &>/dev/null; then

--- a/scripts/setup-staging.sh
+++ b/scripts/setup-staging.sh
@@ -167,14 +167,18 @@ build_images() {
     exit 1
   fi
 
-  # Build all images in one command. Env vars are sourced via `set -a` at script
-  # start, so docker compose reads them from the shell environment — no --env-file
-  # needed. This avoids race conditions with the self-hosted runner's workspace
-  # cleanup cron, which can delete the .env file mid-build.
-  info "Building all images (server, ui, docs, storybook)..."
-  docker compose -f "$COMPOSE_FILE" build
+  # Build critical services first, storybook separately.
+  # If storybook fails to build, the deploy continues without it.
+  info "Building critical images (server, ui, docs)..."
+  docker compose -f "$COMPOSE_FILE" build server ui docs
+  ok "Critical images built"
 
-  ok "Images built successfully"
+  info "Building storybook image..."
+  if docker compose -f "$COMPOSE_FILE" build storybook; then
+    ok "Storybook image built"
+  else
+    warn "Storybook build failed — deploy will continue without it"
+  fi
 }
 
 # ─── Stop existing ───────────────────────────────────────────────────────────
@@ -210,7 +214,11 @@ start_services() {
     docker volume create "$vol" >/dev/null
   done
 
-  docker compose -f "$COMPOSE_FILE" up -d
+  # Start critical services first
+  docker compose -f "$COMPOSE_FILE" up -d server ui docs
+
+  # Start storybook separately — failure is non-fatal
+  docker compose -f "$COMPOSE_FILE" up -d storybook 2>/dev/null || warn "Storybook failed to start (image may not exist)"
 
   info "Waiting for health check..."
   local retries=0


### PR DESCRIPTION
## Summary
- Storybook build/start failures no longer block server, UI, or docs deployment
- `setup-staging.sh --build` builds critical services (server, ui, docs) first, then storybook separately with non-fatal error handling
- `setup-staging.sh --start` starts critical services first, storybook separately
- Rollback logic checks critical services only — missing storybook rollback image won't prevent recovery

## Test plan
- [ ] Deploy succeeds when storybook build works
- [ ] Deploy succeeds when storybook build fails (server/UI/docs still come up)
- [ ] Rollback works even if storybook has no rollback image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved staging deployment resilience by separating critical service builds from storybook builds with non-fatal failure handling
  * Restructured deployment and startup sequences to prioritize essential services while treating storybook as best-effort, preventing staging environment failures from non-critical components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->