### PR TITLE
docs: DRY brand docs — cross-reference design system and frontend philosophy

### DIFF
--- a/docs/dev/frontend-philosophy.md
+++ b/docs/dev/frontend-philosophy.md
@@ -2,6 +2,8 @@
 
 Gold standard decisions for frontend engineering across protoLabs projects. These guidelines apply to automaker and serve as the template for all future proto lab setups.
 
+> **Brand visual identity** — For the canonical color palette, typography, and component specs as they appear on the landing page and marketing properties, see [`design-system.md`](../protolabs/design-system.md). This document covers the _implementation_ of those design decisions in the UI app's OKLch token system.
+
 ## Design tokens
 
 ### Color space: OKLch
@@ -257,15 +259,16 @@ Themes are activated by setting a class on the root HTML element. Each theme def
 
 20+ font families available via `@fontsource/*` packages. Default: Geist (sans) and Geist Mono. Fonts are runtime-switchable through the font selector component.
 
-## Storybook (target state)
+## Storybook
 
-protoMaker does not currently have Storybook. This section defines the target setup.
+Storybook is configured at `apps/ui/.storybook/` with theme integration and accessibility auditing.
 
 ### Setup
 
-- Framework: `@storybook/react-vite` (matches our Vite build)
-- Location: `apps/ui/.storybook/` config, stories co-located with components
-- Addons: essentials (controls, actions, docs, viewport, backgrounds), addon-a11y
+- Framework: `@storybook/react-vite`
+- Config: `apps/ui/.storybook/main.ts` + `preview.tsx`
+- Addons: essentials, `@storybook/addon-a11y`, Chromatic (visual regression)
+- Theme switcher: Toolbar cycles through all 6 curated themes
 
 ### Story conventions
 
@@ -292,7 +295,7 @@ export const Destructive: Story = { args: { children: 'Delete', variant: 'destru
 
 ### Theme integration
 
-A custom toolbar addon switches between all 41 themes by toggling the root class. This validates every component renders correctly in every theme.
+The preview decorator applies theme classes to the document root. All 6 theme CSS files are imported in `preview.tsx`, and the toolbar provides a theme switcher. This validates every component renders correctly across themes.
 
 ### Accessibility
 
@@ -419,7 +422,7 @@ Current gaps between philosophy and implementation. These are tracked as future 
 | -------------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------- | -------- |
 | God store                  | `app-store.ts` is 4,268 lines with all state                                   | Split into domain slices (board, agent, settings, theme)               | High     |
 | Monolithic views           | `board-view.tsx` (1,908 lines), `terminal-view.tsx` (1,809 lines)              | Decompose into sub-components like `settings-view/` already has        | High     |
-| No Storybook               | Zero stories, no `.storybook/` config                                          | Full Storybook setup with theme switcher and a11y addon                | High     |
+| Storybook coverage         | Config + 6 stories (button, card, dialog, tabs, badge, dashboard)              | Stories for all UI primitives, interaction tests, Chromatic CI         | High     |
 | Domain components in `ui/` | `git-diff-panel`, `dependency-selector`, `log-viewer` etc. in `components/ui/` | Move to `components/shared/` or view-specific directories              | Medium   |
 | No UI package              | All components in `apps/ui/`, not shareable                                    | Extract to `libs/ui/` (`@automaker/ui`)                                | Medium   |
 | Static theme files         | 41 hand-written CSS files                                                      | Generate from TypeScript config                                        | Medium   |

--- a/docs/protolabs/design-system.md
+++ b/docs/protolabs/design-system.md
@@ -388,3 +388,20 @@ Map to the shadcn/ui CSS variable system:
 - `--accent` → `surface-2`
 
 Replace fonts with Geist. Keep shadcn/ui component architecture — just update the tokens.
+
+### protoMaker UI App (OKLch)
+
+The UI app uses OKLch (perceptually uniform) rather than hex. Same brand identity, different color space for precision across 41 themes. The `studio-dark` theme in `apps/ui/src/styles/themes/studio-dark.css` is the canonical mapping:
+
+| Brand Token (hex)      | UI Token (OKLch)        | CSS Variable             |
+| ---------------------- | ----------------------- | ------------------------ |
+| `surface-0` `#09090b`  | `oklch(0.13 0.005 260)` | `--background`           |
+| `surface-1` `#111113`  | `oklch(0.16 0.005 260)` | `--card`                 |
+| `surface-2` `#18181b`  | `oklch(0.2 0.005 260)`  | `--muted`                |
+| `accent` `#a78bfa`     | `oklch(0.68 0.153 275)` | `--brand-400`            |
+| `accent-dim` `#7c5cbf` | `oklch(0.45 0.171 275)` | `--brand-600`            |
+| `#fafafa`              | `oklch(0.93 0 0)`       | `--foreground`           |
+| `#a1a1aa`              | `oklch(0.65 0.005 260)` | `--foreground-secondary` |
+| `#71717a`              | `oklch(0.5 0.005 260)`  | `--foreground-muted`     |
+
+The hue 275 (violet) and hue 260 (zinc) carry through identically. See [`frontend-philosophy.md`](../dev/frontend-philosophy.md) for the full OKLch token system and implementation details.


### PR DESCRIPTION
## Summary
- `frontend-philosophy.md`: Adds reference to `design-system.md` as brand source of truth, updates stale Storybook section (now configured with 6 stories, not "target state"), fixes tech debt table
- `design-system.md`: Adds OKLch mapping table showing how brand hex values translate to UI app's perceptually uniform color tokens

Ensures brand visual identity is documented in one place (`design-system.md`) with implementation details in `frontend-philosophy.md` — no duplication.

## Test plan
- [ ] VitePress docs build (`npm run docs:dev`)
- [ ] Cross-links between docs resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated frontend development philosophy guide with detailed Storybook configuration and theme integration specifications.
  * Expanded design system documentation with comprehensive OKLch color token mappings and CSS variable references for UI styling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->