### PR TITLE
chore: codebase cleanup — gitignore, docs, stale branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ docs/.vitepress/cache/
 .automaker/context/context-metadata.json
 .automaker/worktrees/
 .automaker/worktree-init.sh
+.automaker/prd-output.json
 
 # Feature data is runtime-managed by the server — never git-track
 .automaker/features/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,8 @@ automaker/
     ├── tools/        # Unified tool definition and registry system
     ├── flows/        # LangGraph state graph primitives & flow orchestration
     ├── llm-providers/# Multi-provider LLM abstraction layer
-    └── observability/# Langfuse tracing, prompt versioning & cost tracking
+    ├── observability/# Langfuse tracing, prompt versioning & cost tracking
+    └── ui/           # Shared UI components (@protolabs/ui) — atoms, molecules, theme
 ```
 
 ### Package Dependency Chain
@@ -101,9 +102,9 @@ Packages can only depend on packages above them:
     ↓
 @automaker/utils, @automaker/prompts, @automaker/platform, @automaker/model-resolver, @automaker/dependency-resolver, @automaker/spec-parser, @automaker/tools, @automaker/flows, @automaker/llm-providers, @automaker/observability
     ↓
-@automaker/git-utils
+@automaker/git-utils, @protolabs/ui
     ↓
-@automaker/server, @automaker/ui
+@automaker/server, @automaker/ui (apps)
 ```
 
 ### Key Technologies


### PR DESCRIPTION
## Summary
- Add `.automaker/prd-output.json` to `.gitignore` (untracked runtime artifact)
- Add `libs/ui` (`@protolabs/ui`) to CLAUDE.md monorepo structure and dependency chain
- Removed 10 stale worktrees (8 with merged PRs + 2 orphans with no PRs)
- Deleted 15 merged local branches
- Pruned 31 stale remote-tracking refs

## Test plan
- [ ] `.gitignore` correctly ignores prd-output.json
- [ ] CLAUDE.md accurately reflects all 13 libs/ packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to exclude generated output files.

* **Documentation**
  * Updated monorepo architecture documentation to reflect UI package reorganization and revised dependency structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->