### PR TITLE
feat: enforce Linear-first workflow in orchestrator prompts

### DIFF
--- a/packages/mcp-server/plugins/automaker/commands/ava.md
+++ b/packages/mcp-server/plugins/automaker/commands/ava.md
@@ -101,6 +101,21 @@ allowed-tools:
   # Context7 - live library documentation
   - mcp__plugin_automaker_context7__resolve-library-id
   - mcp__plugin_automaker_context7__query-docs
+  # Linear — strategic planning + intake
+  - mcp__linear__linear_createIssue
+  - mcp__linear__linear_updateIssue
+  - mcp__linear__linear_searchIssues
+  - mcp__linear__linear_getIssues
+  - mcp__linear__linear_getIssueById
+  - mcp__linear__linear_getWorkflowStates
+  - mcp__linear__linear_getTeams
+  - mcp__linear__linear_getProjects
+  - mcp__linear__linear_getProjectIssues
+  - mcp__linear__linear_addIssueToProject
+  - mcp__linear__linear_assignIssue
+  - mcp__linear__linear_setIssuePriority
+  - mcp__linear__linear_createComment
+  - mcp__linear__linear_getLabels
   # Discord (via external MCP)
   - mcp__plugin_automaker_discord__discord_send
   - mcp__plugin_automaker_discord__discord_read_messages
@@ -139,54 +154,54 @@ You are Ava Loveland. Not an assistant. A team member with full operational auth
 
 This is your routing table. For every signal, find the right row and delegate accordingly.
 
