### PR TITLE
docs: replace Crew Loop with Lead Engineer in CLAUDE.md

### DIFF
--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,9 +5,9 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 53
-  referenced: 30
-  successfulFeatures: 30
+  loaded: 56
+  referenced: 32
+  successfulFeatures: 32
 ---
 # api
 
@@ -380,3 +380,15 @@ usageStats:
 - **Problem solved:** Test file used selectors like `[data-testid="nav-ideas"], a[href*="/ideas"]` to find elements
 - **Why this works:** Provides flexibility when UI implementation details change. If data-testid is removed, the href-based selector still works. If styling changes the tag type, the selector still finds it. Makes tests resilient to cosmetic refactors
 - **Trade-offs:** Query is more complex to read but more maintainable long-term. Slightly slower selector resolution but negligible in tests
+
+### Enhanced IntegrationService to pass Linear `labels` and `projectId` in signal context rather than inferring from downstream (2026-02-18)
+- **Context:** Linear issue classification depends on labels and project context, but integration layer wasn't providing this metadata
+- **Why:** Early data enrichment (at source) makes classification deterministic and debuggable. Labels and projectId are available at integration time with no additional queries. Passing them enables label-based routing without downstream Linear API calls.
+- **Rejected:** Could have deferred label lookup to classification time by querying Linear API again, but adds latency and complexity
+- **Trade-offs:** IntegrationService now has slightly larger payload, but classification logic stays simple and fast. No N+1 query problem.
+- **Breaking if changed:** If removed, classification would need to fetch Linear context on-demand, requiring API credentials in SignalIntakeService and creating latency/failure points
+
+#### [Gotcha] EventType union in TypeScript wouldn't recognize new 'lead-engineer:feature-processed' event even after types were rebuilt, required explicit 'as EventType' cast in emit call (2026-02-18)
+- **Situation:** Added new event type to types package and rebuilt, but lead-engineer-service.ts still showed type error on emit() call
+- **Root cause:** TypeScript type narrowing on EventEmitter.emit() is strict - the literal string type 'lead-engineer:feature-processed' must be assignable to the EventType union, but type inference can lag behind union updates in complex generic types
+- **How to avoid:** Cast reduces type safety slightly but keeps event payload typing intact. Event names are defined once in types, payload types are still checked at compile time

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -1722,3 +1722,87 @@ usageStats:
 - **Problem solved:** New 'ideas' nav item added to projectItems array in use-navigation.ts with specific shape and properties
 - **Why this works:** Single nav item definition generates: sidebar UI item, keyboard shortcut binding, and route navigation. Changes to nav structure automatically propagate everywhere
 - **Trade-offs:** Declarative config is easier to maintain and audit but less flexible for nav items with custom behavior; requires hook infrastructure to consume and generate UI
