### PR TITLE
feat: per-feature reflection in Lead Engineer

### DIFF
--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,9 +5,9 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 70
-  referenced: 41
-  successfulFeatures: 41
+  loaded: 73
+  referenced: 43
+  successfulFeatures: 43
 ---
 # api
 
@@ -457,3 +457,8 @@ usageStats:
 - **Rejected:** Replace JSONL with signals only - would break any code reading JSONL files; Migrate all data - would require separate data migration feature.
 - **Trade-offs:** Data duplication (same data in JSONL and as events) increases complexity and storage, but provides safe incremental migration path. Extra code paths in Twitch service to maintain both formats.
 - **Breaking if changed:** If JSONL persistence is removed, any downstream code parsing those files breaks. If signal emission is removed, signal pipeline has missing data. If formats diverge, they become out of sync.
+
+#### [Pattern] Created handler abstraction layer that calls /social/* endpoints even though those endpoints don't exist yet (2026-02-22)
+- **Problem solved:** Building MCP tools for social platforms but actual API layer not implemented; endpoints are placeholder
+- **Why this works:** Decouples tool definitions from endpoint implementation details. If endpoint paths/structure changes later, only handlers change not all 20 tools
+- **Trade-offs:** Added abstraction layer costs implementation time now but enables future flexibility. Creates false assumption that endpoints exist (incomplete feature)

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -2254,3 +2254,46 @@ usageStats:
 - **Rejected:** Wire initialization immediately - would expand scope; Skip registration - would require duplicate work later.
 - **Trade-offs:** Cleaner separation of concerns vs gap where integrations exist but don't run. Simpler current feature vs more work in future feature.
 - **Breaking if changed:** If initialization code assumes all registered integrations are initialized, it will have missing services. If startup wiring is never implemented, integrations register but never start.
