### PR TITLE
fix: stale React state in setupLab pipeline retry logic

### DIFF
--- a/apps/ui/src/components/shared/protolabs-report/protolabs-report-dialog.tsx
+++ b/apps/ui/src/components/shared/protolabs-report/protolabs-report-dialog.tsx
@@ -64,6 +64,7 @@ export function ProtoLabsReportDialog({
   const runPipeline = useCallback(
     async (startFrom?: PipelineStep) => {
       const api = getElectronAPI();
+      let currentStep: PipelineStep = startFrom ?? 'researching';
       setError(null);
       setFailedStep(null);
 
@@ -71,6 +72,7 @@ export function ProtoLabsReportDialog({
         // Step 1: Research
         let researchResult = research;
         if (!startFrom || startFrom === 'researching') {
+          currentStep = 'researching';
           setStep('researching');
           const res = await api.setupLab.research(projectPath);
           if (!res.success || !res.research) {
@@ -83,6 +85,7 @@ export function ProtoLabsReportDialog({
         // Step 2: Gap Analysis
         let gapResult = gapReport;
         if (!startFrom || startFrom === 'researching' || startFrom === 'analyzing') {
+          currentStep = 'analyzing';
           setStep('analyzing');
           const res = await api.setupLab.gapAnalysis(projectPath, researchResult!);
           if (!res.success || !res.report) {
@@ -93,6 +96,7 @@ export function ProtoLabsReportDialog({
         }
 
         // Step 3: Generate Report
+        currentStep = 'generating';
         setStep('generating');
         const reportRes = await api.setupLab.report(projectPath, researchResult!, gapResult!);
         if (!reportRes.success || !reportRes.outputPath) {
@@ -105,11 +109,11 @@ export function ProtoLabsReportDialog({
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
         setError(message);
-        setFailedStep(step);
+        setFailedStep(currentStep);
         setStep('error');
       }
     },
-    [projectPath, research, gapReport, step]
+    [projectPath, research, gapReport]
   );
 
   const handleRetry = useCallback(() => {


### PR DESCRIPTION
## Summary
- Fixed stale closure bug where `setFailedStep(step)` captured the render-time React state value instead of the actual in-flight pipeline step
- Introduced local `currentStep` variable to track the active step through the async pipeline
- Removed `step` from useCallback dependency array since it's no longer referenced in the callback body

**Bug**: When the pipeline errored at e.g. the "analyzing" step, `failedStep` would be set to `'idle'` (the render-time value) instead of `'analyzing'`, breaking retry-from-failed-step logic.

## Test plan
- [ ] Open ProtoLabs Report dialog on a project
- [ ] Simulate a failure (e.g. disconnect network during gap analysis)
- [ ] Verify retry button restarts from the correct failed step, not from the beginning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting accuracy for pipeline operations by enhancing step tracking during execution, ensuring errors are correctly attributed to the step where they occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->