### PR TITLE
style: redesign setupLab report to match protoLabs brand

### DIFF
--- a/apps/server/src/services/report-generator-service.ts
+++ b/apps/server/src/services/report-generator-service.ts
@@ -75,28 +75,55 @@ export function generateReport(options: ReportOptions): string {
     techStack.push(research.backend.database);
   }
 
+  const scoreColor =
+    report.overallScore >= 80 ? '#4ade80' : report.overallScore >= 50 ? '#facc15' : '#f87171';
+
   const html = `<!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ProtoLabs Report - ${research.projectName}</title>
+  <title>protoLabs Report — ${research.projectName}</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9670;</text></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Geist', 'system-ui', 'sans-serif'],
+            mono: ['Geist Mono', 'monospace'],
+          },
+          colors: {
+            surface: { 0: '#09090b', 1: '#111113', 2: '#18181b', 3: '#222225' },
+            accent: { DEFAULT: '#a78bfa', dim: '#7c5cbf' },
+            muted: '#71717a',
+          },
+        },
+      },
+    };
+  </script>
   <style>
+    html { scroll-behavior: smooth; }
     body {
-      font-family: system-ui, -apple-system, sans-serif;
+      background-color: #09090b;
+      color: #fafafa;
+      font-family: 'Geist', system-ui, sans-serif;
+    }
+    a:focus-visible, button:focus-visible {
+      outline: 2px solid #a78bfa;
+      outline-offset: 2px;
     }
 
     /* Animated SVG Score Ring */
     @keyframes scoreRingAnimation {
-      from {
-        stroke-dashoffset: 553.097;
-      }
-      to {
-        stroke-dashoffset: calc(553.097 - (553.097 * ${report.overallScore} / 100));
-      }
+      from { stroke-dashoffset: 553.097; }
+      to { stroke-dashoffset: calc(553.097 - (553.097 * ${report.overallScore} / 100)); }
     }
-
     .score-ring {
       animation: scoreRingAnimation 1.5s ease-out forwards;
       stroke-dasharray: 553.097 553.097;
@@ -104,134 +131,103 @@ export function generateReport(options: ReportOptions): string {
     }
 
     /* Expandable gap sections */
-    .gap-card {
-      cursor: pointer;
-      transition: all 0.3s ease;
-    }
+    .gap-card { cursor: pointer; transition: all 0.2s ease; }
+    .gap-card:hover { transform: translateY(-1px); box-shadow: 0 0 40px rgba(167, 139, 250, 0.06); }
+    .gap-details { max-height: 0; overflow: hidden; transition: max-height 0.3s ease; }
+    .gap-details.expanded { max-height: 500px; }
+    .expand-icon { transition: transform 0.3s ease; }
+    .expand-icon.rotated { transform: rotate(180deg); }
 
-    .gap-card:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
-    }
+    /* Badges */
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 6px; font-size: 11px; font-weight: 500; text-transform: uppercase; letter-spacing: 0.05em; }
+    .badge-red { background: rgba(248, 113, 113, 0.15); color: #f87171; }
+    .badge-amber { background: rgba(250, 204, 21, 0.15); color: #facc15; }
+    .badge-blue { background: rgba(96, 165, 250, 0.15); color: #60a5fa; }
+    .badge-green { background: rgba(74, 222, 128, 0.15); color: #4ade80; }
+    .badge-purple { background: rgba(167, 139, 250, 0.15); color: #a78bfa; }
 
-    .gap-details {
-      max-height: 0;
-      overflow: hidden;
-      transition: max-height 0.3s ease;
-    }
+    /* Glow */
+    .glow { box-shadow: 0 0 80px rgba(167, 139, 250, 0.08); }
 
-    .gap-details.expanded {
-      max-height: 500px;
-    }
+    /* Scroll-triggered fade-in */
+    .fade-section { opacity: 0; transform: translateY(24px); transition: opacity 0.7s ease-out, transform 0.7s ease-out; }
+    .fade-section.visible { opacity: 1; transform: translateY(0); }
 
-    .expand-icon {
-      transition: transform 0.3s ease;
-    }
-
-    .expand-icon.rotated {
-      transform: rotate(180deg);
-    }
+    /* Hero animation */
+    @keyframes fade-up { from { opacity: 0; transform: translateY(24px); } to { opacity: 1; transform: translateY(0); } }
+    .animate-fade-up { animation: fade-up 0.8s ease-out forwards; }
+    .animate-delay-1 { animation-delay: 0.15s; opacity: 0; }
+    .animate-delay-2 { animation-delay: 0.3s; opacity: 0; }
 
     /* Print styles */
     @media print {
-      body {
-        background: white;
-      }
-
-      header {
-        background: linear-gradient(to right, #2563eb, #9333ea) !important;
-        print-color-adjust: exact;
-        -webkit-print-color-adjust: exact;
-      }
-
-      .gap-card {
-        page-break-inside: avoid;
-        break-inside: avoid;
-      }
-
-      .gap-details {
-        max-height: none !important;
-      }
-
-      footer {
-        page-break-before: avoid;
-      }
-
-      /* Hide interactive elements in print */
-      .expand-icon {
-        display: none;
-      }
+      body { background: #09090b; print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+      .gap-card { page-break-inside: avoid; break-inside: avoid; }
+      .gap-details { max-height: none !important; }
+      .expand-icon { display: none; }
+      .fade-section { opacity: 1 !important; transform: none !important; }
     }
   </style>
 </head>
-<body class="bg-gray-50 min-h-screen">
+<body class="min-h-screen antialiased">
+
   <!-- Header -->
-  <header class="text-white py-8 px-6 shadow-lg" style="background: linear-gradient(135deg, #1e293b 0%, #2563eb 50%, #9333ea 100%);">
-    <div class="max-w-6xl mx-auto">
-      <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-        <div>
-          <h1 class="text-3xl md:text-4xl font-bold mb-2">ProtoLabs Standards Report</h1>
-          <p class="text-blue-100 text-base md:text-lg">${research.projectName}</p>
+  <header class="border-b border-white/5">
+    <div class="max-w-5xl mx-auto px-6 py-10 md:py-14">
+      <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6">
+        <div class="animate-fade-up">
+          <div class="flex items-center gap-2 text-sm text-zinc-500 mb-3">
+            <span class="text-accent text-lg">&#9670;</span>
+            <span>proto<span class="text-zinc-300">Labs</span></span>
+            <span class="text-zinc-700">&middot;</span>
+            <span>setupLab Report</span>
+          </div>
+          <h1 class="text-2xl md:text-3xl font-bold text-white">${research.projectName}</h1>
         </div>
-        <div class="text-center md:text-right">
-          <div class="text-5xl font-bold">${report.overallScore}</div>
-          <div class="text-sm text-blue-100">Alignment Score</div>
+        <div class="text-center md:text-right animate-fade-up animate-delay-1">
+          <div class="text-5xl font-bold font-mono" style="color: ${scoreColor}">${report.overallScore}</div>
+          <div class="text-xs text-zinc-500 mt-1 uppercase tracking-widest font-mono">Alignment Score</div>
         </div>
       </div>
     </div>
   </header>
 
   <!-- Main Content -->
-  <main class="max-w-6xl mx-auto px-6 py-8">
+  <main class="max-w-5xl mx-auto px-6 py-10">
+
     <!-- Score Gauge -->
-    <section class="bg-white rounded-lg shadow-md p-6 mb-8">
-      <h2 class="text-2xl font-bold mb-4">Overall Alignment</h2>
-      <div class="flex flex-col md:flex-row items-center gap-6">
+    <section class="rounded-xl border border-white/5 bg-surface-1/50 p-6 md:p-8 mb-8 glow fade-section">
+      <p class="text-accent text-sm font-mono uppercase tracking-widest mb-6">Overall Alignment</p>
+      <div class="flex flex-col md:flex-row items-center gap-8">
         <div class="relative w-48 h-48 flex-shrink-0">
           <svg class="transform -rotate-90 w-48 h-48">
-            <circle
-              cx="96"
-              cy="96"
-              r="88"
-              stroke="#e5e7eb"
-              stroke-width="12"
-              fill="none"
-            />
-            <circle
-              class="score-ring"
-              cx="96"
-              cy="96"
-              r="88"
-              stroke="${report.overallScore >= 80 ? '#10b981' : report.overallScore >= 50 ? '#f59e0b' : '#ef4444'}"
-              stroke-width="12"
-              fill="none"
-              stroke-linecap="round"
-            />
+            <circle cx="96" cy="96" r="88" stroke="#222225" stroke-width="12" fill="none" />
+            <circle class="score-ring" cx="96" cy="96" r="88" stroke="${scoreColor}" stroke-width="12" fill="none" stroke-linecap="round" />
           </svg>
           <div class="absolute inset-0 flex items-center justify-center">
             <div class="text-center">
-              <div class="text-5xl font-bold">${report.overallScore}</div>
-              <div class="text-sm text-gray-500">/ 100</div>
+              <div class="text-5xl font-bold font-mono text-white">${report.overallScore}</div>
+              <div class="text-sm text-zinc-500">/ 100</div>
             </div>
           </div>
         </div>
-        <div class="flex-1">
-          <div class="grid grid-cols-2 gap-4">
-            <div class="bg-red-50 p-4 rounded-lg">
-              <div class="text-3xl font-bold text-red-600">${report.summary.critical}</div>
-              <div class="text-sm text-red-800">Critical Gaps</div>
+        <div class="flex-1 w-full">
+          <div class="grid grid-cols-2 gap-3">
+            <div class="rounded-lg border border-white/5 p-4" style="background: rgba(248, 113, 113, 0.06)">
+              <div class="text-3xl font-bold font-mono text-red-400">${report.summary.critical}</div>
+              <div class="text-xs text-zinc-500 mt-1">Critical Gaps</div>
             </div>
-            <div class="bg-amber-50 p-4 rounded-lg">
-              <div class="text-3xl font-bold text-amber-600">${report.summary.recommended}</div>
-              <div class="text-sm text-amber-800">Recommended</div>
+            <div class="rounded-lg border border-white/5 p-4" style="background: rgba(250, 204, 21, 0.06)">
+              <div class="text-3xl font-bold font-mono text-yellow-400">${report.summary.recommended}</div>
+              <div class="text-xs text-zinc-500 mt-1">Recommended</div>
             </div>
-            <div class="bg-blue-50 p-4 rounded-lg">
-              <div class="text-3xl font-bold text-blue-600">${report.summary.optional}</div>
-              <div class="text-sm text-blue-800">Optional</div>
+            <div class="rounded-lg border border-white/5 p-4" style="background: rgba(96, 165, 250, 0.06)">
+              <div class="text-3xl font-bold font-mono text-blue-400">${report.summary.optional}</div>
+              <div class="text-xs text-zinc-500 mt-1">Optional</div>
             </div>
-            <div class="bg-green-50 p-4 rounded-lg">
-              <div class="text-3xl font-bold text-green-600">${report.summary.compliant}</div>
-              <div class="text-sm text-green-800">Compliant</div>
+            <div class="rounded-lg border border-white/5 p-4" style="background: rgba(74, 222, 128, 0.06)">
+              <div class="text-3xl font-bold font-mono text-green-400">${report.summary.compliant}</div>
+              <div class="text-xs text-zinc-500 mt-1">Compliant</div>
             </div>
           </div>
         </div>
@@ -239,53 +235,49 @@ export function generateReport(options: ReportOptions): string {
     </section>
 
     <!-- Tech Stack Summary -->
-    <section class="bg-white rounded-lg shadow-md p-6 mb-8">
-      <h2 class="text-2xl font-bold mb-4">Tech Stack</h2>
+    <section class="rounded-xl border border-white/5 bg-surface-1/50 p-6 md:p-8 mb-8 fade-section">
+      <p class="text-accent text-sm font-mono uppercase tracking-widest mb-4">Detected Stack</p>
       <div class="flex flex-wrap gap-2">
-        ${techStack.map((tech) => `<span class="bg-blue-100 text-blue-800 px-3 py-1 rounded-full text-sm font-medium">${tech}</span>`).join('\n        ')}
+        ${techStack.map((tech) => `<span class="badge badge-purple">${tech}</span>`).join('\n        ')}
       </div>
     </section>
 
     <!-- Gap Analysis -->
-    <section class="bg-white rounded-lg shadow-md p-6 mb-8">
-      <h2 class="text-2xl font-bold mb-4">Gap Analysis</h2>
+    <section class="rounded-xl border border-white/5 bg-surface-1/50 p-6 md:p-8 mb-8 fade-section">
+      <p class="text-accent text-sm font-mono uppercase tracking-widest mb-6">Gap Analysis</p>
 
       ${
         criticalGaps.length > 0
           ? `
       <!-- Critical Gaps -->
