### PR TITLE
fix: crew status API response shape mismatch causing crash

### DIFF
--- a/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
+++ b/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
@@ -87,7 +87,7 @@ export function useFlowGraphData() {
       draggable: false,
     });
 
-    // 2. Crew nodes
+    // 2. Crew nodes (members is now an array after transform in useCrewStatus)
     const crewMembers = crewStatus?.members ?? [];
     for (const member of crewMembers) {
       const nodeId = CREW_NODE_ID_MAP[member.id];
@@ -97,9 +97,9 @@ export function useFlowGraphData() {
         id: member.id,
         label: CREW_DISPLAY_NAMES[member.id] || member.id,
         enabled: member.enabled,
-        isRunning: member.isRunning,
-        lastCheckTime: member.lastCheckTime,
-        lastSeverity: member.lastCheckResult?.severity ?? null,
+        isRunning: member.running,
+        lastCheckTime: member.lastCheck?.timestamp ?? null,
+        lastSeverity: member.lastCheck?.result?.severity ?? null,
       };
       result.push({
         id: nodeId,

--- a/apps/ui/src/hooks/queries/use-crew-status.ts
+++ b/apps/ui/src/hooks/queries/use-crew-status.ts
@@ -14,31 +14,55 @@ export interface CrewMemberStatus {
   id: string;
   enabled: boolean;
   schedule: string;
-  lastCheckTime: string | null;
-  lastCheckResult: {
-    severity: string;
-    findings: Array<{
+  running: boolean;
+  lastCheck?: {
+    timestamp: string;
+    result: {
       severity: string;
-      message: string;
-    }>;
-  } | null;
-  isRunning: boolean;
-  lastEscalationTime: string | null;
+      findings: Array<{
+        severity: string;
+        message: string;
+      }>;
+    };
+    durationMs: number;
+  };
+  lastEscalation?: {
+    timestamp: string;
+    durationMs: number;
+  };
+  checkCount: number;
+  escalationCount: number;
+  displayName: string;
+  templateName: string;
+  defaultSchedule: string;
+}
+
+/** Server response: members keyed by id */
+interface ServerCrewStatusResponse {
+  success: boolean;
+  enabled: boolean;
+  members: Record<string, Omit<CrewMemberStatus, 'id'>>;
 }
 
 export interface CrewStatusResponse {
+  enabled: boolean;
   members: CrewMemberStatus[];
 }
 
 /**
- * Fetch all crew member statuses
+ * Fetch all crew member statuses.
+ * Server returns members as Record<string, object> — we convert to array.
  */
 export function useCrewStatus() {
   return useQuery({
     queryKey: queryKeys.crew.status(),
     queryFn: async (): Promise<CrewStatusResponse> => {
       const api = getHttpApiClient();
-      return api.crew.status();
+      const raw = (await api.crew.status()) as ServerCrewStatusResponse;
+      const members = raw.members
+        ? Object.entries(raw.members).map(([id, member]) => ({ id, ...member }))
+        : [];
+      return { enabled: raw.enabled, members };
     },
     staleTime: CREW_STATUS_STALE_TIME,
     refetchInterval: CREW_STATUS_STALE_TIME,


### PR DESCRIPTION
## Summary

- Server returns crew members as `Record<string, object>` but the UI typed it as `CrewMemberStatus[]`
- `for (const member of crewMembers)` threw `TypeError: y is not iterable` on a plain object
- This crashed the flow graph → render loop → hammered API → 429 rate limiting → session check failed → redirect to `/logged-out`
- Fix: transform `Record` to array via `Object.entries().map()` in `useCrewStatus` queryFn
- Aligned field names: `running` (not `isRunning`), `lastCheck.timestamp` (not `lastCheckTime`), `lastCheck.result.severity` (not `lastCheckResult.severity`)

## Test plan

- [ ] Load `/analytics` (system flow graph) — no crash, crew nodes render
- [ ] Verify crew node status dots match actual crew member states
- [ ] No 429 rate limiting errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded crew member status information with additional metrics: check count, escalation count, template name, and default schedule.
  * Enhanced status tracking with detailed check and escalation history, including timestamps and duration metrics.

* **Refactor**
  * Reorganized status data structure for improved clarity and consistency in crew member information display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->