### PR TITLE
docs: AI editor features and agent tools

### DIFF
--- a/docs/dev/notes-panel.md
+++ b/docs/dev/notes-panel.md
@@ -1,30 +1,149 @@
-# Notes Panel
+# Notes panel
 
-Per-project rich text notes with Tiptap editor, tabbed workspace, and context-aware chat integration.
+Per-project rich text notes with TipTap editor, tabbed workspace, AI writing assistance, and agent tool integration.
 
 ## Storage
 
 Notes are stored at `.automaker/notes/workspace.json` — a single JSON file per project containing all tabs and content.
 
-## API Routes
+## API routes
 
-| Route                       | Body                         | Purpose                          |
-| --------------------------- | ---------------------------- | -------------------------------- |
-| `POST /api/notes/get`       | `{ projectPath }`            | Load workspace or return default |
-| `POST /api/notes/save`      | `{ projectPath, workspace }` | Save workspace                   |
-| `POST /api/notes/get-tab`   | `{ projectPath, tabId }`     | Single tab content (for chat)    |
-| `POST /api/notes/list-tabs` | `{ projectPath }`            | Tab listing with permissions     |
+### Notes CRUD
 
-## Tab Permissions
+| Route                       | Body                                     | Purpose                          |
+| --------------------------- | ---------------------------------------- | -------------------------------- |
+| `POST /api/notes/get`       | `{ projectPath }`                        | Load workspace or return default |
+| `POST /api/notes/save`      | `{ projectPath, workspace }`             | Save workspace                   |
+| `POST /api/notes/get-tab`   | `{ projectPath, tabId }`                 | Single tab content (for chat)    |
+| `POST /api/notes/list-tabs` | `{ projectPath, includeRestricted? }`    | Tab listing with permissions     |
+| `POST /api/notes/write-tab` | `{ projectPath, tabId, content, mode? }` | Agent write-back to a tab        |
+
+### AI streaming endpoints
+
+All AI endpoints return SSE text streams. They power the inline editor features described below.
+
+| Route                   | Body                                         | Model  | Purpose                  |
+| ----------------------- | -------------------------------------------- | ------ | ------------------------ |
+| `POST /api/ai/complete` | `{ context?, currentLine? }`                 | Haiku  | Ghost text autocomplete  |
+| `POST /api/ai/rewrite`  | `{ text, instruction, surroundingContext? }` | Sonnet | Selection rewrite        |
+| `POST /api/ai/generate` | `{ command, context, selection? }`           | Sonnet | Slash command generation |
+
+## Tab permissions
 
 Each tab has two permission flags:
 
-- **agentRead** — Whether the chat sidebar can see the tab's content
-- **agentWrite** — Reserved for future agent write-back capability
+- **agentRead** — Whether AI agents and the chat sidebar can see the tab's content
+- **agentWrite** — Whether AI agents can write to the tab via MCP tools or the `/api/notes/write-tab` endpoint
 
 When `agentRead` is false, the tab name still appears in the chat context listing but content is excluded.
 
