### PR TITLE
fix: enable auto-merge when CI pending + add review transition to pipeline resume

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -2831,6 +2831,34 @@ Complete the pipeline step instructions above. Review the previous work and appl
         }
       }
 
+      // Transition feature to 'review' or 'done' based on git workflow results
+      // (mirrors the pattern in executeFeature)
+      if (gitWorkflowResult?.prUrl) {
+        const updates: Record<string, unknown> = {
+          prUrl: gitWorkflowResult.prUrl,
+          prNumber: gitWorkflowResult.prNumber,
+        };
+
+        if (gitWorkflowResult.prCreatedAt) {
+          updates.prCreatedAt = gitWorkflowResult.prCreatedAt;
+        }
+
+        if (gitWorkflowResult.merged && gitWorkflowResult.prMergedAt) {
+          updates.status = 'done';
+          updates.prMergedAt = gitWorkflowResult.prMergedAt;
+
+          if (gitWorkflowResult.prCreatedAt) {
+            const createdAt = new Date(gitWorkflowResult.prCreatedAt);
+            const mergedAt = new Date(gitWorkflowResult.prMergedAt);
+            updates.prReviewDurationMs = mergedAt.getTime() - createdAt.getTime();
+          }
+        } else {
+          updates.status = 'review';
+        }
+
+        await this.featureLoader.update(projectPath, featureId, updates);
+      }
+
       const gitInfo = gitWorkflowResult?.commitHash
         ? ` | Committed: ${gitWorkflowResult.commitHash}${gitWorkflowResult.pushed ? ', pushed' : ''}${gitWorkflowResult.prUrl ? `, PR: ${gitWorkflowResult.prUrl}` : ''}`
         : '';

--- a/apps/server/src/services/github-merge-service.ts
+++ b/apps/server/src/services/github-merge-service.ts
@@ -78,12 +78,14 @@ interface PRCheckStatus {
  * PR merge result
  */
 export interface PRMergeResult {
-  /** Whether the PR was successfully merged */
+  /** Whether the PR was successfully merged (or auto-merge enabled) */
   success: boolean;
   /** Commit SHA of the merge commit (if successful) */
   mergeCommitSha?: string;
   /** Error message if merge failed */
   error?: string;
+  /** Whether auto-merge was enabled (waiting for CI to pass) */
+  autoMergeEnabled?: boolean;
   /** Whether merge failed due to pending CI checks */
   checksPending?: boolean;
   /** Whether merge failed due to failed CI checks */
@@ -180,14 +182,41 @@ export class GitHubMergeService {
       const checkStatus = await this.checkPRStatus(workDir, prNumber);
 
       if (checkStatus.pendingCount > 0) {
+        // CI is still running — enable auto-merge so GitHub merges once checks pass
         logger.info(
-          `PR #${prNumber} has ${checkStatus.pendingCount} pending checks, skipping merge`
+          `PR #${prNumber} has ${checkStatus.pendingCount} pending checks, enabling auto-merge`
         );
-        return {
-          success: false,
-          error: `${checkStatus.pendingCount} checks still pending`,
-          checksPending: true,
-        };
+        try {
+          let autoMergeCmd = `gh pr merge ${prNumber}`;
+          switch (strategy) {
+            case 'merge':
+              autoMergeCmd += ' --merge';
+              break;
+            case 'squash':
+              autoMergeCmd += ' --squash';
+              break;
+            case 'rebase':
+              autoMergeCmd += ' --rebase';
+              break;
+          }
+          autoMergeCmd += ' --auto';
+          await execAsync(autoMergeCmd, { cwd: workDir, env: execEnv });
+          logger.info(`Auto-merge enabled for PR #${prNumber}, will merge when checks pass`);
+          return {
+            success: true,
+            autoMergeEnabled: true,
+            checksPending: true,
+          };
+        } catch (autoMergeError) {
+          const errMsg =
+            autoMergeError instanceof Error ? autoMergeError.message : String(autoMergeError);
+          logger.warn(`Failed to enable auto-merge for PR #${prNumber}: ${errMsg}`);
+          return {
+            success: false,
+            error: `${checkStatus.pendingCount} checks still pending, auto-merge failed: ${errMsg}`,
+            checksPending: true,
+          };
+        }
       }
 
       if (checkStatus.failedCount > 0) {


### PR DESCRIPTION
## Summary
- **Auto-merge fix**: When CI checks are pending on a new PR, `gh pr merge --auto --squash` is now executed instead of bailing early. The `--auto` flag tells GitHub to merge once all required checks pass — exactly the right behavior for newly-created PRs with running CI. Previously, PRs would sit without auto-merge enabled, relying on the PR Maintainer crew loop (heuristic Haiku agent) for merge.
- **Pipeline resume fix**: `resumePipelineFeature` now transitions features to `review` (or `done` if auto-merged) after git workflow completes, matching `executeFeature`'s existing pattern. Previously features got stuck at `verified` with no status transition after PR creation.

## Test plan
- [ ] Create a PR via git workflow — verify `gh pr merge --auto` is called when CI is pending
- [ ] Verify auto-merge result returns `{ success: true, autoMergeEnabled: true }`
- [ ] Verify failed CI checks still prevent merge (no behavior change)
- [ ] Resume a pipeline feature — verify it transitions to `review` after PR creation
- [ ] Verify PR URL and number are saved to feature metadata
- [ ] `npm run build:server` passes
- [ ] `npm run test:server` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Auto-merge now activates when CI checks are pending, streamlining the PR merge process.

* **Improvements**
  * PR status tracking now captures merge timing details to accurately reflect review duration.
  * Merge results now include detailed failed checks information for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->