### PR TITLE
docs: update ceremony and bug tracking documentation

### DIFF
--- a/docs/agents/ceremonies.md
+++ b/docs/agents/ceremonies.md
@@ -179,13 +179,43 @@ Posted when all milestones complete. Uses an LLM to generate a structured retros
 | `splitMessage()`              | private    | Chunk content for Discord's 2000-char limit       |
 | `emitDiscordEvent()`          | private    | Emit `integration:discord` event                  |
 
+## Discord Delivery
+
+CeremonyService doesn't call Discord directly. Instead, it emits `integration:discord` events via `emitDiscordEvent()`, and a bridge listener in `apps/server/src/index.ts` forwards them to `DiscordBotService.sendToChannel()`.
+
+```
+CeremonyService
+  │
+  └─ emitDiscordEvent(channelId, content)
+        │
+        ▼
+  events.emit('integration:discord', {
+    action: 'send_message',
+    channelId,
+    content
+  })
+        │
+        ▼
+  Bridge listener (index.ts)
+        │
+        ▼
+  DiscordBotService.sendToChannel(channelId, content)
+        │
+        ▼
+  Discord API
+```
+
+This bridge also serves `IntegrationService` and `ChangelogService` — any service that emits `integration:discord` events with `{ action: 'send_message', channelId, content }` payloads will be delivered to Discord.
+
+**Key file:** `apps/server/src/index.ts` — `integration:discord` subscriber (after `eventHookService.initialize()`)
+
 ## Prerequisites
 
 For ceremonies to work:
 
 1. **Ceremonies enabled** in `.automaker/settings.json` (`ceremonySettings.enabled: true`)
-2. **Discord integration enabled** in project settings (`integrations.discord.enabled: true`)
-3. **Discord channel ID set** in ceremony settings
+2. **Discord channel ID set** in ceremony settings (`ceremonySettings.discordChannelId`)
+3. **Discord bot running** — `DiscordBotService` must be initialized (requires `DISCORD_BOT_TOKEN`)
 4. **Project uses the project orchestration system** (milestones, phases)
 5. **Events emitted by ProjM agent** — ceremonies are event-driven, not polled
 

--- a/docs/dev/bug-tracking.md
+++ b/docs/dev/bug-tracking.md
@@ -81,8 +81,7 @@ The pipeline activates on three event types:
 | `apps/server/src/index.ts`                           | `bug:linear-sync` listener (Linear issue creation)                 |
 | `apps/server/src/lib/settings-helpers.ts`            | `getWorkflowSettings()` with bugs merge                            |
 
-## Discord Ceremony Delivery
+## Related Documentation
 
-The same PR also wired `integration:discord` events to `DiscordBotService`. CeremonyService, IntegrationService, and ChangelogService emit `integration:discord` events with `{ action: 'send_message', channelId, content }` payloads. A bridge listener in `index.ts` forwards these to `DiscordBotService.sendToChannel()`.
-
-This enables all ceremony types (epic kickoff, milestone standup, milestone retro, epic delivery, project retro) to automatically post to Discord when `ceremonySettings.enabled` is true and `ceremonySettings.discordChannelId` is configured.
+- [Issue Management & Triage](./issue-management.md) — GitHub issue creation, triage priority, team routing
+- [Agile Ceremony System](/agents/ceremonies) — Ceremony types and Discord delivery

--- a/docs/dev/issue-management.md
+++ b/docs/dev/issue-management.md
@@ -112,6 +112,31 @@ interface Feature {
 | `issue:created`               | `{ featureId, projectPath, issueNumber, issueUrl, trigger, priority, team }` | GitHub issue created         |
 | `issue:triage-completed`      | `{ featureId, projectPath, priority, team, labels, reason }`                 | Triage classification done   |
 
+## Linear Bug Tracking
+
+In addition to GitHub issues, failures can be automatically routed to a Linear "Bugs" project with priority-based severity gating.
+
+When enabled, `IssueCreationService` emits a `bug:linear-sync` event after creating the GitHub issue. A listener in `index.ts` picks this up and creates a Linear issue via `LinearMCPClient`.
+
+**Configuration:** Add `workflow.bugs` to `.automaker/settings.json`:
+
+```json
+{
+  "workflow": {
+    "bugs": {
+      "enabled": true,
+      "linearProjectId": "<linear-project-id>",
+      "linearTeamId": "<linear-team-id>",
+      "minLinearPriority": 3
+    }
+  }
+}
+```
+
+Only bugs with priority at or above `minLinearPriority` (1=urgent through 4=low) are synced. Default threshold is 3 (medium), meaning P1/P2/P3 bugs create Linear issues while P4 (low) bugs only get GitHub issues.
+
+See [Bug Tracking Pipeline](./bug-tracking.md) for full configuration reference and priority mapping.
+
 ## Future: Phase 3 (Bidirectional Sync)
 
 Not yet implemented:


### PR DESCRIPTION
## Summary
- Add Discord delivery bridge section to ceremonies docs explaining how `integration:discord` events get forwarded to `DiscordBotService.sendToChannel()`
- Add Linear bug tracking reference to issue management docs with config example
- Clean up bug-tracking docs to cross-link related pages instead of duplicating ceremony info

## Test plan
- [ ] Verify docs render correctly in the docs site
- [ ] Confirm cross-links between bug-tracking, issue-management, and ceremonies pages work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced ceremony documentation with Discord delivery integration details and prerequisites
  * Added Linear bug tracking integration documentation for GitHub issue mirroring with configurable priority filtering
  * Updated documentation organization and cross-references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->