### PR TITLE
fix: remove duplicate import and wire setPipelineConfig in board-view

### DIFF
--- a/apps/ui/src/components/views/board-view.tsx
+++ b/apps/ui/src/components/views/board-view.tsx
@@ -30,7 +30,6 @@ import { useAppStore, Feature } from '@/store/app-store';
 import { useWorktreeStore } from '@/store/worktree-store';
 import { usePipelineStore } from '@/store/pipeline-store';
 import { useTerminalStore } from '@/store/terminal-store';
-import { useWorktreeStore } from '@/store/worktree-store';
 import { getElectronAPI } from '@/lib/electron';
 import { getHttpApiClient } from '@/lib/http-api-client';
 import type { BacklogPlanResult } from '@automaker/types';
@@ -131,6 +130,7 @@ export function BoardView() {
   const getPrimaryWorktreeBranch = useWorktreeStore((s) => s.getPrimaryWorktreeBranch);
   // Fetch pipeline config via React Query
   const { data: pipelineConfig } = usePipelineConfig(currentProject?.path);
+  const setPipelineConfig = usePipelineStore((s) => s.setPipelineConfig);
   const queryClient = useQueryClient();
 
   // Subscribe to auto mode events for React Query cache invalidation


### PR DESCRIPTION
## Summary
- Removed duplicate `useWorktreeStore` import that caused Vite build failure
- Added missing `setPipelineConfig` selector from `usePipelineStore` that caused runtime error

## Test plan
- [ ] Board view loads without errors
- [ ] Pipeline config changes persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pipeline configuration synchronization to properly update when configuration is loaded.

* **Chores**
  * Removed duplicate import statement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->