### PR TITLE
feat: bottom panel polish — chat trigger, close button, panel icon

### DIFF
--- a/apps/ui/src/components/layout/bottom-panel/bottom-panel.tsx
+++ b/apps/ui/src/components/layout/bottom-panel/bottom-panel.tsx
@@ -7,13 +7,14 @@ import {
   ListTodo,
   Activity,
   GitPullRequest,
-  ChevronUp,
-  ChevronDown,
   History,
   BarChart3,
   MonitorCog,
   LineChart,
   Radio,
+  MessageSquare,
+  PanelBottomOpen,
+  X,
 } from 'lucide-react';
 import { ActivityTab } from './activity-tab';
 import { StatsTab } from './stats-tab';
@@ -30,6 +31,8 @@ export function BottomPanel() {
   const toggleBottomPanel = useAppStore((s) => s.toggleBottomPanel);
   const setBottomPanelActiveTab = useAppStore((s) => s.setBottomPanelActiveTab);
   const features = useAppStore((s) => s.features);
+  const chatSidebarOpen = useAppStore((s) => s.chatSidebarOpen);
+  const toggleChatSidebar = useAppStore((s) => s.toggleChatSidebar);
   const { data: agentCount } = useRunningAgentsCount();
 
   if (isMobile) return null;
@@ -57,7 +60,7 @@ export function BottomPanel() {
             className="h-full flex flex-col gap-0"
           >
             <div className="flex items-center border-b border-border/50 px-3 shrink-0">
-              <TabsList className="h-7 border-0 bg-transparent p-0 gap-0">
+              <TabsList className="h-7 border-0 bg-transparent p-0 gap-0 flex-1">
                 <TabsTrigger value="activity" className={tabTriggerClass}>
                   <History className="h-3.5 w-3.5" />
                   Activity
@@ -79,6 +82,13 @@ export function BottomPanel() {
                   System
                 </TabsTrigger>
               </TabsList>
+              <button
+                onClick={toggleBottomPanel}
+                className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors ml-2"
+                title="Close panel"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
             </div>
             <TabsContent value="activity" className="flex-1 overflow-hidden mt-0">
               <ActivityTab />
@@ -135,12 +145,22 @@ export function BottomPanel() {
         {/* Spacer */}
         <div className="flex-1" />
 
-        {/* Toggle indicator */}
-        {bottomPanelOpen ? (
-          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-        ) : (
-          <ChevronUp className="h-3.5 w-3.5 text-muted-foreground" />
-        )}
+        {/* Chat toggle */}
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            toggleChatSidebar();
+          }}
+          className={`p-1 rounded-md transition-colors ${chatSidebarOpen ? 'text-violet-400' : 'text-muted-foreground hover:text-foreground'}`}
+          title="Toggle chat"
+        >
+          <MessageSquare className="h-3.5 w-3.5" />
+        </button>
+
+        {/* Panel toggle */}
+        <PanelBottomOpen
+          className={`h-3.5 w-3.5 ${bottomPanelOpen ? 'text-foreground' : 'text-muted-foreground'}`}
+        />
       </div>
     </>
   );

--- a/apps/ui/src/components/views/flow-graph/flow-graph-view.tsx
+++ b/apps/ui/src/components/views/flow-graph/flow-graph-view.tsx
@@ -54,9 +54,9 @@ export function FlowGraphView({ onFeatureClick }: FlowGraphViewProps) {
         />
       </ReactFlowProvider>
 
-      {/* Legend popup near controls (bottom-left) */}
+      {/* Legend popup to the right of controls, near bottom */}
       {showLegend && (
-        <div className="absolute bottom-14 left-4 z-10">
+        <div className="absolute bottom-4 left-16 z-10">
           <FlowGraphLegend />
         </div>
       )}


### PR DESCRIPTION
## Summary
- Add **chat sidebar toggle** (MessageSquare icon) to the ticker bar, replacing the floating FAB
- Add **X close button** in the top-right of the expanded panel tab header
- Replace **chevron up/down** with `PanelBottomOpen` icon that highlights when panel is open
- Reposition **flow graph legend** popover to the right of controls instead of above

## Test plan
- [ ] Chat icon in ticker bar toggles chat sidebar; highlights violet when open
- [ ] X button in expanded panel header closes the panel
- [ ] Panel icon in ticker bar highlights (foreground color) when panel is open
- [ ] Legend popover in analytics view appears to the right of React Flow controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)