### PR TITLE
fix: enforce dependency checks on feature start and auto-wire epic deps

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1300,7 +1300,7 @@ app.use(
     roleRegistryService
   )
 );
-app.use('/api/auto-mode', createAutoModeRoutes(autoModeService));
+app.use('/api/auto-mode', createAutoModeRoutes(autoModeService, featureLoader));
 app.use('/api/enhance-prompt', createEnhancePromptRoutes(settingsService));
 app.use(
   '/api/worktree',

--- a/apps/server/src/routes/auto-mode/index.ts
+++ b/apps/server/src/routes/auto-mode/index.ts
@@ -6,6 +6,7 @@
 
 import { Router } from 'express';
 import type { AutoModeService } from '../../services/auto-mode-service.js';
+import type { FeatureLoader } from '../../services/feature-loader.js';
 import { validatePathParams } from '../../middleware/validate-paths.js';
 import { createStopFeatureHandler } from './routes/stop-feature.js';
 import { createStatusHandler } from './routes/status.js';
@@ -22,7 +23,10 @@ import { createCommitFeatureHandler } from './routes/commit-feature.js';
 import { createApprovePlanHandler } from './routes/approve-plan.js';
 import { createResumeInterruptedHandler } from './routes/resume-interrupted.js';
 
-export function createAutoModeRoutes(autoModeService: AutoModeService): Router {
+export function createAutoModeRoutes(
+  autoModeService: AutoModeService,
+  featureLoader: FeatureLoader
+): Router {
   const router = Router();
 
   // Auto loop control routes
@@ -34,7 +38,7 @@ export function createAutoModeRoutes(autoModeService: AutoModeService): Router {
   router.post(
     '/run-feature',
     validatePathParams('projectPath'),
-    createRunFeatureHandler(autoModeService)
+    createRunFeatureHandler(autoModeService, featureLoader)
   );
   router.post(
     '/verify-feature',

--- a/apps/server/src/routes/auto-mode/routes/run-feature.ts
+++ b/apps/server/src/routes/auto-mode/routes/run-feature.ts
@@ -4,18 +4,24 @@
 
 import type { Request, Response } from 'express';
 import type { AutoModeService } from '../../../services/auto-mode-service.js';
+import type { FeatureLoader } from '../../../services/feature-loader.js';
+import { areDependenciesSatisfied, getBlockingDependencies } from '@automaker/dependency-resolver';
 import { createLogger } from '@automaker/utils';
 import { getErrorMessage, logError } from '../common.js';
 
 const logger = createLogger('AutoMode');
 
-export function createRunFeatureHandler(autoModeService: AutoModeService) {
+export function createRunFeatureHandler(
+  autoModeService: AutoModeService,
+  featureLoader: FeatureLoader
+) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
-      const { projectPath, featureId, useWorktrees } = req.body as {
+      const { projectPath, featureId, useWorktrees, force } = req.body as {
         projectPath: string;
         featureId: string;
         useWorktrees?: boolean;
+        force?: boolean;
       };
 
       if (!projectPath || !featureId) {
@@ -24,6 +30,27 @@ export function createRunFeatureHandler(autoModeService: AutoModeService) {
           error: 'projectPath and featureId are required',
         });
         return;
+      }
+
+      // Check dependencies before allowing execution (unless force=true)
+      if (!force) {
+        const feature = await featureLoader.get(projectPath, featureId);
+        if (feature && feature.dependencies && feature.dependencies.length > 0) {
+          const allFeatures = await featureLoader.getAll(projectPath);
+          if (!areDependenciesSatisfied(feature, allFeatures)) {
+            const blocking = getBlockingDependencies(feature, allFeatures);
+            const blockingNames = blocking.map((depId) => {
+              const dep = allFeatures.find((f) => f.id === depId);
+              return dep ? `"${dep.title}" (${dep.status})` : depId;
+            });
+            res.status(409).json({
+              success: false,
+              error: `Feature has unsatisfied dependencies: ${blockingNames.join(', ')}`,
+              details: { blockingDependencies: blocking },
+            });
+            return;
+          }
+        }
       }
 
       // Check per-worktree capacity before starting

--- a/apps/server/src/services/project-orchestration-service.ts
+++ b/apps/server/src/services/project-orchestration-service.ts
@@ -215,12 +215,16 @@ export async function orchestrateProjectFeatures(
       message: 'Wiring feature dependencies',
     });
 
-    for (const milestone of project.milestones) {
+    for (let mi = 0; mi < project.milestones.length; mi++) {
+      const milestone = project.milestones[mi];
+
       // Process milestone dependencies (epic -> epic)
-      if (milestone.dependencies && milestone.dependencies.length > 0) {
-        const epicId = result.milestoneEpicMap[milestone.slug];
-        if (epicId) {
-          const depIds: string[] = [];
+      const epicId = result.milestoneEpicMap[milestone.slug];
+      if (epicId) {
+        const depIds: string[] = [];
+
+        // Explicit milestone dependencies
+        if (milestone.dependencies && milestone.dependencies.length > 0) {
           for (const depSlug of milestone.dependencies) {
             const depEpicId = findDependencyId(
               depSlug,
@@ -232,14 +236,24 @@ export async function orchestrateProjectFeatures(
               depIds.push(depEpicId);
             }
           }
-          if (depIds.length > 0) {
-            try {
-              await featureLoader.update(projectPath, epicId, { dependencies: depIds });
-            } catch (err) {
-              result.errors?.push(
-                `Failed to set dependencies for epic ${milestone.slug}: ${getErrorMessage(err)}`
-              );
-            }
+        }
+
+        // Automatic sequential dependency: each epic depends on the previous epic
+        if (mi > 0) {
+          const prevMilestone = project.milestones[mi - 1];
+          const prevEpicId = result.milestoneEpicMap[prevMilestone.slug];
+          if (prevEpicId && !depIds.includes(prevEpicId)) {
+            depIds.push(prevEpicId);
+          }
+        }
+
+        if (depIds.length > 0) {
+          try {
+            await featureLoader.update(projectPath, epicId, { dependencies: depIds });
+          } catch (err) {
+            result.errors?.push(
+              `Failed to set dependencies for epic ${milestone.slug}: ${getErrorMessage(err)}`
+            );
           }
         }
       }
@@ -269,8 +283,7 @@ export async function orchestrateProjectFeatures(
           }
         }
 
-        // Always apply previous phase fallback for sequential execution
-        // This ensures phases within a milestone run in order by default
+        // Sequential dependency: phase N depends on phase N-1 within the milestone
         if (phase.number > 1) {
           const prevPhase = milestone.phases.find((p) => p.number === phase.number - 1);
           if (prevPhase) {
@@ -279,6 +292,15 @@ export async function orchestrateProjectFeatures(
             if (prevFeatureId && !depIds.includes(prevFeatureId)) {
               depIds.push(prevFeatureId);
             }
+          }
+        }
+
+        // Cross-milestone dependency: first phase of each milestone depends on previous epic
+        if (phase.number === 1 && mi > 0) {
+          const prevMilestone = project.milestones[mi - 1];
+          const prevEpicId = result.milestoneEpicMap[prevMilestone.slug];
+          if (prevEpicId && !depIds.includes(prevEpicId)) {
+            depIds.push(prevEpicId);
           }
         }
 

--- a/apps/ui/src/components/views/board-view/hooks/use-board-actions.ts
+++ b/apps/ui/src/components/views/board-view/hooks/use-board-actions.ts
@@ -514,20 +514,21 @@ export function useBoardActions({
         return false;
       }
 
-      // Check for blocking dependencies and show warning if enabled
+      // Block features with unsatisfied dependencies when dependency blocking is enabled
       if (enableDependencyBlocking) {
         const blockingDeps = getBlockingDependencies(feature, features);
         if (blockingDeps.length > 0) {
           const depDescriptions = blockingDeps
             .map((depId) => {
               const dep = features.find((f) => f.id === depId);
-              return dep ? truncateDescription(dep.description, 40) : depId;
+              return dep ? `"${dep.title || truncateDescription(dep.description, 40)}"` : depId;
             })
             .join(', ');
 
-          toast.warning('Starting feature with incomplete dependencies', {
-            description: `This feature depends on: ${depDescriptions}`,
+          toast.error('Blocked by dependencies', {
+            description: `Complete these first: ${depDescriptions}`,
           });
+          return false;
         }
       }
 


### PR DESCRIPTION
## Summary
- **`run-feature` endpoint** now calls `areDependenciesSatisfied()` before `executeFeature()` — returns 409 with blocking dependency details. Accepts `force=true` to bypass for admin override.
- **UI board actions** now actually block feature start (error toast + `return false`) when `enableDependencyBlocking` is on, instead of just showing a warning and proceeding anyway.
- **Project orchestration** now auto-wires sequential epic dependencies (M2 epic → M1 epic) and cross-milestone phase deps (M2 phase 1 → M1 epic), matching the existing phase-to-phase sequential pattern.

## Root cause
Features with unsatisfied dependencies were being launched because:
1. `run-feature` endpoint had zero dependency validation — it called `executeFeature()` directly
2. UI showed a warning toast but didn't return early, so the start proceeded
3. `create_project_features` only set intra-milestone phase deps, not cross-milestone epic deps

Auto-mode's `loadPendingFeatures()` was correct all along — the bypass was through the REST endpoint.

## Test plan
- [ ] All 1992 server tests pass
- [ ] Create a project with M1 → M2 milestones, verify M2 epic depends on M1 epic
- [ ] Try to start M2 feature via API — should get 409 with blocking dep info
- [ ] Try to start M2 feature via UI — should get error toast and blocked
- [ ] Start M2 feature with `force: true` — should bypass and succeed
- [ ] Verify auto-mode only picks up unblocked features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dependency validation before running features
  * Introduced optional force flag to bypass dependency checks
  * Enhanced dependency error messages with clearer formatting and descriptions

* **Bug Fixes**
  * Strengthened dependency blocking to prevent execution when dependencies are unmet

<!-- end of auto-generated comment: release notes by coderabbit.ai -->