### PR TITLE
fix: increase recursion limit for content creation flow

### DIFF
--- a/apps/server/src/services/content-flow-service.ts
+++ b/apps/server/src/services/content-flow-service.ts
@@ -299,7 +299,11 @@ export class ContentFlowService {
       // Only use thread_id config when HITL is enabled (requires checkpointer).
       // Autonomous mode runs without a checkpointer to avoid serialization
       // issues with ChatAnthropic model instances in state.
-      const streamConfig = isHITL ? { configurable: { thread_id: runId } } : undefined;
+      // 7 phases × up to 7 parallel sections × subgraph nodes = easily 100+ node visits.
+      // Default recursionLimit of 25 is far too low for content generation.
+      const streamConfig = isHITL
+        ? { configurable: { thread_id: runId }, recursionLimit: 150 }
+        : { recursionLimit: 150 };
 
       // Stream the flow to get per-node updates
       let lastState: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary
- Content flows hit LangGraph's default `recursionLimit` of 25 during parallel section generation
- With 5-7 sections each going through a SectionWriter subgraph, node visits easily exceed 25
- Set `recursionLimit: 150` in the stream config for both autonomous and HITL modes

## Test plan
- [ ] Start a content flow — verify it progresses past section generation
- [ ] Confirm flows complete through assembly → final review → output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced content flow execution with increased recursion depth limits, enabling the system to process more complex and deeply nested workflow scenarios efficiently.
  * Improved human-in-the-loop mode with refined thread scoping and management, providing better support for concurrent human-assisted workflow operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->