### PR TITLE
fix: deduplicate Linear intake signals to prevent duplicate board features

### DIFF
--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -260,6 +260,18 @@ export class SignalIntakeService {
       }
 
       // Ops signals: route to Lead Engineer state machine
+      // Guard: For Linear signals, check if feature already exists
+      if (signal.source === 'linear' && signal.channelContext?.issueId) {
+        const linearIssueId = signal.channelContext.issueId as string;
+        const existing = await this.featureLoader.findByLinearIssueId(projectPath, linearIssueId);
+        if (existing) {
+          logger.info(
+            `Feature already exists for Linear issue ${linearIssueId}, skipping creation (feature: ${existing.id})`
+          );
+          return;
+        }
+      }
+
       // Create feature with idea state
       const feature = await this.featureLoader.create(projectPath, {
         title: `[${signal.source}] ${title}`,
@@ -268,6 +280,10 @@ export class SignalIntakeService {
         category: 'Signal Intake',
         complexity: 'medium',
         workItemState: 'idea',
+        // Store Linear issue ID if available
+        ...(signal.source === 'linear' && signal.channelContext?.issueId
+          ? { linearIssueId: signal.channelContext.issueId as string }
+          : {}),
       });
 
       // Trigger PM Agent pipeline


### PR DESCRIPTION
## Summary
- Adds a check-before-create guard in `SignalIntakeService` to prevent duplicate board features when both the Linear webhook and polling intake paths fire for the same issue
- Stores `linearIssueId` on signal-created features so the existing `findByLinearIssueId()` lookup catches duplicates
- Single-file change to `signal-intake-service.ts` (+16 lines)

## Test plan
- [ ] Move a Linear issue to "In Progress" and verify only one board feature is created (not two)
- [ ] Verify existing Linear intake bridge still works for webhook-only and polling-only paths
- [ ] Verify signal intake for non-Linear sources (Discord, GitHub) is unaffected

Fixes PRO-263

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate feature creation for Linear signals by preventing creation when a feature already exists for the given Linear issue.
  * Improved feature tracking by automatically storing Linear issue IDs on features created from Linear signal sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->