### PR TITLE
feat: board query and dependency management tools

### DIFF
--- a/libs/tools/src/domains/features/get-dependencies.ts
+++ b/libs/tools/src/domains/features/get-dependencies.ts
@@ -1,0 +1,113 @@
+/**
+ * Get Feature Dependencies Tool
+ *
+ * Returns the dependency chain for a feature: what it depends on,
+ * what depends on it, and whether all dependencies are satisfied.
+ */
+
+import type { ToolContext, ToolResult } from '../../types.js';
+
+export interface GetDependenciesInput {
+  projectPath: string;
+  featureId: string;
+}
+
+export interface DependencyInfo {
+  id: string;
+  title?: string;
+  status?: string;
+  satisfied: boolean;
+}
+
+export interface GetDependenciesOutput {
+  featureId: string;
+  featureTitle?: string;
+  /** Features this feature depends on (must complete before this one starts) */
+  dependsOn: DependencyInfo[];
+  /** Features that depend on this feature (blocked until this one completes) */
+  blockedBy: DependencyInfo[];
+  /** Whether all dependencies are satisfied */
+  allSatisfied: boolean;
+  /** Statuses that count as "satisfied" */
+  satisfiedStatuses: string[];
+}
+
+const SATISFIED_STATUSES = ['done', 'completed', 'verified', 'review'];
+
+export async function getDependencies(
+  context: ToolContext,
+  input: GetDependenciesInput
+): Promise<ToolResult<GetDependenciesOutput>> {
+  try {
+    const { projectPath, featureId } = input;
+
+    if (!projectPath || !featureId) {
+      return {
+        success: false,
+        error: 'projectPath and featureId are required',
+        errorCode: 'MISSING_REQUIRED_FIELDS',
+      };
+    }
+
+    if (!context.featureLoader) {
+      return {
+        success: false,
+        error: 'featureLoader not available in context',
+        errorCode: 'MISSING_FEATURE_LOADER',
+      };
+    }
+
+    const feature = await context.featureLoader.get(projectPath, featureId);
+    if (!feature) {
+      return {
+        success: false,
+        error: 'Feature not found',
+        errorCode: 'FEATURE_NOT_FOUND',
+      };
+    }
+
+    const allFeatures = await context.featureLoader.getAll(projectPath);
+    const featureMap = new Map(allFeatures.map((f) => [f.id, f]));
+
+    // What this feature depends on
+    const dependsOn: DependencyInfo[] = (feature.dependencies || []).map((depId) => {
+      const dep = featureMap.get(depId);
+      return {
+        id: depId,
+        title: dep?.title,
+        status: dep?.status,
+        satisfied: dep?.status ? SATISFIED_STATUSES.includes(dep.status) : false,
+      };
+    });
+
+    // What depends on this feature (reverse lookup)
+    const blockedBy: DependencyInfo[] = allFeatures
+      .filter((f) => f.dependencies?.includes(featureId))
+      .map((f) => ({
+        id: f.id,
+        title: f.title,
+        status: f.status,
+        satisfied: f.status ? SATISFIED_STATUSES.includes(f.status) : false,
+      }));
+
+    const allSatisfied = dependsOn.length === 0 || dependsOn.every((d) => d.satisfied);
+
+    return {
+      success: true,
+      data: {
+        featureId,
+        featureTitle: feature.title,
+        dependsOn,
+        blockedBy,
+        allSatisfied,
+        satisfiedStatuses: SATISFIED_STATUSES,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      errorCode: 'GET_DEPENDENCIES_FAILED',
+    };
+  }
+}

--- a/libs/tools/src/domains/features/index.ts
+++ b/libs/tools/src/domains/features/index.ts
@@ -7,3 +7,13 @@ export { getFeature } from './get-feature.js';
 export { createFeature } from './create-feature.js';
 export { updateFeature } from './update-feature.js';
 export { deleteFeature } from './delete-feature.js';
+export { queryBoard } from './query-board.js';
+export type { QueryBoardInput, QueryBoardOutput } from './query-board.js';
+export { getDependencies } from './get-dependencies.js';
+export type {
+  GetDependenciesInput,
+  GetDependenciesOutput,
+  DependencyInfo,
+} from './get-dependencies.js';
+export { setDependencies } from './set-dependencies.js';
+export type { SetDependenciesInput, SetDependenciesOutput } from './set-dependencies.js';

--- a/libs/tools/src/domains/features/query-board.ts
+++ b/libs/tools/src/domains/features/query-board.ts
@@ -1,0 +1,177 @@
+/**
+ * Query Board Tool
+ *
+ * Advanced board query with compound filters: status, epic, assignee,
+ * complexity, blocked status, date range. Returns compact results
+ * to minimize agent context usage.
+ */
+
+import type { ToolContext, ToolResult, CompactFeature } from '../../types.js';
+import type { Feature, FeatureStatus } from '@automaker/types';
+
+export interface QueryBoardInput {
+  projectPath: string;
+  status?: FeatureStatus | FeatureStatus[];
+  epicId?: string;
+  assignee?: string | null;
+  complexity?: 'small' | 'medium' | 'large' | 'architectural';
+  isEpic?: boolean;
+  isBlocked?: boolean;
+  hasDependencies?: boolean;
+  updatedAfter?: number;
+  updatedBefore?: number;
+  search?: string;
+  limit?: number;
+}
+
+export interface QueryBoardOutput {
+  features: CompactFeature[];
+  total: number;
+  filters: Record<string, unknown>;
+}
+
+function toCompact(feature: Feature): CompactFeature {
+  return {
+    id: feature.id,
+    title: feature.title,
+    status: feature.status,
+    complexity: feature.complexity,
+    branchName: feature.branchName,
+    costUsd: feature.costUsd,
+    prNumber: feature.prNumber,
+    prUrl: feature.prUrl,
+    epicId: feature.epicId,
+    isEpic: feature.isEpic,
+    assignee: feature.assignee,
+    dependencies: feature.dependencies,
+    updatedAt: feature.updatedAt,
+  };
+}
+
+export async function queryBoard(
+  context: ToolContext,
+  input: QueryBoardInput
+): Promise<ToolResult<QueryBoardOutput>> {
+  try {
+    const { projectPath, limit = 50, ...filters } = input;
+
+    if (!projectPath) {
+      return {
+        success: false,
+        error: 'projectPath is required',
+        errorCode: 'MISSING_PROJECT_PATH',
+      };
+    }
+
+    if (!context.featureLoader) {
+      return {
+        success: false,
+        error: 'featureLoader not available in context',
+        errorCode: 'MISSING_FEATURE_LOADER',
+      };
+    }
+
+    let features = await context.featureLoader.getAll(projectPath);
+    const appliedFilters: Record<string, unknown> = {};
+
+    // Status filter (single or array)
+    if (filters.status) {
+      const statuses = Array.isArray(filters.status) ? filters.status : [filters.status];
+      features = features.filter((f) => statuses.includes(f.status as FeatureStatus));
+      appliedFilters.status = statuses;
+    }
+
+    // Epic filter
+    if (filters.epicId !== undefined) {
+      features = features.filter((f) => f.epicId === filters.epicId);
+      appliedFilters.epicId = filters.epicId;
+    }
+
+    // Assignee filter (null means unassigned)
+    if (filters.assignee !== undefined) {
+      if (filters.assignee === null) {
+        features = features.filter((f) => !f.assignee);
+      } else {
+        features = features.filter((f) => f.assignee === filters.assignee);
+      }
+      appliedFilters.assignee = filters.assignee;
+    }
+
+    // Complexity filter
+    if (filters.complexity) {
+      features = features.filter((f) => f.complexity === filters.complexity);
+      appliedFilters.complexity = filters.complexity;
+    }
+
+    // Epic-only filter
+    if (filters.isEpic !== undefined) {
+      features = features.filter((f) => !!f.isEpic === filters.isEpic);
+      appliedFilters.isEpic = filters.isEpic;
+    }
+
+    // Blocked filter
+    if (filters.isBlocked !== undefined) {
+      if (filters.isBlocked) {
+        features = features.filter((f) => f.status === 'blocked');
+      } else {
+        features = features.filter((f) => f.status !== 'blocked');
+      }
+      appliedFilters.isBlocked = filters.isBlocked;
+    }
+
+    // Has dependencies filter
+    if (filters.hasDependencies !== undefined) {
+      if (filters.hasDependencies) {
+        features = features.filter((f) => f.dependencies && f.dependencies.length > 0);
+      } else {
+        features = features.filter((f) => !f.dependencies || f.dependencies.length === 0);
+      }
+      appliedFilters.hasDependencies = filters.hasDependencies;
+    }
+
+    // Date range filters
+    if (filters.updatedAfter) {
+      features = features.filter((f) => {
+        const updatedAt = typeof f.updatedAt === 'number' ? f.updatedAt : 0;
+        return updatedAt >= filters.updatedAfter!;
+      });
+      appliedFilters.updatedAfter = filters.updatedAfter;
+    }
+
+    if (filters.updatedBefore) {
+      features = features.filter((f) => {
+        const updatedAt = typeof f.updatedAt === 'number' ? f.updatedAt : 0;
+        return updatedAt <= filters.updatedBefore!;
+      });
+      appliedFilters.updatedBefore = filters.updatedBefore;
+    }
+
+    // Text search (title + description)
+    if (filters.search) {
+      const lower = filters.search.toLowerCase();
+      features = features.filter(
+        (f) =>
+          f.title?.toLowerCase().includes(lower) || f.description?.toLowerCase().includes(lower)
+      );
+      appliedFilters.search = filters.search;
+    }
+
+    const total = features.length;
+    const limited = features.slice(0, limit);
+
+    return {
+      success: true,
+      data: {
+        features: limited.map(toCompact),
+        total,
+        filters: appliedFilters,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      errorCode: 'QUERY_BOARD_FAILED',
+    };
+  }
+}

--- a/libs/tools/src/domains/features/set-dependencies.ts
+++ b/libs/tools/src/domains/features/set-dependencies.ts
@@ -1,0 +1,179 @@
+/**
+ * Set Feature Dependencies Tool
+ *
+ * Sets dependencies for a feature with circular dependency detection.
+ * Emits feature:dependencies-changed event when dependencies are updated.
+ */
+
+import type { ToolContext, ToolResult } from '../../types.js';
+import type { Feature } from '@automaker/types';
+
+export interface SetDependenciesInput {
+  projectPath: string;
+  featureId: string;
+  dependencies: string[];
+}
+
+export interface SetDependenciesOutput {
+  featureId: string;
+  featureTitle?: string;
+  dependencies: string[];
+  previousDependencies: string[];
+}
+
+/**
+ * Detect circular dependencies using DFS.
+ * Returns the cycle path if found, null otherwise.
+ */
+function detectCircularDependency(
+  featureId: string,
+  newDeps: string[],
+  featureMap: Map<string, Feature>
+): string[] | null {
+  const visited = new Set<string>();
+  const path: string[] = [];
+
+  function dfs(currentId: string): string[] | null {
+    if (currentId === featureId && path.length > 0) {
+      return [...path, currentId];
+    }
+    if (visited.has(currentId)) return null;
+    visited.add(currentId);
+    path.push(currentId);
+
+    // For the target feature, use the proposed new deps
+    const deps =
+      currentId === featureId ? newDeps : (featureMap.get(currentId)?.dependencies ?? []);
+
+    for (const depId of deps) {
+      const cycle = dfs(depId);
+      if (cycle) return cycle;
+    }
+
+    path.pop();
+    return null;
+  }
+
+  // Start DFS from each new dependency
+  for (const depId of newDeps) {
+    visited.clear();
+    path.length = 0;
+    const cycle = dfs(depId);
+    if (cycle) return cycle;
+  }
+
+  return null;
+}
+
+export async function setDependencies(
+  context: ToolContext,
+  input: SetDependenciesInput
+): Promise<ToolResult<SetDependenciesOutput>> {
+  try {
+    const { projectPath, featureId, dependencies } = input;
+
+    if (!projectPath || !featureId) {
+      return {
+        success: false,
+        error: 'projectPath and featureId are required',
+        errorCode: 'MISSING_REQUIRED_FIELDS',
+      };
+    }
+
+    if (!Array.isArray(dependencies)) {
+      return {
+        success: false,
+        error: 'dependencies must be an array of feature IDs',
+        errorCode: 'INVALID_DEPENDENCIES',
+      };
+    }
+
+    if (!context.featureLoader) {
+      return {
+        success: false,
+        error: 'featureLoader not available in context',
+        errorCode: 'MISSING_FEATURE_LOADER',
+      };
+    }
+
+    const feature = await context.featureLoader.get(projectPath, featureId);
+    if (!feature) {
+      return {
+        success: false,
+        error: 'Feature not found',
+        errorCode: 'FEATURE_NOT_FOUND',
+      };
+    }
+
+    // Self-dependency check
+    if (dependencies.includes(featureId)) {
+      return {
+        success: false,
+        error: 'A feature cannot depend on itself',
+        errorCode: 'SELF_DEPENDENCY',
+      };
+    }
+
+    // Validate all dependency IDs exist
+    const allFeatures = await context.featureLoader.getAll(projectPath);
+    const featureMap = new Map(allFeatures.map((f) => [f.id, f]));
+    const missing = dependencies.filter((id) => !featureMap.has(id));
+    if (missing.length > 0) {
+      return {
+        success: false,
+        error: `Dependencies not found: ${missing.join(', ')}`,
+        errorCode: 'DEPENDENCIES_NOT_FOUND',
+        metadata: { missingIds: missing },
+      };
+    }
+
+    // Circular dependency detection
+    const cycle = detectCircularDependency(featureId, dependencies, featureMap);
+    if (cycle) {
+      return {
+        success: false,
+        error: `Circular dependency detected: ${cycle.join(' → ')}`,
+        errorCode: 'CIRCULAR_DEPENDENCY',
+        metadata: { cycle },
+      };
+    }
+
+    const previousDependencies = feature.dependencies ?? [];
+
+    // Update the feature
+    const updated = await context.featureLoader.update(projectPath, featureId, { dependencies });
+    if (!updated) {
+      return {
+        success: false,
+        error: 'Failed to update feature',
+        errorCode: 'UPDATE_FAILED',
+      };
+    }
+
+    // Emit event
+    if (context.events) {
+      context.events.emit('feature:dependencies-changed', {
+        projectPath,
+        featureId,
+        dependencies,
+        previousDependencies,
+      });
+    }
+
+    return {
+      success: true,
+      data: {
+        featureId,
+        featureTitle: feature.title,
+        dependencies,
+        previousDependencies,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      errorCode: 'SET_DEPENDENCIES_FAILED',
+    };
+  }
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -2744,6 +2744,91 @@ const tools: Tool[] = [
     },
   },
 
+  // ========== Board Query ==========
+  {
+    name: 'query_board',
+    description:
+      'Query features with compound filters. Supports filtering by status, epic, assignee, complexity, blocked state, dependencies, date range, and text search. Returns compact results to minimize context usage.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        status: {
+          oneOf: [
+            {
+              type: 'string',
+              enum: ['backlog', 'in_progress', 'review', 'done', 'blocked', 'verified'],
+            },
+            {
+              type: 'array',
+              items: {
+                type: 'string',
+                enum: ['backlog', 'in_progress', 'review', 'done', 'blocked', 'verified'],
+              },
+            },
+          ],
+          description: 'Filter by status (single or array)',
+        },
+        epicId: {
+          type: 'string',
+          description: 'Filter by parent epic ID',
+        },
+        assignee: {
+          type: ['string', 'null'],
+          description: 'Filter by assignee. Use null for unassigned features.',
+        },
+        complexity: {
+          type: 'string',
+          enum: ['small', 'medium', 'large', 'architectural'],
+          description: 'Filter by complexity level',
+        },
+        isEpic: {
+          type: 'boolean',
+          description: 'Filter for epic features only (true) or non-epic only (false)',
+        },
+        isBlocked: {
+          type: 'boolean',
+          description: 'Filter for blocked features (true) or non-blocked (false)',
+        },
+        hasDependencies: {
+          type: 'boolean',
+          description: 'Filter for features with dependencies (true) or without (false)',
+        },
+        search: {
+          type: 'string',
+          description: 'Text search in title and description',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum results to return (default: 50)',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+  {
+    name: 'get_feature_dependencies',
+    description:
+      'Get the full dependency information for a feature: what it depends on (with satisfaction status), what depends on it (reverse deps), and whether all dependencies are met.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        featureId: {
+          type: 'string',
+          description: 'The feature ID to get dependencies for',
+        },
+      },
+      required: ['projectPath', 'featureId'],
+    },
+  },
+
   // ========== Notes Workspace ==========
   {
     name: 'list_note_tabs',
@@ -3939,6 +4024,128 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         title: args.title,
         description: args.description,
       });
