### PR TITLE
docs: remove stale references to deleted authority agents

### DIFF
--- a/apps/server/src/services/authority-agents/README.md
+++ b/apps/server/src/services/authority-agents/README.md
@@ -25,12 +25,6 @@ Authority agents are AI-powered roles that manage different aspects of the devel
 **Responsibility:** Assign ready features to agents, manage WIP limits, handle PR approvals
 **Pipeline:** ready → in_progress → pr_ready → done
 
-### Status Agent
-
-**File:** `status-agent.ts`
-**Role:** `status-reporter`
-**Responsibility:** Monitor for blockers (stale PRs, stuck features, failed agents), escalate to Discord
-
 ## Agent Utilities
 
 **File:** `agent-utils.ts`
@@ -109,35 +103,6 @@ async initialize(projectPath: string): Promise<void> {
 }
 ```
 
-#### `registerEventListener(state, getListenerRegistered, setListenerRegistered, events, eventName, handler, initialize, options?)`
-
-Event subscription with auto-initialization:
-
-1. Check if listener already registered (skip if yes)
-2. Subscribe to event
-3. Auto-initialize projects from event data
-4. Filter events (optional)
-5. Extract project path (configurable)
-6. Call handler with error handling
-
-**Usage:**
-
-```typescript
-setupEventListeners(): void {
-  registerEventListener(
-    this.state,
-    () => this.listenerRegistered,
-    (val) => { this.listenerRegistered = val; },
-    this.events,
-    'feature:created',
-    async (event) => {
-      await this.reviewFeature(event.projectPath, event.featureId);
-    },
-    (projectPath) => this.initialize(projectPath)
-  );
-}
-```
-
 ## Code Reduction Benefits
 
 ### Per-Agent Savings
@@ -145,18 +110,15 @@ setupEventListeners(): void {
 - **State tracking:** 78% reduction (9 lines → 2 lines)
 - **Initialization:** 36% reduction (14 lines → 9 lines)
 - **Processing guards:** 100% elimination of boilerplate (5 lines per usage)
-- **Event listeners:** 20% reduction (25 lines → 20 lines)
+  **Total per agent:** ~70-80 lines of boilerplate eliminated (~9% of typical agent file size)
 
-**Total per agent:** ~70-80 lines of boilerplate eliminated (~9% of typical agent file size)
-
-### Total Savings (4 Agents)
+### Total Savings (3 Agents)
 
 - **PM Agent:** ~74 lines (from 865 lines)
 - **ProjM Agent:** ~70 lines (from 732 lines)
 - **EM Agent:** ~75 lines (from ~600 lines estimated)
-- **Status Agent:** ~72 lines (from ~500 lines estimated)
 
-**Grand total:** ~290-320 lines of duplicate code eliminated
+**Grand total:** ~220 lines of duplicate code eliminated
 
 ## Testing
 
@@ -167,7 +129,6 @@ Comprehensive test suite covering:
 - State creation and access methods
 - Processing guard blocking and cleanup
 - Initialization patterns and skip logic
-- Event listener registration and filtering
 - Error handling and edge cases
 
 **Run tests:**
@@ -289,7 +250,7 @@ if (this.state.isProcessing(id)) { ... }
 ## Next Steps
 
 1. **Phase 1 Complete:** ✅ Agent utilities extracted and tested
-2. **Phase 2:** Apply to all 4 agents (PM, ProjM, EM, Status)
+2. **Phase 2 Complete:** ✅ Applied to all 3 agents (PM, ProjM, EM)
 3. **Phase 3:** Consider base agent class if patterns warrant it
 4. **Phase 4:** Evaluate domain-specific tool collections (linear-tools, discord-tools, etc.)
 

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -285,12 +285,12 @@ These agents are assigned features dynamically by auto-mode and implement them i
 
 These event-driven agents exist in code but aren't actively staffed yet.
 
-| Agent        | Trigger                  | Purpose                     | Location                                                    |
-| ------------ | ------------------------ | --------------------------- | ----------------------------------------------------------- |
-| PM           | `idea:injected` event    | Research ideas, create PRDs | `apps/server/src/services/authority-agents/pm-agent.ts`     |
-| ProjM        | `prd:approved` event     | Decompose into milestones   | `apps/server/src/services/authority-agents/projm-agent.ts`  |
-| EM           | `decomposition:complete` | Technical feasibility       | `apps/server/src/services/authority-agents/em-agent.ts`     |
-| Status Agent | Periodic polling         | Progress monitoring         | `apps/server/src/services/authority-agents/status-agent.ts` |
+| Agent         | Trigger                  | Purpose                               | Location                                                       |
+| ------------- | ------------------------ | ------------------------------------- | -------------------------------------------------------------- |
+| PM            | `idea:injected` event    | Research ideas, create PRDs           | `apps/server/src/services/authority-agents/pm-agent.ts`        |
+| ProjM         | `prd:approved` event     | Decompose into milestones             | `apps/server/src/services/authority-agents/projm-agent.ts`     |
+| EM            | `decomposition:complete` | Technical feasibility                 | `apps/server/src/services/authority-agents/em-agent.ts`        |
+| Board Janitor | Crew loop (every 15min)  | Blocker detection, deadlock detection | `apps/server/src/services/crew-members/board-janitor-check.ts` |
 
 ## Official Claude Resources
 

--- a/docs/authority/org-chart.md
+++ b/docs/authority/org-chart.md
@@ -283,23 +283,22 @@ The authority system emits these events via WebSocket:
 
 ## File Locations
 
-| File                                                                   | Purpose                                            |
-| ---------------------------------------------------------------------- | -------------------------------------------------- |
-| `libs/types/src/policy.ts`                                             | All policy and trust type definitions              |
-| `libs/types/src/authority.ts`                                          | Authority agent and work item types                |
-| `libs/policy-engine/src/engine.ts`                                     | Core `checkPolicy()` function                      |
-| `libs/policy-engine/src/defaults.ts`                                   | Default permission matrix and transitions          |
-| `libs/policy-engine/tests/engine.test.ts`                              | Unit tests for policy engine                       |
-| `apps/server/src/services/authority-service.ts`                        | Authority service (registry, proposals, approvals) |
-| `apps/server/src/routes/authority/index.ts`                            | REST API routes                                    |
-| `apps/server/src/services/authority-agents/pm-agent.ts`                | PM agent (idea research + PRD + epics)             |
-| `apps/server/src/services/authority-agents/projm-agent.ts`             | ProjM agent (epic decomposition + deps)            |
-| `apps/server/src/services/authority-agents/em-agent.ts`                | EM agent (assignment + capacity + PR feedback)     |
-| `apps/server/src/services/authority-agents/status-agent.ts`            | Status agent (blocker detection + escalation)      |
-| `apps/server/src/services/authority-agents/discord-approval-router.ts` | Discord approval notifications                     |
-| `apps/server/src/services/audit-service.ts`                            | Append-only JSONL audit trail                      |
-| `apps/server/src/services/pr-feedback-service.ts`                      | GitHub PR review monitoring                        |
-| `apps/server/src/services/worktree-lifecycle-service.ts`               | Auto-cleanup on merge/complete                     |
+| File                                                           | Purpose                                            |
+| -------------------------------------------------------------- | -------------------------------------------------- |
+| `libs/types/src/policy.ts`                                     | All policy and trust type definitions              |
+| `libs/types/src/authority.ts`                                  | Authority agent and work item types                |
+| `libs/policy-engine/src/engine.ts`                             | Core `checkPolicy()` function                      |
+| `libs/policy-engine/src/defaults.ts`                           | Default permission matrix and transitions          |
+| `libs/policy-engine/tests/engine.test.ts`                      | Unit tests for policy engine                       |
+| `apps/server/src/services/authority-service.ts`                | Authority service (registry, proposals, approvals) |
+| `apps/server/src/routes/authority/index.ts`                    | REST API routes                                    |
+| `apps/server/src/services/authority-agents/pm-agent.ts`        | PM agent (idea research + PRD + epics)             |
+| `apps/server/src/services/authority-agents/projm-agent.ts`     | ProjM agent (epic decomposition + deps)            |
+| `apps/server/src/services/authority-agents/em-agent.ts`        | EM agent (assignment + capacity + PR feedback)     |
+| `apps/server/src/services/crew-members/board-janitor-check.ts` | Blocker detection, cycle detection, escalation     |
+| `apps/server/src/services/audit-service.ts`                    | Append-only JSONL audit trail                      |
+| `apps/server/src/services/pr-feedback-service.ts`              | GitHub PR review monitoring                        |
+| `apps/server/src/services/worktree-lifecycle-service.ts`       | Auto-cleanup on merge/complete                     |
 
 ## Persistence
 

--- a/docs/protolabs/graph-flow-roadmap.md
+++ b/docs/protolabs/graph-flow-roadmap.md
@@ -95,7 +95,7 @@ graph LR
 ```
 
 **Nodes:** classify, route, enrich (add context), validate (schema check)
