### PR TITLE
feat: wire signal intake bridge + process_idea MCP handler

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -128,6 +128,7 @@ import { graphiteService } from './services/graphite-service.js';
 import { createWebhooksRoutes } from './routes/webhooks/index.js';
 import { createSchedulerRoutes } from './routes/scheduler/index.js';
 import { integrationService } from './services/integration-service.js';
+import { SignalIntakeService } from './services/signal-intake-service.js';
 import { createIntegrationRoutes } from './routes/integrations/index.js';
 import { createDashboardRoutes } from './routes/dashboard.js';
 import { AuthorityService } from './services/authority-service.js';
@@ -475,6 +476,10 @@ const briefingCursorService = getBriefingCursorService(DATA_DIR);
 
 // Initialize Integration Service for Linear, Discord, and other external integrations
 integrationService.initialize(events, settingsService, featureLoader);
+
+// Initialize Signal Intake Service — bridges external signals to PM Agent pipeline
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const signalIntakeService = new SignalIntakeService(events, featureLoader, REPO_ROOT);
 
 // Initialize Authority Service for trust-based policy enforcement
 const authorityService = new AuthorityService(events);

--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -1,0 +1,103 @@
+/**
+ * Signal Intake Service
+ *
+ * Bridges external signals (Linear issues, GitHub issues, Discord messages)
+ * to the PM Agent pipeline. Subscribes to `signal:received` events from
+ * IntegrationService and creates features with `workItemState: 'idea'`,
+ * triggering the PM Agent research → PRD → decomposition flow.
+ */
+
+import { createLogger } from '@automaker/utils';
+import type { EventEmitter } from '../lib/events.js';
+import type { FeatureLoader } from './feature-loader.js';
+
+const logger = createLogger('SignalIntake');
+
+interface SignalPayload {
+  source: string;
+  content: string;
+  author: {
+    id: string;
+    name: string;
+  };
+  channelContext?: {
+    channelId?: string;
+    channelName?: string;
+    issueId?: string;
+    state?: string;
+    [key: string]: unknown;
+  };
+  timestamp: string;
+}
+
+export class SignalIntakeService {
+  private processedSignals = new Set<string>();
+
+  constructor(
+    private events: EventEmitter,
+    private featureLoader: FeatureLoader,
+    private defaultProjectPath: string
+  ) {
+    this.registerListener();
+    logger.info(`Signal intake service initialized for ${defaultProjectPath}`);
+  }
+
+  private registerListener(): void {
+    this.events.subscribe((type, payload) => {
+      if (type === 'signal:received') {
+        void this.handleSignal(payload as SignalPayload);
+      }
+    });
+  }
+
+  private async handleSignal(signal: SignalPayload): Promise<void> {
+    // Deduplicate by source + author ID (e.g., same Linear issue ID)
+    const dedupeKey = `${signal.source}:${signal.author.id}`;
+    if (this.processedSignals.has(dedupeKey)) {
+      logger.debug(`Skipping duplicate signal: ${dedupeKey}`);
+      return;
+    }
+    this.processedSignals.add(dedupeKey);
+
+    // Prevent unbounded growth — trim older entries after 1000
+    if (this.processedSignals.size > 1000) {
+      const entries = [...this.processedSignals];
+      this.processedSignals = new Set(entries.slice(-500));
+    }
+
+    try {
+      // Extract title from first line, description from full content
+      const lines = signal.content.split('\n').filter((l) => l.trim());
+      const title = (lines[0] || 'Untitled signal').substring(0, 100);
+      const description = signal.content;
+
+      logger.info(`Processing signal from ${signal.source}: "${title}"`);
+
+      // Create feature with idea state
+      const feature = await this.featureLoader.create(this.defaultProjectPath, {
+        title: `[${signal.source}] ${title}`,
+        description,
+        status: 'backlog',
+        category: 'Signal Intake',
+        complexity: 'medium',
+        workItemState: 'idea',
+      });
+
+      // Trigger PM Agent pipeline
+      this.events.emit('authority:idea-injected', {
+        projectPath: this.defaultProjectPath,
+        featureId: feature.id,
+        title,
+        description,
+        injectedBy: `signal:${signal.source}`,
+        injectedAt: new Date().toISOString(),
+      });
+
+      logger.info(
+        `Signal routed to PM Agent: "${title}" → feature ${feature.id} (source: ${signal.source})`
+      );
+    } catch (error) {
+      logger.error(`Failed to process signal from ${signal.source}:`, error);
+    }
+  }
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -2743,6 +2743,31 @@ const tools: Tool[] = [
       required: ['suggestionIds', 'projectPath'],
     },
   },
+
+  // Idea Processing
+  {
+    name: 'process_idea',
+    description:
+      'Process an idea through the PM Agent pipeline. Creates a feature with idea state and triggers the PM Agent for research, PRD generation, and feature decomposition.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        title: {
+          type: 'string',
+          description: 'Short title for the idea',
+        },
+        description: {
+          type: 'string',
+          description: 'Detailed description of the idea',
+        },
+      },
+      required: ['projectPath', 'title', 'description'],
+    },
+  },
 ];
 
 // Tool implementations
@@ -3837,6 +3862,14 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         suggestionIds: args.suggestionIds,
         projectPath: args.projectPath,
         durationSeconds: args.durationSeconds,
+      });
+
+    // Idea Processing
+    case 'process_idea':
+      return apiCall('/authority/inject-idea', {
+        projectPath: args.projectPath,
+        title: args.title,
+        description: args.description,
       });
 
     default:


### PR DESCRIPTION
## Summary
- **SignalIntakeService** (new): Subscribes to `signal:received` events from IntegrationService (Linear issues, GitHub issues, Discord messages) and routes them into the PM Agent pipeline. Creates features with `workItemState: 'idea'` and emits `authority:idea-injected`. Includes deduplication by source+authorId.
- **process_idea MCP handler**: Adds the missing tool handler that calls `POST /api/authority/inject-idea`. The tool was documented in docs + plugin manifest but had no implementation.

These two changes together complete **Step 1 (Signal Intake)** of the protoLabs pipeline — external signals now flow automatically into the execution pipeline.

## Test plan
- [ ] Create a Linear issue → verify it appears as a feature with `workItemState: 'idea'`
- [ ] Call `process_idea` via MCP → verify PM Agent picks up the idea
- [ ] Verify existing `/idea` Discord command still works (not affected)
- [ ] Verify existing `inject-idea` REST endpoint still works
- [ ] `npm run build:server` passes
- [ ] `npm run build:packages` passes (MCP server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Signals are now automatically processed and deduplicated by source and author, then converted into features
- Added new "process_idea" tool to create and process ideas through the development pipeline with title and description inputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->