### PR TITLE
fix: move Blocked node under Review in flow graph

### DIFF
--- a/apps/ui/src/components/views/flow-graph/constants.ts
+++ b/apps/ui/src/components/views/flow-graph/constants.ts
@@ -334,7 +334,7 @@ export const PIPELINE_STAGES: Array<{
     nodeId: NODE_IDS.pipelineBlocked,
     stageId: 'blocked',
     label: 'Blocked',
-    position: { x: 475, y: 660 },
+    position: { x: 600, y: 660 },
   },
 ];
 
@@ -361,6 +361,7 @@ export const PIPELINE_EDGES: FlowEdge[] = [
   {
     id: 'e-pipe-review-blocked',
     source: NODE_IDS.pipelineReview,
+    sourceHandle: 'bottom',
     target: NODE_IDS.pipelineBlocked,
     type: 'pipeline',
   },


### PR DESCRIPTION
## Summary

- Move Blocked node position from x=475 to x=600 (directly below Review)
- Route Review→Blocked edge from the bottom handle for a clean vertical connection

## Test plan

- [ ] Open Flow Graph view — Blocked node should be centered directly below Review
- [ ] Edge from Review to Blocked should be a clean vertical line from bottom of Review to top of Blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted flow graph visual layout with repositioned pipeline stages and optimized connection points for improved alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->