### PR TITLE
feat: add graphId mappings for 4 additional engine service nodes

### DIFF
--- a/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
+++ b/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
@@ -179,6 +179,10 @@ function getServiceStatus(
 const SERVICE_TO_GRAPH_MAP: Partial<Record<EngineServiceId, string>> = {
   'auto-mode': 'coordinator-flow',
   'project-planning': 'project-planning',
+  'agent-execution': 'content-creation',
+  'pr-feedback': 'antagonistic-review',
+  'signal-sources': 'research-flow',
+  triage: 'review-flow',
 };
 
 export function useFlowGraphData(


### PR DESCRIPTION
## Summary
- Adds SERVICE_TO_GRAPH_MAP entries for agent-execution, pr-feedback, signal-sources, and triage
- Now 6 of 11 engine service nodes are clickable (was 2)
- Clicking mapped nodes opens flow detail panel with the correct LangGraph topology

## Test plan
- [ ] SERVICE_TO_GRAPH_MAP has 6 entries
- [ ] Clicking mapped nodes opens flow detail panel
- [ ] Non-mapped nodes (decomposition, launch, git-workflow, lead-engineer, reflection) remain non-clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)