### PR TITLE
feat(site): add setupLab report links across all surfaces

### DIFF
--- a/site/consulting/index.html
+++ b/site/consulting/index.html
@@ -371,6 +371,28 @@
                 identify what can be automated today, what needs architectural changes, and what
                 should stay human. You get a concrete assessment, not a generic playbook.
               </p>
+              <a
+                href="https://report.protolabs.studio"
+                target="_blank"
+                rel="noopener"
+                class="inline-flex items-center gap-1.5 mt-3 text-accent hover:text-white text-sm transition-colors"
+              >
+                See an example report
+                <svg
+                  class="w-3.5 h-3.5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                  />
+                </svg>
+              </a>
             </div>
           </div>
           <!-- Step 2 -->
@@ -512,6 +534,13 @@
         <div class="flex items-center gap-5 text-sm text-zinc-500">
           <a href="https://protolabs.studio" class="hover:text-zinc-300 transition-colors"
             >Product</a
+          >
+          <a
+            href="https://report.protolabs.studio"
+            target="_blank"
+            rel="noopener"
+            class="hover:text-zinc-300 transition-colors"
+            >Report</a
           >
           <a
             href="https://docs.protolabs.studio"

--- a/site/index.html
+++ b/site/index.html
@@ -325,6 +325,13 @@
             >Consulting</a
           >
           <a
+            href="https://report.protolabs.studio"
+            target="_blank"
+            rel="noopener"
+            class="hover:text-white transition-colors"
+            >Report</a
+          >
+          <a
             href="https://x.com/protoLabsAI"
             target="_blank"
             rel="noopener"
@@ -1128,6 +1135,49 @@
         </div>
       </section>
 
+      <!-- setupLab Report CTA -->
+      <section class="max-w-5xl mx-auto px-6 py-16 md:py-24">
+        <div
+          class="fade-section rounded-xl border border-white/5 bg-surface-1/50 glow p-8 md:p-12 flex flex-col md:flex-row items-center gap-8"
+        >
+          <div class="flex-1">
+            <p class="text-accent text-sm font-mono uppercase tracking-widest">setupLab</p>
+            <h2 class="mt-3 text-xl md:text-2xl font-semibold text-white">
+              Is your codebase ready for autonomous agents?
+            </h2>
+            <p class="mt-3 text-zinc-400 text-sm leading-relaxed">
+              Our setupLab report scans your repo against the protoLabs gold standard — CI
+              pipelines, branch protection, testing, linting, type safety, and more. See exactly
+              where you stand and what to fix before your first agent ships a PR.
+            </p>
+          </div>
+          <div class="flex-shrink-0">
+            <a
+              href="https://report.protolabs.studio"
+              target="_blank"
+              rel="noopener"
+              class="inline-flex items-center gap-2 px-6 py-3 bg-accent hover:bg-accent-dim text-white text-sm font-medium rounded-lg transition-colors whitespace-nowrap"
+            >
+              See example report
+              <svg
+                class="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                />
+              </svg>
+            </a>
+          </div>
+        </div>
+      </section>
+
       <!-- Newsletter CTA -->
       <div id="notify" class="border-t border-white/5">
         <div class="max-w-5xl mx-auto px-6 py-20 md:py-28">
@@ -1199,6 +1249,13 @@
             rel="noopener"
             class="hover:text-zinc-300 transition-colors"
             >Consulting</a
+          >
+          <a
+            href="https://report.protolabs.studio"
+            target="_blank"
+            rel="noopener"
+            class="hover:text-zinc-300 transition-colors"
+            >Report</a
           >
           <a
             href="https://x.com/protoLabsAI"


### PR DESCRIPTION
## Summary
- **protolabs.studio**: Added "Report" link in nav + footer, new setupLab CTA section ("Is your codebase ready for autonomous agents?") with link to example report
- **consulting page**: Added "See an example report" link under Audit step, "Report" link in footer
- No CLI commands shared — blocked on npm publish (tracked in post-launch project)

## Test plan
- [ ] Verify protolabs.studio nav shows Report link
- [ ] Verify setupLab CTA section renders between Docs and Newsletter sections
- [ ] Verify consulting page Audit step has "See an example report" link
- [ ] All links point to https://report.protolabs.studio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added navigation links to a new Report page in the header, footer, and consulting section.
  * Introduced a new Report call-to-action section highlighting capabilities with a link to view example reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->