### PR TITLE
docs: fix brand casing across protolabs docs

### DIFF
--- a/docs/protolabs/agency-architecture.md
+++ b/docs/protolabs/agency-architecture.md
@@ -1,4 +1,4 @@
-# ProtoLabs Agency System — Architecture
+# protoLabs Agency System — Architecture
 
 ## System Architecture Diagram
 

--- a/docs/protolabs/agency-overview.md
+++ b/docs/protolabs/agency-overview.md
@@ -1,8 +1,8 @@
-# ProtoLabs Agency System — Overview
+# protoLabs Agency System — Overview
 
 ## What It Is
 
-ProtoLabs is a fully autonomous software development agency powered by AI agents. It takes ideas from any source — human conversation, Discord messages, Linear issues, GitHub — and transforms them into shipped, tested, merged code through a repeatable, measurable loop.
+protoLabs is a fully autonomous software development agency powered by AI agents. It takes ideas from any source — human conversation, Discord messages, Linear issues, GitHub — and transforms them into shipped, tested, merged code through a repeatable, measurable loop.
 
 The system doesn't just execute. It plans, challenges its own plans, breaks work into measurable pieces, delegates to specialized agents, monitors quality, and — critically — reflects on what it learned and feeds that back into better future work.
 
@@ -12,7 +12,7 @@ The system doesn't just execute. It plans, challenges its own plans, breaks work
 
 ### The Problem With AI-Assisted Development Today
 
-Most AI coding tools operate at the wrong altitude. They help you write a function or fix a bug. ProtoLabs operates at the **organizational** level — it's not a tool, it's a **team**.
+Most AI coding tools operate at the wrong altitude. They help you write a function or fix a bug. protoLabs operates at the **organizational** level — it's not a tool, it's a **team**.
 
 The gap between "AI can write code" and "AI can run a development organization" is:
 
@@ -22,9 +22,9 @@ The gap between "AI can write code" and "AI can run a development organization" 
 - **Accountability**: How do you know if the work was worth doing?
 - **Learning**: How does the org get smarter over time?
 
-### The ProtoLabs Answer
+### The protoLabs Answer
 
-ProtoLabs is organized into two branches — **Operations** and **Engineering** — with clear boundaries, quality guardrails, and domain tools that enable orchestration at scale.
+protoLabs is organized into two branches — **Operations** and **Engineering** — with clear boundaries, quality guardrails, and domain tools that enable orchestration at scale.
 
 ### Operations
 
@@ -55,7 +55,7 @@ Production orchestration, auto-mode execution, and code quality. The Lead Engine
 
 ## Three Surfaces, Clear Separation
 
-ProtoLabs operates across three systems that each own a distinct layer:
+protoLabs operates across three systems that each own a distinct layer:
 
 ### Linear — Strategic Layer (Source of Truth)
 

--- a/docs/protolabs/agency-prd.md
+++ b/docs/protolabs/agency-prd.md
@@ -1,4 +1,12 @@
-# PRD: ProtoLabs Agency System — Full-Loop Automation
+# PRD: protoLabs Agency System — Full-Loop Automation
+
+> **Implementation Status (2026-02-16):**
+> Milestone 1 (Signal Intake) — partially implemented (signal accumulator, idea processing flow).
+> Milestone 2 (Antagonistic Review) — **complete** (3-stage sequential review with LangGraph + Langfuse tracing).
+> Milestone 3 (Approval Gate) — partially implemented (HITL gates exist, trust boundaries in progress).
+> Milestone 4 (Linear Project API) — **complete** (project lifecycle, Linear sync, bidirectional webhooks).
+> Milestone 5 (Reflection Loop) — partially implemented (ceremonies exist, retro → improvement tickets pending).
+> Milestone 6 (E2E Integration) — in progress (pipeline view pending, core flow functional).
 
 ## Situation
 
@@ -218,7 +226,7 @@ Build the cross-functional PRD review where Ava and Jon challenge each other.
 
 **Phase 6.2: Dashboard & Observability**
 
-- Add ProtoLabs pipeline view to protoLabs UI:
+- Add protoLabs pipeline view to protoLabs UI:
   - Current signals being triaged
   - PRDs in review
   - Projects in execution
@@ -228,7 +236,7 @@ Build the cross-functional PRD review where Ava and Jon challenge each other.
 
 ## Results
 
-When complete, the ProtoLabs agency system will:
+When complete, the protoLabs agency system will:
 
 1. **Accept ideas from any source** (Discord, Linear, GitHub, agent observations) and auto-triage them into the correct pipeline
 2. **Challenge every plan** through antagonistic cross-functional review before committing resources

