### PR TITLE
fix: correct Josh bio — Vizient → Phase2 + Knapsack

### DIFF
--- a/docs/protolabs/content/saas-is-dead-meet-the-intelligent-product-engine.md
+++ b/docs/protolabs/content/saas-is-dead-meet-the-intelligent-product-engine.md
@@ -191,7 +191,7 @@ Your SaaS bill is opaque by design. Ours is open by default.
 
 ---
 
-_Josh Mabry is the founder of protoLabs. Former Principal Application Architect at Vizient. He architects systems and directs AI agents to build them._
+_Josh Mabry is the founder of protoLabs. Design systems architect for Fortune 500 clients, AI lead at Knapsack. He architects systems and directs AI agents to build them._
 
 ---
 

--- a/libs/prompts/src/agents/gtm-specialist-prompt.ts
+++ b/libs/prompts/src/agents/gtm-specialist-prompt.ts
@@ -18,7 +18,7 @@ export function getGTMSpecialistPrompt(config: GTMSpecialistConfig = {}): string
 - NEVER USE: "coded, built in React, implemented, programmed"
 - Josh architects systems. AI agents implement them. This distinction is the entire brand.
 
-**Josh's background:** Former Principal Application Architect at Vizient, now building protoLabs — the first AI-native development agency. He doesn't write code; he designs what gets built and directs agents to build it.
+**Josh's background:** Design systems architect for Fortune 500 clients (Phase2 Technology), AI lead at Knapsack, now building protoLabs — the first AI-native development agency. He doesn't write code; he designs what gets built and directs agents to build it.
 
 ## Ecosystem
 

--- a/libs/prompts/src/agents/jon.ts
+++ b/libs/prompts/src/agents/jon.ts
@@ -24,7 +24,7 @@ You are Jon, the GTM (Go-To-Market) Specialist for protoLabs. You own content st
 - NEVER USE: "coded, built in React, implemented, programmed, developed"
 - Josh architects systems. AI agents implement them. This distinction IS the brand.
 
-**Josh's background:** Former Principal Application Architect at Vizient, now building protoLabs — the first AI-native development agency.
+**Josh's background:** Design systems architect for Fortune 500 clients (Phase2 Technology), AI lead at Knapsack, now building protoLabs — the first AI-native development agency.
 
 ## Revenue Model
 

--- a/site/consulting/index.html
+++ b/site/consulting/index.html
@@ -473,9 +473,9 @@
           </h2>
           <p class="mt-6 text-zinc-400 leading-relaxed">
             protoLabs is led by <span class="text-zinc-200">Josh Mabry</span> — 8+ years shipping
-            production software, former Principal Application Architect at Vizient, 3+ years deep in
-            agentic AI. Josh designed the autonomous development methodology and uses it every day
-            to ship real products.
+            production software, design systems architect for Fortune 500 clients, AI lead at
+            Knapsack, 3+ years deep in agentic AI. Josh designed the autonomous development
+            methodology and uses it every day to ship real products.
           </p>
           <p class="mt-4 text-zinc-400 leading-relaxed">
             The proof is in the git log. 370,000 lines of production TypeScript. Three shipped


### PR DESCRIPTION
## Summary
- Josh never worked at Vizient. Corrects bio across all surfaces to: design systems architect at Phase2 Technology (Fortune 500 clients), AI lead at Knapsack.
- Fixes live consulting site copy, blog content, and agent prompts (Jon + GTM specialist).

## Files Changed
- `site/consulting/index.html` — live consulting site bio
- `docs/protolabs/content/saas-is-dead...md` — blog post bio line
- `libs/prompts/src/agents/jon.ts` — Jon agent prompt
- `libs/prompts/src/agents/gtm-specialist-prompt.ts` — GTM specialist prompt

## Test plan
- [ ] Verify protolabs.consulting bio renders correctly after deploy
- [ ] Verify agent prompts reference correct background

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Updated biographical information for team members across documentation, AI specialist prompts, and consulting web pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->