### PR TITLE
feat: configure npm publishing for @protolabs/ui

### DIFF
--- a/libs/ui/.npmignore
+++ b/libs/ui/.npmignore
@@ -1,0 +1,9 @@
+# Exclude everything by default
+*
+
+# Include only what we need
+!dist/**
+!src/themes/**
+!package.json
+!LICENSE
+!README.md

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -37,14 +37,25 @@
     "build": "tsup",
     "watch": "tsup --watch",
     "build:check": "tsc --noEmit",
+    "prepublishOnly": "npm run build",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
   "keywords": [
     "automaker",
     "ui",
-    "components"
+    "components",
+    "react",
+    "tailwind",
+    "design-system",
+    "radix-ui",
+    "atomic-design"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/proto-labs-ai/automaker.git",
+    "directory": "libs/ui"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Add `.npmignore` with allowlist pattern ensuring only dist, themes, and metadata ship to npm
- Add `prepublishOnly` script to auto-build before publish
- Enhance package.json metadata (keywords, repository URL)

## Test plan
- [ ] Verify `npm pack --dry-run` shows only intended files
- [ ] Verify `prepublishOnly` triggers build before publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm package configuration with automated build step on publishing.
  * Expanded package keywords (react, tailwind, design-system, radix-ui, atomic-design) for improved discoverability.
  * Added repository metadata information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->