### PR TITLE
fix(ui): migrate hardcoded colors to semantic design tokens

### DIFF
--- a/apps/ui/src/components/dashboard/animated-tabs.tsx
+++ b/apps/ui/src/components/dashboard/animated-tabs.tsx
@@ -21,7 +21,7 @@ export function AnimatedTabs({ tabs, activeTab, onTabChange, children }: Animate
   return (
     <div>
       {/* Tab bar */}
-      <div className="flex items-center gap-1 p-1 bg-muted/30 rounded-lg backdrop-blur-sm border border-white/5 w-fit mb-6">
+      <div className="flex items-center gap-1 p-1 bg-muted/30 rounded-lg backdrop-blur-sm border border-border w-fit mb-6">
         {tabs.map((tab) => {
           const isActive = tab.id === activeTab;
           const Icon = tab.icon;
@@ -38,7 +38,7 @@ export function AnimatedTabs({ tabs, activeTab, onTabChange, children }: Animate
               {isActive && (
                 <motion.div
                   layoutId={`activeTabBg-${layoutId}`}
-                  className="absolute inset-0 bg-background/80 rounded-md border border-white/10 shadow-sm"
+                  className="absolute inset-0 bg-background/80 rounded-md border border-border shadow-sm"
                   style={{ zIndex: 0 }}
                   transition={{ type: 'spring', stiffness: 400, damping: 30 }}
                 />

--- a/apps/ui/src/components/dashboard/glow-card.tsx
+++ b/apps/ui/src/components/dashboard/glow-card.tsx
@@ -43,12 +43,12 @@ export function GlowCard({
         transition: { type: 'spring', stiffness: 300, damping: 20 },
       }}
       className={cn(
-        'relative overflow-hidden rounded-xl border border-white/10 backdrop-blur-md',
+        'relative overflow-hidden rounded-xl border border-border backdrop-blur-md',
         'bg-card/80 text-card-foreground',
         'shadow-[0_1px_2px_rgba(0,0,0,0.05),0_4px_6px_rgba(0,0,0,0.05),0_10px_20px_rgba(0,0,0,0.04)]',
-        'hover:shadow-xl hover:border-white/20 transition-shadow duration-300',
+        'hover:shadow-xl hover:border-border transition-shadow duration-300',
         gradientBorder &&
-          'before:absolute before:inset-0 before:rounded-xl before:p-[1px] before:bg-gradient-to-br before:from-white/20 before:via-transparent before:to-white/5 before:pointer-events-none before:-z-10',
+          'before:absolute before:inset-0 before:rounded-xl before:p-[1px] before:bg-gradient-to-br before:from-border before:via-transparent before:to-border/30 before:pointer-events-none before:-z-10',
         className
       )}
       {...props}

--- a/apps/ui/src/components/views/agent-tools-view.tsx
+++ b/apps/ui/src/components/views/agent-tools-view.tsx
@@ -178,7 +178,7 @@ export function AgentToolsView() {
   return (
     <div className="flex-1 flex flex-col overflow-hidden content-bg" data-testid="agent-tools-view">
       {/* Header */}
-      <div className="flex items-center gap-3 p-4 border-b border-border bg-glass backdrop-blur-md">
+      <div className="flex items-center gap-3 p-4 border-b border-border bg-card/80 backdrop-blur-md">
         <Wrench className="w-5 h-5 text-primary" />
         <div>
           <h1 className="text-xl font-bold">Agent Tools</h1>
@@ -236,16 +236,16 @@ export function AgentToolsView() {
                   className={cn(
                     'p-3 rounded-md border',
                     readFileResult.success
-                      ? 'bg-green-500/10 border-green-500/20'
-                      : 'bg-red-500/10 border-red-500/20'
+                      ? 'bg-status-success-bg border-status-success/20'
+                      : 'bg-status-error-bg border-status-error/20'
                   )}
                   data-testid="read-file-result"
                 >
                   <div className="flex items-center gap-2 mb-2">
                     {readFileResult.success ? (
-                      <CheckCircle className="w-4 h-4 text-green-500" />
+                      <CheckCircle className="w-4 h-4 text-status-success" />
                     ) : (
-                      <XCircle className="w-4 h-4 text-red-500" />
+                      <XCircle className="w-4 h-4 text-status-error" />
                     )}
                     <span className="text-sm font-medium">
                       {readFileResult.success ? 'Success' : 'Failed'}
@@ -315,16 +315,16 @@ export function AgentToolsView() {
                   className={cn(
                     'p-3 rounded-md border',
                     writeFileResult.success
-                      ? 'bg-green-500/10 border-green-500/20'
-                      : 'bg-red-500/10 border-red-500/20'
+                      ? 'bg-status-success-bg border-status-success/20'
+                      : 'bg-status-error-bg border-status-error/20'
                   )}
                   data-testid="write-file-result"
                 >
                   <div className="flex items-center gap-2 mb-2">
                     {writeFileResult.success ? (
-                      <CheckCircle className="w-4 h-4 text-green-500" />
+                      <CheckCircle className="w-4 h-4 text-status-success" />
                     ) : (
-                      <XCircle className="w-4 h-4 text-red-500" />
+                      <XCircle className="w-4 h-4 text-status-error" />
                     )}
                     <span className="text-sm font-medium">
                       {writeFileResult.success ? 'Success' : 'Failed'}
@@ -383,16 +383,16 @@ export function AgentToolsView() {
                   className={cn(
                     'p-3 rounded-md border',
                     terminalResult.success
-                      ? 'bg-green-500/10 border-green-500/20'
-                      : 'bg-red-500/10 border-red-500/20'
+                      ? 'bg-status-success-bg border-status-success/20'
+                      : 'bg-status-error-bg border-status-error/20'
                   )}
                   data-testid="terminal-result"
                 >
                   <div className="flex items-center gap-2 mb-2">
                     {terminalResult.success ? (
-                      <CheckCircle className="w-4 h-4 text-green-500" />
+                      <CheckCircle className="w-4 h-4 text-status-success" />
                     ) : (
-                      <XCircle className="w-4 h-4 text-red-500" />
+                      <XCircle className="w-4 h-4 text-status-error" />
                     )}
                     <span className="text-sm font-medium">
                       {terminalResult.success ? 'Success' : 'Failed'}

--- a/apps/ui/src/components/views/analysis-view.tsx
+++ b/apps/ui/src/components/views/analysis-view.tsx
@@ -739,7 +739,7 @@ ${Object.entries(projectAnalysis.filesByExtension)
   return (
     <div className="flex-1 flex flex-col overflow-hidden content-bg" data-testid="analysis-view">
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-white/10 bg-zinc-950/50 backdrop-blur-md">
+      <div className="flex items-center justify-between p-4 border-b border-border bg-card backdrop-blur-md">
         <div className="flex items-center gap-3">
           <Search className="w-5 h-5 text-muted-foreground" />
           <div>

--- a/apps/ui/src/components/views/authority-agents-status.tsx
+++ b/apps/ui/src/components/views/authority-agents-status.tsx
@@ -37,11 +37,11 @@ function getAgentIcon(role: AgentStatus['role']) {
 function getStatusClasses(status: AgentStatus['status']) {
   switch (status) {
     case 'active':
-      return 'text-green-500 border-green-500/30 bg-green-500/10';
+      return 'text-status-success border-status-success/30 bg-status-success-bg';
     case 'processing':
-      return 'text-blue-500 border-blue-500/30 bg-blue-500/10';
+      return 'text-status-info border-status-info/30 bg-status-info-bg';
     case 'idle':
-      return 'text-gray-500 border-gray-500/30 bg-gray-500/10';
+      return 'text-muted-foreground border-muted-foreground/30 bg-muted';
   }
 }
 
@@ -51,11 +51,11 @@ function getStatusClasses(status: AgentStatus['status']) {
 function getStatusDotColor(status: AgentStatus['status']) {
   switch (status) {
     case 'active':
-      return 'bg-green-500';
+      return 'bg-status-success';
     case 'processing':
-      return 'bg-blue-500 animate-pulse';
+      return 'bg-status-info animate-pulse';
     case 'idle':
-      return 'bg-gray-500';
+      return 'bg-muted-foreground';
   }
 }
 

--- a/apps/ui/src/components/views/authority-event-feed.tsx
+++ b/apps/ui/src/components/views/authority-event-feed.tsx
@@ -34,13 +34,13 @@ function getEventIcon(type: EventType) {
 function getSeverityClasses(severity: AuthorityEvent['severity']) {
   switch (severity) {
     case 'success':
-      return 'text-green-400 border-green-500/30 bg-green-500/10';
+      return 'text-status-success border-status-success/30 bg-status-success-bg';
     case 'warning':
-      return 'text-yellow-400 border-yellow-500/30 bg-yellow-500/10';
+      return 'text-status-warning border-status-warning/30 bg-status-warning-bg';
     case 'error':
-      return 'text-red-400 border-red-500/30 bg-red-500/10';
+      return 'text-status-error border-status-error/30 bg-status-error-bg';
     default:
-      return 'text-blue-400 border-blue-500/30 bg-blue-500/10';
+      return 'text-status-info border-status-info/30 bg-status-info-bg';
   }
 }
 
@@ -78,7 +78,7 @@ export const AuthorityEventFeed = memo(function AuthorityEventFeed() {
           <div
             className={cn(
               'h-2 w-2 rounded-full',
-              isConnected ? 'bg-green-500 animate-pulse' : 'bg-gray-500'
+              isConnected ? 'bg-status-success animate-pulse' : 'bg-muted-foreground'
             )}
             title={isConnected ? 'Connected' : 'Disconnected'}
           />

--- a/apps/ui/src/components/views/board-view/board-header.tsx
+++ b/apps/ui/src/components/views/board-view/board-header.tsx
@@ -136,7 +136,7 @@ export function BoardHeader({
   const isTablet = useIsTablet();
 
   return (
-    <div className="flex items-center justify-between gap-5 p-4 border-b border-border bg-glass backdrop-blur-md">
+    <div className="flex items-center justify-between gap-5 p-4 border-b border-border bg-card/80 backdrop-blur-md">
       <div className="flex items-center gap-4">
         <BoardSearchBar
           searchQuery={searchQuery}

--- a/apps/ui/src/components/views/board-view/components/description-image-dropzone.tsx
+++ b/apps/ui/src/components/views/board-view/components/description-image-dropzone.tsx
@@ -469,7 +469,7 @@ export function DescriptionImageDropZone({
                 data-testid={`description-image-preview-${image.id}`}
               >
                 {/* Image thumbnail or placeholder */}
-                <div className="w-16 h-16 flex items-center justify-center bg-zinc-800">
+                <div className="w-16 h-16 flex items-center justify-center bg-muted">
                   {previewImages.has(image.id) ? (
                     <img
                       src={previewImages.get(image.id)}
@@ -503,8 +503,8 @@ export function DescriptionImageDropZone({
                   </button>
                 )}
                 {/* Filename tooltip on hover */}
-                <div className="absolute bottom-0 left-0 right-0 bg-black/60 px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-                  <p className="text-[10px] text-white truncate">{image.filename}</p>
+                <div className="absolute bottom-0 left-0 right-0 bg-background/80 px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <p className="text-[10px] text-foreground truncate">{image.filename}</p>
                 </div>
               </div>
             ))}
@@ -516,7 +516,7 @@ export function DescriptionImageDropZone({
                 data-testid={`description-text-file-preview-${file.id}`}
               >
                 {/* Text file icon */}
-                <div className="w-16 h-16 flex items-center justify-center bg-zinc-800">
+                <div className="w-16 h-16 flex items-center justify-center bg-muted">
                   <FileText className="w-6 h-6 text-muted-foreground" />
                 </div>
                 {/* Remove button */}
@@ -534,9 +534,11 @@ export function DescriptionImageDropZone({
                   </button>
                 )}
                 {/* Filename and size tooltip on hover */}
-                <div className="absolute bottom-0 left-0 right-0 bg-black/60 px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-                  <p className="text-[10px] text-white truncate">{file.filename}</p>
-                  <p className="text-[9px] text-white/70">{formatFileSize(file.content.length)}</p>
+                <div className="absolute bottom-0 left-0 right-0 bg-background/80 px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <p className="text-[10px] text-foreground truncate">{file.filename}</p>
+                  <p className="text-[9px] text-muted-foreground">
+                    {formatFileSize(file.content.length)}
+                  </p>
                 </div>
               </div>
             ))}

--- a/apps/ui/src/components/views/board-view/components/feature-image-upload.tsx
+++ b/apps/ui/src/components/views/board-view/components/feature-image-upload.tsx
@@ -257,8 +257,8 @@ export function FeatureImageUpload({
                   </button>
                 )}
                 {/* Filename tooltip on hover */}
-                <div className="absolute bottom-0 left-0 right-0 bg-black/60 px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-                  <p className="text-[10px] text-white truncate">{image.filename}</p>
+                <div className="absolute bottom-0 left-0 right-0 bg-background/80 px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <p className="text-[10px] text-foreground truncate">{image.filename}</p>
                 </div>
               </div>
             ))}

--- a/apps/ui/src/components/views/board-view/components/kanban-card/card-header.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/card-header.tsx
@@ -132,7 +132,7 @@ export const CardHeaderSection = memo(function CardHeaderSection({
           <Button
             variant="ghost"
             size="sm"
-            className="h-6 w-6 p-0 hover:bg-white/10 text-muted-foreground hover:text-foreground"
+            className="h-6 w-6 p-0 hover:bg-accent text-muted-foreground hover:text-foreground"
             onClick={(e) => {
               e.stopPropagation();
               onSpawnTask?.();
@@ -146,7 +146,7 @@ export const CardHeaderSection = memo(function CardHeaderSection({
           <Button
             variant="ghost"
             size="sm"
-            className="h-6 w-6 p-0 hover:bg-white/10 text-muted-foreground hover:text-destructive"
+            className="h-6 w-6 p-0 hover:bg-accent text-muted-foreground hover:text-destructive"
             onClick={handleDeleteClick}
             onPointerDown={(e) => e.stopPropagation()}
             data-testid={`delete-backlog-${feature.id}`}
@@ -165,7 +165,7 @@ export const CardHeaderSection = memo(function CardHeaderSection({
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-6 w-6 p-0 hover:bg-white/10 text-muted-foreground hover:text-foreground"
+                className="h-6 w-6 p-0 hover:bg-accent text-muted-foreground hover:text-foreground"
                 onClick={(e) => {
                   e.stopPropagation();
                   onEdit();
@@ -181,7 +181,7 @@ export const CardHeaderSection = memo(function CardHeaderSection({
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-6 w-6 p-0 hover:bg-white/10 text-muted-foreground hover:text-foreground"
+                className="h-6 w-6 p-0 hover:bg-accent text-muted-foreground hover:text-foreground"
                 onClick={(e) => {
                   e.stopPropagation();
                   onSpawnTask?.();
@@ -198,7 +198,7 @@ export const CardHeaderSection = memo(function CardHeaderSection({
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-6 w-6 p-0 hover:bg-white/10 text-muted-foreground hover:text-foreground"
+                  className="h-6 w-6 p-0 hover:bg-accent text-muted-foreground hover:text-foreground"
                   onClick={(e) => {
                     e.stopPropagation();
                     onViewOutput();
@@ -215,7 +215,7 @@ export const CardHeaderSection = memo(function CardHeaderSection({
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-6 w-6 p-0 hover:bg-white/10 text-muted-foreground hover:text-destructive"
+                className="h-6 w-6 p-0 hover:bg-accent text-muted-foreground hover:text-destructive"
                 onClick={handleDeleteClick}
                 onPointerDown={(e) => e.stopPropagation()}
                 data-testid={`delete-${
@@ -236,7 +236,7 @@ export const CardHeaderSection = memo(function CardHeaderSection({
             <Button
               variant="ghost"
               size="sm"
-              className="h-6 w-6 p-0 hover:bg-white/10 text-muted-foreground hover:text-destructive"
+              className="h-6 w-6 p-0 hover:bg-accent text-muted-foreground hover:text-destructive"
               onClick={handleDeleteClick}
               onPointerDown={(e) => e.stopPropagation()}
               data-testid={`delete-feature-${feature.id}`}

--- a/apps/ui/src/components/views/board-view/kanban-board.tsx
+++ b/apps/ui/src/components/views/board-view/kanban-board.tsx
@@ -487,7 +487,7 @@ export function KanbanBoard({
                       >
                         <Plus className="w-4 h-4 mr-2" />
                         Add Feature
-                        <span className="ml-auto pl-2 text-[10px] font-mono opacity-70 bg-black/20 px-1.5 py-0.5 rounded">
+                        <span className="ml-auto pl-2 text-[10px] font-mono opacity-70 bg-muted/20 px-1.5 py-0.5 rounded">
                           {formatShortcut(addFeatureShortcut, true)}
                         </span>
                       </Button>

--- a/apps/ui/src/components/views/board-view/worktree-panel/components/dev-server-logs-panel.tsx
+++ b/apps/ui/src/components/views/board-view/worktree-panel/components/dev-server-logs-panel.tsx
@@ -230,7 +230,7 @@ export function DevServerLogsPanel({
 
         {/* Log content area - fills remaining space */}
         <div
-          className="flex-1 min-h-0 overflow-hidden bg-zinc-950"
+          className="flex-1 min-h-0 overflow-hidden bg-background"
           data-testid="dev-server-logs-content"
         >
           {isLoading && !logs ? (

--- a/apps/ui/src/components/views/board-view/worktree-panel/worktree-panel.tsx
+++ b/apps/ui/src/components/views/board-view/worktree-panel/worktree-panel.tsx
@@ -348,7 +348,7 @@ export function WorktreePanel({
     const selectedWorktree = worktrees.find((w) => isWorktreeSelected(w)) || mainWorktree;
 
     return (
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-glass/50 backdrop-blur-sm">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-card/50 backdrop-blur-sm">
         <WorktreeMobileDropdown
           worktrees={worktrees}
           isWorktreeSelected={isWorktreeSelected}
@@ -500,7 +500,7 @@ export function WorktreePanel({
 
   // Desktop view: full tabs layout
   return (
-    <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-glass/50 backdrop-blur-sm">
+    <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-card/50 backdrop-blur-sm">
       <GitBranch className="w-4 h-4 text-muted-foreground" />
       <span className="text-sm text-muted-foreground mr-2">Branch:</span>
 

--- a/apps/ui/src/components/views/chat-history.tsx
+++ b/apps/ui/src/components/views/chat-history.tsx
@@ -180,14 +180,14 @@ export function ChatHistory() {
   return (
     <div
       className={cn(
-        'flex flex-col h-full bg-zinc-950/50 backdrop-blur-md border-r border-white/10 transition-all duration-200',
+        'flex flex-col h-full bg-background/50 backdrop-blur-md border-r border-border transition-all duration-200',
         chatHistoryOpen ? 'w-80' : 'w-0 overflow-hidden'
       )}
     >
       {chatHistoryOpen && (
         <>
           {/* Header */}
-          <div className="flex items-center justify-between p-4 border-b border-white/10">
+          <div className="flex items-center justify-between p-4 border-b border-border">
             <div className="flex items-center gap-2">
               <MessageSquare className="w-5 h-5" />
               <h2 className="font-semibold">Chat History</h2>

--- a/apps/ui/src/components/views/code-view.tsx
+++ b/apps/ui/src/components/views/code-view.tsx
@@ -215,7 +215,7 @@ export function CodeView() {
   return (
     <div className="flex-1 flex flex-col overflow-hidden content-bg" data-testid="code-view">
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-white/10 bg-zinc-950/50 backdrop-blur-md">
+      <div className="flex items-center justify-between p-4 border-b border-border bg-card backdrop-blur-md">
         <div className="flex items-center gap-3">
           <Code className="w-5 h-5 text-muted-foreground" />
           <div>

--- a/apps/ui/src/components/views/context-view.tsx
+++ b/apps/ui/src/components/views/context-view.tsx
@@ -687,7 +687,7 @@ export function ContextView() {
       />
 
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-border bg-glass backdrop-blur-md">
+      <div className="flex items-center justify-between p-4 border-b border-border bg-card/80 backdrop-blur-md">
         <div className="flex items-center gap-3">
           <BookOpen className="w-5 h-5 text-muted-foreground" />
           <div>

--- a/apps/ui/src/components/views/dashboard-view.tsx
+++ b/apps/ui/src/components/views/dashboard-view.tsx
@@ -496,7 +496,7 @@ export function DashboardView() {
   return (
     <div className="flex-1 flex flex-col h-screen content-bg" data-testid="dashboard-view">
       {/* Header with logo */}
-      <header className="shrink-0 border-b border-border bg-glass backdrop-blur-md">
+      <header className="shrink-0 border-b border-border bg-card/80 backdrop-blur-md">
         {/* Electron titlebar drag region */}
         {isElectron() && (
           <div

--- a/apps/ui/src/components/views/dashboard-view/event-feed.tsx
+++ b/apps/ui/src/components/views/dashboard-view/event-feed.tsx
@@ -50,31 +50,31 @@ function getColorClasses(color: 'green' | 'red' | 'blue' | 'yellow') {
   switch (color) {
     case 'green':
       return {
-        bg: 'bg-green-500/10',
-        border: 'border-green-500/30',
-        icon: 'text-green-500',
-        text: 'text-green-600 dark:text-green-400',
+        bg: 'bg-status-success-bg',
+        border: 'border-status-success/30',
+        icon: 'text-status-success',
+        text: 'text-status-success',
       };
     case 'red':
       return {
-        bg: 'bg-red-500/10',
-        border: 'border-red-500/30',
-        icon: 'text-red-500',
-        text: 'text-red-600 dark:text-red-400',
+        bg: 'bg-status-error-bg',
+        border: 'border-status-error/30',
+        icon: 'text-status-error',
+        text: 'text-status-error',
       };
     case 'blue':
       return {
-        bg: 'bg-blue-500/10',
-        border: 'border-blue-500/30',
-        icon: 'text-blue-500',
-        text: 'text-blue-600 dark:text-blue-400',
+        bg: 'bg-status-info-bg',
+        border: 'border-status-info/30',
+        icon: 'text-status-info',
+        text: 'text-status-info',
       };
     case 'yellow':
       return {
-        bg: 'bg-yellow-500/10',
-        border: 'border-yellow-500/30',
-        icon: 'text-yellow-500',
-        text: 'text-yellow-600 dark:text-yellow-400',
+        bg: 'bg-status-warning-bg',
+        border: 'border-status-warning/30',
+        icon: 'text-status-warning',
+        text: 'text-status-warning',
       };
   }
 }
@@ -94,7 +94,7 @@ export function EventFeed({ projectPath, className }: EventFeedProps) {
             <div
               className={cn(
                 'w-2 h-2 rounded-full',
-                isConnected ? 'bg-green-500 animate-pulse' : 'bg-gray-400'
+                isConnected ? 'bg-status-success animate-pulse' : 'bg-muted-foreground'
               )}
               title={isConnected ? 'Connected' : 'Disconnected'}
             />
@@ -106,7 +106,7 @@ export function EventFeed({ projectPath, className }: EventFeedProps) {
       </CardHeader>
       <CardContent className="flex-1 overflow-hidden p-0">
         {error && (
-          <div className="p-4 text-sm text-red-600 dark:text-red-400 bg-red-500/10 border-l-2 border-red-500">
+          <div className="p-4 text-sm text-status-error bg-status-error-bg border-l-2 border-status-error">
             Error: {error}
           </div>
         )}

--- a/apps/ui/src/components/views/dashboard-view/metrics/integrations-tab.tsx
+++ b/apps/ui/src/components/views/dashboard-view/metrics/integrations-tab.tsx
@@ -56,10 +56,8 @@ function IntegrationCard({ title, icon: Icon, status, stats, iconColor }: Integr
           <div className="flex items-center gap-1.5">
             {isConnected ? (
               <>
-                <CheckCircle2 className="h-4 w-4 text-green-500" />
-                <span className="text-xs text-green-600 dark:text-green-400 font-medium">
-                  Connected
-                </span>
+                <CheckCircle2 className="h-4 w-4 text-status-success" />
+                <span className="text-xs text-status-success font-medium">Connected</span>
               </>
             ) : (
               <>
@@ -99,7 +97,7 @@ function ActivityTicker({ projectPath }: ActivityTickerProps) {
     <Card className="bg-card/50 backdrop-blur-sm border-border/50">
       <CardHeader className="pb-3">
         <div className="flex items-center gap-2">
-          <Activity className="h-4 w-4 text-blue-500" />
+          <Activity className="h-4 w-4 text-status-info" />
           <CardTitle className="text-base">Activity Feed</CardTitle>
           <span className="text-xs text-muted-foreground">
             {events.length} recent {events.length === 1 ? 'event' : 'events'}
@@ -120,7 +118,7 @@ function ActivityTicker({ projectPath }: ActivityTickerProps) {
                   key={i}
                   className="flex items-start gap-2 p-2 rounded-md hover:bg-muted/50 transition-colors"
                 >
-                  <div className="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 shrink-0" />
+                  <div className="w-1.5 h-1.5 rounded-full bg-status-info mt-2 shrink-0" />
                   <div className="flex-1 min-w-0">
                     <p className="text-sm text-foreground leading-tight">
                       {event.description || event.message || 'Activity event'}
@@ -151,7 +149,7 @@ function AgentSessionCard() {
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <div className="rounded-lg p-2 bg-purple-500/10 text-purple-500">
+            <div className="rounded-lg p-2 bg-primary/10 text-primary">
               <Bot className="h-4 w-4" />
             </div>
             <CardTitle className="text-base">Agent Sessions</CardTitle>
@@ -186,14 +184,14 @@ function AgentSessionCard() {
                 >
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
-                      <Bot className="h-3.5 w-3.5 text-purple-500" />
+                      <Bot className="h-3.5 w-3.5 text-primary" />
                       <span className="text-sm font-medium text-foreground">
                         {agent.featureId || agent.sessionId}
                       </span>
                     </div>
                     <span
-                      className="text-xs px-2 py-0.5 rounded-full bg-purple-500/10
-                                   text-purple-600 dark:text-purple-400 font-medium"
+                      className="text-xs px-2 py-0.5 rounded-full bg-primary/10
+                                   text-primary font-medium"
                     >
                       {agent.model || 'sonnet'}
                     </span>

--- a/apps/ui/src/components/views/dashboard-view/project-health-card.tsx
+++ b/apps/ui/src/components/views/dashboard-view/project-health-card.tsx
@@ -24,17 +24,17 @@ function StatusBadge({ status }: StatusBadgeProps) {
     running: {
       label: 'Running',
       icon: PlayCircle,
-      className: 'bg-green-500/10 text-green-500',
+      className: 'bg-status-success-bg text-status-success',
     },
     idle: {
       label: 'Idle',
       icon: Clock,
-      className: 'bg-yellow-500/10 text-yellow-500',
+      className: 'bg-status-warning-bg text-status-warning',
     },
     stopped: {
       label: 'Stopped',
       icon: StopCircle,
-      className: 'bg-gray-500/10 text-gray-500',
+      className: 'bg-muted text-muted-foreground',
     },
   };
 

--- a/apps/ui/src/components/views/escalation-dashboard.tsx
+++ b/apps/ui/src/components/views/escalation-dashboard.tsx
@@ -55,17 +55,17 @@ function getSeverityIcon(severity: string) {
 function getSeverityClasses(severity: string) {
   switch (severity) {
     case 'emergency':
-      return 'text-red-600 border-red-600/30 bg-red-600/20';
+      return 'text-status-error border-status-error/30 bg-status-error-bg';
     case 'critical':
-      return 'text-red-500 border-red-500/30 bg-red-500/20';
+      return 'text-status-error border-status-error/30 bg-status-error-bg';
     case 'high':
-      return 'text-orange-500 border-orange-500/30 bg-orange-500/20';
+      return 'text-status-warning border-status-warning/30 bg-status-warning-bg';
     case 'medium':
-      return 'text-yellow-500 border-yellow-500/30 bg-yellow-500/20';
+      return 'text-status-warning border-status-warning/30 bg-status-warning-bg';
     case 'low':
-      return 'text-blue-500 border-blue-500/30 bg-blue-500/20';
+      return 'text-status-info border-status-info/30 bg-status-info-bg';
     default:
-      return 'text-gray-500 border-gray-500/30 bg-gray-500/20';
+      return 'text-muted-foreground border-muted-foreground/30 bg-muted';
   }
 }
 
@@ -132,7 +132,7 @@ const EscalationFeed = memo(function EscalationFeed() {
           <div
             className={cn(
               'h-2 w-2 rounded-full',
-              isConnected ? 'bg-green-500 animate-pulse' : 'bg-gray-500'
+              isConnected ? 'bg-status-success animate-pulse' : 'bg-muted-foreground'
             )}
             title={isConnected ? 'Connected' : 'Disconnected'}
           />
@@ -314,16 +314,18 @@ const ChannelStatus = memo(function ChannelStatus() {
                   <div
                     className={cn(
                       'h-2 w-2 rounded-full',
-                      stats.status === 'active' && 'bg-green-500',
-                      stats.status === 'error' && 'bg-red-500',
-                      stats.status === 'inactive' && 'bg-gray-500'
+                      stats.status === 'active' && 'bg-status-success',
+                      stats.status === 'error' && 'bg-status-error',
+                      stats.status === 'inactive' && 'bg-muted-foreground'
                     )}
                   />
                   <span className="text-sm font-medium capitalize">{channel}</span>
                 </div>
                 <div className="flex items-center gap-3 text-xs">
-                  <span className="text-green-400">{stats.sent} sent</span>
-                  {stats.failed > 0 && <span className="text-red-400">{stats.failed} failed</span>}
+                  <span className="text-status-success">{stats.sent} sent</span>
+                  {stats.failed > 0 && (
+                    <span className="text-status-error">{stats.failed} failed</span>
+                  )}
                 </div>
               </div>
             ))
@@ -378,7 +380,7 @@ const AcknowledgedPendingCounts = memo(function AcknowledgedPendingCounts() {
             onClick={() => setFilter('pending')}
             className="flex flex-col items-center py-3 h-auto"
           >
-            <span className="text-lg font-bold text-yellow-400">{counts.pending}</span>
+            <span className="text-lg font-bold text-status-warning">{counts.pending}</span>
             <span className="text-xs">Pending</span>
           </Button>
           <Button
@@ -387,7 +389,7 @@ const AcknowledgedPendingCounts = memo(function AcknowledgedPendingCounts() {
             onClick={() => setFilter('acknowledged')}
             className="flex flex-col items-center py-3 h-auto"
           >
-            <span className="text-lg font-bold text-green-400">{counts.acknowledged}</span>
+            <span className="text-lg font-bold text-status-success">{counts.acknowledged}</span>
             <span className="text-xs">Acknowledged</span>
           </Button>
         </div>
@@ -402,7 +404,7 @@ const AcknowledgedPendingCounts = memo(function AcknowledgedPendingCounts() {
           </div>
           <div className="h-2 bg-muted/30 rounded-full overflow-hidden">
             <div
-              className="h-full bg-green-500 transition-all"
+              className="h-full bg-status-success transition-all"
               style={{
                 width: `${counts.total > 0 ? (counts.acknowledged / counts.total) * 100 : 0}%`,
               }}

--- a/apps/ui/src/components/views/github-prs-view.tsx
+++ b/apps/ui/src/components/views/github-prs-view.tsx
@@ -51,11 +51,19 @@ export function GitHubPRsView() {
     if (pr.isDraft) return { label: 'Draft', color: 'text-muted-foreground', bg: 'bg-muted' };
     switch (pr.reviewDecision) {
       case 'APPROVED':
-        return { label: 'Approved', color: 'text-green-500', bg: 'bg-green-500/10' };
+        return { label: 'Approved', color: 'text-status-success', bg: 'bg-status-success-bg' };
       case 'CHANGES_REQUESTED':
-        return { label: 'Changes requested', color: 'text-orange-500', bg: 'bg-orange-500/10' };
+        return {
+          label: 'Changes requested',
+          color: 'text-status-warning',
+          bg: 'bg-status-warning-bg',
+        };
       case 'REVIEW_REQUIRED':
-        return { label: 'Review required', color: 'text-yellow-500', bg: 'bg-yellow-500/10' };
+        return {
+          label: 'Review required',
+          color: 'text-status-warning',
+          bg: 'bg-status-warning-bg',
+        };
       default:
         return null;
     }
@@ -101,8 +109,8 @@ export function GitHubPRsView() {
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border">
           <div className="flex items-center gap-3">
-            <div className="p-2 rounded-lg bg-blue-500/10">
-              <GitPullRequest className="h-5 w-5 text-blue-500" />
+            <div className="p-2 rounded-lg bg-status-info-bg">
+              <GitPullRequest className="h-5 w-5 text-status-info" />
             </div>
             <div>
               <h1 className="text-lg font-bold">Pull Requests</h1>
@@ -176,9 +184,9 @@ export function GitHubPRsView() {
           <div className="flex items-center justify-between p-3 border-b border-border bg-muted/30">
             <div className="flex items-center gap-2 min-w-0">
               {selectedPR.state === 'MERGED' ? (
-                <GitMerge className="h-4 w-4 text-purple-500 shrink-0" />
+                <GitMerge className="h-4 w-4 text-primary shrink-0" />
               ) : (
-                <GitPullRequest className="h-4 w-4 text-green-500 shrink-0" />
+                <GitPullRequest className="h-4 w-4 text-status-success shrink-0" />
               )}
               <span className="text-sm font-medium truncate">
                 #{selectedPR.number} {selectedPR.title}
@@ -215,10 +223,10 @@ export function GitHubPRsView() {
                 className={cn(
                   'px-2 py-0.5 rounded-full text-xs font-medium',
                   selectedPR.state === 'MERGED'
-                    ? 'bg-purple-500/10 text-purple-500'
+                    ? 'bg-primary/10 text-primary'
                     : selectedPR.isDraft
                       ? 'bg-muted text-muted-foreground'
-                      : 'bg-green-500/10 text-green-500'
+                      : 'bg-status-success-bg text-status-success'
                 )}
               >
                 {selectedPR.state === 'MERGED' ? 'Merged' : selectedPR.isDraft ? 'Draft' : 'Open'}
@@ -321,9 +329,9 @@ function PRRow({
       onClick={onClick}
     >
       {pr.state === 'MERGED' ? (
-        <GitMerge className="h-4 w-4 text-purple-500 mt-0.5 shrink-0" />
+        <GitMerge className="h-4 w-4 text-primary mt-0.5 shrink-0" />
       ) : (
-        <GitPullRequest className="h-4 w-4 text-green-500 mt-0.5 shrink-0" />
+        <GitPullRequest className="h-4 w-4 text-status-success mt-0.5 shrink-0" />
       )}
 
       <div className="flex-1 min-w-0">

--- a/apps/ui/src/components/views/interview-view.tsx
+++ b/apps/ui/src/components/views/interview-view.tsx
@@ -391,7 +391,7 @@ export function InterviewView() {
   return (
     <div className="flex-1 flex flex-col content-bg min-h-0" data-testid="interview-view">
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-border bg-glass backdrop-blur-md">
+      <div className="flex items-center justify-between p-4 border-b border-border bg-card/80 backdrop-blur-md">
         <div className="flex items-center gap-3">
           <Button
             variant="ghost"
@@ -421,14 +421,14 @@ export function InterviewView() {
               className={cn(
                 'w-2 h-2 rounded-full transition-colors',
                 index < currentQuestionIndex
-                  ? 'bg-green-500'
+                  ? 'bg-status-success'
                   : index === currentQuestionIndex
                     ? 'bg-primary'
-                    : 'bg-zinc-700'
+                    : 'bg-muted'
               )}
             />
           ))}
-          {isComplete && <CheckCircle className="w-4 h-4 text-green-500 ml-2" />}
+          {isComplete && <CheckCircle className="w-4 h-4 text-status-success ml-2" />}
         </div>
       </div>
 
@@ -503,7 +503,7 @@ export function InterviewView() {
         {/* Project Setup Form */}
         {showProjectSetup && (
           <div className="mt-6">
-            <Card className="bg-zinc-900/50 border-white/10" data-testid="project-setup-form">
+            <Card className="bg-card border-border" data-testid="project-setup-form">
               <CardContent className="p-6 space-y-4">
                 <div className="flex items-center gap-2 mb-4">
                   <FileText className="w-5 h-5 text-primary" />
@@ -512,7 +512,10 @@ export function InterviewView() {
 
                 <div className="space-y-4">
                   <div className="space-y-2">
-                    <label htmlFor="project-name" className="text-sm font-medium text-zinc-300">
+                    <label
+                      htmlFor="project-name"
+                      className="text-sm font-medium text-foreground-secondary"
+                    >
                       Project Name
                     </label>
                     <Input
@@ -520,13 +523,16 @@ export function InterviewView() {
                       placeholder="my-awesome-project"
                       value={projectName}
                       onChange={(e) => setProjectName(e.target.value)}
-                      className="bg-zinc-950/50 border-white/10 text-white placeholder:text-zinc-500"
+                      className="bg-background/50 border-border text-foreground placeholder:text-muted-foreground"
                       data-testid="interview-project-name-input"
                     />
                   </div>
 
                   <div className="space-y-2">
-                    <label htmlFor="project-path" className="text-sm font-medium text-zinc-300">
+                    <label
+                      htmlFor="project-path"
+                      className="text-sm font-medium text-foreground-secondary"
+                    >
                       Parent Directory
                     </label>
                     <div className="flex gap-2">
@@ -535,13 +541,13 @@ export function InterviewView() {
                         placeholder="/path/to/projects"
                         value={projectPath}
                         onChange={(e) => setProjectPath(e.target.value)}
-                        className="flex-1 bg-zinc-950/50 border-white/10 text-white placeholder:text-zinc-500"
+                        className="flex-1 bg-background/50 border-border text-foreground placeholder:text-muted-foreground"
                         data-testid="interview-project-path-input"
                       />
                       <Button
                         variant="secondary"
                         onClick={handleSelectDirectory}
-                        className="bg-white/5 hover:bg-white/10 text-white border border-white/10"
+                        className="bg-accent hover:bg-accent/80 text-foreground border border-border"
                         data-testid="interview-browse-directory"
                       >
                         Browse
@@ -551,14 +557,14 @@ export function InterviewView() {
 
                   {/* Preview of generated spec */}
                   <div className="space-y-2">
-                    <label className="text-sm font-medium text-zinc-300">
+                    <label className="text-sm font-medium text-foreground-secondary">
                       Generated Specification Preview
                     </label>
                     <div
-                      className="bg-zinc-950/50 border border-white/10 rounded-md p-3 max-h-48 overflow-y-auto"
+                      className="bg-background/50 border border-border rounded-md p-3 max-h-48 overflow-y-auto"
                       data-testid="spec-preview"
                     >
-                      <pre className="text-xs text-zinc-400 whitespace-pre-wrap font-mono">
+                      <pre className="text-xs text-muted-foreground whitespace-pre-wrap font-mono">
                         {generatedSpec}
                       </pre>
                     </div>

--- a/apps/ui/src/components/views/memory-view.tsx
+++ b/apps/ui/src/components/views/memory-view.tsx
@@ -308,7 +308,7 @@ export function MemoryView() {
   return (
     <div className="flex-1 flex flex-col overflow-hidden content-bg" data-testid="memory-view">
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-border bg-glass backdrop-blur-md">
+      <div className="flex items-center justify-between p-4 border-b border-border bg-card/80 backdrop-blur-md">
         <div className="flex items-center gap-3">
           <Brain className="w-5 h-5 text-muted-foreground" />
           <div>

--- a/apps/ui/src/components/views/project-settings-view/project-settings-view.tsx
+++ b/apps/ui/src/components/views/project-settings-view/project-settings-view.tsx
@@ -130,7 +130,7 @@ export function ProjectSettingsView() {
       data-testid="project-settings-view"
     >
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-border bg-glass backdrop-blur-md">
+      <div className="flex items-center justify-between p-4 border-b border-border bg-card/80 backdrop-blur-md">
         <div className="flex items-center gap-3">
           <Settings className="w-5 h-5 text-muted-foreground" />
           <div>

--- a/apps/ui/src/components/views/settings-view/components/settings-header.tsx
+++ b/apps/ui/src/components/views/settings-view/components/settings-header.tsx
@@ -33,7 +33,7 @@ export function SettingsHeader({
                 'w-10 h-10 lg:w-12 lg:h-12 rounded-xl lg:rounded-2xl flex items-center justify-center',
                 'bg-gradient-to-br from-brand-500 to-brand-600',
                 'shadow-lg shadow-brand-500/25',
-                'ring-1 ring-white/10'
+                'ring-1 ring-border'
               )}
             >
               <Cog className="w-5 h-5 lg:w-6 lg:h-6 text-white" />

--- a/apps/ui/src/components/views/settings-view/providers/claude-settings-tab/api-profiles-section.tsx
+++ b/apps/ui/src/components/views/settings-view/providers/claude-settings-tab/api-profiles-section.tsx
@@ -76,7 +76,7 @@ const PROVIDER_TYPE_COLORS: Record<ClaudeCompatibleProviderType, string> = {
   glm: 'bg-emerald-500/20 text-emerald-500',
   minimax: 'bg-purple-500/20 text-purple-500',
   openrouter: 'bg-amber-500/20 text-amber-500',
-  custom: 'bg-zinc-500/20 text-zinc-400',
+  custom: 'bg-muted text-muted-foreground',
 };
 
 // Claude model display names
@@ -850,7 +850,7 @@ function ProviderCard({ provider, onEdit, onDelete, onToggleEnabled }: ProviderC
               {PROVIDER_TYPE_LABELS[provider.providerType]}
             </Badge>
             {!isEnabled && (
-              <Badge variant="secondary" className="text-xs bg-zinc-500/20 text-zinc-400">
+              <Badge variant="secondary" className="text-xs bg-muted text-muted-foreground">
                 Disabled
               </Badge>
             )}

--- a/apps/ui/src/components/views/setup-view.tsx
+++ b/apps/ui/src/components/views/setup-view.tsx
@@ -93,7 +93,7 @@ export function SetupView() {
   return (
     <div className="h-full flex flex-col content-bg" data-testid="setup-view">
       {/* Header */}
-      <div className="shrink-0 border-b border-border bg-glass backdrop-blur-md titlebar-drag-region">
+      <div className="shrink-0 border-b border-border bg-card/80 backdrop-blur-md titlebar-drag-region">
         <div className="px-8 py-4">
           <div className="flex items-center gap-3 titlebar-no-drag">
             <img src="/logo.png" alt="Automaker" className="w-8 h-8" />

--- a/apps/ui/src/components/views/setup-view/steps/cli-setup-step.tsx
+++ b/apps/ui/src/components/views/setup-view/steps/cli-setup-step.tsx
@@ -544,11 +544,11 @@ export function CliSetupStep({ config, state, onNext, onBack, onSkip }: CliSetup
                           <>
                             <p className="text-sm text-red-400">{mainError}</p>
                             {details && (
-                              <div className="mt-2 p-3 rounded bg-black/20 border border-red-500/20">
+                              <div className="mt-2 p-3 rounded bg-muted/20 border border-status-error/20">
                                 <p className="text-xs font-medium text-muted-foreground mb-1">
                                   Technical details:
                                 </p>
-                                <pre className="text-xs text-red-300 whitespace-pre-wrap font-mono">
+                                <pre className="text-xs text-status-error whitespace-pre-wrap font-mono">
                                   {details}
                                 </pre>
                               </div>
@@ -736,13 +736,13 @@ export function CliSetupStep({ config, state, onNext, onBack, onSkip }: CliSetup
 
                         return (
                           <>
-                            <p className="text-sm text-red-400">{mainError}</p>
+                            <p className="text-sm text-status-error">{mainError}</p>
                             {details && (
-                              <div className="mt-2 p-3 rounded bg-black/20 border border-red-500/20">
+                              <div className="mt-2 p-3 rounded bg-muted/20 border border-status-error/20">
                                 <p className="text-xs font-medium text-muted-foreground mb-1">
                                   Technical details:
                                 </p>
-                                <pre className="text-xs text-red-300 whitespace-pre-wrap font-mono">
+                                <pre className="text-xs text-status-error whitespace-pre-wrap font-mono">
                                   {details}
                                 </pre>
                               </div>

--- a/apps/ui/src/components/views/setup-view/steps/github-setup-step.tsx
+++ b/apps/ui/src/components/views/setup-view/steps/github-setup-step.tsx
@@ -82,8 +82,8 @@ export function GitHubSetupStep({ onNext, onBack, onSkip }: GitHubSetupStepProps
   return (
     <div className="space-y-6">
       <div className="text-center mb-8">
-        <div className="w-16 h-16 rounded-xl bg-zinc-800 flex items-center justify-center mx-auto mb-4">
-          <Github className="w-8 h-8 text-white" />
+        <div className="w-16 h-16 rounded-xl bg-muted flex items-center justify-center mx-auto mb-4">
+          <Github className="w-8 h-8 text-foreground" />
         </div>
         <h2 className="text-2xl font-bold text-foreground mb-2">GitHub CLI Setup</h2>
         <p className="text-muted-foreground">Optional - Used for creating pull requests</p>

--- a/apps/ui/src/components/views/spec-view/components/spec-empty-state.tsx
+++ b/apps/ui/src/components/views/spec-view/components/spec-empty-state.tsx
@@ -26,7 +26,7 @@ export function SpecEmptyState({
   return (
     <div className="flex-1 flex flex-col overflow-hidden content-bg" data-testid="spec-view-empty">
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-border bg-glass backdrop-blur-md">
+      <div className="flex items-center justify-between p-4 border-b border-border bg-card/80 backdrop-blur-md">
         <div className="flex items-center gap-3">
           <FileText className="w-5 h-5 text-muted-foreground" />
           <div>

--- a/apps/ui/src/components/views/spec-view/components/spec-header.tsx
+++ b/apps/ui/src/components/views/spec-view/components/spec-header.tsx
@@ -50,7 +50,7 @@ export function SpecHeader({
 
   return (
     <>
-      <div className="flex items-center justify-between p-4 border-b border-border bg-glass backdrop-blur-md">
+      <div className="flex items-center justify-between p-4 border-b border-border bg-card/80 backdrop-blur-md">
         <div className="flex items-center gap-3">
           <FileText className="w-5 h-5 text-muted-foreground" />
           <div>

--- a/apps/ui/src/components/views/welcome-view.tsx
+++ b/apps/ui/src/components/views/welcome-view.tsx
@@ -527,7 +527,7 @@ export function WelcomeView() {
   return (
     <div className="flex-1 flex flex-col content-bg" data-testid="welcome-view">
       {/* Header Section */}
-      <div className="shrink-0 border-b border-border bg-glass backdrop-blur-md">
+      <div className="shrink-0 border-b border-border bg-card/80 backdrop-blur-md">
         <div className="px-8 py-6">
           <div className="flex items-center gap-4 animate-in fade-in slide-in-from-top-2 duration-500">
             <div className="w-12 h-12 rounded-xl bg-linear-to-br from-brand-500/20 to-brand-600/10 border border-brand-500/20 flex items-center justify-center shadow-lg shadow-brand-500/10">

--- a/apps/ui/src/styles/global.css
+++ b/apps/ui/src/styles/global.css
@@ -431,33 +431,7 @@
   display: none; /* Chrome, Safari, Opera */
 }
 
-/* Glass morphism utilities */
 @layer utilities {
-  .glass {
-    @apply backdrop-blur-md border-white/10;
-  }
-
-  .glass-subtle {
-    @apply backdrop-blur-sm border-white/5;
-  }
-
-  .glass-strong {
-    @apply backdrop-blur-xl border-white/20;
-  }
-
-  /* Text color hierarchy utilities */
-  .text-primary-white {
-    color: oklch(1 0 0);
-  }
-
-  .text-secondary {
-    color: oklch(0.588 0 0); /* zinc-400 equivalent */
-  }
-
-  .text-muted {
-    color: oklch(0.525 0 0); /* zinc-500 equivalent */
-  }
-
   /* Brand gradient utilities */
   .gradient-brand {
     background: linear-gradient(135deg, oklch(0.55 0.25 265), oklch(0.5 0.28 270));
@@ -465,19 +439,6 @@
 
   .gradient-brand-subtle {
     background: linear-gradient(135deg, oklch(0.55 0.25 265 / 0.1), oklch(0.5 0.28 270 / 0.1));
-  }
-
-  /* Glass morphism background utilities */
-  .bg-glass {
-    background: var(--card);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-  }
-
-  .bg-glass-80 {
-    background: var(--popover);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
   }
 
   /* Hover state utilities */


### PR DESCRIPTION
## Summary

- Replace ~80 hardcoded Tailwind color values with semantic design tokens for proper dark mode support across all 41 themes
- Remove dead CSS utilities (glass morphism, hardcoded text colors) from global.css
- Migrate neutral colors (zinc/gray/white/black) to foreground/muted/card/border tokens (Tier 1)
- Migrate status colors (green/red/yellow/blue/purple) to status-success/error/warning/info/primary tokens (Tier 2)
- Replace orphaned `bg-glass` usages with `bg-card/80` across 12 view headers

## Test plan

- [ ] Verify `npm run build` passes (confirmed locally)
- [ ] Visual check: dark mode dashboard, board view, settings, interview flow
- [ ] Visual check: light mode — semantic tokens adapt automatically, no regressions expected
- [ ] Verify status indicators (success/error/warning/info) render correctly in escalation dashboard, event feed, PR view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated dashboard styling with semantic color tokens for improved visual consistency
  * Modernized status indicator colors across success, error, warning, and info states
  * Refined border and background colors across UI panels and cards
  * Removed deprecated glass-morphism styling utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->