### PR TITLE
feat: add verification gates to agent implementation instructions

### DIFF
--- a/libs/prompts/src/defaults.ts
+++ b/libs/prompts/src/defaults.ts
@@ -929,6 +929,32 @@ Implement this feature by:
 **Skill Creation:**
 If you discover a reusable pattern during implementation, consider creating a skill file at \`.automaker/skills/{name}.md\`. Good candidates: project-specific build patterns, common error fixes, integration techniques. See the skill format in the system prompt.
 
+## Verification Gates (MANDATORY)
+
+Before writing your summary, you MUST complete ALL of these:
+
+1. Run \`npm run build:server\` (or the appropriate build command) and verify exit code 0
+2. Run tests if any exist for the modified files
+3. Run \`git diff --stat\` to confirm only intended files were changed
+4. If you claim "tests pass" — paste the actual test output
+5. If you claim "build succeeds" — paste the actual build output
+
+DO NOT write your summary until all gates pass. If a gate fails, fix the issue first.
+
+## When Stuck
+
+If you have attempted 3+ fixes for the same error:
+- STOP attempting more fixes
+- Document what you tried and what happened each time
+- Report this in your summary as a blocker
+- Do NOT continue making speculative changes
+
+## Red Flags — STOP if you catch yourself thinking:
+- "This should work" (without running it)
+- "I'm confident this is correct" (confidence is not evidence)
+- "The build will pass" (run it and prove it)
+- "I'll skip verification since the change is small" (small changes need verification too)
+
 When done, wrap your final summary in <summary> tags like this:
 
 <summary>


### PR DESCRIPTION
## Summary
- Adds verification gates, 3-strike rule, and red flags to `DEFAULT_IMPLEMENTATION_INSTRUCTIONS` in `libs/prompts/src/defaults.ts`
- Agents must now run actual build/test commands and paste output before claiming completion
- Prevents the PR #690 bug class where agents claim "build passes" without evidence
- Part of Superpowers Integration (PRO-233)

## Test plan
- [x] `npm run build:packages` passes
- [ ] Verify new instructions appear in agent prompts on next agent run
- [ ] Existing instruction content preserved (26 lines added, 0 removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced implementation guidance to include mandatory pre-commit verification gates requiring build, test execution, and diff verification before proceeding with changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->