### PR TITLE
feat: expand flow detail views with graphId mappings and pipeline hydration (M3)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1148,7 +1148,8 @@ app.use(
     prFeedbackService,
     eventStreamBuffer,
     projectService,
-    contentFlowService
+    contentFlowService,
+    featureLoader
   )
 );
 app.use('/api/langfuse', createLangfuseRoutes());

--- a/apps/server/src/routes/engine/index.ts
+++ b/apps/server/src/routes/engine/index.ts
@@ -17,6 +17,7 @@ import type { ProjectService } from '../../services/project-service.js';
 import type { EventStreamBuffer } from '../../lib/event-stream-buffer.js';
 import type { ContentFlowService } from '../../services/content-flow-service.js';
 import { getAllGraphs, getGraph } from '../../lib/graph-registry.js';
+import type { FeatureLoader } from '../../services/feature-loader.js';
 
 const logger = createLogger('EngineRoutes');
 
@@ -26,7 +27,8 @@ export function createEngineRoutes(
   prFeedbackService: PRFeedbackService,
   eventStreamBuffer?: EventStreamBuffer,
   projectService?: ProjectService,
-  contentFlowService?: ContentFlowService
+  contentFlowService?: ContentFlowService,
+  featureLoader?: FeatureLoader
 ): Router {
   const router = Router();
 
@@ -328,6 +330,62 @@ export function createEngineRoutes(
       res.status(500).json({
         success: false,
         error: 'Failed to get flow definitions',
+      });
+    }
+  });
+
+  /**
+   * POST /api/engine/pipeline-state
+   * Returns current feature counts by status for pipeline hydration.
+   */
+  router.post('/pipeline-state', async (req: Request, res: Response) => {
+    try {
+      const { projectPath } = (req.body ?? {}) as { projectPath?: string };
+
+      if (!projectPath) {
+        res.status(400).json({
+          success: false,
+          error: 'projectPath is required',
+        });
+        return;
+      }
+
+      if (!featureLoader) {
+        res.status(503).json({
+          success: false,
+          error: 'FeatureLoader not available',
+        });
+        return;
+      }
+
+      // Load all features and count by status
+      const features = await featureLoader.getAll(projectPath);
+      const countsByStatus: Record<string, number> = {
+        backlog: 0,
+        in_progress: 0,
+        review: 0,
+        done: 0,
+        blocked: 0,
+      };
+
+      for (const feature of features) {
+        const status = feature.status || 'backlog';
+        if (status in countsByStatus) {
+          countsByStatus[status]++;
+        }
+      }
+
+      res.json({
+        success: true,
+        countsByStatus,
+        totalFeatures: features.length,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (error) {
+      logger.error('Failed to get pipeline state:', error);
+      res.status(500).json({
+        success: false,
+        error: 'Failed to get pipeline state',
       });
     }
   });

--- a/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
+++ b/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
@@ -195,7 +195,7 @@ export function useFlowGraphData(
   const { data: runningAgentsData } = useRunningAgents();
   const { data: integrationStatus } = useIntegrationStatus(projectPath);
   const { data: engineStatusData } = useEngineStatus(projectPath);
-  const { stageAggregates } = usePipelineTracker();
+  const { stageAggregates } = usePipelineTracker({ projectPath });
 
   const engineStatus = engineStatusData as EngineStatusResponse | undefined;
 

--- a/apps/ui/src/components/views/flow-graph/hooks/use-pipeline-tracker.ts
+++ b/apps/ui/src/components/views/flow-graph/hooks/use-pipeline-tracker.ts
@@ -6,8 +6,10 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { getHttpApiClient } from '@/lib/http-api-client';
 import { createLogger } from '@automaker/utils/logger';
+import { STALE_TIMES } from '@/lib/query-client';
 import type { EventType } from '@automaker/types';
 import type { PipelineStageId, TrackedWorkItem, PipelineStageStatus } from '../types';
 
@@ -67,12 +69,64 @@ export interface UsePipelineTrackerResult {
   stageAggregates: StageAggregate[];
   workItems: TrackedWorkItem[];
   isConnected: boolean;
+  isLoading: boolean;
 }
 
-export function usePipelineTracker(): UsePipelineTrackerResult {
+export interface UsePipelineTrackerProps {
+  projectPath?: string;
+}
+
+export function usePipelineTracker(props?: UsePipelineTrackerProps): UsePipelineTrackerResult {
+  const { projectPath } = props ?? {};
   const [workItems, setWorkItems] = useState<Map<string, TrackedWorkItem>>(new Map());
   const [isConnected, setIsConnected] = useState(false);
   const expiryTimers = useRef<Map<string, NodeJS.Timeout>>(new Map());
+
+  // Fetch initial pipeline state with React Query
+  const { data: initialState, isLoading } = useQuery({
+    queryKey: ['engine', 'pipeline-state', projectPath],
+    queryFn: async () => {
+      if (!projectPath) return null;
+      const api = getHttpApiClient();
+      return api.engine.pipelineState(projectPath);
+    },
+    enabled: !!projectPath,
+    staleTime: STALE_TIMES.DEFAULT,
+    refetchOnWindowFocus: false, // Only hydrate once, then rely on WebSocket
+  });
+
+  // Hydrate initial work items from HTTP response
+  useEffect(() => {
+    if (!initialState?.success || !initialState.countsByStatus) return;
+
+    logger.debug('Hydrating initial pipeline state:', initialState);
+
+    setWorkItems((prev) => {
+      const next = new Map(prev);
+
+      // Create synthetic work items for initial counts
+      // These will be replaced/updated by actual WebSocket events
+      Object.entries(initialState.countsByStatus).forEach(([status, count]) => {
+        if (count > 0) {
+          const stageId = status as PipelineStageId;
+          // Create a single aggregate item per stage for initial display
+          const itemId = `initial-${stageId}`;
+          next.set(itemId, {
+            id: itemId,
+            title: `${count} item${count > 1 ? 's' : ''}`,
+            status: stageId,
+            metadata: {
+              lastEventType: 'feature:created',
+              lastEventTime: Date.now(),
+              isInitial: true,
+            },
+          });
+        }
+      });
+
+      return next;
+    });
+  }, [initialState]);
 
   // Track work items based on incoming events
   const handleEvent = useCallback((type: EventType, payload: any) => {
@@ -91,6 +145,13 @@ export function usePipelineTracker(): UsePipelineTrackerResult {
     setWorkItems((prev) => {
       const next = new Map(prev);
 
+      // Remove initial synthetic items for this stage when first real event arrives
+      for (const [key, item] of next.entries()) {
+        if (item.metadata?.isInitial && item.status === stageId) {
+          next.delete(key);
+        }
+      }
+
       // Update or create work item
       const existing = next.get(itemId);
       const item: TrackedWorkItem = {
@@ -102,6 +163,7 @@ export function usePipelineTracker(): UsePipelineTrackerResult {
           lastEventType: type,
           lastEventTime: Date.now(),
           ...existing?.metadata,
+          isInitial: false,
         },
       };
 
@@ -195,5 +257,6 @@ export function usePipelineTracker(): UsePipelineTrackerResult {
     stageAggregates,
     workItems: Array.from(workItems.values()),
     isConnected,
+    isLoading,
   };
 }

--- a/apps/ui/src/lib/http-api-client.ts
+++ b/apps/ui/src/lib/http-api-client.ts
@@ -2893,6 +2893,15 @@ export class HttpApiClient implements ElectronAPI {
       limit?: number;
     }) => this.post('/api/engine/events/history', filter ?? {}),
     flows: (graphId?: string) => this.post('/api/engine/flows', { graphId }),
+    pipelineState: (
+      projectPath: string
+    ): Promise<{
+      success: boolean;
+      countsByStatus?: Record<string, number>;
+      totalFeatures?: number;
+      timestamp?: string;
+      error?: string;
+    }> => this.post('/api/engine/pipeline-state', { projectPath }),
   };
 
   // Voice API


### PR DESCRIPTION
## Summary
Epic PR for M3: Expand Flow Detail Views — 2 features merged:

- **M3-1**: Add graphId mappings for 4 additional engine service nodes (agent-execution, pr-feedback, signal-sources, triage) — 6 of 11 nodes now clickable in flow graph
- **M3-2**: Add initial pipeline stage hydration from HTTP — pipeline stages now show correct feature counts on page load instead of being empty until WebSocket events fire

## Test plan
- [ ] `npm run build` compiles cleanly
- [ ] `npm run lint` passes
- [ ] 6 engine service nodes clickable in flow graph (open flow detail panel)
- [ ] Pipeline stages show feature counts immediately on page load
- [ ] WebSocket events still update stages in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pipeline state tracking to view feature counts organized by development status (backlog, in progress, review, done, blocked)
  * Enhanced initial data loading with server-side state hydration for improved UI performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->