### PR TITLE
fix: remove auto-mode idle self-termination that kills loop after 20s

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -1081,8 +1081,12 @@ export class AutoModeService {
             // features that become unblocked when dependencies complete.
             logger.debug(`[AutoLoop] Still idle for ${worktreeDesc}, polling again in 30s...`);
           }
-          // Longer sleep when idle to reduce filesystem reads
-          await this.sleep(projectState.hasEmittedIdleEvent ? 30000 : 10000);
+          // Longer sleep when idle to reduce filesystem reads; pass abort signal
+          // so stopAutoLoopForProject() remains responsive even during 30s idle sleep
+          await this.sleep(
+            projectState.hasEmittedIdleEvent ? 30000 : 10000,
+            projectState.abortController.signal
+          );
           continue;
         }
 
@@ -1464,8 +1468,12 @@ export class AutoModeService {
             // features that become unblocked when dependencies complete.
             logger.debug(`[AutoLoop] Still idle, polling again in 30s...`);
           }
-          // Longer sleep when idle to reduce filesystem reads
-          await this.sleep(this.hasEmittedIdleEvent ? 30000 : 10000);
+          // Longer sleep when idle to reduce filesystem reads; pass abort signal
+          // so stopAutoLoop() remains responsive even during 30s idle sleep
+          await this.sleep(
+            this.hasEmittedIdleEvent ? 30000 : 10000,
+            this.autoLoopAbortController?.signal
+          );
           continue;
         }
 


### PR DESCRIPTION
## Summary
- Auto-mode self-terminated after just 2 consecutive idle iterations (~20s) when no features were immediately ready
- This killed the loop before dependency-blocked features could become unblocked
- Replace idle `break` with continued polling at 30s intervals (vs 10s when active)
- Loop now only stops when explicitly told to via `stopAutoLoopForProject()`

## Root Cause
`runAutoLoopForProject()` had a two-iteration idle kill: when `loadPendingFeatures()` returned 0 features twice in a row, it set `isRunning = false` and broke the loop. With a 10s startup delay + 10s sleep, the loop died ~20s after starting — before any dependency-blocked features could become ready.

## Test plan
- [ ] Start auto-mode with dependency-blocked features in backlog
- [ ] Verify loop stays alive for >30s with no ready features
- [ ] Verify features are picked up when dependencies complete
- [ ] `npm run test:server` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-mode no longer stops when idle; it keeps monitoring for new work at a reduced frequency.
  * Idle polling now uses a longer conditional sleep (30s) to lower resource use while remaining active.
  * Idle polling respects abort signals for improved responsiveness.
  * Added logging to indicate continued background polling so status is clearer when idle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->