### PR TITLE
fix(build): remove types export condition causing tsx runtime crash

### DIFF
--- a/libs/dependency-resolver/package.json
+++ b/libs/dependency-resolver/package.json
@@ -7,7 +7,6 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     }

--- a/libs/flows/package.json
+++ b/libs/flows/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     }
   },

--- a/libs/llm-providers/package.json
+++ b/libs/llm-providers/package.json
@@ -7,11 +7,11 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./server": {
-      "types": "./dist/server/index.d.ts",
+      "import": "./dist/server/index.js",
       "default": "./dist/server/index.js"
     }
   },

--- a/libs/observability/package.json
+++ b/libs/observability/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     }
   },

--- a/libs/spec-parser/package.json
+++ b/libs/spec-parser/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     }
   },

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -7,7 +7,6 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     }

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -7,19 +7,19 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./atoms": {
-      "types": "./dist/atoms/index.d.ts",
+      "import": "./dist/atoms/index.js",
       "default": "./dist/atoms/index.js"
     },
     "./molecules": {
-      "types": "./dist/molecules/index.d.ts",
+      "import": "./dist/molecules/index.js",
       "default": "./dist/molecules/index.js"
     },
     "./organisms": {
-      "types": "./dist/organisms/index.d.ts",
+      "import": "./dist/organisms/index.js",
       "default": "./dist/organisms/index.js"
     }
   },

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -7,11 +7,11 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./logger": {
-      "types": "./dist/logger.d.ts",
+      "import": "./dist/logger.js",
       "default": "./dist/logger.js"
     }
   },


### PR DESCRIPTION
## Summary

- Removes `"types"` condition from exports map in all 8 lib package.json files
- Fixes server crash on startup: `SyntaxError: The requested module './logger.js' does not provide an export named 'LogTransport'`

## Root Cause

PR #603 (tsup migration) added `"types": "./dist/index.d.ts"` as an export condition in all packages. tsx (used by `npm run dev` via `tsx watch`) resolves this condition at runtime and loads `.d.ts` files as JavaScript. Since tsup's DTS bundler strips `type` modifiers from re-exports, type-only exports like `LogTransport` appear as value imports — but don't exist in the runtime `.js` file.

## Fix

Remove `"types"` from export conditions. TypeScript still finds `.d.ts` files automatically next to `.js` files via the top-level `"types"` field in each package.json.

## Test plan

- [x] All package imports pass (`node -e "import('@automaker/utils')"` etc.)
- [x] `npm run build:packages` succeeds
- [ ] Dev server starts without `LogTransport` SyntaxError

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module export configurations across internal libraries for improved module resolution compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->