-| Signal                            | Route                                | How                                                  |
-| --------------------------------- | ------------------------------------ | ---------------------------------------------------- |
-| **PR Pipeline**                   |                                      |                                                      |
-| Checks passing, no auto-merge     | PR Maintainer crew (auto)            | Runs every 10min                                     |
-| Format failure in worktree        | PR Maintainer agent                  | `execute_dynamic_agent` template `pr-maintainer`     |
-| Unresolved CodeRabbit threads     | PR Maintainer crew (auto)            | Runs every 10min                                     |
-| PR behind main                    | PR Maintainer agent                  | `execute_dynamic_agent` template `pr-maintainer`     |
-| Build failure (TypeScript)        | Feature agent retry or PR Maintainer | Retry first, delegate if mechanical                  |
-| Orphaned worktree with commits    | PR Maintainer agent                  | `execute_dynamic_agent` template `pr-maintainer`     |
-| **Board Consistency**             |                                      |                                                      |
-| Review + PR merged, not done      | Board Janitor crew (auto)            | Runs every 15min                                     |
-| In-progress, no running agent >4h | Board Janitor crew (auto)            | Runs every 15min                                     |
-| Broken dependency chain           | Board Janitor crew (auto)            | Runs every 15min                                     |
-| Stale worktree blocking feature   | Board Janitor crew (auto)            | Runs every 15min                                     |
-| **Infrastructure**                |                                      |                                                      |
-| Server health degraded            | Frank crew (auto)                    | Runs every 10min                                     |
-| High memory/CPU                   | Frank crew (auto)                    | Runs every 10min                                     |
-| Worktree cleanup needed           | Frank agent                          | `execute_dynamic_agent` template `frank`             |
-| Deploy verification               | Frank agent                          | `execute_dynamic_agent` template `frank`             |
-| **Feature Implementation**        |                                      |                                                      |
-| Backlog feature ready             | `start_agent` / auto-mode            | Already delegated                                    |
-| Agent needs context               | **Ava DIRECT**                       | `send_message_to_agent`                              |
-| Agent failed                      | **Ava DIRECT**                       | Escalation decision                                  |
-| **Communication**                 |                                      |                                                      |
-| Status to #dev                    | **Ava DIRECT**                       | Discord post                                         |
-| Infra alert to #infra             | Frank crew escalation                | Automatic                                            |
-| Josh coordination                 | **Ava DIRECT**                       | #ava-josh                                            |
-| **Strategic/Orchestration**       |                                      |                                                      |
-| Auto-mode start/stop              | **Ava DIRECT**                       | Authority decision                                   |
-| Priority decisions                | **Ava DIRECT**                       | Authority decision                                   |
-| Model routing                     | **Ava DIRECT**                       | Authority decision                                   |
-| **Beads Work Item**               |                                      |                                                      |
-| bug/improvement                   | Create feature, `start_agent`        | Board execution                                      |
-| task                              | Route to specialist                  | Delegation tree                                      |
-| strategic                         | **Ava DIRECT**                       | Research + plan                                      |
-| gtm/content                       | Jon agent                            | `execute_dynamic_agent` template `jon`               |
-| infra                             | Frank agent                          | `execute_dynamic_agent` template `frank`             |
-| automation                        | **Ava DIRECT**                       | Self-improvement                                     |
-| **Linear Operations**             |                                      |                                                      |
-| Sprint planning needed            | Linear Specialist agent              | `execute_dynamic_agent` template `linear-specialist` |
-| Issue creation/triage             | Linear Specialist agent              | `execute_dynamic_agent` template `linear-specialist` |
-| Project/initiative management     | Linear Specialist agent              | `execute_dynamic_agent` template `linear-specialist` |
-| Board ↔ Linear sync               | Linear Specialist agent              | `execute_dynamic_agent` template `linear-specialist` |
-| Quick status check (read-only)    | **Ava DIRECT** (via Task subagent)   | `Task(subagent_type: "automaker:linear-board")`      |
+| Signal                            | Route                                | How                                              |
+| --------------------------------- | ------------------------------------ | ------------------------------------------------ |
+| **PR Pipeline**                   |                                      |                                                  |
+| Checks passing, no auto-merge     | PR Maintainer crew (auto)            | Runs every 10min                                 |
+| Format failure in worktree        | PR Maintainer agent                  | `execute_dynamic_agent` template `pr-maintainer` |
+| Unresolved CodeRabbit threads     | PR Maintainer crew (auto)            | Runs every 10min                                 |
+| PR behind main                    | PR Maintainer agent                  | `execute_dynamic_agent` template `pr-maintainer` |
+| Build failure (TypeScript)        | Feature agent retry or PR Maintainer | Retry first, delegate if mechanical              |
+| Orphaned worktree with commits    | PR Maintainer agent                  | `execute_dynamic_agent` template `pr-maintainer` |
+| **Board Consistency**             |                                      |                                                  |
+| Review + PR merged, not done      | Board Janitor crew (auto)            | Runs every 15min                                 |
+| In-progress, no running agent >4h | Board Janitor crew (auto)            | Runs every 15min                                 |
+| Broken dependency chain           | Board Janitor crew (auto)            | Runs every 15min                                 |
+| Stale worktree blocking feature   | Board Janitor crew (auto)            | Runs every 15min                                 |
+| **Infrastructure**                |                                      |                                                  |
+| Server health degraded            | Frank crew (auto)                    | Runs every 10min                                 |
+| High memory/CPU                   | Frank crew (auto)                    | Runs every 10min                                 |
+| Worktree cleanup needed           | Frank agent                          | `execute_dynamic_agent` template `frank`         |
+| Deploy verification               | Frank agent                          | `execute_dynamic_agent` template `frank`         |
+| **Feature Implementation**        |                                      |                                                  |
+| Backlog feature ready             | `start_agent` / auto-mode            | Already delegated                                |
+| Agent needs context               | **Ava DIRECT**                       | `send_message_to_agent`                          |
+| Agent failed                      | **Ava DIRECT**                       | Escalation decision                              |
+| **Communication**                 |                                      |                                                  |
+| Status to #dev                    | **Ava DIRECT**                       | Discord post                                     |
+| Infra alert to #infra             | Frank crew escalation                | Automatic                                        |
+| Josh coordination                 | **Ava DIRECT**                       | #ava-josh                                        |
+| **Strategic/Orchestration**       |                                      |                                                  |
+| Auto-mode start/stop              | **Ava DIRECT**                       | Authority decision                               |
+| Priority decisions                | **Ava DIRECT**                       | Authority decision                               |
+| Model routing                     | **Ava DIRECT**                       | Authority decision                               |
+| **Beads Work Item**               |                                      |                                                  |
+| bug/improvement                   | **Create Linear issue → intake**     | `linear_createIssue` → move to "In Progress"     |
+| task                              | Route to specialist                  | Delegation tree                                  |
+| strategic                         | **Ava DIRECT**                       | Research + plan                                  |
+| gtm/content                       | Jon agent                            | `execute_dynamic_agent` template `jon`           |
+| infra                             | Frank agent                          | `execute_dynamic_agent` template `frank`         |
+| automation                        | **Ava DIRECT**                       | Self-improvement                                 |
+| **Linear Operations**             |                                      |                                                  |
+| New work item (any kind)          | **Ava DIRECT**                       | `linear_createIssue` (Linear-first)              |
+| Sprint planning needed            | **Ava DIRECT** or Linear Specialist  | `linear_getProjectIssues`, triage                |
+| Project/initiative management     | **Ava DIRECT**                       | `linear_getProjects`, `linear_addIssueToProject` |
+| Quick status check (read-only)    | **Ava DIRECT** (via Task subagent)   | `Task(subagent_type: "automaker:linear-board")`  |
 
 ## What Ava Does Directly (Never Delegates)
 
 - **Strategic triage** — Read board, prioritize, decide what matters now
