### PR TITLE
feat: gate GTM content pipeline behind gtmEnabled setting

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -525,7 +525,12 @@ wireHealthChecks(integrationRegistryService);
 
 // Initialize Signal Intake Service — bridges external signals to PM Agent pipeline
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const signalIntakeService = new SignalIntakeService(events, featureLoader, REPO_ROOT);
+const signalIntakeService = new SignalIntakeService(
+  events,
+  featureLoader,
+  REPO_ROOT,
+  settingsService
+);
 
 // Initialize Pipeline Orchestrator — unified phase tracking across ops + gtm branches
 const pipelineOrchestrator = new PipelineOrchestrator(events, featureLoader, settingsService);
@@ -1298,7 +1303,7 @@ app.use('/api/claude', createClaudeRoutes(claudeUsageService));
 app.use('/api/codex', createCodexRoutes(codexUsageService, codexModelCacheService));
 app.use('/api/github', createGitHubRoutes(events, settingsService));
 app.use('/api/context', createContextRoutes(settingsService));
-app.use('/api/content', createContentRoutes());
+app.use('/api/content', createContentRoutes(settingsService));
 app.use('/api/backlog-plan', createBacklogPlanRoutes(events, settingsService));
 app.use('/api/beads', createBeadsRoutes(beadsService));
 app.use('/api/mcp', createMCPRoutes(mcpTestService));
@@ -1388,7 +1393,8 @@ app.use(
     gtmAgent,
     pipelineOrchestrator,
     ceremonyService,
-    completionDetectorService
+    completionDetectorService,
+    settingsService
   )
 );
 app.use('/api/langfuse', createLangfuseRoutes(promptGitHubSyncService));

--- a/apps/server/src/routes/content/index.ts
+++ b/apps/server/src/routes/content/index.ts
@@ -10,14 +10,29 @@
 import { Router, type Request, type Response } from 'express';
 import { contentFlowService } from '../../services/content-flow-service.js';
 import { createLogger } from '@automaker/utils';
+import type { SettingsService } from '../../services/settings-service.js';
 
 const logger = createLogger('ContentRoutes');
 
 /**
  * Create the content router
  */
