### PR TITLE
feat: add Dev Container config for development

### DIFF
--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -390,3 +390,8 @@ usageStats:
 - **Problem solved:** Agent created 25 story files without manual review of each one. Quality variance between files was minimal.
 - **Why this works:** Each story follows identical structure: (1) import Component, (2) define Meta with autodocs tag, (3) export Default with template, (4) export variant stories using CSF3. This regularity allows agents to generate valid code without human validation.
 - **Trade-offs:** Consistency is high (all stories follow same pattern) but individual stories may lack sophistication (e.g., complex interaction demos). Trade-off is acceptable for coverage—sophisticated stories can be added later.
+
+#### [Pattern] Enum-based escalation routing: `EscalationSource` enum value determines which service/channel handles the signal. Renaming source types (crew_escalation → lead_engineer_escalation) is safe because routing logic reads the enum, not string literals. (2026-02-19)
+- **Problem solved:** Three different files (lead-engineer-service, discord-channel-escalation, github-issue-channel) reference the same escalation source value to route signals. Needed to rename without breaking escalation flow.
+- **Why this works:** Enum-based routing decouples the semantic name (what caused the escalation) from the routing implementation (which service handles it). The name can change (reflects business logic evolution) while routing stays intact because consumers compare enum values, not strings.
+- **Trade-offs:** Requires coordinating the rename across 3+ files for consistency. But enum-based approach forces all references to be type-checked, preventing accidental mismatches that would happen with string literals.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -1855,3 +1855,27 @@ usageStats:
 - **Problem solved:** Writing component usage examples for README had choice between showing just basic button import vs. layered examples of increasing complexity
 - **Why this works:** Users of varying skill levels will read the README. Minimal example gets them running in < 5 minutes (acceptance criteria). Subsequent examples show variants, className overrides, cn() utility, custom themes for users who need more. Cognitive load increases gradually.
 - **Trade-offs:** Longer README, but serves broader audience. Benefits: Self-contained reference without needing to jump to Storybook. Cost: More content to maintain if component API changes.
+
+### Renamed EscalationSource.crew_escalation to lead_engineer_escalation to clarify that this enum value is actively used for Lead Engineer escalations, not legacy crew loop system. (2026-02-19)
+- **Context:** Crew loop system was removed years ago, but EscalationSource.crew_escalation remained and was actively used in escalation routing. Needed to clarify naming during dead code cleanup.
+- **Why:** The enum value is actively referenced in escalation-channels services (discord-channel-escalation, github-issue-channel). Renaming clarifies intent: this is for Lead Engineer, not crew. Prevents future confusion about what 'crew' means.
+- **Rejected:** Could have removed the enum value entirely and aliased to a different escalation type - but that would require more refactoring of escalation routing logic. Renaming is surgical and isolated.
+- **Trade-offs:** Rename requires updating 3 references across services. New name is clearer but slightly longer. Alternative of leaving 'crew_escalation' as-is would perpetuate confusion about the crew loop system.
+- **Breaking if changed:** Any external code (agents, plugins, integrations) that references EscalationSource.crew_escalation will fail at runtime. This is a breaking change but necessary for clarity. Services should fail fast with 'crew_escalation is not a valid enum value' rather than silently using wrong routing.
+
+#### [Pattern] When removing dead code systems, distinguish between dead types/configs (safe to delete) and dead but referenced enum values (must be renamed, not deleted, if still referenced). (2026-02-19)
+- **Problem solved:** Crew loop system removal left behind CrewLoopSettings type, CrewMemberConfig type, crewLoops settings field, and crew event types. But EscalationSource.crew_escalation was still actively used despite crew system being gone.
+- **Why this works:** Types are compile-time constraints - safe to delete if no imports reference them. But enum values are runtime identifiers - deleting an actively-used enum value causes runtime failures. Renaming makes the mismatch explicit.
+- **Trade-offs:** Renaming is more work than deleting (requires 3 reference updates). But it improves code clarity and prevents future confusion about what escalation types are used for.
+
+#### [Gotcha] npm workspace type resolution requires `npm install` at root after modifying shared packages. TypeScript doesn't auto-detect updated types in workspace dependencies even though source files were changed. (2026-02-19)
+- **Situation:** Modified `libs/types/src/escalation.ts` enum. Dependent package `@automaker/server` failed to resolve new enum value despite correct source changes. Build error: enum value not found.
+- **Root cause:** npm workspaces use symlinks to link packages. The symlink target's `dist/` contains the compiled JavaScript/TypeScript declarations. Modifying source doesn't update `dist/` until the package is rebuilt. Running `npm install` at root triggers workspace rebuild and re-links the packages.
+- **How to avoid:** Running full `npm install` is slower than targeted rebuild, but ensures all workspace symlinks are fresh and all dependent packages see consistent types. Prevents subtle version skew bugs.
+
+### Deleted entire `apps/server/src/services/crew-members/` directory as dead code cleanup, rather than marking functions as deprecated. (2026-02-19)
+- **Context:** Directory contained only a placeholder `index.ts` file with comment 'removed'. No active code referenced it. Escalation system uses `EscalationSource.crew_escalation` (now renamed), but the crew-members service never implemented actual crew loop logic.
+- **Why:** Hard deletion is appropriate for code that (1) has never been active, (2) is replaced by a different system (lead engineer escalations), and (3) has no external API contracts. Keeping deprecated code creates maintenance burden and confuses future developers about which escalation system is active.
+- **Rejected:** Could have marked with `@deprecated` and kept as a reference, but the code was never functional. Deprecation is for APIs that need gradual migration; this was orphaned code.
+- **Trade-offs:** Immediate cleanup removes future confusion about 'is crew loop still supported?' But loses history of the experiment in source. Git history preserves the deletion decision.
+- **Breaking if changed:** Any external code that imports from `apps/server/src/services/crew-members` will fail. Build-time check confirmed no imports exist in the codebase.

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 233
-  referenced: 115
-  successfulFeatures: 115
+  loaded: 234
+  referenced: 117
+  successfulFeatures: 117
 ---
 # gotchas
 
