### PR TITLE
fix: resolve arm64 Electron build failure from symlinked deps

### DIFF
--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,9 +5,9 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 56
-  referenced: 32
-  successfulFeatures: 32
+  loaded: 53
+  referenced: 30
+  successfulFeatures: 30
 ---
 # api
 
@@ -381,14 +381,12 @@ usageStats:
 - **Why this works:** Provides flexibility when UI implementation details change. If data-testid is removed, the href-based selector still works. If styling changes the tag type, the selector still finds it. Makes tests resilient to cosmetic refactors
 - **Trade-offs:** Query is more complex to read but more maintainable long-term. Slightly slower selector resolution but negligible in tests
 
-### Enhanced IntegrationService to pass Linear `labels` and `projectId` in signal context rather than inferring from downstream (2026-02-18)
-- **Context:** Linear issue classification depends on labels and project context, but integration layer wasn't providing this metadata
-- **Why:** Early data enrichment (at source) makes classification deterministic and debuggable. Labels and projectId are available at integration time with no additional queries. Passing them enables label-based routing without downstream Linear API calls.
-- **Rejected:** Could have deferred label lookup to classification time by querying Linear API again, but adds latency and complexity
-- **Trade-offs:** IntegrationService now has slightly larger payload, but classification logic stays simple and fast. No N+1 query problem.
-- **Breaking if changed:** If removed, classification would need to fetch Linear context on-demand, requiring API credentials in SignalIntakeService and creating latency/failure points
+#### [Pattern] Theme utility design uses DOM manipulation (document.documentElement) rather than return-value approach, matching existing shadcn theme pattern (2026-02-18)
+- **Problem solved:** Existing apps/ui theme implementation applies CSS classes directly to html element; new utility functions must integrate with this established pattern
+- **Why this works:** applyTheme() mutates document.documentElement.classList; detectPreferredTheme() reads system prefers-color-scheme via matchMedia. This matches Tailwind/shadcn convention where themes are applied globally via class names on root element
+- **Trade-offs:** Direct DOM manipulation is easier to integrate with existing code but couples utility to browser environment; makes testing require jsdom; prevents use in server contexts (e.g., getServerSideProps)
 
-#### [Gotcha] EventType union in TypeScript wouldn't recognize new 'lead-engineer:feature-processed' event even after types were rebuilt, required explicit 'as EventType' cast in emit call (2026-02-18)
-- **Situation:** Added new event type to types package and rebuilt, but lead-engineer-service.ts still showed type error on emit() call
-- **Root cause:** TypeScript type narrowing on EventEmitter.emit() is strict - the literal string type 'lead-engineer:feature-processed' must be assignable to the EventType union, but type inference can lag behind union updates in complex generic types
-- **How to avoid:** Cast reduces type safety slightly but keeps event payload typing intact. Event names are defined once in types, payload types are still checked at compile time
+#### [Pattern] 19 story files created via agent automation shows successful code generation pattern: each story file is 30-50 lines with consistent structure (Meta + Default export + variant exports), enabling reliable bulk creation (2026-02-18)
+- **Problem solved:** Agent created 25 story files without manual review of each one. Quality variance between files was minimal.
+- **Why this works:** Each story follows identical structure: (1) import Component, (2) define Meta with autodocs tag, (3) export Default with template, (4) export variant stories using CSF3. This regularity allows agents to generate valid code without human validation.
+- **Trade-offs:** Consistency is high (all stories follow same pattern) but individual stories may lack sophistication (e.g., complex interaction demos). Trade-off is acceptable for coverage—sophisticated stories can be added later.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -1723,86 +1723,135 @@ usageStats:
 - **Why this works:** Single nav item definition generates: sidebar UI item, keyboard shortcut binding, and route navigation. Changes to nav structure automatically propagate everywhere
 - **Trade-offs:** Declarative config is easier to maintain and audit but less flexible for nav items with custom behavior; requires hook infrastructure to consume and generate UI
 
-### Verified no imports existed before deletion rather than relying on grep alone (2026-02-18)
-- **Context:** Removing dead code files that might have been imported from multiple locations
-- **Why:** Grep can return false positives (string matches in comments, paths, or unrelated code). Needed to distinguish actual import statements from incidental string matches to ensure safe deletion
-- **Rejected:** Assuming grep results were complete without manual verification of the actual import statements in matched files
-- **Trade-offs:** Additional manual verification added safety but required more steps; automated tooling alone was insufficient
-- **Breaking if changed:** Skipping verification step could have resulted in deleting code that was actually imported, breaking the build at deployment time rather than development time
+#### [Pattern] Multi-entry-point tsup configuration for package.json exports map alignment (2026-02-18)
+- **Problem solved:** Building a monorepo UI package with multiple logical entry points (root, atoms, molecules, organisms, lib utilities)
+- **Why this works:** Each entry point in package.json exports map requires a corresponding tsup entry in the entry array. Without both, the build produces no output for that path and consumers get import failures despite the export being declared.
+- **Trade-offs:** Multiple entries increase build time slightly and create more dist files, but enables granular package consumption and proper tree-shaking per entry point. Consumers can import only what they need.
 
-#### [Gotcha] Route files imported from `auto-mode-service.js` not from the deleted `services/auto-mode/` directory (2026-02-18)
-- **Situation:** Initial grep search showed files containing 'services/auto-mode/' path, but these were not actual imports of the code being deleted
-- **Root cause:** The string 'services/auto-mode/' appeared in file paths and comments but the actual imports were from a different module (`auto-mode-service.js`). This is a naming ambiguity where the directory path string is similar to but distinct from the actual module being imported
-- **How to avoid:** Required reading actual file contents to understand the true import structure, adding investigation overhead
+### Vite alias required for workspace CSS imports in monorepo. Added `@protolabs/ui` alias pointing to `libs/ui/src` in vite.config.mts (2026-02-18)
+- **Context:** Theme CSS files moved from apps/ui to libs/ui, but Vite couldn't resolve relative path imports during build. Build failed with module resolution errors.
+- **Why:** Vite's CSS import resolution and Tailwind's content scanning require explicit alias mappings for workspace packages. Without the alias, Vite treats the relative path as external and fails to bundle CSS.
+- **Rejected:** Using package.json 'exports' field alone. Package exports work for JS imports but not for CSS file resolution during Vite build. Also rejected: symlink resolution—unreliable across platforms.
+- **Trade-offs:** Alias adds build config complexity but guarantees consistent resolution. Alternative of using fully-qualified package imports (@protolabs/ui/themes.css) would require additional loader configuration and wouldn't work with Tailwind's content scanning.
+- **Breaking if changed:** Removing the alias breaks the build immediately—Vite can't find libs/ui imports. Any future workspace CSS packages would need similar alias configuration.
 
-#### [Pattern] Dead code from abandoned refactor left in codebase with newer implementation running in parallel (2026-02-18)
-- **Problem solved:** The deleted `AgentExecutionService` and `auto-mode/` directory were part of an abandoned refactor while `AutoModeService` became the active implementation
-- **Why this works:** Parallel implementations can exist during refactor transitions to maintain stability while new code is validated. However, leaving both in place after transition completes creates confusion about which is authoritative and wastes maintenance overhead
-- **Trade-offs:** Keeping dead code during transition provides fallback safety but creates ambiguity; removing it post-validation saves maintenance but requires confidence that transition is complete
+#### [Gotcha] Tailwind CSS content scanning in monorepos requires explicit `@source` directive in global.css. Without it, CSS classes unique to shared packages don't generate. (2026-02-18)
+- **Situation:** This was NOT part of the current feature but is a critical lesson from session history. Theme CSS files in libs/ui wouldn't be scanned by Tailwind in apps/ui unless @source directive is added to global.css.
+- **Root cause:** Tailwind v4 auto-detects content by scanning from the nearest package.json upward. libs/ui/src is outside apps/ui's scan scope. The @source directive extends the scan to include that directory.
+- **How to avoid:** @source directive is explicit and maintainable but easy to forget. Default scanning is simpler but fails silently for monorepos. Explicit wins for reliability.
 
