### PR TITLE
feat: implement AVA signal classification for ops/gtm routing

### DIFF
--- a/apps/server/src/services/integration-service.ts
+++ b/apps/server/src/services/integration-service.ts
@@ -915,11 +915,15 @@ export class IntegrationService {
     title: string;
     description?: string;
     state?: { name: string };
+    labels?: string[];
+    projectId?: string;
     createdAt: string;
   }): Promise<void> {
     // All new Linear issues are treated as signals
     logger.info(`Signal detected from Linear issue: ${payload.title}`, {
       issueId: payload.issueId,
+      labels: payload.labels,
+      projectId: payload.projectId,
     });
 
     if (!this.emitter) return;
@@ -934,6 +938,8 @@ export class IntegrationService {
       channelContext: {
         issueId: payload.issueId,
         state: payload.state?.name,
+        labels: payload.labels,
+        projectId: payload.projectId,
       },
       timestamp: payload.createdAt,
     });

--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -25,9 +25,18 @@ interface SignalPayload {
     channelName?: string;
     issueId?: string;
     state?: string;
+    labels?: string[];
+    projectId?: string;
     [key: string]: unknown;
   };
   timestamp: string;
+}
+
+type SignalCategory = 'ops' | 'gtm';
+
+interface ClassificationResult {
+  category: SignalCategory;
+  reason: string;
 }
 
 export class SignalIntakeService {
@@ -48,6 +57,81 @@ export class SignalIntakeService {
         void this.handleSignal(payload as SignalPayload);
       }
     });
+  }
+
+  /**
+   * Classify signal as Ops (engineering) or GTM (marketing)
+   */
+  private classifySignal(signal: SignalPayload): ClassificationResult {
+    const source = signal.source;
+    const channelContext = signal.channelContext || {};
+
+    // GitHub events → always Ops
+    if (source === 'github') {
+      return { category: 'ops', reason: 'GitHub events are engineering work' };
+    }
+
+    // MCP create_feature → always Ops (fast path)
+    if (source === 'mcp:create_feature') {
+      return { category: 'ops', reason: 'MCP create_feature is engineering work' };
+    }
+
+    // MCP process_idea → Ops with PM pipeline
+    if (source === 'mcp:process_idea') {
+      return { category: 'ops', reason: 'MCP process_idea routes through PM pipeline' };
+    }
+
+    // Linear signals classified by label/project
+    if (source === 'linear') {
+      const labels = (channelContext.labels as string[]) || [];
+      const projectId = channelContext.projectId as string | undefined;
+
+      // Check for GTM labels
+      const gtmLabels = ['marketing', 'content', 'social', 'gtm', 'campaign', 'seo'];
+      const hasGtmLabel = labels.some((label) =>
+        gtmLabels.some((gtmLabel) => label.toLowerCase().includes(gtmLabel))
+      );
+
+      if (hasGtmLabel) {
+        return { category: 'gtm', reason: `Linear issue has GTM label: ${labels.join(', ')}` };
+      }
+
+      // Check for Ops labels
+      const opsLabels = ['bug', 'feature', 'enhancement', 'engineering', 'ops', 'infra'];
+      const hasOpsLabel = labels.some((label) =>
+        opsLabels.some((opsLabel) => label.toLowerCase().includes(opsLabel))
+      );
+
+      if (hasOpsLabel) {
+        return { category: 'ops', reason: `Linear issue has Ops label: ${labels.join(', ')}` };
+      }
+
+      // Default to Ops for Linear (engineering is primary use case)
+      return { category: 'ops', reason: 'Linear issue defaults to Ops (no GTM labels found)' };
+    }
+
+    // Discord messages classified by channel
+    if (source === 'discord') {
+      const channelName = (channelContext.channelName as string | undefined)?.toLowerCase() || '';
+
+      // GTM channels
+      const gtmChannels = ['marketing', 'social', 'content', 'gtm', 'campaign'];
+      if (gtmChannels.some((ch) => channelName.includes(ch))) {
+        return { category: 'gtm', reason: `Discord channel is GTM: ${channelName}` };
+      }
+
+      // Ops channels
+      const opsChannels = ['dev', 'infra', 'engineering', 'ops', 'tech'];
+      if (opsChannels.some((ch) => channelName.includes(ch))) {
+        return { category: 'ops', reason: `Discord channel is Ops: ${channelName}` };
+      }
+
+      // Default to Ops for Discord (engineering is primary use case)
+      return { category: 'ops', reason: 'Discord message defaults to Ops (no GTM channel found)' };
+    }
+
+    // Default: all other signals → Ops
+    return { category: 'ops', reason: 'Default classification: Ops' };
   }
 
   private async handleSignal(signal: SignalPayload): Promise<void> {
@@ -71,8 +155,31 @@ export class SignalIntakeService {
       const title = (lines[0] || 'Untitled signal').substring(0, 100);
       const description = signal.content;
 
-      logger.info(`Processing signal from ${signal.source}: "${title}"`);
+      // Classify signal as Ops or GTM
+      const classification = this.classifySignal(signal);
 
+      logger.info(
+        `Processing signal from ${signal.source}: "${title}" (${classification.category} - ${classification.reason})`
+      );
+
+      // GTM signals: log and park (manual handling for now)
+      if (classification.category === 'gtm') {
+        logger.info(
+          `GTM signal parked for manual handling: "${title}" (source: ${signal.source})`
+        );
+        this.events.emit('signal:routed', {
+          projectPath: this.defaultProjectPath,
+          title,
+          description,
+          category: 'gtm',
+          reason: classification.reason,
+          source: signal.source,
+          timestamp: signal.timestamp,
+        });
+        return;
+      }
+
+      // Ops signals: route to Lead Engineer state machine
       // Create feature with idea state
       const feature = await this.featureLoader.create(this.defaultProjectPath, {
         title: `[${signal.source}] ${title}`,
@@ -93,8 +200,20 @@ export class SignalIntakeService {
         injectedAt: new Date().toISOString(),
       });
 
+      // Emit routing event for observability
+      this.events.emit('signal:routed', {
+        projectPath: this.defaultProjectPath,
+        featureId: feature.id,
+        title,
+        description,
+        category: 'ops',
+        reason: classification.reason,
+        source: signal.source,
+        timestamp: signal.timestamp,
+      });
+
       logger.info(
-        `Signal routed to PM Agent: "${title}" → feature ${feature.id} (source: ${signal.source})`
+        `Ops signal routed to Lead Engineer: "${title}" → feature ${feature.id} (source: ${signal.source})`
       );
     } catch (error) {
       logger.error(`Failed to process signal from ${signal.source}:`, error);


### PR DESCRIPTION
## Summary
- Added `classifySignal()` pure function to `SignalIntakeService` that routes incoming signals as Ops or GTM
- Linear signals classified by labels (marketing/content/social → GTM, bug/feature/engineering → Ops)
- GitHub events always route to Ops
- Discord messages classified by channel name (#dev/#infra → Ops, #marketing/#social → GTM)
- MCP tools (`create_feature`, `process_idea`) always route to Ops
- GTM signals logged and parked (manual handling for now)
- Added `signal:routed` event emission for observability
- Enhanced `IntegrationService` to pass labels and projectId from Linear events

## Test plan
- [x] Server builds cleanly
- [x] Agent ran verification tests (deleted after passing)
- [ ] CI passes on epic merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)