### PR TITLE
feat: Ava Anywhere M2 — conversation management + model selection

### DIFF
--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-view.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-view.tsx
@@ -4,30 +4,41 @@
  * Renders a full-window chat interface for the Electron overlay panel.
  * Uses shared @protolabs/ui/ai components. The overlay is shown/hidden
  * via global shortcut (Cmd/Ctrl+Shift+Space) managed by Electron main process.
+ *
+ * M2: Adds conversation management (list, switch, delete), model selection,
+ * and persistent chat history via useChatSession.
  */
 
 import { useState, useCallback, useEffect } from 'react';
-import { useChat } from '@ai-sdk/react';
-import { X } from 'lucide-react';
+import { History, X } from 'lucide-react';
 import { ChatMessageList, ChatInput } from '@protolabs/ui/ai';
 import { Button } from '@protolabs/ui/atoms';
 import { cn } from '@/lib/utils';
 import { getElectronAPI, isElectron } from '@/lib/electron';
+import { useChatSession } from '@/hooks/use-chat-session';
+import { ChatModelSelect } from '@/components/views/chat/components/chat-model-select';
+import { ConversationList } from './conversation-list';
 
 export function ChatOverlayView() {
   const [inputValue, setInputValue] = useState('');
 
-  const { messages, sendMessage, stop, status, setMessages, error } = useChat({
-    api: '/api/chat',
-    headers: {
-      'x-model-alias': 'sonnet',
-    },
-    onError: (err) => {
-      console.error('Chat overlay error:', err);
-    },
-  });
-
-  const isStreaming = status === 'streaming' || status === 'submitted';
+  const {
+    messages,
+    sendMessage,
+    stop,
+    isStreaming,
+    error,
+    sessions,
+    currentSessionId,
+    modelAlias,
+    handleNewChat,
+    handleSwitchSession,
+    handleDeleteSession,
+    handleModelChange,
+    historyOpen,
+    toggleHistory,
+    setHistoryOpen,
+  } = useChatSession({ defaultModel: 'sonnet' });
 
   const handleSubmit = useCallback(() => {
     const text = inputValue.trim();
@@ -42,28 +53,26 @@ export function ChatOverlayView() {
     }
   }, []);
 
-  const handleNewChat = useCallback(() => {
-    setMessages([]);
-    setInputValue('');
-  }, [setMessages]);
-
   // Escape key hides the overlay
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        handleHide();
+        if (historyOpen) {
+          setHistoryOpen(false);
+        } else {
+          handleHide();
+        }
       }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [handleHide]);
