### PR TITLE
feat: rich node dialogs — o11y as UX

### DIFF
--- a/.automaker/notes/workspace.json
+++ b/.automaker/notes/workspace.json
@@ -8,16 +8,16 @@
     "f35b89fb-3cc2-4e1f-8e58-98165c82df08": {
       "id": "f35b89fb-3cc2-4e1f-8e58-98165c82df08",
       "name": "Notes",
-      "content": "<p>test</p>",
+      "content": "<p>test</p><h2>GTM Ideas — Jon</h2><h3>o11y as UX — Brand Positioning Concept</h3><p><strong>Date:</strong> 2026-02-20</p><h4>The Core Insight</h4><p>Every other AI dev tool treats observability as a backend concern — Grafana dashboards, log aggregators, separate trace viewers bolted on after the fact. protoMaker flips this: <strong>the product UI IS the observability layer.</strong> The flow graph board surfaces pipeline phases, Langfuse trace links, agent costs, gate states, and execution status all inline, in context, where you're already working. You don't leave to check a dashboard. You never had to open one.</p><h4>Why It's Differentiated</h4><ul><li>Competitors (Cursor, Devin, GitHub Copilot Workspace) all have zero native observability in the product UI — you're flying blind or tab-switching to external tools</li><li>The flow graph isn't just a pretty diagram — it's a live state machine view. What you see is what's actually running.</li><li>Agent costs, model choices, trace IDs: visible without asking. This builds trust in the autonomy, not just the output.</li><li>This is a <em>design philosophy</em>, not a feature — impossible to copy quickly without rearchitecting the whole product</li></ul><h4>Content Angles</h4><ul><li><strong>Blog post:</strong> \"Why we don't have a monitoring dashboard (and never will)\" — explain the o11y-as-UX bet, contrast with the standard observability bolted-on approach</li><li><strong>Landing page section:</strong> \"See everything. Switch nothing.\" — screenshot the flow graph with callouts: trace link, agent cost, gate state, live phase indicator. No Grafana tab in the background.</li><li><strong>Demo talking point:</strong> Open the flow graph mid-run. Point at the cost badge, the trace link, the gate. Say: \"This IS your observability layer. This is the only tab you need open.\"</li><li><strong>Twitter/X thread:</strong> \"Hot take: if your AI dev tool requires a separate observability tool, it's not actually autonomous — it's just automated.\" Thread unpacking o11y as UX.</li><li><strong>Positioning wedge in analyst/investor convos:</strong> Frame as \"embedded observability\" — a new category claim between AIOps and developer tooling</li></ul><h4>Working Taglines</h4><ul><li>\"The pipeline is the dashboard.\"</li><li>\"See the agent think.\" (more visceral)</li><li>\"Observability isn't a tab. It's the product.\"</li><li>\"No Grafana. No Datadog. Just the board.\"</li><li>\"o11y as UX — not as afterthought.\"</li></ul><h4>Notes / Next Steps</h4><ul><li>Strongest differentiator angle: competitors can't copy this fast — it requires the flow graph architecture to already exist. We have it. Use it.</li><li>Should be a named section on the landing page — not buried in a features list</li><li>Consider a short Loom demo clip specifically framing this: \"Here's what observability looks like when it's built in from day one\"</li><li>Potential brand phrase to own: <strong>\"o11y as UX\"</strong> — technical enough to resonate with engineers, concept is graspable by non-engineers when shown visually</li></ul>",
       "permissions": {
         "agentRead": false,
         "agentWrite": true
       },
       "metadata": {
         "createdAt": 1771448161228,
-        "updatedAt": 1771480210111,
-        "wordCount": 1,
-        "characterCount": 4
+        "updatedAt": 1771626711566,
+        "wordCount": 402,
+        "characterCount": 2648
       }
     }
   }

--- a/apps/server/src/routes/engine/index.ts
+++ b/apps/server/src/routes/engine/index.ts
@@ -386,7 +386,7 @@ export function createEngineRoutes(
         return;
       }
 
