### PR TITLE
fix: verify PR state after merge command to prevent false success

### DIFF
--- a/apps/server/src/services/github-merge-service.ts
+++ b/apps/server/src/services/github-merge-service.ts
@@ -265,11 +265,43 @@ export class GitHubMergeService {
       const shaMatch = stdout.match(/[0-9a-f]{40}/i);
       const mergeCommitSha = shaMatch ? shaMatch[0].substring(0, 8) : undefined;
 
-      logger.info(`Successfully merged PR #${prNumber}`);
-      return {
-        success: true,
-        mergeCommitSha,
-      };
+      // Verify the PR is actually merged by checking its state
+      // The --auto flag can enable auto-merge without immediately merging
+      logger.debug(`Verifying PR #${prNumber} state after merge command`);
+      const { stdout: prStateJson } = await execAsync(`gh pr view ${prNumber} --json state`, {
+        cwd: workDir,
+        env: execEnv,
+      });
+
+      const prData = JSON.parse(prStateJson);
+      const prState = prData.state?.toUpperCase();
+
+      if (prState === 'MERGED') {
+        logger.info(`Successfully merged PR #${prNumber}`);
+        return {
+          success: true,
+          mergeCommitSha,
+        };
+      } else if (prState === 'OPEN') {
+        // PR is still open - auto-merge was enabled but not merged yet
+        // Return success: false to prevent false confidence that the PR landed
+        logger.warn(
+          `PR #${prNumber} is still OPEN after merge command - auto-merge may be enabled but PR is not merged`
+        );
+        return {
+          success: false,
+          error:
+            'PR merge command succeeded but PR is still OPEN. Auto-merge may be enabled, waiting for checks to pass.',
+          autoMergeEnabled: true,
+        };
+      } else {
+        // Unexpected state (CLOSED without merge?)
+        logger.warn(`PR #${prNumber} is in unexpected state: ${prState}`);
+        return {
+          success: false,
+          error: `PR is in unexpected state: ${prState}`,
+        };
+      }
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       logger.error(`Failed to merge PR #${prNumber}: ${errorMsg}`);


### PR DESCRIPTION
## Summary

- `merge_pr` MCP tool returned `{ success: true }` even when the PR remained OPEN (auto-merge enabled but not yet merged)
- Now verifies PR state via `gh pr view --json state` after the merge command
- Returns `success: false` with `autoMergeEnabled: true` hint when PR is still OPEN

Fixes [PRO-261](https://linear.app/protolabsai/issue/PRO-261)

## Changes

- `apps/server/src/services/github-merge-service.ts` — Added post-merge state verification

## Test plan

- [ ] Build passes
- [ ] Merge a PR normally → returns `{ success: true, mergeCommitSha }`
- [ ] Enable auto-merge on a PR with pending checks → returns `{ success: false, autoMergeEnabled: true }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GitHub PR merge verification to properly validate merge completion. The system now correctly detects when a merge succeeds, when auto-merge is pending checks, or when unexpected issues occur, with improved error handling and logging for each scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->