### PR TITLE
fix: remove unused type imports from #945

### DIFF
--- a/apps/ui/src/components/views/inbox-view.tsx
+++ b/apps/ui/src/components/views/inbox-view.tsx
@@ -30,7 +30,6 @@ import type {
   ActionableItem,
   ActionableItemActionType,
   ActionableItemPriority,
-  ActionableItemStatus,
 } from '@automaker/types';
 import { getEffectivePriority } from '@automaker/types';
 import { cn } from '@/lib/utils';

--- a/apps/ui/src/lib/http-api-client.ts
+++ b/apps/ui/src/lib/http-api-client.ts
@@ -32,8 +32,6 @@ import type {
   EventHistoryFilter,
   ActionableItem,
   ActionableItemStatus,
-  ActionableItemActionType,
-  ActionableItemPriority,
   CreateActionableItemInput,
   RepoResearchResult,
   GapAnalysisReport,


### PR DESCRIPTION
## Summary
- Removes unused `ActionableItemStatus` import from `inbox-view.tsx`
- Removes unused `ActionableItemActionType` and `ActionableItemPriority` imports from `http-api-client.ts`
- Leftover from #945 (async HITL inbox system)

## Test plan
- [x] Build passes
- [x] Lint warnings resolved for these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)