### PR TITLE
fix: use execFile for git commit to prevent shell escaping failures

### DIFF
--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 305
-  referenced: 158
-  successfulFeatures: 158
+  loaded: 308
+  referenced: 160
+  successfulFeatures: 160
 ---
 # gotchas
 
@@ -262,3 +262,8 @@ usageStats:
 - **Situation:** WebSocket event stream may contain duplicate tool-use events due to network retries or server-side resend logic
 - **Root cause:** Timestamp comparison is simpler than tracking event IDs across distributed components, but vulnerable to clock drift between client and server
 - **How to avoid:** Timestamp approach is 3 lines of code vs event ID registry (20+ lines). Trade-off: 1-2% edge case failures on high-latency networks vs code complexity
+
+#### [Gotcha] useIsMobile hook uses 768px breakpoint, but feature required 640px (Tailwind sm). Custom media query was necessary instead of reusing existing hook. (2026-02-24)
+- **Situation:** Initially attempted to use existing useIsMobile() hook for sidebar auto-hide, but it checks max-width: 768px while feature spec required below 640px (Tailwind sm breakpoint).
+- **Root cause:** The Tailwind sm breakpoint (640px) is a specific design decision. Using a mismatched breakpoint (768px) would hide sidebar at wrong viewport width, breaking mobile UX alignment with Tailwind grid system.
+- **How to avoid:** Custom media query adds ~25 lines of code vs reusing hook, but ensures correct breakpoint alignment. Maintainability trade-off: custom query lives in __root.tsx rather than shared hook.

--- a/apps/server/src/routes/worktree/common.ts
+++ b/apps/server/src/routes/worktree/common.ts
@@ -4,12 +4,13 @@
 
 import { createLogger } from '@automaker/utils';
 import { spawnProcess } from '@automaker/platform';
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import { getErrorMessage as getErrorMessageShared, createLogError } from '../common.js';
 
 const logger = createLogger('Worktree');
 export const execAsync = promisify(exec);
