### PR TITLE
fix: add AUTOMAKER_PROJECT_PATH for Docker webhook path resolution

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -205,13 +205,15 @@ logger.info(
 // Determine the repository/project root directory
 // When running via npm workspace (npm run dev:web), process.cwd() is apps/server/
 // but services like Discord bot need the monorepo root where .automaker/ lives
-const REPO_ROOT = (() => {
-  try {
-    return execSync('git rev-parse --show-toplevel', { encoding: 'utf-8', timeout: 5000 }).trim();
-  } catch {
-    return process.cwd();
-  }
-})();
+const REPO_ROOT =
+  process.env.AUTOMAKER_PROJECT_PATH ||
+  (() => {
+    try {
+      return execSync('git rev-parse --show-toplevel', { encoding: 'utf-8', timeout: 5000 }).trim();
+    } catch {
+      return process.cwd();
+    }
+  })();
 logger.info('[SERVER_STARTUP] REPO_ROOT:', REPO_ROOT);
 
 const ENABLE_REQUEST_LOGGING_DEFAULT = process.env.ENABLE_REQUEST_LOGGING !== 'false'; // Default to true

--- a/apps/server/src/routes/linear/webhook.ts
+++ b/apps/server/src/routes/linear/webhook.ts
@@ -378,15 +378,18 @@ async function handleIssueUpdated(
 
   // Delegate to sync service for status, title, priority, and relation sync
   const stateName = data.state?.name || 'Unknown';
-  let projectPath: string;
-  try {
-    projectPath = execSync('git rev-parse --show-toplevel', {
-      encoding: 'utf-8',
-      timeout: 5000,
-    }).trim();
-  } catch {
-    projectPath = process.cwd();
-  }
+  const projectPath =
+    process.env.AUTOMAKER_PROJECT_PATH ||
+    (() => {
+      try {
+        return execSync('git rev-parse --show-toplevel', {
+          encoding: 'utf-8',
+          timeout: 5000,
+        }).trim();
+      } catch {
+        return process.cwd();
+      }
+    })();
 
   await linearSyncService.onLinearIssueUpdated(data.id, stateName, projectPath, {
     title: data.title,


### PR DESCRIPTION
## Summary

- In Docker, `git rev-parse --show-toplevel` returns `/app` but features live at the volume-mounted `/home/josh/dev/ava`
- Adds `AUTOMAKER_PROJECT_PATH` env var that overrides auto-detection in both `REPO_ROOT` (index.ts) and the webhook handler
- Without this, all webhook-triggered operations (Linear intake bridge, sync service) fail with EACCES trying to write to `/app/.automaker/`

## Test plan

- [ ] Set `AUTOMAKER_PROJECT_PATH=/home/josh/dev/ava` in staging `.env`
- [ ] Move a Linear issue to "In Progress" → verify feature created on board
- [ ] Local dev (no env var set) continues to use `git rev-parse` auto-detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable configuration for project path resolution, allowing users to explicitly set the project root directory via `AUTOMAKER_PROJECT_PATH` for enhanced deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->