### PR TITLE
feat: sidebar layout polish + settings scroll fix

### DIFF
--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -1,13 +1,13 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { createLogger } from '@automaker/utils/logger';
 import { useNavigate, useLocation } from '@tanstack/react-router';
 
 const logger = createLogger('Sidebar');
-import { cn } from '@/lib/utils';
+import { cn, isMac } from '@/lib/utils';
 import { useAppStore } from '@/store/app-store';
 import { useNotificationsStore } from '@/store/notifications-store';
 import { useKeyboardShortcuts, useKeyboardShortcutsConfig } from '@/hooks/use-keyboard-shortcuts';
-import { getElectronAPI } from '@/lib/electron';
+import { getElectronAPI, isElectron } from '@/lib/electron';
 import { initializeProject, hasAppSpec, hasAutomakerDir } from '@/lib/project-init';
 import { toast } from 'sonner';
 import { DeleteProjectDialog } from '@/components/views/settings-view/components/delete-project-dialog';
@@ -59,6 +59,34 @@ export function Sidebar() {
   } = useAppStore();
 
   const isCompact = useIsCompact();
+
+  // Content fade: delay content appearance until sidebar width transition completes on open,
+  // and fade out content before collapsing on close.
+  const [contentReady, setContentReady] = useState(sidebarOpen);
+  const closingRef = useRef(false);
+
+  useEffect(() => {
+    if (sidebarOpen && !closingRef.current) {
+      // Opening: wait for width transition to finish, then fade in content
+      const timer = setTimeout(() => setContentReady(true), 300);
+      return () => clearTimeout(timer);
+    }
+  }, [sidebarOpen]);
+
+  const handleToggleSidebar = useCallback(() => {
+    if (sidebarOpen) {
+      // Closing: fade out content first, then collapse sidebar width
+      setContentReady(false);
+      closingRef.current = true;
+      setTimeout(() => {
+        toggleSidebar();
+        closingRef.current = false;
+      }, 150);
+    } else {
+      // Opening: expand width immediately (content fades in via useEffect)
+      toggleSidebar();
+    }
+  }, [sidebarOpen, toggleSidebar]);
 
   // Environment variable flags for hiding sidebar items
   const { hideTerminal, hideContext, hideSpecEditor } = SIDEBAR_FEATURE_FLAGS;
