### PR TITLE
feat: notes panel AI enhancements — autocomplete threshold + pipeline actions

### DIFF
--- a/apps/server/src/routes/ai/index.ts
+++ b/apps/server/src/routes/ai/index.ts
@@ -39,9 +39,10 @@ export function createAIRoutes(): Router {
    */
   router.post('/complete', async (req: Request, res: Response) => {
     try {
-      const { context, currentLine } = req.body as {
+      const { context, currentLine, projectContext } = req.body as {
         context?: string;
         currentLine?: string;
+        projectContext?: string;
       };
 
       if (!currentLine && !context) {
@@ -56,8 +57,16 @@ export function createAIRoutes(): Router {
       // Limit context to last ~2000 chars to keep latency low
       const trimmedContext = contextText.slice(-2000);
 
+      // Optionally include project context for domain-aware predictions
+      const projectHint = projectContext
+        ? `\n- Use the project context to make relevant predictions that fit the project domain`
+        : '';
+      const projectSection = projectContext
+        ? `Project context:\n${stripHtml(projectContext).slice(0, 500)}\n\n`
+        : '';
+
       logger.debug(
-        `AI complete: context=${trimmedContext.length}chars, line="${lineText.slice(0, 50)}"`
+        `AI complete: context=${trimmedContext.length}chars, line="${lineText.slice(0, 50)}", projectContext=${projectContext ? 'yes' : 'no'}`
       );
 
       const result = streamText({
@@ -68,13 +77,13 @@ export function createAIRoutes(): Router {
 - Match the tone, style, and vocabulary of the existing text
 - Keep predictions concise and natural
 - Do not include any formatting, markdown, or HTML
-- If the context is too ambiguous, output nothing`,
+- If the context is too ambiguous, output nothing${projectHint}`,
         messages: [
           {
             role: 'user',
             content: trimmedContext
-              ? `Preceding text:\n${trimmedContext}\n\nCurrent line being typed:\n${lineText}\n\nContinue naturally:`
-              : `Current line being typed:\n${lineText}\n\nContinue naturally:`,
+              ? `${projectSection}Preceding text:\n${trimmedContext}\n\nCurrent line being typed:\n${lineText}\n\nContinue naturally:`
+              : `${projectSection}Current line being typed:\n${lineText}\n\nContinue naturally:`,
           },
         ],
         maxOutputTokens: 60,

--- a/apps/ui/src/components/views/notes-view/ai-bubble-menu.tsx
+++ b/apps/ui/src/components/views/notes-view/ai-bubble-menu.tsx
@@ -7,8 +7,22 @@
 
 import { useState, useCallback } from 'react';
 import { BubbleMenu, type Editor } from '@tiptap/react';
-import { Wand2, Shrink, SpellCheck, Briefcase, Expand, Loader2, SendHorizonal } from 'lucide-react';
+import {
+  Wand2,
+  Shrink,
+  SpellCheck,
+  Briefcase,
+  Expand,
+  Loader2,
+  SendHorizonal,
+  FileText,
+  Megaphone,
+  BookOpen,
+  Lightbulb,
+} from 'lucide-react';
+import { toast } from 'sonner';
 import { getHttpApiClient } from '@/lib/http-api-client';
+import { useAppStore } from '@/store/app-store';
 
 interface AIBubbleMenuProps {
   editor: Editor;
@@ -30,6 +44,13 @@ const PRESET_ACTIONS = [
     instruction: 'Rewrite in a professional tone',
   },
   { id: 'expand', label: 'Expand', icon: Expand, instruction: 'Expand with more detail' },
+] as const;
+
+const PIPELINE_ACTIONS = [
+  { id: 'blog', label: 'Blog Post', icon: FileText, format: 'guide', tone: 'conversational' },
+  { id: 'social', label: 'Social', icon: Megaphone, format: 'guide', tone: 'conversational' },
+  { id: 'docs', label: 'Docs', icon: BookOpen, format: 'reference', tone: 'technical' },
+  { id: 'idea', label: 'Idea', icon: Lightbulb },
 ] as const;
 
 export function AIBubbleMenu({ editor }: AIBubbleMenuProps) {
@@ -110,6 +131,46 @@ export function AIBubbleMenu({ editor }: AIBubbleMenuProps) {
     [handleCustomSubmit]
   );
 
+  const handleSendToPipeline = useCallback(
+    async (action: (typeof PIPELINE_ACTIONS)[number]) => {
+      const { from, to } = editor.state.selection;
+      const selectedText = editor.state.doc.textBetween(from, to, ' ');
+      if (!selectedText.trim()) return;
+
+      const projectPath = useAppStore.getState().currentProject?.path;
+      if (!projectPath) {
+        toast.error('No project selected');
+        return;
+      }
+
+      setIsLoading(true);
+      try {
+        const client = getHttpApiClient();
+        if (action.id === 'idea') {
+          await client.authorityPipeline.injectIdea(
+            projectPath,
+            selectedText.slice(0, 100),
+            selectedText
+          );
+        } else {
+          await client.contentPipeline.create(projectPath, selectedText, {
+            format: 'format' in action ? action.format : undefined,
+            tone: 'tone' in action ? action.tone : undefined,
+            audience: 'intermediate',
+          });
+        }
+        const label = action.id === 'idea' ? 'Idea pipeline' : `${action.label} pipeline`;
+        toast.success(`Sent to ${label}`);
+        editor.commands.setTextSelection(to);
+      } catch {
+        toast.error('Failed to send to pipeline');
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [editor]
+  );
+
   return (
     <BubbleMenu
       editor={editor}
@@ -167,6 +228,23 @@ export function AIBubbleMenu({ editor }: AIBubbleMenuProps) {
               <SendHorizonal className="size-3" />
             )}
           </button>
+        </div>
+
+        {/* Send to pipeline */}
+        <div className="flex items-center gap-0.5 border-t border-border pt-1">
+          <span className="px-2 text-[10px] text-muted-foreground/60">Send to</span>
+          {PIPELINE_ACTIONS.map((action) => (
+            <button
+              key={action.id}
+              onClick={() => handleSendToPipeline(action)}
+              disabled={isLoading}
+              className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+              title={`Send to ${action.label} pipeline`}
+            >
+              <action.icon className="size-3" />
+              <span>{action.label}</span>
+            </button>
+          ))}
         </div>
       </div>
     </BubbleMenu>

--- a/apps/ui/src/components/views/notes-view/extensions/ghost-text.ts
+++ b/apps/ui/src/components/views/notes-view/extensions/ghost-text.ts
@@ -21,8 +21,16 @@ interface GhostTextState {
 }
 
 export interface GhostTextOptions {
-  /** Function that fetches a completion given context and current line */
-  fetchCompletion: (context: string, currentLine: string) => Promise<string | null>;
+  /** Function that fetches a completion given context, current line, and optional project context */
+  fetchCompletion: (
+    context: string,
+    currentLine: string,
+    projectContext?: string | null
+  ) => Promise<string | null>;
+  /** Minimum total document chars before autocomplete activates (default: 100) */
+  minDocLength?: number;
+  /** Callback returning project context string for domain-aware predictions */
+  getProjectContext?: () => string | null;
 }
 
 export const GhostText = Extension.create<GhostTextOptions>({
@@ -35,7 +43,7 @@ export const GhostText = Extension.create<GhostTextOptions>({
   },
 
   addProseMirrorPlugins() {
-    const { fetchCompletion } = this.options;
+    const { fetchCompletion, minDocLength = 100, getProjectContext } = this.options;
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
     let abortController: AbortController | null = null;
 
@@ -114,13 +122,20 @@ export const GhostText = Extension.create<GhostTextOptions>({
               // Don't trigger on empty lines
               if (!currentLine.trim()) return;
 
+              // Don't trigger until the document has enough content
+              const totalDocLength = doc.textContent.length;
+              if (totalDocLength < minDocLength) return;
+
               // Get preceding context (up to ~2000 chars before current block)
               const contextStart = Math.max(0, blockStart - 2000);
               const context = doc.textBetween(contextStart, blockStart, '\n', '');
 
+              // Get project context for domain-aware predictions
+              const projectContext = getProjectContext?.() ?? null;
+
               try {
                 abortController = new AbortController();
-                const suggestion = await fetchCompletion(context, currentLine);
+                const suggestion = await fetchCompletion(context, currentLine, projectContext);
 
                 // Verify editor state hasn't changed while we were fetching
                 if (editorView.state.selection.head !== pos) return;

--- a/apps/ui/src/components/views/notes-view/tiptap-editor.tsx
+++ b/apps/ui/src/components/views/notes-view/tiptap-editor.tsx
@@ -13,6 +13,7 @@ import {
 import { SlashCommandList, type SlashCommandListRef } from './slash-command-list';
 import { AIBubbleMenu } from './ai-bubble-menu';
 import { getHttpApiClient } from '@/lib/http-api-client';
+import { useAppStore } from '@/store/app-store';
 
 interface TiptapEditorProps {
   content: string;
@@ -68,6 +69,15 @@ async function readFullStream(response: Response): Promise<string> {
 
 export function TiptapEditor({ content, onUpdate, onEditorReady }: TiptapEditorProps) {
   const editorRef = useRef<Editor | null>(null);
+  const appSpec = useAppStore((s) => s.appSpec);
+  const currentProject = useAppStore((s) => s.currentProject);
+
+  const getProjectContext = useCallback(() => {
+    const parts: string[] = [];
+    if (currentProject?.name) parts.push(`Project: ${currentProject.name}`);
+    if (appSpec) parts.push(appSpec.slice(0, 500));
+    return parts.length > 0 ? parts.join('\n') : null;
+  }, [appSpec, currentProject]);
 
   // Handle AI slash commands via custom event
   useEffect(() => {
@@ -100,9 +110,19 @@ export function TiptapEditor({ content, onUpdate, onEditorReady }: TiptapEditorP
   const ghostTextExtension = useMemo(
     () =>
       GhostText.configure({
-        fetchCompletion: async (context: string, currentLine: string) => {
+        minDocLength: 100,
+        getProjectContext,
+        fetchCompletion: async (
+          context: string,
+          currentLine: string,
+          projectContext?: string | null
+        ) => {
           try {
-            const response = await getHttpApiClient().ai.complete(context, currentLine);
+            const response = await getHttpApiClient().ai.complete(
+              context,
+              currentLine,
+              projectContext
+            );
             if (!response.ok) return null;
             const text = await readStream(response);
             return text || null;
@@ -111,7 +131,7 @@ export function TiptapEditor({ content, onUpdate, onEditorReady }: TiptapEditorP
           }
         },
       }),
-    []
+    [getProjectContext]
   );
 
   const slashCommandsExtension = useMemo(

--- a/apps/ui/src/lib/http-api-client.ts
+++ b/apps/ui/src/lib/http-api-client.ts
@@ -2653,12 +2653,20 @@ export class HttpApiClient implements ElectronAPI {
   // AI Editor API (streaming endpoints for notes panel AI features)
   ai = {
     /** Ghost text autocomplete — returns a ReadableStream of predicted text */
-    complete: (context: string, currentLine: string): Promise<Response> =>
+    complete: (
+      context: string,
+      currentLine: string,
+      projectContext?: string | null
+    ): Promise<Response> =>
       fetch(`${this.serverUrl}/api/ai/complete`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ context, currentLine }),
+        body: JSON.stringify({
+          context,
+          currentLine,
+          projectContext: projectContext || undefined,
+        }),
       }),
 
     /** Rewrite selected text — returns a ReadableStream of replacement HTML */
@@ -2678,6 +2686,26 @@ export class HttpApiClient implements ElectronAPI {
         credentials: 'include',
         body: JSON.stringify({ command, context, selection }),
       }),
+  };
+
+  // Content Pipeline API — route text to Jon/Cindi for content creation
+  contentPipeline = {
+    create: (
+      projectPath: string,
+      topic: string,
+      contentConfig?: { format?: string; tone?: string; audience?: string }
+    ): Promise<{ success: boolean; runId?: string; error?: string }> =>
+      this.post('/api/content/create', { projectPath, topic, contentConfig }),
+  };
+
+  // Authority Pipeline API — route ideas to the PM agent
+  authorityPipeline = {
+    injectIdea: (
+      projectPath: string,
+      title: string,
+      description: string
+    ): Promise<{ success: boolean; feature?: unknown; message?: string; error?: string }> =>
+      this.post('/api/authority/inject-idea', { projectPath, title, description }),
   };
 
   // Backlog Plan API


### PR DESCRIPTION
## Summary

- Ghost text autocomplete now requires 100+ chars before activating, preventing eager triggers on near-empty documents
- Autocomplete sends project context (name + spec) to Haiku for domain-aware predictions instead of generic continuations
- Bubble menu gains a "Send to" row with Blog Post, Social, Docs, and Idea pipeline actions for routing highlighted text

## Changes

| File | Change |
|------|--------|
| `extensions/ghost-text.ts` | `minDocLength` threshold + `getProjectContext` callback in options |
| `tiptap-editor.tsx` | Wires app store project context into ghost text config |
| `ai-bubble-menu.tsx` | Pipeline action row (Blog, Social, Docs, Idea) with toast feedback |
| `http-api-client.ts` | `projectContext` param on `ai.complete()`, new `contentPipeline` + `authorityPipeline` sections |
| `routes/ai/index.ts` | Accepts `projectContext`, injects into system prompt + user message |

## Test plan

- [ ] Type < 100 chars in notes — no ghost text should appear
- [ ] Type 100+ chars — ghost text resumes on next line
- [ ] With project spec loaded, verify autocomplete uses project-specific terminology
- [ ] Select text → bubble menu shows "Send to" row → click Blog Post → verify content flow starts
- [ ] Select text → click Idea → verify feature created with `workItemState: 'idea'`
- [ ] Existing rewrite/shorten/fix/expand/custom actions still work
- [ ] Slash commands unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added "Send to Pipeline" feature to route selected text to Blog Post, Social Media, Documentation, or Ideas workflows
  - AI suggestions now leverage project context for more relevant and contextual recommendations

* **Improvements**
  - Enhanced AI ghost text with minimum document length requirement for activation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->