### PR TITLE
fix: Linear projectCreate 255-char description limit

### DIFF
--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -1,0 +1,119 @@
+# GTM Signal Intelligence & Content Operations
+
+## Status: Ready to create in Linear (server was down during session)
+
+## Date: 2026-02-21
+
+## Research Completed
+- Codebase deep-research: Full audit of content pipeline, signal intake, monitors, event bus, MCP patterns, OAuth flows
+- External due diligence: Social media APIs, Twitch→YouTube tools, Google Workspace, analytics, competitive landscape
+
+## Vision
+
+Build signal monitoring and content operations infrastructure. Listen before we speak. Monitor incoming engagement across Twitter/X, YouTube, Substack, Twitch. Route signals through existing event bus and GTM pipeline. Establish Twitch→YouTube content pipeline for Mon/Wed/Fri streams.
+
+## What Already Exists (Codebase)
+- **Content creation pipeline**: 7-phase LangGraph flow, 3 antagonistic review gates, HITL, multi-format output
+- **Signal intake service**: Rule-based classifier, ops vs gtm routing, generic SignalPayload interface — EXTENSIBLE
+- **Monitor service pattern**: Discord, GitHub, Linear monitors all follow same polling pattern — TEMPLATE for social monitors
+- **Twitch integration**: MVP shipped (PRs #703-705). !idea command, suggestions, polls, overlay
+- **Discord as aggregation layer**: 20+ MCP tools, keyword detection, channel routing
+- **Event bus**: 347+ event types, GTM events already typed
+- **OAuth pattern**: Linear reference implementation — template for Google Workspace
+- **Pipeline orchestrator**: Has explicit gtm branch with phase mapping
+
+## Critical Gaps
+1. No social media signal sources (Twitter, YouTube, Substack)
+2. No content distribution (pipeline creates but can't publish)
+3. No Google Workspace integration
+4. MCP server monolithic (80+ tools in single index.ts)
+
+## Workstreams (6)
+
+### 1. Signal Monitoring Infrastructure (PRIORITY)
+- SocialMonitor service following DiscordMonitor/GitHubMonitor/LinearMonitor pattern
+- Twitter/X: TwitterAPI.io (~$5/mo pay-as-you-go)
+- YouTube: Data API v3 (free, 10K units/day)
+- Substack: RSS feed polling (free)
+- Wire Twitch into SignalIntakeService (currently siloed)
+- n8n self-hosted on staging for signal aggregation
+- All signals → signal:received → SignalIntakeService → GTM Agent
+
+### 2. Twitch → YouTube Content Pipeline
+- Mon/Wed/Fri 1hr live coding streams
+- OBS → MKV local recording
+- OpusClip for AI clip detection (free 60 min/mo)
+- Gling ($10/mo) for filler word cleanup
+- YouTube Studio / TubeBuddy for scheduling Shorts
+
+### 3. Google Workspace Integration
+- Install taylorwilsdon/google_workspace_mcp (100+ tools, OAuth 2.1)
+- Calendar for scheduling
+- Gmail for email I/O with HITL approval gates
+- Calendar webhooks → Discord reminders
+
+### 4. Content Production
+- Personal blog: "Everywhere all at once: the age of invisible machines"
+- Glyphkit Storybook release (MythXEngine design system)
+- Content pipeline flows via Cindi
+
+### 5. Analytics & Attribution
+- Umami self-hosted on staging ($0)
+- UTM parameter system
+- YouTube Studio + Twitch native analytics
+
+### 6. Infrastructure Hardening
+- Modularize MCP server before adding 20+ new tools
+- Add social sources to SignalIntakeService classification
+- Discord channel structure (#signals-urgent, #signals-engagement)
+
+## External Tool Stack (~$25-50/mo)
+| Tool | Cost | Purpose |
+|------|------|---------|
+| TwitterAPI.io | ~$5/mo | X mention monitoring |
+| YouTube Data API | $0 | Comment monitoring |
+| Substack RSS | $0 | Post monitoring |
+| OpusClip | $0 | AI clip detection |
+| Gling | $10/mo | Filler word cleanup |
+| TubeBuddy | $9/mo | YouTube SEO + scheduling |
+| Umami | $0 | Self-hosted analytics |
+| n8n | $0 | Self-hosted signal routing |
+| Google Workspace MCP | $0 | Calendar + email |
+
+## Architecture
+```
+Twitter mentions (TwitterAPI.io) ──┐
+YouTube comments (Data API poll) ──┤── SocialMonitor / n8n ──> signal:received
+Substack comments (RSS + poll)   ──┤                           │
+Twitch suggestions (existing)    ──┘                           ▼
+                                                        SignalIntakeService
+                                                         (classify: gtm)
+                                                              │
+                                                              ▼
+                                                        GTM Agent (Jon+Cindi)
+                                                              │
+                                                              ▼
+                                                        Discord #signals
+                                                        + Board feature if actionable
+```
+
+## Competitive Intel
+- OpenClaw: 140K stars, personal assistant not dev tool. Gateway+Agent Loop+Heartbeat architecture similar to Automaker
+- Cursor/Windsurf/Devin: Enterprise pivot, $100M+ ARR via product-led growth
+- Lovable: Fastest to $100M ARR in history (~8 months)
+- Build in public: 70/30 rule (70% distribution, 30% building). Revenue transparency. Ship weekly, post daily.
+- Key insight: "The strongest solo companies behave like media businesses first and product businesses second."
+
+## Josh's Content Plans
+- Twitch: Mon/Wed/Fri 1hr live coding + Q&A
+- YouTube: Cut streams into scheduled Shorts
+- Blog: "Everywhere all at once: the age of invisible machines" (personal)
+- Glyphkit: Release Storybook for MythXEngine design system
+- Google Workspace: Calendar + email with HITL
+
+## Dependencies (Josh action items)
+- Google Workspace account setup
+- Twitter/X account access for monitoring API
+- YouTube channel configured
+- Twitch streaming setup (OBS, scenes, overlays)
+- n8n deployment on staging

--- a/apps/server/src/services/linear-mcp-client.ts
+++ b/apps/server/src/services/linear-mcp-client.ts
@@ -217,8 +217,10 @@ export interface DocumentResult {
 export interface CreateProjectOptions {
   /** Project name */
   name: string;
-  /** Project description (markdown) */
+  /** Short project description (max 255 chars). Shown in project list views. */
   description?: string;
+  /** Long-form project content (markdown). Shown on project detail page. */
+  content?: string;
   /** Team IDs to associate with the project */
   teamIds: string[];
 }
@@ -669,18 +671,25 @@ export class LinearMCPClient {
    * @throws {LinearAPIError} On API errors
    */
   async createProject(options: CreateProjectOptions): Promise<CreateProjectResult> {
-    const { name, description, teamIds } = options;
+    const { name, description, content, teamIds } = options;
+
+    // Linear's `description` field has a 255-char limit.
+    // Long content goes in the `content` field (rendered on project detail page).
+    const shortDescription =
+      description && description.length > 255 ? description.substring(0, 252) + '...' : description;
 
     const mutation = `
       mutation CreateProject(
         $name: String!
         $description: String
+        $content: String
         $teamIds: [String!]!
       ) {
         projectCreate(
           input: {
             name: $name
             description: $description
+            content: $content
             teamIds: $teamIds
           }
         ) {
@@ -695,7 +704,8 @@ export class LinearMCPClient {
 
     const variables = {
       name,
-      description,
+      description: shortDescription,
+      content,
       teamIds,
     };
 

--- a/apps/server/src/services/project-lifecycle-service.ts
+++ b/apps/server/src/services/project-lifecycle-service.ts
@@ -87,9 +87,12 @@ export class ProjectLifecycleService {
     }
 
     // Create Linear project
+    // Linear `description` has a 255-char limit; long content goes in `content`
     const result = await client.createProject({
       name: title,
-      description: ideaDescription,
+      description:
+        ideaDescription.length > 255 ? ideaDescription.substring(0, 252) + '...' : ideaDescription,
+      content: ideaDescription.length > 255 ? ideaDescription : undefined,
       teamIds: [teamId],
     });
 


### PR DESCRIPTION
## Summary
- Linear's `description` field on projects has a 255-character max. Long descriptions from `initiate_project` were failing with "Argument Validation Error"
- Now truncates `description` to 255 chars and puts full content in Linear's `content` field (rendered on project detail page)
- Also adds GTM Signal Intelligence research spec to agent memory

## Test plan
- [ ] Create a Linear project via `initiate_project` MCP tool with a description longer than 255 chars
- [ ] Verify project is created with truncated description and full content visible in Linear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for long-form project content. Project descriptions exceeding 255 characters are now automatically split into a condensed description field and a separate content field, preserving the full text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->