### PR TITLE
fix: wire remaining linear pipeline gaps

### DIFF
--- a/apps/server/src/services/linear-approval-bridge.ts
+++ b/apps/server/src/services/linear-approval-bridge.ts
@@ -152,6 +152,13 @@ export class LinearApprovalBridge {
       .filter(Boolean)
       .join('\n');
 
+    // Check if feature already exists for this Linear issue
+    const existing = await this.featureLoader.findByLinearIssueId(projectPath, issueId);
+    if (existing) {
+      logger.info(`Feature already exists for Linear issue ${issueId}: ${existing.id}, skipping`);
+      return;
+    }
+
     // Create epic feature with approved state (same as CoS submit-prd)
     const feature = await this.featureLoader.create(projectPath, {
       title,

--- a/apps/server/src/services/linear-sync-service.ts
+++ b/apps/server/src/services/linear-sync-service.ts
@@ -212,6 +212,8 @@ export class LinearSyncService {
         this.handleProjectStatusChanged(payload as ProjectStatusChangedPayload);
       } else if (type === 'linear:comment:created') {
         this.handleCommentCreated(payload as CommentCreatedPayload);
+      } else if (type === 'authority:pm-prd-ready') {
+        this.handlePrdReady(payload as { projectPath?: string; featureId?: string; prd?: string });
       }
     });
 
@@ -1921,6 +1923,43 @@ export class LinearSyncService {
     }
 
     logger.info(`Added comment to Linear issue ${issueId}`);
+  }
+
+  /**
+   * Handle authority:pm-prd-ready events — post PRD back to originating Linear issue
+   */
+  private handlePrdReady(payload: {
+    projectPath?: string;
+    featureId?: string;
+    prd?: string;
+  }): void {
+    const { projectPath, featureId, prd } = payload;
+    if (!projectPath || !featureId || !prd || !this.featureLoader) return;
+
+    this.postPrdToLinear(projectPath, featureId, prd).catch((err) => {
+      logger.warn(`Failed to post PRD to Linear for feature ${featureId}:`, err);
+    });
+  }
+
+  private async postPrdToLinear(
+    projectPath: string,
+    featureId: string,
+    prd: string
+  ): Promise<void> {
+    const feature = await this.featureLoader!.get(projectPath, featureId);
+    if (!feature?.linearIssueId) {
+      logger.debug(`Feature ${featureId} has no linearIssueId, skipping PRD comment`);
+      return;
+    }
+
+    const MAX_PRD_LENGTH = 4000;
+    const truncatedPrd =
+      prd.length > MAX_PRD_LENGTH ? prd.slice(0, MAX_PRD_LENGTH) + '\n\n…(truncated)' : prd;
+
+    const commentBody = `## PRD Generated\n\n${truncatedPrd}`;
+
+    await this.addCommentToIssue(projectPath, feature.linearIssueId, commentBody);
+    logger.info(`Posted PRD to Linear issue ${feature.linearIssueId} for feature ${featureId}`);
   }
 
   /**

--- a/apps/server/src/services/project-lifecycle-service.ts
+++ b/apps/server/src/services/project-lifecycle-service.ts
@@ -264,7 +264,7 @@ export class ProjectLifecycleService {
 
     this.events.emit('project:lifecycle:launched', {
       projectPath,
-      slug: projectSlug,
+      projectSlug,
       featuresInBacklog: backlogFeatures.length,
       autoModeStarted,
     });

--- a/apps/server/tests/unit/services/linear-approval-bridge.test.ts
+++ b/apps/server/tests/unit/services/linear-approval-bridge.test.ts
@@ -36,6 +36,7 @@ function createMockEventEmitter(): EventEmitter {
 function createMockFeatureLoader(): Partial<FeatureLoader> {
   return {
     create: vi.fn().mockResolvedValue({ id: 'feature-created-123' }),
+    findByLinearIssueId: vi.fn().mockResolvedValue(null),
     getAll: vi.fn(),
     load: vi.fn(),
     update: vi.fn(),


### PR DESCRIPTION
## Summary

- **Fix Lead Engineer auto-start**: `project-lifecycle-service.ts` emitted `{ slug }` but `lead-engineer-service.ts` reads `{ projectSlug }` — key mismatch meant auto-start never fired after project launch. Fixed the event key.
- **Add dedup to approval bridge**: `LinearApprovalBridge.handleApproval()` now checks `findByLinearIssueId()` before creating a feature, preventing duplicates. Matches the pattern the intake bridge (#675) already uses.
- **Post PRD to Linear issue**: When PM agent emits `authority:pm-prd-ready`, `LinearSyncService` now posts the PRD as a comment on the originating Linear issue, closing the feedback loop.

## Test plan

- [x] `npm run build:server` passes
- [x] All 1919 server tests pass (0 failures)
- [x] Prettier formatting clean
- [ ] Manual: Launch a project and verify Lead Engineer auto-starts (no longer silently drops the event)
- [ ] Manual: Trigger two approvals for the same Linear issue — second should be skipped with log message
- [ ] Manual: Generate a PRD for a feature with `linearIssueId` — verify comment appears on the Linear issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate epic features from being created in Linear when processing approvals

* **New Features**
  * Automatically post Product Requirement Documents to Linear when they are ready, keeping issues synchronized with the latest PRD information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->