@@ -180,3 +180,8 @@ usageStats:
 - **Situation:** Initial .npmignore excluded src/ globally, but package.json exports included ./src/themes/themes.css. Standard exclude patterns would have prevented themes from being packaged while still leaking other src/ files.
 - **Root cause:** npm's .npmignore matching is line-order dependent. Blacklist approach (exclude src/, then include src/themes/) fails because the first match wins. Whitelist approach (exclude *, then include dist/ and src/themes/) guarantees only intended paths are packaged.
 - **How to avoid:** Whitelist is more explicit but requires maintaining the include list as exports change. Easier to verify what's shipped (npm pack --dry-run shows exactly what publishes). Harder to onboard new developers who expect standard .gitignore semantics.
+
+#### [Gotcha] TypeScript build cache in tsup creates stale bundled config files that prevent type updates from being recognized. Clearing `tsup.config.bundled_*.mjs` files resolves phantom type errors. (2026-02-19)
+- **Situation:** After renaming EscalationSource enum value, build failed with 'does not provide an export named' errors even though dist/index.d.ts was correct. Rebuilding individual packages didn't help.
+- **Root cause:** tsup caches bundled config files with timestamps. When types change, the cache isn't invalidated automatically, causing tsc to read stale .d.ts files from previous bundles.
+- **How to avoid:** Clearing cache solves the problem instantly vs full rebuilds taking 90+ seconds. Risk: may lose other tsup optimizations briefly, but they rebuild automatically.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "protoLabs.studio",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:22",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "forwardPorts": [3007, 3008],
+  "portsAttributes": {
+    "3007": { "label": "UI (Vite)", "onAutoForward": "notify" },
+    "3008": { "label": "API Server", "onAutoForward": "silent" }
+  },
+  "postCreateCommand": "npm install && npm run build:packages",
+  "remoteEnv": {
+    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
+    "AUTOMAKER_AUTO_LOGIN": "true"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
+        "ms-playwright.playwright"
+      ],
+      "settings": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -384,6 +384,23 @@ services:
 
 The Docker image supports both AMD64 and ARM64 architectures. The GitHub CLI and Claude CLI are automatically downloaded for the correct architecture during build.
 
