### PR TITLE
feat: add touch DnD support for kanban cards

### DIFF
--- a/apps/ui/src/components/views/board-view.tsx
+++ b/apps/ui/src/components/views/board-view.tsx
@@ -4,6 +4,8 @@ import { createLogger } from '@automaker/utils/logger';
 import {
   DndContext,
   PointerSensor,
+  MouseSensor,
+  TouchSensor,
   useSensor,
   useSensors,
   rectIntersection,
@@ -395,6 +397,17 @@ export function BoardView() {
     useSensor(DialogAwarePointerSensor, {
       activationConstraint: {
         distance: 8,
+      },
+    }),
+    useSensor(MouseSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 200,
+        tolerance: 5,
       },
     })
   );

--- a/apps/ui/src/components/views/board-view/components/kanban-card/kanban-card.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/kanban-card.tsx
@@ -173,6 +173,7 @@ export const KanbanCard = memo(function KanbanCard({
 
   const wrapperClasses = cn(
     'relative select-none outline-none touch-none transition-transform duration-200 ease-out',
+    'draggable-card',
     getCursorClass(isOverlay, isDraggable, isSelectable),
     isOverlay && isLifted && 'scale-105 rotate-1 z-50',
     // Visual feedback when another card is being dragged over this one

--- a/apps/ui/src/styles/global.css
+++ b/apps/ui/src/styles/global.css
@@ -154,6 +154,11 @@
 }
 
 @layer utilities {
+  /* Touch-action for draggable cards - prevents browser scroll during drag */
+  .draggable-card {
+    touch-action: none;
+  }
+
   /* Brand gradient utilities */
   .gradient-brand {
     background: linear-gradient(135deg, oklch(0.55 0.25 265), oklch(0.5 0.28 270));


### PR DESCRIPTION
## Summary
- Add `TouchSensor` from `@dnd-kit/core` with 200ms delay / 5px tolerance activation constraint
- Add `MouseSensor` alongside existing `DialogAwarePointerSensor` for consistent desktop behavior
- Add `touch-action: none` CSS class (`.draggable-card`) to prevent browser scroll interception during drag

## Test plan
- [ ] Cards can be dragged on touch devices (iOS Safari, Android Chrome)
- [ ] Desktop mouse drag still works correctly
- [ ] 200ms press-and-hold activates drag (not immediate, to allow scroll)
- [ ] Column scroll still works on touch (only card-level touch triggers DnD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)