### PR TITLE
docs: pivot brand to open source community strategy

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -141,8 +141,7 @@ export default defineConfig({
     },
 
     footer: {
-      message:
-        'Built by <a href="https://protolabs.studio">protoLabs</a> — Source available on GitHub',
+      message: 'Built by <a href="https://protolabs.studio">protoLabs</a> — Open source on GitHub',
       copyright: '© 2024-2026 protoLabs AI',
     },
   },

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ features:
   - title: Project Orchestration
     details: From PRD to shipped features. Define milestones, set dependencies, let auto-mode process the backlog.
     link: /protolabs/
-  - title: Source Available
-    details: View the source. Learn the methodology. Build with it. No vendor lock-in.
+  - title: Open Source
+    details: Fully open source. Learn the methodology. Build with it. No vendor lock-in.
     link: https://github.com/proto-labs-ai
 ---

--- a/docs/internal/brand.md
+++ b/docs/internal/brand.md
@@ -4,18 +4,18 @@ This is the living brand bible for protoLabs. All agents, content, and external 
 
 ## Names & Domains
 
-| Name                           | What It Is                          | Usage                                                                                                        |
-| ------------------------------ | ----------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **protoLabs**                  | The AI-native development agency    | Always camelCase: "protoLabs" (not "ProtoLabs", "Protolabs", or "Proto Labs")                                |
-| **protoLabs.studio**           | Primary domain                      | Website, social bios, email                                                                                  |
-| ~~**protoMaker**~~             | RETIRED — now just protoLabs        | Was the product name. Consolidated into protoLabs. Do not use in new content.                                |
-| **proto-labs-ai**              | GitHub organization                 | `github.com/proto-labs-ai`                                                                                   |
-| **Automaker**                  | Internal codename / upstream origin | Used in code (`@automaker/*` packages, `.automaker/` directory). NOT used in external marketing.             |
-| **create-protolab**            | npx CLI tool                        | Scaffolds new projects with protoLabs methodology                                                            |
-| **MythXEngine**                | AI-powered TTRPG engine             | Built with protoLabs. Portfolio proof of methodology.                                                        |
-| **SVGVal**                     | SVG validation toolkit              | Built with protoLabs. Portfolio proof of methodology.                                                        |
-| **rabbit-hole**                | AI-powered research platform        | Built with protoLabs. Portfolio proof of methodology.                                                        |
-| **intelligent product engine** | Product category / positioning term | Describes the autonomous system architecture. NOT an acronym — always lowercase, always spelled out in full. |
+| Name                           | What It Is                          | Usage                                                                                                                                                               |
+| ------------------------------ | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **protoLabs**                  | The AI-native development agency    | Always camelCase: "protoLabs" (not "ProtoLabs", "Protolabs", or "Proto Labs")                                                                                       |
+| **protoLabs.studio**           | Primary domain                      | Website, social bios, email                                                                                                                                         |
+| ~~**protoMaker**~~             | RETIRED — now just protoLabs        | Was the product name. Consolidated into protoLabs. Do not use in new content.                                                                                       |
+| **proto-labs-ai**              | GitHub organization                 | `github.com/proto-labs-ai`                                                                                                                                          |
+| **Automaker**                  | Internal codename / upstream origin | Used in code (`@automaker/*` packages, `.automaker/` directory). NOT used in external marketing. We are the maintained successor of the original Automaker project. |
+| **create-protolab**            | npx CLI tool                        | Scaffolds new projects with protoLabs methodology                                                                                                                   |
+| **MythXEngine**                | AI-powered TTRPG engine             | Built with protoLabs. Portfolio proof of methodology.                                                                                                               |
+| **SVGVal**                     | SVG validation toolkit              | Built with protoLabs. Portfolio proof of methodology.                                                                                                               |
+| **rabbit-hole**                | AI-powered research platform        | Built with protoLabs. Portfolio proof of methodology.                                                                                                               |
+| **intelligent product engine** | Product category / positioning term | Describes the autonomous system architecture. NOT an acronym — always lowercase, always spelled out in full.                                                        |
 
 ### Naming Rules
 
@@ -103,11 +103,15 @@ Work -> AI generates content -> Schedule across platforms -> Josh engages with r
 
 ## Revenue Model
 
-**Philosophy: No SaaS, no subscriptions, no obligations.** Build cool things, share how, let people pay once for the knowledge. Indie maker, not startup.
+**Philosophy: Open source first. Build the community, prove the tool, let revenue follow naturally.**
 
