### PR TITLE
fix(docs): correct auth headers, crew members, and Infisical status

### DIFF
--- a/docs/dev/crew-loops.md
+++ b/docs/dev/crew-loops.md
@@ -1,6 +1,6 @@
 # Crew Loop System
 
-The Crew Loop system provides unified scheduling for team members (Ava, Frank, GTM, and future agents). Each member runs a lightweight in-process check on an independent cron schedule. When a check detects problems, the system escalates by spawning the member's agent template via `DynamicAgentExecutor`.
+The Crew Loop system provides unified scheduling for team members (Ava, Frank, GTM, PR Maintainer, Board Janitor, System Health, PR State Sync). Each member runs a lightweight in-process check on an independent cron schedule. When a check detects problems, the system escalates by spawning the member's agent template via `DynamicAgentExecutor`.
 
 ## Architecture
 
@@ -41,13 +41,15 @@ Re-export from `crew-members/index.ts`.
 
 ## Current Crew Members
 
-| Member        | ID              | Schedule                | Default  | Purpose                                                           |
-| ------------- | --------------- | ----------------------- | -------- | ----------------------------------------------------------------- |
-| Ava           | `ava`           | `*/10 * * * *` (10 min) | Enabled  | Stuck agents, blocked features, auto-mode health, capacity        |
-| Frank         | `frank`         | `*/10 * * * *` (10 min) | Enabled  | Server health, memory, capacity, health monitor, worktree health  |
-| GTM           | `gtm`           | `0 */6 * * *` (6 hours) | Disabled | Content pipeline (placeholder)                                    |
-| PR Maintainer | `pr-maintainer` | `*/10 * * * *` (10 min) | Enabled  | Stale PRs, auto-merge, CodeRabbit threads, orphaned worktrees     |
-| Board Janitor | `board-janitor` | `*/15 * * * *` (15 min) | Enabled  | Merged-not-done, orphaned in-progress, broken deps, stale blocked |
+| Member        | ID              | Schedule                | Default  | Purpose                                                                    |
+| ------------- | --------------- | ----------------------- | -------- | -------------------------------------------------------------------------- |
+| Ava           | `ava`           | `*/10 * * * *` (10 min) | Enabled  | Stuck agents, blocked features, auto-mode health, capacity                 |
+| Frank         | `frank`         | `*/10 * * * *` (10 min) | Enabled  | Server health, memory, capacity, health monitor, worktree health           |
+| GTM           | `gtm`           | `0 */6 * * *` (6 hours) | Disabled | Content pipeline (placeholder)                                             |
+| PR Maintainer | `pr-maintainer` | `*/10 * * * *` (10 min) | Enabled  | Stale PRs, auto-merge, CodeRabbit threads, orphaned worktrees              |
+| Board Janitor | `board-janitor` | `*/10 * * * *` (10 min) | Enabled  | Merged-not-done, orphaned in-progress, broken deps, stale blocked          |
+| System Health | `system-health` | `*/10 * * * *` (10 min) | Enabled  | System RAM, swap, disk, CPU load, temperature, GPU/VRAM, zombie processes  |
+| PR State Sync | `pr-state-sync` | `*/5 * * * *` (5 min)   | Enabled  | GitHub-to-board state drift detection (merged PRs, CI failures, stale PRs) |
 
 ## API Endpoints
 

--- a/docs/dev/issue-management.md
+++ b/docs/dev/issue-management.md
@@ -83,7 +83,7 @@ Create issues manually via the REST API:
 ```bash
 curl -X POST http://localhost:3008/api/issues/create \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $AUTOMAKER_API_KEY" \
+  -H "X-API-Key: $AUTOMAKER_API_KEY" \
   -d '{"projectPath": "/path/to/project", "featureId": "feature-id"}'
 ```
 

--- a/docs/infra/monitoring.md
+++ b/docs/infra/monitoring.md
@@ -166,7 +166,7 @@ The server emits events for:
 
 ```bash
 curl http://localhost:3008/api/board/summary \
-  -H "Authorization: Bearer YOUR_API_KEY"
+  -H "X-API-Key: YOUR_API_KEY"
 ```
 
 Response:
@@ -188,7 +188,7 @@ Response:
 
 ```bash
 curl http://localhost:3008/api/agents/running \
-  -H "Authorization: Bearer YOUR_API_KEY"
+  -H "X-API-Key: YOUR_API_KEY"
 ```
 
 ## Alerting

--- a/docs/infra/secrets.md
+++ b/docs/infra/secrets.md
@@ -15,6 +15,8 @@ This causes friction when onboarding team members and creates security risks fro
 
 ## Solution: Infisical
 
+> **Status: Planned.** Infisical is not yet deployed. protoLabs currently uses `.env` files (gitignored) for secret management. This section describes the target architecture for when centralized secret management is adopted.
+
 [Infisical](https://infisical.com) is an open-source secret management platform that provides:
 
 - Web UI for browsing and editing secrets

--- a/docs/infra/security.md
+++ b/docs/infra/security.md
@@ -216,7 +216,7 @@ Files that should NEVER be mounted or committed:
 The protoLabs API requires authentication:
 
 ```bash
-curl -H "Authorization: Bearer YOUR_API_KEY" \
+curl -H "X-API-Key: YOUR_API_KEY" \
   http://localhost:3008/api/health
 ```
 

--- a/docs/infra/troubleshooting.md
+++ b/docs/infra/troubleshooting.md
@@ -408,7 +408,7 @@ docker compose logs -f server | grep -i agent
 docker exec automaker-server ls -la /path/to/project/.automaker/features
 
 # Check API response
-curl -H "Authorization: Bearer KEY" \
+curl -H "X-API-Key: KEY" \
   "http://localhost:3008/api/features?projectPath=/path/to/project"
 ```
 


### PR DESCRIPTION
## Summary

- Fix `Authorization: Bearer` → `X-API-Key` in 5 docs (monitoring, security, troubleshooting, issue-management)
- Add 2 missing crew members to `crew-loops.md`: `system-health` and `pr-state-sync` (verified against source in `apps/server/src/services/crew-members/`)
- Fix board-janitor schedule: `*/15` → `*/10` (matches source code `board-janitor-check.ts:27`)
- Add "Status: Planned" disclaimer to `secrets.md` for Infisical (not yet deployed)

## Test plan

- [ ] Verify auth header examples match server implementation (`X-API-Key` header)
- [ ] Verify crew member table matches source code registrations
- [ ] Verify Infisical disclaimer accurately reflects current state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API authentication across guides to use X-API-Key header format instead of Bearer tokens
  * Added documentation for newly introduced System Health and PR State Sync automation crew members  
  * Adjusted Board Janitor automation schedule for increased frequency
  * Clarified current secret management using .env files and upcoming improvements via Infisical

<!-- end of auto-generated comment: release notes by coderabbit.ai -->