### PR TITLE
fix(setup): prevent crash when research.python is undefined

### DIFF
--- a/apps/server/src/services/gap-analysis-service.ts
+++ b/apps/server/src/services/gap-analysis-service.ts
@@ -593,7 +593,7 @@ export function analyzeGaps(
   }
 
   // --- Python: Ruff ---
-  if (research.python.hasPythonServices && !research.python.hasRuff) {
+  if (research.python?.hasPythonServices && !research.python.hasRuff) {
     addGap({
       id: 'python-ruff',
       category: 'python',
@@ -608,7 +608,7 @@ export function analyzeGaps(
   }
 
   // --- Python: pytest ---
-  if (research.python.hasPythonServices && !research.python.hasPytest) {
+  if (research.python?.hasPythonServices && !research.python.hasPytest) {
     addGap({
       id: 'python-pytest',
       category: 'python',


### PR DESCRIPTION
## Summary
- Gap analysis crashes with `Cannot read properties of undefined (reading 'hasPythonServices')` when the UI calls the endpoint before the research object is fully populated
- Added optional chaining (`research.python?.`) on the two Python check accesses (lines 596, 611)

## Test plan
- [ ] Run gap analysis on a project without Python services — should not crash
- [ ] Run gap analysis on a project with Python services — should still detect gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of gap analysis to prevent runtime errors when Python configuration is missing or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->