### PR TITLE
feat: add idea flow node and edge type definitions

### DIFF
--- a/apps/ui/src/components/views/idea-flow/types.ts
+++ b/apps/ui/src/components/views/idea-flow/types.ts
@@ -1,0 +1,79 @@
+/**
+ * Idea Flow Types
+ *
+ * Node/edge type definitions for the idea intake and pipeline flow.
+ */
+
+import type { Node, Edge } from '@xyflow/react';
+
+// ============================================
+// Pipeline Step Type
+// ============================================
+
+export type PipelineStep =
+  | 'intake'
+  | 'research'
+  | 'draft-prd'
+  | 'review-prd'
+  | 'approve'
+  | 'scaffold'
+  | 'backlog';
+
+export type StepStatus = 'pending' | 'active' | 'completed' | 'skipped' | 'error';
+
+// ============================================
+// Node Data Types
+// ============================================
+
+export interface IntakeNodeData {
+  label: string;
+  description?: string;
+  source?: 'manual' | 'linear' | 'discord' | 'github';
+  timestamp?: string;
+  [key: string]: unknown;
+}
+
+export interface PipelineStepNodeData {
+  label: string;
+  step: PipelineStep;
+  status: StepStatus;
+  assignee?: string;
+  startTime?: number;
+  endTime?: number;
+  [key: string]: unknown;
+}
+
+export interface ApprovalNodeData {
+  label: string;
+  approved: boolean | null;
+  approver?: string;
+  approvalTime?: string;
+  feedback?: string;
+  [key: string]: unknown;
+}
+
+export interface TerminalNodeData {
+  label: string;
+  destination: 'backlog' | 'rejected' | 'archived';
+  timestamp?: string;
+  [key: string]: unknown;
+}
+
+export interface PipelineEdgeData {
+  label?: string;
+  animated?: boolean;
+  [key: string]: unknown;
+}
+
+// ============================================
+// Typed Node/Edge Aliases
+// ============================================
+
+export type IntakeNode = Node<IntakeNodeData, 'intake'>;
+export type PipelineStepNode = Node<PipelineStepNodeData, 'pipelineStep'>;
+export type ApprovalNode = Node<ApprovalNodeData, 'approval'>;
+export type TerminalNode = Node<TerminalNodeData, 'terminal'>;
+
+export type IdeaFlowNode = IntakeNode | PipelineStepNode | ApprovalNode | TerminalNode;
+
+export type PipelineEdge = Edge<PipelineEdgeData>;


### PR DESCRIPTION
## Summary
- Create `apps/ui/src/components/views/idea-flow/types.ts` with 4 node data interfaces and 1 edge data interface
- Define `PipelineStep` and `StepStatus` union types
- Add typed React Flow node/edge aliases for type-safe graph construction

## Test plan
- [ ] TypeScript compiles without errors
- [ ] Node data interfaces have `[key: string]: unknown` index signatures (React Flow requirement)
- [ ] All 5 status values defined: pending, active, completed, skipped, error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Added foundational type infrastructure for the idea flow visualization system to support pipeline stage management and workflow tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->