### PR TITLE
feat: add rich message part rendering to Ava Anywhere chat (M3)

### DIFF
--- a/apps/server/src/routes/chat/index.ts
+++ b/apps/server/src/routes/chat/index.ts
@@ -117,9 +117,10 @@ export function createChatRoutes(): Router {
         },
       });
 
-      // Pipe the AI SDK data stream to the response.
-      // This uses the AI SDK's built-in SSE format that useChat expects.
-      result.pipeTextStreamToResponse(res);
+      // Pipe the full AI SDK UI message stream to the response.
+      // Uses the AI SDK's UI message stream protocol so tool calls, reasoning,
+      // and source parts flow through to the client (not just text tokens).
+      result.pipeUIMessageStreamToResponse(res);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       logger.error('Chat stream error:', error);

--- a/libs/ui/src/ai/chat-message.tsx
+++ b/libs/ui/src/ai/chat-message.tsx
@@ -1,8 +1,11 @@
 /**
- * ChatMessage — Role-based message bubble with avatar and markdown rendering.
+ * ChatMessage — Role-based message bubble with avatar and rich part rendering.
  *
  * Composable: ChatMessage wraps ChatMessageAvatar + ChatMessageBubble.
  * Uses CVA variants for user/assistant/system styling.
+ *
+ * Renders all UIMessagePart types: text (markdown), reasoning (collapsible),
+ * tool calls (collapsible card), sources, and step boundaries.
  */
 
 import { cva, type VariantProps } from 'class-variance-authority';
@@ -11,6 +14,8 @@ import ReactMarkdown from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
 import type { UIMessage } from 'ai';
 import { cn } from '../lib/utils.js';