-### Default routing classification to Ops for ambiguous signals, requiring explicit GTM pattern matching (2026-02-18)
-- **Context:** Signal classification needs to handle signals from multiple sources (GitHub, Linear, Discord, MCP) and route to either Ops or GTM pipelines
-- **Why:** Automaker is primarily an engineering tool. Defaulting to Ops is safer - false negatives (GTM signals misclassified as Ops) are preferable to false positives (Ops signals going to GTM pipeline). GTM signals explicitly opt-in via labels/channels rather than implicit.
-- **Rejected:** Could have defaulted to GTM and required Ops signals to explicitly opt-in, or used 50/50 default requiring all signals to match patterns
-- **Trade-offs:** Simpler mental model for Ops-heavy tool, but GTM users need to be aware they must use correct labels/channels. Easier to add Ops sources than GTM sources.
-- **Breaking if changed:** If changed to GTM-first or 50/50 default, would need to audit all signal sources and risk misrouting existing Ops signals through GTM pipeline
+#### [Gotcha] CSS import path uses relative traversal (../../../../libs/ui/src/themes/base.css) from app-level global.css to shared package-level theme file. This creates a fragile dependency on directory structure. (2026-02-18)
+- **Situation:** When extracting theme definitions from monorepo app to shared package, the import statement must reach across the workspace tree.
+- **Root cause:** Relative paths work because Tailwind CSS 4 processes @import statements without path resolution during compilation. Workspace symlinks don't apply to CSS-level imports.
+- **How to avoid:** Relative paths are fragile to directory moves but work immediately. Package-level imports would be cleaner but require PostCSS plugin for CSS module resolution, adding build complexity.
 
-#### [Pattern] Event-driven classification layered between IntegrationService and feature creation, using emitted events as integration points (2026-02-18)
-- **Problem solved:** Need to add intelligent routing logic without modifying signal source integrations (GitHub, Linear, Discord, MCP handlers)
-- **Why this works:** IntegrationService emits `signal:received` events, SignalIntakeService listens and classifies. This separation allows classification logic to evolve without touching integration code. New routing rules can be added to classifySignal() without side effects.
-- **Trade-offs:** Clean separation requires event layer overhead, but enables independent evolution of integrations and routing logic. Makes it easier to test classification in isolation.
+#### [Pattern] CSS variable extraction creates two-level indirection: @theme inline (Tailwind → CSS var bridge) + :root declaration (CSS var → actual values). This decouples token naming from value assignment. (2026-02-18)
+- **Problem solved:** Tailwind 4 @theme blocks expect CSS variables as values, but color values are expressed in oklch color space. Separating the mapping from the values allows reuse across themes.
+- **Why this works:** The pattern allows @custom-variant definitions and @theme inline to remain static (theme-agnostic structure), while :root and @media (prefers-color-scheme) can swap actual values. Single source of truth for token structure, multiple sources for values.
+- **Trade-offs:** Extra indirection adds one layer of lookup (Tailwind → CSS var → oklch value), negligible performance cost. But it prevents accidental direct color references and forces consistent token usage.
 
