### PR TITLE
fix: reduce Langfuse prompt-not-found noise and add negative caching

### DIFF
--- a/apps/server/src/services/prompt-resolver.ts
+++ b/apps/server/src/services/prompt-resolver.ts
@@ -104,6 +104,12 @@ export class PromptResolver {
           this.cacheResult(cacheKey, result);
           return result;
         }
+
+        // Negative cache: prompt not in Langfuse — cache the default to avoid
+        // repeated Langfuse API calls for prompts that haven't been seeded.
+        const fallback: ResolvedPrompt = { prompt: defaultValue, source: 'default' };
+        this.cacheResult(cacheKey, fallback);
+        return fallback;
       } catch (error) {
         // Graceful degradation — fall through to default
         logger.debug(`Langfuse fetch failed for ${promptName}, using default`, error);

--- a/libs/observability/src/langfuse/client.ts
+++ b/libs/observability/src/langfuse/client.ts
@@ -86,7 +86,14 @@ export class LangfuseClient {
         config: prompt.config as Record<string, any> | undefined,
       };
     } catch (error) {
-      logger.error(`Failed to fetch prompt from Langfuse: ${name}`, error);
+      // "Prompt not found" is expected when prompts haven't been seeded to Langfuse —
+      // the three-layer resolver falls back to hardcoded defaults gracefully.
+      const isNotFound = error instanceof Error && error.message.includes('Prompt not found');
+      if (isNotFound) {
+        logger.debug(`Prompt not in Langfuse: ${name} (will use default)`);
+      } else {
+        logger.error(`Failed to fetch prompt from Langfuse: ${name}`, error);
+      }
       return null;
     }
   }


### PR DESCRIPTION
## Summary

- Langfuse prompts not seeded with `production` label trigger ERROR-level logs on every resolution cycle, even though the three-layer resolver correctly falls back to hardcoded defaults
- Changed `LangfuseClient.getPrompt()` to log "Prompt not found" at **debug** level (expected behavior) while keeping real errors at **error** level
- Added **negative caching** in `PromptResolver`: when a prompt is confirmed missing from Langfuse, the default is cached for the TTL window (5min) to avoid repeated API calls

Fixes the noisy error logs reported in the backlog feature `[ui:flow-graph] lets investigate the prompts setup`.

## Files Changed

- `libs/observability/src/langfuse/client.ts` — Differentiate not-found (debug) from real errors (error)
- `apps/server/src/services/prompt-resolver.ts` — Negative caching for missing prompts

## Test plan

- [ ] Build passes (`npm run build:packages`)
- [ ] Server starts without ERROR-level Langfuse prompt logs for unseeded prompts
- [ ] Prompts still resolve correctly (fallback to defaults works)
- [ ] Seeded prompts in Langfuse still resolve from Langfuse (positive cache path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing prompts by implementing fallback caching, preventing repeated API calls for non-existent prompts.
  * Enhanced error logging to distinguish between missing prompts and actual errors, providing better debugging information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->