### PR TITLE
feat: add REST API endpoints for idea processing

### DIFF
--- a/apps/server/src/routes/ideas/index.ts
+++ b/apps/server/src/routes/ideas/index.ts
@@ -9,17 +9,25 @@ import type { IdeaProcessingService } from '../../services/idea-processing-servi
 import { createProcessHandler } from './routes/process.js';
 import { createStatusHandler } from './routes/status.js';
 import { createResumeHandler } from './routes/resume.js';
+import { createListHandler } from './routes/list.js';
+import { createGetHandler } from './routes/get.js';
+import { createCreateHandler } from './routes/create.js';
+import { createApproveHandler } from './routes/approve.js';
+import { createRejectHandler } from './routes/reject.js';
 
 export function createIdeasRoutes(ideaService: IdeaProcessingService): Router {
   const router = Router();
 
-  // Process a new idea
+  // REST endpoints (new, cleaner URLs)
+  router.get('/', createListHandler(ideaService)); // GET /api/ideas - list all sessions
+  router.get('/:sessionId', createGetHandler(ideaService)); // GET /api/ideas/:sessionId - get session details
+  router.post('/', createCreateHandler(ideaService)); // POST /api/ideas - create new session
+  router.post('/:sessionId/approve', createApproveHandler(ideaService)); // POST /api/ideas/:sessionId/approve
+  router.post('/:sessionId/reject', createRejectHandler(ideaService)); // POST /api/ideas/:sessionId/reject
+
+  // Legacy endpoints (backward compatibility)
   router.post('/process', createProcessHandler(ideaService));
-
-  // Get session status (with or without sessionId)
   router.post('/status', createStatusHandler(ideaService));
-
-  // Resume an interrupted session
   router.post('/resume', createResumeHandler(ideaService));
 
   return router;

--- a/apps/server/src/routes/ideas/routes/approve.ts
+++ b/apps/server/src/routes/ideas/routes/approve.ts
@@ -1,0 +1,44 @@
+/**
+ * POST /api/ideas/:sessionId/approve - Approve an idea processing session
+ *
+ * Approves a session awaiting user input and resumes the flow.
+ */
+
+import type { Request, Response } from 'express';
+import type { IdeaProcessingService } from '../../../services/idea-processing-service.js';
+
+export function createApproveHandler(ideaService: IdeaProcessingService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { sessionId } = req.params;
+      const { feedback } = req.body as { feedback?: string };
+
+      if (!sessionId || typeof sessionId !== 'string') {
+        res.status(400).json({
+          success: false,
+          error: 'sessionId is required',
+        });
+        return;
+      }
+
+      await ideaService.resumeSession({
+        sessionId,
+        approved: true,
+        feedback,
+      });
+
+      res.json({
+        success: true,
+        message: 'Session approved and resumed',
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const statusCode = errorMessage.includes('not found') ? 404 : 500;
+
+      res.status(statusCode).json({
+        success: false,
+        error: errorMessage,
+      });
+    }
+  };
+}

--- a/apps/server/src/routes/ideas/routes/create.ts
+++ b/apps/server/src/routes/ideas/routes/create.ts
@@ -1,0 +1,46 @@
+/**
+ * POST /api/ideas - Create a new idea processing session
+ *
+ * Cleaner URL alternative to POST /api/ideas/process (maintained for backward compatibility).
+ * Starts a new idea processing session through the LangGraph flow.
+ */
+
+import type { Request, Response } from 'express';
+import type { IdeaProcessingService } from '../../../services/idea-processing-service.js';
+
+export function createCreateHandler(ideaService: IdeaProcessingService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { idea, autoApprove, countdownSeconds } = req.body as {
+        idea: string;
+        autoApprove?: boolean;
+        countdownSeconds?: number;
+      };
+
+      if (!idea || typeof idea !== 'string' || idea.trim().length === 0) {
+        res.status(400).json({
+          success: false,
+          error: 'Idea is required and must be a non-empty string',
+        });
+        return;
+      }
+
+      const sessionId = await ideaService.processIdea({
+        idea: idea.trim(),
+        autoApprove,
+        countdownSeconds,
+      });
+
+      res.status(201).json({
+        success: true,
+        sessionId,
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      res.status(500).json({
+        success: false,
+        error: errorMessage,
+      });
+    }
+  };
+}

--- a/apps/server/src/routes/ideas/routes/get.ts
+++ b/apps/server/src/routes/ideas/routes/get.ts
@@ -1,0 +1,45 @@
+/**
+ * GET /api/ideas/:sessionId - Get detailed session with graph definition
+ *
+ * Returns the full session details including graph definition for a specific session.
+ */
+
+import type { Request, Response } from 'express';
+import type { IdeaProcessingService } from '../../../services/idea-processing-service.js';
+
+export function createGetHandler(ideaService: IdeaProcessingService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { sessionId } = req.params;
+
+      if (!sessionId || typeof sessionId !== 'string') {
+        res.status(400).json({
+          success: false,
+          error: 'sessionId is required',
+        });
+        return;
+      }
+
+      const session = await ideaService.getSessionStatus(sessionId);
+
+      if (!session) {
+        res.status(404).json({
+          success: false,
+          error: `Session ${sessionId} not found`,
+        });
+        return;
+      }
+
+      res.json({
+        success: true,
+        session,
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      res.status(500).json({
+        success: false,
+        error: errorMessage,
+      });
+    }
+  };
+}

--- a/apps/server/src/routes/ideas/routes/list.ts
+++ b/apps/server/src/routes/ideas/routes/list.ts
@@ -1,0 +1,28 @@
+/**
+ * GET /api/ideas - List all idea processing sessions
+ *
+ * Returns a summary of all sessions with counts and status.
+ */
+
+import type { Request, Response } from 'express';
+import type { IdeaProcessingService } from '../../../services/idea-processing-service.js';
+
+export function createListHandler(ideaService: IdeaProcessingService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const sessions = await ideaService.listSessions();
+
+      res.json({
+        success: true,
+        sessions,
+        count: sessions.length,
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      res.status(500).json({
+        success: false,
+        error: errorMessage,
+      });
+    }
+  };
+}

--- a/apps/server/src/routes/ideas/routes/reject.ts
+++ b/apps/server/src/routes/ideas/routes/reject.ts
@@ -1,0 +1,44 @@
+/**
+ * POST /api/ideas/:sessionId/reject - Reject an idea processing session
+ *
+ * Rejects a session awaiting user input and terminates the flow.
+ */
+
+import type { Request, Response } from 'express';
+import type { IdeaProcessingService } from '../../../services/idea-processing-service.js';
+
+export function createRejectHandler(ideaService: IdeaProcessingService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { sessionId } = req.params;
+      const { feedback } = req.body as { feedback?: string };
+
+      if (!sessionId || typeof sessionId !== 'string') {
+        res.status(400).json({
+          success: false,
+          error: 'sessionId is required',
+        });
+        return;
+      }
+
+      await ideaService.resumeSession({
+        sessionId,
+        approved: false,
+        feedback,
+      });
+
+      res.json({
+        success: true,
+        message: 'Session rejected',
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const statusCode = errorMessage.includes('not found') ? 404 : 500;
+
+      res.status(statusCode).json({
+        success: false,
+        error: errorMessage,
+      });
+    }
+  };
+}


### PR DESCRIPTION
## Summary

- Adds clean RESTful endpoints for idea processing sessions: `GET /api/ideas`, `GET /api/ideas/:sessionId`, `POST /api/ideas`, `POST /api/ideas/:sessionId/approve`, `POST /api/ideas/:sessionId/reject`
- Preserves backward compatibility with legacy `/process`, `/status`, `/resume` endpoints
- Each route handler follows existing patterns with proper error handling and input validation

## Test plan

- [ ] `GET /api/ideas` returns list of all sessions with count
- [ ] `POST /api/ideas` with `{ idea: "test" }` creates session and returns 201
- [ ] `GET /api/ideas/:sessionId` returns session details or 404
- [ ] `POST /api/ideas/:sessionId/approve` resumes approved session
- [ ] `POST /api/ideas/:sessionId/reject` terminates session
- [ ] Legacy endpoints still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new RESTful API endpoints for comprehensive idea management: list all sessions, retrieve session details, create new idea sessions, approve or reject ideas with optional feedback, and track session status.
  * Maintained full backward compatibility with existing legacy endpoints for seamless integration.
  * Enhanced all endpoints with robust error handling, validation, and structured error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->