-      // Load all features and count by status
+      // Load all features — count and group by status
       const features = await featureLoader.getAll(projectPath);
       const countsByStatus: Record<string, number> = {
         backlog: 0,
@@ -395,17 +395,42 @@ export function createEngineRoutes(
         done: 0,
         blocked: 0,
       };
+      const featuresByStatus: Record<
+        string,
+        Array<{
+          id: string;
+          title: string;
+          status: string;
+          branchName?: string;
+          createdAt?: string;
+          complexity?: string;
+          lastTraceId?: string;
+          costUsd?: number;
+        }>
+      > = {};
 
       for (const feature of features) {
         const status = feature.status || 'backlog';
         if (status in countsByStatus) {
           countsByStatus[status]++;
+          if (!featuresByStatus[status]) featuresByStatus[status] = [];
+          featuresByStatus[status].push({
+            id: feature.id,
+            title: feature.title || feature.id,
+            status,
+            branchName: feature.branchName,
+            createdAt: feature.createdAt,
+            complexity: feature.complexity,
+            lastTraceId: feature.lastTraceId,
+            costUsd: feature.costUsd,
+          });
         }
       }
 
       res.json({
         success: true,
         countsByStatus,
+        featuresByStatus,
         totalFeatures: features.length,
         timestamp: new Date().toISOString(),
       });

--- a/apps/ui/src/components/views/flow-graph/dialogs/node-detail-sections.tsx
+++ b/apps/ui/src/components/views/flow-graph/dialogs/node-detail-sections.tsx
@@ -5,7 +5,7 @@
  * existing hooks and the node's data prop.
  */
 
-import { ExternalLink, Clock, DollarSign, Square, FileText } from 'lucide-react';
+import { ExternalLink, Clock, DollarSign, Square, FileText, GitBranch, Signal } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { Badge } from '@protolabs/ui/atoms';
 import { Button } from '@protolabs/ui/atoms';
@@ -14,6 +14,7 @@ import { formatCostUsd } from '@/lib/format';
 import { getLangfuseTraceUrl, getLangfuseSpanUrl } from '@/lib/langfuse-url';
 import { getHttpApiClient } from '@/lib/http-api-client';
 import { queryKeys } from '@/lib/query-keys';
+import { useEngineStatus } from '@/hooks/queries/use-metrics';
 import type {
   OrchestratorNodeData,
   ServiceNodeData,
@@ -57,6 +58,21 @@ function formatDuration(ms: number): string {
   if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`;
   return `${(ms / 3_600_000).toFixed(1)}h`;
 }
+
+function formatTimeAgo(dateStr: string): string {
+  const ms = Date.now() - new Date(dateStr).getTime();
+  if (ms < 60_000) return 'just now';
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.round(ms / 3_600_000)}h ago`;
+  return `${Math.round(ms / 86_400_000)}d ago`;
+}
+
+const COMPLEXITY_COLORS: Record<string, string> = {
+  small: 'text-emerald-400',
+  medium: 'text-amber-400',
+  large: 'text-orange-400',
+  architectural: 'text-red-400',
+};
 
 // ============================================
 // Orchestrator Section
@@ -151,6 +167,8 @@ export function EngineServiceSection({ data }: { data: EngineServiceNodeData }) 
       {data.serviceId === 'auto-mode' && <AutoModeDetailPanel />}
       {data.serviceId === 'pr-feedback' && <PRFeedbackDetailPanel />}
       {data.serviceId === 'lead-engineer-rules' && <LeadEngineerDetailPanel />}
+      {data.serviceId === 'signal-sources' && <SignalSourcesDetailPanel />}
+      {data.serviceId === 'git-workflow' && <GitWorkflowDetailPanel />}
     </div>
   );
 }
@@ -360,6 +378,106 @@ function LeadEngineerDetailPanel() {
   );
 }
 
