### PR TITLE
feat: flow node components and edge type for LangGraph viewer

### DIFF
--- a/apps/ui/src/components/views/flow-graph/edges/flow-edge.tsx
+++ b/apps/ui/src/components/views/flow-graph/edges/flow-edge.tsx
@@ -1,0 +1,76 @@
+/**
+ * Flow Edge — LangGraph edge connector
+ *
+ * Thin edges with smooth step path.
+ * Orange for conditional edges, violet for standard.
+ * Edge labels for routing decisions.
+ */
+
+import { memo } from 'react';
+import {
+  getSmoothStepPath,
+  EdgeLabelRenderer,
+  type EdgeProps,
+  BaseEdge,
+} from '@xyflow/react';
+
+export interface FlowEdgeData {
+  label?: string;
+  isConditional?: boolean;
+}
+
+function FlowEdgeComponent({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  data,
+}: EdgeProps) {
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    borderRadius: 8,
+  });
+
+  const edgeData = data as FlowEdgeData | undefined;
+  const isConditional = edgeData?.isConditional ?? false;
+  const strokeColor = isConditional ? 'oklch(0.65 0.18 40)' : 'oklch(0.65 0.2 290)';
+
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} style={{ stroke: strokeColor, strokeWidth: 2 }} />
+
+      {edgeData?.label && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+              pointerEvents: 'all',
+            }}
+            className="nodrag nopan"
+          >
+            <div
+              className={`px-2 py-1 rounded text-[10px] font-medium border ${
+                isConditional
+                  ? 'bg-orange-50 text-orange-900 border-orange-400'
+                  : 'bg-violet-50 text-violet-900 border-violet-400'
+              }`}
+            >
+              {edgeData.label}
+            </div>
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+}
+
+export const FlowEdge = memo(FlowEdgeComponent);

--- a/apps/ui/src/components/views/flow-graph/edges/index.ts
+++ b/apps/ui/src/components/views/flow-graph/edges/index.ts
@@ -7,15 +7,18 @@ import { DelegationEdge } from './delegation-edge';
 import { WorkflowEdge } from './workflow-edge';
 import { IntegrationEdge } from './integration-edge';
 import { PipelineEdge } from './pipeline-edge';
+import { FlowEdge } from './flow-edge';
 
 export { DelegationEdge } from './delegation-edge';
 export { WorkflowEdge } from './workflow-edge';
 export { IntegrationEdge } from './integration-edge';
 export { PipelineEdge } from './pipeline-edge';
+export { FlowEdge } from './flow-edge';
 
 export const edgeTypes: EdgeTypes = {
   delegation: DelegationEdge,
   workflow: WorkflowEdge,
   integration: IntegrationEdge,
   pipeline: PipelineEdge,
+  'flow-edge': FlowEdge,
 };

--- a/apps/ui/src/components/views/flow-graph/nodes/flow-decision-node.tsx
+++ b/apps/ui/src/components/views/flow-graph/nodes/flow-decision-node.tsx
@@ -1,0 +1,58 @@
+/**
+ * Flow Decision Node — LangGraph branching logic
+ *
+ * 80x80px diamond (rotated 45°), orange for branching logic.
+ */
+
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { cn } from '@/lib/utils';
+
+export interface FlowDecisionNodeData {
+  label: string;
+  description?: string;
+  isActive?: boolean;
+  isCompleted?: boolean;
+  type: 'processor' | 'decision' | 'hitl' | 'fanout' | 'aggregate';
+}
+
+function FlowDecisionNodeComponent({ data }: NodeProps & { data: FlowDecisionNodeData }) {
+  return (
+    <div className="relative w-[80px] h-[80px]">
+      <div
+        className={cn(
+          'absolute inset-0 rotate-45 rounded-lg border-2 border-orange-400 bg-orange-50',
+          'flex items-center justify-center transition-all',
+          data.isCompleted && 'opacity-50'
+        )}
+      >
+        <span className="text-xs font-semibold text-orange-900 -rotate-45 truncate max-w-[50px]">
+          {data.label}
+        </span>
+      </div>
+
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!bg-orange-400 !w-2 !h-2 !border-0 !-translate-y-1"
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!bg-orange-400 !w-2 !h-2 !border-0 !translate-y-1"
+      />
+      <Handle
+        type="source"
+        position={Position.Left}
+        className="!bg-orange-400 !w-2 !h-2 !border-0 !-translate-x-1"
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="!bg-orange-400 !w-2 !h-2 !border-0 !translate-x-1"
+      />
+    </div>
+  );
+}
+
+export const FlowDecisionNode = memo(FlowDecisionNodeComponent);

