### PR TITLE
feat: integrate Lead Engineer state machine with auto-mode

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -555,6 +555,9 @@ const leadEngineerService = new LeadEngineerService(
 );
 await leadEngineerService.initialize();
 
+// Wire Lead Engineer service into auto-mode for delegated feature execution
+autoModeService.setLeadEngineerService(leadEngineerService);
+
 const projmAgent = new ProjMAuthorityAgent(events, authorityService, featureLoader, projectService);
 const emAgent = new EMAuthorityAgent(
   events,

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -443,6 +443,8 @@ export class AutoModeService {
   private authorityService: AuthorityService | null = null;
   // Data integrity watchdog service for monitoring feature count (optional)
   private integrityWatchdogService: DataIntegrityWatchdogService | null = null;
+  // Lead Engineer service for delegated feature execution (optional)
+  private leadEngineerService: any | null = null; // Type is any to avoid circular dependency
   // Rate-limiting for auto_mode_progress events (per feature)
   private lastProgressEventTime = new Map<string, number>();
   private readonly PROGRESS_EVENT_MIN_INTERVAL_MS = 100; // Max 1 event per 100ms per feature
@@ -474,6 +476,14 @@ export class AutoModeService {
    */
   setIntegrityWatchdogService(service: DataIntegrityWatchdogService): void {
     this.integrityWatchdogService = service;
+  }
+
+  /**
+   * Wire up the Lead Engineer service for delegated feature execution.
+   * When set, auto-mode will delegate feature processing to the state machine.
+   */
+  setLeadEngineerService(service: any): void {
+    this.leadEngineerService = service;
   }
 
   /**
@@ -1072,13 +1082,20 @@ export class AutoModeService {
           }, 30000);
 
           // Start feature execution in background
-          this.executeFeature(projectPath, nextFeature.id, projectState.config.useWorktrees, true)
+          // Delegate to Lead Engineer if available, otherwise use legacy executeFeature
+          const executionPromise = this.leadEngineerService
+            ? this.leadEngineerService.process(projectPath, nextFeature.id, {
+                model: getModelForFeature(nextFeature),
+              } as any) // Cast to any since state machine will build full ExecuteOptions internally
+            : this.executeFeature(projectPath, nextFeature.id, projectState.config.useWorktrees, true);
+
+          executionPromise
             .then(() => {
-              // Remove from starting set once executeFeature completes (successfully or not)
+              // Remove from starting set once execution completes (successfully or not)
               clearTimeout(startingTimeout);
               projectState.startingFeatures.delete(nextFeature.id);
             })
-            .catch((error) => {
+            .catch((error: unknown) => {
               logger.error(`Feature ${nextFeature.id} error:`, error);
               // Remove from starting set on error
               clearTimeout(startingTimeout);

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -778,6 +778,60 @@ export class LeadEngineerService {
     return Array.from(this.sessions.keys());
   }
 
+  /**
+   * Process a feature through the state machine.
+   * This method is called by AutoModeService instead of the monolithic executeFeature().
+   * Delegates to the FeatureStateMachine which handles all state transitions,
+   * PR maintenance, and board consistency.
+   *
+   * @param projectPath - The project path
+   * @param featureId - The feature ID to process
+   * @param options - Execution options (model, useWorktrees, etc.)
+   * @returns Promise that resolves when processing completes
+   */
+  async process(
+    projectPath: string,
+    featureId: string,
+    options: ExecuteOptions
+  ): Promise<void> {
+    logger.info(`[LeadEngineer] Processing feature ${featureId}`, {
+      projectPath,
+      model: options.model,
+    });
+
+    try {
+      // Load the feature
+      const feature = await this.featureLoader.get(projectPath, featureId);
+      if (!feature) {
+        throw new Error(`Feature ${featureId} not found`);
+      }
+
+      // Create state machine and process the feature
+      const stateMachine = new FeatureStateMachine();
+      const result = await stateMachine.processFeature(feature, projectPath, options);
+
+      logger.info(`[LeadEngineer] Feature processing completed`, {
+        featureId,
+        finalState: result.finalState,
+        escalated: result.finalState === 'ESCALATE',
+      });
+
+      // Emit completion event for the world state to react to
+      this.events.emit('lead-engineer:feature-processed' as EventType, {
+        projectPath,
+        featureId,
+        finalState: result.finalState,
+        success: result.finalState !== 'ESCALATE',
+      });
+    } catch (error: unknown) {
+      logger.error(`[LeadEngineer] Feature processing failed`, {
+        featureId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
   // ────────────────────────── Private ──────────────────────────
 
   /**

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -290,6 +290,7 @@ export type EventType =
   // Lead Engineer events (production-phase nerve center)
   | 'lead-engineer:started'
   | 'lead-engineer:stopped'
+  | 'lead-engineer:feature-processed'
   | 'lead-engineer:action-executed'
   | 'lead-engineer:rule-evaluated'
   | 'lead-engineer:project-completing'
@@ -519,6 +520,12 @@ export interface EventPayloadMap {
     ruleName: string;
     eventType: string;
     actionCount: number;
+  };
+  'lead-engineer:feature-processed': {
+    projectPath: string;
+    featureId: string;
+    finalState: string;
+    success: boolean;
   };
   'lead-engineer:project-completing': { projectPath: string; projectSlug: string };
   'lead-engineer:project-completed': { projectPath: string; projectSlug: string };


### PR DESCRIPTION
## Summary
- Added `LeadEngineerService.process()` method wrapping FeatureStateMachine
- AutoModeService conditionally delegates to Lead Engineer when available, falls back to legacy `executeFeature()` otherwise
- Added `setLeadEngineerService()` DI method + wiring in `index.ts`
- Added `lead-engineer:feature-processed` event type + payload for observability
- 4 files changed, +84/-3 lines

## Architecture
- **AutoModeService**: Orchestration, resource management, scheduling (unchanged)
- **LeadEngineerService**: Feature lifecycle, state transitions (new delegation target)
- Backward compatible — projects without Lead Engineer use legacy path

## Known limitations
- Uses `as any` cast for ExecuteOptions (state machine stubs don't use options yet)
- Uses `as EventType` cast (types package build order issue)

## Test plan
- [x] Server builds cleanly
- [x] Backward compatible — legacy path preserved
- [ ] CI passes on epic merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)