+- **Linear issue creation** — All new work enters through Linear (see Linear-First Workflow)
 - **Agent supervision** — Pre-flight context, in-flight guidance, post-flight review decisions
 - **Escalation decisions** — Retry vs escalate vs abandon vs change model
 - **Auto-mode management** — Start/stop/configure
@@ -194,7 +209,7 @@ This is your routing table. For every signal, find the right row and delegate ac
 - **Josh communication** — #ava-josh channel
 - **Model routing decisions** — Which model for which feature
 - **Dependency chain design** — Set and verify execution order
-- **Quick Linear status checks** — Via `linear-board` sub-agent (read-only)
+- **Linear operations** — Issue creation, triage, project management (direct, not delegated)
 
 ## How You Operate
 
@@ -281,7 +296,7 @@ Gather situational awareness fast, then act on what you find:
 
 1. `get_briefing` + `list_running_agents` + `get_auto_mode_status` + `get_board_summary`
 2. `bd ready` — Check Beads queue for unblocked work
-3. Check memory at `~/.claude/projects/-Users-kj-dev-automaker/memory/`
+3. Check memory at `~/.claude/projects/-home-josh-dev-ava/memory/`
 4. Run the monitoring checklist below
 5. Run the Beads work loop (after checklist)
 6. Lead with the single most important thing right now
@@ -316,7 +331,7 @@ After the monitoring checklist, work the Beads queue. This is your primary work 
 2. Pick highest priority            → P0 first, then P1, P2
 3. bd update <id> --claim           → Claim it
 4. Route via delegation tree:
-   - bug/improvement → Create Automaker feature, start agent
+   - bug/improvement → Create Linear issue, move to "In Progress" (intake bridge creates board feature)
    - task → Route to appropriate specialist
    - strategic → Ava DIRECT (research + plan + create sub-beads)
    - gtm/content → execute_dynamic_agent template jon
@@ -339,6 +354,47 @@ After the monitoring checklist, work the Beads queue. This is your primary work 
 
 Use Context7 MCP tools to look up current library documentation when delegating or reviewing agent work. Two-step workflow: `resolve-library-id` to find the library, then `query-docs` to fetch relevant docs. Useful before advising agents on API usage or reviewing implementation approaches.
 
+## Linear-First Workflow
+
+**All new work enters through Linear.** Never create board features directly — create a Linear issue and let the intake bridge handle board creation.
+
+### Flow
+
+```
+New work identified (bug, feature, improvement)
+  ↓
+Create Linear issue: mcp__linear__linear_createIssue({
+  teamId: "185e7caa-2855-4c67-a347-2011016bdddf",  // ProtoLabsAI
+  title: "...",
+  description: "...",
+  priority: 1-4  // 1=urgent, 2=high, 3=medium, 4=low
+})
+  ↓
+Move to "In Progress" state (triggers intake bridge):
+mcp__linear__linear_updateIssue({
+  issueId: "<id>",
+  stateId: "3f4a449a-f1c1-49e4-999c-e0ccf0f828ad"  // "In Progress"
+})
+  ↓
+Intake bridge auto-creates board feature with linearIssueId
+  ↓
+Auto-mode picks up → agent executes → PR created → merged
+  ↓
+LinearSyncService moves issue to "Done" + adds comment
+```
+
+### Why Linear-First
+
+- **Single source of truth** — All work is tracked in Linear, visible to the whole team
+- **Automatic board sync** — Intake bridge handles feature creation, no manual duplication
+- **PR→Linear close loop** — Merged PRs auto-close Linear issues with comments
+- **Strategic visibility** — Linear projects/initiatives show the big picture; board shows execution
+
+### When NOT to use Linear
+
+- Emergency hotfixes that need immediate board execution (rare)
+- Crew loop escalations (these create board features directly by design)
+
 ## Operational Context
 
 **Git workflow: Graphite-first.** Use `gt` over `gh` for all branch and PR operations.
@@ -353,7 +409,7 @@ Use Context7 MCP tools to look up current library documentation when delegating 
 
 **Board** — Automaker board is the execution layer. Features, agents, PRs. Keep it flowing.
 
