### PR TITLE
fix: add Umami analytics ID to consulting page

### DIFF
--- a/site/consulting/index.html
+++ b/site/consulting/index.html
@@ -33,11 +33,11 @@
       href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
-    <!-- Umami Analytics — Josh will configure data-website-id -->
+    <!-- Umami Analytics -->
     <script
       defer
       src="https://umami.proto-labs.ai/script.js"
-      data-website-id="REPLACE_WITH_WEBSITE_ID"
+      data-website-id="b5ac1874-7bda-411f-9115-168d230f80a6"
     ></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>


### PR DESCRIPTION
## Summary
- Replace placeholder `REPLACE_WITH_WEBSITE_ID` with actual Umami analytics ID for protolabs.consulting

## Test plan
- [ ] Verify analytics tracking in Umami dashboard after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected analytics configuration to properly track site activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->