### PR TITLE
refactor: migrate domain store consumers from app-store

### DIFF
--- a/apps/ui/src/components/layout/sidebar/components/theme-toggle-button.tsx
+++ b/apps/ui/src/components/layout/sidebar/components/theme-toggle-button.tsx
@@ -1,7 +1,8 @@
 import { memo, useState, useCallback } from 'react';
 import { Palette } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { useAppStore, type ThemeMode } from '@/store/app-store';
+import { useThemeStore } from '@/store/theme-store';
+import type { ThemeMode } from '@/store/types';
 import { darkThemes, lightThemes } from '@/config/theme-options';
 import { Popover, PopoverContent, PopoverTrigger } from '@protolabs/ui/atoms';
 import { useThemeTransition } from '@/lib/theme/transitions';
@@ -53,8 +54,8 @@ export const ThemeToggleButton = memo(function ThemeToggleButton({
 }: ThemeToggleButtonProps) {
   const [open, setOpen] = useState(false);
   const { transition } = useThemeTransition();
-  const theme = useAppStore((s) => s.theme);
-  const setTheme = useAppStore((s) => s.setTheme);
+  const theme = useThemeStore((s) => s.theme);
+  const setTheme = useThemeStore((s) => s.setTheme);
 
   // Curated theme names for filtering
   const curatedNames = new Set(curatedThemes.map((t) => t.name));

--- a/apps/ui/src/components/views/board-view.tsx
+++ b/apps/ui/src/components/views/board-view.tsx
@@ -28,6 +28,7 @@ class DialogAwarePointerSensor extends PointerSensor {
 }
 import { useAppStore, Feature } from '@/store/app-store';
 import { useTerminalStore } from '@/store/terminal-store';
+import { useWorktreeStore } from '@/store/worktree-store';
 import { getElectronAPI } from '@/lib/electron';
 import { getHttpApiClient } from '@/lib/http-api-client';
 import type { BacklogPlanResult } from '@automaker/types';
@@ -89,58 +90,45 @@ import { queryKeys } from '@/lib/query-keys';
 import { useAutoModeQueryInvalidation } from '@/hooks/use-query-invalidation';
 
 // Stable empty array to avoid infinite loop in selector
-const EMPTY_WORKTREES: ReturnType<ReturnType<typeof useAppStore.getState>['getWorktrees']> = [];
+const EMPTY_WORKTREES: ReturnType<ReturnType<typeof useWorktreeStore.getState>['getWorktrees']> =
+  [];
 
 const logger = createLogger('Board');
 
 export function BoardView() {
   const {
     currentProject,
-    maxConcurrency: _legacyMaxConcurrency,
-    setMaxConcurrency: _legacySetMaxConcurrency,
     defaultSkipTests,
     specCreatingForProject,
     setSpecCreatingForProject,
     pendingPlanApproval,
     setPendingPlanApproval,
     updateFeature,
-    getCurrentWorktree,
-    setCurrentWorktree,
-    getWorktrees,
-    setWorktrees,
-    useWorktrees: _useWorktrees,
-    enableDependencyBlocking: _enableDependencyBlocking,
-    skipVerificationInAutoMode: _skipVerificationInAutoMode,
     planUseSelectedWorktreeBranch,
     addFeatureUseSelectedWorktreeBranch,
-    isPrimaryWorktreeBranch,
-    getPrimaryWorktreeBranch,
     setPipelineConfig,
   } = useAppStore(
     useShallow((state) => ({
       currentProject: state.currentProject,
-      maxConcurrency: state.maxConcurrency,
-      setMaxConcurrency: state.setMaxConcurrency,
       defaultSkipTests: state.defaultSkipTests,
       specCreatingForProject: state.specCreatingForProject,
       setSpecCreatingForProject: state.setSpecCreatingForProject,
       pendingPlanApproval: state.pendingPlanApproval,
       setPendingPlanApproval: state.setPendingPlanApproval,
       updateFeature: state.updateFeature,
-      getCurrentWorktree: state.getCurrentWorktree,
-      setCurrentWorktree: state.setCurrentWorktree,
-      getWorktrees: state.getWorktrees,
-      setWorktrees: state.setWorktrees,
-      useWorktrees: state.useWorktrees,
-      enableDependencyBlocking: state.enableDependencyBlocking,
-      skipVerificationInAutoMode: state.skipVerificationInAutoMode,
       planUseSelectedWorktreeBranch: state.planUseSelectedWorktreeBranch,
       addFeatureUseSelectedWorktreeBranch: state.addFeatureUseSelectedWorktreeBranch,
-      isPrimaryWorktreeBranch: state.isPrimaryWorktreeBranch,
-      getPrimaryWorktreeBranch: state.getPrimaryWorktreeBranch,
       setPipelineConfig: state.setPipelineConfig,
     }))
   );
+
+  // Worktree state from domain store
+  const getCurrentWorktree = useWorktreeStore((s) => s.getCurrentWorktree);
+  const setCurrentWorktree = useWorktreeStore((s) => s.setCurrentWorktree);
+  const getWorktrees = useWorktreeStore((s) => s.getWorktrees);
+  const setWorktrees = useWorktreeStore((s) => s.setWorktrees);
+  const isPrimaryWorktreeBranch = useWorktreeStore((s) => s.isPrimaryWorktreeBranch);
+  const getPrimaryWorktreeBranch = useWorktreeStore((s) => s.getPrimaryWorktreeBranch);
   // Fetch pipeline config via React Query
   const { data: pipelineConfig } = usePipelineConfig(currentProject?.path);
   const queryClient = useQueryClient();
@@ -148,13 +136,15 @@ export function BoardView() {
   // Subscribe to auto mode events for React Query cache invalidation
   useAutoModeQueryInvalidation(currentProject?.path);
   // Subscribe to worktreePanelVisibleByProject to trigger re-renders when it changes
-  const worktreePanelVisibleByProject = useAppStore((state) => state.worktreePanelVisibleByProject);
+  const worktreePanelVisibleByProject = useWorktreeStore(
+    (state) => state.worktreePanelVisibleByProject
+  );
   // Subscribe to showInitScriptIndicatorByProject to trigger re-renders when it changes
   const _showInitScriptIndicatorByProject = useTerminalStore(
     (state) => state.showInitScriptIndicatorByProject
   );
   const getShowInitScriptIndicator = useTerminalStore((state) => state.getShowInitScriptIndicator);
-  const getDefaultDeleteBranch = useAppStore((state) => state.getDefaultDeleteBranch);
+  const getDefaultDeleteBranch = useWorktreeStore((state) => state.getDefaultDeleteBranch);
   const _shortcuts = useKeyboardShortcutsConfig();
   const {
     features: hookFeatures,
@@ -507,7 +497,7 @@ export function BoardView() {
   // This needs to be before useBoardActions so we can pass currentWorktreeBranch
   const currentWorktreeInfo = currentProject ? getCurrentWorktree(currentProject.path) : null;
   const currentWorktreePath = currentWorktreeInfo?.path ?? null;
-  const worktreesByProject = useAppStore((s) => s.worktreesByProject);
+  const worktreesByProject = useWorktreeStore((s) => s.worktreesByProject);
   const worktrees = useMemo(
     () =>
       currentProject
@@ -536,7 +526,9 @@ export function BoardView() {
   // Get worktree-specific maxConcurrency from the hook
   const maxConcurrency = autoMode.maxConcurrency;
   // Get worktree-specific setter
-  const setMaxConcurrencyForWorktree = useAppStore((state) => state.setMaxConcurrencyForWorktree);
+  const setMaxConcurrencyForWorktree = useWorktreeStore(
+    (state) => state.setMaxConcurrencyForWorktree
+  );
 
   // Get the current branch from the selected worktree (not from store which may be stale)
   const currentWorktreeBranch = selectedWorktree?.branch ?? null;

--- a/apps/ui/src/components/views/board-view/board-header.tsx
+++ b/apps/ui/src/components/views/board-view/board-header.tsx
@@ -6,6 +6,7 @@ import { ConflictBadge } from './components/conflict-badge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@protolabs/ui/atoms';
 import { UsagePopover } from '@/components/usage-popover';
 import { useAppStore } from '@/store/app-store';
+import { useWorktreeStore } from '@/store/worktree-store';
 import { useSetupStore } from '@/store/setup-store';
 import { useIsTablet } from '@/hooks/use-media-query';
 import { AutoModeSettingsPopover } from './dialogs/auto-mode-settings-popover';
@@ -93,8 +94,10 @@ export function BoardHeader({
   const codexAuthStatus = useSetupStore((state) => state.codexAuthStatus);
 
   // Worktree panel visibility (per-project)
-  const worktreePanelVisibleByProject = useAppStore((state) => state.worktreePanelVisibleByProject);
-  const setWorktreePanelVisible = useAppStore((state) => state.setWorktreePanelVisible);
+  const worktreePanelVisibleByProject = useWorktreeStore(
+    (state) => state.worktreePanelVisibleByProject
+  );
+  const setWorktreePanelVisible = useWorktreeStore((state) => state.setWorktreePanelVisible);
   const isWorktreePanelVisible = worktreePanelVisibleByProject[projectPath] ?? true;
 
   const handleWorktreePanelToggle = useCallback(

--- a/apps/ui/src/components/views/board-view/dialogs/agent-output-modal.tsx
+++ b/apps/ui/src/components/views/board-view/dialogs/agent-output-modal.tsx
@@ -13,7 +13,7 @@ import { LogViewer } from '@/components/shared/log-viewer';
 import { GitDiffPanel } from '@/components/shared/git-diff-panel';
 import { TaskProgressPanel } from '@/components/shared/task-progress-panel';
 import { Markdown } from '@protolabs/ui/molecules';
-import { useAppStore } from '@/store/app-store';
+import { useWorktreeStore } from '@/store/worktree-store';
 import { extractSummary } from '@/lib/log-parser';
 import { useAgentOutput } from '@/hooks/queries';
 import type { AutoModeEvent } from '@/types/electron';
@@ -78,7 +78,7 @@ export function AgentOutputModal({
   const effectiveViewMode = viewMode ?? (summary ? 'summary' : 'parsed');
   const scrollRef = useRef<HTMLDivElement>(null);
   const autoScrollRef = useRef(true);
-  const useWorktrees = useAppStore((state) => state.useWorktrees);
+  const useWorktrees = useWorktreeStore((state) => state.useWorktrees);
 
   // Auto-scroll to bottom when output changes
   useEffect(() => {

--- a/apps/ui/src/components/views/board-view/hooks/use-board-actions.ts
+++ b/apps/ui/src/components/views/board-view/hooks/use-board-actions.ts
@@ -8,6 +8,7 @@ import {
   PlanningMode,
   useAppStore,
 } from '@/store/app-store';
+import { useWorktreeStore } from '@/store/worktree-store';
 import type { ReasoningEffort } from '@automaker/types';
 import { FeatureImagePath as DescriptionImagePath } from '@/components/views/board-view/components/description-image-dropzone';
 import { getElectronAPI } from '@/lib/electron';
@@ -87,13 +88,11 @@ export function useBoardActions({
     updateFeature,
     removeFeature,
     moveFeature,
-    useWorktrees,
     enableDependencyBlocking,
     skipVerificationInAutoMode,
-    isPrimaryWorktreeBranch,
-    getPrimaryWorktreeBranch,
-    getAutoModeState,
   } = useAppStore();
+  const { useWorktrees, isPrimaryWorktreeBranch, getPrimaryWorktreeBranch, getAutoModeState } =
+    useWorktreeStore();
   const autoMode = useAutoMode();
 
   // React Query mutations for feature operations
@@ -923,7 +922,7 @@ export function useBoardActions({
       return featureBranch === currentWorktreeBranch;
     });
 
-    const availableSlots = useAppStore.getState().maxConcurrency - runningAutoTasks.length;
+    const availableSlots = useWorktreeStore.getState().maxConcurrency - runningAutoTasks.length;
 
     if (availableSlots <= 0) {
       toast.error('Concurrency limit reached', {

--- a/apps/ui/src/components/views/board-view/hooks/use-board-background.ts
+++ b/apps/ui/src/components/views/board-view/hooks/use-board-background.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
-import { useAppStore, defaultBackgroundSettings } from '@/store/app-store';
+import { useThemeStore } from '@/store/theme-store';
+import { defaultBackgroundSettings } from '@/store/types';
 import { getAuthenticatedImageUrl } from '@/lib/api-fetch';
 
 interface UseBoardBackgroundProps {
@@ -7,7 +8,7 @@ interface UseBoardBackgroundProps {
 }
 
 export function useBoardBackground({ currentProject }: UseBoardBackgroundProps) {
-  const boardBackgroundByProject = useAppStore((state) => state.boardBackgroundByProject);
+  const boardBackgroundByProject = useThemeStore((state) => state.boardBackgroundByProject);
 
   // Get background settings for current project
   const backgroundSettings = useMemo(() => {

--- a/apps/ui/src/components/views/board-view/hooks/use-board-column-features.ts
+++ b/apps/ui/src/components/views/board-view/hooks/use-board-column-features.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck -- Feature index signature causes property access type errors
 import { useMemo, useCallback } from 'react';
 import { Feature, useAppStore } from '@/store/app-store';
+import { useWorktreeStore } from '@/store/worktree-store';
 import {
   createFeatureMap,
   getBlockingDependenciesFromMap,
@@ -102,8 +103,8 @@ export function useBoardColumnFeatures({
         // (worktrees disabled or haven't loaded yet).
         // Show features assigned to primary worktree's branch.
         if (projectPath) {
-          const worktrees = useAppStore.getState().worktreesByProject[projectPath] ?? [];
-          const isWorktreesLoading = useAppStore.getState().getWorktreesLoading(projectPath);
+          const worktrees = useWorktreeStore.getState().worktreesByProject[projectPath] ?? [];
+          const isWorktreesLoading = useWorktreeStore.getState().getWorktreesLoading(projectPath);
 
           if (isWorktreesLoading) {
             // Worktrees are still loading - show ALL features to prevent disappearing
@@ -111,12 +112,12 @@ export function useBoardColumnFeatures({
           } else if (worktrees.length === 0) {
             // Worktrees finished loading but list is empty - feature disabled or failed load
             // Apply strict filtering: only show on primary branch
-            matchesWorktree = useAppStore
+            matchesWorktree = useWorktreeStore
               .getState()
               .isPrimaryWorktreeBranch(projectPath, featureBranch);
           } else {
             // Worktrees loaded successfully - apply normal filtering
-            matchesWorktree = useAppStore
+            matchesWorktree = useWorktreeStore
               .getState()
               .isPrimaryWorktreeBranch(projectPath, featureBranch);
           }

--- a/apps/ui/src/components/views/board-view/worktree-panel/hooks/use-worktrees.ts
+++ b/apps/ui/src/components/views/board-view/worktree-panel/hooks/use-worktrees.ts
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useAppStore } from '@/store/app-store';
+import { useWorktreeStore } from '@/store/worktree-store';
 import { useWorktrees as useWorktreesQuery } from '@/hooks/queries';
 import { queryKeys } from '@/lib/query-keys';
 import { pathsEqual } from '@/lib/utils';
@@ -19,11 +19,11 @@ export function useWorktrees({
 }: UseWorktreesOptions) {
   const queryClient = useQueryClient();
 
-  const currentWorktree = useAppStore((s) => s.getCurrentWorktree(projectPath));
-  const setCurrentWorktree = useAppStore((s) => s.setCurrentWorktree);
-  const setWorktreesInStore = useAppStore((s) => s.setWorktrees);
-  const setWorktreesLoading = useAppStore((s) => s.setWorktreesLoading);
-  const useWorktreesEnabled = useAppStore((s) => s.useWorktrees);
+  const currentWorktree = useWorktreeStore((s) => s.getCurrentWorktree(projectPath));
+  const setCurrentWorktree = useWorktreeStore((s) => s.setCurrentWorktree);
+  const setWorktreesInStore = useWorktreeStore((s) => s.setWorktrees);
+  const setWorktreesLoading = useWorktreeStore((s) => s.setWorktreesLoading);
+  const useWorktreesEnabled = useWorktreeStore((s) => s.useWorktrees);
 
   // Use the React Query hook
   const { data, isLoading, refetch } = useWorktreesQuery(projectPath);

--- a/apps/ui/src/components/views/board-view/worktree-panel/worktree-panel.tsx
+++ b/apps/ui/src/components/views/board-view/worktree-panel/worktree-panel.tsx
@@ -23,6 +23,7 @@ import {
   BranchSwitchDropdown,
 } from './components';
 import { useAppStore } from '@/store/app-store';
+import { useWorktreeStore } from '@/store/worktree-store';
 import { ViewWorktreeChangesDialog, PushToRemoteDialog, MergeWorktreeDialog } from '../dialogs';
 import { ConfirmDialog } from '@protolabs/ui/molecules';
 import { Undo2 } from 'lucide-react';
@@ -98,7 +99,7 @@ export function WorktreePanel({
 
   // Auto-mode state management using the store
   // Use separate selectors to avoid creating new object references on each render
-  const autoModeByWorktree = useAppStore((state) => state.autoModeByWorktree);
+  const autoModeByWorktree = useWorktreeStore((state) => state.autoModeByWorktree);
   const currentProject = useAppStore((state) => state.currentProject);
 
   // Helper to generate worktree key for auto-mode (inlined to avoid selector issues)

--- a/apps/ui/src/components/views/project-settings-view/worktree-preferences-section.tsx
+++ b/apps/ui/src/components/views/project-settings-view/worktree-preferences-section.tsx
@@ -16,7 +16,7 @@ import { Spinner } from '@protolabs/ui/atoms';
 import { cn } from '@/lib/utils';
 import { apiGet, apiPut, apiDelete } from '@/lib/api-fetch';
 import { toast } from 'sonner';
-import { useAppStore } from '@/store/app-store';
+import { useWorktreeStore } from '@/store/worktree-store';
 import { useTerminalStore } from '@/store/terminal-store';
 import { getHttpApiClient } from '@/lib/http-api-client';
 import type { Project } from '@/lib/electron';
@@ -34,13 +34,13 @@ interface InitScriptResponse {
 }
 
 export function WorktreePreferencesSection({ project }: WorktreePreferencesSectionProps) {
-  const globalUseWorktrees = useAppStore((s) => s.useWorktrees);
-  const getProjectUseWorktrees = useAppStore((s) => s.getProjectUseWorktrees);
-  const setProjectUseWorktrees = useAppStore((s) => s.setProjectUseWorktrees);
+  const globalUseWorktrees = useWorktreeStore((s) => s.useWorktrees);
+  const getProjectUseWorktrees = useWorktreeStore((s) => s.getProjectUseWorktrees);
+  const setProjectUseWorktrees = useWorktreeStore((s) => s.setProjectUseWorktrees);
   const getShowInitScriptIndicator = useTerminalStore((s) => s.getShowInitScriptIndicator);
   const setShowInitScriptIndicator = useTerminalStore((s) => s.setShowInitScriptIndicator);
-  const getDefaultDeleteBranch = useAppStore((s) => s.getDefaultDeleteBranch);
-  const setDefaultDeleteBranch = useAppStore((s) => s.setDefaultDeleteBranch);
+  const getDefaultDeleteBranch = useWorktreeStore((s) => s.getDefaultDeleteBranch);
+  const setDefaultDeleteBranch = useWorktreeStore((s) => s.setDefaultDeleteBranch);
   const getAutoDismissInitScriptIndicator = useTerminalStore(
     (s) => s.getAutoDismissInitScriptIndicator
   );

--- a/apps/ui/src/components/views/settings-view/components/settings-navigation.tsx
+++ b/apps/ui/src/components/views/settings-view/components/settings-navigation.tsx
@@ -6,7 +6,7 @@ import type { Project } from '@/lib/electron';
 import type { NavigationItem } from '../config/navigation';
 import { GLOBAL_NAV_GROUPS } from '../config/navigation';
 import type { SettingsViewId } from '../hooks/use-settings-view';
-import { useAppStore } from '@/store/app-store';
+import { useAIModelsStore } from '@/store/ai-models-store';
 import type { ModelProvider } from '@automaker/types';
 
 const PROVIDERS_DROPDOWN_KEY = 'settings-providers-dropdown-open';
@@ -83,7 +83,7 @@ function NavItemWithSubItems({
   activeSection: SettingsViewId;
   onNavigate: (sectionId: SettingsViewId) => void;
 }) {
-  const disabledProviders = useAppStore((state) => state.disabledProviders);
+  const disabledProviders = useAIModelsStore((state) => state.disabledProviders);
 
   const [isOpen, setIsOpen] = useState(() => {
     if (typeof window !== 'undefined') {

--- a/apps/ui/src/hooks/use-settings-migration.ts
+++ b/apps/ui/src/hooks/use-settings-migration.ts
@@ -28,7 +28,11 @@ import { getHttpApiClient, waitForApiKeyInit } from '@/lib/http-api-client';
 import { getItem, setItem } from '@/lib/storage';
 import { useAppStore, THEME_STORAGE_KEY } from '@/store/app-store';
 import { useTerminalStore } from '@/store/terminal-store';
+import { useThemeStore } from '@/store/theme-store';
+import { useWorktreeStore } from '@/store/worktree-store';
+import { useAIModelsStore } from '@/store/ai-models-store';
 import { useSetupStore } from '@/store/setup-store';
+import type { ThemeMode } from '@/store/types';
 import {
   DEFAULT_OPENCODE_MODEL,
   DEFAULT_MAX_CONCURRENCY,
@@ -746,7 +750,8 @@ export function hydrateStoreFromSettings(settings: GlobalSettings): void {
     }),
   });
 
-  // Also hydrate terminal-store directly (app-store subscription only goes terminal→app)
+  // Hydrate domain stores so consumers reading from them get fresh values
+  // (app-store subscriptions only go domain→app, not app→domain)
   if (settings.terminalFontFamily) {
     const currentTerminal = useTerminalStore.getState().terminalState;
     useTerminalStore.setState({
@@ -756,6 +761,36 @@ export function hydrateStoreFromSettings(settings: GlobalSettings): void {
   if (settings.defaultTerminalId !== undefined) {
     useTerminalStore.setState({ defaultTerminalId: settings.defaultTerminalId ?? null });
   }
+
+  useThemeStore.setState({
+    theme: settings.theme as unknown as ThemeMode,
+    fontFamilySans: settings.fontFamilySans ?? null,
+    fontFamilyMono: settings.fontFamilyMono ?? null,
+  });
+
+  useWorktreeStore.setState({
+    autoModeByWorktree: restoredAutoModeByWorktree,
+    maxConcurrency: settings.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
+    useWorktrees: settings.useWorktrees ?? true,
+    worktreePanelCollapsed: settings.worktreePanelCollapsed ?? false,
+  });
+
+  useAIModelsStore.setState({
+    enhancementModel: settings.enhancementModel ?? 'claude-sonnet',
+    validationModel: settings.validationModel ?? 'claude-opus',
+    phaseModels: settings.phaseModels ?? current.phaseModels,
+    enabledCursorModels: allCursorModels,
+    cursorDefaultModel: sanitizedCursorDefaultModel,
+    enabledOpencodeModels: sanitizedEnabledOpencodeModels,
+    opencodeDefaultModel: sanitizedOpencodeDefaultModel,
+    enabledDynamicModelIds: sanitizedDynamicModelIds,
+    disabledProviders: settings.disabledProviders ?? [],
+    autoLoadClaudeMd: settings.autoLoadClaudeMd ?? false,
+    skipSandboxWarning: settings.skipSandboxWarning ?? false,
+    claudeApiProfiles: settings.claudeApiProfiles ?? [],
+    activeClaudeApiProfileId: settings.activeClaudeApiProfileId ?? null,
+    claudeCompatibleProviders: settings.claudeCompatibleProviders ?? [],
+  });
 
   // Hydrate setup wizard state from global settings (API-backed)
   useSetupStore.setState({

--- a/apps/ui/src/hooks/use-settings-sync.ts
+++ b/apps/ui/src/hooks/use-settings-sync.ts
@@ -17,6 +17,9 @@ import { getHttpApiClient, waitForApiKeyInit } from '@/lib/http-api-client';
 import { setItem } from '@/lib/storage';
 import { useAppStore, type ThemeMode, THEME_STORAGE_KEY } from '@/store/app-store';
 import { useTerminalStore } from '@/store/terminal-store';
+import { useThemeStore } from '@/store/theme-store';
+import { useWorktreeStore } from '@/store/worktree-store';
+import { useAIModelsStore } from '@/store/ai-models-store';
 import { useSetupStore } from '@/store/setup-store';
 import { useAuthStore } from '@/store/auth-store';
 import { waitForMigrationComplete, resetMigrationState } from './use-settings-migration';
@@ -118,7 +121,7 @@ function getSettingsFieldValue(
   }
   if (field === 'autoModeByWorktree') {
     // Only persist settings (maxConcurrency), not runtime state (isRunning, runningTasks)
-    const autoModeByWorktree = appState.autoModeByWorktree;
+    const autoModeByWorktree = useWorktreeStore.getState().autoModeByWorktree;
     const persistedSettings: Record<string, { maxConcurrency: number; branchName: string | null }> =
       {};
     for (const [key, value] of Object.entries(autoModeByWorktree)) {
@@ -128,6 +131,15 @@ function getSettingsFieldValue(
       };
     }
     return persistedSettings;
+  }
+  if (field === 'theme') {
+    return useThemeStore.getState().theme;
+  }
+  if (field === 'useWorktrees') {
+    return useWorktreeStore.getState().useWorktrees;
+  }
+  if (field === 'disabledProviders') {
+    return useAIModelsStore.getState().disabledProviders;
   }
   return appState[field as keyof typeof appState];
 }
@@ -698,7 +710,8 @@ export async function refreshSettingsFromServer(): Promise<boolean> {
       }),
     });
 
-    // Also hydrate terminal-store directly (app-store subscription only goes terminal→app)
+    // Hydrate domain stores so consumers reading from them get fresh values
+    // (app-store subscriptions only go domain→app, not app→domain)
     if (serverSettings.terminalFontFamily || serverSettings.openTerminalMode) {
       const currentTerminal = useTerminalStore.getState().terminalState;
       useTerminalStore.setState({
@@ -716,6 +729,34 @@ export async function refreshSettingsFromServer(): Promise<boolean> {
     if (serverSettings.defaultTerminalId !== undefined) {
       useTerminalStore.setState({ defaultTerminalId: serverSettings.defaultTerminalId ?? null });
     }
+
+    useThemeStore.setState({
+      theme: serverSettings.theme as unknown as ThemeMode,
+      fontFamilySans: serverSettings.fontFamilySans ?? null,
+      fontFamilyMono: serverSettings.fontFamilyMono ?? null,
+    });
+
+    useWorktreeStore.setState({
+      autoModeByWorktree: restoredAutoModeByWorktree,
+      maxConcurrency: serverSettings.maxConcurrency,
+      useWorktrees: serverSettings.useWorktrees,
+      worktreePanelCollapsed: serverSettings.worktreePanelCollapsed ?? false,
+    });
+
+    useAIModelsStore.setState({
+      enhancementModel: serverSettings.enhancementModel,
+      validationModel: serverSettings.validationModel,
+      phaseModels: migratedPhaseModels ?? serverSettings.phaseModels,
+      enabledCursorModels: allCursorModels,
+      cursorDefaultModel: sanitizedCursorDefault,
+      enabledOpencodeModels: sanitizedEnabledOpencodeModels,
+      opencodeDefaultModel: sanitizedOpencodeDefaultModel,
+      enabledDynamicModelIds: sanitizedDynamicModelIds,
+      disabledProviders: serverSettings.disabledProviders ?? [],
+      autoLoadClaudeMd: serverSettings.autoLoadClaudeMd ?? false,
+      claudeApiProfiles: serverSettings.claudeApiProfiles ?? [],
+      activeClaudeApiProfileId: serverSettings.activeClaudeApiProfileId ?? null,
+    });
 
     // Also refresh setup wizard state
     useSetupStore.setState({


### PR DESCRIPTION
## Summary

- Migrate 13 UI files from `useAppStore` to their respective domain stores (`useThemeStore`, `useWorktreeStore`, `useAIModelsStore`)
- Add domain store hydration in `use-settings-sync.ts` (`refreshSettingsFromServer`) and `use-settings-migration.ts` (`hydrateStoreFromSettings`) so server-fetched settings propagate to domain stores
- Phase 7 of the god store decomposition — consumers now read directly from domain stores while forwarding stubs keep app-store in sync

### Files migrated by domain

**Theme (2 files):**
- `theme-toggle-button.tsx` — `theme`, `setTheme`
- `use-board-background.ts` — `boardBackgroundByProject`

**Worktree (8 files):**
- `worktree-preferences-section.tsx` — all worktree fields
- `use-worktrees.ts` — full replacement
- `worktree-panel.tsx` — `autoModeByWorktree`
- `agent-output-modal.tsx` — `useWorktrees`
- `board-header.tsx` — `worktreePanelVisibleByProject`, `setWorktreePanelVisible`
- `board-view.tsx` — 6 worktree selectors extracted to `useWorktreeStore`
- `use-board-actions.ts` — worktree fields split from app-store destructure
- `use-board-column-features.ts` — `worktreesByProject`, `getWorktreesLoading`, `isPrimaryWorktreeBranch`

**AI Models (1 file):**
- `settings-navigation.tsx` — `disabledProviders`

**Settings hydration (2 files):**
- `use-settings-sync.ts` — reads domain fields from domain stores, hydrates domain stores on refresh
- `use-settings-migration.ts` — hydrates domain stores on initial migration/startup

## Test plan

- [ ] Verify settings persist across refresh (change theme, reload, verify it sticks)
- [ ] Verify worktree panel shows correct auto-mode state
- [ ] Verify board background settings work per-project
- [ ] Verify AI model provider disable/enable works in settings nav
- [ ] Verify TypeScript compiles (no new errors beyond pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated theme, worktree, and AI model state into dedicated domain stores; UI now reads/writes these domains directly.
  * Improved settings hydration and sync so server and in-memory domain settings (theme, worktrees, auto-mode, concurrency, models, disabled providers, backgrounds, fonts) stay consistent across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->