### PR TITLE
fix(deploy): smoke test checks for #app not #root

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -107,13 +107,13 @@ echo ""
 echo "UI (port 3007):"
 UI_URL="${UI_URL:-${BASE_URL/3008/3007}}"
 if UI_RESPONSE=$(curl -sf --max-time 10 "$UI_URL/" 2>/dev/null); then
-  if echo "$UI_RESPONSE" | grep -q '<div id="root"'; then
-    echo "  PASS: UI serves HTML with #root"
+  if echo "$UI_RESPONSE" | grep -q '<div id="app"'; then
+    echo "  PASS: UI serves HTML with #app"
     PASSED=$((PASSED + 1))
   else
-    echo "  FAIL: UI response missing <div id=\"root\""
+    echo "  FAIL: UI response missing <div id=\"app\""
     FAILED=$((FAILED + 1))
-    FAILURES="${FAILURES}\n- UI HTML: missing <div id=\"root\">"
+    FAILURES="${FAILURES}\n- UI HTML: missing <div id=\"app\">"
   fi
 else
   echo "  FAIL: UI not responding on ${UI_URL}"


### PR DESCRIPTION
## Summary
- The UI mount point is `<div id="app">` not `<div id="root">`, causing smoke tests to fail on every deploy

One-line fix in `scripts/smoke-test.sh`.

## Test plan
- [ ] Staging deploy passes smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated smoke test to verify correct HTML root element identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->