### PR TITLE
feat: agent notes tools for reading and writing note tabs

### DIFF
--- a/apps/server/src/routes/notes/index.ts
+++ b/apps/server/src/routes/notes/index.ts
@@ -126,7 +126,10 @@ export function createNotesRoutes(): Router {
    */
   router.post('/list-tabs', async (req: Request, res: Response) => {
     try {
-      const { projectPath } = req.body as { projectPath: string };
+      const { projectPath, includeRestricted } = req.body as {
+        projectPath: string;
+        includeRestricted?: boolean;
+      };
       if (!projectPath) {
         res.status(400).json({ error: 'projectPath is required' });
         return;
@@ -141,6 +144,7 @@ export function createNotesRoutes(): Router {
       }> = workspace.tabOrder
         .map((id) => workspace.tabs[id])
         .filter(Boolean)
+        .filter((tab) => includeRestricted || tab.permissions.agentRead)
         .map((tab) => ({
           id: tab.id,
           name: tab.name,
@@ -151,6 +155,66 @@ export function createNotesRoutes(): Router {
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       logger.error('Failed to list note tabs:', error);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  /**
+   * POST /api/notes/write-tab
+   * Agent-oriented write: checks agentWrite permission, supports replace/append
+   */
+  router.post('/write-tab', async (req: Request, res: Response) => {
+    try {
+      const {
+        projectPath,
+        tabId,
+        content,
+        mode = 'replace',
+      } = req.body as {
+        projectPath: string;
+        tabId: string;
+        content: string;
+        mode?: 'replace' | 'append';
+      };
+      if (!projectPath || !tabId || content === undefined) {
+        res.status(400).json({ error: 'projectPath, tabId, and content are required' });
+        return;
+      }
+      validatePath(projectPath);
+      const workspace = await loadWorkspace(projectPath);
+      const tab = workspace.tabs[tabId];
+      if (!tab) {
+        res.status(404).json({ error: 'Tab not found' });
+        return;
+      }
+      if (!tab.permissions.agentWrite) {
+        res.status(403).json({ error: 'Agent does not have write permission for this tab' });
+        return;
+      }
+
+      const now = Date.now();
+      const newContent = mode === 'append' ? tab.content + content : content;
+      tab.content = newContent;
+      tab.metadata.updatedAt = now;
+      // Recalculate word/char counts
+      const plainText = newContent.replace(/<[^>]*>/g, '');
+      tab.metadata.wordCount = plainText.trim() ? plainText.trim().split(/\s+/).length : 0;
+      tab.metadata.characterCount = plainText.length;
+
+      await saveWorkspace(projectPath, workspace);
+      res.json({
+        success: true,
+        tab: {
+          id: tab.id,
+          name: tab.name,
+          wordCount: tab.metadata.wordCount,
+          characterCount: tab.metadata.characterCount,
+          updatedAt: now,
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Failed to write note tab:', error);
       res.status(500).json({ error: message });
     }
   });

--- a/libs/tools/src/domains/notes/index.ts
+++ b/libs/tools/src/domains/notes/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Notes workspace tools
+ */
+
+export { listTabs } from './list-tabs.js';
+export type { ListTabsInput, ListTabsOutput } from './list-tabs.js';
+
+export { readTab } from './read-tab.js';
+export type { ReadTabInput, ReadTabOutput } from './read-tab.js';
+
+export { writeTab } from './write-tab.js';
+export type { WriteTabInput, WriteTabOutput } from './write-tab.js';

--- a/libs/tools/src/domains/notes/list-tabs.ts
+++ b/libs/tools/src/domains/notes/list-tabs.ts
@@ -1,0 +1,73 @@
+/**
+ * List Notes Tabs Tool
+ *
+ * Lists all note tabs with their permissions and metadata.
+ * Only returns tabs where agentRead is enabled.
+ */
+
+import type { ToolContext, ToolResult } from '../../types.js';
+
+export interface ListTabsInput {
+  projectPath: string;
+  includeRestricted?: boolean;
+}
+
+export interface ListTabsOutput {
+  tabs: Array<{
+    id: string;
+    name: string;
+    agentRead: boolean;
+    agentWrite: boolean;
+    wordCount: number;
+  }>;
+}
+
+export async function listTabs(
+  context: ToolContext,
+  input: ListTabsInput
+): Promise<ToolResult<ListTabsOutput>> {
+  try {
+    const { projectPath, includeRestricted = false } = input;
+
+    if (!projectPath) {
+      return {
+        success: false,
+        error: 'projectPath is required',
+        errorCode: 'MISSING_PROJECT_PATH',
+      };
+    }
+
+    if (!context.notesLoader) {
+      return {
+        success: false,
+        error: 'notesLoader not available in context',
+        errorCode: 'MISSING_NOTES_LOADER',
+      };
+    }
+
+    const workspace = await context.notesLoader.load(projectPath);
+
+    const tabs = workspace.tabOrder
+      .map((id) => workspace.tabs[id])
+      .filter(Boolean)
+      .filter((tab) => includeRestricted || tab.permissions.agentRead)
+      .map((tab) => ({
+        id: tab.id,
+        name: tab.name,
+        agentRead: tab.permissions.agentRead,
+        agentWrite: tab.permissions.agentWrite,
+        wordCount: tab.metadata.wordCount ?? 0,
+      }));
+
+    return {
+      success: true,
+      data: { tabs },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      errorCode: 'LIST_TABS_FAILED',
+    };
+  }
+}

--- a/libs/tools/src/domains/notes/read-tab.ts
+++ b/libs/tools/src/domains/notes/read-tab.ts
@@ -1,0 +1,84 @@
+/**
+ * Read Note Tab Tool
+ *
+ * Reads the content of a single note tab.
+ * Respects agentRead permission — returns error if tab has agentRead: false.
+ */
+
+import type { ToolContext, ToolResult } from '../../types.js';
+
+export interface ReadTabInput {
+  projectPath: string;
+  tabId: string;
+}
+
+export interface ReadTabOutput {
+  id: string;
+  name: string;
+  content: string;
+  wordCount: number;
+  characterCount: number;
+  updatedAt: number;
+}
+
+export async function readTab(
+  context: ToolContext,
+  input: ReadTabInput
+): Promise<ToolResult<ReadTabOutput>> {
+  try {
+    const { projectPath, tabId } = input;
+
+    if (!projectPath || !tabId) {
+      return {
+        success: false,
+        error: 'projectPath and tabId are required',
+        errorCode: 'MISSING_REQUIRED_FIELDS',
+      };
+    }
+
+    if (!context.notesLoader) {
+      return {
+        success: false,
+        error: 'notesLoader not available in context',
+        errorCode: 'MISSING_NOTES_LOADER',
+      };
+    }
+
+    const workspace = await context.notesLoader.load(projectPath);
+    const tab = workspace.tabs[tabId];
+
+    if (!tab) {
+      return {
+        success: false,
+        error: 'Tab not found',
+        errorCode: 'TAB_NOT_FOUND',
+      };
+    }
+
+    if (!tab.permissions.agentRead) {
+      return {
+        success: false,
+        error: 'Agent does not have read permission for this tab',
+        errorCode: 'PERMISSION_DENIED',
+      };
+    }
+
+    return {
+      success: true,
+      data: {
+        id: tab.id,
+        name: tab.name,
+        content: tab.content,
+        wordCount: tab.metadata.wordCount ?? 0,
+        characterCount: tab.metadata.characterCount ?? 0,
+        updatedAt: tab.metadata.updatedAt,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      errorCode: 'READ_TAB_FAILED',
+    };
+  }
+}

--- a/libs/tools/src/domains/notes/write-tab.ts
+++ b/libs/tools/src/domains/notes/write-tab.ts
@@ -1,0 +1,122 @@
+/**
+ * Write Note Tab Tool
+ *
+ * Updates the content of a single note tab.
+ * Respects agentWrite permission — returns error if tab has agentWrite: false.
+ * Supports full replace or append mode.
+ */
+
+import type { ToolContext, ToolResult } from '../../types.js';
+
+export interface WriteTabInput {
+  projectPath: string;
+  tabId: string;
+  content: string;
+  mode?: 'replace' | 'append';
+}
+
+export interface WriteTabOutput {
+  id: string;
+  name: string;
+  wordCount: number;
+  characterCount: number;
+  updatedAt: number;
+}
+
+function countWords(html: string): number {
+  const text = html.replace(/<[^>]*>/g, ' ').trim();
+  if (!text) return 0;
+  return text.split(/\s+/).length;
+}
+
+function countCharacters(html: string): number {
+  return html.replace(/<[^>]*>/g, '').length;
+}
+
+export async function writeTab(
+  context: ToolContext,
+  input: WriteTabInput
+): Promise<ToolResult<WriteTabOutput>> {
+  try {
+    const { projectPath, tabId, content, mode = 'replace' } = input;
+
+    if (!projectPath || !tabId) {
+      return {
+        success: false,
+        error: 'projectPath and tabId are required',
+        errorCode: 'MISSING_REQUIRED_FIELDS',
+      };
+    }
+
+    if (content === undefined || content === null) {
+      return {
+        success: false,
+        error: 'content is required',
+        errorCode: 'MISSING_CONTENT',
+      };
+    }
+
+    if (!context.notesLoader) {
+      return {
+        success: false,
+        error: 'notesLoader not available in context',
+        errorCode: 'MISSING_NOTES_LOADER',
+      };
+    }
+
+    const workspace = await context.notesLoader.load(projectPath);
+    const tab = workspace.tabs[tabId];
+
+    if (!tab) {
+      return {
+        success: false,
+        error: 'Tab not found',
+        errorCode: 'TAB_NOT_FOUND',
+      };
+    }
+
+    if (!tab.permissions.agentWrite) {
+      return {
+        success: false,
+        error: 'Agent does not have write permission for this tab',
+        errorCode: 'PERMISSION_DENIED',
+      };
+    }
+
+    const now = Date.now();
+    const newContent = mode === 'append' ? tab.content + content : content;
+
+    tab.content = newContent;
+    tab.metadata.updatedAt = now;
+    tab.metadata.wordCount = countWords(newContent);
+    tab.metadata.characterCount = countCharacters(newContent);
+
+    await context.notesLoader.save(projectPath, workspace);
+
+    if (context.events) {
+      context.events.emit('notes:tab-updated', {
+        projectPath,
+        tabId,
+        name: tab.name,
+        source: 'agent',
+      });
+    }
+
+    return {
+      success: true,
+      data: {
+        id: tab.id,
+        name: tab.name,
+        wordCount: tab.metadata.wordCount,
+        characterCount: tab.metadata.characterCount,
+        updatedAt: now,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      errorCode: 'WRITE_TAB_FAILED',
+    };
+  }
+}

--- a/libs/tools/src/index.ts
+++ b/libs/tools/src/index.ts
@@ -14,4 +14,5 @@ export { toExpressRouter, type ExpressAdapterOptions } from './adapters/index.js
 
 // Domain-specific tools
 export * from './domains/features/index.js';
+export * from './domains/notes/index.js';
 export * from './domains/twitch/index.js';

--- a/libs/tools/src/types.ts
+++ b/libs/tools/src/types.ts
@@ -3,7 +3,7 @@
  */
 
 import type { z } from 'zod';
-import type { Feature, FeatureStatus } from '@automaker/types';
+import type { Feature, FeatureStatus, NotesWorkspace, NoteTab } from '@automaker/types';
 
 /**
  * Tool execution context - dependency injection container
@@ -28,6 +28,13 @@ export interface ToolContext {
       excludeId?: string
     ) => Promise<Feature | null>;
   };
+
+  // Notes workspace services
+  notesLoader?: {
+    load: (projectPath: string) => Promise<NotesWorkspace>;
+    save: (projectPath: string, workspace: NotesWorkspace) => Promise<void>;
+  };
+
   events?: {
     emit: (event: string, data: unknown) => void;
   };

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -2744,6 +2744,74 @@ const tools: Tool[] = [
     },
   },
 
+  // ========== Notes Workspace ==========
+  {
+    name: 'list_note_tabs',
+    description:
+      'List all note tabs in a project workspace. Returns tab names, permissions (agentRead/agentWrite), and word counts. Only tabs with agentRead enabled are shown by default.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        includeRestricted: {
+          type: 'boolean',
+          description: 'Include tabs where agentRead is false (default: false)',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+  {
+    name: 'read_note_tab',
+    description:
+      'Read the content of a specific note tab. Requires agentRead permission on the tab. Returns HTML content, word count, and metadata.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        tabId: {
+          type: 'string',
+          description: 'The tab ID (UUID). Use list_note_tabs to discover tab IDs.',
+        },
+      },
+      required: ['projectPath', 'tabId'],
+    },
+  },
+  {
+    name: 'write_note_tab',
+    description:
+      'Write content to a specific note tab. Requires agentWrite permission on the tab. Supports replace (default) or append mode. Content should be TipTap-compatible HTML.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        tabId: {
+          type: 'string',
+          description: 'The tab ID (UUID). Use list_note_tabs to discover tab IDs.',
+        },
+        content: {
+          type: 'string',
+          description: 'HTML content to write. For rich text, use TipTap-compatible HTML tags.',
+        },
+        mode: {
+          type: 'string',
+          enum: ['replace', 'append'],
+          description: 'Write mode: replace (default) overwrites, append adds to end',
+        },
+      },
+      required: ['projectPath', 'tabId', 'content'],
+    },
+  },
+
   // Idea Processing
   {
     name: 'process_idea',
@@ -3870,6 +3938,27 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         projectPath: args.projectPath,
         title: args.title,
         description: args.description,
+      });
+
+    // Notes Workspace
+    case 'list_note_tabs':
+      return apiCall('/notes/list-tabs', {
+        projectPath: args.projectPath,
+        includeRestricted: args.includeRestricted,
+      });
+
+    case 'read_note_tab':
+      return apiCall('/notes/get-tab', {
+        projectPath: args.projectPath,
+        tabId: args.tabId,
+      });
+
+    case 'write_note_tab':
+      return apiCall('/notes/write-tab', {
+        projectPath: args.projectPath,
+        tabId: args.tabId,
+        content: args.content,
+        mode: args.mode,
       });
 
     default:


### PR DESCRIPTION
## Summary
- Adds `notesLoader` interface to `ToolContext` in `@automaker/tools` for notes workspace access
- 3 new shared tool functions: `listTabs`, `readTab`, `writeTab` with per-tab permission enforcement
- 3 new MCP tools: `list_note_tabs`, `read_note_tab`, `write_note_tab` for agent access
- New server endpoint `POST /api/notes/write-tab` with agentWrite permission check and replace/append modes
- Updated `list-tabs` endpoint to support `includeRestricted` filter

## Test plan
- [ ] `list_note_tabs` returns only agentRead-enabled tabs by default
- [ ] `read_note_tab` returns content for readable tabs, 403 for restricted
- [ ] `write_note_tab` replaces content in writable tabs, 403 for restricted
- [ ] `write_note_tab` with mode=append adds to existing content
- [ ] Word/character counts update correctly after writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * List all note tabs in a project with optional permission-based filtering
  * Read individual note tab content with metadata (word count, character count, last updated)
  * Write or append content to note tabs with automatic metadata updates
  * Support for replace and append modes when editing tab content
<!-- end of auto-generated comment: release notes by coderabbit.ai -->