### PR TITLE
fix(deploy): force-recreate docs container on staging deploy

### DIFF
--- a/scripts/setup-staging.sh
+++ b/scripts/setup-staging.sh
@@ -220,7 +220,8 @@ start_services() {
   docker compose -f "$COMPOSE_FILE" up -d server ui
 
   # Start docs independently (won't be affected by app restarts)
-  docker compose -f "$DOCS_COMPOSE_FILE" up -d 2>/dev/null || warn "Docs failed to start"
+  # Force-recreate ensures the container picks up the newly built image.
+  docker compose -f "$DOCS_COMPOSE_FILE" up -d --force-recreate 2>/dev/null || warn "Docs failed to start"
 
   # Start storybook separately — failure is non-fatal
   docker compose -f "$COMPOSE_FILE" up -d storybook 2>/dev/null || warn "Storybook failed to start (image may not exist)"


### PR DESCRIPTION
## Summary

- Adds `--force-recreate` to the docs container `up -d` command in `setup-staging.sh`
- Without this, the docs container keeps running the old image even after a rebuild because `docker compose up -d` skips recreation when it doesn't detect config changes
- Root cause of docs.protolabs.studio not updating after PR #656 merged

## Test plan

- [ ] Merge this PR
- [ ] Verify next deploy restarts the docs container (check `docker ps` shows fresh creation time for `automaker-docs`)
- [ ] Verify docs.protolabs.studio reflects latest content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated staging setup to rebuild the docs container with the latest image on each deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->