### PR TITLE
fix: content pipeline not writing output files to disk

### DIFF
--- a/apps/server/src/services/content-flow-service.ts
+++ b/apps/server/src/services/content-flow-service.ts
@@ -496,8 +496,10 @@ export class ContentFlowService {
     try {
       // Stream the resumed flow to track node transitions.
       // Same reducer-aware accumulation as executeFlow.
+      // Initialize from checkpointed state to preserve config and prior accumulations.
       const REDUCER_FIELDS = new Set(['researchResults', 'sections', 'reviewFeedback', 'outputs']);
-      let lastState: Record<string, unknown> = {};
+      const checkpoint = await flow.getState(threadConfig);
+      let lastState: Record<string, unknown> = (checkpoint.values as Record<string, unknown>) || {};
       const stream = await flow.stream(resumeState, threadConfig);
 
       for await (const update of stream) {


### PR DESCRIPTION
## Summary
- Fix stream state accumulation to use array reduction for LangGraph reducer fields (`outputs`, `researchResults`, `sections`, `reviewFeedback`) — parallel Send() delegates' outputs were being overwritten instead of appended
- Initialize `lastState` with input config so metadata captures topic/format instead of "Unknown"
- Fix `extractReviewScores` to read `finalReview` (correct field name) instead of `finalContentReview`
- Add `assembledContent` fallback so content.md is still written when output phase is skipped

## Test plan
- [ ] Start a content flow with `create_content`
- [ ] Verify `content.md` is written to `.automaker/content/{runId}/`
- [ ] Verify `metadata.json` includes correct topic, format, and all 3 review scores
- [ ] Verify `export_content` succeeds
- [ ] Test with multiple output formats to confirm array accumulation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved content flow state handling and streaming accumulation so incremental updates merge and append correctly across live and resumed flows.

* **Bug Fixes**
  * Added fallback write/save of assembled content when no output files are produced to ensure content is always generated and persisted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->