### PR TITLE
feat: expose reflection/ceremony observability in flow graph

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -693,7 +693,6 @@ const completionDetectorService = new CompletionDetectorService();
 completionDetectorService.initialize(events, featureLoader, projectService, settingsService);
 
 // Initialize Reflection Service — generates retrospective when projects complete
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const reflectionService = new ReflectionService(events, featureLoader);
 
 // Initialize Lead Engineer Service — production-phase nerve center
@@ -1368,7 +1367,10 @@ app.use(
     pipelineCheckpointService,
     events,
     gtmAgent,
-    pipelineOrchestrator
+    pipelineOrchestrator,
+    ceremonyService,
+    reflectionService,
+    completionDetectorService
   )
 );
 app.use('/api/langfuse', createLangfuseRoutes());

--- a/apps/server/src/routes/engine/index.ts
+++ b/apps/server/src/routes/engine/index.ts
@@ -24,6 +24,9 @@ import type { PipelineCheckpointService } from '../../services/pipeline-checkpoi
 import type { EventEmitter } from '../../lib/events.js';
 import type { GTMAuthorityAgent } from '../../services/authority-agents/gtm-agent.js';
 import type { PipelineOrchestrator } from '../../services/pipeline-orchestrator.js';
+import type { CeremonyService } from '../../services/ceremony-service.js';
+import type { ReflectionService } from '../../services/reflection-service.js';
+import type { CompletionDetectorService } from '../../services/completion-detector-service.js';
 import { getNotesWorkspacePath, ensureNotesDir, secureFs } from '@automaker/platform';
 import type { NotesWorkspace, PipelinePhase } from '@automaker/types';
 import { PIPELINE_PHASES } from '@automaker/types';
@@ -43,7 +46,10 @@ export function createEngineRoutes(
   pipelineCheckpointService?: PipelineCheckpointService,
   events?: EventEmitter,
   gtmAgent?: GTMAuthorityAgent,
-  pipelineOrchestrator?: PipelineOrchestrator
+  pipelineOrchestrator?: PipelineOrchestrator,
+  ceremonyService?: CeremonyService,
+  reflectionService?: ReflectionService,
+  completionDetectorService?: CompletionDetectorService
 ): Router {
   const router = Router();
 
@@ -162,6 +168,24 @@ export function createEngineRoutes(
               totalActive: 0,
               pendingDrafts: gtmAgent ? gtmAgent.getPendingDraftCount() : 0,
             },
+        reflection: {
+          ceremonies: ceremonyService?.getStatus() ?? {
+            counts: {},
+            total: 0,
+            lastCeremonyAt: null,
+          },
+          reflections: reflectionService?.getStatus() ?? {
+            active: false,
+            activeProject: null,
+            reflectionCount: 0,
+            lastReflection: null,
+          },
+          completions: completionDetectorService?.getStatus() ?? {
+            completionCounts: { epics: 0, milestones: 0, projects: 0 },
+            emittedMilestones: 0,
+            emittedProjects: 0,
+          },
+        },
         timestamp: new Date().toISOString(),
       });
     } catch (error) {

--- a/apps/server/src/services/ceremony-service.ts
+++ b/apps/server/src/services/ceremony-service.ts
@@ -108,6 +108,17 @@ export class CeremonyService {
   private linearProjectUpdateService: LinearProjectUpdateService | null = null;
   private unsubscribe: (() => void) | null = null;
 
+  /** Observability counters for engine status */
+  private ceremonyCounts = {
+    epicKickoff: 0,
+    standup: 0,
+    milestoneRetro: 0,
+    epicDelivery: 0,
+    contentBrief: 0,
+    projectRetro: 0,
+  };
+  private lastCeremonyAt: string | null = null;
+
   /**
    * Initialize the service with dependencies
    */
@@ -184,6 +195,18 @@ export class CeremonyService {
   }
 
   /**
+   * Get observability status for engine status API
+   */
+  getStatus(): {
+    counts: Record<string, number>;
+    total: number;
+    lastCeremonyAt: string | null;
+  } {
+    const total = Object.values(this.ceremonyCounts).reduce((a, b) => a + b, 0);
+    return { counts: { ...this.ceremonyCounts }, total, lastCeremonyAt: this.lastCeremonyAt };
+  }
+
+  /**
    * Handle epic creation event — post kickoff announcement with scope and complexity
    */
   private async handleEpicCreated(payload: EpicCreatedEventPayload): Promise<void> {
@@ -224,6 +247,8 @@ export class CeremonyService {
         );
       }
 
+      this.ceremonyCounts.epicKickoff++;
+      this.lastCeremonyAt = new Date().toISOString();
       logger.info(`Posted epic kickoff for ${project.title} - Epic: ${milestone.title}`);
     } catch (error) {
       logger.error('Failed to generate epic kickoff:', error);
@@ -275,6 +300,8 @@ export class CeremonyService {
         }
       }
 
+      this.ceremonyCounts.standup++;
+      this.lastCeremonyAt = new Date().toISOString();
       logger.info(
         `Posted milestone standup for ${projectTitle} - Milestone ${milestoneNumber}: ${milestoneTitle}`
       );
@@ -352,6 +379,8 @@ export class CeremonyService {
         );
       }
 
