### PR TITLE
feat: slash commands for notes editor

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -92,6 +92,7 @@
     "@tiptap/extension-placeholder": "^2.27.2",
     "@tiptap/react": "^2.27.2",
     "@tiptap/starter-kit": "^2.27.2",
+    "@tiptap/suggestion": "^3.20.0",
     "@uiw/react-codemirror": "4.25.4",
     "@xterm/addon-fit": "0.10.0",
     "@xterm/addon-search": "0.15.0",

--- a/apps/ui/src/components/views/notes-view/extensions/slash-commands.ts
+++ b/apps/ui/src/components/views/notes-view/extensions/slash-commands.ts
@@ -1,0 +1,174 @@
+/**
+ * Slash Commands Extension — type / to open a command palette
+ *
+ * Uses @tiptap/suggestion to detect "/" trigger and render a popup
+ * with AI commands and formatting shortcuts.
+ */
+
+import { Extension } from '@tiptap/core';
+import { type Editor } from '@tiptap/core';
+import Suggestion, { type SuggestionOptions } from '@tiptap/suggestion';
+
+export interface SlashCommandItem {
+  id: string;
+  label: string;
+  description: string;
+  icon: string;
+  category: 'ai' | 'format';
+  command: (editor: Editor) => void;
+}
+
+/** AI commands that call /api/ai/generate */
+function createAICommand(commandId: string): (editor: Editor) => void {
+  return (editor: Editor) => {
+    // Dispatch a custom event that the React component will listen for
+    const event = new CustomEvent('slash-command-ai', {
+      detail: { command: commandId, editor },
+    });
+    window.dispatchEvent(event);
+  };
+}
+
+export const SLASH_COMMAND_ITEMS: SlashCommandItem[] = [
+  // AI commands
+  {
+    id: 'continue',
+    label: 'Continue writing',
+    description: 'AI continues from where you left off',
+    icon: '✏️',
+    category: 'ai',
+    command: createAICommand('continue'),
+  },
+  {
+    id: 'summarize',
+    label: 'Summarize',
+    description: 'Summarize the document so far',
+    icon: '📋',
+    category: 'ai',
+    command: createAICommand('summarize'),
+  },
+  {
+    id: 'expand',
+    label: 'Expand',
+    description: 'Expand with more detail',
+    icon: '📝',
+    category: 'ai',
+    command: createAICommand('expand'),
+  },
+  {
+    id: 'fix-grammar',
+    label: 'Fix grammar',
+    description: 'Fix grammar and spelling',
+    icon: '🔤',
+    category: 'ai',
+    command: createAICommand('fix-grammar'),
+  },
+  {
+    id: 'translate',
+    label: 'Translate',
+    description: 'Translate to/from English',
+    icon: '🌐',
+    category: 'ai',
+    command: createAICommand('translate'),
+  },
+  // Formatting commands
+  {
+    id: 'h1',
+    label: 'Heading 1',
+    description: 'Large heading',
+    icon: 'H1',
+    category: 'format',
+    command: (editor) => editor.chain().focus().toggleHeading({ level: 1 }).run(),
+  },
+  {
+    id: 'h2',
+    label: 'Heading 2',
+    description: 'Medium heading',
+    icon: 'H2',
+    category: 'format',
+    command: (editor) => editor.chain().focus().toggleHeading({ level: 2 }).run(),
+  },
+  {
+    id: 'h3',
+    label: 'Heading 3',
+    description: 'Small heading',
+    icon: 'H3',
+    category: 'format',
+    command: (editor) => editor.chain().focus().toggleHeading({ level: 3 }).run(),
+  },
+  {
+    id: 'bullet',
+    label: 'Bullet list',
+    description: 'Unordered list',
+    icon: '•',
+    category: 'format',
+    command: (editor) => editor.chain().focus().toggleBulletList().run(),
+  },
+  {
+    id: 'ordered',
+    label: 'Numbered list',
+    description: 'Ordered list',
+    icon: '1.',
+    category: 'format',
+    command: (editor) => editor.chain().focus().toggleOrderedList().run(),
+  },
+  {
+    id: 'code',
+    label: 'Code block',
+    description: 'Fenced code block',
+    icon: '<>',
+    category: 'format',
+    command: (editor) => editor.chain().focus().toggleCodeBlock().run(),
+  },
+  {
+    id: 'quote',
+    label: 'Blockquote',
+    description: 'Indented quote',
+    icon: '❝',
+    category: 'format',
+    command: (editor) => editor.chain().focus().toggleBlockquote().run(),
+  },
+  {
+    id: 'hr',
+    label: 'Divider',
+    description: 'Horizontal rule',
+    icon: '—',
+    category: 'format',
+    command: (editor) => editor.chain().focus().setHorizontalRule().run(),
+  },
+];
+
+export type SlashCommandSuggestionOptions = Omit<SuggestionOptions<SlashCommandItem>, 'editor'>;
+
+export const SlashCommands = Extension.create<{
+  suggestion: Partial<SlashCommandSuggestionOptions>;
+}>({
+  name: 'slashCommands',
+
+  addOptions() {
+    return {
+      suggestion: {
+        char: '/',
+        startOfLine: false,
+        items: ({ query }: { query: string }) => {
+          const lower = query.toLowerCase();
+          return SLASH_COMMAND_ITEMS.filter(
+            (item) =>
+              item.label.toLowerCase().includes(lower) ||
+              item.description.toLowerCase().includes(lower) ||
+              item.id.includes(lower)
+          ).slice(0, 10);
+        },
+      },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      Suggestion({
+        editor: this.editor,
+        ...this.options.suggestion,
+      } as SuggestionOptions<SlashCommandItem>),
+    ];
+  },
+});

