### PR TITLE
fix: remove orphan signal-intake EngineServiceId from flow graph types

### DIFF
--- a/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
+++ b/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
@@ -111,12 +111,6 @@ function getServiceStatus(
         throughput: 0,
         statusLine: 'Activate auto-mode + Lead Engineer',
       };
-    case 'signal-intake':
-      return {
-        status: engineStatus.signalIntake?.active ? 'active' : 'idle',
-        throughput: 0,
-        statusLine: 'Classifies signals from GitHub, Linear, Discord',
-      };
     case 'auto-mode': {
       const am = engineStatus.autoMode;
       const running = am?.running ?? false;

--- a/apps/ui/src/components/views/flow-graph/nodes/engine-service-node.tsx
+++ b/apps/ui/src/components/views/flow-graph/nodes/engine-service-node.tsx
@@ -31,7 +31,6 @@ const SERVICE_ICONS: Record<EngineServiceId, typeof Cog> = {
   'project-planning': FileText,
   decomposition: Network,
   launch: Rocket,
-  'signal-intake': Radio,
   'auto-mode': Cog,
   'agent-execution': Bot,
   'git-workflow': GitBranch,

--- a/apps/ui/src/components/views/flow-graph/types.ts
+++ b/apps/ui/src/components/views/flow-graph/types.ts
@@ -33,7 +33,6 @@ export type EngineServiceId =
   | 'project-planning'
   | 'decomposition'
   | 'launch'
-  | 'signal-intake'
   | 'auto-mode'
   | 'agent-execution'
   | 'git-workflow'


### PR DESCRIPTION
## Summary
- Removes `signal-intake` from EngineServiceId union type (no node uses it, triage covers this)
- Removes dead `case 'signal-intake'` from getServiceStatus()
- Removes unused `signal-intake: Radio` from SERVICE_ICONS mapping

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] No references to signal-intake as EngineServiceId remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)