### PR TITLE
feat: PromptCITriggerService for repository_dispatch on prompt changes

### DIFF
--- a/apps/server/src/services/prompt-ci-trigger-service.ts
+++ b/apps/server/src/services/prompt-ci-trigger-service.ts
@@ -31,7 +31,7 @@ if (process.platform === 'win32') {
     '/opt/homebrew/bin',
     '/usr/local/bin',
     '/home/linuxbrew/.linuxbrew/bin',
-    `${process.env.HOME}/.local/bin`,
+    `${process.env.HOME}/.local/bin`
   );
 }
 
@@ -133,7 +133,7 @@ export class PromptCITriggerService {
       const triggerCmd = `gh api repos/{owner}/{repo}/dispatches -f event_type='langfuse-prompt-update' -f client_payload='${payloadJson}'`;
 
       logger.info(
-        `Triggering CI for prompt update: ${promptPayload.name} v${promptPayload.version} (${promptPayload.action})`,
+        `Triggering CI for prompt update: ${promptPayload.name} v${promptPayload.version} (${promptPayload.action})`
       );
 
       await execAsync(triggerCmd, {
@@ -166,7 +166,7 @@ export class PromptCITriggerService {
    */
   async triggerCIAfterCommit(
     workDir: string,
-    promptPayload: PromptPayload,
+    promptPayload: PromptPayload
   ): Promise<CITriggerResult> {
     logger.debug('Checking if CI trigger should fire after successful commit');
     return this.triggerCI(workDir, promptPayload);


### PR DESCRIPTION
## Summary
- Adds `PromptCITriggerService` that fires GitHub `repository_dispatch` events when prompts are committed to GitHub
- Uses `gh` CLI to dispatch `langfuse-prompt-update` events with prompt metadata in `client_payload`
- Controlled by `LANGFUSE_SYNC_CI_TRIGGER` env var (only fires when set to `true` or `1`)
- Graceful no-op when env var is unset or `gh` CLI unavailable

## Test plan
- [ ] Verify service skips when `LANGFUSE_SYNC_CI_TRIGGER` is unset
- [ ] Verify service skips when `LANGFUSE_SYNC_CI_TRIGGER=false`
- [ ] Verify service fires dispatch when `LANGFUSE_SYNC_CI_TRIGGER=true`
- [ ] Verify graceful error when `gh` CLI not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic CI workflow dispatch for prompt updates—prompts can now trigger CI runs to validate/process changes.
  * Configurable via environment variable; triggering will be skipped when disabled.
  * Provides clear outcomes (success, skipped, or error) and logs progress so admins can see dispatch status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->