### PR TITLE
chore(docs): rename protoMaker → protoLabs across all docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -136,10 +136,10 @@ export default defineConfig({
       ],
     },
 
-    socialLinks: [{ icon: 'github', link: 'https://github.com/proto-labs-ai/protolabs-studio' }],
+    socialLinks: [{ icon: 'github', link: 'https://github.com/proto-labs-ai/automaker' }],
 
     editLink: {
-      pattern: 'https://github.com/proto-labs-ai/protolabs-studio/edit/main/docs/:path',
+      pattern: 'https://github.com/proto-labs-ai/automaker/edit/main/docs/:path',
       text: 'Edit this page on GitHub',
     },
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,17 +2,17 @@
 
 ## Quick Links
 
-| Service  | URL                                                                                 | Description              |
-| -------- | ----------------------------------------------------------------------------------- | ------------------------ |
-| GitHub   | [proto-labs-ai/protolabs-studio](https://github.com/proto-labs-ai/protolabs-studio) | Source code, issues, PRs |
-| Graphite | [proto-labs-ai](https://app.graphite.dev/github/pr/proto-labs-ai/protolabs-studio)  | Stacked PR dashboard     |
-| Discord  | [Agentic Jumpstart](https://discord.gg/jjem7aEDKU)                                  | Community and team chat  |
+| Service | URL                                               | Description              |
+| ------- | ------------------------------------------------- | ------------------------ |
+| GitHub  | [proto-labs-ai](https://github.com/proto-labs-ai) | Source code, issues, PRs |
+| X       | [@protoLabsAI](https://x.com/protoLabsAI)         | Updates and threads      |
+| Twitch  | [protoLabsTV](https://twitch.tv/protoLabsTV)      | Live building sessions   |
 
 ## Getting Started
 
 | Document                                                               | Description                      |
 | ---------------------------------------------------------------------- | -------------------------------- |
-| [Overview](./getting-started/index.md)                                 | What is protoMaker, key concepts |
+| [Overview](./getting-started/index.md)                                 | What is protoLabs, key concepts  |
 | [Installation (Fedora/RHEL)](./getting-started/installation-fedora.md) | Install the desktop app on Linux |
 
 ## Agent System

--- a/docs/agents/adding-teammates.md
+++ b/docs/agents/adding-teammates.md
@@ -1,6 +1,6 @@
 # Adding Agent Teammates
 
-This guide explains how to add new **authority agents** (autonomous team members like PM, ProjM, EM) to protoMaker's agent team.
+This guide explains how to add new **authority agents** (autonomous team members like PM, ProjM, EM) to protoLabs's agent team.
 
 ## Table of Contents
 

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -1,6 +1,6 @@
 # Agent Architecture Overview
 
-This document provides a high-level overview of protoMaker's agent system architecture, execution model, and key concepts for contributors.
+This document provides a high-level overview of protoLabs's agent system architecture, execution model, and key concepts for contributors.
 
 ## Table of Contents
 
@@ -13,24 +13,24 @@ This document provides a high-level overview of protoMaker's agent system archit
 
 ## Core Concepts
 
-protoMaker's agent system is built on three key concepts from Claude's agent ecosystem:
+protoLabs's agent system is built on three key concepts from Claude's agent ecosystem:
 
 ### Skills
 
 **What:** Reusable CLI commands that invoke specific modes or workflows
-**protoMaker Examples:** `/ava` (Chief of Staff), `/board` (Kanban management), `/headsdown` (autonomous work mode)
+**protoLabs Examples:** `/ava` (Chief of Staff), `/board` (Kanban management), `/headsdown` (autonomous work mode)
 **Claude Docs:** [Skills explained](https://claude.com/blog/skills-explained)
 
 ### Subagents
 
 **What:** Independent Claude instances with custom prompts, tool restrictions, and isolated contexts
-**protoMaker Examples:** Task tool agents (explore, plan, deepdive, deepcode), feature execution agents
+**protoLabs Examples:** Task tool agents (explore, plan, deepdive, deepcode), feature execution agents
 **Claude Docs:** [Create custom subagents](https://code.claude.com/docs/en/sub-agents)
 
 ### Agent Teams
 
 **What:** Multiple independent agents that coordinate autonomously via shared task lists
-**protoMaker Examples:** Authority agents (PM, ProjM, EM) working together on idea → PRD → decomposition → execution pipeline
+**protoLabs Examples:** Authority agents (PM, ProjM, EM) working together on idea → PRD → decomposition → execution pipeline
 **Claude Docs:** [Agent Teams](https://code.claude.com/docs/en/agent-teams)
 
 ## Architecture Layers
@@ -76,7 +76,7 @@ protoMaker's agent system is built on three key concepts from Claude's agent eco
 
 ### All Agents Use Native Claude SDK
 
-**Every agent in protoMaker** (whether triggered by UI, CLI, or MCP) executes via the native Claude Agent SDK with full capabilities:
+**Every agent in protoLabs** (whether triggered by UI, CLI, or MCP) executes via the native Claude Agent SDK with full capabilities:
 
 - ✅ **Cost tracking** - Every agent execution tracks `total_cost_usd`
 - ✅ **File checkpointing** - Safe rollback on errors without git operations

--- a/docs/agents/ceremonies.md
+++ b/docs/agents/ceremonies.md
@@ -1,6 +1,6 @@
 # Agile Ceremony System
 
-protoMaker's Ceremony Service automates agile ceremonies — standups, milestone retros, project retros, and board grooming — posting structured updates to Discord as projects progress through their lifecycle.
+protoLabs's Ceremony Service automates agile ceremonies — standups, milestone retros, project retros, and board grooming — posting structured updates to Discord as projects progress through their lifecycle.
 
 ## Ceremony Types
 

--- a/docs/agents/context-system.md
+++ b/docs/agents/context-system.md
@@ -1,6 +1,6 @@
 # Context System Deep Dive
 
-This guide provides a comprehensive overview of protoMaker's context loading system - how project-specific rules, conventions, and learnings flow into agent prompts.
+This guide provides a comprehensive overview of protoLabs's context loading system - how project-specific rules, conventions, and learnings flow into agent prompts.
 
 ## Table of Contents
 

--- a/docs/agents/creating-agent-teams.md
+++ b/docs/agents/creating-agent-teams.md
@@ -5,7 +5,7 @@ This guide explains how to build **multi-agent coordination systems** where mult
 ## Table of Contents
 
 - [What are Agent Teams?](#what-are-agent-teams)
-- [protoMaker's Agent Team Architecture](#automakers-agent-team-architecture)
+- [protoLabs's Agent Team Architecture](#automakers-agent-team-architecture)
 - [Team Coordination Patterns](#team-coordination-patterns)
 - [Building a New Agent Team](#building-a-new-agent-team)
 - [Example: Security Review Team](#example-security-review-team)
@@ -23,14 +23,14 @@ This guide explains how to build **multi-agent coordination systems** where mult
 - Independent context windows per agent
 - **Reference:** [Agent Teams Docs](https://code.claude.com/docs/en/agent-teams)
 
-**protoMaker's Implementation:**
+**protoLabs's Implementation:**
 
 - Event-driven coordination (shared EventEmitter bus)
 - Policy-gated state transitions (AuthorityService)
 - Persistent state (Feature data in `.automaker/features/`)
 - Discord integration for human oversight
 
-## protoMaker's Agent Team Architecture
+## protoLabs's Agent Team Architecture
 
 ### Current Teams
 

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -1,10 +1,10 @@
 # Agent System Documentation
 
-protoMaker's agent system. Specialized AI agents claim features, work in isolated worktrees, and ship PRs — autonomously.
+protoLabs's agent system. Specialized AI agents claim features, work in isolated worktrees, and ship PRs — autonomously.
 
 ## Quick Start
 
-**New to protoMaker's agents?** Start here:
+**New to protoLabs's agents?** Start here:
 
 1. Read [Architecture Overview](./architecture.md) for the big picture
 2. Read [Context System](./context-system.md) to understand how agents get project knowledge
@@ -26,7 +26,7 @@ Covers:
 - Agent types (Interactive, Feature Execution, Authority)
 - Context system overview
 
-**Read this if:** You're new to protoMaker or want to understand how agents work.
+**Read this if:** You're new to protoLabs or want to understand how agents work.
 
 ### Agent Development
 
@@ -97,7 +97,7 @@ Covers:
 Covers:
 
 - What is MCP?
-- protoMaker's MCP architecture
+- protoLabs's MCP architecture
 - MCP → Agent execution flow
 - Available MCP tools (32 tools documented)
 - Creating new MCP tools
@@ -201,7 +201,7 @@ Covers:
 
 ### MCP Tools
 
-**Programmatic API for controlling protoMaker**
+**Programmatic API for controlling protoLabs**
 
 - 32 tools for features, agents, auto-mode, context, etc.
 - Used by the Chief of Staff agent and external integrations

--- a/docs/agents/mcp-integration.md
+++ b/docs/agents/mcp-integration.md
@@ -1,11 +1,11 @@
 # MCP Integration with Agents
 
-This guide explains how **Model Context Protocol (MCP) tools** interact with protoMaker's agent system, enabling programmatic control of agent execution.
+This guide explains how **Model Context Protocol (MCP) tools** interact with protoLabs's agent system, enabling programmatic control of agent execution.
 
 ## Table of Contents
 
 - [What is MCP?](#what-is-mcp)
-- [protoMaker's MCP Architecture](#automakers-mcp-architecture)
+- [protoLabs's MCP Architecture](#automakers-mcp-architecture)
 - [MCP → Agent Flow](#mcp--agent-flow)
 - [Available MCP Tools](#available-mcp-tools)
 - [Creating New MCP Tools](#creating-new-mcp-tools)
@@ -22,15 +22,15 @@ This guide explains how **Model Context Protocol (MCP) tools** interact with pro
 - **MCP Tool** - Individual capability (e.g., "start_agent", "create_feature")
 - **MCP Resource** - Data that can be read (e.g., feature list, agent output)
 
-**protoMaker's MCP Server:**
+**protoLabs's MCP Server:**
 
 - **Location:** `packages/mcp-server/`
-- **Exposes:** 32 tools for controlling protoMaker programmatically
+- **Exposes:** 32 tools for controlling protoLabs programmatically
 - **Used By:** The Chief of Staff agent, other AI agents, external integrations
 
 **Official Docs:** [MCP Specification](https://spec.modelcontextprotocol.io/)
 
-## protoMaker's MCP Architecture
+## protoLabs's MCP Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -39,15 +39,15 @@ This guide explains how **Model Context Protocol (MCP) tools** interact with pro
 └──────────────────────┬──────────────────────────────────┘
                        │ MCP Protocol (stdio/HTTP)
 ┌──────────────────────▼──────────────────────────────────┐
-│  protoMaker MCP Server                                   │
+│  protoLabs MCP Server                                   │
 │  Location: packages/mcp-server/src/index.ts            │
 │  - Tool definitions (32 tools)                          │
-│  - API client (calls protoMaker server)                  │
+│  - API client (calls protoLabs server)                  │
 │  - Auth (AUTOMAKER_API_KEY)                            │
 └──────────────────────┬──────────────────────────────────┘
                        │ HTTP REST API
 ┌──────────────────────▼──────────────────────────────────┐
-│  protoMaker Server                                       │
+│  protoLabs Server                                       │
 │  Location: apps/server/src/                            │
 │  - API routes (agent, features, auto-mode)              │
 │  - Services (AgentService, AutoModeService)             │

--- a/docs/architecture/agent-flows.md
+++ b/docs/architecture/agent-flows.md
@@ -1,10 +1,10 @@
 # Agent Flows
 
-End-to-end pipeline diagrams documenting how work moves through protoMaker's autonomous development system.
+End-to-end pipeline diagrams documenting how work moves through protoLabs's autonomous development system.
 
-## protoMaker Dev Cycle — Idea to Merged PR
+## protoLabs Dev Cycle — Idea to Merged PR
 
-The complete lifecycle from an idea entering the system through to code merged on main. This is the core pipeline that protoMaker automates.
+The complete lifecycle from an idea entering the system through to code merged on main. This is the core pipeline that protoLabs automates.
 
 ### Full Pipeline Diagram
 
@@ -130,7 +130,7 @@ sequenceDiagram
     participant CoS as Ava (Chief of Staff)
     participant API as Server API
     participant ProjM as ProjM Agent
-    participant Board as protoMaker Board
+    participant Board as protoLabs Board
     participant Git as Git / Worktrees
 
     CoS->>API: POST /api/cos/submit-prd
@@ -226,7 +226,7 @@ flowchart LR
 
 ## Instance State & Onboarding
 
-All flows above operate within a single protoMaker instance. Each instance starts with a **clean operational slate** — no inherited board, no stale task queue.
+All flows above operate within a single protoLabs instance. Each instance starts with a **clean operational slate** — no inherited board, no stale task queue.
 
 ### What's Shared vs Instance-Local
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,6 +1,6 @@
 # Architecture
 
-System architecture documentation for protoMaker's autonomous development pipeline.
+System architecture documentation for protoLabs's autonomous development pipeline.
 
 ## Pages
 

--- a/docs/architecture/instance-state.md
+++ b/docs/architecture/instance-state.md
@@ -1,10 +1,10 @@
 # Instance State Architecture
 
-How protoMaker manages state across instances, and why each machine starts fresh.
+How protoLabs manages state across instances, and why each machine starts fresh.
 
 ## Core Principle: Fresh State Per Instance
 
-Every protoMaker instance — whether a dev laptop, staging VM, or production node in a hivemind mesh — starts with a **clean operational slate**. There is no inherited task queue, no stale project plans, no accumulated operational debt from another machine's history.
+Every protoLabs instance — whether a dev laptop, staging VM, or production node in a hivemind mesh — starts with a **clean operational slate**. There is no inherited task queue, no stale project plans, no accumulated operational debt from another machine's history.
 
 This is intentional. An instance's operational state is ephemeral. Its _knowledge_ is persistent.
 
@@ -56,7 +56,7 @@ When a new instance spins up against a repo, it doesn't inherit understanding �
 6. EXECUTE     →  Agents implement alignment work
 ```
 
-This is the `/setuplab` skill. It takes a git URL or local path and produces a fully contextualized protoMaker instance in minutes. The instance understands the codebase _because it researched it_, not because someone told it.
+This is the `/setuplab` skill. It takes a git URL or local path and produces a fully contextualized protoLabs instance in minutes. The instance understands the codebase _because it researched it_, not because someone told it.
 
 ### Future: Onboarding Task Templates
 
@@ -72,7 +72,7 @@ These tasks produce the context files and memory entries that make all subsequen
 
 ## Hivemind: Multi-Instance Mesh
 
-The fresh-state model is foundational for **hivemind** — protoMaker's multi-instance architecture where several machines work together on the same codebase, each owning specific domains.
+The fresh-state model is foundational for **hivemind** — protoLabs's multi-instance architecture where several machines work together on the same codebase, each owning specific domains.
 
 ### Architecture Overview
 

--- a/docs/authority/index.md
+++ b/docs/authority/index.md
@@ -1,6 +1,6 @@
 # Authority System
 
-protoMaker uses a trust hierarchy to manage what agents can do. The authority system defines roles, permissions, and team structure for multi-agent coordination.
+protoLabs uses a trust hierarchy to manage what agents can do. The authority system defines roles, permissions, and team structure for multi-agent coordination.
 
 ## Documentation
 

--- a/docs/authority/roles.md
+++ b/docs/authority/roles.md
@@ -81,7 +81,7 @@ Autonomous operator with full authority. Manages operations, coordinates agents,
 - [Backend Engineer](#backend-engineer) — Implements server-side features, APIs, services, and database logic
 - [Product Manager](#product-manager) — Manages requirements, priorities, roadmap, and stakeholder communication
 - [Engineering Manager](#engineering-manager) — Oversees engineering execution, code review, team coordination, and technical decisions
-- [Linear Specialist](#linear-specialist) — Owns all Linear workspace operations: project management, sprint planning, issue lifecycle, initiative tracking, and protoMaker board synchronization
+- [Linear Specialist](#linear-specialist) — Owns all Linear workspace operations: project management, sprint planning, issue lifecycle, initiative tracking, and protoLabs board synchronization
 - [PR Maintainer](#pr-maintainer) — Handles PR pipeline mechanics: auto-merge enablement, CodeRabbit thread resolution, format fixing in worktrees, branch rebasing, and PR creation from orphaned worktrees
 - [Board Janitor](#board-janitor) — Maintains board consistency: moves merged-PR features to done, resets stale in-progress features, repairs dependency chains
 
@@ -223,7 +223,7 @@ Oversees engineering execution, code review, team coordination, and technical de
 
 ### Description
 
-Owns all Linear workspace operations: project management, sprint planning, issue lifecycle, initiative tracking, and protoMaker board synchronization.
+Owns all Linear workspace operations: project management, sprint planning, issue lifecycle, initiative tracking, and protoLabs board synchronization.
 
 ---
 

--- a/docs/dev/adding-team-members.md
+++ b/docs/dev/adding-team-members.md
@@ -1,6 +1,6 @@
 # Adding New Team Members
 
-How to add a new agent role to protoMaker's multi-agent system. There are two approaches:
+How to add a new agent role to protoLabs's multi-agent system. There are two approaches:
 
 1. **Dynamic (recommended)** — Register a template at runtime via API/MCP. No code changes needed. See [Dynamic Role Registry](/agents/dynamic-role-registry).
 2. **Static** — Add to the type system, create a prompt, wire Discord routing. Requires code changes and a deploy.

--- a/docs/dev/copilotkit-integration.md
+++ b/docs/dev/copilotkit-integration.md
@@ -1,6 +1,6 @@
 # CopilotKit Integration
 
-How the CopilotKit sidebar provides AI chat, LangGraph workflows, and HITL approval flows in the protoMaker UI.
+How the CopilotKit sidebar provides AI chat, LangGraph workflows, and HITL approval flows in the protoLabs UI.
 
 ## Architecture
 
@@ -77,7 +77,7 @@ The route is guarded behind `process.env.ANTHROPIC_API_KEY`. When the key is not
 
 ### Server Actions
 
-Server actions let the chat assistant interact with the protoMaker board:
+Server actions let the chat assistant interact with the protoLabs board:
 
 | Action            | Description                                  |
 | ----------------- | -------------------------------------------- |
@@ -106,11 +106,11 @@ This ensures the app works in CI and environments without an API key.
 
 ### Sidebar
 
-`CopilotSidebarWrapper` renders the CopilotKit sidebar on the right side. The left sidebar is protoMaker's navigation. Configuration:
+`CopilotSidebarWrapper` renders the CopilotKit sidebar on the right side. The left sidebar is protoLabs's navigation. Configuration:
 
 - `defaultOpen={false}` — starts collapsed
 - `shortcut="\\"` — toggle with backslash key
-- Theme mapped from protoMaker CSS variables via `getCopilotKitThemeStyles()`
+- Theme mapped from protoLabs CSS variables via `getCopilotKitThemeStyles()`
 
 ### Context Injection
 
@@ -186,7 +186,7 @@ If `editedContent` is provided:
 
 ## Theming
 
-CopilotKit CSS variables are mapped from protoMaker's theme in `theme-bridge.tsx`:
+CopilotKit CSS variables are mapped from protoLabs's theme in `theme-bridge.tsx`:
 
 ```typescript
 {
@@ -200,7 +200,7 @@ CopilotKit CSS variables are mapped from protoMaker's theme in `theme-bridge.tsx
 }
 ```
 
-This ensures the sidebar matches all protoMaker themes (dark, light, custom).
+This ensures the sidebar matches all protoLabs themes (dark, light, custom).
 
 ## Model Selection
 

--- a/docs/dev/design-philosophy.md
+++ b/docs/dev/design-philosophy.md
@@ -1,6 +1,6 @@
 # Design philosophy
 
-Design decisions for protoMaker's UI, informed by Linear, Vercel, and shadcn/ui. This document is the source of truth for visual direction — agents and humans should reference it when making UI decisions.
+Design decisions for protoLabs's UI, informed by Linear, Vercel, and shadcn/ui. This document is the source of truth for visual direction — agents and humans should reference it when making UI decisions.
 
 ## Inspirations and what we take from each
 

--- a/docs/dev/docs-site-decision.md
+++ b/docs/dev/docs-site-decision.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-protoMaker has 50+ markdown files across a well-organized `docs/` directory with multiple sections (agents, infra, dev, protolabs, server, integrations). These docs were only accessible via GitHub's markdown renderer or direct file reading. We need a generated documentation site with search, navigation, and dark mode.
+protoLabs has 50+ markdown files across a well-organized `docs/` directory with multiple sections (agents, infra, dev, protolabs, server, integrations). These docs were only accessible via GitHub's markdown renderer or direct file reading. We need a generated documentation site with search, navigation, and dark mode.
 
 ## Options Evaluated
 

--- a/docs/dev/docs-site.md
+++ b/docs/dev/docs-site.md
@@ -1,6 +1,6 @@
 # Documentation Site
 
-protoMaker uses [VitePress](https://vitepress.dev) to generate a documentation site from the `docs/` directory.
+protoLabs uses [VitePress](https://vitepress.dev) to generate a documentation site from the `docs/` directory.
 
 ## Quick Start
 

--- a/docs/dev/feature-status-system.md
+++ b/docs/dev/feature-status-system.md
@@ -2,7 +2,7 @@
 
 ## Canonical 6-Status Flow
 
-protoMaker uses a consolidated 6-status system for all features:
+protoLabs uses a consolidated 6-status system for all features:
 
 ```
 backlog → in_progress → review → done

--- a/docs/dev/frontend-philosophy.md
+++ b/docs/dev/frontend-philosophy.md
@@ -353,7 +353,7 @@ This enables sharing UI components across future apps (docs site, template repos
 
 ### Not adopted
 
-- **Server Components:** protoMaker is a Vite SPA (+ Electron), not Next.js. All components are client components. If/when we build Next.js apps (template repos, setupLab), Server Components become relevant there.
+- **Server Components:** protoLabs is a Vite SPA (+ Electron), not Next.js. All components are client components. If/when we build Next.js apps (template repos, setupLab), Server Components become relevant there.
 
 ## Accessibility
 

--- a/docs/dev/hivemind-interfaces.md
+++ b/docs/dev/hivemind-interfaces.md
@@ -1,6 +1,6 @@
 # Hivemind Interface Extraction
 
-Interface abstractions that decouple protoMaker's core services from their concrete implementations, enabling the future hivemind multi-instance architecture.
+Interface abstractions that decouple protoLabs's core services from their concrete implementations, enabling the future hivemind multi-instance architecture.
 
 ## Overview
 

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -1,6 +1,6 @@
 # Development
 
-Extend protoMaker. Architecture, packages, code standards, and how to contribute.
+Extend protoLabs. Architecture, packages, code standards, and how to contribute.
 
 ## Architecture
 

--- a/docs/dev/issue-management.md
+++ b/docs/dev/issue-management.md
@@ -1,6 +1,6 @@
 # Issue Management & Triage
 
-protoMaker includes an automated failure-to-issue pipeline that creates GitHub issues when features fail permanently, triages them by priority, and notifies the team via Discord.
+protoLabs includes an automated failure-to-issue pipeline that creates GitHub issues when features fail permanently, triages them by priority, and notifies the team via Discord.
 
 ## Architecture
 
@@ -116,6 +116,6 @@ interface Feature {
 
 Not yet implemented:
 
-- GitHub `issues.opened` webhook -> create protoMaker feature
-- Linear issue create -> create protoMaker feature
+- GitHub `issues.opened` webhook -> create protoLabs feature
+- Linear issue create -> create protoLabs feature
 - Feature status changes -> update linked issues

--- a/docs/dev/shared-packages.md
+++ b/docs/dev/shared-packages.md
@@ -108,17 +108,17 @@ if (isValidEnhancementMode('improve')) {
 
 **Import for:**
 
-- `getprotoMakerDir(projectPath)` - Get .automaker directory
+- `getprotoLabsDir(projectPath)` - Get .automaker directory
 - `getFeaturesDir(projectPath)` - Get features directory
 - `getFeatureDir(projectPath, featureId)` - Get specific feature directory
-- `ensureprotoMakerDir(projectPath)` - Create .automaker if needed
+- `ensureprotoLabsDir(projectPath)` - Create .automaker if needed
 - `spawnJSONLProcess()` - Spawn process with JSONL output
 - `initAllowedPaths()` - Security path validation
 
 **Example:**
 
 ```typescript
-import { getFeatureDir, ensureprotoMakerDir } from '@automaker/platform';
+import { getFeatureDir, ensureprotoLabsDir } from '@automaker/platform';
 ```
 
 **Never import from:** `lib/automaker-paths`, `lib/subprocess-manager`, `lib/security`
@@ -411,7 +411,7 @@ import { createLogger, classifyError } from '@automaker/utils';
 import { getEnhancementPrompt, isValidEnhancementMode } from '@automaker/prompts';
 
 // Import platform utils from @automaker/platform
-import { getFeatureDir, ensureprotoMakerDir } from '@automaker/platform';
+import { getFeatureDir, ensureprotoLabsDir } from '@automaker/platform';
 
 // Import model resolution from @automaker/model-resolver
 import { resolveModelString } from '@automaker/model-resolver';

--- a/docs/dev/terminal.md
+++ b/docs/dev/terminal.md
@@ -1,6 +1,6 @@
 # Terminal
 
-The integrated terminal provides a full-featured terminal emulator within protoMaker, powered by xterm.js.
+The integrated terminal provides a full-featured terminal emulator within protoLabs, powered by xterm.js.
 
 ## Configuration
 

--- a/docs/dev/testing-patterns.md
+++ b/docs/dev/testing-patterns.md
@@ -1,6 +1,6 @@
 # Testing Patterns
 
-Patterns and anti-patterns for writing tests in the protoMaker codebase.
+Patterns and anti-patterns for writing tests in the protoLabs codebase.
 
 ## Event-Driven Testing
 

--- a/docs/dev/ui-architecture.md
+++ b/docs/dev/ui-architecture.md
@@ -1,6 +1,6 @@
 # UI Component Architecture
 
-This document maps protoMaker's UI component structure for developers working on the frontend. All UI code lives in `apps/ui/src/`.
+This document maps protoLabs's UI component structure for developers working on the frontend. All UI code lives in `apps/ui/src/`.
 
 ## Table of Contents
 
@@ -290,7 +290,7 @@ Idea management and prompt organization.
 
 ## Store Architecture
 
-protoMaker uses [Zustand](https://zustand-demo.pmnd.rs/) for state management with localStorage persistence.
+protoLabs uses [Zustand](https://zustand-demo.pmnd.rs/) for state management with localStorage persistence.
 
 ### App Store (`store/app-store.ts`)
 
@@ -419,7 +419,7 @@ useEffect(() => {
 
 ## Routing
 
-protoMaker uses [TanStack Router](https://tanstack.com/router) with file-based routing.
+protoLabs uses [TanStack Router](https://tanstack.com/router) with file-based routing.
 
 ### Route Structure
 

--- a/docs/disclaimer.md
+++ b/docs/disclaimer.md
@@ -2,7 +2,7 @@
 
 ## Important Warning
 
-**protoMaker uses AI-powered tooling that has access to your operating system and can read, modify, and delete files. Use at your own risk.**
+**protoLabs uses AI-powered tooling that has access to your operating system and can read, modify, and delete files. Use at your own risk.**
 
 ## Risk Assessment
 
@@ -20,13 +20,13 @@ While we have made efforts to review this codebase for security vulnerabilities 
 
 ### 1. Review the Code First
 
-Before running protoMaker, we strongly recommend reviewing the source code yourself to understand what operations it performs and ensure you are comfortable with its behavior.
+Before running protoLabs, we strongly recommend reviewing the source code yourself to understand what operations it performs and ensure you are comfortable with its behavior.
 
 ### 2. Use Sandboxing (Highly Recommended)
 
-**We do not recommend running protoMaker directly on your local computer** due to the risk of AI agents having access to your entire file system. Instead, consider:
+**We do not recommend running protoLabs directly on your local computer** due to the risk of AI agents having access to your entire file system. Instead, consider:
 
-- **Docker**: Run protoMaker in a Docker container to isolate it from your host system
+- **Docker**: Run protoLabs in a Docker container to isolate it from your host system
 - **Virtual Machine**: Use a VM (such as VirtualBox, VMware, or Parallels) to create an isolated environment
 - **Cloud Development Environment**: Use a cloud-based development environment that provides isolation
 
@@ -53,7 +53,7 @@ This software is provided "as is", without warranty of any kind, express or impl
 
 ## Acknowledgment
 
-By using protoMaker, you acknowledge that:
+By using protoLabs, you acknowledge that:
 
 1. You have read and understood this disclaimer
 2. You accept full responsibility for any consequences of using this software

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-protoMaker is an AI development studio. You describe features. AI agents build them in isolated git branches and create PRs. You review and merge.
+protoLabs is an AI development studio. You describe features. AI agents build them in isolated git branches and create PRs. You review and merge.
 
 ## How It Works
 
@@ -47,4 +47,4 @@ Every feature runs in an isolated [git worktree](https://git-scm.com/docs/git-wo
 - **[Installation (Fedora/RHEL)](./installation-fedora)** — Install the desktop app on Linux
 - **[Deployment Options](/infra/deployment)** — Docker, systemd, and staging setups
 - **[Agent System](/agents/)** — Deep dive into how agents work
-- **[MCP Plugin](/integrations/claude-plugin)** — Control protoMaker from Claude Code CLI
+- **[MCP Plugin](/integrations/claude-plugin)** — Control protoLabs from Claude Code CLI

--- a/docs/getting-started/installation-fedora.md
+++ b/docs/getting-started/installation-fedora.md
@@ -1,10 +1,10 @@
-# Installing protoMaker on Fedora/RHEL
+# Installing protoLabs on Fedora/RHEL
 
-This guide covers installation of protoMaker on Fedora, RHEL, Rocky Linux, AlmaLinux, and other RPM-based distributions.
+This guide covers installation of protoLabs on Fedora, RHEL, Rocky Linux, AlmaLinux, and other RPM-based distributions.
 
 ## Prerequisites
 
-protoMaker requires:
+protoLabs requires:
 
 - **64-bit x86_64 architecture**
 - **Fedora 39+** or **RHEL 9+** (earlier versions may work but not officially supported)
@@ -27,18 +27,18 @@ See main [README.md authentication section](../README.md#authentication) for det
 
 1. Visit [GitHub Releases](https://github.com/AutoMaker-Org/automaker/releases)
 2. Find the latest release and download the `.rpm` file:
-   - Download: `protoMaker-<version>-x86_64.rpm`
+   - Download: `protoLabs-<version>-x86_64.rpm`
 
 3. Install using dnf (Fedora):
 
    ```bash
-   sudo dnf install ./protoMaker-<version>-x86_64.rpm
+   sudo dnf install ./protoLabs-<version>-x86_64.rpm
    ```
 
    Or using yum (RHEL/CentOS):
 
    ```bash
-   sudo yum localinstall ./protoMaker-<version>-x86_64.rpm
+   sudo yum localinstall ./protoLabs-<version>-x86_64.rpm
    ```
 
 ### Option 2: Install Directly from URL
@@ -49,24 +49,24 @@ Install from GitHub releases URL without downloading first. Visit [releases page
 
 ```bash
 # Replace v0.11.0 with the actual latest version
-sudo dnf install https://github.com/AutoMaker-Org/automaker/releases/download/v0.11.0/protoMaker-0.11.0-x86_64.rpm
+sudo dnf install https://github.com/AutoMaker-Org/automaker/releases/download/v0.11.0/protoLabs-0.11.0-x86_64.rpm
 ```
 
 **RHEL/CentOS:**
 
 ```bash
 # Replace v0.11.0 with the actual latest version
-sudo yum install https://github.com/AutoMaker-Org/automaker/releases/download/v0.11.0/protoMaker-0.11.0-x86_64.rpm
+sudo yum install https://github.com/AutoMaker-Org/automaker/releases/download/v0.11.0/protoLabs-0.11.0-x86_64.rpm
 ```
 
-## Running protoMaker
+## Running protoLabs
 
-After successful installation, launch protoMaker:
+After successful installation, launch protoLabs:
 
 ### From Application Menu
 
 - Open Activities/Applications
-- Search for "protoMaker"
+- Search for "protoLabs"
 - Click to launch
 
 ### From Terminal
@@ -151,7 +151,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 
 ### Configuration Directory
 
-protoMaker stores configuration and cache in:
+protoLabs stores configuration and cache in:
 
 ```
 ~/.automaker/                # Project-specific data
@@ -201,7 +201,7 @@ sudo dnf install gtk3 libnotify nss libXScrnSaver libXtst xdg-utils at-spi2-core
 
 ### SELinux Denials
 
-If protoMaker fails on SELinux-enforced systems:
+If protoLabs fails on SELinux-enforced systems:
 
 **Temporary workaround (testing):**
 
@@ -209,7 +209,7 @@ If protoMaker fails on SELinux-enforced systems:
 # Set SELinux to permissive mode
 sudo setenforce 0
 
-# Run protoMaker
+# Run protoLabs
 automaker
 
 # Check for denials
@@ -224,7 +224,7 @@ Create custom SELinux policy based on ausearch output. For support, see [GitHub 
 
 ### Port Conflicts
 
-protoMaker uses port 3008 for the internal server. If port is already in use:
+protoLabs uses port 3008 for the internal server. If port is already in use:
 
 **Find process using port 3008:**
 
@@ -240,7 +240,7 @@ lsof -i :3008
 sudo kill -9 <PID>
 ```
 
-Or configure protoMaker to use different port (see Configuration section).
+Or configure protoLabs to use different port (see Configuration section).
 
 ### Firewall Issues
 
@@ -254,7 +254,7 @@ sudo firewall-cmd --permanent --add-port=3008/tcp
 
 ### GPU/Acceleration
 
-protoMaker uses Chromium for rendering. GPU acceleration should work automatically on supported systems.
+protoLabs uses Chromium for rendering. GPU acceleration should work automatically on supported systems.
 
 **Check acceleration:**
 
@@ -335,7 +335,7 @@ rm -rf ~/.cache/automaker
 
 ## Building from Source
 
-To build protoMaker from source on Fedora/RHEL:
+To build protoLabs from source on Fedora/RHEL:
 
 **Prerequisites:**
 
@@ -370,10 +370,10 @@ ls apps/ui/release/*.rpm
 
 See main [README.md](../README.md) for detailed build instructions.
 
-## Updating protoMaker
+## Updating protoLabs
 
 **Automatic Updates:**
-protoMaker checks for updates on startup. Install available updates through notifications.
+protoLabs checks for updates on startup. Install available updates through notifications.
 
 **Manual Update:**
 
@@ -390,7 +390,7 @@ sudo dnf remove automaker
 # Download the latest .rpm from releases page
 # https://github.com/AutoMaker-Org/automaker/releases
 # Then reinstall with:
-# sudo dnf install ./protoMaker-<VERSION>-x86_64.rpm
+# sudo dnf install ./protoLabs-<VERSION>-x86_64.rpm
 ```
 
 ## Getting Help
@@ -411,7 +411,7 @@ When reporting Fedora/RHEL issues, include:
 lsb_release -a
 uname -m
 
-# protoMaker version
+# protoLabs version
 rpm -qi automaker
 
 # Error output (run from terminal)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 layout: home
 
 hero:
-  name: protoMaker
+  name: protoLabs
   text: AI-Native Development Studio
   tagline: Describe what you want. Agents build it. PRs ship automatically.
   actions:
@@ -11,7 +11,7 @@ hero:
       link: /getting-started/
     - theme: alt
       text: View on GitHub
-      link: https://github.com/proto-labs-ai/protolabs-studio
+      link: https://github.com/proto-labs-ai
 
 features:
   - title: Ship Features with AI
@@ -31,18 +31,17 @@ features:
     link: /protolabs/
   - title: Source Available
     details: View the source. Learn the methodology. Build with it. No vendor lock-in.
-    link: https://github.com/proto-labs-ai/protolabs-studio
+    link: https://github.com/proto-labs-ai
 ---
 
 ## Quick Links
 
-| Service  | URL                                                                                 | Description                       |
-| -------- | ----------------------------------------------------------------------------------- | --------------------------------- |
-| GitHub   | [proto-labs-ai/protolabs-studio](https://github.com/proto-labs-ai/protolabs-studio) | Source code, issues, PRs          |
-| Linear   | [protolabsai](https://linear.app/protolabsai)                                       | Strategic roadmap and initiatives |
-| Graphite | [proto-labs-ai](https://app.graphite.dev/github/pr/proto-labs-ai/protolabs-studio)  | Stacked PR dashboard              |
-| Discord  | [Agentic Jumpstart](https://discord.gg/jjem7aEDKU)                                  | Community and team chat           |
+| Service | URL                                               | Description              |
+| ------- | ------------------------------------------------- | ------------------------ |
+| GitHub  | [proto-labs-ai](https://github.com/proto-labs-ai) | Source code, issues, PRs |
+| X       | [@protoLabsAI](https://x.com/protoLabsAI)         | Updates and threads      |
+| Twitch  | [protoLabsTV](https://twitch.tv/protoLabsTV)      | Live building sessions   |
 
 ---
 
-<small>Built with <a href="https://github.com/proto-labs-ai/protolabs-studio">protoMaker</a> — the source-available AI development studio that powers protoLabs.</small>
+<small>Built with <a href="https://protolabs.studio">protoLabs</a> — the source-available AI-native development studio.</small>

--- a/docs/infra/architecture.md
+++ b/docs/infra/architecture.md
@@ -1,7 +1,7 @@
 # System Architecture
 
 This document covers both the single-instance architecture (what runs on one machine)
-and the multi-instance topology (how multiple protoMaker instances coordinate as
+and the multi-instance topology (how multiple protoLabs instances coordinate as
 autonomous dev teams via Linear and Discord).
 
 ## High-Level Architecture
@@ -361,7 +361,7 @@ Browser                 nginx (UI)              Express (Server)
 
 ## Multi-Instance Topology
 
-protoMaker is designed to run as multiple independent instances, each acting as an
+protoLabs is designed to run as multiple independent instances, each acting as an
 autonomous development team. Coordination happens through Linear (project management)
 and Discord (communication), not through direct instance-to-instance communication.
 
@@ -388,7 +388,7 @@ and Discord (communication), not through direct instance-to-instance communicati
 │              │         Execution Layer             │                       │
 │              ▼                                    ▼                       │
 │  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐       │
-│  │  protoMaker        │  │  protoMaker        │  │  protoMaker        │       │
+│  │  protoLabs        │  │  protoLabs        │  │  protoLabs        │       │
 │  │  Instance A       │  │  Instance B       │  │  Instance N       │       │
 │  │  (Team Alpha)     │  │  (Team Beta)      │  │  (Team ...)       │       │
 │  │                   │  │                   │  │                   │       │
@@ -411,7 +411,7 @@ AI Agent (PE)                    Does the work, produces code + output
     │
     │ completion status, errors, PR links
     ▼
-protoMaker Board (Team Lead)      Local Kanban tracks features, manages agents
+protoLabs Board (Team Lead)      Local Kanban tracks features, manages agents
     │
     │ milestone progress, blockers, key decisions
     ▼
@@ -422,7 +422,7 @@ Linear Issues (Project Manager)  Cross-team visibility, priority, scheduling
 Linear Projects (PM / Owner)    Strategic view, resource allocation
 ```
 
-**What stays local (protoMaker instance):**
+**What stays local (protoLabs instance):**
 
 - Agent conversation logs and raw output
 - Individual feature status transitions
@@ -445,17 +445,17 @@ Linear Projects (PM / Owner)    Strategic view, resource allocation
 
 ### Role Mapping
 
-| Role                     | Where It Lives      | Responsibility                            |
-| ------------------------ | ------------------- | ----------------------------------------- |
-| Project Owner (Human)    | Linear + Discord    | Strategic direction, final approvals      |
-| PM                       | Linear projects     | What to build, why, priorities            |
-| Project Manager          | Linear issues       | When, how, milestone tracking             |
-| EM (Engineering Manager) | protoMaker instance | Who does what, capacity, agent assignment |
-| PE (Product Engineer)    | protoMaker agent    | Implementation, code, tests, PRs          |
+| Role                     | Where It Lives     | Responsibility                            |
+| ------------------------ | ------------------ | ----------------------------------------- |
+| Project Owner (Human)    | Linear + Discord   | Strategic direction, final approvals      |
+| PM                       | Linear projects    | What to build, why, priorities            |
+| Project Manager          | Linear issues      | When, how, milestone tracking             |
+| EM (Engineering Manager) | protoLabs instance | Who does what, capacity, agent assignment |
+| PE (Product Engineer)    | protoLabs agent    | Implementation, code, tests, PRs          |
 
 ### Each Instance is Autonomous
 
-Each protoMaker instance:
+Each protoLabs instance:
 
 - Has its own Kanban board with features and backlog
 - Runs its own AI agents in isolated git worktrees

--- a/docs/infra/ava-headless-quickstart.md
+++ b/docs/infra/ava-headless-quickstart.md
@@ -5,13 +5,13 @@ Setup guide for running the autonomous monitoring loop on any environment (local
 ## Prerequisites
 
 1. **Claude Code CLI** installed and authenticated
-2. **protoMaker plugin** installed: `claude plugin install automaker`
+2. **protoLabs plugin** installed: `claude plugin install automaker`
 3. **Environment variables** available in shell:
-   - `AUTOMAKER_API_KEY` — authenticates MCP plugin to protoMaker server
+   - `AUTOMAKER_API_KEY` — authenticates MCP plugin to protoLabs server
    - `DISCORD_BOT_TOKEN` — Discord bot auth (for status updates)
    - `ANTHROPIC_API_KEY` — Claude API key (or CLI auth)
 
-4. **protoMaker dev server** running on `localhost:3008`
+4. **protoLabs dev server** running on `localhost:3008`
 5. **GitHub CLI** (`gh`) authenticated with repo access
 
 ## Quick Start
@@ -57,7 +57,7 @@ export ANTHROPIC_API_KEY="<your-key>"
 export DISCORD_BOT_TOKEN="<your-token>"
 ```
 
-### 3. Install the protoMaker plugin
+### 3. Install the protoLabs plugin
 
 ```bash
 cd /path/to/automaker
@@ -80,7 +80,7 @@ Create `/etc/systemd/system/ava-monitor.service`:
 
 ```ini
 [Unit]
-Description=protoMaker Headless Monitor
+Description=protoLabs Headless Monitor
 After=network.target
 
 [Service]
@@ -114,7 +114,7 @@ sudo journalctl -u ava-monitor -f  # Watch logs
 
 **Option C: Docker sidecar**
 
-If protoMaker runs in Docker, add to `docker-compose.yml`:
+If protoLabs runs in Docker, add to `docker-compose.yml`:
 
 ```yaml
 ava-monitor:
@@ -171,7 +171,7 @@ Auto-cleaned to last 100 log files.
 
 **"Connection refused to localhost:3008"**
 
-- protoMaker server not running. Start it first.
+- protoLabs server not running. Start it first.
 
 **Pass runs but takes no action**
 

--- a/docs/infra/backup-recovery.md
+++ b/docs/infra/backup-recovery.md
@@ -1,6 +1,6 @@
 # Backup & Recovery
 
-This guide covers backup and recovery procedures for protoMaker data.
+This guide covers backup and recovery procedures for protoLabs data.
 
 ## What to Back Up
 
@@ -283,7 +283,7 @@ tar tzf automaker-full-20260205.tar.gz > /dev/null && echo "OK" || echo "CORRUPT
 
 1. Set up new server
 2. Install Docker and Docker Compose
-3. Clone protoMaker repository
+3. Clone protoLabs repository
 4. Transfer backup file from offsite storage
 5. Restore volumes (see "Restore to New Installation")
 6. Update environment variables (`.env`)

--- a/docs/infra/ci-cd.md
+++ b/docs/infra/ci-cd.md
@@ -1,6 +1,6 @@
 # CI/CD Pipelines
 
-protoMaker uses GitHub Actions for continuous integration and delivery.
+protoLabs uses GitHub Actions for continuous integration and delivery.
 
 ## Workflows Overview
 
@@ -517,7 +517,7 @@ The `ava-staging` runner has access to resources that GitHub-hosted runners don'
 | -------------------------- | ----------------------------------------------------- |
 | Claude CLI (authenticated) | AI-assisted PR reviews, changelog generation          |
 | Anthropic API key          | Automated code analysis, release notes                |
-| protoMaker MCP server      | Board updates, feature status, agent orchestration    |
+| protoLabs MCP server       | Board updates, feature status, agent orchestration    |
 | Docker (host)              | Staging deploys, integration tests against real infra |
 | gh CLI (authenticated)     | PR creation, issue management, release publishing     |
 | 125GB RAM / 24 CPUs        | Full E2E test suites, parallel builds                 |
@@ -557,7 +557,7 @@ The `ava-staging` runner has access to resources that GitHub-hosted runners don'
 ### Adding New Workflows
 
 Self-hosted workflows use `runs-on: self-hosted` and have access to the host environment.
-The self-hosted runner has access to the host environment where protoMaker is deployed.
+The self-hosted runner has access to the host environment where protoLabs is deployed.
 
 ```yaml
 jobs:
@@ -566,7 +566,7 @@ jobs:
     steps:
       - name: Use Claude CLI
         run: claude --version
-      - name: Use protoMaker MCP
+      - name: Use protoLabs MCP
         run: curl -sf http://localhost:3008/api/health
 ```
 

--- a/docs/infra/deployment.md
+++ b/docs/infra/deployment.md
@@ -1,6 +1,6 @@
 # Deployment Guide
 
-This guide covers different deployment options for protoMaker.
+This guide covers different deployment options for protoLabs.
 
 ## Deployment Options
 
@@ -80,7 +80,7 @@ curl -I http://protolabs.studio        # redirect → HTTPS
 
 ## Local Development
 
-For development, run protoMaker directly on your machine:
+For development, run protoLabs directly on your machine:
 
 ```bash
 # Install dependencies
@@ -111,7 +111,7 @@ AUTOMAKER_API_KEY=your-local-key
 
 ## Docker (Isolated)
 
-Run protoMaker in complete isolation from your filesystem:
+Run protoLabs in complete isolation from your filesystem:
 
 ```bash
 docker compose up -d
@@ -127,7 +127,7 @@ Access at `http://localhost:3007` (UI), `http://localhost:3008` (API), `http://l
 
 ### When to Use
 
-- Testing protoMaker safely
+- Testing protoLabs safely
 - Demo environments
 - CI/CD testing
 
@@ -195,7 +195,7 @@ Edit the service file:
 
 ```ini
 [Unit]
-Description=protoMaker AI Development Studio
+Description=protoLabs AI Development Studio
 After=docker.service
 Requires=docker.service
 
@@ -257,13 +257,13 @@ sudo systemctl disable automaker
 
 ### Authentication
 
-| Variable                   | Required | Description                                  |
-| -------------------------- | -------- | -------------------------------------------- |
-| `ANTHROPIC_API_KEY`        | Yes\*    | Anthropic API key                            |
-| `CLAUDE_OAUTH_CREDENTIALS` | Yes\*    | Claude CLI OAuth JSON                        |
-| `AUTOMAKER_API_KEY`        | No       | protoMaker API key (auto-generated if blank) |
-| `CURSOR_AUTH_TOKEN`        | No       | Cursor CLI OAuth token                       |
-| `GH_TOKEN`                 | No       | GitHub CLI token                             |
+| Variable                   | Required | Description                                 |
+| -------------------------- | -------- | ------------------------------------------- |
+| `ANTHROPIC_API_KEY`        | Yes\*    | Anthropic API key                           |
+| `CLAUDE_OAUTH_CREDENTIALS` | Yes\*    | Claude CLI OAuth JSON                       |
+| `AUTOMAKER_API_KEY`        | No       | protoLabs API key (auto-generated if blank) |
+| `CURSOR_AUTH_TOKEN`        | No       | Cursor CLI OAuth token                      |
+| `GH_TOKEN`                 | No       | GitHub CLI token                            |
 
 \*At least one of `ANTHROPIC_API_KEY` or `CLAUDE_OAUTH_CREDENTIALS` is required.
 

--- a/docs/infra/docker-compose.md
+++ b/docs/infra/docker-compose.md
@@ -1,6 +1,6 @@
 # Docker Compose Configuration
 
-protoMaker provides multiple Docker Compose configurations for different use cases.
+protoLabs provides multiple Docker Compose configurations for different use cases.
 
 ## Compose Files
 
@@ -15,7 +15,7 @@ protoMaker provides multiple Docker Compose configurations for different use cas
 
 ## Production Configuration
 
-`docker-compose.yml` runs protoMaker in complete isolation:
+`docker-compose.yml` runs protoLabs in complete isolation:
 
 ```yaml
 services:
@@ -212,11 +212,11 @@ services:
 
 ### Optional Authentication
 
-| Variable            | Description                                                     |
-| ------------------- | --------------------------------------------------------------- |
-| `AUTOMAKER_API_KEY` | API key for protoMaker authentication (auto-generated if blank) |
-| `CURSOR_AUTH_TOKEN` | Cursor CLI OAuth token                                          |
-| `GH_TOKEN`          | GitHub CLI token for git operations                             |
+| Variable            | Description                                                    |
+| ------------------- | -------------------------------------------------------------- |
+| `AUTOMAKER_API_KEY` | API key for protoLabs authentication (auto-generated if blank) |
+| `CURSOR_AUTH_TOKEN` | Cursor CLI OAuth token                                         |
+| `GH_TOKEN`          | GitHub CLI token for git operations                            |
 
 ### Optional Configuration
 

--- a/docs/infra/docker.md
+++ b/docs/infra/docker.md
@@ -1,6 +1,6 @@
 # Docker Architecture
 
-protoMaker uses a multi-stage Dockerfile to build both server and UI images from a single file.
+protoLabs uses a multi-stage Dockerfile to build both server and UI images from a single file.
 
 ## Files
 

--- a/docs/infra/index.md
+++ b/docs/infra/index.md
@@ -1,6 +1,6 @@
 # Infrastructure Documentation
 
-Deploy protoMaker. Docker, systemd, staging — pick what fits your stack.
+Deploy protoLabs. Docker, systemd, staging — pick what fits your stack.
 
 ## Quick Links
 
@@ -23,7 +23,7 @@ Deploy protoMaker. Docker, systemd, staging — pick what fits your stack.
 
 ## Infrastructure Overview
 
-protoMaker uses a containerized architecture with three services:
+protoLabs uses a containerized architecture with three services:
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -141,7 +141,7 @@ See [deployment.md](./deployment.md) for a complete list of environment variable
 
 ## Using the /devops Skill
 
-protoMaker includes a `/devops` skill for managing infrastructure from Claude Code:
+protoLabs includes a `/devops` skill for managing infrastructure from Claude Code:
 
 ```
 /devops           # Show container status

--- a/docs/infra/monitoring.md
+++ b/docs/infra/monitoring.md
@@ -1,6 +1,6 @@
 # Monitoring & Observability
 
-This guide covers health checks, logging, and observability for protoMaker.
+This guide covers health checks, logging, and observability for protoLabs.
 
 ## Health Checks
 

--- a/docs/infra/networking.md
+++ b/docs/infra/networking.md
@@ -274,7 +274,7 @@ services:
 ### UFW (Ubuntu)
 
 ```bash
-# Allow protoMaker ports (if exposing externally)
+# Allow protoLabs ports (if exposing externally)
 sudo ufw allow 3007/tcp
 sudo ufw allow 3008/tcp
 

--- a/docs/infra/secrets.md
+++ b/docs/infra/secrets.md
@@ -1,6 +1,6 @@
 # Secret Management
 
-This guide covers how to set up centralized secret management for protoMaker deployments, including integration with MCP servers, Docker, and CLI tools.
+This guide covers how to set up centralized secret management for protoLabs deployments, including integration with MCP servers, Docker, and CLI tools.
 
 ## Problem
 
@@ -204,7 +204,7 @@ docker compose --env-file .env up -d
 Add to `~/.bashrc` or `~/.zshrc` for ambient secret access:
 
 ```bash
-# Load protoMaker secrets into shell
+# Load protoLabs secrets into shell
 alias automaker-env='eval $(infisical export --env=dev --format=shell --projectId=<id>)'
 ```
 
@@ -269,8 +269,8 @@ If your team uses 1Password Teams/Business (~$8/user/month):
 
 ```bash
 # Template file (.env.tpl)
-ANTHROPIC_API_KEY=op://protoMaker/Anthropic/api-key
-DISCORD_TOKEN=op://protoMaker/Discord Bot/token
+ANTHROPIC_API_KEY=op://protoLabs/Anthropic/api-key
+DISCORD_TOKEN=op://protoLabs/Discord Bot/token
 
 # Inject
 op run --env-file=.env.tpl -- node mcp-server/dist/index.js

--- a/docs/infra/security.md
+++ b/docs/infra/security.md
@@ -213,7 +213,7 @@ Files that should NEVER be mounted or committed:
 
 ### API Key Authentication
 
-The protoMaker API requires authentication:
+The protoLabs API requires authentication:
 
 ```bash
 curl -H "Authorization: Bearer YOUR_API_KEY" \

--- a/docs/infra/staging-deployment.md
+++ b/docs/infra/staging-deployment.md
@@ -1,6 +1,6 @@
 # High-Concurrency Deployment
 
-This guide covers deploying protoMaker in a staging or high-concurrency environment with high-memory configuration for increased concurrent agent capacity.
+This guide covers deploying protoLabs in a staging or high-concurrency environment with high-memory configuration for increased concurrent agent capacity.
 
 ## Overview
 
@@ -51,7 +51,7 @@ Based on observed behavior and Claude Agent SDK usage patterns:
 
 **Important:** Multiple projects with the same name can coexist without conflicts.
 
-protoMaker isolates projects by **absolute path**, not by name. Each project's data is stored in `{projectPath}/.automaker/`.
+protoLabs isolates projects by **absolute path**, not by name. Each project's data is stored in `{projectPath}/.automaker/`.
 
 Example - no conflicts:
 
@@ -513,9 +513,9 @@ curl -s https://api.linear.app/graphql \
   -d '{"query":"{ viewer { id name } }"}' | python3 -m json.tool
 ```
 
-### protoMaker API Key (`AUTOMAKER_API_KEY`)
+### protoLabs API Key (`AUTOMAKER_API_KEY`)
 
-protoMaker uses `X-API-Key` header (NOT `Authorization: Bearer`):
+protoLabs uses `X-API-Key` header (NOT `Authorization: Bearer`):
 
 ```bash
 # Correct
@@ -854,4 +854,4 @@ Failed smoke tests trigger automatic rollback to previous working images.
 
 ---
 
-**Applies to:** protoMaker v1.x with Docker deployment
+**Applies to:** protoLabs v1.x with Docker deployment

--- a/docs/infra/systemd.md
+++ b/docs/infra/systemd.md
@@ -1,6 +1,6 @@
 # systemd Service Configuration
 
-This guide covers running protoMaker as a systemd service for persistent deployments.
+This guide covers running protoLabs as a systemd service for persistent deployments.
 
 ## Service File
 
@@ -8,7 +8,7 @@ The service file is located at `automaker.service` in the repository root.
 
 ```ini
 [Unit]
-Description=protoMaker AI Development Studio
+Description=protoLabs AI Development Studio
 Documentation=https://github.com/proto-labs-ai/automaker
 After=docker.service
 Requires=docker.service
@@ -50,7 +50,7 @@ sudo nano /etc/systemd/system/automaker.service
 
 Update:
 
-- `WorkingDirectory` - Path to your protoMaker installation
+- `WorkingDirectory` - Path to your protoLabs installation
 - `User` / `Group` - Your username
 
 ### 3. Reload systemd
@@ -75,7 +75,7 @@ sudo systemctl start automaker
 
 ```ini
 [Unit]
-Description=protoMaker AI Development Studio
+Description=protoLabs AI Development Studio
 Documentation=https://github.com/proto-labs-ai/automaker
 After=docker.service
 Requires=docker.service
@@ -147,7 +147,7 @@ sudo systemctl status automaker
 Output:
 
 ```
-● automaker.service - protoMaker AI Development Studio
+● automaker.service - protoLabs AI Development Studio
      Loaded: loaded (/etc/systemd/system/automaker.service; enabled)
      Active: active (exited) since Wed 2026-02-05 10:00:00 UTC
        Docs: https://github.com/proto-labs-ai/automaker
@@ -295,7 +295,7 @@ sudo systemctl status docker
 # Start Docker if needed
 sudo systemctl start docker
 
-# Then restart protoMaker
+# Then restart protoLabs
 sudo systemctl restart automaker
 ```
 
@@ -330,7 +330,7 @@ Create a timer:
 ```ini
 # /etc/systemd/system/automaker-healthcheck.timer
 [Unit]
-Description=protoMaker Health Check
+Description=protoLabs Health Check
 
 [Timer]
 OnBootSec=5min
@@ -343,7 +343,7 @@ WantedBy=timers.target
 ```ini
 # /etc/systemd/system/automaker-healthcheck.service
 [Unit]
-Description=protoMaker Health Check
+Description=protoLabs Health Check
 
 [Service]
 Type=oneshot
@@ -359,12 +359,12 @@ sudo systemctl start automaker-healthcheck.timer
 
 ### Multiple Instances
 
-For running multiple protoMaker instances:
+For running multiple protoLabs instances:
 
 ```ini
 # /etc/systemd/system/automaker@.service
 [Unit]
-Description=protoMaker AI Development Studio - %i
+Description=protoLabs AI Development Studio - %i
 After=docker.service
 Requires=docker.service
 

--- a/docs/infra/troubleshooting.md
+++ b/docs/infra/troubleshooting.md
@@ -478,7 +478,7 @@ docker network inspect automaker_default
 
 Include:
 
-1. protoMaker version (git commit)
+1. protoLabs version (git commit)
 2. Docker version
 3. Operating system
 4. Steps to reproduce

--- a/docs/integrations/api-key-profiles.md
+++ b/docs/integrations/api-key-profiles.md
@@ -4,7 +4,7 @@ This document describes the implementation of Claude Compatible Providers, allow
 
 ## Overview
 
-Claude Compatible Providers allow protoMaker to work with third-party API endpoints that implement Claude's API protocol. This enables:
+Claude Compatible Providers allow protoLabs to work with third-party API endpoints that implement Claude's API protocol. This enables:
 
 - **Cost savings**: Use providers like z.AI GLM or MiniMax at lower costs
 - **Alternative models**: Access models like GLM-4.7 or MiniMax M2.1 through familiar interfaces

--- a/docs/integrations/claude-plugin.md
+++ b/docs/integrations/claude-plugin.md
@@ -1,6 +1,6 @@
-# Claude Code Plugin for protoMaker
+# Claude Code Plugin for protoLabs
 
-Comprehensive guide to using the Claude Code plugin and MCP server for programmatic control of protoMaker.
+Comprehensive guide to using the Claude Code plugin and MCP server for programmatic control of protoLabs.
 
 ## Quick Start
 
@@ -9,13 +9,13 @@ Comprehensive guide to using the Claude Code plugin and MCP server for programma
 Install directly from the GitHub repository:
 
 ```bash
-# 1. Add the protoMaker plugin marketplace from GitHub
+# 1. Add the protoLabs plugin marketplace from GitHub
 claude plugin marketplace add https://github.com/proto-labs-ai/automaker/tree/main/packages/mcp-server/plugins
 
 # 2. Install the plugin
 claude plugin install automaker
 
-# 3. Start protoMaker server (in a separate terminal)
+# 3. Start protoLabs server (in a separate terminal)
 git clone https://github.com/proto-labs-ai/automaker.git
 cd automaker
 npm install
@@ -28,10 +28,10 @@ claude
 
 ### Option 2: Install from Local Clone (Development)
 
-For developers working on protoMaker:
+For developers working on protoLabs:
 
 ```bash
-# 1. Clone and install protoMaker
+# 1. Clone and install protoLabs
 git clone https://github.com/proto-labs-ai/automaker.git
 cd automaker
 npm install
@@ -39,7 +39,7 @@ npm install
 # 2. Build the MCP server
 npm run build:packages
 
-# 3. Start protoMaker server
+# 3. Start protoLabs server
 npm run dev:web
 
 # 4. In a new terminal, add the plugin marketplace and install
@@ -82,7 +82,7 @@ That's it! You now have access to 32 MCP tools and slash commands for managing y
 
 ## Overview
 
-The protoMaker Claude Code plugin enables you to:
+The protoLabs Claude Code plugin enables you to:
 
 - **Manage Features**: Create, update, and track features on your Kanban board
 - **Control Agents**: Start, stop, and monitor AI agents working on features
@@ -91,23 +91,23 @@ The protoMaker Claude Code plugin enables you to:
 
 The plugin consists of:
 
-1. **MCP Server** (`@automaker/mcp-server`) - Exposes protoMaker's API via Model Context Protocol
+1. **MCP Server** (`@automaker/mcp-server`) - Exposes protoLabs's API via Model Context Protocol
 2. **Claude Plugin** (`packages/mcp-server/plugins/automaker`) - Provides slash commands and subagents
 
 ## Installation
 
 ### Prerequisites
 
-- protoMaker server running (`npm run dev` from the automaker root directory)
+- protoLabs server running (`npm run dev` from the automaker root directory)
 - Claude Code CLI installed and authenticated
 - Node.js 22+
 
-### Step 1: Start protoMaker with a Fixed API Key
+### Step 1: Start protoLabs with a Fixed API Key
 
-By default, protoMaker generates a random API key on each restart. For Claude Code integration, use a fixed key:
+By default, protoLabs generates a random API key on each restart. For Claude Code integration, use a fixed key:
 
 ```bash
-# Start protoMaker with a fixed API key
+# Start protoLabs with a fixed API key
 AUTOMAKER_API_KEY=your-dev-key-2026 npm run dev
 ```
 
@@ -159,7 +159,7 @@ Test that the plugin is working:
 /board
 ```
 
-You should see your Kanban board or a message to start the protoMaker server.
+You should see your Kanban board or a message to start the protoLabs server.
 
 ## Configuration
 
@@ -169,7 +169,7 @@ Configure these in your shell or the plugin's `plugin.json`:
 
 | Variable            | Description                | Default                 |
 | ------------------- | -------------------------- | ----------------------- |
-| `AUTOMAKER_API_URL` | protoMaker API base URL    | `http://localhost:3008` |
+| `AUTOMAKER_API_URL` | protoLabs API base URL     | `http://localhost:3008` |
 | `AUTOMAKER_API_KEY` | API key for authentication | (required)              |
 
 ### Plugin Configuration
@@ -179,7 +179,7 @@ The plugin configuration is in `packages/mcp-server/plugins/automaker/.claude-pl
 ```json
 {
   "name": "automaker",
-  "description": "protoMaker - AI Development Studio",
+  "description": "protoLabs - AI Development Studio",
   "version": "1.0.0",
   "mcpServers": {
     "automaker": {
@@ -215,12 +215,12 @@ If you prefer to configure MCP directly, add to `~/.claude/claude_desktop_config
 
 ## Docker Deployment
 
-For production deployments using Docker, follow these steps to configure the MCP plugin to communicate with a containerized protoMaker server.
+For production deployments using Docker, follow these steps to configure the MCP plugin to communicate with a containerized protoLabs server.
 
 ### Prerequisites
 
 - Docker and Docker Compose installed
-- protoMaker repository cloned
+- protoLabs repository cloned
 - Claude Code CLI installed
 
 ### Step 1: Configure docker-compose.override.yml
@@ -228,7 +228,7 @@ For production deployments using Docker, follow these steps to configure the MCP
 Create `docker-compose.override.yml` in the automaker root directory:
 
 ```yaml
-# protoMaker Production Override
+# protoLabs Production Override
 # Mounts host project directories for development work
 
 services:
@@ -293,7 +293,7 @@ Edit `packages/mcp-server/plugins/automaker/.claude-plugin/plugin.json` to use a
 ```json
 {
   "name": "automaker",
-  "description": "protoMaker - AI Development Studio",
+  "description": "protoLabs - AI Development Studio",
   "version": "1.0.2",
   "mcpServers": {
     "automaker": {
@@ -356,7 +356,7 @@ Adjust Docker memory limits based on your workload:
 
 ### Working with Multiple Projects
 
-With the path mapping configuration above, you can use protoMaker with any project under your `ALLOWED_ROOT_DIRECTORY`:
+With the path mapping configuration above, you can use protoLabs with any project under your `ALLOWED_ROOT_DIRECTORY`:
 
 ```bash
 # Project A
@@ -378,7 +378,7 @@ Each project maintains its own `.automaker/` directory with independent features
 
 ### /board
 
-View and manage the protoMaker Kanban board.
+View and manage the protoLabs Kanban board.
 
 ```bash
 /board                    # Show board overview with feature counts
@@ -899,10 +899,10 @@ The MCP server exposes 32 tools organized by category:
 
 ### Utilities
 
-| Tool                | Description                           |
-| ------------------- | ------------------------------------- |
-| `health_check`      | Check if protoMaker server is running |
-| `get_board_summary` | Get feature counts by status          |
+| Tool                | Description                          |
+| ------------------- | ------------------------------------ |
+| `health_check`      | Check if protoLabs server is running |
+| `get_board_summary` | Get feature counts by status         |
 
 ## Examples
 
@@ -1020,7 +1020,7 @@ Claude: Let me check the agent output.
 
 ### Connection Errors
 
-1. Ensure protoMaker server is running:
+1. Ensure protoLabs server is running:
 
    ```bash
    npm run dev
@@ -1035,14 +1035,14 @@ Claude: Let me check the agent output.
 
 3. Verify the API key:
    ```bash
-   # Should match what's set in protoMaker
+   # Should match what's set in protoLabs
    echo $AUTOMAKER_API_KEY
    ```
 
 ### Authentication Errors
 
 1. Ensure `AUTOMAKER_API_KEY` is set in both:
-   - protoMaker server (via env or .env file)
+   - protoLabs server (via env or .env file)
    - Plugin configuration (plugin.json)
 
 2. The keys must match exactly
@@ -1055,7 +1055,7 @@ Claude: Let me check the agent output.
    /board
    ```
 
-   If it fails with "server not running", start protoMaker.
+   If it fails with "server not running", start protoLabs.
 
 2. Verify MCP tools are loaded:
    ```bash
@@ -1423,5 +1423,5 @@ mcp__automaker__create_feature({
 
 ## Related Documentation
 
-- [protoMaker README](../README.md) - Main project documentation
+- [protoLabs README](../README.md) - Main project documentation
 - [Context System](/agents/context-system) - Best practices for context files

--- a/docs/integrations/discord.md
+++ b/docs/integrations/discord.md
@@ -1,10 +1,10 @@
 # Discord Communication Guide
 
-This document defines the communication channels and rules for Discord integration with protoMaker, which serves as the real-time coordination layer for development teams.
+This document defines the communication channels and rules for Discord integration with protoLabs, which serves as the real-time coordination layer for development teams.
 
 ## Server Setup
 
-Create a Discord server for your protoMaker team. The channel structure below is the recommended layout.
+Create a Discord server for your protoLabs team. The channel structure below is the recommended layout.
 
 ## Channel Structure
 
@@ -44,7 +44,7 @@ Domain-specific technical discussion. Each channel maps to a team role in the [a
 
 ### AUTOMAKER
 
-protoMaker system activity and monitoring. Primarily bot/webhook-driven.
+protoLabs system activity and monitoring. Primarily bot/webhook-driven.
 
 | Channel           | Purpose                                               |
 | ----------------- | ----------------------------------------------------- |
@@ -231,7 +231,7 @@ Post in #standups daily (async, no specific time required):
 - `#team-*` channels are team workspaces for day-to-day sprint coordination
 - Keep project-specific discussions in the appropriate team channel
 
-### protoMaker Channels
+### protoLabs Channels
 
 These channels are primarily automated:
 
@@ -240,7 +240,7 @@ These channels are primarily automated:
 - `#deployments` - CI/CD pipeline notifications
 - `#bugs-and-issues` - Manual bug reports and automated error alerts
 
-Human messages in protoMaker channels should be limited to:
+Human messages in protoLabs channels should be limited to:
 
 - Responding to alerts
 - Adding context to automated notifications
@@ -248,7 +248,7 @@ Human messages in protoMaker channels should be limited to:
 
 ## Agent Communication Protocol
 
-AI agents in the protoMaker hierarchy use Discord for status updates and coordination.
+AI agents in the protoLabs hierarchy use Discord for status updates and coordination.
 
 ### Which agents post where
 
@@ -277,7 +277,7 @@ Details: <brief description>
 
 ### Event-Driven Notifications
 
-protoMaker emits events that can be routed to Discord channels:
+protoLabs emits events that can be routed to Discord channels:
 
 | Event                  | Channel           | Message                                   |
 | ---------------------- | ----------------- | ----------------------------------------- |
@@ -326,32 +326,32 @@ Content-Type: application/json
 
 {
   "content": "Message text",
-  "username": "protoMaker Bot"
+  "username": "protoLabs Bot"
 }
 ```
 
 Recommended webhooks:
 
-| Channel           | Webhook Name      | Source                |
-| ----------------- | ----------------- | --------------------- |
-| #agent-logs       | protoMaker Agent  | protoMaker server     |
-| #pr-notifications | GitHub            | GitHub webhook        |
-| #deployments      | CI/CD             | GitHub Actions        |
-| #ai-news          | AI News Feed      | RSS/Atom aggregator   |
-| #alerts           | protoMaker Alerts | Health monitor        |
-| #approvals        | Trust System      | Policy engine         |
-| #infra            | DevOps Bot        | Backup/deploy scripts |
+| Channel           | Webhook Name     | Source                |
+| ----------------- | ---------------- | --------------------- |
+| #agent-logs       | protoLabs Agent  | protoLabs server      |
+| #pr-notifications | GitHub           | GitHub webhook        |
+| #deployments      | CI/CD            | GitHub Actions        |
+| #ai-news          | AI News Feed     | RSS/Atom aggregator   |
+| #alerts           | protoLabs Alerts | Health monitor        |
+| #approvals        | Trust System     | Policy engine         |
+| #infra            | DevOps Bot       | Backup/deploy scripts |
 
 ### Linear Integration
 
 Linear issues map to Discord channels through the team hierarchy:
 
-| Linear Team | Discord Channel | protoMaker Role |
-| ----------- | --------------- | --------------- |
-| Frontend    | #team-frontend  | `frontend`      |
-| Backend     | #team-backend   | `backend`       |
-| AI/ML       | #team-ai-ml     | `ai-ml`         |
-| DevOps      | #team-devops    | `devops`        |
+| Linear Team | Discord Channel | protoLabs Role |
+| ----------- | --------------- | -------------- |
+| Frontend    | #team-frontend  | `frontend`     |
+| Backend     | #team-backend   | `backend`      |
+| AI/ML       | #team-ai-ml     | `ai-ml`        |
+| DevOps      | #team-devops    | `devops`       |
 
 Cross-team blockers identified in Linear triage are posted to #project-issues.
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,12 +1,12 @@
 # Integrations
 
-Connect protoMaker to your workflow. Discord, Linear, GitHub, Claude Code CLI.
+Connect protoLabs to your workflow. Discord, Linear, GitHub, Claude Code CLI.
 
 ## Available Integrations
 
 ### [Claude Code Plugin](./claude-plugin)
 
-Control protoMaker from the Claude Code CLI via MCP tools. Create features, start agents, manage the board, and orchestrate projects — all from your terminal.
+Control protoLabs from the Claude Code CLI via MCP tools. Create features, start agents, manage the board, and orchestrate projects — all from your terminal.
 
 ### [Discord](./discord)
 
@@ -22,7 +22,7 @@ Full Linear integration with three modes: @mention the agent on any issue for co
 
 ## External Tools
 
-protoMaker also works with:
+protoLabs also works with:
 
 - **[GitHub Actions](/infra/ci-cd)** — CI/CD pipelines for testing and deployment
 - **[Graphite](https://graphite.dev)** — Stack-aware PR management for epic workflows

--- a/docs/integrations/linear-sync.md
+++ b/docs/integrations/linear-sync.md
@@ -1,11 +1,11 @@
 # Linear integration
 
-protoMaker integrates with [Linear](https://linear.app) for bidirectional project management and AI agent interaction. @mention the agent on any issue to get context-aware analysis, or create a Linear project to trigger automated planning.
+protoLabs integrates with [Linear](https://linear.app) for bidirectional project management and AI agent interaction. @mention the agent on any issue to get context-aware analysis, or create a Linear project to trigger automated planning.
 
 ## Architecture
 
 ```
-Linear                              protoMaker
+Linear                              protoLabs
 ┌──────────────────┐               ┌───────────────────────────┐
 │ @mention agent   │──webhook────▶ │ LinearAgentRouter          │
 │                  │               │   ↓ intelligent routing    │
@@ -29,8 +29,8 @@ Linear                              protoMaker
 | ------------ | ------------- | ---------------------- | -------------------------------------------------- |
 | **Agent**    | Bidirectional | @mention or delegation | AI agent responds via activities, multi-turn chat  |
 | **Planning** | Bidirectional | Project created        | LangGraph flow with HITL checkpoints and documents |
-| **Push**     | protoMaker →  | Feature events         | Creates issues, syncs status                       |
-| **Pull**     | → protoMaker  | Webhooks               | Detects approvals, syncs priority changes          |
+| **Push**     | protoLabs →   | Feature events         | Creates issues, syncs status                       |
+| **Pull**     | → protoLabs   | Webhooks               | Detects approvals, syncs priority changes          |
 
 ## Setup
 
@@ -39,7 +39,7 @@ Linear                              protoMaker
 1. Go to [Linear Settings > API > OAuth Applications](https://linear.app/settings/api/applications)
 2. Click **New Application**
 3. Fill in:
-   - **Name**: `protoMaker` (this is the name users will see when they @mention the agent)
+   - **Name**: `protoLabs` (this is the name users will see when they @mention the agent)
    - **Description**: `AI Development Studio agent`
    - **Redirect URI**: your callback URL (see below)
    - **Client credentials**: **Yes**
@@ -253,29 +253,29 @@ At each checkpoint, users can:
 
 ### Status sync mapping
 
-| protoMaker Status | Linear Status           | Direction           |
-| ----------------- | ----------------------- | ------------------- |
-| `backlog`         | `Backlog` / `Todo`      | Both                |
-| `in_progress`     | `In Progress`           | Both                |
-| `review`          | `In Review`             | protoMaker → Linear |
-| `done`            | `Done`                  | Both                |
-| `blocked`         | `Blocked` / `Cancelled` | protoMaker → Linear |
+| protoLabs Status | Linear Status           | Direction          |
+| ---------------- | ----------------------- | ------------------ |
+| `backlog`        | `Backlog` / `Todo`      | Both               |
+| `in_progress`    | `In Progress`           | Both               |
+| `review`         | `In Review`             | protoLabs → Linear |
+| `done`           | `Done`                  | Both               |
+| `blocked`        | `Blocked` / `Cancelled` | protoLabs → Linear |
 
 ### Priority mapping
 
-| Linear Priority | protoMaker Complexity | Claude Model |
-| --------------- | --------------------- | ------------ |
-| Urgent (1)      | `large`               | Opus         |
-| High (2)        | `large`               | Opus         |
-| Normal (3)      | `medium`              | Sonnet       |
-| Low (4)         | `small`               | Haiku        |
-| None (0)        | `medium`              | Sonnet       |
+| Linear Priority | protoLabs Complexity | Claude Model |
+| --------------- | -------------------- | ------------ |
+| Urgent (1)      | `large`              | Opus         |
+| High (2)        | `large`              | Opus         |
+| Normal (3)      | `medium`             | Sonnet       |
+| Low (4)         | `small`              | Haiku        |
+| None (0)        | `medium`             | Sonnet       |
 
 ### Approval workflow
 
 1. Product manager creates issue and moves to "Approved" state
 2. Webhook fires → `LinearApprovalHandler` detects the state match
-3. `ApprovalBridge` creates an epic feature on the protoMaker board
+3. `ApprovalBridge` creates an epic feature on the protoLabs board
 4. AI classifier suggests an agent role based on issue content
 5. Auto-mode picks up features and assigns agents
 6. Agent implements, creates PR, merges
@@ -291,7 +291,7 @@ At each checkpoint, users can:
 | `syncOnFeatureCreate` | boolean  | `true`                               | Create Linear issue when feature is created              |
 | `syncOnStatusChange`  | boolean  | `true`                               | Sync status changes to Linear                            |
 | `commentOnCompletion` | boolean  | `true`                               | Add comment when agent completes work                    |
-| `syncEnabled`         | boolean  | `false`                              | Enable bidirectional sync (Linear → protoMaker)          |
+| `syncEnabled`         | boolean  | `false`                              | Enable bidirectional sync (Linear → protoLabs)           |
 | `approvalStates`      | string[] | `["Approved", "Ready for Planning"]` | Workflow states that trigger approval pipeline           |
 | `conflictResolution`  | string   | `"linear"`                           | Who wins on conflict: `linear`, `automaker`, or `manual` |
 | `labelName`           | string   | —                                    | Custom label applied to synced issues                    |
@@ -354,13 +354,13 @@ This error means the Authorization header has `Bearer lin_api_...`. Linear API k
 
 ### Sync conflicts
 
-When the same field is modified in both Linear and protoMaker simultaneously:
+When the same field is modified in both Linear and protoLabs simultaneously:
 
 - **`conflictResolution: "linear"`** — Linear's value wins (default, safest)
-- **`conflictResolution: "automaker"`** — protoMaker's value wins
+- **`conflictResolution: "automaker"`** — protoLabs's value wins
 - **`conflictResolution: "manual"`** — Neither side overwrites; requires manual resolution
 
-Loop prevention: Every sync operation sets a `syncedFromLinear` / `syncedFromprotoMaker` flag. The other side checks this flag and skips updates that originated from itself.
+Loop prevention: Every sync operation sets a `syncedFromLinear` / `syncedFromprotoLabs` flag. The other side checks this flag and skips updates that originated from itself.
 
 ### Status not syncing
 

--- a/docs/server/index.md
+++ b/docs/server/index.md
@@ -1,6 +1,6 @@
 # Server Reference
 
-Technical reference for the protoMaker backend (`apps/server/`).
+Technical reference for the protoLabs backend (`apps/server/`).
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Complete brand consolidation: retire "protoMaker" as separate product name
- Updated 53 files across docs site, vitepress config, and README
- Fixed Quick Links: removed internal-only services (Linear, Graphite, Discord invite), replaced with public links (GitHub org, X, Twitch)
- Fixed GitHub social link and edit URLs pointing to non-existent `protolabs-studio` repo → `automaker`

## Test plan
- [ ] Verify docs.protolabs.studio renders correctly after deploy
- [ ] Confirm Quick Links table shows GitHub, X, Twitch (no Linear/Graphite/Discord)
- [ ] Confirm footer says "protoLabs" not "protoMaker"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation across all sections to reflect product naming changes and repository references.
  * Updated GitHub links and social media integration points.

* **Refactor**
  * Renamed platform package functions for consistency: `getprotoMakerDir()` → `getprotoLabsDir()` and `ensureprotoMakerDir()` → `ensureprotoLabsDir()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->