### PR TITLE
feat: inject SignalIntakeService into engine routes with real status data

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1146,6 +1146,7 @@ app.use(
     autoModeService,
     leadEngineerService,
     prFeedbackService,
+    signalIntakeService,
     eventStreamBuffer,
     projectService,
     contentFlowService

--- a/apps/server/src/routes/engine/index.ts
+++ b/apps/server/src/routes/engine/index.ts
@@ -16,6 +16,7 @@ import type { PRFeedbackService } from '../../services/pr-feedback-service.js';
 import type { ProjectService } from '../../services/project-service.js';
 import type { EventStreamBuffer } from '../../lib/event-stream-buffer.js';
 import type { ContentFlowService } from '../../services/content-flow-service.js';
+import type { SignalIntakeService } from '../../services/signal-intake-service.js';
 import { getAllGraphs, getGraph } from '../../lib/graph-registry.js';
 
 const logger = createLogger('EngineRoutes');
@@ -24,6 +25,7 @@ export function createEngineRoutes(
   autoModeService: AutoModeService,
   leadEngineerService: LeadEngineerService | undefined,
   prFeedbackService: PRFeedbackService,
+  signalIntakeService: SignalIntakeService,
   eventStreamBuffer?: EventStreamBuffer,
   projectService?: ProjectService,
   contentFlowService?: ContentFlowService
@@ -78,11 +80,15 @@ export function createEngineRoutes(
         }
       }
 
+      // Signal intake status
+      const signalIntakeStatus = signalIntakeService.getStatus();
+
       res.json({
         success: true,
         signalIntake: {
-          active: true,
-          description: 'Classifies incoming signals (GitHub, Linear, Discord, MCP)',
+          active: signalIntakeStatus.active,
+          signalCounts: signalIntakeStatus.signalCounts,
+          lastSignalAt: signalIntakeStatus.lastSignalAt,
         },
         autoMode: {
           running: autoModeStatus.isRunning,

--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -39,8 +39,28 @@ interface ClassificationResult {
   reason: string;
 }
 
+interface SignalCounts {
+  linear: number;
+  github: number;
+  discord: number;
+  mcp: number;
+}
+
+export interface SignalIntakeStatus {
+  active: boolean;
+  signalCounts: SignalCounts;
+  lastSignalAt: string | null;
+}
+
 export class SignalIntakeService {
   private processedSignals = new Set<string>();
+  private signalCounts: SignalCounts = {
+    linear: 0,
+    github: 0,
+    discord: 0,
+    mcp: 0,
+  };
+  private lastSignalAt: string | null = null;
 
   constructor(
     private events: EventEmitter,
@@ -57,6 +77,34 @@ export class SignalIntakeService {
         void this.handleSignal(payload as SignalPayload);
       }
     });
+  }
+
+  /**
+   * Get current signal intake status
+   */
+  public getStatus(): SignalIntakeStatus {
+    return {
+      active: true,
+      signalCounts: { ...this.signalCounts },
+      lastSignalAt: this.lastSignalAt,
+    };
+  }
+
+  /**
+   * Increment signal count by source
+   */
+  private incrementSignalCount(source: string): void {
+    // Normalize source to known categories
+    if (source === 'linear') {
+      this.signalCounts.linear++;
+    } else if (source === 'github') {
+      this.signalCounts.github++;
+    } else if (source === 'discord') {
+      this.signalCounts.discord++;
+    } else if (source.startsWith('mcp')) {
+      this.signalCounts.mcp++;
+    }
+    // Unknown sources are silently ignored
   }
 
   /**
@@ -148,6 +196,10 @@ export class SignalIntakeService {
       const entries = [...this.processedSignals];
       this.processedSignals = new Set(entries.slice(-500));
     }
+
+    // Track signal receipt
+    this.lastSignalAt = signal.timestamp;
+    this.incrementSignalCount(signal.source);
 
     try {
       // Extract title from first line, description from full content


### PR DESCRIPTION
## Summary
- Adds `getStatus()` method to SignalIntakeService returning active boolean, signal counts by source, lastSignalAt
- Passes signalIntakeService into createEngineRoutes() from index.ts
- Engine status endpoint now returns real signal intake data instead of hardcoded stub

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] Engine status API returns real signal intake data

🤖 Generated with [Claude Code](https://claude.com/claude-code)