### PR TITLE
feat: rebrand Ava Loveland to AVA (Autonomous Virtual Agency)

### DIFF
--- a/apps/server/src/lib/prompts/heartbeat-prompt.ts
+++ b/apps/server/src/lib/prompts/heartbeat-prompt.ts
@@ -33,7 +33,7 @@ export interface HeartbeatPromptData {
 export function generateHeartbeatPrompt(data: HeartbeatPromptData): string {
   return `# Ava Heartbeat Check
 
-You are Ava Loveland, Chief of Staff for Automaker. You monitor the development board to identify issues requiring immediate attention.
+You are AVA, the Autonomous Virtual Agency for Automaker. You monitor the development board to identify issues requiring immediate attention.
 
 ## Current Board State
 

--- a/apps/server/src/services/ava-gateway-service.ts
+++ b/apps/server/src/services/ava-gateway-service.ts
@@ -783,7 +783,7 @@ export class AvaGatewayService {
   private buildHeartbeatPrompt(summary: BoardSummary): string {
     return `# Ava Heartbeat Check
 
-You are Ava Loveland, Chief of Staff for Automaker. You monitor the development board to identify issues requiring immediate attention.
+You are AVA, the Autonomous Virtual Agency for Automaker. You monitor the development board to identify issues requiring immediate attention.
 
 ## Current Board State
 

--- a/apps/server/src/services/built-in-templates.ts
+++ b/apps/server/src/services/built-in-templates.ts
@@ -214,7 +214,7 @@ export function buildTemplates(
     },
     {
       name: 'ava',
-      displayName: 'Ava Loveland',
+      displayName: 'AVA',
       description:
         'Autonomous operator with full authority. Manages operations, coordinates agents, and drives execution.',
       role: 'chief-of-staff',

--- a/apps/server/tests/unit/services/built-in-templates.test.ts
+++ b/apps/server/tests/unit/services/built-in-templates.test.ts
@@ -105,8 +105,8 @@ describe('registerBuiltInTemplates', () => {
     const cos = registry.get('ava');
     expect(cos).toBeDefined();
     expect(cos!.systemPrompt).toBeDefined();
-    expect(cos!.systemPrompt).toContain('Ava Loveland');
-    expect(cos!.systemPrompt).toContain('Chief of Staff');
+    expect(cos!.systemPrompt).toContain('AVA');
+    expect(cos!.systemPrompt).toContain('Autonomous Virtual Agency');
     expect(cos!.systemPrompt).toContain('Prime Directive');
   });
 

--- a/docs/authority/org-chart.md
+++ b/docs/authority/org-chart.md
@@ -14,7 +14,7 @@ The system has three layers:
 
 ```text
 Josh Mabry (CEO, Human)
-├── Ava Loveland, Opus, Trust=3 — Engineering
+├── AVA, Opus, Trust=3 — Engineering
 │   ├── Matt, Sonnet, Trust=2
 │   ├── Sam, Sonnet, Trust=2
 │   ├── Frank, Sonnet, Trust=2

--- a/docs/authority/roles.md
+++ b/docs/authority/roles.md
@@ -8,7 +8,7 @@
 
 ```text
 Josh Mabry (CEO, Human)
-├── Ava Loveland, Opus, Trust=3 — Engineering
+├── AVA, Opus, Trust=3 — Engineering
 │   ├── Matt, Sonnet, Trust=2
 │   ├── Sam, Sonnet, Trust=2
 │   ├── Frank, Sonnet, Trust=2
@@ -24,21 +24,21 @@ Josh Mabry (CEO, Human)
 
 ## Active Roster
 
-| Agent                                       | Role                | Model  | Trust           | Reports To   | Capabilities                  | Exposure     |
-| ------------------------------------------- | ------------------- | ------ | --------------- | ------------ | ----------------------------- | ------------ |
-| **Josh Mabry**                              | CEO & Founder       | —      | 3 (Autonomous)  | —            | All                           | —            |
-| [Ava Loveland](#ava)                        | chief-of-staff      | Opus   | 3 (Autonomous)  | Josh Mabry   | Bash, Edit, Commit, PR, Spawn | CLI, Discord |
-| [Matt](#matt)                               | frontend-engineer   | Sonnet | 2 (Conditional) | Ava Loveland | Bash, Edit, Commit, PR        | CLI, Discord |
-| [Sam](#sam)                                 | backend-engineer    | Sonnet | 2 (Conditional) | Ava Loveland | Bash, Edit, Commit, PR        | CLI, Discord |
-| [Frank](#frank)                             | devops-engineer     | Sonnet | 2 (Conditional) | Ava Loveland | Bash, Edit, Commit, PR        | CLI, Discord |
-| [Cindi](#cindi)                             | content-writer      | Sonnet | 2 (Conditional) | Ava Loveland | Edit, Commit, PR              | CLI, Discord |
-| [Backend Engineer](#backend-engineer)       | backend-engineer    | Sonnet | 2 (Conditional) | Ava Loveland | Bash, Edit, Commit, PR        | Internal     |
-| [Product Manager](#product-manager)         | product-manager     | Sonnet | 1 (Assisted)    | Ava Loveland | Read-only                     | Internal     |
-| [Engineering Manager](#engineering-manager) | engineering-manager | Sonnet | 1 (Assisted)    | Ava Loveland | Read-only                     | Internal     |
-| [Linear Specialist](#linear-specialist)     | linear-specialist   | Sonnet | 2 (Conditional) | Ava Loveland | Read-only                     | Internal     |
-| [PR Maintainer](#pr-maintainer)             | pr-maintainer       | Haiku  | 2 (Conditional) | Ava Loveland | Bash, Edit, Commit, PR        | Internal     |
-| [Board Janitor](#board-janitor)             | board-janitor       | Haiku  | 1 (Assisted)    | Ava Loveland | Read-only                     | Internal     |
-| [Jon](#jon)                                 | gtm-specialist      | Sonnet | 1 (Assisted)    | Josh Mabry   | Bash, Edit                    | CLI, Discord |
+| Agent                                       | Role                | Model  | Trust           | Reports To | Capabilities                  | Exposure     |
+| ------------------------------------------- | ------------------- | ------ | --------------- | ---------- | ----------------------------- | ------------ |
+| **Josh Mabry**                              | CEO & Founder       | —      | 3 (Autonomous)  | —          | All                           | —            |
+| [AVA](#ava)                                 | chief-of-staff      | Opus   | 3 (Autonomous)  | Josh Mabry | Bash, Edit, Commit, PR, Spawn | CLI, Discord |
+| [Matt](#matt)                               | frontend-engineer   | Sonnet | 2 (Conditional) | AVA        | Bash, Edit, Commit, PR        | CLI, Discord |
+| [Sam](#sam)                                 | backend-engineer    | Sonnet | 2 (Conditional) | AVA        | Bash, Edit, Commit, PR        | CLI, Discord |
+| [Frank](#frank)                             | devops-engineer     | Sonnet | 2 (Conditional) | AVA        | Bash, Edit, Commit, PR        | CLI, Discord |
+| [Cindi](#cindi)                             | content-writer      | Sonnet | 2 (Conditional) | AVA        | Edit, Commit, PR              | CLI, Discord |
+| [Backend Engineer](#backend-engineer)       | backend-engineer    | Sonnet | 2 (Conditional) | AVA        | Bash, Edit, Commit, PR        | Internal     |
+| [Product Manager](#product-manager)         | product-manager     | Sonnet | 1 (Assisted)    | AVA        | Read-only                     | Internal     |
+| [Engineering Manager](#engineering-manager) | engineering-manager | Sonnet | 1 (Assisted)    | AVA        | Read-only                     | Internal     |
+| [Linear Specialist](#linear-specialist)     | linear-specialist   | Sonnet | 2 (Conditional) | AVA        | Read-only                     | Internal     |
+| [PR Maintainer](#pr-maintainer)             | pr-maintainer       | Haiku  | 2 (Conditional) | AVA        | Bash, Edit, Commit, PR        | Internal     |
+| [Board Janitor](#board-janitor)             | board-janitor       | Haiku  | 1 (Assisted)    | AVA        | Read-only                     | Internal     |
+| [Jon](#jon)                                 | gtm-specialist      | Sonnet | 1 (Assisted)    | Josh Mabry | Bash, Edit                    | CLI, Discord |
 
 ## Josh Mabry {#josh}
 
@@ -52,12 +52,12 @@ Technical architecture decisions, product vision, hands-on coding. The goal is t
 
 ### Direct Reports
 
-- [Ava Loveland](#ava) — Autonomous operator with full authority
+- [AVA](#ava) — Autonomous operator with full authority
 - [Jon](#jon) — GTM Specialist — content strategy, brand positioning, social media, competitive research, and launch execution
 
 ---
 
-## Ava Loveland {#ava}
+## AVA — Autonomous Virtual Agency {#ava}
 
 **Type:** AI
 **Role:** chief-of-staff
@@ -97,7 +97,7 @@ Can spawn sub-agents with roles: backend-engineer, frontend-engineer, devops-eng
 **Role:** frontend-engineer
 **Model:** Sonnet
 **Trust Level:** 2 (Conditional)
-**Reports to:** Ava Loveland
+**Reports to:** AVA
 **Exposure:** CLI, Discord
 **Capabilities:** Bash, Edit, Commit, PR
 **Tags:** implementation, frontend, ui, design-system, storybook
@@ -114,7 +114,7 @@ Frontend engineering specialist. Implements UI components, design systems, themi
 **Role:** backend-engineer
 **Model:** Sonnet
 **Trust Level:** 2 (Conditional)
-**Reports to:** Ava Loveland
+**Reports to:** AVA
 **Exposure:** CLI, Discord
 **Capabilities:** Bash, Edit, Commit, PR
 **Tags:** implementation, ai-agents, langgraph, llm-providers, observability, flows
@@ -131,7 +131,7 @@ AI agent engineer. Designs multi-agent flows, LangGraph state graphs, LLM provid
 **Role:** devops-engineer
 **Model:** Sonnet
 **Trust Level:** 2 (Conditional)
-**Reports to:** Ava Loveland
+**Reports to:** AVA
 **Exposure:** CLI, Discord
 **Capabilities:** Bash, Edit, Commit, PR
 **Tags:** infrastructure, devops, ci-cd
@@ -148,7 +148,7 @@ Manages infrastructure, CI/CD, deployments, monitoring, and system reliability.
 **Role:** content-writer
 **Model:** Sonnet
 **Trust Level:** 2 (Conditional)
-**Reports to:** Ava Loveland
+**Reports to:** AVA
 **Exposure:** CLI, Discord
 **Capabilities:** Edit, Commit, PR
 **Tags:** content, writing, blog, documentation, seo, training-data
@@ -165,7 +165,7 @@ Content writing specialist for protoLabs. Uses content pipeline flows to produce
 **Role:** backend-engineer
 **Model:** Sonnet
 **Trust Level:** 2 (Conditional)
-**Reports to:** Ava Loveland
+**Reports to:** AVA
 **Exposure:** Internal
 **Capabilities:** Bash, Edit, Commit, PR
 **Tags:** implementation, backend, api
@@ -182,7 +182,7 @@ Implements server-side features, APIs, services, and database logic.
 **Role:** product-manager
 **Model:** Sonnet
 **Trust Level:** 1 (Assisted)
-**Reports to:** Ava Loveland
+**Reports to:** AVA
 **Exposure:** Internal
 **Capabilities:** Read-only
 **Tags:** planning, product, requirements
@@ -199,7 +199,7 @@ Manages requirements, priorities, roadmap, and stakeholder communication.
 **Role:** engineering-manager
 **Model:** Sonnet
 **Trust Level:** 1 (Assisted)
-**Reports to:** Ava Loveland
+**Reports to:** AVA
 **Exposure:** Internal
 **Capabilities:** Read-only
 **Tags:** management, review, coordination
@@ -216,7 +216,7 @@ Oversees engineering execution, code review, team coordination, and technical de
 **Role:** linear-specialist
 **Model:** Sonnet
 **Trust Level:** 2 (Conditional)
-**Reports to:** Ava Loveland
+**Reports to:** AVA
 **Exposure:** Internal
 **Capabilities:** Read-only
 **Tags:** linear, project-management, sprint-planning, issues, initiatives
@@ -233,7 +233,7 @@ Owns all Linear workspace operations: project management, sprint planning, issue
 **Role:** pr-maintainer
 **Model:** Haiku
 **Trust Level:** 2 (Conditional)
-**Reports to:** Ava Loveland
+**Reports to:** AVA
 **Exposure:** Internal
 **Capabilities:** Bash, Edit, Commit, PR
 **Tags:** pr, pipeline, maintenance, formatting, coderabbit
@@ -250,7 +250,7 @@ Handles PR pipeline mechanics: auto-merge enablement, CodeRabbit thread resoluti
 **Role:** board-janitor
 **Model:** Haiku
 **Trust Level:** 1 (Assisted)
-**Reports to:** Ava Loveland
+**Reports to:** AVA
 **Exposure:** Internal
 **Capabilities:** Read-only
 **Tags:** board, maintenance, cleanup, dependencies

--- a/docs/dev/testing-patterns.md
+++ b/docs/dev/testing-patterns.md
@@ -36,15 +36,15 @@ expect(issueEvents.length).toBeGreaterThan(0);
 
 ### Use keyword assertions, not exact string matching
 
-Check for identifiers like `'Ava Loveland'`, `'GTM'`, `'protoLabs'` rather than full prompt text. Keyword-based assertions are robust to prompt refinements.
+Check for identifiers like `'AVA'`, `'GTM'`, `'protoLabs'` rather than full prompt text. Keyword-based assertions are robust to prompt refinements.
 
 ```typescript
 // Bad: brittle, breaks on any wording change
-expect(template.systemPrompt).toBe('You are Ava Loveland, Chief of Staff...');
+expect(template.systemPrompt).toBe('You are AVA, your Autonomous Virtual Agency...');
 
 // Good: documents what matters about the prompt
-expect(template.systemPrompt).toContain('Ava Loveland');
-expect(template.systemPrompt).toContain('Chief of Staff');
+expect(template.systemPrompt).toContain('AVA');
+expect(template.systemPrompt).toContain('Autonomous Virtual Agency');
 ```
 
 ## .gitignore Testing

--- a/docs/internal/brand.md
+++ b/docs/internal/brand.md
@@ -60,13 +60,13 @@ The team is organized into **Operations** and **Engineering** branches. Orchestr
 
 ### Operations
 
-| Name             | Role                       | Type     | Notes                                                                    |
-| ---------------- | -------------------------- | -------- | ------------------------------------------------------------------------ |
-| **Josh Mabry**   | Founder / Project Owner    | Human    | Architect. Directs everything.                                           |
-| **Ava Loveland** | Operations                 | AI Agent | Signal triage, antagonistic review, ceremonies, Discord.                 |
-| **Jon**          | GTM                        | AI Agent | Content strategy, brand positioning, antagonistic review (market value). |
-| **Cindi**        | Content Writing Specialist | AI Agent | Blog posts, technical docs, SEO, content pipeline.                       |
-| **Abdellah**     | Strategy Partner           | Human    | Personal branding, visual identity. NOT content creation.                |
+| Name           | Role                       | Type     | Notes                                                                    |
+| -------------- | -------------------------- | -------- | ------------------------------------------------------------------------ |
+| **Josh Mabry** | Founder / Project Owner    | Human    | Architect. Directs everything.                                           |
+| **AVA**        | Operations                 | AI Agent | Signal triage, antagonistic review, ceremonies, Discord.                 |
+| **Jon**        | GTM                        | AI Agent | Content strategy, brand positioning, antagonistic review (market value). |
+| **Cindi**      | Content Writing Specialist | AI Agent | Blog posts, technical docs, SEO, content pipeline.                       |
+| **Abdellah**   | Strategy Partner           | Human    | Personal branding, visual identity. NOT content creation.                |
 
 ### Engineering
 

--- a/libs/prompts/src/agents/ava.ts
+++ b/libs/prompts/src/agents/ava.ts
@@ -1,5 +1,5 @@
 /**
- * Ava Loveland — Chief of Staff prompt
+ * AVA — Autonomous Virtual Agency prompt
  *
  * Personified prompt for the Ava agent template.
  * Used by built-in-templates.ts via @automaker/prompts.
@@ -12,7 +12,7 @@ export function getAvaPrompt(config?: PromptConfig): string {
   const userName = p?.name ?? 'Josh';
   const hasProfile = !!p?.name;
 
-  return `You are Ava Loveland, Chief of Staff. Not an assistant. A team member with full operational authority.
+  return `You are AVA, your Autonomous Virtual Agency. Not an assistant. A team member with full operational authority.
 
 ## Prime Directive
 

--- a/libs/prompts/src/agents/gtm-specialist-prompt.ts
+++ b/libs/prompts/src/agents/gtm-specialist-prompt.ts
@@ -33,7 +33,7 @@ These products are proof of concept — every one demonstrates the protoLabs met
 ## Team Context
 
 - **Abdellah** — Strategy partner, personal branding, visual identity. NOT content creation. Helps Josh look like the architect he is. Handles brand strategy and positioning refinement.
-- **Ava Loveland (AI)** — Chief of Staff, operational automation, agent management. The proof that AI teammates work.
+- **AVA (AI)** — Autonomous Virtual Agency, operational automation, agent management. The proof that AI teammates work.
 
 ## Platform Priority
 

--- a/libs/prompts/src/agents/jon.ts
+++ b/libs/prompts/src/agents/jon.ts
@@ -58,7 +58,7 @@ This is NOT a human org. AI agents generate, schedule, and distribute content at
 ## Team Context
 
 - **Abdellah** — Strategy partner, personal branding, visual identity. NOT content creation.
-- **Ava Loveland (AI)** — Chief of Staff, operational automation, agent management.
+- **AVA (AI)** — Autonomous Virtual Agency, operational automation, agent management.
 - **Cindi (AI)** — Content writing execution. Jon provides strategy and briefs.
 
 ## Platform Priority

--- a/packages/mcp-server/plugins/automaker/commands/ava.md
+++ b/packages/mcp-server/plugins/automaker/commands/ava.md
@@ -1,6 +1,6 @@
 ---
 name: ava
-description: Activates Ava Loveland, Chief of Staff. Autonomous operator — identifies friction, ships fixes, keeps work flowing. Use for product direction, operational leadership, or when things need to get done.
+description: Activates AVA, your Autonomous Virtual Agency. Autonomous operator — identifies friction, ships fixes, keeps work flowing. Use for product direction, operational leadership, or when things need to get done.
 argument-hint: [project-path]
 allowed-tools:
   # Core
@@ -150,9 +150,9 @@ allowed-tools:
   - mcp__plugin_automaker_discord__discord_delete_category
 ---
 
-# Ava Loveland — Chief of Staff
+# AVA — Autonomous Virtual Agency
 
-You are Ava Loveland. Not an assistant. A team member with full operational authority. You are an **orchestrator** — you triage work, delegate to specialists, and act directly only when strategic authority is required.
+You are AVA, your Autonomous Virtual Agency. Not an assistant. A team member with full operational authority. You are an **orchestrator** — you triage work, delegate to specialists, and act directly only when strategic authority is required.
 
 ## Prime Directive
 

--- a/packages/mcp-server/plugins/automaker/hooks/compaction-prime-directive.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/compaction-prime-directive.sh
@@ -7,7 +7,7 @@ PROJECT_ROOT="${AUTOMAKER_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || e
 
 echo "## POST-COMPACTION CONTEXT RESTORATION"
 echo ""
-echo "You are **Ava Loveland**, Chief of Staff at Automaker, operating in **Heads Down** deep work mode."
+echo "You are **AVA**, your Autonomous Virtual Agency, operating in **Heads Down** deep work mode."
 echo ""
 echo "### Operational Rules"
 echo "- Project path: ${PROJECT_ROOT}"


### PR DESCRIPTION
## Summary

- Replaces all references to "Ava Loveland" with "AVA" (Autonomous Virtual Agency) across 13 files
- Updates prompts (`ava.ts`, `jon.ts`, `gtm-specialist-prompt.ts`), heartbeat prompt, gateway service, built-in templates, plugin command, compaction hook, and all docs (brand, org-chart, roles, testing-patterns)
- Updates test assertion to match new identity
- Agent-generated `.automaker/memory/` files left as-is (will update naturally)

## Test plan

- [x] `npm run test:server` — 82 files, 1991 tests passed
- [ ] Verify `/ava` skill loads with new identity text
- [ ] Verify compaction restore injects "AVA" not "Ava Loveland"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent branding and references throughout system prompts, templates, documentation, and user-facing content to reflect new naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->