--- a/docs/protolabs/ci-cd-setup.md
+++ b/docs/protolabs/ci-cd-setup.md
@@ -1,6 +1,6 @@
-# CI/CD Setup Guide for ProtoLab
+# CI/CD Setup Guide for protoLabs
 
-Complete guide for setting up GitHub Actions CI/CD and branch protection for ProtoLab projects.
+Complete guide for setting up GitHub Actions CI/CD and branch protection for protoLabs projects.
 
 ## Quick Start
 
@@ -143,7 +143,7 @@ Choose an option (1-3):
 
 **Warning**: This overwrites existing workflows!
 
-**Choose 3** to standardize on ProtoLab workflows
+**Choose 3** to standardize on protoLabs workflows
 
 ---
 

--- a/docs/protolabs/content/README.md
+++ b/docs/protolabs/content/README.md
@@ -1,4 +1,4 @@
-# ProtoLabs Content
+# protoLabs Content
 
 Pre-launch content required for official launch (per Jon's requirement from review).
 
@@ -67,7 +67,7 @@ Pre-launch content required for official launch (per Jon's requirement from revi
 
 - **Voice:** Both pieces use Josh's authentic builder voice (architect/orchestrator, not developer)
 - **Tone:** Technical, direct, pragmatic, show-the-work
-- **Brand alignment:** Uses protoLabs/protoLabs naming correctly (never "Automaker" in public-facing content)
+- **Brand alignment:** Uses protoLabs naming correctly (never "Automaker" in public-facing content)
 - **Team attribution:** Ava, Jon, ProjM, Matt, Sam, Frank, Cindi correctly referenced
 - **Technical accuracy:** All architecture details verified against actual codebase (agency-architecture.md, agency-overview.md)
 

--- a/docs/protolabs/content/saas-is-dead-meet-the-intelligent-product-engine.md
+++ b/docs/protolabs/content/saas-is-dead-meet-the-intelligent-product-engine.md
@@ -187,7 +187,7 @@ The architecture is documented. The source is available. The costs are transpare
 
 Your SaaS bill is opaque by design. Ours is open by default.
 
-**[protolabs.studio](https://protolabs.studio)**
+**[protoLabs.studio](https://protolabs.studio)**
 
 ---
 

--- a/docs/protolabs/index.md
+++ b/docs/protolabs/index.md
@@ -1,4 +1,4 @@
-# ProtoLabs
+# protoLabs
 
 protoLabs methodology. Scan any repo, analyze gaps, propose alignment, and execute — all automated.
 
@@ -13,5 +13,9 @@ protoLabs methodology. Scan any repo, analyze gaps, propose alignment, and execu
 ## Guides
 
 - [Brand Identity](./brand.md) — Brand bible: naming, voice, team, content strategy, revenue model
+- [Agency Overview](./agency-overview.md) — How the full-loop automation system works
+- [Agency Architecture](./agency-architecture.md) — System architecture, component inventory, data flow
+- [Agency PRD](./agency-prd.md) — Full-loop automation PRD with implementation status
+- [Design System](./design-system.md) — Visual identity: surfaces, typography, components, animations
 - [Setup Pipeline](./setup-pipeline.md) — Technical reference for the 5-phase `/setuplab` pipeline
 - [CI/CD Setup](./ci-cd-setup.md) — GitHub Actions and branch protection setup

--- a/docs/protolabs/setup-pipeline.md
+++ b/docs/protolabs/setup-pipeline.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `/setuplab` command is the entry point for onboarding any repository to ProtoLabs. It runs a 5-phase pipeline that scans, analyzes, initializes, proposes, and (on approval) executes alignment work.
+The `/setuplab` command is the entry point for onboarding any repository to protoLabs. It runs a 5-phase pipeline that scans, analyzes, initializes, proposes, and (on approval) executes alignment work.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Fix `ProtoLabs` → `protoLabs` casing across 8 documentation files (~14 instances)
- Fix `ProtoLab` (missing 's') → `protoLabs` in ci-cd-setup.md
- Fix `protolabs.studio` → `protoLabs.studio` display text in SaaS article CTA
- Fix redundant `protoLabs/protoLabs` → `protoLabs` in content README
- Add implementation status blockquote to agency-prd.md (marks which milestones are complete)
- Add 4 missing doc links to index.md (overview, architecture, PRD, design system)

## Test plan
- [ ] Verify all docs render correctly in VitePress
- [ ] Search for remaining `ProtoLabs` instances (should only exist in brand.md "not this" guidance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)