### PR TITLE
fix: add AUTOMAKER_PROJECT_PATH to Docker compose env

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -97,6 +97,7 @@ services:
 
       # Project access - host path mounted at same path for MCP compatibility
       - ALLOWED_ROOT_DIRECTORY=${ALLOWED_ROOT_DIRECTORY:-/home/josh/dev}
+      - AUTOMAKER_PROJECT_PATH=${AUTOMAKER_PROJECT_PATH:-/home/josh/dev/ava}
 
       # CORS
       - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:3007}


### PR DESCRIPTION
## Summary

- Adds `AUTOMAKER_PROJECT_PATH` to the server's environment variables in `docker-compose.staging.yml`
- Companion to #676 — without this, the env var from `.env` isn't passed through to the container

## Test plan

- [x] Verified manually: moved PRO-215 to "In Progress" → feature created on board

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging environment configuration with a new path variable for improved deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->