### PR TITLE
fix(ui): remove hsl() wrappers around OKLch token values

### DIFF
--- a/apps/ui/src/components/dashboard/animated-counter.tsx
+++ b/apps/ui/src/components/dashboard/animated-counter.tsx
@@ -81,7 +81,7 @@ interface SparklineProps {
 
 export function Sparkline({
   data,
-  color = 'hsl(var(--primary))',
+  color = 'var(--primary)',
   height = 32,
   className = '',
 }: SparklineProps) {

--- a/apps/ui/src/components/dashboard/glow-area-chart.tsx
+++ b/apps/ui/src/components/dashboard/glow-area-chart.tsx
@@ -78,19 +78,19 @@ export function GlowAreaChart({
             </defs>
             <CartesianGrid
               strokeDasharray="3 3"
-              stroke="hsl(var(--border))"
+              stroke="var(--border)"
               strokeOpacity={0.3}
               vertical={false}
             />
             <XAxis
               dataKey={xKey}
-              stroke="hsl(var(--muted-foreground))"
+              stroke="var(--muted-foreground)"
               fontSize={10}
               tickLine={false}
               axisLine={false}
             />
             <YAxis
-              stroke="hsl(var(--muted-foreground))"
+              stroke="var(--muted-foreground)"
               fontSize={10}
               tickLine={false}
               axisLine={false}
@@ -98,8 +98,8 @@ export function GlowAreaChart({
             />
             <Tooltip
               contentStyle={{
-                backgroundColor: 'hsl(var(--card))',
-                border: '1px solid hsl(var(--border))',
+                backgroundColor: 'var(--card)',
+                border: '1px solid var(--border)',
                 borderRadius: '8px',
                 fontSize: '12px',
                 backdropFilter: 'blur(8px)',

--- a/apps/ui/src/components/dashboard/glow-card.tsx
+++ b/apps/ui/src/components/dashboard/glow-card.tsx
@@ -20,7 +20,7 @@ interface GlowCardProps extends React.ComponentProps<typeof motion.div> {
 }
 
 export function GlowCard({
-  glowColor = 'hsl(var(--primary))',
+  glowColor = 'var(--primary)',
   gradientBorder = false,
   orb = 'none',
   orbColor,

--- a/apps/ui/src/components/dashboard/glow-donut.tsx
+++ b/apps/ui/src/components/dashboard/glow-donut.tsx
@@ -72,8 +72,8 @@ export function GlowDonut({
             </Pie>
             <Tooltip
               contentStyle={{
-                backgroundColor: 'hsl(var(--card))',
-                border: '1px solid hsl(var(--border))',
+                backgroundColor: 'var(--card)',
+                border: '1px solid var(--border)',
                 borderRadius: '8px',
                 fontSize: '12px',
               }}

--- a/apps/ui/src/components/dashboard/hero-stat.tsx
+++ b/apps/ui/src/components/dashboard/hero-stat.tsx
@@ -30,7 +30,7 @@ export function HeroStat({
   icon: Icon,
   trend,
   sparkline,
-  color = 'hsl(var(--primary))',
+  color = 'var(--primary)',
   orb = 'top-right',
 }: HeroStatProps) {
   return (

--- a/apps/ui/src/components/dashboard/system-health.tsx
+++ b/apps/ui/src/components/dashboard/system-health.tsx
@@ -45,7 +45,7 @@ export function Gauge({
         <path
           d={`M ${6} ${size / 2} A ${radius} ${radius} 0 0 1 ${size - 6} ${size / 2}`}
           fill="none"
-          stroke="hsl(var(--muted))"
+          stroke="var(--muted)"
           strokeWidth={6}
           strokeLinecap="round"
         />

--- a/apps/ui/src/components/views/analytics-view/capacity-panel.tsx
+++ b/apps/ui/src/components/views/analytics-view/capacity-panel.tsx
@@ -61,10 +61,10 @@ export function CapacityPanel({
                     width: `${Math.min(utilizationPercent, 100)}%`,
                     backgroundColor:
                       utilizationPercent > 80
-                        ? 'hsl(var(--destructive))'
+                        ? 'var(--destructive)'
                         : utilizationPercent > 50
-                          ? '#f59e0b'
-                          : 'hsl(var(--primary))',
+                          ? 'var(--chart-3)'
+                          : 'var(--primary)',
                   }}
                 />
               </div>

--- a/apps/ui/src/components/views/analytics-view/cost-panel.tsx
+++ b/apps/ui/src/components/views/analytics-view/cost-panel.tsx
@@ -70,7 +70,7 @@ export function CostPanel({ costByModel, totalCost, isLoading }: CostPanelProps)
                     innerRadius={25}
                     outerRadius={50}
                     strokeWidth={2}
-                    stroke="hsl(var(--card))"
+                    stroke="var(--card)"
                   >
                     {chartData.map((entry, idx) => (
                       <Cell key={idx} fill={entry.fill} />
@@ -79,8 +79,8 @@ export function CostPanel({ costByModel, totalCost, isLoading }: CostPanelProps)
                   <Tooltip
                     formatter={(value: number) => [`$${value.toFixed(2)}`, 'Cost']}
                     contentStyle={{
-                      backgroundColor: 'hsl(var(--card))',
-                      border: '1px solid hsl(var(--border))',
+                      backgroundColor: 'var(--card)',
+                      border: '1px solid var(--border)',
                       borderRadius: '8px',
                       fontSize: '12px',
                     }}

--- a/apps/ui/src/components/views/dashboard-view/metrics/cost-chart.tsx
+++ b/apps/ui/src/components/views/dashboard-view/metrics/cost-chart.tsx
@@ -50,31 +50,27 @@ export function CostChart({ data, isLoading }: CostChartProps) {
             <AreaChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 0 }}>
               <defs>
                 <linearGradient id="costGradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="hsl(var(--primary))" stopOpacity={0.3} />
-                  <stop offset="95%" stopColor="hsl(var(--primary))" stopOpacity={0} />
+                  <stop offset="5%" stopColor="var(--primary)" stopOpacity={0.3} />
+                  <stop offset="95%" stopColor="var(--primary)" stopOpacity={0} />
                 </linearGradient>
               </defs>
-              <CartesianGrid
-                strokeDasharray="3 3"
-                stroke="hsl(var(--border))"
-                strokeOpacity={0.5}
-              />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" strokeOpacity={0.5} />
               <XAxis
                 dataKey="date"
-                tick={{ fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
+                tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
                 axisLine={false}
                 tickLine={false}
               />
               <YAxis
-                tick={{ fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
+                tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
                 axisLine={false}
                 tickLine={false}
                 tickFormatter={(v: number) => `$${v}`}
               />
               <Tooltip
                 contentStyle={{
-                  backgroundColor: 'hsl(var(--card))',
-                  border: '1px solid hsl(var(--border))',
+                  backgroundColor: 'var(--card)',
+                  border: '1px solid var(--border)',
                   borderRadius: '8px',
                   fontSize: '12px',
                 }}
@@ -83,7 +79,7 @@ export function CostChart({ data, isLoading }: CostChartProps) {
               <Area
                 type="monotone"
                 dataKey="cost"
-                stroke="hsl(var(--primary))"
+                stroke="var(--primary)"
                 fill="url(#costGradient)"
                 strokeWidth={2}
               />

--- a/apps/ui/src/components/views/dashboard-view/metrics/cycle-time-chart.tsx
+++ b/apps/ui/src/components/views/dashboard-view/metrics/cycle-time-chart.tsx
@@ -39,27 +39,23 @@ export function CycleTimeChart({ data, isLoading }: CycleTimeChartProps) {
         <div className="h-[200px]">
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={data.buckets} margin={{ top: 5, right: 10, left: 0, bottom: 0 }}>
-              <CartesianGrid
-                strokeDasharray="3 3"
-                stroke="hsl(var(--border))"
-                strokeOpacity={0.5}
-              />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" strokeOpacity={0.5} />
               <XAxis
                 dataKey="label"
-                tick={{ fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
+                tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
                 axisLine={false}
                 tickLine={false}
               />
               <YAxis
-                tick={{ fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
+                tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
                 axisLine={false}
                 tickLine={false}
                 allowDecimals={false}
               />
               <Tooltip
                 contentStyle={{
-                  backgroundColor: 'hsl(var(--card))',
-                  border: '1px solid hsl(var(--border))',
+                  backgroundColor: 'var(--card)',
+                  border: '1px solid var(--border)',
                   borderRadius: '8px',
                   fontSize: '12px',
                 }}

--- a/apps/ui/src/components/views/dashboard-view/metrics/model-pie.tsx
+++ b/apps/ui/src/components/views/dashboard-view/metrics/model-pie.tsx
@@ -70,8 +70,8 @@ export function ModelPieChart({ data, isLoading }: ModelPieChartProps) {
               </Pie>
               <Tooltip
                 contentStyle={{
-                  backgroundColor: 'hsl(var(--card))',
-                  border: '1px solid hsl(var(--border))',
+                  backgroundColor: 'var(--card)',
+                  border: '1px solid var(--border)',
                   borderRadius: '8px',
                   fontSize: '12px',
                 }}

--- a/apps/ui/src/components/views/dashboard-view/metrics/success-chart.tsx
+++ b/apps/ui/src/components/views/dashboard-view/metrics/success-chart.tsx
@@ -55,20 +55,16 @@ export function SuccessChart({ data, isLoading }: SuccessChartProps) {
                   <stop offset="95%" stopColor="var(--chart-2)" stopOpacity={0} />
                 </linearGradient>
               </defs>
-              <CartesianGrid
-                strokeDasharray="3 3"
-                stroke="hsl(var(--border))"
-                strokeOpacity={0.5}
-              />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" strokeOpacity={0.5} />
               <XAxis
                 dataKey="date"
-                tick={{ fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
+                tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
                 axisLine={false}
                 tickLine={false}
               />
               <YAxis
                 domain={[0, 100]}
-                tick={{ fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
+                tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
                 axisLine={false}
                 tickLine={false}
                 tickFormatter={(v: number) => `${v}%`}
@@ -81,8 +77,8 @@ export function SuccessChart({ data, isLoading }: SuccessChartProps) {
               />
               <Tooltip
                 contentStyle={{
-                  backgroundColor: 'hsl(var(--card))',
-                  border: '1px solid hsl(var(--border))',
+                  backgroundColor: 'var(--card)',
+                  border: '1px solid var(--border)',
                   borderRadius: '8px',
                   fontSize: '12px',
                 }}

--- a/apps/ui/src/components/views/dashboard-view/metrics/throughput-chart.tsx
+++ b/apps/ui/src/components/views/dashboard-view/metrics/throughput-chart.tsx
@@ -18,7 +18,7 @@ export function ThroughputChart({
   title,
   data,
   isLoading,
-  color = 'hsl(var(--primary))',
+  color = 'var(--primary)',
   valueLabel = 'Features',
 }: ThroughputChartProps) {
   if (isLoading || !data?.points?.length) {
@@ -50,27 +50,23 @@ export function ThroughputChart({
         <div className="h-[200px]">
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 0 }}>
-              <CartesianGrid
-                strokeDasharray="3 3"
-                stroke="hsl(var(--border))"
-                strokeOpacity={0.5}
-              />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" strokeOpacity={0.5} />
               <XAxis
                 dataKey="date"
-                tick={{ fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
+                tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
                 axisLine={false}
                 tickLine={false}
               />
               <YAxis
-                tick={{ fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
+                tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
                 axisLine={false}
                 tickLine={false}
                 allowDecimals={false}
               />
               <Tooltip
                 contentStyle={{
-                  backgroundColor: 'hsl(var(--card))',
-                  border: '1px solid hsl(var(--border))',
+                  backgroundColor: 'var(--card)',
+                  border: '1px solid var(--border)',
                   borderRadius: '8px',
                   fontSize: '12px',
                 }}


### PR DESCRIPTION
## Summary
- Theme tokens use OKLch format (`oklch(0.5 0.005 260)`) but chart/dashboard components wrapped them in `hsl()`, producing invalid CSS like `hsl(oklch(...))` that falls back to black
- Removes all `hsl(var(--*))` patterns across 13 files, using `var(--*)` directly since tokens are already complete color values
- Also replaces hardcoded `#f59e0b` in capacity-panel with `var(--chart-3)` token

## Test plan
- [ ] Verify chart axis labels are visible on dark mode (were previously black/invisible)
- [ ] Check tooltip backgrounds render correctly across all chart types
- [ ] Verify capacity bar colors (normal, warning, destructive) render correctly
- [ ] Check glow effects on dashboard cards still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated color theming across dashboard, analytics, and metrics components to use unified CSS variable references for consistent visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->