### PR TITLE
feat: add unified pipeline to graph registry

### DIFF
--- a/apps/server/src/lib/graph-registry.ts
+++ b/apps/server/src/lib/graph-registry.ts
@@ -287,6 +287,52 @@ const GRAPH_REGISTRY: GraphDefinition[] = [
     useCase: 'End-to-end content generation with quality gates',
   },
   {
+    id: 'unified-pipeline',
+    name: 'Unified Idea-to-Production Pipeline',
+    description:
+      'End-to-end pipeline from signal intake to production. Branches into ops (engineering) or gtm (content) with per-phase gates.',
+    topology: 'multi-stage-hitl',
+    nodes: [
+      {
+        id: 'triage',
+        type: 'decision',
+        description: 'Classify signal, route to ops or gtm branch',
+      },
+      { id: 'research', type: 'processor', description: 'Investigate feasibility, gather context' },
+      { id: 'spec', type: 'processor', description: 'Generate spec (PRD) or content brief' },
+      { id: 'spec_review', type: 'hitl', description: 'User reviews and approves/rejects/edits' },
+      {
+        id: 'design',
+        type: 'processor',
+        description: 'Architecture and structure planning (ops only)',
+      },
+      {
+        id: 'plan',
+        type: 'processor',
+        description: 'Break into executable tasks with dependencies (ops only)',
+      },
+      { id: 'execute', type: 'processor', description: 'Do the work (agent or content flow)' },
+      { id: 'verify', type: 'hitl', description: 'Quality checks, review, CI' },
+      { id: 'publish', type: 'processor', description: 'Ship it (PR merge or content export)' },
+    ],
+    edges: [
+      { from: 'triage', to: 'research' },
+      { from: 'research', to: 'spec' },
+      { from: 'spec', to: 'spec_review' },
+      { from: 'spec_review', to: 'design', condition: 'ops: approved' },
+      { from: 'spec_review', to: 'execute', condition: 'gtm: approved (skip design/plan)' },
+      { from: 'design', to: 'plan' },
+      { from: 'plan', to: 'execute' },
+      { from: 'execute', to: 'verify' },
+      { from: 'verify', to: 'publish', condition: 'approved' },
+      { from: 'verify', to: 'execute', condition: 'revise' },
+      { from: 'publish', to: 'END' },
+    ],
+    entryPoint: 'triage',
+    features: ['multi-phase', 'branch-routing', 'gate-system', 'langfuse-tracing', 'hitl'],
+    useCase: 'Unified signal-to-production pipeline with ops and gtm branches',
+  },
+  {
     id: 'interrupt-loop',
     name: 'Interrupt Loop',
     description:


### PR DESCRIPTION
## Summary
- Registers the 9-phase unified idea-to-production pipeline as an 8th flow topology in the graph registry
- Shows up in the LangGraph flow viewer alongside existing flows (content-creation, project-planning, etc.)
- Includes all 9 nodes (triage → research → spec → spec_review → design → plan → execute → verify → publish) with branch routing edges

## Test plan
- [ ] Verify `POST /api/engine/flows` returns 8 graphs (was 7)
- [ ] LangGraph flow viewer shows "Unified Idea-to-Production Pipeline" card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "Unified Idea-to-Production Pipeline" workflow supporting end-to-end process management from ideation through production. Includes multi-stage processing (triage, research, specification, design, planning, execution, verification, publishing), intelligent branch-routing with separate operational and GTM branches, and integrated gate-system controls for multi-stakeholder approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->