### PR TITLE
chore: gitignore storybook-static build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 dist/
 build/
 out/
+storybook-static/
 docs/.vitepress/dist/
 docs/.vitepress/cache/
 .next/


### PR DESCRIPTION
## Summary
- Adds `storybook-static/` to `.gitignore` to prevent Vite dep optimizer from scanning stale build artifacts
- Fixes ENOENT errors for removed dependencies (e.g., `@emotion/is-prop-valid`) during dev server startup

## Test plan
- [ ] `npm run dev:web` starts without dep scan warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ignore additional temporary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->