### PR TITLE
docs: fix stale references and audit findings across 8 files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -108,12 +108,21 @@ DevOps documentation in [`docs/infra/`](./infra/):
 | [Docs Site Decision](./dev/docs-site-decision.md)         | ADR: Why VitePress was chosen                        |
 | [Docs Standard](./dev/docs-standard.md)                   | IA rules, content guidelines, maintenance            |
 
-## ProtoLabs
+## protoLabs
 
-| Document                                        | Description                        |
-| ----------------------------------------------- | ---------------------------------- |
-| [Setup Pipeline](./protolabs/setup-pipeline.md) | 5-phase ProtoLab setup pipeline    |
-| [CI/CD Setup](./protolabs/ci-cd-setup.md)       | CI/CD pipeline setup for ProtoLabs |
+| Document                                                            | Description                                         |
+| ------------------------------------------------------------------- | --------------------------------------------------- |
+| [Overview](./protolabs/index.md)                                    | protoLabs methodology and guides                    |
+| [Brand Identity](./protolabs/brand.md)                              | Brand bible: naming, voice, team, content strategy  |
+| [Design System](./protolabs/design-system.md)                       | Visual identity: surfaces, typography, components   |
+| [Agency Overview](./protolabs/agency-overview.md)                   | How the full-loop automation system works           |
+| [Agency Architecture](./protolabs/agency-architecture.md)           | System architecture, component inventory, data flow |
+| [Agency PRD](./protolabs/agency-prd.md)                             | Full-loop automation PRD with implementation status |
+| [Setup Pipeline](./protolabs/setup-pipeline.md)                     | 5-phase protoLabs setup pipeline                    |
+| [CI/CD Setup](./protolabs/ci-cd-setup.md)                           | CI/CD pipeline setup for protoLabs                  |
+| [Flow Builder Agent Spec](./protolabs/flow-builder-agent-spec.md)   | Agent spec for LangGraph flow generation            |
+| [Flow Development Pattern](./protolabs/flow-development-pattern.md) | 5-layer flow development pattern                    |
+| [Graph Flow Roadmap](./protolabs/graph-flow-roadmap.md)             | LangGraph migration roadmap and status              |
 
 ## Legal
 

--- a/docs/agents/creating-agent-teams.md
+++ b/docs/agents/creating-agent-teams.md
@@ -371,7 +371,7 @@ logger.info('Security Review Team initialized');
 
 ## Example: Security Review Team
 
-Full implementation: see `apps/server/src/services/security-agents/` in the repo
+The security review team above is a reference architecture example showing the multi-agent coordination pattern
 
 **Trigger:** PR created
 **Coordination:** Event bus + shared JSON state

--- a/docs/dev/docs-standard.md
+++ b/docs/dev/docs-standard.md
@@ -17,7 +17,7 @@ Every documentation page must belong to one of these 8 top-level sections:
 | Server Reference | `server/`          | Backend API reference and internals      | Developers       |
 | Authority        | `authority/`       | Trust hierarchy, roles, team structure   | Team leads       |
 | Development      | `dev/`             | Contributing, architecture, processes    | Contributors     |
-| ProtoLabs        | `protolabs/`       | Agency setup pipeline and onboarding     | Agency operators |
+| protoLabs        | `protolabs/`       | Agency setup pipeline and onboarding     | Agency operators |
 
 **Special locations:**
 

--- a/docs/dev/shared-packages.md
+++ b/docs/dev/shared-packages.md
@@ -14,7 +14,7 @@ libs/
 ├── platform/           # Platform utilities
 ├── model-resolver/     # Claude model resolution
 ├── dependency-resolver/# Feature dependency resolution
-├── policy-engine/      # Trust-based policy checking
+├── tools/              # Unified tool definition and registry system
 ├── spec-parser/        # XML/markdown spec parsing
 ├── git-utils/          # Git operations
 ├── flows/              # LangGraph state graph primitives
