### PR TITLE
fix(build): externalize CJS-only deps in tsup and fix board janitor

### DIFF
--- a/apps/server/src/services/crew-members/board-janitor-check.ts
+++ b/apps/server/src/services/crew-members/board-janitor-check.ts
@@ -1,7 +1,7 @@
 /**
  * Board Janitor Crew Member - Board consistency checks
  *
- * Lightweight check (every 15 min):
+ * Lightweight check (every 10 min):
  *   - Features in review with merged PRs → should be done
  *   - Features in in_progress with no running agent for >4h → orphaned
  *   - Dependency chain: features with deps on done features but deps not cleared
@@ -24,7 +24,7 @@ export const boardJanitorCrewMember: CrewMemberDefinition = {
   id: 'board-janitor',
   displayName: 'Board Janitor',
   templateName: 'board-janitor',
-  defaultSchedule: '*/15 * * * *',
+  defaultSchedule: '*/10 * * * *',
   enabledByDefault: true,
 
   async check(ctx: CrewCheckContext): Promise<CrewCheckResult> {
@@ -57,7 +57,7 @@ export const boardJanitorCrewMember: CrewMemberDefinition = {
         // 1. Features in review with merged PR → should be done
         const reviewFeatures = allFeatures.filter((f) => f.status === 'review');
         for (const feature of reviewFeatures) {
-          if (feature.prMerged) {
+          if (feature.prMergedAt) {
             findings.push({
               type: 'merged-not-done',
               message: `Feature "${feature.title}" has merged PR but is still in review`,

--- a/libs/llm-providers/tsup.config.ts
+++ b/libs/llm-providers/tsup.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
+  external: ['groq-sdk'],
 });

--- a/libs/platform/package.json
+++ b/libs/platform/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "@automaker/types": "1.0.0",
-    "p-limit": "6.2.0"
+    "p-limit": "6.2.0",
+    "tree-kill": "1.2.2"
   },
   "devDependencies": {
     "@types/node": "22.19.3",

--- a/libs/platform/tsup.config.ts
+++ b/libs/platform/tsup.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
+  external: ['tree-kill'],
 });


### PR DESCRIPTION
## Summary
- Mark `tree-kill` and `groq-sdk` as external in tsup configs so their internal `require()` calls aren't bundled into ESM output (fixes "Dynamic require of 'child_process' is not supported" crash)
- Add `tree-kill` to `@automaker/platform` dependencies (was a phantom dep resolved from root)
- Fix board-janitor checking `feature.prMerged` (doesn't exist) instead of `feature.prMergedAt` — merged PRs were silently skipped
- Reduce board-janitor interval from 15min to 10min

## Test plan
- [x] `npm run build:packages` succeeds
- [x] `npm run test:server` — 1874 tests pass
- [ ] Server starts without "Dynamic require" error
- [ ] Board janitor detects merged PRs in review status

🤖 Generated with [Claude Code](https://claude.com/claude-code)