### PR TITLE
fix: add @source directive so Tailwind CSS 4 scans libs/ui components

### DIFF
--- a/apps/ui/src/styles/global.css
+++ b/apps/ui/src/styles/global.css
@@ -1,6 +1,9 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
+/* Scan shared UI component library for Tailwind class usage */
+@source "../../../../libs/ui/src";
+
 /* Curated themes */
 @custom-variant studio-dark (&:is(.studio-dark *));
 @custom-variant studio-light (&:is(.studio-light *));


### PR DESCRIPTION
## Summary
- Dialogs (and other `@automaker/ui-components` elements) were invisible because Tailwind CSS 4's automatic content detection only scanned `apps/ui/src/`, missing class names defined in `libs/ui/src/`
- Added `@source "../../../../libs/ui/src"` to `global.css` so all utility classes in the shared UI component library are included in the generated CSS
- Fixes: dialog centering (`left-[50%]`, `translate-x/y-[-50%]`), shadows (`shadow-2xl`, `shadow-[...]`), max-height constraints, and any other arbitrary-value classes only used in `libs/ui/`

## Root Cause
Tailwind CSS 4 detects content automatically from the CSS file's project root (`apps/ui/`). Since `libs/ui/dist/` is in `.gitignore`, the built output was skipped. The source at `libs/ui/src/` was outside the scanning scope entirely. Classes like `bg-card` worked because they're also used in `apps/ui/src/` files, but unique classes in `libs/ui/` (dialog positioning, shadows) were never generated.

## Test plan
- [x] Verified dialog renders centered with proper shadow via agent-browser screenshot
- [ ] Check other dialogs (settings, feature edit) render correctly
- [ ] Verify card shadows, input shadows, select positioning all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced styling configuration to improve component library integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->