### PR TITLE
docs: update protoLabs docs for ops/engineering split and pipeline

### DIFF
--- a/docs/authority/org-chart.md
+++ b/docs/authority/org-chart.md
@@ -14,32 +14,35 @@ The system has three layers:
 
 ```text
 Josh Mabry (CEO, Human)
-├── Ava Loveland, Opus, Trust=3 — Engineering
-│   ├── Matt, Sonnet, Trust=2
-│   ├── Sam, Sonnet, Trust=2
-│   ├── Frank, Sonnet, Trust=2
-│   ├── Cindi, Sonnet, Trust=2
-│   ├── Backend Engineer, Sonnet, Trust=2
-│   ├── Product Manager, Sonnet, Trust=1
-│   ├── Engineering Manager, Sonnet, Trust=1
-│   ├── Linear Specialist, Sonnet, Trust=2
+├── Operations (Ava Loveland, CoS, Opus, Trust=3)
+│   ├── Jon, Sonnet, Trust=2 — GTM / Antagonistic Review
+│   ├── Cindi, Sonnet, Trust=2 — Content
 │   ├── PR Maintainer, Haiku, Trust=2 [Crew]
-│   └── Board Janitor, Haiku, Trust=1 [Crew]
-└── Jon, Sonnet, Trust=1 — Go-to-Market
+│   ├── Board Janitor, Haiku, Trust=1 [Crew]
+│   └── System Health, Haiku, Trust=1 [Crew]
+└── Engineering (Lead Engineer, Service)
+    ├── Auto-mode Agents, Sonnet/Opus — Feature Implementation
+    ├── Matt, Sonnet, Trust=2 — Frontend
+    ├── Sam, Sonnet, Trust=2 — AI Agent Engineering
+    ├── Frank, Sonnet, Trust=2 — DevOps [Crew]
+    └── Kai, Sonnet, Trust=2 — Backend
 ```
+
+**Note:** PM, ProjM, and EM authority agents still exist in code but are now absorbed into the pipeline's automated steps (PRD generation, milestone decomposition, auto-mode orchestration) rather than being standalone team members. Their policy roles remain active for trust-gated permission checks.
 
 ## Roles
 
-| Role                | Code     | Trust           | Owns                   | Description                                                                                         |
-| ------------------- | -------- | --------------- | ---------------------- | --------------------------------------------------------------------------------------------------- |
-| GTM Specialist      | `GTM`    | 2 (Conditional) | Growth & Go-to-Market  | Top-level orchestrator. Content pipeline, brand strategy, external outreach.                        |
-| Project Owner       | `CTO`    | 3 (Autonomous)  | Strategy & direction   | **The human user.** Full access to all actions. Sets vision, approves proposals, sets trust levels. |
-| Chief of Staff      | `CoS`    | 2 (Conditional) | Operations & alignment | AI operational leader. Product direction, audit, team expansion, context continuity.                |
-| DevOps Engineer     | `DevOps` | 1 (Assisted)    | Infrastructure         | Deployment, monitoring, staging, Docker, CI/CD, system health.                                      |
-| Product Manager     | `PM`     | 1 (Assisted)    | What & Why             | Researches ideas, creates PRDs, defines scope. Creates work and manages scope changes.              |
-| Project Manager     | `ProjM`  | 1 (Assisted)    | When & How             | Decomposes epics into tasks, manages dependencies, assigns work.                                    |
-| Engineering Manager | `EM`     | 1 (Assisted)    | Who & Capacity         | Assigns engineers, manages capacity/WIP limits, quality gates.                                      |
-| Principal Engineer  | `PE`     | 2 (Conditional) | Architecture & Quality | Reviews architecture decisions, approves work, blocks releases for quality.                         |
+| Role                | Code     | Trust           | Owns                       | Description                                                                                         |
+| ------------------- | -------- | --------------- | -------------------------- | --------------------------------------------------------------------------------------------------- |
+| Project Owner       | `CTO`    | 3 (Autonomous)  | Strategy & direction       | **The human user.** Full access to all actions. Sets vision, approves proposals, sets trust levels. |
+| Chief of Staff      | `CoS`    | 2 (Conditional) | Operations & orchestration | AI operational leader. Signal triage, antagonistic review, crew loops, ceremonies.                  |
+| GTM Specialist      | `GTM`    | 2 (Conditional) | Growth & Go-to-Market      | Content pipeline, brand strategy, antagonistic review (market perspective).                         |
+| Lead Engineer       | —        | —               | Production orchestration   | Service (not an agent). Fast-path rules, auto-mode management, event-driven actions.                |
+| DevOps Engineer     | `DevOps` | 1 (Assisted)    | Infrastructure             | Deployment, monitoring, staging, Docker, CI/CD, system health.                                      |
+| Product Manager     | `PM`     | 1 (Assisted)    | What & Why                 | PRD generation pipeline step. Creates work and manages scope changes.                               |
+| Project Manager     | `ProjM`  | 1 (Assisted)    | When & How                 | Milestone decomposition pipeline step. Manages dependencies.                                        |
+| Engineering Manager | `EM`     | 1 (Assisted)    | Who & Capacity             | Auto-mode orchestration step. Capacity/WIP limits, quality gates.                                   |
+| Principal Engineer  | `PE`     | 2 (Conditional) | Architecture & Quality     | Reviews architecture decisions, approves work, blocks releases for quality.                         |
 
 ## Trust Levels
 

