### PR TITLE
fix: auto-unblock features when dependencies complete (PRO-260)

### DIFF
--- a/.automaker/notes/workspace.json
+++ b/.automaker/notes/workspace.json
@@ -3,38 +3,22 @@
   "activeTabId": "f35b89fb-3cc2-4e1f-8e58-98165c82df08",
   "tabOrder": [
     "f35b89fb-3cc2-4e1f-8e58-98165c82df08",
-    "55f88e41-228e-4ce9-b3d3-4bb645404f53",
     "a69c769a-e33e-41fd-b6d2-1d7cd9996f2f"
   ],
   "tabs": {
     "f35b89fb-3cc2-4e1f-8e58-98165c82df08": {
       "id": "f35b89fb-3cc2-4e1f-8e58-98165c82df08",
       "name": "Notes",
-      "content": "<h2>Sprint Plan — Feb 21-22</h2><h3>Today (Saturday) — Functionality + Tooling</h3><ul><li><p>Event Observability &amp; Budget Tracking (M5)</p></li></ul><h3>Today (cont.) — MCP &amp; Plugin Polish</h3><ul><li><p>Dial in MCP tools — verify all tools working, clean up stale ones</p></li><li><p>Plugin polish — hooks, commands, agent templates up to date</p></li><li><p>Plugin update + reinstall after any changes</p></li></ul><h3>Tomorrow (Sunday) — Content Pipeline</h3><ul><li><p>Content pipeline end-to-end review</p></li><li><p>Jon / Cindi flow testing — create_content, HITL gates, export</p></li><li><p>Content scheduling &amp; distribution automation</p></li><li><p>First real content pieces through the pipeline</p></li></ul><p></p><h2>Setup Google Cloud </h2><p>The real work happens in Google Cloud Console (separate from Admin Console):</p><p>1. Go to <a target=\"_blank\" rel=\"noopener noreferrer nofollow\" class=\"notes-link\" href=\"http://console.cloud.google.com\">console.cloud.google.com</a></p><p>2. Create a new project (e.g. \"protoLabs Studio\")</p><p>3. APIs &amp; Services → Library → Enable these 3:</p><p>- Gmail API</p><p>- Google Calendar API</p><p>- Cloud Pub/Sub API (for webhook push notifications)</p><p>4. APIs &amp; Services → Credentials → Create OAuth 2.0 Client ID:</p><p>- Application type: Web application</p><p>- Authorized redirect URI: <a target=\"_blank\" rel=\"noopener noreferrer nofollow\" class=\"notes-link\" href=\"http://localhost:3008/api/auth/google/callback\">http://localhost:3008/api/auth/google/callback</a></p><p>(for local dev)</p><p>- Save the Client ID and Client Secret</p><p>5. OAuth consent screen → Set to Internal (since you have Workspace, this</p><p>skips Google review)</p><p>Once you have the Client ID + Secret, drop them in Discord or let me know —</p><p>we'll wire them into the Google Workspace MCP server</p><p>(taylorwilsdon/google_workspace_mcp) which has 100+ tools for Calendar + Gmail</p><p>out of the box.</p>",
+      "content": "<h2>Sprint Plan — Feb 21-22</h2><h3>Today (Saturday) — Functionality + Tooling</h3><ul><li><p>Event Observability &amp; Budget Tracking (M5)</p></li></ul><h3>Today (cont.) — MCP &amp; Plugin Polish</h3><ul><li><p>Dial in MCP tools — verify all tools working, clean up stale ones</p></li><li><p>Plugin polish — hooks, commands, agent templates up to date</p></li><li><p>Plugin update + reinstall after any changes</p></li></ul><h3>Tomorrow (Sunday) — Content Pipeline</h3><ul><li><p>Content pipeline end-to-end review</p></li><li><p>Jon / Cindi flow testing — create_content, HITL gates, export</p></li><li><p>Content scheduling &amp; distribution automation</p></li><li><p>First real content pieces through the pipeline</p></li></ul><p></p><h2>Setup Google Cloud</h2><p>The real work happens in Google Cloud Console (separate from Admin Console):</p><p>1. Go to <a target=\"_blank\" rel=\"noopener noreferrer nofollow\" class=\"notes-link\" href=\"http://console.cloud.google.com\">console.cloud.google.com</a></p><p>2. Create a new project (e.g. \"protoLabs Studio\")</p><p>3. APIs &amp; Services → Library → Enable these 3:</p><p>- Gmail API</p><p>- Google Calendar API</p><p>- Cloud Pub/Sub API (for webhook push notifications)</p><p>4. APIs &amp; Services → Credentials → Create OAuth 2.0 Client ID:</p><p>- Application type: Web application</p><p>- Authorized redirect URI: <a target=\"_blank\" rel=\"noopener noreferrer nofollow\" class=\"notes-link\" href=\"http://localhost:3008/api/auth/google/callback\">http://localhost:3008/api/auth/google/callback</a></p><p>(for local dev)</p><p>- Save the Client ID and Client Secret</p><p>5. OAuth consent screen → Set to Internal (since you have Workspace, this</p><p>skips Google review)</p><p>Once you have the Client ID + Secret, drop them in Discord or let me know —</p><p>we'll wire them into the Google Workspace MCP server</p><p>(taylorwilsdon/google_workspace_mcp) which has 100+ tools for Calendar + Gmail</p><p>out of the box.</p>",
       "permissions": {
         "agentRead": true,
         "agentWrite": true
       },
       "metadata": {
         "createdAt": 1771448161228,
-        "updatedAt": 1771748637453,
+        "updatedAt": 1771893027314,
         "wordCount": 225,
-        "characterCount": 1393
-      }
-    },
-    "55f88e41-228e-4ce9-b3d3-4bb645404f53": {
-      "id": "55f88e41-228e-4ce9-b3d3-4bb645404f53",
-      "name": "Ava",
-      "content": "<h2>Ava — Strategic Direction</h2><p>Josh writes priorities here. Ava reads on activation and appends status updates.</p><h3>Status — 2026-02-21</h3><p>Notes tools verified: list, read, create, write (append) all working. Jon tab created (id: a69c769a-e33e-41fd-b6d2-1d7cd9996f2f).</p>",
-      "permissions": {
-        "agentRead": true,
-        "agentWrite": true
-      },
-      "metadata": {
-        "createdAt": 1771715814797,
-        "updatedAt": 1771716029965,
-        "wordCount": 31,
-        "characterCount": 253
+        "characterCount": 1392
       }
     },
     "a69c769a-e33e-41fd-b6d2-1d7cd9996f2f": {

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -4533,96 +4533,129 @@ Format your response as a structured markdown document.`;
             status: canonicalStatus,
           };
           allFeatures.push(normalizedFeature);
+        }
+      }
 
-          // Track pending features separately, filtered by worktree/branch
-          // Note: Features in 'review', 'done', or 'verified' are NOT eligible
-          // Those features have completed execution and should not be picked up again
-          const isEligibleStatus =
-            canonicalStatus === 'backlog' ||
-            (feature.planSpec?.status === 'approved' &&
-              (feature.planSpec.tasksCompleted ?? 0) < (feature.planSpec.tasksTotal ?? 0));
+      // ── Dependency re-evaluation: unblock features whose deps are now satisfied ──
+      // Features can be set to 'blocked' when their dependencies aren't ready.
+      // When those deps complete, we need to automatically move them back to 'backlog'.
+      const blockedWithDeps = allFeatures.filter(
+        (f) => f.status === 'blocked' && f.dependencies && f.dependencies.length > 0
+      );
 
-          // Log ALL features with their eligibility status for debugging
-          logger.debug(
-            `[loadPendingFeatures] Feature ${feature.id}: status="${feature.status}", assignee="${feature.assignee ?? 'null'}", isEpic=${feature.isEpic ?? false}, branchName="${feature.branchName ?? 'null'}", eligible=${isEligibleStatus}`
+      for (const feature of blockedWithDeps) {
+        const satisfied = areDependenciesSatisfied(feature, allFeatures);
+        if (satisfied) {
+          logger.info(
+            `[loadPendingFeatures] Unblocking feature ${feature.id} — all dependencies now satisfied`
           );
+          feature.status = 'backlog';
+          try {
+            await this.featureLoader.update(projectPath, feature.id, { status: 'backlog' });
+            this.events.emit('feature:status-changed', {
+              projectPath,
+              featureId: feature.id,
+              previousStatus: 'blocked',
+              newStatus: 'backlog',
+            });
+          } catch (error) {
+            logger.error(`[loadPendingFeatures] Failed to unblock feature ${feature.id}:`, error);
+          }
+        }
+      }
 
-          if (isEligibleStatus) {
-            // Skip epic features - they are containers, not executable
-            if (feature.isEpic) {
-              logger.info(
-                `[loadPendingFeatures] ❌ Skipping epic feature ${feature.id} - ${feature.title}`
-              );
-              continue;
-            }
+      // ── Filter eligible features for execution ──
+      for (const feature of allFeatures) {
+        const canonicalStatus = feature.status;
 
-            // Skip features assigned to humans (non-agent assignees)
-            if (feature.assignee && feature.assignee !== 'agent') {
-              logger.info(
-                `[loadPendingFeatures] ❌ Skipping feature ${feature.id} - assigned to "${feature.assignee}" (not agent)`
-              );
-              continue;
-            }
-            // Filter by branchName:
-            // - If branchName is null (main worktree), include features with:
-            //   - branchName === null (unassigned), OR
-            //   - branchName === primaryBranch (e.g., "main", "master", "develop"), OR
-            //   - branchName has no corresponding worktree (orphaned - will auto-create worktree)
-            // - If branchName is set, only include features with matching branchName
-            const featureBranch = feature.branchName ?? null;
-            if (branchName === null) {
-              // Main worktree: include features that are unassigned, on primary branch, or orphaned
-              const isPrimaryOrUnassigned =
-                featureBranch === null || (primaryBranch && featureBranch === primaryBranch);
-              // Orphaned = has branchName but no corresponding worktree exists
-              const isOrphaned = featureBranch !== null && !worktreeBranches.has(featureBranch);
-              // Stale worktree = has branchName with existing worktree BUT feature is in backlog
-              // This happens when a previous agent attempt created the worktree but failed before starting.
-              // The agent service will reuse the existing worktree, so we should include these.
-              const hasStaleWorktree =
-                featureBranch !== null &&
-                worktreeBranches.has(featureBranch) &&
-                (feature.status === 'backlog' ||
-                  feature.status === 'pending' ||
-                  feature.status === 'ready');
+        // Track pending features separately, filtered by worktree/branch
+        // Note: Features in 'review', 'done', or 'verified' are NOT eligible
+        // Those features have completed execution and should not be picked up again
+        const isEligibleStatus =
+          canonicalStatus === 'backlog' ||
+          (feature.planSpec?.status === 'approved' &&
+            (feature.planSpec.tasksCompleted ?? 0) < (feature.planSpec.tasksTotal ?? 0));
 
-              logger.debug(
-                `[loadPendingFeatures] Feature ${feature.id} branch filter - featureBranch: ${featureBranch}, primaryBranch: ${primaryBranch}, isPrimaryOrUnassigned: ${isPrimaryOrUnassigned}, isOrphaned: ${isOrphaned}, hasStaleWorktree: ${hasStaleWorktree}`
-              );
+        // Log ALL features with their eligibility status for debugging
+        logger.debug(
+          `[loadPendingFeatures] Feature ${feature.id}: status="${feature.status}", assignee="${feature.assignee ?? 'null'}", isEpic=${feature.isEpic ?? false}, branchName="${feature.branchName ?? 'null'}", eligible=${isEligibleStatus}`
+        );
 
-              if (isPrimaryOrUnassigned || isOrphaned || hasStaleWorktree) {
-                if (hasStaleWorktree) {
-                  logger.info(
-                    `[loadPendingFeatures] ✅ Including feature ${feature.id} with stale worktree (branchName: ${featureBranch}, status: ${feature.status}) for main worktree`
-                  );
-                } else if (isOrphaned) {
-                  logger.info(
-                    `[loadPendingFeatures] ✅ Including orphaned feature ${feature.id} (branchName: ${featureBranch} has no worktree) for main worktree`
-                  );
-                } else {
-                  logger.info(
-                    `[loadPendingFeatures] ✅ Including feature ${feature.id} for main worktree (featureBranch: ${featureBranch})`
-                  );
-                }
-                pendingFeatures.push(feature);
-              } else {
-                // Feature belongs to a specific worktree AND is actively being worked on (in_progress)
+        if (isEligibleStatus) {
+          // Skip epic features - they are containers, not executable
+          if (feature.isEpic) {
+            logger.info(
+              `[loadPendingFeatures] ❌ Skipping epic feature ${feature.id} - ${feature.title}`
+            );
+            continue;
+          }
+
+          // Skip features assigned to humans (non-agent assignees)
+          if (feature.assignee && feature.assignee !== 'agent') {
+            logger.info(
+              `[loadPendingFeatures] ❌ Skipping feature ${feature.id} - assigned to "${feature.assignee}" (not agent)`
+            );
+            continue;
+          }
+          // Filter by branchName:
+          // - If branchName is null (main worktree), include features with:
+          //   - branchName === null (unassigned), OR
+          //   - branchName === primaryBranch (e.g., "main", "master", "develop"), OR
+          //   - branchName has no corresponding worktree (orphaned - will auto-create worktree)
+          // - If branchName is set, only include features with matching branchName
+          const featureBranch = feature.branchName ?? null;
+          if (branchName === null) {
+            // Main worktree: include features that are unassigned, on primary branch, or orphaned
+            const isPrimaryOrUnassigned =
+              featureBranch === null || (primaryBranch && featureBranch === primaryBranch);
+            // Orphaned = has branchName but no corresponding worktree exists
+            const isOrphaned = featureBranch !== null && !worktreeBranches.has(featureBranch);
+            // Stale worktree = has branchName with existing worktree BUT feature is in backlog
+            // This happens when a previous agent attempt created the worktree but failed before starting.
+            // The agent service will reuse the existing worktree, so we should include these.
+            const hasStaleWorktree =
+              featureBranch !== null &&
+              worktreeBranches.has(featureBranch) &&
+              (feature.status === 'backlog' ||
+                feature.status === 'pending' ||
+                feature.status === 'ready');
+
+            logger.debug(
+              `[loadPendingFeatures] Feature ${feature.id} branch filter - featureBranch: ${featureBranch}, primaryBranch: ${primaryBranch}, isPrimaryOrUnassigned: ${isPrimaryOrUnassigned}, isOrphaned: ${isOrphaned}, hasStaleWorktree: ${hasStaleWorktree}`
+            );
+
+            if (isPrimaryOrUnassigned || isOrphaned || hasStaleWorktree) {
+              if (hasStaleWorktree) {
                 logger.info(
-                  `[loadPendingFeatures] ❌ Filtering out feature ${feature.id} (branchName: ${featureBranch} has worktree, status: ${feature.status}) for main worktree`
+                  `[loadPendingFeatures] ✅ Including feature ${feature.id} with stale worktree (branchName: ${featureBranch}, status: ${feature.status}) for main worktree`
+                );
+              } else if (isOrphaned) {
+                logger.info(
+                  `[loadPendingFeatures] ✅ Including orphaned feature ${feature.id} (branchName: ${featureBranch} has no worktree) for main worktree`
+                );
+              } else {
+                logger.info(
+                  `[loadPendingFeatures] ✅ Including feature ${feature.id} for main worktree (featureBranch: ${featureBranch})`
                 );
               }
+              pendingFeatures.push(feature);
             } else {
-              // Feature worktree: include features with matching branchName
-              if (featureBranch === branchName) {
-                logger.info(
-                  `[loadPendingFeatures] ✅ Including feature ${feature.id} for worktree ${branchName}`
-                );
-                pendingFeatures.push(feature);
-              } else {
-                logger.info(
-                  `[loadPendingFeatures] ❌ Filtering out feature ${feature.id} (branchName: ${featureBranch}, expected: ${branchName}) for worktree ${branchName}`
-                );
-              }
+              // Feature belongs to a specific worktree AND is actively being worked on (in_progress)
+              logger.info(
+                `[loadPendingFeatures] ❌ Filtering out feature ${feature.id} (branchName: ${featureBranch} has worktree, status: ${feature.status}) for main worktree`
+              );
+            }
+          } else {
+            // Feature worktree: include features with matching branchName
+            if (featureBranch === branchName) {
+              logger.info(
+                `[loadPendingFeatures] ✅ Including feature ${feature.id} for worktree ${branchName}`
+              );
+              pendingFeatures.push(feature);
+            } else {
+              logger.info(
+                `[loadPendingFeatures] ❌ Filtering out feature ${feature.id} (branchName: ${featureBranch}, expected: ${branchName}) for worktree ${branchName}`
+              );
             }
           }
         }

--- a/apps/server/src/services/lead-engineer-rules.ts
+++ b/apps/server/src/services/lead-engineer-rules.ts
@@ -99,20 +99,32 @@ export const staleDeps: LeadFastPathRule = {
   triggers: ['feature:status-changed'],
 
   evaluate(worldState, _eventType, payload): LeadRuleAction[] {
-    const feature = featureFromPayload(worldState, payload);
-    if (!feature) return [];
-    if (feature.status !== 'blocked') return [];
-    if (!feature.dependencies || feature.dependencies.length === 0) return [];
+    const actions: LeadRuleAction[] = [];
 
-    const allDepsDone = feature.dependencies.every((depId) => {
-      const dep = worldState.features[depId];
-      return dep && (dep.status === 'done' || dep.status === 'verified');
-    });
+    // When a feature status changes (e.g., dep moves to 'done'), check ALL blocked
+    // features — not just the payload feature. The payload is the feature that changed,
+    // which is typically the dependency, not the dependent.
+    const changedFeature = featureFromPayload(worldState, payload);
+    const changedId = changedFeature?.id;
 
-    if (allDepsDone) {
-      return [{ type: 'unblock_feature', featureId: feature.id }];
+    const candidates = Object.values(worldState.features).filter(
+      (f) => f.status === 'blocked' && f.dependencies && f.dependencies.length > 0
+    );
+
+    for (const feature of candidates) {
+      // If we know which feature changed, only check features that depend on it
+      if (changedId && !feature.dependencies!.includes(changedId)) continue;
+
+      const allDepsDone = feature.dependencies!.every((depId) => {
+        const dep = worldState.features[depId];
+        return dep && (dep.status === 'done' || dep.status === 'verified');
+      });
+
+      if (allDepsDone) {
+        actions.push({ type: 'unblock_feature', featureId: feature.id });
+      }
     }
-    return [];
+    return actions;
   },
 };
 

--- a/apps/server/tests/unit/services/lead-engineer-rules.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-rules.test.ts
@@ -127,63 +127,75 @@ describe('orphanedInProgress', () => {
 // ────────────────────────── staleDeps ──────────────────────────
 
 describe('staleDeps', () => {
-  it('unblocks feature when all deps are done', () => {
-    const feature = createFeature({
+  it('unblocks feature when dependency changes to done (payload is the dep)', () => {
+    const f3 = createFeature({
       id: 'f3',
       status: 'blocked',
       dependencies: ['f1', 'f2'],
     });
     const f1 = createFeature({ id: 'f1', status: 'done' });
     const f2 = createFeature({ id: 'f2', status: 'done' });
-    const ws = createMockWorldState({ features: { f1, f2, f3: feature } });
-    const actions = staleDeps.evaluate(ws, 'feature:status-changed', { featureId: 'f3' });
+    const ws = createMockWorldState({ features: { f1, f2, f3 } });
+    // Payload is the dep that just changed to done — not the blocked feature
+    const actions = staleDeps.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
     expect(actions).toHaveLength(1);
     expect(actions[0]).toEqual({ type: 'unblock_feature', featureId: 'f3' });
   });
 
   it('unblocks feature when deps are verified', () => {
-    const feature = createFeature({
+    const f2 = createFeature({
       id: 'f2',
       status: 'blocked',
       dependencies: ['f1'],
     });
     const f1 = createFeature({ id: 'f1', status: 'verified' });
-    const ws = createMockWorldState({ features: { f1, f2: feature } });
-    const actions = staleDeps.evaluate(ws, 'feature:status-changed', { featureId: 'f2' });
+    const ws = createMockWorldState({ features: { f1, f2 } });
+    // Payload is the dep that changed
+    const actions = staleDeps.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
     expect(actions).toHaveLength(1);
     expect(actions[0].type).toBe('unblock_feature');
   });
 
   it('no-ops when some deps are still in progress', () => {
-    const feature = createFeature({
+    const f3 = createFeature({
       id: 'f3',
       status: 'blocked',
       dependencies: ['f1', 'f2'],
     });
     const f1 = createFeature({ id: 'f1', status: 'done' });
     const f2 = createFeature({ id: 'f2', status: 'in_progress' });
-    const ws = createMockWorldState({ features: { f1, f2, f3: feature } });
-    const actions = staleDeps.evaluate(ws, 'feature:status-changed', { featureId: 'f3' });
+    const ws = createMockWorldState({ features: { f1, f2, f3 } });
+    const actions = staleDeps.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
     expect(actions).toHaveLength(0);
   });
 
   it('no-ops when feature is not blocked', () => {
-    const feature = createFeature({
+    const f2 = createFeature({
       id: 'f2',
       status: 'backlog',
       dependencies: ['f1'],
     });
     const f1 = createFeature({ id: 'f1', status: 'done' });
-    const ws = createMockWorldState({ features: { f1, f2: feature } });
-    const actions = staleDeps.evaluate(ws, 'feature:status-changed', { featureId: 'f2' });
+    const ws = createMockWorldState({ features: { f1, f2 } });
+    const actions = staleDeps.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
     expect(actions).toHaveLength(0);
   });
 
   it('no-ops when feature has no deps', () => {
-    const feature = createFeature({ id: 'f1', status: 'blocked' });
-    const ws = createMockWorldState({ features: { f1: feature } });
+    const f1 = createFeature({ id: 'f1', status: 'blocked' });
+    const ws = createMockWorldState({ features: { f1 } });
     const actions = staleDeps.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
     expect(actions).toHaveLength(0);
+  });
+
+  it('unblocks multiple features when shared dep completes', () => {
+    const f1 = createFeature({ id: 'f1', status: 'done' });
+    const f2 = createFeature({ id: 'f2', status: 'blocked', dependencies: ['f1'] });
+    const f3 = createFeature({ id: 'f3', status: 'blocked', dependencies: ['f1'] });
+    const ws = createMockWorldState({ features: { f1, f2, f3 } });
+    const actions = staleDeps.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
+    expect(actions).toHaveLength(2);
+    expect(actions.map((a) => a.featureId).sort()).toEqual(['f2', 'f3']);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Auto-mode dep re-evaluation**: `loadPendingFeatures` now scans all `blocked` features on every iteration and automatically moves them to `backlog` when their dependencies are satisfied. Previously, blocked features were completely invisible to the scan loop.
- **Lead engineer `staleDeps` rule fix**: The rule now checks ALL blocked features that depend on the changed feature, instead of checking only the payload feature (which was the dep that changed, not the dependent).
- **New test**: Added coverage for multi-feature unblock when a shared dependency completes.

Fixes PRO-260.

## Test plan

- [x] All 1992 server tests pass (0 failures)
- [x] `lead-engineer-rules.test.ts` — 46/46 pass including new multi-unblock test
- [x] Prettier clean
- [ ] CI: build, test, lint, CodeRabbit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Improvements**
* Features with blocking dependencies now automatically unblock when those dependencies are completed, improving execution flow and reducing delays.
* Optimized dependency tracking ensures blocked features become eligible for execution at the appropriate time across automatic execution workflows.
* Enhanced status management and event propagation for real-time visibility into feature dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->