### PR TITLE
fix(e2e): replace hardcoded ports with env-driven config

### DIFF
--- a/apps/ui/tests/copilotkit-sidebar.spec.ts
+++ b/apps/ui/tests/copilotkit-sidebar.spec.ts
@@ -8,7 +8,7 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { authenticateForTests, API_BASE_URL } from './utils';
+import { authenticateForTests, API_BASE_URL, UI_BASE_URL } from './utils';
 
 test.describe('CopilotKit Integration', () => {
   test('CopilotKit endpoint responds or returns 404 gracefully', async ({ page }) => {
@@ -46,7 +46,7 @@ test.describe('CopilotKit Integration', () => {
     await authenticateForTests(page);
 
     // Navigate to the app root
-    await page.goto('http://localhost:3007');
+    await page.goto(UI_BASE_URL);
     await page.waitForLoadState('networkidle');
 
     // The app should render without crashing
@@ -62,7 +62,7 @@ test.describe('CopilotKit Integration', () => {
   test('Sidebar toggle shortcut does not crash the app', async ({ page }) => {
     await authenticateForTests(page);
 
-    await page.goto('http://localhost:3007');
+    await page.goto(UI_BASE_URL);
     await page.waitForLoadState('networkidle');
 
     // Press the sidebar toggle shortcut (backslash)

--- a/apps/ui/tests/global-setup.ts
+++ b/apps/ui/tests/global-setup.ts
@@ -8,7 +8,8 @@
  * setup and use stale server settings instead.
  */
 
-const API_BASE_URL = 'http://localhost:3008';
+const API_PORT = process.env.TEST_SERVER_PORT || '3008';
+const API_BASE_URL = `http://localhost:${API_PORT}`;
 
 async function globalSetup() {
   const apiKey = process.env.AUTOMAKER_API_KEY || 'test-api-key-for-e2e-tests';

--- a/apps/ui/tests/utils/api/client.ts
+++ b/apps/ui/tests/utils/api/client.ts
@@ -4,7 +4,7 @@
  */
 
 import { Page, APIResponse } from '@playwright/test';
-import { API_BASE_URL, API_ENDPOINTS } from '../core/constants';
+import { API_BASE_URL, API_ENDPOINTS, UI_BASE_URL } from '../core/constants';
 
 // ============================================================================
 // Types
@@ -346,7 +346,7 @@ export async function authenticateWithApiKey(page: Page, apiKey: string): Promis
     // Ensure we're on a page (needed for cookies to work)
     const currentUrl = page.url();
     if (!currentUrl || currentUrl === 'about:blank') {
-      await page.goto('http://localhost:3007', { waitUntil: 'domcontentloaded' });
+      await page.goto(UI_BASE_URL, { waitUntil: 'domcontentloaded' });
     }
 
     // Use Playwright request API (tied to this browser context) to avoid flakiness

--- a/apps/ui/tests/utils/core/constants.ts
+++ b/apps/ui/tests/utils/core/constants.ts
@@ -8,9 +8,18 @@
 // ============================================================================
 
 /**
- * Base URL for the API server
+ * Base URL for the API server.
+ * In CI, TEST_SERVER_PORT offsets the port to avoid conflicts with Docker staging.
  */
-export const API_BASE_URL = 'http://localhost:3008';
+const API_PORT = process.env.TEST_SERVER_PORT || '3008';
+export const API_BASE_URL = `http://localhost:${API_PORT}`;
+
+/**
+ * Base URL for the frontend (Vite dev server).
+ * In CI, TEST_PORT offsets the port to avoid conflicts with Docker staging.
+ */
+const UI_PORT = process.env.TEST_PORT || '3007';
+export const UI_BASE_URL = `http://localhost:${UI_PORT}`;
 
 /**
  * API endpoints for worktree operations

--- a/apps/ui/vite.config.mts
+++ b/apps/ui/vite.config.mts
@@ -71,7 +71,7 @@ export default defineConfig(({ command }) => {
       allowedHosts: true,
       proxy: {
         '/api': {
-          target: 'http://localhost:3008',
+          target: process.env.VITE_SERVER_URL || 'http://localhost:3008',
           changeOrigin: true,
           ws: true,
         },


### PR DESCRIPTION
## Summary
- E2E tests hardcoded `localhost:3007` (UI) and `localhost:3008` (API) in 5 files
- Self-hosted runner shares ports with Docker staging, causing connection resets across all 23 tests
- Now reads `TEST_PORT`, `TEST_SERVER_PORT`, and `VITE_SERVER_URL` env vars (already set in CI workflow)
- Local dev unchanged — all env vars default to 3007/3008

## Files changed
- `tests/utils/core/constants.ts` — `API_BASE_URL` + new `UI_BASE_URL` from env vars
- `tests/global-setup.ts` — reads `TEST_SERVER_PORT`
- `tests/utils/api/client.ts` — uses `UI_BASE_URL`
- `tests/copilotkit-sidebar.spec.ts` — uses `UI_BASE_URL`
- `vite.config.mts` — proxy target reads `VITE_SERVER_URL`

## Test plan
- [ ] CI E2E tests pass on self-hosted runner (ports 3017/3018) with Docker staging running
- [ ] Local `npm run test` still works with default ports (3007/3008)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test and configuration infrastructure to support environment-based endpoint configuration, replacing hard-coded values for improved flexibility across different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->