--- a/docs/dev/project-lifecycle.md
+++ b/docs/dev/project-lifecycle.md
@@ -8,20 +8,22 @@ Linear as the single source of truth for project state. Projects flow from idea 
 planned + "idea"          → User expanding the idea
 planned + "idea-approved" → PRD being generated/reviewed
 planned + "prd-approved"  → Milestones created, ready to launch
-started                   → Auto-mode running, agents implementing
+started                   → Lead Engineer active, auto-mode running, agents implementing
 completed                 → All features done
 ```
 
 ## MCP Tools
 
-| Tool                     | Description                                                    |
-| ------------------------ | -------------------------------------------------------------- |
-| `initiate_project`       | Dedup check + create Linear project + write idea doc           |
-| `generate_project_prd`   | Check for existing PRD, suggest generation if missing          |
-| `approve_project_prd`    | Create board features from milestones + sync to Linear         |
-| `launch_project`         | Set Linear status to "started" + start auto-mode               |
-| `get_lifecycle_status`   | Read Linear + local state, return current phase + next actions |
-| `collect_related_issues` | Move existing Linear issues into a project                     |
+| Tool                     | Description                                                        |
+| ------------------------ | ------------------------------------------------------------------ |
+| `process_idea`           | LangGraph flow to validate idea with optional HITL gate            |
+| `initiate_project`       | Dedup check + create Linear project + write idea doc               |
+| `generate_project_prd`   | Check for existing PRD, suggest generation if missing              |
+| `approve_project_prd`    | Create board features from milestones + sync to Linear             |
+| `launch_project`         | Set Linear status to "started" + start auto-mode                   |
+| `start_lead_engineer`    | Manually start Lead Engineer for a project (auto-starts on launch) |
+| `get_lifecycle_status`   | Read Linear + local state, return current phase + next actions     |
+| `collect_related_issues` | Move existing Linear issues into a project                         |
 
 ## Skill
 
@@ -38,14 +40,38 @@ All endpoints are under `POST /api/projects/lifecycle/`:
 - `/status` — Get lifecycle phase
 - `/collect-related` — Add issues to project
 
+## Step 5: Lead Engineer Auto-Starts
+
+When `launch_project` is called, the server emits a `project:lifecycle:launched` event. The Lead Engineer service subscribes to this event and automatically starts a production session for the project.
+
+The Lead Engineer is **not an LLM agent** — it's a service that evaluates fast-path rules (pure functions) on every relevant event. It only invokes LLM agents when a situation exceeds what rules can handle.
+
+**Fast-path rules** (defined in `lead-engineer-rules.ts`):
+
+| Rule                 | What It Does                                                  |
+| -------------------- | ------------------------------------------------------------- |
+| `mergedNotDone`      | Moves features to done when their PR is merged                |
+| `orphanedInProgress` | Resets in-progress features with no running agent (>4h stale) |
+| `staleDeps`          | Clears dependencies on features that are already done         |
+| `autoModeHealth`     | Restarts auto-mode if it stopped unexpectedly                 |
+| `staleReview`        | Enables auto-merge on PRs stuck in review (>24h)              |
+| `stuckAgent`         | Sends nudge messages to agents idle >2h                       |
+| `capacityRestart`    | Restarts auto-mode when capacity frees up                     |
+| `projectCompleting`  | Detects when all features are done and triggers completion    |
+
+The Lead Engineer maintains a comprehensive world state (`LeadWorldState`) refreshed every 5 minutes and on significant events.
+
 ## Key Files
 
-| File                                                             | Purpose                             |
-| ---------------------------------------------------------------- | ----------------------------------- |
-| `apps/server/src/services/project-lifecycle-service.ts`          | Service orchestrating the lifecycle |
-| `apps/server/src/routes/projects/lifecycle/`                     | Route handlers                      |
-| `packages/mcp-server/plugins/automaker/commands/plan-project.md` | Skill file                          |
-| `libs/types/src/project.ts`                                      | `ProjectLifecyclePhase` type        |
+| File                                                             | Purpose                                    |
+| ---------------------------------------------------------------- | ------------------------------------------ |
+| `apps/server/src/services/project-lifecycle-service.ts`          | Service orchestrating the lifecycle        |
+| `apps/server/src/services/lead-engineer-service.ts`              | Lead Engineer production orchestrator      |
+| `apps/server/src/services/lead-engineer-rules.ts`                | 8 fast-path rules (pure functions, no LLM) |
+| `apps/server/src/routes/projects/lifecycle/`                     | Route handlers                             |
+| `packages/mcp-server/plugins/automaker/commands/plan-project.md` | Skill file                                 |
+| `libs/types/src/project.ts`                                      | `ProjectLifecyclePhase` type               |
+| `libs/types/src/lead-engineer.ts`                                | `LeadWorldState`, session types            |
 
 ## Mid-Stream Joins
 

--- a/docs/protolabs/agency-architecture.md
+++ b/docs/protolabs/agency-architecture.md
@@ -14,53 +14,25 @@ graph TB
 
     subgraph TRIAGE["2. TRIAGE & ROUTING"]
         AVA_TRIAGE["Ava (CoS)<br/>Signal Classification"]
-        AVA_TRIAGE -->|idea| PRD_PIPE
+        AVA_TRIAGE -->|idea| IDEA_PROC
         AVA_TRIAGE -->|bug| BUG_FAST["Fast-track:<br/>Create feature → Agent"]
         AVA_TRIAGE -->|ops improvement| BEADS_CREATE["Create Bead<br/>→ Self-improvement"]
         AVA_TRIAGE -->|gtm/content| JON_ROUTE["Route to Jon"]
     end
 
-    subgraph PRD_REVIEW["3. PRD PIPELINE"]
-        PRD_PIPE["SPARC PRD<br/>Creation"]
-        PRD_PIPE --> ANTAG["Antagonistic Review"]
-        AVA_REV["Ava: Feasibility<br/>Risk, Capacity"]
-        JON_REV["Jon: Market Value<br/>Positioning, ROI"]
-        AVA_REV <-->|Challenge| JON_REV
-        ANTAG --> AVA_REV
-        ANTAG --> JON_REV
-        AVA_REV --> CONSOLIDATED["Consolidated PRD"]
-        JON_REV --> CONSOLIDATED
+    subgraph PIPELINE["3. IDEA → PRODUCTION PIPELINE"]
+        IDEA_PROC["process_idea<br/>LangGraph Flow"]
+        IDEA_PROC --> INITIATE["initiate_project<br/>Dedup + Linear project"]
+        INITIATE --> GEN_PRD["generate_project_prd<br/>SPARC PRD Creation"]
+        GEN_PRD --> ANTAG["Antagonistic Review<br/>Ava (ops) + Jon (market)"]
+        ANTAG --> APPROVE["approve_project_prd<br/>Board features + Linear sync"]
+        APPROVE --> LAUNCH["launch_project<br/>Linear → started"]
     end
 
-    subgraph APPROVAL["4. APPROVAL GATE"]
-        CONSOLIDATED --> GATE{Approval?}
-        GATE -->|preApproved<br/>small/ops| AUTO_APPROVE["Auto-approve"]
-        GATE -->|standard| JOSH_REVIEW["Josh reviews<br/>in Linear"]
-        JOSH_REVIEW -->|approved| APPROVED
-        JOSH_REVIEW -->|changes| CONSOLIDATED
-        AUTO_APPROVE --> APPROVED["Approved PRD"]
-    end
-
-    subgraph PLANNING["5. PLANNING"]
-        APPROVED --> PROJM["ProjM Agent<br/>Deep Research"]
-        PROJM --> MILESTONES["Milestones + Phases<br/>+ Dependencies"]
-        MILESTONES --> LINEAR_POST["Post to Linear<br/>Project + Issues"]
-        LINEAR_POST --> HITL_CHECK{HITL<br/>Scope Review?}
-        HITL_CHECK -->|adjust| MILESTONES
-        HITL_CHECK -->|proceed| BOARD_CREATE["Create Features<br/>on protoMaker Board"]
-    end
-
-    subgraph SYNC["6. SYSTEM OF RECORD"]
-        LINEAR_SOT["Linear<br/>(Source of Truth)"]
-        AUTOMAKER_BOARD["protoMaker Board<br/>(Execution)"]
-        GITHUB_REPO["GitHub<br/>(Code + PRs)"]
-        LINEAR_SOT <-->|Bidirectional Sync| AUTOMAKER_BOARD
-        AUTOMAKER_BOARD <-->|Branches + PRs| GITHUB_REPO
-        GITHUB_REPO <-->|Issue Sync| LINEAR_SOT
-    end
-
-    subgraph EXECUTION["7. EXECUTION LOOP"]
-        AUTO_MODE["Auto-Mode<br/>Tick Loop"]
+    subgraph PRODUCTION["4. PRODUCTION PHASE"]
+        LAUNCH --> LEAD_ENG["Lead Engineer<br/>auto-starts on launch event"]
+        LEAD_ENG --> FAST_PATH["Fast-Path Rules<br/>no-LLM reactive orchestration"]
+        LEAD_ENG --> AUTO_MODE["Auto-Mode<br/>Tick Loop"]
         AUTO_MODE --> PICK["Pick Unblocked<br/>Feature"]
         PICK --> WORKTREE["Create Worktree"]
         WORKTREE --> AGENT["Agent Implements<br/>(Sonnet/Opus)"]
@@ -70,7 +42,7 @@ graph TB
         TESTS -->|yes| VERIFIED["Verified"]
     end
 
-    subgraph PR_PIPELINE["8. PR PIPELINE"]
+    subgraph PR_PIPELINE["5. PR PIPELINE"]
         VERIFIED --> REBASE["Rebase + Format"]
         REBASE --> PR_CREATE["Push + PR"]
         PR_CREATE --> CI["CI Checks<br/>build, test, format, audit"]
@@ -80,7 +52,7 @@ graph TB
         MERGE --> DONE["Feature → Done"]
     end
 
-    subgraph REFLECTION["9. REFLECTION LOOP"]
+    subgraph REFLECTION["6. REFLECTION LOOP"]
         DONE --> EPIC_CHECK{Epic Done?}
         EPIC_CHECK -->|no| AUTO_MODE
         EPIC_CHECK -->|yes| RETRO["Milestone Retro"]
@@ -95,94 +67,162 @@ graph TB
 
     %% Cross-cutting connections
     INTAKE --> AVA_TRIAGE
-    BOARD_CREATE --> AUTO_MODE
-    BOARD_CREATE --> SYNC
-    DONE --> SYNC
+    DONE --> LEAD_ENG
+    FAST_PATH -->|"mergedNotDone, staleReview,<br/>stuckAgent, capacityRestart"| AUTO_MODE
 ```
