### PR TITLE
feat: Safe-Area Insets and Mobile Baseline CSS

### DIFF
--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <title>protoLabs.studio - Autonomous AI Development Studio</title>
     <meta name="description" content="Build software autonomously with AI agents" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <script>

--- a/apps/ui/src/routes/__root.tsx
+++ b/apps/ui/src/routes/__root.tsx
@@ -173,6 +173,7 @@ function RootLayoutContent() {
     getEffectiveFontMono,
     sidebarOpen: _sidebarOpen,
     toggleSidebar: _toggleSidebar,
+    setMobileSidebarHidden,
   } = useAppStore();
   // Subscribe to theme and font state to trigger re-renders when they change
   const { theme, fontFamilySans, fontFamilyMono } = useThemeStore();
@@ -592,6 +593,37 @@ function RootLayoutContent() {
   useEffect(() => {
     setGlobalFileBrowser(openFileBrowser);
   }, [openFileBrowser]);
+
+  // Auto-hide sidebar on mobile (below 640px / Tailwind sm breakpoint)
+  // Uses a custom media query check for 640px specifically
+  const [isBelow640, setIsBelow640] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia('(max-width: 640px)').matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const mediaQuery = window.matchMedia('(max-width: 640px)');
+    const handleChange = (e: MediaQueryListEvent) => {
+      setIsBelow640(e.matches);
+    };
+
+    // Sync initial state
+    setIsBelow640(mediaQuery.matches);
+
+    // Listen for changes
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    // Hide sidebar when viewport width is below 640px
+    setMobileSidebarHidden(isBelow640);
+  }, [isBelow640, setMobileSidebarHidden]);
 
   // Test IPC connection on mount
   useEffect(() => {

--- a/apps/ui/src/styles/global.css
+++ b/apps/ui/src/styles/global.css
@@ -24,6 +24,11 @@
     @apply bg-background text-foreground;
     background-color: var(--background);
     font-family: var(--font-sans);
+    /* Safe area insets for iOS devices (notch, Dynamic Island, home indicator) */
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
   }
 
   /* Apply monospace font to code elements */
@@ -307,6 +312,16 @@
   word-wrap: break-word;
   overflow-wrap: break-word;
   hyphens: auto;
+}
+
+/* Kanban scroll container: prevent pull-to-refresh on mobile */
+.overflow-x-auto {
+  overscroll-behavior: contain;
+}
+
+/* Vertical scroll areas: allow vertical pan but prevent pull-to-refresh */
+.overflow-y-auto {
+  touch-action: pan-y;
 }
 
 /* Ensure proper column layout in double-width kanban columns */


### PR DESCRIPTION
## Summary
- Add CSS safe-area inset handling for iPhone notch, Dynamic Island, and home indicator
- Auto-hide sidebar on mobile viewports (< 640px)
- Add overscroll-behavior: contain to prevent pull-to-refresh conflicts
- Add viewport-fit=cover meta tag for full-screen iPhone display

## Test plan
- [ ] Test on iOS Safari — content not obscured by notch/home indicator
- [ ] Verify sidebar auto-hides on mobile viewport
- [ ] Verify pull-to-refresh doesn't interfere with kanban scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)