+
+### Verified no imports existed before deletion rather than relying on grep alone (2026-02-18)
+- **Context:** Removing dead code files that might have been imported from multiple locations
+- **Why:** Grep can return false positives (string matches in comments, paths, or unrelated code). Needed to distinguish actual import statements from incidental string matches to ensure safe deletion
+- **Rejected:** Assuming grep results were complete without manual verification of the actual import statements in matched files
+- **Trade-offs:** Additional manual verification added safety but required more steps; automated tooling alone was insufficient
+- **Breaking if changed:** Skipping verification step could have resulted in deleting code that was actually imported, breaking the build at deployment time rather than development time
+
+#### [Gotcha] Route files imported from `auto-mode-service.js` not from the deleted `services/auto-mode/` directory (2026-02-18)
+- **Situation:** Initial grep search showed files containing 'services/auto-mode/' path, but these were not actual imports of the code being deleted
+- **Root cause:** The string 'services/auto-mode/' appeared in file paths and comments but the actual imports were from a different module (`auto-mode-service.js`). This is a naming ambiguity where the directory path string is similar to but distinct from the actual module being imported
+- **How to avoid:** Required reading actual file contents to understand the true import structure, adding investigation overhead
+
+#### [Pattern] Dead code from abandoned refactor left in codebase with newer implementation running in parallel (2026-02-18)
+- **Problem solved:** The deleted `AgentExecutionService` and `auto-mode/` directory were part of an abandoned refactor while `AutoModeService` became the active implementation
+- **Why this works:** Parallel implementations can exist during refactor transitions to maintain stability while new code is validated. However, leaving both in place after transition completes creates confusion about which is authoritative and wastes maintenance overhead
+- **Trade-offs:** Keeping dead code during transition provides fallback safety but creates ambiguity; removing it post-validation saves maintenance but requires confidence that transition is complete
+
+### Default routing classification to Ops for ambiguous signals, requiring explicit GTM pattern matching (2026-02-18)
+- **Context:** Signal classification needs to handle signals from multiple sources (GitHub, Linear, Discord, MCP) and route to either Ops or GTM pipelines
+- **Why:** Automaker is primarily an engineering tool. Defaulting to Ops is safer - false negatives (GTM signals misclassified as Ops) are preferable to false positives (Ops signals going to GTM pipeline). GTM signals explicitly opt-in via labels/channels rather than implicit.
+- **Rejected:** Could have defaulted to GTM and required Ops signals to explicitly opt-in, or used 50/50 default requiring all signals to match patterns
+- **Trade-offs:** Simpler mental model for Ops-heavy tool, but GTM users need to be aware they must use correct labels/channels. Easier to add Ops sources than GTM sources.
+- **Breaking if changed:** If changed to GTM-first or 50/50 default, would need to audit all signal sources and risk misrouting existing Ops signals through GTM pipeline
+
+#### [Pattern] Event-driven classification layered between IntegrationService and feature creation, using emitted events as integration points (2026-02-18)
+- **Problem solved:** Need to add intelligent routing logic without modifying signal source integrations (GitHub, Linear, Discord, MCP handlers)
+- **Why this works:** IntegrationService emits `signal:received` events, SignalIntakeService listens and classifies. This separation allows classification logic to evolve without touching integration code. New routing rules can be added to classifySignal() without side effects.
+- **Trade-offs:** Clean separation requires event layer overhead, but enables independent evolution of integrations and routing logic. Makes it easier to test classification in isolation.
+
+#### [Pattern] Emitting `signal:routed` event with category and reasoning for every signal, in addition to existing event stream (2026-02-18)
+- **Problem solved:** Need visibility into why signals were classified and routed to specific pipelines for debugging and monitoring
+- **Why this works:** Event emission enables observability without adding logging coupling. Downstream systems can consume `signal:routed` events to track classification decisions, build dashboards, alert on anomalies. The `reason` field captures why classification happened, not just the result.
+- **Trade-offs:** Adds event emission overhead, but provides production observability. Makes classification auditable.
+
+### Used dependency injection with setLeadEngineerService() and 'any' type cast to avoid circular dependency between AutoModeService and LeadEngineerService (2026-02-18)
+- **Context:** Both services needed to reference each other - AutoModeService delegates to LeadEngineerService, but initializing them in sequence created a type safety problem
+- **Why:** Circular imports in TypeScript cause reference errors at runtime. Using 'any' type for injected dependency breaks the cycle while maintaining runtime correctness since AutoModeService only calls the process() method
+- **Rejected:** Could have merged services (breaks separation of concerns), used interfaces (still creates circular reference), or strict dependency ordering (fragile initialization)
+- **Trade-offs:** Gained loose coupling and clean separation of orchestration from execution, lost type safety on injected dependency - but the interface is simple enough (one method) that this is acceptable
+- **Breaking if changed:** If the injected service interface changes beyond process(), or if circular logic is added to LeadEngineerService that references AutoModeService, type safety will mask runtime errors
+
+#### [Pattern] Delegation pattern where AutoModeService (orchestrator) remains unchanged in its polling loop, only adds conditional delegation point for feature execution (2026-02-18)
+- **Problem solved:** Needed to integrate new Lead Engineer state machine into existing auto-mode without refactoring the orchestration logic
+- **Why this works:** Orchestration concerns (heap monitoring, concurrency limits, feature selection, dependency resolution) are orthogonal to execution concerns (state transitions, PR management). Delegation keeps these separate and testable independently
+- **Trade-offs:** Slightly more code paths to maintain (delegation + fallback), but execution engine can be iterated independently and auto-mode remains a stable orchestration layer
+
+### Fallback to legacy executeFeature() when LeadEngineerService not available, rather than requiring it (2026-02-18)
+- **Context:** LeadEngineerService might be disabled or not initialized in some deployments or test scenarios
+- **Why:** Maintains backward compatibility and allows gradual rollout - projects without Lead Engineer continue functioning. Prevents hard dependency that could break existing deployments
+- **Rejected:** Could have required Lead Engineer (forces migration), or removed legacy path entirely (breaks existing code)
+- **Trade-offs:** Gained flexibility and safety, added conditional logic and two code paths to test. But risk is mitigated since both paths have same input/output contract
+- **Breaking if changed:** If legacy executeFeature() is ever removed, this fallback must be removed too or auto-mode will silently fail to process features
+
+#### [Gotcha] Used minimal ExecuteOptions interface at delegation point because Lead Engineer state machine will build complete options internally, but state machine processors are still stubs (2026-02-18)
+- **Situation:** AutoModeService had full ExecuteOptions ready, but Lead Engineer state machine doesn't currently use most fields
+- **Root cause:** Avoids over-engineering the interface before state machine processors are implemented. State machine is responsible for assembling execution context
+- **How to avoid:** Simpler integration now, but when state machine processors are implemented and need AutoModeService data, the interface will need to expand - caught by type system then
+
+### Use environment variable (GITHUB_ENV) to signal restart exhaustion from verification step to notification step rather than exit code or file artifact (2026-02-18)
+- **Context:** Needed to communicate restart exhaustion condition between two separate GitHub Action steps for conditional alerting
+- **Why:** GITHUB_ENV persists state across steps in same job, making it visible to downstream steps without adding complexity. Exit codes are consumed by if conditions and don't preserve semantic meaning
+- **Rejected:** Output files (would require artifact upload) or exit codes (would need step condition logic); GITHUB_ENV is GitHub Actions native for cross-step communication
+- **Trade-offs:** Easier to read/debug than parsing exit codes, but couples implementation to GitHub Actions runtime
+- **Breaking if changed:** Without this pattern, restart exhaustion alert would need to be detected independently in Discord notification step, doubling the detection logic
+
+### Kept crew-members/index.ts as a stub file with backward compatibility note instead of complete deletion (2026-02-18)
+- **Context:** Feature scope specified removing crew loop checks but maintaining system stability. Index file existed as a re-export barrel.
+- **Why:** Prevents import errors if external code references the crew-members directory. Provides a clear migration path with documentation rather than hard breaking changes.
+- **Rejected:** Complete deletion of the directory would have been simpler but would break any code that imports from services/crew-members/ even if those specific members are removed.
+- **Trade-offs:** Slightly more code to maintain vs. cleaner directory structure. Tradeoff favors stability during multi-phase deprecation.
+- **Breaking if changed:** Removing the stub would cause import-time failures for any consuming code, requiring coordinated multi-service updates.
+
+#### [Gotcha] Dashboard endpoint was the only external consumer of crew status despite crew loop being a large system (2026-02-18)
+- **Situation:** Crew loop service was extensively implemented with 7 different member checks and multiple initialization steps, yet only dashboard.ts consumed the status output.
+- **Root cause:** This indicates the crew loop was well-isolated - a large internal system with minimal external API surface. The system did extensive work but only surfaced crew status in one place.
+- **How to avoid:** Well-isolated systems are easier to remove but can hide their scale from initial code review. The isolation made this removal very clean.
+
+### Left scheduler service intact despite crew loop deletion, even though crew loop depended on it (2026-02-18)
+- **Context:** CrewLoopService was a consumer of the scheduler service. Crew member checks were scheduled tasks managed by this scheduler.
+- **Why:** Scheduler service has other legitimate uses (system health monitoring will use it). Removing scheduler would have cascading effects on other features. Better to remove the consumer (crew loop) than the general utility.
+- **Rejected:** Could have removed scheduler too, but that would eliminate infrastructure others depend on.
+- **Trade-offs:** Scheduler remains in codebase even with one fewer consumer vs. complete cleanup. Tradeoff favors general utility preservation.
+- **Breaking if changed:** If scheduler were removed, AVA's health monitoring and any other scheduled tasks would break. The crew loop removal should not affect scheduler lifecycle.

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 218
-  referenced: 104
-  successfulFeatures: 104
+  loaded: 230
+  referenced: 110
+  successfulFeatures: 110
 ---
 # gotchas
 
