### PR TITLE
docs: fix MCP tool count, org chart, and agent roster

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -99,7 +99,7 @@ Covers:
 - What is MCP?
 - protoLabs's MCP architecture
 - MCP → Agent execution flow
-- Available MCP tools (32 tools documented)
+- Available MCP tools (112 tools)
 - Creating new MCP tools
 - Context passing
 
@@ -203,7 +203,7 @@ Covers:
 
 **Programmatic API for controlling protoLabs**
 
-- 32 tools for features, agents, auto-mode, context, etc.
+- 112 tools for features, agents, auto-mode, context, projects, content, observability, and more
 - Used by the Chief of Staff agent and external integrations
 - **Official Docs:** [MCP Specification](https://spec.modelcontextprotocol.io/)
 
@@ -237,37 +237,43 @@ Covers:
 
 These agents can be invoked interactively via CLI skills or Discord.
 
-| Role              | Model  | Trigger                 | Location                               |
-| ----------------- | ------ | ----------------------- | -------------------------------------- |
-| Chief of Staff    | Opus   | CLI, Discord, crew loop | `services/built-in-templates.ts`       |
-| DevOps Engineer   | Sonnet | CLI, Discord, crew loop | `services/crew-members/frank-check.ts` |
-| Frontend Engineer | Sonnet | CLI, Discord            | `services/built-in-templates.ts`       |
-| GTM Specialist    | Sonnet | CLI, Discord, crew loop | `services/built-in-templates.ts`       |
+| Role              | Agent | Model  | Trigger                 | Location                         |
+| ----------------- | ----- | ------ | ----------------------- | -------------------------------- |
+| Chief of Staff    | Ava   | Opus   | CLI, Discord, crew loop | `services/built-in-templates.ts` |
+| Frontend Engineer | Matt  | Sonnet | CLI, Discord            | `services/built-in-templates.ts` |
+| AI Agent Engineer | Sam   | Sonnet | CLI, Discord            | `services/built-in-templates.ts` |
+| Backend Engineer  | Kai   | Sonnet | CLI, Discord            | `services/built-in-templates.ts` |
+| DevOps Engineer   | Frank | Sonnet | CLI, Discord, crew loop | `services/built-in-templates.ts` |
+| Content Writer    | Cindi | Sonnet | CLI, Discord            | `services/built-in-templates.ts` |
+| GTM Specialist    | Jon   | Sonnet | CLI, Discord            | `services/built-in-templates.ts` |
 
 ### Crew Loop Members (Scheduled)
 
 These run lightweight checks on cron schedules and escalate to full agents only when problems are detected. See [Crew Loops](../dev/crew-loops.md) for details.
 
-| Member          | Model  | Schedule | Checks                                                    |
-| --------------- | ------ | -------- | --------------------------------------------------------- |
-| Chief of Staff  | Opus   | 10 min   | Stuck agents, blocked features, auto-mode health          |
-| DevOps Engineer | Sonnet | 10 min   | V8 heap, RSS memory, agent capacity, health monitor       |
-| PR Maintainer   | Haiku  | 10 min   | Stale PRs, auto-merge status, orphaned worktrees          |
-| Board Janitor   | Haiku  | 15 min   | Merged-not-done, orphaned in-progress, stale dependencies |
-| GTM Specialist  | Sonnet | 6 hours  | Recently completed features (disabled by default)         |
+| Member          | Model  | Schedule | Checks                                                      |
+| --------------- | ------ | -------- | ----------------------------------------------------------- |
+| Chief of Staff  | Opus   | 10 min   | Stuck agents, blocked features, auto-mode health            |
+| DevOps Engineer | Sonnet | 10 min   | V8 heap, RSS memory, agent capacity, health monitor         |
+| PR Maintainer   | Haiku  | 10 min   | Stale PRs, auto-merge status, orphaned worktrees            |
+| Board Janitor   | Haiku  | 15 min   | Merged-not-done, orphaned in-progress, stale dependencies   |
+| System Health   | —      | 10 min   | System RAM, swap, disk, CPU load, temperature, zombie procs |
+| PR State Sync   | —      | 5 min    | GitHub → Linear state drift detection and event emission    |
+| GTM Specialist  | Sonnet | 6 hours  | Recently completed features (disabled by default)           |
 
 ### Implementation Agents (Auto-Mode)
 
 These agents are assigned features dynamically by auto-mode and implement them in isolated worktrees.
 
-| Template               | Model  | Purpose                                  |
-| ---------------------- | ------ | ---------------------------------------- |
-| Backend Engineer       | Sonnet | Server-side features, APIs, services     |
-| Frontend Engineer      | Sonnet | UI components, design system, styling    |
-| QA Engineer            | Sonnet | Tests, bug identification, validation    |
-| Documentation Engineer | Haiku  | Docs, READMEs, API guides                |
-| Product Manager        | Sonnet | Requirements, priorities, roadmap        |
-| Engineering Manager    | Sonnet | Code review, capacity, quality standards |
+| Template            | Model  | Purpose                                     |
+| ------------------- | ------ | ------------------------------------------- |
+| Backend Engineer    | Sonnet | Server-side features, APIs, services        |
+| Frontend Engineer   | Sonnet | UI components, design system, styling       |
+| Product Manager     | Sonnet | Requirements, priorities, roadmap           |
+| Engineering Manager | Sonnet | Code review, capacity, quality standards    |
+| PR Maintainer       | Haiku  | Format fixes, PR creation, auto-merge       |
+| Board Janitor       | Haiku  | Board consistency, status reconciliation    |
+| Linear Specialist   | Sonnet | Linear workspace ops, sprint planning, sync |
 
 - Run in isolated worktrees
 - Create PRs on completion

--- a/docs/agents/mcp-integration.md
+++ b/docs/agents/mcp-integration.md
@@ -25,7 +25,7 @@ This guide explains how **Model Context Protocol (MCP) tools** interact with pro
 **protoLabs's MCP Server:**
 
 - **Location:** `packages/mcp-server/`
-- **Exposes:** 32 tools for controlling protoLabs programmatically
+- **Exposes:** 112 tools for controlling protoLabs programmatically
 - **Used By:** The Chief of Staff agent, other AI agents, external integrations
 
 **Official Docs:** [MCP Specification](https://spec.modelcontextprotocol.io/)
@@ -41,7 +41,7 @@ This guide explains how **Model Context Protocol (MCP) tools** interact with pro
 ┌──────────────────────▼──────────────────────────────────┐
 │  protoLabs MCP Server                                   │
 │  Location: packages/mcp-server/src/index.ts            │
-│  - Tool definitions (32 tools)                          │
+│  - Tool definitions (112 tools)                         │
 │  - API client (calls protoLabs server)                  │
 │  - Auth (AUTOMAKER_API_KEY)                            │
 └──────────────────────┬──────────────────────────────────┘

--- a/docs/authority/org-chart.md
+++ b/docs/authority/org-chart.md
@@ -14,21 +14,27 @@ The system has three layers:
 
 ```text
 Josh Mabry (CEO, Human)
-├── Operations (Ava Loveland, CoS, Opus, Trust=3)
-│   ├── Jon, Sonnet, Trust=2 — GTM / Antagonistic Review
-│   ├── Cindi, Sonnet, Trust=2 — Content
+├── Ava Loveland, Opus, Trust=3 — Chief of Staff
+│   ├── Matt, Sonnet, Trust=2 — Frontend Engineer
+│   ├── Sam, Sonnet, Trust=2 — AI Agent Engineer
+│   ├── Kai, Sonnet, Trust=2 — Backend Engineer
+│   ├── Frank, Sonnet, Trust=2 — DevOps Engineer
+│   ├── Cindi, Sonnet, Trust=2 — Content Writer
+│   ├── Backend Engineer, Sonnet, Trust=2 — Generic Implementation
+│   ├── Product Manager, Sonnet, Trust=1 — Planning
+│   ├── Engineering Manager, Sonnet, Trust=1 — Coordination
+│   ├── Linear Specialist, Sonnet, Trust=2 — Linear Ops
 │   ├── PR Maintainer, Haiku, Trust=2 [Crew]
-│   ├── Board Janitor, Haiku, Trust=1 [Crew]
-│   └── System Health, Haiku, Trust=1 [Crew]
-└── Engineering (Lead Engineer, Service)
-    ├── Auto-mode Agents, Sonnet/Opus — Feature Implementation
-    ├── Matt, Sonnet, Trust=2 — Frontend
-    ├── Sam, Sonnet, Trust=2 — AI Agent Engineering
-    ├── Frank, Sonnet, Trust=2 — DevOps [Crew]
-    └── Kai, Sonnet, Trust=2 — Backend
+│   └── Board Janitor, Haiku, Trust=1 [Crew]
+└── Jon, Sonnet, Trust=1 — GTM Specialist
 ```
 
-**Note:** PM, ProjM, and EM authority agents still exist in code but are now absorbed into the pipeline's automated steps (PRD generation, milestone decomposition, auto-mode orchestration) rather than being standalone team members. Their policy roles remain active for trust-gated permission checks.
+> **Source of truth:** `docs/authority/roles.md` is auto-generated from `built-in-templates.ts` via `scripts/generate-org-docs.ts`. This org chart should match that file. Run `npx tsx scripts/generate-org-docs.ts` to regenerate roles.md.
+
+**Notes:**
+
+- PM, ProjM, and EM authority agents still exist in code but are now absorbed into the pipeline's automated steps (PRD generation, milestone decomposition, auto-mode orchestration) rather than being standalone team members. Their policy roles remain active for trust-gated permission checks.
+- Crew checks (System Health, PR State Sync) run as lightweight in-process monitors without corresponding agent templates. They escalate to Frank when issues are detected. See [Crew Loops](../dev/crew-loops.md) for details.
 
 ## Roles
 

--- a/docs/integrations/claude-plugin.md
+++ b/docs/integrations/claude-plugin.md
@@ -51,7 +51,7 @@ claude
 > /board
 ```
 
-That's it! You now have access to 32 MCP tools and slash commands for managing your Kanban board directly from Claude Code.
+That's it! You now have access to 112 MCP tools and slash commands for managing your Kanban board directly from Claude Code.
 
 ### What You Can Do
 
@@ -828,20 +828,21 @@ Wave 3: [UI Components] - parallel work
 
 ## MCP Tools Reference
 
-The MCP server exposes 32 tools organized by category:
+The MCP server exposes 112 tools organized by category. See `packages/mcp-server/src/index.ts` for the full definitions.
 
-### Feature Management
+### Feature Management (7 tools)
 
-| Tool             | Description                                      |
-| ---------------- | ------------------------------------------------ |
-| `list_features`  | List all features, optionally filtered by status |
-| `get_feature`    | Get detailed info about a specific feature       |
-| `create_feature` | Create a new feature on the board                |
-| `update_feature` | Update feature properties                        |
-| `delete_feature` | Delete a feature                                 |
-| `move_feature`   | Move feature to a different column               |
+| Tool                          | Description                                      |
+| ----------------------------- | ------------------------------------------------ |
+| `list_features`               | List all features, optionally filtered by status |
+| `get_feature`                 | Get detailed info about a specific feature       |
+| `create_feature`              | Create a new feature on the board                |
+| `update_feature`              | Update feature properties                        |
+| `delete_feature`              | Delete a feature                                 |
+| `move_feature`                | Move feature to a different column               |
+| `update_feature_git_settings` | Update git branch/worktree settings for feature  |
 
-### Agent Control
+### Agent Control (5 tools)
 
 | Tool                    | Description                          |
 | ----------------------- | ------------------------------------ |
@@ -851,7 +852,7 @@ The MCP server exposes 32 tools organized by category:
 | `get_agent_output`      | Get the log/output from an agent run |
 | `send_message_to_agent` | Send a message to a running agent    |
 
-### Queue Management
+### Queue Management (3 tools)
 
 | Tool            | Description                           |
 | --------------- | ------------------------------------- |
@@ -859,7 +860,7 @@ The MCP server exposes 32 tools organized by category:
 | `list_queue`    | List queued features                  |
 | `clear_queue`   | Clear the queue                       |
 
-### Context Files
+### Context & Skills (8 tools)
 
 | Tool                  | Description                       |
 | --------------------- | --------------------------------- |
@@ -867,15 +868,19 @@ The MCP server exposes 32 tools organized by category:
 | `get_context_file`    | Read a context file               |
 | `create_context_file` | Create a new context file         |
 | `delete_context_file` | Delete a context file             |
+| `list_skills`         | List skills in .automaker/skills/ |
+| `get_skill`           | Read a skill file                 |
+| `create_skill`        | Create a new skill file           |
+| `delete_skill`        | Delete a skill file               |
 
-### Project Spec
+### Project Spec (2 tools)
 
 | Tool                  | Description                    |
 | --------------------- | ------------------------------ |
 | `get_project_spec`    | Get .automaker/spec.md content |
 | `update_project_spec` | Update the project spec        |
 
-### Orchestration
+### Orchestration (6 tools)
 
 | Tool                       | Description                                        |
 | -------------------------- | -------------------------------------------------- |
@@ -886,7 +891,7 @@ The MCP server exposes 32 tools organized by category:
 | `get_auto_mode_status`     | Check if auto-mode is running                      |
 | `get_execution_order`      | Get resolved execution order based on dependencies |
 
-### Project Orchestration
+### Project Orchestration (7 tools)
 
 | Tool                      | Description                                                       |
 | ------------------------- | ----------------------------------------------------------------- |
@@ -895,14 +900,177 @@ The MCP server exposes 32 tools organized by category:
 | `create_project`          | Create a new project with SPARC PRD and milestone/phase structure |
 | `update_project`          | Update project title, goal, or status                             |
 | `delete_project`          | Delete a project plan and all its files                           |
+| `archive_project`         | Archive a completed project                                       |
 | `create_project_features` | Convert project phases to Kanban board features with epic support |
 
-### Utilities
+### Project Lifecycle (7 tools)
+
+| Tool                     | Description                                     |
+| ------------------------ | ----------------------------------------------- |
+| `initiate_project`       | Start the full project lifecycle                |
+| `generate_project_prd`   | Generate a SPARC PRD for a project              |
+| `approve_project_prd`    | Approve or reject a generated PRD               |
+| `launch_project`         | Launch an approved project into execution       |
+| `get_lifecycle_status`   | Get current lifecycle stage for a project       |
+| `collect_related_issues` | Gather Linear issues related to a project       |
+| `sync_project_to_linear` | Sync project milestones/phases to Linear issues |
+
+### PRD & CoS Pipeline (1 tool)
+
+| Tool         | Description                                      |
+| ------------ | ------------------------------------------------ |
+| `submit_prd` | Submit a PRD through the CoS pipeline for review |
+
+### Ralph Loops (6 tools)
+
+| Tool                       | Description                                |
+| -------------------------- | ------------------------------------------ |
+| `start_ralph_loop`         | Start a Ralph autonomous verification loop |
+| `stop_ralph_loop`          | Stop a running Ralph loop                  |
+| `pause_ralph_loop`         | Pause a Ralph loop                         |
+| `resume_ralph_loop`        | Resume a paused Ralph loop                 |
+| `get_ralph_status`         | Get Ralph loop status for a project        |
+| `list_running_ralph_loops` | List all active Ralph loops                |
+
+### GitHub Operations (4 tools)
+
+| Tool                 | Description                          |
+| -------------------- | ------------------------------------ |
+| `merge_pr`           | Merge a pull request                 |
+| `check_pr_status`    | Check PR status (CI, reviews, merge) |
+| `get_pr_feedback`    | Get PR review feedback               |
+| `resolve_pr_threads` | Resolve CodeRabbit review threads    |
+
+### Escalation (3 tools)
+
+| Tool                     | Description                      |
+| ------------------------ | -------------------------------- |
+| `get_escalation_status`  | Get current escalation state     |
+| `get_escalation_log`     | Get escalation history           |
+| `acknowledge_escalation` | Acknowledge and resolve an alert |
+
+### Lead Engineer (3 tools)
+
+| Tool                       | Description                      |
+| -------------------------- | -------------------------------- |
+| `start_lead_engineer`      | Start the lead engineer service  |
+| `stop_lead_engineer`       | Stop the lead engineer service   |
+| `get_lead_engineer_status` | Get lead engineer running status |
+
+### Worktrees (3 tools)
+
+| Tool                      | Description                          |
+| ------------------------- | ------------------------------------ |
+| `list_worktrees`          | List all git worktrees for a project |
+| `get_worktree_status`     | Get status of a specific worktree    |
+| `create_pr_from_worktree` | Create a PR from worktree changes    |
+
+### Agent Templates (7 tools)
+
+| Tool                        | Description                         |
+| --------------------------- | ----------------------------------- |
+| `list_agent_templates`      | List all registered agent templates |
+| `get_agent_template`        | Get a specific template by name     |
+| `register_agent_template`   | Register a new agent template       |
+| `update_agent_template`     | Update an existing template         |
+| `unregister_agent_template` | Remove a template                   |
+| `execute_dynamic_agent`     | Execute an agent from a template    |
+| `get_role_registry_status`  | Get template registry statistics    |
+
+### Content Pipeline (6 tools)
+
+| Tool                          | Description                          |
+| ----------------------------- | ------------------------------------ |
+| `create_content`              | Start a content creation flow        |
+| `get_content_status`          | Get content flow progress and gates  |
+| `list_content`                | List all content flows               |
+| `review_content`              | Approve/revise/reject at HITL gates  |
+| `export_content`              | Export final content to file formats |
+| `execute_antagonistic_review` | Run antagonistic quality review      |
+
+### Reports (2 tools)
+
+| Tool              | Description                     |
+| ----------------- | ------------------------------- |
+| `generate_report` | Generate a project/board report |
+| `open_report`     | Open a generated report         |
+
+### SetupLab (7 tools)
+
+| Tool                | Description                            |
+| ------------------- | -------------------------------------- |
+| `setup_lab`         | Run setupLab analysis on a project     |
+| `research_repo`     | Research a repository's structure      |
+| `analyze_gaps`      | Analyze gaps against gold standard     |
+| `propose_alignment` | Propose alignment work for a repo      |
+| `clone_repo`        | Clone a repository for analysis        |
+| `deliver_alignment` | Deliver alignment changes to a project |
+| `run_full_setup`    | Run the full setupLab pipeline         |
+
+### Discord (4 tools)
+
+| Tool                | Description                            |
+| ------------------- | -------------------------------------- |
+| `send_discord_dm`   | Send a Discord direct message          |
+| `read_discord_dms`  | Read recent Discord DMs                |
+| `provision_discord` | Provision Discord server for a project |
+| `trigger_ceremony`  | Trigger an agile ceremony via Discord  |
+
+### Setup & Beads (1 tool)
+
+| Tool          | Description                   |
+| ------------- | ----------------------------- |
+| `setup_beads` | Initialize Beads task tracker |
+
+### Settings & Health (4 tools)
+
+| Tool                  | Description                        |
+| --------------------- | ---------------------------------- |
+| `get_settings`        | Get project or global settings     |
+| `update_settings`     | Update settings                    |
+| `get_detailed_health` | Get detailed server health metrics |
+| `get_server_logs`     | Get recent server log entries      |
+
+### Events & Notifications (2 tools)
+
+| Tool                 | Description               |
+| -------------------- | ------------------------- |
+| `list_events`        | List recent system events |
+| `list_notifications` | List notification history |
+
+### Metrics & Forecasting (3 tools)
+
+| Tool                   | Description                        |
+| ---------------------- | ---------------------------------- |
+| `get_project_metrics`  | Get project-level metrics          |
+| `get_capacity_metrics` | Get agent capacity and utilization |
+| `get_forecast`         | Get delivery forecasts             |
+
+### Observability (6 tools)
+
+| Tool                      | Description                        |
+| ------------------------- | ---------------------------------- |
+| `langfuse_list_traces`    | List Langfuse traces               |
+| `langfuse_get_trace`      | Get a specific trace               |
+| `langfuse_get_costs`      | Get cost breakdown                 |
+| `langfuse_list_prompts`   | List prompt versions               |
+| `langfuse_score_trace`    | Score a trace for quality tracking |
+| `langfuse_add_to_dataset` | Add trace to evaluation dataset    |
+
+### Utilities (4 tools)
 
 | Tool                | Description                          |
 | ------------------- | ------------------------------------ |
 | `health_check`      | Check if protoLabs server is running |
 | `get_board_summary` | Get feature counts by status         |
+| `get_briefing`      | Get operational briefing digest      |
+| `graphite_restack`  | Restack Graphite branch stacks       |
+
+### Other (1 tool)
+
+| Tool           | Description                                    |
+| -------------- | ---------------------------------------------- |
+| `process_idea` | Process a raw idea through the intake pipeline |
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Batch 5 of the documentation accuracy audit — final batch.

- **claude-plugin.md**: MCP tool count 32 → 112, expanded tool reference from 7 categories to 22 (added skills, Ralph loops, templates, content pipeline, setupLab, observability, worktrees, metrics, Discord, etc.)
- **org-chart.md**: Aligned tree structure with auto-generated `roles.md` — fixed Jon reporting (Ava → Josh), Jon trust (2 → 1), added Kai and Linear Specialist, added crew check notes
- **agents/index.md**: Fixed tool count, added missing interactive agents (Kai, Cindi, Sam), added System Health and PR State Sync crew members, removed phantom QA/Documentation Engineer templates
- **agents/mcp-integration.md**: Fixed tool count references

## Test plan

- [ ] Markdown tables render correctly
- [ ] Org chart matches roles.md (auto-generated source of truth)
- [ ] Tool count matches `grep -c "name: '" packages/mcp-server/src/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded MCP tool catalog from 32 to 112 tools with comprehensive categorization across multiple feature areas.
  * Updated organizational documentation reflecting new role assignments and restructured team structure.
  * Enhanced integration guides with detailed tool references and API surface documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->