### PR TITLE
refactor: move Global Settings to toolbar, remove Theme from sidebar

### DIFF
--- a/.automaker/notes/workspace.json
+++ b/.automaker/notes/workspace.json
@@ -1,9 +1,10 @@
 {
   "version": 1,
-  "activeTabId": "f35b89fb-3cc2-4e1f-8e58-98165c82df08",
+  "activeTabId": "a69c769a-e33e-41fd-b6d2-1d7cd9996f2f",
   "tabOrder": [
     "f35b89fb-3cc2-4e1f-8e58-98165c82df08",
-    "38053e42-0e0d-4793-8c76-1a2eb8eb72a5"
+    "55f88e41-228e-4ce9-b3d3-4bb645404f53",
+    "a69c769a-e33e-41fd-b6d2-1d7cd9996f2f"
   ],
   "tabs": {
     "f35b89fb-3cc2-4e1f-8e58-98165c82df08": {
@@ -21,20 +22,36 @@
         "characterCount": 542
       }
     },
-    "38053e42-0e0d-4793-8c76-1a2eb8eb72a5": {
-      "id": "38053e42-0e0d-4793-8c76-1a2eb8eb72a5",
-      "name": "Tab 2",
-      "content": "<p>testing 1 23 4 5 testing testing 1 2 3</p>",
+    "55f88e41-228e-4ce9-b3d3-4bb645404f53": {
+      "id": "55f88e41-228e-4ce9-b3d3-4bb645404f53",
+      "name": "Ava",
+      "content": "<h2>Ava — Strategic Direction</h2><p>Josh writes priorities here. Ava reads on activation and appends status updates.</p><h3>Status — 2026-02-21</h3><p>Notes tools verified: list, read, create, write (append) all working. Jon tab created (id: a69c769a-e33e-41fd-b6d2-1d7cd9996f2f).</p>",
       "permissions": {
-        "agentRead": false,
+        "agentRead": true,
         "agentWrite": true
       },
       "metadata": {
-        "createdAt": 1771653138808,
-        "updatedAt": 1771653472651,
-        "wordCount": 10,
-        "characterCount": 38
+        "createdAt": 1771715814797,
+        "updatedAt": 1771716029965,
+        "wordCount": 31,
+        "characterCount": 253
+      }
+    },
+    "a69c769a-e33e-41fd-b6d2-1d7cd9996f2f": {
+      "id": "a69c769a-e33e-41fd-b6d2-1d7cd9996f2f",
+      "name": "Jon",
+      "content": "<h2>Jon — GTM Direction</h2><p>Strategic priorities, content calendar, and launch coordination notes. Josh and Ava leave direction here.</p><h3>Current Focus</h3><ul><li>Brand reveal content — draft tweets, announcement posts</li><li>Competitive research — AI dev tools landscape</li><li>Content pipeline — verify end-to-end flow works</li></ul>",
+      "permissions": {
+        "agentRead": true,
+        "agentWrite": true
+      },
+      "metadata": {
+        "createdAt": 1771716024584,
+        "updatedAt": 1771716024584,
+        "wordCount": 37,
+        "characterCount": 284
       }
     }
-  }
+  },
+  "workspaceVersion": 3
 }

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -20,7 +20,6 @@ import {
   QuickActionsBar,
   SidebarHeader,
   SidebarNavigation,
-  SidebarFooter,
   MobileSidebarToggle,
 } from './sidebar/components';
 import { useIsCompact } from '@/hooks/use-media-query';
@@ -296,6 +295,7 @@ export function Sidebar() {
               onDocs={() => getElectronAPI().openExternalLink('https://protolabs.studio/docs')}
               onNewProject={() => setShowNewProjectModal(true)}
               onOpenFolder={handleOpenFolder}
+              onSettings={() => navigate({ to: '/settings' })}
             />
           )}
 
@@ -307,13 +307,6 @@ export function Sidebar() {
             navigate={navigate}
           />
         </div>
-
-        <SidebarFooter
-          sidebarOpen={sidebarOpen}
-          isActiveRoute={isActiveRoute}
-          navigate={navigate}
-          shortcuts={{ settings: shortcuts.settings }}
-        />
 
         {sidebarOpen && (
           <div className="shrink-0 border-t border-border/40 px-4 py-3">

--- a/apps/ui/src/components/layout/sidebar/components/index.ts
+++ b/apps/ui/src/components/layout/sidebar/components/index.ts
@@ -6,7 +6,5 @@ export { SidebarHeader } from './sidebar-header';
 export { ProjectActions } from './project-actions';
 export { SidebarNavigation } from './sidebar-navigation';
 export { ProjectSelectorWithOptions } from './project-selector-with-options';
-export { SidebarFooter } from './sidebar-footer';
-export { ThemeToggleButton } from './theme-toggle-button';
 export { MobileSidebarToggle } from './mobile-sidebar-toggle';
 export { QuickActionsBar } from './quick-actions-bar';

--- a/apps/ui/src/components/layout/sidebar/components/quick-actions-bar.tsx
+++ b/apps/ui/src/components/layout/sidebar/components/quick-actions-bar.tsx
@@ -1,4 +1,4 @@
-import { Bug, BookOpen, Plus, FolderOpen } from 'lucide-react';
+import { Bug, BookOpen, Plus, FolderOpen, Settings } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface QuickActionsBarProps {
@@ -6,6 +6,7 @@ interface QuickActionsBarProps {
   onDocs: () => void;
   onNewProject: () => void;
   onOpenFolder: () => void;
+  onSettings: () => void;
 }
 
 const actions = [
@@ -13,6 +14,7 @@ const actions = [
   { key: 'docs', icon: BookOpen, label: 'Documentation', testId: 'quick-action-docs' },
   { key: 'new', icon: Plus, label: 'New Project', testId: 'quick-action-new' },
   { key: 'open', icon: FolderOpen, label: 'Open Folder', testId: 'quick-action-open' },
+  { key: 'settings', icon: Settings, label: 'Global Settings', testId: 'quick-action-settings' },
 ] as const;
 
 export function QuickActionsBar({
@@ -20,12 +22,14 @@ export function QuickActionsBar({
   onDocs,
   onNewProject,
   onOpenFolder,
+  onSettings,
 }: QuickActionsBarProps) {
   const handlers: Record<string, () => void> = {
     bug: onBugReport,
     docs: onDocs,
     new: onNewProject,
     open: onOpenFolder,
+    settings: onSettings,
   };
 
   return (


### PR DESCRIPTION
## Summary

- Remove Theme toggle button from sidebar footer
- Move Global Settings to the QuickActionsBar toolbar (bug/docs/+/open/settings)
- Remove now-empty `SidebarFooter` component from render
- Clean up unused barrel exports (`SidebarFooter`, `ThemeToggleButton`)

## Test plan

- [ ] Sidebar no longer shows Theme toggle at the bottom
- [ ] Global Settings gear icon appears in the toolbar row at the top
- [ ] Clicking the gear icon navigates to `/settings`
- [ ] Global Settings keyboard shortcut (`S`) still works
- [ ] Collapsed sidebar still functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Settings button to the quick actions bar for easy access to application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->