### PR TITLE
feat: wire project completion to reflection output

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -134,6 +134,7 @@ import { AuthorityService } from './services/authority-service.js';
 import { createAuthorityRoutes } from './routes/authority/index.js';
 import { createCosRoutes } from './routes/cos/index.js';
 import { CompletionDetectorService } from './services/completion-detector-service.js';
+import { ReflectionService } from './services/reflection-service.js';
 import { createCeremoniesRoutes } from './routes/ceremonies/index.js';
 import { PMAuthorityAgent } from './services/authority-agents/pm-agent.js';
 import { ProjMAuthorityAgent } from './services/authority-agents/projm-agent.js';
@@ -531,6 +532,10 @@ changelogService.initialize(events, settingsService, featureLoader, projectServi
 // Initialize Completion Detector Service — cascades feature done → epic → milestone → project
 const completionDetectorService = new CompletionDetectorService();
 completionDetectorService.initialize(events, featureLoader, projectService, settingsService);
+
+// Initialize Reflection Service — generates retrospective when projects complete
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const reflectionService = new ReflectionService(events, featureLoader);
 
 // Initialize Lead Engineer Service — production-phase nerve center
 const { LeadEngineerService } = await import('./services/lead-engineer-service.js');

--- a/apps/server/src/services/reflection-service.ts
+++ b/apps/server/src/services/reflection-service.ts
@@ -1,0 +1,150 @@
+/**
+ * Reflection Service
+ *
+ * Generates a retrospective reflection when a project completes.
+ * Unlike CeremonyService (which gates on ceremony settings), this always runs
+ * to ensure every project gets a reflection output.
+ *
+ * Listens for: project:completed (from CompletionDetectorService)
+ * Writes to: .automaker/projects/{slug}/reflection.md
+ * Emits: project:reflection:complete
+ */
+
+import path from 'node:path';
+import { createLogger } from '@automaker/utils';
+import { ensureAutomakerDir, secureFs } from '@automaker/platform';
+import type { EventEmitter } from '../lib/events.js';
+import type { FeatureLoader } from './feature-loader.js';
+import type { Feature } from '@automaker/types';
+import { simpleQuery } from '../providers/simple-query-service.js';
+
+const logger = createLogger('Reflection');
+
+interface ProjectCompletedPayload {
+  projectPath: string;
+  projectTitle: string;
+  projectSlug: string;
+  totalMilestones: number;
+  totalFeatures: number;
+}
+
+export class ReflectionService {
+  private processedProjects = new Set<string>();
+
+  constructor(
+    private events: EventEmitter,
+    private featureLoader: FeatureLoader
+  ) {
+    this.registerListener();
+    logger.info('Reflection service initialized');
+  }
+
+  private registerListener(): void {
+    this.events.subscribe((type, payload) => {
+      if (type === 'project:completed') {
+        void this.handleProjectCompleted(payload as ProjectCompletedPayload);
+      }
+    });
+  }
+
+  private async handleProjectCompleted(payload: ProjectCompletedPayload): Promise<void> {
+    const { projectPath, projectTitle, projectSlug, totalMilestones, totalFeatures } = payload;
+
+    // Deduplicate
+    const key = `${projectPath}:${projectSlug}`;
+    if (this.processedProjects.has(key)) return;
+    this.processedProjects.add(key);
+
+    logger.info(`Generating reflection for completed project: ${projectTitle}`);
+
+    try {
+      const features = await this.featureLoader.getAll(projectPath);
+      const projectFeatures = features.filter((f) => f.projectSlug === projectSlug || f.epicId);
+
+      const summary = this.buildSummary(
+        projectTitle,
+        projectFeatures,
+        totalMilestones,
+        totalFeatures
+      );
+
+      // Generate retrospective via LLM
+      const result = await simpleQuery({
+        prompt: `You are a project retrospective analyst. Given these completion stats, write a concise reflection covering:
+
+1. **Summary**: What was built and why
+2. **What Went Well**: Successes, efficient patterns, smooth executions
+3. **What Went Wrong**: Failures, retries, blockers encountered
+4. **Metrics**: Feature count, cost, time, retry rate
+5. **Lessons Learned**: Key takeaways for future projects
+6. **Improvement Ideas**: Concrete items that would make the next project better
+
+Be specific, reference actual features and numbers. Keep it under 500 words.
+
+Project Data:
+${summary}`,
+        model: 'sonnet',
+        cwd: projectPath,
+        maxTurns: 1,
+        allowedTools: [],
+      });
+
+      const reflection = result.text;
+
+      // Store reflection
+      const projectDir = path.join(projectPath, '.automaker', 'projects', projectSlug);
+      await ensureAutomakerDir(projectDir);
+      const reflectionPath = path.join(projectDir, 'reflection.md');
+      const content = `# Reflection: ${projectTitle}\n\n_Generated: ${new Date().toISOString()}_\n\n${reflection}\n`;
+      await secureFs.writeFile(reflectionPath, content, 'utf-8');
+
+      logger.info(`Reflection stored at ${reflectionPath}`);
+
+      // Emit event
+      this.events.emit('project:reflection:complete', {
+        projectPath,
+        projectTitle,
+        projectSlug,
+        reflectionPath,
+      });
+    } catch (error) {
+      logger.error(`Failed to generate reflection for ${projectTitle}:`, error);
+    }
+  }
+
+  private buildSummary(
+    title: string,
+    features: Feature[],
+    totalMilestones: number,
+    totalFeatures: number
+  ): string {
+    const done = features.filter((f) => f.status === 'done');
+    const withPR = features.filter((f) => f.prUrl);
+    const failed = features.filter((f) => (f.failureCount || 0) > 0);
+    const totalCost = features.reduce((sum, f) => sum + (f.costUsd || 0), 0);
+    const totalRetries = features.reduce((sum, f) => sum + (f.failureCount || 0), 0);
+
+    const lines = [
+      `Project: ${title}`,
+      `Total Milestones: ${totalMilestones}`,
+      `Total Features: ${totalFeatures}`,
+      `Features Done: ${done.length}`,
+      `PRs Created: ${withPR.length}`,
+      `Features with Failures: ${failed.length}`,
+      `Total Retries: ${totalRetries}`,
+      `Estimated Cost: $${totalCost.toFixed(2)}`,
+      '',
+      'Feature Details:',
+    ];
+
+    for (const f of features) {
+      const status = f.status === 'done' ? 'DONE' : (f.status ?? 'unknown').toUpperCase();
+      const cost = f.costUsd ? ` ($${f.costUsd.toFixed(2)})` : '';
+      const retries = f.failureCount ? ` [${f.failureCount} retries]` : '';
+      const pr = f.prUrl ? ` PR: ${f.prUrl}` : '';
+      lines.push(`  - [${status}] ${f.title}${cost}${retries}${pr}`);
+    }
+
+    return lines.join('\n');
+  }
+}

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -202,6 +202,7 @@ export type EventType =
   | 'milestone:cto-approved'
   // Project completion events
   | 'project:completed'
+  | 'project:reflection:complete'
   // CoS intake events
   | 'cos:prd-submitted'
   // PR feedback loop events (EM dev lifecycle)


### PR DESCRIPTION
## Summary

- Adds `ReflectionService` that listens for `project:completed` events and generates a retrospective via LLM
- Unlike `CeremonyService` (gated on ceremony settings), this always runs to ensure every completed project gets a reflection
- Stores output at `.automaker/projects/{slug}/reflection.md`
- Emits `project:reflection:complete` event for downstream consumers

## Context

Part of the signal-to-production pipeline demo fixes. This wires up the final step (Reflection Loop) so completed projects automatically get a retrospective analysis with metrics, lessons learned, and improvement ideas.

## Test plan

- [ ] Server compiles cleanly (`npx tsc --noEmit`)
- [ ] `project:completed` event triggers reflection generation
- [ ] Reflection markdown written to correct path
- [ ] `project:reflection:complete` event emitted after storage
- [ ] Deduplication prevents double-processing same project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Automated retrospective reflections now generated upon project completion, summarizing key milestones, features, costs, and retries for comprehensive project review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->