### PR TITLE
feat(docs): add Umami analytics to docs site

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -35,18 +35,14 @@ export default defineConfig({
 
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }],
-    ...(process.env.UMAMI_WEBSITE_ID
-      ? [
-          [
-            'script',
-            {
-              defer: '',
-              src: process.env.UMAMI_URL || 'https://umami.proto-labs.ai/script.js',
-              'data-website-id': process.env.UMAMI_WEBSITE_ID,
-            },
-          ] as [string, Record<string, string>],
-        ]
-      : []),
+    [
+      'script',
+      {
+        defer: '',
+        src: 'https://umami.proto-labs.ai/script.js',
+        'data-website-id': process.env.UMAMI_WEBSITE_ID || '64973d40-7eb6-4044-816e-b2302d1025e8',
+      },
+    ],
   ],
 
   // Allow dead links to: files outside docs/ (../foo or ./../foo)


### PR DESCRIPTION
## Summary

- Adds Umami tracking to docs.protolabs.studio with website ID `64973d40-7eb6-4044-816e-b2302d1025e8`
- Hardcodes the default so it works in Docker builds without needing build args
- Env var `UMAMI_WEBSITE_ID` still overrides if set

## Test plan

- [ ] After deploy, verify `<script>` tag in docs page source
- [ ] Check Umami dashboard for docs page views

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics tracking reliability by ensuring consistent script initialization across all deployment environments with improved fallback configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->