### PR TITLE
feat: setupLab UI integration — report dialog in project switcher

### DIFF
--- a/apps/ui/src/components/layout/project-switcher/components/project-context-menu.tsx
+++ b/apps/ui/src/components/layout/project-switcher/components/project-context-menu.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useRef, useState, memo, useCallback, useMemo } from 'react';
 import type { LucideIcon } from 'lucide-react';
-import { Edit2, Trash2, Palette, ChevronRight, Moon, Sun, Monitor } from 'lucide-react';
+import {
+  Edit2,
+  Trash2,
+  Palette,
+  ChevronRight,
+  Moon,
+  Sun,
+  Monitor,
+  FlaskConical,
+} from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { type ThemeMode, useAppStore } from '@/store/app-store';
@@ -167,6 +176,8 @@ interface ProjectContextMenuProps {
   onClose: () => void;
   /** Callback when user selects "Edit Name & Icon" option */
   onEdit: (project: Project) => void;
+  /** Callback when user selects "ProtoLabs Report" option */
+  onRunReport?: (projectPath: string) => void;
 }
 
 /**
@@ -189,6 +200,7 @@ export function ProjectContextMenu({
   position,
   onClose,
   onEdit,
+  onRunReport,
 }: ProjectContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const { moveProjectToTrash, setProjectTheme } = useAppStore();
@@ -478,6 +490,25 @@ export function ProjectContextMenu({
                 </div>
               )}
             </div>
+
+            {onRunReport && (
+              <button
+                onClick={() => {
+                  onRunReport(project.path);
+                  onClose();
+                }}
+                className={cn(
+                  'w-full flex items-center gap-2 px-3 py-2 rounded-md',
+                  'text-sm font-medium text-left',
+                  'hover:bg-accent transition-colors',
+                  'focus:outline-none focus:bg-accent'
+                )}
+                data-testid="run-report-button"
+              >
+                <FlaskConical className="w-4 h-4" />
+                <span>ProtoLabs Report</span>
+              </button>
+            )}
 
             <button
               onClick={handleRemove}

--- a/apps/ui/src/components/layout/project-switcher/project-switcher.tsx
+++ b/apps/ui/src/components/layout/project-switcher/project-switcher.tsx
@@ -18,6 +18,7 @@ import { getElectronAPI } from '@/lib/electron';
 import { initializeProject, hasAppSpec, hasAutomakerDir } from '@/lib/project-init';
 import { toast } from 'sonner';
 import { CreateSpecDialog } from '@/components/views/spec-view/dialogs';
+import { ProtoLabsReportDialog } from '@/components/shared/protolabs-report';
 import type { FeatureCount } from '@/components/views/spec-view/types';
 
 function getOSAbbreviation(os: string): string {
@@ -50,6 +51,10 @@ export function ProjectSwitcher() {
   );
   const [editDialogProject, setEditDialogProject] = useState<Project | null>(null);
 
+  // ProtoLabs report dialog state
+  const [showReportDialog, setShowReportDialog] = useState(false);
+  const [reportProjectPath, setReportProjectPath] = useState<string | null>(null);
+
   // Setup dialog state for opening existing projects
   const [showSetupDialog, setShowSetupDialog] = useState(false);
   const [setupProjectPath, setSetupProjectPath] = useState<string | null>(null);
@@ -81,6 +86,11 @@ export function ProjectSwitcher() {
   } = useProjectCreation({
     upsertAndSetCurrentProject,
   });
+
+  const handleRunReport = useCallback((path: string) => {
+    setReportProjectPath(path);
+    setShowReportDialog(true);
+  }, []);
 
   const handleContextMenu = (project: Project, event: React.MouseEvent) => {
     event.preventDefault();
@@ -174,6 +184,10 @@ export function ProjectSwitcher() {
         } else {
           toast.success('Project opened', {
             description: `Opened ${name}`,
+            action: {
+              label: 'Run Report',
+              onClick: () => handleRunReport(path),
+            },
           });
         }
 
@@ -448,6 +462,7 @@ export function ProjectSwitcher() {
           position={contextMenuPosition}
           onClose={handleCloseContextMenu}
           onEdit={handleEditProject}
+          onRunReport={handleRunReport}
         />
       )}
 
@@ -478,6 +493,15 @@ export function ProjectSwitcher() {
         onSkip={handleOnboardingSkip}
         onGenerateSpec={handleOnboardingSkip}
       />
+
+      {/* ProtoLabs Report Dialog */}
+      {reportProjectPath && (
+        <ProtoLabsReportDialog
+          open={showReportDialog}
+          onOpenChange={setShowReportDialog}
+          projectPath={reportProjectPath}
+        />
+      )}
 
       {/* Setup Dialog for Open Project */}
       <CreateSpecDialog

