### PR TITLE
fix: suppress EPIPE crash in Electron when launched from Finder

### DIFF
--- a/apps/ui/src/main.ts
+++ b/apps/ui/src/main.ts
@@ -1,3 +1,16 @@
+// Suppress EPIPE errors on stdout/stderr.
+// When Electron is launched from Finder (not a terminal), these streams
+// are broken pipes. console.log/warn/error writes throw EPIPE, crashing
+// the main process before the UI can render.
+process.stdout?.on('error', (err) => {
+  if ((err as NodeJS.ErrnoException).code === 'EPIPE') return;
+  throw err;
+});
+process.stderr?.on('error', (err) => {
+  if ((err as NodeJS.ErrnoException).code === 'EPIPE') return;
+  throw err;
+});
+
 /**
  * Electron main process (TypeScript)
  *


### PR DESCRIPTION
## Summary
- Add EPIPE error handlers for `process.stdout` and `process.stderr` at the top of Electron's `main.ts`, before any imports that trigger logging
- When the packaged app launches from Finder (no TTY), logger writes to broken pipes throw synchronous EPIPE errors that crash the main process before the UI renders
- Non-EPIPE errors are still re-thrown as a safety net

## Test plan
- [ ] `npm run build:packages && npm run build:electron` succeeds
- [ ] Launch built DMG from Finder — app window shows UI (not blank screen)
- [ ] `npm run dev:electron` still works (terminal-attached mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed application crashes that occurred when launching from Finder on macOS. The app now handles system errors gracefully during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->