### PR TITLE
fix(site): replace internal role title in landing page mockup

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -519,7 +519,7 @@
                   A
                 </div>
                 <div>
-                  <div class="text-xs text-zinc-500">ava (chief of staff)</div>
+                  <div class="text-xs text-zinc-500">ava (operations)</div>
                   <div class="text-sm mt-0.5">
                     <span class="success">Signal received.</span>
                     <span class="dim">


### PR DESCRIPTION
## Summary
- Changes "ava (chief of staff)" to "ava (operations)" in the signal intake mockup
- "Chief of staff" is an internal role title that shouldn't appear on the public landing page

## Test plan
- [ ] Open site/index.html, verify the Describe section mockup shows "ava (operations)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated role information in demo section content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->