+
+## The Pipeline: 7 Steps from Idea to Production
+
+The core execution flow is a 7-step pipeline backed by MCP tools:
+
+| Step | MCP Tool / Service      | What Happens                                                            |
+| ---- | ----------------------- | ----------------------------------------------------------------------- |
+| 1    | `process_idea`          | LangGraph flow validates idea, optional HITL approval gate              |
+| 2    | `initiate_project`      | Dedup check, create Linear project, write idea doc                      |
+| 3    | `generate_project_prd`  | SPARC PRD creation + antagonistic review (Ava ops + Jon market)         |
+| 4    | `approve_project_prd`   | Create board features from milestones, sync to Linear, set dependencies |
+| 5    | `launch_project`        | Set Linear status to "started", start auto-mode                         |
+| 6    | Lead Engineer (service) | Auto-starts on `project:lifecycle:launched` event, runs fast-path rules |
+| 7    | Auto-mode + PR pipeline | Agents implement features → CI → CodeRabbit → merge → done              |
+
+Steps 1-5 are MCP tools callable from any context (CLI, UI, agent). Step 6 is event-driven. Step 7 is the autonomous execution loop.
+
+## Operations + Engineering Split
+
+The agency is organized into two branches with clear boundaries:
+
+### Operations (Ava, Chief of Staff)
+
+Signal triage, quality gates, team health, and external communication.
+
+- **Signal classification** — Routes incoming ideas, bugs, ops improvements, GTM work
+- **Antagonistic review** — Challenges every PRD alongside Jon before approval
+- **Crew loops** — Manages PR Maintainer, Board Janitor, System Health monitors
+- **Ceremonies** — Standup, retro, project-retro via Discord
+- **Beads** — Operational work queue for self-improvement tasks
+- **Discord comms** — Status updates, alerts, Josh coordination
+
+### Engineering (Lead Engineer)
+
+Production orchestration, auto-mode execution, and code quality.
+
+- **Lead Engineer** — Event-driven orchestrator with fast-path rules (no LLM for routine decisions)
+- **Auto-mode** — Dependency-aware feature processing with model escalation
+- **Worktree isolation** — Per-feature git worktrees protect main branch
+- **Agent execution** — Sonnet for standard work, Opus for architectural, Haiku for mechanical
+- **PR pipeline** — Rebase → push → CI → CodeRabbit → thread resolution → merge
+- **CI/CD guardrails** — Build, test, format, audit checks on every PR
+
+### Cross-Cutting
+
+- **Domain tools** — SharedTool system with Zod schemas, used across MCP/LangGraph/Express
+- **Antagonistic review** — Bridges ops (Ava feasibility) and engineering (Jon market value)
+- **HITL gates** — Human approval at milestone boundaries, optional interrupt-before in flows
+- **Langfuse observability** — Traces, costs, prompt versioning across all agent execution
+
+## Agent Communication Topology
+
+```
+                    Josh (Human)
+                    ↕ Discord / Linear
+                   Ava (CoS)
+              ╱         │         ╲
+      Operations    Cross-cut    Engineering
+       ╱    ╲          │          ╱      ╲
+    Jon    Cindi    Antag.    Lead Eng    Frank
+   (GTM)  (Content) Review   (Orchestr.) (DevOps)
+                               │
+                           Auto-mode
+                          ╱    │    ╲
+                      Agent₁ Agent₂ Agent₃
+                     (Sonnet)(Sonnet)(Haiku)
+                          ╲    │    ╱
+                    PR Maintainer (Crew)
+                    Board Janitor (Crew)
+```
+
+Ava is the hub. All strategic decisions flow through her. Communication channels:
+
+- **MCP tools** for system operations (48+ tools)
+- **Discord** for human-facing updates and Josh coordination
+- **Events** for system-to-system (`feature:completed`, `project:lifecycle:launched`, etc.)
+- **Agent memory** for persistent cross-session learning
+- **Domain tools** for feature management, git ops, and project orchestration
 
 ## Component Inventory
 