+
+    // Board Query
+    case 'query_board': {
+      const qResult = (await apiCall('/features/list', {
+        projectPath: args.projectPath,
+      })) as { features?: Array<Record<string, unknown>> };
+      let qFeatures = qResult.features || [];
+
+      if (args.status) {
+        const statuses = Array.isArray(args.status) ? args.status : [args.status];
+        qFeatures = qFeatures.filter((f) => statuses.includes(f.status as string));
+      }
+      if (args.epicId !== undefined) {
+        qFeatures = qFeatures.filter((f) => f.epicId === args.epicId);
+      }
+      if (args.assignee !== undefined) {
+        if (args.assignee === null) {
+          qFeatures = qFeatures.filter((f) => !f.assignee);
+        } else {
+          qFeatures = qFeatures.filter((f) => f.assignee === args.assignee);
+        }
+      }
+      if (args.complexity) {
+        qFeatures = qFeatures.filter((f) => f.complexity === args.complexity);
+      }
+      if (args.isEpic !== undefined) {
+        qFeatures = qFeatures.filter((f) => !!f.isEpic === args.isEpic);
+      }
+      if (args.isBlocked !== undefined) {
+        if (args.isBlocked) {
+          qFeatures = qFeatures.filter((f) => f.status === 'blocked');
+        } else {
+          qFeatures = qFeatures.filter((f) => f.status !== 'blocked');
+        }
+      }
+      if (args.hasDependencies !== undefined) {
+        if (args.hasDependencies) {
+          qFeatures = qFeatures.filter(
+            (f) => Array.isArray(f.dependencies) && (f.dependencies as string[]).length > 0
+          );
+        } else {
+          qFeatures = qFeatures.filter(
+            (f) => !Array.isArray(f.dependencies) || (f.dependencies as string[]).length === 0
+          );
+        }
+      }
+      if (args.search) {
+        const lower = (args.search as string).toLowerCase();
+        qFeatures = qFeatures.filter(
+          (f) =>
+            (f.title as string)?.toLowerCase().includes(lower) ||
+            (f.description as string)?.toLowerCase().includes(lower)
+        );
+      }
+
+      const qTotal = qFeatures.length;
+      const qLimit = (args.limit as number) || 50;
+      const qLimited = qFeatures.slice(0, qLimit);
+
+      return {
+        features: qLimited.map((f) => ({
+          id: f.id,
+          title: f.title,
+          status: f.status,
+          complexity: f.complexity,
+          branchName: f.branchName,
+          epicId: f.epicId,
+          isEpic: f.isEpic,
+          assignee: f.assignee,
+          dependencies: f.dependencies,
+          prNumber: f.prNumber,
+        })),
+        total: qTotal,
+        returned: qLimited.length,
+      };
+    }
+
+    case 'get_feature_dependencies': {
+      const depResult = (await apiCall('/features/list', {
+        projectPath: args.projectPath,
+      })) as { features?: Array<Record<string, unknown>> };
+      const depFeatures = depResult.features || [];
+      const depMap = new Map(depFeatures.map((f) => [f.id, f]));
+      const depTarget = depMap.get(args.featureId as string);
+
+      if (!depTarget) {
+        return { error: 'Feature not found' };
+      }
+
+      const satStatuses = ['done', 'completed', 'verified', 'review'];
+      const dependsOn = ((depTarget.dependencies as string[]) || []).map((depId: string) => {
+        const dep = depMap.get(depId);
+        return {
+          id: depId,
+          title: dep?.title,
+          status: dep?.status,
+          satisfied: dep ? satStatuses.includes(dep.status as string) : false,
+        };
+      });
+
+      const reverseDeps = depFeatures
+        .filter(
+          (f) =>
+            Array.isArray(f.dependencies) &&
+            (f.dependencies as string[]).includes(args.featureId as string)
+        )
+        .map((f) => ({
+          id: f.id,
+          title: f.title,
+          status: f.status,
+          satisfied: satStatuses.includes(f.status as string),
+        }));
+
+      return {
+        featureId: args.featureId,
+        featureTitle: depTarget.title,
+        dependsOn,
+        blockedBy: reverseDeps,
+        allSatisfied:
+          dependsOn.length === 0 || dependsOn.every((d: { satisfied: boolean }) => d.satisfied),
+      };
+    }
 
     // Notes Workspace
     case 'list_note_tabs':


