### PR TITLE
feat: create pipeline edge and activity panel

### DIFF
--- a/apps/ui/src/components/views/flow-graph/edges/index.ts
+++ b/apps/ui/src/components/views/flow-graph/edges/index.ts
@@ -6,13 +6,16 @@ import type { EdgeTypes } from '@xyflow/react';
 import { DelegationEdge } from './delegation-edge';
 import { WorkflowEdge } from './workflow-edge';
 import { IntegrationEdge } from './integration-edge';
+import { PipelineEdge } from './pipeline-edge';
 
 export { DelegationEdge } from './delegation-edge';
 export { WorkflowEdge } from './workflow-edge';
 export { IntegrationEdge } from './integration-edge';
+export { PipelineEdge } from './pipeline-edge';
 
 export const edgeTypes: EdgeTypes = {
   delegation: DelegationEdge,
   workflow: WorkflowEdge,
   integration: IntegrationEdge,
+  pipeline: PipelineEdge,
 };

--- a/apps/ui/src/components/views/flow-graph/edges/pipeline-edge.tsx
+++ b/apps/ui/src/components/views/flow-graph/edges/pipeline-edge.tsx
@@ -1,0 +1,120 @@
+/**
+ * Pipeline Edge — Horizontal smooth step path for pipeline stages
+ *
+ * Dashed when idle, animated particle flow when active (cyan palette).
+ * Active state determined by source completed + target active.
+ */
+
+import { memo, useId } from 'react';
+import { getSmoothStepPath, type EdgeProps } from '@xyflow/react';
+
+export interface PipelineEdgeData {
+  sourceCompleted?: boolean;
+  targetActive?: boolean;
+}
+
+function PipelineEdgeComponent({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  data,
+}: EdgeProps<PipelineEdgeData>) {
+  const uid = useId();
+  const gradientId = `pipeline-gradient-${uid}`;
+  const pathId = `pipeline-path-${id}`;
+
+  const [edgePath] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    borderRadius: 12,
+  });
+
+  // Edge is active when source is completed AND target is active
+  const isActive = data?.sourceCompleted && data?.targetActive;
+
+  return (
+    <g>
+      <defs>
+        <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stopColor="oklch(0.7 0.15 195)" stopOpacity={0.5} />
+          <stop offset="100%" stopColor="oklch(0.7 0.15 210)" stopOpacity={0.5} />
+        </linearGradient>
+      </defs>
+
+      {isActive ? (
+        <>
+          {/* Background glow when active */}
+          <path
+            d={edgePath}
+            fill="none"
+            stroke="oklch(0.7 0.15 200 / 0.08)"
+            strokeWidth={8}
+            strokeLinecap="round"
+          />
+
+          {/* Base path (solid, gradient) */}
+          <path
+            id={pathId}
+            d={edgePath}
+            fill="none"
+            stroke={`url(#${gradientId})`}
+            strokeWidth={1.5}
+            strokeLinecap="round"
+          />
+
+          {/* Animated particle 1 (cyan) */}
+          <circle r="3" fill="oklch(0.75 0.15 200)" opacity={0.8}>
+            <animateMotion dur="2.5s" repeatCount="indefinite">
+              <mpath href={`#${pathId}`} />
+            </animateMotion>
+            <animate
+              attributeName="opacity"
+              values="0;0.8;0.8;0"
+              keyTimes="0;0.1;0.8;1"
+              dur="2.5s"
+              repeatCount="indefinite"
+            />
+          </circle>
+
+          {/* Animated particle 2 (offset timing) */}
+          <circle r="2" fill="oklch(0.7 0.15 210)" opacity={0.6}>
+            <animateMotion dur="2.5s" repeatCount="indefinite" begin="1.25s">
+              <mpath href={`#${pathId}`} />
+            </animateMotion>
+            <animate
+              attributeName="opacity"
+              values="0;0.6;0.6;0"
+              keyTimes="0;0.1;0.8;1"
+              dur="2.5s"
+              repeatCount="indefinite"
+              begin="1.25s"
+            />
+          </circle>
+        </>
+      ) : (
+        <>
+          {/* Dashed line when idle */}
+          <path
+            d={edgePath}
+            fill="none"
+            stroke="oklch(0.4 0.05 240)"
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            strokeDasharray="5,5"
+            opacity={0.3}
+          />
+        </>
+      )}
+    </g>
+  );
+}
+
+export const PipelineEdge = memo(PipelineEdgeComponent);