-### Exists and Working
+| Component                       | Location                                                    | Notes                                                   |
+| ------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------- |
+| **Idea processing flow**        | `libs/tools/src/domains/ideas/process-idea.ts`              | LangGraph flow with HITL checkpoints                    |
+| **Antagonistic review**         | `apps/server/src/services/antagonistic-review-service.ts`   | 3-stage: Ava ops → Jon market → consolidated resolution |
+| **Antagonistic review adapter** | `apps/server/src/services/antagonistic-review-adapter.ts`   | LangGraph flow wrapper with Langfuse tracing            |
+| **Lead Engineer service**       | `apps/server/src/services/lead-engineer-service.ts`         | Production orchestrator with fast-path rules            |
+| **Lead Engineer rules**         | `apps/server/src/services/lead-engineer-rules.ts`           | 8 pure-function rules (no LLM, no service imports)      |
+| **SharedTool system**           | `libs/tools/src/types.ts`, `define-tool.ts`                 | Zod-validated tool definitions for MCP/LangGraph/REST   |
+| **Feature domain tools**        | `libs/tools/src/domains/features/`                          | CRUD operations via SharedTool pattern                  |
+| **Project lifecycle**           | `apps/server/src/services/project-lifecycle-service.ts`     | 6 MCP tool steps from idea to launch                    |
+| **submit_prd MCP tool**         | `packages/mcp-server/src/index.ts`                          | Creates epic, ProjM decomposes                          |
+| **SPARC PRD skill**             | `plugins/automaker/commands/sparc-prd.md`                   | Interactive PRD creation                                |
+| **ProjM deep research**         | `apps/server/src/services/authority-agents/`                | Milestone/phase decomposition                           |
+| **Auto-mode execution**         | `apps/server/src/services/auto-mode-service.ts`             | Dependency-aware, model escalation                      |
+| **Agent factory + registry**    | `apps/server/src/services/agent-factory-service.ts`         | Template-based agent creation                           |
+| **Dynamic agent executor**      | `apps/server/src/services/dynamic-agent-executor.ts`        | Runs agents in worktrees via Claude Agent SDK           |
+| **Worktree isolation**          | `apps/server/src/services/agent-service.ts`                 | Per-feature branches                                    |
+| **PR pipeline**                 | `apps/server/src/services/git-workflow-service.ts`          | Create, push, merge                                     |
+| **CodeRabbit integration**      | Branch protection + `resolve_review_threads`                | Required check                                          |
+| **CI/CD**                       | `.github/workflows/`                                        | Build, test, format, audit                              |
+| **Linear sync**                 | `apps/server/src/services/linear-sync-service.ts`           | Feature → Linear issue push                             |
+| **Linear webhook**              | `apps/server/src/routes/linear/webhook.ts`                  | Receives mentions/delegations                           |
+| **Ceremony service**            | `apps/server/src/services/ceremony-service.ts`              | Standup, retro, project-retro                           |
+| **Crew loops**                  | `apps/server/src/services/crew-loop-service.ts`             | PR Maintainer, Board Janitor, Frank, System Health      |
+| **Escalation pipeline**         | `apps/server/src/services/escalation-router.ts`             | 5 channels, SLA engine                                  |
+| **Signal accumulator**          | `apps/server/src/services/`                                 | Severity classification + briefing                      |
+| **Agent memory**                | `.automaker/memory/*.md`                                    | Per-agent learning files                                |
+| **Beads task tracking**         | `.beads/issues.jsonl`                                       | Operational task queue                                  |
+| **Discord MCP**                 | `packages/mcp-server/plugins/automaker/`                    | Send, read, channels, webhooks                          |
+| **Conflict resolution UI**      | `apps/ui/src/`                                              | Linear sync conflict handling                           |
+| **Idea processing service**     | `apps/server/src/services/idea-processing-service.ts`       | Session management for LangGraph idea flow              |
+| **Content review pipeline**     | `libs/flows/src/content/subgraphs/antagonistic-reviewer.ts` | 8-dimension scoring for content quality                 |
 
