### PR TITLE
feat: rename @automaker/ui-components to @protolabs/ui

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -46,7 +46,7 @@
     "@automaker/dependency-resolver": "1.0.0",
     "@automaker/spec-parser": "1.0.0",
     "@automaker/types": "1.0.0",
-    "@automaker/ui-components": "*",
+    "@protolabs/ui": "*",
     "@codemirror/lang-xml": "6.1.0",
     "@codemirror/language": "^6.12.1",
     "@codemirror/legacy-modes": "^6.5.2",

--- a/apps/ui/src/components/ui/accordion.tsx
+++ b/apps/ui/src/components/ui/accordion.tsx
@@ -1,6 +1,1 @@
-export {
-  Accordion,
-  AccordionItem,
-  AccordionTrigger,
-  AccordionContent,
-} from '@automaker/ui-components/atoms';
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/badge.tsx
+++ b/apps/ui/src/components/ui/badge.tsx
@@ -1,1 +1,1 @@
-export { Badge, badgeVariants } from '@automaker/ui-components/atoms';
+export { Badge, badgeVariants } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/breadcrumb.tsx
+++ b/apps/ui/src/components/ui/breadcrumb.tsx
@@ -6,4 +6,4 @@ export {
   BreadcrumbPage,
   BreadcrumbSeparator,
   BreadcrumbEllipsis,
-} from '@automaker/ui-components/atoms';
+} from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/button.tsx
+++ b/apps/ui/src/components/ui/button.tsx
@@ -1,1 +1,1 @@
-export { Button, buttonVariants } from '@automaker/ui-components/atoms';
+export { Button, buttonVariants } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/card.tsx
+++ b/apps/ui/src/components/ui/card.tsx
@@ -5,4 +5,4 @@ export {
   CardTitle,
   CardDescription,
   CardContent,
-} from '@automaker/ui-components/atoms';
+} from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/checkbox.tsx
+++ b/apps/ui/src/components/ui/checkbox.tsx
@@ -1,1 +1,1 @@
-export { Checkbox } from '@automaker/ui-components/atoms';
+export { Checkbox } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/collapsible.tsx
+++ b/apps/ui/src/components/ui/collapsible.tsx
@@ -1,5 +1,1 @@
-export {
-  Collapsible,
-  CollapsibleTrigger,
-  CollapsibleContent,
-} from '@automaker/ui-components/atoms';
+export { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/command.tsx
+++ b/apps/ui/src/components/ui/command.tsx
@@ -8,4 +8,4 @@ export {
   CommandList,
   CommandSeparator,
   CommandShortcut,
-} from '@automaker/ui-components/atoms';
+} from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/dialog.tsx
+++ b/apps/ui/src/components/ui/dialog.tsx
@@ -9,4 +9,4 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-} from '@automaker/ui-components/atoms';
+} from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/dropdown-menu.tsx
+++ b/apps/ui/src/components/ui/dropdown-menu.tsx
@@ -14,4 +14,4 @@ export {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   DropdownMenuCheckboxItem,
-} from '@automaker/ui-components/atoms';
+} from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/input.tsx
+++ b/apps/ui/src/components/ui/input.tsx
@@ -1,1 +1,1 @@
-export { Input } from '@automaker/ui-components/atoms';
+export { Input } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/kbd.tsx
+++ b/apps/ui/src/components/ui/kbd.tsx
@@ -1,1 +1,1 @@
-export { Kbd, KbdGroup } from '@automaker/ui-components/atoms';
+export { Kbd, KbdGroup } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/label.tsx
+++ b/apps/ui/src/components/ui/label.tsx
@@ -1,1 +1,1 @@
-export { Label } from '@automaker/ui-components/atoms';
+export { Label } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/popover.tsx
+++ b/apps/ui/src/components/ui/popover.tsx
@@ -1,1 +1,1 @@
-export { Popover, PopoverContent, PopoverTrigger } from '@automaker/ui-components/atoms';
+export { Popover, PopoverContent, PopoverTrigger } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/radio-group.tsx
+++ b/apps/ui/src/components/ui/radio-group.tsx
@@ -1,1 +1,1 @@
-export { RadioGroup, RadioGroupItem } from '@automaker/ui-components/atoms';
+export { RadioGroup, RadioGroupItem } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/scroll-area.tsx
+++ b/apps/ui/src/components/ui/scroll-area.tsx
@@ -1,1 +1,1 @@
-export { ScrollArea, ScrollBar } from '@automaker/ui-components/atoms';
+export { ScrollArea, ScrollBar } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/select.tsx
+++ b/apps/ui/src/components/ui/select.tsx
@@ -7,4 +7,4 @@ export {
   SelectSeparator,
   SelectTrigger,
   SelectValue,
-} from '@automaker/ui-components/atoms';
+} from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/sheet.tsx
+++ b/apps/ui/src/components/ui/sheet.tsx
@@ -7,4 +7,4 @@ export {
   SheetTitle,
   SheetTrigger,
   SheetClose,
-} from '@automaker/ui-components/atoms';
+} from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/skeleton.tsx
+++ b/apps/ui/src/components/ui/skeleton.tsx
@@ -1,1 +1,1 @@
-export { SkeletonPulse } from '@automaker/ui-components/atoms';
+export { SkeletonPulse } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/slider.tsx
+++ b/apps/ui/src/components/ui/slider.tsx
@@ -1,1 +1,1 @@
-export { Slider } from '@automaker/ui-components/atoms';
+export { Slider } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/spinner.tsx
+++ b/apps/ui/src/components/ui/spinner.tsx
@@ -1,1 +1,1 @@
-export { Spinner } from '@automaker/ui-components/atoms';
+export { Spinner } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/switch.tsx
+++ b/apps/ui/src/components/ui/switch.tsx
@@ -1,1 +1,1 @@
-export { Switch } from '@automaker/ui-components/atoms';
+export { Switch } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/tabs.tsx
+++ b/apps/ui/src/components/ui/tabs.tsx
@@ -1,1 +1,1 @@
-export { Tabs, TabsList, TabsTrigger, TabsContent } from '@automaker/ui-components/atoms';
+export { Tabs, TabsList, TabsTrigger, TabsContent } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/textarea.tsx
+++ b/apps/ui/src/components/ui/textarea.tsx
@@ -1,1 +1,1 @@
-export { Textarea } from '@automaker/ui-components/atoms';
+export { Textarea } from '@protolabs/ui/atoms';