+
+### Externalized SignalCounts type from signal-intake-service.ts to centralized @automaker/types/signal.ts package (2026-02-22)
+- **Context:** Type needed to be imported by both server services and tools domain packages, creating cross-package dependency
+- **Why:** Creating explicit contract in shared types package enforces compatibility and single source of truth. Alternative was duplicating type or using any
+- **Rejected:** Keep type local to SignalIntakeService; import in tools would require circular dependency or re-exporting from server package
+- **Trade-offs:** Easy cross-package reuse now, but changes to SignalCounts structure break both packages simultaneously - tightly couples them
+- **Breaking if changed:** Removing from @automaker/types breaks both server and tools package imports; changing field structure breaks both packages at same time
+
+#### [Pattern] Signal classification uses string prefix matching (twitter:, youtube:, substack:) to route to GTM category rather than enum-based dispatch (2026-02-22)
+- **Problem solved:** Multiple unrelated platforms need to be classified as marketing signals and routed to same queue
+- **Why this works:** Prefix pattern allows new sources to be added without modifying classification logic - new source just needs matching prefix. More extensible than hardcoded enum
+- **Trade-offs:** Gained extensibility and implicit namespacing, lost type-safety of enum classification. Prefix convention is implicit, not part of public contract
+
+### Routed all social media sources (Twitter, YouTube, Substack) to single GTM (marketing) signal category rather than platform-specific categories (2026-02-22)
+- **Context:** Multiple unrelated platforms with different APIs and interaction patterns need signal classification for routing
+- **Why:** Signal intelligence interpretation treats all three as marketing/communications channels. Simpler routing logic with less category overhead
+- **Rejected:** Platform-specific categories (twitter_category, youtube_category); more granular classification (content_distribution, community_engagement)
+- **Trade-offs:** Simpler classification logic and fewer signal queues, but groups diverse platforms together - masks different handling needs. Hard to un-group later
+- **Breaking if changed:** If future requirements need platform-specific signal handling (e.g., YouTube needs different rate limits than Twitter), classification refactoring required throughout signal pipeline
+
+#### [Pattern] Signal classification uses source prefix matching (twitter:, youtube:, substack:) rather than explicit switch statements for routing (2026-02-22)
+- **Problem solved:** New signal sources need to be added to SignalIntakeService classification; pattern enables extensibility
+- **Why this works:** Prefix-based routing decouples signal source additions from routing logic; new platforms require only new tool definitions and count tracking, not signal service modification
+- **Trade-offs:** More flexible and scalable but requires discipline to maintain naming conventions; harder to find all signal handlers via IDE search
+
+### Centralized SignalCounts type in @automaker/types package instead of keeping in signal-intake-service (2026-02-22)
+- **Context:** Multiple packages (tools, server) need to reference signal count structure; placed in shared types package
+- **Why:** Breaks circular dependency; prevents server package from exposing implementation details to tools package; establishes single source of truth
+- **Rejected:** Defining SignalCounts in server package - would require tools package to depend on server or duplicate the type
+- **Trade-offs:** Cleaner dependency graph but requires types package rebuild when signal structure changes; moved implementation concern to shared layer
+- **Breaking if changed:** If SignalCounts moves back to server, tools package cannot type its signal handling correctly
+
+#### [Pattern] Three-layer separation: tool definitions (social-tools.ts), API handlers (social-handlers.ts), signal routing (SignalIntakeService) (2026-02-22)
+- **Problem solved:** Social media tools need definitions, implementations, and classification logic across different modules
+- **Why this works:** Enables deferred implementation - tools defined before /social/* endpoints exist; handlers can call unimplemented endpoints; separates concerns for testability
+- **Trade-offs:** Adds abstraction layer and extra file; enables parallelized development (tool definitions before endpoint implementation); easier to test handlers independently
+
+### Exceeded minimum requirement (15-20) by implementing exactly 20 tools across 3 platforms with balanced distribution (7 Twitter, 8 YouTube, 6 Substack) (2026-02-22)
+- **Context:** Feature scope allowed 15-20 tools; team chose deliberate distribution across platforms rather than concentrating on single platform
+- **Why:** Comprehensive coverage across major social platforms; distribution ensures feature completeness; 20 is memorable boundary
+- **Rejected:** 15 tools concentrated on single platform (e.g., 15 Twitter tools); variable distribution
+- **Trade-offs:** Higher initial maintenance burden but more valuable feature surface; future social sources fit established pattern
+- **Breaking if changed:** If reduced below 7-8 per platform, some platform functionality becomes limited; API client code must support all tool paths

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 274
-  referenced: 141
-  successfulFeatures: 141
+  loaded: 277
+  referenced: 143
+  successfulFeatures: 143
 ---
 # gotchas
 
@@ -212,3 +212,13 @@ usageStats:
 - **Rejected:** Fixing the build error (scope creep); blocking feature on unrelated issues
 - **Trade-offs:** Faster feature delivery; leaves technical debt in codebase; hides fragility in build system
 - **Breaking if changed:** If feature requirements change and now require the broken package, hidden debt becomes visible crisis; if someone tries to build entire monorepo, they hit the error and must debug it; if CI/CD fails on build, teams can't easily distinguish feature-related failures from pre-existing ones
+
+#### [Gotcha] Package build verification strategy shifted to isolated package builds when upstream platform package had pre-existing TypeScript errors, masking potential integration issues (2026-02-22)
+- **Situation:** npm run build:packages failed on platform package import errors unrelated to social tools feature
+- **Root cause:** Isolated build (libs/tools, apps/server) faster feedback and clear scope, but can't verify cross-package integration or type compatibility with platform package
+- **How to avoid:** Unblocked feature verification and identified that tools package itself compiles cleanly, but may have missed integration bugs with types package
+
+#### [Gotcha] TypeScript incremental compilation cache can report 'no exported member' errors even when types are correctly built and exported in dist files (2026-02-22)
+- **Situation:** SignalCounts type showed compilation error in server even though grep verified it was present in libs/types/dist/index.d.ts
+- **Root cause:** TypeScript's incremental cache stores stale references from previous compilation state; resolves on worktree merge or IDE restart
+- **How to avoid:** Delayed developer feedback but doesn't block builds; confusing to troubleshoot without understanding cache behavior

--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -5,9 +5,9 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 3
-  referenced: 3
-  successfulFeatures: 3
+  loaded: 6
+  referenced: 5
+  successfulFeatures: 5
 ---
 # GTM Signal Intelligence & Content Operations
 

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -121,6 +121,7 @@ export interface StateContext {
   planRetryCount: number;
   escalationReason?: string;
   reviewFeedback?: string;
+  siblingReflections?: string[];
 }
 
 /**
@@ -444,6 +445,42 @@ class ExecuteProcessor implements StateProcessor {
       }
     }
 
+    // Load reflections from completed sibling features for feed-forward context
+    try {
+      const allFeatures = await this.serviceContext.featureLoader.getAll(ctx.projectPath);
+      const siblings = allFeatures.filter(
+        (f) =>
+          f.id !== ctx.feature.id &&
+          (f.status === 'done' || f.status === 'verified') &&
+          (ctx.feature.epicId
+            ? f.epicId === ctx.feature.epicId
+            : f.projectSlug === ctx.feature.projectSlug)
+      );
+      const recent = siblings
+        .sort((a, b) => (b.completedAt || '').localeCompare(a.completedAt || ''))
+        .slice(0, 3);
+
+      const reflections: string[] = [];
+      const fs = await import('node:fs/promises');
+      for (const sib of recent) {
+        try {
+          const content = await fs.readFile(
+            path.join(getFeatureDir(ctx.projectPath, sib.id), 'reflection.md'),
+            'utf-8'
+          );
+          if (content.trim()) reflections.push(content.trim());
+        } catch {
+          /* no reflection yet */
+        }
+      }
+      if (reflections.length > 0) {
+        ctx.siblingReflections = reflections;
+        logger.info(`[EXECUTE] Loaded ${reflections.length} sibling reflections`);
+      }
+    } catch (err) {
+      logger.warn('[EXECUTE] Failed to load sibling reflections:', err);
+    }
+
     logger.info('[EXECUTE] Launching agent via autoModeService.executeFeature()', {
       featureId: ctx.feature.id,
       retryCount: ctx.retryCount,
@@ -522,7 +559,7 @@ class ExecuteProcessor implements StateProcessor {
         }
       });
 
