### PR TITLE
fix: pipeline phase gap causes PRD dialog to never open

### DIFF
--- a/apps/server/src/services/authority-agents/pm-agent.ts
+++ b/apps/server/src/services/authority-agents/pm-agent.ts
@@ -402,6 +402,14 @@ export class PMAuthorityAgent {
         );
         const researchSummary = await this.researchCodebase(feature, projectPath, triage);
 
+        // Signal research phase complete so pipeline advances RESEARCH → SPEC
+        this.events.emit('authority:pm-research-completed', {
+          projectPath,
+          featureId,
+          agentId: agent.id,
+          analysis: { complexity: 'medium' },
+        });
+
         // Step 3: Generate SPARC PRD from research + original idea
         logger.info(`Generating SPARC PRD for idea: "${feature.title}"`);
         const prdResult = await this.generateSPARCPRD(feature, researchSummary, projectPath);

--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -225,17 +225,18 @@ export class SignalIntakeService {
       );
 
       // GTM signals: route to GTM Authority Agent for content creation
+      const projectPath = signal.channelContext?.projectPath || this.defaultProjectPath;
       if (classification.category === 'gtm') {
         logger.info(`GTM signal routed: "${title}" (source: ${signal.source})`);
         this.events.emit('authority:gtm-signal-received', {
-          projectPath: this.defaultProjectPath,
+          projectPath,
           title,
           description,
           source: signal.source,
           timestamp: signal.timestamp,
         });
         this.events.emit('signal:routed', {
-          projectPath: this.defaultProjectPath,
+          projectPath,
           title,
           description,
           category: 'gtm',
@@ -248,7 +249,7 @@ export class SignalIntakeService {
 
       // Ops signals: route to Lead Engineer state machine
       // Create feature with idea state
-      const feature = await this.featureLoader.create(this.defaultProjectPath, {
+      const feature = await this.featureLoader.create(projectPath, {
         title: `[${signal.source}] ${title}`,
         description,
         status: 'backlog',
@@ -259,7 +260,7 @@ export class SignalIntakeService {
 
       // Trigger PM Agent pipeline
       this.events.emit('authority:idea-injected', {
-        projectPath: this.defaultProjectPath,
+        projectPath,
         featureId: feature.id,
         title,
         description,
@@ -271,7 +272,7 @@ export class SignalIntakeService {
 
       // Emit routing event for observability
       this.events.emit('signal:routed', {
-        projectPath: this.defaultProjectPath,
+        projectPath,
         featureId: feature.id,
         title,
         description,


### PR DESCRIPTION
## Summary
- **Root cause**: `processIdea()` emitted `authority:pm-research-started` but never `authority:pm-research-completed`, leaving the pipeline stuck at RESEARCH. When `ideation:prd-generated` fired, the orchestrator checked `currentPhase === 'SPEC'` → false → silently skipped. No gate, no PRD dialog.
- **Fix**: Emit `authority:pm-research-completed` after `researchCodebase()` returns, advancing pipeline RESEARCH → SPEC before PRD generation.
- **Also fixes**: `signal/submit` API silently failing — was using `this.defaultProjectPath` instead of the signal's `channelContext.projectPath`.

## Test plan
- [ ] Submit signal via Signal Sources dialog on /analytics
- [ ] Pipeline progress bar should show TRIAGE → RESEARCH → SPEC → SPEC_REVIEW
- [ ] PRD review dialog should auto-open at SPEC_REVIEW gate
- [ ] Approve PRD → pipeline advances through remaining phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)