-**Replaces:** `signal-router-service.ts` manual routing logic
+**Replaces:** Manual signal routing logic (signal-router-service was removed in PR #673)
 **Risk:** LOW — Deterministic classification is straightforward. LLM fallback for ambiguous signals.
 
 ### 2. Approval Gate Flow
@@ -238,13 +238,13 @@ Replace Claude Code deep agents with LangGraph ReAct agents using `@automaker/ll
 
 Segments of the full IDEA → SHIP pipeline and their current implementation:
 
-| Segment               | Current                     | Target                       | Status   |
-| --------------------- | --------------------------- | ---------------------------- | -------- |
-| Signal classification | `signal-router-service.ts`  | Signal Intake Flow           | Planned  |
-| PRD review            | `DynamicAgentExecutor`      | **Antagonistic Review Flow** | **DONE** |
-| Approval              | Discord manual              | Approval Gate Flow           | Planned  |
-| Decomposition         | `proj-m-agent.ts`           | Planning Flow                | Planned  |
-| Agent execution       | `AgentService` + Claude SDK | Keep as-is (Phase 3 future)  | N/A      |
-| PR lifecycle          | PR Maintainer crew          | PR Pipeline Flow             | Planned  |
-| Reflection            | `trigger_ceremony`          | Retrospective Flow           | Planned  |
-| Full orchestration    | Ava manual loop             | Master Orchestrator Flow     | Planned  |
+| Segment               | Current                       | Target                       | Status   |
+| --------------------- | ----------------------------- | ---------------------------- | -------- |
+| Signal classification | Escalation channels (PR #673) | Signal Intake Flow           | Partial  |
+| PRD review            | `DynamicAgentExecutor`        | **Antagonistic Review Flow** | **DONE** |
+| Approval              | Discord manual                | Approval Gate Flow           | Planned  |
+| Decomposition         | `proj-m-agent.ts`             | Planning Flow                | Planned  |
+| Agent execution       | `AgentService` + Claude SDK   | Keep as-is (Phase 3 future)  | N/A      |
+| PR lifecycle          | PR Maintainer crew            | PR Pipeline Flow             | Planned  |
+| Reflection            | `trigger_ceremony`            | Retrospective Flow           | Planned  |
+| Full orchestration    | Ava manual loop               | Master Orchestrator Flow     | Planned  |


### PR DESCRIPTION
## Summary

- Remove references to deleted `status-agent.ts` and `discord-approval-router.ts` from org-chart, agents index, and authority-agents README
- Replace with `board-janitor-check.ts` (which now handles blocker/deadlock detection)
- Remove `registerEventListener` docs from README (utility deleted in PR #673)
- Update `signal-router-service.ts` references in graph-flow-roadmap

Follow-up to #673.

## Test plan

- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal authority agents documentation with revised agent framework details
  * Reorganized organizational documentation with updated configuration references
  
* **Chores**
  * Updated cross-references and documentation structure for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->