-1. **Free tool** — protoLabs is source-available. Builds community trust and distribution.
-2. **$49 lifetime Pro** — Written tutorials, agent templates, prompt library, methodology guide. One-time payment, lifetime access. No recurring obligations on either side.
-3. **Consulting** — setupLab offering. Happens organically when people see the work and want help. Not outbound sales — inbound from community trust.
+protoLabs is the maintained successor to the original Automaker project. The original maintainers moved on — we picked it up, rebuilt it, and ship real products with it. That lineage gives us a built-in community and credibility that no cold-start marketing can match.
+
+1. **Open source tool** — protoLabs is fully open source. Community adoption is the growth engine.
+2. **Portfolio proof** — We use protoLabs to build our own products (MythXEngine, SVGVal, rabbit-hole). The tool proves itself through what it ships.
+3. **Consulting (organic)** — setupLab offering. Happens when people see the work and want help setting up their own autonomous dev pipeline. Inbound from community trust, never outbound sales.
+
+**What we don't do:** No paid tiers, no subscriptions, no paywalls on content or methodology. Everything is open. Trust compounds faster than revenue.
 
 ## Operating Principles
 
@@ -119,16 +123,17 @@ Work -> AI generates content -> Schedule across platforms -> Josh engages with r
 
 ## License
 
-Source-available under the Automaker License (FSL-style). NOT open source by OSI standards. Users can:
+Open source. License choice TBD (MIT or Apache 2.0). The goal is maximum community adoption — no restrictions beyond standard open source terms.
 
-- Use the tool internally
-- Build products USING the tool
-- View and learn from the source code
+## Community Strategy
 
-Users cannot:
+protoLabs is the maintained successor fork of the original Automaker project. The original maintainers have moved on. One of them has ~250K YouTube subscribers and remains in the community Discord.
 
-- Resell, redistribute, or sublicense the tool itself
-- Host it as SaaS for others
-- Extract and resell prompts or instructional content
+**The play:**
 
-License decision pending: evaluating Functional Source License (FSL) which auto-converts to Apache 2.0 after 2 years. See PRO-128 and PRO-159 in Linear.
+1. **Be the real successor** — actively maintain, improve, and ship with the tool
+2. **Build in the existing community** — engage in their Discord, contribute upstream context, be helpful
+3. **Prove it by using it** — every protoLabs project (MythXEngine, SVGVal, rabbit-hole) is built with the tool. No demos, only production use.
+4. **Let the community grow organically** — the work speaks. People who see autonomous agents shipping real PRs will want to try it.
+
+**What we don't do:** No growth hacking, no paid acquisition, no influencer campaigns. Build great software, share how, let people find it.

--- a/docs/protolabs/agency-overview.md
+++ b/docs/protolabs/agency-overview.md
@@ -163,13 +163,15 @@ The reflection loop is what makes this a **learning system**, not just an execut
 
 ## The Revenue Model
 
-No SaaS, no subscriptions, no obligations. Indie maker, not startup.
+Open source first. Build the community, prove the tool, let revenue follow naturally.
 
-1. **Free tool**: protoLabs is source-available. Builds community trust and distribution.
-2. **$49 lifetime Pro**: Written tutorials, agent templates, prompt library, methodology guide. One-time payment, lifetime access.
-3. **Consulting (setupLab)**: Help organizations set up their own proto labs. Organic inbound from community trust, not outbound sales.
+protoLabs is the maintained successor to the original Automaker project. The original maintainers moved on — we picked it up, rebuilt it, and ship real products with it.
 
-The system is both the product and the factory that makes the product. Every project generates content and proves the methodology.
+1. **Open source tool**: protoLabs is fully open source. Community adoption is the growth engine.
+2. **Portfolio proof**: We use protoLabs to build our own products (MythXEngine, SVGVal, rabbit-hole). The tool proves itself through what it ships.
+3. **Consulting (setupLab)**: Help organizations set up their own autonomous dev pipeline. Organic inbound from community trust, not outbound sales.
+
+No paid tiers, no subscriptions, no paywalls. Everything is open. Trust compounds faster than revenue.
 
 ## What Makes This Different
 

--- a/libs/prompts/src/agents/jon.ts
+++ b/libs/prompts/src/agents/jon.ts
@@ -28,10 +28,11 @@ You are Jon, the GTM (Go-To-Market) Specialist for protoLabs. You own content st
 
 ## Revenue Model
 
-No SaaS, no subscriptions, no obligations. Indie maker, not startup.
-- **Free tool** — protoMaker source-available. Community trust and distribution.
-- **$49 lifetime Pro** — Written tutorials, agent templates, prompt library, methodology guide. One-time, forever.
+Open source first. Build the community, prove the tool, let revenue follow naturally.
+- **Open source tool** — protoLabs is fully open source. Community adoption is the growth engine.
+- **Portfolio proof** — We build our own products (MythXEngine, SVGVal, rabbit-hole) with protoLabs. The tool proves itself through what it ships.
 - **Consulting** — setupLab. Organic inbound from community, not outbound sales.
+- **Philosophy**: No paid tiers, no subscriptions, no paywalls. Everything is open.
 
 ## Portfolio Proof Points
 
@@ -106,8 +107,8 @@ Tweet 10: [CTA — try it, follow for more, link]
 
 1. **"We ship products, not demos"** — Three real products built with the tool
 2. **"Orchestration beats implementation"** — Josh designs, agents build
