### PR TITLE
chore: update docs for APF agent reliability services

### DIFF
--- a/.automaker/memory/storage.md
+++ b/.automaker/memory/storage.md
@@ -1,0 +1,17 @@
+---
+tags: [storage]
+summary: storage implementation decisions and patterns
+relevantTo: [storage]
+importance: 0.7
+relatedFiles: []
+usageStats:
+  loaded: 1
+  referenced: 0
+  successfulFeatures: 0
+---
+# storage
+
+#### [Pattern] Uses atomicWriteJson and readJsonWithRecovery utilities instead of direct fs operations for trajectory persistence (2026-02-24)
+- **Problem solved:** Storing execution metadata to filesystem for later learning analysis
+- **Why this works:** Atomic writes prevent partial/corrupted files on unexpected termination; recovery mechanism handles stale data from prior crashes without requiring manual intervention
+- **Trade-offs:** Atomic writes slightly slower and more complex than direct writes vs eliminates corrupted trajectory data issues; slightly higher latency for non-blocking writes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ Packages can only depend on packages above them:
 The server (`apps/server/src/`) follows a modular pattern:
 
 - `routes/` - Express route handlers organized by feature (agent, features, auto-mode, worktree, etc.)
-- `services/` - Business logic (AgentService, AutoModeService, FeatureLoader, TerminalService, AuthorityService, PRFeedbackService)
+- `services/` - Business logic (AgentService, AutoModeService, FeatureLoader, TerminalService, AuthorityService, PRFeedbackService, TrajectoryStoreService, FailureClassifierService)
 - `services/authority-agents/` - AI authority agents (PM, ProjM, EM, Status, Discord approval routing)
 - `providers/` - AI provider abstraction (currently Claude via Claude Agent SDK)
 - `lib/` - Utilities (events, auth, worktree metadata)
@@ -167,6 +167,9 @@ The UI (`apps/ui/src/`) uses:
 │       ├── agent-output.md
 │       └── images/
 ├── context/               # Context files for AI agents (CLAUDE.md, etc.)
+├── trajectory/            # Verified execution trajectories (learning flywheel)
+│   └── {featureId}/
+│       └── attempt-{N}.json
 ├── settings.json          # Project-specific settings
 ├── spec.md               # Project specification
 └── analysis.json         # Project structure analysis


### PR DESCRIPTION
## Summary
- Add TrajectoryStoreService and FailureClassifierService to server architecture listing in CLAUDE.md
- Document `.automaker/trajectory/` directory structure in data storage section
- Include agent memory file from trajectory store implementation

## Test plan
- [x] No code changes — documentation only
- [x] Prettier formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system architecture documentation and storage guidance to reflect new service components and execution trajectory data storage structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->