### PR TITLE
feat(flows): add event bus integration and world state injection

### DIFF
--- a/libs/flows/src/index.ts
+++ b/libs/flows/src/index.ts
@@ -308,3 +308,23 @@ export {
   type ResearchResult as IdeaResearchResult,
   type ReviewOutput,
 } from './idea-processing/index.js';
+
+// Idea processing nodes — research tree utilities
+export {
+  createResearchTreeSubgraph,
+  createResearchTreeNode,
+  runResearchTree,
+  type AvaTriageAssessment,
+  type AvaSynthesisResult,
+  type ResearchTreeState,
+  ResearchTreeStateAnnotation,
+} from './idea-processing/nodes/ava-research-tree.js';
+export {
+  jonTriage,
+  fanOutGTM,
+  gtmResearchWorker,
+  aggregateGTM,
+  jonSynthesis,
+  type WorldStateContext,
+  type GTMResearchResult,
+} from './idea-processing/nodes/jon-research-tree.js';

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -294,7 +294,16 @@ export type EventType =
   | 'project:lifecycle:prd-approved'
   | 'project:lifecycle:launched'
   | 'project:lifecycle:completed'
-  | 'project:lifecycle:phase-changed';
+  | 'project:lifecycle:phase-changed'
+  // Idea processing events (Ava + Jon research trees)
+  | 'idea:research-started'
+  | 'idea:research-progress'
+  | 'idea:research-completed'
+  | 'idea:ava-analysis'
+  | 'idea:jon-analysis'
+  | 'idea:synthesis-started'
+  | 'idea:synthesis-completed'
+  | 'idea:processing-error';
 
 export type EventCallback = (type: EventType, payload: unknown) => void;
 


### PR DESCRIPTION
## Summary
- Adds 8 `idea:*` event types to `libs/types/src/event.ts` for idea processing lifecycle
- Creates `IdeaProcessingService` in server with EventBus emission and WebSocket streaming
- Implements world state injection for Ava (board/capacity/velocity) and Jon (Discord/launches/backlog) research tree nodes
- Refactors research tree nodes to accept world state context via function parameters

## Test plan
- [ ] `npm run build:packages` succeeds
- [ ] Event types compile and export correctly from `@automaker/types`
- [ ] `IdeaProcessingService` emits correct events
- [ ] Research tree nodes accept world state parameters
- [ ] No regressions in existing flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added event types to track idea research workflows: research started, progress, completed, analysis (Ava/Jon), synthesis start/completion, and processing errors.
  * Expanded public API to expose research-tree and world-state utilities for idea-processing and synthesis workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->