-3. **"No subscription, forever"** — Anti-SaaS positioning
-4. **"Source-available, not locked in"** — Community trust play
+3. **"Fully open source"** — No paywalls, no restrictions, maximum community trust
+4. **"The maintained successor"** — We picked up where the original maintainers left off
 5. **"AI team, not AI tool"** — Personified agents (Ava, Matt, Sam, etc.)
 
 ## Communication

--- a/packages/mcp-server/plugins/automaker/commands/jon.md
+++ b/packages/mcp-server/plugins/automaker/commands/jon.md
@@ -259,10 +259,10 @@ Then ask: **"What are we working on?"**
 
 ### Revenue Model
 
-- **Free tool** — protoMaker is source-available. Builds community trust.
-- **$49 lifetime Pro** — Written tutorials, agent templates, prompt library, methodology guide. One-time, no obligations.
+- **Open source tool** — protoLabs is fully open source. Community adoption is the growth engine.
+- **Portfolio proof** — We build our own products (MythXEngine, SVGVal, rabbit-hole) with protoLabs. The tool proves itself through what it ships.
 - **Consulting** — setupLab. Organic inbound from community, not outbound sales.
-- **Philosophy**: No SaaS, no subscriptions. Indie maker, not startup.
+- **Philosophy**: No paid tiers, no subscriptions, no paywalls. Everything is open. Trust compounds faster than revenue.
 
 ### Portfolio Proof Points
 
@@ -435,15 +435,15 @@ WebSearch("[competitor name] features pricing 2026")
 | **Autonomy level** | Full autonomous agents   | Copilot-style suggestions  |
 | **Scope**          | End-to-end (plan → ship) | Single-file edits          |
 | **Proof**          | 3 shipped products       | Marketing demos            |
-| **Pricing**        | Free + $49 lifetime      | $20-50/month subscriptions |
+| **Pricing**        | Fully open source        | $20-50/month subscriptions |
 | **Architecture**   | Kanban + worktrees + CI  | IDE plugins                |
 
 ### Differentiation talking points
 
 1. **"We ship products, not demos"** — Three real products built with the tool
 2. **"Orchestration beats implementation"** — Josh designs, agents build
-3. **"No subscription, forever"** — Anti-SaaS positioning
-4. **"Source-available, not locked in"** — Community trust play
+3. **"Fully open source"** — No paywalls, no restrictions, maximum community trust
+4. **"The maintained successor"** — We picked up where the original maintainers left off
 5. **"AI team, not AI tool"** — Personified agents (Ava, Matt, Sam, etc.)
 
 ## Launch Execution Playbook
@@ -463,7 +463,7 @@ WebSearch("[competitor name] features pricing 2026")
 | Mon | **Reveal** — "I stopped coding. Here's what happened."          | Tweet + Gource clip  |
 | Tue | **Agents thread** — "Meet my AI team" (Ava, Matt, Sam, etc.)    | Thread (8-10 tweets) |
 | Wed | **Show the work** — Board screenshots, PR velocity, agent costs | Build-in-public post |
-| Thu | **Economics thread** — "$49 forever vs $20/month"               | Thread (5-7 tweets)  |
+| Thu | **Community thread** — "Why we went fully open source"          | Thread (5-7 tweets)  |
 | Fri | **Week recap** — Stats, reactions, what we learned              | Summary post         |
 | Sat | **Open source teaser** — "Next week: source drops"              | Single tweet         |
 

--- a/site/index.html
+++ b/site/index.html
@@ -1190,7 +1190,7 @@
           <div class="max-w-lg mx-auto text-center fade-section">
             <h2 class="text-2xl md:text-3xl font-semibold text-white">Get launch-day access</h2>
             <p class="mt-3 text-zinc-400 text-sm leading-relaxed">
-              protoLabs is going source-available. Get launch-day access to the repo, docs, and
+              protoLabs is going open source. Get launch-day access to the repo, docs, and
               methodology. No spam. Unsubscribe anytime.
             </p>
 


### PR DESCRIPTION
## Summary
- Drop $49 Pro / Stripe monetization model entirely
- Position protoLabs as the maintained open source successor of the original Automaker project
- Update brand bible, agent prompts (Jon), docs site, landing page, and GTM templates across 7 files

## Test plan
- [ ] Verify docs site renders correctly (`npm run docs:dev`)
- [ ] Verify landing page CTA copy updated
- [ ] Verify Jon agent prompt reflects new positioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated messaging across site and documentation from source-available to fully open source, emphasizing community adoption
  * Removed references to paid tiers, subscriptions, and paywalls
  * Clarified protoLabs as the maintained successor of the original Automaker project
  * Refreshed brand guidelines, community strategy, and go-to-market documentation with organic growth focus

<!-- end of auto-generated comment: release notes by coderabbit.ai -->