-#### [Pattern] Emitting `signal:routed` event with category and reasoning for every signal, in addition to existing event stream (2026-02-18)
-- **Problem solved:** Need visibility into why signals were classified and routed to specific pipelines for debugging and monitoring
-- **Why this works:** Event emission enables observability without adding logging coupling. Downstream systems can consume `signal:routed` events to track classification decisions, build dashboards, alert on anomalies. The `reason` field captures why classification happened, not just the result.
-- **Trade-offs:** Adds event emission overhead, but provides production observability. Makes classification auditable.
+#### [Gotcha] Pre-existing build issue (@protolabs/ui/atoms import resolution failure) blocks verification of CSS changes, creating false uncertainty about correctness. The CSS extraction itself is valid; the test failure masks other problems. (2026-02-18)
+- **Situation:** After extracting theme CSS, E2E tests fail because the app won't load due to unrelated import resolution errors.
+- **Root cause:** The @protolabs/ui package name mismatch (package declares @protolabs/ui, tsconfig doesn't map it, but build still references it) is a separate, pre-existing issue that prevents the app from running at all.
+- **How to avoid:** CSS changes are correct and verified by static inspection (syntax, structure, line reduction), but cannot be validated via end-to-end tests until the import issue is resolved. Increasing build/test complexity to work around unrelated issues is worse than documenting the blockers.
 
-### Used dependency injection with setLeadEngineerService() and 'any' type cast to avoid circular dependency between AutoModeService and LeadEngineerService (2026-02-18)
-- **Context:** Both services needed to reference each other - AutoModeService delegates to LeadEngineerService, but initializing them in sequence created a type safety problem
-- **Why:** Circular imports in TypeScript cause reference errors at runtime. Using 'any' type for injected dependency breaks the cycle while maintaining runtime correctness since AutoModeService only calls the process() method
-- **Rejected:** Could have merged services (breaks separation of concerns), used interfaces (still creates circular reference), or strict dependency ordering (fragile initialization)
-- **Trade-offs:** Gained loose coupling and clean separation of orchestration from execution, lost type safety on injected dependency - but the interface is simple enough (one method) that this is acceptable
-- **Breaking if changed:** If the injected service interface changes beyond process(), or if circular logic is added to LeadEngineerService that references AutoModeService, type safety will mask runtime errors
+### Multi-entry-point tsup configuration with explicit package.json exports field for theme utilities sub-export (2026-02-18)
+- **Context:** Need to expose theme utilities from @protolabs/ui without polluting main export; library already uses tsup with single entry point
+- **Why:** tsup's entry point array allows building isolated chunks; package.json exports creates conditional resolution paths. Consumers import @protolabs/ui/themes (clean API) which resolves to dist/themes/index.js without modifying main entry
+- **Rejected:** Re-export from main index.ts (pollutes bundle, mixes concerns); separate package (adds monorepo complexity); direct dist imports (no type safety, fragile paths)
+- **Trade-offs:** Requires maintaining parallel tsup config array and package.json exports in sync; slightly higher build artifact count; enables precise tree-shaking per sub-export
+- **Breaking if changed:** Removing entry from tsup array or package.json exports breaks @protolabs/ui/themes imports; changing dist folder structure breaks consumer imports
 
-#### [Pattern] Delegation pattern where AutoModeService (orchestrator) remains unchanged in its polling loop, only adds conditional delegation point for feature execution (2026-02-18)
-- **Problem solved:** Needed to integrate new Lead Engineer state machine into existing auto-mode without refactoring the orchestration logic
-- **Why this works:** Orchestration concerns (heap monitoring, concurrency limits, feature selection, dependency resolution) are orthogonal to execution concerns (state transitions, PR management). Delegation keeps these separate and testable independently
-- **Trade-offs:** Slightly more code paths to maintain (delegation + fallback), but execution engine can be iterated independently and auto-mode remains a stable orchestration layer
+### Centralized THEMES constant array over per-file theme definitions, enabling single source of truth for theme metadata (2026-02-18)
+- **Context:** Apps previously had hardcoded theme lists scattered across components; adding new utilities requires consistent metadata (name, class, type, label)
+- **Why:** Array of { name, class, type, label } objects enables reuse across all theme utilities; allows functions like getThemeClass() and UI dropdowns to derive data from single source; future applications can import and consume without re-defining
+- **Rejected:** Enum (lacks rich metadata like labels); Record<string, ThemeInfo> (loses order); inline definitions in each utility function (high duplication, hard to sync)
+- **Trade-offs:** Adds small runtime overhead (one array definition); enables powerful composability and eliminates duplication; slight learning curve for consumers (must understand THEMES structure)
+- **Breaking if changed:** Removing THEMES breaks all downstream code that uses it; changing structure (e.g., renaming 'class' to 'className') requires cascading updates in all consumers and type definitions
 
-### Fallback to legacy executeFeature() when LeadEngineerService not available, rather than requiring it (2026-02-18)
-- **Context:** LeadEngineerService might be disabled or not initialized in some deployments or test scenarios
-- **Why:** Maintains backward compatibility and allows gradual rollout - projects without Lead Engineer continue functioning. Prevents hard dependency that could break existing deployments
-- **Rejected:** Could have required Lead Engineer (forces migration), or removed legacy path entirely (breaks existing code)
-- **Trade-offs:** Gained flexibility and safety, added conditional logic and two code paths to test. But risk is mitigated since both paths have same input/output contract
-- **Breaking if changed:** If legacy executeFeature() is ever removed, this fallback must be removed too or auto-mode will silently fail to process features
+#### [Gotcha] Node.js-specific dependencies bundled into browser build when moving components between packages without declaring them in the target package (2026-02-18)
+- **Situation:** Moved `markdown` component from apps/ui to libs/ui. Build failed with Node.js module errors (fs, path) because react-markdown, rehype-raw, rehype-sanitize were in apps/ui/package.json but not libs/ui/package.json. Vite bundled them as external dependencies into the browser build.
+- **Root cause:** Package.json dependencies control what Vite can resolve. When a package imports a dependency it doesn't declare, the bundler treats it as external and includes it in the output, causing runtime failures in the browser.
+- **How to avoid:** Adding dependencies to libs/ui increases package size and dependency surface, but ensures the package is truly portable and doesn't depend on consumer package.json entries. Required for publishing @protolabs/ui as a standalone package.
 
-#### [Gotcha] Used minimal ExecuteOptions interface at delegation point because Lead Engineer state machine will build complete options internally, but state machine processors are still stubs (2026-02-18)
-- **Situation:** AutoModeService had full ExecuteOptions ready, but Lead Engineer state machine doesn't currently use most fields
-- **Root cause:** Avoids over-engineering the interface before state machine processors are implemented. State machine is responsible for assembling execution context
-- **How to avoid:** Simpler integration now, but when state machine processors are implemented and need AutoModeService data, the interface will need to expand - caught by type system then
+### Move dependent components (hotkey-button before confirm-dialog) in dependency order to avoid circular references when consolidating into single package (2026-02-18)
+- **Context:** confirm-dialog depends on hotkey-button. Both were in apps/ui but needed to move to libs/ui/molecules. Moving only confirm-dialog first would create cross-package dependency (confirm-dialog in libs/ui → hotkey-button in apps/ui).
+- **Why:** When consolidating related components into a shared package, topological ordering prevents circular dependency chains across package boundaries. Keeping dependent components in the same package ensures they share the same resolution scope.
+- **Rejected:** Moving all components simultaneously without ordering. Creates merge conflicts and makes it harder to identify which dependency causes build failures.
+- **Trade-offs:** Requires upfront dependency mapping before refactoring. Easier verification and isolation of build issues per component. Slightly more manual effort vs. bulk-moving everything.
+- **Breaking if changed:** If confirm-dialog remains in apps/ui while hotkey-button moves to libs/ui, the import path becomes apps/ui → libs/ui → apps/ui (circular reference through import chain), causing module resolution loops or duplicate instantiation.
 
-### Use environment variable (GITHUB_ENV) to signal restart exhaustion from verification step to notification step rather than exit code or file artifact (2026-02-18)
-- **Context:** Needed to communicate restart exhaustion condition between two separate GitHub Action steps for conditional alerting
-- **Why:** GITHUB_ENV persists state across steps in same job, making it visible to downstream steps without adding complexity. Exit codes are consumed by if conditions and don't preserve semantic meaning
-- **Rejected:** Output files (would require artifact upload) or exit codes (would need step condition logic); GITHUB_ENV is GitHub Actions native for cross-step communication
-- **Trade-offs:** Easier to read/debug than parsing exit codes, but couples implementation to GitHub Actions runtime
-- **Breaking if changed:** Without this pattern, restart exhaustion alert would need to be detected independently in Discord notification step, doubling the detection logic
+#### [Pattern] libs/ui package uses relative imports with .js extensions (e.g., `from '../atoms/button.js'`) instead of aliased paths (@protolabs/ui/atoms) within the library (2026-02-18)
+- **Problem solved:** When moving components to libs/ui, internal imports must use relative paths with .js extensions, not the @protolabs/ui alias. The alias is only for external consumers (apps/ui, etc).
+- **Why this works:** ESM module resolution in Node.js requires explicit extensions in relative imports. Internal package imports using relative paths resolve directly without going through the export map. Using aliases internally would create circular reference issues during bundling and adds resolution overhead.
+- **Trade-offs:** Internal imports are less consistent with external API, but avoids circular resolution. Requires developers to know the internal convention. However, this is standard practice in monorepo libraries (shadcn/ui follows same pattern).
 
-### Kept crew-members/index.ts as a stub file with backward compatibility note instead of complete deletion (2026-02-18)
-- **Context:** Feature scope specified removing crew loop checks but maintaining system stability. Index file existed as a re-export barrel.
-- **Why:** Prevents import errors if external code references the crew-members directory. Provides a clear migration path with documentation rather than hard breaking changes.
-- **Rejected:** Complete deletion of the directory would have been simpler but would break any code that imports from services/crew-members/ even if those specific members are removed.
-- **Trade-offs:** Slightly more code to maintain vs. cleaner directory structure. Tradeoff favors stability during multi-phase deprecation.
-- **Breaking if changed:** Removing the stub would cause import-time failures for any consuming code, requiring coordinated multi-service updates.
+#### [Pattern] Package.json exports field with type definitions (./molecules export) enables TypeScript and build tools to resolve both ESM and type definitions without manual tsconfig paths (2026-02-18)
+- **Problem solved:** libs/ui/package.json already had `./molecules` configured in exports with types field pointing to dist/molecules/index.d.ts. This made the component consolidation work immediately without adding tsconfig paths or additional configuration.
+- **Why this works:** Modern Node.js and TypeScript resolve packages via exports field first, before falling back to main/types. Properly configured exports work for both runtime (ESM) and type-checking without duplication. This follows Node.js package standard.
+- **Trade-offs:** Requires upfront configuration of package.json exports (which was already done), but eliminates need for tsconfig paths coordination. Scales better across monorepo projects.
 
-#### [Gotcha] Dashboard endpoint was the only external consumer of crew status despite crew loop being a large system (2026-02-18)
-- **Situation:** Crew loop service was extensively implemented with 7 different member checks and multiple initialization steps, yet only dashboard.ts consumed the status output.
-- **Root cause:** This indicates the crew loop was well-isolated - a large internal system with minimal external API surface. The system did extensive work but only surfaced crew status in one place.
-- **How to avoid:** Well-isolated systems are easier to remove but can hide their scale from initial code review. The isolation made this removal very clean.
+#### [Gotcha] NPM workspace hoisting causes version conflicts when different workspace packages need incompatible versions of the same dependency (e.g., apps/ui@Storybook^10.2.8 vs libs/ui@Storybook^8.4.7). Hoisting aggregates dependencies to root node_modules, forcing version resolution that may break the package with stricter constraints. (2026-02-18)
+- **Situation:** Moving Storybook config from apps/ui to libs/ui failed with runtime errors ('No matching export for definePreview', 'Missing ./internal/theming'). Root cause: NPM hoisted the newer v10.2.8 from apps/ui to root, breaking v8.4.7 consumers in libs/ui.
+- **Root cause:** NPM workspace hoisting is a dependency deduplication optimization—it moves common dependencies to root to save disk space. However, this breaks when versions are incompatible across workspaces, and there's no automatic fallback to workspace-local node_modules.
+- **How to avoid:** NPM hoisting saves disk space but forces version lock-in across all workspaces. Isolation (pnpm strict-peer-dependencies or yarn workspaces) would prevent this but costs disk/install time. Monorepo split (Storybook in separate repo) eliminates conflict but increases operational complexity.
 
-### Left scheduler service intact despite crew loop deletion, even though crew loop depended on it (2026-02-18)
-- **Context:** CrewLoopService was a consumer of the scheduler service. Crew member checks were scheduled tasks managed by this scheduler.
-- **Why:** Scheduler service has other legitimate uses (system health monitoring will use it). Removing scheduler would have cascading effects on other features. Better to remove the consumer (crew loop) than the general utility.
-- **Rejected:** Could have removed scheduler too, but that would eliminate infrastructure others depend on.
-- **Trade-offs:** Scheduler remains in codebase even with one fewer consumer vs. complete cleanup. Tradeoff favors general utility preservation.
-- **Breaking if changed:** If scheduler were removed, AVA's health monitoring and any other scheduled tasks would break. The crew loop removal should not affect scheduler lifecycle.
+#### [Pattern] Theme decorator with toolbar switcher pattern: Create a Storybook preview decorator that imports all theme CSS files and exposes theme selection via the toolbar control. The decorator applies a theme class to the story container, allowing all stories to inherit theme styling without manual per-story setup. (2026-02-18)
+- **Problem solved:** libs/ui has 6 theme variants (violet/zinc/slate × dark/light). Goal: allow theme switching in Storybook without duplicating 6 theme CSS imports in every story file.
+- **Why this works:** Centralizing theme setup in the preview decorator scales with N theme variants—adding a 7th theme only requires updating preview.tsx (one file) and doesn't touch individual story files. The toolbar control is discoverable (visible in Storybook UI) and doesn't require story code changes.
+- **Trade-offs:** Importing all theme files upfront (at preview load time) means all CSS is parsed even if only 1 theme is active. Alternative: lazy-load theme CSS only when selected (requires async decorator, more complex). The current approach is simpler and theme CSS files are small (~1KB each).
+
+### Configure Storybook story glob to scan monorepo paths (../src/**/*.stories.*) instead of app-specific paths. This decouples story discovery from app location, allowing libs/ui stories to be found by name pattern alone. (2026-02-18)
+- **Context:** apps/ui previously had Storybook scanning apps/ui/src/. When moving Storybook config to libs/ui, the glob needed to point to libs/ui/src/ instead. Question: should it reference relative paths (../src/) or absolute paths (@protolabs/ui)?
+- **Why:** Relative paths are the Storybook convention (main.ts in .storybook/ is the reference point). They're agnostic to monorepo structure and work with any workspace layout. Absolute paths (@protolabs/ui/src/) would require resolving package imports, adding a dependency on webpack/tsup import configuration.
+- **Rejected:** Absolute imports using @protolabs/ui (adds coupling to package name and import resolution configuration; harder to refactor if package is renamed). Glob that includes both apps/ui and libs/ui (creates confusion about which stories are canonical; duplicates stories if both locations exist).
+- **Trade-offs:** Relative paths are simple and discoverable but break if someone moves .storybook/ to a different depth (would need to update ../../../src/ refs). Absolute imports are more resilient to directory reshuffles but require import resolution setup.
+- **Breaking if changed:** If you change the glob pattern, stories won't be discovered—Storybook UI shows empty story list. If you move .storybook/ without updating ../src/ paths, stories disappear again.
+
+### Storybook story files located in libs/ui/src/atoms/ (shared package) rather than apps/ui/src/ (app project), with configuration update to scan both locations (2026-02-18)
+- **Context:** Component library (@protolabs/ui) is a shared package in monorepo. Stories need discovery by Storybook running in apps/ui app.
+- **Why:** Stories are part of the component library contract, not the consuming app. Co-locating stories with components in libs/ makes them versioned with the library and re-usable across any app that imports components.
+- **Rejected:** Keeping stories only in apps/ui/src/ would decouple component documentation from the library itself, making it impossible to document components when the library is consumed by external projects.
+- **Trade-offs:** Requires Storybook config to explicitly include out-of-project paths (../../../libs/ui/src/). Without this config, story discovery fails silently (no error, just missing stories). Discovered stories now come from TWO locations, increasing cognitive load for maintainers.
+- **Breaking if changed:** Removing the '../../../libs/ui/src/**/*.stories.@(js|jsx|mjs|ts|tsx)' entry from .storybook/main.ts stories array causes 25 stories to vanish from Storybook with no error message—only detection is 'fewer stories than expected'.
+
+#### [Gotcha] CSF3 stories in monorepo shared packages (libs/) with relative imports to component src files can fail silently during Storybook build if typescript path resolution hasn't resolved workspace symlinks (2026-02-18)
+- **Situation:** Stories import from @automaker/ui components using workspace symlink, which must be fully resolved before Storybook transpiles stories.
+- **Root cause:** Monorepo workspace symlinks are 'lazy'—they exist but don't guarantee module resolution order. Storybook can transpile and bundle the story file before the symlink is followed, resulting in 'module not found' at runtime.
+- **How to avoid:** Using workspace symlinks (@automaker/ui) is correct long-term (works in both monorepo and published package) but requires careful Storybook config and occasionally needs full clean rebuild to fix symlink resolution issues.
+
+### Storybook configuration must explicitly include shared library paths via @source directive or story discovery config, not rely on automatic scanning from project root (2026-02-18)
+- **Context:** Stories in libs/ui/src/ were not being discovered by Storybook even though they existed. Tailwind CSS 4 had similar issue (PR #749) where content scanning stopped at package.json boundary
+- **Why:** Storybook scans for stories relative to each project's package.json. Since libs/ui is outside apps/ui project root, stories weren't found without explicit path configuration in main.ts. This mirrors the Tailwind CSS 4 root cause from MEMORY.md
+- **Rejected:** Assumption that Storybook would auto-discover all .stories.tsx files in workspace. Reality: monorepo structure requires explicit scope declaration
+- **Trade-offs:** Explicit config is more verbose but guarantees story discovery across workspace boundaries. Alternative of moving stories into apps/ui/ would break the libs/ui as standalone package principle
+- **Breaking if changed:** Removing the libs/ui/src path from Storybook main.ts makes all 25 component stories disappear from Storybook UI. Any future shared components in libs/ also won't be discoverable
+
+#### [Pattern] Consistent story structure across 25 components: Default export + multiple variant exports + interactive argTypes achieves both discoverability and comprehensive prop coverage without boilerplate (2026-02-18)
+- **Problem solved:** All 25 atoms follow identical pattern: Meta config, Default story, AllVariants/AllSizes/AllStates stories, argTypes for interactive controls. Total 193 stories from consistent template
+- **Why this works:** Pattern scales to new components automatically. Any new atom can copy the template and fill in props. autodocs tag generates docs from Default + argTypes without additional documentation work. Consistent naming (Default, AllVariants) makes Storybook sidebar predictable
+- **Trade-offs:** 194-story structure is higher maintenance than 25-story version but provides much better coverage. Developers can test all prop combinations interactively. Time investment in consistent template pays off across all 25 atoms
+
+### Monorepo workspace commands (--workspace=@protolabs/ui) are used from repo root in CI, not with working-directory context switching (2026-02-18)
+- **Context:** CI workflow needed to run build-storybook for a specific package in a monorepo. Initial implementation used working-directory: libs/ui with workspace flag, then corrected to use workspace flag from root.
+- **Why:** Workspace-aware package managers (npm with workspace support) understand relative paths from the repo root. Using --workspace flag eliminates the need to change directories in CI runners, reducing state management complexity. Running from root means the PATH, environment variables, and relative imports all work consistently regardless of which package is being built.
+- **Rejected:** Could have used cd libs/ui && npm run build-storybook (no workspace flag). This couples the CI step to the physical directory structure and breaks if the package moves. Working-directory context switching also makes it harder to reason about which files are where in CI logs.
+- **Trade-offs:** Workspace flag requires npm 7+ (monorepo support). The package.json must be workspace-aware. Upside: CI steps are directory-agnostic and resilient to package restructuring.
+- **Breaking if changed:** Removing the --workspace flag and expecting cwd to be libs/ui fails because CI starts from root. The script would need to explicitly cd first, adding state management overhead.
+
+### prepublishOnly script (not prepare) for automatic build before npm publish in monorepo packages (2026-02-18)
+- **Context:** Monorepo UI package needs build artifacts in dist/ before publishing, but developers might forget to run build before npm publish
+- **Why:** prepublishOnly only runs during `npm publish`, not on every `npm install`. In a monorepo, prepare runs for every dependency install, causing unnecessary rebuilds and potential CI slowdown. prepublishOnly is surgical - only when package is actually being published.
+- **Rejected:** prepare script - fires on every install, would rebuild package during workspace hoisting and for every developer setup
+- **Trade-offs:** prepublishOnly is safer but requires discipline - if someone runs npm publish without a build, it fails (good failure mode). prepare is always-safe but wastes resources in monorepo context.
+- **Breaking if changed:** If prepublishOnly is removed, package must be manually built before every publish, or old dist/ artifacts get shipped
+
+#### [Pattern] Package documentation (README) should live in package root and reference upper-level philosophy docs, not duplicate content (2026-02-18)
+- **Problem solved:** Creating @protolabs/ui package documentation required deciding where to place README and how to avoid duplication with docs/dev/frontend-philosophy.md
+- **Why this works:** Keeps package-level docs (installation, usage, API) close to source code for discoverability, while higher-level philosophy and design decisions live in docs/ for team-wide reference. Single source of truth per layer prevents drift.
+- **Trade-offs:** Requires maintaining two documents with overlapping content. Benefit: Each document serves its intended audience (package users vs. frontend team philosophy readers) without context-switching.
+
+#### [Pattern] Code examples in README should progress from minimal (5-line getting started) to comprehensive (full component with variants/customization), not jump to advanced patterns (2026-02-18)
+- **Problem solved:** Writing component usage examples for README had choice between showing just basic button import vs. layered examples of increasing complexity
+- **Why this works:** Users of varying skill levels will read the README. Minimal example gets them running in < 5 minutes (acceptance criteria). Subsequent examples show variants, className overrides, cn() utility, custom themes for users who need more. Cognitive load increases gradually.
+- **Trade-offs:** Longer README, but serves broader audience. Benefits: Self-contained reference without needing to jump to Storybook. Cost: More content to maintain if component API changes.

--- a/.automaker/memory/documentation.md
+++ b/.automaker/memory/documentation.md
@@ -5,9 +5,9 @@ relevantTo: [documentation]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 12
-  referenced: 8
-  successfulFeatures: 8
+  loaded: 15
+  referenced: 11
+  successfulFeatures: 11
 ---
 # documentation
 

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 230
-  referenced: 110
-  successfulFeatures: 110
+  loaded: 233
+  referenced: 115
+  successfulFeatures: 115
 ---
 # gotchas
 
@@ -146,12 +146,37 @@ usageStats:
 - **Root cause:** Playwright bundles Chromium/Firefox/WebKit which require glibc and other system libraries. TEST_REUSE_SERVER allows CI/testing in restricted environments by reusing running instance
 - **How to avoid:** Reusing server makes tests faster and environment-agnostic but requires coordination that server is running; less isolated than full Playwright setup
 
-#### [Gotcha] Classification uses keyword matching on Discord channel names and Linear labels - extensibility requires code changes, not configuration (2026-02-18)
-- **Situation:** Discord channels like '#marketing' and '#social' route to GTM, but the keywords are hardcoded in gtmChannels/opsChannels arrays
-- **Root cause:** Keyword matching is simple and fast for current use case, but discovered limitation is that adding new channels or labels requires code deployment
-- **How to avoid:** Simple implementation vs. runtime flexibility. Current approach works for static organization structure, but breaks if company frequently adds/renames channels or labels.
+#### [Gotcha] Package.json exports map must exactly match tsup entry points for all export paths to work (2026-02-18)
+- **Situation:** Multiple export paths declared (./atoms, ./molecules, ./organisms, ./lib, root) but only some had corresponding tsup entries during development
+- **Root cause:** tsup generates a separate chunk for each entry point. If an entry point is declared in package.json exports but missing from tsup entry array, no JavaScript file is generated. The TypeScript declaration file may exist (if dts generation happens), but the .js file is missing, causing 'module not found' at runtime.
+- **How to avoid:** Requires discipline to keep two configuration sources in sync, but catches mismatches at build time rather than at runtime in production
 
-#### [Gotcha] Docker container restart exhaustion (5 consecutive restart failures) requires explicit detection and signaling - not observable via simple container status checks (2026-02-18)
-- **Situation:** Deployment pipeline was exiting on readiness check timeout but didn't distinguish between 'slow startup' (temporary) vs 'restart loop exhaustion' (permanent failure requiring manual intervention)
-- **Root cause:** Docker restart policy silently caps restart attempts; after 5 failures, container moves to 'exited' state but pipeline wasn't reading RestartCount metric to trigger escalated alert
-- **How to avoid:** Requires querying docker inspect (2 extra calls) but enables critical alerting for infrastructure-level failures vs application-level transient issues
+#### [Gotcha] CSS imports in monorepos must use relative paths at runtime, not package imports, despite package.json exports being configured (2026-02-18)
+- **Situation:** Added `./themes.css` export to libs/ui/package.json for API completeness, but actual imports in apps/ui still use relative paths (../../../../libs/ui/src/themes/themes.css)
+- **Root cause:** Tailwind CSS content scanner and Vite CSS import resolution don't honor package.json exports for CSS files. They treat CSS imports as file paths, not module specifiers. Package imports work for JS but not CSS in build tools.
+- **How to avoid:** Relative paths are fragile and verbose but work reliably. Package imports are clean but break silently (file not found). Chose paths that work over APIs that fail.
+
+#### [Gotcha] Duplicate nested directory path (libs/ui/libs/ui/) in worktree test file creation due to incorrect write context (2026-02-18)
+- **Situation:** Test file generated during verification landed in doubly-nested path, indicating lost context about working directory during file write operation
+- **Root cause:** Agent context drift: CWD was within worktree subdirectory; relative path construction didn't anchor properly; Write tool used relative paths without verification
+- **How to avoid:** Required manual diagnosis via glob search and path repair; lesson reinforces requirement to always use absolute paths in worktrees
+
+#### [Gotcha] Bulk import updates via task agents missed relative imports (../ui/markdown) that weren't part of standard aliased import patterns (2026-02-18)
+- **Situation:** After moving components and running bulk import updates with aliases (@protolabs/ui/molecules), two files (memory-view.tsx, context-view.tsx) still had old relative imports (from '../ui/markdown'). These weren't caught by the import replacement because they used a different pattern than the task expected.
+- **Root cause:** Automated bulk updates use regex patterns that match common import styles. Relative imports vary widely and may not match the exact pattern. Manual post-verification of grep results catches patterns the automation missed.
+- **How to avoid:** Added manual verification step (grep for old import paths) increases refactoring time but ensures complete migration. Prevents runtime errors from missed imports.
+
+#### [Gotcha] Storybook addon version incompatibility: Removing one problematic addon (addon-a11y) doesn't prevent cascading failures in other addons. The root cause (version mismatch at the monorepo level) persists, breaking remaining addons that depend on the same internal APIs. (2026-02-18)
+- **Situation:** Removed addon-a11y to eliminate addon-highlight dependency (which was throwing 'No matching export' error). After npm install, Storybook still failed with 'Missing ./internal/theming' from @storybook/blocks. This suggests the problem wasn't addon-a11y—it was the version mismatch itself.
+- **Root cause:** All Storybook addons depend on internal APIs that changed between v8 and v10. Removing one addon doesn't update the hoisted Storybook version—it remains v10.2.8 from apps/ui, breaking any addon trying to use v8.x internal APIs.
+- **How to avoid:** Removing addons buys time but hides the real problem. Eventually, you run out of addons to remove. Fixing the root cause (version alignment) is more effort upfront but prevents cascading failures.
+
+#### [Gotcha] Storybook build output directory must be explicitly specified in npm scripts, not just in storybook config, for CI/CD reproducibility (2026-02-18)
+- **Situation:** Feature required configuring Storybook to build into a predictable location for CI verification. The default storybook build behavior outputs to storybook-static/, but this wasn't explicit in the script.
+- **Root cause:** CI workflows that reference the output directory need the location to be declared in the script itself. Relying only on Storybook config defaults makes the contract between package.json scripts and CI workflows implicit and fragile. Explicit --output-dir flag makes the contract visible to anyone reading the script.
+- **How to avoid:** More verbose script declaration but gains explicit visibility. The flag is idempotent (specifying --output-dir storybook-static when that's already the default is harmless).
+
+#### [Gotcha] .npmignore whitelist approach: `*` (exclude all) followed by `!path/**` (include specific) is required for monorepo packages to avoid accidentally including source files when exports reference src/ (2026-02-18)
+- **Situation:** Initial .npmignore excluded src/ globally, but package.json exports included ./src/themes/themes.css. Standard exclude patterns would have prevented themes from being packaged while still leaking other src/ files.
+- **Root cause:** npm's .npmignore matching is line-order dependent. Blacklist approach (exclude src/, then include src/themes/) fails because the first match wins. Whitelist approach (exclude *, then include dist/ and src/themes/) guarantees only intended paths are packaged.
+- **How to avoid:** Whitelist is more explicit but requires maintaining the include list as exports change. Easier to verify what's shipped (npm pack --dry-run shows exactly what publishes). Harder to onboard new developers who expect standard .gitignore semantics.

--- a/.automaker/memory/performance.md
+++ b/.automaker/memory/performance.md
@@ -74,3 +74,13 @@ usageStats:
 - **Rejected:** Instant toggle without animation - feels broken/unpolished, hard to follow in interface
 - **Trade-offs:** Slight performance cost on older devices, but improved perceived performance. Animation adds 16-24 line motion component wrapper.
 - **Breaking if changed:** If motion/react library is removed or browser doesn't support animations, panels appear/disappear instantly without visual feedback.
+
+#### [Pattern] Named ESM exports preserve tree-shaking across multi-entry monorepo builds (2026-02-18)
+- **Problem solved:** Exporting a utility function (cn) from a shared package that must remain tree-shakeable when imported by multiple apps
+- **Why this works:** The built dist/lib/index.js uses named exports (`export { cn }`) rather than default or wrapped exports. This allows bundlers (webpack, vite, esbuild) to statically analyze which exports are actually used and remove unused code.
+- **Trade-offs:** Named exports require explicit import syntax from consumers (`import { cn } from '@protolabs/ui/lib'`), but this is explicitly desired for clarity. Unused utilities in lib/ are automatically dropped during consumer build.
+
+#### [Gotcha] Large story files (12+ export statements) can impact Storybook build time but tradeoff is worth it for comprehensive component coverage in single file vs split files (2026-02-18)
+- **Situation:** Some atoms (textarea, skeleton, spinner, label, kbd) have 11-12 story exports. Textarea has 12 stories in single file
+- **Root cause:** Keeping variant stories together makes it obvious all variants exist and interact together. Splitting across files spreads them through filesystem making coverage less obvious. Single file per component matches the component file organization principle
+- **How to avoid:** Larger file size (few KB each) with better coherence vs smaller files scattered across directory. Storybook loads all stories anyway so no real performance impact

--- a/.automaker/memory/security.md
+++ b/.automaker/memory/security.md
@@ -129,12 +129,7 @@ usageStats:
 - **Trade-offs:** URL parameter is visible in logs and browser history (but session ID itself isn't sensitive), but provides explicit authorization checkpoints
 - **Breaking if changed:** If sessions become cross-user shareable, the assumption that URL sessionId = owner identity breaks, requiring additional permission checks inside handlers
 
-#### [Pattern] Multi-layer deployment readiness verification via /api/health/ready endpoint that checks API key configuration, data directory accessibility, and writability before marking server as ready (2026-02-18)
-- **Problem solved:** Deploy pipeline was accepting server as ready without verifying critical runtime dependencies were properly initialized
-- **Why this works:** Container restart loops can occur silently; checking only HTTP 200 response status misses misconfiguration states. Verifying API key presence and data directory state prevents deployments that appear successful but fail during operation
-- **Trade-offs:** Adds 2-3 extra curl calls per deployment verification (30ms total) but prevents cascading failures and manual rollbacks
-
-#### [Pattern] Graduated alerting strategy: success message includes version and doc status, failure message branches on rollback outcome, critical alerts (restart exhaustion) append to failure message (2026-02-18)
-- **Problem solved:** Discord notifications were generic and didn't provide actionable information about failure root cause or what operator should do
-- **Why this works:** Different failure modes require different human responses: rollback success = monitoring only, rollback failure = immediate manual intervention, restart exhaustion = infrastructure restart. Graduated alerts direct operator attention appropriately
-- **Trade-offs:** More complex notification script but provides semantic information that prevents wrong remediation actions
+#### [Pattern] Repository field in package.json with monorepo directory path ("directory": "libs/ui") enables npm audit and tooling to resolve vulnerabilities to correct source location in monorepo (2026-02-18)
+- **Problem solved:** Monorepo packages without explicit directory path confuse npm tooling about where the source code actually lives
+- **Why this works:** npm audit, GitHub dependency tracking, and third-party supply-chain tools use repository.directory to map published packages back to source. Without it, tools report vulnerabilities against wrong path or fail to cross-reference.
+- **Trade-offs:** Explicit directory adds 1-2 lines to package.json but gives complete supply-chain visibility. Cost is negligible, benefit is infrastructure-level.

--- a/.automaker/memory/testing.md
+++ b/.automaker/memory/testing.md
@@ -524,7 +524,47 @@ usageStats:
 - **Root cause:** TypeScript compilation and Vite build are sufficient for catching structural errors, but Storybook failure prevented visual verification of component rendering. Decision to skip story given unrelated Storybook configuration issues.
 - **How to avoid:** Saved time by skipping broken Storybook, but lost visual verification benefit. Component structure verified but actual rendering in browser not confirmed.
 
-#### [Pattern] Created temporary integration test using vitest (not Playwright) that verified removal by attempting imports that should fail (2026-02-18)
-- **Problem solved:** Needed to verify 7 crew members, crew-loop-service, and crew routes were all deleted before committing.
-- **Why this works:** Import-time failures are the clearest verification that code paths have been removed. This catches the removal at compile-time rather than runtime. Vitest (existing server test framework) was appropriate rather than Playwright (which tests HTTP endpoints).
-- **Trade-offs:** Temporary test files must be cleaned up after verification vs. permanent regression detection. Tradeoff favors clean commit over permanent test cruft.
+#### [Pattern] Verification of export paths and TypeScript declarations via dynamic import testing (2026-02-18)
+- **Problem solved:** Need to verify that newly exported functions are actually importable and properly typed after a build change
+- **Why this works:** Static analysis alone cannot detect that an export path produces no JavaScript output. Dynamic imports at runtime can load and test the actual built artifacts. Testing includes: function import, type existence, package.json export map structure.
+- **Trade-offs:** Requires running the full test suite after build changes, but catches export path errors before they reach consumers. Temporary test files can be created and deleted for verification without permanent test overhead.
+
+#### [Pattern] Ephemeral verification test suite: create comprehensive Playwright tests, run them to verify the feature works, then delete the test file (2026-02-18)
+- **Problem solved:** Theme extraction required complex verification across file locations, CSS syntax, build artifacts, and import paths. A permanent test suite would be fragile and maintenance-heavy.
+- **Why this works:** Playwright tests verify real file I/O and CSS syntax without running the app. One-time verification catches mistakes immediately. Deleting after success avoids maintaining brittle filesystem tests that break if the codebase structure changes.
+- **Trade-offs:** Ephemeral tests catch issues faster than manual verification but don't prevent regressions. Permanent e2e tests would catch regressions but add maintenance burden. Pattern trades regression coverage for implementation speed.
+
+#### [Gotcha] E2E test for CSS verification requires the app to successfully load and execute, but unrelated import errors prevent load. Static CSS validation (file inspection, line counts, syntax) becomes the only available verification method. (2026-02-18)
+- **Situation:** Created theme-verification.spec.ts to check CSS variables via Playwright, but app fails to load before any CSS is evaluated.
+- **Root cause:** CSS is evaluated only after TypeScript/JavaScript loads and bundles. Import resolution failures occur earlier in the pipeline, blocking CSS validation. Tests cannot reach the CSS layer if the app fails to start.
+- **How to avoid:** Static verification (head, grep, line counts, syntax checks) is fast and deterministic but less authoritative than runtime verification. Runtime tests are more convincing but depend on independent systems (build, bundler, import resolution).
+
+#### [Gotcha] Node.js ESM import test from browser app context requires explicit path verification and absolute imports due to CWD unpredictability in worktrees (2026-02-18)
+- **Situation:** Test command 'import from @protolabs/ui/themes' executed from apps/ui directory, but actual resolution depends on package.json exports and workspace symlinks being correct
+- **Root cause:** Package resolution in monorepos relies on workspace symlinks + exports field, not relative paths; CWD shifts in worktrees can cause relative path lookups to fail; Node.js import() resolves package names globally first
+- **How to avoid:** Using package name requires correct workspace setup and build artifacts in place; moving code between projects just works; adding new exports requires coordinated changes to tsup + package.json
+
+#### [Gotcha] Storybook major version upgrades (8.x→10.x) introduce breaking changes in internal APIs (internal/theming, internal/preview-api) that aren't caught at build time. The tsup build succeeds, but Storybook dev server fails at runtime when importing addon code. (2026-02-18)
+- **Situation:** Build succeeded (`npm run build -w @protolabs/ui` passed), but `npm run storybook -w @protolabs/ui` failed with internal module errors. This suggests internal APIs aren't part of the public type definitions, making breakage invisible until runtime.
+- **Root cause:** Storybook maintains internal APIs without semantic versioning guarantees. Addons depend on these internals, making major upgrades fragile. The pattern of exposing internals in package exports (e.g., '@storybook/blocks/internal/theming') creates a hidden API surface.
+- **How to avoid:** Testing Storybook locally requires running the dev server, which only fails at runtime. CI that only runs builds won't catch these errors. Adding a Storybook build step (`build-storybook`) to CI would catch errors, but slows CI and adds false positives when Storybook config is unrelated to the change.
+
+#### [Pattern] CSF3 format with autodocs tag + a11y addon provides dual benefit: auto-generated documentation AND automatic accessibility violation detection in one artifact (2026-02-18)
+- **Problem solved:** Need for comprehensive component documentation that also catches a11y regressions during development.
+- **Why this works:** autodocs tag enables Storybook to generate docs from stories without additional doc files, reducing maintenance burden. a11y addon is already in Storybook config, so it runs automatically on every story at dev time—catching a11y issues before code review.
+- **Trade-offs:** Stories become the single source of truth for docs + a11y validation, which is powerful but couples documentation build/visibility to Storybook infra. If Storybook breaks, docs become unavailable.
+
+#### [Pattern] CSF3 with satisfies Meta<typeof Component> provides compile-time type safety for story definitions, preventing prop mismatches that would only surface at runtime (2026-02-18)
+- **Problem solved:** All 25 story files use 'satisfies Meta<typeof Component>' pattern rather than loose typing. This was chosen as the consistent pattern across all atoms
+- **Why this works:** Satisfies operator validates story argTypes and template props against actual component props at TS compile time. Catches typos, missing props, and type mismatches before Storybook loads. Prevents the silent failures common in loosely-typed story files
+- **Trade-offs:** Satisfies requires slightly more verbose type declarations upfront but eliminates entire class of prop-mismatch bugs. Zero runtime cost - purely compile-time validation
+
+#### [Gotcha] Build configuration changes cannot be verified with Playwright tests—verification must be structural (artifact inspection) not functional (UI rendering) (2026-02-18)
+- **Situation:** Feature acceptance criteria included 'Storybook accessible at public URL' but the implementation task only covers build config and CI setup, not deployment. Team initially tried to apply Playwright verification pattern to a non-UI task.
+- **Root cause:** Playwright tests verify rendered UI behavior. Storybook build config produces static artifacts, not interactive pages. Verification happens offline (checking file existence, structure, validity) not via browser automation. The distinction matters: build config is proven by running the build and inspecting output; UI behavior is proven by rendering and interaction.
+- **How to avoid:** Structural verification (test -f index.html && test -d assets) is fast and reliable but doesn't test that the site actually renders correctly in a browser. Deployment/hosting verification is separate and requires a live environment.
+
+#### [Gotcha] Documentation-only features (README, philosophy docs) don't require Playwright verification, only confirmation that files exist, build succeeds, and formatting is correct (2026-02-18)
+- **Situation:** Feature requirement specified 'Playwright verification required' but this milestone is purely documentation with no runtime functionality
+- **Root cause:** Playwright tests verify user-facing behavior and interaction. Documentation has no runtime behavior — it's static content. Verification shifts to: file existence, no build errors, no unintended file changes, correct formatting.
+- **How to avoid:** Simpler verification process for documentation features means faster turnaround. Risk: Could merge malformed docs. Mitigation: Visual review in PR and build gate ensures no syntax errors.

--- a/.automaker/memory/ui.md
+++ b/.automaker/memory/ui.md
@@ -319,3 +319,20 @@ usageStats:
 - **Rejected:** Keep tab bar but conditionally hide/show based on route - would create hidden complexity and make future maintenance harder
 - **Trade-offs:** Simpler components but requires new route file; easier to reason about but slightly more routing boilerplate
 - **Breaking if changed:** If future features need tab selection in analytics, would need to rebuild the state management pattern
+
+#### [Gotcha] Storybook stories.array config with multiple globs must maintain order: local app stories BEFORE library stories, otherwise type discovery or import resolution can fail (2026-02-18)
+- **Situation:** Added '../../../libs/ui/src/**/*.stories' to stories array that already had '../src/**/*.stories'. Configuration order matters for module resolution.
+- **Root cause:** Storybook processes stories array in sequence. If library path comes first and apps/ui stories import from libs/ui, the library stories may be processed before @automaker/ui module symlink is fully resolved by the monorepo.
+- **How to avoid:** Correct ordering ensures reliable builds but requires discipline—new maintainers may accidentally reorder and break CI silently (build succeeds, stories fail to load at runtime).
+
+#### [Gotcha] Interactive Storybook controls (argTypes) enable dark/light theme switching without explicit story variants - Storybook's theme addon handles this automatically (2026-02-18)
+- **Situation:** Requirement stated 'dark/light comparison possible' but implementation doesn't have separate Dark/Light variant stories. Instead, argTypes + Storybook theme switcher UI achieves this
+- **Root cause:** Storybook's built-in theme switching (via toolbar) applies CSS class/theme context globally. Components using CSS variables for theming (shadcn pattern) automatically render in both themes without duplicate stories. This is more maintainable than duplicating every story
+- **How to avoid:** Fewer stories (193 total) with automatic theme switching vs 2x stories with explicit variants. First approach scales better - adding a new component doesn't double story count
+
+### Theme system documentation should enumerate all available themes with their characteristics (light/dark mode, color palette, use cases) rather than generic 'how to switch themes' (2026-02-18)
+- **Context:** Writing theme setup section of README had to balance between technical 'how to' and discovery 'which theme fits my project'
+- **Why:** Users evaluating the package need to know what visual options exist before writing code. Listing 6 specific themes (studio-light, studio-dark, nord, catppuccin, dracula, monokai) with their characteristics (perceptual uniformity via OKLch, design intent) lets them make informed choice upfront rather than trying themes trial-and-error.
+- **Rejected:** Alternative: Generic 'import theme and apply' without listing options. Would force users to browse source code to discover available themes.
+- **Trade-offs:** Longer documentation initially, but reduces friction for new users and showcases package variety. Small maintenance burden if new themes added (must update enumeration).
+- **Breaking if changed:** If theme enumeration becomes stale (new theme added but not documented), users miss it and may not use it. Creates false sense that only documented themes exist.

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -46,7 +46,6 @@
     "@automaker/dependency-resolver": "1.0.0",
     "@automaker/spec-parser": "1.0.0",
     "@automaker/types": "1.0.0",
-    "@protolabs/ui": "*",
     "@codemirror/lang-xml": "6.1.0",
     "@codemirror/language": "^6.12.1",
     "@codemirror/legacy-modes": "^6.5.2",
@@ -133,6 +132,7 @@
     "lightningcss-win32-x64-msvc": "1.29.2"
   },
   "devDependencies": {
+    "@protolabs/ui": "*",
     "@chromatic-com/storybook": "^5.0.1",
     "@electron/rebuild": "^4.0.3",
     "@eslint/js": "9.0.0",

--- a/apps/ui/scripts/prepare-server.mjs
+++ b/apps/ui/scripts/prepare-server.mjs
@@ -7,8 +7,18 @@
  */
 
 import { execSync } from 'child_process';
-import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'fs';
-import { join, dirname } from 'path';
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+} from 'fs';
+import { join, dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -116,7 +126,36 @@ execSync('npm install --omit=dev --legacy-peer-deps', {
   },
 });
 
-// Step 7: Rebuild native modules for current architecture
+// Step 7: Replace symlinks with real directory copies
+// npm install with file: references creates symlinks, which break electron-builder
+// when packaging for architectures other than the host (e.g. arm64 on x64).
+console.log('🔗 Resolving symlinks in node_modules...');
+const bundleNodeModules = join(BUNDLE_DIR, 'node_modules');
+
+function resolveSymlinksInDir(dir) {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir)) {
+    const entryPath = join(dir, entry);
+    // Handle scoped packages (@automaker/*)
+    if (entry.startsWith('@') && lstatSync(entryPath).isDirectory()) {
+      resolveSymlinksInDir(entryPath);
+      continue;
+    }
+    if (lstatSync(entryPath).isSymbolicLink()) {
+      const realPath = resolve(dirname(entryPath), readlinkSync(entryPath));
+      if (existsSync(realPath)) {
+        console.log(`   ↳ ${entry}: symlink → real copy`);
+        rmSync(entryPath);
+        cpSync(realPath, entryPath, { recursive: true });
+      }
+    }
+  }
+}
+
+resolveSymlinksInDir(bundleNodeModules);
+console.log('✅ Symlinks resolved\n');
+
+// Step 8: Rebuild native modules for current architecture
 // This is critical for modules like node-pty that have native bindings
 console.log('🔨 Rebuilding native modules for current architecture...');
 try {


### PR DESCRIPTION
## Summary
- Fix arm64 Electron build failure caused by symlinked `@automaker/*` packages in `server-bundle/node_modules`
- Add post-install symlink resolution step in `prepare-server.mjs` that replaces symlinks with real directory copies
- Move `@protolabs/ui` from dependencies to devDependencies (bundled by Vite at build time, not needed in packaged app)

## Root Cause
`npm install` with `file:` references creates symlinks. `electron-builder` fails to follow these symlinks when packaging for arm64 architecture, resulting in `ENOENT` errors during cross-architecture builds.

## Test plan
- [x] Verified x64 DMG + ZIP build succeeds (380MB each)
- [x] Verified arm64 DMG + ZIP build succeeds (376MB each) — previously failed with ENOENT
- [x] `@protolabs/ui` dependency warning eliminated
- [x] Native module rebuilds succeed for both architectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved a UI package from runtime dependencies to development-only dependencies to streamline packaging and reduce runtime footprint.
  * Enhanced the build/prepare process to resolve linked packages into real copies before rebuilding native modules, improving bundled module consistency and build reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->