### PR TITLE
fix: catch synchronous EPIPE throws via uncaughtException handler

### DIFF
--- a/apps/ui/src/main.ts
+++ b/apps/ui/src/main.ts
@@ -2,6 +2,7 @@
 // When Electron is launched from Finder (not a terminal), these streams
 // are broken pipes. console.log/warn/error writes throw EPIPE, crashing
 // the main process before the UI can render.
+// Belt: catch async stream errors.
 process.stdout?.on('error', (err) => {
   if ((err as NodeJS.ErrnoException).code === 'EPIPE') return;
   throw err;
@@ -9,6 +10,18 @@ process.stdout?.on('error', (err) => {
 process.stderr?.on('error', (err) => {
   if ((err as NodeJS.ErrnoException).code === 'EPIPE') return;
   throw err;
+});
+// Suspenders: catch synchronous EPIPE throws from afterWriteDispatched
+// that bypass the stream error handler entirely.
+process.on('uncaughtException', (err) => {
+  if ((err as NodeJS.ErrnoException).code === 'EPIPE') return;
+  // Non-EPIPE: log to stderr (may itself fail if pipe is broken, that's fine)
+  try {
+    process.stderr.write(`Uncaught exception: ${err.stack || err.message}\n`);
+  } catch {
+    // stderr is broken too — nothing we can do
+  }
+  process.exit(1);
 });
 
 /**


### PR DESCRIPTION
## Summary
- Stream error handlers from #788 only catch **async** EPIPE errors on `process.stdout`/`process.stderr`
- When Electron is launched from Finder, `console.log` writes can throw EPIPE **synchronously** via `afterWriteDispatched`, bypassing the stream `on('error')` handler entirely
- Adds `process.on('uncaughtException')` safety net that swallows EPIPE and exits cleanly for all other uncaught errors

## Test plan
- [ ] Build Electron app (`npm run build:electron`)
- [ ] Launch from Finder (not terminal) — no crash dialog
- [ ] Verify non-EPIPE uncaught exceptions still cause exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error handling for uncaught exceptions in the application with improved distinction between exception types, resulting in better application stability and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->