+      this.ceremonyCounts.milestoneRetro++;
+      this.lastCeremonyAt = new Date().toISOString();
       logger.info(
         `Posted milestone ceremony for ${projectTitle} - Milestone ${milestoneNumber}: ${milestoneTitle}`
       );
@@ -440,6 +469,8 @@ Keep it concise, actionable, and focused on what makes this milestone interestin
         );
       }
 
+      this.ceremonyCounts.contentBrief++;
+      this.lastCeremonyAt = new Date().toISOString();
       logger.info(`Posted content brief to GTM channel for milestone: ${milestoneTitle}`);
     } catch (error) {
       logger.error('Failed to generate milestone content brief:', error);
@@ -484,6 +515,8 @@ Keep it concise, actionable, and focused on what makes this milestone interestin
         );
       }
 
+      this.ceremonyCounts.epicDelivery++;
+      this.lastCeremonyAt = new Date().toISOString();
       logger.info(`Posted epic delivery announcement for "${featureTitle}"`);
     } catch (error) {
       logger.error('Failed to generate epic delivery announcement:', error);
@@ -607,6 +640,8 @@ ${dataSummary}`;
         );
       }
 
+      this.ceremonyCounts.projectRetro++;
+      this.lastCeremonyAt = new Date().toISOString();
       logger.info(`Posted project retrospective with impact report for ${projectTitle}`);
 
       // Extract and create improvement items (closes the REFLECT → REPEAT loop)

--- a/apps/server/src/services/completion-detector-service.ts
+++ b/apps/server/src/services/completion-detector-service.ts
@@ -47,6 +47,9 @@ export class CompletionDetectorService {
   private emittedMilestones = new Set<string>();
   private emittedProjects = new Set<string>();
 
+  /** Observability counters for engine status API */
+  private completionCounts = { epics: 0, milestones: 0, projects: 0 };
+
   initialize(
     emitter: EventEmitter,
     featureLoader: FeatureLoader,
@@ -93,6 +96,21 @@ export class CompletionDetectorService {
   }
 
   /**
+   * Get observability status for engine status API
+   */
+  getStatus(): {
+    completionCounts: { epics: number; milestones: number; projects: number };
+    emittedMilestones: number;
+    emittedProjects: number;
+  } {
+    return {
+      completionCounts: { ...this.completionCounts },
+      emittedMilestones: this.emittedMilestones.size,
+      emittedProjects: this.emittedProjects.size,
+    };
+  }
+
+  /**
    * Core handler: a feature moved to "done". Check cascading completions.
    */
   private async onFeatureDone(projectPath: string, featureId: string): Promise<void> {
@@ -133,6 +151,7 @@ export class CompletionDetectorService {
     const epic = allFeatures.find((f) => f.id === epicId);
     if (!epic || epic.status === 'done') return;
 
+    this.completionCounts.epics++;
     logger.info(`All children of epic "${epic.title}" are done — marking epic done`);
     await this.featureLoader!.update(projectPath, epicId, { status: 'done' });
 
@@ -173,6 +192,7 @@ export class CompletionDetectorService {
     if (!allPhasesDone) return;
 
     // Mark milestone completed
+    this.completionCounts.milestones++;
     this.emittedMilestones.add(dedupeKey);
     milestone.status = 'completed';
     await this.projectService!.updateProject(projectPath, projectSlug, {
@@ -218,6 +238,7 @@ export class CompletionDetectorService {
     const allCompleted = project.milestones.every((m) => m.status === 'completed');
     if (!allCompleted) return;
 
+    this.completionCounts.projects++;
     this.emittedProjects.add(dedupeKey);
     await this.projectService!.updateProject(projectPath, projectSlug, {
       status: 'completed',

--- a/apps/server/src/services/reflection-service.ts
+++ b/apps/server/src/services/reflection-service.ts
@@ -31,12 +31,38 @@ interface ProjectCompletedPayload {
 export class ReflectionService {
   private processedProjects = new Set<string>();
 
+  /** Observability state for engine status API */
+  private lastReflection: {
+    projectTitle: string;
+    projectSlug: string;
+    completedAt: string;
+  } | null = null;
+  private reflectionCount = 0;
+  private activeReflection: string | null = null;
+
   constructor(
     private events: EventEmitter,
     private featureLoader: FeatureLoader
   ) {
     this.registerListener();
     logger.info('Reflection service initialized');
+  }
+
+  /**
+   * Get observability status for engine status API
+   */
+  getStatus(): {
+    active: boolean;
+    activeProject: string | null;
+    reflectionCount: number;
+    lastReflection: { projectTitle: string; projectSlug: string; completedAt: string } | null;
+  } {
+    return {
+      active: this.activeReflection !== null,
+      activeProject: this.activeReflection,
+      reflectionCount: this.reflectionCount,
+      lastReflection: this.lastReflection,
+    };
   }
 
   private registerListener(): void {
@@ -56,6 +82,7 @@ export class ReflectionService {
     this.processedProjects.add(key);
 
     logger.info(`Generating reflection for completed project: ${projectTitle}`);
+    this.activeReflection = projectTitle;
 
     try {
       const features = await this.featureLoader.getAll(projectPath);
@@ -100,6 +127,14 @@ ${summary}`,
 
       logger.info(`Reflection stored at ${reflectionPath}`);
 
+      this.activeReflection = null;
+      this.reflectionCount++;
+      this.lastReflection = {
+        projectTitle,
+        projectSlug,
+        completedAt: new Date().toISOString(),
+      };
+
       // Emit event
       this.events.emit('project:reflection:complete', {
         projectPath,
@@ -108,6 +143,7 @@ ${summary}`,
         reflectionPath,
       });
     } catch (error) {
+      this.activeReflection = null;
       logger.error(`Failed to generate reflection for ${projectTitle}:`, error);
     }
   }

--- a/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
+++ b/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
@@ -77,6 +77,27 @@ interface EngineStatusResponse {
     pendingDrafts: number;
     completedToday: number;
   };
+  reflection?: {
+    ceremonies: {
+      total: number;
+      lastCeremonyAt: string | null;
+      counts: Record<string, number>;
+    };
+    reflections: {
+      active: boolean;
+      activeProject: string | null;
+      reflectionCount: number;
+      lastReflection: {
+        projectTitle: string;
+        completedAt: string;
+      } | null;
+    };
+    completions: {
+      completionCounts: { epics: number; milestones: number; projects: number };
+      emittedMilestones: number;
+      emittedProjects: number;
+    };
+  };
 }
 
 function getServiceStatus(
@@ -193,12 +214,23 @@ function getServiceStatus(
               : 'Research \u2192 Draft \u2192 Review \u2192 Publish',
       };
     }
-    case 'reflection':
+    case 'reflection': {
+      const r = engineStatus.reflection;
+      const totalCeremonies = r?.ceremonies?.total ?? 0;
+      const reflectionActive = r?.reflections?.active ?? false;
+      const completions = r?.completions?.completionCounts;
+      const totalCompletions =
+        (completions?.epics ?? 0) + (completions?.milestones ?? 0) + (completions?.projects ?? 0);
       return {
-        status: 'idle',
-        throughput: 0,
-        statusLine: 'Retro \u2192 Reflection \u2192 Knowledge synthesis',
+        status: reflectionActive ? 'active' : totalCeremonies > 0 ? 'active' : 'idle',
+        throughput: totalCeremonies + (r?.reflections?.reflectionCount ?? 0),
+        statusLine: reflectionActive
+          ? `Reflecting on ${r?.reflections?.activeProject}`
+          : totalCeremonies > 0
+            ? `${totalCeremonies} ceremonies, ${totalCompletions} completions`
+            : 'Retro \u2192 Reflection \u2192 Knowledge synthesis',
       };
+    }
     default:
       return { status: 'idle', throughput: 0 };
   }


### PR DESCRIPTION
## Summary
- Add `getStatus()` methods to `CeremonyService`, `ReflectionService`, and `CompletionDetectorService` with counters incremented in each handler
- Wire all 3 services into the engine status API (`/api/engine/status`) under a new `reflection` field
- Update the flow graph hook to display real ceremony counts, active reflections, and completion cascade metrics instead of a static "Idle" state

## Test plan
- [x] `npm run build:server` passes (type check)
- [x] `npm run test:server` passes (1955 tests, 0 failures)
- [ ] Trigger a ceremony via MCP `trigger_ceremony` and verify `/api/engine/status` response includes non-zero `reflection.ceremonies.total`
- [ ] Verify flow graph reflection node shows real throughput count when ceremonies have fired

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced real-time system status monitoring with comprehensive tracking of ceremonies, reflections, and project completions.
  * Enhanced status dashboard displaying live activity metrics including ceremony counts, active reflection states, and completion statistics.
  * Improved workflow visibility with tracking of current and historical system state for better transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->