### PR TITLE
fix: clear pipeline tracker state on project switch

### DIFF
--- a/apps/ui/src/components/views/flow-graph/hooks/use-pipeline-tracker.ts
+++ b/apps/ui/src/components/views/flow-graph/hooks/use-pipeline-tracker.ts
@@ -82,6 +82,13 @@ export function usePipelineTracker(props?: UsePipelineTrackerProps): UsePipeline
   const [isConnected, setIsConnected] = useState(false);
   const expiryTimers = useRef<Map<string, NodeJS.Timeout>>(new Map());
 
+  // Clear work items when project changes
+  useEffect(() => {
+    setWorkItems(new Map());
+    expiryTimers.current.forEach((timer) => clearTimeout(timer));
+    expiryTimers.current.clear();
+  }, [projectPath]);
+
   // Fetch initial pipeline state with React Query
   const { data: initialState, isLoading } = useQuery({
     queryKey: ['engine', 'pipeline-state', projectPath],
@@ -101,8 +108,8 @@ export function usePipelineTracker(props?: UsePipelineTrackerProps): UsePipeline
 
     logger.debug('Hydrating initial pipeline state:', initialState);
 
-    setWorkItems((prev) => {
-      const next = new Map(prev);
+    setWorkItems(() => {
+      const next = new Map<string, TrackedWorkItem>();
 
       // If server returned feature lists, create individual work items
       if (initialState.featuresByStatus) {


### PR DESCRIPTION
## Summary
- Pipeline stage nodes were showing features from previously selected projects because work items persisted across project switches
- Root cause: hydration effect merged new items into existing map (`new Map(prev)`) instead of starting fresh
- Added `useEffect` to clear work items and expiry timers when `projectPath` changes
- Hydration now starts from an empty map instead of merging with stale state

## Test plan
- [ ] Open flow graph with project A selected → see project A features in pipeline stages
- [ ] Switch to project B → pipeline stages should show only project B features (no leftover from A)
- [ ] Switch back to A → only A's features shown
- [ ] WebSocket events still update pipeline stages in real time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal state initialization and cleanup logic for better reliability when switching projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->