### PR TITLE
feat: expose agent model in running-agents API response

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -2728,11 +2728,17 @@ Complete the pipeline step instructions above. Review the previous work and appl
       const workDir = worktreePath ? path.resolve(worktreePath) : path.resolve(projectPath);
       validateWorkingDirectory(workDir);
 
-      // Update running feature with worktree info
+      // Get model and provider for this feature
+      const model = getModelForFeature(feature);
+      const provider = ProviderFactory.getProviderNameForModel(model);
+
+      // Update running feature with worktree info and model
       const runningFeature = this.runningFeatures.get(featureId);
       if (runningFeature) {
         runningFeature.worktreePath = worktreePath;
         runningFeature.branchName = branchName ?? null;
+        runningFeature.model = model;
+        runningFeature.provider = provider;
       }
 
       // Emit resume event
@@ -2745,6 +2751,8 @@ Complete the pipeline step instructions above. Review the previous work and appl
           title: feature.title || 'Resuming Pipeline',
           description: feature.description,
         },
+        model,
+        provider,
       });
 
       this.emitAutoModeEvent('auto_mode_progress', {

--- a/apps/server/tests/unit/routes/running-agents.test.ts
+++ b/apps/server/tests/unit/routes/running-agents.test.ts
@@ -191,5 +191,50 @@ describe('running-agents routes', () => {
       expect(response.runningAgents[0].projectPath).toBe('/workspace/project-alpha');
       expect(response.runningAgents[1].projectPath).toBe('/workspace/project-beta');
     });
+
+    it('should include model and provider information in response', async () => {
+      // Arrange
+      const runningAgents = [
+        {
+          featureId: 'feature-sonnet',
+          projectPath: '/home/user/project',
+          projectName: 'project',
+          isAutoMode: true,
+          model: 'claude-sonnet-4-5-20250929',
+          provider: 'claude',
+          title: 'Sonnet Feature',
+          description: 'Running with sonnet',
+        },
+        {
+          featureId: 'feature-haiku',
+          projectPath: '/home/user/project',
+          projectName: 'project',
+          isAutoMode: true,
+          model: 'claude-haiku-4-5-20251001',
+          provider: 'claude',
+          title: 'Haiku Feature',
+          description: 'Running with haiku',
+        },
+      ];
+
+      vi.mocked(mockAutoModeService.getRunningAgents!).mockResolvedValue(runningAgents);
+
+      // Act
+      const handler = createIndexHandler(mockAutoModeService as AutoModeService);
+      await handler(req, res);
+
+      // Assert
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        runningAgents,
+        totalCount: 2,
+      });
+
+      const response = vi.mocked(res.json).mock.calls[0][0];
+      expect(response.runningAgents[0].model).toBe('claude-sonnet-4-5-20250929');
+      expect(response.runningAgents[0].provider).toBe('claude');
+      expect(response.runningAgents[1].model).toBe('claude-haiku-4-5-20251001');
+      expect(response.runningAgents[1].provider).toBe('claude');
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Populates `model` and `provider` fields in the pipeline resume path of `AutoModeService` so `/api/running-agents` returns which model each agent is using
- Agent nodes in the flow graph can now display model badges (Haiku/Sonnet/Opus) with no UI changes needed

## Changes

- **`apps/server/src/services/auto-mode-service.ts`** — Added `getModelForFeature()` + `ProviderFactory.getProviderNameForModel()` calls in the pipeline resume path, storing results on `runningFeature`
- **`apps/server/tests/unit/routes/running-agents.test.ts`** — Added test verifying model and provider fields in API response

## Test plan

- [x] Unit tests pass (8 running-agents tests including new model/provider test)
- [x] Server builds cleanly
- [ ] Verify flow graph agent nodes show model badge when agents are running

Closes PRO-226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model and provider information are now tracked and exposed for each feature execution, allowing users to see which AI model and provider was used when running features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->