-      // Build recovery context from plan output, review feedback, and context fidelity
+      // Build recovery context from plan output, review feedback, and sibling reflections
       const contextParts: string[] = [];
       if (ctx.planOutput) {
         contextParts.push(`## Implementation Plan\n\n${ctx.planOutput}`);
@@ -530,6 +567,11 @@ class ExecuteProcessor implements StateProcessor {
       if (ctx.reviewFeedback) {
         contextParts.push(
           `## Review Feedback (Changes Requested)\n\nAddress these issues:\n\n${ctx.reviewFeedback}`
+        );
+      }
+      if (ctx.siblingReflections && ctx.siblingReflections.length > 0) {
+        contextParts.push(
+          `## Learnings from Prior Features\n\nApply relevant lessons:\n\n${ctx.siblingReflections.join('\n\n---\n\n')}`
         );
       }
       const recoveryContext = contextParts.length > 0 ? contextParts.join('\n\n') : undefined;
@@ -872,6 +914,9 @@ class DeployProcessor implements StateProcessor {
       remediationAttempts: ctx.remediationAttempts,
     });
 
+    // Fire-and-forget reflection (non-blocking)
+    void this.generateReflection(ctx);
+
     return {
       nextState: null,
       shouldContinue: false,
@@ -881,6 +926,69 @@ class DeployProcessor implements StateProcessor {
 
   async exit(_ctx: StateContext): Promise<void> {
     logger.info('[DEPLOY] Deployment verification completed');
+  }
+
+  private async generateReflection(ctx: StateContext): Promise<void> {
+    try {
+      const featureDir = getFeatureDir(ctx.projectPath, ctx.feature.id);
+      const fs = await import('node:fs/promises');
+
+      // Read agent output tail for outcome context
+      let agentOutputTail = '';
+      try {
+        const full = await fs.readFile(path.join(featureDir, 'agent-output.md'), 'utf-8');
+        agentOutputTail = full.length > 2000 ? full.slice(-2000) : full;
+      } catch {
+        /* no output file */
+      }
+
+      const summary = [
+        `Feature: ${ctx.feature.title}`,
+        `Cost: $${(ctx.feature.costUsd || 0).toFixed(2)}`,
+        `Retries: ${ctx.retryCount} | Remediation cycles: ${ctx.remediationAttempts}`,
+        ctx.reviewFeedback ? `PR feedback received: ${ctx.reviewFeedback.slice(0, 500)}` : '',
+        `Execution history: ${JSON.stringify(
+          ctx.feature.executionHistory?.map((e) => ({
+            model: e.model,
+            success: e.success,
+            durationMs: e.durationMs,
+            costUsd: e.costUsd,
+          })) || []
+        )}`,
+        agentOutputTail ? `\nAgent output (tail):\n${agentOutputTail}` : '',
+      ]
+        .filter(Boolean)
+        .join('\n');
+
+      const result = await simpleQuery({
+        prompt: `You are a concise engineering retrospective analyst. Given this feature's execution data, write a brief reflection (under 200 words) covering:
+1. **Outcome**: What was built, success or partial success
+2. **Efficiency**: Cost/retry count reasonable? Wasted cycles?
+3. **Lessons**: 1-2 specific, actionable takeaways for the next feature
+4. **Pitfalls**: Anything the next agent should avoid
+Be specific. No generic advice.
+
+Feature Data:
+${summary}`,
+        model: 'haiku',
+        cwd: ctx.projectPath,
+        maxTurns: 1,
+        allowedTools: [],
+      });
+
+      const content = `# Reflection: ${ctx.feature.title}\n\n_Generated: ${new Date().toISOString()}_\n_Cost: $${(ctx.feature.costUsd || 0).toFixed(2)} | Retries: ${ctx.retryCount} | Remediation: ${ctx.remediationAttempts}_\n\n${result.text}\n`;
+      const reflectionPath = path.join(featureDir, 'reflection.md');
+      await fs.writeFile(reflectionPath, content, 'utf-8');
+
+      this.serviceContext.events.emit('feature:reflection:complete' as EventType, {
+        featureId: ctx.feature.id,
+        projectPath: ctx.projectPath,
+        reflectionPath,
+      });
+      logger.info(`[DEPLOY] Reflection generated for feature ${ctx.feature.id}`);
+    } catch (err) {
+      logger.warn(`[DEPLOY] Reflection generation failed:`, err);
+    }
   }
 }
 

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -25,6 +25,7 @@ export type EventType =
   | 'feature:follow-up-started'
   | 'feature:follow-up-completed'
   | 'feature:verified'
+  | 'feature:reflection:complete'
   | 'feature:committed'
   | 'feature:retry'
   | 'feature:recovery'


### PR DESCRIPTION
## Summary
- After each feature completes (DEPLOY state), a fire-and-forget haiku LLM call generates a structured reflection (~200 words) covering outcome, efficiency, lessons, and pitfalls
- Reflections stored as `.automaker/features/{id}/reflection.md`
- Up to 3 most recent sibling reflections (same epic or project) are fed into the next feature's recovery context via the existing `contextParts` injection point
- Creates a learning loop within each project — each feature benefits from the last
- Cost: ~$0.001/reflection (haiku)

## Changes
- `libs/types/src/event.ts` — add `feature:reflection:complete` event type
- `apps/server/src/services/lead-engineer-service.ts`:
  - `StateContext.siblingReflections` field
  - `DeployProcessor.generateReflection()` — haiku-powered reflection generation
  - `ExecuteProcessor.process()` — loads sibling reflections before agent launch
  - `ExecuteProcessor.waitForCompletion()` — injects reflections into recovery context

## Test plan
- [ ] Build passes (`npm run build:packages && npm run build:server`)
- [ ] Run a feature through Lead Engineer pipeline → verify `reflection.md` created in feature dir
- [ ] Run a second feature in same epic/project → verify "Learnings from Prior Features" in agent context
- [ ] Verify reflection generation failure does not block feature completion (fire-and-forget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System now automatically generates and persists reflections after feature deployment and execution.
  * Learnings from previously completed features are loaded and integrated into the recovery context during planning cycles.
  * New event type added to notify when reflections are generated and ready for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->