+#### Dev Containers / GitHub Codespaces
+
+The repo includes a [Dev Container](https://containers.dev/) config for a one-click development environment. Works with VS Code, Cursor, JetBrains, and GitHub Codespaces.
+
+```bash
+# Open in VS Code with the Dev Containers extension
+code .
+# → Command Palette → "Dev Containers: Reopen in Container"
+
+# Or launch directly on GitHub Codespaces
+# → repo page → Code → Codespaces → "Create codespace on main"
+```
+
+The container provides Node.js 22, GitHub CLI, forwarded ports (3007/3008), and runs `npm install && build:packages` automatically on creation. Set `ANTHROPIC_API_KEY` in your host environment or Codespaces secrets — it's passed through automatically.
+
+See [docs/dev/dev-containers.md](docs/dev/dev-containers.md) for full setup details.
+
 ### Testing
 
 #### End-to-End Tests (Playwright)

--- a/docs/dev/dev-containers.md
+++ b/docs/dev/dev-containers.md
@@ -1,0 +1,95 @@
+# Dev Containers
+
+protoLabs.studio ships a [Dev Container](https://containers.dev/) configuration for consistent, reproducible development environments. This works with VS Code, Cursor, JetBrains, and GitHub Codespaces.
+
+## Quick Start
+
+### VS Code / Cursor
+
+1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+2. Open the repo folder
+3. Command Palette → **Dev Containers: Reopen in Container**
+4. Wait for the container to build (~2-3 minutes first time)
+5. Run `npm run dev:web` to start developing
+
+### GitHub Codespaces
+
+1. Go to the repo on GitHub
+2. Click **Code → Codespaces → Create codespace on main**
+3. Wait for setup to complete
+4. Run `npm run dev:web` — Codespaces auto-forwards ports
+
+### JetBrains (Gateway)
+
+1. Open JetBrains Gateway
+2. Connect to the Dev Container via Docker or Codespaces
+3. The `.devcontainer/devcontainer.json` is detected automatically
+
+## What's Included
+
+The Dev Container config (`.devcontainer/devcontainer.json`) provides:
+
+| Component              | Details                                                                 |
+| ---------------------- | ----------------------------------------------------------------------- |
+| **Base image**         | `mcr.microsoft.com/devcontainers/typescript-node:22` (Node.js 22 + npm) |
+| **GitHub CLI**         | Pre-installed via Dev Container feature                                 |
+| **Ports**              | 3007 (UI/Vite) and 3008 (API server) forwarded automatically            |
+| **Post-create**        | `npm install && npm run build:packages` runs on first launch            |
+| **VS Code extensions** | ESLint, Prettier, Tailwind CSS IntelliSense, Playwright                 |
+| **Environment**        | `ANTHROPIC_API_KEY` passed from host, `AUTOMAKER_AUTO_LOGIN=true`       |
+
+## Environment Variables
+
+The container passes `ANTHROPIC_API_KEY` from your host environment. Set it before opening the container:
+
+```bash
+# macOS/Linux — add to ~/.bashrc, ~/.zshrc, or ~/.profile
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# Or for GitHub Codespaces:
+# Settings → Codespaces → Secrets → New secret
+# Name: ANTHROPIC_API_KEY
+# Value: sk-ant-...
+# Repository: proto-labs-ai/protolabs-studio
+```
+
+Other optional variables can be added to `remoteEnv` in `devcontainer.json`:
+
+```jsonc
+"remoteEnv": {
+  "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
+  "LINEAR_API_KEY": "${localEnv:LINEAR_API_KEY}",
+  "DISCORD_TOKEN": "${localEnv:DISCORD_TOKEN}"
+}
+```
+
+## Electron Note
+
+Dev Containers run headless Linux — the Electron desktop app won't work inside the container. Use `npm run dev:web` for browser-based development. The Electron build pipeline (`npm run build:electron`) still works for producing distributable packages.
+
+## Customizing
+
+To add tools or change the base image, edit `.devcontainer/devcontainer.json`. Common additions:
+
+```jsonc
+{
+  "features": {
+    // Add Docker-in-Docker for testing container builds
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    // Add Python (for scripts/tooling)
+    "ghcr.io/devcontainers/features/python:1": { "version": "3.12" },
+  },
+}
+```
+
+After changing the config, rebuild: **Command Palette → Dev Containers: Rebuild Container**.
+
+## Troubleshooting
+
+**Container build fails on `npm install`**: Check that you have enough disk space. The full `node_modules` is ~1.5GB.
+
+**`ANTHROPIC_API_KEY` not available**: Verify the variable is set in your host shell (`echo $ANTHROPIC_API_KEY`). For Codespaces, check that the secret is configured for the correct repository.
+
+**Port 3007/3008 not forwarding**: Check the Ports tab in VS Code. If another process is using those ports on the host, change the local port mapping.
+
+**`build:packages` fails**: This occasionally happens if the container runs out of memory. Increase Docker's memory limit (Docker Desktop → Settings → Resources → Memory → 8GB+).


### PR DESCRIPTION
## Summary
- Adds `.devcontainer/devcontainer.json` with Node.js 22, GitHub CLI, port forwarding (3007/3008), and auto `npm install && build:packages` on creation
- Adds Dev Containers section to README under Docker Deployment
- Adds `docs/dev/dev-containers.md` with full setup guide (VS Code, Codespaces, JetBrains, env vars, troubleshooting)

## Test plan
- [ ] Open repo in VS Code with Dev Containers extension, verify "Reopen in Container" works
- [ ] Verify `npm run dev:web` starts correctly inside the container
- [ ] Verify ports 3007/3008 are forwarded
- [ ] Verify `ANTHROPIC_API_KEY` is passed from host env

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Dev Container and GitHub Codespaces setup guides for one-click development environment initialization
  * Included quick-start instructions for VS Code, Codespaces, and JetBrains IDEs
  * Documented environment variables, port forwarding configuration, and troubleshooting tips

* **Chores**
  * Configured development container with pre-installed tools, port forwarding, and VS Code extensions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->