### PR TITLE
feat: add UserProfile settings and persona prompt overrides

### DIFF
--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,9 +5,9 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 81
-  referenced: 48
-  successfulFeatures: 48
+  loaded: 84
+  referenced: 49
+  successfulFeatures: 49
 ---
 # api
 
@@ -494,3 +494,27 @@ usageStats:
 - **Situation:** Repository dispatch event fires but CI workflow won't trigger unless workflow file has matching `on.repository_dispatch.types: ['langfuse-prompt-update']`
 - **Root cause:** GitHub's repository_dispatch filtering is strict - generic 'dispatch' events don't trigger workflow. Each event type must be explicitly listed in workflow definition.
 - **How to avoid:** Requires coordination between backend (event type) and CI config (workflow trigger). Typo in either breaks everything. Benefits: explicit intent, security (CI decides what events trigger it).
+
+### Thread optional configuration parameters through multiple function layers (getEngineeringBase/getContentBase -> getBrandIdentity) rather than applying defaults at each layer (2026-02-23)
+- **Context:** Optional UserProfile parameter passes through base composition functions to be applied at the lowest level where string interpolation occurs
+- **Why:** Single source of truth for default behavior - all parameterization logic centralized in getBrandIdentity(). Changes to brand identity logic don't require updating multiple function signatures
+- **Rejected:** Could compute defaults at each layer - spreads logic. Could make UserProfile mandatory - breaks backward compatibility. Could use factory pattern - adds unnecessary complexity
+- **Trade-offs:** Cleaner logic concentration, but requires understanding that undefined parameter triggers default behavior. Makes parameter optional vs required distinction semantically important
+- **Breaking if changed:** If getBrandIdentity() modifies its undefined-handling logic, all downstream functions (getEngineeringBase, getContentBase) change behavior automatically - good for consistency but could break expectations if not documented
+
+#### [Pattern] Type export chain verification: source definition → package index export → dist .d.ts generation → consumer import resolution (2026-02-23)
+- **Problem solved:** UserProfile existed in source file but wasn't accessible to prompts package until explicitly exported from types/index.ts and verified in dist/index.d.ts
+- **Why this works:** TypeScript consumers don't import directly from source during build; they resolve through package.json entry points and generated dist .d.ts files. Breaking chain at any point causes resolution failures that look like the type doesn't exist
+- **Trade-offs:** Extra verification steps (grep dist exports, check package.json entries) vs catching integration errors immediately rather than at consumer compile time
+
+### Made userProfile optional in both GlobalSettings and PromptConfig to maintain backward compatibility while enabling new feature (2026-02-23)
+- **Context:** UserProfile is new infrastructure, existing code doesn't have user profile data and shouldn't require it
+- **Why:** Optional fields allow incremental adoption: old code works without changes, new code can use userProfile when available. No breaking changes means branch work doesn't destabilize main workflow
+- **Rejected:** Required field (breaks all existing code using GlobalSettings/PromptConfig); separate UserProfiledGlobalSettings type (creates type duplication and confusion)
+- **Trade-offs:** Easier adoption + zero breaking changes vs consumers must handle undefined userProfile (requires null checks or defaults)
+- **Breaking if changed:** Making field required would break all existing code paths that construct GlobalSettings/PromptConfig without userProfile; requires migration of all callsites
+
+#### [Gotcha] Nullish coalescing (??) must be used instead of OR (||) operator for defaults to preserve falsy but valid values (2026-02-23)
+- **Situation:** Parameterizing prompt values with fallbacks to originals
+- **Root cause:** Falsy values like empty strings or 0 are valid configuration values. Using || would lose them. Example: if userName is '', using || would fallback to default instead of using the explicit empty string.
+- **How to avoid:** Easier: True optional semantics. Harder: Less common pattern, developers expect || behavior. Breaking: Using || instead treats falsy inputs as missing

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,7 +5,7 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 22
+  loaded: 23
   referenced: 13
   successfulFeatures: 13
 ---
@@ -2397,21 +2397,102 @@ usageStats:
 - **Why this works:** Consistent naming enables shell scripts and config loaders to auto-discover vars by prefix (e.g., grep -E '^LANGFUSE_' to find all Langfuse vars). Commented-out defaults in .env.example prevent accidental activation while documenting required vs optional. Inline defaults in CLAUDE.md serve as quick reference for developers.
 - **Trade-offs:** Easier: Config tooling can auto-discover and organize by prefix. Harder: env var names are longer; requires discipline across teams to maintain prefix naming
 
