### PR TITLE
feat: add web fallback chat modal for Ava Anywhere (M4)

### DIFF
--- a/apps/ui/src/components/layout/chat-modal.tsx
+++ b/apps/ui/src/components/layout/chat-modal.tsx
@@ -1,0 +1,58 @@
+/**
+ * ChatModal — Web fallback for the Ava Anywhere chat overlay.
+ *
+ * In Electron mode, the chat overlay runs in its own window.
+ * In web mode, this Dialog-based modal provides the same experience.
+ * Triggered via Cmd+K (macOS) or Ctrl+K (Windows/Linux).
+ */
+
+import { useCallback, useEffect } from 'react';
+import { Dialog, DialogContent, DialogTitle } from '@protolabs/ui/atoms';
+import { useChatSession } from '@/hooks/use-chat-session';
+import { useChatStore } from '@/store/chat-store';
+import { ChatOverlayContent } from '@/components/views/chat-overlay/chat-overlay-content';
+
+export function ChatModal() {
+  const chatModalOpen = useChatStore((s) => s.chatModalOpen);
+  const setChatModalOpen = useChatStore((s) => s.setChatModalOpen);
+  const chatSession = useChatSession({ defaultModel: 'sonnet' });
+
+  const handleClose = useCallback(() => {
+    setChatModalOpen(false);
+  }, [setChatModalOpen]);
+
+  return (
+    <Dialog open={chatModalOpen} onOpenChange={setChatModalOpen}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-w-2xl h-[70vh] p-0 gap-0 overflow-hidden"
+      >
+        <DialogTitle className="sr-only">Ava Chat</DialogTitle>
+        <ChatOverlayContent {...chatSession} onHide={handleClose} isModal />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * useChatModalShortcut — Global keyboard shortcut for the chat modal.
+ *
+ * Registers Cmd+K (macOS) / Ctrl+K (other) to toggle the chat modal.
+ * Should be called once in the root layout.
+ */
+export function useChatModalShortcut() {
+  const chatModalOpen = useChatStore((s) => s.chatModalOpen);
+  const setChatModalOpen = useChatStore((s) => s.setChatModalOpen);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        setChatModalOpen(!chatModalOpen);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [chatModalOpen, setChatModalOpen]);
+}

--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
@@ -1,0 +1,155 @@
+/**
+ * ChatOverlayContent — Shared chat content for overlay and modal.
+ *
+ * Contains the header, message list, input, and conversation history.
+ * Used by both the Electron overlay view and the web fallback modal.
+ */
+
+import { useState, useCallback } from 'react';
+import { History, X } from 'lucide-react';
+import { ChatMessageList, ChatInput } from '@protolabs/ui/ai';
+import { Button } from '@protolabs/ui/atoms';
+import { cn } from '@/lib/utils';
+import { ChatModelSelect } from '@/components/views/chat/components/chat-model-select';
+import { ConversationList } from './conversation-list';
+import type { useChatSession } from '@/hooks/use-chat-session';
+
+type ChatSessionReturn = ReturnType<typeof useChatSession>;
+
+export interface ChatOverlayContentProps extends ChatSessionReturn {
+  /** Called when the user wants to close/hide the overlay or modal */
+  onHide: () => void;
+  /** When true, renders in modal mode (no drag region, different hint text) */
+  isModal?: boolean;
+}
+
+export function ChatOverlayContent({
+  messages,
+  sendMessage,
+  stop,
+  isStreaming,
+  error,
+  sessions,
+  currentSessionId,
+  modelAlias,
+  handleNewChat,
+  handleSwitchSession,
+  handleDeleteSession,
+  handleModelChange,
+  historyOpen,
+  toggleHistory,
+  setHistoryOpen,
+  onHide,
+  isModal = false,
+}: ChatOverlayContentProps) {
+  const [inputValue, setInputValue] = useState('');
+
+  const handleSubmit = useCallback(() => {
+    const text = inputValue.trim();
+    if (!text || isStreaming) return;
+    sendMessage({ text });
+    setInputValue('');
+  }, [inputValue, isStreaming, sendMessage]);
+
+  const shortcutHint = isModal ? '\u2318K to close' : 'Esc to hide';
+
+  return (
+    <div data-slot="chat-overlay-content" className="flex h-full w-full flex-col overflow-hidden">
+      {/* Header */}
+      <div
+        className={cn(
+          'flex items-center justify-between border-b border-border px-3 py-2',
+          !isModal && 'titlebar-drag-region'
+        )}
+      >
+        <div className={cn('flex items-center gap-2', !isModal && 'pointer-events-none')}>
+          <div className="size-2 rounded-full bg-primary animate-pulse" />
+          <span className="text-sm font-medium text-foreground">Ava</span>
+        </div>
+        <div className={cn('flex items-center gap-1', !isModal && 'pointer-events-auto')}>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            onClick={toggleHistory}
+            title="Conversation history"
+            aria-label="Toggle conversation history"
+          >
+            <History className="size-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            onClick={handleNewChat}
+            title="New chat"
+            aria-label="New chat"
+          >
+            <span className="text-xs">New</span>
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            onClick={onHide}
+            title={isModal ? 'Close' : 'Hide (Esc)'}
+            aria-label={isModal ? 'Close chat' : 'Hide overlay'}
+          >
+            <X className="size-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="border-b border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          {error.message || 'An error occurred'}
+        </div>
+      )}
+
+      {/* Main content area */}
+      <div className="flex min-h-0 flex-1">
+        {/* Conversation list panel — slide in from left */}
+        {historyOpen && (
+          <ConversationList
+            sessions={sessions}
+            currentSessionId={currentSessionId}
+            onSelect={(id) => {
+              handleSwitchSession(id);
+              setHistoryOpen(false);
+            }}
+            onNew={() => {
+              handleNewChat();
+              setHistoryOpen(false);
+            }}
+            onDelete={handleDeleteSession}
+            onClose={() => setHistoryOpen(false)}
+            className="animate-in slide-in-from-left duration-200"
+          />
+        )}
+
+        {/* Chat area */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          <ChatMessageList messages={messages} emptyMessage="Ask Ava anything..." />
+
+          <ChatInput
+            value={inputValue}
+            onChange={setInputValue}
+            onSubmit={handleSubmit}
+            onStop={stop}
+            isStreaming={isStreaming}
+            placeholder="Ask Ava..."
+            actions={
+              <>
+                <ChatModelSelect value={modelAlias} onValueChange={handleModelChange} />
+                <span className="text-[10px] text-muted-foreground">
+                  {isStreaming ? 'Streaming...' : `Enter to send \u00B7 ${shortcutHint}`}
+                </span>
+              </>
+            }
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-view.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-view.tsx
@@ -1,51 +1,22 @@
 /**
- * ChatOverlayView — Ava Anywhere global chat overlay.
+ * ChatOverlayView — Ava Anywhere global chat overlay (Electron window).
  *
  * Renders a full-window chat interface for the Electron overlay panel.
- * Uses shared @protolabs/ui/ai components. The overlay is shown/hidden
- * via global shortcut (Cmd/Ctrl+Shift+Space) managed by Electron main process.
+ * The overlay is shown/hidden via global shortcut (Cmd/Ctrl+Shift+Space)
+ * managed by Electron main process.
  *
- * M2: Adds conversation management (list, switch, delete), model selection,
- * and persistent chat history via useChatSession.
+ * In web mode, this route is unused — ChatModal provides the equivalent.
  */
 
-import { useState, useCallback, useEffect } from 'react';
-import { History, X } from 'lucide-react';
-import { ChatMessageList, ChatInput } from '@protolabs/ui/ai';
-import { Button } from '@protolabs/ui/atoms';
+import { useCallback, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import { getElectronAPI, isElectron } from '@/lib/electron';
 import { useChatSession } from '@/hooks/use-chat-session';
-import { ChatModelSelect } from '@/components/views/chat/components/chat-model-select';
-import { ConversationList } from './conversation-list';
+import { ChatOverlayContent } from './chat-overlay-content';
 
 export function ChatOverlayView() {
-  const [inputValue, setInputValue] = useState('');
-
-  const {
-    messages,
-    sendMessage,
-    stop,
-    isStreaming,
-    error,
-    sessions,
-    currentSessionId,
-    modelAlias,
-    handleNewChat,
-    handleSwitchSession,
-    handleDeleteSession,
-    handleModelChange,
-    historyOpen,
-    toggleHistory,
-    setHistoryOpen,
-  } = useChatSession({ defaultModel: 'sonnet' });
-
-  const handleSubmit = useCallback(() => {
-    const text = inputValue.trim();
-    if (!text || isStreaming) return;
-    sendMessage({ text });
-    setInputValue('');
-  }, [inputValue, isStreaming, sendMessage]);
+  const chatSession = useChatSession({ defaultModel: 'sonnet' });
+  const { historyOpen, setHistoryOpen } = chatSession;
 
   const handleHide = useCallback(() => {
     if (isElectron()) {
@@ -53,7 +24,7 @@ export function ChatOverlayView() {
     }
   }, []);
 
-  // Escape key hides the overlay
+  // Escape key hides the overlay (or closes history panel first)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -76,95 +47,7 @@ export function ChatOverlayView() {
         'overflow-hidden rounded-xl border border-border'
       )}
     >
-      {/* Drag handle + header */}
-      <div className="flex items-center justify-between border-b border-border px-3 py-2 titlebar-drag-region">
-        <div className="flex items-center gap-2 pointer-events-none">
-          <div className="size-2 rounded-full bg-primary animate-pulse" />
-          <span className="text-sm font-medium text-foreground">Ava</span>
-        </div>
-        <div className="flex items-center gap-1 pointer-events-auto">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-7"
-            onClick={toggleHistory}
-            title="Conversation history"
-            aria-label="Toggle conversation history"
-          >
-            <History className="size-3.5" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-7"
-            onClick={handleNewChat}
-            title="New chat"
-            aria-label="New chat"
-          >
-            <span className="text-xs">New</span>
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-7"
-            onClick={handleHide}
-            title="Hide (Esc)"
-            aria-label="Hide overlay"
-          >
-            <X className="size-3.5" />
-          </Button>
-        </div>
-      </div>
-
-      {/* Error banner */}
-      {error && (
-        <div className="border-b border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-          {error.message || 'An error occurred'}
-        </div>
-      )}
-
-      {/* Main content area */}
-      <div className="flex min-h-0 flex-1">
-        {/* Conversation list panel */}
-        {historyOpen && (
-          <ConversationList
-            sessions={sessions}
-            currentSessionId={currentSessionId}
-            onSelect={(id) => {
-              handleSwitchSession(id);
-              setHistoryOpen(false);
-            }}
-            onNew={() => {
-              handleNewChat();
-              setHistoryOpen(false);
-            }}
-            onDelete={handleDeleteSession}
-            onClose={() => setHistoryOpen(false)}
-          />
-        )}
-
-        {/* Chat area */}
-        <div className="flex min-w-0 flex-1 flex-col">
-          <ChatMessageList messages={messages} emptyMessage="Ask Ava anything..." />
-
-          <ChatInput
-            value={inputValue}
-            onChange={setInputValue}
-            onSubmit={handleSubmit}
-            onStop={stop}
-            isStreaming={isStreaming}
-            placeholder="Ask Ava..."
-            actions={
-              <>
-                <ChatModelSelect value={modelAlias} onValueChange={handleModelChange} />
-                <span className="text-[10px] text-muted-foreground">
-                  {isStreaming ? 'Streaming...' : 'Enter to send \u00B7 Esc to hide'}
-                </span>
-              </>
-            }
-          />
-        </div>
-      </div>
+      <ChatOverlayContent {...chatSession} onHide={handleHide} />
     </div>
   );
 }

--- a/apps/ui/src/routes/__root.tsx
+++ b/apps/ui/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import { createLogger } from '@automaker/utils/logger';
 import { Sidebar } from '@/components/layout/sidebar';
 import { ProjectSwitcher } from '@/components/layout/project-switcher';
 import { ChatSidebar } from '@/components/views/chat/chat-sidebar';
+import { ChatModal, useChatModalShortcut } from '@/components/layout/chat-modal';
 import {
   FileBrowserProvider,
   useFileBrowser,
@@ -182,6 +183,9 @@ function RootLayoutContent() {
 
   // Load project settings when switching projects
   useProjectSettingsLoader();
+
+  // Global Cmd+K / Ctrl+K shortcut for the chat modal (web mode)
+  useChatModalShortcut();
 
   // Check if we're in compact mode (< 1240px) to hide project switcher
   const isCompact = useIsCompact();
@@ -841,6 +845,7 @@ function RootLayoutContent() {
           <Outlet />
         </div>
         <ChatSidebar />
+        <ChatModal />
         <Toaster richColors position="bottom-right" />
       </main>
       <SandboxRiskDialog

--- a/apps/ui/src/store/chat-store.ts
+++ b/apps/ui/src/store/chat-store.ts
@@ -31,6 +31,7 @@ interface ChatStoreState {
   sessions: ChatSession[];
   currentSessionId: string | null;
   historyOpen: boolean;
+  chatModalOpen: boolean;
 }
 
 interface ChatActions {
@@ -42,6 +43,7 @@ interface ChatActions {
   updateModel: (id: string, modelAlias: string) => void;
   setHistoryOpen: (open: boolean) => void;
   toggleHistory: () => void;
+  setChatModalOpen: (open: boolean) => void;
   getCurrentSession: () => ChatSession | null;
 }
 
@@ -79,6 +81,7 @@ export const useChatStore = create<ChatStoreState & ChatActions>()(
       sessions: [],
       currentSessionId: null,
       historyOpen: false,
+      chatModalOpen: false,
 
       createSession: (modelAlias = 'sonnet') => {
         const now = Date.now();
@@ -144,6 +147,7 @@ export const useChatStore = create<ChatStoreState & ChatActions>()(
 
       setHistoryOpen: (open) => set({ historyOpen: open }),
       toggleHistory: () => set({ historyOpen: !get().historyOpen }),
+      setChatModalOpen: (open) => set({ chatModalOpen: open }),
 
       getCurrentSession: () => {
         const state = get();


### PR DESCRIPTION
## Summary

- Extract `ChatOverlayContent` as shared component used by both the Electron overlay and the new web modal
- Add `ChatModal` dialog component — same chat experience accessible in web/browser mode
- Add `Cmd+K` / `Ctrl+K` global keyboard shortcut to toggle the chat modal
- Add slide-in animation for the conversation history panel
- Refactor `ChatOverlayView` to be a thin Electron wrapper around `ChatOverlayContent`

## Test plan

- [ ] Verify Cmd+K / Ctrl+K opens the chat modal in web mode
- [ ] Verify the modal has the same functionality (send messages, switch models, conversation history)
- [ ] Verify the Electron overlay still works (Esc to hide, drag region)
- [ ] Verify conversation history panel animates in from the left
- [ ] Verify `npm run build:packages` and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global chat modal accessible via keyboard shortcut—Cmd+K on macOS or Ctrl+K on other platforms—allowing instant access to chat functionality from anywhere in the application
  * Toggle the modal open and closed with the shortcut, or press Escape to dismiss it immediately

<!-- end of auto-generated comment: release notes by coderabbit.ai -->