### PR TITLE
fix(docs): resolve dead links breaking VitePress build

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -49,8 +49,8 @@ export default defineConfig({
       : []),
   ],
 
-  // Allow dead links to: files outside docs/
-  ignoreDeadLinks: [/^\.\.\//],
+  // Allow dead links to: files outside docs/ (../foo or ./../foo)
+  ignoreDeadLinks: [/^(?:\.\/)?\.\.\/(?!\.)/],
 
   themeConfig: {
     logo: '/logo.svg',

--- a/docs/protolabs/content/idea-processing-architecture.md
+++ b/docs/protolabs/content/idea-processing-architecture.md
@@ -468,10 +468,10 @@ If you're building with AI agents, this is the blueprint.
 ## Resources
 
 - **Source Code:** [github.com/proto-labs-ai/protomaker](https://github.com/proto-labs-ai/protomaker)
-- **Architecture Docs:** [docs/protolabs/agency-architecture.md](./agency-architecture.md)
-- **Brand & Team:** [docs/protolabs/brand.md](./brand.md)
-- **PRD Pipeline:** [docs/protolabs/agency-prd.md](./agency-prd.md)
-- **Setup Guide:** [docs/protolabs/setup-pipeline.md](./setup-pipeline.md)
+- **Architecture Docs:** [docs/protolabs/agency-architecture.md](../agency-architecture.md)
+- **Brand & Team:** [docs/protolabs/brand.md](../brand.md)
+- **PRD Pipeline:** [docs/protolabs/agency-prd.md](../agency-prd.md)
+- **Setup Guide:** [docs/protolabs/setup-pipeline.md](../setup-pipeline.md)
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix 4 relative links in `protolabs/content/idea-processing-architecture.md` that used `./` (same directory) instead of `../` (parent directory) to reach files in `protolabs/`
- Update `ignoreDeadLinks` regex in VitePress config to match `./../` format VitePress uses for links pointing outside the docs tree

This fixes the VitePress build failure that has been blocking the last 3 staging deploys.

## Test plan
- [ ] VitePress docs build succeeds in Docker (no dead link errors)
- [ ] Staging deploy completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated resource links in documentation to correctly reference related materials from the appropriate directory levels.
  * Improved documentation system configuration to support broader validation of external documentation references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->