### PR TITLE
fix: deep-merge workflow settings to prevent crash on partial API response

### DIFF
--- a/apps/ui/src/components/views/settings-view/workflow/workflow-settings-panel.tsx
+++ b/apps/ui/src/components/views/settings-view/workflow/workflow-settings-panel.tsx
@@ -194,7 +194,36 @@ export function WorkflowSettingsPanel() {
 
   useEffect(() => {
     if (data?.workflow) {
-      setLocalSettings(data.workflow as unknown as WorkflowSettings);
+      // Deep-merge with defaults so missing sections don't crash the UI
+      const merged: WorkflowSettings = {
+        ...DEFAULT_WORKFLOW_SETTINGS,
+        ...(data.workflow as Record<string, unknown>),
+        pipeline: {
+          ...DEFAULT_WORKFLOW_SETTINGS.pipeline,
+          ...((data.workflow as Record<string, unknown>).pipeline as
+            | Record<string, unknown>
+            | undefined),
+        },
+        retro: {
+          ...DEFAULT_WORKFLOW_SETTINGS.retro,
+          ...((data.workflow as Record<string, unknown>).retro as
+            | Record<string, unknown>
+            | undefined),
+        },
+        cleanup: {
+          ...DEFAULT_WORKFLOW_SETTINGS.cleanup,
+          ...((data.workflow as Record<string, unknown>).cleanup as
+            | Record<string, unknown>
+            | undefined),
+        },
+        signalIntake: {
+          ...DEFAULT_WORKFLOW_SETTINGS.signalIntake,
+          ...((data.workflow as Record<string, unknown>).signalIntake as
+            | Record<string, unknown>
+            | undefined),
+        },
+      };
+      setLocalSettings(merged);
       setIsDirty(false);
     }
   }, [data]);


### PR DESCRIPTION
## Summary
- Fixes `Cannot read properties of undefined (reading 'goalGatesEnabled')` crash on Settings > Workflows page
- When the API returns a partial `workflow` object missing nested sections (e.g., no `pipeline` key), the UI now deep-merges with `DEFAULT_WORKFLOW_SETTINGS` so missing keys fall back to defaults

## Test plan
- [ ] Open Settings > Workflows with a project that has no workflow settings saved yet
- [ ] Verify all toggle/number fields render with default values instead of crashing
- [ ] Verify saving partial settings round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Enhanced the stability of the workflow settings panel by improving how configuration data is initialized, preventing potential crashes when certain settings are unavailable or incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->