--- a/apps/ui/src/components/views/flow-graph/nodes/flow-hitl-node.tsx
+++ b/apps/ui/src/components/views/flow-graph/nodes/flow-hitl-node.tsx
@@ -1,0 +1,50 @@
+/**
+ * Flow HITL Node — Human-in-the-Loop interaction
+ *
+ * 120x40px red node with user icon.
+ * Yellow pulse when active (signals human action needed).
+ */
+
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { User } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface FlowHitlNodeData {
+  label: string;
+  description?: string;
+  isActive?: boolean;
+  isCompleted?: boolean;
+  type: 'processor' | 'decision' | 'hitl' | 'fanout' | 'aggregate';
+}
+
+function FlowHitlNodeComponent({ data }: NodeProps & { data: FlowHitlNodeData }) {
+  return (
+    <div className="relative">
+      <div
+        className={cn(
+          'w-[120px] h-[40px] rounded-lg border-2 border-red-400 bg-red-50',
+          'flex items-center justify-center gap-2 px-3 transition-all',
+          data.isActive && 'ring-4 ring-yellow-400 animate-pulse',
+          data.isCompleted && 'opacity-50'
+        )}
+      >
+        <User className="w-3.5 h-3.5 text-red-600 shrink-0" />
+        <span className="text-xs font-semibold text-red-900 truncate">{data.label}</span>
+      </div>
+
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!bg-red-400 !w-2 !h-2 !border-0"
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!bg-red-400 !w-2 !h-2 !border-0"
+      />
+    </div>
+  );
+}
+
+export const FlowHitlNode = memo(FlowHitlNodeComponent);

--- a/apps/ui/src/components/views/flow-graph/nodes/flow-process-node.tsx
+++ b/apps/ui/src/components/views/flow-graph/nodes/flow-process-node.tsx
@@ -1,0 +1,48 @@
+/**
+ * Flow Process Node — LangGraph process step
+ *
+ * 120x40px violet node for process steps.
+ * Green pulse when active, reduced opacity when complete.
+ */
+
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { cn } from '@/lib/utils';
+
+export interface FlowProcessNodeData {
+  label: string;
+  description?: string;
+  isActive?: boolean;
+  isCompleted?: boolean;
+  type: 'processor' | 'decision' | 'hitl' | 'fanout' | 'aggregate';
+}
+
+function FlowProcessNodeComponent({ data }: NodeProps & { data: FlowProcessNodeData }) {
+  return (
+    <div className="relative">
+      <div
+        className={cn(
+          'w-[120px] h-[40px] rounded-lg border-2 border-violet-400 bg-violet-50',
+          'flex items-center justify-center px-3 transition-all',
+          data.isActive && 'ring-4 ring-green-400 animate-pulse',
+          data.isCompleted && 'opacity-50'
+        )}
+      >
+        <span className="text-xs font-semibold text-violet-900 truncate">{data.label}</span>
+      </div>
+
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!bg-violet-400 !w-2 !h-2 !border-0"
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!bg-violet-400 !w-2 !h-2 !border-0"
+      />
+    </div>
+  );
+}
+
+export const FlowProcessNode = memo(FlowProcessNodeComponent);