@@ -145,3 +145,13 @@ usageStats:
 - **Situation:** Initial test attempt failed because Playwright browsers weren't installed and environment lacked required dependencies
 - **Root cause:** Playwright bundles Chromium/Firefox/WebKit which require glibc and other system libraries. TEST_REUSE_SERVER allows CI/testing in restricted environments by reusing running instance
 - **How to avoid:** Reusing server makes tests faster and environment-agnostic but requires coordination that server is running; less isolated than full Playwright setup
+
+#### [Gotcha] Classification uses keyword matching on Discord channel names and Linear labels - extensibility requires code changes, not configuration (2026-02-18)
+- **Situation:** Discord channels like '#marketing' and '#social' route to GTM, but the keywords are hardcoded in gtmChannels/opsChannels arrays
+- **Root cause:** Keyword matching is simple and fast for current use case, but discovered limitation is that adding new channels or labels requires code deployment
+- **How to avoid:** Simple implementation vs. runtime flexibility. Current approach works for static organization structure, but breaks if company frequently adds/renames channels or labels.
+
+#### [Gotcha] Docker container restart exhaustion (5 consecutive restart failures) requires explicit detection and signaling - not observable via simple container status checks (2026-02-18)
+- **Situation:** Deployment pipeline was exiting on readiness check timeout but didn't distinguish between 'slow startup' (temporary) vs 'restart loop exhaustion' (permanent failure requiring manual intervention)
+- **Root cause:** Docker restart policy silently caps restart attempts; after 5 failures, container moves to 'exited' state but pipeline wasn't reading RestartCount metric to trigger escalated alert
+- **How to avoid:** Requires querying docker inspect (2 extra calls) but enables critical alerting for infrastructure-level failures vs application-level transient issues

