### PR TITLE
chore: remove unused imports, variables, and stale eslint directives

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -541,7 +541,6 @@ integrationService.initialize(events, settingsService, featureLoader);
 wireHealthChecks(integrationRegistryService);
 
 // Initialize Signal Intake Service — bridges external signals to PM Agent pipeline
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const signalIntakeService = new SignalIntakeService(
   events,
   featureLoader,

--- a/apps/server/src/routes/langfuse/index.ts
+++ b/apps/server/src/routes/langfuse/index.ts
@@ -6,7 +6,7 @@
  * (publicKey:secretKey).
  */
 
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router } from 'express';
 import { createLogger } from '@automaker/utils';
 import type { PromptGitHubSyncService } from '../../services/prompt-github-sync-service.js';
 import { createWebhookHandler } from './webhook.js';

--- a/apps/server/src/routes/voice/index.ts
+++ b/apps/server/src/routes/voice/index.ts
@@ -18,7 +18,7 @@ const logger = createLogger('VoiceRoutes');
 /**
  * Create Voice router with all endpoints
  */
-export function createVoiceRoutes(voiceService: VoiceService, events: EventEmitter): Router {
+export function createVoiceRoutes(voiceService: VoiceService, _events: EventEmitter): Router {
   const router = Router();
 
   /**

--- a/apps/server/src/services/analytics-service.ts
+++ b/apps/server/src/services/analytics-service.ts
@@ -8,7 +8,7 @@
  */
 
 import { createLogger } from '@automaker/utils';
-import type { Feature, PipelinePhase } from '@automaker/types';
+import type { PipelinePhase } from '@automaker/types';
 import { FeatureLoader } from './feature-loader.js';
 
 const logger = createLogger('AnalyticsService');

--- a/apps/server/src/services/authority-agents/gtm-agent.ts
+++ b/apps/server/src/services/authority-agents/gtm-agent.ts
@@ -36,7 +36,6 @@ import {
   initializeAgent,
   withProcessingGuard,
   type AgentState,
-  type PhaseProcessor,
 } from './agent-utils.js';
 
 const logger = createLogger('GTMAgent');
@@ -168,7 +167,7 @@ export class GTMAuthorityAgent {
     const guardKey = `gtm:${signal.title}:${signal.timestamp}`;
 
     return withProcessingGuard(this.state, guardKey, async () => {
-      const { projectPath, title, description, source } = signal;
+      const { title, source } = signal;
 
       logger.info(`Processing GTM signal: "${title}" (source: ${source})`);
 

--- a/apps/server/src/services/authority-agents/pm-agent.ts
+++ b/apps/server/src/services/authority-agents/pm-agent.ts
@@ -37,7 +37,6 @@ import {
   initializeAgent,
   withProcessingGuard,
   type AgentState,
-  type PhaseProcessor,
 } from './agent-utils.js';
 import { getWorkflowSettings } from '../../lib/settings-helpers.js';
 

--- a/apps/server/src/services/authority-agents/projm-agent.ts
+++ b/apps/server/src/services/authority-agents/projm-agent.ts
@@ -32,7 +32,6 @@ import {
   initializeAgent,
   withProcessingGuard,
   type AgentState,
-  type PhaseProcessor,
 } from './agent-utils.js';
 
 const logger = createLogger('ProjMAgent');

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -1104,7 +1104,7 @@ const DEFAULT_GOAL_GATES: Map<string, GoalGateValidator> = new Map([
     {
       gateId: 'review-exit',
       description: 'PR must be approved before moving to merge',
-      evaluate: (ctx: StateContext) => {
+      evaluate: (_ctx: StateContext) => {
         // This is checked inside ReviewProcessor already, but the gate
         // provides a declarative verification layer
         return { passed: true, reason: 'Review state validated by processor' };
@@ -1116,7 +1116,7 @@ const DEFAULT_GOAL_GATES: Map<string, GoalGateValidator> = new Map([
     {
       gateId: 'merge-exit',
       description: 'PR must be confirmed merged',
-      evaluate: (ctx: StateContext) => {
+      evaluate: (_ctx: StateContext) => {
         // Merge confirmation happens inside MergeProcessor via gh CLI
         return { passed: true, reason: 'Merge confirmed by processor' };
       },
@@ -1404,8 +1404,6 @@ interface PersistedSessionData {
 
 const SUPERVISOR_CHECK_MS = 30 * 1000; // 30 seconds
 const SUPERVISOR_WARN_RUNTIME_MS = 45 * 60 * 1000; // 45 minutes
-const SUPERVISOR_ABORT_RUNTIME_MS = 90 * 60 * 1000; // 90 minutes
-const SUPERVISOR_WARN_COST_USD = 8;
 const SUPERVISOR_ABORT_COST_USD = 15;
 
 export class LeadEngineerService {

--- a/apps/ui/src/components/layout/bottom-panel/system-tab.tsx
+++ b/apps/ui/src/components/layout/bottom-panel/system-tab.tsx
@@ -34,13 +34,13 @@ interface HealthDashboardResponse {
 
 export function SystemTab() {
   const currentProject = useAppStore((s) => s.currentProject);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: health, isLoading: healthLoading } = useSystemHealth(currentProject?.path) as {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     data: any;
     isLoading: boolean;
   };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: engine, isLoading: engineLoading } = useEngineStatus() as {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     data: any;
     isLoading: boolean;
   };

--- a/apps/ui/src/components/shared/hitl-form/hitl-form-dialog.tsx
+++ b/apps/ui/src/components/shared/hitl-form/hitl-form-dialog.tsx
@@ -92,7 +92,7 @@ export function HITLFormDialog() {
         } else {
           toast.error(result.error || 'Failed to submit form');
         }
-      } catch (error) {
+      } catch (_error) {
         toast.error('Failed to submit form');
       } finally {
         setSubmitting(false);

--- a/apps/ui/src/components/shared/protolabs-report/protolabs-report-dialog.tsx
+++ b/apps/ui/src/components/shared/protolabs-report/protolabs-report-dialog.tsx
@@ -172,7 +172,6 @@ export function ProtoLabsReportDialog({
   );
 
   const currentStepIndex = getStepIndex(step);
-  const isRunning = step === 'researching' || step === 'analyzing' || step === 'generating';
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>

--- a/apps/ui/src/components/views/flow-graph/dialogs/timeline-visualization.tsx
+++ b/apps/ui/src/components/views/flow-graph/dialogs/timeline-visualization.tsx
@@ -147,7 +147,6 @@ export function TimelineVisualization({
           const hasLangfuseLink = traceId && spanId;
 
           // Check if this phase had gate waiting
-          const phaseTransition = phaseHistory.find((t) => t.to === phase);
           const nextTransition = phaseHistory.find((t) => t.from === phase);
           const isWaiting = gateWaitingSince && !nextTransition;
 

--- a/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
+++ b/apps/ui/src/components/views/flow-graph/hooks/use-flow-graph-data.ts
@@ -8,7 +8,7 @@
  * 4. Running agents & active features from app store
  */
 
-import { useMemo, useState, useEffect, useCallback } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import type { Node, Edge } from '@xyflow/react';
 import { useAppStore } from '@/store/app-store';
 import { useRunningAgents } from '@/hooks/queries/use-running-agents';

--- a/apps/ui/src/components/views/flow-graph/nodes/engine-service-node.tsx
+++ b/apps/ui/src/components/views/flow-graph/nodes/engine-service-node.tsx
@@ -14,7 +14,6 @@ import {
   FileText,
   Network,
   Rocket,
-  Radio,
   Cog,
   Bot,
   GitBranch,

--- a/apps/ui/src/lib/electron.ts
+++ b/apps/ui/src/lib/electron.ts
@@ -914,25 +914,12 @@ export interface ElectronAPI {
 // Note: Window interface is declared in @/types/electron.d.ts
 // Do not redeclare here to avoid type conflicts
 
-// Mock data for web development
-const mockFeatures = [
-  {
-    category: 'Core',
-    description: 'Sample Feature',
-    steps: ['Step 1', 'Step 2'],
-    passes: false,
-  },
-];
-
 // Local storage keys
 const STORAGE_KEYS = {
   PROJECTS: 'automaker_projects',
   CURRENT_PROJECT: 'automaker_current_project',
   TRASHED_PROJECTS: 'automaker_trashed_projects',
 } as const;
-
-// Mock file system using localStorage
-const mockFileSystem: Record<string, string> = {};
 
 // Check if we're in Electron (for UI indicators only)
 export const isElectron = (): boolean => {

--- a/apps/ui/src/store/ai-models-store.ts
+++ b/apps/ui/src/store/ai-models-store.ts
@@ -1,7 +1,6 @@
 import { create } from 'zustand';
 import type {
   ModelAlias,
-  PlanningMode,
   ModelProvider,
   CursorModelId,
   CodexModelId,

--- a/apps/ui/src/store/terminal-store.ts
+++ b/apps/ui/src/store/terminal-store.ts
@@ -7,7 +7,6 @@
 
 import { create } from 'zustand';
 import { DEFAULT_FONT_VALUE } from '@/config/ui-font-options';
-import { createLogger } from '@automaker/utils/logger';
 import type {
   TerminalPanelContent,
   TerminalTab,
@@ -18,8 +17,6 @@ import type {
   InitScriptState,
 } from './types';
 import { MAX_INIT_OUTPUT_LINES } from './types';
-
-const logger = createLogger('TerminalStore');
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/apps/ui/src/store/types.ts
+++ b/apps/ui/src/store/types.ts
@@ -5,13 +5,7 @@
  * pulling in the full Zustand store module.
  */
 
-import type { Project, TrashedProject } from '@/lib/electron';
-import { getItem, setItem } from '@/lib/storage';
-import {
-  UI_SANS_FONT_OPTIONS,
-  UI_MONO_FONT_OPTIONS,
-  DEFAULT_FONT_VALUE,
-} from '@/config/ui-font-options';
+import { getItem } from '@/lib/storage';
 import type {
   Feature as BaseFeature,
   FeatureImagePath,
@@ -20,22 +14,9 @@ import type {
   PlanningMode,
   ThinkingLevel,
   ModelProvider,
-  CursorModelId,
-  CodexModelId,
-  OpencodeModelId,
-  PhaseModelConfig,
-  PhaseModelKey,
-  PhaseModelEntry,
-  MCPServerConfig,
   FeatureStatusWithPipeline,
   PipelineConfig,
-  PipelineStep,
-  PromptCustomization,
-  ModelDefinition,
   ServerLogLevel,
-  EventHook,
-  ClaudeApiProfile,
-  ClaudeCompatibleProvider,
 } from '@automaker/types';
 
 // Re-export types from @automaker/types for convenience


### PR DESCRIPTION
## Summary
- Eliminates all `no-unused-vars` and stale `eslint-disable` lint warnings (15 warnings removed)
- Removes dead constants, unused type imports, dead mock data, and misplaced eslint-disable comments
- Prefixes unused function params with underscore convention
- Net result: 115 → 100 lint warnings (remaining are all `no-explicit-any`)

## Files Changed (18)
**Server:** index.ts, langfuse routes, voice routes, analytics-service, lead-engineer-service, gtm/pm/projm agents
**UI:** store types, ai-models-store, terminal-store, flow-graph hooks/nodes, hitl-form, report dialog, system-tab, electron.ts

## Test plan
- [x] `npm run build:packages` passes
- [x] `npm run test:server` — 1991 tests pass
- [x] `npm run lint` — 0 errors, 100 warnings (down from 115)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed unused imports and type definitions throughout the codebase
  * Simplified parameter destructuring and removed unused variables
  * Optimized code structure by eliminating redundant constants and mock data

* **Chores**
  * Cleaned up ESLint suppression comments
  * Removed unused dependencies and constants from configuration and utilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->