-export function createContentRoutes(): Router {
+export function createContentRoutes(settingsService: SettingsService): Router {
   const router = Router();
+
+  // Gate: return 403 for all content routes when GTM pipeline is disabled
+  router.use(async (_req: Request, res: Response, next) => {
+    try {
+      const settings = await settingsService.getGlobalSettings();
+      if (!settings.gtmEnabled) {
+        res.status(403).json({ error: 'GTM pipeline is disabled' });
+        return;
+      }
+      next();
+    } catch {
+      next();
+    }
+  });
 
   /**
    * POST /api/content/create

--- a/apps/server/src/routes/engine/index.ts
+++ b/apps/server/src/routes/engine/index.ts
@@ -26,6 +26,7 @@ import type { GTMAuthorityAgent } from '../../services/authority-agents/gtm-agen
 import type { PipelineOrchestrator } from '../../services/pipeline-orchestrator.js';
 import type { CeremonyService } from '../../services/ceremony-service.js';
 import type { CompletionDetectorService } from '../../services/completion-detector-service.js';
+import type { SettingsService } from '../../services/settings-service.js';
 import { getNotesWorkspacePath, ensureNotesDir, secureFs } from '@automaker/platform';
 import type { NotesWorkspace, PipelinePhase } from '@automaker/types';
 import { PIPELINE_PHASES } from '@automaker/types';
@@ -47,7 +48,8 @@ export function createEngineRoutes(
   gtmAgent?: GTMAuthorityAgent,
   pipelineOrchestrator?: PipelineOrchestrator,
   ceremonyService?: CeremonyService,
-  completionDetectorService?: CompletionDetectorService
+  completionDetectorService?: CompletionDetectorService,
+  settingsService?: SettingsService
 ): Router {
   const router = Router();
 
@@ -58,6 +60,17 @@ export function createEngineRoutes(
   router.post('/status', async (req: Request, res: Response) => {
     try {
       const { projectPath } = (req.body ?? {}) as { projectPath?: string };
+
+      // Resolve gtmEnabled setting for the response
+      let gtmEnabled = false;
+      if (settingsService) {
+        try {
+          const settings = await settingsService.getGlobalSettings();
+          gtmEnabled = settings.gtmEnabled ?? false;
+        } catch {
+          // Fall back to false if settings unavailable
+        }
+      }
 
       // Auto-mode status
       const autoModeStatus = autoModeService.getStatus();
@@ -184,6 +197,7 @@ export function createEngineRoutes(
             emittedProjects: 0,
           },
         },
+        gtmEnabled,
         timestamp: new Date().toISOString(),
       });
     } catch (error) {
@@ -648,7 +662,15 @@ export function createEngineRoutes(
    * GET /api/engine/content/drafts
    * Returns all pending content drafts (survives page refresh).
    */
-  router.get('/content/drafts', (_req: Request, res: Response) => {
+  router.get('/content/drafts', async (_req: Request, res: Response) => {
+    // Gate: return empty when GTM pipeline is disabled
+    if (settingsService) {
+      const settings = await settingsService.getGlobalSettings();
+      if (!settings.gtmEnabled) {
+        res.json({ success: true, drafts: [] });
+        return;
+      }
+    }
     const drafts = gtmAgent ? gtmAgent.getPendingDrafts() : [];
     res.json({ success: true, drafts });
   });
@@ -660,6 +682,15 @@ export function createEngineRoutes(
    * On request_changes: re-processes with feedback.
    */
   router.post('/content/review', async (req: Request, res: Response) => {
+    // Gate: return 403 when GTM pipeline is disabled
+    if (settingsService) {
+      const settings = await settingsService.getGlobalSettings();
+      if (!settings.gtmEnabled) {
+        res.status(403).json({ success: false, error: 'GTM pipeline is disabled' });
+        return;
+      }
+    }
+
     try {
       const { projectPath, contentId, decision, editedContent, tabName, feedback } = (req.body ??
         {}) as {

--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -10,6 +10,7 @@
 import { createLogger } from '@automaker/utils';
 import type { EventEmitter } from '../lib/events.js';
 import type { FeatureLoader } from './feature-loader.js';
+import type { SettingsService } from './settings-service.js';
 
 const logger = createLogger('SignalIntake');
 
@@ -66,7 +67,8 @@ export class SignalIntakeService {
   constructor(
     private events: EventEmitter,
     private featureLoader: FeatureLoader,
-    private defaultProjectPath: string
+    private defaultProjectPath: string,
+    private settingsService?: SettingsService
   ) {
     this.registerListener();
     logger.info(`Signal intake service initialized for ${defaultProjectPath}`);
@@ -109,9 +111,18 @@ export class SignalIntakeService {
   }
 
   /**
-   * Classify signal as Ops (engineering) or GTM (marketing)
+   * Classify signal as Ops (engineering) or GTM (marketing).
+   * When gtmEnabled is false in settings, all signals are forced to ops.
    */
-  private classifySignal(signal: SignalPayload): ClassificationResult {
+  private async classifySignal(signal: SignalPayload): Promise<ClassificationResult> {
+    // Gate: if GTM pipeline is disabled, force all signals to ops
+    if (this.settingsService) {
+      const settings = await this.settingsService.getGlobalSettings();
+      if (!settings.gtmEnabled) {
+        return { category: 'ops', reason: 'GTM pipeline disabled in settings' };
+      }
+    }
+
     const source = signal.source;
     const channelContext = signal.channelContext || {};
 
@@ -219,7 +230,7 @@ export class SignalIntakeService {
       const description = signal.content;
 
       // Classify signal as Ops or GTM
-      const classification = this.classifySignal(signal);
+      const classification = await this.classifySignal(signal);
 
       logger.info(
         `Processing signal from ${signal.source}: "${title}" (${classification.category} - ${classification.reason})`

--- a/apps/ui/src/components/views/flow-graph/flow-graph-view.tsx
+++ b/apps/ui/src/components/views/flow-graph/flow-graph-view.tsx
@@ -29,7 +29,7 @@ export interface FlowGraphViewProps {
 }
 
 export function FlowGraphView({ onFeatureClick }: FlowGraphViewProps) {
-  const { nodes, edges } = useFlowGraphData();
+  const { nodes, edges, gtmEnabled } = useFlowGraphData();
   const pipeline = usePipelineProgress();
 
   // Legend visibility
@@ -223,8 +223,8 @@ export function FlowGraphView({ onFeatureClick }: FlowGraphViewProps) {
         prdData={prdReviewData}
       />
 
-      {/* Content review dialog (auto-opens via WebSocket) */}
-      {contentReviewData && (
+      {/* Content review dialog (auto-opens via WebSocket, hidden when GTM disabled) */}
+      {gtmEnabled && contentReviewData && (
         <ContentReviewDialog
           open={contentReviewOpen}
           onOpenChange={setContentReviewOpen}

--- a/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
+++ b/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
@@ -38,6 +38,7 @@ import type {
 
 /** Engine status response shape from /api/engine/status */
 interface EngineStatusResponse {
+  gtmEnabled?: boolean;
   signalIntake?: { active?: boolean };
   autoMode?: {
     running?: boolean;
@@ -295,11 +296,16 @@ export function useFlowGraphData(
     [features]
   );
 
+  const gtmEnabled = engineStatus?.gtmEnabled ?? false;
+
   const nodes = useMemo(() => {
     const result: Node[] = [];
 
-    // 1. Engine service nodes
-    for (const svc of ENGINE_SERVICES) {
+    // 1. Engine service nodes (filter out content-pipeline when GTM is disabled)
+    const services = gtmEnabled
+      ? ENGINE_SERVICES
+      : ENGINE_SERVICES.filter((s) => s.serviceId !== 'content-pipeline');
+    for (const svc of services) {
       const { status, throughput, statusLine } = getServiceStatus(svc.serviceId, engineStatus);
       const graphId = SERVICE_TO_GRAPH_MAP[svc.serviceId];
       const pipelineHighlight =
@@ -487,11 +493,16 @@ export function useFlowGraphData(
     highlightedServiceId,
     awaitingGate,
     pipelineState,
+    gtmEnabled,
   ]);
 
   // Build edges: static service flow + pipeline + bridge + dynamic
   const edges = useMemo(() => {
-    const result: Edge[] = [...STATIC_EDGES, ...PIPELINE_EDGES, ...BRIDGE_EDGES];
+    // Filter out the GTM edge when content pipeline is disabled
+    const staticEdges = gtmEnabled
+      ? STATIC_EDGES
+      : STATIC_EDGES.filter((e) => e.id !== 'e-triage-content');
+    const result: Edge[] = [...staticEdges, ...PIPELINE_EDGES, ...BRIDGE_EDGES];
 
     // Auto-mode -> active features (workflow edges)
     for (const feature of activeFeatures) {
@@ -517,7 +528,7 @@ export function useFlowGraphData(
     }
 
     return result;
-  }, [activeFeatures, runningAgents, nodes]);
+  }, [activeFeatures, runningAgents, nodes, gtmEnabled]);
 
-  return { nodes, edges };
+  return { nodes, edges, gtmEnabled };
 }

--- a/docs/dev/content-pipeline.md
+++ b/docs/dev/content-pipeline.md
@@ -2,6 +2,17 @@
 
 Multi-format content generation pipeline at `libs/flows/src/content/`. Transforms research into content (guides, tutorials, reference docs) using a 7-phase LangGraph flow with autonomous antagonistic review, parallel processing, and Langfuse tracing.
 
+## GTM Gate
+
+The content pipeline is part of the GTM branch and is gated by the `gtmEnabled` global setting (default: `false`). When disabled:
+
+- All content API routes (`/api/content/*`) return 403
+- Engine content draft/review endpoints return empty or 403
+- The content pipeline node is hidden from the flow graph
+- Signals that would route to GTM are forced to ops
+
+Enable `gtmEnabled` in global settings to activate the content pipeline.
+
 ## Quick Start
 
 Start a content flow via MCP:

--- a/docs/dev/engine-architecture.md
+++ b/docs/dev/engine-architecture.md
@@ -64,11 +64,11 @@ The Ops branch owns all code — from feature creation to production deployment.
 
 **Peer requests** create feature dependencies. If Matt needs an API endpoint, that spawns a Kai feature as a dependency. The Lead Engineer handles ordering.
 
-### GTM Branch (Parked)
+### GTM Branch (Gated)
 
 GTM handles go-to-market: market research, content creation, social media, competitive analysis, metrics. Agents: Jon (strategy) and Cindi (content).
 
-**Status: PARKED.** GTM signals are logged but handled manually for now. The architecture supports it — AVA classifies GTM signals and can route them once the machines are built.
+**Controlled by `gtmEnabled` setting** (default: `false`). When disabled, the `SignalIntakeService` forces all signals to ops classification, content API routes return 403, and the flow graph hides GTM nodes. Enable via global settings to activate the full GTM pipeline.
 
 ---
 

--- a/docs/dev/idea-to-production.md
+++ b/docs/dev/idea-to-production.md
@@ -20,10 +20,12 @@ Work enters through five channels, all routed by `SignalIntakeService`:
 | Source                     | Classification  | Path                           |
 | -------------------------- | --------------- | ------------------------------ |
 | Linear issue (engineering) | ops             | Full pipeline or intake bridge |
-| Linear issue (marketing)   | gtm             | GTM pipeline (parked)          |
+| Linear issue (marketing)   | gtm             | GTM pipeline (gated)           |
 | GitHub issue/PR event      | ops             | Lead Engineer state machine    |
 | MCP `create_feature`       | ops (fast path) | Direct to board, skip PM       |
 | MCP `process_idea`         | ops (full path) | PM Agent research + PRD        |
+
+**GTM gate:** The entire GTM branch is controlled by the `gtmEnabled` global setting (default: `false`). When disabled, `SignalIntakeService` forces all signals to ops, content API routes return 403, and the UI hides GTM-related nodes. Enable via settings to activate GTM routing.
 
 **Fast path** skips the PM pipeline — feature goes straight to the board and Lead Engineer picks it up. Use when you know exactly what needs building.
 

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -1556,6 +1556,13 @@ export interface GlobalSettings {
    */
   useGraphFlows?: boolean;
 
+  /**
+   * Enable the GTM (Go-To-Market) content creation pipeline.
+   * When false, all signals are routed to ops and content endpoints are disabled.
+   * @default false
+   */
+  gtmEnabled?: boolean;
+
   // Hivemind Configuration
   /**
    * Unique identifier for this Automaker instance in a hivemind mesh.


### PR DESCRIPTION
## Summary

- Add `gtmEnabled: boolean` to `GlobalSettings` (default: `false`) to control the entire GTM branch
- Gate at 3 entry points: `SignalIntakeService` forces ops classification, content API routes return 403, engine content endpoints are gated
- UI hides content-pipeline node and ContentReviewDialog when disabled
- Update engine-architecture, idea-to-production, and content-pipeline docs

## Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] `npm run test:server` passes — 1966 tests (verified locally)
- [ ] With `gtmEnabled: false` (default): signals route to ops, `/api/content/create` returns 403, flow graph hides content-pipeline node
- [ ] With `gtmEnabled: true`: full GTM pipeline works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added global GTM Gate setting to control content pipeline availability (disabled by default). When enabled, activates the full GTM pipeline; when disabled, content endpoints return 403 and GTM features are hidden from the UI.

* **Documentation**
  * Added documentation describing GTM gating mechanism and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->