### PR TITLE
feat: idea flow canvas and view shell with tab navigation

### DIFF
--- a/apps/ui/src/components/views/analytics-view.tsx
+++ b/apps/ui/src/components/views/analytics-view.tsx
@@ -1,19 +1,24 @@
 /**
- * AnalyticsView — System Flow Graph (full-screen hero)
+ * AnalyticsView — System Flow Graph + Idea Pipeline
  *
- * Renders the React Flow system architecture graph with floating panels.
+ * Tab bar view with:
+ * - System Graph: React Flow system architecture with floating panels
+ * - Idea Pipeline: Idea intake and processing flow
+ *
  * Feature node clicks navigate to the board for editing.
  */
 
 import { useCallback } from 'react';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useSearch } from '@tanstack/react-router';
 import { useAppStore } from '@/store/app-store';
 import { FlowGraphView } from './flow-graph';
+import { IdeaFlowView } from './idea-flow/idea-flow-view';
 
 export function AnalyticsView() {
   const currentProject = useAppStore((s) => s.currentProject);
   const projectPath = currentProject?.path;
   const navigate = useNavigate();
+  const { tab } = useSearch({ from: '/analytics' });
 
   const handleFeatureClick = useCallback(
     (featureId: string) => {
@@ -23,17 +28,55 @@ export function AnalyticsView() {
     [navigate]
   );
 
+  const handleTabChange = useCallback(
+    (newTab: 'system' | 'ideas') => {
+      navigate({ to: '/analytics', search: { tab: newTab } });
+    },
+    [navigate]
+  );
+
   if (!currentProject) {
     return (
       <div className="flex h-full items-center justify-center">
-        <p className="text-muted-foreground">Select a project to view system graph</p>
+        <p className="text-muted-foreground">Select a project to view analytics</p>
       </div>
     );
   }
 
   return (
     <div className="flex flex-col h-full">
-      <FlowGraphView projectPath={projectPath} onFeatureClick={handleFeatureClick} />
+      {/* Tab bar */}
+      <div className="flex items-center gap-1 px-4 py-2 border-b border-border bg-card/50">
+        <button
+          onClick={() => handleTabChange('system')}
+          className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+            tab === 'system'
+              ? 'bg-accent text-accent-foreground'
+              : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+          }`}
+        >
+          System Graph
+        </button>
+        <button
+          onClick={() => handleTabChange('ideas')}
+          className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+            tab === 'ideas'
+              ? 'bg-accent text-accent-foreground'
+              : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+          }`}
+        >
+          Idea Pipeline
+        </button>
+      </div>
+
+      {/* Tab content */}
+      <div className="flex-1 overflow-hidden">
+        {tab === 'system' ? (
+          <FlowGraphView projectPath={projectPath} onFeatureClick={handleFeatureClick} />
+        ) : (
+          <IdeaFlowView projectPath={projectPath} />
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/ui/src/components/views/idea-flow/edges/index.ts
+++ b/apps/ui/src/components/views/idea-flow/edges/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Idea Flow Edge Types Registry
+ *
+ * Barrel export + React Flow edgeTypes map for the idea pipeline.
+ */
+
+import type { EdgeTypes } from '@xyflow/react';
+
+// Placeholder edge component — will be implemented in future features
+const PipelineEdge = () => null;
+
+export const edgeTypes: EdgeTypes = {
+  pipeline: PipelineEdge,
+};

--- a/apps/ui/src/components/views/idea-flow/idea-flow-canvas.tsx
+++ b/apps/ui/src/components/views/idea-flow/idea-flow-canvas.tsx
@@ -1,0 +1,96 @@
+/**
+ * IdeaFlowCanvas — React Flow canvas for idea pipeline visualization
+ *
+ * Uses controlled mode with nodeTypes/edgeTypes registration.
+ * Renders the idea intake and pipeline flow with draggable nodes.
+ */
+
+import { useCallback, useEffect } from 'react';
+import {
+  ReactFlow,
+  Background,
+  BackgroundVariant,
+  MiniMap,
+  Controls,
+  useNodesState,
+  useEdgesState,
+  type Node,
+  type Edge,
+  type OnNodesChange,
+  type OnEdgesChange,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { ideaFlowNodeTypes } from './nodes';
+import { edgeTypes } from './edges';
+
+interface IdeaFlowCanvasProps {
+  nodes: Node[];
+  edges: Edge[];
+  onNodeClick?: (nodeId: string, nodeType: string, nodeData: Record<string, unknown>) => void;
+}
+
+export function IdeaFlowCanvas({
+  nodes: externalNodes,
+  edges: externalEdges,
+  onNodeClick,
+}: IdeaFlowCanvasProps) {
+  const [nodes, setNodes, onNodesChange] = useNodesState(externalNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(externalEdges);
+
+  // Sync external data changes into React Flow state
+  useEffect(() => {
+    setNodes(externalNodes);
+  }, [externalNodes, setNodes]);
+
+  useEffect(() => {
+    setEdges(externalEdges);
+  }, [externalEdges, setEdges]);
+
+  const handleNodeClick = useCallback(
+    (_event: React.MouseEvent, node: Node) => {
+      onNodeClick?.(node.id, node.type || '', node.data as Record<string, unknown>);
+    },
+    [onNodeClick]
+  );
+
+  return (
+    <div className="w-full h-full">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange as OnNodesChange<Node>}
+        onEdgesChange={onEdgesChange as OnEdgesChange<Edge>}
+        onNodeClick={handleNodeClick}
+        nodeTypes={ideaFlowNodeTypes}
+        edgeTypes={edgeTypes}
+        fitView
+        fitViewOptions={{ padding: 0.2, maxZoom: 1.2 }}
+        minZoom={0.3}
+        maxZoom={2}
+        proOptions={{ hideAttribution: true }}
+        defaultEdgeOptions={{
+          animated: false,
+        }}
+        aria-label="Idea pipeline flow graph"
+      >
+        <Background
+          variant={BackgroundVariant.Dots}
+          gap={24}
+          size={1}
+          color="oklch(0.4 0 0 / 0.15)"
+        />
+        <MiniMap
+          nodeStrokeWidth={3}
+          pannable
+          zoomable
+          className="!bg-card/80 !border-border/50 !rounded-lg backdrop-blur-sm"
+          maskColor="oklch(0.15 0 0 / 0.7)"
+        />
+        <Controls
+          showInteractive={false}
+          className="!bg-card/90 !border-border/50 !rounded-lg !shadow-lg backdrop-blur-sm [&>button]:!bg-transparent [&>button]:!border-border/30 [&>button]:!text-foreground [&>button:hover]:!bg-accent"
+        />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/apps/ui/src/components/views/idea-flow/idea-flow-view.tsx
+++ b/apps/ui/src/components/views/idea-flow/idea-flow-view.tsx
@@ -1,0 +1,56 @@
+/**
+ * IdeaFlowView — Top-level view component for idea pipeline
+ *
+ * Wraps IdeaFlowCanvas with ReactFlowProvider and panel layout.
+ * Displays empty state when no sessions exist.
+ */
+
+import { ReactFlowProvider } from '@xyflow/react';
+import { Loader2 } from 'lucide-react';
+import { IdeaFlowCanvas } from './idea-flow-canvas';
+import { useIdeaFlowData } from './hooks/use-idea-flow-data';
+
+export interface IdeaFlowViewProps {
+  projectPath?: string;
+}
+
+export function IdeaFlowView({ projectPath }: IdeaFlowViewProps) {
+  const { nodes, edges, isLoading, error } = useIdeaFlowData(projectPath);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-sm text-destructive">Failed to load idea sessions</p>
+      </div>
+    );
+  }
+
+  if (nodes.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-center space-y-2">
+          <p className="text-lg font-medium text-muted-foreground">No idea sessions yet</p>
+          <p className="text-sm text-muted-foreground">
+            Idea sessions will appear here once created
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative w-full h-full overflow-hidden bg-background">
+      <ReactFlowProvider>
+        <IdeaFlowCanvas nodes={nodes} edges={edges} />
+      </ReactFlowProvider>
+    </div>
+  );
+}

--- a/apps/ui/src/routes/analytics.tsx
+++ b/apps/ui/src/routes/analytics.tsx
@@ -1,6 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { AnalyticsView } from '@/components/views/analytics-view';
+import { z } from 'zod';
+
+const analyticsSearchSchema = z.object({
+  tab: z.enum(['system', 'ideas']).optional().default('system'),
+});
 
 export const Route = createFileRoute('/analytics')({
   component: AnalyticsView,
+  validateSearch: analyticsSearchSchema,
 });


### PR DESCRIPTION
## Summary
- Add `IdeaFlowCanvas` component — React Flow canvas with controlled nodes/edges, minimap, controls
- Add `IdeaFlowView` component — wires `useIdeaFlowData` hook for real-time session visualization
- Add tab bar to Analytics view: "System Graph" | "Idea Pipeline" with `?tab=ideas` deep linking
- Add placeholder edge types barrel for pipeline edges (being built in parallel PR)

## Test plan
- [ ] Navigate to /analytics — System Graph tab shown by default
- [ ] Click "Idea Pipeline" tab — switches to idea flow canvas
- [ ] URL updates to `?tab=ideas` when switching tabs
- [ ] Direct nav to `/analytics?tab=ideas` works
- [ ] Empty state shown when no sessions exist
- [ ] Loading spinner shown during data fetch

Part of Idea Flow Visualization project (UI Foundation milestone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Analytics page now features two tabs: System Graph and Idea Pipeline
  * Tab selection persists in the URL for shareable bookmarked views
  * Idea Pipeline displays an interactive visual flow diagram with draggable canvas, minimap, and zoom controls
  * Loading and empty states provide clear feedback during data retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->