### PR TITLE
feat: add consulting cross-links to studio and docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -65,6 +65,7 @@ export default defineConfig({
         items: [
           { text: 'Reference', link: '/dev/' },
           { text: 'ProtoLabs', link: '/protolabs/' },
+          { text: 'Consulting', link: 'https://protolabs.consulting' },
         ],
       },
     ],

--- a/site/index.html
+++ b/site/index.html
@@ -318,6 +318,13 @@
             >Docs</a
           >
           <a
+            href="https://protolabs.consulting"
+            target="_blank"
+            rel="noopener"
+            class="hover:text-white transition-colors"
+            >Consulting</a
+          >
+          <a
             href="https://x.com/protoLabsAI"
             target="_blank"
             rel="noopener"
@@ -1185,6 +1192,13 @@
             rel="noopener"
             class="hover:text-zinc-300 transition-colors"
             >Docs</a
+          >
+          <a
+            href="https://protolabs.consulting"
+            target="_blank"
+            rel="noopener"
+            class="hover:text-zinc-300 transition-colors"
+            >Consulting</a
           >
           <a
             href="https://x.com/protoLabsAI"


### PR DESCRIPTION
## Summary
- Add `protolabs.consulting` link to protolabs.studio nav bar (between Docs and Twitter)
- Add `protolabs.consulting` link to protolabs.studio footer (between Docs and X/Twitter)
- Add Consulting link to docs.protolabs.studio VitePress nav (More dropdown)

Ensures all three protoLabs surfaces cross-link to each other.

## Test plan
- [ ] Verify protolabs.studio nav shows Consulting link
- [ ] Verify protolabs.studio footer shows Consulting link
- [ ] Verify docs.protolabs.studio More dropdown shows Consulting link
- [ ] All links resolve to https://protolabs.consulting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Consulting navigation link in both header and footer navigation menus, providing quick access to consulting services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->