### PR TITLE
fix: wire flow graph to real data sources and add crew status tests

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1073,7 +1073,11 @@ app.use('/api/backlog-plan', createBacklogPlanRoutes(events, settingsService));
 app.use('/api/beads', createBeadsRoutes(beadsService));
 app.use('/api/mcp', createMCPRoutes(mcpTestService));
 app.use('/api/integrations', authMiddleware, createIntegrationRoutes(settingsService));
-app.use('/api/system', authMiddleware, createDashboardRoutes(autoModeService, crewLoopService));
+app.use(
+  '/api/system',
+  authMiddleware,
+  createDashboardRoutes(autoModeService, crewLoopService, leadEngineerService)
+);
 app.use(
   '/api/authority',
   authMiddleware,

--- a/apps/server/src/routes/dashboard.ts
+++ b/apps/server/src/routes/dashboard.ts
@@ -2,33 +2,42 @@
  * Dashboard Routes - System health and status endpoints
  */
 
+import { freemem, totalmem, cpus, loadavg } from 'node:os';
+import v8 from 'node:v8';
 import { Router, Request, Response } from 'express';
 import { createLogger } from '@automaker/utils';
 import type { AutoModeService } from '../services/auto-mode-service.js';
 import type { CrewLoopService } from '../services/crew-loop-service.js';
+import type { LeadEngineerService } from '../services/lead-engineer-service.js';
 
 const logger = createLogger('DashboardRoutes');
 
 export function createDashboardRoutes(
   autoModeService: AutoModeService,
-  crewLoopService: CrewLoopService
+  crewLoopService: CrewLoopService,
+  leadEngineerService?: LeadEngineerService
 ): Router {
   const router = Router();
 
   /**
    * POST /api/system/health-dashboard
-   * Get comprehensive system health including memory, CPU, heap, agent count, auto-mode status, crew status
+   * Comprehensive system health with computed percentages for UI gauges.
    */
   router.post('/health-dashboard', async (req: Request, res: Response) => {
     try {
-      // Get memory and CPU metrics
       const memoryUsage = process.memoryUsage();
-      const cpuUsage = process.cpuUsage();
+      const heapStats = v8.getHeapStatistics();
+      const totalSystemMem = totalmem();
+      const freeSystemMem = freemem();
+      const usedSystemMem = totalSystemMem - freeSystemMem;
 
-      // Get auto-mode status (no arguments)
+      // CPU load average (1 min) normalized to 0-100 by core count
+      const coreCount = cpus().length || 1;
+      const loadAvg = loadavg()[0];
+      const cpuPercent = Math.min((loadAvg / coreCount) * 100, 100);
+
       const autoModeStatus = autoModeService.getStatus();
 
-      // Get crew status
       let crewStatus = null;
       try {
         crewStatus = crewLoopService.getStatus();
@@ -36,22 +45,36 @@ export function createDashboardRoutes(
         logger.warn('Failed to get crew status:', error);
       }
 
+      // Lead engineer sessions
+      const leadEngineerSessions = leadEngineerService
+        ? leadEngineerService.getAllSessions().map((s) => ({
+            projectPath: s.projectPath,
+            projectSlug: s.projectSlug,
+            flowState: s.flowState,
+            startedAt: s.startedAt,
+          }))
+        : [];
+
       res.json({
         success: true,
         memory: {
+          rss: memoryUsage.rss,
           heapUsed: memoryUsage.heapUsed,
           heapTotal: memoryUsage.heapTotal,
-          rss: memoryUsage.rss,
           external: memoryUsage.external,
+          systemUsed: usedSystemMem,
+          systemTotal: totalSystemMem,
+          usedPercent: Math.round((usedSystemMem / totalSystemMem) * 100),
         },
         cpu: {
-          user: cpuUsage.user,
-          system: cpuUsage.system,
+          loadAvg1m: loadAvg,
+          cores: cpus().length,
+          loadPercent: Math.round(cpuPercent),
         },
         heap: {
           used: memoryUsage.heapUsed,
-          total: memoryUsage.heapTotal,
-          percentage: (memoryUsage.heapUsed / memoryUsage.heapTotal) * 100,
+          total: heapStats.heap_size_limit,
+          percentage: Math.round((memoryUsage.heapUsed / heapStats.heap_size_limit) * 100),
         },
         agents: {
           count: autoModeStatus.runningCount,
@@ -61,6 +84,11 @@ export function createDashboardRoutes(
           isRunning: autoModeStatus.isRunning,
           runningCount: autoModeStatus.runningCount,
           runningFeatures: autoModeStatus.runningFeatures,
+        },
+        leadEngineer: {
+          running: leadEngineerSessions.length > 0,
+          sessionCount: leadEngineerSessions.length,
+          sessions: leadEngineerSessions,
         },
         crew: crewStatus,
         uptime: process.uptime(),

--- a/apps/server/tests/unit/routes/crew.test.ts
+++ b/apps/server/tests/unit/routes/crew.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Crew Status Route Tests
+ *
+ * Validates GET /api/crew/status response shape.
+ * The client transforms Record<string, member> into an array — these tests
+ * ensure the server contract matches what the client expects.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response } from 'express';
+import { createGetStatusHandler } from '@/routes/crew/routes/get-status.js';
+import type { CrewLoopService, CrewStatus } from '@/services/crew-loop-service.js';
+import { createMockExpressContext } from '../../utils/mocks.js';
+
+describe('crew routes', () => {
+  let mockCrewLoopService: Partial<CrewLoopService>;
+  let req: Request;
+  let res: Response;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockCrewLoopService = {
+      getStatus: vi.fn(),
+    };
+
+    const context = createMockExpressContext();
+    req = context.req;
+    res = context.res;
+  });
+
+  describe('GET /status', () => {
+    it('should return members as Record<string, object> (not array)', async () => {
+      // This test exists because the client crashed when members was assumed to be
+      // an array. The server returns Record<string, member> and the client must
+      // transform it. If this test breaks, the client will crash.
+      const mockStatus: CrewStatus = {
+        enabled: true,
+        members: {
+          frank: {
+            id: 'frank',
+            displayName: 'Frank',
+            templateName: 'frank',
+            defaultSchedule: '*/10 * * * *',
+            enabled: true,
+            schedule: '*/10 * * * *',
+            running: false,
+            checkCount: 3,
+            escalationCount: 0,
+          },
+        },
+      };
+      vi.mocked(mockCrewLoopService.getStatus!).mockReturnValue(mockStatus);
+
+      const handler = createGetStatusHandler(mockCrewLoopService as CrewLoopService);
+      await handler(req, res);
+
+      const response = vi.mocked(res.json).mock.calls[0][0];
+
+      // Critical shape assertion: members MUST be a Record, NOT an array
+      expect(response.success).toBe(true);
+      expect(response.members).toBeDefined();
+      expect(Array.isArray(response.members)).toBe(false);
+      expect(typeof response.members).toBe('object');
+      expect(response.members.frank).toBeDefined();
+      expect(response.members.frank.id).toBe('frank');
+    });
+
+    it('should include all required member fields', async () => {
+      const mockStatus: CrewStatus = {
+        enabled: true,
+        members: {
+          ava: {
+            id: 'ava',
+            displayName: 'Ava',
+            templateName: 'ava',
+            defaultSchedule: '*/10 * * * *',
+            enabled: true,
+            schedule: '*/10 * * * *',
+            running: true,
+            lastCheck: {
+              timestamp: '2026-02-17T20:00:00Z',
+              result: { severity: 'ok', title: 'All clear', findings: [] },
+              durationMs: 150,
+            },
+            lastEscalation: {
+              timestamp: '2026-02-17T19:00:00Z',
+              result: { success: true, output: 'Fixed' },
+              durationMs: 5000,
+            },
+            checkCount: 42,
+            escalationCount: 3,
+          },
+        },
+      };
+      vi.mocked(mockCrewLoopService.getStatus!).mockReturnValue(mockStatus);
+
+      const handler = createGetStatusHandler(mockCrewLoopService as CrewLoopService);
+      await handler(req, res);
+
+      const response = vi.mocked(res.json).mock.calls[0][0];
+      const ava = response.members.ava;
+
+      // Validate field names the client depends on
+      expect(ava).toHaveProperty('id');
+      expect(ava).toHaveProperty('running'); // NOT "isRunning"
+      expect(ava).toHaveProperty('enabled');
+      expect(ava).toHaveProperty('schedule');
+      expect(ava).toHaveProperty('lastCheck');
+      expect(ava.lastCheck).toHaveProperty('timestamp'); // NOT "lastCheckTime"
+      expect(ava.lastCheck).toHaveProperty('result');
+      expect(ava.lastCheck.result).toHaveProperty('severity'); // nested in lastCheck.result
+      expect(ava).toHaveProperty('checkCount');
+      expect(ava).toHaveProperty('escalationCount');
+    });
+
+    it('should return empty members object when no crew members registered', async () => {
+      const mockStatus: CrewStatus = {
+        enabled: true,
+        members: {},
+      };
+      vi.mocked(mockCrewLoopService.getStatus!).mockReturnValue(mockStatus);
+
+      const handler = createGetStatusHandler(mockCrewLoopService as CrewLoopService);
+      await handler(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        enabled: true,
+        members: {},
+      });
+    });
+
+    it('should return system enabled status', async () => {
+      const mockStatus: CrewStatus = {
+        enabled: false,
+        members: {},
+      };
+      vi.mocked(mockCrewLoopService.getStatus!).mockReturnValue(mockStatus);
+
+      const handler = createGetStatusHandler(mockCrewLoopService as CrewLoopService);
+      await handler(req, res);
+
+      const response = vi.mocked(res.json).mock.calls[0][0];
+      expect(response.enabled).toBe(false);
+    });
+
+    it('should handle members without optional lastCheck/lastEscalation', async () => {
+      const mockStatus: CrewStatus = {
+        enabled: true,
+        members: {
+          'board-janitor': {
+            id: 'board-janitor',
+            displayName: 'Board Janitor',
+            templateName: 'board-janitor',
+            defaultSchedule: '*/15 * * * *',
+            enabled: true,
+            schedule: '*/15 * * * *',
+            running: false,
+            checkCount: 0,
+            escalationCount: 0,
+            // No lastCheck or lastEscalation — fresh member
+          },
+        },
+      };
+      vi.mocked(mockCrewLoopService.getStatus!).mockReturnValue(mockStatus);
+
+      const handler = createGetStatusHandler(mockCrewLoopService as CrewLoopService);
+      await handler(req, res);
+
+      const response = vi.mocked(res.json).mock.calls[0][0];
+      const janitor = response.members['board-janitor'];
+      expect(janitor.lastCheck).toBeUndefined();
+      expect(janitor.lastEscalation).toBeUndefined();
+      expect(janitor.running).toBe(false);
+    });
+
+    it('should handle service errors gracefully', async () => {
+      vi.mocked(mockCrewLoopService.getStatus!).mockImplementation(() => {
+        throw new Error('CrewLoopService not initialized');
+      });
+
+      const handler = createGetStatusHandler(mockCrewLoopService as CrewLoopService);
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'CrewLoopService not initialized',
+      });
+    });
+
+    it('should handle non-Error exceptions', async () => {
+      vi.mocked(mockCrewLoopService.getStatus!).mockImplementation(() => {
+        throw 'unexpected string error';
+      });
+
+      const handler = createGetStatusHandler(mockCrewLoopService as CrewLoopService);
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'unexpected string error',
+      });
+    });
+
+    it('should return multiple crew members keyed by id', async () => {
+      const mockStatus: CrewStatus = {
+        enabled: true,
+        members: {
+          ava: {
+            id: 'ava',
+            displayName: 'Ava',
+            templateName: 'ava',
+            defaultSchedule: '*/10 * * * *',
+            enabled: true,
+            schedule: '*/10 * * * *',
+            running: false,
+            checkCount: 10,
+            escalationCount: 1,
+          },
+          frank: {
+            id: 'frank',
+            displayName: 'Frank',
+            templateName: 'frank',
+            defaultSchedule: '*/10 * * * *',
+            enabled: true,
+            schedule: '*/10 * * * *',
+            running: true,
+            checkCount: 8,
+            escalationCount: 0,
+          },
+          'pr-maintainer': {
+            id: 'pr-maintainer',
+            displayName: 'PR Maintainer',
+            templateName: 'pr-maintainer',
+            defaultSchedule: '*/10 * * * *',
+            enabled: false,
+            schedule: '*/10 * * * *',
+            running: false,
+            checkCount: 0,
+            escalationCount: 0,
+          },
+        },
+      };
+      vi.mocked(mockCrewLoopService.getStatus!).mockReturnValue(mockStatus);
+
+      const handler = createGetStatusHandler(mockCrewLoopService as CrewLoopService);
+      await handler(req, res);
+
+      const response = vi.mocked(res.json).mock.calls[0][0];
+      expect(Object.keys(response.members)).toHaveLength(3);
+      expect(response.members.ava.running).toBe(false);
+      expect(response.members.frank.running).toBe(true);
+      expect(response.members['pr-maintainer'].enabled).toBe(false);
+    });
+  });
+});

--- a/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
+++ b/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
@@ -62,11 +62,17 @@ export function useFlowGraphData() {
     [features]
   );
 
-  // Auto-mode status from health data (untyped API response)
-  const health = healthData as Record<string, any> | undefined;
-  const autoModeRunning = health?.autoMode?.status === 'running';
-  const capacity = capacityData as Record<string, any> | undefined;
-  const queueDepth = (capacity?.backlog as number) ?? 0;
+  // Typed health dashboard response fields
+  const health = healthData as
+    | {
+        autoMode?: { isRunning?: boolean; runningCount?: number };
+        leadEngineer?: { running?: boolean; sessionCount?: number };
+      }
+    | undefined;
+  const autoModeRunning = health?.autoMode?.isRunning === true;
+  const leadEngineerRunning = health?.leadEngineer?.running === true;
+  const capacity = capacityData as { backlogSize?: number; maxConcurrency?: number } | undefined;
+  const queueDepth = capacity?.backlogSize ?? 0;
 
   const nodes = useMemo(() => {
     const result: Node[] = [];
@@ -148,7 +154,7 @@ export function useFlowGraphData() {
     const leadEngData: ServiceNodeData = {
       label: 'Lead Engineer',
       serviceType: 'lead-engineer',
-      running: false, // TODO: wire to actual lead engineer status
+      running: leadEngineerRunning,
       queueDepth: 0,
     };
     result.push({
@@ -236,6 +242,7 @@ export function useFlowGraphData() {
     agentCount,
     activeFeatures,
     autoModeRunning,
+    leadEngineerRunning,
     queueDepth,
     crewStatus,
     integrationStatus,

--- a/apps/ui/src/components/views/flow-graph/panels/health-panel.tsx
+++ b/apps/ui/src/components/views/flow-graph/panels/health-panel.tsx
@@ -9,6 +9,13 @@ import { Gauge } from '@/components/dashboard';
 import { useSystemHealth, useCapacityMetrics } from '@/hooks/queries/use-metrics';
 import { useRunningAgentsCount } from '@/hooks/queries/use-running-agents';
 
+interface HealthDashboardResponse {
+  memory?: { usedPercent?: number };
+  cpu?: { loadPercent?: number };
+  heap?: { percentage?: number };
+  agents?: { count?: number };
+}
+
 interface HealthPanelProps {
   projectPath?: string;
 }
@@ -18,11 +25,12 @@ export function HealthPanel({ projectPath }: HealthPanelProps) {
   const { data: rawCapacity } = useCapacityMetrics(projectPath);
   const { data: agentCount } = useRunningAgentsCount();
 
-  const health = rawHealth as Record<string, any> | undefined;
-  const capacity = rawCapacity as Record<string, any> | undefined;
-  const memoryPercent = (health?.memory?.usedPercent as number) ?? 0;
-  const cpuPercent = (health?.cpu?.loadPercent as number) ?? 0;
-  const heapPercent = (health?.heap?.usedPercent as number) ?? 0;
+  const health = rawHealth as HealthDashboardResponse | undefined;
+  const capacity = rawCapacity as { maxConcurrency?: number } | undefined;
+
+  const memoryPercent = health?.memory?.usedPercent ?? 0;
+  const cpuPercent = health?.cpu?.loadPercent ?? 0;
+  const heapPercent = health?.heap?.percentage ?? 0;
 
   return (
     <motion.div
@@ -44,7 +52,7 @@ export function HealthPanel({ projectPath }: HealthPanelProps) {
       <div className="flex items-center justify-between text-xs px-1 pt-1 border-t border-border/30">
         <span className="text-muted-foreground">Agents</span>
         <span className="font-semibold tabular-nums">
-          {agentCount}/{(capacity?.maxConcurrency as number) ?? 6}
+          {agentCount}/{capacity?.maxConcurrency ?? 6}
         </span>
       </div>
     </motion.div>


### PR DESCRIPTION
## Summary

- **Health panel gauges showing 0**: Server now returns `memory.usedPercent` (system RAM %), `cpu.loadPercent` (1-min load avg normalized by cores), `heap.percentage` (V8 heap used / heap_size_limit). Panel reads the correct field names.
- **Auto-mode node always "off"**: Was checking `autoMode.status === 'running'` (string) but server returns `autoMode.isRunning` (boolean). Fixed.
- **Lead Engineer node hardcoded `false`**: Now wired to real session data via health-dashboard endpoint. Shows running state when lead engineer has active sessions.
- **Queue depth always 0**: Now reads `backlogSize` from capacity metrics endpoint.
- **8 new crew status tests**: Validates response shape is `Record<string, member>` (not array), correct field names (`running` not `isRunning`, `lastCheck.timestamp` not `lastCheckTime`), error handling. **This test would have caught the TypeError crash from PR #698.**

## Test plan

- [x] `npm run test:server -- tests/unit/routes/crew.test.ts` — 8/8 pass
- [ ] Health panel shows non-zero RAM/CPU/Heap gauges
- [ ] Auto-mode node glows when auto-mode is running
- [ ] Lead Engineer node shows running when a session is active
- [ ] No TypeScript errors in changed flow-graph files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Expanded system health dashboard with memory usage percentages, CPU load metrics, and lead engineer session data.
* Lead engineer running status now tracked and displayed in the flow graph.
* Enhanced health data typing for improved reliability.

## Tests
* Added comprehensive unit tests for the crew endpoint status route validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->