### PR TITLE
feat(lead-engineer): production phase orchestration service

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -515,6 +515,20 @@ changelogService.initialize(events, settingsService, featureLoader, projectServi
 const completionDetectorService = new CompletionDetectorService();
 completionDetectorService.initialize(events, featureLoader, projectService, settingsService);
 
+// Initialize Lead Engineer Service — production-phase nerve center
+const { LeadEngineerService } = await import('./services/lead-engineer-service.js');
+const leadEngineerService = new LeadEngineerService(
+  events,
+  featureLoader,
+  autoModeService,
+  projectService,
+  projectLifecycleService,
+  settingsService,
+  metricsService,
+  REPO_ROOT
+);
+leadEngineerService.initialize();
+
 const projmAgent = new ProjMAuthorityAgent(events, authorityService, featureLoader, projectService);
 const emAgent = new EMAuthorityAgent(
   events,
@@ -674,7 +688,15 @@ const crewCheckContext = {
   healthMonitorService,
   autoModeService,
   settingsService,
+  managedProjectPaths: new Set<string>(),
 };
+
+// Sync managed paths when Lead Engineer starts/stops
+events.subscribe((type) => {
+  if (type === 'lead-engineer:started' || type === 'lead-engineer:stopped') {
+    crewCheckContext.managedProjectPaths = new Set(leadEngineerService.getManagedProjectPaths());
+  }
+});
 const crewLoopService = new CrewLoopService(
   events,
   schedulerService,
@@ -1073,6 +1095,10 @@ app.use('/api/crew', createCrewRoutes(crewLoopService));
 app.use('/api/deploy', createDeployRoutes(autoModeService));
 app.use('/api/escalation', createEscalationRoutes(escalationRouter));
 app.use('/api/analytics', createAnalyticsRoutes(events));
+
+// Lead Engineer routes (production-phase nerve center)
+const { createLeadEngineerRoutes } = await import('./routes/lead-engineer/index.js');
+app.use('/api/lead-engineer', createLeadEngineerRoutes(leadEngineerService));
 app.use('/api/langfuse', createLangfuseRoutes());
 app.use('/api/flows', createFlowsRoutes(antagonisticReviewService, projectPlanningService));
 app.use('/api/ideas', createIdeasRoutes(ideaProcessingService));
@@ -1564,6 +1590,7 @@ async function gracefulShutdown() {
     logger.warn('[SHUTDOWN] Failed to write clean shutdown marker:', err);
   }
 
+  leadEngineerService.destroy();
   await autoModeService.shutdown();
   healthMonitorService.stopMonitoring();
   schedulerService.stop();

--- a/apps/server/src/routes/lead-engineer/index.ts
+++ b/apps/server/src/routes/lead-engineer/index.ts
@@ -1,0 +1,90 @@
+/**
+ * Lead Engineer Routes
+ *
+ * POST /api/lead-engineer/start  — Start managing a project
+ * POST /api/lead-engineer/status — Get session + world state
+ * POST /api/lead-engineer/stop   — Stop managing a project
+ */
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { validatePathParams } from '../../middleware/validate-paths.js';
+import type { LeadEngineerService } from '../../services/lead-engineer-service.js';
+import { getErrorMessage, createLogError } from '../common.js';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('LeadEngineerRoutes');
+const logError = createLogError(logger);
+
+export function createLeadEngineerRoutes(service: LeadEngineerService): Router {
+  const router = Router();
+
+  router.post('/start', validatePathParams('projectPath'), async (req: Request, res: Response) => {
+    try {
+      const { projectPath, projectSlug, maxConcurrency } = req.body as {
+        projectPath: string;
+        projectSlug: string;
+        maxConcurrency?: number;
+      };
+
+      if (!projectPath || !projectSlug) {
+        res.status(400).json({ success: false, error: 'projectPath and projectSlug are required' });
+        return;
+      }
+
+      const session = await service.start(projectPath, projectSlug, { maxConcurrency });
+      res.json({ success: true, session });
+    } catch (error) {
+      logError(error, 'Lead Engineer start failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  });
+
+  router.post('/status', validatePathParams('projectPath'), async (req: Request, res: Response) => {
+    try {
+      const { projectPath } = req.body as { projectPath: string };
+
+      if (!projectPath) {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+
+      const session = service.getSession(projectPath);
+      const allSessions = service.getAllSessions().map((s) => ({
+        projectPath: s.projectPath,
+        projectSlug: s.projectSlug,
+        flowState: s.flowState,
+        startedAt: s.startedAt,
+        actionsTaken: s.actionsTaken,
+      }));
+
+      res.json({
+        success: true,
+        session: session || null,
+        allSessions,
+      });
+    } catch (error) {
+      logError(error, 'Lead Engineer status failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  });
+
+  router.post('/stop', validatePathParams('projectPath'), async (req: Request, res: Response) => {
+    try {
+      const { projectPath } = req.body as { projectPath: string };
+
+      if (!projectPath) {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+
+      service.stop(projectPath);
+      res.json({ success: true });
+    } catch (error) {
+      logError(error, 'Lead Engineer stop failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/services/crew-loop-service.ts
+++ b/apps/server/src/services/crew-loop-service.ts
@@ -44,6 +44,8 @@ export interface CrewCheckContext {
   healthMonitorService: HealthMonitorService;
   autoModeService: AutoModeService;
   settingsService: SettingsService;
+  /** Project paths managed by Lead Engineer — crew members should skip these */
+  managedProjectPaths?: Set<string>;
 }
 
 /** Result returned by a crew member's check function */

--- a/apps/server/src/services/crew-members/ava-check.ts
+++ b/apps/server/src/services/crew-members/ava-check.ts
@@ -77,6 +77,8 @@ export const avaCrewMember: CrewMemberDefinition = {
     // 2. Count blocked features
     try {
       for (const projectPath of ctx.projectPaths) {
+        if (ctx.managedProjectPaths?.has(projectPath)) continue;
+
         const allFeatures = await ctx.featureLoader.getAll(projectPath);
         const blockedFeatures = allFeatures.filter((f) => f.status === 'blocked');
         if (blockedFeatures.length >= 3) {

--- a/apps/server/src/services/crew-members/board-janitor-check.ts
+++ b/apps/server/src/services/crew-members/board-janitor-check.ts
@@ -52,6 +52,8 @@ export const boardJanitorCrewMember: CrewMemberDefinition = {
 
     try {
       for (const projectPath of ctx.projectPaths) {
+        if (ctx.managedProjectPaths?.has(projectPath)) continue;
+
         const allFeatures = await ctx.featureLoader.getAll(projectPath);
 
         // 1. Features in review with merged PR → should be done

--- a/apps/server/src/services/crew-members/pr-maintainer-check.ts
+++ b/apps/server/src/services/crew-members/pr-maintainer-check.ts
@@ -134,6 +134,8 @@ export const prMaintainerCrewMember: CrewMemberDefinition = {
 
     try {
       for (const projectPath of ctx.projectPaths) {
+        if (ctx.managedProjectPaths?.has(projectPath)) continue;
+
         const allFeatures = await ctx.featureLoader.getAll(projectPath);
         const reviewFeatures = allFeatures.filter((f) => f.status === 'review');
 

--- a/apps/server/src/services/lead-engineer-rules.ts
+++ b/apps/server/src/services/lead-engineer-rules.ts
@@ -1,0 +1,287 @@
+/**
+ * Lead Engineer fast-path rules
+ *
+ * Pure functions only. No service imports. Only types.
+ * Each rule evaluates a WorldState + event and returns zero or more actions.
+ */
+
+import type {
+  LeadWorldState,
+  LeadRuleAction,
+  LeadFastPathRule,
+  LeadFeatureSnapshot,
+} from '@automaker/types';
+
+// ────────────────────────── Thresholds ──────────────────────────
+
+const ORPHANED_IN_PROGRESS_MS = 4 * 60 * 60 * 1000; // 4 hours
+const STUCK_AGENT_MS = 2 * 60 * 60 * 1000; // 2 hours
+const STALE_REVIEW_MS = 30 * 60 * 1000; // 30 minutes
+
+// ────────────────────────── Helper ──────────────────────────
+
+function featureFromPayload(
+  worldState: LeadWorldState,
+  payload: unknown
+): LeadFeatureSnapshot | undefined {
+  const p = payload as Record<string, unknown> | null;
+  const id = p?.featureId as string | undefined;
+  if (!id) return undefined;
+  return worldState.features[id];
+}
+
+// ────────────────────────── Rules ──────────────────────────
+
+/**
+ * mergedNotDone — Features in review with a merged PR should be moved to done.
+ * Absorbed from: board-janitor
+ */
+export const mergedNotDone: LeadFastPathRule = {
+  name: 'mergedNotDone',
+  description: 'Feature in review with merged PR → move to done',
+  triggers: ['feature:pr-merged', 'feature:status-changed'],
+
+  evaluate(worldState, _eventType, payload): LeadRuleAction[] {
+    const feature = featureFromPayload(worldState, payload);
+    if (!feature) return [];
+    if (feature.status === 'review' && feature.prMergedAt) {
+      return [{ type: 'move_feature', featureId: feature.id, toStatus: 'done' }];
+    }
+    return [];
+  },
+};
+
+/**
+ * orphanedInProgress — In-progress >4h with no running agent → reset to backlog.
+ * Absorbed from: board-janitor
+ */
+export const orphanedInProgress: LeadFastPathRule = {
+  name: 'orphanedInProgress',
+  description: 'In-progress >4h with no running agent → reset to backlog',
+  triggers: ['feature:error', 'feature:stopped', 'lead-engineer:rule-evaluated'],
+
+  evaluate(worldState, _eventType, payload): LeadRuleAction[] {
+    const actions: LeadRuleAction[] = [];
+    const now = Date.now();
+    const runningFeatureIds = new Set(worldState.agents.map((a) => a.featureId));
+
+    // If triggered by a specific feature event, check just that feature
+    const feature = featureFromPayload(worldState, payload);
+    const candidates = feature ? [feature] : Object.values(worldState.features);
+
+    for (const f of candidates) {
+      if (f.status !== 'in_progress') continue;
+      if (runningFeatureIds.has(f.id)) continue;
+      if (!f.startedAt) continue;
+
+      const age = now - new Date(f.startedAt).getTime();
+      if (age > ORPHANED_IN_PROGRESS_MS) {
+        const hours = Math.round(age / (60 * 60 * 1000));
+        actions.push({
+          type: 'reset_feature',
+          featureId: f.id,
+          reason: `Orphaned in-progress for ${hours}h with no running agent`,
+        });
+      }
+    }
+    return actions;
+  },
+};
+
+/**
+ * staleDeps — Blocked feature with all deps done → unblock (move to backlog).
+ * Absorbed from: board-janitor
+ */
+export const staleDeps: LeadFastPathRule = {
+  name: 'staleDeps',
+  description: 'Blocked + all deps done → unblock',
+  triggers: ['feature:status-changed'],
+
+  evaluate(worldState, _eventType, payload): LeadRuleAction[] {
+    const feature = featureFromPayload(worldState, payload);
+    if (!feature) return [];
+    if (feature.status !== 'blocked') return [];
+    if (!feature.dependencies || feature.dependencies.length === 0) return [];
+
+    const allDepsDone = feature.dependencies.every((depId) => {
+      const dep = worldState.features[depId];
+      return dep && (dep.status === 'done' || dep.status === 'verified');
+    });
+
+    if (allDepsDone) {
+      return [{ type: 'unblock_feature', featureId: feature.id }];
+    }
+    return [];
+  },
+};
+
+/**
+ * autoModeHealth — Backlog >0 + auto-mode not running → restart auto-mode.
+ * Absorbed from: ava-check
+ */
+export const autoModeHealth: LeadFastPathRule = {
+  name: 'autoModeHealth',
+  description: 'Backlog >0 + auto-mode not running → restart auto-mode',
+  triggers: ['auto-mode:stopped', 'auto-mode:idle'],
+
+  evaluate(worldState): LeadRuleAction[] {
+    const backlogCount = worldState.boardCounts['backlog'] || 0;
+    if (backlogCount > 0 && !worldState.autoModeRunning) {
+      return [
+        {
+          type: 'restart_auto_mode',
+          projectPath: worldState.projectPath,
+          maxConcurrency: worldState.maxConcurrency,
+        },
+      ];
+    }
+    return [];
+  },
+};
+
+/**
+ * staleReview — In review >30min with no auto-merge → enable auto-merge.
+ * Absorbed from: pr-maintainer
+ */
+export const staleReview: LeadFastPathRule = {
+  name: 'staleReview',
+  description: 'In review >30min + no auto-merge → enable auto-merge',
+  triggers: ['feature:status-changed', 'lead-engineer:rule-evaluated'],
+
+  evaluate(worldState, _eventType, payload): LeadRuleAction[] {
+    const actions: LeadRuleAction[] = [];
+    const now = Date.now();
+
+    const feature = featureFromPayload(worldState, payload);
+    const candidates = feature ? [feature] : Object.values(worldState.features);
+
+    for (const f of candidates) {
+      if (f.status !== 'review') continue;
+      if (!f.prNumber) continue;
+
+      // Check if PR already has auto-merge
+      const pr = worldState.openPRs.find((p) => p.featureId === f.id);
+      if (pr?.autoMergeEnabled) continue;
+
+      // Check age
+      const reviewStart = f.prCreatedAt;
+      if (!reviewStart) continue;
+      const age = now - new Date(reviewStart).getTime();
+      if (age > STALE_REVIEW_MS) {
+        actions.push({
+          type: 'enable_auto_merge',
+          featureId: f.id,
+          prNumber: f.prNumber,
+        });
+      }
+    }
+    return actions;
+  },
+};
+
+/**
+ * stuckAgent — Agent running >2h → send "wrap up" message.
+ * Absorbed from: ava-check
+ */
+export const stuckAgent: LeadFastPathRule = {
+  name: 'stuckAgent',
+  description: 'Agent running >2h → send wrap-up message',
+  triggers: ['lead-engineer:rule-evaluated'],
+
+  evaluate(worldState): LeadRuleAction[] {
+    const actions: LeadRuleAction[] = [];
+    const now = Date.now();
+
+    for (const agent of worldState.agents) {
+      const age = now - new Date(agent.startTime).getTime();
+      if (age > STUCK_AGENT_MS) {
+        const hours = Math.round((age / (60 * 60 * 1000)) * 10) / 10;
+        actions.push({
+          type: 'send_agent_message',
+          featureId: agent.featureId,
+          message: `You have been running for ${hours}h. Please wrap up your current work, commit changes, and create a PR. If you are stuck, describe what's blocking you.`,
+        });
+      }
+    }
+    return actions;
+  },
+};
+
+/**
+ * capacityRestart — Feature completed + agents < max + backlog > 0 + auto-mode stopped → restart.
+ * Absorbed from: ava-check
+ */
+export const capacityRestart: LeadFastPathRule = {
+  name: 'capacityRestart',
+  description: 'Agents < max + backlog > 0 + auto-mode stopped → restart',
+  triggers: ['feature:completed', 'feature:pr-merged'],
+
+  evaluate(worldState): LeadRuleAction[] {
+    const backlogCount = worldState.boardCounts['backlog'] || 0;
+    if (
+      backlogCount > 0 &&
+      !worldState.autoModeRunning &&
+      worldState.agents.length < worldState.maxConcurrency
+    ) {
+      return [
+        {
+          type: 'restart_auto_mode',
+          projectPath: worldState.projectPath,
+          maxConcurrency: worldState.maxConcurrency,
+        },
+      ];
+    }
+    return [];
+  },
+};
+
+/**
+ * projectCompleting — All features done → transition to completing state.
+ */
+export const projectCompleting: LeadFastPathRule = {
+  name: 'projectCompleting',
+  description: 'All features done → trigger project completion',
+  triggers: ['project:completed'],
+
+  evaluate(worldState): LeadRuleAction[] {
+    const total = worldState.metrics.totalFeatures;
+    const completed = worldState.metrics.completedFeatures;
+    if (total > 0 && completed >= total) {
+      return [{ type: 'project_completing' }];
+    }
+    return [];
+  },
+};
+
+// ────────────────────────── Exports ──────────────────────────
+
+/** Default set of fast-path rules */
+export const DEFAULT_RULES: LeadFastPathRule[] = [
+  mergedNotDone,
+  orphanedInProgress,
+  staleDeps,
+  autoModeHealth,
+  staleReview,
+  stuckAgent,
+  capacityRestart,
+  projectCompleting,
+];
+
+/**
+ * Evaluate all applicable rules for an event.
+ * Returns the union of all actions from matching rules.
+ */
+export function evaluateRules(
+  rules: LeadFastPathRule[],
+  worldState: LeadWorldState,
+  eventType: string,
+  eventPayload: unknown
+): LeadRuleAction[] {
+  const actions: LeadRuleAction[] = [];
+  for (const rule of rules) {
+    if (!rule.triggers.includes(eventType)) continue;
+    const ruleActions = rule.evaluate(worldState, eventType, eventPayload);
+    actions.push(...ruleActions);
+  }
+  return actions;
+}

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -1,0 +1,712 @@
+/**
+ * Lead Engineer Service — Production Phase Nerve Center
+ *
+ * Orchestrates the full execution lifecycle for a project:
+ * 1. Triggers from project:lifecycle:launched event or MCP tool
+ * 2. Starts auto-mode and subscribes to the event bus
+ * 3. Maintains a WorldState (board + agents + PRs + metrics)
+ * 4. Evaluates fast-path rules on every event (pure functions, no LLM)
+ * 5. On project completion: CeremonyService handles retro, we handle metrics
+ * 6. Guards crew members from duplicating work on managed projects
+ */
+
+import { createLogger } from '@automaker/utils';
+import type {
+  EventType,
+  Feature,
+  LeadWorldState,
+  LeadFeatureSnapshot,
+  LeadAgentSnapshot,
+  LeadPRSnapshot,
+  LeadMilestoneSnapshot,
+  LeadRuleAction,
+  LeadEngineerSession,
+  LeadEngineerFlowState,
+  LeadRuleLogEntry,
+} from '@automaker/types';
+import type { EventEmitter } from '../lib/events.js';
+import type { FeatureLoader } from './feature-loader.js';
+import type { AutoModeService } from './auto-mode-service.js';
+import type { ProjectService } from './project-service.js';
+import type { ProjectLifecycleService } from './project-lifecycle-service.js';
+import type { SettingsService } from './settings-service.js';
+import type { MetricsService } from './metrics-service.js';
+import { DEFAULT_RULES, evaluateRules } from './lead-engineer-rules.js';
+
+const logger = createLogger('LeadEngineerService');
+
+const WORLD_STATE_REFRESH_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_RULE_LOG_ENTRIES = 200;
+
+export class LeadEngineerService {
+  private sessions = new Map<string, LeadEngineerSession>();
+  private unsubscribe: (() => void) | null = null;
+  private refreshIntervals = new Map<string, ReturnType<typeof setInterval>>();
+
+  constructor(
+    private events: EventEmitter,
+    private featureLoader: FeatureLoader,
+    private autoModeService: AutoModeService,
+    private projectService: ProjectService,
+    private projectLifecycleService: ProjectLifecycleService,
+    private settingsService: SettingsService,
+    private metricsService: MetricsService,
+    private repoRoot: string
+  ) {}
+
+  /**
+   * Subscribe to events for auto-start and routing.
+   */
+  initialize(): void {
+    // Auto-start when a project is launched
+    this.unsubscribe = this.events.subscribe((type: EventType, payload: unknown) => {
+      if (type === 'project:lifecycle:launched') {
+        const p = payload as { projectPath?: string; projectSlug?: string } | null;
+        if (p?.projectPath && p?.projectSlug) {
+          this.start(p.projectPath, p.projectSlug).catch((err) => {
+            logger.error(`Auto-start failed for ${p.projectSlug}:`, err);
+          });
+        }
+        return;
+      }
+
+      // Route all events to managed sessions
+      this.onEvent(type, payload);
+    });
+
+    logger.info('LeadEngineerService initialized');
+  }
+
+  /**
+   * Clean up subscriptions and stop all sessions.
+   */
+  destroy(): void {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
+
+    for (const [projectPath] of this.sessions) {
+      this.stopSession(projectPath);
+    }
+    this.sessions.clear();
+
+    logger.info('LeadEngineerService destroyed');
+  }
+
+  /**
+   * Start managing a project through the production phase.
+   */
+  async start(
+    projectPath: string,
+    projectSlug: string,
+    opts?: { maxConcurrency?: number }
+  ): Promise<LeadEngineerSession> {
+    if (this.sessions.has(projectPath)) {
+      const existing = this.sessions.get(projectPath)!;
+      logger.warn(`Already managing project at ${projectPath}, returning existing session`);
+      return existing;
+    }
+
+    logger.info(`Starting Lead Engineer for ${projectSlug} at ${projectPath}`);
+
+    // Build initial world state
+    const worldState = await this.buildWorldState(projectPath, projectSlug, opts?.maxConcurrency);
+
+    // Create session
+    const session: LeadEngineerSession = {
+      projectPath,
+      projectSlug,
+      flowState: 'running',
+      worldState,
+      startedAt: new Date().toISOString(),
+      ruleLog: [],
+      actionsTaken: 0,
+    };
+
+    this.sessions.set(projectPath, session);
+
+    // Start auto-mode if not already running
+    if (!worldState.autoModeRunning && (worldState.boardCounts['backlog'] || 0) > 0) {
+      try {
+        await this.projectLifecycleService.launch(projectPath, projectSlug, opts?.maxConcurrency);
+      } catch (err) {
+        logger.warn(`Failed to start auto-mode for ${projectSlug}:`, err);
+      }
+    }
+
+    // Set up periodic world state refresh
+    const interval = setInterval(async () => {
+      try {
+        const s = this.sessions.get(projectPath);
+        if (!s || s.flowState !== 'running') return;
+
+        s.worldState = await this.buildWorldState(
+          projectPath,
+          projectSlug,
+          s.worldState.maxConcurrency
+        );
+
+        // Evaluate periodic rules (stuckAgent, staleReview, orphanedInProgress)
+        this.evaluateAndExecute(s, 'lead-engineer:rule-evaluated', {});
+      } catch (err) {
+        logger.error(`WorldState refresh failed for ${projectSlug}:`, err);
+      }
+    }, WORLD_STATE_REFRESH_MS);
+    this.refreshIntervals.set(projectPath, interval);
+
+    this.events.emit('lead-engineer:started', { projectPath, projectSlug });
+    logger.info(`Lead Engineer started for ${projectSlug}`);
+
+    return session;
+  }
+
+  /**
+   * Stop managing a project.
+   */
+  stop(projectPath: string): void {
+    const session = this.sessions.get(projectPath);
+    if (!session) {
+      logger.warn(`No session found for ${projectPath}`);
+      return;
+    }
+
+    this.stopSession(projectPath);
+    session.flowState = 'stopped';
+    session.stoppedAt = new Date().toISOString();
+    this.sessions.delete(projectPath);
+
+    this.events.emit('lead-engineer:stopped', {
+      projectPath,
+      projectSlug: session.projectSlug,
+    });
+
+    logger.info(`Lead Engineer stopped for ${session.projectSlug}`);
+  }
+
+  /**
+   * Get session for a project.
+   */
+  getSession(projectPath: string): LeadEngineerSession | undefined {
+    return this.sessions.get(projectPath);
+  }
+
+  /**
+   * Get all active sessions.
+   */
+  getAllSessions(): LeadEngineerSession[] {
+    return Array.from(this.sessions.values());
+  }
+
+  /**
+   * Check if a project is managed by Lead Engineer.
+   * Used by crew members to skip managed projects.
+   */
+  isManaged(projectPath: string): boolean {
+    return this.sessions.has(projectPath);
+  }
+
+  /**
+   * Get all managed project paths.
+   */
+  getManagedProjectPaths(): string[] {
+    return Array.from(this.sessions.keys());
+  }
+
+  // ────────────────────────── Private ──────────────────────────
+
+  private stopSession(projectPath: string): void {
+    const interval = this.refreshIntervals.get(projectPath);
+    if (interval) {
+      clearInterval(interval);
+      this.refreshIntervals.delete(projectPath);
+    }
+  }
+
+  /**
+   * Route an event to the appropriate session.
+   */
+  private onEvent(type: EventType, payload: unknown): void {
+    const p = payload as Record<string, unknown> | null;
+    const projectPath = p?.projectPath as string | undefined;
+
+    if (projectPath) {
+      const session = this.sessions.get(projectPath);
+      if (session && session.flowState === 'running') {
+        this.updateWorldStateFromEvent(session.worldState, type, payload);
+        this.evaluateAndExecute(session, type, payload);
+      }
+      return;
+    }
+
+    // For events without projectPath (e.g., auto-mode events), try to match by featureId
+    const featureId = p?.featureId as string | undefined;
+    if (featureId) {
+      for (const session of this.sessions.values()) {
+        if (session.flowState !== 'running') continue;
+        if (session.worldState.features[featureId]) {
+          this.updateWorldStateFromEvent(session.worldState, type, payload);
+          this.evaluateAndExecute(session, type, payload);
+          return;
+        }
+      }
+    }
+  }
+
+  /**
+   * Build a complete WorldState from scratch.
+   */
+  private async buildWorldState(
+    projectPath: string,
+    projectSlug: string,
+    maxConcurrency?: number
+  ): Promise<LeadWorldState> {
+    const features = await this.featureLoader.getAll(projectPath);
+
+    // Board counts
+    const boardCounts: Record<string, number> = {};
+    for (const f of features) {
+      const status = f.status || 'backlog';
+      boardCounts[status] = (boardCounts[status] || 0) + 1;
+    }
+
+    // Feature snapshots
+    const featureMap: Record<string, LeadFeatureSnapshot> = {};
+    for (const f of features) {
+      featureMap[f.id] = this.featureToSnapshot(f);
+    }
+
+    // Running agents
+    const agents: LeadAgentSnapshot[] = [];
+    try {
+      const runningAgents = await this.autoModeService.getRunningAgents();
+      for (const a of runningAgents) {
+        if (a.projectPath === projectPath) {
+          agents.push({
+            featureId: a.featureId,
+            startTime: new Date(a.startTime).toISOString(),
+            branch: a.branchName ?? undefined,
+          });
+        }
+      }
+    } catch {
+      // Running agents API may fail
+    }
+
+    // Open PRs
+    const openPRs: LeadPRSnapshot[] = [];
+    const reviewFeatures = features.filter((f) => f.status === 'review' && f.prNumber);
+    for (const f of reviewFeatures) {
+      openPRs.push({
+        featureId: f.id,
+        prNumber: f.prNumber!,
+        prUrl: f.prUrl,
+        prCreatedAt: f.prCreatedAt,
+      });
+    }
+
+    // Milestones
+    const milestones: LeadMilestoneSnapshot[] = [];
+    try {
+      const project = await this.projectService.getProject(projectPath, projectSlug);
+      if (project?.milestones) {
+        for (const ms of project.milestones) {
+          const totalPhases = ms.phases?.length || 0;
+          // Count completed phases by checking if their linked features are done
+          const completedPhases =
+            ms.phases?.filter((p) => {
+              if (!p.featureId) return false;
+              const f = featureMap[p.featureId];
+              return f && (f.status === 'done' || f.status === 'verified');
+            }).length || 0;
+          milestones.push({
+            slug: ms.slug || ms.title.toLowerCase().replace(/\s+/g, '-'),
+            title: ms.title,
+            totalPhases,
+            completedPhases,
+          });
+        }
+      }
+    } catch {
+      // Project may not have milestones
+    }
+
+    // Metrics
+    const completedFeatures = features.filter(
+      (f) => f.status === 'done' || f.status === 'verified'
+    ).length;
+    const totalCostUsd = features.reduce((sum, f) => sum + (f.costUsd || 0), 0);
+
+    let avgCycleTimeMs: number | undefined;
+    try {
+      const metrics = await this.metricsService.getProjectMetrics(projectPath);
+      avgCycleTimeMs = metrics.avgCycleTimeMs > 0 ? metrics.avgCycleTimeMs : undefined;
+    } catch {
+      // Metrics may not be available
+    }
+
+    // Auto-mode status
+    const activeProjects = this.autoModeService.getActiveAutoLoopProjects();
+    const autoModeRunning = activeProjects.includes(projectPath);
+
+    // Resolve max concurrency
+    let resolvedMaxConcurrency = maxConcurrency || 1;
+    try {
+      const settings = await this.settingsService.getGlobalSettings();
+      resolvedMaxConcurrency = maxConcurrency || settings.maxConcurrency || 1;
+    } catch {
+      // Fallback
+    }
+
+    return {
+      projectPath,
+      projectSlug,
+      updatedAt: new Date().toISOString(),
+      boardCounts,
+      features: featureMap,
+      agents,
+      openPRs,
+      milestones,
+      metrics: {
+        totalFeatures: features.length,
+        completedFeatures,
+        totalCostUsd,
+        avgCycleTimeMs,
+      },
+      autoModeRunning,
+      maxConcurrency: resolvedMaxConcurrency,
+    };
+  }
+
+  /**
+   * Incrementally patch WorldState from a single event.
+   */
+  private updateWorldStateFromEvent(
+    state: LeadWorldState,
+    type: EventType,
+    payload: unknown
+  ): void {
+    const p = payload as Record<string, unknown> | null;
+    const featureId = p?.featureId as string | undefined;
+    const now = new Date().toISOString();
+
+    state.updatedAt = now;
+
+    switch (type) {
+      case 'feature:status-changed': {
+        if (featureId && state.features[featureId]) {
+          const newStatus = p?.newStatus as string | undefined;
+          if (newStatus) {
+            const oldStatus = state.features[featureId].status;
+            state.features[featureId].status = newStatus;
+
+            // Update board counts
+            if (oldStatus) {
+              state.boardCounts[oldStatus] = Math.max(0, (state.boardCounts[oldStatus] || 0) - 1);
+            }
+            state.boardCounts[newStatus] = (state.boardCounts[newStatus] || 0) + 1;
+
+            // Update metrics
+            if (newStatus === 'done' || newStatus === 'verified') {
+              state.metrics.completedFeatures++;
+              state.features[featureId].completedAt = now;
+            }
+          }
+        }
+        break;
+      }
+
+      case 'feature:started': {
+        if (featureId && state.features[featureId]) {
+          state.features[featureId].status = 'in_progress';
+          state.features[featureId].startedAt = now;
+          state.agents.push({ featureId, startTime: now });
+        }
+        break;
+      }
+
+      case 'feature:completed':
+      case 'feature:stopped':
+      case 'feature:error': {
+        if (featureId) {
+          state.agents = state.agents.filter((a) => a.featureId !== featureId);
+        }
+        break;
+      }
+
+      case 'feature:pr-merged': {
+        if (featureId && state.features[featureId]) {
+          state.features[featureId].prMergedAt = now;
+          state.openPRs = state.openPRs.filter((pr) => pr.featureId !== featureId);
+        }
+        break;
+      }
+
+      case 'auto-mode:started': {
+        state.autoModeRunning = true;
+        break;
+      }
+
+      case 'auto-mode:stopped': {
+        state.autoModeRunning = false;
+        break;
+      }
+    }
+  }
+
+  /**
+   * Evaluate rules and execute resulting actions.
+   */
+  private evaluateAndExecute(
+    session: LeadEngineerSession,
+    eventType: string,
+    payload: unknown
+  ): void {
+    const actions = evaluateRules(DEFAULT_RULES, session.worldState, eventType, payload);
+
+    if (actions.length === 0) return;
+
+    // Log the evaluation
+    const logEntry: LeadRuleLogEntry = {
+      timestamp: new Date().toISOString(),
+      ruleName: '', // Will be set below
+      eventType,
+      actions,
+    };
+
+    // Determine which rules produced actions (for logging)
+    for (const rule of DEFAULT_RULES) {
+      if (!rule.triggers.includes(eventType)) continue;
+      const ruleActions = rule.evaluate(session.worldState, eventType, payload);
+      if (ruleActions.length > 0) {
+        const entry: LeadRuleLogEntry = {
+          timestamp: new Date().toISOString(),
+          ruleName: rule.name,
+          eventType,
+          actions: ruleActions,
+        };
+        session.ruleLog.push(entry);
+
+        this.events.emit('lead-engineer:rule-evaluated', {
+          projectPath: session.projectPath,
+          ruleName: rule.name,
+          eventType,
+          actionCount: ruleActions.length,
+        });
+      }
+    }
+
+    // Cap rule log size
+    if (session.ruleLog.length > MAX_RULE_LOG_ENTRIES) {
+      session.ruleLog = session.ruleLog.slice(-MAX_RULE_LOG_ENTRIES);
+    }
+
+    // Execute all actions
+    for (const action of actions) {
+      this.executeAction(session, action).catch((err) => {
+        logger.error(`Action execution failed (${action.type}):`, err);
+      });
+    }
+  }
+
+  /**
+   * Execute a single rule action.
+   */
+  private async executeAction(session: LeadEngineerSession, action: LeadRuleAction): Promise<void> {
+    session.actionsTaken++;
+
+    this.events.emit('lead-engineer:action-executed', {
+      projectPath: session.projectPath,
+      actionType: action.type,
+      details: action as unknown as Record<string, unknown>,
+    });
+
+    switch (action.type) {
+      case 'move_feature': {
+        try {
+          await this.featureLoader.update(session.projectPath, action.featureId, {
+            status: action.toStatus,
+          });
+          logger.info(`Moved feature ${action.featureId} to ${action.toStatus}`);
+        } catch (err) {
+          logger.error(`Failed to move feature ${action.featureId}:`, err);
+        }
+        break;
+      }
+
+      case 'reset_feature': {
+        try {
+          await this.featureLoader.update(session.projectPath, action.featureId, {
+            status: 'backlog',
+          });
+          logger.info(`Reset feature ${action.featureId}: ${action.reason}`);
+        } catch (err) {
+          logger.error(`Failed to reset feature ${action.featureId}:`, err);
+        }
+        break;
+      }
+
+      case 'unblock_feature': {
+        try {
+          await this.featureLoader.update(session.projectPath, action.featureId, {
+            status: 'backlog',
+          });
+          logger.info(`Unblocked feature ${action.featureId}`);
+        } catch (err) {
+          logger.error(`Failed to unblock feature ${action.featureId}:`, err);
+        }
+        break;
+      }
+
+      case 'enable_auto_merge': {
+        try {
+          const { execSync } = await import('child_process');
+          execSync(`gh pr merge ${action.prNumber} --auto --squash`, {
+            cwd: session.projectPath,
+            stdio: 'pipe',
+          });
+          logger.info(`Enabled auto-merge on PR #${action.prNumber}`);
+        } catch (err) {
+          logger.warn(`Failed to enable auto-merge on PR #${action.prNumber}:`, err);
+        }
+        break;
+      }
+
+      case 'resolve_threads': {
+        // This would use the PR feedback service; log for now
+        logger.info(
+          `Would resolve threads on PR #${action.prNumber} for feature ${action.featureId}`
+        );
+        break;
+      }
+
+      case 'restart_auto_mode': {
+        try {
+          await this.autoModeService.startAutoLoop(
+            action.projectPath,
+            action.maxConcurrency || session.worldState.maxConcurrency
+          );
+          session.worldState.autoModeRunning = true;
+          logger.info(`Restarted auto-mode for ${action.projectPath}`);
+        } catch (err) {
+          logger.warn(`Failed to restart auto-mode:`, err);
+        }
+        break;
+      }
+
+      case 'stop_agent': {
+        try {
+          await this.autoModeService.stopFeature(action.featureId);
+          logger.info(`Stopped agent for feature ${action.featureId}`);
+        } catch (err) {
+          logger.warn(`Failed to stop agent for ${action.featureId}:`, err);
+        }
+        break;
+      }
+
+      case 'send_agent_message': {
+        try {
+          await this.autoModeService.followUpFeature(
+            session.projectPath,
+            action.featureId,
+            action.message
+          );
+          logger.info(`Sent message to agent for feature ${action.featureId}`);
+        } catch (err) {
+          logger.warn(`Failed to send message to agent ${action.featureId}:`, err);
+        }
+        break;
+      }
+
+      case 'post_discord': {
+        logger.info(`Discord post to ${action.channelId}: ${action.message}`);
+        break;
+      }
+
+      case 'log': {
+        logger[action.level](`[Rule] ${action.message}`);
+        break;
+      }
+
+      case 'escalate_llm': {
+        logger.info(`LLM escalation requested: ${action.reason}`);
+        break;
+      }
+
+      case 'project_completing': {
+        await this.handleProjectCompleting(session);
+        break;
+      }
+    }
+  }
+
+  /**
+   * Handle project completion: transition to completing state.
+   * CeremonyService handles retro + Discord automatically (already subscribed to project:completed).
+   * Lead Engineer aggregates final metrics.
+   */
+  private async handleProjectCompleting(session: LeadEngineerSession): Promise<void> {
+    session.flowState = 'completing';
+    this.events.emit('lead-engineer:project-completing', {
+      projectPath: session.projectPath,
+      projectSlug: session.projectSlug,
+    });
+
+    logger.info(`Project ${session.projectSlug} completing — aggregating final metrics`);
+
+    // Refresh final world state
+    try {
+      session.worldState = await this.buildWorldState(
+        session.projectPath,
+        session.projectSlug,
+        session.worldState.maxConcurrency
+      );
+    } catch (err) {
+      logger.error(`Failed to build final world state:`, err);
+    }
+
+    // Emit completion event
+    this.events.emit('lead-engineer:project-completed', {
+      projectPath: session.projectPath,
+      projectSlug: session.projectSlug,
+    });
+
+    // Transition to idle
+    session.flowState = 'idle';
+
+    // Clean up
+    this.stopSession(session.projectPath);
+    this.sessions.delete(session.projectPath);
+
+    this.events.emit('lead-engineer:stopped', {
+      projectPath: session.projectPath,
+      projectSlug: session.projectSlug,
+    });
+
+    logger.info(`Project ${session.projectSlug} completed. Lead Engineer session ended.`);
+  }
+
+  /**
+   * Convert a Feature to a LeadFeatureSnapshot.
+   */
+  private featureToSnapshot(f: Feature): LeadFeatureSnapshot {
+    return {
+      id: f.id,
+      title: f.title,
+      status: (f.status as string) || 'backlog',
+      branchName: f.branchName,
+      prNumber: f.prNumber,
+      prUrl: f.prUrl,
+      prCreatedAt: f.prCreatedAt,
+      prMergedAt: f.prMergedAt,
+      costUsd: f.costUsd,
+      failureCount: f.failureCount,
+      dependencies: f.dependencies,
+      epicId: f.epicId,
+      isEpic: f.isEpic,
+      complexity: f.complexity,
+      startedAt: f.startedAt,
+      completedAt: f.completedAt,
+    };
+  }
+}

--- a/apps/server/tests/unit/services/lead-engineer-rules.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-rules.test.ts
@@ -1,0 +1,443 @@
+import { describe, it, expect } from 'vitest';
+import type { LeadWorldState, LeadFeatureSnapshot, LeadAgentSnapshot } from '@automaker/types';
+import {
+  mergedNotDone,
+  orphanedInProgress,
+  staleDeps,
+  autoModeHealth,
+  staleReview,
+  stuckAgent,
+  capacityRestart,
+  projectCompleting,
+  evaluateRules,
+  DEFAULT_RULES,
+} from '@/services/lead-engineer-rules.js';
+
+// ────────────────────────── Test Helpers ──────────────────────────
+
+function createMockWorldState(overrides: Partial<LeadWorldState> = {}): LeadWorldState {
+  return {
+    projectPath: '/test/project',
+    projectSlug: 'test-project',
+    updatedAt: new Date().toISOString(),
+    boardCounts: { backlog: 0, in_progress: 0, review: 0, done: 0, blocked: 0 },
+    features: {},
+    agents: [],
+    openPRs: [],
+    milestones: [],
+    metrics: { totalFeatures: 0, completedFeatures: 0, totalCostUsd: 0 },
+    autoModeRunning: true,
+    maxConcurrency: 3,
+    ...overrides,
+  };
+}
+
+function createFeature(overrides: Partial<LeadFeatureSnapshot> = {}): LeadFeatureSnapshot {
+  return {
+    id: 'feat-1',
+    title: 'Test Feature',
+    status: 'backlog',
+    ...overrides,
+  };
+}
+
+// ────────────────────────── mergedNotDone ──────────────────────────
+
+describe('mergedNotDone', () => {
+  it('moves review feature with merged PR to done', () => {
+    const feature = createFeature({
+      id: 'f1',
+      status: 'review',
+      prMergedAt: new Date().toISOString(),
+      prNumber: 100,
+    });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = mergedNotDone.evaluate(ws, 'feature:pr-merged', { featureId: 'f1' });
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toEqual({ type: 'move_feature', featureId: 'f1', toStatus: 'done' });
+  });
+
+  it('no-ops when feature is not in review', () => {
+    const feature = createFeature({ id: 'f1', status: 'in_progress', prMergedAt: '2026-01-01' });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = mergedNotDone.evaluate(ws, 'feature:pr-merged', { featureId: 'f1' });
+    expect(actions).toHaveLength(0);
+  });
+
+  it('no-ops when PR is not merged', () => {
+    const feature = createFeature({ id: 'f1', status: 'review' });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = mergedNotDone.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
+    expect(actions).toHaveLength(0);
+  });
+
+  it('no-ops when featureId is missing from payload', () => {
+    const ws = createMockWorldState();
+    const actions = mergedNotDone.evaluate(ws, 'feature:pr-merged', {});
+    expect(actions).toHaveLength(0);
+  });
+});
+
+// ────────────────────────── orphanedInProgress ──────────────────────────
+
+describe('orphanedInProgress', () => {
+  it('resets feature in-progress >4h with no agent', () => {
+    const fiveHoursAgo = new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString();
+    const feature = createFeature({ id: 'f1', status: 'in_progress', startedAt: fiveHoursAgo });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = orphanedInProgress.evaluate(ws, 'feature:stopped', { featureId: 'f1' });
+    expect(actions).toHaveLength(1);
+    expect(actions[0].type).toBe('reset_feature');
+  });
+
+  it('no-ops when agent is still running', () => {
+    const fiveHoursAgo = new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString();
+    const feature = createFeature({ id: 'f1', status: 'in_progress', startedAt: fiveHoursAgo });
+    const agent: LeadAgentSnapshot = {
+      featureId: 'f1',
+      startTime: fiveHoursAgo,
+    };
+    const ws = createMockWorldState({ features: { f1: feature }, agents: [agent] });
+    const actions = orphanedInProgress.evaluate(ws, 'feature:stopped', { featureId: 'f1' });
+    expect(actions).toHaveLength(0);
+  });
+
+  it('no-ops when in-progress less than 4h', () => {
+    const oneHourAgo = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+    const feature = createFeature({ id: 'f1', status: 'in_progress', startedAt: oneHourAgo });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = orphanedInProgress.evaluate(ws, 'feature:stopped', { featureId: 'f1' });
+    expect(actions).toHaveLength(0);
+  });
+
+  it('scans all features on periodic trigger', () => {
+    const fiveHoursAgo = new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString();
+    const f1 = createFeature({ id: 'f1', status: 'in_progress', startedAt: fiveHoursAgo });
+    const f2 = createFeature({ id: 'f2', status: 'in_progress', startedAt: fiveHoursAgo });
+    const f3 = createFeature({ id: 'f3', status: 'done' });
+    const ws = createMockWorldState({ features: { f1, f2, f3 } });
+    const actions = orphanedInProgress.evaluate(ws, 'lead-engineer:rule-evaluated', {});
+    expect(actions).toHaveLength(2);
+  });
+});
+
+// ────────────────────────── staleDeps ──────────────────────────
+
+describe('staleDeps', () => {
+  it('unblocks feature when all deps are done', () => {
+    const feature = createFeature({
+      id: 'f3',
+      status: 'blocked',
+      dependencies: ['f1', 'f2'],
+    });
+    const f1 = createFeature({ id: 'f1', status: 'done' });
+    const f2 = createFeature({ id: 'f2', status: 'done' });
+    const ws = createMockWorldState({ features: { f1, f2, f3: feature } });
+    const actions = staleDeps.evaluate(ws, 'feature:status-changed', { featureId: 'f3' });
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toEqual({ type: 'unblock_feature', featureId: 'f3' });
+  });
+
+  it('unblocks feature when deps are verified', () => {
+    const feature = createFeature({
+      id: 'f2',
+      status: 'blocked',
+      dependencies: ['f1'],
+    });
+    const f1 = createFeature({ id: 'f1', status: 'verified' });
+    const ws = createMockWorldState({ features: { f1, f2: feature } });
+    const actions = staleDeps.evaluate(ws, 'feature:status-changed', { featureId: 'f2' });
+    expect(actions).toHaveLength(1);
+    expect(actions[0].type).toBe('unblock_feature');
+  });
+
+  it('no-ops when some deps are still in progress', () => {
+    const feature = createFeature({
+      id: 'f3',
+      status: 'blocked',
+      dependencies: ['f1', 'f2'],
+    });
+    const f1 = createFeature({ id: 'f1', status: 'done' });
+    const f2 = createFeature({ id: 'f2', status: 'in_progress' });
+    const ws = createMockWorldState({ features: { f1, f2, f3: feature } });
+    const actions = staleDeps.evaluate(ws, 'feature:status-changed', { featureId: 'f3' });
+    expect(actions).toHaveLength(0);
+  });
+
+  it('no-ops when feature is not blocked', () => {
+    const feature = createFeature({
+      id: 'f2',
+      status: 'backlog',
+      dependencies: ['f1'],
+    });
+    const f1 = createFeature({ id: 'f1', status: 'done' });
+    const ws = createMockWorldState({ features: { f1, f2: feature } });
+    const actions = staleDeps.evaluate(ws, 'feature:status-changed', { featureId: 'f2' });
+    expect(actions).toHaveLength(0);
+  });
+
+  it('no-ops when feature has no deps', () => {
+    const feature = createFeature({ id: 'f1', status: 'blocked' });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = staleDeps.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
+    expect(actions).toHaveLength(0);
+  });
+});
+
+// ────────────────────────── autoModeHealth ──────────────────────────
+
+describe('autoModeHealth', () => {
+  it('restarts auto-mode when backlog > 0 and auto-mode stopped', () => {
+    const ws = createMockWorldState({
+      boardCounts: { backlog: 5 },
+      autoModeRunning: false,
+    });
+    const actions = autoModeHealth.evaluate(ws, 'auto-mode:stopped', {});
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toEqual({
+      type: 'restart_auto_mode',
+      projectPath: '/test/project',
+      maxConcurrency: 3,
+    });
+  });
+
+  it('no-ops when auto-mode is running', () => {
+    const ws = createMockWorldState({
+      boardCounts: { backlog: 5 },
+      autoModeRunning: true,
+    });
+    const actions = autoModeHealth.evaluate(ws, 'auto-mode:stopped', {});
+    expect(actions).toHaveLength(0);
+  });
+
+  it('no-ops when backlog is empty', () => {
+    const ws = createMockWorldState({
+      boardCounts: { backlog: 0 },
+      autoModeRunning: false,
+    });
+    const actions = autoModeHealth.evaluate(ws, 'auto-mode:stopped', {});
+    expect(actions).toHaveLength(0);
+  });
+});
+
+// ────────────────────────── staleReview ──────────────────────────
+
+describe('staleReview', () => {
+  it('enables auto-merge for review feature >30min without auto-merge', () => {
+    const fortyMinAgo = new Date(Date.now() - 40 * 60 * 1000).toISOString();
+    const feature = createFeature({
+      id: 'f1',
+      status: 'review',
+      prNumber: 42,
+      prCreatedAt: fortyMinAgo,
+    });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = staleReview.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toEqual({ type: 'enable_auto_merge', featureId: 'f1', prNumber: 42 });
+  });
+
+  it('no-ops when auto-merge is already enabled', () => {
+    const fortyMinAgo = new Date(Date.now() - 40 * 60 * 1000).toISOString();
+    const feature = createFeature({
+      id: 'f1',
+      status: 'review',
+      prNumber: 42,
+      prCreatedAt: fortyMinAgo,
+    });
+    const ws = createMockWorldState({
+      features: { f1: feature },
+      openPRs: [{ featureId: 'f1', prNumber: 42, autoMergeEnabled: true }],
+    });
+    const actions = staleReview.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
+    expect(actions).toHaveLength(0);
+  });
+
+  it('no-ops when review is < 30min', () => {
+    const tenMinAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const feature = createFeature({
+      id: 'f1',
+      status: 'review',
+      prNumber: 42,
+      prCreatedAt: tenMinAgo,
+    });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = staleReview.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
+    expect(actions).toHaveLength(0);
+  });
+
+  it('no-ops when feature has no PR number', () => {
+    const fortyMinAgo = new Date(Date.now() - 40 * 60 * 1000).toISOString();
+    const feature = createFeature({
+      id: 'f1',
+      status: 'review',
+      prCreatedAt: fortyMinAgo,
+    });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = staleReview.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
+    expect(actions).toHaveLength(0);
+  });
+});
+
+// ────────────────────────── stuckAgent ──────────────────────────
+
+describe('stuckAgent', () => {
+  it('sends wrap-up message to agent running >2h', () => {
+    const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+    const ws = createMockWorldState({
+      agents: [{ featureId: 'f1', startTime: threeHoursAgo }],
+    });
+    const actions = stuckAgent.evaluate(ws, 'lead-engineer:rule-evaluated', {});
+    expect(actions).toHaveLength(1);
+    expect(actions[0].type).toBe('send_agent_message');
+    if (actions[0].type === 'send_agent_message') {
+      expect(actions[0].featureId).toBe('f1');
+      expect(actions[0].message).toContain('wrap up');
+    }
+  });
+
+  it('no-ops when agents are under 2h', () => {
+    const oneHourAgo = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+    const ws = createMockWorldState({
+      agents: [{ featureId: 'f1', startTime: oneHourAgo }],
+    });
+    const actions = stuckAgent.evaluate(ws, 'lead-engineer:rule-evaluated', {});
+    expect(actions).toHaveLength(0);
+  });
+
+  it('sends message to multiple stuck agents', () => {
+    const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+    const ws = createMockWorldState({
+      agents: [
+        { featureId: 'f1', startTime: threeHoursAgo },
+        { featureId: 'f2', startTime: threeHoursAgo },
+      ],
+    });
+    const actions = stuckAgent.evaluate(ws, 'lead-engineer:rule-evaluated', {});
+    expect(actions).toHaveLength(2);
+  });
+
+  it('no-ops when no agents running', () => {
+    const ws = createMockWorldState();
+    const actions = stuckAgent.evaluate(ws, 'lead-engineer:rule-evaluated', {});
+    expect(actions).toHaveLength(0);
+  });
+});
+
+// ────────────────────────── capacityRestart ──────────────────────────
+
+describe('capacityRestart', () => {
+  it('restarts auto-mode when agents < max and backlog > 0 and auto-mode stopped', () => {
+    const ws = createMockWorldState({
+      boardCounts: { backlog: 3 },
+      autoModeRunning: false,
+      agents: [{ featureId: 'f1', startTime: new Date().toISOString() }],
+      maxConcurrency: 3,
+    });
+    const actions = capacityRestart.evaluate(ws, 'feature:completed', { featureId: 'f2' });
+    expect(actions).toHaveLength(1);
+    expect(actions[0].type).toBe('restart_auto_mode');
+  });
+
+  it('no-ops when auto-mode is running', () => {
+    const ws = createMockWorldState({
+      boardCounts: { backlog: 3 },
+      autoModeRunning: true,
+    });
+    const actions = capacityRestart.evaluate(ws, 'feature:completed', { featureId: 'f2' });
+    expect(actions).toHaveLength(0);
+  });
+
+  it('no-ops when at max capacity', () => {
+    const ws = createMockWorldState({
+      boardCounts: { backlog: 3 },
+      autoModeRunning: false,
+      agents: [
+        { featureId: 'f1', startTime: new Date().toISOString() },
+        { featureId: 'f2', startTime: new Date().toISOString() },
+        { featureId: 'f3', startTime: new Date().toISOString() },
+      ],
+      maxConcurrency: 3,
+    });
+    const actions = capacityRestart.evaluate(ws, 'feature:completed', { featureId: 'f4' });
+    expect(actions).toHaveLength(0);
+  });
+
+  it('no-ops when backlog is empty', () => {
+    const ws = createMockWorldState({
+      boardCounts: { backlog: 0 },
+      autoModeRunning: false,
+    });
+    const actions = capacityRestart.evaluate(ws, 'feature:completed', {});
+    expect(actions).toHaveLength(0);
+  });
+});
+
+// ────────────────────────── projectCompleting ──────────────────────────
+
+describe('projectCompleting', () => {
+  it('fires when all features are done', () => {
+    const ws = createMockWorldState({
+      metrics: { totalFeatures: 5, completedFeatures: 5, totalCostUsd: 10 },
+    });
+    const actions = projectCompleting.evaluate(ws, 'project:completed', {});
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toEqual({ type: 'project_completing' });
+  });
+
+  it('no-ops when not all features are done', () => {
+    const ws = createMockWorldState({
+      metrics: { totalFeatures: 5, completedFeatures: 3, totalCostUsd: 10 },
+    });
+    const actions = projectCompleting.evaluate(ws, 'project:completed', {});
+    expect(actions).toHaveLength(0);
+  });
+
+  it('no-ops when there are no features', () => {
+    const ws = createMockWorldState({
+      metrics: { totalFeatures: 0, completedFeatures: 0, totalCostUsd: 0 },
+    });
+    const actions = projectCompleting.evaluate(ws, 'project:completed', {});
+    expect(actions).toHaveLength(0);
+  });
+});
+
+// ────────────────────────── evaluateRules ──────────────────────────
+
+describe('evaluateRules', () => {
+  it('only runs rules matching the event type', () => {
+    const feature = createFeature({
+      id: 'f1',
+      status: 'review',
+      prMergedAt: new Date().toISOString(),
+    });
+    const ws = createMockWorldState({
+      features: { f1: feature },
+      boardCounts: { backlog: 5 },
+      autoModeRunning: false,
+    });
+    // 'feature:pr-merged' should trigger mergedNotDone and capacityRestart
+    const actions = evaluateRules(DEFAULT_RULES, ws, 'feature:pr-merged', { featureId: 'f1' });
+    const actionTypes = actions.map((a) => a.type);
+    expect(actionTypes).toContain('move_feature');
+    expect(actionTypes).toContain('restart_auto_mode');
+  });
+
+  it('returns empty array when no rules match', () => {
+    const ws = createMockWorldState();
+    const actions = evaluateRules(DEFAULT_RULES, ws, 'some:random-event', {});
+    expect(actions).toHaveLength(0);
+  });
+
+  it('collects actions from multiple matching rules', () => {
+    const fiveHoursAgo = new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString();
+    const f1 = createFeature({ id: 'f1', status: 'in_progress', startedAt: fiveHoursAgo });
+    const ws = createMockWorldState({
+      features: { f1 },
+      agents: [{ featureId: 'f1', startTime: fiveHoursAgo }],
+    });
+    // 'feature:stopped' triggers orphanedInProgress only, but agent is running so no action
+    const actions = evaluateRules(DEFAULT_RULES, ws, 'feature:stopped', { featureId: 'f1' });
+    expect(actions).toHaveLength(0);
+  });
+});

--- a/apps/server/tests/unit/services/lead-engineer-service.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-service.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { EventType, Feature } from '@automaker/types';
+import { LeadEngineerService } from '@/services/lead-engineer-service.js';
+
+// ────────────────────────── Mocks ──────────────────────────
+
+function createMockEvents() {
+  const subscribers: Array<(type: EventType, payload: unknown) => void> = [];
+  return {
+    emit: vi.fn(),
+    subscribe: vi.fn((cb: (type: EventType, payload: unknown) => void) => {
+      subscribers.push(cb);
+      const unsub = () => {
+        const idx = subscribers.indexOf(cb);
+        if (idx >= 0) subscribers.splice(idx, 1);
+      };
+      (unsub as any).unsubscribe = unsub;
+      return unsub;
+    }),
+    _fire(type: EventType, payload: unknown) {
+      for (const cb of subscribers) cb(type, payload);
+    },
+    _subscribers: subscribers,
+  };
+}
+
+function createMockFeature(overrides: Partial<Feature> = {}): Feature {
+  return {
+    id: 'f1',
+    category: 'feature',
+    description: 'Test feature',
+    status: 'backlog',
+    ...overrides,
+  };
+}
+
+function createMockFeatureLoader(features: Feature[] = []) {
+  return {
+    getAll: vi.fn().mockResolvedValue(features),
+    update: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn().mockImplementation(async (_path: string, id: string) => {
+      return features.find((f) => f.id === id) || null;
+    }),
+  };
+}
+
+function createMockAutoModeService() {
+  return {
+    getRunningAgents: vi.fn().mockResolvedValue([]),
+    getActiveAutoLoopProjects: vi.fn().mockReturnValue([]),
+    startAutoLoop: vi.fn().mockResolvedValue(undefined),
+    stopFeature: vi.fn().mockResolvedValue(true),
+    followUpFeature: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockProjectService() {
+  return {
+    getProject: vi.fn().mockResolvedValue({
+      title: 'Test Project',
+      slug: 'test-project',
+      milestones: [],
+    }),
+  };
+}
+
+function createMockProjectLifecycleService() {
+  return {
+    launch: vi.fn().mockResolvedValue({ autoModeStarted: true }),
+  };
+}
+
+function createMockSettingsService() {
+  return {
+    getGlobalSettings: vi.fn().mockResolvedValue({ maxConcurrency: 3 }),
+  };
+}
+
+function createMockMetricsService() {
+  return {
+    getProjectMetrics: vi.fn().mockResolvedValue({
+      avgCycleTimeMs: 60000,
+      totalCostUsd: 5.0,
+      completedFeatures: 3,
+    }),
+  };
+}
+
+// ────────────────────────── Tests ──────────────────────────
+
+describe('LeadEngineerService', () => {
+  let service: LeadEngineerService;
+  let events: ReturnType<typeof createMockEvents>;
+  let featureLoader: ReturnType<typeof createMockFeatureLoader>;
+  let autoModeService: ReturnType<typeof createMockAutoModeService>;
+  let projectService: ReturnType<typeof createMockProjectService>;
+  let projectLifecycleService: ReturnType<typeof createMockProjectLifecycleService>;
+  let settingsService: ReturnType<typeof createMockSettingsService>;
+  let metricsService: ReturnType<typeof createMockMetricsService>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    events = createMockEvents();
+    featureLoader = createMockFeatureLoader([]);
+    autoModeService = createMockAutoModeService();
+    projectService = createMockProjectService();
+    projectLifecycleService = createMockProjectLifecycleService();
+    settingsService = createMockSettingsService();
+    metricsService = createMockMetricsService();
+
+    service = new LeadEngineerService(
+      events as any,
+      featureLoader as any,
+      autoModeService as any,
+      projectService as any,
+      projectLifecycleService as any,
+      settingsService as any,
+      metricsService as any,
+      '/test/repo'
+    );
+  });
+
+  afterEach(() => {
+    service.destroy();
+    vi.useRealTimers();
+  });
+
+  // ──── Session Management ────
+
+  describe('session management', () => {
+    it('starts a session and emits lead-engineer:started', async () => {
+      service.initialize();
+      const session = await service.start('/test/project', 'my-project');
+
+      expect(session.projectPath).toBe('/test/project');
+      expect(session.projectSlug).toBe('my-project');
+      expect(session.flowState).toBe('running');
+      expect(events.emit).toHaveBeenCalledWith('lead-engineer:started', {
+        projectPath: '/test/project',
+        projectSlug: 'my-project',
+      });
+    });
+
+    it('returns existing session on duplicate start', async () => {
+      service.initialize();
+      const session1 = await service.start('/test/project', 'my-project');
+      const session2 = await service.start('/test/project', 'my-project');
+
+      expect(session1).toBe(session2);
+    });
+
+    it('stops a session and emits lead-engineer:stopped', async () => {
+      service.initialize();
+      await service.start('/test/project', 'my-project');
+      service.stop('/test/project');
+
+      expect(events.emit).toHaveBeenCalledWith('lead-engineer:stopped', {
+        projectPath: '/test/project',
+        projectSlug: 'my-project',
+      });
+      expect(service.getSession('/test/project')).toBeUndefined();
+    });
+
+    it('isManaged returns true for managed projects', async () => {
+      service.initialize();
+      expect(service.isManaged('/test/project')).toBe(false);
+
+      await service.start('/test/project', 'my-project');
+      expect(service.isManaged('/test/project')).toBe(true);
+
+      service.stop('/test/project');
+      expect(service.isManaged('/test/project')).toBe(false);
+    });
+
+    it('getManagedProjectPaths returns all managed paths', async () => {
+      service.initialize();
+      await service.start('/test/project-a', 'project-a');
+      await service.start('/test/project-b', 'project-b');
+
+      expect(service.getManagedProjectPaths()).toEqual(
+        expect.arrayContaining(['/test/project-a', '/test/project-b'])
+      );
+    });
+
+    it('getAllSessions returns all active sessions', async () => {
+      service.initialize();
+      await service.start('/test/project-a', 'project-a');
+      await service.start('/test/project-b', 'project-b');
+
+      expect(service.getAllSessions()).toHaveLength(2);
+    });
+  });
+
+  // ──── Auto-start from lifecycle event ────
+
+  describe('auto-start', () => {
+    it('auto-starts when project:lifecycle:launched fires', async () => {
+      service.initialize();
+
+      // Simulate lifecycle launched event
+      events._fire('project:lifecycle:launched' as EventType, {
+        projectPath: '/test/project',
+        projectSlug: 'my-project',
+      });
+
+      // Wait for async start
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(service.isManaged('/test/project')).toBe(true);
+    });
+  });
+
+  // ──── Event routing ────
+
+  describe('event routing', () => {
+    it('ignores events for unmanaged projects', async () => {
+      service.initialize();
+      await service.start('/test/project', 'my-project');
+
+      // Fire event for a different project
+      events._fire('feature:status-changed' as EventType, {
+        featureId: 'f1',
+        projectPath: '/other/project',
+        newStatus: 'done',
+      });
+
+      // No actions should be taken — session unaffected
+      const session = service.getSession('/test/project');
+      expect(session?.actionsTaken).toBe(0);
+    });
+
+    it('routes events by featureId when projectPath is missing', async () => {
+      const features = [createMockFeature({ id: 'f1', status: 'in_progress' })];
+      featureLoader = createMockFeatureLoader(features);
+      service = new LeadEngineerService(
+        events as any,
+        featureLoader as any,
+        autoModeService as any,
+        projectService as any,
+        projectLifecycleService as any,
+        settingsService as any,
+        metricsService as any,
+        '/test/repo'
+      );
+      service.initialize();
+      await service.start('/test/project', 'my-project');
+
+      // Feature event without projectPath but with featureId
+      events._fire('feature:completed' as EventType, { featureId: 'f1' });
+
+      // The agent should be removed from world state
+      const session = service.getSession('/test/project');
+      expect(session?.worldState.agents.find((a) => a.featureId === 'f1')).toBeUndefined();
+    });
+  });
+
+  // ──── WorldState updates ────
+
+  describe('world state updates', () => {
+    it('patches board counts on feature:status-changed', async () => {
+      const features = [createMockFeature({ id: 'f1', status: 'review' })];
+      featureLoader = createMockFeatureLoader(features);
+      service = new LeadEngineerService(
+        events as any,
+        featureLoader as any,
+        autoModeService as any,
+        projectService as any,
+        projectLifecycleService as any,
+        settingsService as any,
+        metricsService as any,
+        '/test/repo'
+      );
+      service.initialize();
+      await service.start('/test/project', 'my-project');
+
+      events._fire('feature:status-changed' as EventType, {
+        featureId: 'f1',
+        oldStatus: 'review',
+        newStatus: 'done',
+        projectPath: '/test/project',
+      });
+
+      const session = service.getSession('/test/project');
+      expect(session?.worldState.features['f1'].status).toBe('done');
+    });
+
+    it('updates autoModeRunning on auto-mode events', async () => {
+      service.initialize();
+      await service.start('/test/project', 'my-project');
+
+      events._fire('auto-mode:started' as EventType, { projectPath: '/test/project' });
+      expect(service.getSession('/test/project')?.worldState.autoModeRunning).toBe(true);
+
+      events._fire('auto-mode:stopped' as EventType, { projectPath: '/test/project' });
+      expect(service.getSession('/test/project')?.worldState.autoModeRunning).toBe(false);
+    });
+  });
+
+  // ──── Flow state transitions ────
+
+  describe('flow state transitions', () => {
+    it('starts in running state', async () => {
+      service.initialize();
+      const session = await service.start('/test/project', 'my-project');
+      expect(session.flowState).toBe('running');
+    });
+
+    it('transitions to stopped on stop()', async () => {
+      service.initialize();
+      await service.start('/test/project', 'my-project');
+      service.stop('/test/project');
+
+      // Session is removed after stop, but stopped event was emitted
+      expect(events.emit).toHaveBeenCalledWith('lead-engineer:stopped', expect.any(Object));
+    });
+  });
+
+  // ──── Action execution ────
+
+  describe('action execution', () => {
+    it('launches auto-mode on start when backlog > 0', async () => {
+      const features = [
+        createMockFeature({ id: 'f1', status: 'backlog' }),
+        createMockFeature({ id: 'f2', status: 'backlog' }),
+      ];
+      featureLoader = createMockFeatureLoader(features);
+      service = new LeadEngineerService(
+        events as any,
+        featureLoader as any,
+        autoModeService as any,
+        projectService as any,
+        projectLifecycleService as any,
+        settingsService as any,
+        metricsService as any,
+        '/test/repo'
+      );
+      service.initialize();
+      await service.start('/test/project', 'my-project');
+
+      expect(projectLifecycleService.launch).toHaveBeenCalledWith(
+        '/test/project',
+        'my-project',
+        undefined
+      );
+    });
+
+    it('does not launch auto-mode when auto-mode is already running', async () => {
+      autoModeService.getActiveAutoLoopProjects.mockReturnValue(['/test/project']);
+      service.initialize();
+      await service.start('/test/project', 'my-project');
+
+      expect(projectLifecycleService.launch).not.toHaveBeenCalled();
+    });
+  });
+
+  // ──── Cleanup ────
+
+  describe('cleanup', () => {
+    it('destroy clears all sessions and subscriptions', async () => {
+      service.initialize();
+      await service.start('/test/project', 'my-project');
+      expect(service.getAllSessions()).toHaveLength(1);
+
+      service.destroy();
+      expect(service.getAllSessions()).toHaveLength(0);
+    });
+  });
+});

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -303,7 +303,14 @@ export type EventType =
   | 'idea:jon-analysis'
   | 'idea:synthesis-started'
   | 'idea:synthesis-completed'
-  | 'idea:processing-error';
+  | 'idea:processing-error'
+  // Lead Engineer events (production-phase nerve center)
+  | 'lead-engineer:started'
+  | 'lead-engineer:stopped'
+  | 'lead-engineer:action-executed'
+  | 'lead-engineer:rule-evaluated'
+  | 'lead-engineer:project-completing'
+  | 'lead-engineer:project-completed';
 
 export type EventCallback = (type: EventType, payload: unknown) => void;
 
@@ -508,6 +515,23 @@ export interface EventPayloadMap {
   // Milestone/project lifecycle
   'milestone:completed': { milestone?: string; projectPath?: string };
   'project:completed': { project?: string; projectPath?: string };
+
+  // Lead Engineer events
+  'lead-engineer:started': { projectPath: string; projectSlug: string };
+  'lead-engineer:stopped': { projectPath: string; projectSlug: string };
+  'lead-engineer:action-executed': {
+    projectPath: string;
+    actionType: string;
+    details?: Record<string, unknown>;
+  };
+  'lead-engineer:rule-evaluated': {
+    projectPath: string;
+    ruleName: string;
+    eventType: string;
+    actionCount: number;
+  };
+  'lead-engineer:project-completing': { projectPath: string; projectSlug: string };
+  'lead-engineer:project-completed': { projectPath: string; projectSlug: string };
 }
 
 /**

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -723,3 +723,17 @@ export type {
   PhaseApprovalInterrupt,
   GenericInterrupt,
 } from './copilotkit.js';
+
+// Lead Engineer types (production-phase nerve center)
+export type {
+  LeadFeatureSnapshot,
+  LeadAgentSnapshot,
+  LeadPRSnapshot,
+  LeadMilestoneSnapshot,
+  LeadWorldState,
+  LeadRuleAction,
+  LeadFastPathRule,
+  LeadEngineerFlowState,
+  LeadEngineerSession,
+  LeadRuleLogEntry,
+} from './lead-engineer.js';

--- a/libs/types/src/lead-engineer.ts
+++ b/libs/types/src/lead-engineer.ts
@@ -1,0 +1,158 @@
+/**
+ * Lead Engineer Service types
+ *
+ * The Lead Engineer is the production-phase nerve center.
+ * It orchestrates auto-mode, reacts to events with fast-path rules,
+ * and wraps up projects with retro + improvement tickets.
+ */
+
+import type { FeatureStatus } from './feature.js';
+
+// ────────────────────────── Snapshots ──────────────────────────
+
+/** Per-feature state as seen by the Lead Engineer */
+export interface LeadFeatureSnapshot {
+  id: string;
+  title?: string;
+  status: FeatureStatus | string;
+  branchName?: string;
+  prNumber?: number;
+  prUrl?: string;
+  prCreatedAt?: string;
+  prMergedAt?: string;
+  costUsd?: number;
+  failureCount?: number;
+  dependencies?: string[];
+  epicId?: string;
+  isEpic?: boolean;
+  complexity?: 'small' | 'medium' | 'large' | 'architectural';
+  startedAt?: string;
+  completedAt?: string;
+}
+
+/** Running agent snapshot */
+export interface LeadAgentSnapshot {
+  featureId: string;
+  startTime: string;
+  branch?: string;
+}
+
+/** Open PR snapshot */
+export interface LeadPRSnapshot {
+  featureId: string;
+  prNumber: number;
+  prUrl?: string;
+  prCreatedAt?: string;
+  autoMergeEnabled?: boolean;
+  unresolvedThreads?: number;
+}
+
+/** Milestone progress snapshot */
+export interface LeadMilestoneSnapshot {
+  slug: string;
+  title: string;
+  totalPhases: number;
+  completedPhases: number;
+}
+
+// ────────────────────────── World State ──────────────────────────
+
+/** Comprehensive state of a managed project */
+export interface LeadWorldState {
+  projectPath: string;
+  projectSlug: string;
+  updatedAt: string;
+
+  /** Board counts by status */
+  boardCounts: Record<string, number>;
+
+  /** Per-feature state map (featureId → snapshot) */
+  features: Record<string, LeadFeatureSnapshot>;
+
+  /** Currently running agents */
+  agents: LeadAgentSnapshot[];
+
+  /** Open PRs */
+  openPRs: LeadPRSnapshot[];
+
+  /** Milestone progress */
+  milestones: LeadMilestoneSnapshot[];
+
+  /** Aggregate metrics */
+  metrics: {
+    totalFeatures: number;
+    completedFeatures: number;
+    totalCostUsd: number;
+    avgCycleTimeMs?: number;
+  };
+
+  /** Auto-mode running? */
+  autoModeRunning: boolean;
+
+  /** Max concurrency for auto-mode */
+  maxConcurrency: number;
+}
+
+// ────────────────────────── Rule Actions ──────────────────────────
+
+/** Discriminated union of actions a rule can emit */
+export type LeadRuleAction =
+  | { type: 'move_feature'; featureId: string; toStatus: FeatureStatus }
+  | { type: 'reset_feature'; featureId: string; reason: string }
+  | { type: 'unblock_feature'; featureId: string }
+  | { type: 'enable_auto_merge'; featureId: string; prNumber: number }
+  | { type: 'resolve_threads'; featureId: string; prNumber: number }
+  | { type: 'restart_auto_mode'; projectPath: string; maxConcurrency?: number }
+  | { type: 'stop_agent'; featureId: string }
+  | { type: 'send_agent_message'; featureId: string; message: string }
+  | { type: 'post_discord'; channelId: string; message: string }
+  | { type: 'log'; level: 'info' | 'warn' | 'error'; message: string }
+  | { type: 'escalate_llm'; reason: string; context: Record<string, unknown> }
+  | { type: 'project_completing' };
+
+// ────────────────────────── Fast-Path Rules ──────────────────────────
+
+/** A fast-path rule: pure function, no LLM, no service imports */
+export interface LeadFastPathRule {
+  /** Unique rule name */
+  name: string;
+  /** Human-readable description */
+  description: string;
+  /** Event types that trigger this rule */
+  triggers: string[];
+  /** Pure function: given world state + event, return actions (or empty array) */
+  evaluate: (
+    worldState: LeadWorldState,
+    eventType: string,
+    eventPayload: unknown
+  ) => LeadRuleAction[];
+}
+
+// ────────────────────────── Session ──────────────────────────
+
+/** Flow state machine for a managed project */
+export type LeadEngineerFlowState = 'idle' | 'running' | 'completing' | 'stopped';
+
+/** Per-project session maintained by the Lead Engineer */
+export interface LeadEngineerSession {
+  projectPath: string;
+  projectSlug: string;
+  flowState: LeadEngineerFlowState;
+  worldState: LeadWorldState;
+  startedAt: string;
+  stoppedAt?: string;
+
+  /** Rolling log of rule evaluations (capped at 200) */
+  ruleLog: LeadRuleLogEntry[];
+
+  /** Count of actions taken since session start */
+  actionsTaken: number;
+}
+
+/** Entry in the rule evaluation log */
+export interface LeadRuleLogEntry {
+  timestamp: string;
+  ruleName: string;
+  eventType: string;
+  actions: LeadRuleAction[];
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1699,6 +1699,60 @@ const tools: Tool[] = [
     },
   },
 
+  // ========== Lead Engineer (Production Phase) ==========
+  {
+    name: 'start_lead_engineer',
+    description:
+      'Start the Lead Engineer to manage a project through the production phase. Orchestrates auto-mode, reacts to events with fast-path rules, and wraps up with retro + improvement tickets.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        projectSlug: {
+          type: 'string',
+          description: 'Project slug',
+        },
+        maxConcurrency: {
+          type: 'number',
+          description: 'Maximum number of features to process concurrently (default: 1)',
+        },
+      },
+      required: ['projectPath', 'projectSlug'],
+    },
+  },
+  {
+    name: 'stop_lead_engineer',
+    description: 'Stop the Lead Engineer from managing a project.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+  {
+    name: 'get_lead_engineer_status',
+    description:
+      'Get Lead Engineer status including world state, flow state, rule execution log, and metrics.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+
   // ========== Worktree Management ==========
   {
     name: 'list_worktrees',
@@ -3592,6 +3646,24 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         projectSlug: args.projectSlug,
         linearProjectId: args.linearProjectId,
         issueIds: args.issueIds,
+      });
+
+    // Lead Engineer (Production Phase)
+    case 'start_lead_engineer':
+      return apiCall('/lead-engineer/start', {
+        projectPath: args.projectPath,
+        projectSlug: args.projectSlug,
+        maxConcurrency: args.maxConcurrency,
+      });
+
+    case 'stop_lead_engineer':
+      return apiCall('/lead-engineer/stop', {
+        projectPath: args.projectPath,
+      });
+
+    case 'get_lead_engineer_status':
+      return apiCall('/lead-engineer/status', {
+        projectPath: args.projectPath,
       });
 
     // ProtoLabs Setup Pipeline


### PR DESCRIPTION
## Summary

- Adds a **Lead Engineer Service** that orchestrates projects through the production lifecycle — from launch to completion
- Implements **8 fast-path rules** (pure functions, no LLM) that react to events and execute board/agent/PR actions automatically
- Absorbs board-janitor, PR-maintainer, and ava-check logic for managed projects via crew member guards
- Exposes 3 API routes (`/api/lead-engineer/{start,status,stop}`) and 3 MCP tools

### What it does

The Lead Engineer maintains a **WorldState** snapshot (features, agents, PRs, metrics, milestones) that updates incrementally on every event. Rules evaluate against this state and produce typed actions:

| Rule | Trigger | Action |
|------|---------|--------|
| mergedNotDone | PR merged | Move review → done |
| orphanedInProgress | Agent stopped/error | Reset to backlog after 4h |
| staleDeps | Status changed | Unblock when all deps done |
| autoModeHealth | Auto-mode stopped | Restart if backlog > 0 |
| staleReview | Status changed | Enable auto-merge after 30min |
| stuckAgent | Periodic refresh | Send wrap-up message after 2h |
| capacityRestart | Feature completed | Restart auto-mode if capacity available |
| projectCompleting | All features done | Trigger completion flow |

### Files changed (14)

**New files (6):** types, rules, service, routes, 2 test files
**Modified files (8):** event types, barrel export, server wiring, crew loop interface, 3 crew members, MCP tools

## Test plan

- [x] 34 rule unit tests (all pure functions with synthetic WorldState)
- [x] 16 service tests (session management, event routing, world state updates, flow transitions, action execution)
- [x] Full server test suite: 1924 tests pass, 0 failures
- [x] TypeScript compiles clean
- [x] Prettier formatting passes
- [ ] Manual MCP test: `start_lead_engineer` → verify auto-mode starts, events trigger rules
- [ ] Integration: launch project, verify completion triggers retro + improvement ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Lead Engineer service to manage and orchestrate project sessions with automated rules and actions
  * Added API endpoints to start, stop, and monitor Lead Engineer status per project
  * Integrated Lead Engineer with existing project management components to prevent task conflicts and streamline coordination
<!-- end of auto-generated comment: release notes by coderabbit.ai -->