### PR TITLE
feat: Opus triage + web research for PM Agent

### DIFF
--- a/apps/server/src/routes/engine/index.ts
+++ b/apps/server/src/routes/engine/index.ts
@@ -412,13 +412,15 @@ export function createEngineRoutes(
    */
   router.post('/signal/submit', async (req: Request, res: Response) => {
     try {
-      const { projectPath, content, source, images, files, autoApprove } = (req.body ?? {}) as {
+      const { projectPath, content, source, images, files, autoApprove, webResearch } = (req.body ??
+        {}) as {
         projectPath?: string;
         content?: string;
         source?: string;
         images?: string[];
         files?: string[];
         autoApprove?: boolean;
+        webResearch?: boolean;
       };
 
       if (!content) {
@@ -437,6 +439,7 @@ export function createEngineRoutes(
         images,
         files,
         autoApprove,
+        webResearch,
       });
 
       res.json({

--- a/apps/server/src/services/authority-agents/pm-agent.ts
+++ b/apps/server/src/services/authority-agents/pm-agent.ts
@@ -50,6 +50,9 @@ const PM_RESEARCH_MODEL = resolveModelString('sonnet');
 /** Model for SPARC PRD generation (structured writing) */
 const PM_PRD_MODEL = resolveModelString('sonnet');
 
+/** Model for idea triage (quick 1-turn classification) */
+const PM_TRIAGE_MODEL = resolveModelString('opus');
+
 /** Valid complexity values for runtime validation */
 const VALID_COMPLEXITIES = new Set(['small', 'medium', 'large', 'architectural']);
 
@@ -61,6 +64,15 @@ interface IdeaInjectedPayload {
   injectedBy: string;
   injectedAt: string;
   autoApprove?: boolean;
+  webResearch?: boolean;
+}
+
+/** Result of Opus idea triage */
+interface TriageResult {
+  needsWebResearch: boolean;
+  searchQueries: string[];
+  focusAreas: string[];
+  reasoning: string;
 }
 
 /** Result of an AI-powered PRD review */
@@ -259,7 +271,7 @@ export class PMAuthorityAgent {
 
     // Delay slightly to allow for any rapid-fire injections
     setTimeout(() => {
-      void this.processIdea(idea.projectPath, idea.featureId, idea.autoApprove);
+      void this.processIdea(idea.projectPath, idea.featureId, idea.autoApprove, idea.webResearch);
     }, IDEA_PROCESSING_DELAY_MS);
   }
 
@@ -295,7 +307,8 @@ export class PMAuthorityAgent {
   private async processIdea(
     projectPath: string,
     featureId: string,
-    autoApproveOverride?: boolean
+    autoApproveOverride?: boolean,
+    webResearchOverride?: boolean
   ): Promise<void> {
     return withProcessingGuard(this.state, featureId, async () => {
       try {
@@ -365,8 +378,24 @@ export class PMAuthorityAgent {
           agentId: agent.id,
         });
 
-        logger.info(`Researching codebase for idea: "${feature.title}"`);
-        const researchSummary = await this.researchCodebase(feature, projectPath);
+        // Opus triage: decide if web research is needed (skipped if per-signal override is set)
+        let triage: TriageResult | undefined;
+        if (webResearchOverride) {
+          logger.info(`Web research forced by per-signal override for: "${feature.title}"`);
+          triage = {
+            needsWebResearch: true,
+            searchQueries: [],
+            focusAreas: [],
+            reasoning: 'Per-signal override',
+          };
+        } else {
+          triage = await this.triageIdea(feature, projectPath);
+        }
+
+        logger.info(
+          `Researching codebase for idea: "${feature.title}"${triage?.needsWebResearch ? ' (with web research)' : ''}`
+        );
+        const researchSummary = await this.researchCodebase(feature, projectPath, triage);
 
         // Step 3: Generate SPARC PRD from research + original idea
         logger.info(`Generating SPARC PRD for idea: "${feature.title}"`);
@@ -450,11 +479,109 @@ export class PMAuthorityAgent {
   }
 
   /**
+   * Triage an idea with Opus to decide if web research is needed.
+   * Quick 1-turn classification — no tools, minimal cost.
+   * Falls back to { needsWebResearch: false } on any failure.
+   */
+  private async triageIdea(feature: Feature, projectPath: string): Promise<TriageResult> {
+    const title = feature.title || 'Untitled';
+    const description = feature.description || '';
+
+    const systemPrompt = `You are a senior PM triaging a feature idea to decide if web research is needed.
+
+Evaluate whether the idea requires EXTERNAL context that can't be found in the codebase:
+- Competitor analysis or market positioning
+- Unfamiliar third-party libraries, APIs, or services
+- Integration patterns with external systems (payment providers, auth services, etc.)
+- Industry best practices or standards the team may not know
+- Technology evaluation or comparison
+
+If the idea is purely internal codebase work (refactoring, UI changes, bug fixes, extending existing patterns), web research is NOT needed.
+
+You MUST respond with valid JSON:
+{
+  "needsWebResearch": boolean,
+  "searchQueries": ["suggested search query 1", "..."],
+  "focusAreas": ["what to look for in web results"],
+  "reasoning": "brief explanation of your decision"
+}
+
+Keep searchQueries to 3-5 max. Only include them if needsWebResearch is true.`;
+
+    const prompt = `Triage this feature idea:
+
+**Title:** ${title}
+
+**Description:**
+${description}
+
+Should we research the web for external context, or is codebase-only research sufficient?`;
+
+    try {
+      const result = await simpleQuery({
+        prompt,
+        systemPrompt,
+        model: PM_TRIAGE_MODEL,
+        cwd: projectPath,
+        maxTurns: 1,
+        allowedTools: [],
+      });
+
+      const jsonMatch = result.text.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        logger.warn('Triage did not return valid JSON, defaulting to no web research');
+        return {
+          needsWebResearch: false,
+          searchQueries: [],
+          focusAreas: [],
+          reasoning: 'Triage parse failure',
+        };
+      }
+
+      const parsed = JSON.parse(jsonMatch[0]) as TriageResult;
+
+      if (typeof parsed.needsWebResearch !== 'boolean') {
+        logger.warn('Triage missing needsWebResearch field, defaulting to false');
+        return {
+          needsWebResearch: false,
+          searchQueries: [],
+          focusAreas: [],
+          reasoning: 'Invalid triage response',
+        };
+      }
+
+      logger.info(
+        `Triage result for "${title}": webResearch=${parsed.needsWebResearch} — ${parsed.reasoning}`
+      );
+
+      return {
+        needsWebResearch: parsed.needsWebResearch,
+        searchQueries: Array.isArray(parsed.searchQueries) ? parsed.searchQueries : [],
+        focusAreas: Array.isArray(parsed.focusAreas) ? parsed.focusAreas : [],
+        reasoning: parsed.reasoning || '',
+      };
+    } catch (error) {
+      logger.error('Idea triage failed, defaulting to no web research:', error);
+      return {
+        needsWebResearch: false,
+        searchQueries: [],
+        focusAreas: [],
+        reasoning: 'Triage error',
+      };
+    }
+  }
+
+  /**
    * Research the codebase to understand context for an idea.
    * Uses sonnet with read-only tools to explore project structure,
    * find relevant patterns, and identify existing code to build on.
+   * Optionally includes WebSearch/WebFetch tools based on triage results.
    */
-  private async researchCodebase(feature: Feature, projectPath: string): Promise<string> {
+  private async researchCodebase(
+    feature: Feature,
+    projectPath: string,
+    triage?: TriageResult
+  ): Promise<string> {
     const title = feature.title || 'Untitled';
     const description = feature.description || '';
 
@@ -487,6 +614,26 @@ Be thorough but efficient. Focus on understanding:
 
 Provide a structured research summary at the end.`;
 
+    // Conditionally enhance with web research instructions
+    const useWebResearch = triage?.needsWebResearch === true;
+    const webInstructions = useWebResearch
+      ? `\n\n## Web Research
+You also have access to WebSearch and WebFetch tools. Use them to:
+- Research external libraries, APIs, or integrations mentioned in the idea
+- Find official documentation for unfamiliar technologies
+- Look up best practices or common patterns for the approach
+- Gather competitive/market context if relevant
+
+${triage.searchQueries.length > 0 ? `Suggested search queries:\n${triage.searchQueries.map((q) => `- "${q}"`).join('\n')}` : ''}
+${triage.focusAreas.length > 0 ? `\nFocus areas:\n${triage.focusAreas.map((a) => `- ${a}`).join('\n')}` : ''}`
+      : '';
+
+    const fullSystemPrompt = systemPrompt + webInstructions;
+
+    const allowedTools = useWebResearch
+      ? ['Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch']
+      : ['Read', 'Glob', 'Grep'];
+
     const prompt = `Research the codebase for this feature idea:
 
 **Title:** ${title}
@@ -499,12 +646,12 @@ Explore the project structure and relevant code, then provide a structured resea
     try {
       const result = await streamingQuery({
         prompt,
-        systemPrompt,
+        systemPrompt: fullSystemPrompt,
         model: PM_RESEARCH_MODEL,
         cwd: projectPath,
         maxTurns: 30,
-        allowedTools: ['Read', 'Glob', 'Grep'],
-        readOnly: true,
+        allowedTools,
+        readOnly: !useWebResearch,
       });
 
       if (result.text && result.text.length > 50) {

--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -254,6 +254,7 @@ export class SignalIntakeService {
         injectedBy: `signal:${signal.source}`,
         injectedAt: new Date().toISOString(),
         autoApprove: signal.channelContext?.autoApprove as boolean | undefined,
+        webResearch: signal.channelContext?.webResearch as boolean | undefined,
       });
 
       // Emit routing event for observability
@@ -287,6 +288,7 @@ export class SignalIntakeService {
     images?: string[];
     files?: string[];
     autoApprove?: boolean;
+    webResearch?: boolean;
   }): void {
     // Enrich content with file and image references
     let enrichedContent = params.content;
@@ -309,6 +311,7 @@ export class SignalIntakeService {
         images: params.images,
         files: params.files,
         autoApprove: params.autoApprove,
+        webResearch: params.webResearch,
       },
       timestamp: new Date().toISOString(),
     };

--- a/apps/ui/src/components/views/flow-graph/dialogs/signal-input-dialog.tsx
+++ b/apps/ui/src/components/views/flow-graph/dialogs/signal-input-dialog.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState, useCallback } from 'react';
-import { Send, Loader2, Paperclip, X, Zap } from 'lucide-react';
+import { Send, Loader2, Paperclip, X, Zap, Globe } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -46,6 +46,7 @@ export function SignalInputDialog({ open, onOpenChange }: SignalInputDialogProps
   const [files, setFiles] = useState<TextAttachment[]>([]);
   const [showImageUpload, setShowImageUpload] = useState(false);
   const [autoApprove, setAutoApprove] = useState(false);
+  const [webResearch, setWebResearch] = useState(false);
   const projectPath = useAppStore((s) => s.currentProject?.path);
 
   const reset = useCallback(() => {
@@ -62,6 +63,7 @@ export function SignalInputDialog({ open, onOpenChange }: SignalInputDialogProps
       images?: string[];
       files?: string[];
       autoApprove?: boolean;
+      webResearch?: boolean;
     }) => {
       const api = getHttpApiClient();
       return api.engine.signalSubmit({
@@ -71,6 +73,7 @@ export function SignalInputDialog({ open, onOpenChange }: SignalInputDialogProps
         images: signal.images,
         files: signal.files,
         autoApprove: signal.autoApprove,
+        webResearch: signal.webResearch,
       });
     },
     onSuccess: (_data, variables) => {
@@ -96,8 +99,9 @@ export function SignalInputDialog({ open, onOpenChange }: SignalInputDialogProps
       images: images.length > 0 ? images.map((img) => img.data) : undefined,
       files: files.length > 0 ? files.map((f) => `--- ${f.name} ---\n${f.content}`) : undefined,
       autoApprove: autoApprove || undefined,
+      webResearch: webResearch || undefined,
     });
-  }, [content, projectPath, images, files, autoApprove, submitMutation]);
+  }, [content, projectPath, images, files, autoApprove, webResearch, submitMutation]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -213,6 +217,19 @@ export function SignalInputDialog({ open, onOpenChange }: SignalInputDialogProps
               </p>
             </div>
             <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setWebResearch((v) => !v)}
+                className={`flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded transition-colors ${
+                  webResearch
+                    ? 'bg-blue-500/20 text-blue-400'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+                title="Force web research (WebSearch + WebFetch) during PM research phase"
+              >
+                <Globe className="w-3 h-3" />
+                Web
+              </button>
               <button
                 type="button"
                 onClick={() => setAutoApprove((v) => !v)}

--- a/apps/ui/src/lib/http-api-client.ts
+++ b/apps/ui/src/lib/http-api-client.ts
@@ -2976,6 +2976,7 @@ export class HttpApiClient implements ElectronAPI {
       images?: string[];
       files?: string[];
       autoApprove?: boolean;
+      webResearch?: boolean;
     }): Promise<{ success: boolean; message?: string; error?: string }> =>
       this.post('/api/engine/signal/submit', params),
     approvePrd: (


### PR DESCRIPTION
## Summary

- Adds **Opus triage** step to PM Agent's `processIdea()` flow — cheap 1-turn classification that evaluates whether an idea needs external web context (competitor analysis, unfamiliar APIs, integration patterns) or is purely internal codebase work
- Conditionally enables **WebSearch + WebFetch** tools in the Sonnet research phase based on triage results, with suggested search queries injected into the research prompt
- Adds per-signal **Web toggle** in the signal input dialog (blue Globe button) to force web research regardless of triage

**Priority chain:** per-signal UI override > Opus triage > off by default

## Test plan

- [ ] Submit a signal like "add Stripe payment integration" → Opus triage should decide web research needed → Sonnet research includes web results → PRD references external docs
- [ ] Submit a signal like "fix the login button color" → Opus triage should skip web research → standard codebase-only research
- [ ] Toggle Web button in signal dialog → forces web research regardless of triage
- [ ] Verify Auto + Web toggles work independently
- [ ] `npm run build:packages && npm run build:server` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Web" toggle control in the signal submission interface, enabling users to optionally enable web research when submitting signals or ideas.
  * Implemented intelligent triage capability to automatically assess whether web research would be beneficial for processing submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->