### PR TITLE
feat(langfuse): M2 prompt iteration pipeline

### DIFF
--- a/apps/server/src/routes/langfuse/index.ts
+++ b/apps/server/src/routes/langfuse/index.ts
@@ -288,5 +288,43 @@ export function createLangfuseRoutes(
    */
   router.post('/webhook/prompt', createWebhookHandler(promptGitHubSyncService));
 
+  /**
+   * POST /api/langfuse/prompts/seed
+   * Upload default prompt baselines to Langfuse for version tracking and A/B experiments.
+   *
+   * Body: { labels?: string[], force?: boolean }
+   * - labels: Langfuse labels to apply (default: ["production"])
+   * - force: Create new version even if prompt exists (default: false)
+   */
+  router.post('/prompts/seed', async (req, res) => {
+    try {
+      const { PromptSeedService } = await import('../../services/prompt-seed-service.js');
+      const { labels, force } = req.body ?? {};
+      const summary = await PromptSeedService.getInstance().seedDefaults(
+        labels ?? ['production'],
+        force ?? false
+      );
+      res.json(summary);
+    } catch (error) {
+      logger.error('Failed to seed prompts:', error);
+      res.status(500).json({ error: 'Failed to seed prompts' });
+    }
+  });
+
+  /**
+   * POST /api/langfuse/prompts/catalog
+   * Returns the prompt catalog (names and tags) without seeding.
+   */
+  router.post('/prompts/catalog', async (_req, res) => {
+    try {
+      const { PromptSeedService } = await import('../../services/prompt-seed-service.js');
+      const catalog = PromptSeedService.getInstance().getCatalog();
+      res.json({ catalog });
+    } catch (error) {
+      logger.error('Failed to get prompt catalog:', error);
+      res.status(500).json({ error: 'Failed to get prompt catalog' });
+    }
+  });
+
   return router;
 }

--- a/apps/server/src/services/agent-scoring-service.ts
+++ b/apps/server/src/services/agent-scoring-service.ts
@@ -103,13 +103,21 @@ export class AgentScoringService {
         this.scoreSuccess(langfuse, traceId, 1.0, 'Feature completed — PR merged');
         this.scoreEfficiency(langfuse, traceId, feature);
         this.scoreQuality(langfuse, traceId, feature);
+        this.scoreBuildPass(langfuse, traceId, true);
+        this.scoreReworkCount(langfuse, traceId, feature);
       } else if (newStatus === 'review' && oldStatus === 'in_progress') {
         this.scoreSuccess(langfuse, traceId, 0.7, 'Feature in review — PR created');
         this.scoreEfficiency(langfuse, traceId, feature);
+        this.scoreBuildPass(langfuse, traceId, true);
+        this.scoreReworkCount(langfuse, traceId, feature);
       } else if (newStatus === 'backlog' && oldStatus === 'in_progress') {
         this.scoreSuccess(langfuse, traceId, 0.0, 'Feature reset to backlog — agent failed');
+        this.scoreBuildPass(langfuse, traceId, false);
+        this.scoreReworkCount(langfuse, traceId, feature);
       } else if (newStatus === 'blocked' && oldStatus === 'in_progress') {
         this.scoreSuccess(langfuse, traceId, 0.0, 'Feature blocked — agent failed');
+        this.scoreBuildPass(langfuse, traceId, false);
+        this.scoreReworkCount(langfuse, traceId, feature);
       }
 
       // Flush after scoring
