### PR TITLE
fix(ci): eliminate .gitconfig.lock race between parallel runners

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -35,8 +35,12 @@ runs:
     - name: Configure Git for HTTPS
       shell: bash
       # Convert SSH URLs to HTTPS for git dependencies (e.g., @electron/node-gyp)
-      # This is needed because SSH authentication isn't available in CI
-      run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+      # Use a per-workspace config file to avoid .gitconfig.lock races when
+      # multiple self-hosted runners share the same $HOME directory.
+      run: |
+        GIT_CONF="${RUNNER_TEMP:-.}/.gitconfig-ci"
+        git config -f "$GIT_CONF" url."https://github.com/".insteadOf "git@github.com:"
+        echo "GIT_CONFIG_GLOBAL=$GIT_CONF" >> "$GITHUB_ENV"
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
## Summary
- Root cause: 8 self-hosted runners share `~/.gitconfig`. Concurrent `git config --global` calls race for the lock file, failing with "could not lock config file"
- Fix: write git config to a per-workspace temp file (`$RUNNER_TEMP/.gitconfig-ci`) and export `GIT_CONFIG_GLOBAL` so git uses it instead of the shared `~/.gitconfig`
- This was blocking all CI on PRs #610 and #611

## Test plan
- [ ] Multiple CI jobs run concurrently without `.gitconfig.lock` errors
- [ ] `npm install` still resolves git dependencies via HTTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions setup process to use per-workspace Git configuration instead of global configuration for improved CI environment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->