### PR TITLE
fix: correct consulting URL in report page

### DIFF
--- a/site/report/index.html
+++ b/site/report/index.html
@@ -1031,7 +1031,7 @@
             Get Started Free
           </a>
           <a
-            href="https://consulting.protolabs.studio"
+            href="https://protolabs.consulting"
             class="px-6 py-3 rounded-lg border border-white/10 text-zinc-300 hover:text-white hover:border-white/20 transition-all text-sm font-medium"
           >
             Book a Consulting Session
@@ -1053,9 +1053,7 @@
         </div>
         <div class="flex items-center gap-6 text-sm text-zinc-600">
           <a href="https://protolabs.studio" class="hover:text-zinc-400 transition-colors">Home</a>
-          <a
-            href="https://consulting.protolabs.studio"
-            class="hover:text-zinc-400 transition-colors"
+          <a href="https://protolabs.consulting" class="hover:text-zinc-400 transition-colors"
             >Consulting</a
           >
           <a href="https://github.com/proto-labs-ai" class="hover:text-zinc-400 transition-colors"


### PR DESCRIPTION
## Summary
- Fix consulting links in `site/report/index.html` to use `protolabs.consulting` instead of `consulting.protolabs.studio`
- Affects CTA button and footer link

## Test plan
- [ ] Verify report.protolabs.studio CTA button links to protolabs.consulting
- [ ] Verify report.protolabs.studio footer "Consulting" link goes to protolabs.consulting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated navigation links for Consulting pages to use the correct domain URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->