--- a/apps/ui/src/components/views/flow-graph/panels/pipeline-panel.tsx
+++ b/apps/ui/src/components/views/flow-graph/panels/pipeline-panel.tsx
@@ -1,0 +1,103 @@
+/**
+ * PipelinePanel — Tracked work items list
+ *
+ * Shows work items with status dot, title, current stage, elapsed time.
+ * Glass-morphism styling matching existing panels.
+ */
+
+import { motion } from 'motion/react';
+import { cn } from '@/lib/utils';
+
+export interface WorkItem {
+  id: string;
+  title: string;
+  status: 'active' | 'completed' | 'error' | 'idle';
+  currentStage: string;
+  elapsedTime: string;
+}
+
+interface PipelinePanelProps {
+  workItems: WorkItem[];
+}
+
+function getStatusColor(status: WorkItem['status']): string {
+  switch (status) {
+    case 'active':
+      return 'bg-violet-500';
+    case 'completed':
+      return 'bg-emerald-500';
+    case 'error':
+      return 'bg-red-500';
+    case 'idle':
+    default:
+      return 'bg-zinc-500';
+  }
+}
+
+function getStatusTextColor(status: WorkItem['status']): string {
+  switch (status) {
+    case 'active':
+      return 'text-violet-400';
+    case 'completed':
+      return 'text-emerald-400';
+    case 'error':
+      return 'text-red-400';
+    case 'idle':
+    default:
+      return 'text-zinc-400';
+  }
+}
+
+export function PipelinePanel({ workItems }: PipelinePanelProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -10 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: -10 }}
+      className="rounded-xl border border-border/50 bg-card/90 backdrop-blur-md shadow-lg p-3 space-y-3 min-w-[280px]"
+    >
+      <h3 className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold px-1">
+        Pipeline Work Items
+      </h3>
+
+      <div className="space-y-2">
+        {workItems.length === 0 ? (
+          <div className="text-xs text-muted-foreground text-center py-4">No active work items</div>
+        ) : (
+          workItems.map((item) => (
+            <div
+              key={item.id}
+              className="rounded-lg border border-border/30 bg-card/50 p-2.5 space-y-1.5"
+            >
+              <div className="flex items-start gap-2">
+                {/* Status dot */}
+                <div className="flex-shrink-0 mt-0.5">
+                  <div
+                    className={cn(
+                      'w-2 h-2 rounded-full',
+                      getStatusColor(item.status),
+                      item.status === 'active' && 'animate-pulse'
+                    )}
+                  />
+                </div>
+
+                {/* Title */}
+                <div className="flex-1 min-w-0">
+                  <p className="text-xs font-medium truncate">{item.title}</p>
+                </div>
+              </div>
+
+              {/* Current stage and elapsed time */}
+              <div className="flex items-center justify-between text-[10px] pl-4">
+                <span className={cn('font-medium', getStatusTextColor(item.status))}>
+                  {item.currentStage}
+                </span>
+                <span className="text-muted-foreground tabular-nums">{item.elapsedTime}</span>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary
- Creates `pipeline-edge.tsx` with dashed idle and animated active states
- Creates `pipeline-panel.tsx` showing tracked work items with status dots, stage labels, and elapsed time
- Glass-morphism styling matching existing flow graph panels
- Registers pipeline edge type in `edges/index.ts`

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] Edge renders dashed when idle, animated when active
- [ ] Panel shows work items with correct status
- [ ] No lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animated pipeline edge for flow graphs with distinct active and idle visuals, gradient glow and particle motion.
  * Pipeline panel to list work items with status indicators, current stage, and elapsed time; shows a placeholder when empty and uses smooth entry/exit animations.
  * Pipeline visuals and panel integrated into the flow-graph UI for improved pipeline visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->