### PR TITLE
feat: move Idea Pipeline to own sidebar item

### DIFF
--- a/apps/ui/src/components/layout/sidebar/hooks/use-navigation.ts
+++ b/apps/ui/src/components/layout/sidebar/hooks/use-navigation.ts
@@ -9,6 +9,7 @@ import {
   GitPullRequest,
   Brain,
   Network,
+  Lightbulb,
   Bell,
   Settings,
 } from 'lucide-react';
@@ -139,6 +140,12 @@ export function useNavigation({
         id: 'analytics',
         label: 'System View',
         icon: Network,
+      },
+      {
+        id: 'ideas',
+        label: 'Idea Pipeline',
+        icon: Lightbulb,
+        shortcut: shortcuts.ideation,
       },
       {
         id: 'board',

--- a/apps/ui/src/components/views/analytics-view.tsx
+++ b/apps/ui/src/components/views/analytics-view.tsx
@@ -1,36 +1,23 @@
 /**
- * AnalyticsView — System Flow Graph + Idea Pipeline
+ * AnalyticsView — System Flow Graph
  *
- * Tab bar view with:
- * - System Graph: React Flow system architecture with floating panels
- * - Idea Pipeline: Idea intake and processing flow
- *
+ * React Flow system architecture with floating panels.
  * Feature node clicks navigate to the board for editing.
  */
 
 import { useCallback } from 'react';
-import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 import { useAppStore } from '@/store/app-store';
 import { FlowGraphView } from './flow-graph';
-import { IdeaFlowView } from './idea-flow/idea-flow-view';
 
 export function AnalyticsView() {
   const currentProject = useAppStore((s) => s.currentProject);
   const projectPath = currentProject?.path;
   const navigate = useNavigate();
-  const { tab } = useSearch({ from: '/analytics' });
 
   const handleFeatureClick = useCallback(
     (featureId: string) => {
-      // Navigate to board — the feature will be highlighted there
       navigate({ to: '/board', search: { featureId } });
-    },
-    [navigate]
-  );
-
-  const handleTabChange = useCallback(
-    (newTab: 'system' | 'ideas') => {
-      navigate({ to: '/analytics', search: { tab: newTab } });
     },
     [navigate]
   );
@@ -43,40 +30,5 @@ export function AnalyticsView() {
     );
   }
 
-  return (
-    <div className="flex flex-col h-full">
-      {/* Tab bar */}
-      <div className="flex items-center gap-1 px-4 py-2 border-b border-border bg-card/50">
-        <button
-          onClick={() => handleTabChange('system')}
-          className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
-            tab === 'system'
-              ? 'bg-accent text-accent-foreground'
-              : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
-          }`}
-        >
-          System Graph
-        </button>
-        <button
-          onClick={() => handleTabChange('ideas')}
-          className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
-            tab === 'ideas'
-              ? 'bg-accent text-accent-foreground'
-              : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
-          }`}
-        >
-          Idea Pipeline
-        </button>
-      </div>
-
-      {/* Tab content */}
-      <div className="flex-1 overflow-hidden">
-        {tab === 'system' ? (
-          <FlowGraphView projectPath={projectPath} onFeatureClick={handleFeatureClick} />
-        ) : (
-          <IdeaFlowView projectPath={projectPath} />
-        )}
-      </div>
-    </div>
-  );
+  return <FlowGraphView projectPath={projectPath} onFeatureClick={handleFeatureClick} />;
 }

--- a/apps/ui/src/routes/analytics.tsx
+++ b/apps/ui/src/routes/analytics.tsx
@@ -1,12 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { AnalyticsView } from '@/components/views/analytics-view';
-import { z } from 'zod';
-
-const analyticsSearchSchema = z.object({
-  tab: z.enum(['system', 'ideas']).optional().default('system'),
-});
 
 export const Route = createFileRoute('/analytics')({
   component: AnalyticsView,
-  validateSearch: analyticsSearchSchema,
 });

--- a/apps/ui/src/routes/ideas.tsx
+++ b/apps/ui/src/routes/ideas.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useAppStore } from '@/store/app-store';
+import { IdeaFlowView } from '@/components/views/idea-flow/idea-flow-view';
+
+function IdeasRoute() {
+  const projectPath = useAppStore((s) => s.currentProject?.path);
+  return <IdeaFlowView projectPath={projectPath} />;
+}
+
+export const Route = createFileRoute('/ideas')({
+  component: IdeasRoute,
+});


### PR DESCRIPTION
## Summary
- Extract Idea Pipeline from analytics tab bar into a standalone `/ideas` route with its own Lightbulb sidebar icon
- Analytics view now renders only the System Graph without a tab switcher
- New route wired to existing `shortcuts.ideation` keyboard shortcut

## Test plan
- [ ] Sidebar shows new Lightbulb icon for "Idea Pipeline" in the Project section
- [ ] Clicking it navigates to `/ideas` and shows the Idea Flow view
- [ ] `/analytics` shows only the System Graph (no tab bar)
- [ ] Ideation keyboard shortcut navigates to `/ideas`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Idea Pipeline" navigation item to the sidebar for quick access
  * New dedicated Ideas section accessible through the main navigation menu

* **Updates**
  * Analytics view now displays System Flow Graph visualization exclusively
  * Tab-based navigation removed from the Analytics interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->