### PR TITLE
fix(ui): scope CopilotKit CSS to fix invisible dialogs/popovers

### DIFF
--- a/apps/ui/src/components/copilotkit/provider.tsx
+++ b/apps/ui/src/components/copilotkit/provider.tsx
@@ -14,7 +14,6 @@ import {
   CopilotSidebar,
   useAgentContext,
 } from '@copilotkitnext/react';
-import '@copilotkitnext/react/styles.css';
 import { getCopilotKitThemeStyles } from './theme-bridge';
 import { getAuthHeaders } from '@/lib/api-fetch';
 import { useAuthStore } from '@/store/auth-store';

--- a/apps/ui/src/styles/global.css
+++ b/apps/ui/src/styles/global.css
@@ -1,3 +1,4 @@
+@import '@copilotkitnext/react/styles.css' layer(copilotkit);
 @import 'tailwindcss';
 @import 'tw-animate-css';
 


### PR DESCRIPTION
## Summary
- CopilotKit's bundled `styles.css` includes a full Tailwind CSS 4 build that resets animation variables (`--tw-enter-opacity`, `--tw-translate-x`, etc.) on all elements, conflicting with `tw-animate-css` and making dialog/popover content invisible (backdrop shows, card doesn't)
- Move CopilotKit CSS import from JS (`import '@copilotkitnext/react/styles.css'`) to CSS `@import` with `layer(copilotkit)`, giving it lower cascade priority than our Tailwind layers
- CopilotKit sidebar still renders correctly — its styles apply to its own elements without competition

## Test plan
- [ ] Open any dialog (e.g. node detail dialog on flow graph, settings, delete project) — card content should be visible
- [ ] Open any popover (e.g. project context menu, theme picker) — popover content should be visible  
- [ ] CopilotKit sidebar (Cmd+K) still opens and renders correctly
- [ ] No visual regressions on other UI elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized CopilotKit stylesheet imports for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->