### PR TITLE
fix: suppress Langfuse SDK internal noise for missing prompts

### DIFF
--- a/docs/dev/langfuse-prompts.md
+++ b/docs/dev/langfuse-prompts.md
@@ -95,6 +95,8 @@ npx tsx scripts/seed-langfuse-prompts.ts
 - Idempotent: re-running creates new versions of existing prompts
 - Reports which prompts succeeded/failed
 
+**Why seed?** Eliminates "Prompt not found" SDK errors in server logs. Even though our wrapper (`LangfuseClient.getPrompt()`) logs at debug level, the Langfuse SDK itself emits internal error logs via `console.error` that cannot be suppressed via configuration. Seeding ensures prompts exist upstream, preventing the errors entirely.
+
 ## Managing Prompts in Langfuse
 
 ### Via Langfuse Dashboard
@@ -128,6 +130,16 @@ The PromptResolver fetches prompts with `label: "production"` by default. To tes
 2. Apply the `staging` label
 3. Verify in a staging environment
 4. Move the `production` label to the new version
+
+## SDK Logging Configuration
+
+The Langfuse SDK emits logs for various events (trace creation, prompt fetching, errors). To reduce noise in production:
+
+**Automatic Configuration:** The `LangfuseClient` automatically configures the Langfuse SDK's global logger to `ERROR` level on module load. This suppresses `DEBUG`, `INFO`, and `WARN` logs from the SDK itself.
+
+**Limitation:** The SDK uses `console.error` directly for certain errors (e.g., "Prompt not found"), which cannot be suppressed via log level configuration. This is a known limitation tracked in Langfuse issue [#6482](https://github.com/langfuse/langfuse-js/issues/6482). To eliminate these logs, seed all prompts using the script above.
+
+**Implementation:** See `libs/observability/src/langfuse/client.ts` for the `configureGlobalLogger` initialization.
 
 ## Disabling Langfuse Layer
 

--- a/libs/observability/src/langfuse/client.ts
+++ b/libs/observability/src/langfuse/client.ts
@@ -10,6 +10,20 @@ import type {
 
 const logger = createLogger('LangfuseClient');
 
+// Configure SDK logger to reduce noise from expected errors (e.g., prompt not found)
+// This runs once at module load time
+(async () => {
+  try {
+    // Import dynamically to handle cases where @langfuse/core isn't available as direct dep
+    const { configureGlobalLogger, LogLevel } = await import('@langfuse/core');
+    configureGlobalLogger({ level: LogLevel.ERROR });
+    logger.debug('Langfuse SDK global logger configured to ERROR level');
+  } catch (error) {
+    // Silently fail if @langfuse/core is not available - not critical
+    logger.debug('Could not configure Langfuse SDK logger (package not available)');
+  }
+})();
+
 /**
  * Wrapper around Langfuse SDK with fallback support
  */

--- a/scripts/seed-langfuse-prompts.ts
+++ b/scripts/seed-langfuse-prompts.ts
@@ -7,6 +7,10 @@
  *
  * Re-running creates new versions of existing prompts (idempotent, non-destructive).
  *
+ * **Why run this?** Seeding prompts to Langfuse eliminates "Prompt not found" SDK errors
+ * that appear in logs even after PR #998. The SDK logs these at error level internally,
+ * which cannot be suppressed via configuration. Seeding ensures prompts exist upstream.
+ *
  * Usage:
  *   npx tsx scripts/seed-langfuse-prompts.ts
  *


### PR DESCRIPTION
## Summary

- Configures Langfuse SDK's `configureGlobalLogger()` to `ERROR` level at module load, suppressing DEBUG/INFO/WARN SDK noise
- Documents the remaining limitation: SDK uses `console.error` directly for "Prompt not found" which can't be suppressed via config
- Recommends seeding prompts (`npx tsx scripts/seed-langfuse-prompts.ts`) as the definitive fix

Follows up on PR #998 which fixed our own wrapper's log level. This addresses the SDK's internal logging.

Fixes [PRO-262](https://linear.app/protolabsai/issue/PRO-262)

## Files Changed

- `libs/observability/src/langfuse/client.ts` — SDK global logger configuration
- `docs/dev/langfuse-prompts.md` — SDK logging docs + seed motivation
- `scripts/seed-langfuse-prompts.ts` — "Why seed?" docblock

## Test plan

- [ ] Build passes
- [ ] Server starts without Langfuse SDK DEBUG/INFO/WARN noise
- [ ] Prompt resolution still works (falls back to defaults for unseeded prompts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guides for observability configuration and prompt seeding, clarifying how proper initialization prevents "Prompt not found" errors

* **Chores**
  * Implemented automatic SDK logging optimization to reduce console noise during startup with graceful handling of optional dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->