### PR TITLE
feat(site): add Umami analytics to landing page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -33,6 +33,11 @@
       href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
+    <script
+      defer
+      src="https://umami.proto-labs.ai/script.js"
+      data-website-id="417982ad-56b0-47ea-9184-ca785e2fd1dc"
+    ></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {


### PR DESCRIPTION
## Summary

- Adds self-hosted Umami tracking script to protolabs.studio landing page
- Script loads deferred, zero impact on page load performance
- Tracking instance at umami.proto-labs.ai

Note: docs site already supports Umami via `UMAMI_WEBSITE_ID` env var in VitePress config — set it in staging `.env` when ready.

## Test plan

- [ ] Verify script tag is present in page source
- [ ] Check Umami dashboard for incoming page views after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added analytics tracking to the website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->