### PR TITLE
fix: integrity watchdog tracks feature deletions and exposes clear API

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -184,6 +184,7 @@ import { linearApprovalHandler } from './services/linear-approval-handler.js';
 import { LinearApprovalBridge } from './services/linear-approval-bridge.js';
 import { LinearIntakeBridge } from './services/linear-intake-bridge.js';
 import { createDeployRoutes } from './routes/deploy/index.js';
+import { createIntegrityRoutes } from './routes/integrity.js';
 import { createAnalyticsRoutes } from './routes/analytics.js';
 import { AntagonisticReviewService } from './services/antagonistic-review-service.js';
 import { createLangfuseRoutes } from './routes/langfuse/index.js';
@@ -467,6 +468,7 @@ const { getDataIntegrityWatchdogService } =
   await import('./services/data-integrity-watchdog-service.js');
 const integrityWatchdogService = getDataIntegrityWatchdogService(DATA_DIR);
 integrityWatchdogService.setEventEmitter(events);
+featureLoader.setIntegrityWatchdog(integrityWatchdogService);
 
 // Initialize Event History Service
 const eventHistoryService = getEventHistoryService();
@@ -1149,6 +1151,7 @@ app.use('/api/ceremonies', createCeremoniesRoutes(events, featureLoader, project
 app.use('/api/issues', createIssuesRoutes(events));
 app.use('/api/crew', createCrewRoutes(crewLoopService));
 app.use('/api/deploy', createDeployRoutes(autoModeService));
+app.use('/api/integrity', createIntegrityRoutes(integrityWatchdogService));
 app.use('/api/escalation', createEscalationRoutes(escalationRouter));
 app.use('/api/analytics', createAnalyticsRoutes());
 

--- a/apps/server/src/routes/integrity.ts
+++ b/apps/server/src/routes/integrity.ts
@@ -1,0 +1,64 @@
+/**
+ * Integrity routes - HTTP API for data integrity watchdog
+ */
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import type { DataIntegrityWatchdogService } from '../services/data-integrity-watchdog-service.js';
+import { validatePathParams } from '../middleware/validate-paths.js';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('IntegrityRoutes');
+
+export function createIntegrityRoutes(
+  integrityWatchdogService: DataIntegrityWatchdogService
+): Router {
+  const router = Router();
+
+  // POST /clear - Clear integrity breach for a project
+  router.post('/clear', validatePathParams('projectPath'), async (req: Request, res: Response) => {
+    try {
+      const { projectPath } = req.body as { projectPath: string };
+
+      if (!projectPath) {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+
+      await integrityWatchdogService.clearBreach(projectPath);
+      const status = await integrityWatchdogService.getStatus(projectPath);
+
+      logger.info(`Cleared integrity breach for ${projectPath}`);
+      res.json({ success: true, ...status });
+    } catch (error) {
+      logger.error('Failed to clear integrity breach:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  // POST /status - Get integrity status for a project
+  router.post('/status', validatePathParams('projectPath'), async (req: Request, res: Response) => {
+    try {
+      const { projectPath } = req.body as { projectPath: string };
+
+      if (!projectPath) {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+
+      const status = await integrityWatchdogService.getStatus(projectPath);
+      res.json({ success: true, ...status });
+    } catch (error) {
+      logger.error('Failed to get integrity status:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/services/data-integrity-watchdog-service.ts
+++ b/apps/server/src/services/data-integrity-watchdog-service.ts
@@ -392,6 +392,24 @@ export class DataIntegrityWatchdogService {
   }
 
   /**
+   * Notify the watchdog that a feature was intentionally deleted.
+   * Decrements lastKnownCount so the threshold isn't tripped by normal operations.
+   */
+  async notifyFeatureDeleted(projectPath: string, count: number = 1): Promise<void> {
+    const state = await this.readState();
+    const projectState = state.projects[projectPath];
+    if (!projectState) return;
+
+    projectState.lastKnownCount = Math.max(0, projectState.lastKnownCount - count);
+    projectState.lastCheckedAt = new Date().toISOString();
+    await this.writeState(state);
+
+    logger.debug(
+      `Decremented lastKnownCount by ${count} for ${projectPath}, now ${projectState.lastKnownCount}`
+    );
+  }
+
+  /**
    * Get current integrity status for a project
    */
   async getStatus(projectPath: string): Promise<{

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -31,6 +31,7 @@ import {
 } from '@automaker/platform';
 import { addImplementedFeature, type ImplementedFeature } from '../lib/xml-extractor.js';
 import { debugLog } from '../lib/debug-log.js';
+import type { DataIntegrityWatchdogService } from './data-integrity-watchdog-service.js';
 
 const logger = createLogger('FeatureLoader');
 
@@ -38,6 +39,11 @@ const logger = createLogger('FeatureLoader');
 export type { Feature };
 
 export class FeatureLoader implements FeatureStore {
+  private integrityWatchdog: DataIntegrityWatchdogService | null = null;
+
+  setIntegrityWatchdog(watchdog: DataIntegrityWatchdogService): void {
+    this.integrityWatchdog = watchdog;
+  }
   /**
    * Normalize feature status to canonical values
    * Defensive: ensures all features use the 6-status system
@@ -605,6 +611,12 @@ export class FeatureLoader implements FeatureStore {
       const featureDir = this.getFeatureDir(projectPath, featureId);
       await secureFs.rm(featureDir, { recursive: true, force: true });
       logger.info(`Deleted feature ${featureId}`);
+
+      // Notify integrity watchdog so it doesn't flag this as data loss
+      if (this.integrityWatchdog) {
+        await this.integrityWatchdog.notifyFeatureDeleted(projectPath);
+      }
+
       return true;
     } catch (error) {
       logger.error(`Failed to delete feature ${featureId}:`, error);

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -824,6 +824,12 @@ const tools: Tool[] = [
           type: 'string',
           description: 'Optional branch/worktree name to run auto-mode on',
         },
+        forceStart: {
+          type: 'boolean',
+          description:
+            'Bypass data integrity check. Use when feature count dropped intentionally (e.g., cleanup).',
+          default: false,
+        },
       },
       required: ['projectPath'],
     },
@@ -3037,6 +3043,7 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         projectPath: args.projectPath,
         maxConcurrency: args.maxConcurrency || 1,
         branchName: args.branchName || null,
+        forceStart: args.forceStart || false,
       });
 
     case 'stop_auto_mode':


### PR DESCRIPTION
## Summary
- FeatureLoader now notifies `DataIntegrityWatchdogService` when features are deleted, decrementing `lastKnownCount` so routine cleanup doesn't trip the >50% breach threshold
- New `POST /api/integrity/clear` endpoint to manually reset breach state
- New `POST /api/integrity/status` endpoint to check current status
- `forceStart` param added to `start_auto_mode` MCP tool to bypass integrity check

## Context
Auto-mode was blocked because the watchdog recorded 49 features (high-water mark) but only 9 remain after normal lifecycle cleanup. The ratchet-only design didn't account for legitimate feature deletions.

## Test plan
- [ ] Delete a feature via API, verify `integrity-state.json` `lastKnownCount` decrements
- [ ] Bulk delete features, verify count adjusts correctly
- [ ] Call `POST /api/integrity/clear` with a breached project, verify it unblocks auto-mode
- [ ] Call `start_auto_mode` MCP with `forceStart: true`, verify it bypasses integrity check
- [ ] Normal feature additions still ratchet `lastKnownCount` upward

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced integrity monitoring API with endpoints to check and clear breach status by project path.
  * Added optional parameter to bypass data integrity checks during auto-mode startup for intentional feature count reductions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->