-## Context-Aware Chat
+## AI editor features
+
+The notes editor integrates three AI writing features, all powered by the streaming endpoints above.
+
+### Ghost text autocomplete
+
+Copilot-style inline predictions. As you type, the editor requests a short continuation (5-15 words) from Haiku after a 500ms debounce. The prediction appears as gray phantom text at the cursor position.
+
+- **Tab** — Accept the suggestion (inserts into the document)
+- **Escape** — Dismiss the suggestion
+- Any other typing dismisses the current suggestion and triggers a new one
+
+Implementation: ProseMirror `Plugin` with `Decoration.widget` renders a span with class `.ghost-text-suggestion`. An `AbortController` cancels in-flight requests when the user types again.
+
+### AI bubble menu
+
+Select any text to reveal a floating toolbar with AI actions. Five presets plus a custom prompt input:
+
+| Action   | Instruction                        |
+| -------- | ---------------------------------- |
+| Rewrite  | Rewrite this more clearly          |
+| Shorten  | Make this shorter and more concise |
+| Fix      | Fix grammar and spelling           |
+| Pro tone | Rewrite in a professional tone     |
+| Expand   | Expand with more detail            |
+| Custom   | Any freeform instruction you type  |
+
+The response streams in via `/api/ai/rewrite` and replaces the selected text using `editor.commands.insertContentAt({ from, to }, result)`.
+
+### Slash commands
+
+Type `/` at the start of a line or after a space to open the command palette. Commands are divided into AI and formatting categories:
+
+**AI commands** (call `/api/ai/generate`):
+
+| Command          | Description                     |
+| ---------------- | ------------------------------- |
+| Continue writing | AI continues from cursor        |
+| Summarize        | Summarize the document so far   |
+| Expand           | Expand with more detail         |
+| Fix grammar      | Fix grammar and spelling errors |
+| Professional     | Rewrite in professional tone    |
+
+**Formatting commands** (instant, no AI):
+
+| Command    | Description       |
+| ---------- | ----------------- |
+| Heading 1  | Insert H1         |
+| Heading 2  | Insert H2         |
+| Heading 3  | Insert H3         |
+| Bullet     | Bullet list       |
+| Numbered   | Numbered list     |
+| Quote      | Blockquote        |
+| Code block | Fenced code block |
+| Divider    | Horizontal rule   |
+
+Navigate with arrow keys, select with Enter, dismiss with Escape. The popup uses `tippy.js` for positioning and `ReactRenderer` from `@tiptap/react` for the React component.
+
+## Agent notes tools
+
+AI agents can read and write notes programmatically via shared tools in `@automaker/tools` and corresponding MCP tools.
+
+### MCP tools
+
+| MCP Tool         | Parameters                           | Description                                |
+| ---------------- | ------------------------------------ | ------------------------------------------ |
+| `list_note_tabs` | `projectPath, includeRestricted?`    | List tabs with permissions and word counts |
+| `read_note_tab`  | `projectPath, tabId`                 | Read tab content (requires agentRead)      |
+| `write_note_tab` | `projectPath, tabId, content, mode?` | Write to tab (requires agentWrite)         |
+
+The `mode` parameter for `write_note_tab` accepts `"replace"` (default) or `"append"`.
+
+### Shared tool functions
+
+Available from `@automaker/tools` for use in LangGraph flows and custom agents:
+
+```typescript
+import { listTabs, readTab, writeTab } from '@automaker/tools';
+
+// List all agent-readable tabs
+const result = await listTabs(context, { projectPath: '/path/to/project' });
+
+// Read a specific tab
+const tab = await readTab(context, { projectPath: '/path/to/project', tabId: 'tab-id' });
+
+// Append to a tab
+await writeTab(context, {
+  projectPath: '/path/to/project',
+  tabId: 'tab-id',
+  content: '<p>Agent-generated content</p>',
+  mode: 'append',
+});
+```
+
+The `ToolContext` must include a `notesLoader` service for these tools to work:
+
+```typescript
+const context: ToolContext = {
+  notesLoader: {
+    load: (projectPath) => loadWorkspace(projectPath),
+    save: (projectPath, workspace) => saveWorkspace(projectPath, workspace),
+  },
+  events: { emit: (event, data) => eventEmitter.emit(event, data) },
+};
+```
+
+## Context-aware chat
 
 When the user navigates to `/notes`, the chat sidebar injects notes context into the request body. The server selects a persona based on the active tab name:
 
@@ -34,18 +153,31 @@ When the user navigates to `/notes`, the chat sidebar injects notes context into
 | **Ava** (Ops) | prd, spec, design, architecture, ops, runbook, doc, plan, rfc                     | Precise, structured       |
 | **Writer**    | (default)                                                                         | General writing assistant |
 
-## Tiptap Extensions
+## TipTap extensions
 
-MVP uses **StarterKit** and **Placeholder** only. This provides headings, bold, italic, strike, code, lists, blockquote, and code blocks.
+The editor uses these extensions:
 
-## Key Files
+| Extension     | Source                          | Purpose                                    |
+| ------------- | ------------------------------- | ------------------------------------------ |
+| StarterKit    | `@tiptap/starter-kit`           | Headings, bold, italic, lists, etc.        |
+| Placeholder   | `@tiptap/extension-placeholder` | Empty editor placeholder text              |
+| GhostText     | `extensions/ghost-text.ts`      | Copilot-style autocomplete                 |
+| SlashCommands | `extensions/slash-commands.ts`  | `/` command palette via @tiptap/suggestion |
 