### PR DESCRIPTION
## Summary
- `queryBoard` shared tool with compound filters: status (single/array), epicId, assignee (null=unassigned), complexity, isEpic, isBlocked, hasDependencies, updatedAfter/Before, search text, limit
- `getDependencies` shared tool: forward deps (with satisfaction status), reverse deps (what depends on this), allSatisfied flag
- `setDependencies` shared tool: circular dependency detection via DFS, missing dep validation, event emission
- New MCP tools: `query_board`, `get_feature_dependencies`
- All tools follow existing patterns in `libs/tools/src/domains/features/`

## Test plan
- [ ] `query_board` with no filters returns all features (compact)
- [ ] `query_board` with `status: ["backlog", "in_progress"]` returns only those statuses
- [ ] `query_board` with `isBlocked: true` returns only blocked features
- [ ] `query_board` with `search: "auth"` matches title/description
- [ ] `get_feature_dependencies` returns forward and reverse deps with satisfaction status
- [ ] `setDependencies` rejects circular dependencies
- [ ] `setDependencies` rejects self-dependencies
- [ ] `setDependencies` rejects nonexistent dependency IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query features with advanced filtering including status, assignee, complexity, date range, and search capabilities
  * View feature dependencies and their satisfaction status
  * Manage feature dependencies with built-in validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->