### PR TITLE
feat(tools): add process_idea SharedTool with MCP integration

### DIFF
--- a/libs/tools/src/domains/ideas/index.ts
+++ b/libs/tools/src/domains/ideas/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Ideas domain tools
+ *
+ * Tools for idea processing and management through LangGraph flows.
+ */
+
+export { processIdea } from './process-idea.js';
+export type { ProcessIdeaInput, ProcessIdeaOutput } from './process-idea.js';

--- a/libs/tools/src/domains/ideas/process-idea.ts
+++ b/libs/tools/src/domains/ideas/process-idea.ts
@@ -1,0 +1,99 @@
+/**
+ * process_idea - Shared tool for processing ideas through the LangGraph flow
+ *
+ * This tool wraps the IdeaProcessingService and provides a unified interface
+ * for processing ideas across MCP, REST API, and LangGraph contexts.
+ */
+
+import { z } from 'zod';
+import { defineSharedTool } from '../../define-tool.js';
+import type { ToolContext, ToolResult } from '../../types.js';
+
+/**
+ * Input schema for process_idea tool
+ */
+const ProcessIdeaInputSchema = z.object({
+  idea: z.string().min(1, 'Idea must be a non-empty string'),
+  autoApprove: z.boolean().optional().describe('Automatically approve the idea after processing'),
+  countdownSeconds: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Number of seconds for pre-approval countdown'),
+});
+
+/**
+ * Output schema for process_idea tool
+ */
+const ProcessIdeaOutputSchema = z.object({
+  sessionId: z.string().describe('Unique session ID for tracking the idea processing'),
+  status: z
+    .enum(['processing', 'awaiting_approval', 'completed', 'failed'])
+    .describe('Current status of the idea processing session'),
+  message: z.string().optional().describe('Additional information about the processing status'),
+});
+
+export type ProcessIdeaInput = z.infer<typeof ProcessIdeaInputSchema>;
+export type ProcessIdeaOutput = z.infer<typeof ProcessIdeaOutputSchema>;
+
+/**
+ * process_idea - Process an idea through the LangGraph flow
+ *
+ * Takes an idea string and initiates the processing flow. Returns a session ID
+ * that can be used to track progress and resume if human approval is needed.
+ */
+export const processIdea = defineSharedTool({
+  name: 'process_idea',
+  description:
+    'Process an idea through the LangGraph flow. Returns a session ID for tracking progress and resuming if human approval is needed.',
+  inputSchema: ProcessIdeaInputSchema,
+  outputSchema: ProcessIdeaOutputSchema,
+  metadata: {
+    category: 'ideas',
+    tags: ['ideation', 'langgraph', 'workflow'],
+    version: '1.0.0',
+  },
+  execute: async (input, context) => {
+    try {
+      // Type assertion for input (validated by defineSharedTool)
+      const typedInput = input as ProcessIdeaInput;
+
+      // Get IdeaProcessingService from context
+      const ideaService = context.services?.ideaProcessingService as any;
+
+      if (!ideaService) {
+        return {
+          success: false,
+          error:
+            'IdeaProcessingService not available in context. Ensure the service is injected when executing this tool.',
+        };
+      }
+
+      // Call the service to process the idea
+      const sessionId = await ideaService.processIdea({
+        idea: typedInput.idea,
+        autoApprove: typedInput.autoApprove,
+        countdownSeconds: typedInput.countdownSeconds,
+      });
+
+      return {
+        success: true,
+        data: {
+          sessionId,
+          status: 'processing',
+          message: `Idea processing started. Session ID: ${sessionId}`,
+        },
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        error: `Failed to process idea: ${errorMessage}`,
+        metadata: {
+          originalError: error,
+        },
+      };
+    }
+  },
+});

--- a/libs/tools/src/index.ts
+++ b/libs/tools/src/index.ts
@@ -11,3 +11,6 @@ export { toLangGraphTool, toLangGraphTools } from './adapters/langgraph-adapter.
 export type { ToolContext, ToolResult, SharedTool, ToolDefinition } from './types.js';
 export { toMCPTool, toMCPTools, type MCPToolEntry } from './adapters/index.js';
 export { toExpressRouter, type ExpressAdapterOptions } from './adapters/index.js';
+
+// Domain-specific tools
+export * from './domains/ideas/index.js';

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -25,6 +25,7 @@
     "kanban"
   ],
   "dependencies": {
+    "@automaker/tools": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -20,6 +20,7 @@ import {
   ListToolsRequestSchema,
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
+import { processIdea, toMCPTool } from '@automaker/tools';
 
 // Configuration
 const API_URL = process.env.AUTOMAKER_API_URL || 'http://localhost:3008';
@@ -2614,6 +2615,31 @@ const tools: Tool[] = [
       required: ['datasetName', 'traceId'],
     },
   },
+
+  // ========== Idea Processing ==========
+  {
+    name: 'process_idea',
+    description:
+      'Process an idea through the LangGraph flow. Returns a session ID for tracking progress and resuming if human approval is needed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        idea: {
+          type: 'string',
+          description: 'The idea text to process',
+        },
+        autoApprove: {
+          type: 'boolean',
+          description: 'Automatically approve the idea after processing',
+        },
+        countdownSeconds: {
+          type: 'number',
+          description: 'Number of seconds for pre-approval countdown',
+        },
+      },
+      required: ['idea'],
+    },
+  },
 ];
 
 // Tool implementations
@@ -3648,6 +3674,14 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         traceId: args.traceId,
         observationId: args.observationId,
         metadata: args.metadata,
+      });
+
+    // Idea Processing
+    case 'process_idea':
+      return apiCall('/ideas/process', {
+        idea: args.idea,
+        autoApprove: args.autoApprove,
+        countdownSeconds: args.countdownSeconds,
       });
 
     default:


### PR DESCRIPTION
## Summary
- Adds `process_idea` SharedTool in `libs/tools/src/domains/ideas/` using `defineSharedTool` pattern
- Registers tool in MCP server (`packages/mcp-server/src/index.ts`) for Claude Code plugin access
- Exports `processIdea` and `processIdeaSchema` from `@automaker/tools` package

## Test plan
- [ ] `npm run build -w @automaker/tools` succeeds
- [ ] MCP tool registration compiles without errors
- [ ] `process_idea` tool callable via MCP plugin
- [ ] No regressions in existing MCP tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new idea processing tool enabling users to submit ideas with optional auto-approval and customizable countdown timer settings. The system assigns a session ID for real-time progress tracking and workflow resumption when human approval is needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->