### PR TITLE
fix: rebrand Electron productName and appId to protoLabs.studio

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -165,8 +165,8 @@
     "vite-plugin-electron-renderer": "0.14.6"
   },
   "build": {
-    "appId": "com.automaker.app",
-    "productName": "Automaker",
+    "appId": "studio.protolabs.app",
+    "productName": "protoLabs.studio",
     "artifactName": "${productName}-${version}-${arch}.${ext}",
     "npmRebuild": false,
     "publish": {


### PR DESCRIPTION
## Summary

- Changed `productName` from `Automaker` to `protoLabs.studio` in electron-builder config
- Changed `appId` from `com.automaker.app` to `studio.protolabs.app`
- DMG, app bundle, and macOS menu bar now show the correct brand name

## Test plan

- [x] Built and verified arm64 DMG shows "protoLabs.studio" in installer
- [x] App name in Finder/Dock displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Application branding and metadata have been updated to reflect the new product identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->