--- a/apps/ui/src/components/views/flow-graph/nodes/flow-start-end-node.tsx
+++ b/apps/ui/src/components/views/flow-graph/nodes/flow-start-end-node.tsx
@@ -1,0 +1,51 @@
+/**
+ * Flow Start/End Node — Graph entry/exit points
+ *
+ * 80x40px rounded node for start and end points.
+ */
+
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { cn } from '@/lib/utils';
+
+export interface FlowStartEndNodeData {
+  label: string;
+  description?: string;
+  isActive?: boolean;
+  isCompleted?: boolean;
+  type: 'processor' | 'decision' | 'hitl' | 'fanout' | 'aggregate';
+  nodeType: 'start' | 'end';
+}
+
+function FlowStartEndNodeComponent({ data }: NodeProps & { data: FlowStartEndNodeData }) {
+  const isStart = data.nodeType === 'start';
+
+  return (
+    <div className="relative">
+      <div
+        className={cn(
+          'w-[80px] h-[40px] rounded-full border-2 flex items-center justify-center px-3 transition-all',
+          isStart
+            ? 'border-green-400 bg-green-50 text-green-900'
+            : 'border-gray-400 bg-gray-50 text-gray-900',
+          data.isCompleted && 'opacity-50'
+        )}
+      >
+        <span className="text-xs font-semibold truncate">{data.label}</span>
+      </div>
+
+      {isStart && (
+        <Handle
+          type="source"
+          position={Position.Bottom}
+          className="!bg-green-400 !w-2 !h-2 !border-0"
+        />
+      )}
+      {!isStart && (
+        <Handle type="target" position={Position.Top} className="!bg-gray-400 !w-2 !h-2 !border-0" />
+      )}
+    </div>
+  );
+}
+
+export const FlowStartEndNode = memo(FlowStartEndNodeComponent);

--- a/apps/ui/src/components/views/flow-graph/nodes/index.ts
+++ b/apps/ui/src/components/views/flow-graph/nodes/index.ts
@@ -12,6 +12,10 @@ import { IntegrationNode } from './integration-node';
 import { FeatureNode } from './feature-node';
 import { AgentNode } from './agent-node';
 import { PipelineStageNode } from './pipeline-stage-node';
+import { FlowProcessNode } from './flow-process-node';
+import { FlowDecisionNode } from './flow-decision-node';
+import { FlowHitlNode } from './flow-hitl-node';
+import { FlowStartEndNode } from './flow-start-end-node';
 
 export { OrchestratorNode } from './orchestrator-node';
 export { ServiceNode } from './service-node';
@@ -20,6 +24,10 @@ export { IntegrationNode } from './integration-node';
 export { FeatureNode } from './feature-node';
 export { AgentNode } from './agent-node';
 export { PipelineStageNode } from './pipeline-stage-node';