@@ -151,6 +159,26 @@ export class AgentScoringService {
 
     langfuse.createScore({ traceId, name: 'agent.quality', value: quality, comment });
     logger.debug(`Scored agent.quality=${quality.toFixed(2)} for trace ${traceId}`);
+  }
+
+  private scoreBuildPass(langfuse: LangfuseClient, traceId: string, passed: boolean): void {
+    const value = passed ? 1.0 : 0.0;
+    const comment = passed
+      ? 'Build passed — agent produced compilable code'
+      : 'Build failed — agent did not produce working code';
+    langfuse.createScore({ traceId, name: 'agent.build_pass', value, comment });
+    logger.debug(`Scored agent.build_pass=${value} for trace ${traceId}`);
+  }
+
+  private scoreReworkCount(langfuse: LangfuseClient, traceId: string, feature: Feature): void {
+    const attempts = feature.executionHistory?.length ?? 1;
+    // Normalize: 1 attempt = 1.0 (perfect), 2 = 0.5, 3 = 0.33, etc.
+    const value = Math.min(1.0, 1 / attempts);
+    const comment = `${attempts} execution attempt(s)${attempts > 1 ? ' — required rework' : ''}`;
+    langfuse.createScore({ traceId, name: 'agent.rework_count', value, comment });
+    logger.debug(
+      `Scored agent.rework_count=${value.toFixed(2)} (${attempts} attempts) for trace ${traceId}`
+    );
   }
 
   private async scorePipelinePhase(

--- a/apps/server/src/services/prompt-seed-service.ts
+++ b/apps/server/src/services/prompt-seed-service.ts
@@ -1,0 +1,202 @@
+/**
+ * PromptSeedService — Seeds default prompts into Langfuse as managed baselines.
+ *
+ * Uploads the key prompt templates from @automaker/prompts to Langfuse,
+ * enabling version tracking, A/B experiments, and rollout management
+ * through the Langfuse dashboard.
+ *
+ * Prompt naming convention: `{category}.{key}` (e.g., `autoMode.featurePromptTemplate`)
+ * This matches the PromptResolver lookup pattern.
+ */
+
+import { createLogger } from '@automaker/utils';
+import { DEFAULT_PROMPTS } from '@automaker/prompts';
+import type { LangfuseClient } from '@automaker/observability';
+import { getLangfuseInstance } from '../lib/langfuse-singleton.js';
+
+const logger = createLogger('PromptSeedService');
+
+/** Result of seeding a single prompt */
+interface SeedResult {
+  name: string;
+  version: number;
+  status: 'created' | 'skipped' | 'error';
+  error?: string;
+}
+
+/** Summary of a seed operation */
+export interface SeedSummary {
+  total: number;
+  created: number;
+  skipped: number;
+  errors: number;
+  results: SeedResult[];
+}
+
+/**
+ * The prompt catalog — maps Langfuse prompt names to their default values.
+ * Only includes high-impact prompts used by auto-mode agents.
+ * Category.key naming matches PromptResolver lookup convention.
+ */
+function buildPromptCatalog(): Array<{
+  name: string;
+  prompt: string;
+  tags: string[];
+}> {
+  const catalog: Array<{ name: string; prompt: string; tags: string[] }> = [];
+
+  // Auto-mode prompts (most impactful for agent quality)
+  const autoMode = DEFAULT_PROMPTS.autoMode;
+  catalog.push(
+    {
+      name: 'autoMode.featurePromptTemplate',
+      prompt: autoMode.featurePromptTemplate,
+      tags: ['auto-mode', 'agent', 'high-impact'],
+    },
+    {
+      name: 'autoMode.planningLite',
+      prompt: autoMode.planningLite,
+      tags: ['auto-mode', 'planning'],
+    },
+    {
+      name: 'autoMode.planningSpec',
+      prompt: autoMode.planningSpec,
+      tags: ['auto-mode', 'planning'],
+    },
+    {
+      name: 'autoMode.planningFull',
+      prompt: autoMode.planningFull,
+      tags: ['auto-mode', 'planning'],
+    }
+  );
+
+  // Task execution prompts
+  const taskExec = DEFAULT_PROMPTS.taskExecution;
+  catalog.push(
+    {
+      name: 'taskExecution.implementationInstructions',
+      prompt: taskExec.implementationInstructions,
+      tags: ['task-execution', 'agent', 'high-impact'],
+    },
+    {
+      name: 'taskExecution.taskPromptTemplate',
+      prompt: taskExec.taskPromptTemplate,
+      tags: ['task-execution', 'agent'],
+    }
+  );
+
+  // Agent system prompt
+  catalog.push({
+    name: 'agent.systemPrompt',
+    prompt: DEFAULT_PROMPTS.agent.systemPrompt,
+    tags: ['agent', 'system-prompt'],
+  });
+
+  // Backlog planning
+  const backlog = DEFAULT_PROMPTS.backlogPlan;
+  catalog.push({
+    name: 'backlogPlan.systemPrompt',
+    prompt: backlog.systemPrompt,
+    tags: ['planning', 'backlog'],
+  });
+
+  return catalog;
+}
+
+export class PromptSeedService {
+  private static instance: PromptSeedService;
+
+  static getInstance(): PromptSeedService {
+    if (!PromptSeedService.instance) {
+      PromptSeedService.instance = new PromptSeedService();
+    }
+    return PromptSeedService.instance;
+  }
+
+  /**
+   * Seed all default prompts to Langfuse as v1 baselines.
+   *
+   * @param labels - Labels to apply (default: ["production"])
+   * @param force - If true, creates new versions even if prompt exists
+   */
+  async seedDefaults(labels: string[] = ['production'], force = false): Promise<SeedSummary> {
+    const langfuse = getLangfuseInstance();
+
+    if (!langfuse.isAvailable()) {
+      logger.warn('Langfuse not available — cannot seed prompts');
+      return { total: 0, created: 0, skipped: 0, errors: 0, results: [] };
+    }
+
+    const catalog = buildPromptCatalog();
+    const results: SeedResult[] = [];
+
+    for (const entry of catalog) {
+      const result = await this.seedPrompt(langfuse, entry, labels, force);
+      results.push(result);
+    }
+
+    const summary: SeedSummary = {
+      total: results.length,
+      created: results.filter((r) => r.status === 'created').length,
+      skipped: results.filter((r) => r.status === 'skipped').length,
+      errors: results.filter((r) => r.status === 'error').length,
+      results,
+    };
+
+    logger.info(
+      `Prompt seeding complete: ${summary.created} created, ${summary.skipped} skipped, ${summary.errors} errors`
+    );
+
+    return summary;
+  }
+
+  private async seedPrompt(
+    langfuse: LangfuseClient,
+    entry: { name: string; prompt: string; tags: string[] },
+    labels: string[],
+    force: boolean
+  ): Promise<SeedResult> {
+    try {
+      // Check if prompt already exists (skip unless force)
+      if (!force) {
+        const existing = await langfuse.getPrompt(entry.name);
+        if (existing) {
+          logger.debug(`Prompt already exists: ${entry.name} (v${existing.version}), skipping`);
+          return { name: entry.name, version: existing.version, status: 'skipped' };
+        }
+      }
+
+      const result = await langfuse.createPrompt({
+        name: entry.name,
+        prompt: entry.prompt,
+        labels,
+        tags: entry.tags,
+        commitMessage: force
+          ? 'Baseline update from prompt seed service'
+          : 'Initial baseline from @automaker/prompts defaults',
+      });
+
+      if (!result) {
+        return {
+          name: entry.name,
+          version: 0,
+          status: 'error',
+          error: 'createPrompt returned null',
+        };
+      }
+
+      return { name: entry.name, version: result.version, status: 'created' };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      logger.error(`Failed to seed prompt ${entry.name}:`, error);
+      return { name: entry.name, version: 0, status: 'error', error: msg };
+    }
+  }
+
+  /**
+   * Get the prompt catalog without seeding — useful for documentation.
+   */
+  getCatalog(): Array<{ name: string; tags: string[] }> {
+    return buildPromptCatalog().map((e) => ({ name: e.name, tags: e.tags }));
+  }
+}

--- a/docs/dev/langfuse-prompts.md
+++ b/docs/dev/langfuse-prompts.md
@@ -76,26 +76,75 @@ All prompts use hierarchical dot-notation: `{category}.{key}`
 | `suggestions`        | `featuresPrompt`, `refactoringPrompt`, `securityPrompt`, `performancePrompt`, `baseTemplate`                                                                                                                                                                                                            | `libs/prompts/defaults.ts`    |
 | `taskExecution`      | `taskPromptTemplate`, `implementationInstructions`, `playwrightVerificationInstructions`, `learningExtractionSystemPrompt`, `learningExtractionUserPromptTemplate`, `planRevisionTemplate`, `continuationAfterApprovalTemplate`, `resumeFeatureTemplate`, `projectAnalysisPrompt`, `prFeedbackTemplate` | `libs/prompts/defaults.ts`    |
 
-## Seed Script
+## Seeding Prompts
 
-Push all hardcoded prompts to Langfuse:
+Push default prompt baselines to Langfuse for version tracking and A/B experiments.
+
+### Via MCP Tool (Recommended)
+
+```
+langfuse_seed_prompts({ labels: ["production"], force: false })
+```
+
+### Via API
+
+```bash
+curl -X POST http://localhost:3008/api/langfuse/prompts/seed \
+  -H "Content-Type: application/json" \
+  -d '{"labels": ["production"], "force": false}'
+```
+
+### Via Seed Script (Legacy)
 
 ```bash
 npx tsx scripts/seed-langfuse-prompts.ts
 ```
 
-**Requirements:**
+### Prompt Catalog
 
-- `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` in your `.env`
-- `LANGFUSE_BASE_URL` (optional, defaults to `https://cloud.langfuse.com`)
+The seed service uploads 8 high-impact prompts:
 
-**Behavior:**
+| Langfuse Name                              | Tags                               | Impact                                        |
+| ------------------------------------------ | ---------------------------------- | --------------------------------------------- |
+| `autoMode.featurePromptTemplate`           | auto-mode, agent, high-impact      | Main feature prompt — controls agent behavior |
+| `autoMode.planningLite`                    | auto-mode, planning                | Lightweight planning phase                    |
+| `autoMode.planningSpec`                    | auto-mode, planning                | Spec-level planning                           |
+| `autoMode.planningFull`                    | auto-mode, planning                | Full planning with detailed analysis          |
+| `taskExecution.implementationInstructions` | task-execution, agent, high-impact | Implementation guidelines, verification gates |
+| `taskExecution.taskPromptTemplate`         | task-execution, agent              | Task execution template                       |
+| `agent.systemPrompt`                       | agent, system-prompt               | Base agent system prompt                      |
+| `backlogPlan.systemPrompt`                 | planning, backlog                  | Backlog planning system prompt                |
 
-- Creates each prompt with the `production` label
-- Idempotent: re-running creates new versions of existing prompts
-- Reports which prompts succeeded/failed
+### Options
 
-**Why seed?** Eliminates "Prompt not found" SDK errors in server logs. Even though our wrapper (`LangfuseClient.getPrompt()`) logs at debug level, the Langfuse SDK itself emits internal error logs via `console.error` that cannot be suppressed via configuration. Seeding ensures prompts exist upstream, preventing the errors entirely.
+- `labels`: Langfuse labels to apply (default: `["production"]`)
+- `force`: If `false` (default), skips prompts that already exist. If `true`, creates a new version.
+
+**Why seed?** Eliminates "Prompt not found" SDK errors in server logs. Also enables version tracking and A/B experiments through the Langfuse dashboard.
+
+## A/B Experiments & Rollout
+
+Once prompts are seeded, experiment with variants via the Langfuse dashboard:
+
+1. **Create variant**: Edit a prompt in Langfuse to create a new version
+2. **Label for testing**: Apply `staging` label to the new version
+3. **Test**: Configure a staging server with `LANGFUSE_SYNC_LABEL=staging`
+4. **Promote**: Move the `production` label to the winning version
+5. **Monitor**: Check agent scores in Langfuse to compare version performance
+
+### Scoring Signals
+
+The `AgentScoringService` automatically scores every agent execution trace:
+
+| Score                | Range      | Description                            |
+| -------------------- | ---------- | -------------------------------------- |
+| `agent.success`      | 0.0–1.0    | 1.0 = done, 0.7 = review, 0.0 = failed |
+| `agent.efficiency`   | 0.0–1.0    | 1 - (turnsUsed / maxTurns)             |
+| `agent.quality`      | 0.0–1.0    | 1 - (reviewThreads × 0.1)              |
+| `agent.build_pass`   | 0.0 or 1.0 | Whether agent produced compilable code |
+| `agent.rework_count` | 0.0–1.0    | 1/attempts (1.0 = first try success)   |
+
+Compare these scores across prompt versions to identify improvements.
 
 ## Managing Prompts in Langfuse
 
@@ -320,7 +369,8 @@ The dispatch event type is `langfuse-prompt-sync` and includes the prompt name, 
 | `apps/server/src/routes/langfuse/webhook.ts`             | Webhook route handler — filters by label, dispatches to sync |
 | `apps/server/src/services/prompt-github-sync-service.ts` | Octokit-based GitHub sync (commit prompts to `prompts/`)     |
 | `apps/server/src/services/prompt-ci-trigger-service.ts`  | `repository_dispatch` trigger after prompt commits           |
-| `libs/observability/src/langfuse/client.ts`              | `LangfuseClient.getPrompt()` with label support              |
+| `apps/server/src/services/prompt-seed-service.ts`        | Prompt seeding service — uploads baselines to Langfuse       |
+| `libs/observability/src/langfuse/client.ts`              | `LangfuseClient.getPrompt()` / `createPrompt()` with labels  |
 | `libs/observability/src/langfuse/cache.ts`               | `PromptCache` for TTL-based caching                          |
 | `libs/observability/src/langfuse/versioning.ts`          | `getRawPrompt()`, `prefetchPrompts()`, label/version pinning |
 | `scripts/seed-langfuse-prompts.ts`                       | One-time script to push all prompts to Langfuse              |

--- a/libs/observability/src/langfuse/client.ts
+++ b/libs/observability/src/langfuse/client.ts
@@ -223,6 +223,43 @@ export class LangfuseClient {
   }
 
   /**
+   * Create or update a text prompt in Langfuse.
+   *
+   * If a prompt with the same name already exists, a new version is created.
+   * Returns the created prompt metadata (name, version, labels).
+   */
+  async createPrompt(options: {
+    name: string;
+    prompt: string;
+    labels?: string[];
+    tags?: string[];
+    commitMessage?: string;
+    config?: Record<string, any>;
+  }): Promise<{ name: string; version: number; labels: string[] } | null> {
+    if (!this.isAvailable()) {
+      logger.debug('Langfuse unavailable, skipping prompt creation');
+      return null;
+    }
+
+    try {
+      const result = await this.client!.api.promptsCreate({
+        type: 'text',
+        name: options.name,
+        prompt: options.prompt,
+        labels: options.labels ?? [],
+        tags: options.tags ?? [],
+        commitMessage: options.commitMessage,
+        config: options.config,
+      });
+      logger.info(`Created prompt in Langfuse: ${options.name} (v${result.version})`);
+      return { name: result.name, version: result.version, labels: result.labels };
+    } catch (error) {
+      logger.error(`Failed to create prompt in Langfuse: ${options.name}`, error);
+      return null;
+    }
+  }
+
+  /**
    * Create a score for a trace
    */
   createScore(options: CreateScoreOptions) {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1274,6 +1274,12 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         metadata: args.metadata,
       });
 