-| Component                    | Location                                            | Status  | Notes                               |
-| ---------------------------- | --------------------------------------------------- | ------- | ----------------------------------- |
-| **submit_prd MCP tool**      | `packages/mcp-server/src/index.ts`                  | Working | Creates epic, ProjM decomposes      |
-| **SPARC PRD skill**          | `plugins/automaker/commands/sparc-prd.md`           | Working | Interactive PRD creation            |
-| **ProjM deep research**      | `apps/server/src/services/authority-agents/`        | Working | Milestone/phase decomposition       |
-| **Auto-mode execution**      | `apps/server/src/services/auto-mode-service.ts`     | Working | Dependency-aware, model escalation  |
-| **Agent factory + registry** | `apps/server/src/services/agent-factory-service.ts` | Working | Template-based agent creation       |
-| **Worktree isolation**       | `apps/server/src/services/agent-service.ts`         | Working | Per-feature branches                |
-| **PR pipeline**              | `apps/server/src/services/git-workflow-service.ts`  | Working | Create, push, merge                 |
-| **CodeRabbit integration**   | Branch protection + resolve_review_threads          | Working | Required check                      |
-| **CI/CD**                    | `.github/workflows/`                                | Working | Build, test, format, audit          |
-| **Linear sync (features)**   | `apps/server/src/services/linear-sync-service.ts`   | Working | Feature → Linear issue push         |
-| **Linear webhook**           | `apps/server/src/routes/linear/webhook.ts`          | Working | Receives mentions/delegations       |
-| **Ceremony service**         | `apps/server/src/services/ceremony-service.ts`      | Working | Standup, retro, project-retro       |
-| **Crew loops**               | `apps/server/src/services/crew-loop-service.ts`     | Working | PR Maintainer, Board Janitor, Frank |
-| **Escalation pipeline**      | `apps/server/src/services/escalation-router.ts`     | Working | 5 channels, SLA engine              |
-| **Signal accumulator**       | `apps/server/src/services/`                         | Working | Severity classification + briefing  |
-| **Agent memory**             | `.automaker/memory/*.md`                            | Working | Per-agent learning files            |
-| **Beads task tracking**      | `.beads/issues.jsonl`                               | Working | Operational task queue              |
-| **Discord MCP**              | `packages/mcp-server/plugins/automaker/`            | Working | Send, read, channels, webhooks      |
-| **Conflict resolution UI**   | `apps/ui/src/`                                      | Working | Linear sync conflict handling       |
+## Quality Guardrails
 
-### Partially Built
+Four layers of quality assurance protect the pipeline:
 
-| Component               | What Exists                              | What's Missing                                                           |
-| ----------------------- | ---------------------------------------- | ------------------------------------------------------------------------ |
-| **Signal intake**       | Discord/Linear/GitHub receive messages   | No auto-triage pipeline. Messages don't auto-trigger PRD creation.       |
-| **Jon GTM agent**       | Template registered, `/gtm` skill exists | Not wired into PRD review pipeline. Only does standalone content work.   |
-| **Linear project sync** | Feature-level sync works                 | Can't create Linear projects or documents programmatically. Only issues. |
-| **Ceremonies**          | Discord posts on milestone events        | Don't spawn improvement tickets. Don't capture learnings systematically. |
-| **HITL approval**       | Linear agent sessions, elicitation tools | No structured approval gate for milestones/scope in Linear.              |
-| **preApproved flag**    | submit_prd creates features directly     | No trust-boundary logic for auto-approval vs. human review.              |
+### 1. Antagonistic Review
 
