### PR TITLE
fix: safety hooks false-positive on branch names containing 'main'

### DIFF
--- a/.claude/hooks/guard-bash.sh
+++ b/.claude/hooks/guard-bash.sh
@@ -46,8 +46,9 @@ if echo "$STRIPPED" | grep -qE '(^[[:space:]]*|&&[[:space:]]*|\|\|[[:space:]]*|;
 fi
 
 # Guard: force push to main (catches --force, -f, --force-with-lease targeting main/master)
+# Uses word boundary \b to avoid matching "maintenance" or "mastering" etc.
 if echo "$STRIPPED" | grep -qE 'git[[:space:]]+push[[:space:]].*(-f|--force|--force-with-lease)' && \
-   echo "$STRIPPED" | grep -qE 'git[[:space:]]+push[[:space:]].*(main|master)'; then
+   echo "$STRIPPED" | grep -qE 'git[[:space:]]+push[[:space:]].*\b(main|master)\b'; then
   jq -n '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
@@ -83,7 +84,7 @@ if echo "$STRIPPED" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge[[:space:]].*--
 fi
 
 # Guard: git push directly to main (non-force, but still bypasses PR workflow)
-if echo "$STRIPPED" | grep -qE 'git[[:space:]]+push[[:space:]]+(origin[[:space:]]+)?(main|master)[[:space:]]*$'; then
+if echo "$STRIPPED" | grep -qE 'git[[:space:]]+push[[:space:]]+(origin[[:space:]]+)?\b(main|master)\b[[:space:]]*$'; then
   jq -n '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",

--- a/packages/mcp-server/plugins/automaker/hooks/block-dangerous.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/block-dangerous.sh
@@ -28,12 +28,15 @@ if echo "$COMMAND" | grep -qE 'find\s+/\s.*-delete'; then
   exit 2
 fi
 
-# Block force push to main/master
-if echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force.*\s+(main|master)'; then
+# Block force push to main/master (but allow force push to feature/epic branches)
+# Match: git push --force origin main, git push -f origin master
+# Don't match: git push --force origin feat/maintenance-scheduler-settings
+if echo "$COMMAND" | grep -qE 'git\s+push\s+.*(-f|--force|--force-with-lease)\s+\S+\s+(main|master)\b'; then
   echo "Blocked: force push to main/master" >&2
   exit 2
 fi
-if echo "$COMMAND" | grep -qE 'git\s+push\s+-f\s+.*\s+(main|master)'; then
+# Also catch: git push origin main --force (flag after branch)
+if echo "$COMMAND" | grep -qE 'git\s+push\s+\S+\s+(main|master)\s+.*(-f|--force|--force-with-lease)'; then
   echo "Blocked: force push to main/master" >&2
   exit 2
 fi


### PR DESCRIPTION
## Summary
- Fixed regex in both `.claude/hooks/guard-bash.sh` and plugin `block-dangerous.sh`
- The guard regex matched 'main' inside words like 'maintenance', blocking legitimate pushes to feature branches
- Added `\b` word boundaries to ensure only exact branch ref names are blocked

## Test plan
- [x] Push to `feat/maintenance-scheduler-settings` now succeeds
- [x] Protected branch refs still guarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)