### PR TITLE
feat(ui): add detailed execution timeline dialog

### DIFF
--- a/apps/ui/src/components/views/flow-graph/dialogs/node-detail-sections.tsx
+++ b/apps/ui/src/components/views/flow-graph/dialogs/node-detail-sections.tsx
@@ -1048,17 +1048,21 @@ export function AgentSection({ data, onStop, onViewLogs, isStopping }: AgentSect
   const [timelineExpanded, setTimelineExpanded] = useState(false);
 
   // Access pipeline state if available
-  const pipelineState = (data as AgentNodeData & { pipelineState?: PipelineState & {
-    phaseDurations?: Partial<Record<string, number>>;
-    toolExecutions?: Array<{
-      name: string;
-      icon?: string;
-      duration?: number;
-      phase?: string;
-      timestamp?: string;
-      success?: boolean;
-    }>;
-  }}).pipelineState;
+  const pipelineState = (
+    data as AgentNodeData & {
+      pipelineState?: PipelineState & {
+        phaseDurations?: Partial<Record<string, number>>;
+        toolExecutions?: Array<{
+          name: string;
+          icon?: string;
+          duration?: number;
+          phase?: string;
+          timestamp?: string;
+          success?: boolean;
+        }>;
+      };
+    }
+  ).pipelineState;
 
   const hasTimelineData = pipelineState?.phaseHistory && pipelineState.phaseHistory.length > 0;
 

--- a/apps/ui/src/components/views/flow-graph/dialogs/timeline-visualization.tsx
+++ b/apps/ui/src/components/views/flow-graph/dialogs/timeline-visualization.tsx
@@ -68,7 +68,11 @@ function formatDuration(ms: number): string {
 
 function formatTimestamp(isoString: string): string {
   const date = new Date(isoString);
-  return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  return date.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
 }
 
 export function TimelineVisualization({
@@ -185,13 +189,12 @@ export function TimelineVisualization({
               {tools.length > 0 && (
                 <div className="ml-4 pl-3 border-l-2 border-border/30 space-y-1">
                   {tools.map((tool, idx) => (
-                    <div
-                      key={idx}
-                      className="flex items-center justify-between text-[11px] py-0.5"
-                    >
+                    <div key={idx} className="flex items-center justify-between text-[11px] py-0.5">
                       <div className="flex items-center gap-1.5 min-w-0 flex-1">
                         {tool.icon && <span className="shrink-0">{tool.icon}</span>}
-                        <span className={`truncate ${tool.success === false ? 'text-red-400' : 'text-muted-foreground'}`}>
+                        <span
+                          className={`truncate ${tool.success === false ? 'text-red-400' : 'text-muted-foreground'}`}
+                        >
                           {tool.name}
                         </span>
                         {tool.success === false && (


### PR DESCRIPTION
## Summary
- New `TimelineVisualization` component with phase duration bars, tool execution logs, and Langfuse trace links
- Adds expandable "Execution Timeline" section to node detail dialog via `node-detail-sections.tsx`
- Progressive disclosure: summary in node → full timeline in dialog

## Dependencies
Depends on #955 (foundation types + backend persistence). Will need rebase after #955 merges.

## Test plan
- [ ] Verify timeline section appears in node detail dialog
- [ ] Verify phase bars show relative durations
- [ ] Verify tool logs display with success/failure indicators
- [ ] Verify Langfuse links open correct trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an expandable Execution Timeline visualization to agent details, displaying phase durations, nested tool executions, gate-wait indicators, and integrated tracing links for deeper inspection of execution flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->