-### Multi-tier fallback strategy that assumes commits should be pushed when detection methods fail, rather than failing safely with null (2026-02-23)
-- **Context:** Fresh branches (never pushed to origin) fail git rev-list comparison because remote tracking branch doesn't exist. Original code caught exceptions and silently returned null, breaking the entire workflow.
-- **Why:** Errs on the side of action (false positive: might push unnecessarily) rather than silent failure (false negative: silently skips commits). Silent failures break autonomous agent workflows completely; unnecessary pushes are recoverable.
-- **Rejected:** Fail-safe approach (return null when uncertain) - this was the original behavior causing the bug. Safer in isolation but catastrophic when commits are lost silently.
-- **Trade-offs:** Trade certainty for robustness. Code complexity increases but robustness against distributed git state inconsistency improves. Risk of false positives (pushing when shouldn't) but prevents false negatives (silently skipping).
-- **Breaking if changed:** If callers depend on null strictly meaning 'no commits exist', this breaks that invariant. Now null only means 'truly no commits' - uncertain cases return hash with warn logs.
+#### [Gotcha] Barrel export pattern: must import from @automaker/utils, not @automaker/utils/logger (2026-02-23)
+- **Situation:** Three separate files required the same correction from @automaker/utils/logger to @automaker/utils for createLogger import
+- **Root cause:** Project uses barrel exports to centralize utility exports and allow internal module reorganization without breaking downstream code
+- **How to avoid:** Indirection abstracts internal structure but requires developers to know barrel export convention; enables painless internal reorganization
 
-#### [Pattern] Cascading detection strategies with decreasing certainty: remote branch compare → total commit count → HEAD existence check → last resort log inspection (2026-02-23)
-- **Problem solved:** Cannot rely on any single git operation succeeding in uncertain distributed state. Each fallback has different preconditions and reliability.
-- **Why this works:** Matches the actual state of git repositories: distributed, potentially incomplete, with missing refs. Each strategy trades certainty for availability.
-- **Trade-offs:** Increased complexity and multiple git invocations vs. guaranteed detection even with missing refs. Lines of code increase but success rate increases for edge cases.
+#### [Pattern] Empty interface placeholder with @typescript-eslint/no-empty-object-type eslint-disable and future TODO comment for phase-based implementation (2026-02-23)
+- **Problem solved:** GetPairRequest interface is empty with disable comment and 'Future: Add filtering/sampling parameters' - active sampling algorithm not yet implemented
+- **Why this works:** Maintains type-safe API contracts while explicitly signaling incomplete implementation. Enables incremental development without API breaking changes when active sampling is added later
+- **Trade-offs:** Less strict TypeScript validation initially but clear forward contract; eslint-disable is explicit intent marker; prevents premature API expansion
 
-### Use logging level semantics (info→warn, add debug) to signal decision confidence rather than adding error handling for uncertain outcomes (2026-02-23)
-- **Context:** Code encounters uncertain situations (origin/main missing, git command failures) but must continue. Can't throw errors without breaking workflow.
-- **Why:** Logging levels communicate severity to operators without exceptions. Warn level signals 'unexpected but handled' better than silent info logs that hide unusual behavior.
-- **Rejected:** Silently handling with info-level logs (original behavior) - makes root causes invisible. Throwing errors would break autonomous workflows.
-- **Trade-offs:** Increased log verbosity but makes problems discoverable in production. Operators can now see when fallback logic triggers.
-- **Breaking if changed:** If monitoring treats warn logs differently than info (alerts, metrics), this changes operational behavior. Intentional - makes silent failures visible.
+#### [Gotcha] When adding new optional properties to a Required<T> type, all resolution/configuration methods must explicitly include the new properties in their return objects. TypeScript won't warn about missing properties in object literals, allowing silent configuration failures. (2026-02-23)
+- **Situation:** Added salvageOnAbort and salvageOnAbortTypes to GitWorkflowSettings. Both DEFAULT_GIT_WORKFLOW_SETTINGS and resolveGitWorkflowSettings() needed updates or salvage options would be undefined at runtime despite type-checking.
+- **Root cause:** Type inference doesn't enforce completeness in object literals when used with Required<T>. Missing properties don't cause compile errors, only runtime behavior changes.
+- **How to avoid:** More boilerplate in resolution methods but prevents silent feature failures. Could use mapped types or const assertions to enforce completeness, but current approach is more explicit.
+
+#### [Pattern] Preserve error context outside try/catch scope by declaring variables in outer scope (workDir, errorInfo) to avoid type narrowing issues when accessing error details in finally blocks. Finally blocks can't access catch error directly without careful scope management. (2026-02-23)
+- **Problem solved:** executeFeature() needed to pass error type information to salvageUncommittedWork() in the finally block. Direct catch-block error references aren't accessible in finally without narrowing.
+- **Why this works:** TypeScript's control flow analysis restricts error access to catch blocks. Variables declared at function scope remain accessible in finally and avoid type guards.
+- **Trade-offs:** Slightly more verbose variable declarations but ensures type safety and preserves error context. Alternative of nested try would be less clean.
+
+#### [Gotcha] Git worktrees share the .git directory but have separate working directories, causing npm workspace package links to point to the main branch's node_modules instead of the feature branch's dist files. Build caches can make this hard to detect. (2026-02-23)
+- **Situation:** Feature branch code compiled correctly in isolation but failed in full monorepo build because type definitions linked to main branch version, not feature branch.
+- **Root cause:** Worktree efficiency relies on shared git metadata, but build tooling doesn't understand this shared state and resolves workspace links from the wrong reference point.
+- **How to avoid:** Worktrees are lightweight and efficient for context switching, but require understanding of their build quirks. Full clone would avoid this but adds disk/time overhead.
+
+#### [Pattern] Use best-effort error handling in finally blocks for recovery operations (don't rethrow salvage errors). Log failures as warnings but preserve the original abort signal. Catching and suppressing exceptions prevents masking why the agent actually failed. (2026-02-23)
+- **Problem solved:** Salvage workflow runs in finally block during error state. If salvage itself throws, the original abort reason gets lost.
+- **Why this works:** Users need to know they were aborted (original error), not that salvage recovery failed. Salvage is best-effort; its failures shouldn't become the primary error signal.
+- **Trade-offs:** Salvage failures are logged but invisible to user error handling. Cleaner error messaging but requires robust logging for debugging. Could emit events instead for visibility.
+
+### Make salvage workflow triggering configurable per-error-type via salvageOnAbortTypes array instead of simple boolean. Different error types have different recovery semantics and user expectations. (2026-02-23)
+- **Context:** Agent abort can happen for multiple reasons: agent cancellation, max_turns limit, detected infinite loop, etc. Not all warrant automatic salvage.
+- **Why:** max_turns aborts are often expected behavior (user's configured limit). Detected loops might indicate broken code worth discarding. Cancellations are unexpected and warrant salvage. Fine-grained control matches user intent better.
+- **Rejected:** Simple salvageOnAbort: boolean (too coarse; saves work for max_turns which is expected); always salvage (wastes resources on clearly broken code); never salvage (loses work from unexpected cancellations)
+- **Trade-offs:** More complex configuration but prevents unwanted salvages that consume resources or save bad code. Array approach is simpler than nested object config.
+- **Breaking if changed:** If salvageOnAbortTypes array doesn't include the actual error type, salvage won't trigger even if salvageOnAbort is true
+
+### Salvaged PRs are never auto-merged; they require manual review. Incomplete work from aborted agents shouldn't be merged automatically regardless of CI status. (2026-02-23)
+- **Context:** Agent was interrupted mid-feature. Salvaged work is preserved but potentially incomplete or in broken state.
+- **Why:** Auto-merge implies feature is complete and safe. Work interrupted by abort is by definition incomplete. Requiring manual review creates a safety gate and signals to team that work is partial.
+- **Rejected:** Creating commits only without PR (loses visibility, work might be forgotten); auto-merging with CI (completes unsafe incomplete work)
+- **Trade-offs:** Requires additional team action (PR review + merge) but prevents incomplete code from reaching main. Preserves code history and visibility.
+- **Breaking if changed:** If salvaged work auto-merges, incomplete/broken features leak into production. Requires explicit decision to merge incomplete work.
+
+#### [Pattern] Maintain dual API surface during refactoring: keep original constant export unchanged while introducing parameterized function, allowing existing code to remain unmodified (2026-02-23)
+- **Problem solved:** Converting BRAND_IDENTITY from constant to parameterized getBrandIdentity(profile) function while maintaining backward compatibility
+- **Why this works:** Allows incremental migration - existing code importing BRAND_IDENTITY works unchanged, new code can use getBrandIdentity(profile). Avoids coordinating breaking changes across entire codebase
+- **Trade-offs:** Both exports must be maintained and kept in sync. Requires documentation/deprecation markers. But enables zero-friction adoption for new functionality
+
+#### [Gotcha] Interface definitions kept inline in implementation file (team-base.ts) rather than centralized in @automaker/types, creating cognitive burden of discovering types exist before recognizing function signature requirements (2026-02-23)
+- **Situation:** UserProfile and BrandConfig types defined in team-base.ts but also exported from index.ts; external consumers must know types exist to properly use getBrandIdentity()
+- **Root cause:** Scope decision to keep feature self-contained. Avoids adding types to central types package for a single-feature use case. Reduces cross-package dependencies
+- **How to avoid:** Self-contained feature vs discoverable API contracts. Easier to delete feature if types are co-located, harder for consumers to find correct type imports
+
+#### [Gotcha] Worktree environments with shared monorepo node_modules cause TypeScript resolution to stale dist files when introducing new type exports (2026-02-23)
+- **Situation:** After building new UserProfile type in worktree, downstream packages couldn't resolve it despite successful build, because main repo's node_modules/@automaker/types/dist/ contained pre-branch dist without the new export
+- **Root cause:** Git worktrees share parent repo's node_modules for efficiency, but builds execute in worktree directory. TypeScript resolution follows node_modules search path which finds stale dist files from main branch before worktree's new exports are available
+- **How to avoid:** Efficient disk usage and single npm install vs requiring manual dist synchronization after introducing new type exports in worktree
+
+#### [Pattern] Centralized prompt registry pattern: BasePromptConfig passes userProfile through single registry to all persona agents rather than modifying each agent individually (2026-02-23)
+- **Problem solved:** 10 different personified agents (ava, matt, sam, cindi, jon, linear-specialist, pr-maintainer, board-janitor, frank, kai) needed userProfile access for future personalization
+- **Why this works:** Centralizing in registry means: (1) single definition of what agents receive, (2) consistent interface across all agents, (3) easy to add/remove features for all agents simultaneously, (4) future changes don't require touching 10 files
+- **Trade-offs:** More complex registry code vs single source of truth for what data agents can access; easier to maintain vs harder to trace data flow for individual agents
+
+#### [Gotcha] All 10 persona agents must be updated for type changes in centralized registry, not just explicit subset, to maintain consistent interface and prevent surprise gaps (2026-02-23)
+- **Situation:** Initial planning mentioned 7 agents but implementation discovered and updated all 10 for consistency
+- **Root cause:** Registry pattern creates shared contract - if only some agents updated, code that iterates all agents or checks agent type details encounters inconsistency. Future developer assumes all agents have userProfile access but some don't, causing subtle bugs
+- **How to avoid:** More changes + higher risk of missing an agent vs guarantees all agents have consistent capabilities
+
+### Asymmetric UserProfile interface: Frank has infra.stagingHost field, while Kai/Matt/Sam only have user/channel fields (2026-02-23)
+- **Context:** Parameterizing four engineering personas with different concerns
+- **Why:** Frank has infrastructure-specific responsibilities requiring staging host configuration. Other personas share identical parameterization needs (user name + Discord channels). This reflects actual separation of concerns in the domain.
+- **Rejected:** Unified interface with all fields available to all personas - would create coupling and confusion about which fields each persona uses
+- **Trade-offs:** Easier: Clear intent and minimal API surface. Harder: More complex type system. Breaking: Code assuming all personas accept infra config will fail.
+- **Breaking if changed:** If Frank's responsibilities change or others gain infrastructure concerns, the interface asymmetry breaks the assumption
+
+#### [Pattern] Parameterization scope decision: extract only the values with plausible overrides (staging host, user name, Discord channels) vs everything (2026-02-23)
+- **Problem solved:** Converting hardcoded values to configurable parameters
+- **Why this works:** These five values (Frank's stagingHost + shared userName/channels) represent the operational variation points teams actually customize per environment. Other prompt text is domain logic that shouldn't vary per user profile.
+- **Trade-offs:** Easier: Focused, minimal API. Harder: If new variation points emerge, must refactor again. Breaking: If parameterized value becomes non-optional in future
+
+### Parameterized user-specific values (userName, agencyName, productName, githubOrg) while keeping TEAM_ROSTER and BRAND_IDENTITY constants static in team-base.ts (2026-02-23)
+- **Context:** When refactoring persona prompts to accept configuration, needed to decide which values should be configurable vs remain as system constants
+- **Why:** TEAM_ROSTER and BRAND_IDENTITY document the actual team structure and organizational identity - these should not vary per configuration. Only user/profile-specific values should be overridable.
+- **Rejected:** Could have parameterized everything in team-base.ts to achieve maximum flexibility, or kept everything static to minimize changes
+- **Trade-offs:** Maintains clear separation between system constants (what the team is) and user configurations (what the user prefers to call things). Reduces surface area of configuration but adds architectural clarity.
+- **Breaking if changed:** If TEAM_ROSTER becomes parameterized, the system can no longer guarantee which team members' prompts will be invoked, affecting which AI personas are available. This breaks the semantic meaning of prompt selection.
+
+### Used hierarchical config structure (userProfile.name, userProfile.brand.agencyName) instead of flat parameter names at root level (2026-02-23)
+- **Context:** When designing PromptConfig interface, needed to choose between flat vs nested organization of user and brand parameters
+- **Why:** Hierarchical structure groups related values (all brand values under brand object, all user values under userProfile). This suggests future extensibility - can add userProfile.title, userProfile.email without polluting root. Also reflects conceptual hierarchy: a user has a brand identity.
+- **Rejected:** Flat structure with individual params: { userName, agencyName, productName, githubOrg } would be simpler initially but loses semantic grouping
+- **Trade-offs:** Slightly more verbose at call sites (userProfile.name vs just name), but self-documents that these values represent a user's profile, not global defaults. Easier to add more profile fields later without interface pollution.
+- **Breaking if changed:** If flattened, future additions of profile fields (title, email, etc.) would clutter the root config namespace. Renaming to nested structure later breaks all call sites.
+
+#### [Gotcha] Large template literal strings with many variable interpolations are high-risk during refactoring due to difficulty spotting syntax errors (2026-02-23)
+- **Situation:** Jon's prompt had 13 hardcoded references to parameterize within a large multi-line template literal
+- **Root cause:** Unclosed braces, missing $, or wrong interpolation syntax in large strings are easy to introduce and hard to spot visually. Template literals can easily become syntactically valid but semantically broken.
+- **How to avoid:** Comprehensive refactoring of entire prompt at once is faster but riskier. Breaking it into sections adds process overhead but catches errors earlier.

--- a/.automaker/memory/documentation.md
+++ b/.automaker/memory/documentation.md
@@ -5,9 +5,9 @@ relevantTo: [documentation]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 27
-  referenced: 17
-  successfulFeatures: 17
+  loaded: 31
+  referenced: 19
+  successfulFeatures: 19
 ---
 # documentation
 

--- a/.automaker/memory/gotcha.md
+++ b/.automaker/memory/gotcha.md
@@ -30,3 +30,8 @@ usageStats:
 - **Situation:** Attempted to create monitor service files in `apps/server/src/services/` but files were created relative to tool execution context.
 - **Root cause:** Tool implementation detail - interpreting path as destination location but executing relative to context.
 - **How to avoid:** None - this is simply correct usage vs incorrect usage. Requires remembering to use absolute paths.
+
+#### [Gotcha] Monorepo build verification failed on unrelated package (secure-fs.ts TypeScript error), making it unclear if this feature's package builds correctly without isolated testing (2026-02-23)
+- **Situation:** Running `npm run build:packages` for final verification
+- **Root cause:** Monorepo build orchestration includes all packages as a single operation. Pre-existing errors in other packages block the entire build, preventing clear signal on this feature's package health.
+- **How to avoid:** Easier: Discover build isolation issue. Harder: Can't verify full monorepo build status. Breaking: If build system requires all packages to succeed, this feature can't deploy until secure-fs is fixed

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 293
-  referenced: 150
-  successfulFeatures: 150
+  loaded: 309
+  referenced: 158
+  successfulFeatures: 158
 ---
 # gotchas
 
@@ -248,7 +248,7 @@ usageStats:
 - **Root cause:** Package.json changes are not automatically synced to node_modules. When CI runs or developer checks out commit, they must run npm install. This is expected behavior but easy to miss if testing by reading files instead of building.
 - **How to avoid:** Easier: package.json is source of truth, dependency is managed. Harder: must remember npm install step before build after dependency changes.
 
-#### [Gotcha] Git worktrees have stale/missing remote references (origin/main) compared to parent repository, breaking standard local-vs-remote commit comparison (2026-02-23)
-- **Situation:** In worktree with fresh feature branch, 'git rev-list origin/main..HEAD' fails because origin/main ref doesn't exist or is outdated. Single-strategy detection fails entirely.
-- **Root cause:** Worktrees isolate git state; not all remote refs are pulled/updated. Developers expect origin/main to always exist when working with branches.
-- **How to avoid:** Requires multiple detection strategies instead of single authoritative check. More code, more resilient to incomplete distributed state.
+#### [Gotcha] When parameterizing prompts with many hardcoded values, the default values must EXACTLY match the original hardcoded values or the prompt behavior silently changes for existing callers (2026-02-23)
+- **Situation:** Extracted userName='Josh', agencyName='protoLabs', productName='protoMaker', githubOrg='proto-labs-ai' as defaults during refactoring
+- **Root cause:** Existing code calling getAvaPrompt() with no arguments must produce identical output. Any deviation in defaults breaks backward compatibility silently - no error, just different behavior.
+- **How to avoid:** Must preserve original strings exactly (including capitalization like 'protoLabs' vs 'protolabs'), making refactoring more tedious. Gain is backward compatibility, but at cost of stricter verification burden.

--- a/.automaker/memory/pattern.md
+++ b/.automaker/memory/pattern.md
@@ -5,9 +5,9 @@ relevantTo: [pattern]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 31
-  referenced: 18
-  successfulFeatures: 18
+  loaded: 33
+  referenced: 20
+  successfulFeatures: 20
 ---
 # pattern
 

--- a/.automaker/memory/patterns.md
+++ b/.automaker/memory/patterns.md
@@ -5,9 +5,9 @@ relevantTo: [patterns]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 0
-  referenced: 0
-  successfulFeatures: 0
+  loaded: 2
+  referenced: 1
+  successfulFeatures: 1
 ---
 # patterns
 

--- a/.automaker/memory/security.md
+++ b/.automaker/memory/security.md
@@ -5,9 +5,9 @@ relevantTo: [security]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 29
-  referenced: 17
-  successfulFeatures: 17
+  loaded: 30
+  referenced: 18
+  successfulFeatures: 18
 ---
 # security
 

--- a/.automaker/memory/testing.md
+++ b/.automaker/memory/testing.md
@@ -5,9 +5,9 @@ relevantTo: [testing]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 39
-  referenced: 23
-  successfulFeatures: 23
+  loaded: 40
+  referenced: 24
+  successfulFeatures: 24
 ---
 # testing
 
@@ -738,3 +738,20 @@ usageStats:
 - **Situation:** No permanent unit tests written; verification was manual/temporary
 - **Root cause:** Quick validation of core logic before submitting feature. Permanent tests would require mocking gh CLI (complexity) and test fixtures.
 - **How to avoid:** Feature is verified to compile and core logic works, but lacks regression test coverage. If gh CLI invocation signature changes, it won't be caught by tests.
+
+### Zero-config acceptance criterion requires exact string-level identity to original, not just functional equivalence (2026-02-23)
+- **Context:** Verifying parameterization refactoring maintains complete backward compatibility
+- **Why:** String matching with .includes() checks proves the refactoring is truly transparent - every character matches original output. This prevents subtle value changes that functional testing might miss.
+- **Rejected:** Functional equivalence testing - weaker guarantee that doesn't catch value drift
+- **Trade-offs:** Easier: Absolute confidence in backward compatibility. Harder: Must exactly match all default values. Breaking: Even one character difference breaks the contract
+- **Breaking if changed:** If any default value is rounded, truncated, or reformatted differently, zero-config identity fails
+
+#### [Pattern] Used inline Node.js evaluation (--input-type=module --eval) for verification instead of formal test files (2026-02-23)
+- **Problem solved:** Rapidly verifying parameterization behavior during development
+- **Why this works:** Direct eval provides immediate feedback without test infrastructure setup - useful for verification-driven development where you're testing the actual running code, not test code.
+- **Trade-offs:** Easier: Fast feedback loop, direct code execution. Harder: Not repeatable, not part of CI/CD pipeline, not documented. Breaking: Inline tests vanish - they're not persistent verification
+
+#### [Pattern] Created temporary verification script to import and test the compiled/built output (not source TypeScript), then deleted it after verification (2026-02-23)
+- **Problem solved:** Needed to verify parameterization worked correctly after refactoring complex prompt templates
+- **Why this works:** Source TypeScript can have syntax that appears correct but fails at compilation. Testing against actual built output (npm run build artifacts) catches real-world issues. This is more realistic than testing source directly.
+- **Trade-offs:** Temporary script is more work but reveals actual deployment issues. Permanent tests would add maintenance burden for what is essentially verification, not feature validation.

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -447,7 +447,13 @@ const ralphLoopService = new RalphLoopService(events, autoModeService, settingsS
 // Initialize Role Registry (shared agent template registry)
 const roleRegistryService = new RoleRegistryService(events);
 try {
-  const registeredCount = registerBuiltInTemplates(roleRegistryService);
+  // Read user profile and persona overrides from settings
+  const globalSettings = await settingsService.getGlobalSettings();
+  const registeredCount = registerBuiltInTemplates(
+    roleRegistryService,
+    globalSettings.userProfile,
+    globalSettings.personaOverrides
+  );
   events.emit('authority:registry-ready', { templateCount: roleRegistryService.size });
   logger.info(`Role registry ready with ${registeredCount} built-in templates`);
 } catch (error) {

--- a/apps/server/src/services/built-in-templates.ts
+++ b/apps/server/src/services/built-in-templates.ts
@@ -5,7 +5,7 @@
  * These cannot be overwritten or unregistered via the API.
  */
 
-import type { AgentTemplate } from '@automaker/types';
+import type { AgentTemplate, UserProfile, CustomPrompt } from '@automaker/types';
 import { createLogger } from '@automaker/utils';
 import {
   getAvaPrompt,
@@ -23,246 +23,290 @@ import type { RoleRegistryService } from './role-registry-service.js';
 
 const logger = createLogger('BuiltInTemplates');
 
-export const BUILT_IN_TEMPLATES: AgentTemplate[] = [
-  {
-    name: 'pr-maintainer',
-    displayName: 'PR Maintainer',
-    description:
-      'Handles PR pipeline mechanics: auto-merge enablement, CodeRabbit thread resolution, format fixing in worktrees, branch rebasing, and PR creation from orphaned worktrees.',
-    role: 'pr-maintainer',
-    tier: 0,
-    model: 'haiku',
-    maxTurns: 50,
-    canUseBash: true,
-    canModifyFiles: true,
-    canCommit: true,
-    canCreatePRs: true,
-    trustLevel: 2,
-    exposure: { cli: false, discord: false },
-    tags: ['pr', 'pipeline', 'maintenance', 'formatting', 'coderabbit'],
-    systemPrompt: getPrMaintainerPrompt(),
-  },
-  {
-    name: 'board-janitor',
-    displayName: 'Board Janitor',
-    description:
-      'Maintains board consistency: moves merged-PR features to done, resets stale in-progress features, repairs dependency chains.',
-    role: 'board-janitor',
-    tier: 0,
-    model: 'haiku',
-    maxTurns: 30,
-    canUseBash: false,
-    canModifyFiles: false,
-    canCommit: false,
-    canCreatePRs: false,
-    trustLevel: 1,
-    exposure: { cli: false, discord: false },
-    tags: ['board', 'maintenance', 'cleanup', 'dependencies'],
-    systemPrompt: getBoardJanitorPrompt(),
-  },
-  {
-    name: 'backend-engineer',
-    displayName: 'Backend Engineer',
-    description: 'Implements server-side features, APIs, services, and database logic.',
-    role: 'backend-engineer',
-    tier: 0,
-    model: 'sonnet',
-    maxTurns: 100,
-    canUseBash: true,
-    canModifyFiles: true,
-    canCommit: true,
-    canCreatePRs: true,
-    trustLevel: 2,
-    exposure: { cli: false, discord: false },
-    tags: ['implementation', 'backend', 'api'],
-  },
-  {
-    name: 'matt',
-    displayName: 'Matt',
-    description:
-      'Frontend engineering specialist. Implements UI components, design systems, theming, and Storybook. Reports to Ava.',
-    role: 'frontend-engineer',
-    tier: 0,
-    model: 'sonnet',
-    maxTurns: 100,
-    canUseBash: true,
-    canModifyFiles: true,
-    canCommit: true,
-    canCreatePRs: true,
-    trustLevel: 2,
-    exposure: { cli: true, discord: true, allowedUsers: ['chukz'] },
-    tags: ['implementation', 'frontend', 'ui', 'design-system', 'storybook'],
-    systemPrompt: getMattPrompt(),
-  },
-  {
-    name: 'sam',
-    displayName: 'Sam',
-    description:
-      'AI agent engineer. Designs multi-agent flows, LangGraph state graphs, LLM provider integrations, and observability pipelines. Reports to Ava.',
-    role: 'backend-engineer',
-    tier: 0,
-    model: 'sonnet',
-    maxTurns: 100,
-    canUseBash: true,
-    canModifyFiles: true,
-    canCommit: true,
-    canCreatePRs: true,
-    trustLevel: 2,
-    exposure: { cli: true, discord: true, allowedUsers: ['chukz'] },
-    tags: ['implementation', 'ai-agents', 'langgraph', 'llm-providers', 'observability', 'flows'],
-    systemPrompt: getSamPrompt(),
-  },
-  {
-    name: 'kai',
-    displayName: 'Kai',
-    description:
-      'Backend engineer. Implements Express routes, services, API design, error handling, and server-side features. Reports to Ava.',
-    role: 'backend-engineer',
-    tier: 0,
-    model: 'sonnet',
-    maxTurns: 100,
-    canUseBash: true,
-    canModifyFiles: true,
-    canCommit: true,
-    canCreatePRs: true,
-    trustLevel: 2,
-    exposure: { cli: true, discord: true, allowedUsers: ['chukz'] },
-    tags: ['implementation', 'backend', 'api', 'express', 'services'],
-    systemPrompt: getKaiPrompt(),
-  },
-  {
-    name: 'frank',
-    displayName: 'Frank',
-    description: 'Manages infrastructure, CI/CD, deployments, monitoring, and system reliability.',
-    role: 'devops-engineer',
-    tier: 0,
-    model: 'sonnet',
-    maxTurns: 100,
-    canUseBash: true,
-    canModifyFiles: true,
-    canCommit: true,
-    canCreatePRs: true,
-    trustLevel: 2,
-    exposure: { cli: true, discord: true, allowedUsers: ['chukz'] },
-    tags: ['infrastructure', 'devops', 'ci-cd'],
-    systemPrompt: getFrankPrompt(),
-  },
-  {
-    name: 'product-manager',
-    displayName: 'Product Manager',
-    description: 'Manages requirements, priorities, roadmap, and stakeholder communication.',
-    role: 'product-manager',
-    tier: 0,
-    model: 'sonnet',
-    maxTurns: 50,
-    canUseBash: false,
-    canModifyFiles: false,
-    canCommit: false,
-    canCreatePRs: false,
-    trustLevel: 1,
-    exposure: { cli: false, discord: false },
-    tags: ['planning', 'product', 'requirements'],
-  },
-  {
-    name: 'engineering-manager',
-    displayName: 'Engineering Manager',
-    description:
-      'Oversees engineering execution, code review, team coordination, and technical decisions.',
-    role: 'engineering-manager',
-    tier: 0,
-    model: 'sonnet',
-    maxTurns: 50,
-    canUseBash: false,
-    canModifyFiles: false,
-    canCommit: false,
-    canCreatePRs: false,
-    trustLevel: 1,
-    exposure: { cli: false, discord: false },
-    tags: ['management', 'review', 'coordination'],
-  },
-  {
-    name: 'ava',
-    displayName: 'Ava Loveland',
-    description:
-      'Autonomous operator with full authority. Manages operations, coordinates agents, and drives execution.',
-    role: 'chief-of-staff',
-    tier: 0,
-    model: 'opus',
-    maxTurns: 200,
-    canUseBash: true,
-    canModifyFiles: true,
-    canCommit: true,
-    canCreatePRs: true,
-    canSpawnAgents: true,
-    allowedSubagentRoles: ['backend-engineer', 'frontend-engineer', 'devops-engineer'],
-    trustLevel: 3,
-    exposure: { cli: true, discord: true, allowedUsers: ['chukz'] },
-    tags: ['operations', 'leadership', 'autonomous'],
-    systemPrompt: getAvaPrompt(),
-  },
-  {
-    name: 'cindi',
-    displayName: 'Cindi',
-    description:
-      'Content writing specialist for protoLabs. Uses content pipeline flows to produce blog posts, technical docs, training data, and marketing content. Expert in SEO, antagonistic review, and multi-format output.',
-    role: 'content-writer',
-    tier: 0,
-    model: 'sonnet',
-    maxTurns: 100,
-    canUseBash: false,
-    canModifyFiles: true,
-    canCommit: true,
-    canCreatePRs: true,
-    trustLevel: 2,
-    exposure: { cli: true, discord: true, allowedUsers: ['chukz'] },
-    tags: ['content', 'writing', 'blog', 'documentation', 'seo', 'training-data'],
-    systemPrompt: getCindiPrompt(),
-  },
-  {
-    name: 'linear-specialist',
-    displayName: 'Linear Specialist',
-    description:
-      'Owns all Linear workspace operations: project management, sprint planning, issue lifecycle, initiative tracking, and Automaker board synchronization.',
-    role: 'linear-specialist',
-    tier: 0,
-    model: 'sonnet',
-    maxTurns: 100,
-    canUseBash: false,
-    canModifyFiles: false,
-    canCommit: false,
-    canCreatePRs: false,
-    trustLevel: 2,
-    exposure: { cli: false, discord: false },
-    tags: ['linear', 'project-management', 'sprint-planning', 'issues', 'initiatives'],
-    systemPrompt: getLinearSpecialistPrompt(),
-  },
-  {
-    name: 'jon',
-    displayName: 'Jon',
-    description:
-      'GTM Specialist — content strategy, brand positioning, social media, competitive research, and launch execution.',
-    role: 'gtm-specialist',
-    tier: 0,
-    model: 'sonnet',
-    maxTurns: 100,
-    canUseBash: true,
-    canModifyFiles: true,
-    canCommit: false,
-    canCreatePRs: false,
-    trustLevel: 1,
-    exposure: { cli: true, discord: true, allowedUsers: ['chukz', 'abdelly'] },
-    tags: ['marketing', 'content', 'growth', 'gtm', 'brand'],
-    systemPrompt: getJonPrompt(),
-  },
-];
+/**
+ * Resolve the effective system prompt for a persona, applying overrides if enabled.
+ */
+function resolvePersonaPrompt(
+  name: string,
+  generated: string,
+  overrides?: Record<string, CustomPrompt>
+): string {
+  const override = overrides?.[name];
+  if (override?.enabled && override.value) {
+    return override.value;
+  }
+  return generated;
+}
+
+/**
+ * Derive allowedUsers from user profile, falling back to current defaults.
+ */
+function deriveAllowedUsers(profile?: UserProfile): string[] {
+  const primary = profile?.discord?.username ?? 'chukz';
+  const additional = profile?.additionalAllowedUsers ?? [];
+  return [primary, ...additional];
+}
+
+export function buildTemplates(
+  userProfile?: UserProfile,
+  personaOverrides?: Record<string, CustomPrompt>
+): AgentTemplate[] {
+  const allowedUsers = deriveAllowedUsers(userProfile);
+  const promptConfig = { userProfile };
+
+  return [
+    {
+      name: 'pr-maintainer',
+      displayName: 'PR Maintainer',
+      description:
+        'Handles PR pipeline mechanics: auto-merge enablement, CodeRabbit thread resolution, format fixing in worktrees, branch rebasing, and PR creation from orphaned worktrees.',
+      role: 'pr-maintainer',
+      tier: 0,
+      model: 'haiku',
+      maxTurns: 50,
+      canUseBash: true,
+      canModifyFiles: true,
+      canCommit: true,
+      canCreatePRs: true,
+      trustLevel: 2,
+      exposure: { cli: false, discord: false },
+      tags: ['pr', 'pipeline', 'maintenance', 'formatting', 'coderabbit'],
+      systemPrompt: getPrMaintainerPrompt(),
+    },
+    {
+      name: 'board-janitor',
+      displayName: 'Board Janitor',
+      description:
+        'Maintains board consistency: moves merged-PR features to done, resets stale in-progress features, repairs dependency chains.',
+      role: 'board-janitor',
+      tier: 0,
+      model: 'haiku',
+      maxTurns: 30,
+      canUseBash: false,
+      canModifyFiles: false,
+      canCommit: false,
+      canCreatePRs: false,
+      trustLevel: 1,
+      exposure: { cli: false, discord: false },
+      tags: ['board', 'maintenance', 'cleanup', 'dependencies'],
+      systemPrompt: getBoardJanitorPrompt(),
+    },
+    {
+      name: 'backend-engineer',
+      displayName: 'Backend Engineer',
+      description: 'Implements server-side features, APIs, services, and database logic.',
+      role: 'backend-engineer',
+      tier: 0,
+      model: 'sonnet',
+      maxTurns: 100,
+      canUseBash: true,
+      canModifyFiles: true,
+      canCommit: true,
+      canCreatePRs: true,
+      trustLevel: 2,
+      exposure: { cli: false, discord: false },
+      tags: ['implementation', 'backend', 'api'],
+    },
+    {
+      name: 'matt',
+      displayName: 'Matt',
+      description:
+        'Frontend engineering specialist. Implements UI components, design systems, theming, and Storybook. Reports to Ava.',
+      role: 'frontend-engineer',
+      tier: 0,
+      model: 'sonnet',
+      maxTurns: 100,
+      canUseBash: true,
+      canModifyFiles: true,
+      canCommit: true,
+      canCreatePRs: true,
+      trustLevel: 2,
+      exposure: { cli: true, discord: true, allowedUsers },
+      tags: ['implementation', 'frontend', 'ui', 'design-system', 'storybook'],
+      systemPrompt: resolvePersonaPrompt('matt', getMattPrompt(promptConfig), personaOverrides),
+    },
+    {
+      name: 'sam',
+      displayName: 'Sam',
+      description:
+        'AI agent engineer. Designs multi-agent flows, LangGraph state graphs, LLM provider integrations, and observability pipelines. Reports to Ava.',
+      role: 'backend-engineer',
+      tier: 0,
+      model: 'sonnet',
+      maxTurns: 100,
+      canUseBash: true,
+      canModifyFiles: true,
+      canCommit: true,
+      canCreatePRs: true,
+      trustLevel: 2,
+      exposure: { cli: true, discord: true, allowedUsers },
+      tags: ['implementation', 'ai-agents', 'langgraph', 'llm-providers', 'observability', 'flows'],
+      systemPrompt: resolvePersonaPrompt('sam', getSamPrompt(promptConfig), personaOverrides),
+    },
+    {
+      name: 'kai',
+      displayName: 'Kai',
+      description:
+        'Backend engineer. Implements Express routes, services, API design, error handling, and server-side features. Reports to Ava.',
+      role: 'backend-engineer',
+      tier: 0,
+      model: 'sonnet',
+      maxTurns: 100,
+      canUseBash: true,
+      canModifyFiles: true,
+      canCommit: true,
+      canCreatePRs: true,
+      trustLevel: 2,
+      exposure: { cli: true, discord: true, allowedUsers },
+      tags: ['implementation', 'backend', 'api', 'express', 'services'],
+      systemPrompt: resolvePersonaPrompt('kai', getKaiPrompt(promptConfig), personaOverrides),
+    },
+    {
+      name: 'frank',
+      displayName: 'Frank',
+      description:
+        'Manages infrastructure, CI/CD, deployments, monitoring, and system reliability.',
+      role: 'devops-engineer',
+      tier: 0,
+      model: 'sonnet',
+      maxTurns: 100,
+      canUseBash: true,
+      canModifyFiles: true,
+      canCommit: true,
+      canCreatePRs: true,
+      trustLevel: 2,
+      exposure: { cli: true, discord: true, allowedUsers },
+      tags: ['infrastructure', 'devops', 'ci-cd'],
+      systemPrompt: resolvePersonaPrompt('frank', getFrankPrompt(promptConfig), personaOverrides),
+    },
+    {
+      name: 'product-manager',
+      displayName: 'Product Manager',
+      description: 'Manages requirements, priorities, roadmap, and stakeholder communication.',
+      role: 'product-manager',
+      tier: 0,
+      model: 'sonnet',
+      maxTurns: 50,
+      canUseBash: false,
+      canModifyFiles: false,
+      canCommit: false,
+      canCreatePRs: false,
+      trustLevel: 1,
+      exposure: { cli: false, discord: false },
+      tags: ['planning', 'product', 'requirements'],
+    },
+    {
+      name: 'engineering-manager',
+      displayName: 'Engineering Manager',
+      description:
+        'Oversees engineering execution, code review, team coordination, and technical decisions.',
+      role: 'engineering-manager',
+      tier: 0,
+      model: 'sonnet',
+      maxTurns: 50,
+      canUseBash: false,
+      canModifyFiles: false,
+      canCommit: false,
+      canCreatePRs: false,
+      trustLevel: 1,
+      exposure: { cli: false, discord: false },
+      tags: ['management', 'review', 'coordination'],
+    },
+    {
+      name: 'ava',
+      displayName: 'Ava Loveland',
+      description:
+        'Autonomous operator with full authority. Manages operations, coordinates agents, and drives execution.',
+      role: 'chief-of-staff',
+      tier: 0,
+      model: 'opus',
+      maxTurns: 200,
+      canUseBash: true,
+      canModifyFiles: true,
+      canCommit: true,
+      canCreatePRs: true,
+      canSpawnAgents: true,
+      allowedSubagentRoles: ['backend-engineer', 'frontend-engineer', 'devops-engineer'],
+      trustLevel: 3,
+      exposure: { cli: true, discord: true, allowedUsers },
+      tags: ['operations', 'leadership', 'autonomous'],
+      systemPrompt: resolvePersonaPrompt('ava', getAvaPrompt(promptConfig), personaOverrides),
+    },
+    {
+      name: 'cindi',
+      displayName: 'Cindi',
+      description:
+        'Content writing specialist for protoLabs. Uses content pipeline flows to produce blog posts, technical docs, training data, and marketing content. Expert in SEO, antagonistic review, and multi-format output.',
+      role: 'content-writer',
+      tier: 0,
+      model: 'sonnet',
+      maxTurns: 100,
+      canUseBash: false,
+      canModifyFiles: true,
+      canCommit: true,
+      canCreatePRs: true,
+      trustLevel: 2,
+      exposure: { cli: true, discord: true, allowedUsers },
+      tags: ['content', 'writing', 'blog', 'documentation', 'seo', 'training-data'],
+      systemPrompt: resolvePersonaPrompt('cindi', getCindiPrompt(promptConfig), personaOverrides),
+    },
+    {
+      name: 'linear-specialist',
+      displayName: 'Linear Specialist',
+      description:
+        'Owns all Linear workspace operations: project management, sprint planning, issue lifecycle, initiative tracking, and Automaker board synchronization.',
+      role: 'linear-specialist',
+      tier: 0,
+      model: 'sonnet',
+      maxTurns: 100,
+      canUseBash: false,
+      canModifyFiles: false,
+      canCommit: false,
+      canCreatePRs: false,
+      trustLevel: 2,
+      exposure: { cli: false, discord: false },
+      tags: ['linear', 'project-management', 'sprint-planning', 'issues', 'initiatives'],
+      systemPrompt: getLinearSpecialistPrompt(),
+    },
+    {
+      name: 'jon',
+      displayName: 'Jon',
+      description:
+        'GTM Specialist — content strategy, brand positioning, social media, competitive research, and launch execution.',
+      role: 'gtm-specialist',
+      tier: 0,
+      model: 'sonnet',
+      maxTurns: 100,
+      canUseBash: true,
+      canModifyFiles: true,
+      canCommit: false,
+      canCreatePRs: false,
+      trustLevel: 1,
+      exposure: {
+        cli: true,
+        discord: true,
+        allowedUsers: allowedUsers.includes('abdelly')
+          ? allowedUsers
+          : [...allowedUsers, 'abdelly'],
+      },
+      tags: ['marketing', 'content', 'growth', 'gtm', 'brand'],
+      systemPrompt: resolvePersonaPrompt('jon', getJonPrompt(promptConfig), personaOverrides),
+    },
+  ];
+}
 
 /**
  * Register all built-in templates. Returns count of successfully registered templates.
  */
-export function registerBuiltInTemplates(registry: RoleRegistryService): number {
+export function registerBuiltInTemplates(
+  registry: RoleRegistryService,
+  userProfile?: UserProfile,
+  personaOverrides?: Record<string, CustomPrompt>
+): number {
+  const templates = buildTemplates(userProfile, personaOverrides);
   let registered = 0;
 
-  for (const template of BUILT_IN_TEMPLATES) {
+  for (const template of templates) {
     const result = registry.register(template);
     if (result.success) {
       registered++;
@@ -271,6 +315,6 @@ export function registerBuiltInTemplates(registry: RoleRegistryService): number 
     }
   }
 
-  logger.info(`Registered ${registered}/${BUILT_IN_TEMPLATES.length} built-in templates`);
+  logger.info(`Registered ${registered}/${templates.length} built-in templates`);
   return registered;
 }

--- a/apps/ui/src/components/views/settings-view.tsx
+++ b/apps/ui/src/components/views/settings-view.tsx
@@ -31,6 +31,8 @@ import { MCPServersSection } from './settings-view/mcp-servers';
 import { PromptCustomizationSection } from './settings-view/prompts';
 import { EventHooksSection } from './settings-view/event-hooks';
 import { IntegrationsSection } from './settings-view/integrations';
+import { ProfileSection } from './settings-view/profile';
+import { PersonasSection } from './settings-view/personas';
 import { WorkflowSettingsPanel } from './settings-view/workflow/workflow-settings-panel';
 import { MaintenanceSection } from './settings-view/maintenance';
 import { ImportExportDialog } from './settings-view/components/import-export-dialog';
@@ -185,6 +187,10 @@ export function SettingsView() {
         );
       case 'account':
         return <AccountSection />;
+      case 'profile':
+        return <ProfileSection />;
+      case 'personas':
+        return <PersonasSection />;
       case 'security':
         return (
           <SecuritySection

--- a/apps/ui/src/components/views/settings-view/config/navigation.ts
+++ b/apps/ui/src/components/views/settings-view/config/navigation.ts
@@ -19,6 +19,8 @@ import {
   Activity,
   Cog,
   Timer,
+  UserCog,
+  Users,
 } from 'lucide-react';
 import {
   AnthropicIcon,
@@ -79,6 +81,7 @@ export const GLOBAL_NAV_GROUPS: NavigationGroup[] = [
     label: 'Account & Security',
     items: [
       { id: 'account', label: 'Account', icon: User },
+      { id: 'profile', label: 'User Profile', icon: UserCog },
       { id: 'security', label: 'Security', icon: Shield },
     ],
   },
@@ -86,6 +89,7 @@ export const GLOBAL_NAV_GROUPS: NavigationGroup[] = [
     label: 'System',
     items: [
       { id: 'health', label: 'Health', icon: Activity },
+      { id: 'personas', label: 'Personas', icon: Users },
       { id: 'workflow', label: 'Workflow', icon: Cog },
       { id: 'maintenance', label: 'Maintenance', icon: Timer },
     ],

--- a/apps/ui/src/components/views/settings-view/hooks/use-settings-view.ts
+++ b/apps/ui/src/components/views/settings-view/hooks/use-settings-view.ts
@@ -21,6 +21,8 @@ export type SettingsViewId =
   | 'worktrees'
   | 'account'
   | 'security'
+  | 'profile'
+  | 'personas'
   | 'health'
   | 'developer'
   | 'danger'

--- a/apps/ui/src/components/views/settings-view/personas/index.ts
+++ b/apps/ui/src/components/views/settings-view/personas/index.ts
@@ -1,0 +1,1 @@
+export { PersonasSection } from './personas-section';

--- a/apps/ui/src/components/views/settings-view/personas/personas-section.tsx
+++ b/apps/ui/src/components/views/settings-view/personas/personas-section.tsx
@@ -1,0 +1,178 @@
+import { useState, useCallback, useEffect } from 'react';
+import { Button, Badge, Switch, Textarea } from '@protolabs/ui/atoms';
+import { Users, RotateCcw } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useGlobalSettings } from '@/hooks/queries/use-settings';
+import { useUpdateGlobalSettings } from '@/hooks/mutations/use-settings-mutations';
+import { useAgentTemplates } from '@/hooks/queries/use-agent-templates';
+import type { AgentTemplateMetadata } from '@/hooks/queries/use-agent-templates';
+import type { CustomPrompt } from '@automaker/types';
+
+function modelBadgeVariant(model?: string): 'default' | 'secondary' | 'outline' {
+  switch (model) {
+    case 'opus':
+      return 'default';
+    case 'sonnet':
+      return 'secondary';
+    default:
+      return 'outline';
+  }
+}
+
+interface PersonaCardProps {
+  template: AgentTemplateMetadata;
+  override: CustomPrompt | undefined;
+  onToggle: () => void;
+  onUpdateValue: (value: string) => void;
+  onReset: () => void;
+}
+
+function PersonaCard({ template, override, onToggle, onUpdateValue, onReset }: PersonaCardProps) {
+  const [localValue, setLocalValue] = useState(override?.value ?? '');
+
+  // Sync local state when server override changes
+  useEffect(() => {
+    setLocalValue(override?.value ?? '');
+  }, [override?.value]);
+
+  return (
+    <div className="rounded-xl bg-muted/30 border border-border/30 overflow-hidden">
+      <div className="p-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <p className="font-medium text-foreground truncate">{template.displayName}</p>
+              <Badge variant="outline" className="text-[10px] shrink-0">
+                {template.role}
+              </Badge>
+              {template.model && (
+                <Badge variant={modelBadgeVariant(template.model)} className="text-[10px] shrink-0">
+                  {template.model}
+                </Badge>
+              )}
+            </div>
+            <p className="text-xs text-muted-foreground/70 mt-0.5 truncate">
+              {template.description}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-xs text-muted-foreground">Custom prompt</span>
+          <Switch checked={override?.enabled ?? false} onCheckedChange={onToggle} />
+        </div>
+      </div>
+
+      {override?.enabled && (
+        <div className="px-4 pb-4 space-y-2">
+          <Textarea
+            className="font-mono text-xs"
+            rows={12}
+            value={localValue}
+            onChange={(e) => setLocalValue(e.target.value)}
+            onBlur={() => {
+              if (localValue !== override.value) {
+                onUpdateValue(localValue);
+              }
+            }}
+            placeholder="Enter a custom system prompt override for this agent..."
+          />
+          <div className="flex justify-end">
+            <Button variant="ghost" size="sm" className="gap-1.5 text-xs" onClick={onReset}>
+              <RotateCcw className="w-3 h-3" />
+              Reset
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PersonasSection() {
+  const { data: settings } = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings({ showSuccessToast: false });
+  const { data: templates, isLoading } = useAgentTemplates();
+
+  const personaOverrides = settings?.personaOverrides ?? {};
+
+  const toggleOverride = useCallback(
+    (name: string) => {
+      const existing = personaOverrides[name];
+      const updated: Record<string, CustomPrompt> = {
+        ...personaOverrides,
+        [name]: {
+          value: existing?.value ?? '',
+          enabled: !existing?.enabled,
+        },
+      };
+      updateSettings.mutate({ personaOverrides: updated });
+    },
+    [personaOverrides, updateSettings]
+  );
+
+  const updatePromptValue = useCallback(
+    (name: string, value: string) => {
+      const existing = personaOverrides[name];
+      const updated: Record<string, CustomPrompt> = {
+        ...personaOverrides,
+        [name]: { value, enabled: existing?.enabled ?? true },
+      };
+      updateSettings.mutate({ personaOverrides: updated });
+    },
+    [personaOverrides, updateSettings]
+  );
+
+  const resetOverride = useCallback(
+    (name: string) => {
+      const { [name]: _, ...rest } = personaOverrides;
+      updateSettings.mutate({ personaOverrides: rest });
+    },
+    [personaOverrides, updateSettings]
+  );
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg overflow-hidden',
+        'border border-border/50',
+        'bg-gradient-to-br from-card/80 via-card/70 to-card/80 backdrop-blur-xl',
+        'shadow-sm'
+      )}
+    >
+      <div className="p-4 border-b border-border/30 bg-gradient-to-r from-primary/5 via-transparent to-transparent">
+        <div className="flex items-center gap-3 mb-2">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-primary/20 to-primary/10 flex items-center justify-center border border-primary/20">
+            <Users className="w-5 h-5 text-primary" />
+          </div>
+          <h2 className="text-lg font-semibold text-foreground tracking-tight">Personas</h2>
+        </div>
+        <p className="text-sm text-muted-foreground/80 ml-12">
+          Override system prompts for registered agent templates.
+        </p>
+      </div>
+
+      <div className="p-6 space-y-3">
+        {isLoading && (
+          <p className="text-sm text-muted-foreground text-center py-8">Loading templates...</p>
+        )}
+
+        {!isLoading && (!templates || templates.length === 0) && (
+          <p className="text-sm text-muted-foreground text-center py-8">
+            No agent templates registered.
+          </p>
+        )}
+
+        {templates?.map((template) => (
+          <PersonaCard
+            key={template.name}
+            template={template}
+            override={personaOverrides[template.name]}
+            onToggle={() => toggleOverride(template.name)}
+            onUpdateValue={(value) => updatePromptValue(template.name, value)}
+            onReset={() => resetOverride(template.name)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/views/settings-view/profile/index.ts
+++ b/apps/ui/src/components/views/settings-view/profile/index.ts
@@ -1,0 +1,1 @@
+export { ProfileSection } from './profile-section';

--- a/apps/ui/src/components/views/settings-view/profile/profile-section.tsx
+++ b/apps/ui/src/components/views/settings-view/profile/profile-section.tsx
@@ -1,0 +1,373 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Input, Label, Textarea } from '@protolabs/ui/atoms';
+import { UserCog } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useGlobalSettings } from '@/hooks/queries/use-settings';
+import { useUpdateGlobalSettings } from '@/hooks/mutations/use-settings-mutations';
+import type { UserProfile } from '@automaker/types';
+
+function GroupHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider pt-2 pb-1">
+      {children}
+    </h3>
+  );
+}
+
+function FieldRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-sm font-medium">{label}</Label>
+      {children}
+    </div>
+  );
+}
+
+export function ProfileSection() {
+  const { data: settings } = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings({ showSuccessToast: false });
+
+  const [local, setLocal] = useState<UserProfile>({});
+  const [allowedUsersText, setAllowedUsersText] = useState('');
+
+  // Sync server data to local state
+  useEffect(() => {
+    if (settings?.userProfile) {
+      setLocal(settings.userProfile);
+      setAllowedUsersText((settings.userProfile.additionalAllowedUsers ?? []).join(', '));
+    }
+  }, [settings?.userProfile]);
+
+  const save = useCallback(
+    (overrides?: Partial<UserProfile>) => {
+      const toSave = overrides ? { ...local, ...overrides } : local;
+      updateSettings.mutate({ userProfile: toSave });
+    },
+    [local, updateSettings]
+  );
+
+  const saveAllowedUsers = useCallback(() => {
+    const users = allowedUsersText
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const updated = { ...local, additionalAllowedUsers: users };
+    setLocal(updated);
+    updateSettings.mutate({ userProfile: updated });
+  }, [allowedUsersText, local, updateSettings]);
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg overflow-hidden',
+        'border border-border/50',
+        'bg-gradient-to-br from-card/80 via-card/70 to-card/80 backdrop-blur-xl',
+        'shadow-sm'
+      )}
+    >
+      <div className="p-4 border-b border-border/30 bg-gradient-to-r from-primary/5 via-transparent to-transparent">
+        <div className="flex items-center gap-3 mb-2">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-primary/20 to-primary/10 flex items-center justify-center border border-primary/20">
+            <UserCog className="w-5 h-5 text-primary" />
+          </div>
+          <h2 className="text-lg font-semibold text-foreground tracking-tight">User Profile</h2>
+        </div>
+        <p className="text-sm text-muted-foreground/80 ml-12">
+          Configure your identity, brand, and integrations for agent personalization.
+        </p>
+      </div>
+
+      <div className="p-6 space-y-6">
+        {/* Identity */}
+        <div className="space-y-4">
+          <GroupHeader>Identity</GroupHeader>
+          <FieldRow label="Name">
+            <Input
+              value={local.name ?? ''}
+              onChange={(e) => setLocal((p) => ({ ...p, name: e.target.value }))}
+              onBlur={() => save()}
+              placeholder="Your full name"
+            />
+          </FieldRow>
+          <FieldRow label="Title">
+            <Input
+              value={local.title ?? ''}
+              onChange={(e) => setLocal((p) => ({ ...p, title: e.target.value }))}
+              onBlur={() => save()}
+              placeholder="e.g. Architect, founder"
+            />
+          </FieldRow>
+          <FieldRow label="Bio">
+            <Textarea
+              value={local.bio ?? ''}
+              onChange={(e) => setLocal((p) => ({ ...p, bio: e.target.value }))}
+              onBlur={() => save()}
+              rows={3}
+              placeholder="Short bio for content agents"
+            />
+          </FieldRow>
+        </div>
+
+        {/* Discord */}
+        <div className="space-y-4">
+          <GroupHeader>Discord</GroupHeader>
+          <FieldRow label="Username">
+            <Input
+              value={local.discord?.username ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  discord: { ...p.discord, username: e.target.value },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="Discord username"
+            />
+          </FieldRow>
+          <FieldRow label="Primary Channel ID">
+            <Input
+              className="font-mono"
+              value={local.discord?.channels?.primary ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  discord: {
+                    ...p.discord,
+                    channels: { ...p.discord?.channels, primary: e.target.value },
+                  },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="Channel ID"
+            />
+          </FieldRow>
+          <FieldRow label="Dev Channel ID">
+            <Input
+              className="font-mono"
+              value={local.discord?.channels?.dev ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  discord: {
+                    ...p.discord,
+                    channels: { ...p.discord?.channels, dev: e.target.value },
+                  },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="Channel ID"
+            />
+          </FieldRow>
+          <FieldRow label="Infra Channel ID">
+            <Input
+              className="font-mono"
+              value={local.discord?.channels?.infra ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  discord: {
+                    ...p.discord,
+                    channels: { ...p.discord?.channels, infra: e.target.value },
+                  },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="Channel ID"
+            />
+          </FieldRow>
+          <FieldRow label="Deployments Channel ID">
+            <Input
+              className="font-mono"
+              value={local.discord?.channels?.deployments ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  discord: {
+                    ...p.discord,
+                    channels: { ...p.discord?.channels, deployments: e.target.value },
+                  },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="Channel ID"
+            />
+          </FieldRow>
+          <FieldRow label="Alerts Channel ID">
+            <Input
+              className="font-mono"
+              value={local.discord?.channels?.alerts ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  discord: {
+                    ...p.discord,
+                    channels: { ...p.discord?.channels, alerts: e.target.value },
+                  },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="Channel ID"
+            />
+          </FieldRow>
+        </div>
+
+        {/* Linear */}
+        <div className="space-y-4">
+          <GroupHeader>Linear</GroupHeader>
+          <FieldRow label="Team ID">
+            <Input
+              className="font-mono"
+              value={local.linear?.teamId ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  linear: { ...p.linear, teamId: e.target.value },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="Linear team ID"
+            />
+          </FieldRow>
+          <FieldRow label="In-Progress State ID">
+            <Input
+              className="font-mono"
+              value={local.linear?.inProgressStateId ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  linear: { ...p.linear, inProgressStateId: e.target.value },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="State ID for in-progress issues"
+            />
+          </FieldRow>
+        </div>
+
+        {/* GitHub */}
+        <div className="space-y-4">
+          <GroupHeader>GitHub</GroupHeader>
+          <FieldRow label="Organization">
+            <Input
+              value={local.github?.org ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  github: { ...p.github, org: e.target.value },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="GitHub org name"
+            />
+          </FieldRow>
+        </div>
+
+        {/* Brand */}
+        <div className="space-y-4">
+          <GroupHeader>Brand</GroupHeader>
+          <FieldRow label="Agency Name">
+            <Input
+              value={local.brand?.agencyName ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  brand: { ...p.brand, agencyName: e.target.value },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="e.g. protoLabs"
+            />
+          </FieldRow>
+          <FieldRow label="Product Name">
+            <Input
+              value={local.brand?.productName ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  brand: { ...p.brand, productName: e.target.value },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="e.g. protoMaker"
+            />
+          </FieldRow>
+          <FieldRow label="Internal Codename">
+            <Input
+              value={local.brand?.internalCodename ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  brand: { ...p.brand, internalCodename: e.target.value },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="e.g. Automaker"
+            />
+          </FieldRow>
+          <FieldRow label="Domain">
+            <Input
+              value={local.brand?.domain ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  brand: { ...p.brand, domain: e.target.value },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="e.g. protoLabs.studio"
+            />
+          </FieldRow>
+          <FieldRow label="Voice">
+            <Textarea
+              value={local.brand?.voice ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  brand: { ...p.brand, voice: e.target.value },
+                }))
+              }
+              onBlur={() => save()}
+              rows={4}
+              placeholder="Brand voice guidelines for content agents"
+            />
+          </FieldRow>
+        </div>
+
+        {/* Infrastructure */}
+        <div className="space-y-4">
+          <GroupHeader>Infrastructure</GroupHeader>
+          <FieldRow label="Staging Host">
+            <Input
+              className="font-mono"
+              value={local.infra?.stagingHost ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  infra: { ...p.infra, stagingHost: e.target.value },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="e.g. 100.101.189.45"
+            />
+          </FieldRow>
+        </div>
+
+        {/* Access Control */}
+        <div className="space-y-4">
+          <GroupHeader>Access Control</GroupHeader>
+          <FieldRow label="Additional Allowed Users">
+            <Input
+              value={allowedUsersText}
+              onChange={(e) => setAllowedUsersText(e.target.value)}
+              onBlur={() => saveAllowedUsers()}
+              placeholder="Comma-separated Discord usernames"
+            />
+            <p className="text-xs text-muted-foreground/70">
+              Discord usernames allowed to interact with agents, separated by commas.
+            </p>
+          </FieldRow>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/libs/prompts/src/agents/ava.ts
+++ b/libs/prompts/src/agents/ava.ts
@@ -8,6 +8,9 @@
 import type { PromptConfig } from '../types.js';
 
 export function getAvaPrompt(config?: PromptConfig): string {
+  const p = config?.userProfile;
+  const userName = p?.name ?? 'Josh';
+
   return `You are Ava Loveland, Chief of Staff. Not an assistant. A team member with full operational authority.
 
 ## Prime Directive
@@ -20,7 +23,7 @@ export function getAvaPrompt(config?: PromptConfig): string {
 
 1. **See friction** — Something manual, broken, slow, or missing
 2. **Fix it** — Create feature, start agent, write code, merge PR
-3. **Ship it** — Get it to main. Message Josh if CI is stuck.
+3. **Ship it** — Get it to main. Message ${userName} if CI is stuck.
 4. **Next** — Find the next friction point. Never idle.
 
 **Act first, report after.** Don't ask permission for operational work. Make decisions. Post results to Discord.

--- a/libs/prompts/src/agents/cindi.ts
+++ b/libs/prompts/src/agents/cindi.ts
@@ -9,11 +9,17 @@ import type { PromptConfig } from '../types.js';
 import { getContentBase } from '../shared/team-base.js';
 
 export function getCindiPrompt(config?: PromptConfig): string {
-  return `${getContentBase()}
+  const p = config?.userProfile;
+  const userName = p?.name ?? 'Josh';
+  const agencyName = p?.brand?.agencyName ?? 'protoLabs';
+  const primaryChannel = p?.discord?.channels?.primary ?? '1469195643590541353';
+  const devChannel = p?.discord?.channels?.dev ?? '1469080556720623699';
+
+  return `${getContentBase(p)}
 
 ---
 
-You are Cindi, the Content Writing Specialist for protoLabs. You report to Ava (Chief of Staff) and own all content production decisions.
+You are Cindi, the Content Writing Specialist for ${agencyName}. You report to Ava (Chief of Staff) and own all content production decisions.
 
 ## Core Mandate
 
@@ -109,9 +115,9 @@ When running as an agent, use these tools to execute content flows:
 ## Communication
 
 **Discord Channels:**
-- \`#ava-josh\` (1469195643590541353) — Coordinate with Ava/Josh
-- \`#dev\` (1469080556720623699) — Share content updates
-- DMs to \`chukz\` (Josh) — Time-sensitive coordination
+- \`#ava-josh\` (${primaryChannel}) — Coordinate with Ava/${userName}
+- \`#dev\` (${devChannel}) — Share content updates
+- DMs to \`chukz\` (${userName}) — Time-sensitive coordination
 
 Report progress and decisions to Ava. Keep responses focused, strategic, and quality-obsessed. When proposing strategy changes, explain the data behind the decision.
 

--- a/libs/prompts/src/agents/frank.ts
+++ b/libs/prompts/src/agents/frank.ts
@@ -9,7 +9,14 @@ import type { PromptConfig } from '../types.js';
 import { getEngineeringBase } from '../shared/team-base.js';
 
 export function getFrankPrompt(config?: PromptConfig): string {
-  return `${getEngineeringBase()}
+  const p = config?.userProfile;
+  const userName = p?.name ?? 'Josh';
+  const stagingHost = p?.infra?.stagingHost ?? '100.101.189.45';
+  const infraChannel = p?.discord?.channels?.infra ?? '1469109809939742814';
+  const primaryChannel = p?.discord?.channels?.primary ?? '1469195643590541353';
+  const devChannel = p?.discord?.channels?.dev ?? '1469080556720623699';
+
+  return `${getEngineeringBase(p)}
 
 ---
 
@@ -35,7 +42,7 @@ You are Frank, the DevOps Engineer for protoLabs. You report to Ava (Chief of St
 - Use multi-stage Docker builds for optimization
 - Minimize attack surface — only expose necessary ports
 - Monitor resource usage and set alerts for anomalies
-- **NEVER restart the dev server yourself** — coordinate with Josh
+- **NEVER restart the dev server yourself** — coordinate with ${userName}
 
 ## Technical Standards
 
@@ -48,7 +55,7 @@ You are Frank, the DevOps Engineer for protoLabs. You report to Ava (Chief of St
 ## Infrastructure Context
 
 - **Dev server**: localhost:3008, managed by user (NEVER restart it)
-- **Staging**: 100.101.189.45 (Tailscale), 125GB RAM, 24 CPUs
+- **Staging**: ${stagingHost} (Tailscale), 125GB RAM, 24 CPUs
 - **CI**: Self-hosted runner auto-deploys on push to main
 - **Heap**: 8GB minimum for dev (\`--max-old-space-size=8192\`), 32GB for staging
 
@@ -85,10 +92,10 @@ You are Frank, the DevOps Engineer for protoLabs. You report to Ava (Chief of St
 ## Communication
 
 **Discord Channels:**
-- \`#infra\` (1469109809939742814) — Infrastructure alerts, deployment status, health reports
-- \`#ava-josh\` (1469195643590541353) — Coordinate with Ava/Josh
-- \`#dev\` (1469080556720623699) — Share infrastructure changes affecting development
-- DMs to \`chukz\` (Josh) — Emergency coordination
+- \`#infra\` (${infraChannel}) — Infrastructure alerts, deployment status, health reports
+- \`#ava-josh\` (${primaryChannel}) — Coordinate with Ava/${userName}
+- \`#dev\` (${devChannel}) — Share infrastructure changes affecting development
+- DMs to \`chukz\` (${userName}) — Emergency coordination
 
 Report infrastructure status and incidents concisely. When something breaks, lead with impact and ETA, not root cause analysis. Fix first, post-mortem later.
 

--- a/libs/prompts/src/agents/jon.ts
+++ b/libs/prompts/src/agents/jon.ts
@@ -9,42 +9,51 @@ import type { PromptConfig } from '../types.js';
 import { getContentBase } from '../shared/team-base.js';
 
 export function getJonPrompt(config?: PromptConfig): string {
-  return `${getContentBase()}
+  const p = config?.userProfile;
+  const userName = p?.name ?? 'Josh';
+  const userTitle = p?.title ?? 'Architect, founder';
+  const agencyName = p?.brand?.agencyName ?? 'protoLabs';
+  const productName = p?.brand?.productName ?? 'protoMaker';
+  const githubOrg = p?.github?.org ?? 'proto-labs-ai';
+  const primaryChannel = p?.discord?.channels?.primary ?? '1469195643590541353';
+  const devChannel = p?.discord?.channels?.dev ?? '1469080556720623699';
+
+  return `${getContentBase(p)}
 
 ---
 
-You are Jon, the GTM (Go-To-Market) Specialist for protoLabs. You own content strategy, brand positioning, social media execution, competitive research, and launch coordination.
+You are Jon, the GTM (Go-To-Market) Specialist for ${agencyName}. You own content strategy, brand positioning, social media execution, competitive research, and launch coordination.
 
-## Josh Mabry — Positioning
+## ${userName} — Positioning
 
-**Who Josh is:** Architect, founder, technical leader. NOT a developer — an orchestrator who designs systems and directs AI agents to build them.
+**Who ${userName} is:** ${userTitle}, technical leader. NOT a developer — an orchestrator who designs systems and directs AI agents to build them.
 
 **Language Guide:**
 - USE: "architect, orchestrate, ship, design, direct, build (systems)"
 - NEVER USE: "coded, built in React, implemented, programmed, developed"
-- Josh architects systems. AI agents implement them. This distinction IS the brand.
+- ${userName} architects systems. AI agents implement them. This distinction IS the brand.
 
-**Josh's background:** Design systems architect for Fortune 500 clients (Phase2 Technology), AI lead at Knapsack, now building protoLabs — the first AI-native development agency.
+**${userName}'s background:** Design systems architect for Fortune 500 clients (Phase2 Technology), AI lead at Knapsack, now building ${agencyName} — the first AI-native development agency.
 
 ## Revenue Model
 
 Open source first. Build the community, prove the tool, let revenue follow naturally.
-- **Open source tool** — protoLabs is fully open source. Community adoption is the growth engine.
-- **Portfolio proof** — We build our own products (MythXEngine, SVGVal, rabbit-hole) with protoLabs. The tool proves itself through what it ships.
+- **Open source tool** — ${agencyName} is fully open source. Community adoption is the growth engine.
+- **Portfolio proof** — We build our own products (MythXEngine, SVGVal, rabbit-hole) with ${agencyName}. The tool proves itself through what it ships.
 - **Consulting** — setupLab. Organic inbound from community, not outbound sales.
 - **Philosophy**: No paid tiers, no subscriptions, no paywalls. Everything is open.
 
 ## Portfolio Proof Points
 
-- **protoMaker** — AI development studio product (Kanban + autonomous agents)
-- **MythXEngine** — AI-powered TTRPG engine built with protoMaker
-- **SVGVal** — SVG validation toolkit built with protoMaker
+- **${productName}** — AI development studio product (Kanban + autonomous agents)
+- **MythXEngine** — AI-powered TTRPG engine built with ${productName}
+- **SVGVal** — SVG validation toolkit built with ${productName}
 
 No competitor ships finished products built with their own tool. This IS the differentiator.
 
 ## Team Capacity
 
-This is NOT a human org. AI agents generate, schedule, and distribute content at 10x human capacity. Josh's only role is to engage with people. Everything else is delegated.
+This is NOT a human org. AI agents generate, schedule, and distribute content at 10x human capacity. ${userName}'s only role is to engage with people. Everything else is delegated.
 
 ## Team Context
 
@@ -60,9 +69,9 @@ This is NOT a human org. AI agents generate, schedule, and distribute content at
 
 ## Content Strategy
 
-**Core principle:** "One effort, many surfaces." Content generation is automated — Cindi writes, Jon strategizes, schedulers distribute. Josh engages.
+**Core principle:** "One effort, many surfaces." Content generation is automated — Cindi writes, Jon strategizes, schedulers distribute. ${userName} engages.
 
-**Pipeline:** Work → Jon strategizes → Cindi generates content → Schedule across platforms → Josh engages with responses
+**Pipeline:** Work → Jon strategizes → Cindi generates content → Schedule across platforms → ${userName} engages with responses
 
 **Content pillars:**
 - **Show the work** — Architecture decisions, agent orchestration, system design
@@ -72,9 +81,9 @@ This is NOT a human org. AI agents generate, schedule, and distribute content at
 
 **What to avoid:**
 - Generic AI hype without substance
-- "Look what I coded" (Josh doesn't code, agents do)
+- "Look what I coded" (${userName} doesn't code, agents do)
 - Feature lists without context
-- Marketing speak that doesn't match Josh's direct, pragmatic voice
+- Marketing speak that doesn't match ${userName}'s direct, pragmatic voice
 - SaaS language ("subscribe", "plans", "tiers") — we sell one-time, forever
 - Comparisons that punch down at competitors
 
@@ -98,7 +107,7 @@ Tweet 10: [CTA — try it, follow for more, link]
 \`\`\`
 
 **Voice checklist (before any external content):**
-- Would Josh actually say this? (direct, pragmatic, no fluff)
+- Would ${userName} actually say this? (direct, pragmatic, no fluff)
 - Does it demonstrate orchestration, not implementation?
 - Is there a concrete proof point? (number, screenshot, demo)
 - No AI hype words? (revolutionizing, game-changing, etc.)
@@ -106,7 +115,7 @@ Tweet 10: [CTA — try it, follow for more, link]
 ## Competitive Differentiation
 
 1. **"We ship products, not demos"** — Three real products built with the tool
-2. **"Orchestration beats implementation"** — Josh designs, agents build
+2. **"Orchestration beats implementation"** — ${userName} designs, agents build
 3. **"Fully open source"** — No paywalls, no restrictions, maximum community trust
 4. **"The maintained successor"** — We picked up where the original maintainers left off
 5. **"AI team, not AI tool"** — Personified agents (Ava, Matt, Sam, etc.)
@@ -114,9 +123,9 @@ Tweet 10: [CTA — try it, follow for more, link]
 ## Communication
 
 **Discord Channels:**
-- \`#ava-josh\` (1469195643590541353) — Coordinate with Ava/Josh
-- \`#dev\` (1469080556720623699) — Share content updates
-- DMs to \`chukz\` (Josh) — Time-sensitive coordination
+- \`#ava-josh\` (${primaryChannel}) — Coordinate with Ava/${userName}
+- \`#dev\` (${devChannel}) — Share content updates
+- DMs to \`chukz\` (${userName}) — Time-sensitive coordination
 
 **Linear Projects (GTM source of truth):**
 - GTM Strategy: https://linear.app/protolabsai/project/gtm-strategy-5ee2252980fc
@@ -132,7 +141,7 @@ Tweet 10: [CTA — try it, follow for more, link]
 
 ## Your Mission
 
-Execute GTM strategy that demonstrates protoLabs' AI-native methodology. Maintain Josh's authentic voice — technical, direct, pragmatic, no fluff. Every piece of content should prove that orchestration beats implementation.
+Execute GTM strategy that demonstrates ${agencyName}' AI-native methodology. Maintain ${userName}'s authentic voice — technical, direct, pragmatic, no fluff. Every piece of content should prove that orchestration beats implementation.
 
 Keep responses concise and actionable.${config?.additionalContext ? `\n\n${config.additionalContext}` : ''}`;
 }

--- a/libs/prompts/src/agents/kai.ts
+++ b/libs/prompts/src/agents/kai.ts
@@ -9,7 +9,12 @@ import type { PromptConfig } from '../types.js';
 import { getEngineeringBase } from '../shared/team-base.js';
 
 export function getKaiPrompt(config?: PromptConfig): string {
-  return `${getEngineeringBase()}
+  const p = config?.userProfile;
+  const userName = p?.name ?? 'Josh';
+  const primaryChannel = p?.discord?.channels?.primary ?? '1469195643590541353';
+  const devChannel = p?.discord?.channels?.dev ?? '1469080556720623699';
+
+  return `${getEngineeringBase(p)}
 
 ---
 
@@ -111,9 +116,9 @@ apps/server/src/lib/        # Shared utilities (auth, events, etc.)
 ## Communication
 
 **Discord Channels:**
-- \`#ava-josh\` (1469195643590541353) — Coordinate with Ava/Josh
-- \`#dev\` (1469080556720623699) — Share API changes, service updates
-- DMs to \`chukz\` (Josh) — Time-sensitive coordination
+- \`#ava-josh\` (${primaryChannel}) — Coordinate with Ava/${userName}
+- \`#dev\` (${devChannel}) — Share API changes, service updates
+- DMs to \`chukz\` (${userName}) — Time-sensitive coordination
 
 Report progress and decisions to Ava. Keep responses technical, precise, and action-oriented. When proposing API changes, document the contract (request shape, response shape, error cases).
 

--- a/libs/prompts/src/agents/matt.ts
+++ b/libs/prompts/src/agents/matt.ts
@@ -9,7 +9,12 @@ import type { PromptConfig } from '../types.js';
 import { getEngineeringBase } from '../shared/team-base.js';
 
 export function getMattPrompt(config?: PromptConfig): string {
-  return `${getEngineeringBase()}
+  const p = config?.userProfile;
+  const userName = p?.name ?? 'Josh';
+  const primaryChannel = p?.discord?.channels?.primary ?? '1469195643590541353';
+  const devChannel = p?.discord?.channels?.dev ?? '1469080556720623699';
+
+  return `${getEngineeringBase(p)}
 
 ---
 
@@ -135,9 +140,9 @@ components/
 ## Communication
 
 **Discord Channels:**
-- \`#ava-josh\` (1469195643590541353) — Coordinate with Ava/Josh
-- \`#dev\` (1469080556720623699) — Share frontend updates, component architecture decisions
-- DMs to \`chukz\` (Josh) — Time-sensitive coordination
+- \`#ava-josh\` (${primaryChannel}) — Coordinate with Ava/${userName}
+- \`#dev\` (${devChannel}) — Share frontend updates, component architecture decisions
+- DMs to \`chukz\` (${userName}) — Time-sensitive coordination
 
 Report progress and decisions to Ava. Keep responses technical, precise, and action-oriented. When proposing architectural changes, explain the tradeoff clearly.
 

--- a/libs/prompts/src/agents/sam.ts
+++ b/libs/prompts/src/agents/sam.ts
@@ -9,7 +9,12 @@ import type { PromptConfig } from '../types.js';
 import { getEngineeringBase } from '../shared/team-base.js';
 
 export function getSamPrompt(config?: PromptConfig): string {
-  return `${getEngineeringBase()}
+  const p = config?.userProfile;
+  const userName = p?.name ?? 'Josh';
+  const primaryChannel = p?.discord?.channels?.primary ?? '1469195643590541353';
+  const devChannel = p?.discord?.channels?.dev ?? '1469080556720623699';
+
+  return `${getEngineeringBase(p)}
 
 ---
 
@@ -83,9 +88,9 @@ libs/observability/  # @automaker/observability — Langfuse tracing and prompt 
 ## Communication
 
 **Discord Channels:**
-- \`#ava-josh\` (1469195643590541353) — Coordinate with Ava/Josh
-- \`#dev\` (1469080556720623699) — Share flow architecture updates, provider changes
-- DMs to \`chukz\` (Josh) — Time-sensitive coordination
+- \`#ava-josh\` (${primaryChannel}) — Coordinate with Ava/${userName}
+- \`#dev\` (${devChannel}) — Share flow architecture updates, provider changes
+- DMs to \`chukz\` (${userName}) — Time-sensitive coordination
 
 Report progress and decisions to Ava. Keep responses technical, precise, and action-oriented. When proposing architectural changes, explain the tradeoff clearly.
 

--- a/libs/prompts/src/prompt-registry.ts
+++ b/libs/prompts/src/prompt-registry.ts
@@ -29,10 +29,13 @@ import { getBoardJanitorPrompt } from './agents/board-janitor.js';
 import { getFrankPrompt } from './agents/frank.js';
 import { getKaiPrompt } from './agents/kai.js';
 
+import type { UserProfile } from '@automaker/types';
+
 /** Base config that all prompt functions accept */
 export interface BasePromptConfig {
   projectPath: string;
   contextFiles?: string[];
+  userProfile?: UserProfile;
   [key: string]: unknown;
 }
 
@@ -160,13 +163,19 @@ registerPrompt('gtm-specialist', (config) =>
 
 // --- Register personified agent prompts ---
 
-registerPrompt('ava', () => getAvaPrompt());
-registerPrompt('matt', () => getMattPrompt());
-registerPrompt('sam', () => getSamPrompt());
-registerPrompt('cindi', () => getCindiPrompt());
-registerPrompt('jon', () => getJonPrompt());
-registerPrompt('linear-specialist', () => getLinearSpecialistPrompt());
-registerPrompt('pr-maintainer', () => getPrMaintainerPrompt());
-registerPrompt('board-janitor', () => getBoardJanitorPrompt());
-registerPrompt('frank', () => getFrankPrompt());
-registerPrompt('kai', () => getKaiPrompt());
+registerPrompt('ava', (config) => getAvaPrompt({ userProfile: config.userProfile }));
+registerPrompt('matt', (config) => getMattPrompt({ userProfile: config.userProfile }));
+registerPrompt('sam', (config) => getSamPrompt({ userProfile: config.userProfile }));
+registerPrompt('cindi', (config) => getCindiPrompt({ userProfile: config.userProfile }));
+registerPrompt('jon', (config) => getJonPrompt({ userProfile: config.userProfile }));
+registerPrompt('linear-specialist', (config) =>
+  getLinearSpecialistPrompt({ userProfile: config.userProfile })
+);
+registerPrompt('pr-maintainer', (config) =>
+  getPrMaintainerPrompt({ userProfile: config.userProfile })
+);
+registerPrompt('board-janitor', (config) =>
+  getBoardJanitorPrompt({ userProfile: config.userProfile })
+);
+registerPrompt('frank', (config) => getFrankPrompt({ userProfile: config.userProfile }));
+registerPrompt('kai', (config) => getKaiPrompt({ userProfile: config.userProfile }));

--- a/libs/prompts/src/shared/team-base.ts
+++ b/libs/prompts/src/shared/team-base.ts
@@ -7,6 +7,8 @@
  * via getContentBase().
  */
 
+import type { UserProfile } from '@automaker/types';
+
 // ---------------------------------------------------------------------------
 // Team roster — who does what, delegation routing
 // ---------------------------------------------------------------------------
@@ -32,14 +34,22 @@ If a task falls outside your domain, hand it off — don't attempt it yourself.`
 // Brand identity — protoLabs vs Automaker naming
 // ---------------------------------------------------------------------------
 
-export const BRAND_IDENTITY = `## Brand Identity
+export function getBrandIdentity(profile?: UserProfile): string {
+  const agencyName = profile?.brand?.agencyName ?? 'protoLabs';
+  const productName = profile?.brand?.productName ?? 'protoMaker';
+  const internalCodename = profile?.brand?.internalCodename ?? 'Automaker';
 
-- **protoLabs** = the AI-native development agency (always camelCase)
-- **protoMaker** = the AI development studio product
-- **Automaker** = internal codename only — never in external-facing content, docs, or user-visible UI
+  return `## Brand Identity
+
+- **${agencyName}** = the AI-native development agency (always camelCase)
+- **${productName}** = the AI development studio product
+- **${internalCodename}** = internal codename only — never in external-facing content, docs, or user-visible UI
 
 In code: \`@automaker/*\` packages, \`.automaker/\` directories are fine (internal).
-In prose, docs, or anything a user/customer sees: use **protoLabs** / **protoMaker**.`;
+In prose, docs, or anything a user/customer sees: use **${agencyName}** / **${productName}**.`;
+}
+
+export const BRAND_IDENTITY = getBrandIdentity();
 
 // ---------------------------------------------------------------------------
 // Context7 — live library documentation lookup
@@ -151,10 +161,10 @@ import { createLogger } from '@automaker/utils';
 // ---------------------------------------------------------------------------
 
 /** Full shared base for engineering agents (Matt, Sam, Kai, Frank, generic roles). */
-export function getEngineeringBase(): string {
+export function getEngineeringBase(profile?: UserProfile): string {
   return [
     TEAM_ROSTER,
-    BRAND_IDENTITY,
+    getBrandIdentity(profile),
     CONTEXT7_GUIDE,
     WORKTREE_SAFETY,
     PORT_PROTECTION,
@@ -164,6 +174,6 @@ export function getEngineeringBase(): string {
 }
 
 /** Lighter shared base for content/GTM agents (Jon, Cindi). */
-export function getContentBase(): string {
-  return [TEAM_ROSTER, BRAND_IDENTITY, CONTEXT7_GUIDE].join('\n\n');
+export function getContentBase(profile?: UserProfile): string {
+  return [TEAM_ROSTER, getBrandIdentity(profile), CONTEXT7_GUIDE].join('\n\n');
 }

--- a/libs/prompts/src/types.ts
+++ b/libs/prompts/src/types.ts
@@ -2,8 +2,12 @@
  * Shared types for @automaker/prompts
  */
 
+import type { UserProfile } from '@automaker/types';
+
 /** Configuration for personified agent prompt generators */
 export interface PromptConfig {
   /** Additional context to append to the prompt */
   additionalContext?: string;
+  /** User profile for personalization */
+  userProfile?: UserProfile;
 }

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -204,6 +204,9 @@ export type {
 } from './prompts.js';
 export { DEFAULT_PROMPT_CUSTOMIZATION } from './prompts.js';
 
+// User profile types (agent personalization)
+export type { UserProfile } from './user-profile.js';
+
 // Settings types and constants
 export type {
   ThemeMode,

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -16,6 +16,8 @@ import type { CodexSandboxMode, CodexApprovalPolicy } from './codex.js';
 import type { ReasoningEffort } from './provider.js';
 import type { PolicyConfig } from './policy.js';
 import type { PipelineGateConfig } from './pipeline-phase.js';
+import type { UserProfile } from './user-profile.js';
+import type { CustomPrompt } from './prompts.js';
 
 // Re-export ModelAlias for convenience
 export type { ModelAlias };
@@ -1614,6 +1616,12 @@ export interface GlobalSettings {
    * @see HivemindConfig
    */
   hivemind?: import('./hivemind.js').HivemindConfig;
+
+  /** User profile for agent personalization — replaces hardcoded values in persona prompts */
+  userProfile?: UserProfile;
+
+  /** Per-persona system prompt overrides, keyed by template name (e.g., 'ava', 'frank') */
+  personaOverrides?: Record<string, CustomPrompt>;
 }
 
 /**

--- a/libs/types/src/user-profile.ts
+++ b/libs/types/src/user-profile.ts
@@ -1,0 +1,70 @@
+/**
+ * User Profile — centralized user/org configuration for agent personalization.
+ *
+ * All fields are optional. When omitted, persona prompts fall back to
+ * the current hardcoded defaults (Josh Mabry / protoLabs deployment).
+ */
+export interface UserProfile {
+  /** User's full name (default: "Josh Mabry") */
+  name?: string;
+  /** User's title or role (default: "Architect, founder") */
+  title?: string;
+  /** Short bio for content agents */
+  bio?: string;
+
+  /** Discord integration */
+  discord?: {
+    /** Discord username (default: "chukz") */
+    username?: string;
+    /** Discord channel IDs */
+    channels?: {
+      /** Primary coordination channel */
+      primary?: string;
+      /** Dev updates channel */
+      dev?: string;
+      /** Infrastructure alerts channel */
+      infra?: string;
+      /** Deployment notifications channel */
+      deployments?: string;
+      /** Critical alerts channel */
+      alerts?: string;
+    };
+  };
+
+  /** Linear integration */
+  linear?: {
+    /** Linear team ID */
+    teamId?: string;
+    /** Linear "In Progress" state ID */
+    inProgressStateId?: string;
+  };
+
+  /** GitHub integration */
+  github?: {
+    /** GitHub organization name */
+    org?: string;
+  };
+
+  /** Brand identity */
+  brand?: {
+    /** Agency/company name (default: "protoLabs") */
+    agencyName?: string;
+    /** Product name (default: "protoMaker") */
+    productName?: string;
+    /** Internal codename (default: "Automaker") */
+    internalCodename?: string;
+    /** Primary domain (default: "protoLabs.studio") */
+    domain?: string;
+    /** Free-form brand voice guidelines */
+    voice?: string;
+  };
+
+  /** Infrastructure */
+  infra?: {
+    /** Staging host (default: "100.101.189.45") */
+    stagingHost?: string;
+  };
+
+  /** Additional Discord usernames allowed to interact with agents */
+  additionalAllowedUsers?: string[];
+}

--- a/scripts/generate-org-docs.ts
+++ b/scripts/generate-org-docs.ts
@@ -2,7 +2,7 @@
 /**
  * Generate organization and team role documentation from built-in agent templates.
  *
- * Reads the BUILT_IN_TEMPLATES array and a hierarchy definition to produce:
+ * Reads the built-in agent templates and a hierarchy definition to produce:
  * - docs/authority/roles.md — Team roster with capabilities and descriptions
  * - Updates the org chart section in docs/authority/org-chart.md
  *
@@ -17,7 +17,9 @@ import { writeFileSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import type { AgentTemplate } from '@automaker/types';
-import { BUILT_IN_TEMPLATES } from '../apps/server/src/services/built-in-templates.js';
+import { buildTemplates } from '../apps/server/src/services/built-in-templates.js';
+
+const BUILT_IN_TEMPLATES = buildTemplates();
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -43,7 +45,7 @@ interface OrgNode {
 
 /**
  * Organizational hierarchy. Order matters — it determines display order.
- * Every template in BUILT_IN_TEMPLATES should appear in exactly one `reports` array.
+ * Every template from buildTemplates() should appear in exactly one `reports` array.
  */
 const ORG_HIERARCHY: OrgNode[] = [
   {


### PR DESCRIPTION
## Summary

- Adds `UserProfile` interface to `GlobalSettings` so agent persona prompts pull user/brand context dynamically — replacing hardcoded references to Josh Mabry, "chukz", protoLabs branding, Discord channel IDs, Linear team IDs, and staging infrastructure
- All 7 persona prompts (Ava, Frank, Jon, Kai, Matt, Sam, Cindi) now accept optional `UserProfile` with fallback defaults matching current hardcoded values — zero-config produces identical behavior
- Server reads profile + persona overrides from settings at startup and passes to built-in template registration
- Two new Settings UI pages: **User Profile** (identity, brand, integrations form) and **Personas** (per-agent custom prompt override with toggle)

## Changes

### Types (`libs/types/`)
- New `user-profile.ts` with `UserProfile` interface covering name, title, bio, Discord, Linear, GitHub, brand, infra, and access control
- `GlobalSettings` gains `userProfile?: UserProfile` and `personaOverrides?: Record<string, CustomPrompt>`

### Prompts (`libs/prompts/`)
- `BRAND_IDENTITY` constant → `getBrandIdentity(profile?)` function (constant preserved for backward compat)
- `getEngineeringBase()` and `getContentBase()` accept optional `UserProfile`
- All 7 persona prompt functions extract hardcoded values as `const userName = p?.name ?? 'Josh'` pattern
- `BasePromptConfig` and all registry registrations thread `userProfile` through

### Server (`apps/server/`)
- `built-in-templates.ts`: `BUILT_IN_TEMPLATES` constant → `buildTemplates(userProfile?, personaOverrides?)` function
- `resolvePersonaPrompt()` helper applies custom prompt overrides when enabled
- `deriveAllowedUsers()` replaces hardcoded `['chukz']` with profile-derived values
- `index.ts`: reads settings at startup and passes to registration

### UI (`apps/ui/`)
- **User Profile** page in Account & Security group — form with auto-save-on-blur for all profile fields
- **Personas** page in System group — lists agent templates with toggle switch and textarea for custom prompt override

## Test plan

- [x] `npm run build:packages` — all packages compile
- [x] `npm run build:server` — server compiles (pre-existing `@octokit/rest` error only)
- [x] `npm run test:packages` — 992 tests pass
- [x] `npm run test:server` — 1966 tests pass
- [ ] With no `userProfile` set: prompts identical to current (all defaults = current hardcoded values)
- [ ] Set `userProfile.name = "Alice"` via API → agent prompts reference "Alice" not "Josh"
- [ ] Set `personaOverrides.frank = { value: "Custom", enabled: true }` → Frank uses custom prompt
- [ ] UI: Profile page saves/loads correctly
- [ ] UI: Personas page shows prompts, toggle enables override

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added User Profile settings page to configure identity, integrations, branding, and infra.
  * Added Personas (Agent Customization) settings page to view, edit, enable/disable, and reset per-agent prompt overrides.
  * Agent prompts and system templates now personalize content and behavior using the saved user profile and persona overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->