--- a/apps/ui/src/components/ui/tooltip.tsx
+++ b/apps/ui/src/components/ui/tooltip.tsx
@@ -1,6 +1,1 @@
-export {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@automaker/ui-components/atoms';
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@protolabs/ui/atoms';

--- a/docs/dev/frontend-philosophy.md
+++ b/docs/dev/frontend-philosophy.md
@@ -311,7 +311,7 @@ The preview decorator applies theme classes to the document root. All theme CSS 
 
 ## Extracted UI package
 
-UI primitives are extracted to `@automaker/ui-components` at `libs/ui/`. The package uses an atoms/molecules/organisms structure with 26+ atom components (button, card, dialog, badge, etc.).
+UI primitives are extracted to `@protolabs/ui` at `libs/ui/`. The package uses an atoms/molecules/organisms structure with 26+ atom components (button, card, dialog, badge, etc.).
 
 ### Package structure
 
@@ -326,11 +326,11 @@ libs/ui/
       theme/           # Theme generator and utilities
       utils.ts         # cn() and helpers
     index.ts           # Barrel export
-  package.json         # @automaker/ui-components
+  package.json         # @protolabs/ui
   tsconfig.json
 ```
 
-`apps/ui/` depends on `@automaker/ui-components` via workspace linking. This enables sharing UI components across future apps (docs site, template repos, setupLab offerings).
+`apps/ui/` depends on `@protolabs/ui` via workspace linking. This enables sharing UI components across future apps (docs site, template repos, setupLab offerings).
 
 ## React 19 patterns
 
@@ -421,7 +421,7 @@ Current gaps between philosophy and implementation. These are tracked as future 
 | Monolithic views           | `board-view.tsx` (1,908 lines), `terminal-view.tsx` (1,809 lines)              | Decompose into sub-components like `settings-view/` already has        | High     |
 | Storybook coverage         | Config + 14 stories (5 ui primitives + 9 dashboard components)                 | Stories for all UI primitives, interaction tests, Chromatic CI         | High     |
 | Domain components in `ui/` | `git-diff-panel`, `dependency-selector`, `log-viewer` etc. in `components/ui/` | Move to `components/shared/` or view-specific directories              | Medium   |
-| UI package gaps            | 26 atoms extracted to `@automaker/ui-components`; molecules/organisms pending  | Full extraction of all primitives to `libs/ui/`                        | Medium   |
+| UI package gaps            | 26 atoms extracted to `@protolabs/ui`; molecules/organisms pending             | Full extraction of all primitives to `libs/ui/`                        | Medium   |
 | Static theme files         | 6 hand-written CSS files                                                       | Generate from TypeScript config                                        | Medium   |
 | No typography tokens       | Font sizes, line heights are ad-hoc Tailwind classes                           | Formalize as semantic tokens                                           | Low      |
 | No spacing tokens          | Spacing uses Tailwind defaults only                                            | Define semantic spacing scale if needed                                | Low      |

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@automaker/ui-components",
+  "name": "@protolabs/ui",
   "version": "1.0.0",
   "type": "module",
   "description": "Shared UI components for AutoMaker",

--- a/package-lock.json
+++ b/package-lock.json
@@ -683,7 +683,6 @@
         "@automaker/dependency-resolver": "1.0.0",
         "@automaker/spec-parser": "1.0.0",
         "@automaker/types": "1.0.0",
-        "@automaker/ui-components": "*",
         "@codemirror/lang-xml": "6.1.0",
         "@codemirror/language": "^6.12.1",
         "@codemirror/legacy-modes": "^6.5.2",
@@ -708,6 +707,7 @@
         "@fontsource/source-sans-3": "^5.2.9",
         "@fontsource/work-sans": "^5.2.8",
         "@lezer/highlight": "1.2.3",
+        "@protolabs/ui": "*",
         "@radix-ui/react-checkbox": "1.3.3",
         "@radix-ui/react-collapsible": "1.1.12",
         "@radix-ui/react-dialog": "1.1.15",
@@ -1711,7 +1711,7 @@
       }
     },
     "libs/ui": {
-      "name": "@automaker/ui-components",
+      "name": "@protolabs/ui",
       "version": "1.0.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
@@ -2289,10 +2289,6 @@
     },
     "node_modules/@automaker/ui": {
       "resolved": "apps/ui",
-      "link": true
-    },
-    "node_modules/@automaker/ui-components": {
-      "resolved": "libs/ui",
       "link": true
     },
     "node_modules/@automaker/utils": {
@@ -7502,6 +7498,10 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@protolabs/ui": {
+      "resolved": "libs/ui",
+      "link": true
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev:docker:rebuild": "docker compose build --no-cache && docker compose up",
     "dev:full": "npm run build:packages && concurrently \"npm run _dev:server\" \"npm run _dev:web\"",
     "build": "npm run build:packages && npm run build --workspace=apps/ui",
-    "build:libs": "npm run build -w @automaker/types && npm run build -w @automaker/platform && npm run build -w @automaker/utils -w @automaker/spec-parser && npm run build -w @automaker/prompts -w @automaker/model-resolver -w @automaker/dependency-resolver -w @automaker/tools && npm run build -w @automaker/llm-providers -w @automaker/observability -w @automaker/flows && npm run build -w @automaker/git-utils && npm run build -w @automaker/ui-components",
+    "build:libs": "npm run build -w @automaker/types && npm run build -w @automaker/platform && npm run build -w @automaker/utils -w @automaker/spec-parser && npm run build -w @automaker/prompts -w @automaker/model-resolver -w @automaker/dependency-resolver -w @automaker/tools && npm run build -w @automaker/llm-providers -w @automaker/observability -w @automaker/flows && npm run build -w @automaker/git-utils && npm run build -w @protolabs/ui",
     "build:packages": "npm run build:libs && tsc --project packages/mcp-server/tsconfig.json",
     "build:server": "npm run build:packages && npm run build --workspace=apps/server",
     "build:electron": "npm run build:packages && npm run build:electron --workspace=apps/ui",


### PR DESCRIPTION
## Summary
- Renames the shared UI component package from `@automaker/ui-components` to `@protolabs/ui` to align with the public protoLabs brand
- Updates all 30 files with import references across apps/ui components, root package.json, and docs
- Pure rename — no logic changes, no new dependencies

## Test plan
- [ ] `npm install` resolves correctly with new package name
- [ ] `npm run build:packages` succeeds
- [ ] `npm run build` (UI) succeeds
- [ ] All component imports resolve at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized the internal structure of the UI component library, including dependency consolidation and package naming updates. This restructuring improves project maintainability while preserving all existing functionality. All user-facing UI components continue to work as before with no behavioral or visual changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->