+export { FlowProcessNode } from './flow-process-node';
+export { FlowDecisionNode } from './flow-decision-node';
+export { FlowHitlNode } from './flow-hitl-node';
+export { FlowStartEndNode } from './flow-start-end-node';
 
 export const nodeTypes: NodeTypes = {
   orchestrator: OrchestratorNode,
@@ -29,4 +37,8 @@ export const nodeTypes: NodeTypes = {
   feature: FeatureNode,
   agent: AgentNode,
   'pipeline-stage': PipelineStageNode,
+  'flow-process': FlowProcessNode,
+  'flow-decision': FlowDecisionNode,
+  'flow-hitl': FlowHitlNode,
+  'flow-start-end': FlowStartEndNode,
 };

--- a/apps/ui/src/components/views/flow-graph/types.ts
+++ b/apps/ui/src/components/views/flow-graph/types.ts
@@ -105,6 +105,32 @@ export interface PipelineStageNodeData {
   [key: string]: unknown;
 }
 
+export interface FlowNodeData {
+  label: string;
+  description?: string;
+  isActive?: boolean;
+  isCompleted?: boolean;
+  type: 'processor' | 'decision' | 'hitl' | 'fanout' | 'aggregate';
+  [key: string]: unknown;
+}
+
+export interface FlowProcessNodeData extends FlowNodeData {
+  [key: string]: unknown;
+}
+
+export interface FlowDecisionNodeData extends FlowNodeData {
+  [key: string]: unknown;
+}
+
+export interface FlowHitlNodeData extends FlowNodeData {
+  [key: string]: unknown;
+}
+
+export interface FlowStartEndNodeData extends FlowNodeData {
+  nodeType: 'start' | 'end';
+  [key: string]: unknown;
+}
+
 // ============================================
 // Typed Node/Edge Aliases
 // ============================================
@@ -116,6 +142,10 @@ export type IntegrationNode = Node<IntegrationNodeData, 'integration'>;
 export type FeatureNode = Node<FeatureNodeData, 'feature'>;
 export type AgentNode = Node<AgentNodeData, 'agent'>;
 export type PipelineStageNode = Node<PipelineStageNodeData, 'pipeline-stage'>;
+export type FlowProcessNode = Node<FlowProcessNodeData, 'flow-process'>;
+export type FlowDecisionNode = Node<FlowDecisionNodeData, 'flow-decision'>;
+export type FlowHitlNode = Node<FlowHitlNodeData, 'flow-hitl'>;
+export type FlowStartEndNode = Node<FlowStartEndNodeData, 'flow-start-end'>;
 
 export type FlowNode =
   | OrchestratorNode
@@ -124,14 +154,19 @@ export type FlowNode =
   | IntegrationNode
   | FeatureNode
   | AgentNode
-  | PipelineStageNode;
+  | PipelineStageNode
+  | FlowProcessNode
+  | FlowDecisionNode
+  | FlowHitlNode
+  | FlowStartEndNode;
 
 export type DelegationEdge = Edge & { type: 'delegation' };
 export type WorkflowEdge = Edge & { type: 'workflow' };
 export type IntegrationEdge = Edge & { type: 'integration' };
 export type PipelineEdge = Edge & { type: 'pipeline' };
+export type FlowEdgeType = Edge & { type: 'flow-edge'; data?: { label?: string; isConditional?: boolean } };
 
-export type FlowEdge = DelegationEdge | WorkflowEdge | IntegrationEdge | PipelineEdge;
+export type FlowEdge = DelegationEdge | WorkflowEdge | IntegrationEdge | PipelineEdge | FlowEdgeType;
 
 // ============================================
 // Brand Constants
@@ -165,4 +200,8 @@ export const NODE_DIMENSIONS = {
   feature: { width: 180, height: 80 },
   agent: { width: 160, height: 70 },
   'pipeline-stage': { width: 200, height: 120 },
+  'flow-process': { width: 120, height: 40 },
+  'flow-decision': { width: 80, height: 80 },
+  'flow-hitl': { width: 120, height: 40 },
+  'flow-start-end': { width: 80, height: 40 },
 } as const;


### PR DESCRIPTION
## Summary
- 4 new React Flow node types for LangGraph visualization:
  - `flow-process` — Violet 120x40px, green pulse when active
  - `flow-decision` — Orange 80x80px diamond (rotated 45°)
  - `flow-hitl` — Red 120x40px with user icon, yellow pulse when active
  - `flow-start-end` — Small 80x40px terminal nodes
- 1 new edge type (`flow-edge`) with conditional routing labels
- Extended `types.ts` with FlowNodeData interfaces and NODE_DIMENSIONS
- Registered all types in node/edge index files

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] Node components render in React Flow context
- [ ] Active state shows pulsing animation
- [ ] Completed state shows reduced opacity
- [ ] Decision nodes render as diamonds
- [ ] Edge labels display on conditional edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)