+import { ReasoningPart } from './reasoning-part.js';
+import { ToolInvocationPart, type ToolInvocationPartProps } from './tool-invocation-part.js';
 
 const messageVariants = cva('flex gap-3 px-4 py-2', {
   variants: {
@@ -97,21 +102,110 @@ export function ChatMessageMarkdown({
               className="text-primary underline underline-offset-2 hover:text-primary/80"
             />
           ),
-          pre: ({ ...props }) => (
+          pre: ({ children: preChildren, ...props }) => (
             <pre
               {...props}
-              className="my-2 overflow-x-auto rounded-md bg-background/50 p-3 text-xs"
-            />
+              className="group/code relative my-2 overflow-x-auto rounded-md bg-background/50 p-3 text-xs"
+            >
+              {preChildren}
+            </pre>
           ),
-          code: ({ ...props }) => (
-            <code {...props} className="rounded bg-background/50 px-1 py-0.5 text-xs" />
-          ),
+          code: ({ className: codeClassName, children: codeChildren, ...props }) => {
+            // Detect fenced code blocks via language class (e.g. "language-typescript")
+            const langMatch = codeClassName?.match(/language-(\w+)/);
+            if (langMatch) {
+              return (
+                <code {...props} className={cn(codeClassName, 'text-xs')}>
+                  <span className="absolute right-2 top-1.5 select-none text-[10px] font-medium uppercase tracking-wider text-muted-foreground opacity-60">
+                    {langMatch[1]}
+                  </span>
+                  {codeChildren}
+                </code>
+              );
+            }
+            // Inline code
+            return (
+              <code {...props} className="rounded bg-background/50 px-1 py-0.5 text-xs">
+                {codeChildren}
+              </code>
+            );
+          },
         }}
       >
         {content}
       </ReactMarkdown>
     </div>
   );
+}
+
+/** Extract the tool name from a part that could be typed or dynamic */
+function getToolName(part: Record<string, unknown>): string {
+  // DynamicToolUIPart has { type: 'dynamic-tool', toolName: '...' }
+  if ('toolName' in part && typeof part.toolName === 'string') return part.toolName;
+  // ToolUIPart has { type: 'tool-<name>' }
+  const typeStr = part.type as string;
+  if (typeStr.startsWith('tool-')) return typeStr.slice(5);
+  return 'unknown';
+}
+
+/** Check if a part is a tool invocation (typed or dynamic) */
+function isToolPart(part: Record<string, unknown>): boolean {
+  const t = part.type as string;
+  return t === 'dynamic-tool' || (t.startsWith('tool-') && t !== 'tool');
+}
+
+/**
+ * Render a single message part based on its type.
+ */
+function MessagePartRenderer({ part, index }: { part: Record<string, unknown>; index: number }) {
+  const type = part.type as string;
+
+  if (type === 'text') {
+    const text = part.text as string;
+    if (!text) return null;
+    return <ChatMessageMarkdown content={text} />;
+  }
+
+  if (type === 'reasoning') {
+    return (
+      <ReasoningPart
+        text={part.text as string}
+        state={part.state as 'streaming' | 'done' | undefined}
+      />
+    );
+  }
+
+  if (isToolPart(part)) {
+    return (
+      <ToolInvocationPart
+        toolName={getToolName(part)}
+        toolCallId={(part.toolCallId as string) ?? `tool-${index}`}
+        state={((part.state as string) ?? 'input-available') as ToolInvocationPartProps['state']}
+        input={part.input}
+        output={part.output}
+        errorText={part.errorText as string | undefined}
+        title={part.title as string | undefined}
+      />
+    );
+  }
+
+  if (type === 'source-url') {
+    const url = part.url as string;
+    const title = (part.title as string) || url;
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="my-0.5 inline-flex items-center gap-1 rounded-full border border-border/50 bg-muted/50 px-2 py-0.5 text-[10px] text-primary hover:bg-muted"
+      >
+        {title}
+      </a>
+    );
+  }
+
+  // step-start, source-document, file, data-* — render nothing for now
+  return null;
 }
 
 export function ChatMessage({
@@ -122,23 +216,42 @@ export function ChatMessage({
   className?: string;
 } & Partial<VariantProps<typeof messageVariants>>) {
   const role = message.role as MessageRole;
+  const parts = message.parts ?? [];
 
-  const textContent = message.parts
-    .filter((part): part is { type: 'text'; text: string } => part.type === 'text')
-    .map((part) => part.text)
-    .join('');
+  // For user messages, extract text only (users don't produce tool calls)
+  if (role === 'user') {
+    const textContent = parts
+      .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+      .map((p) => p.text)
+      .join('');
+    if (!textContent) return null;
+    return (
+      <div data-slot="chat-message" className={cn(messageVariants({ role }), className)}>
+        <ChatMessageAvatar role={role} />
+        <ChatMessageBubble role={role}>
+          <p className="whitespace-pre-wrap">{textContent}</p>
+        </ChatMessageBubble>
+      </div>
+    );
+  }
 
-  if (!textContent) return null;
+  // For assistant/system messages, render all parts
+  const hasContent = parts.some(
+    (p) =>
+      (p.type === 'text' && (p as { text: string }).text) ||
+      p.type === 'reasoning' ||
+      isToolPart(p as Record<string, unknown>) ||
+      p.type === 'source-url'
+  );
+  if (!hasContent) return null;
 
   return (
     <div data-slot="chat-message" className={cn(messageVariants({ role }), className)}>
       <ChatMessageAvatar role={role} />
       <ChatMessageBubble role={role}>
-        {role === 'assistant' ? (
-          <ChatMessageMarkdown content={textContent} />
-        ) : (
-          <p className="whitespace-pre-wrap">{textContent}</p>
-        )}
+        {parts.map((part, i) => (
+          <MessagePartRenderer key={i} part={part as Record<string, unknown>} index={i} />
+        ))}
       </ChatMessageBubble>
     </div>
   );

--- a/libs/ui/src/ai/index.ts
+++ b/libs/ui/src/ai/index.ts
@@ -14,3 +14,7 @@ export { ChatMessageList } from './chat-message-list.js';
 export { ChatInput } from './chat-input.js';
 
 export { SuggestionList, type SuggestionItem } from './suggestion.js';
+
+export { ReasoningPart, type ReasoningPartProps } from './reasoning-part.js';
+
+export { ToolInvocationPart, type ToolInvocationPartProps } from './tool-invocation-part.js';

--- a/libs/ui/src/ai/reasoning-part.tsx
+++ b/libs/ui/src/ai/reasoning-part.tsx
@@ -1,0 +1,62 @@
+/**
+ * ReasoningPart — Collapsible thinking/reasoning block for AI messages.
+ *
+ * Renders the model's reasoning (extended thinking) as a collapsible section.
+ * Shows a streaming indicator when the model is still thinking.
+ */
+
+import { useState } from 'react';
+import { Brain, ChevronDown } from 'lucide-react';
+import { cn } from '../lib/utils.js';
+
+export interface ReasoningPartProps {
+  text: string;
+  state?: 'streaming' | 'done';
+  className?: string;
+}
+
+export function ReasoningPart({ text, state, className }: ReasoningPartProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const isStreaming = state === 'streaming';
+
+  // Show first line as preview when collapsed
+  const preview = text.split('\n')[0]?.slice(0, 80) || 'Thinking...';
+
+  return (
+    <div
+      data-slot="reasoning-part"
+      className={cn('my-1 rounded-md border border-border/50 bg-muted/30 text-xs', className)}
+    >
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left"
+        onClick={() => setIsOpen(!isOpen)}
+        aria-expanded={isOpen}
+      >
+        <Brain
+          className={cn(
+            'size-3.5 shrink-0 text-muted-foreground',
+            isStreaming && 'animate-pulse text-primary'
+          )}
+        />
+        <span className="flex-1 truncate text-muted-foreground">
+          {isStreaming ? 'Thinking...' : preview}
+        </span>
+        <ChevronDown
+          className={cn(
+            'size-3 shrink-0 text-muted-foreground transition-transform',
+            isOpen && 'rotate-180'
+          )}
+        />
+      </button>
+      {isOpen && (
+        <div className="border-t border-border/50 px-2.5 py-2">
+          <pre className="whitespace-pre-wrap font-mono text-[11px] leading-relaxed text-muted-foreground">
+            {text}
+            {isStreaming && <span className="animate-pulse">|</span>}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/libs/ui/src/ai/tool-invocation-part.tsx
+++ b/libs/ui/src/ai/tool-invocation-part.tsx
@@ -1,0 +1,132 @@
+/**
+ * ToolInvocationPart — Collapsible card for rendering tool calls in chat.
+ *
+ * Displays the tool name, state badge, and expandable input/output JSON.
+ * Supports all AI SDK tool invocation states: streaming, available,
+ * output-available, and output-error.
+ */
+
+import { useState } from 'react';
+import { ChevronDown, Wrench, Loader2, Check, AlertTriangle } from 'lucide-react';
+import { cn } from '../lib/utils.js';
+
+type ToolState =
+  | 'input-streaming'
+  | 'input-available'
+  | 'approval-requested'
+  | 'approval-responded'
+  | 'output-available'
+  | 'output-error'
+  | 'output-denied';
+
+export interface ToolInvocationPartProps {
+  toolName: string;
+  toolCallId: string;
+  state: ToolState;
+  input?: unknown;
+  output?: unknown;
+  errorText?: string;
+  title?: string;
+  className?: string;
+}
+
+const stateConfig: Record<ToolState, { label: string; color: string; icon: typeof Loader2 }> = {
+  'input-streaming': { label: 'Running', color: 'text-primary', icon: Loader2 },
+  'input-available': { label: 'Running', color: 'text-primary', icon: Loader2 },
+  'approval-requested': { label: 'Awaiting', color: 'text-yellow-500', icon: Loader2 },
+  'approval-responded': { label: 'Running', color: 'text-primary', icon: Loader2 },
+  'output-available': { label: 'Done', color: 'text-green-500', icon: Check },
+  'output-error': { label: 'Error', color: 'text-destructive', icon: AlertTriangle },
+  'output-denied': { label: 'Denied', color: 'text-muted-foreground', icon: AlertTriangle },
+};
+
+function formatToolName(name: string): string {
+  // Convert snake_case or camelCase to readable form
+  return name
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/^./, (c) => c.toUpperCase());
+}
+
+function JsonPreview({ data, label }: { data: unknown; label: string }) {
+  if (data === undefined || data === null) return null;
+
+  const json = typeof data === 'string' ? data : JSON.stringify(data, null, 2);
+  if (!json || json === '{}' || json === 'undefined') return null;
+
+  return (
+    <div className="mt-1.5">
+      <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </span>
+      <pre className="mt-0.5 overflow-x-auto rounded bg-background/50 p-2 font-mono text-[11px] leading-relaxed text-foreground/80">
+        {json}
+      </pre>
+    </div>
+  );
+}
+
+export function ToolInvocationPart({
+  toolName,
+  state,
+  input,
+  output,
+  errorText,
+  title,
+  className,
+}: ToolInvocationPartProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const config = stateConfig[state] ?? stateConfig['input-available'];
+  const StateIcon = config.icon;
+  const isRunning =
+    state === 'input-streaming' || state === 'input-available' || state === 'approval-responded';
+
+  return (
+    <div
+      data-slot="tool-invocation-part"
+      className={cn(
+        'my-1 rounded-md border border-border/50 bg-muted/30 text-xs',
+        state === 'output-error' && 'border-destructive/30',
+        className
+      )}
+    >
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left"
+        onClick={() => setIsOpen(!isOpen)}
+        aria-expanded={isOpen}
+      >
+        <Wrench className="size-3.5 shrink-0 text-muted-foreground" />
+        <span className="flex-1 truncate font-medium text-foreground/80">
+          {title || formatToolName(toolName)}
+        </span>
+        <span className={cn('flex items-center gap-1', config.color)}>
+          <StateIcon className={cn('size-3', isRunning && 'animate-spin')} />
+          <span className="text-[10px]">{config.label}</span>
+        </span>
+        <ChevronDown
+          className={cn(
+            'size-3 shrink-0 text-muted-foreground transition-transform',
+            isOpen && 'rotate-180'
+          )}
+        />
+      </button>
+      {isOpen && (
+        <div className="border-t border-border/50 px-2.5 py-2">
+          <JsonPreview data={input} label="Input" />
+          {state === 'output-available' && <JsonPreview data={output} label="Output" />}
+          {state === 'output-error' && errorText && (
+            <div className="mt-1.5">
+              <span className="text-[10px] font-medium uppercase tracking-wider text-destructive">
+                Error
+              </span>
+              <pre className="mt-0.5 overflow-x-auto rounded bg-destructive/5 p-2 font-mono text-[11px] leading-relaxed text-destructive">
+                {errorText}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Switch server chat endpoint from `pipeTextStreamToResponse` to `pipeUIMessageStreamToResponse` — enables the full AI SDK data stream protocol (tool calls, reasoning, sources)
- Extend `ChatMessage` in `@protolabs/ui/ai` to render all `UIMessagePart` types instead of only extracting text
- Add `ReasoningPart` component — collapsible thinking/reasoning block with streaming indicator
- Add `ToolInvocationPart` component — collapsible tool call card showing name, state, input/output JSON, and error text
- Code blocks now display a language label badge in the top-right corner

## Test plan

- [ ] Verify chat still works (send a message, get streaming response)
- [ ] Verify code blocks in responses show language labels
- [ ] Verify `npm run build:packages` succeeds
- [ ] Verify `npm run build:server` succeeds
- [ ] Verify lint passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI reasoning and thinking now display in collapsible blocks within chat messages.
  * Tool invocations with input/output details shown in expandable cards with status indicators.
  * Code blocks now display language badges for improved readability.
  * Source URLs are now surfaced in chat messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->