### PR TITLE
fix: add credentials to AI streaming fetch calls

### DIFF
--- a/apps/ui/src/lib/http-api-client.ts
+++ b/apps/ui/src/lib/http-api-client.ts
@@ -2578,6 +2578,7 @@ export class HttpApiClient implements ElectronAPI {
       fetch(`${this.serverUrl}/api/ai/complete`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({ context, currentLine }),
       }),
 
@@ -2586,6 +2587,7 @@ export class HttpApiClient implements ElectronAPI {
       fetch(`${this.serverUrl}/api/ai/rewrite`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({ text, instruction, surroundingContext }),
       }),
 
@@ -2594,6 +2596,7 @@ export class HttpApiClient implements ElectronAPI {
       fetch(`${this.serverUrl}/api/ai/generate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({ command, context, selection }),
       }),
   };


### PR DESCRIPTION
## Summary
- Added `credentials: 'include'` to all three AI streaming fetch calls (complete, rewrite, generate)
- These raw `fetch()` calls were missing session cookies, causing 401 errors in web mode

## Test plan
- [ ] Open notes panel in web mode (localhost:3007)
- [ ] Type text — ghost text autocomplete should appear (no 401)
- [ ] Select text — AI bubble menu rewrite should work (no 401)
- [ ] Type `/` — slash command AI actions should work (no 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication credential handling for AI-powered features to ensure session cookies are properly included with API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->