+  }, [handleHide, historyOpen, setHistoryOpen]);
 
   return (
     <div
       data-slot="chat-overlay"
       className={cn(
         'flex h-screen w-screen flex-col bg-background',
-        // Rounded corners for the overlay panel window
         'overflow-hidden rounded-xl border border-border'
       )}
     >
@@ -78,8 +87,19 @@ export function ChatOverlayView() {
             variant="ghost"
             size="icon"
             className="size-7"
+            onClick={toggleHistory}
+            title="Conversation history"
+            aria-label="Toggle conversation history"
+          >
+            <History className="size-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7"
             onClick={handleNewChat}
             title="New chat"
+            aria-label="New chat"
           >
             <span className="text-xs">New</span>
           </Button>
@@ -89,6 +109,7 @@ export function ChatOverlayView() {
             className="size-7"
             onClick={handleHide}
             title="Hide (Esc)"
+            aria-label="Hide overlay"
           >
             <X className="size-3.5" />
           </Button>
@@ -102,23 +123,48 @@ export function ChatOverlayView() {
         </div>
       )}
 
-      {/* Messages */}
-      <ChatMessageList messages={messages} emptyMessage="Ask Ava anything..." />
+      {/* Main content area */}
+      <div className="flex min-h-0 flex-1">
+        {/* Conversation list panel */}
+        {historyOpen && (
+          <ConversationList
+            sessions={sessions}
+            currentSessionId={currentSessionId}
+            onSelect={(id) => {
+              handleSwitchSession(id);
+              setHistoryOpen(false);
+            }}
+            onNew={() => {
+              handleNewChat();
+              setHistoryOpen(false);
+            }}
+            onDelete={handleDeleteSession}
+            onClose={() => setHistoryOpen(false)}
+          />
+        )}
 
-      {/* Input */}
-      <ChatInput
-        value={inputValue}
-        onChange={setInputValue}
-        onSubmit={handleSubmit}
-        onStop={stop}
-        isStreaming={isStreaming}
-        placeholder="Ask Ava..."
-        actions={
-          <span className="text-[10px] text-muted-foreground">
-            {isStreaming ? 'Streaming...' : 'Enter to send \u00B7 Esc to hide'}
-          </span>
-        }
-      />
+        {/* Chat area */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          <ChatMessageList messages={messages} emptyMessage="Ask Ava anything..." />
+
+          <ChatInput
+            value={inputValue}
+            onChange={setInputValue}
+            onSubmit={handleSubmit}
+            onStop={stop}
+            isStreaming={isStreaming}
+            placeholder="Ask Ava..."
+            actions={
+              <>
+                <ChatModelSelect value={modelAlias} onValueChange={handleModelChange} />
+                <span className="text-[10px] text-muted-foreground">
+                  {isStreaming ? 'Streaming...' : 'Enter to send \u00B7 Esc to hide'}
+                </span>
+              </>
+            }
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/ui/src/components/views/chat-overlay/conversation-list.tsx
+++ b/apps/ui/src/components/views/chat-overlay/conversation-list.tsx
@@ -1,0 +1,122 @@
+/**
+ * ConversationList — Slide-out panel showing chat history in the overlay.
+ *
+ * Lists saved conversations with title, timestamp, and delete action.
+ * Clicking a conversation switches to it.
+ */
+
+import { MessageSquare, Plus, Trash2, X } from 'lucide-react';
+import { Button } from '@protolabs/ui/atoms';
+import { cn } from '@/lib/utils';
+import type { ChatSession } from '@/store/chat-store';
+
+function formatTime(epoch: number): string {
+  const date = new Date(epoch);
+  const now = Date.now();
+  const diff = now - epoch;
+
+  if (diff < 60_000) return 'Just now';
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  if (diff < 604_800_000) return `${Math.floor(diff / 86_400_000)}d ago`;
+
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export function ConversationList({
+  sessions,
+  currentSessionId,
+  onSelect,
+  onNew,
+  onDelete,
+  onClose,
+  className,
+}: {
+  sessions: ChatSession[];
+  currentSessionId: string | null;
+  onSelect: (id: string) => void;
+  onNew: () => void;
+  onDelete: (id: string) => void;
+  onClose: () => void;
+  className?: string;
+}) {
+  return (
+    <div
+      data-slot="conversation-list"
+      className={cn(
+        'flex h-full w-56 shrink-0 flex-col border-r border-border bg-muted/30',
+        className
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        <span className="text-xs font-medium text-muted-foreground">Conversations</span>
+        <div className="flex items-center gap-0.5">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6"
+            onClick={onNew}
+            aria-label="New conversation"
+          >
+            <Plus className="size-3" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6"
+            onClick={onClose}
+            aria-label="Close history"
+          >
+            <X className="size-3" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Session list */}
+      <div className="flex-1 overflow-y-auto">
+        {sessions.length === 0 ? (
+          <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+            No conversations yet
+          </div>
+        ) : (
+          sessions.map((session) => (
+            <button
+              key={session.id}
+              className={cn(
+                'group flex w-full items-start gap-2 px-3 py-2 text-left transition-colors hover:bg-accent/50',
+                session.id === currentSessionId && 'bg-accent'
+              )}
+              onClick={() => onSelect(session.id)}
+            >
+              <MessageSquare className="mt-0.5 size-3 shrink-0 text-muted-foreground" />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-xs font-medium text-foreground">{session.title}</div>
+                <div className="flex items-center justify-between gap-1">
+                  <span className="text-[10px] text-muted-foreground">
+                    {formatTime(session.updatedAt)}
+                  </span>
+                  <span className="text-[10px] text-muted-foreground">
+                    {session.messages.length} msg{session.messages.length !== 1 ? 's' : ''}
+                  </span>
+                </div>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(session.id);
+                }}
+                aria-label="Delete conversation"
+              >
+                <Trash2 className="size-3 text-muted-foreground" />
+              </Button>
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/views/chat/chat-sidebar.tsx
+++ b/apps/ui/src/components/views/chat/chat-sidebar.tsx
@@ -1,24 +1,23 @@
 /**
  * ChatSidebar — Collapsible right-side chat panel.
  *
- * Integrates AI SDK's useChat with the chat message list and input components.
+ * Integrates useChatSession for persistent conversations with the chat UI.
  * Sits alongside the main content area in the root layout.
  */
 
 import { useState, useCallback, useMemo } from 'react';
-import { useChat } from '@ai-sdk/react';
 import { useLocation } from '@tanstack/react-router';
 import { MessageSquare, X, Plus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@protolabs/ui/atoms';
 import { ChatMessageList, ChatInput } from '@protolabs/ui/ai';
-import { ChatModelSelect, useChatModelSelection } from './components/chat-model-select';
+import { ChatModelSelect } from './components/chat-model-select';
+import { useChatSession } from '@/hooks/use-chat-session';
 import { useNotesStore } from '@/store/notes-store';
 import { useAppStore } from '@/store/app-store';
 
 export function ChatSidebar({ className }: { className?: string }) {
   const [isOpen, setIsOpen] = useState(false);
-  const [modelAlias, setModelAlias] = useChatModelSelection('sonnet');
   const [inputValue, setInputValue] = useState('');
   const location = useLocation();
   const workspace = useNotesStore((s) => s.workspace);
@@ -47,18 +46,19 @@ export function ChatSidebar({ className }: { className?: string }) {
     };
   }, [location.pathname, workspace, currentProject?.path]);
 
-  const { messages, sendMessage, stop, status, setMessages, error } = useChat({
-    api: '/api/chat',
-    headers: {
-      'x-model-alias': modelAlias,
-    },
+  const {
+    messages,
+    sendMessage,
+    stop,
+    isStreaming,
+    error,
+    modelAlias,
+    handleNewChat,
+    handleModelChange,
+  } = useChatSession({
+    defaultModel: 'sonnet',
     body: notesContext ? { context: notesContext } : undefined,
-    onError: (err) => {
-      console.error('Chat error:', err);
-    },
   });
-
-  const isStreaming = status === 'streaming' || status === 'submitted';
 
   const handleSubmit = useCallback(() => {
     const text = inputValue.trim();
@@ -66,11 +66,6 @@ export function ChatSidebar({ className }: { className?: string }) {
     sendMessage({ text });
     setInputValue('');
   }, [inputValue, isStreaming, sendMessage]);
-
-  const handleNewChat = useCallback(() => {
-    setMessages([]);
-    setInputValue('');
-  }, [setMessages]);
 
   // Collapsed state — just show a toggle button
   if (!isOpen) {
@@ -144,7 +139,7 @@ export function ChatSidebar({ className }: { className?: string }) {
         isStreaming={isStreaming}
         actions={
           <>
-            <ChatModelSelect value={modelAlias} onValueChange={setModelAlias} />
+            <ChatModelSelect value={modelAlias} onValueChange={handleModelChange} />
             <span className="text-[10px] text-muted-foreground">
               {isStreaming ? 'Streaming...' : 'Enter to send'}
             </span>

--- a/apps/ui/src/hooks/use-chat-session.ts
+++ b/apps/ui/src/hooks/use-chat-session.ts
@@ -1,0 +1,147 @@
+/**
+ * useChatSession — Coordinates AI SDK useChat with persistent chat store.
+ *
+ * Manages the lifecycle of chat sessions: creating, switching, persisting messages,
+ * and syncing between useChat's live state and the Zustand store.
+ */
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+import { useChatStore } from '@/store/chat-store';
+
+interface UseChatSessionOptions {
+  /** Default model for new sessions */
+  defaultModel?: string;
+  /** Extra body data sent with every chat request (e.g. notes context) */
+  body?: Record<string, unknown>;
+}
+
+export function useChatSession({ defaultModel = 'sonnet', body }: UseChatSessionOptions = {}) {
+  const {
+    sessions,
+    currentSessionId,
+    createSession,
+    deleteSession,
+    switchSession,
+    saveMessages,
+    updateModel,
+    getCurrentSession,
+    historyOpen,
+    toggleHistory,
+    setHistoryOpen,
+  } = useChatStore();
+
+  const currentSession = getCurrentSession();
+  const modelAlias = currentSession?.modelAlias ?? defaultModel;
+
+  // Track session switch to avoid saving stale messages
+  const activeSessionRef = useRef(currentSessionId);
+
+  // AI SDK v6 requires transport instead of api/headers/body
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        api: '/api/chat',
+        headers: { 'x-model-alias': modelAlias },
+        body,
+      }),
+    [modelAlias, body]
+  );
+
+  const { messages, sendMessage, stop, status, setMessages, error } = useChat({
+    id: currentSessionId ?? undefined,
+    transport,
+    messages: currentSession?.messages,
+    onError: (err) => {
+      console.error('Chat error:', err);
+    },
+  });
+
+  const isStreaming = status === 'streaming' || status === 'submitted';
+
+  // When messages change, persist to store
+  useEffect(() => {
+    if (currentSessionId && activeSessionRef.current === currentSessionId && messages.length > 0) {
+      saveMessages(currentSessionId, messages);
+    }
+  }, [messages, currentSessionId, saveMessages]);
+
+  // When switching sessions, load the new session's messages
+  useEffect(() => {
+    if (currentSessionId !== activeSessionRef.current) {
+      activeSessionRef.current = currentSessionId;
+      const session = getCurrentSession();
+      setMessages(session?.messages ?? []);
+    }
+  }, [currentSessionId, getCurrentSession, setMessages]);
+
+  const handleNewChat = useCallback(() => {
+    const session = createSession(modelAlias);
+    setMessages([]);
+    activeSessionRef.current = session.id;
+  }, [createSession, modelAlias, setMessages]);
+
+  const handleSwitchSession = useCallback(
+    (id: string) => {
+      // Save current messages before switching
+      if (currentSessionId && messages.length > 0) {
+        saveMessages(currentSessionId, messages);
+      }
+      switchSession(id);
+    },
+    [currentSessionId, messages, saveMessages, switchSession]
+  );
+
+  const handleDeleteSession = useCallback(
+    (id: string) => {
+      deleteSession(id);
+    },
+    [deleteSession]
+  );
+
+  const handleModelChange = useCallback(
+    (model: string) => {
+      if (currentSessionId) {
+        updateModel(currentSessionId, model);
+      }
+    },
+    [currentSessionId, updateModel]
+  );
+
+  // Ensure there's always a session
+  useEffect(() => {
+    if (!currentSessionId || !sessions.find((s) => s.id === currentSessionId)) {
+      if (sessions.length > 0) {
+        switchSession(sessions[0].id);
+      } else {
+        createSession(defaultModel);
+      }
+    }
+  }, [currentSessionId, sessions, switchSession, createSession, defaultModel]);
+
+  return {
+    // Chat state
+    messages,
+    sendMessage,
+    stop,
+    isStreaming,
+    error,
+    setMessages,
+
+    // Session management
+    sessions,
+    currentSessionId,
+    currentSession,
+    modelAlias,
+    handleNewChat,
+    handleSwitchSession,
+    handleDeleteSession,
+    handleModelChange,
+
+    // History panel
+    historyOpen,
+    toggleHistory,
+    setHistoryOpen,
+  };
+}

--- a/apps/ui/src/store/chat-store.ts
+++ b/apps/ui/src/store/chat-store.ts
@@ -1,184 +1,163 @@
 /**
- * Chat Store - State management for chat sessions and messages
+ * Chat Store — Persistent conversation management for Ava chat.
+ *
+ * Stores conversation sessions with messages in localStorage via Zustand persist.
+ * Messages are stored as serializable snapshots compatible with AI SDK's UIMessage.
+ * Both the sidebar and overlay share this store for unified conversation history.
  */
 
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { UIMessage } from 'ai';
 
 // ============================================================================
 // Types
 // ============================================================================
 
-export interface ImageAttachment {
-  id?: string; // Optional - may not be present in messages loaded from server
-  data: string; // base64 encoded image data
-  mimeType: string; // e.g., "image/png", "image/jpeg"
-  filename: string;
-  size?: number; // file size in bytes - optional for messages from server
-}
-
-export interface TextFileAttachment {
-  id: string;
-  content: string; // text content of the file
-  mimeType: string; // e.g., "text/plain", "text/markdown"
-  filename: string;
-  size: number; // file size in bytes
-}
-
-export interface ChatMessage {
-  id: string;
-  role: 'user' | 'assistant';
-  content: string;
-  timestamp: Date;
-  images?: ImageAttachment[];
-  textFiles?: TextFileAttachment[];
-}
-
 export interface ChatSession {
   id: string;
   title: string;
-  projectId: string;
-  messages: ChatMessage[];
-  createdAt: Date;
-  updatedAt: Date;
-  archived: boolean;
+  modelAlias: string;
+  messages: UIMessage[];
+  createdAt: number; // epoch ms (serializable)
+  updatedAt: number;
 }
 
 // ============================================================================
-// State Interface
+// State + Actions
 // ============================================================================
 
 interface ChatStoreState {
-  chatSessions: ChatSession[];
-  currentChatSession: ChatSession | null;
-  chatHistoryOpen: boolean;
+  sessions: ChatSession[];
+  currentSessionId: string | null;
+  historyOpen: boolean;
 }
-
-// ============================================================================
-// Actions Interface
-// ============================================================================
 
 interface ChatActions {
-  createChatSession: (title?: string) => ChatSession;
-  updateChatSession: (sessionId: string, updates: Partial<ChatSession>) => void;
-  addMessageToSession: (sessionId: string, message: ChatMessage) => void;
-  setCurrentChatSession: (session: ChatSession | null) => void;
-  archiveChatSession: (sessionId: string) => void;
-  unarchiveChatSession: (sessionId: string) => void;
-  deleteChatSession: (sessionId: string) => void;
-  setChatHistoryOpen: (open: boolean) => void;
-  toggleChatHistory: () => void;
+  createSession: (modelAlias?: string) => ChatSession;
+  deleteSession: (id: string) => void;
+  switchSession: (id: string) => void;
+  saveMessages: (id: string, messages: UIMessage[]) => void;
+  updateTitle: (id: string, title: string) => void;
+  updateModel: (id: string, modelAlias: string) => void;
+  setHistoryOpen: (open: boolean) => void;
+  toggleHistory: () => void;
+  getCurrentSession: () => ChatSession | null;
 }
 
 // ============================================================================
-// Initial State
+// Helpers
 // ============================================================================
 
-const initialState: ChatStoreState = {
-  chatSessions: [],
-  currentChatSession: null,
-  chatHistoryOpen: false,
-};
+function generateId(): string {
+  return `chat-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+/** Auto-generate a title from the first user message */
+export function autoTitle(messages: UIMessage[]): string {
+  const firstUser = messages.find((m) => m.role === 'user');
+  if (!firstUser) return 'New chat';
+  // Extract text content
+  const text =
+    firstUser.parts
+      ?.filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+      .map((p) => p.text)
+      .join('') || '';
+  if (!text) return 'New chat';
+  return text.length > 50 ? text.slice(0, 47) + '...' : text;
+}
 
 // ============================================================================
 // Store
 // ============================================================================
 
-export const useChatStore = create<ChatStoreState & ChatActions>((set, get) => ({
-  ...initialState,
+const MAX_SESSIONS = 50;
 
-  createChatSession: (title) => {
-    const now = new Date();
-    const session: ChatSession = {
-      id: `chat-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-      title: title || `Chat ${new Date().toLocaleDateString()} ${new Date().toLocaleTimeString()}`,
-      projectId: '', // Will be set by the caller if needed
-      messages: [
-        {
-          id: 'welcome',
-          role: 'assistant',
-          content:
-            "Hello! I'm the Automaker Agent. I can help you build software autonomously. What would you like to create today?",
-          timestamp: now,
-        },
-      ],
-      createdAt: now,
-      updatedAt: now,
-      archived: false,
-    };
+export const useChatStore = create<ChatStoreState & ChatActions>()(
+  persist(
+    (set, get) => ({
+      sessions: [],
+      currentSessionId: null,
+      historyOpen: false,
 
-    set({
-      chatSessions: [...get().chatSessions, session],
-      currentChatSession: session,
-    });
+      createSession: (modelAlias = 'sonnet') => {
+        const now = Date.now();
+        const session: ChatSession = {
+          id: generateId(),
+          title: 'New chat',
+          modelAlias,
+          messages: [],
+          createdAt: now,
+          updatedAt: now,
+        };
 
-    return session;
-  },
+        const sessions = [session, ...get().sessions];
+        // Cap stored sessions
+        if (sessions.length > MAX_SESSIONS) {
+          sessions.length = MAX_SESSIONS;
+        }
 
-  updateChatSession: (sessionId, updates) => {
-    set({
-      chatSessions: get().chatSessions.map((session) =>
-        session.id === sessionId ? { ...session, ...updates, updatedAt: new Date() } : session
-      ),
-    });
+        set({ sessions, currentSessionId: session.id });
+        return session;
+      },
 
-    // Update current session if it's the one being updated
-    const currentSession = get().currentChatSession;
-    if (currentSession && currentSession.id === sessionId) {
-      set({
-        currentChatSession: {
-          ...currentSession,
-          ...updates,
-          updatedAt: new Date(),
-        },
-      });
+      deleteSession: (id) => {
+        const state = get();
+        const sessions = state.sessions.filter((s) => s.id !== id);
+        const currentSessionId =
+          state.currentSessionId === id ? (sessions[0]?.id ?? null) : state.currentSessionId;
+        set({ sessions, currentSessionId });
+      },
+
+      switchSession: (id) => {
+        set({ currentSessionId: id });
+      },
+
+      saveMessages: (id, messages) => {
+        const sessions = get().sessions.map((s) =>
+          s.id === id
+            ? {
+                ...s,
+                messages,
+                updatedAt: Date.now(),
+                // Auto-title on first user message if still default
+                title: s.title === 'New chat' ? autoTitle(messages) : s.title,
+              }
+            : s
+        );
+        set({ sessions });
+      },
+
+      updateTitle: (id, title) => {
+        const sessions = get().sessions.map((s) =>
+          s.id === id ? { ...s, title, updatedAt: Date.now() } : s
+        );
+        set({ sessions });
+      },
+
+      updateModel: (id, modelAlias) => {
+        const sessions = get().sessions.map((s) =>
+          s.id === id ? { ...s, modelAlias, updatedAt: Date.now() } : s
+        );
+        set({ sessions });
+      },
+
+      setHistoryOpen: (open) => set({ historyOpen: open }),
+      toggleHistory: () => set({ historyOpen: !get().historyOpen }),
+
+      getCurrentSession: () => {
+        const state = get();
+        return state.sessions.find((s) => s.id === state.currentSessionId) ?? null;
+      },
+    }),
+    {
+      name: 'ava-chat-sessions',
+      version: 1,
+      // Only persist sessions and currentSessionId, not UI state
+      partialize: (state) => ({
+        sessions: state.sessions,
+        currentSessionId: state.currentSessionId,
+      }),
     }
-  },
-
-  addMessageToSession: (sessionId, message) => {
-    const sessions = get().chatSessions;
-    const sessionIndex = sessions.findIndex((s) => s.id === sessionId);
-
-    if (sessionIndex >= 0) {
-      const updatedSessions = [...sessions];
-      updatedSessions[sessionIndex] = {
-        ...updatedSessions[sessionIndex],
-        messages: [...updatedSessions[sessionIndex].messages, message],
-        updatedAt: new Date(),
-      };
-
-      set({ chatSessions: updatedSessions });
-
-      // Update current session if it's the one being updated
-      const currentSession = get().currentChatSession;
-      if (currentSession && currentSession.id === sessionId) {
-        set({
-          currentChatSession: updatedSessions[sessionIndex],
-        });
-      }
-    }
-  },
-
-  setCurrentChatSession: (session) => {
-    set({ currentChatSession: session });
-  },
-
-  archiveChatSession: (sessionId) => {
-    get().updateChatSession(sessionId, { archived: true });
-  },
-
-  unarchiveChatSession: (sessionId) => {
-    get().updateChatSession(sessionId, { archived: false });
-  },
-
-  deleteChatSession: (sessionId) => {
-    const currentSession = get().currentChatSession;
-    set({
-      chatSessions: get().chatSessions.filter((s) => s.id !== sessionId),
-      currentChatSession: currentSession?.id === sessionId ? null : currentSession,
-    });
-  },
-
-  setChatHistoryOpen: (open) => set({ chatHistoryOpen: open }),
-
-  toggleChatHistory: () => set({ chatHistoryOpen: !get().chatHistoryOpen }),
-}));
+  )
+);


### PR DESCRIPTION
## Summary

- **Persistent conversations**: Refactored chat store with Zustand `persist` middleware, storing up to 50 chat sessions in localStorage with AI SDK `UIMessage` compatibility
- **Conversation list panel**: Slide-out panel in the overlay showing chat history with title, timestamp, message count, and delete action
- **Model selection in overlay**: Added `ChatModelSelect` dropdown (haiku/sonnet/opus) with per-conversation model persistence
- **`useChatSession` hook**: New coordination hook bridging AI SDK's `useChat` with the persistent Zustand store — handles session creation, switching, message sync, and auto-titling
- **Sidebar unification**: Sidebar now uses the same `useChatSession` hook, sharing conversation history with the overlay
- **AI SDK v6 transport**: Migrated from deprecated `api`/`headers` options to `DefaultChatTransport`

## Test plan

- [ ] Open overlay (Cmd/Ctrl+Shift+Space), send a message — verify it persists after hiding/showing
- [ ] Create multiple conversations via "New" button, switch between them
- [ ] Delete a conversation from the history panel
- [ ] Change model in overlay, verify it persists per-conversation
- [ ] Open sidebar chat, verify shared conversation history with overlay
- [ ] Refresh page, verify conversations persist in localStorage
- [ ] Verify auto-title updates from first user message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Conversation history panel now displays all saved chat sessions with timestamps and message counts
  * Create new conversations, switch between sessions, and delete old chats with improved session management
  * AI model selection control integrated directly into the chat interface for easy switching
  * Chat sessions and conversation history now persist across browser sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->