### PR TITLE
fix: settings scroll with min-h-0 on flex chain

### DIFF
--- a/apps/ui/src/components/views/settings-view.tsx
+++ b/apps/ui/src/components/views/settings-view.tsx
@@ -203,7 +203,10 @@ export function SettingsView() {
   };
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden content-bg" data-testid="settings-view">
+    <div
+      className="flex-1 flex flex-col min-h-0 overflow-hidden content-bg"
+      data-testid="settings-view"
+    >
       {/* Header Section */}
       <SettingsHeader
         showNavigation={showNavigation}
@@ -212,7 +215,7 @@ export function SettingsView() {
       />
 
       {/* Content Area with Sidebar */}
-      <div className="flex-1 flex overflow-hidden">
+      <div className="flex-1 flex min-h-0 overflow-hidden">
         {/* Side Navigation - Overlay on mobile, sidebar on desktop */}
         <SettingsNavigation
           navItems={NAV_ITEMS}

--- a/apps/ui/src/routes/__root.tsx
+++ b/apps/ui/src/routes/__root.tsx
@@ -836,8 +836,8 @@ function RootLayoutContent() {
           />
         )}
         <Sidebar />
-        <div className="flex-1 flex flex-col overflow-hidden">
-          <div className="flex-1 flex flex-col overflow-hidden">
+        <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+          <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
             <Outlet />
           </div>
           <BottomPanel />


### PR DESCRIPTION
## Summary

- Add `min-h-0` to nested flex containers in the settings view and Outlet wrapper
- Fixes settings panels (Workflow, etc.) not being scrollable — content below the fold was clipped

The root cause: nested flex items default to `min-height: auto`, preventing them from shrinking below their content height even with `overflow-hidden`. The inner `overflow-y-auto` panel never got a constrained height to trigger scrolling.

## Test plan

- [ ] Navigate to Settings > Workflow — scroll to see Pipeline Gates section at bottom
- [ ] Check other tall settings tabs (Feature Defaults, Keyboard Shortcuts) scroll properly
- [ ] Verify other views (Board, Terminal, Chat) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed layout overflow and display inconsistencies on various screen sizes by optimizing flex container behavior to ensure proper content shrinking and visibility across different viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->