### PR TITLE
fix(build): externalize workspace deps in all tsup configs

### DIFF
--- a/libs/dependency-resolver/tsup.config.ts
+++ b/libs/dependency-resolver/tsup.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
+  external: [/^@automaker\//],
 });

--- a/libs/flows/tsup.config.ts
+++ b/libs/flows/tsup.config.ts
@@ -8,4 +8,5 @@ export default defineConfig({
   sourcemap: true,
   treeshake: true,
   splitting: true, // Enable code splitting for better tree-shaking
+  external: [/^@automaker\//, /^@langchain\//],
 });

--- a/libs/git-utils/tsup.config.ts
+++ b/libs/git-utils/tsup.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
+  external: [/^@automaker\//],
 });

--- a/libs/llm-providers/tsup.config.ts
+++ b/libs/llm-providers/tsup.config.ts
@@ -9,5 +9,5 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
-  external: ['groq-sdk'],
+  external: [/^@automaker\//, 'groq-sdk'],
 });

--- a/libs/model-resolver/tsup.config.ts
+++ b/libs/model-resolver/tsup.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
+  external: [/^@automaker\//],
 });

--- a/libs/observability/tsup.config.ts
+++ b/libs/observability/tsup.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
+  external: [/^@automaker\//],
 });

--- a/libs/platform/tsup.config.ts
+++ b/libs/platform/tsup.config.ts
@@ -7,5 +7,5 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
-  external: ['tree-kill'],
+  external: [/^@automaker\//, 'tree-kill'],
 });

--- a/libs/prompts/tsup.config.ts
+++ b/libs/prompts/tsup.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
+  external: [/^@automaker\//],
 });

--- a/libs/spec-parser/tsup.config.ts
+++ b/libs/spec-parser/tsup.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
+  external: [/^@automaker\//],
 });

--- a/libs/tools/tsup.config.ts
+++ b/libs/tools/tsup.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
+  external: [/^@automaker\//],
 });

--- a/libs/utils/tsup.config.ts
+++ b/libs/utils/tsup.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
+  external: [/^@automaker\//],
 });


### PR DESCRIPTION
## Summary
- Add `external: [/^@automaker\//]` to all 11 lib tsup configs to prevent workspace packages from being re-bundled into downstream consumers
- Also externalize `@langchain/*` in flows package
- Fixes server crash: `git-utils` → `utils` → `platform` → `tree-kill` chain caused `Dynamic require of "child_process" is not supported`

## Test plan
- [x] `npm run build:packages` succeeds
- [x] `npm run test:server` — 1874 tests pass
- [x] Verified `tree-kill` no longer appears in `git-utils/dist/index.js` or `utils/dist/index.js`
- [ ] Server starts without "Dynamic require" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)