### PR TITLE
fix: use source instead of xargs for .env loading in start script

### DIFF
--- a/start-automaker.sh
+++ b/start-automaker.sh
@@ -9,7 +9,7 @@ set -e
 # ============================================================================
 # CONFIGURATION & CONSTANTS
 # ============================================================================
-export $(grep -v '^#' .env | xargs)
+if [ -f .env ]; then set -a; source .env; set +a; fi
 APP_NAME="Automaker"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HISTORY_FILE="${HOME}/.automaker_launcher_history"
@@ -1091,7 +1091,7 @@ fi
 # Execute the appropriate command
 case $MODE in
     web)
-        export $(grep -v '^#' .env | xargs) 
+        if [ -f .env ]; then set -a; source .env; set +a; fi 
         export TEST_PORT="$WEB_PORT"
         export VITE_SERVER_URL="http://${APP_HOST}:$SERVER_PORT"
         export PORT="$SERVER_PORT"


### PR DESCRIPTION
## Summary
- Replace `export $(grep -v '^#' .env | xargs)` with `set -a; source .env; set +a` in both instances (lines 12 and 1094)
- The old pattern breaks on env values containing `=` signs (URLs, base64 tokens) or spaces — `xargs` tokenizes them incorrectly

## Test plan
- [ ] Run `./start-automaker.sh` and verify it loads without `export: '=': not a valid identifier` errors
- [ ] Verify env vars with special characters (URLs, `=` in values) are loaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced startup process robustness by improving how environment variables are loaded, with better handling of missing configuration files to prevent initialization failures and ensure more stable application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->