### PR TITLE
refactor: migrate terminal consumers to terminal-store

### DIFF
--- a/apps/ui/src/components/shared/xterm-log-viewer.tsx
+++ b/apps/ui/src/components/shared/xterm-log-viewer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback, useState, forwardRef, useImperativeHandle } from 'react';
 import { useAppStore } from '@/store/app-store';
+import { useTerminalStore } from '@/store/terminal-store';
 import { getTerminalTheme, getTerminalFontFamily } from '@/config/terminal-themes';
 
 // Types for dynamically imported xterm modules
@@ -61,8 +62,8 @@ export const XtermLogViewer = forwardRef<XtermLogViewerRef, XtermLogViewerProps>
     // Get theme and font settings from store
     const getEffectiveTheme = useAppStore((state) => state.getEffectiveTheme);
     const effectiveTheme = getEffectiveTheme();
-    const terminalFontFamily = useAppStore((state) => state.terminalState.fontFamily);
-    const terminalFontSize = useAppStore((state) => state.terminalState.defaultFontSize);
+    const terminalFontFamily = useTerminalStore((state) => state.terminalState.fontFamily);
+    const terminalFontSize = useTerminalStore((state) => state.terminalState.defaultFontSize);
 
     // Use prop if provided, otherwise use store value, fallback to 13
     const effectiveFontSize = fontSize ?? terminalFontSize ?? 13;
@@ -112,7 +113,7 @@ export const XtermLogViewer = forwardRef<XtermLogViewerRef, XtermLogViewerProps>
         const terminalTheme = getTerminalTheme(resolvedTheme);
 
         // Get font settings from store at initialization time
-        const terminalState = useAppStore.getState().terminalState;
+        const terminalState = useTerminalStore.getState().terminalState;
         const fontFamily = getTerminalFontFamily(terminalState.fontFamily);
         const initFontSize = fontSize ?? terminalState.defaultFontSize ?? 13;
 

--- a/apps/ui/src/components/views/board-view/worktree-panel/components/worktree-actions-dropdown.tsx
+++ b/apps/ui/src/components/views/board-view/worktree-panel/components/worktree-actions-dropdown.tsx
@@ -45,7 +45,7 @@ import {
 } from '../hooks/use-available-terminals';
 import { getEditorIcon } from '@/components/icons/editor-icons';
 import { getTerminalIcon } from '@/components/icons/terminal-icons';
