### PR TITLE
fix: remove agent names from content pipeline status line

### DIFF
--- a/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
+++ b/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
@@ -101,7 +101,7 @@ function getServiceStatus(
       return {
         status: isActive ? 'active' : 'idle',
         throughput: 0, // TODO: Show signal processing rate when available
-        statusLine: isActive ? 'Classifying signals' : 'Ava classifies: Ops vs GTM',
+        statusLine: isActive ? 'Classifying signals' : 'Route signals: Ops vs GTM',
       };
     }
     case 'project-planning': {
@@ -126,7 +126,7 @@ function getServiceStatus(
       return {
         status: engineStatus.autoMode?.running ? 'active' : 'idle',
         throughput: 0,
-        statusLine: 'Activate auto-mode + Lead Engineer',
+        statusLine: 'Queue features + start agents',
       };
     case 'auto-mode': {
       const am = engineStatus.autoMode;
@@ -190,7 +190,7 @@ function getServiceStatus(
             ? `${activeFlows} running, ${pendingDrafts} pending review`
             : pendingDrafts > 0
               ? `${pendingDrafts} drafts pending review`
-              : 'Jon \u2192 Cindi \u2192 Review \u2192 Notes',
+              : 'Research \u2192 Draft \u2192 Review \u2192 Publish',
       };
     }
     case 'reflection':


### PR DESCRIPTION
## Summary
- Replace "Jon → Cindi → Review → Notes" with "Research → Draft → Review → Publish" in the flow graph content pipeline node

## Test plan
- [ ] Flow graph shows generic pipeline stages instead of agent names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Other**
  * Updated workflow status labels shown in the flow graph:
    * Triage: "Route signals: Ops vs GTM"
    * Launch: "Queue features + start agents"
    * Content pipeline: "Research → Draft → Review → Publish"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->