### PR TITLE
fix: populate Langfuse trace input/output fields

### DIFF
--- a/libs/observability/src/langfuse/client.ts
+++ b/libs/observability/src/langfuse/client.ts
@@ -105,12 +105,31 @@ export class LangfuseClient {
         sessionId: options.sessionId,
         metadata: options.metadata,
         tags: options.tags,
+        input: options.input,
+        output: options.output,
       });
       logger.debug('Created trace in Langfuse', { traceId: options.id });
       return trace;
     } catch (error) {
       logger.error('Failed to create trace in Langfuse', error);
       return null;
+    }
+  }
+
+  /**
+   * Update an existing trace with new data (e.g., input/output after execution)
+   */
+  updateTrace(
+    traceId: string,
+    data: { input?: any; output?: any; metadata?: Record<string, any> }
+  ) {
+    if (!this.isAvailable()) return;
+    try {
+      const trace = this.client!.trace({ id: traceId });
+      trace.update(data);
+      logger.debug('Updated trace in Langfuse', { traceId });
+    } catch (error) {
+      logger.error('Failed to update trace in Langfuse', error);
     }
   }
 

--- a/libs/observability/src/langfuse/langfuse.d.ts
+++ b/libs/observability/src/langfuse/langfuse.d.ts
@@ -26,6 +26,15 @@ declare module 'langfuse' {
     sessionId?: string;
     metadata?: Record<string, any>;
     tags?: string[];
+    input?: any;
+    output?: any;
+  }
+
+  export interface LangfuseTraceObject {
+    id: string;
+    update(body: Partial<LangfuseTraceBody>): void;
+    generation(body: Omit<LangfuseGenerationBody, 'traceId'> & { traceId?: string }): any;
+    span(body: any): any;
   }
 
   export interface LangfuseGenerationBody {
@@ -49,7 +58,7 @@ declare module 'langfuse' {
   export class Langfuse {
     constructor(options: LangfuseOptions);
     getPrompt(name: string, version?: number): Promise<LangfusePromptResponse | null>;
-    trace(body: LangfuseTraceBody): any;
+    trace(body: LangfuseTraceBody): LangfuseTraceObject;
     generation(body: LangfuseGenerationBody): any;
     flush(): Promise<void>;
     flushAsync(): Promise<void>;

--- a/libs/observability/src/langfuse/middleware.ts
+++ b/libs/observability/src/langfuse/middleware.ts
@@ -235,6 +235,12 @@ export async function* wrapProviderWithTracing<T>(
 
     client.createGeneration(generationOptions);
 
+    // Update parent trace with I/O for visibility in Langfuse dashboard
+    client.updateTrace(traceId, {
+      input: options.input,
+      output: messages.length > 0 ? messages[messages.length - 1] : undefined,
+    });
+
     // Flush events to Langfuse
     await client.flush();
 
@@ -338,6 +344,12 @@ export async function completeTracingContext(
     metadata: generationMetadata,
     startTime: context.startTime,
     endTime,
+  });
+
+  // Update parent trace with I/O
+  client.updateTrace(context.traceId, {
+    input: options.input,
+    output: options.output,
   });
 
   await client.flush();

--- a/libs/observability/src/langfuse/types.ts
+++ b/libs/observability/src/langfuse/types.ts
@@ -90,6 +90,10 @@ export interface CreateTraceOptions {
   metadata?: Record<string, any>;
   /** Tags for filtering */
   tags?: string[];
+  /** Trace input (prompt, messages, etc.) */
+  input?: any;
+  /** Trace output (response, completion, etc.) */
+  output?: any;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `input`/`output` fields to `LangfuseTraceBody` and `CreateTraceOptions` types so callers can pass trace-level I/O
- Types the `trace()` return as `LangfuseTraceObject` with `.update()` method instead of `any`
- Adds `updateTrace()` to `LangfuseClient` for setting I/O after execution completes
- Calls `updateTrace()` in both `wrapProviderWithTracing()` (streaming) and `completeTracingContext()` (manual) to propagate generation I/O up to the parent trace

Fixes empty input/output fields on Langfuse traces per [Langfuse FAQ](https://langfuse.com/faq/all/empty-trace-input-and-output).

## Test plan
- [x] `npm run build:packages` — all packages compile with no errors
- [x] `npm run test:packages` — 992 tests pass
- [ ] Trigger an agent execution and verify Langfuse dashboard shows input/output on traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended trace creation to capture and embed input and output data.
  * Introduced updateTrace method to modify existing traces with input, output, and metadata.
  * Traces now automatically capture I/O data from generations and manual tracing contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->