-### Doesn't Exist Yet
+Every PRD passes through a 3-stage sequential review before approval:
 
-| Component                            | Purpose                                                   | Priority                                                 |
-| ------------------------------------ | --------------------------------------------------------- | -------------------------------------------------------- |
-| **Antagonistic review**              | Ava + Jon cross-challenge PRDs before approval            | Critical — prevents garbage-in                           |
-| **Unified signal router**            | Any signal source → classification → correct pipeline     | Critical — intake bottleneck                             |
-| **Retro → improvement tickets**      | Ceremony retros auto-create Beads/Linear items            | High — closes the loop                                   |
-| **Linear project/document creation** | Programmatic project + doc creation in Linear             | High — can't be automation agency with manual Linear ops |
-| **Automated changelog**              | Generate changelog from merged features per epic/project  | Medium — visibility                                      |
-| **Metrics-driven impact analysis**   | "Was this project worth it?" automated analysis           | Medium — accountability                                  |
-| **Knowledge synthesis**              | Project-level learning rollup (not just per-agent memory) | Medium — organizational learning                         |
-| **preApproved trust boundaries**     | Rules: complexity ≤ small + category = ops → auto-approve | Medium — removes bottleneck                              |
+1. **Ava (operational feasibility)** — Capacity, risk, technical debt, implementation feasibility
+2. **Jon (market value)** — Customer impact, ROI, positioning, priority. Sees Ava's critique.
+3. **Resolution (Ava as CoS)** — Merges both verdicts into consolidated PRD with final decision
+
+Uses LangGraph flows with Langfuse tracing. 3-minute timeout for the entire pipeline. Fallback to DynamicAgentExecutor if graph flows are disabled.
+
+### 2. HITL Gates
+
+- Human scope review at milestone boundaries
+- Optional interrupt-before in LangGraph flows
+- Josh reviews PRDs in Linear (standard path)
+- preApproved path for low-risk operational items
+
+### 3. CI Pipeline
+
+Required checks on every PR before merge:
+
+- `build` — TypeScript compilation
+- `test` — Playwright E2E + Vitest unit
+- `format` — Prettier formatting
+- `audit` — Security audit
+
+### 4. Code Quality
+
+- **CodeRabbit** — AI-powered code review (required check)
+- **Branch protection** — Squash-only merges, required status checks, admin bypass
+- **TypeScript strict mode** — Catches type errors at compile time
+- **Prettier** — Enforced formatting consistency
+- **Thread resolution** — All review threads must be resolved before merge
 
 ## Data Flow
-
-### Signal → Production
-
-```
-Signal (Discord/Linear/GitHub)
-  ↓
-Ava classifies signal type and urgency
-  ↓
-[idea] → SPARC PRD created
-  ↓
-Antagonistic review: Ava ↔ Jon
-  ↓
-Consolidated PRD → Linear document
-  ↓
-Approval gate (Josh or preApproved)
-  ↓
-ProjM: deep research → milestones → phases
-  ↓
-Linear project + protoMaker board features
-  ↓
-Auto-mode picks features in dependency order
-  ↓
-Agent implements in worktree → tests → verified
-  ↓
-PR pipeline: rebase → push → CI → CodeRabbit → merge
-  ↓
-Feature → done, sync to Linear
-  ↓
-Epic complete → ceremony (retro + metrics)
-  ↓
-Improvement tickets + knowledge update → REPEAT
-```
 
 ### System of Record Boundaries
 