@@ -138,7 +138,7 @@ import { getFeatureDir, ensureprotoLabsDir } from '@automaker/platform';
 import { resolveModelString, DEFAULT_MODELS } from '@automaker/model-resolver';
 
 // Convert user input to model ID
-const modelId = resolveModelString('sonnet'); // → 'claude-sonnet-4-20250514'
+const modelId = resolveModelString('sonnet'); // → 'claude-sonnet-4-5-20250929'
 
 // Use default for auto-mode feature implementation
 const autoModeModel = DEFAULT_MODELS.autoMode; // → sonnet
@@ -148,8 +148,8 @@ const autoModeModel = DEFAULT_MODELS.autoMode; // → sonnet
 
 **Model aliases:**
 
-- `haiku` → `claude-haiku-4-5` (fast, simple/trivial tasks)
-- `sonnet` → `claude-sonnet-4-20250514` (balanced, feature implementation)
+- `haiku` → `claude-haiku-4-5-20251001` (fast, simple/trivial tasks)
+- `sonnet` → `claude-sonnet-4-5-20250929` (balanced, feature implementation)
 - `opus` → `claude-opus-4-5-20251101` (maximum capability, orchestration/architecture)
 
 **DEFAULT_MODELS use cases:**
@@ -475,6 +475,7 @@ Understanding the dependency chain helps prevent circular dependencies:
 @automaker/observability
 @automaker/llm-providers
 @automaker/flows
+@automaker/tools
     ↓
 @automaker/git-utils
     ↓
@@ -531,6 +532,7 @@ import { Feature } from '../../../src/services/feature-loader';
 - LangGraph Flows → `@automaker/flows`
 - LLM Providers → `@automaker/llm-providers`
 - Tracing/Observability → `@automaker/observability`
+- Tool Definitions → `@automaker/tools`
 
 **Never import from:** `lib/*`, `services/feature-loader` (for types), `providers/types`, `routes/common`
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -20,13 +20,14 @@ You create a feature → Agent claims it → Works in isolated branch → Create
 
 Features are units of work on the Kanban board. Each has a status:
 
-| Status        | Meaning                     |
-| ------------- | --------------------------- |
-| `backlog`     | Queued, ready to start      |
-| `in_progress` | Being worked on by an agent |
-| `review`      | PR created, under review    |
-| `blocked`     | Temporarily halted          |
-| `done`        | PR merged, work complete    |
+| Status        | Meaning                             |
+| ------------- | ----------------------------------- |
+| `backlog`     | Queued, ready to start              |
+| `in_progress` | Being worked on by an agent         |
+| `review`      | PR created, under review            |
+| `blocked`     | Temporarily halted                  |
+| `done`        | PR merged, work complete            |
+| `verified`    | Quality checks passed (Ralph loops) |
 
 ### Agents
 

--- a/docs/server/index.md
+++ b/docs/server/index.md
@@ -9,7 +9,7 @@ The server is an Express 5 application with WebSocket streaming, organized into 
 ## Reference
 
 - **[Route Organization](./route-organization)** — Express route structure, middleware, and patterns
-- **[Providers](./providers)** — AI provider abstraction (Claude, Cursor, Codex)
+- **[Providers](./providers)** — AI provider abstraction (Claude, Cursor, Codex, OpenCode)
 - **[Utilities](./utilities)** — Server utility functions and helpers
 
 ## Key Technologies

