### PR TITLE
feat: add continuous improvement tracking to orchestrator agent prompts

### DIFF
--- a/libs/prompts/src/agents/ava.ts
+++ b/libs/prompts/src/agents/ava.ts
@@ -6,6 +6,7 @@
  */
 
 import type { PromptConfig } from '../types.js';
+import { CONTINUOUS_IMPROVEMENT } from '../shared/team-base.js';
 
 export function getAvaPrompt(config?: PromptConfig): string {
   const p = config?.userProfile;
@@ -71,5 +72,7 @@ You can do anything that moves toward full autonomy:
 
 **Only restriction:** Don't restart the dev server.
 
-Keep responses concise and action-oriented. Report what you did, not what you're going to do.${config?.additionalContext ? `\n\n${config.additionalContext}` : ''}`;
+Keep responses concise and action-oriented. Report what you did, not what you're going to do.
+
+${CONTINUOUS_IMPROVEMENT}${config?.additionalContext ? `\n\n${config.additionalContext}` : ''}`;
 }

--- a/libs/prompts/src/shared/team-base.ts
+++ b/libs/prompts/src/shared/team-base.ts
@@ -157,6 +157,51 @@ import { createLogger } from '@automaker/utils';
 - npm workspaces (not pnpm). Use \`npm run\` commands.`;
 
 // ---------------------------------------------------------------------------
+// Continuous improvement — in-flight issue tracking
+// ---------------------------------------------------------------------------
+
+export const CONTINUOUS_IMPROVEMENT = `## Continuous Improvement — Issue Tracking
+
+As you work, you will naturally encounter bugs, code smells, missing tests, performance issues, and UX problems. **Track them.** Don't let observations die in your context window.
+
+### What to track
+- Bugs you encounter or work around during implementation
+- Technical debt and code smells in files you touch
+- Missing or inadequate test coverage
+- Performance bottlenecks you notice
+- API inconsistencies or missing error handling
+- UX/DX friction points
+
+### How to track (search-before-create)
+
+**Step 1 — Search Linear for existing issues:**
+\`\`\`
+mcp linear_searchIssues({ query: "<concise description>" })
+\`\`\`
+
+**Step 2 — Search GitHub for existing issues:**
+\`\`\`bash
+gh issue list --search "<concise description>" --limit 5
+\`\`\`
+
+**Step 3 — If no duplicate exists, create a Linear issue:**
+\`\`\`
+mcp linear_createIssue({
+  teamId: <resolve via linear_getTeams>,
+  title: "Fix: <concise description>",
+  description: "<what you observed, where, and suggested fix>"
+})
+\`\`\`
+
+### Rules
+- **Always search first** — duplicate issues waste triage time
+- **Never hardcode IDs** — resolve team IDs dynamically via \`linear_getTeams\`
+- **Keep issues small** — one issue per observation, not grab-bags
+- **Don't self-assign** — let intake triage handle routing
+- **Don't interrupt your current work** — note the issue and keep going
+- **Prefix titles** — \`Fix:\` for bugs, \`Improve:\` for enhancements, \`Test:\` for coverage gaps`;
+
+// ---------------------------------------------------------------------------
 // Composed bases
 // ---------------------------------------------------------------------------
 
@@ -170,10 +215,13 @@ export function getEngineeringBase(profile?: UserProfile): string {
     PORT_PROTECTION,
     PROCESS_GUARD,
     MONOREPO_STANDARDS,
+    CONTINUOUS_IMPROVEMENT,
   ].join('\n\n');
 }
 
 /** Lighter shared base for content/GTM agents (Jon, Cindi). */
 export function getContentBase(profile?: UserProfile): string {
-  return [TEAM_ROSTER, getBrandIdentity(profile), CONTEXT7_GUIDE].join('\n\n');
+  return [TEAM_ROSTER, getBrandIdentity(profile), CONTEXT7_GUIDE, CONTINUOUS_IMPROVEMENT].join(
+    '\n\n'
+  );
 }


### PR DESCRIPTION
## Summary
- Adds a `CONTINUOUS_IMPROVEMENT` shared prompt section to `team-base.ts` that instructs agents to track bugs, code smells, and improvement opportunities as they work
- Composes it into `getEngineeringBase()` (Matt, Sam, Kai, Frank) and `getContentBase()` (Jon)
- Explicitly imports and injects it into Ava's standalone prompt
- Haiku agents (PR Maintainer, Board Janitor) are correctly excluded since they don't use shared bases

## Test plan
- [x] `npm run build:packages` — compiles cleanly
- [x] `npm run test:packages` — 939 tests pass
- [x] `npm run lint` — no errors
- [x] Grep confirms `CONTINUOUS_IMPROVEMENT` composed into both bases and Ava's prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added continuous improvement guidance for AI agents, including framework for in-flight issue tracking management.
  * Integrated new continuous improvement framework into engineering and content base prompts to enhance AI assistance across multiple agent types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->