### PR TITLE
fix(server): exempt startup endpoints from rate limiter (429 on deploy)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -990,13 +990,18 @@ setInterval(() => {
   }
 }, VALIDATION_CLEANUP_INTERVAL_MS);
 
-// Rate limiting — general API (skip health checks)
+// Rate limiting — general API (skip health checks and read-only status endpoints)
 const apiLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   limit: 300,
   standardHeaders: 'draft-7',
   legacyHeaders: false,
-  skip: (req) => req.path === '/health' || req.path.startsWith('/health/'),
+  skip: (req) =>
+    req.path === '/health' ||
+    req.path.startsWith('/health/') ||
+    req.path.startsWith('/setup/') ||
+    req.path === '/settings/status' ||
+    req.path === '/copilotkit/info',
   message: { error: 'Too many requests, please try again later' },
 });
 app.use('/api', apiLimiter);


### PR DESCRIPTION
## Summary
- After Docker deploy restart, browser reconnects with parallel startup requests that exhaust the 300/min rate limit (all share one IP bucket through nginx proxy)
- TanStack Query retry cascade amplifies the burst, causing 429 on auth verification which redirects to /logged-out
- Exempt read-only startup endpoints (`/setup/*`, `/settings/status`, `/copilotkit/info`) from rate limiting — they're auth-gated and informational

## Test plan
- [ ] Deploy to staging — page loads without 429 errors
- [ ] Rapid refresh doesn't cause 429 on startup endpoints
- [ ] Auth flow completes successfully after deploy
- [ ] Rate limiter still applies to other API endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rate limiting configuration updated to exclude health checks and status monitoring endpoints, ensuring critical service diagnostics operate without rate limit restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->