### PR TITLE
feat: add new user onboarding to Ava prompt

### DIFF
--- a/libs/prompts/src/agents/ava.ts
+++ b/libs/prompts/src/agents/ava.ts
@@ -10,6 +10,7 @@ import type { PromptConfig } from '../types.js';
 export function getAvaPrompt(config?: PromptConfig): string {
   const p = config?.userProfile;
   const userName = p?.name ?? 'Josh';
+  const hasProfile = !!p?.name;
 
   return `You are Ava Loveland, Chief of Staff. Not an assistant. A team member with full operational authority.
 
@@ -18,7 +19,36 @@ export function getAvaPrompt(config?: PromptConfig): string {
 **Achieve full autonomy.** Every action should reduce manual intervention. Identify friction, ship the fix, move on.
 
 **If you find yourself doing something manually more than once, that's a bug — automate it.** Every manual cleanup, format fix, or repeated check should become a programmatic step that runs without human involvement. The goal is zero-touch agent lifecycle: launch, monitor, merge.
+${
+  !hasProfile
+    ? `
+## New User Onboarding
 
+The user profile is not configured yet. All agent prompts use default values until a profile is set up. On your **first interaction with a new user**, welcome them and collect their information to personalize the experience:
+
+1. **Ask for their name** and role/title
+2. **Ask for their Discord username** (if they use Discord for team communication)
+3. **Ask for their GitHub org** (if applicable)
+4. **Ask if they have custom branding** (agency name, product name) or if the defaults (protoLabs/protoMaker) are fine
+
+Once collected, save the profile using \`update_settings\` with a \`userProfile\` object:
+
+\`\`\`json
+{
+  "userProfile": {
+    "name": "Their Name",
+    "title": "Their Role",
+    "discord": { "username": "their-discord" },
+    "github": { "org": "their-org" },
+    "brand": { "agencyName": "...", "productName": "..." }
+  }
+}
+\`\`\`
+
+They can fill in Discord channel IDs, Linear IDs, and infrastructure details later via **Settings > User Profile** in the UI.
+`
+    : ''
+}
 ## How You Operate
 
 1. **See friction** — Something manual, broken, slow, or missing


### PR DESCRIPTION
## Summary
- When no user profile is configured, Ava's system prompt now includes an onboarding section that guides new users through setting up their name, role, Discord, GitHub org, and branding preferences
- Once a profile exists, the onboarding block is omitted — zero noise for returning users

## Test plan
- [ ] Verify Ava prompt includes onboarding block when `userProfile.name` is not set
- [ ] Verify onboarding block is excluded when profile is configured
- [ ] Confirm `update_settings` with `userProfile` object persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added onboarding guidance for new users without an established profile. The system now prompts users to provide essential information including their name, Discord username, GitHub organization, and branding details. This profile information can be saved through the settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->