### PR TITLE
docs: add Langfuse sync env vars to CLAUDE.md and .env.example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,12 @@ mcp__automaker__create_feature({
 - `LANGFUSE_PUBLIC_KEY` - Langfuse public key (optional, enables observability)
 - `LANGFUSE_SECRET_KEY` - Langfuse secret key (optional, enables observability)
 - `LANGFUSE_BASE_URL` - Langfuse API URL (default: https://cloud.langfuse.com)
+- `LANGFUSE_WEBHOOK_SECRET` - Webhook secret for verifying Langfuse webhook payloads
+- `GITHUB_TOKEN` - GitHub personal access token for repository operations
+- `GITHUB_REPO_OWNER` - GitHub repository owner/organization name
+- `GITHUB_REPO_NAME` - GitHub repository name
+- `LANGFUSE_SYNC_LABEL` - Prompt label to filter webhook events (default: production)
+- `LANGFUSE_SYNC_CI_TRIGGER` - Enable repository_dispatch after prompt sync (true/1 to enable)
 
 ## MCP Server & Claude Code Plugin
 

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -107,6 +107,41 @@ LINEAR_WEBHOOK_SECRET=
 DISCORD_TOKEN=
 
 # ============================================
+# OPTIONAL - Langfuse Integration
+# ============================================
+
+# Langfuse public key for observability (optional)
+# LANGFUSE_PUBLIC_KEY=
+
+# Langfuse secret key for observability (optional)
+# LANGFUSE_SECRET_KEY=
+
+# Langfuse API base URL (default: https://cloud.langfuse.com)
+# LANGFUSE_BASE_URL=https://cloud.langfuse.com
+
+# Webhook secret for verifying Langfuse webhook payloads
+# LANGFUSE_WEBHOOK_SECRET=
+
+# ============================================
+# OPTIONAL - GitHub Sync
+# ============================================
+
+# GitHub personal access token for repository operations
+# GITHUB_TOKEN=
+
+# GitHub repository owner/organization name
+# GITHUB_REPO_OWNER=
+
+# GitHub repository name
+# GITHUB_REPO_NAME=
+
+# Prompt label to filter webhook events (default: production)
+# LANGFUSE_SYNC_LABEL=production
+
+# Enable repository_dispatch after prompt sync (true/1 to enable)
+# LANGFUSE_SYNC_CI_TRIGGER=
+
+# ============================================
 # OPTIONAL - Debugging
 # ============================================
 


### PR DESCRIPTION
## Summary
- Adds 6 new environment variables for the Langfuse Prompt GitHub Sync feature to CLAUDE.md and .env.example
- Variables: `LANGFUSE_WEBHOOK_SECRET`, `GITHUB_TOKEN`, `GITHUB_REPO_OWNER`, `GITHUB_REPO_NAME`, `LANGFUSE_SYNC_LABEL`, `LANGFUSE_SYNC_CI_TRIGGER`
- Organized into Langfuse Integration and GitHub Sync sections in .env.example

## Test plan
- [ ] Verify CLAUDE.md env var table has all 6 new entries
- [ ] Verify .env.example has commented-out entries with descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GitHub integration to enable automatic prompt synchronization from Langfuse via webhooks.
  * Introduced webhook verification for enhanced security and configurable repository dispatch triggers for CI/CD workflows.
  * Added configuration options for prompt filtering and sync controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->