### PR TITLE
fix: archival service falls back to status history when completedAt missing

### DIFF
--- a/apps/server/src/services/archival-service.ts
+++ b/apps/server/src/services/archival-service.ts
@@ -125,8 +125,17 @@ export class ArchivalService {
     for (const feature of completedFeatures) {
       if (this.aborted) break;
 
-      // Check retention period
-      const completedAt = feature.completedAt ? new Date(feature.completedAt).getTime() : undefined;
+      // Check retention period — use completedAt, fall back to last status transition timestamp
+      let completedAt = feature.completedAt ? new Date(feature.completedAt).getTime() : undefined;
+      if (!completedAt) {
+        // Fall back to the timestamp of the last status transition to done/verified
+        const lastDoneTransition = feature.statusHistory
+          ?.filter((t) => t.to === 'done' || t.to === 'verified')
+          .pop();
+        if (lastDoneTransition?.timestamp) {
+          completedAt = new Date(lastDoneTransition.timestamp).getTime();
+        }
+      }
       if (!completedAt || now - completedAt < retentionMs) continue;
 
       // Skip epics with active children


### PR DESCRIPTION
## Summary
- Features marked done before PR #211 (Feb 11) lacked `completedAt` timestamps, causing the archival service to skip them indefinitely
- Now falls back to the last `done`/`verified` status transition timestamp from `statusHistory` when `completedAt` is missing
- Prevents future accumulation of orphaned done features on the board

## Test plan
- [x] Verified archival ran successfully and cleaned up 90+ features after backfilling timestamps
- [ ] Verify features without `completedAt` but with statusHistory get archived after retention period
- [ ] Verify features with `completedAt` still work as before (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced archival eligibility logic to evaluate alternative timestamp sources, allowing items without primary completion timestamps to be considered for archival based on their latest status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->