### PR TITLE
fix: remove Agentic Jumpstart branding, update rabbit-hole description

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -124,8 +124,8 @@ Any amendment, modification, or update to this License Agreement must be agreed 
 
 For inquiries regarding this license or permissions for Monetization, please contact the Core Contributors through the official project channels:
 
-- Agentic Jumpstart Discord: https://discord.gg/JUDWZDN3VT
-- Website: https://automaker.app
+- Discord: https://discord.gg/jjem7aEDKU
+- Website: https://protolabs.studio
 - Email: automakerapp@gmail.com
 
 Any permission for Monetization requires the unanimous written consent of all Core Contributors.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 > **Learn more about Agentic Coding!**
 >
 > protoLabs.studio was built using AI and agentic coding techniques, leveraging tools like Cursor IDE and Claude Code CLI to orchestrate AI agents that implement complex functionality in days instead of weeks.
->
-> **Learn how:** Master these same techniques and workflows in the [Agentic Jumpstart course](https://agenticjumpstart.com/?utm=protomaker-gh).
 
 # protoLabs.studio
 
@@ -118,7 +116,7 @@ The future of software development is **swarm intelligence**—where multiple AI
 
 ## Community & Support
 
-Join the **Agentic Jumpstart** to connect with other builders exploring **agentic coding** and autonomous development workflows.
+Join the **protoLabs community** to connect with other builders exploring **agentic coding** and autonomous development workflows.
 
 In the Discord, you can:
 
@@ -128,7 +126,7 @@ In the Discord, you can:
 - 🚀 Show off projects built with AI agents
 - 🤝 Collaborate with other developers and contributors
 
-👉 **Join the Discord:** [Agentic Jumpstart Discord](https://discord.gg/jjem7aEDKU)
+👉 **Join the Discord:** [protoLabs Discord](https://discord.gg/jjem7aEDKU)
 
 ---
 
@@ -749,9 +747,9 @@ data/
 
 ### Community
 
-Join the **Agentic Jumpstart** Discord to connect with other builders exploring **agentic coding**:
+Join the **protoLabs** Discord to connect with other builders exploring **agentic coding**:
 
-👉 [Agentic Jumpstart Discord](https://discord.gg/jjem7aEDKU)
+👉 [protoLabs Discord](https://discord.gg/jjem7aEDKU)
 
 ## License
 

--- a/docs/protolabs/brand.md
+++ b/docs/protolabs/brand.md
@@ -4,19 +4,18 @@ This is the living brand bible for protoLabs. All agents, content, and external 
 
 ## Names & Domains
 
-| Name                           | What It Is                            | Usage                                                                                                        |
-| ------------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **protoLabs**                  | The AI-native development agency      | Always camelCase: "protoLabs" (not "ProtoLabs", "Protolabs", or "Proto Labs")                                |
-| **protoLabs.studio**           | Primary domain                        | Website, social bios, email                                                                                  |
-| ~~**protoMaker**~~             | RETIRED — now just protoLabs          | Was the product name. Consolidated into protoLabs. Do not use in new content.                                |
-| **proto-labs-ai**              | GitHub organization                   | `github.com/proto-labs-ai`                                                                                   |
-| **Automaker**                  | Internal codename / upstream origin   | Used in code (`@automaker/*` packages, `.automaker/` directory). NOT used in external marketing.             |
-| **create-protolab**            | npx CLI tool                          | Scaffolds new projects with protoLabs methodology                                                            |
-| **MythXEngine**                | AI-powered TTRPG engine               | Built with protoLabs. Portfolio proof of methodology.                                                        |
-| **SVGVal**                     | SVG validation toolkit                | Built with protoLabs. Portfolio proof of methodology.                                                        |
-| **rabbit-hole**                | AI-powered TTRPG (legacy name)        | Now MythXEngine. Built with protoLabs.                                                                       |
-| **Agentic Jumpstart**          | Community Discord / educational brand | Community-facing, not the agency brand                                                                       |
-| **intelligent product engine** | Product category / positioning term   | Describes the autonomous system architecture. NOT an acronym — always lowercase, always spelled out in full. |
+| Name                           | What It Is                          | Usage                                                                                                        |
+| ------------------------------ | ----------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **protoLabs**                  | The AI-native development agency    | Always camelCase: "protoLabs" (not "ProtoLabs", "Protolabs", or "Proto Labs")                                |
+| **protoLabs.studio**           | Primary domain                      | Website, social bios, email                                                                                  |
+| ~~**protoMaker**~~             | RETIRED — now just protoLabs        | Was the product name. Consolidated into protoLabs. Do not use in new content.                                |
+| **proto-labs-ai**              | GitHub organization                 | `github.com/proto-labs-ai`                                                                                   |
+| **Automaker**                  | Internal codename / upstream origin | Used in code (`@automaker/*` packages, `.automaker/` directory). NOT used in external marketing.             |
+| **create-protolab**            | npx CLI tool                        | Scaffolds new projects with protoLabs methodology                                                            |
+| **MythXEngine**                | AI-powered TTRPG engine             | Built with protoLabs. Portfolio proof of methodology.                                                        |
+| **SVGVal**                     | SVG validation toolkit              | Built with protoLabs. Portfolio proof of methodology.                                                        |
+| **rabbit-hole**                | AI-powered research platform        | Built with protoLabs. Portfolio proof of methodology.                                                        |
+| **intelligent product engine** | Product category / positioning term | Describes the autonomous system architecture. NOT an acronym — always lowercase, always spelled out in full. |
 
 ### Naming Rules
 

--- a/libs/prompts/src/agents/gtm-specialist-prompt.ts
+++ b/libs/prompts/src/agents/gtm-specialist-prompt.ts
@@ -24,8 +24,8 @@ export function getGTMSpecialistPrompt(config: GTMSpecialistConfig = {}): string
 
 - **protoLabs** — The AI-native development agency (the org)
 - **protoMaker** — AI development studio product (Kanban + autonomous agents)
-- **rabbit-hole** — AI-powered TTRPG built with protoMaker
-- **mythΞengine** — AI RPG engine powering rabbit-hole
+- **rabbit-hole** — AI-powered research platform built with protoLabs
+- **MythXEngine** — AI-powered TTRPG engine built with protoLabs
 - **proto-ux** — UX automation toolkit
 
 These products are proof of concept — every one demonstrates the protoLabs methodology.


### PR DESCRIPTION
## Summary
- Remove all "Agentic Jumpstart" references from README, LICENSE, and brand docs — replaced with protoLabs community branding
- Change rabbit-hole description from "AI-powered TTRPG" to "AI-powered research platform" across brand docs and GTM prompt
- Update LICENSE contact info to point to protolabs.studio and current Discord invite

## Files changed
- `README.md` — Community sections now reference protoLabs Discord
- `LICENSE` — Updated contact URLs
- `docs/protolabs/brand.md` — Removed Agentic Jumpstart row, updated rabbit-hole description
- `libs/prompts/src/agents/gtm-specialist-prompt.ts` — Updated ecosystem section

## Test plan
- [ ] Verify docs site rebuilds cleanly
- [ ] Check README renders correctly on GitHub
- [ ] Confirm no remaining Agentic Jumpstart references (except third-party template repo name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)