### PR TITLE
feat: add CI workflow for Electron builds

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -1,0 +1,111 @@
+name: Build Electron
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: electron-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-mac:
+    runs-on: macos-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Update package.json version
+        run: node apps/ui/scripts/update-version.mjs "${{ steps.version.outputs.version }}"
+
+      - name: Setup project
+        uses: ./.github/actions/setup-project
+        with:
+          check-lockfile: 'true'
+
+      - name: Build Electron app (macOS x64 + arm64)
+        run: npm run build:electron:mac --workspace=apps/ui
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mac-builds
+          path: |
+            apps/ui/release/*.dmg
+            apps/ui/release/*.zip
+            apps/ui/release/*.blockmap
+          retention-days: 30
+
+  build-linux:
+    runs-on: self-hosted
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Update package.json version
+        run: node apps/ui/scripts/update-version.mjs "${{ steps.version.outputs.version }}"
+
+      - name: Setup project
+        uses: ./.github/actions/setup-project
+        with:
+          check-lockfile: 'true'
+
+      - name: Install RPM build tools
+        run: sudo apt-get update && sudo apt-get install -y rpm
+
+      - name: Build Electron app (Linux x64)
+        run: npm run build:electron:linux --workspace=apps/ui
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-builds
+          path: |
+            apps/ui/release/*.AppImage
+            apps/ui/release/*.deb
+            apps/ui/release/*.rpm
+            apps/ui/release/*.blockmap
+          retention-days: 30
+
+  upload-release:
+    needs: [build-mac, build-linux]
+    runs-on: self-hosted
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: mac-builds
+          path: artifacts/mac
+
+      - name: Download Linux artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-builds
+          path: artifacts/linux
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/mac/*
+            artifacts/linux/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build-electron.yml` triggered on `v*` tag pushes
- Builds macOS (x64 + arm64 via electron-builder cross-compilation) and Linux (x64) Electron apps
- Uploads DMG, ZIP, AppImage, deb, and rpm artifacts to the GitHub Release via `softprops/action-gh-release`
- 15-minute timeout per build job
- Note: `release.yml` still exists for manual release-triggered builds; this workflow is the primary tag-driven CI

## Test plan
- [ ] Push a `v0.0.1-test` tag and verify workflow triggers
- [ ] Verify macOS job produces both x64 and arm64 DMG/ZIP artifacts
- [ ] Verify Linux job produces AppImage, deb, rpm artifacts
- [ ] Verify upload-release job attaches all artifacts to the GitHub Release
- [ ] Verify build completes within 15 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated build workflow now generates platform-specific installers for macOS (Intel and ARM64) and Linux when version tags are created
  * Multi-format package outputs enable streamlined distribution across supported platforms
  * Release artifacts automatically published to GitHub Releases with retention management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->