--- a/docs/server/route-organization.md
+++ b/docs/server/route-organization.md
@@ -153,7 +153,7 @@ export function create{Module}Routes(events: EventEmitter): Router {
 **Pattern**:
 
 ```typescript
-import { createLogger } from '../../lib/logger.js';
+import { createLogger } from '@automaker/utils';
 
 const logger = createLogger('{ModuleName}');
 
@@ -203,7 +203,7 @@ export function getErrorMessage(error: unknown): string {
 ```typescript
 import type { Request, Response } from "express";
 import type { EventEmitter } from "../../../lib/events.js";
-import { createLogger } from "../../../lib/logger.js";
+import { createLogger } from "@automaker/utils";
 import {
   isRunning,
   setRunningState,
@@ -288,7 +288,7 @@ export function create{Action}Handler(events: EventEmitter) {
 
 import { query, type Options } from '@anthropic-ai/claude-agent-sdk';
 import type { EventEmitter } from '../../lib/events.js';
-import { createLogger } from '../../lib/logger.js';
+import { createLogger } from '@automaker/utils';
 import { logAuthStatus } from './common.js';
 import { anotherBusinessFunction } from './another-business-function.js';
 

--- a/docs/server/utilities.md
+++ b/docs/server/utilities.md
@@ -1,6 +1,17 @@
 # Server Utilities Reference
 
-This document describes all utility modules available in `apps/server/src/lib/`. These utilities provide reusable functionality for image handling, prompt building, model resolution, conversation management, and error handling.
+> **Note:** Most utilities documented here have been extracted to shared packages. Import from `@automaker/utils`, `@automaker/model-resolver`, and `@automaker/platform` instead of `apps/server/src/lib/`. See [Shared Packages](../dev/shared-packages) for the canonical import guide.
+>
+> | Old Path                    | New Package                 |
+> | --------------------------- | --------------------------- |
+> | `lib/image-handler.ts`      | `@automaker/utils`          |
+> | `lib/prompt-builder.ts`     | `@automaker/utils`          |
+> | `lib/model-resolver.ts`     | `@automaker/model-resolver` |
+> | `lib/conversation-utils.ts` | `@automaker/utils`          |
+> | `lib/error-handler.ts`      | `@automaker/utils`          |
+> | `lib/subprocess-manager.ts` | `@automaker/platform`       |
+
+This document describes utility functions available for server-side code. The canonical imports use shared packages (`@automaker/utils`, `@automaker/model-resolver`, `@automaker/platform`), not direct `lib/` paths.
 
 ---
 
@@ -211,8 +222,8 @@ Model alias mapping for Claude models.
 
 ```typescript
 export const CLAUDE_MODEL_MAP: Record<string, string> = {
-  haiku: 'claude-haiku-4-5',
-  sonnet: 'claude-sonnet-4-20250514',
+  haiku: 'claude-haiku-4-5-20251001',
+  sonnet: 'claude-sonnet-4-5-20250929',
   opus: 'claude-opus-4-5-20251101',
 } as const;
 ```


### PR DESCRIPTION
## Summary

Fixes identified by the comprehensive docs audit (Ava, Sam, Jon agents — session 62):

- **docs/README.md**: Add 9 missing protoLabs docs to the table, fix `ProtoLabs` → `protoLabs` casing
- **docs/dev/shared-packages.md**: Remove phantom `policy-engine` package (doesn't exist as a shared lib), add missing `@automaker/tools`, fix stale model IDs (`sonnet → claude-sonnet-4-5-20250929`, `haiku → claude-haiku-4-5-20251001`)
- **docs/server/utilities.md**: Add deprecation notice with migration table pointing to shared packages, fix stale model map values
- **docs/server/route-organization.md**: Fix 3 stale import paths (`../../lib/logger.js` → `@automaker/utils`)
- **docs/getting-started/index.md**: Add missing `verified` status to feature status table
- **docs/agents/creating-agent-teams.md**: Fix false reference to non-existent `security-agents/` directory
- **docs/dev/docs-standard.md**: Fix `ProtoLabs` → `protoLabs` in section map
- **docs/server/index.md**: Add OpenCode to provider list

## Test plan

- [ ] Verify VitePress build still succeeds (markdown only, no code changes)
- [ ] Spot-check that new README links resolve to existing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized and expanded documentation structure for improved clarity and navigation.
  * Updated model version references to latest Claude variants for enhanced performance.
  * Enhanced agent team examples with clearer architectural guidance and output specifications.

* **New Features**
  * Added "verified" workflow status for quality check tracking.
  * Included additional AI provider support in server documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->