### PR TITLE
fix: resolve lint-staged commander version conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@typescript-eslint/utils": "8.50.0",
     "@typescript-eslint/eslint-plugin": "8.50.0",
     "@typescript-eslint/parser": "8.50.0",
-    "@typescript-eslint/typescript-estree": "8.50.0"
+    "@typescript-eslint/typescript-estree": "8.50.0",
+    "commander": "14.0.3"
   }
 }


### PR DESCRIPTION
## Summary
- lint-staged@16.2.7 requires commander@^14, but npm hoisted commander@5 from electron-builder's dependencies
- This caused `TypeError: program.version(...).allowExcessArguments is not a function` on every pre-commit hook
- Added `commander: "14.0.3"` to npm overrides to force correct resolution

## Test plan
- [x] `npx lint-staged --version` returns 16.2.7 without error
- [x] Pre-commit hook runs successfully (prettier formats staged files)
- [x] `npm install` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency override configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->