### PR TITLE
feat: mobile visibility and virtual keyboard hooks

### DIFF
--- a/apps/ui/src/hooks/use-mobile-visibility.ts
+++ b/apps/ui/src/hooks/use-mobile-visibility.ts
@@ -1,0 +1,78 @@
+/**
+ * Mobile Visibility Hook
+ *
+ * Overrides React Query's default focus manager to prevent excessive API refetches
+ * when users switch between apps on mobile. Only triggers refetch if the app has been
+ * backgrounded for more than 30 seconds.
+ *
+ * This addresses the mobile browser quirk where window focus events fire on every
+ * app switch, causing a burst of API requests that can impact performance and data usage.
+ */
+
+import { useEffect } from 'react';
+import { focusManager } from '@tanstack/react-query';
+
+const REFETCH_THRESHOLD_MS = 30 * 1000; // 30 seconds
+
+/**
+ * Hook to manage mobile visibility behavior for React Query
+ * Prevents refetch spam when switching apps on mobile devices
+ *
+ * @param enabled - Whether to activate the custom visibility behavior (typically useIsMobile())
+ */
+export function useMobileVisibility(enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    let lastHiddenTime: number | null = null;
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        // App is being backgrounded - record timestamp
+        lastHiddenTime = Date.now();
+      } else if (document.visibilityState === 'visible') {
+        // App is coming back to foreground
+        const now = Date.now();
+        const wasBackgroundedLongEnough =
+          lastHiddenTime !== null && now - lastHiddenTime >= REFETCH_THRESHOLD_MS;
+
+        if (wasBackgroundedLongEnough) {
+          // Been away for 30+ seconds - trigger refetch
+          focusManager.setFocused(true);
+        }
+        // else: Been away for < 30s - don't trigger refetch
+      }
+    };
+
+    // Override the focus manager with our custom visibility listener
+    focusManager.setEventListener((_handleFocus) => {
+      // Set up our custom visibility change handler
+      document.addEventListener('visibilitychange', handleVisibilityChange);
+
+      // Return cleanup function
+      return () => {
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
+      };
+    });
+
+    return () => {
+      // Restore default focus manager behavior on cleanup
+      focusManager.setEventListener((_handleFocus) => {
+        if (typeof window === 'undefined' || !window.addEventListener) {
+          return;
+        }
+
+        const listener = () => _handleFocus();
+        window.addEventListener('focus', listener, false);
+        window.addEventListener('visibilitychange', listener, false);
+
+        return () => {
+          window.removeEventListener('focus', listener);
+          window.removeEventListener('visibilitychange', listener);
+        };
+      });
+    };
+  }, [enabled]);
+}

--- a/apps/ui/src/hooks/use-virtual-keyboard-resize.ts
+++ b/apps/ui/src/hooks/use-virtual-keyboard-resize.ts
@@ -1,0 +1,55 @@
+/**
+ * Virtual Keyboard Resize Hook
+ *
+ * Handles the iOS/Android quirk where the virtual keyboard changes the viewport height,
+ * causing jarring re-layouts. Uses the VisualViewport API to detect keyboard appearance
+ * and sets a CSS custom property (--visual-viewport-height) that can be used instead of
+ * 100vh in layouts.
+ *
+ * This ensures the kanban board, terminal, and other full-height layouts maintain their
+ * position when the keyboard appears, rather than being pushed up or squished.
+ */
+
+import { useEffect } from 'react';
+
+/**
+ * Hook to manage virtual keyboard resize behavior on mobile devices
+ * Sets --visual-viewport-height CSS variable on :root
+ *
+ * @param enabled - Whether to activate the keyboard resize behavior (typically useIsMobile())
+ */
+export function useVirtualKeyboardResize(enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    // Check if VisualViewport API is available
+    if (typeof window === 'undefined' || !window.visualViewport) {
+      return;
+    }
+
+    const updateViewportHeight = () => {
+      if (!window.visualViewport) return;
+
+      // Set CSS custom property to the actual visual viewport height
+      // This is different from window.innerHeight when the keyboard is shown
+      const height = window.visualViewport.height;
+      document.documentElement.style.setProperty('--visual-viewport-height', `${height}px`);
+    };
+
+    // Set initial value
+    updateViewportHeight();
+
+    // Listen for resize events (keyboard show/hide)
+    window.visualViewport.addEventListener('resize', updateViewportHeight);
+
+    return () => {
+      if (window.visualViewport) {
+        window.visualViewport.removeEventListener('resize', updateViewportHeight);
+      }
+      // Clean up the CSS variable
+      document.documentElement.style.removeProperty('--visual-viewport-height');
+    };
+  }, [enabled]);
+}

--- a/apps/ui/src/routes/__root.tsx
+++ b/apps/ui/src/routes/__root.tsx
@@ -45,7 +45,9 @@ import { SandboxRejectionScreen } from '@/components/dialogs/sandbox-rejection-s
 import { LoadingState } from '@protolabs/ui/molecules';
 import { useProjectSettingsLoader } from '@/hooks/use-project-settings-loader';
 import { useBrowserNotifications } from '@/hooks/use-browser-notifications';
-import { useIsCompact } from '@/hooks/use-media-query';
+import { useIsCompact, useIsMobile } from '@/hooks/use-media-query';
+import { useMobileVisibility } from '@/hooks/use-mobile-visibility';
+import { useVirtualKeyboardResize } from '@/hooks/use-virtual-keyboard-resize';
 import { BottomPanel } from '@/components/layout/bottom-panel';
 import type { Project } from '@/lib/electron';
 
