### PR TITLE
fix: use raw body for Linear webhook signature verification

### DIFF
--- a/apps/server/src/routes/linear/webhook.ts
+++ b/apps/server/src/routes/linear/webhook.ts
@@ -210,7 +210,9 @@ export function createWebhookHandler(
     // Verify signature if secret is configured
     if (webhookSecret) {
       const signature = req.headers['linear-signature'] as string | undefined;
-      const rawBody = JSON.stringify(req.body);
+      const rawBody = (req as any).rawBody
+        ? (req as any).rawBody.toString('utf-8')
+        : JSON.stringify(req.body);
 
       if (!verifyWebhookSignature(rawBody, signature, webhookSecret)) {
         logger.warn('Invalid webhook signature');


### PR DESCRIPTION
## Summary
- Uses `req.rawBody` (preserved by Express verify middleware) instead of `JSON.stringify(req.body)` for webhook HMAC signature verification
- Re-stringifying parsed JSON can produce different output than the original raw body that Linear signed, causing all webhooks to fail with 401

## Test plan
- [ ] Create/update a Linear issue and verify webhook no longer returns 401
- [ ] Verify webhook handler processes the event correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook signature verification to ensure accurate matching of the original payload format for more reliable and consistent validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->