### PR TITLE
feat: step detail and approval dialogs for idea flow

### DIFF
--- a/apps/ui/src/components/views/idea-flow/dialogs/approval-dialog.tsx
+++ b/apps/ui/src/components/views/idea-flow/dialogs/approval-dialog.tsx
@@ -1,0 +1,267 @@
+/**
+ * Approval Dialog
+ *
+ * Displays review output and approval form for idea approval:
+ * - Category, impact, effort, and suggestions
+ * - Feedback textarea
+ * - Approve/reject buttons
+ * - Countdown display (when enabled)
+ */
+
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Check, X, AlertCircle } from 'lucide-react';
+
+/**
+ * Review output structure (from LangGraph flow)
+ */
+export interface ReviewOutput {
+  approve: boolean;
+  category: string;
+  impact: 'low' | 'medium' | 'high';
+  effort: 'low' | 'medium' | 'high';
+  suggestions?: string[];
+  reasoning?: string;
+}
+
+/**
+ * Countdown state for auto-approval
+ */
+export interface CountdownState {
+  startedAt: string;
+  expiresAt: string;
+  durationSeconds: number;
+}
+
+export interface ApprovalDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  reviewOutput: ReviewOutput | null;
+  onApprove: (feedback?: string) => void;
+  onReject: (feedback?: string) => void;
+  isLoading?: boolean;
+  countdown?: CountdownState;
+}
+
+/**
+ * Get badge color based on level
+ */
+function getBadgeColor(level: 'low' | 'medium' | 'high'): string {
+  switch (level) {
+    case 'low':
+      return 'bg-green-500/20 text-green-400';
+    case 'medium':
+      return 'bg-yellow-500/20 text-yellow-400';
+    case 'high':
+      return 'bg-red-500/20 text-red-400';
+  }
+}
+
+/**
+ * Calculate remaining time in seconds
+ */
+function getRemainingSeconds(expiresAt: string): number {
+  const now = Date.now();
+  const expires = new Date(expiresAt).getTime();
+  return Math.max(0, Math.floor((expires - now) / 1000));
+}
+
+/**
+ * Format seconds to human-readable time
+ */
+function formatTime(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+export function ApprovalDialog({
+  open,
+  onOpenChange,
+  reviewOutput,
+  onApprove,
+  onReject,
+  isLoading = false,
+  countdown,
+}: ApprovalDialogProps) {
+  const [feedback, setFeedback] = useState('');
+  const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
+
+  // Update countdown timer
+  useEffect(() => {
+    if (!countdown || !open) {
+      setRemainingSeconds(null);
+      return;
+    }
+
+    const updateTimer = () => {
+      const remaining = getRemainingSeconds(countdown.expiresAt);
+      setRemainingSeconds(remaining);
+
+      // Auto-approve when countdown reaches zero
+      if (remaining === 0 && reviewOutput?.approve) {
+        onApprove(feedback || undefined);
+      }
+    };
+
+    // Update immediately
+    updateTimer();
+
+    // Update every second
+    const interval = setInterval(updateTimer, 1000);
+
+    return () => clearInterval(interval);
+  }, [countdown, open, feedback, reviewOutput, onApprove]);
+
+  // Reset feedback when dialog opens/closes
+  useEffect(() => {
+    if (open) {
+      setFeedback('');
+    }
+  }, [open]);
+
+  const handleApprove = () => {
+    onApprove(feedback.trim() || undefined);
+  };
+
+  const handleReject = () => {
+    onReject(feedback.trim() || undefined);
+  };
+
+  const handleClose = (open: boolean) => {
+    if (!open && !isLoading) {
+      onOpenChange(false);
+    }
+  };
+
+  if (!reviewOutput) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-2xl" data-testid="approval-dialog">
+        <DialogHeader>
+          <DialogTitle>Review & Approve Idea</DialogTitle>
+          <DialogDescription>
+            Review the AI-generated assessment and provide your decision.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Countdown Warning */}
+          {remainingSeconds !== null && remainingSeconds > 0 && (
+            <div className="flex items-center gap-2 p-3 bg-yellow-500/10 border border-yellow-500/20 rounded-lg">
+              <AlertCircle className="w-5 h-5 text-yellow-400 flex-shrink-0" />
+              <div className="flex-1 text-sm">
+                <span className="font-medium text-yellow-400">Auto-approval in progress</span>
+                <span className="text-muted-foreground ml-2">
+                  Time remaining: {formatTime(remainingSeconds)}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* Review Assessment */}
+          <div className="space-y-3">
+            <div className="grid grid-cols-3 gap-3">
+              {/* Category */}
+              <div>
+                <Label className="text-xs text-muted-foreground">Category</Label>
+                <div className="mt-1 px-3 py-2 bg-muted/50 rounded text-sm font-medium">
+                  {reviewOutput.category}
+                </div>
+              </div>
+
+              {/* Impact */}
+              <div>
+                <Label className="text-xs text-muted-foreground">Impact</Label>
+                <div className="mt-1">
+                  <span
+                    className={`inline-block px-3 py-2 rounded text-sm font-medium ${getBadgeColor(reviewOutput.impact)}`}
+                  >
+                    {reviewOutput.impact}
+                  </span>
+                </div>
+              </div>
+
+              {/* Effort */}
+              <div>
+                <Label className="text-xs text-muted-foreground">Effort</Label>
+                <div className="mt-1">
+                  <span
+                    className={`inline-block px-3 py-2 rounded text-sm font-medium ${getBadgeColor(reviewOutput.effort)}`}
+                  >
+                    {reviewOutput.effort}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* Reasoning */}
+            {reviewOutput.reasoning && (
+              <div>
+                <Label className="text-xs text-muted-foreground">AI Reasoning</Label>
+                <div className="mt-1 px-3 py-2 bg-muted/50 rounded text-sm">
+                  {reviewOutput.reasoning}
+                </div>
+              </div>
+            )}
+
+            {/* Suggestions */}
+            {reviewOutput.suggestions && reviewOutput.suggestions.length > 0 && (
+              <div>
+                <Label className="text-xs text-muted-foreground">Suggestions</Label>
+                <ul className="mt-1 space-y-1">
+                  {reviewOutput.suggestions.map((suggestion, idx) => (
+                    <li
+                      key={idx}
+                      className="flex items-start gap-2 px-3 py-2 bg-muted/50 rounded text-sm"
+                    >
+                      <span className="text-muted-foreground mt-0.5">•</span>
+                      <span className="flex-1">{suggestion}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+
+          {/* Feedback Textarea */}
+          <div>
+            <Label htmlFor="feedback" className="text-sm">
+              Your Feedback (Optional)
+            </Label>
+            <Textarea
+              id="feedback"
+              value={feedback}
+              onChange={(e) => setFeedback(e.target.value)}
+              placeholder="Add any comments or modifications..."
+              className="mt-1.5 min-h-[100px]"
+              disabled={isLoading}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={handleReject} disabled={isLoading}>
+            <X className="w-4 h-4 mr-2" />
+            Reject
+          </Button>
+          <Button onClick={handleApprove} disabled={isLoading}>
+            <Check className="w-4 h-4 mr-2" />
+            Approve
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/ui/src/components/views/idea-flow/dialogs/index.ts
+++ b/apps/ui/src/components/views/idea-flow/dialogs/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Idea Flow Dialogs
+ *
+ * Exports dialog components for the idea flow pipeline.
+ */
+
+export { StepDetailDialog, type StepDetailDialogProps } from './step-detail-dialog';
+export {
+  ApprovalDialog,
+  type ApprovalDialogProps,
+  type ReviewOutput,
+  type CountdownState,
+} from './approval-dialog';

--- a/apps/ui/src/components/views/idea-flow/dialogs/step-detail-dialog.tsx
+++ b/apps/ui/src/components/views/idea-flow/dialogs/step-detail-dialog.tsx
@@ -1,0 +1,180 @@
+/**
+ * Step Detail Dialog
+ *
+ * Displays details of a pipeline step node including:
+ * - Input/output data as formatted JSON
+ * - Duration and processing notes
+ * - Langfuse span link (when available)
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { ExternalLink, Clock } from 'lucide-react';
+import type { PipelineStepNodeData } from '../types';
+
+export interface StepDetailDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  step: PipelineStepNodeData | null;
+}
+
+/**
+ * Format milliseconds to human-readable duration
+ */
+function formatDuration(startTime?: number, endTime?: number): string {
+  if (!startTime) return 'N/A';
+  const end = endTime || Date.now();
+  const durationMs = end - startTime;
+  const seconds = Math.floor(durationMs / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+
+  if (hours > 0) {
+    return `${hours}h ${minutes % 60}m ${seconds % 60}s`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds % 60}s`;
+  }
+  return `${seconds}s`;
+}
+
+/**
+ * Format JSON with proper indentation
+ */
+function formatJSON(data: unknown): string {
+  if (data === undefined || data === null) return 'N/A';
+  try {
+    return JSON.stringify(data, null, 2);
+  } catch {
+    return String(data);
+  }
+}
+
+/**
+ * Extract Langfuse span ID from step data
+ */
+function getSpanId(step: PipelineStepNodeData): string | undefined {
+  // Check common locations for spanId
+  if ('spanId' in step && typeof step.spanId === 'string') {
+    return step.spanId;
+  }
+  return undefined;
+}
+
+/**
+ * Get Langfuse URL for a span
+ */
+function getLangfuseUrl(spanId: string): string {
+  const baseUrl = process.env.LANGFUSE_BASE_URL || 'https://cloud.langfuse.com';
+  return `${baseUrl}/trace/${spanId}`;
+}
+
+export function StepDetailDialog({ open, onOpenChange, step }: StepDetailDialogProps) {
+  if (!step) return null;
+
+  const spanId = getSpanId(step);
+  const duration = formatDuration(step.startTime, step.endTime);
+  const inputData = 'input' in step ? step.input : undefined;
+  const outputData = 'output' in step ? step.output : undefined;
+  const notes = 'notes' in step && Array.isArray(step.notes) ? step.notes : [];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <DialogTitle className="text-base">{step.label}</DialogTitle>
+              <DialogDescription className="text-xs">Pipeline Step: {step.step}</DialogDescription>
+            </div>
+            {spanId && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="gap-2"
+                onClick={() => window.open(getLangfuseUrl(spanId), '_blank')}
+              >
+                <ExternalLink className="w-3.5 h-3.5" />
+                View in Langfuse
+              </Button>
+            )}
+          </div>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto space-y-4">
+          {/* Status and Duration */}
+          <div className="flex items-center gap-4 text-sm">
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground">Status:</span>
+              <span
+                className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+                  step.status === 'completed'
+                    ? 'bg-green-500/20 text-green-400'
+                    : step.status === 'active'
+                      ? 'bg-blue-500/20 text-blue-400'
+                      : step.status === 'error'
+                        ? 'bg-red-500/20 text-red-400'
+                        : 'bg-gray-500/20 text-gray-400'
+                }`}
+              >
+                {step.status}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Clock className="w-4 h-4 text-muted-foreground" />
+              <span className="text-muted-foreground">Duration:</span>
+              <span>{duration}</span>
+            </div>
+          </div>
+
+          {/* Assignee */}
+          {step.assignee && (
+            <div className="text-sm">
+              <span className="text-muted-foreground">Assignee:</span>
+              <span className="ml-2">{step.assignee}</span>
+            </div>
+          )}
+
+          {/* Processing Notes */}
+          {notes.length > 0 && (
+            <div>
+              <h3 className="text-sm font-medium mb-2">Processing Notes</h3>
+              <div className="space-y-1">
+                {notes.map((note, idx) => (
+                  <div
+                    key={idx}
+                    className="text-sm text-muted-foreground bg-muted/50 rounded px-3 py-2"
+                  >
+                    {String(note)}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Input Data */}
+          <div>
+            <h3 className="text-sm font-medium mb-2">Input</h3>
+            <pre className="text-xs bg-muted/50 rounded p-3 overflow-x-auto">
+              <code>{formatJSON(inputData)}</code>
+            </pre>
+          </div>
+
+          {/* Output Data */}
+          <div>
+            <h3 className="text-sm font-medium mb-2">Output</h3>
+            <pre className="text-xs bg-muted/50 rounded p-3 overflow-x-auto">
+              <code>{formatJSON(outputData)}</code>
+            </pre>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `StepDetailDialog` — shows input/output JSON, duration, status, Langfuse span link
- Add `ApprovalDialog` — full HITL approval form with review output, feedback textarea, approve/reject actions
- Both use shadcn/ui Dialog components with consistent styling
- Barrel export for dialogs directory

## Test plan
- [ ] Click pipeline step node -> step detail dialog opens with formatted JSON
- [ ] Langfuse link appears when spanId present
- [ ] Click approval node in awaiting state -> approval dialog opens
- [ ] Approve button calls POST /api/ideas/:sessionId/approve
- [ ] Reject button with feedback calls POST /api/ideas/:sessionId/reject
- [ ] Loading states on mutation buttons

Part of Idea Flow Visualization project (Panels & Dialogs milestone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Approval Dialog with countdown timer and automatic approval functionality for review decisions
  * Added Step Detail Dialog to display step information including status, duration, processing notes, data details, and external monitoring links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->