### PR TITLE
fix: enable ceremonies by default and fix dedup guard ordering

### DIFF
--- a/apps/server/src/services/ceremony-service.ts
+++ b/apps/server/src/services/ceremony-service.ts
@@ -236,6 +236,15 @@ export class CeremonyService {
   }
 
   /**
+   * Clear processed project from dedup guard (used by retry endpoint)
+   */
+  clearProcessedProject(projectPath: string, projectSlug: string): void {
+    const dedupeKey = `${projectPath}:${projectSlug}`;
+    this.processedProjects.delete(dedupeKey);
+    logger.info(`Cleared processed project: ${projectSlug}`);
+  }
+
+  /**
    * Handle epic creation event — post kickoff announcement with scope and complexity
    */
   private async handleEpicCreated(payload: EpicCreatedEventPayload): Promise<void> {
@@ -565,7 +574,6 @@ Keep it concise, actionable, and focused on what makes this milestone interestin
       logger.debug(`Project retro already processed for ${projectSlug}, skipping`);
       return;
     }
-    this.processedProjects.add(dedupeKey);
 
     // Check if ceremonies are enabled
     const ceremonySettings = await this.getCeremonySettings(projectPath);
@@ -573,6 +581,9 @@ Keep it concise, actionable, and focused on what makes this milestone interestin
       logger.debug('Ceremonies disabled, skipping project retrospective');
       return;
     }
+
+    // Mark as processed only after config check succeeds
+    this.processedProjects.add(dedupeKey);
 
     this.activeReflection = projectTitle;
 

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -959,7 +959,7 @@ export interface CeremonySettings {
  * DEFAULT_CEREMONY_SETTINGS - Default ceremony configuration
  */
 export const DEFAULT_CEREMONY_SETTINGS: CeremonySettings = {
-  enabled: false,
+  enabled: true,
   enableEpicKickoff: true,
   enableStandups: true,
   enableMilestoneUpdates: true,


### PR DESCRIPTION
## Summary
- Ceremonies were silently disabled for all projects because `DEFAULT_CEREMONY_SETTINGS.enabled` defaulted to `false`
- The dedup guard in `handleProjectCompleted` added the project key before checking if ceremonies were enabled, permanently blocking retries
- Added `clearProcessedProject()` public method for the retry endpoint (Milestone 2)

## Test plan
- [ ] Verify `DEFAULT_CEREMONY_SETTINGS.enabled` is `true` in settings.ts
- [ ] Verify dedup guard only fires after config check in handleProjectCompleted
- [ ] Verify `clearProcessedProject()` exists and is callable
- [ ] Run `npm run test:server` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ceremonies are now enabled by default, including epic kickoffs, standups, and milestone updates.

* **Bug Fixes**
  * Improved ceremony processing logic for more reliable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->