### PR TITLE
fix: add missing createdLinearIssueIds to wrap-up initial state

### DIFF
--- a/libs/flows/src/wrap-up/with-tracing.ts
+++ b/libs/flows/src/wrap-up/with-tracing.ts
@@ -74,6 +74,7 @@ export async function executeWrapUpFlowWithTracing(
       createdBeadsIds: [],
       createdFeatureIds: [],
       createdPrdIds: [],
+      createdLinearIssueIds: [],
       errors: [],
     };
 


### PR DESCRIPTION
## Summary
- Adds missing `createdLinearIssueIds: []` to the initial state in `libs/flows/src/wrap-up/with-tracing.ts`
- The `WrapUpState` type requires this field but it was omitted, causing a DTS build error during Docker deploy
- This is the sole blocker for staging deployment — two consecutive deploys failed due to this type error

## Test plan
- [x] `npm run build --workspace=libs/flows` passes locally
- [x] `npm run build:libs` full chain passes
- [ ] Deploy staging succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking of linear issues created during wrap-up operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->