### PR TITLE
feat: close release gaps — pair review, HITL resume, escalation, EM bridge

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -687,7 +687,8 @@ const emAgent = new EMAuthorityAgent(
   featureLoader,
   autoModeService,
   auditService,
-  settingsService
+  settingsService,
+  hitlFormService
 );
 
 // Initialize Linear approval detection + bridge to CoS pipeline

--- a/apps/server/src/routes/escalation.ts
+++ b/apps/server/src/routes/escalation.ts
@@ -97,11 +97,17 @@ export function createEscalationRoutes(escalationRouter: EscalationRouter): Rout
         return;
       }
 
-      // For now, we'll log the acknowledgment
-      // In the future, this could update the log entry or emit an event
-      logger.info(
-        `Signal ${signalId} acknowledged by ${acknowledgedBy}${notes ? `: ${notes}` : ''}`
+      const result = escalationRouter.acknowledgeSignal(
+        signalId,
+        acknowledgedBy,
+        notes,
+        req.body.clearDedup === true
       );
+
+      if (!result.success) {
+        res.status(404).json({ success: false, error: result.error });
+        return;
+      }
 
       res.json({
         success: true,

--- a/apps/server/src/routes/flows/routes/resume.ts
+++ b/apps/server/src/routes/flows/routes/resume.ts
@@ -11,7 +11,7 @@ export interface ResumeRequest {
   hitlFeedback: string;
 }
 
-export function createResumeHandler(_reviewService: AntagonisticReviewService) {
+export function createResumeHandler(reviewService: AntagonisticReviewService) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
       const { threadId, hitlFeedback } = req.body as ResumeRequest;
@@ -27,13 +27,8 @@ export function createResumeHandler(_reviewService: AntagonisticReviewService) {
         return;
       }
 
-      // TODO: Implement resume logic when HITL (Human-in-the-Loop) support is added
-      // For now, return a placeholder response indicating the feature is not yet implemented
-      res.status(501).json({
-        success: false,
-        error:
-          'Resume functionality is not yet implemented. HITL interrupts are not currently supported.',
-      });
+      const result = await reviewService.resumeReview(threadId, hitlFeedback);
+      res.json(result);
     } catch (error) {
       logError(error, 'Resume antagonistic review flow failed');
       res.status(500).json({ success: false, error: getErrorMessage(error) });

--- a/apps/server/src/services/antagonistic-review-adapter.ts
+++ b/apps/server/src/services/antagonistic-review-adapter.ts
@@ -40,6 +40,8 @@ export interface ConsolidatedReview {
   totalDurationMs: number;
   totalCost?: number;
   traceId?: string;
+  threadId?: string;
+  hitlPending?: boolean;
   error?: string;
 }
 
@@ -62,11 +64,23 @@ export interface AdapterConfig {
 }
 
 /**
+ * Stored graph instance for HITL resume
+ */
+interface ActiveReview {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  graph: any;
+  traceId: string;
+  startTime: number;
+  prd: SPARCPrd;
+}
+
+/**
  * AntagonisticReviewAdapter - wraps flow execution with legacy interface
  */
 export class AntagonisticReviewAdapter {
   private config: AdapterConfig;
   private langfuse: LangfuseClient | null;
+  private activeReviews: Map<string, ActiveReview> = new Map();
 
   constructor(config: AdapterConfig = {}) {
     this.config = {
@@ -121,13 +135,52 @@ export class AntagonisticReviewAdapter {
         maxTokens: 8192,
       });
 
+      // Use thread ID for checkpointing (required for HITL resume)
+      const threadId = uuidv4();
+      const config = { configurable: { thread_id: threadId } };
+
       // Execute the flow with PRD state + injected models
-      const result = await graph.invoke({
-        prd,
-        hitlRequired: this.config.enableHITL,
-        smartModel,
-        fastModel: undefined,
-      });
+      const result = await graph.invoke(
+        {
+          prd,
+          hitlRequired: this.config.enableHITL,
+          smartModel,
+          fastModel: undefined,
+        },
+        config
+      );
+
+      // Check if graph paused at HITL interrupt
+      if (this.config.enableHITL) {
+        const snapshot = await graph.getState(config);
+        if (snapshot.next && snapshot.next.length > 0) {
+          // Graph interrupted — store for resume
+          this.activeReviews.set(threadId, { graph, traceId, startTime, prd });
+
+          const totalDurationMs = Date.now() - startTime;
+          const avaReview = this.extractAvaReview(result);
+          const jonReview = this.extractJonReview(result);
+          const resolution =
+            result.finalVerdict || result.consolidatedReview?.synthesizedReview || '';
+          const finalPRD = result.consolidatedPrd || this.extractFinalPRD(resolution, prd);
+
+          logger.info(
+            `Review paused for HITL at node(s): ${snapshot.next.join(', ')} (thread: ${threadId})`
+          );
+
+          return {
+            success: true,
+            avaReview,
+            jonReview,
+            resolution,
+            finalPRD,
+            totalDurationMs,
+            traceId,
+            threadId,
+            hitlPending: true,
+          };
+        }
+      }
 
       const totalDurationMs = Date.now() - startTime;
 
@@ -250,6 +303,95 @@ export class AntagonisticReviewAdapter {
         totalDurationMs,
         totalCost: 0,
         traceId,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Resume a review that was paused for HITL input.
+   *
+   * @param threadId - Thread ID from the paused review
+   * @param feedback - Human feedback to inject into graph state
+   */
+  async resumeReview(threadId: string, feedback: string): Promise<ConsolidatedReview> {
+    const active = this.activeReviews.get(threadId);
+    if (!active) {
+      throw new Error(`No active review found for thread ${threadId}. It may have expired.`);
+    }
+
+    const { graph, traceId, startTime, prd } = active;
+    const config = { configurable: { thread_id: threadId } };
+
+    logger.info(`Resuming review for thread ${threadId} with HITL feedback`);
+
+    try {
+      // Inject HITL feedback into checkpoint state
+      await graph.updateState(config, { hitlFeedback: feedback });
+
+      // Resume execution from the interrupt point
+      const result = await graph.invoke(null, config);
+
+      const totalDurationMs = Date.now() - startTime;
+
+      // Clean up stored graph
+      this.activeReviews.delete(threadId);
+
+      if (result.error) {
+        throw new Error(result.error);
+      }
+
+      const avaReview = this.extractAvaReview(result);
+      const jonReview = this.extractJonReview(result);
+      const resolution = result.finalVerdict || result.consolidatedReview?.synthesizedReview || '';
+      const finalPRD = result.consolidatedPrd || this.extractFinalPRD(resolution, prd);
+
+      // Flush Langfuse events
+      await this.langfuse?.flush();
+
+      logger.info(`Resumed review completed in ${totalDurationMs}ms (thread: ${threadId})`);
+
+      return {
+        success: true,
+        avaReview,
+        jonReview,
+        resolution,
+        finalPRD,
+        totalDurationMs,
+        traceId,
+        threadId,
+        hitlPending: false,
+      };
+    } catch (error) {
+      const totalDurationMs = Date.now() - startTime;
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      // Clean up on failure
+      this.activeReviews.delete(threadId);
+
+      logger.error(`Resume failed for thread ${threadId}: ${errorMessage}`);
+
+      return {
+        success: false,
+        avaReview: {
+          success: false,
+          reviewer: 'ava',
+          verdict: '',
+          durationMs: 0,
+          error: errorMessage,
+        },
+        jonReview: {
+          success: false,
+          reviewer: 'jon',
+          verdict: '',
+          durationMs: 0,
+          error: errorMessage,
+        },
+        resolution: '',
+        totalDurationMs,
+        traceId,
+        threadId,
+        hitlPending: false,
         error: errorMessage,
       };
     }

--- a/apps/server/src/services/antagonistic-review-service.ts
+++ b/apps/server/src/services/antagonistic-review-service.ts
@@ -46,6 +46,10 @@ export interface ConsolidatedReview {
   resolution: string;
   finalPRD?: SPARCPrd;
   totalDurationMs: number;
+  totalCost?: number;
+  traceId?: string;
+  threadId?: string;
+  hitlPending?: boolean;
   error?: string;
 }
 
@@ -268,6 +272,20 @@ export class AntagonisticReviewService {
         error: errorMessage,
       };
     }
+  }
+
+  /**
+   * Resume a review that was paused for HITL input
+   */
+  async resumeReview(threadId: string, hitlFeedback: string): Promise<ConsolidatedReview> {
+    await this.ensureInitialized();
+
+    if (!this.adapter) {
+      throw new Error('Flow adapter not available — cannot resume review');
+    }
+
+    logger.info(`Resuming review for thread ${threadId}`);
+    return this.adapter.resumeReview(threadId, hitlFeedback);
   }
 
   /**

--- a/apps/server/src/services/authority-agents/em-agent.ts
+++ b/apps/server/src/services/authority-agents/em-agent.ts
@@ -23,6 +23,7 @@ import type { AutoModeService } from '../auto-mode-service.js';
 import { githubMergeService } from '../github-merge-service.js';
 import type { AuditService } from '../audit-service.js';
 import type { SettingsService } from '../settings-service.js';
+import type { HITLFormService } from '../hitl-form-service.js';
 import {
   createAgentState,
   initializeAgent,
@@ -50,6 +51,7 @@ export class EMAuthorityAgent {
   private readonly autoModeService: AutoModeService;
   private readonly auditService: AuditService;
   private readonly settingsService: SettingsService;
+  private readonly hitlFormService: HITLFormService | null;
 
   /** Agent state (agents, initialization, processing tracking, poll timers) */
   private readonly state: AgentState<EMCustomState>;
@@ -60,7 +62,8 @@ export class EMAuthorityAgent {
     featureLoader: FeatureLoader,
     autoModeService: AutoModeService,
     auditService: AuditService,
-    settingsService: SettingsService
+    settingsService: SettingsService,
+    hitlFormService?: HITLFormService
   ) {
     this.events = events;
     this.authorityService = authorityService;
@@ -68,6 +71,7 @@ export class EMAuthorityAgent {
     this.autoModeService = autoModeService;
     this.auditService = auditService;
     this.settingsService = settingsService;
+    this.hitlFormService = hitlFormService || null;
     this.state = createAgentState<EMCustomState>({
       pollTimers: new Map(),
     });
@@ -394,7 +398,15 @@ export class EMAuthorityAgent {
 
         if (assignDecision.verdict === 'require_approval') {
           logger.info(`Assignment requires approval for ${feature.id}`);
-          return;
+          const approved = await this.requestHITLApproval(
+            projectPath,
+            feature,
+            `Approve assigning "${feature.title}" (complexity: ${feature.complexity || 'medium'}) for agent execution?`
+          );
+          if (!approved) {
+            logger.info(`Assignment denied via HITL for ${feature.id}`);
+            return;
+          }
         }
 
         // Step 3: Propose transition ready → in_progress
@@ -417,7 +429,15 @@ export class EMAuthorityAgent {
 
         if (startDecision.verdict === 'require_approval') {
           logger.info(`Start transition requires approval for ${feature.id}`);
-          return;
+          const approved = await this.requestHITLApproval(
+            projectPath,
+            feature,
+            `Approve starting execution of "${feature.title}"?`
+          );
+          if (!approved) {
+            logger.info(`Start transition denied via HITL for ${feature.id}`);
+            return;
+          }
         }
 
         // Transition approved - update workItemState and trigger auto-mode
@@ -465,6 +485,87 @@ export class EMAuthorityAgent {
     if (wordCount > 300) return 'large';
     if (wordCount > 100) return 'medium';
     return 'small';
+  }
+
+  /**
+   * Request human approval via HITL form.
+   * Returns true if approved, false if denied or timed out.
+   */
+  private async requestHITLApproval(
+    projectPath: string,
+    feature: Feature,
+    question: string
+  ): Promise<boolean> {
+    if (!this.hitlFormService) {
+      logger.debug('No HITLFormService available, auto-denying approval request');
+      return false;
+    }
+
+    const form = this.hitlFormService.create({
+      title: `EM: Approve Feature Assignment`,
+      description: question,
+      steps: [
+        {
+          title: 'Decision',
+          description: `Feature: "${feature.title}" (${feature.id})`,
+          schema: {
+            type: 'object',
+            properties: {
+              decision: {
+                type: 'string',
+                title: 'Decision',
+                enum: ['approve', 'deny'],
+              },
+            },
+            required: ['decision'],
+          },
+          uiSchema: {
+            decision: { 'ui:widget': 'radio' },
+          },
+        },
+      ],
+      callerType: 'agent',
+      featureId: feature.id,
+      projectPath,
+      ttlSeconds: 300,
+    });
+
+    logger.info(`HITL approval form created: ${form.id} for feature ${feature.id}`);
+
+    const response = await this.waitForFormResponse(form.id, 300_000);
+    return response?.[0]?.decision === 'approve';
+  }
+
+  /**
+   * Wait for a HITL form response with timeout.
+   */
+  private waitForFormResponse(
+    formId: string,
+    timeoutMs: number
+  ): Promise<Record<string, unknown>[] | null> {
+    return new Promise((resolve) => {
+      let settled = false;
+      const unsub = this.events.subscribe((type, payload) => {
+        if (settled) return;
+        const p = payload as {
+          formId: string;
+          cancelled: boolean;
+          response?: Record<string, unknown>[];
+        };
+        if (type === 'hitl:form-responded' && p.formId === formId) {
+          settled = true;
+          unsub();
+          resolve(p.cancelled ? null : (p.response ?? null));
+        }
+      });
+      setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          unsub();
+          resolve(null);
+        }
+      }, timeoutMs);
+    });
   }
 
   getAgent(projectPath: string): AuthorityAgent | null {

--- a/apps/server/src/services/escalation-router.ts
+++ b/apps/server/src/services/escalation-router.ts
@@ -27,6 +27,10 @@ export interface EscalationLogEntry {
   routedTo: string[];
   deduplicated: boolean;
   rateLimited: string[];
+  acknowledged?: boolean;
+  acknowledgedBy?: string;
+  acknowledgedAt?: string;
+  acknowledgeNotes?: string;
 }
 
 /**
@@ -280,6 +284,53 @@ export class EscalationRouter {
     if (this.signalLog.length > this.MAX_LOG_ENTRIES) {
       this.signalLog = this.signalLog.slice(-this.MAX_LOG_ENTRIES);
     }
+  }
+
+  /**
+   * Acknowledge a signal by its deduplication key.
+   * Finds the most recent matching log entry and marks it acknowledged.
+   * Optionally clears the dedup window so the signal can re-fire.
+   */
+  acknowledgeSignal(
+    deduplicationKey: string,
+    acknowledgedBy: string,
+    notes?: string,
+    clearDedup = false
+  ): { success: boolean; error?: string } {
+    // Find the most recent log entry matching this key
+    const entry = [...this.signalLog]
+      .reverse()
+      .find((e) => e.signal.deduplicationKey === deduplicationKey);
+
+    if (!entry) {
+      return { success: false, error: `No signal found with key "${deduplicationKey}"` };
+    }
+
+    if (entry.acknowledged) {
+      return { success: false, error: `Signal already acknowledged by ${entry.acknowledgedBy}` };
+    }
+
+    entry.acknowledged = true;
+    entry.acknowledgedBy = acknowledgedBy;
+    entry.acknowledgedAt = new Date().toISOString();
+    entry.acknowledgeNotes = notes;
+
+    // Optionally clear dedup window so signal can re-fire if it recurs
+    if (clearDedup) {
+      this.recentSignals.delete(deduplicationKey);
+    }
+
+    logger.info(`Signal acknowledged: ${deduplicationKey} by ${acknowledgedBy}`);
+
+    if (this.events) {
+      this.events.emit('escalation:acknowledged', {
+        deduplicationKey,
+        acknowledgedBy,
+        notes,
+      });
+    }
+
+    return { success: true };
   }
 
   /**

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -2302,6 +2302,19 @@ export class LeadEngineerService {
             status: 'backlog',
           });
           logger.info(`Reset feature ${action.featureId}: ${action.reason}`);
+
+          this.events.emit('escalation:signal-received', {
+            source: 'lead_engineer',
+            severity: 'medium',
+            type: 'feature_reset',
+            context: {
+              featureId: action.featureId,
+              projectPath: session.projectPath,
+              reason: action.reason,
+            },
+            deduplicationKey: `reset_feature_${action.featureId}`,
+            timestamp: new Date().toISOString(),
+          });
         } catch (err) {
           logger.error(`Failed to reset feature ${action.featureId}:`, err);
         }
@@ -2429,6 +2442,19 @@ export class LeadEngineerService {
             featureId: action.featureId,
             action: 'abort_and_resume',
             reason: action.resumePrompt,
+          });
+
+          this.events.emit('escalation:signal-received', {
+            source: 'lead_engineer',
+            severity: 'medium',
+            type: 'agent_abort_and_resume',
+            context: {
+              featureId: action.featureId,
+              projectPath: session.projectPath,
+              resumePrompt: action.resumePrompt,
+            },
+            deduplicationKey: `abort_resume_${action.featureId}`,
+            timestamp: new Date().toISOString(),
           });
 
           logger.info(`Supervisor: resumed agent for ${action.featureId}`);

--- a/libs/flows/src/antagonistic-review/nodes/pair-review.ts
+++ b/libs/flows/src/antagonistic-review/nodes/pair-review.ts
@@ -8,12 +8,18 @@
  *
  * Uses wrapSubgraph() for state isolation from the parent graph.
  * Supports configurable reviewer pairs (Frank↔Chris, Matt↔Cindi, Sam↔Jake).
+ *
+ * LLM nodes use executeWithFallback for model fallback (smart → fast).
+ * When no models are provided, falls back to deterministic mock behavior.
  */
 
 import { Annotation } from '@langchain/langgraph';
-import { type PairReviewResult, type SPARCPrd } from '@automaker/types';
+import { type PairReviewResult, type ReviewVerdict, type SPARCPrd } from '@automaker/types';
+import { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { z } from 'zod';
 import { GraphBuilder } from '../../graphs/builder.js';
 import { wrapSubgraph } from '../../graphs/utils/subgraph-wrapper.js';
+import { executeWithFallback } from './classify-topic.js';
 
 /**
  * Configuration for a reviewer in the pair
@@ -48,6 +54,10 @@ export interface PairReviewState {
   prd: SPARCPrd;
   /** Configuration for this pair */
   pairConfig: PairConfig;
+  /** Smart LLM model (injected from parent graph) */
+  smartModel?: BaseChatModel;
+  /** Fast LLM model for fallback (injected from parent graph) */
+  fastModel?: BaseChatModel;
   /** Reviewer A's review output */
   reviewerAOutput?: string;
   /** Reviewer B's review output (includes A's context) */
@@ -62,42 +72,147 @@ export interface PairReviewState {
 export const PairReviewStateAnnotation = Annotation.Root({
   prd: Annotation<SPARCPrd>,
   pairConfig: Annotation<PairConfig>,
+  smartModel: Annotation<BaseChatModel | undefined>,
+  fastModel: Annotation<BaseChatModel | undefined>,
   reviewerAOutput: Annotation<string | undefined>,
   reviewerBOutput: Annotation<string | undefined>,
   result: Annotation<PairReviewResult | undefined>,
 });
 
 /**
+ * Serialize SPARCPrd to markdown for LLM prompts
+ */
+function serializePrd(prd: SPARCPrd): string {
+  return `## Situation
+${prd.situation}
+
+## Problem
+${prd.problem}
+
+## Approach
+${prd.approach}
+
+## Results
+${prd.results}
+
+## Constraints
+${prd.constraints || 'None specified'}`;
+}
+
+/**
+ * Zod schema for reviewer output
+ */
+const ReviewerOutputSchema = z.object({
+  assessment: z.string(),
+  concerns: z.array(z.string()),
+  recommendations: z.array(z.string()),
+  verdict: z.enum(['approve', 'approve-with-concerns', 'revise', 'reject']),
+});
+
+/**
+ * Zod schema for consolidation output
+ */
+const ConsolidationOutputSchema = z.object({
+  consensus: z.boolean(),
+  agreedVerdict: z.enum(['approve', 'concern', 'block']),
+  consolidatedComments: z.string(),
+});
+
+/**
+ * Parse JSON from LLM output, handling markdown code blocks
+ */
+function extractJson(output: string): unknown {
+  let jsonStr = output.trim();
+  const jsonMatch = jsonStr.match(/```(?:json)?\s*(\{[\s\S]*\})\s*```/);
+  if (jsonMatch) {
+    jsonStr = jsonMatch[1];
+  }
+  return JSON.parse(jsonStr);
+}
+
+/**
  * Node: Reviewer A conducts initial review
  */
 async function reviewerANode(state: PairReviewState): Promise<Partial<PairReviewState>> {
-  const { prd, pairConfig } = state;
+  const { prd, pairConfig, smartModel, fastModel } = state;
   const { reviewerA } = pairConfig;
+  const nodeName = `PairReview:${pairConfig.section}:${reviewerA.name}`;
 
-  console.log(`[PairReview:${pairConfig.section}] ${reviewerA.name} starting review`);
+  console.log(`[${nodeName}] Starting review`);
 
-  // Mock implementation - deterministic output based on reviewer and section
-  const reviewerAOutput = `[${reviewerA.name} (${reviewerA.role})] Review for ${pairConfig.section}:
+  // Fallback: deterministic output when no models available
+  if (!smartModel && !fastModel) {
+    const reviewerAOutput = `[${reviewerA.name} (${reviewerA.role})] Review for ${pairConfig.section}: Evaluated from ${reviewerA.role} perspective. Focus: ${reviewerA.prompt}. Preliminary verdict: APPROVE.`;
+    return { reviewerAOutput };
+  }
 
-Focus: ${reviewerA.prompt}
+  const prdString = serializePrd(prd);
 
-Assessment:
-- The ${pairConfig.section} aspects of this PRD have been evaluated.
-- Key considerations from a ${reviewerA.role} perspective have been identified.
-- Specific attention paid to: ${reviewerA.prompt}
+  const result = await executeWithFallback(
+    { primary: smartModel, fallback: fastModel },
+    async (model) => {
+      const response = await model.invoke([
+        {
+          role: 'user',
+          content: `You are ${reviewerA.name}, a ${reviewerA.role}. You are reviewing a PRD (Product Requirements Document) for your area of expertise.
 
-Preliminary verdict: APPROVE (pending review by ${pairConfig.reviewerB.name})
-Timestamp: ${new Date().toISOString()}`;
+Your focus area: ${reviewerA.prompt}
 
-  return { reviewerAOutput };
+PRD to review:
+${prdString}
+
+Provide your review in the following JSON format:
+{
+  "assessment": "Your overall assessment of the ${pairConfig.section} aspects",
+  "concerns": ["List of specific concerns from your ${reviewerA.role} perspective"],
+  "recommendations": ["Actionable recommendations to address concerns"],
+  "verdict": "approve" | "approve-with-concerns" | "revise" | "reject"
+}
+
+Verdict guidelines:
+- approve: No significant concerns in your domain
+- approve-with-concerns: Can proceed but monitor listed issues
+- revise: Changes needed before approval
+- reject: Fundamental issues that block progress
+
+Be thorough, specific, and direct. Return ONLY the JSON object.`,
+        },
+      ]);
+      return response.content.toString();
+    },
+    nodeName
+  );
+
+  try {
+    const parsed = ReviewerOutputSchema.parse(extractJson(result));
+    const reviewerAOutput = `[${reviewerA.name} (${reviewerA.role})] Review for ${pairConfig.section}:
+
+Assessment: ${parsed.assessment}
+
+Concerns:
+${parsed.concerns.map((c) => `- ${c}`).join('\n')}
+
+Recommendations:
+${parsed.recommendations.map((r) => `- ${r}`).join('\n')}
+
+Verdict: ${parsed.verdict.toUpperCase()}`;
+
+    console.log(`[${nodeName}] Review complete: ${parsed.verdict}`);
+    return { reviewerAOutput };
+  } catch (error) {
+    // If parsing fails, use raw output
+    console.warn(`[${nodeName}] Failed to parse structured output, using raw`);
+    return { reviewerAOutput: result };
+  }
 }
 
 /**
  * Node: Reviewer B reviews with A's context
  */
 async function reviewerBNode(state: PairReviewState): Promise<Partial<PairReviewState>> {
-  const { prd, pairConfig, reviewerAOutput } = state;
-  const { reviewerB } = pairConfig;
+  const { prd, pairConfig, reviewerAOutput, smartModel, fastModel } = state;
+  const { reviewerB, reviewerA } = pairConfig;
+  const nodeName = `PairReview:${pairConfig.section}:${reviewerB.name}`;
 
   if (!reviewerAOutput) {
     throw new Error(
@@ -105,36 +220,110 @@ async function reviewerBNode(state: PairReviewState): Promise<Partial<PairReview
     );
   }
 
-  console.log(
-    `[PairReview:${pairConfig.section}] ${reviewerB.name} reviewing with ${pairConfig.reviewerA.name}'s context`
+  console.log(`[${nodeName}] Reviewing with ${reviewerA.name}'s context`);
+
+  // Fallback: deterministic output when no models available
+  if (!smartModel && !fastModel) {
+    const reviewerBOutput = `[${reviewerB.name} (${reviewerB.role})] Review for ${pairConfig.section}: Building on ${reviewerA.name}'s assessment. Focus: ${reviewerB.prompt}. Verdict: APPROVE (concurring).`;
+    return { reviewerBOutput };
+  }
+
+  const prdString = serializePrd(prd);
+
+  const result = await executeWithFallback(
+    { primary: smartModel, fallback: fastModel },
+    async (model) => {
+      const response = await model.invoke([
+        {
+          role: 'user',
+          content: `You are ${reviewerB.name}, a ${reviewerB.role}. You are reviewing a PRD (Product Requirements Document) with the benefit of a previous review by ${reviewerA.name} (${reviewerA.role}).
+
+Your focus area: ${reviewerB.prompt}
+
+PRD to review:
+${prdString}
+
+Previous reviewer's assessment (${reviewerA.name}, ${reviewerA.role}):
+${reviewerAOutput}
+
+Your job is to:
+1. Validate or challenge ${reviewerA.name}'s findings from your ${reviewerB.role} perspective
+2. Identify any gaps ${reviewerA.name} may have missed
+3. Add your domain-specific analysis
+
+Provide your review in the following JSON format:
+{
+  "assessment": "Your assessment, referencing and building on ${reviewerA.name}'s review",
+  "concerns": ["Your additional or differing concerns as ${reviewerB.role}"],
+  "recommendations": ["Your recommendations, noting agreements/disagreements with ${reviewerA.name}"],
+  "verdict": "approve" | "approve-with-concerns" | "revise" | "reject"
+}
+
+Be thorough and don't just agree with ${reviewerA.name} — provide genuine independent analysis. Return ONLY the JSON object.`,
+        },
+      ]);
+      return response.content.toString();
+    },
+    nodeName
   );
 
-  // Mock implementation - deterministic output that references A's review
-  const reviewerBOutput = `[${reviewerB.name} (${reviewerB.role})] Review for ${pairConfig.section}:
+  try {
+    const parsed = ReviewerOutputSchema.parse(extractJson(result));
+    const reviewerBOutput = `[${reviewerB.name} (${reviewerB.role})] Review for ${pairConfig.section}:
 
-Focus: ${reviewerB.prompt}
+Building on ${reviewerA.name}'s assessment:
 
-Building on ${pairConfig.reviewerA.name}'s assessment:
-- Acknowledging the points raised by ${pairConfig.reviewerA.name}
-- Providing complementary perspective from a ${reviewerB.role} viewpoint
-- Focus area: ${reviewerB.prompt}
+Assessment: ${parsed.assessment}
 
-Additional considerations:
-- Cross-checking ${pairConfig.reviewerA.name}'s findings
-- Identifying any gaps or alternative viewpoints
-- Ensuring comprehensive coverage of ${pairConfig.section}
+Concerns:
+${parsed.concerns.map((c) => `- ${c}`).join('\n')}
 
-Verdict: APPROVE (concurring with ${pairConfig.reviewerA.name})
-Timestamp: ${new Date().toISOString()}`;
+Recommendations:
+${parsed.recommendations.map((r) => `- ${r}`).join('\n')}
 
-  return { reviewerBOutput };
+Verdict: ${parsed.verdict.toUpperCase()}`;
+
+    console.log(`[${nodeName}] Review complete: ${parsed.verdict}`);
+    return { reviewerBOutput };
+  } catch (error) {
+    console.warn(`[${nodeName}] Failed to parse structured output, using raw`);
+    return { reviewerBOutput: result };
+  }
+}
+
+/**
+ * Map raw verdict strings to ReviewVerdict type
+ */
+function mapVerdict(verdictA: string, verdictB: string): ReviewVerdict {
+  const severity: Record<string, number> = {
+    reject: 3,
+    revise: 2,
+    'approve-with-concerns': 1,
+    approve: 0,
+  };
+  // Conservative: take the more severe verdict
+  const sevA = severity[verdictA] ?? 1;
+  const sevB = severity[verdictB] ?? 1;
+  const worst = sevA >= sevB ? verdictA : verdictB;
+
+  switch (worst) {
+    case 'reject':
+      return 'block';
+    case 'revise':
+      return 'concern';
+    case 'approve-with-concerns':
+      return 'concern';
+    default:
+      return 'approve';
+  }
 }
 
 /**
  * Node: Mini-consolidation produces PairReviewResult
  */
 async function miniConsolidationNode(state: PairReviewState): Promise<Partial<PairReviewState>> {
-  const { pairConfig, reviewerAOutput, reviewerBOutput } = state;
+  const { pairConfig, reviewerAOutput, reviewerBOutput, smartModel, fastModel } = state;
+  const nodeName = `PairReview:${pairConfig.section}:consolidation`;
 
   if (!reviewerAOutput || !reviewerBOutput) {
     throw new Error(
@@ -143,30 +332,88 @@ async function miniConsolidationNode(state: PairReviewState): Promise<Partial<Pa
   }
 
   console.log(
-    `[PairReview:${pairConfig.section}] Consolidating ${pairConfig.reviewerA.name} and ${pairConfig.reviewerB.name} reviews`
+    `[${nodeName}] Consolidating ${pairConfig.reviewerA.name} and ${pairConfig.reviewerB.name} reviews`
   );
 
-  // Mock implementation - produces structured PairReviewResult
-  const result: PairReviewResult = {
-    section: pairConfig.section,
-    consensus: true, // Mock: always reach consensus
-    agreedVerdict: 'approve',
-    consolidatedComments: `${pairConfig.reviewerA.name} (${pairConfig.reviewerA.role}) and ${pairConfig.reviewerB.name} (${pairConfig.reviewerB.role}) have reviewed the ${pairConfig.section} aspects of this PRD.
+  // Fallback: deterministic consolidation when no models available
+  if (!smartModel && !fastModel) {
+    const result: PairReviewResult = {
+      section: pairConfig.section,
+      consensus: true,
+      agreedVerdict: 'approve',
+      consolidatedComments: `${pairConfig.reviewerA.name} (${pairConfig.reviewerA.role}) and ${pairConfig.reviewerB.name} (${pairConfig.reviewerB.role}) reviewed the ${pairConfig.section} aspects. No blocking concerns identified (deterministic fallback).`,
+      completedAt: new Date().toISOString(),
+    };
+    return { result };
+  }
 
-Key findings:
-- ${pairConfig.reviewerA.name}'s perspective: Focus on ${pairConfig.reviewerA.prompt}
-- ${pairConfig.reviewerB.name}'s perspective: Focus on ${pairConfig.reviewerB.prompt}
+  const consolidationResult = await executeWithFallback(
+    { primary: smartModel, fallback: fastModel },
+    async (model) => {
+      const response = await model.invoke([
+        {
+          role: 'user',
+          content: `You are a neutral consolidator. Two reviewers have assessed the ${pairConfig.section} aspects of a PRD. Synthesize their findings into a final verdict.
 
-Consensus: Both reviewers approve the ${pairConfig.section} section.
-No blocking concerns identified.`,
-    completedAt: new Date().toISOString(),
-  };
+Reviewer A (${pairConfig.reviewerA.name}, ${pairConfig.reviewerA.role}):
+${reviewerAOutput}
 
-  console.log(
-    `[PairReview:${pairConfig.section}] Consolidation complete: consensus=${result.consensus}, verdict=${result.agreedVerdict}`
+Reviewer B (${pairConfig.reviewerB.name}, ${pairConfig.reviewerB.role}):
+${reviewerBOutput}
+
+Provide your consolidation in the following JSON format:
+{
+  "consensus": true/false,
+  "agreedVerdict": "approve" | "concern" | "block",
+  "consolidatedComments": "Synthesis of both reviews with key findings, areas of agreement/disagreement, and final recommendation"
+}
+
+Verdict mapping:
+- "approve": Both reviewers approve or minor concerns only
+- "concern": Significant concerns raised that need attention but don't block
+- "block": Critical issues identified that must be resolved
+
+Return ONLY the JSON object.`,
+        },
+      ]);
+      return response.content.toString();
+    },
+    nodeName
   );
 
-  return { result };
+  try {
+    const parsed = ConsolidationOutputSchema.parse(extractJson(consolidationResult));
+    const result: PairReviewResult = {
+      section: pairConfig.section,
+      consensus: parsed.consensus,
+      agreedVerdict: parsed.agreedVerdict,
+      consolidatedComments: parsed.consolidatedComments,
+      completedAt: new Date().toISOString(),
+    };
+
+    console.log(
+      `[${nodeName}] Consolidation complete: consensus=${result.consensus}, verdict=${result.agreedVerdict}`
+    );
+    return { result };
+  } catch (error) {
+    // Fallback: extract verdicts heuristically from raw outputs
+    console.warn(`[${nodeName}] Failed to parse consolidation, using heuristic fallback`);
+
+    const verdictA =
+      reviewerAOutput.match(/Verdict:\s*(\w[\w-]*)/i)?.[1]?.toLowerCase() || 'approve';
+    const verdictB =
+      reviewerBOutput.match(/Verdict:\s*(\w[\w-]*)/i)?.[1]?.toLowerCase() || 'approve';
+    const agreedVerdict = mapVerdict(verdictA, verdictB);
+
+    const result: PairReviewResult = {
+      section: pairConfig.section,
+      consensus: verdictA === verdictB,
+      agreedVerdict,
+      consolidatedComments: `${pairConfig.reviewerA.name}: ${reviewerAOutput.slice(0, 200)}...\n\n${pairConfig.reviewerB.name}: ${reviewerBOutput.slice(0, 200)}...`,
+      completedAt: new Date().toISOString(),
+    };
+    return { result };
+  }
 }
 
 /**
@@ -199,23 +446,30 @@ export function createPairReviewSubgraph() {
  * Creates a wrapped pair review node for use in parent graph
  *
  * This wrapper provides state isolation using wrapSubgraph().
- * The parent graph only needs to provide prd and pairConfig,
+ * The parent graph only needs to provide prd, pairConfig, and models,
  * and will receive back a PairReviewResult.
  *
  * @param pairConfig - Configuration for the reviewer pair
  * @returns Wrapped node function for parent graph
  */
 export function createPairReviewNode<
-  TParentState extends { prd: SPARCPrd; pairReviews?: PairReviewResult[] },
+  TParentState extends {
+    prd: SPARCPrd;
+    pairReviews?: PairReviewResult[];
+    smartModel?: any;
+    fastModel?: any;
+  },
 >(pairConfig: PairConfig) {
   const compiledSubgraph = createPairReviewSubgraph();
 
   return wrapSubgraph<TParentState, PairReviewState, PairReviewState>(
     compiledSubgraph,
-    // Input mapper: extract prd from parent state and inject pairConfig
+    // Input mapper: extract prd and models from parent state, inject pairConfig
     (parentState) => ({
       prd: parentState.prd,
       pairConfig,
+      smartModel: parentState.smartModel,
+      fastModel: parentState.fastModel,
       reviewerAOutput: undefined,
       reviewerBOutput: undefined,
       result: undefined,
@@ -239,13 +493,17 @@ export function createPairReviewNode<
  */
 export async function runPairReview(
   prd: SPARCPrd,
-  pairConfig: PairConfig
+  pairConfig: PairConfig,
+  smartModel?: BaseChatModel,
+  fastModel?: BaseChatModel
 ): Promise<PairReviewResult> {
   const subgraph = createPairReviewSubgraph();
 
   const initialState: PairReviewState = {
     prd,
     pairConfig,
+    smartModel,
+    fastModel,
     reviewerAOutput: undefined,
     reviewerBOutput: undefined,
     result: undefined,

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -272,6 +272,7 @@ export type EventType =
   | 'escalation:signal-sent'
   | 'escalation:signal-failed'
   | 'escalation:signal-deduplicated'
+  | 'escalation:acknowledged'
   | 'escalation:ui-notification'
   // Feedback analytics events (pattern detection and metrics)
   | 'feedback:pattern-detected'


### PR DESCRIPTION
## Summary

- **Real pair review nodes**: Replaced 3 mock nodes with LLM calls using `executeWithFallback` (smart→fast model fallback), Zod validation, and model threading through `wrapSubgraph`
- **HITL resume handler**: Adapter stores interrupted graph instances by threadId, `resumeReview()` injects feedback via `graph.updateState()` and resumes from checkpoint — route returns 200 instead of 501
- **Stateful escalation acknowledgment**: `acknowledgeSignal()` finds log entries by dedup key, marks acknowledged with timestamp/user/notes, optionally clears dedup window, emits `escalation:acknowledged` event
- **LE escalation signals**: `reset_feature` and `abort_and_resume` fast-path actions now emit `escalation:signal-received` with medium severity
- **EM HITL bridge**: When authority service returns `require_approval`, EM creates a HITL form with approve/deny options and waits for human response (5-min timeout)

## Test plan

- [ ] `npm run build:packages` passes
- [ ] `npx tsc --noEmit --project apps/server/tsconfig.json` — zero errors
- [ ] `npx tsc --noEmit --project libs/flows/tsconfig.json` — zero errors
- [ ] Verify antagonistic review flow executes end-to-end via MCP `execute_antagonistic_review`
- [ ] Verify escalation `/api/escalation/acknowledge` returns 200 with valid signal
- [ ] Verify EM agent creates HITL form when authority requires approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced human-in-the-loop form approval for authority operations
  * Added signal acknowledgment capability to escalation logs
  * Enabled review resumption with human feedback integration
  * Implemented model fallback support for pair reviews
  * Added escalation signals for feature resets and task resumptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->