--- a/.automaker/memory/security.md
+++ b/.automaker/memory/security.md
@@ -128,3 +128,13 @@ usageStats:
 - **Rejected:** Could extract session from JWT/auth context only, but would require business logic inside handlers to validate session ownership, creating authorization bypass opportunities
 - **Trade-offs:** URL parameter is visible in logs and browser history (but session ID itself isn't sensitive), but provides explicit authorization checkpoints
 - **Breaking if changed:** If sessions become cross-user shareable, the assumption that URL sessionId = owner identity breaks, requiring additional permission checks inside handlers
+
+#### [Pattern] Multi-layer deployment readiness verification via /api/health/ready endpoint that checks API key configuration, data directory accessibility, and writability before marking server as ready (2026-02-18)
+- **Problem solved:** Deploy pipeline was accepting server as ready without verifying critical runtime dependencies were properly initialized
+- **Why this works:** Container restart loops can occur silently; checking only HTTP 200 response status misses misconfiguration states. Verifying API key presence and data directory state prevents deployments that appear successful but fail during operation
+- **Trade-offs:** Adds 2-3 extra curl calls per deployment verification (30ms total) but prevents cascading failures and manual rollbacks
+
+#### [Pattern] Graduated alerting strategy: success message includes version and doc status, failure message branches on rollback outcome, critical alerts (restart exhaustion) append to failure message (2026-02-18)
+- **Problem solved:** Discord notifications were generic and didn't provide actionable information about failure root cause or what operator should do
+- **Why this works:** Different failure modes require different human responses: rollback success = monitoring only, rollback failure = immediate manual intervention, restart exhaustion = infrastructure restart. Graduated alerts direct operator attention appropriately
+- **Trade-offs:** More complex notification script but provides semantic information that prevents wrong remediation actions

--- a/.automaker/memory/testing.md
+++ b/.automaker/memory/testing.md
@@ -523,3 +523,8 @@ usageStats:
 - **Situation:** Story file was created but Storybook build failed, requiring decision on verification strategy for component correctness
 - **Root cause:** TypeScript compilation and Vite build are sufficient for catching structural errors, but Storybook failure prevented visual verification of component rendering. Decision to skip story given unrelated Storybook configuration issues.
 - **How to avoid:** Saved time by skipping broken Storybook, but lost visual verification benefit. Component structure verified but actual rendering in browser not confirmed.
+
+#### [Pattern] Created temporary integration test using vitest (not Playwright) that verified removal by attempting imports that should fail (2026-02-18)
+- **Problem solved:** Needed to verify 7 crew members, crew-loop-service, and crew routes were all deleted before committing.
+- **Why this works:** Import-time failures are the clearest verification that code paths have been removed. This catches the removal at compile-time rather than runtime. Vitest (existing server test framework) was appropriate rather than Playwright (which tests HTTP endpoints).
+- **Trade-offs:** Temporary test files must be cleaned up after verification vs. permanent regression detection. Tradeoff favors clean commit over permanent test cruft.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,34 +212,36 @@ Use `resolveModelString()` from `@automaker/model-resolver` to convert model ali
 - `sonnet` → `claude-sonnet-4-5-20250929`
 - `opus` → `claude-opus-4-5-20251101`
 
-### Crew Loop System
+### Lead Engineer State Machine
 
-Scheduled health checks and automated escalation for crew members. Lightweight in-process checks run on cron schedules — full agent escalation only when problems are detected.
+The Lead Engineer service (`lead-engineer-service.ts`) is the production-phase nerve center. It manages per-feature lifecycle through a state machine, reacts to events with fast-path rules, and integrates with auto-mode for autonomous execution.
 
 ```
-SchedulerService (cron tick)
-  --> CrewLoopService.runCheck(memberId)
-    --> member.check(context) — lightweight, no API calls
-      --> IF needsEscalation: DynamicAgentExecutor.execute(template, prompt)
-      --> ELSE: log "ok", emit event, done
+Signal (Linear webhook, GitHub event, MCP tool)
+  --> SignalIntakeService.classifySignal() — ops vs gtm routing
+  --> LeadEngineerService.process(feature)
+    --> FeatureStateMachine: INTAKE → PLAN → EXECUTE → REVIEW → MERGE → DONE
+    --> Fast-path rules: pure functions, no LLM, event-driven
+    --> Short-circuit: Any state → ESCALATE (on critical errors)
 ```
 
-**Current crew members:**
+**Feature lifecycle states:**
 
-| Member        | Schedule       | Checks                                                                   | Escalation           |
-| ------------- | -------------- | ------------------------------------------------------------------------ | -------------------- |
-| Ava           | `*/10 * * * *` | Stuck agents (>2h), blocked features, auto-mode health, capacity         | Warning+ findings    |
-| Frank         | `*/10 * * * *` | V8 heap, RSS memory, agent capacity, health monitor                      | Critical issues only |
-| PR Maintainer | `*/10 * * * *` | Stale PRs (>24h), review features needing auto-merge, orphaned worktrees | Warning+ findings    |
-| Board Janitor | `*/15 * * * *` | Merged PRs still in review, orphaned in-progress (>4h), stale deps       | Warning+ findings    |
-| System Health | `*/10 * * * *` | System RAM, swap, disk, CPU load, temperature, GPU/VRAM, zombie procs    | Warning+ findings    |
-| GTM           | `0 */6 * * *`  | Recently completed features (placeholder)                                | Disabled by default  |
+| State    | Description                          | Transitions To              |
+| -------- | ------------------------------------ | --------------------------- |
+| INTAKE   | Feature created, awaiting processing | PLAN, ESCALATE              |
+| PLAN     | Requirements analysis, spec gen      | EXECUTE, ESCALATE           |
+| EXECUTE  | Implementation in worktree           | REVIEW, ESCALATE            |
+| REVIEW   | PR created, under CI/CodeRabbit      | MERGE, EXECUTE (on failure) |
+| MERGE    | PR approved, merging                 | DONE, ESCALATE              |
+| DONE     | Feature fully deployed and verified  | (terminal)                  |
+| ESCALATE | Blocked, needs intervention          | Any state (after fix)       |
 
-Ava acts as orchestrator — PR pipeline monitoring is delegated to PR Maintainer, board consistency to Board Janitor. Both run on Haiku for cost efficiency.
+**Integration with auto-mode:** When `LeadEngineerService` is available, auto-mode delegates to `leadEngineerService.process()` instead of `executeFeature()` directly. This adds state tracking, fast-path rules, and escalation handling on top of the existing agent execution pipeline.
 
-**Adding a new crew member** = one file implementing `CrewMemberDefinition` in `apps/server/src/services/crew-members/`, then register with `crewLoopService.registerMember(def)` in `index.ts`. See `docs/dev/crew-loops.md` for full details.
+**Types:** See `libs/types/src/lead-engineer.ts` for `FeatureState`, `LeadWorldState`, `LeadFastPathRule`, `LeadRuleAction`.
 
-**API:** `GET /api/crew/status`, `POST /api/crew/:id/{trigger,enable,disable,schedule}`
+**API:** `GET /api/lead-engineer/status`, `POST /api/lead-engineer/{start,stop}`
 
 ### Feature Status System
 


### PR DESCRIPTION
## Summary
- Replace the deleted Crew Loop System section in CLAUDE.md with the new Lead Engineer State Machine architecture
- Documents the feature lifecycle states (INTAKE → PLAN → EXECUTE → REVIEW → MERGE → DONE → ESCALATE)
- Updates API endpoints and type references
- Includes .automaker/memory updates from autonomous agent work

## Context
The crew loop system (cron-based health checks with 6 crew members) was removed in PR #774 (-2,935 lines). The Lead Engineer state machine now drives per-feature lifecycle through auto-mode.

## Test plan
- [ ] Verify CLAUDE.md renders correctly in GitHub
- [ ] Confirm Lead Engineer section matches actual code in `lead-engineer-service.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system architecture documentation to reflect the Lead Engineer State Machine model.
  * Documented new feature lifecycle workflow with states: INTAKE, PLAN, EXECUTE, REVIEW, MERGE, DONE, and ESCALATE.
  * Updated API endpoint references to the new lead-engineer service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->