### PR TITLE
fix: route Review→Blocked edge via top handle, tighten gap

### DIFF
--- a/apps/ui/src/components/views/flow-graph/constants.ts
+++ b/apps/ui/src/components/views/flow-graph/constants.ts
@@ -334,7 +334,7 @@ export const PIPELINE_STAGES: Array<{
     nodeId: NODE_IDS.pipelineBlocked,
     stageId: 'blocked',
     label: 'Blocked',
-    position: { x: 600, y: 660 },
+    position: { x: 600, y: 620 },
   },
 ];
 
@@ -363,6 +363,7 @@ export const PIPELINE_EDGES: FlowEdge[] = [
     source: NODE_IDS.pipelineReview,
     sourceHandle: 'bottom',
     target: NODE_IDS.pipelineBlocked,
+    targetHandle: 'top',
     type: 'pipeline',
   },
 ];

--- a/apps/ui/src/components/views/flow-graph/nodes/pipeline-stage-node.tsx
+++ b/apps/ui/src/components/views/flow-graph/nodes/pipeline-stage-node.tsx
@@ -132,6 +132,7 @@ function PipelineStageNodeComponent({ data }: NodeProps & { data: PipelineStageN
         <Handle
           type="target"
           position={Position.Top}
+          id="top"
           className="!bg-border !w-1.5 !h-1.5 !border-0"
         />
         <Handle


### PR DESCRIPTION
## Summary

- Add explicit `id="top"` to pipeline stage node's top target handle so edges can target it
- Set `targetHandle: 'top'` on Review→Blocked edge for a clean vertical connection
- Move Blocked y from 660→620 to reduce the gap between Review and Blocked

Follows up on #907.

## Test plan

- [ ] Flow graph: edge from Review bottom connects straight down to Blocked top
- [ ] Gap between Review and Blocked nodes is tighter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted pipeline stage positioning for improved layout alignment.

* **Style**
  * Enhanced component structure with improved identifier organization for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->