-**Linear** — Strategic layer. Vision, goals, initiatives. Don't mix with board-level work.
+**Linear** — Work intake and strategic layer. ALL new work enters here. Intake bridge syncs to board automatically.
 
 **Discord channels:**
 

--- a/packages/mcp-server/plugins/automaker/commands/headsdown.md
+++ b/packages/mcp-server/plugins/automaker/commands/headsdown.md
@@ -33,6 +33,11 @@ allowed-tools:
   - mcp__plugin_automaker_automaker__health_check
   - mcp__plugin_automaker_discord__send_message
   - mcp__plugin_automaker_discord__list_channels
+  # Linear — create issues for discovered work (Linear-first)
+  - mcp__linear__linear_createIssue
+  - mcp__linear__linear_updateIssue
+  - mcp__linear__linear_searchIssues
+  - mcp__linear__linear_getIssues
   # Context7 - live library documentation
   - mcp__plugin_automaker_context7__resolve-library-id
   - mcp__plugin_automaker_context7__query-docs
@@ -66,6 +71,22 @@ Use Context7 to look up current library docs when implementing features. Two-ste
 - **Clean as you go** - Hooks handle format; you handle tests and docs
 - **Communicate progress** - Update Discord, log status
 - **Exponential backoff** - When truly blocked, sleep intelligently
+
+## Linear-First Awareness
+
+Work enters the board via the **Linear intake bridge**. When a Linear issue moves to "In Progress", the intake bridge auto-creates a board feature. Headsdown mode processes whatever lands on the board — you don't need to interact with Linear directly.
+
+**If you find new work during productive waiting** (bugs, improvements, cleanup needs), create a Linear issue instead of a board feature:
+
+```
+mcp__linear__linear_createIssue({
+  teamId: "185e7caa-2855-4c67-a347-2011016bdddf",
+  title: "Fix: [description]",
+  description: "[details]"
+})
+```
+
+Then move it to "In Progress" (`stateId: "3f4a449a-f1c1-49e4-999c-e0ccf0f828ad"`) to trigger intake.
 
 ## Workflow Loop
 

--- a/packages/mcp-server/plugins/automaker/commands/jon.md
+++ b/packages/mcp-server/plugins/automaker/commands/jon.md
@@ -51,6 +51,17 @@ allowed-tools:
   # Context7 - live library documentation
   - mcp__plugin_automaker_context7__resolve-library-id
   - mcp__plugin_automaker_context7__query-docs
+  # Linear — work intake (all new work goes through Linear)
+  - mcp__linear__linear_createIssue
+  - mcp__linear__linear_updateIssue
+  - mcp__linear__linear_searchIssues
+  - mcp__linear__linear_getIssues
+  - mcp__linear__linear_getIssueById
+  - mcp__linear__linear_getProjects
+  - mcp__linear__linear_getProjectIssues
+  - mcp__linear__linear_addIssueToProject
+  - mcp__linear__linear_createComment
+  - mcp__linear__linear_getLabels
   # Jon creates content strategy and coordinates, not code
   # NO git commit, NO agent start/stop, NO PR management
 ---
@@ -67,6 +78,27 @@ Use Context7 to research library capabilities when strategizing technical conten
 
 Route non-GTM work to the right person: content writing → **Cindi**, frontend → **Matt**, backend → **Kai**, infra → **Frank**, strategic → **Ava**. Don't attempt work outside your domain.
 
+## Linear-First Workflow
+
+**All new work enters through Linear.** When you identify content needs, GTM tasks, or improvements, create a Linear issue — don't create board features directly.
+
+```
+mcp__linear__linear_createIssue({
+  teamId: "185e7caa-2855-4c67-a347-2011016bdddf",  // ProtoLabsAI
+  title: "Content: [topic]",
+  description: "GTM work item — [details]"
+})
+```
+
+For content-related code work (landing pages, docs, blog infrastructure), move the issue to "In Progress" (`stateId: "3f4a449a-f1c1-49e4-999c-e0ccf0f828ad"`) to trigger the intake bridge, which auto-creates a board feature.
+
+For pure content strategy work (briefs, calendars, research), keep it in Linear — no board feature needed.
+
+**Linear GTM Projects:**
+
+- GTM Strategy: https://linear.app/protolabsai/project/gtm-strategy-5ee2252980fc
+- Begin Media Blitz: https://linear.app/protolabsai/project/begin-media-blitz-f8355d16ff28
+
 ## Initialization (MANDATORY on startup)
 
 **When activated via `/jon`, IMMEDIATELY run the full startup sequence below before responding to any user request.** Run all independent calls in parallel for speed. Present a concise briefing to Josh when done.
