### PR TITLE
fix: remove unused HITLFormStatus import

### DIFF
--- a/apps/server/src/services/hitl-form-service.ts
+++ b/apps/server/src/services/hitl-form-service.ts
@@ -19,7 +19,6 @@ import type {
   HITLFormRequest,
   HITLFormRequestInput,
   HITLFormRequestSummary,
-  HITLFormStatus,
 } from '@automaker/types';
 import type { EventEmitter } from '../lib/events.js';
 


### PR DESCRIPTION
## Summary
- Removes unused `HITLFormStatus` type import from `hitl-form-service.ts` that was introduced in #945

## Test plan
- [x] ESLint warning resolved
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release. This update includes only internal code adjustments with no impact to functionality or public features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->