### PR TITLE
fix: clarify decomposition hierarchy label in flow graph

### DIFF
--- a/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
+++ b/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
@@ -110,7 +110,9 @@ function getServiceStatus(
       return {
         status: activeProjects > 0 ? 'active' : 'idle',
         throughput: activeProjects,
-        statusLine: 'Milestones \u2192 Epics \u2192 Features',
+        // Decomposition hierarchy: Projects → Milestones → Phases
+        // On the board, milestones become epics and phases become features
+        statusLine: 'Projects \u2192 Milestones \u2192 Features',
       };
     }
     case 'launch':


### PR DESCRIPTION
## Summary
- Updated decomposition engine status line from "Milestones → Epics → Features" to "Projects → Milestones → Features"
- Added code comment explaining the board conversion (milestones → epics, phases → features)

## Test plan
- [ ] Open flow graph view, check decomposition node shows "Projects → Milestones → Features"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive explanatory comments documenting the decomposition hierarchy structure, clarifying how projects, milestones, and features are organized and related, and explaining the mapping to board elements.

* **Refactor**
  * Updated the decomposition hierarchy structure to improve organizational clarity and provide better representation of how system elements relate to board components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->