### PR TITLE
docs: add agent-browser to agent and testing documentation

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -237,15 +237,15 @@ Covers:
 
 These agents can be invoked interactively via CLI skills or Discord.
 
-| Role              | Agent | Model  | Trigger                 | Location                         |
-| ----------------- | ----- | ------ | ----------------------- | -------------------------------- |
-| Chief of Staff    | Ava   | Opus   | CLI, Discord, crew loop | `services/built-in-templates.ts` |
-| Frontend Engineer | Matt  | Sonnet | CLI, Discord            | `services/built-in-templates.ts` |
-| AI Agent Engineer | Sam   | Sonnet | CLI, Discord            | `services/built-in-templates.ts` |
-| Backend Engineer  | Kai   | Sonnet | CLI, Discord            | `services/built-in-templates.ts` |
-| DevOps Engineer   | Frank | Sonnet | CLI, Discord, crew loop | `services/built-in-templates.ts` |
-| Content Writer    | Cindi | Sonnet | CLI, Discord            | `services/built-in-templates.ts` |
-| GTM Specialist    | Jon   | Sonnet | CLI, Discord            | `services/built-in-templates.ts` |
+| Role              | Agent | Model  | Trigger                 | Exclusive Tools                   |
+| ----------------- | ----- | ------ | ----------------------- | --------------------------------- |
+| Chief of Staff    | Ava   | Opus   | CLI, Discord, crew loop | —                                 |
+| Frontend Engineer | Matt  | Sonnet | CLI, Discord            | Pencil design tool, agent-browser |
+| AI Agent Engineer | Sam   | Sonnet | CLI, Discord            | —                                 |
+| Backend Engineer  | Kai   | Sonnet | CLI, Discord            | —                                 |
+| DevOps Engineer   | Frank | Sonnet | CLI, Discord, crew loop | —                                 |
+| Content Writer    | Cindi | Sonnet | CLI, Discord            | —                                 |
+| GTM Specialist    | Jon   | Sonnet | CLI, Discord            | —                                 |
 
 ### Crew Loop Members (Scheduled)
 

--- a/docs/dev/frontend-philosophy.md
+++ b/docs/dev/frontend-philosophy.md
@@ -387,6 +387,7 @@ Lucide React is the standard icon library. It provides tree-shakeable, consisten
 | Unit              | Vitest                      | Utility functions, hooks, store logic                               |
 | Component         | Storybook interaction tests | UI behavior, accessibility, visual states                           |
 | Visual regression | Chromatic (target)          | Unintended UI changes between releases                              |
+| Agent visual      | agent-browser               | Theme validation, chart colors, responsive layouts (Matt exclusive) |
 | E2E               | Playwright                  | Critical user flows (create feature, run agent, board interactions) |
 
 ## Build and tooling

--- a/docs/dev/testing-patterns.md
+++ b/docs/dev/testing-patterns.md
@@ -83,6 +83,43 @@ Regex-based verification of source code catches structural issues (95% accurate)
 
 Helpers designed for single-use setup (`createFeatures(path, count)`) may overwrite data when called multiple times. Inline manual creation when test flow requires incremental mutations.
 
+## Visual Testing with agent-browser
+
+### When to use
+
+Matt (Frontend Engineer) has exclusive access to `agent-browser`, a headless browser CLI built for AI agents. Use it for visual verification during frontend work — not as a replacement for Playwright E2E tests.
+
+| Use case                                      | Tool          |
+| --------------------------------------------- | ------------- |
+| Verify component renders after implementation | agent-browser |
+| Theme/token change validation across views    | agent-browser |
+| Responsive layout spot-checks                 | agent-browser |
+| Critical user flow testing                    | Playwright    |
+| CI regression gates                           | Playwright    |
+
+### Snapshot-ref workflow
+
+agent-browser uses accessibility tree snapshots with deterministic refs (`@e1`, `@e2`) instead of CSS selectors. Always re-snapshot after navigation or state changes — refs are only valid for the current page state.
+
+```bash
+# Take snapshot, interact, verify
+agent-browser open http://localhost:3007/dashboard
+agent-browser snapshot -i --json        # Get interactive element refs
+agent-browser click @e5                  # Click by ref
+agent-browser wait --load networkidle    # Wait for state change
+agent-browser snapshot -i --json        # Re-snapshot (refs may change)
+agent-browser screenshot result.png      # Visual proof
+agent-browser close                      # Free resources
+```
+
+### Rules
+
+- Dev server must be running on `localhost:3007` before using agent-browser
+- Always close the browser session when done (`agent-browser close`)
+- Don't commit screenshots — use them for verification only, then clean up
+- Use `--json` flag when parsing snapshot output programmatically
+- For Electron testing, connect via CDP: `agent-browser --cdp 9222 open http://localhost:3007`
+
 ## Integration Testing
 
 ### Mock boundaries, not internals


### PR DESCRIPTION
## Summary

- **docs/agents/index.md**: Replace Location column with Exclusive Tools column in the Interactive Agents table. Documents Matt's exclusive access to Pencil design tool and agent-browser.
- **docs/dev/frontend-philosophy.md**: Add "Agent visual" testing layer (agent-browser) to the testing strategy table.
- **docs/dev/testing-patterns.md**: New section on visual testing with agent-browser — covers snapshot-ref workflow, use case matrix (agent-browser vs Playwright), and operational rules.

## Test plan

- [ ] Verify markdown tables render correctly in all three files
- [ ] Confirm agent-browser section in testing-patterns.md is consistent with Matt's `/matt` prompt documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised agents table to display exclusive tools available for each agent role
  * Added new crew loop members reference with scheduling details and model assignments
  * Enhanced testing documentation with visual testing patterns, including use cases, workflow examples, and best practices for frontend verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->