### PR TITLE
feat: Bottom Tab Navigation for Mobile

### DIFF
--- a/apps/ui/src/components/layout/mobile-bottom-nav.tsx
+++ b/apps/ui/src/components/layout/mobile-bottom-nav.tsx
@@ -1,0 +1,73 @@
+import { useNavigate, useRouterState } from '@tanstack/react-router';
+import { Grid, BarChart3, FileText, Settings } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/hooks/use-media-query';
+
+interface NavItem {
+  id: string;
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  path: string;
+}
+
+const navItems: NavItem[] = [
+  { id: 'board', icon: Grid, label: 'Board', path: '/board' },
+  { id: 'analytics', icon: BarChart3, label: 'Analytics', path: '/analytics' },
+  { id: 'notes', icon: FileText, label: 'Notes', path: '/notes' },
+  { id: 'settings', icon: Settings, label: 'Settings', path: '/settings' },
+];
+
+export function MobileBottomNav() {
+  const navigate = useNavigate();
+  const routerState = useRouterState();
+  const isMobile = useIsMobile();
+
+  // Don't render on desktop
+  if (!isMobile) {
+    return null;
+  }
+
+  const currentPath = routerState.location.pathname;
+
+  const handleNavigate = (path: string) => {
+    navigate({ to: path });
+  };
+
+  return (
+    <nav
+      className={cn(
+        'fixed bottom-0 left-0 right-0 z-40',
+        'h-[56px] pb-[env(safe-area-inset-bottom)]',
+        'bg-gradient-to-b from-sidebar/95 via-sidebar/85 to-sidebar/90 backdrop-blur-2xl',
+        'border-t border-border/60 shadow-[0_-1px_20px_-5px_rgba(0,0,0,0.1)]',
+        'flex items-center justify-around px-2'
+      )}
+      data-testid="mobile-bottom-nav"
+    >
+      {navItems.map((item) => {
+        const Icon = item.icon;
+        const isActive = currentPath === item.path;
+
+        return (
+          <button
+            key={item.id}
+            onClick={() => handleNavigate(item.path)}
+            className={cn(
+              'flex flex-col items-center justify-center gap-1 px-4 py-2 rounded-lg',
+              'transition-all duration-200',
+              'min-w-[60px]',
+              isActive
+                ? 'text-primary bg-primary/10'
+                : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+            )}
+            aria-label={item.label}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            <Icon className={cn('h-5 w-5', isActive && 'scale-110')} />
+            <span className="text-xs font-medium">{item.label}</span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/ui/src/components/layout/sidebar/components/mobile-sidebar-toggle.tsx
+++ b/apps/ui/src/components/layout/sidebar/components/mobile-sidebar-toggle.tsx
@@ -1,16 +1,23 @@
 import { PanelLeft } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAppStore } from '@/store/app-store';
-import { useIsCompact } from '@/hooks/use-media-query';
+import { useIsCompact, useIsMobile } from '@/hooks/use-media-query';
 
 /**
  * Floating toggle button for mobile that completely hides/shows the sidebar.
  * Positioned at the left-center of the screen.
  * Only visible on compact/mobile screens when the sidebar is hidden.
+ * Hidden on mobile screens (< 768px) where bottom nav is present.
  */
 export function MobileSidebarToggle() {
   const isCompact = useIsCompact();
+  const isMobile = useIsMobile();
   const { mobileSidebarHidden, toggleMobileSidebarHidden } = useAppStore();
+
+  // Hide on mobile screens where bottom nav is present
+  if (isMobile) {
+    return null;
+  }
 
   // Only show on compact screens when sidebar is hidden
   if (!isCompact || !mobileSidebarHidden) {

--- a/apps/ui/src/routes/__root.tsx
+++ b/apps/ui/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { createLogger } from '@automaker/utils/logger';
 import { Sidebar } from '@/components/layout/sidebar';
+import { MobileBottomNav } from '@/components/layout/mobile-bottom-nav';
 import { ChatSidebar } from '@/components/views/chat/chat-sidebar';
 import { ChatModal, useChatModalShortcut } from '@/components/layout/chat-modal';
 import {
@@ -840,7 +841,7 @@ function RootLayoutContent() {
           />
         )}
         <Sidebar />
-        <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+        <div className="flex-1 flex flex-col min-h-0 overflow-hidden pb-[calc(56px+env(safe-area-inset-bottom))] md:pb-0">
           <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
             <Outlet />
           </div>
@@ -848,6 +849,7 @@ function RootLayoutContent() {
         </div>
         <ChatSidebar />
         <ChatModal />
+        <MobileBottomNav />
         <Toaster richColors position="bottom-right" />
       </main>
       <SandboxRiskDialog

--- a/apps/ui/tests/mobile-bottom-nav.spec.ts
+++ b/apps/ui/tests/mobile-bottom-nav.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '@playwright/test';
+import { UI_BASE_URL, TIMEOUTS } from './utils';
+import { setupProjectWithAuth } from './utils/project/setup';
+
+test.describe('Mobile Bottom Navigation', () => {
+  test('should show bottom nav on mobile and hide on desktop', async ({ page }) => {
+    // Set up a project with authentication
+    await setupProjectWithAuth(page);
+
+    // Set desktop viewport first
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto(`${UI_BASE_URL}/board`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(TIMEOUTS.settle);
+
+    // Bottom nav should not be visible on desktop
+    const bottomNav = page.getByTestId('mobile-bottom-nav');
+    await expect(bottomNav).not.toBeVisible();
+
+    // Switch to mobile viewport
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.waitForTimeout(TIMEOUTS.settle);
+
+    // Bottom nav should be visible on mobile
+    await expect(bottomNav).toBeVisible();
+  });
+
+  test('should navigate between tabs correctly on mobile', async ({ page }) => {
+    await setupProjectWithAuth(page);
+
+    // Set mobile viewport
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto(`${UI_BASE_URL}/board`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(TIMEOUTS.settle);
+
+    const bottomNav = page.getByTestId('mobile-bottom-nav');
+    await expect(bottomNav).toBeVisible();
+
+    // Test navigation to Analytics
+    const analyticsButton = page.getByRole('button', { name: 'Analytics' });
+    await analyticsButton.click();
+    await page.waitForTimeout(TIMEOUTS.animation);
+    expect(page.url()).toContain('/analytics');
+    await expect(analyticsButton).toHaveClass(/text-primary/);
+
+    // Test navigation to Notes
+    const notesButton = page.getByRole('button', { name: 'Notes' });
+    await notesButton.click();
+    await page.waitForTimeout(TIMEOUTS.animation);
+    expect(page.url()).toContain('/notes');
+    await expect(notesButton).toHaveClass(/text-primary/);
+
+    // Test navigation to Settings
+    const settingsButton = page.getByRole('button', { name: 'Settings' });
+    await settingsButton.click();
+    await page.waitForTimeout(TIMEOUTS.animation);
+    expect(page.url()).toContain('/settings');
+    await expect(settingsButton).toHaveClass(/text-primary/);
+
+    // Test navigation back to Board
+    const boardButton = page.getByRole('button', { name: 'Board' });
+    await boardButton.click();
+    await page.waitForTimeout(TIMEOUTS.animation);
+    expect(page.url()).toContain('/board');
+    await expect(boardButton).toHaveClass(/text-primary/);
+  });
+
+  test('should have correct safe area padding', async ({ page }) => {
+    await setupProjectWithAuth(page);
+
+    // Set mobile viewport
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto(`${UI_BASE_URL}/board`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(TIMEOUTS.settle);
+
+    const bottomNav = page.getByTestId('mobile-bottom-nav');
+    await expect(bottomNav).toBeVisible();
+
+    // Check that bottom nav has the correct classes for safe area
+    const classes = await bottomNav.getAttribute('class');
+    expect(classes).toContain('pb-[env(safe-area-inset-bottom)]');
+    expect(classes).toContain('h-[56px]');
+  });
+
+  test('should hide sidebar toggle on mobile', async ({ page }) => {
+    await setupProjectWithAuth(page);
+
+    // Set mobile viewport
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto(`${UI_BASE_URL}/board`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(TIMEOUTS.settle);
+
+    // Sidebar toggle should not be visible on mobile (< 768px)
+    const sidebarToggle = page.getByTestId('mobile-sidebar-toggle');
+    await expect(sidebarToggle).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Create MobileBottomNav component with 4 tabs: Board, Analytics, Notes, Settings
- Fixed bottom bar with safe-area-inset-bottom for iOS home indicator
- Uses TanStack Router for navigation and active state
- Auto-hides on desktop, visible only on mobile (< 768px)
- Hide sidebar hamburger toggle when bottom nav is present
- Includes Playwright test for mobile viewport

## Test plan
- [ ] Bottom nav visible on mobile viewport
- [ ] Tab navigation works with correct active states
- [ ] Content not obscured by bottom nav
- [ ] Desktop viewport shows no bottom nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)