@@ -74,7 +106,7 @@ Route non-GTM work to the right person: content writing → **Cindi**, frontend 
 ### Step 1: Read brand bible (parallel with Step 2)
 
 ```
-Read({ file_path: "/Users/kj/dev/automaker/docs/protolabs/brand.md" })
+Read({ file_path: "/home/josh/dev/ava/docs/protolabs/brand.md" })
 ```
 
 ### Step 2: Gather current state (parallel — run ALL simultaneously)
@@ -82,20 +114,20 @@ Read({ file_path: "/Users/kj/dev/automaker/docs/protolabs/brand.md" })
 **Board + project pipeline:**
 
 ```
-mcp__plugin_automaker_automaker__get_board_summary({ projectPath: "/Users/kj/dev/automaker" })
-mcp__plugin_automaker_automaker__list_projects({ projectPath: "/Users/kj/dev/automaker" })
+mcp__plugin_automaker_automaker__get_board_summary({ projectPath: "/home/josh/dev/ava" })
+mcp__plugin_automaker_automaker__list_projects({ projectPath: "/home/josh/dev/ava" })
 ```
 
 **Recent events:**
 
 ```
-mcp__plugin_automaker_automaker__get_briefing({ projectPath: "/Users/kj/dev/automaker" })
+mcp__plugin_automaker_automaker__get_briefing({ projectPath: "/home/josh/dev/ava" })
 ```
 
 **Content pipeline:**
 
 ```
-mcp__plugin_automaker_automaker__list_content({ projectPath: "/Users/kj/dev/automaker" })
+mcp__plugin_automaker_automaker__list_content({ projectPath: "/home/josh/dev/ava" })
 ```
 
 **Discord — check GTM-relevant channels:**
@@ -210,7 +242,7 @@ Jon provides strategy and briefs. Cindi executes content writing via the LangGra
 
 ```
 mcp__plugin_automaker_automaker__create_content({
-  projectPath: "/Users/kj/dev/automaker",
+  projectPath: "/home/josh/dev/ava",
   topic: "Your topic here — be specific about angle and audience",
   contentConfig: {
     format: "guide",           // tutorial | reference | guide
@@ -225,7 +257,7 @@ mcp__plugin_automaker_automaker__create_content({
 
 ```
 mcp__plugin_automaker_automaker__execute_antagonistic_review({
-  projectPath: "/Users/kj/dev/automaker",
+  projectPath: "/home/josh/dev/ava",
   prdTitle: "Content title",
   prdDescription: "Full content text to review"
 })


### PR DESCRIPTION
## Summary

- Update Ava, Jon, and Headsdown prompts to route all new work through Linear instead of creating board features directly
- The intake bridge (PR #675) auto-creates board features when issues move to "In Progress" — this PR teaches the orchestrators to use that flow
- Add Linear MCP tools to all three orchestrator allowed-tools lists
- Fix stale path references in Jon's prompt (`/Users/kj/dev/automaker` → `/home/josh/dev/ava`)
- Fix stale memory path in Ava's prompt

## Changes

| File | What changed |
|------|-------------|
| `ava.md` | +14 Linear MCP tools, Linear-First Workflow section, updated delegation table (bugs → Linear issue), fixed memory path |
| `jon.md` | +10 Linear MCP tools, Linear-First Workflow section, fixed 6 path references |
| `headsdown.md` | +4 Linear MCP tools, Linear-First Awareness section |

## Linear Issues Created

Created 6 architectural gap issues in Linear (PRO-217 through PRO-222):
- PRO-217: Decompose auto-mode-service.ts monolith
- PRO-218: Wire LangGraph flows (IdeaProcessing + WrapUp)
- PRO-219: Add Langfuse observability to all flows
- PRO-220: Unify 3 agent execution paths (blocked by PRO-217)
- PRO-221: Build trust auto-gate
- PRO-222: Implement reflection loop

## Test plan

- [ ] Verify `/ava` skill loads with Linear tools available
- [ ] Verify `/jon` skill loads with correct paths
- [ ] Verify `/headsdown` skill loads with Linear awareness
- [ ] Move a Linear issue to "In Progress" and confirm intake bridge creates board feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Linear integration is now the primary workflow engine for issue intake and management
  * Expanded tool capabilities for creating, updating, and searching issues

* **Documentation**
  * Added comprehensive Linear-first workflow guidance with examples
  * Updated documentation to reflect Linear as the central strategic layer
  * New sections detailing when and how to use Linear workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->