### PR TITLE
fix: resolve overlapping nodes in flow graph layout

### DIFF
--- a/apps/ui/src/components/views/flow-graph/constants.ts
+++ b/apps/ui/src/components/views/flow-graph/constants.ts
@@ -117,12 +117,12 @@ export const ENGINE_SERVICES: Array<{
     position: { x: 1100, y: 280 },
   },
 
-  // Reflection (bottom, y=680)
+  // Reflection (bottom, y=840)
   {
     nodeId: NODE_IDS.reflection,
     serviceId: 'reflection',
     label: 'Reflection Loop',
-    position: { x: 600, y: 680 },
+    position: { x: 600, y: 840 },
   },
 ];
 
@@ -137,7 +137,7 @@ export const INTEGRATION_POSITIONS: Record<string, { x: number; y: number }> = {
 };
 
 // Dynamic feature/agent zone starts below reflection
-export const DYNAMIC_ZONE_START_Y = 820;
+export const DYNAMIC_ZONE_START_Y = 1000;
 export const DYNAMIC_ZONE_CENTER_X = 600;
 
 // ============================================
@@ -314,7 +314,7 @@ export const PIPELINE_STAGES: Array<{
     nodeId: NODE_IDS.pipelineBlocked,
     stageId: 'blocked',
     label: 'Blocked',
-    position: { x: 600, y: 630 },
+    position: { x: 475, y: 660 },
   },
 ];
 


### PR DESCRIPTION
## Summary
- Repositioned **Blocked** node from (600, 630) to (475, 660) — centered between In Progress and Review
- Pushed **Reflection Loop** from (600, 680) to (600, 840) — clear gap below Blocked
- Updated `DYNAMIC_ZONE_START_Y` from 820 to 1000 for the new spacing

## Test plan
- [ ] Open System View — verify Blocked and Reflection Loop no longer overlap
- [ ] Verify edges still connect correctly (Review → Blocked, Done → Reflection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted layout positioning in the flow graph visualization, including repositioned elements for improved component spacing and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->