-      <div class="mb-6">
-        <h3 class="text-xl font-semibold text-red-600 mb-3 flex items-center gap-2">
-          <span class="inline-flex items-center justify-center bg-red-500 text-white px-3 py-1 rounded-full text-sm font-bold">${criticalGaps.length}</span>
+      <div class="mb-8">
+        <h3 class="text-base font-semibold text-red-400 mb-3 flex items-center gap-2">
+          <span class="badge badge-red">${criticalGaps.length}</span>
           Critical Gaps
         </h3>
         <div class="space-y-3">
           ${criticalGaps
             .map(
               (gap, index) => `
-          <div class="gap-card border-l-4 border-red-500 bg-red-50 p-4 rounded shadow-sm" data-gap-id="critical-${index}">
+          <div class="gap-card border-l-2 border-red-500/60 rounded-lg p-4" style="background: rgba(248, 113, 113, 0.04)" data-gap-id="critical-${index}">
             <div class="flex items-start justify-between">
               <div class="flex-1">
-                <div class="flex items-center gap-2 mb-2">
-                  <span class="inline-flex items-center bg-red-500 text-white px-2 py-0.5 rounded-full text-xs font-bold uppercase">Critical</span>
-                  <span class="font-semibold text-red-900">${gap.title}</span>
+                <div class="flex items-center gap-2 mb-1">
+                  <span class="badge badge-red">Critical</span>
+                  <span class="font-medium text-zinc-200">${gap.title}</span>
                 </div>
               </div>
-              <svg class="expand-icon w-5 h-5 text-red-600 flex-shrink-0 ml-2" fill="currentColor" viewBox="0 0 20 20">
+              <svg class="expand-icon w-5 h-5 text-zinc-500 flex-shrink-0 ml-2" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
               </svg>
             </div>
             <div class="gap-details expanded">
-              <div class="text-sm text-gray-700 mt-2 pt-2 border-t border-red-200">
-                <div class="mb-2">
-                  <span class="font-medium text-red-900">Current:</span> ${gap.current}
-                </div>
-                <div class="mb-2">
-                  <span class="font-medium text-red-900">Target:</span> ${gap.target}
-                </div>
+              <div class="text-sm mt-3 pt-3 border-t border-white/5 space-y-2">
+                <div><span class="text-zinc-500">Current:</span> <span class="text-zinc-300">${gap.current}</span></div>
+                <div><span class="text-zinc-500">Target:</span> <span class="text-zinc-300">${gap.target}</span></div>
                 <div class="flex flex-wrap gap-2 mt-3">
-                  <span class="inline-flex items-center bg-red-200 text-red-800 px-3 py-1 rounded-full text-xs font-medium">${gap.effort} effort</span>
-                  <span class="inline-flex items-center bg-gray-200 text-gray-700 px-3 py-1 rounded-full text-xs">${gap.category}</span>
+                  <span class="badge badge-red">${gap.effort} effort</span>
+                  <span class="badge" style="background: rgba(255,255,255,0.05); color: #71717a">${gap.category}</span>
                 </div>
               </div>
             </div>
@@ -303,38 +295,34 @@ export function generateReport(options: ReportOptions): string {
         recommendedGaps.length > 0
           ? `
       <!-- Recommended Gaps -->
-      <div class="mb-6">
-        <h3 class="text-xl font-semibold text-amber-600 mb-3 flex items-center gap-2">
-          <span class="inline-flex items-center justify-center bg-amber-500 text-white px-3 py-1 rounded-full text-sm font-bold">${recommendedGaps.length}</span>
+      <div class="mb-8">
+        <h3 class="text-base font-semibold text-yellow-400 mb-3 flex items-center gap-2">
+          <span class="badge badge-amber">${recommendedGaps.length}</span>
           Recommended Improvements
         </h3>
         <div class="space-y-3">
           ${recommendedGaps
             .map(
               (gap, index) => `
-          <div class="gap-card border-l-4 border-amber-500 bg-amber-50 p-4 rounded shadow-sm" data-gap-id="recommended-${index}">
+          <div class="gap-card border-l-2 border-yellow-500/60 rounded-lg p-4" style="background: rgba(250, 204, 21, 0.04)" data-gap-id="recommended-${index}">
             <div class="flex items-start justify-between">
               <div class="flex-1">
-                <div class="flex items-center gap-2 mb-2">
-                  <span class="inline-flex items-center bg-amber-500 text-white px-2 py-0.5 rounded-full text-xs font-bold uppercase">Recommended</span>
-                  <span class="font-semibold text-amber-900">${gap.title}</span>
+                <div class="flex items-center gap-2 mb-1">
+                  <span class="badge badge-amber">Recommended</span>
+                  <span class="font-medium text-zinc-200">${gap.title}</span>
                 </div>
               </div>
-              <svg class="expand-icon w-5 h-5 text-amber-600 flex-shrink-0 ml-2" fill="currentColor" viewBox="0 0 20 20">
+              <svg class="expand-icon w-5 h-5 text-zinc-500 flex-shrink-0 ml-2" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
               </svg>
             </div>
             <div class="gap-details">
-              <div class="text-sm text-gray-700 mt-2 pt-2 border-t border-amber-200">
-                <div class="mb-2">
-                  <span class="font-medium text-amber-900">Current:</span> ${gap.current}
-                </div>
-                <div class="mb-2">
-                  <span class="font-medium text-amber-900">Target:</span> ${gap.target}
-                </div>
+              <div class="text-sm mt-3 pt-3 border-t border-white/5 space-y-2">
+                <div><span class="text-zinc-500">Current:</span> <span class="text-zinc-300">${gap.current}</span></div>
+                <div><span class="text-zinc-500">Target:</span> <span class="text-zinc-300">${gap.target}</span></div>
                 <div class="flex flex-wrap gap-2 mt-3">
-                  <span class="inline-flex items-center bg-amber-200 text-amber-800 px-3 py-1 rounded-full text-xs font-medium">${gap.effort} effort</span>
-                  <span class="inline-flex items-center bg-gray-200 text-gray-700 px-3 py-1 rounded-full text-xs">${gap.category}</span>
+                  <span class="badge badge-amber">${gap.effort} effort</span>
+                  <span class="badge" style="background: rgba(255,255,255,0.05); color: #71717a">${gap.category}</span>
                 </div>
               </div>
             </div>
@@ -352,38 +340,34 @@ export function generateReport(options: ReportOptions): string {
         optionalGaps.length > 0
           ? `
       <!-- Optional Gaps -->
-      <div class="mb-6">
-        <h3 class="text-xl font-semibold text-blue-600 mb-3 flex items-center gap-2">
-          <span class="inline-flex items-center justify-center bg-blue-500 text-white px-3 py-1 rounded-full text-sm font-bold">${optionalGaps.length}</span>
+      <div class="mb-8">
+        <h3 class="text-base font-semibold text-blue-400 mb-3 flex items-center gap-2">
+          <span class="badge badge-blue">${optionalGaps.length}</span>
           Optional Enhancements
         </h3>
         <div class="space-y-3">
           ${optionalGaps
             .map(
               (gap, index) => `
-          <div class="gap-card border-l-4 border-blue-500 bg-blue-50 p-4 rounded shadow-sm" data-gap-id="optional-${index}">
+          <div class="gap-card border-l-2 border-blue-500/60 rounded-lg p-4" style="background: rgba(96, 165, 250, 0.04)" data-gap-id="optional-${index}">
             <div class="flex items-start justify-between">
               <div class="flex-1">
-                <div class="flex items-center gap-2 mb-2">
-                  <span class="inline-flex items-center bg-blue-500 text-white px-2 py-0.5 rounded-full text-xs font-bold uppercase">Optional</span>
-                  <span class="font-semibold text-blue-900">${gap.title}</span>
+                <div class="flex items-center gap-2 mb-1">
+                  <span class="badge badge-blue">Optional</span>
+                  <span class="font-medium text-zinc-200">${gap.title}</span>
                 </div>
               </div>
-              <svg class="expand-icon w-5 h-5 text-blue-600 flex-shrink-0 ml-2" fill="currentColor" viewBox="0 0 20 20">
+              <svg class="expand-icon w-5 h-5 text-zinc-500 flex-shrink-0 ml-2" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
               </svg>
             </div>
             <div class="gap-details">
-              <div class="text-sm text-gray-700 mt-2 pt-2 border-t border-blue-200">
-                <div class="mb-2">
-                  <span class="font-medium text-blue-900">Current:</span> ${gap.current}
-                </div>
-                <div class="mb-2">
-                  <span class="font-medium text-blue-900">Target:</span> ${gap.target}
-                </div>
+              <div class="text-sm mt-3 pt-3 border-t border-white/5 space-y-2">
+                <div><span class="text-zinc-500">Current:</span> <span class="text-zinc-300">${gap.current}</span></div>
+                <div><span class="text-zinc-500">Target:</span> <span class="text-zinc-300">${gap.target}</span></div>
                 <div class="flex flex-wrap gap-2 mt-3">
-                  <span class="inline-flex items-center bg-blue-200 text-blue-800 px-3 py-1 rounded-full text-xs font-medium">${gap.effort} effort</span>
-                  <span class="inline-flex items-center bg-gray-200 text-gray-700 px-3 py-1 rounded-full text-xs">${gap.category}</span>
+                  <span class="badge badge-blue">${gap.effort} effort</span>
+                  <span class="badge" style="background: rgba(255,255,255,0.05); color: #71717a">${gap.category}</span>
                 </div>
               </div>
             </div>
@@ -400,10 +384,10 @@ export function generateReport(options: ReportOptions): string {
       ${
         report.gaps.length === 0
           ? `
-      <div class="text-center py-8 text-gray-500">
-        <div class="text-6xl mb-4">🎉</div>
-        <div class="text-xl font-semibold">No gaps detected!</div>
-        <div class="text-sm">Your project is fully aligned with ProtoLabs standards.</div>
+      <div class="text-center py-12">
+        <div class="text-5xl mb-4">&#9670;</div>
+        <div class="text-xl font-semibold text-white">Fully aligned</div>
+        <div class="text-sm text-zinc-500 mt-2">No gaps detected. Your project meets protoLabs standards.</div>
       </div>
       `
           : ''
@@ -411,8 +395,8 @@ export function generateReport(options: ReportOptions): string {
     </section>
 
     <!-- Compliance Checklist -->
-    <section class="bg-white rounded-lg shadow-md p-6 mb-8">
-      <h2 class="text-2xl font-bold mb-4">Compliance Checklist</h2>
+    <section class="rounded-xl border border-white/5 bg-surface-1/50 p-6 md:p-8 mb-8 fade-section">
+      <p class="text-accent text-sm font-mono uppercase tracking-widest mb-6">Compliance Checklist</p>
       ${
         report.compliant.length > 0
           ? `
@@ -420,14 +404,12 @@ export function generateReport(options: ReportOptions): string {
         ${report.compliant
           .map(
             (item) => `
-        <div class="flex items-start gap-3 p-3 bg-green-50 rounded">
-          <svg class="w-6 h-6 text-green-600 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
-          </svg>
+        <div class="flex items-start gap-3 p-3 rounded-lg" style="background: rgba(74, 222, 128, 0.04)">
+          <div class="inline-flex items-center justify-center w-5 h-5 rounded-full flex-shrink-0 mt-0.5" style="background: rgba(74, 222, 128, 0.15); color: #4ade80; font-size: 10px;">&#10003;</div>
           <div class="flex-1">
-            <div class="font-semibold text-green-900">${item.title}</div>
-            <div class="text-sm text-gray-700">${item.detail}</div>
-            <div class="text-xs text-gray-500 mt-1">${item.category}</div>
+            <div class="font-medium text-zinc-200 text-sm">${item.title}</div>
+            <div class="text-sm text-zinc-500 mt-0.5">${item.detail}</div>
+            <div class="text-xs text-zinc-600 mt-1">${item.category}</div>
           </div>
         </div>
         `
@@ -436,7 +418,7 @@ export function generateReport(options: ReportOptions): string {
       </div>
       `
           : `
-      <div class="text-center py-8 text-gray-500">
+      <div class="text-center py-8 text-zinc-500">
         <div class="text-sm">No compliant items detected yet.</div>
       </div>
       `
@@ -445,26 +427,27 @@ export function generateReport(options: ReportOptions): string {
   </main>
 
   <!-- Footer -->
-  <footer class="bg-gray-900 text-gray-300 py-8 px-6 mt-12">
-    <div class="max-w-6xl mx-auto text-center">
-      <div class="text-2xl font-bold text-white mb-2">ProtoLabs</div>
-      <div class="text-sm mb-4">AI-Powered Development Agency</div>
-      <div class="text-xs text-gray-400">
+  <footer class="border-t border-white/5">
+    <div class="max-w-5xl mx-auto px-6 py-10 flex flex-col md:flex-row items-center justify-between gap-4">
+      <div class="flex items-center gap-2 text-sm text-zinc-500">
+        <span class="text-accent">&#9670;</span>
+        <span>proto<span class="text-zinc-400">Labs</span></span>
+        <span class="text-zinc-700">&middot;</span>
+        <span>AI-native development agency</span>
+      </div>
+      <div class="text-xs text-zinc-600">
         Generated on ${timestamp}
       </div>
     </div>
   </footer>
 
   <script>
-    // Expandable gap sections
     document.addEventListener('DOMContentLoaded', () => {
-      const gapCards = document.querySelectorAll('.gap-card');
-
-      gapCards.forEach(card => {
+      // Expandable gap sections
+      document.querySelectorAll('.gap-card').forEach(card => {
         card.addEventListener('click', () => {
           const details = card.querySelector('.gap-details');
           const icon = card.querySelector('.expand-icon');
-
           if (details && icon) {
             details.classList.toggle('expanded');
             icon.classList.toggle('rotated');
@@ -472,7 +455,21 @@ export function generateReport(options: ReportOptions): string {
         });
       });
 
-      console.log('ProtoLabs Report loaded - interactive features enabled');
+      // Scroll-triggered fade-in
+      const sections = document.querySelectorAll('.fade-section');
+      if ('IntersectionObserver' in window) {
+        const observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if (entry.isIntersecting) {
+              entry.target.classList.add('visible');
+              observer.unobserve(entry.target);
+            }
+          });
+        }, { threshold: 0.15, rootMargin: '0px 0px -40px 0px' });
+        sections.forEach(s => observer.observe(s));
+      } else {
+        sections.forEach(s => s.classList.add('visible'));
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary

- Replaces the light-mode generic Tailwind design with the protoLabs dark brand theme
- Aligns the setupLab HTML report with `site/index.html` and `site/consulting/index.html` design language
- Single file change: `apps/server/src/services/report-generator-service.ts` (190 ins / 193 del)

### Design changes

- **Theme**: Dark background (#09090b) with surface tiers matching brand
- **Font**: Geist via Google Fonts CDN
- **Colors**: Violet accent (#a78bfa), translucent severity badges, brand-aligned score ring
- **Header**: Diamond logo + "protoLabs · setupLab Report" branding
- **Cards**: Dark surface backgrounds with translucent severity tints
- **Footer**: Diamond + "protoLabs · AI-native development agency"
- **Animations**: Scroll-triggered fade-in via IntersectionObserver
- **Print styles**: Updated for dark theme

## Test plan

- [ ] Run `setuplab` on a test repo and verify the generated HTML report renders correctly
- [ ] Verify score ring colors match severity (green >= 80, yellow >= 50, red < 50)
- [ ] Check print styles produce clean output
- [ ] Verify TypeScript compiles (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scroll-triggered fade-in animations for report sections
  * Introduced dynamic score colorization based on alignment metrics

* **Style**
  * Complete visual refresh with dark theme and updated branding assets
  * Modernized typography, color system, and overall layout
  * Redesigned tech stack display and gap analysis cards
  * Enhanced footer styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->