--- a/apps/ui/src/components/shared/protolabs-report/index.ts
+++ b/apps/ui/src/components/shared/protolabs-report/index.ts
@@ -1,0 +1,2 @@
+export { ProtoLabsReportDialog } from './protolabs-report-dialog';
+export { ProtoLabsReportResults } from './protolabs-report-results';

--- a/apps/ui/src/components/shared/protolabs-report/protolabs-report-dialog.tsx
+++ b/apps/ui/src/components/shared/protolabs-report/protolabs-report-dialog.tsx
@@ -1,0 +1,257 @@
+import { useState, useCallback } from 'react';
+import { CheckCircle2, AlertCircle, RotateCcw, FlaskConical } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Spinner,
+} from '@protolabs/ui/atoms';
+import { Button } from '@protolabs/ui/atoms';
+import { cn } from '@/lib/utils';
+import { getElectronAPI } from '@/lib/electron';
+import { toast } from 'sonner';
+import { ProtoLabsReportResults } from './protolabs-report-results';
+import type { RepoResearchResult, GapAnalysisReport, AlignmentProposal } from '@automaker/types';
+
+type PipelineStep = 'idle' | 'researching' | 'analyzing' | 'generating' | 'complete' | 'error';
+
+interface ProtoLabsReportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectPath: string;
+}
+
+const STEPS = [
+  { key: 'researching' as const, label: 'Scanning repository...' },
+  { key: 'analyzing' as const, label: 'Analyzing gaps...' },
+  { key: 'generating' as const, label: 'Generating report...' },
+  { key: 'complete' as const, label: 'Complete' },
+];
+
+function getStepIndex(step: PipelineStep): number {
+  return STEPS.findIndex((s) => s.key === step);
+}
+
+export function ProtoLabsReportDialog({
+  open,
+  onOpenChange,
+  projectPath,
+}: ProtoLabsReportDialogProps) {
+  const [step, setStep] = useState<PipelineStep>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [failedStep, setFailedStep] = useState<PipelineStep | null>(null);
+
+  // Pipeline data
+  const [research, setResearch] = useState<RepoResearchResult | null>(null);
+  const [gapReport, setGapReport] = useState<GapAnalysisReport | null>(null);
+  const [reportPath, setReportPath] = useState<string | null>(null);
+  const [proposal, setProposal] = useState<AlignmentProposal | null>(null);
+  const [isCreatingFeatures, setIsCreatingFeatures] = useState(false);
+
+  const resetState = useCallback(() => {
+    setStep('idle');
+    setError(null);
+    setFailedStep(null);
+    setResearch(null);
+    setGapReport(null);
+    setReportPath(null);
+    setProposal(null);
+    setIsCreatingFeatures(false);
+  }, []);
+
+  const runPipeline = useCallback(
+    async (startFrom?: PipelineStep) => {
+      const api = getElectronAPI();
+      setError(null);
+      setFailedStep(null);
+
+      try {
+        // Step 1: Research
+        let researchResult = research;
+        if (!startFrom || startFrom === 'researching') {
+          setStep('researching');
+          const res = await api.setupLab.research(projectPath);
+          if (!res.success || !res.research) {
+            throw new Error(res.error || 'Research failed');
+          }
+          researchResult = res.research;
+          setResearch(researchResult);
+        }
+
+        // Step 2: Gap Analysis
+        let gapResult = gapReport;
+        if (!startFrom || startFrom === 'researching' || startFrom === 'analyzing') {
+          setStep('analyzing');
+          const res = await api.setupLab.gapAnalysis(projectPath, researchResult!);
+          if (!res.success || !res.report) {
+            throw new Error(res.error || 'Gap analysis failed');
+          }
+          gapResult = res.report;
+          setGapReport(gapResult);
+        }
+
+        // Step 3: Generate Report
+        setStep('generating');
+        const reportRes = await api.setupLab.report(projectPath, researchResult!, gapResult!);
+        if (!reportRes.success || !reportRes.outputPath) {
+          throw new Error(reportRes.error || 'Report generation failed');
+        }
+        setReportPath(reportRes.outputPath);
+
+        // Done
+        setStep('complete');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        setError(message);
+        setFailedStep(step);
+        setStep('error');
+      }
+    },
+    [projectPath, research, gapReport, step]
+  );
+
+  const handleRetry = useCallback(() => {
+    if (failedStep) {
+      runPipeline(failedStep);
+    } else {
+      runPipeline();
+    }
+  }, [failedStep, runPipeline]);
+
+  const handleOpenReport = useCallback(async () => {
+    if (!reportPath) return;
+    try {
+      const api = getElectronAPI();
+      await api.setupLab.openReport(reportPath);
+    } catch {
+      toast.error('Failed to open report');
+    }
+  }, [reportPath]);
+
+  const handleCreateFeatures = useCallback(async () => {
+    if (!gapReport) return;
+    setIsCreatingFeatures(true);
+    try {
+      const api = getElectronAPI();
+      const res = await api.setupLab.propose(projectPath, gapReport, true);
+      if (!res.success) {
+        throw new Error(res.error || 'Failed to create features');
+      }
+      setProposal(res.proposal ?? null);
+      toast.success('Alignment features created', {
+        description: `${res.featuresCreated ?? res.proposal?.totalFeatures ?? 0} features added to the board`,
+      });
+    } catch (err) {
+      toast.error('Failed to create features', {
+        description: err instanceof Error ? err.message : 'Unknown error',
+      });
+    } finally {
+      setIsCreatingFeatures(false);
+    }
+  }, [projectPath, gapReport]);
+
+  // Auto-start pipeline when dialog opens
+  const handleOpenChange = useCallback(
+    (isOpen: boolean) => {
+      if (isOpen && step === 'idle') {
+        runPipeline();
+      }
+      if (!isOpen) {
+        // Reset when closing so next open starts fresh
+        resetState();
+      }
+      onOpenChange(isOpen);
+    },
+    [step, runPipeline, resetState, onOpenChange]
+  );
+
+  const currentStepIndex = getStepIndex(step);
+  const isRunning = step === 'researching' || step === 'analyzing' || step === 'generating';
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FlaskConical className="size-5" />
+            ProtoLabs Report
+          </DialogTitle>
+          <DialogDescription>
+            Scanning your project against the ProtoLabs gold standard.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Step indicators */}
+          {step !== 'complete' && (
+            <div className="space-y-2">
+              {STEPS.slice(0, -1).map((s, i) => {
+                const isActive = s.key === step;
+                const isDone = currentStepIndex > i || step === 'complete';
+                const isPending = currentStepIndex < i && step !== 'error';
+
+                return (
+                  <div key={s.key} className="flex items-center gap-3">
+                    <div className="flex-shrink-0 w-5 h-5 flex items-center justify-center">
+                      {isActive && !error ? (
+                        <Spinner size="sm" />
+                      ) : isDone ? (
+                        <CheckCircle2 className="size-5 text-green-500" />
+                      ) : step === 'error' && failedStep === s.key ? (
+                        <AlertCircle className="size-5 text-destructive" />
+                      ) : (
+                        <div
+                          className={cn(
+                            'size-2 rounded-full',
+                            isPending ? 'bg-muted-foreground/30' : 'bg-muted-foreground/50'
+                          )}
+                        />
+                      )}
+                    </div>
+                    <span
+                      className={cn(
+                        'text-sm',
+                        isActive && 'font-medium text-foreground',
+                        isDone && 'text-muted-foreground',
+                        isPending && 'text-muted-foreground/50'
+                      )}
+                    >
+                      {s.label}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Error state */}
+          {step === 'error' && error && (
+            <div className="space-y-3">
+              <div className="rounded-md bg-destructive/10 p-3">
+                <p className="text-sm text-destructive">{error}</p>
+              </div>
+              <Button onClick={handleRetry} variant="outline" size="sm" className="gap-2">
+                <RotateCcw className="size-3.5" />
+                Retry
+              </Button>
+            </div>
+          )}
+
+          {/* Complete state */}
+          {step === 'complete' && gapReport && reportPath && (
+            <ProtoLabsReportResults
+              report={gapReport}
+              reportPath={reportPath}
+              onOpenReport={handleOpenReport}
+              onCreateFeatures={handleCreateFeatures}
+              isCreatingFeatures={isCreatingFeatures}
+              proposal={proposal ?? undefined}
+            />
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/ui/src/components/shared/protolabs-report/protolabs-report-results.tsx
+++ b/apps/ui/src/components/shared/protolabs-report/protolabs-report-results.tsx
@@ -1,0 +1,136 @@
+import { ExternalLink, Plus, AlertTriangle, Info, CheckCircle2 } from 'lucide-react';
+import { Button } from '@protolabs/ui/atoms';
+import { Badge } from '@protolabs/ui/atoms';
+import { cn } from '@/lib/utils';
+import type { GapAnalysisReport, AlignmentProposal } from '@automaker/types';
+
+interface ProtoLabsReportResultsProps {
+  report: GapAnalysisReport;
+  reportPath: string;
+  onOpenReport: () => void;
+  onCreateFeatures: () => void;
+  isCreatingFeatures: boolean;
+  proposal?: AlignmentProposal;
+}
+
+function getScoreColor(score: number): string {
+  if (score >= 80) return 'text-green-500';
+  if (score >= 50) return 'text-yellow-500';
+  return 'text-red-500';
+}
+
+function getScoreRingColor(score: number): string {
+  if (score >= 80) return 'stroke-green-500';
+  if (score >= 50) return 'stroke-yellow-500';
+  return 'stroke-red-500';
+}
+
+function ScoreRing({ score }: { score: number }) {
+  const radius = 40;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (score / 100) * circumference;
+
+  return (
+    <div className="relative inline-flex items-center justify-center">
+      <svg width="100" height="100" className="-rotate-90">
+        <circle
+          cx="50"
+          cy="50"
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="6"
+          className="text-muted/20"
+        />
+        <circle
+          cx="50"
+          cy="50"
+          r={radius}
+          fill="none"
+          strokeWidth="6"
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          className={cn('transition-all duration-1000 ease-out', getScoreRingColor(score))}
+        />
+      </svg>
+      <span className={cn('absolute text-2xl font-bold', getScoreColor(score))}>{score}</span>
+    </div>
+  );
+}
+
+export function ProtoLabsReportResults({
+  report,
+  reportPath,
+  onOpenReport,
+  onCreateFeatures,
+  isCreatingFeatures,
+  proposal,
+}: ProtoLabsReportResultsProps) {
+  return (
+    <div className="space-y-6">
+      {/* Score + Summary */}
+      <div className="flex items-center gap-6">
+        <ScoreRing score={report.overallScore} />
+        <div className="flex-1 space-y-2">
+          <h3 className="text-lg font-semibold">Alignment Score</h3>
+          <div className="flex flex-wrap gap-2">
+            {report.summary.critical > 0 && (
+              <Badge variant="destructive" className="gap-1">
+                <AlertTriangle className="size-3" />
+                {report.summary.critical} critical
+              </Badge>
+            )}
+            {report.summary.recommended > 0 && (
+              <Badge variant="secondary" className="gap-1 bg-yellow-500/10 text-yellow-600">
+                <Info className="size-3" />
+                {report.summary.recommended} recommended
+              </Badge>
+            )}
+            {report.summary.optional > 0 && (
+              <Badge variant="outline" className="gap-1">
+                <Info className="size-3" />
+                {report.summary.optional} optional
+              </Badge>
+            )}
+            {report.summary.compliant > 0 && (
+              <Badge variant="secondary" className="gap-1 bg-green-500/10 text-green-600">
+                <CheckCircle2 className="size-3" />
+                {report.summary.compliant} compliant
+              </Badge>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex gap-3">
+        <Button onClick={onOpenReport} variant="outline" className="gap-2">
+          <ExternalLink className="size-4" />
+          Open HTML Report
+        </Button>
+        <Button
+          onClick={onCreateFeatures}
+          disabled={isCreatingFeatures || report.gaps.length === 0}
+          className="gap-2"
+        >
+          <Plus className="size-4" />
+          {isCreatingFeatures ? 'Creating...' : `Create Alignment Features (${report.gaps.length})`}
+        </Button>
+      </div>
+
+      {/* Proposal summary */}
+      {proposal && (
+        <p className="text-sm text-muted-foreground">
+          {proposal.totalFeatures} features across {proposal.milestones.length} milestones created
+          on the board.
+        </p>
+      )}
+
+      {/* Report path */}
+      <p className="text-xs text-muted-foreground truncate" title={reportPath}>
+        Report saved to: {reportPath}
+      </p>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/electron.ts
+++ b/apps/ui/src/lib/electron.ts
@@ -15,6 +15,9 @@ import type {
   ReasoningEffort,
   GitHubComment,
   IssueCommentsResult,
+  RepoResearchResult,
+  GapAnalysisReport,
+  AlignmentProposal,
 } from '@automaker/types';
 import { DEFAULT_MAX_CONCURRENCY } from '@automaker/types';
 import { getJSON, setJSON, removeItem } from './storage';
@@ -684,6 +687,46 @@ export interface ElectronAPI {
   // Setup API surface is implemented by the main process and mirrored by HttpApiClient.
   // Keep this intentionally loose to avoid tight coupling between front-end and server types.
   setup?: any;
+  // SetupLab pipeline (repo research, gap analysis, report generation, alignment proposals)
+  setupLab?: {
+    research: (projectPath: string) => Promise<{
+      success: boolean;
+      research?: RepoResearchResult;
+      error?: string;
+    }>;
+    gapAnalysis: (
+      projectPath: string,
+      research: RepoResearchResult,
+      skipChecks?: string[]
+    ) => Promise<{
+      success: boolean;
+      report?: GapAnalysisReport;
+      error?: string;
+    }>;
+    report: (
+      projectPath: string,
+      research: RepoResearchResult,
+      report: GapAnalysisReport
+    ) => Promise<{
+      success: boolean;
+      outputPath?: string;
+      error?: string;
+    }>;
+    openReport: (reportPath: string) => Promise<{
+      success: boolean;
+      error?: string;
+    }>;
+    propose: (
+      projectPath: string,
+      gapAnalysis: GapAnalysisReport,
+      autoCreate?: boolean
+    ) => Promise<{
+      success: boolean;
+      proposal?: AlignmentProposal;
+      featuresCreated?: number;
+      error?: string;
+    }>;
+  };
   agent?: {
     start: (
       sessionId: string,

--- a/apps/ui/src/lib/http-api-client.ts
+++ b/apps/ui/src/lib/http-api-client.ts
@@ -35,6 +35,9 @@ import type {
   ActionableItemActionType,
   ActionableItemPriority,
   CreateActionableItemInput,
+  RepoResearchResult,
+  GapAnalysisReport,
+  AlignmentProposal,
 } from '@automaker/types';
 import type { Message, SessionListItem } from '@/types/electron';
 import type { Feature, ClaudeUsageResponse, CodexUsageResponse } from '@/store/types';
@@ -1747,6 +1750,55 @@ export class HttpApiClient implements ElectronAPI {
     onAuthProgress: (callback: (progress: unknown) => void) => {
       return this.subscribeToEvent('agent:stream', callback);
     },
+  };
+
+  // SetupLab Pipeline API (repo research, gap analysis, report generation)
+  setupLab = {
+    research: (
+      projectPath: string
+    ): Promise<{
+      success: boolean;
+      research?: RepoResearchResult;
+      error?: string;
+    }> => this.post('/api/setup/research', { projectPath }),
+
+    gapAnalysis: (
+      projectPath: string,
+      research: RepoResearchResult,
+      skipChecks?: string[]
+    ): Promise<{
+      success: boolean;
+      report?: GapAnalysisReport;
+      error?: string;
+    }> => this.post('/api/setup/gap-analysis', { projectPath, research, skipChecks }),
+
+    report: (
+      projectPath: string,
+      research: RepoResearchResult,
+      gapReport: GapAnalysisReport
+    ): Promise<{
+      success: boolean;
+      outputPath?: string;
+      error?: string;
+    }> => this.post('/api/setup/report', { projectPath, research, report: gapReport }),
+
+    openReport: (
+      reportPath: string
+    ): Promise<{
+      success: boolean;
+      error?: string;
+    }> => this.post('/api/setup/open-report', { reportPath }),
+
+    propose: (
+      projectPath: string,
+      gapAnalysis: GapAnalysisReport,
+      autoCreate?: boolean
+    ): Promise<{
+      success: boolean;
+      proposal?: AlignmentProposal;
+      featuresCreated?: number;
+      error?: string;
+    }> => this.post('/api/setup/propose', { projectPath, gapAnalysis, autoCreate }),
   };
 
   // Features API


### PR DESCRIPTION
## Summary
- Wire the existing `/api/setup/*` pipeline (research, gap analysis, report generation, alignment proposals) into the UI
- Add `setupLab` namespace to `HttpApiClient` and typed `ElectronAPI` interface
- Create `ProtoLabsReportDialog` with 4-step pipeline orchestration, error recovery, and retry
- Add "ProtoLabs Report" context menu item and "Run Report" toast action on project open

## Test plan
- [ ] Open an existing project → toast shows "Run Report" action → click → dialog runs pipeline → report generates
- [ ] Right-click project in sidebar → "ProtoLabs Report" → same dialog flow
- [ ] "Open HTML Report" button opens the generated `protoLabs.report.html` in browser
- [ ] "Create Alignment Features" button creates features on the board
- [ ] Error at any step shows error message with "Retry" button that resumes from the failed step
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added ProtoLabs Report functionality to analyze repositories and generate alignment reports.
* New "ProtoLabs Report" button in project context menu for quick access.
* Multi-step report pipeline with progress tracking: research, gap analysis, and report generation.
* Report summary displays overall score, findings breakdown, and action buttons to view the full report or create alignment features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->