--- a/apps/ui/src/components/views/notes-view/slash-command-list.tsx
+++ b/apps/ui/src/components/views/notes-view/slash-command-list.tsx
@@ -1,0 +1,96 @@
+/**
+ * Slash Command List — floating popup rendered by @tiptap/suggestion
+ *
+ * Shows filtered commands with keyboard navigation (Arrow Up/Down, Enter, Escape).
+ */
+
+import { forwardRef, useEffect, useImperativeHandle, useState, useCallback } from 'react';
+import type { SlashCommandItem } from './extensions/slash-commands';
+
+interface SlashCommandListProps {
+  items: SlashCommandItem[];
+  command: (item: SlashCommandItem) => void;
+}
+
+export interface SlashCommandListRef {
+  onKeyDown: (props: { event: KeyboardEvent }) => boolean;
+}
+
+export const SlashCommandList = forwardRef<SlashCommandListRef, SlashCommandListProps>(
+  ({ items, command }, ref) => {
+    const [selectedIndex, setSelectedIndex] = useState(0);
+
+    // Reset selection when items change
+    useEffect(() => {
+      setSelectedIndex(0);
+    }, [items]);
+
+    const selectItem = useCallback(
+      (index: number) => {
+        const item = items[index];
+        if (item) command(item);
+      },
+      [items, command]
+    );
+
+    useImperativeHandle(ref, () => ({
+      onKeyDown: ({ event }: { event: KeyboardEvent }) => {
+        if (event.key === 'ArrowUp') {
+          setSelectedIndex((prev) => (prev - 1 + items.length) % items.length);
+          return true;
+        }
+        if (event.key === 'ArrowDown') {
+          setSelectedIndex((prev) => (prev + 1) % items.length);
+          return true;
+        }
+        if (event.key === 'Enter') {
+          selectItem(selectedIndex);
+          return true;
+        }
+        if (event.key === 'Escape') {
+          return true;
+        }
+        return false;
+      },
+    }));
+
+    if (items.length === 0) {
+      return (
+        <div className="rounded-lg border border-border bg-popover p-2 shadow-lg">
+          <p className="px-2 py-1 text-xs text-muted-foreground">No results</p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="max-h-64 overflow-y-auto rounded-lg border border-border bg-popover p-1 shadow-lg">
+        {items.map((item, index) => (
+          <button
+            key={item.id}
+            onClick={() => selectItem(index)}
+            className={`flex w-full items-center gap-3 rounded px-2 py-1.5 text-left text-sm transition-colors ${
+              index === selectedIndex
+                ? 'bg-accent text-accent-foreground'
+                : 'text-foreground hover:bg-accent/50'
+            }`}
+          >
+            <span className="flex size-7 shrink-0 items-center justify-center rounded bg-muted text-xs">
+              {item.icon}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-sm font-medium">{item.label}</div>
+              <div className="truncate text-xs text-muted-foreground">{item.description}</div>
+            </div>
+            {item.category === 'ai' && (
+              <span className="shrink-0 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                AI
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+    );
+  }
+);
+
+SlashCommandList.displayName = 'SlashCommandList';

--- a/apps/ui/src/components/views/notes-view/tiptap-editor.tsx
+++ b/apps/ui/src/components/views/notes-view/tiptap-editor.tsx
@@ -1,9 +1,16 @@
-import { useEffect, useMemo } from 'react';
-import { useEditor, EditorContent } from '@tiptap/react';
+import { useEffect, useMemo, useCallback, useRef } from 'react';
+import { useEditor, EditorContent, type ReactRenderer } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Placeholder from '@tiptap/extension-placeholder';
 import type { Editor } from '@tiptap/react';
+import tippy, { type Instance as TippyInstance } from 'tippy.js';
 import { GhostText } from './extensions/ghost-text';
+import {
+  SlashCommands,
+  SLASH_COMMAND_ITEMS,
+  type SlashCommandItem,
+} from './extensions/slash-commands';
+import { SlashCommandList, type SlashCommandListRef } from './slash-command-list';
 import { AIBubbleMenu } from './ai-bubble-menu';
 import { getHttpApiClient } from '@/lib/http-api-client';
 
@@ -38,7 +45,58 @@ async function readStream(response: Response, maxChars = 200): Promise<string> {
   return result.slice(0, maxChars);
 }
 
+/** Read a full streaming response (no cap) for AI generation */
+async function readFullStream(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return '';
+
+  const decoder = new TextDecoder();
+  let result = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      result += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return result;
+}
+
 export function TiptapEditor({ content, onUpdate, onEditorReady }: TiptapEditorProps) {
+  const editorRef = useRef<Editor | null>(null);
+
+  // Handle AI slash commands via custom event
+  useEffect(() => {
+    const handler = async (e: Event) => {
+      const detail = (e as CustomEvent).detail as { command: string };
+      const currentEditor = editorRef.current;
+      if (!currentEditor) return;
+
+      const docText = currentEditor.state.doc.textContent;
+      const pos = currentEditor.state.selection.head;
+      const contextBefore = docText.slice(Math.max(0, pos - 3000), pos);
+
+      try {
+        const response = await getHttpApiClient().ai.generate(detail.command, contextBefore);
+        if (!response.ok) return;
+
+        const html = await readFullStream(response);
+        if (html.trim()) {
+          currentEditor.commands.insertContent(html.trim());
+        }
+      } catch {
+        // Silently handle errors
+      }
+    };
+
+    window.addEventListener('slash-command-ai', handler);
+    return () => window.removeEventListener('slash-command-ai', handler);
+  }, []);
+
   const ghostTextExtension = useMemo(
     () =>
       GhostText.configure({
@@ -56,13 +114,102 @@ export function TiptapEditor({ content, onUpdate, onEditorReady }: TiptapEditorP
     []
   );
 
+  const slashCommandsExtension = useMemo(
+    () =>
+      SlashCommands.configure({
+        suggestion: {
+          items: ({ query }: { query: string }) => {
+            const lower = query.toLowerCase();
+            return SLASH_COMMAND_ITEMS.filter(
+              (item) =>
+                item.label.toLowerCase().includes(lower) ||
+                item.description.toLowerCase().includes(lower) ||
+                item.id.includes(lower)
+            ).slice(0, 10);
+          },
+          render: () => {
+            let component: ReactRenderer<SlashCommandListRef> | null = null;
+            let popup: TippyInstance[] | null = null;
+
+            return {
+              onStart: (props) => {
+                component = new ReactRenderer(SlashCommandList, {
+                  props,
+                  editor: props.editor,
+                });
+
+                if (!props.clientRect) return;
+
+                popup = tippy('body', {
+                  getReferenceClientRect: props.clientRect as () => DOMRect,
+                  appendTo: () => document.body,
+                  content: component.element,
+                  showOnCreate: true,
+                  interactive: true,
+                  trigger: 'manual',
+                  placement: 'bottom-start',
+                  maxWidth: 320,
+                });
+              },
+
+              onUpdate: (props) => {
+                component?.updateProps(props);
+                if (props.clientRect && popup?.[0]) {
+                  popup[0].setProps({
+                    getReferenceClientRect: props.clientRect as () => DOMRect,
+                  });
+                }
+              },
+
+              onKeyDown: (props) => {
+                if (props.event.key === 'Escape') {
+                  popup?.[0]?.hide();
+                  return true;
+                }
+                return component?.ref?.onKeyDown(props) ?? false;
+              },
+
+              onExit: () => {
+                popup?.[0]?.destroy();
+                component?.destroy();
+              },
+            };
+          },
+          command: ({
+            editor,
+            range,
+            props,
+          }: {
+            editor: Editor;
+            range: { from: number; to: number };
+            props: SlashCommandItem;
+          }) => {
+            // Delete the /command text first
+            editor.chain().focus().deleteRange(range).run();
+            // Then execute the command
+            props.command(editor);
+          },
+        },
+      }),
+    []
+  );
+
+  const handleEditorReady = useCallback(
+    (e: Editor) => {
+      editorRef.current = e;
+      onEditorReady?.(e);
+    },
+    [onEditorReady]
+  );
+
   const editor = useEditor({
     extensions: [
       StarterKit,
       Placeholder.configure({
-        placeholder: 'Start writing...',
+        placeholder: 'Type / for commands...',
       }),
       ghostTextExtension,
+      slashCommandsExtension,
     ],
     content,
     onUpdate: ({ editor: e }) => {
@@ -77,10 +224,10 @@ export function TiptapEditor({ content, onUpdate, onEditorReady }: TiptapEditorP
 
   // Notify parent when editor is ready
   useEffect(() => {
-    if (editor && onEditorReady) {
-      onEditorReady(editor);
+    if (editor) {
+      handleEditorReady(editor);
     }
-  }, [editor, onEditorReady]);
+  }, [editor, handleEditorReady]);
 
   // Sync content when tab switches (content prop changes from outside)
   useEffect(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -731,6 +731,7 @@
         "@tiptap/extension-placeholder": "^2.27.2",
         "@tiptap/react": "^2.27.2",
         "@tiptap/starter-kit": "^2.27.2",
+        "@tiptap/suggestion": "^3.20.0",
         "@uiw/react-codemirror": "4.25.4",
         "@xterm/addon-fit": "0.10.0",
         "@xterm/addon-search": "0.15.0",
@@ -11103,6 +11104,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/suggestion": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.20.0.tgz",
+      "integrity": "sha512-OA9Fe+1Q/Ex0ivTcpRcVFiLnNsVdIBmiEoctt/gu4H2ayCYmZ906veioXNdc1m/3MtVVUIuEnvwwsrOZXlfDEw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.0",
+        "@tiptap/pm": "^3.20.0"
       }
     },
     "node_modules/@twurple/api": {


### PR DESCRIPTION
## Summary
- Adds `/` slash command extension using `@tiptap/suggestion` with tippy.js popup
- 5 AI commands (continue, summarize, expand, fix-grammar, translate) that stream responses from `/api/ai/generate`
- 8 formatting commands (H1-H3, bullet/ordered lists, code block, blockquote, divider)
- Keyboard navigation (Arrow Up/Down, Enter, Escape) in command palette
- AI badge on AI commands for visual distinction

## Test plan
- [ ] Type `/` in notes editor — command palette appears
- [ ] Arrow keys navigate, Enter selects, Escape dismisses
- [ ] Filter by typing after `/` (e.g., `/head` shows heading commands)
- [ ] Formatting commands apply correctly (H1, bullet list, code block, etc.)
- [ ] AI commands stream response and insert content at cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added slash command palette triggered by "/" in the notes editor
  * Introduced AI-powered writing assistance (continue, summarize, expand, fix grammar, translate)
  * Added formatting commands for headings, lists, code blocks, blockquote, and horizontal rule
  * Implemented searchable command list with keyboard navigation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->