-import { useAppStore } from '@/store/app-store';
+import { useTerminalStore } from '@/store/terminal-store';
 
 interface WorktreeActionsDropdownProps {
   worktree: WorktreeInfo;
@@ -145,7 +145,7 @@ export function WorktreeActionsDropdown({
   const effectiveDefaultTerminal = useEffectiveDefaultTerminal(terminals);
 
   // Get the user's preferred mode for opening terminals (new tab vs split)
-  const openTerminalMode = useAppStore((s) => s.terminalState.openTerminalMode);
+  const openTerminalMode = useTerminalStore((s) => s.terminalState.openTerminalMode);
 
   // Get icon component for the effective terminal
   const DefaultTerminalIcon = effectiveDefaultTerminal

--- a/apps/ui/src/hooks/use-settings-migration.ts
+++ b/apps/ui/src/hooks/use-settings-migration.ts
@@ -27,6 +27,7 @@ import { createLogger } from '@automaker/utils/logger';
 import { getHttpApiClient, waitForApiKeyInit } from '@/lib/http-api-client';
 import { getItem, setItem } from '@/lib/storage';
 import { useAppStore, THEME_STORAGE_KEY } from '@/store/app-store';
+import { useTerminalStore } from '@/store/terminal-store';
 import { useSetupStore } from '@/store/setup-store';
 import {
   DEFAULT_OPENCODE_MODEL,
@@ -745,6 +746,17 @@ export function hydrateStoreFromSettings(settings: GlobalSettings): void {
     }),
   });
 
+  // Also hydrate terminal-store directly (app-store subscription only goes terminal→app)
+  if (settings.terminalFontFamily) {
+    const currentTerminal = useTerminalStore.getState().terminalState;
+    useTerminalStore.setState({
+      terminalState: { ...currentTerminal, fontFamily: settings.terminalFontFamily },
+    });
+  }
+  if (settings.defaultTerminalId !== undefined) {
+    useTerminalStore.setState({ defaultTerminalId: settings.defaultTerminalId ?? null });
+  }
+
   // Hydrate setup wizard state from global settings (API-backed)
   useSetupStore.setState({
     setupComplete: settings.setupComplete ?? false,
@@ -814,7 +826,7 @@ function buildSettingsUpdateFromStore(): Record<string, unknown> {
     worktreePanelCollapsed: state.worktreePanelCollapsed,
     lastProjectDir: state.lastProjectDir,
     recentFolders: state.recentFolders,
-    terminalFontFamily: state.terminalState.fontFamily,
+    terminalFontFamily: useTerminalStore.getState().terminalState.fontFamily,
   };
 }
 

--- a/apps/ui/src/hooks/use-settings-sync.ts
+++ b/apps/ui/src/hooks/use-settings-sync.ts
@@ -16,6 +16,7 @@ import { createLogger } from '@automaker/utils/logger';
 import { getHttpApiClient, waitForApiKeyInit } from '@/lib/http-api-client';
 import { setItem } from '@/lib/storage';
 import { useAppStore, type ThemeMode, THEME_STORAGE_KEY } from '@/store/app-store';
+import { useTerminalStore } from '@/store/terminal-store';
 import { useSetupStore } from '@/store/setup-store';
 import { useAuthStore } from '@/store/auth-store';
 import { waitForMigrationComplete, resetMigrationState } from './use-settings-migration';
@@ -110,10 +111,10 @@ function getSettingsFieldValue(
     return appState.currentProject?.id ?? null;
   }
   if (field === 'terminalFontFamily') {
-    return appState.terminalState.fontFamily;
+    return useTerminalStore.getState().terminalState.fontFamily;
   }
   if (field === 'openTerminalMode') {
-    return appState.terminalState.openTerminalMode;
+    return useTerminalStore.getState().terminalState.openTerminalMode;
   }
   if (field === 'autoModeByWorktree') {
     // Only persist settings (maxConcurrency), not runtime state (isRunning, runningTasks)
@@ -696,6 +697,25 @@ export async function refreshSettingsFromServer(): Promise<boolean> {
         },
       }),
     });
+
+    // Also hydrate terminal-store directly (app-store subscription only goes terminal→app)
+    if (serverSettings.terminalFontFamily || serverSettings.openTerminalMode) {
+      const currentTerminal = useTerminalStore.getState().terminalState;
+      useTerminalStore.setState({
+        terminalState: {
+          ...currentTerminal,
+          ...(serverSettings.terminalFontFamily && {
+            fontFamily: serverSettings.terminalFontFamily,
+          }),
+          ...(serverSettings.openTerminalMode && {
+            openTerminalMode: serverSettings.openTerminalMode,
+          }),
+        },
+      });
+    }
+    if (serverSettings.defaultTerminalId !== undefined) {
+      useTerminalStore.setState({ defaultTerminalId: serverSettings.defaultTerminalId ?? null });
+    }
 
     // Also refresh setup wizard state
     useSetupStore.setState({


### PR DESCRIPTION
## Summary

- Migrates `xterm-log-viewer.tsx` and `worktree-actions-dropdown.tsx` from reading terminal fields via `useAppStore` to `useTerminalStore` directly
- Fixes settings hydration gap: server settings were only written to app-store via `setState()`, but terminal-store never received them (subscription only goes terminal→app). Now both `use-settings-migration.ts` and `use-settings-sync.ts` hydrate terminal-store directly
- Part of Phase 7 (Consumer Migration) of the god store decomposition plan (#848)

## Files Changed

| File | Change |
|------|--------|
| `xterm-log-viewer.tsx` | Terminal selectors → `useTerminalStore` (keeps app-store for theme) |
| `worktree-actions-dropdown.tsx` | Fully migrated from app-store to terminal-store |
| `use-settings-migration.ts` | Added terminal-store hydration + reads from terminal-store |
| `use-settings-sync.ts` | Added terminal-store hydration + reads from terminal-store |

## Test plan

- [ ] Verify terminal font family persists across refresh (Settings → Terminal → Font)
- [ ] Verify open terminal mode setting persists (worktree dropdown should reflect saved preference)
- [ ] Verify xterm log viewer uses correct font size from settings
- [ ] `npm run build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal refactoring of state management to improve code organization and maintainability across terminal and application settings synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->