+export const execFileAsync = promisify(execFile);
 
 // Re-export validation functions from platform package
 export {

--- a/apps/server/src/routes/worktree/routes/commit.ts
+++ b/apps/server/src/routes/worktree/routes/commit.ts
@@ -6,12 +6,13 @@
  */
 
 import type { Request, Response } from 'express';
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import { getErrorMessage, logError } from '../common.js';
 import { sanitizeCommitMessage } from '@automaker/platform';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export function createCommitHandler() {
   return async (req: Request, res: Response): Promise<void> => {
@@ -52,7 +53,7 @@ export function createCommitHandler() {
       const sanitizedMessage = sanitizeCommitMessage(message);
 
       // Create commit
-      await execAsync(`git commit -m "${sanitizedMessage}"`, {
+      await execFileAsync('git', ['commit', '-m', sanitizedMessage], {
         cwd: worktreePath,
       });
 

--- a/apps/server/src/routes/worktree/routes/create-pr.ts
+++ b/apps/server/src/routes/worktree/routes/create-pr.ts
@@ -7,6 +7,7 @@ import {
   getErrorMessage,
   logError,
   execAsync,
+  execFileAsync,
   execEnv,
   isValidBranchName,
   isGhCliAvailable,
@@ -84,7 +85,7 @@ export function createCreatePRHandler() {
 
           // Create commit
           logger.debug(`Running: git commit`);
-          await execAsync(`git commit -m "${message.replace(/"/g, '\\"')}"`, {
+          await execFileAsync('git', ['commit', '-m', message], {
             cwd: worktreePath,
             env: execEnv,
           });

--- a/apps/server/src/routes/worktree/routes/merge.ts
+++ b/apps/server/src/routes/worktree/routes/merge.ts
@@ -8,13 +8,14 @@
  */
 
 import type { Request, Response } from 'express';
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import { getErrorMessage, logError, execGitCommand } from '../common.js';
 import { createLogger } from '@automaker/utils';
 import { isValidBranchName, sanitizeCommitMessage } from '@automaker/platform';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 const logger = createLogger('Worktree');
 
 export function createMergeHandler() {
@@ -117,7 +118,7 @@ export function createMergeHandler() {
         const squashMessage = options?.message
           ? sanitizeCommitMessage(options.message)
           : sanitizeCommitMessage(`Merge ${branchName} (squash)`);
-        await execAsync(`git commit -m "${squashMessage}"`, {
+        await execFileAsync('git', ['commit', '-m', squashMessage], {
           cwd: projectPath,
         });
       }

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -71,7 +71,7 @@ import {
   getExecutionStatePath,
   ensureAutomakerDir,
 } from '@automaker/platform';
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import { randomUUID } from 'crypto';
 import path from 'path';
@@ -102,6 +102,7 @@ import { gitWorkflowService } from './git-workflow-service.js';
 import { graphiteService } from './graphite-service.js';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 /**
  * Get the current branch name for a git repository
@@ -3709,7 +3710,7 @@ Address the follow-up instructions above. Review the previous work and make the 
 
       // Stage and commit
       await execAsync("git add -A -- ':!.automaker/'", { cwd: workDir });
-      await execAsync(`git commit -m "${commitMessage.replace(/"/g, '\\"')}"`, {
+      await execFileAsync('git', ['commit', '-m', commitMessage], {
         cwd: workDir,
       });
 

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -5,7 +5,7 @@
  * complete features in auto-mode.
  */
 
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import { createLogger } from '@automaker/utils';
 import type {
@@ -23,6 +23,7 @@ import { codeRabbitResolverService } from './coderabbit-resolver-service.js';
 import type { EventEmitter } from '../lib/events.js';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 const logger = createLogger('GitWorkflow');
 
 // Extended PATH for finding git and gh CLI (same as worktree routes)
@@ -814,7 +815,9 @@ export class GitWorkflowService {
     }
 
     // Create commit (--no-verify bypasses commitlint hook; agents use auto-generated messages)
-    await execAsync(`git commit --no-verify -m "${commitMessage.replace(/"/g, '\\"')}"`, {
+    // Use execFile to pass the commit message as an argument directly, avoiding shell
+    // interpolation issues with newlines and special characters in the message.
+    await execFileAsync('git', ['commit', '--no-verify', '-m', commitMessage], {
       cwd: workDir,
       env: execEnv,
     });

--- a/apps/server/src/services/graphite-service.ts
+++ b/apps/server/src/services/graphite-service.ts
@@ -8,13 +8,14 @@
  * @see https://graphite.dev/docs/graphite-cli
  */
 
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import { createLogger } from '@automaker/utils';
 import type { GraphiteSettings } from '@automaker/types';
 import { DEFAULT_GRAPHITE_SETTINGS } from '@automaker/types';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 const logger = createLogger('GraphiteService');
 
 // Extended PATH for finding gt CLI (same as git-workflow-service)
@@ -402,8 +403,9 @@ export class GraphiteService {
       }
 
       // Use gt commit - it handles stack metadata
-      const escapedMessage = message.replace(/"/g, '\\"');
-      await execAsync(`gt commit -m "${escapedMessage}"`, {
+      // Use execFile to pass the message as an argument directly, avoiding shell
+      // interpolation issues with newlines and special characters.
+      await execFileAsync('gt', ['commit', '-m', message], {
         cwd: workDir,
         env: execEnv,
       });


### PR DESCRIPTION
## Summary
- **Root cause**: Multi-line commit messages (containing `\n`) were passed through `exec()` shell interpolation in `git commit -m "..."`. The shell broke on newlines inside the double-quoted argument, causing every `runPostCompletionWorkflow` call to fail silently
- **Impact**: All post-agent git workflows (commit → push → PR) have been broken. Agents complete work successfully but nothing gets committed, pushed, or PR'd — requiring manual post-flight every time
- **Fix**: Switch all `git commit` invocations from `exec()` (shell) to `execFile()` (direct arg passing), which bypasses shell interpretation entirely. Newlines, quotes, and special characters in commit messages now work correctly
- Server logs showed 14 consecutive `Git workflow failed` errors confirming this was 100% reproduction

Files changed (7):
- `git-workflow-service.ts` — primary post-agent workflow
- `graphite-service.ts` — Graphite CLI commit path  
- `auto-mode-service.ts` — follow-up commit path
- `worktree/common.ts` — shared execFileAsync export
- `worktree/routes/commit.ts`, `create-pr.ts`, `merge.ts` — worktree commit routes

## Test plan
- [ ] Start an agent on a feature → verify it auto-commits, pushes, and creates PR after completion
- [ ] Verify commit messages with newlines work correctly
- [ ] Verify existing single-line commit paths still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved security and stability of git commit operations by implementing safer command execution. Special characters and quotes in commit messages are now handled more reliably across all commit workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->