### PR TITLE
fix: guard ms.phases.length in PRD review dialog

### DIFF
--- a/apps/ui/src/components/views/flow-graph/dialogs/prd-review-dialog.tsx
+++ b/apps/ui/src/components/views/flow-graph/dialogs/prd-review-dialog.tsx
@@ -295,9 +295,11 @@ export function PrdReviewDialog({
                   {milestones.map((ms: any, i: number) => (
                     <div key={i} className="text-sm p-2 rounded bg-muted/30">
                       <span className="font-medium">{ms.title}</span>
-                      <span className="text-muted-foreground ml-2">
-                        ({ms.phases.length} phase{ms.phases.length !== 1 ? 's' : ''})
-                      </span>
+                      {ms.phases?.length > 0 && (
+                        <span className="text-muted-foreground ml-2">
+                          ({ms.phases.length} phase{ms.phases.length !== 1 ? 's' : ''})
+                        </span>
+                      )}
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
## Summary
- Guards `ms.phases.length` with optional chaining to prevent crash when WebSocket milestone data lacks a `phases` array

## Test plan
- [ ] Submit a signal via analytics flow graph, wait for PRD review dialog
- [ ] Milestones without phases render without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)