+    case 'langfuse_seed_prompts':
+      return apiCall('/langfuse/prompts/seed', {
+        labels: args.labels,
+        force: args.force,
+      });
+
     // Twitch Integration
     case 'twitch_list_suggestions':
       return apiCall(

--- a/packages/mcp-server/src/tools/observability-tools.ts
+++ b/packages/mcp-server/src/tools/observability-tools.ts
@@ -246,4 +246,23 @@ export const observabilityTools: Tool[] = [
       required: ['datasetName', 'traceId'],
     },
   },
+  {
+    name: 'langfuse_seed_prompts',
+    description:
+      'Upload default prompt baselines to Langfuse for version tracking and A/B experiments. Seeds key prompts (auto-mode, task execution, agent, planning) as managed Langfuse prompts. Skips prompts that already exist unless force=true.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        labels: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Labels to apply to seeded prompts (default: ["production"])',
+        },
+        force: {
+          type: 'boolean',
+          description: 'Create new version even if prompt already exists (default: false)',
+        },
+      },
+    },
+  },
 ];


### PR DESCRIPTION
## Summary
- **PromptSeedService** — uploads 8 key prompt baselines to Langfuse for version tracking and A/B experiments
- **LangfuseClient.createPrompt()** — new method wrapping `api.promptsCreate()` for text prompt upload
- **API routes** — `POST /api/langfuse/prompts/seed` and `/prompts/catalog`
- **MCP tool** — `langfuse_seed_prompts` for seeding via Claude Code
- **Agent scoring** — adds `agent.build_pass` and `agent.rework_count` scores to AgentScoringService
- **Docs** — updated `docs/dev/langfuse-prompts.md` with seed catalog, A/B experiment workflow, scoring table

## Test plan
- [x] `npm run build:packages` passes (14/14)
- [x] `npm run build:server` passes
- [x] Prettier formatting clean
- [ ] Seed prompts via MCP tool with Langfuse credentials configured
- [ ] Verify agent scores appear after feature status transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to seed default prompt baselines to Langfuse for version tracking and A/B experiments.
  * New scoring signals for build success and rework attempts now integrated into feature status transitions.
  * New endpoints and tools available to manage prompt seeding with labels and version control support.

* **Documentation**
  * Updated Langfuse prompt management documentation with seeding workflow and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->