### PR TITLE
chore: add gource visualization scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,8 +150,9 @@ labs/
 # Local project plans (not repo content)
 /projects/
 
-# Large media files (render locally, don't commit)
+# Gource visualization (render locally, don't commit)
 gource.mp4
+.gource/
 
 # Test fixture runtime artifacts
 test/fixtures/**/.automaker/categories.json

--- a/scripts/fetch-gource-avatars.sh
+++ b/scripts/fetch-gource-avatars.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Fetch GitHub avatars for gource visualization
+# Uses git log emails to find GitHub usernames, then downloads profile pictures
+set -eo pipefail
+
+AVATAR_DIR="${1:-.gource/avatars}"
+mkdir -p "$AVATAR_DIR"
+
+echo "Fetching GitHub avatars into $AVATAR_DIR..."
+
+# Tab-separated: "Git Name<TAB>GitHub username"
+USERS="Josh Mabry	mabry1985
+Kacper	kacperlachowiczwp
+Shirone	kacperlachowiczwp
+Cody Seibert	WebDevCody
+Web Dev Cody	WebDevCody
+webdevcody	WebDevCody
+WebDevCody	WebDevCody
+DhanushSantosh	DhanushSantosh
+Dhanush Santosh	DhanushSantosh
+SuperComboGamer	SuperComboGamer
+Stefan de Vogelaere	stefandevogelaere
+Ben	trueheads
+trueheads	trueheads
+GTheMachine	GTheMachine
+RayFernando	RayFernando1337
+Rik Smale	WikiRik
+James Botwina	JBotwina
+James	JBotwina
+jbotwina	JBotwina
+Stephan Cho	stephan271c
+Waaiez Kinnear	Waaiez
+antdev	yumesha
+yumesha	yumesha
+Alec Koifman	SuperComboGamer
+Anand (Andy) Houston	andydataguy
+Soham Dasgupta	thesobercoder
+Leon van Zyl	leonvanzyl
+Tobias Weber	comzine
+Illia Filippov	illia-filippov
+Stephan Rieche	stephanrieche
+USerik	USerik
+M Zubair	labim34
+Ramiro Rivera	ramarivera
+Jay Zhou	jzilla808
+Scott	tfodotcom
+Mohamad Yahia	xyzt70
+Manuel Grillo	manuelgrillo
+Seonfx	Seonfx
+shevanio	shevanio
+DenyCZ	DenyCZ
+eclipxe	eclipxe
+firstfloris	firstfloris
+Tony Nekola	tonynekola"
+
+downloaded=0
+skipped=0
+failed=0
+
+while IFS=$'\t' read -r name username; do
+  output="$AVATAR_DIR/${name}.png"
+
+  if [[ -f "$output" ]]; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  url="https://github.com/${username}.png?size=256"
+  http_code=$(curl -sL -o "$output" -w "%{http_code}" "$url")
+  if [[ "$http_code" == "200" ]]; then
+    downloaded=$((downloaded + 1))
+    echo "  + $name ($username)"
+  else
+    rm -f "$output"
+    failed=$((failed + 1))
+    echo "  x $name ($username) — HTTP $http_code"
+  fi
+
+  sleep 0.2
+done <<< "$USERS"
+
+echo ""
+echo "Done: $downloaded downloaded, $skipped cached, $failed failed"
+echo "Avatars in: $AVATAR_DIR"

--- a/scripts/render-gource.sh
+++ b/scripts/render-gource.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Render a 15-second gource visualization of protoMaker
+# Starting from the fork date (2026-02-04) through present
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+OUTPUT="${1:-gource.mp4}"
+AVATAR_DIR=".gource/avatars"
+FORK_DATE="2026-02-04"
+TARGET_DURATION=30
+
+# Calculate seconds-per-day for target duration
+days_since_fork=$(python3 -c "
+from datetime import date
+d = (date.today() - date.fromisoformat('$FORK_DATE')).days
+print(d)
+")
+spd=$(python3 -c "print(round($TARGET_DURATION / $days_since_fork, 2))")
+
+echo "=== protoMaker Gource Render ==="
+echo "Fork date:    $FORK_DATE"
+echo "Days elapsed: $days_since_fork"
+echo "Target:       ${TARGET_DURATION}s video"
+echo "Speed:        ${spd}s per day"
+echo "Output:       $OUTPUT"
+echo ""
+
+# Fetch avatars if directory is empty or missing
+if [[ ! -d "$AVATAR_DIR" ]] || [[ -z "$(ls -A "$AVATAR_DIR" 2>/dev/null)" ]]; then
+  echo "Fetching GitHub avatars..."
+  bash scripts/fetch-gource-avatars.sh "$AVATAR_DIR"
+  echo ""
+fi
+
+avatar_count=$(ls -1 "$AVATAR_DIR"/*.png 2>/dev/null | wc -l | tr -d ' ')
+echo "Using $avatar_count avatars from $AVATAR_DIR"
+echo "Rendering..."
+echo ""
+
+gource \
+  --start-date "$FORK_DATE" \
+  --seconds-per-day "$spd" \
+  --auto-skip-seconds 0.5 \
+  --stop-at-end \
+  --disable-input \
+  --disable-auto-rotate \
+  --max-file-lag 0.8 \
+  --elasticity 0.01 \
+  --time-scale 0.5 \
+  --max-user-speed 200 \
+  --user-friction 1.0 \
+  --title "protoMaker — 1,000 PRs in $days_since_fork Days" \
+  --key \
+  --multi-sampling \
+  --bloom-multiplier 1.2 \
+  --bloom-intensity 0.4 \
+  --camera-mode overview \
+  --padding 1.15 \
+  --user-scale 1.5 \
+  --user-image-dir "$AVATAR_DIR" \
+  --highlight-users \
+  --highlight-colour 7C3AED \
+  --font-colour FFFFFF \
+  --date-format "%b %d" \
+  --hide mouse,filenames \
+  --dir-name-depth 2 \
+  --file-idle-time 3 \
+  --max-files 0 \
+  --background-colour 111111 \
+  --font-size 18 \
+  --file-filter "package-lock|\.automaker/memory" \
+  --output-ppm-stream - \
+  --output-framerate 60 \
+  -1920x1080 \
+  | ffmpeg -y -r 60 -f image2pipe -vcodec ppm -i - \
+  -vcodec libx264 -preset medium -pix_fmt yuv420p \
+  -crf 18 -movflags +faststart \
+  "$OUTPUT"
+
+echo ""
+echo "Done! Output: $OUTPUT"
+ls -lh "$OUTPUT"


### PR DESCRIPTION
## Summary
- `scripts/render-gource.sh` — renders a 1080p60 gource visualization starting from the fork date, auto-calculates playback speed, fetches GitHub avatars
- `scripts/fetch-gource-avatars.sh` — downloads contributor profile pictures for gource `--user-image-dir`
- `.gitignore` — adds `.gource/` for cached avatars

Celebrating PR #1000!

## Test plan
- [x] `bash scripts/render-gource.sh` produces a valid MP4
- [x] Avatars download successfully (34/43 contributors)
- [x] Physics are smooth (dampened elasticity, half time-scale, file fade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Gource visualization scripts for generating repository history videos with customizable rendering parameters
  * Implemented automated script for fetching GitHub avatars to enhance repository visualizations with contributor images
  * Updated .gitignore configuration to exclude Gource visualization output files and generated directories
<!-- end of auto-generated comment: release notes by coderabbit.ai -->