@@ -193,6 +195,13 @@ function RootLayoutContent() {
 
   // Global Cmd+K / Ctrl+K shortcut for the chat modal (web mode)
   useChatModalShortcut();
+
+  // Mobile device detection for PWA optimizations
+  const isMobile = useIsMobile();
+
+  // Mobile-specific hooks for performance and UX
+  useMobileVisibility(isMobile);
+  useVirtualKeyboardResize(isMobile);
 
   const isSetupRoute = location.pathname === '/setup';
   const isLoginRoute = location.pathname === '/login';
@@ -750,7 +759,7 @@ function RootLayoutContent() {
   // Note: No sandbox dialog here - it only shows after login and setup complete
   if (isLoginRoute || isLoggedOutRoute) {
     return (
-      <main className="h-screen overflow-hidden" data-testid="app-container">
+      <main className="h-screen-safe overflow-hidden" data-testid="app-container">
         <Outlet />
       </main>
     );
@@ -759,7 +768,7 @@ function RootLayoutContent() {
   // Chat overlay — chromeless, full window, no sidebar/project switcher
   if (isChatOverlayRoute) {
     return (
-      <main className="h-screen w-screen overflow-hidden" data-testid="app-container">
+      <main className="h-screen-safe w-screen overflow-hidden" data-testid="app-container">
         <Outlet />
       </main>
     );
@@ -768,7 +777,7 @@ function RootLayoutContent() {
   // Wait for auth check before rendering protected routes (ALL modes - unified flow)
   if (!authChecked) {
     return (
-      <main className="flex h-screen items-center justify-center" data-testid="app-container">
+      <main className="flex h-screen-safe items-center justify-center" data-testid="app-container">
         <LoadingState message="Loading..." />
       </main>
     );
@@ -778,7 +787,7 @@ function RootLayoutContent() {
   // Show loading state while navigation is in progress
   if (!isAuthenticated) {
     return (
-      <main className="flex h-screen items-center justify-center" data-testid="app-container">
+      <main className="flex h-screen-safe items-center justify-center" data-testid="app-container">
         <LoadingState message="Redirecting..." />
       </main>
     );
@@ -786,7 +795,7 @@ function RootLayoutContent() {
 
   if (shouldBlockForSettings) {
     return (
-      <main className="flex h-screen items-center justify-center" data-testid="app-container">
+      <main className="flex h-screen-safe items-center justify-center" data-testid="app-container">
         <LoadingState message="Loading settings..." />
       </main>
     );
@@ -794,7 +803,7 @@ function RootLayoutContent() {
 
   if (shouldAutoOpen) {
     return (
-      <main className="flex h-screen items-center justify-center" data-testid="app-container">
+      <main className="flex h-screen-safe items-center justify-center" data-testid="app-container">
         <LoadingState message="Opening project..." />
       </main>
     );
@@ -803,7 +812,7 @@ function RootLayoutContent() {
   // Show setup page (full screen, no sidebar) - authenticated only
   if (isSetupRoute) {
     return (
-      <main className="h-screen overflow-hidden" data-testid="app-container">
+      <main className="h-screen-safe overflow-hidden" data-testid="app-container">
         <Outlet />
       </main>
     );
@@ -813,7 +822,7 @@ function RootLayoutContent() {
   if (isDashboardRoute) {
     return (
       <>
-        <main className="h-screen overflow-hidden" data-testid="app-container">
+        <main className="h-screen-safe overflow-hidden" data-testid="app-container">
           <Outlet />
           <Toaster richColors position="bottom-right" />
         </main>
@@ -831,7 +840,7 @@ function RootLayoutContent() {
   // Also hide on compact screens (< 1240px) - the sidebar will show a logo instead
   return (
     <>
-      <main className="flex h-screen overflow-hidden" data-testid="app-container">
+      <main className="flex h-screen-safe overflow-hidden" data-testid="app-container">
         {/* Full-width titlebar drag region for Electron window dragging */}
         {isElectron() && (
           <div

--- a/apps/ui/src/styles/global.css
+++ b/apps/ui/src/styles/global.css
@@ -26,6 +26,12 @@
     font-family: var(--font-sans);
   }
 
+  /* Mobile viewport height handling for virtual keyboard */
+  :root {
+    /* Fallback to 100vh when not set by JS (desktop or unsupported browsers) */
+    --visual-viewport-height: 100vh;
+  }
+
   /* Apply monospace font to code elements */
   code,
   pre,
@@ -154,6 +160,19 @@
 }
 
 @layer utilities {
+  /* Mobile-safe height utilities using visual viewport */
+  .h-screen-safe {
+    height: var(--visual-viewport-height, 100vh);
+  }
+
+  .min-h-screen-safe {
+    min-height: var(--visual-viewport-height, 100vh);
+  }
+
+  .max-h-screen-safe {
+    max-height: var(--visual-viewport-height, 100vh);
+  }
+
   /* Brand gradient utilities */
   .gradient-brand {
     background: linear-gradient(135deg, oklch(0.55 0.25 265), oklch(0.5 0.28 270));


### PR DESCRIPTION
## Summary
- Add `useMobileVisibility` hook — overrides React Query `focusManager` to prevent refetch storms on mobile app switches (30s background threshold)
- Add `useVirtualKeyboardResize` hook — uses `VisualViewport` API to set `--visual-viewport-height` CSS variable when virtual keyboard appears
- Add `.h-screen-safe` utility class using the viewport height variable
- Both hooks are no-ops on desktop (`useIsMobile()` guard)

## Test plan
- [ ] Switching apps and returning within 30s does NOT trigger API refetches
- [ ] Switching away 30+ seconds triggers fresh refetch on return
- [ ] `--visual-viewport-height` CSS variable set correctly when virtual keyboard is shown
- [ ] Desktop behavior unchanged (hooks are no-ops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)