### PR TITLE
chore: remove redundant quick links from docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,5 @@
 # protoLabs Studio Documentation
 
-## Quick Links
-
-| Service | URL                                               | Description              |
-| ------- | ------------------------------------------------- | ------------------------ |
-| GitHub  | [proto-labs-ai](https://github.com/proto-labs-ai) | Source code, issues, PRs |
-| X       | [@protoLabsAI](https://x.com/protoLabsAI)         | Updates and threads      |
-| Twitch  | [protoLabsTV](https://twitch.tv/protoLabsTV)      | Live building sessions   |
-
 ## Getting Started
 
 | Document                                                               | Description                      |

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,15 +33,3 @@ features:
     details: View the source. Learn the methodology. Build with it. No vendor lock-in.
     link: https://github.com/proto-labs-ai
 ---
-
-## Quick Links
-
-| Service | URL                                               | Description              |
-| ------- | ------------------------------------------------- | ------------------------ |
-| GitHub  | [proto-labs-ai](https://github.com/proto-labs-ai) | Source code, issues, PRs |
-| X       | [@protoLabsAI](https://x.com/protoLabsAI)         | Updates and threads      |
-| Twitch  | [protoLabsTV](https://twitch.tv/protoLabsTV)      | Live building sessions   |
-
----
-
-<small>Built with <a href="https://protolabs.studio">protoLabs</a> — the source-available AI-native development studio.</small>


### PR DESCRIPTION
## Summary
- Remove Quick Links table (GitHub, X, Twitch) from docs homepage and README
- GitHub is already in the VitePress nav social links
- X and Twitch are on the main site — no need to duplicate in docs

## Test plan
- [ ] Docs homepage renders without the links table or footer tagline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Removed Quick Links sections and attribution footer from documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->