@@ -206,46 +246,21 @@ Improvement tickets + knowledge update → REPEAT
 └──────────────────────────────────────────────────────┘
 ```
 
-### Agent Communication Topology
-
-```
-                    Josh (Human)
-                    ↕ Discord / Linear
-                   Ava (CoS)
-                 ↙    ↓    ↘
-              Jon    ProjM    Frank
-             (GTM)  (Plan)   (DevOps)
-                      ↓
-                   Features
-                 ↙    ↓    ↘
-            Agent₁  Agent₂  Agent₃
-            (Sonnet) (Sonnet) (Haiku)
-                 ↘    ↓    ↙
-               PR Maintainer (Crew)
-               Board Janitor (Crew)
-```
-
-Ava is the hub. All strategic decisions flow through her. Agents communicate via:
-
-- **MCP tools** for system operations
-- **Discord** for human-facing updates
-- **Events** for system-to-system (feature:completed, milestone:started, etc.)
-- **Agent memory** for persistent cross-session learning
-
 ## Scalability Considerations
 
 ### Current Limits
 
 - 2-3 concurrent agents on dev hardware (8GB heap)
-- 6-10 concurrent agents on staging (32GB heap, 125GB RAM)
-- Linear MCP has basic CRUD only (no project/doc creation)
+- 6-10 concurrent agents on staging (48GB heap limit, 125GB RAM, 24 CPUs)
 - Agent turns limited (hit turn limit = uncommitted work)
+- Lead Engineer fast-path rules run with zero LLM cost
 
 ### Scaling Strategy
 
 - **Vertical**: Staging hardware handles more concurrent agents
 - **Horizontal**: Multiple protoMaker instances via [Hivemind](../architecture/instance-state.md#hivemind-multi-instance-mesh) — domain-scoped mesh where each instance owns a slice of the codebase
-- **Efficiency**: Model routing (Haiku for mechanical work, Opus only for architectural decisions)
+- **Efficiency**: Model routing (Haiku for mechanical work, Sonnet default, Opus only for architectural decisions or 2+ failures)
+- **Fast-path rules**: Lead Engineer handles routine orchestration decisions (mergedNotDone, orphanedInProgress, staleDeps, autoModeHealth, staleReview, stuckAgent, capacityRestart, projectCompleting) without LLM calls
 - **Automation**: Every manual step today becomes automated tomorrow — this is the self-improvement loop
 
 ### Instance State Model

--- a/docs/protolabs/agency-overview.md
+++ b/docs/protolabs/agency-overview.md
@@ -24,20 +24,34 @@ The gap between "AI can write code" and "AI can run a development organization" 
 
 ### The ProtoLabs Answer
 
-Every human development org has these roles: product (what), engineering (how), QA (quality), PM (when), and leadership (why). ProtoLabs fills these with specialized AI agents that communicate through well-defined interfaces:
+ProtoLabs is organized into two branches — **Operations** and **Engineering** — with clear boundaries, quality guardrails, and domain tools that enable orchestration at scale.
 
-| Role                | Agent           | Responsibilities                                            |
-| ------------------- | --------------- | ----------------------------------------------------------- |
-| CEO / Visionary     | Josh (human)    | Ideas, direction, final approval                            |
-| Chief of Staff      | Ava             | Triage, orchestration, quality gates, antagonistic review   |
-| GTM / Strategy      | Jon             | Market perspective, customer value, content, positioning    |
-| Project Manager     | ProjM           | Deep research, milestone decomposition, dependency planning |
-| Engineering Manager | EM              | PR pipeline, merge strategy, build health                   |
-| Backend Engineer    | Agents (Sonnet) | Feature implementation in worktrees                         |
-| Frontend Engineer   | Matt            | UI components, design systems, Storybook                    |
-| DevOps              | Frank           | Infrastructure health, deploys, monitoring                  |
-| PR Maintainer       | Crew (Haiku)    | Auto-merge, format fixes, CodeRabbit resolution             |
-| Board Janitor       | Crew (Haiku)    | Board consistency, orphaned features, stale deps            |
+### Operations
+
+Signal triage, quality gates, team health, and external communication. Orchestration agents use domain tools and subagents to manage tasks, distill information, and maintain context.
+
+| Agent               | Type         | Responsibilities                                                          |
+| ------------------- | ------------ | ------------------------------------------------------------------------- |
+| **Josh Mabry**      | Human (CEO)  | Ideas, direction, final approval                                          |
+| **Ava** (CoS)       | AI Orchestr. | Signal triage, antagonistic review, crew loops, ceremonies, Discord comms |
+| **Jon** (GTM)       | AI Agent     | Market perspective, content strategy, positioning, antagonistic review    |
+| **Cindi** (Content) | AI Agent     | Blog posts, technical docs, SEO, content pipeline                         |
+| **PR Maintainer**   | Crew (Haiku) | Auto-merge, format fixes, CodeRabbit thread resolution                    |
+| **Board Janitor**   | Crew (Haiku) | Board consistency, orphaned features, stale deps                          |
+| **System Health**   | Crew (Haiku) | RAM, swap, disk, CPU, temperature, zombie processes                       |
+
+### Engineering
+
+Production orchestration, auto-mode execution, and code quality. The Lead Engineer uses fast-path rules (pure functions, no LLM) for routine decisions and escalates to full agent execution only when needed.
+
+| Agent                  | Type        | Responsibilities                                                        |
+| ---------------------- | ----------- | ----------------------------------------------------------------------- |
+| **Lead Engineer**      | Service     | Production orchestrator — fast-path rules, auto-mode management, events |
+| **Matt** (Frontend)    | AI Agent    | React 19, design systems, Storybook, component architecture             |
+| **Sam** (AI Agent Eng) | AI Agent    | LangGraph flows, LLM providers, observability, multi-agent coordination |
+| **Frank** (DevOps)     | AI + Crew   | Infrastructure health, deploys, monitoring, system reliability          |
+| **Kai** (Backend)      | AI Agent    | Server-side features, API design, database, services                    |
+| **Auto-mode Agents**   | Sonnet/Opus | Feature implementation in isolated git worktrees                        |
 
 ## Three Surfaces, Clear Separation
 
@@ -87,7 +101,7 @@ Every idea gets a SPARC PRD (Situation, Problem, Approach, Results, Constraints)
 - **Ava (CoS)**: Is this operationally feasible? Does it align with current capacity? What's the risk?
 - **Jon (GTM)**: Does this create customer value? Can we sell this? Does it strengthen our positioning?
 
-They challenge each other. The output is a consolidated plan that has survived cross-functional scrutiny.
+They challenge each other in a 3-stage sequential review. The output is a consolidated plan that has survived cross-functional scrutiny.
 
 ### 3. Approval Gate
 
@@ -108,7 +122,16 @@ ProjM takes the approved PRD and does deep research:
 
 Output: Milestones with ordered phases, posted to Linear for visibility.
 
-### 5. Execution
+### 5. Launch + Lead Engineer
+
+`launch_project` sets Linear status to "started" and kicks off auto-mode. The Lead Engineer auto-starts on the `project:lifecycle:launched` event and takes over production orchestration:
+
+- Maintains comprehensive world state (board counts, features, agents, PRs, milestones)
+- Evaluates fast-path rules on every event — no LLM calls for routine decisions
+- Handles: mergedNotDone, orphanedInProgress, staleDeps, autoModeHealth, staleReview, stuckAgent, capacityRestart, projectCompleting
+- Refreshes state every 5 minutes and on significant events
+
+### 6. Execution
 
 Auto-mode processes features in dependency order:
 
@@ -117,7 +140,7 @@ Auto-mode processes features in dependency order:
 - Agent implements, tests, verifies
 - On failure: iterate with more context, escalate model, or flag for human help
 
-### 6. PR Pipeline
+### 7. PR Pipeline
 
 Automated quality assurance:
 
@@ -129,7 +152,7 @@ Automated quality assurance:
 - Thread resolution
 - Auto-merge (squash to main)
 
-### 7. Reflection
+### 8. Reflection
 
 When an epic completes:
 
@@ -153,8 +176,9 @@ The system is both the product and the factory that makes the product. Every pro
 
 ## What Makes This Different
 
-- **Not a copilot** — it's a team. Multiple specialized agents with defined roles and communication protocols.
+- **Not a copilot** — it's a team. Operations + Engineering branches with specialized agents, domain tools, and subagent delegation.
 - **Not one-shot** — it's a loop. Continuous improvement feeds learning back into planning.
-- **Not just code** — it's organizational. Planning, review, execution, reflection, knowledge management.
-- **Not a black box** — it's observable. Linear for strategy, protoMaker board for tactics, Discord for communication. Full audit trail.
+- **Not just code** — it's organizational. Antagonistic review, HITL gates, CI pipeline, and code quality checks form four layers of quality assurance.
+- **Not a black box** — it's observable. Linear for strategy, protoMaker board for tactics, Discord for communication. Langfuse for traces and costs. Full audit trail.
 - **Not static** — it's self-improving. The system upgrades itself through the same pipeline it uses for customer work.
+- **Not LLM-dependent** — fast-path rules handle routine orchestration decisions without API calls. LLM agents are reserved for creative work.

--- a/docs/protolabs/brand.md
+++ b/docs/protolabs/brand.md
@@ -56,16 +56,27 @@ This is the living brand bible for protoLabs. All agents, content, and external 
 
 ## Team
 
+The team is organized into **Operations** and **Engineering** branches. Orchestration agents use domain tools (feature management, git ops, Linear, Discord) and subagents rather than direct agent execution for every task.
+
+### Operations
+
 | Name             | Role                       | Type     | Notes                                                                    |
 | ---------------- | -------------------------- | -------- | ------------------------------------------------------------------------ |
 | **Josh Mabry**   | Founder / Project Owner    | Human    | Architect. Directs everything.                                           |
-| **Ava Loveland** | Chief of Staff             | AI Agent | Operational automation, agent management. The proof AI teammates work.   |
-| **Jon**          | GTM Specialist             | AI Agent | Content strategy, brand positioning, social media, launch execution.     |
-| **Matt**         | Frontend Engineer          | AI Agent | React 19, design systems, Storybook, component architecture.             |
-| **Sam**          | AI Agent Engineer          | AI Agent | LangGraph flows, LLM providers, observability, multi-agent coordination. |
-| **Frank**        | DevOps Engineer            | AI Agent | Staging infra, deployments, health monitoring, system reliability.       |
+| **Ava Loveland** | Chief of Staff             | AI Agent | Signal triage, antagonistic review, crew loops, ceremonies, Discord.     |
+| **Jon**          | GTM Specialist             | AI Agent | Content strategy, brand positioning, antagonistic review (market value). |
 | **Cindi**        | Content Writing Specialist | AI Agent | Blog posts, technical docs, SEO, content pipeline.                       |
 | **Abdellah**     | Strategy Partner           | Human    | Personal branding, visual identity. NOT content creation.                |
+
+### Engineering
+
+| Name              | Role                 | Type     | Notes                                                                    |
+| ----------------- | -------------------- | -------- | ------------------------------------------------------------------------ |
+| **Lead Engineer** | Production Orchestr. | Service  | Fast-path rules, auto-mode management, event-driven orchestration.       |
+| **Matt**          | Frontend Engineer    | AI Agent | React 19, design systems, Storybook, component architecture.             |
+| **Sam**           | AI Agent Engineer    | AI Agent | LangGraph flows, LLM providers, observability, multi-agent coordination. |
+| **Frank**         | DevOps Engineer      | AI Agent | Staging infra, deployments, health monitoring, system reliability.       |
+| **Kai**           | Backend Engineer     | AI Agent | Server-side features, API design, database, services.                    |
 
 ## Content Strategy
 


### PR DESCRIPTION
## Summary

- **agency-architecture.md**: Major rewrite — removed stale "Partially Built"/"Doesn't Exist Yet" sections, added 7-step pipeline table, ops/engineering split section, quality guardrails (antagonistic review, HITL, CI, code quality), updated mermaid diagram and component inventory (30 components)
- **agency-overview.md**: Replaced flat role table with Operations + Engineering tables, added Lead Engineer and Launch step to the flow, updated "What Makes This Different"
- **org-chart.md**: Restructured into Operations (Ava) + Engineering (Lead Engineer) branches, noted PM/ProjM/EM absorbed into pipeline steps
- **brand.md**: Split team table into Operations + Engineering sections, added Lead Engineer and Kai
- **project-lifecycle.md**: Added `process_idea` and `start_lead_engineer` MCP tools, added "Lead Engineer Auto-Starts" section with all 8 fast-path rules, updated key files table

## Test plan

- [x] `prettier --check` passes on all 5 files
- [x] All files under 800 lines per docs-standard.md
- [ ] Verify mermaid diagram renders correctly on GitHub


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized organizational structure with new Operations and Engineering branch separation
  * Introduced Lead Engineer role with updated responsibilities and fast-path rules
  * Updated project lifecycle workflow and developer documentation
  * Streamlined agency architecture with modernized execution pipeline and production phase
  * Enhanced team structure definitions and clarified role responsibilities across branches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->