### PR TITLE
fix(deploy): remove old docs container before recreating

### DIFF
--- a/scripts/setup-staging.sh
+++ b/scripts/setup-staging.sh
@@ -220,8 +220,10 @@ start_services() {
   docker compose -f "$COMPOSE_FILE" up -d server ui
 
   # Start docs independently (won't be affected by app restarts)
-  # Force-recreate ensures the container picks up the newly built image.
-  docker compose -f "$DOCS_COMPOSE_FILE" up -d --force-recreate 2>/dev/null || warn "Docs failed to start"
+  # Remove old container first — it may belong to a different compose project
+  # (automaker-staging vs automaker-docs), causing name conflicts on recreate.
+  docker rm -f automaker-docs 2>/dev/null || true
+  docker compose -f "$DOCS_COMPOSE_FILE" up -d 2>/dev/null || warn "Docs failed to start"
 
   # Start storybook separately — failure is non-fatal
   docker compose -f "$COMPOSE_FILE" up -d storybook 2>/dev/null || warn "Storybook failed to start (image may not exist)"


### PR DESCRIPTION
## Summary

- Fixes docs site not updating on staging deploy
- Root cause: docs container belongs to compose project `automaker-staging` but `docker-compose.docs.yml` uses project `automaker-docs` — name conflict prevents recreation
- Fix: `docker rm -f automaker-docs` before `up -d` to clear the stale container
- Supersedes the `--force-recreate` approach from #657 which didn't work due to this project mismatch

## Test plan

- [ ] After merge, verify staging deploy log shows docs container freshly created (not "5 hours ago")
- [ ] Verify docs.protolabs.studio shows "protoLabs" (not "protoMaker") 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging environment setup by preventing documentation container name conflicts. The docs container is now properly cleaned up before restarting, ensuring more reliable deployment without force-recreate operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->