@@ -127,7 +155,7 @@ export function Sidebar() {
     specCreatingForProject !== null && specCreatingForProject === currentProject?.path;
 
   // Auto-collapse sidebar on small screens and update Electron window minWidth
-  useSidebarAutoCollapse({ sidebarOpen, toggleSidebar });
+  useSidebarAutoCollapse({ sidebarOpen, toggleSidebar: handleToggleSidebar });
 
   // Unviewed validations count
   const { count: unviewedValidationsCount } = useUnviewedValidations(currentProject);
@@ -226,7 +254,7 @@ export function Sidebar() {
     projects,
     projectHistory,
     navigate,
-    toggleSidebar,
+    toggleSidebar: handleToggleSidebar,
     handleOpenFolder,
     cyclePrevProject,
     cycleNextProject,
@@ -256,7 +284,7 @@ export function Sidebar() {
       {sidebarOpen && !shouldHideSidebar && (
         <div
           className="fixed inset-0 bg-black/50 z-20 lg:hidden"
-          onClick={toggleSidebar}
+          onClick={handleToggleSidebar}
           data-testid="sidebar-backdrop"
         />
       )}
@@ -277,31 +305,45 @@ export function Sidebar() {
         )}
         data-testid="sidebar"
       >
-        <div className="flex-1 flex flex-col overflow-hidden">
+        <div
+          className={cn(
+            'flex-1 flex flex-col overflow-hidden',
+            isMac && isElectron() && 'pt-[10px]'
+          )}
+        >
+          {sidebarOpen && (
+            <div
+              className={cn(
+                'transition-opacity duration-200',
+                contentReady ? 'opacity-100' : 'opacity-0'
+              )}
+            >
+              <QuickActionsBar
+                onBugReport={() =>
+                  getElectronAPI().openExternalLink(
+                    'https://github.com/proto-labs-ai/automaker/issues'
+                  )
+                }
+                onDocs={() => getElectronAPI().openExternalLink('https://protolabs.studio/docs')}
+                onNewProject={() => setShowNewProjectModal(true)}
+                onOpenFolder={handleOpenFolder}
+                onSettings={() => navigate({ to: '/settings' })}
+                onClose={handleToggleSidebar}
+              />
+            </div>
+          )}
+
           <SidebarHeader
             sidebarOpen={sidebarOpen}
+            contentReady={contentReady}
             currentProject={currentProject}
-            onClose={toggleSidebar}
-            onExpand={toggleSidebar}
+            onExpand={handleToggleSidebar}
           />
-
-          {sidebarOpen && (
-            <QuickActionsBar
-              onBugReport={() =>
-                getElectronAPI().openExternalLink(
-                  'https://github.com/proto-labs-ai/automaker/issues'
-                )
-              }
-              onDocs={() => getElectronAPI().openExternalLink('https://protolabs.studio/docs')}
-              onNewProject={() => setShowNewProjectModal(true)}
-              onOpenFolder={handleOpenFolder}
-              onSettings={() => navigate({ to: '/settings' })}
-            />
-          )}
 
           <SidebarNavigation
             currentProject={currentProject}
             sidebarOpen={sidebarOpen}
+            contentReady={contentReady}
             navSections={navSections}
             isActiveRoute={isActiveRoute}
             navigate={navigate}
@@ -309,7 +351,13 @@ export function Sidebar() {
         </div>
 
         {sidebarOpen && (
-          <div className="shrink-0 border-t border-border/40 px-4 py-3">
+          <div
+            className={cn(
+              'shrink-0 border-t border-border/40 px-4 py-3',
+              'transition-opacity duration-200',
+              contentReady ? 'opacity-100' : 'opacity-0'
+            )}
+          >
             <AutomakerLogo sidebarOpen={sidebarOpen} navigate={navigate} />
           </div>
         )}

--- a/apps/ui/src/components/layout/sidebar/components/quick-actions-bar.tsx
+++ b/apps/ui/src/components/layout/sidebar/components/quick-actions-bar.tsx
@@ -1,4 +1,4 @@
-import { Bug, BookOpen, Plus, FolderOpen, Settings } from 'lucide-react';
+import { Bug, BookOpen, Plus, FolderOpen, Settings, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface QuickActionsBarProps {
@@ -7,14 +7,15 @@ interface QuickActionsBarProps {
   onNewProject: () => void;
   onOpenFolder: () => void;
   onSettings: () => void;
+  onClose: () => void;
 }
 
 const actions = [
-  { key: 'bug', icon: Bug, label: 'Report Bug', testId: 'quick-action-bug' },
-  { key: 'docs', icon: BookOpen, label: 'Documentation', testId: 'quick-action-docs' },
   { key: 'new', icon: Plus, label: 'New Project', testId: 'quick-action-new' },
   { key: 'open', icon: FolderOpen, label: 'Open Folder', testId: 'quick-action-open' },
   { key: 'settings', icon: Settings, label: 'Global Settings', testId: 'quick-action-settings' },
+  { key: 'docs', icon: BookOpen, label: 'Documentation', testId: 'quick-action-docs' },
+  { key: 'bug', icon: Bug, label: 'Report Bug', testId: 'quick-action-bug' },
 ] as const;
 
 export function QuickActionsBar({
@@ -23,6 +24,7 @@ export function QuickActionsBar({
   onNewProject,
   onOpenFolder,
   onSettings,
+  onClose,
 }: QuickActionsBarProps) {
   const handlers: Record<string, () => void> = {
     bug: onBugReport,
@@ -51,6 +53,20 @@ export function QuickActionsBar({
           <Icon className="size-4" />
         </button>
       ))}
+      <div className="flex-1" />
+      <button
+        onClick={onClose}
+        className={cn(
+          'flex items-center justify-center size-8 rounded-lg',
+          'text-muted-foreground hover:text-foreground',
+          'hover:bg-muted/50',
+          'transition-colors duration-150'
+        )}
+        aria-label="Close sidebar"
+        data-testid="sidebar-close"
+      >
+        <X className="size-4" />
+      </button>
     </div>
   );
 }

--- a/apps/ui/src/components/layout/sidebar/components/sidebar-header.tsx
+++ b/apps/ui/src/components/layout/sidebar/components/sidebar-header.tsx
@@ -1,23 +1,23 @@
 import { useState } from 'react';
-import { Folder, LucideIcon, X, Menu, Check, ChevronsUpDown } from 'lucide-react';
+import { Folder, LucideIcon, Menu, Check, ChevronsUpDown } from 'lucide-react';
 import * as LucideIcons from 'lucide-react';
-import { cn, isMac } from '@/lib/utils';
+import { cn } from '@/lib/utils';
 import { getAuthenticatedImageUrl } from '@/lib/api-fetch';
-import { isElectron, type Project } from '@/lib/electron';
+import type { Project } from '@/lib/electron';
 import { Popover, PopoverContent, PopoverTrigger } from '@protolabs/ui/atoms';
 import { useAppStore } from '@/store/app-store';
 
 interface SidebarHeaderProps {
   sidebarOpen: boolean;
+  contentReady: boolean;
   currentProject: Project | null;
-  onClose?: () => void;
   onExpand?: () => void;
 }
 
 export function SidebarHeader({
   sidebarOpen,
+  contentReady,
   currentProject,
-  onClose,
   onExpand,
 }: SidebarHeaderProps) {
   const [projectListOpen, setProjectListOpen] = useState(false);
@@ -34,13 +34,7 @@ export function SidebarHeader({
   const hasCustomIcon = !!currentProject?.customIconPath;
 
   return (
-    <div
-      className={cn(
-        'shrink-0 flex flex-col relative',
-        // Add padding on macOS Electron for traffic light buttons
-        isMac && isElectron() && 'pt-[10px]'
-      )}
-    >
+    <div className="shrink-0 flex flex-col relative">
       {/* Expand button - hamburger menu when sidebar is collapsed */}
       {!sidebarOpen && onExpand && (
         <button
@@ -57,7 +51,7 @@ export function SidebarHeader({
           <Menu className="w-5 h-5" />
         </button>
       )}
-      {/* Project switcher row with close button */}
+      {/* Project switcher row */}
       {currentProject && (
         <div className={cn('flex items-center', sidebarOpen ? 'px-2 pt-3 pb-1 gap-1' : 'pt-1')}>
           <Popover open={projectListOpen} onOpenChange={setProjectListOpen}>
@@ -91,14 +85,20 @@ export function SidebarHeader({
 
                 {/* Project Name - only show when sidebar is open */}
                 {sidebarOpen && (
-                  <>
+                  <div
+                    className={cn(
+                      'flex items-center gap-3 flex-1 min-w-0',
+                      'transition-opacity duration-200',
+                      contentReady ? 'opacity-100' : 'opacity-0'
+                    )}
+                  >
                     <div className="flex-1 min-w-0">
                       <h2 className="text-sm font-semibold text-foreground truncate">
                         {currentProject.name}
                       </h2>
                     </div>
                     <ChevronsUpDown className="w-4 h-4 text-muted-foreground shrink-0" />
-                  </>
+                  </div>
                 )}
               </button>
             </PopoverTrigger>
@@ -158,21 +158,6 @@ export function SidebarHeader({
               </div>
             </PopoverContent>
           </Popover>
-          {/* Close sidebar button - visible when expanded */}
-          {sidebarOpen && onClose && (
-            <button
-              onClick={onClose}
-              className={cn(
-                'shrink-0 flex items-center justify-center w-8 h-8 rounded-lg',
-                'text-muted-foreground hover:text-foreground hover:bg-muted/50',
-                'transition-colors duration-150'
-              )}
-              aria-label="Close sidebar"
-              data-testid="sidebar-close"
-            >
-              <X className="w-4 h-4" />
-            </button>
-          )}
         </div>
       )}
     </div>

--- a/apps/ui/src/components/layout/sidebar/components/sidebar-navigation.tsx
+++ b/apps/ui/src/components/layout/sidebar/components/sidebar-navigation.tsx
@@ -8,6 +8,7 @@ import { Spinner } from '@protolabs/ui/atoms';
 interface SidebarNavigationProps {
   currentProject: Project | null;
   sidebarOpen: boolean;
+  contentReady: boolean;
   navSections: NavSection[];
   isActiveRoute: (id: string) => boolean;
   navigate: (opts: NavigateOptions) => void;
@@ -16,6 +17,7 @@ interface SidebarNavigationProps {
 export function SidebarNavigation({
   currentProject,
   sidebarOpen,
+  contentReady,
   navSections,
   isActiveRoute,
   navigate,
@@ -29,7 +31,13 @@ export function SidebarNavigation({
     >
       {!currentProject && sidebarOpen ? (
         // Placeholder when no project is selected (only in expanded state)
-        <div className="flex items-center justify-center h-full px-4">
+        <div
+          className={cn(
+            'flex items-center justify-center h-full px-4',
+            'transition-opacity duration-200',
+            contentReady ? 'opacity-100' : 'opacity-0'
+          )}
+        >
           <p className="text-muted-foreground text-sm text-center">
             <span className="block">Select or create a project above</span>
           </p>
@@ -40,7 +48,12 @@ export function SidebarNavigation({
           <div key={sectionIdx} className={sectionIdx > 0 && sidebarOpen ? 'mt-6' : ''}>
             {/* Section Label */}
             {section.label && sidebarOpen && (
-              <div className="px-3 mb-2">
+              <div
+                className={cn(
+                  'px-3 mb-2 transition-opacity duration-200',
+                  contentReady ? 'opacity-100' : 'opacity-0'
+                )}
+              >
                 <span className="text-[10px] font-semibold text-muted-foreground/70 uppercase tracking-widest">
                   {section.label}
                 </span>
@@ -48,7 +61,12 @@ export function SidebarNavigation({
             )}
             {/* Separator for sections without label (visual separation) */}
             {!section.label && sectionIdx > 0 && sidebarOpen && (
-              <div className="h-px bg-border/40 mx-3 mb-4"></div>
+              <div
+                className={cn(
+                  'h-px bg-border/40 mx-3 mb-4 transition-opacity duration-200',
+                  contentReady ? 'opacity-100' : 'opacity-0'
+                )}
+              ></div>
             )}
             {(section.label || sectionIdx > 0) && !sidebarOpen && (
               <div className="h-px bg-border/30 mx-2 my-1.5"></div>
@@ -127,7 +145,9 @@ export function SidebarNavigation({
                     <span
                       className={cn(
                         'ml-3 font-medium text-sm flex-1 text-left',
-                        sidebarOpen ? 'block' : 'hidden'
+                        sidebarOpen ? 'block' : 'hidden',
+                        'transition-opacity duration-200',
+                        contentReady ? 'opacity-100' : 'opacity-0'
                       )}
                     >
                       {item.label}
@@ -139,7 +159,8 @@ export function SidebarNavigation({
                           'flex items-center justify-center',
                           'min-w-5 h-5 px-1.5 text-[10px] font-bold rounded-full',
                           'bg-primary text-primary-foreground shadow-sm',
-                          'animate-in fade-in zoom-in duration-200'
+                          'transition-opacity duration-200',
+                          contentReady ? 'opacity-100' : 'opacity-0'
                         )}
                         data-testid={`count-${item.id}`}
                       >
@@ -152,7 +173,8 @@ export function SidebarNavigation({
                           'flex items-center justify-center min-w-5 h-5 px-1.5 text-[10px] font-mono rounded-md transition-all duration-200',
                           isActive
                             ? 'bg-brand-500/20 text-brand-400'
-                            : 'bg-muted text-muted-foreground group-hover:bg-accent'
+                            : 'bg-muted text-muted-foreground group-hover:bg-accent',
+                          contentReady ? 'opacity-100' : 'opacity-0'
                         )}
                         data-testid={`shortcut-${item.id}`}
                       >

--- a/apps/ui/src/routes/__root.tsx
+++ b/apps/ui/src/routes/__root.tsx
@@ -837,7 +837,7 @@ function RootLayoutContent() {
         )}
         <Sidebar />
         <div className="flex-1 flex flex-col overflow-hidden">
-          <div className="flex-1 overflow-hidden">
+          <div className="flex-1 flex flex-col overflow-hidden">
             <Outlet />
           </div>
           <BottomPanel />


### PR DESCRIPTION
## Summary

- **Swap sidebar header/toolbar**: When expanded, quick action icons now sit at top alongside the X close button, with the project dropdown below — mirroring the collapsed layout
- **Reorder quick actions**: new, open, settings, docs, bug (most-used first)
- **Fade transitions**: Expanded content fades in after the width transition completes (300ms), and fades out before collapsing (150ms) — eliminates text reflow during animation
- **Fix settings scroll**: Settings panels were unscrollable because the Outlet wrapper in `__root.tsx` wasn't a flex container, so child views with `flex-1` couldn't get a constrained height

## Test plan

- [ ] Open/close sidebar — content should fade in after expansion, fade out before collapse
- [ ] Quick action icons ordered: +, folder, gear, book, bug with X at far right
- [ ] Project dropdown appears below the toolbar when sidebar is open
- [ ] Navigate to Settings — scroll down in any tab (e.g. Appearance, Feature Defaults) to verify content below the fold is accessible
- [ ] Keyboard shortcut to toggle sidebar still works with fade animation
- [ ] Collapsed sidebar still shows hamburger, project icon, nav icons correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated close button to the sidebar's quick actions area for easier navigation.

* **Improvements**
  * Enhanced sidebar open/close animations with smooth content fade and progressive reveal transitions.
  * Refined layout transitions for better visual polish when toggling sidebar visibility.
  * Adjusted spacing on macOS for improved UI presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->