### PR TITLE
feat: add pipeline types and layout constants

### DIFF
--- a/apps/ui/src/components/views/flow-graph/constants.ts
+++ b/apps/ui/src/components/views/flow-graph/constants.ts
@@ -6,7 +6,7 @@
  * Dynamic nodes (features, agents) use dagre layout below center.
  */
 
-import type { FlowNode, FlowEdge } from './types';
+import type { FlowNode, FlowEdge, PipelineStageId } from './types';
 
 // ============================================
 // Static Node IDs
@@ -26,6 +26,15 @@ export const NODE_IDS = {
   github: 'integration-github',
   linear: 'integration-linear',
   discord: 'integration-discord',
+  // Pipeline stages
+  pipelineBacklog: 'pipeline-backlog',
+  pipelineInProgress: 'pipeline-in-progress',
+  pipelineReview: 'pipeline-review',
+  pipelineMerge: 'pipeline-merge',
+  pipelineTest: 'pipeline-test',
+  pipelineVerify: 'pipeline-verify',
+  pipelineDone: 'pipeline-done',
+  pipelineBlocked: 'pipeline-blocked',
 } as const;
 
 // ============================================
@@ -141,3 +150,109 @@ export const CREW_NODE_ID_MAP: Record<string, string> = {
   'board-janitor': NODE_IDS.boardJanitor,
   'system-health': NODE_IDS.systemHealth,
 };
+
+// ============================================
+// Pipeline Stages
+// ============================================
+
+export const PIPELINE_STAGES: Array<{
+  nodeId: string;
+  stageId: PipelineStageId;
+  label: string;
+  position: { x: number; y: number };
+}> = [
+  {
+    nodeId: NODE_IDS.pipelineBacklog,
+    stageId: 'backlog',
+    label: 'Backlog',
+    position: { x: 100, y: 800 },
+  },
+  {
+    nodeId: NODE_IDS.pipelineInProgress,
+    stageId: 'in_progress',
+    label: 'In Progress',
+    position: { x: 350, y: 800 },
+  },
+  {
+    nodeId: NODE_IDS.pipelineReview,
+    stageId: 'review',
+    label: 'Review',
+    position: { x: 600, y: 800 },
+  },
+  {
+    nodeId: NODE_IDS.pipelineMerge,
+    stageId: 'merge',
+    label: 'Merge',
+    position: { x: 850, y: 800 },
+  },
+  {
+    nodeId: NODE_IDS.pipelineTest,
+    stageId: 'test',
+    label: 'Test',
+    position: { x: 1100, y: 800 },
+  },
+  {
+    nodeId: NODE_IDS.pipelineVerify,
+    stageId: 'verify',
+    label: 'Verify',
+    position: { x: 1350, y: 800 },
+  },
+  {
+    nodeId: NODE_IDS.pipelineDone,
+    stageId: 'done',
+    label: 'Done',
+    position: { x: 1600, y: 800 },
+  },
+  {
+    nodeId: NODE_IDS.pipelineBlocked,
+    stageId: 'blocked',
+    label: 'Blocked',
+    position: { x: 600, y: 950 },
+  },
+];
+
+// Pipeline edges connecting stages left-to-right
+export const PIPELINE_EDGES: FlowEdge[] = [
+  {
+    id: 'e-pipe-backlog-progress',
+    source: NODE_IDS.pipelineBacklog,
+    target: NODE_IDS.pipelineInProgress,
+    type: 'pipeline',
+  },
+  {
+    id: 'e-pipe-progress-review',
+    source: NODE_IDS.pipelineInProgress,
+    target: NODE_IDS.pipelineReview,
+    type: 'pipeline',
+  },
+  {
+    id: 'e-pipe-review-merge',
+    source: NODE_IDS.pipelineReview,
+    target: NODE_IDS.pipelineMerge,
+    type: 'pipeline',
+  },
+  {
+    id: 'e-pipe-merge-test',
+    source: NODE_IDS.pipelineMerge,
+    target: NODE_IDS.pipelineTest,
+    type: 'pipeline',
+  },
+  {
+    id: 'e-pipe-test-verify',
+    source: NODE_IDS.pipelineTest,
+    target: NODE_IDS.pipelineVerify,
+    type: 'pipeline',
+  },
+  {
+    id: 'e-pipe-verify-done',
+    source: NODE_IDS.pipelineVerify,
+    target: NODE_IDS.pipelineDone,
+    type: 'pipeline',
+  },
+  {
+    id: 'e-pipe-review-blocked',
+    source: NODE_IDS.pipelineReview,
+    target: NODE_IDS.pipelineBlocked,
+    type: 'pipeline',
+  },
+];