-| File                                          | Purpose                                            |
-| --------------------------------------------- | -------------------------------------------------- |
-| `libs/types/src/notes.ts`                     | NoteTab, NotesWorkspace types                      |
-| `libs/platform/src/paths.ts`                  | getNotesDir, getNotesWorkspacePath, ensureNotesDir |
-| `apps/server/src/routes/notes/index.ts`       | CRUD routes                                        |
-| `apps/server/src/routes/chat/personas.ts`     | Persona selection and prompts                      |
-| `apps/ui/src/store/notes-store.ts`            | Zustand store with debounced save                  |
-| `apps/ui/src/components/views/notes-view.tsx` | Main view component                                |
-| `apps/ui/src/components/views/notes-view/`    | Tab bar, toolbar, editor, status bar               |
+## Key files
+
+| File                                                                   | Purpose                                          |
+| ---------------------------------------------------------------------- | ------------------------------------------------ |
+| `libs/types/src/notes.ts`                                              | NoteTab, NotesWorkspace types                    |
+| `libs/platform/src/paths.ts`                                           | getNotesDir, getNotesWorkspacePath               |
+| `apps/server/src/routes/notes/index.ts`                                | CRUD + agent write routes                        |
+| `apps/server/src/routes/ai/index.ts`                                   | AI streaming endpoints                           |
+| `apps/server/src/routes/chat/personas.ts`                              | Persona selection and prompts                    |
+| `apps/ui/src/store/notes-store.ts`                                     | Zustand store with debounced save                |
+| `apps/ui/src/components/views/notes-view/tiptap-editor.tsx`            | Main editor component                            |
+| `apps/ui/src/components/views/notes-view/ai-bubble-menu.tsx`           | Selection-based AI actions                       |
+| `apps/ui/src/components/views/notes-view/extensions/ghost-text.ts`     | ProseMirror plugin for autocomplete              |
+| `apps/ui/src/components/views/notes-view/extensions/slash-commands.ts` | Slash command trigger and items                  |
+| `apps/ui/src/components/views/notes-view/slash-command-list.tsx`       | Popup UI for slash commands                      |
+| `libs/tools/src/domains/notes/`                                        | Shared agent tools (listTabs, readTab, writeTab) |
+| `packages/mcp-server/src/index.ts`                                     | MCP tool definitions                             |

--- a/docs/dev/tool-package.md
+++ b/docs/dev/tool-package.md
@@ -40,15 +40,21 @@ The `ToolContext` interface enables **dependency injection** at execution time:
 
 ```typescript
 interface ToolContext {
-  services?: Record<string, any>; // Service instances (DB, API clients, etc.)
-  config?: Record<string, any>; // Configuration values
+  // Domain-specific service loaders
+  featureLoader?: { getAll; get; create; update; delete; findDuplicateTitle };
+  notesLoader?: { load; save };
+  events?: { emit: (event: string, data: unknown) => void };
+
+  // Generic services (from defineSharedTool pattern)
+  services?: Record<string, unknown>; // Service instances (DB, API clients, etc.)
+  config?: Record<string, unknown>; // Configuration values
   featureId?: string; // Current feature/context identifier
   projectPath?: string; // Project file system path
-  metadata?: Record<string, any>; // Additional metadata
+  metadata?: Record<string, unknown>; // Additional metadata
 }
 ```
 
-This allows tools to access external dependencies without hardcoding them.
+This allows tools to access external dependencies without hardcoding them. The `featureLoader` and `notesLoader` fields provide typed access to domain services, while `services` remains available for generic dependency injection.
 
 ### Tool Result
 
@@ -630,11 +636,14 @@ Context interface for dependency injection.
 
 ```typescript
 interface ToolContext {
-  services?: Record<string, any>; // Service instances (DB, API clients, etc.)
-  config?: Record<string, any>; // Configuration values
-  featureId?: string; // Current feature/context identifier
-  projectPath?: string; // Project file system path
-  metadata?: Record<string, any>; // Additional metadata
+  featureLoader?: { getAll; get; create; update; delete; findDuplicateTitle };
+  notesLoader?: { load; save };
+  events?: { emit: (event: string, data: unknown) => void };
+  services?: Record<string, unknown>;
+  config?: Record<string, unknown>;
+  featureId?: string;
+  projectPath?: string;
+  metadata?: Record<string, unknown>;
 }
 ```
 