+function SignalSourcesDetailPanel() {
+  const { data: engineStatus } = useEngineStatus() as {
+    data?: {
+      signalIntake?: {
+        signalCounts?: Record<string, number>;
+        lastSignalAt?: string | null;
+      };
+    };
+  };
+
+  const signalCounts = engineStatus?.signalIntake?.signalCounts;
+  const lastSignalAt = engineStatus?.signalIntake?.lastSignalAt;
+  const totalSignals = signalCounts
+    ? Object.values(signalCounts).reduce((sum, n) => sum + n, 0)
+    : 0;
+
+  return (
+    <div className="border-t border-border/30 pt-2 space-y-2">
+      <p className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
+        Signal History
+      </p>
+      {totalSignals === 0 ? (
+        <p className="text-xs text-muted-foreground">No signals received yet</p>
+      ) : (
+        <>
+          <div className="flex flex-wrap gap-2">
+            {signalCounts &&
+              Object.entries(signalCounts)
+                .filter(([, count]) => count > 0)
+                .map(([source, count]) => (
+                  <Badge key={source} variant="outline" className="text-[10px]">
+                    <Signal className="w-2.5 h-2.5 mr-1" />
+                    {source}: {count}
+                  </Badge>
+                ))}
+          </div>
+          {lastSignalAt && (
+            <p className="text-[10px] text-muted-foreground">
+              Last signal: {formatTimeAgo(lastSignalAt)}
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function GitWorkflowDetailPanel() {
+  const { data: engineStatus } = useEngineStatus() as {
+    data?: {
+      gitWorkflow?: {
+        activeWorkflows?: number;
+        recentOperations?: Array<{
+          type: string;
+          featureId?: string;
+          timestamp: string;
+          success?: boolean;
+        }>;
+      };
+    };
+  };
+
+  const activeWorkflows = engineStatus?.gitWorkflow?.activeWorkflows ?? 0;
+  const recentOps = engineStatus?.gitWorkflow?.recentOperations ?? [];
+
+  return (
+    <div className="border-t border-border/30 pt-2 space-y-2">
+      <p className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
+        Git Operations
+      </p>
+      <SectionRow label="Active Workflows">{activeWorkflows}</SectionRow>
+      {recentOps.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No recent operations</p>
+      ) : (
+        <div className="space-y-1">
+          {recentOps.slice(0, 5).map((op, i) => (
+            <div
+              key={i}
+              className="text-xs flex items-center justify-between p-1.5 rounded bg-muted/30"
+            >
+              <span className="flex items-center gap-1.5">
+                <GitBranch className="w-3 h-3 text-muted-foreground" />
+                <span className="font-medium">{op.type}</span>
+                {op.success === false && (
+                  <Badge variant="destructive" className="text-[9px] px-1 py-0">
+                    failed
+                  </Badge>
+                )}
+              </span>
+              <span className="text-muted-foreground text-[10px]">
+                {formatTimeAgo(op.timestamp)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ============================================
 // Integration Section
 // ============================================
@@ -505,6 +623,8 @@ export function AgentSection({ data, onStop, onViewLogs, isStopping }: AgentSect
 // ============================================
 
 export function PipelineStageSection({ data }: { data: PipelineStageNodeData }) {
+  const hasRealItems = data.workItems.some((item) => !item.metadata?.isInitial);
+
   return (
     <div className="space-y-3">
       <div className="space-y-1">
@@ -524,29 +644,50 @@ export function PipelineStageSection({ data }: { data: PipelineStageNodeData }) 
             {data.status}
           </Badge>
         </SectionRow>
-        <SectionRow label="Work Items">{data.workItems.length}</SectionRow>
+        <SectionRow label="Features">{data.workItems.length}</SectionRow>
       </div>
 
-      {/* Work items list */}
+      {/* Feature cards */}
       {data.workItems.length > 0 && (
         <div className="border-t border-border/30 pt-2 space-y-1.5">
           <p className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
-            Items
+            {hasRealItems ? 'Features' : 'Items'}
           </p>
-          {data.workItems.slice(0, 5).map((item) => (
-            <div
-              key={item.id}
-              className="text-xs p-1.5 rounded bg-muted/30 flex items-center justify-between"
-            >
-              <span className="truncate max-w-[180px]">{item.title}</span>
-              <Badge variant="outline" className="text-[10px] ml-2">
-                {item.status}
-              </Badge>
-            </div>
-          ))}
-          {data.workItems.length > 5 && (
-            <p className="text-[10px] text-muted-foreground">+{data.workItems.length - 5} more</p>
-          )}
+          <div className="max-h-64 overflow-y-auto space-y-1.5 pr-0.5">
+            {data.workItems.map((item) => (
+              <div key={item.id} className="text-xs space-y-1 p-2 rounded-lg bg-muted/30">
+                <p className="font-medium truncate" title={item.title}>
+                  {item.title}
+                </p>
+                <div className="flex flex-wrap items-center gap-2 text-muted-foreground">
+                  {item.metadata?.complexity && (
+                    <span
+                      className={`text-[10px] font-medium ${COMPLEXITY_COLORS[item.metadata.complexity] || ''}`}
+                    >
+                      {item.metadata.complexity}
+                    </span>
+                  )}
+                  {item.metadata?.branchName && (
+                    <code className="text-[10px] bg-muted px-1 py-0.5 rounded truncate max-w-[140px]">
+                      {item.metadata.branchName}
+                    </code>
+                  )}
+                  {typeof item.metadata?.costUsd === 'number' && item.metadata.costUsd > 0 && (
+                    <span className="text-emerald-400 text-[10px]">
+                      {formatCostUsd(item.metadata.costUsd)}
+                    </span>
+                  )}
+                  {item.metadata?.createdAt && (
+                    <span className="text-[10px]">
+                      <Clock className="w-2.5 h-2.5 inline mr-0.5" />
+                      {formatTimeAgo(item.metadata.createdAt)}
+                    </span>
+                  )}
+                </div>
+                {item.metadata?.lastTraceId && <TraceLink traceId={item.metadata.lastTraceId} />}
+              </div>
+            ))}
+          </div>
         </div>
       )}
 

--- a/apps/ui/src/components/views/flow-graph/hooks/use-pipeline-tracker.ts
+++ b/apps/ui/src/components/views/flow-graph/hooks/use-pipeline-tracker.ts
@@ -104,12 +104,35 @@ export function usePipelineTracker(props?: UsePipelineTrackerProps): UsePipeline
     setWorkItems((prev) => {
       const next = new Map(prev);
 
-      // Create synthetic work items for initial counts
-      // These will be replaced/updated by actual WebSocket events
+      // If server returned feature lists, create individual work items
+      if (initialState.featuresByStatus) {
+        Object.entries(initialState.featuresByStatus).forEach(([status, features]) => {
+          const stageId = status as PipelineStageId;
+          for (const feature of features) {
+            next.set(feature.id, {
+              id: feature.id,
+              title: feature.title,
+              status: stageId,
+              metadata: {
+                branchName: feature.branchName,
+                createdAt: feature.createdAt,
+                complexity: feature.complexity,
+                lastTraceId: feature.lastTraceId,
+                costUsd: feature.costUsd,
+                lastEventType: 'feature:created',
+                lastEventTime: Date.now(),
+                isInitial: true,
+              },
+            });
+          }
+        });
+        return next;
+      }
+
+      // Fallback: synthetic aggregate items when featuresByStatus is absent
       Object.entries(initialState.countsByStatus).forEach(([status, count]) => {
         if (count > 0) {
           const stageId = status as PipelineStageId;
-          // Create a single aggregate item per stage for initial display
           const itemId = `initial-${stageId}`;
           next.set(itemId, {
             id: itemId,

--- a/apps/ui/src/components/views/flow-graph/types.ts
+++ b/apps/ui/src/components/views/flow-graph/types.ts
@@ -104,7 +104,17 @@ export interface TrackedWorkItem {
   title: string;
   status: PipelineStageId;
   progress?: number;
-  metadata?: Record<string, unknown>;
+  metadata?: {
+    branchName?: string;
+    createdAt?: string;
+    complexity?: string;
+    lastTraceId?: string;
+    costUsd?: number;
+    lastEventType?: string;
+    lastEventTime?: number;
+    isInitial?: boolean;
+    [key: string]: unknown;
+  };
 }
 
 export interface PipelineStageNodeData {

--- a/apps/ui/src/lib/http-api-client.ts
+++ b/apps/ui/src/lib/http-api-client.ts
@@ -2965,6 +2965,19 @@ export class HttpApiClient implements ElectronAPI {
     ): Promise<{
       success: boolean;
       countsByStatus?: Record<string, number>;
+      featuresByStatus?: Record<
+        string,
+        Array<{
+          id: string;
+          title: string;
+          status: string;
+          branchName?: string;
+          createdAt?: string;
+          complexity?: string;
+          lastTraceId?: string;
+          costUsd?: number;
+        }>
+      >;
       totalFeatures?: number;
       timestamp?: string;
       error?: string;


### PR DESCRIPTION
## Summary
- **Pipeline stage nodes** now show real feature cards (title, branch, complexity badge, cost, Langfuse trace link) instead of synthetic "N items" placeholders
- **Signal Sources node** gets a detail panel showing signal counts by source and last signal time
- **Git Workflow node** gets a detail panel showing active workflows and recent git operations
- Server `/api/engine/pipeline-state` extended with `featuresByStatus` (backward-compatible — `countsByStatus` preserved)

## Test plan
- [ ] Open flow graph → click a pipeline stage node (e.g. Backlog) → verify actual feature titles appear with branch/complexity/cost metadata
- [ ] Click Signal Sources → verify signal counts and last signal time display
- [ ] Click Git Workflow → verify active workflows count and recent operations list
- [ ] Click Auto Mode / PR Feedback / Lead Engineer → verify existing panels still work
- [ ] Pipeline tracker still updates via WebSocket events (real items replace initial hydration)
- [ ] `npm run build:server && npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline now groups features by status and displays them as detailed cards with complexity levels, branch names, costs, and creation times.
  * Enhanced visibility into feature status and metrics across the pipeline.

* **Documentation**
  * Added comprehensive guide on GTM and observability integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->