--- a/apps/ui/src/components/views/flow-graph/types.ts
+++ b/apps/ui/src/components/views/flow-graph/types.ts
@@ -70,6 +70,34 @@ export interface AgentNodeData {
   [key: string]: unknown;
 }
 
+export type PipelineStageId =
+  | 'backlog'
+  | 'in_progress'
+  | 'review'
+  | 'merge'
+  | 'test'
+  | 'verify'
+  | 'done'
+  | 'blocked';
+
+export type PipelineStageStatus = 'idle' | 'active' | 'blocked' | 'error';
+
+export interface TrackedWorkItem {
+  id: string;
+  title: string;
+  status: PipelineStageId;
+  progress?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PipelineStageNodeData {
+  stageId: PipelineStageId;
+  label: string;
+  status: PipelineStageStatus;
+  workItems: TrackedWorkItem[];
+  [key: string]: unknown;
+}
+
 // ============================================
 // Typed Node/Edge Aliases
 // ============================================
@@ -80,6 +108,7 @@ export type ServiceNode = Node<ServiceNodeData, 'service'>;
 export type IntegrationNode = Node<IntegrationNodeData, 'integration'>;
 export type FeatureNode = Node<FeatureNodeData, 'feature'>;
 export type AgentNode = Node<AgentNodeData, 'agent'>;
+export type PipelineStageNode = Node<PipelineStageNodeData, 'pipeline-stage'>;
 
 export type FlowNode =
   | OrchestratorNode
@@ -87,13 +116,15 @@ export type FlowNode =
   | ServiceNode
   | IntegrationNode
   | FeatureNode
-  | AgentNode;
+  | AgentNode
+  | PipelineStageNode;
 
 export type DelegationEdge = Edge & { type: 'delegation' };
 export type WorkflowEdge = Edge & { type: 'workflow' };
 export type IntegrationEdge = Edge & { type: 'integration' };
+export type PipelineEdge = Edge & { type: 'pipeline' };
 
-export type FlowEdge = DelegationEdge | WorkflowEdge | IntegrationEdge;
+export type FlowEdge = DelegationEdge | WorkflowEdge | IntegrationEdge | PipelineEdge;
 
 // ============================================
 // Brand Constants
@@ -126,4 +157,5 @@ export const NODE_DIMENSIONS = {
   integration: { width: 160, height: 80 },
   feature: { width: 180, height: 80 },
   agent: { width: 160, height: 70 },
+  'pipeline-stage': { width: 200, height: 120 },
 } as const;


### PR DESCRIPTION
## Summary
- Extends `types.ts` with `PipelineStageId`, `PipelineStageStatus`, `PipelineStageNodeData` types and `PipelineEdge` edge type
- Adds `PIPELINE_STAGES` array with positions and `PIPELINE_EDGES` connecting stages left-to-right in `constants.ts`
- Updates `FlowNode`/`FlowEdge` unions to include pipeline types

## Test plan
- [ ] TypeScript compiles cleanly (`npm run build`)
- [ ] No lint errors
- [ ] Flow graph still renders existing nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pipeline stage visualization to flow graph with eight workflow stages: Backlog, In Progress, Review, Merge, Test, Verify, Done, and Blocked.
  * Enabled tracking and status monitoring of work items through pipeline stages.
  * Configured automatic stage positioning and workflow connections for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->