@@ -653,8 +662,126 @@ interface ToolResult<TOutput> {
 }
 ```
 
-## Related Documentation
+## Domain tools
 
-- [Flows Package](./flows.md) — LangGraph flow architecture and patterns
-- [Shared Packages](./shared-packages.md) — Monorepo package overview
+The package ships pre-built tools organized by domain. Import them directly for use in agents and flows.
+
+### Feature tools
+
+CRUD operations on Kanban board features.
+
+```typescript
+import {
+  listFeatures,
+  getFeature,
+  createFeature,
+  updateFeature,
+  deleteFeature,
+  queryBoard,
+  getDependencies,
+  setDependencies,
+} from '@automaker/tools';
+```
+
+| Tool              | Input                                        | Description                                  |
+| ----------------- | -------------------------------------------- | -------------------------------------------- |
+| `listFeatures`    | `projectPath, status?, compact?`             | List features, optionally filter by status   |
+| `getFeature`      | `projectPath, featureId`                     | Get a single feature by ID                   |
+| `createFeature`   | `projectPath, feature`                       | Create a new feature                         |
+| `updateFeature`   | `projectPath, featureId, updates`            | Update feature fields                        |
+| `deleteFeature`   | `projectPath, featureId`                     | Delete a feature                             |
+| `queryBoard`      | `projectPath` + compound filters (see below) | Advanced board query with compound filtering |
+| `getDependencies` | `projectPath, featureId`                     | Get forward and reverse dependencies         |
+| `setDependencies` | `projectPath, featureId, dependencies`       | Set dependencies with circular detection     |
+
+#### queryBoard filters
+
+The `queryBoard` tool supports compound filtering to help agents find specific features:
+
+```typescript
+const result = await queryBoard(context, {
+  projectPath: '/path/to/project',
+  status: ['backlog', 'in_progress'], // Single status or array
+  epicId: 'epic-123', // Filter by parent epic
+  assignee: 'agent-name', // Filter by assignee (null = unassigned)
+  complexity: 'medium', // small | medium | large | architectural
+  isEpic: false, // Filter epics vs child features
+  isBlocked: true, // Only features with unsatisfied deps
+  hasDependencies: true, // Only features with any deps
+  updatedAfter: 1708300800000, // Timestamp filters
+  search: 'authentication', // Case-insensitive title/description search
+  limit: 20, // Max results (default: 50)
+});
+```
+
+Returns `{ features: CompactFeature[], total: number, filters: Record<string, unknown> }`.
+
+#### getDependencies output
+
+Returns both forward and reverse dependency relationships with satisfaction status:
+
+```typescript
+const result = await getDependencies(context, {
+  projectPath: '/path/to/project',
+  featureId: 'feature-123',
+});
+// result.data = {
+//   featureId: 'feature-123',
+//   dependsOn: [
+//     { featureId: 'feature-100', title: 'Setup types', status: 'done', satisfied: true }
+//   ],
+//   blockedBy: [
+//     { featureId: 'feature-200', title: 'Add UI', status: 'backlog', satisfied: false }
+//   ],
+//   allSatisfied: true,
+//   total: 2,
+// }
+```
+
+#### setDependencies validation
+
+The `setDependencies` tool validates before writing:
+
+- Checks for self-dependencies
+- Validates that all dependency feature IDs exist on the board
+- Detects circular dependencies via DFS traversal
+- Emits `feature:dependencies-updated` event on success
+
+### Notes tools
+
+Read and write notes tab content. Respects per-tab `agentRead` / `agentWrite` permissions.
+
+```typescript
+import { listTabs, readTab, writeTab } from '@automaker/tools';
+```
+
+| Tool       | Input                                | Description                                |
+| ---------- | ------------------------------------ | ------------------------------------------ |
+| `listTabs` | `projectPath, includeRestricted?`    | List tabs with permissions and word counts |
+| `readTab`  | `projectPath, tabId`                 | Read tab content (requires agentRead)      |
+| `writeTab` | `projectPath, tabId, content, mode?` | Write tab content (requires agentWrite)    |
+
+The `mode` parameter for `writeTab` accepts `"replace"` (default) or `"append"`.
+
+These tools require a `notesLoader` service in the `ToolContext`:
+
+```typescript
+interface ToolContext {
+  notesLoader?: {
+    load: (projectPath: string) => Promise<NotesWorkspace>;
+    save: (projectPath: string, workspace: NotesWorkspace) => Promise<void>;
+  };
+  events?: { emit: (event: string, data: unknown) => void };
+}
+```
+
+### Twitch tools
+
+Twitch chat interaction tools (see `libs/tools/src/domains/twitch/`).
+
+## Related documentation
+
+- [Notes Panel](./notes-panel) — AI editor features and agent integration
+- [Flows Package](./flows) — LangGraph flow architecture and patterns
+- [Shared Packages](./shared-packages) — Monorepo package overview
 - [Types Package](../libs/types/README.md) — Core TypeScript type definitions


### PR DESCRIPTION
## Summary
- Updated `docs/dev/notes-panel.md` with ghost text autocomplete, AI bubble menu, slash commands, AI streaming endpoints, and agent notes tools (MCP + shared tools)
- Updated `docs/dev/tool-package.md` with domain tools reference (features, notes, board query, dependency management) and updated ToolContext interface

## Test plan
- [ ] Verify notes-panel doc renders correctly in VitePress
- [ ] Verify tool-package doc renders correctly in VitePress
- [ ] Cross-references between docs work

🤖 Generated with [Claude Code](https://claude.com/claude-code)