### PR TITLE
feat(prompts): M3 prompt testing infrastructure

### DIFF
--- a/libs/prompts/src/index.ts
+++ b/libs/prompts/src/index.ts
@@ -165,6 +165,10 @@ export { getBoardJanitorPrompt } from './agents/board-janitor.js';
 export { getFrankPrompt } from './agents/frank.js';
 export { getKaiPrompt } from './agents/kai.js';
 
+// Prompt quality linter
+export { lintPrompt, lintAllPrompts } from './lint.js';
+export type { LintResult, LintWarning, LintError, LintSummary } from './lint.js';
+
 // Content generation prompts
 export { getOutlinePlannerPrompt } from './content/outline-planner.js';
 export type { OutlinePlannerConfig } from './content/outline-planner.js';

--- a/libs/prompts/src/lint.ts
+++ b/libs/prompts/src/lint.ts
@@ -1,0 +1,227 @@
+/**
+ * Prompt Quality Linter
+ *
+ * Static analysis tool that checks prompt strings for common quality issues.
+ * Designed to run in CI to catch prompt regressions before they reach agents.
+ *
+ * Quality signals checked:
+ * 1. Token budget — prompts exceeding ~4000 tokens risk context window pressure
+ * 2. Verification gates — agent prompts must include verification steps
+ * 3. Scope discipline — agent prompts must constrain scope
+ * 4. Output format — prompts should specify expected output structure
+ * 5. Anti-patterns — flag dangerous instructions (e.g., "skip tests")
+ * 6. Actionability — prompts should end with clear next steps
+ */
+
+import { DEFAULT_PROMPTS } from './defaults.js';
+
+/** Result of linting a single prompt */
+export interface LintResult {
+  name: string;
+  passed: boolean;
+  warnings: LintWarning[];
+  errors: LintError[];
+}
+
+export interface LintWarning {
+  rule: string;
+  message: string;
+}
+
+export interface LintError {
+  rule: string;
+  message: string;
+}
+
+/** Summary of linting all prompts */
+export interface LintSummary {
+  total: number;
+  passed: number;
+  failed: number;
+  warnings: number;
+  results: LintResult[];
+}
+
+/** Approximate token count (1 token ≈ 4 chars for English text) */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/** Check if a prompt is an agent-facing prompt (not a user-facing one) */
+function isAgentPrompt(name: string): boolean {
+  const agentCategories = ['autoMode.', 'taskExecution.', 'agent.', 'backlogPlan.'];
+  return agentCategories.some((prefix) => name.startsWith(prefix));
+}
+
+/**
+ * Rule 1: Token budget — warn if prompt exceeds threshold
+ */
+function checkTokenBudget(name: string, prompt: string): LintWarning[] {
+  const warnings: LintWarning[] = [];
+  const tokens = estimateTokens(prompt);
+  if (tokens > 4000) {
+    warnings.push({
+      rule: 'token-budget',
+      message: `Prompt "${name}" is ~${tokens} tokens (exceeds 4000 token threshold). Consider splitting or condensing.`,
+    });
+  }
+  return warnings;
+}
+
+/**
+ * Rule 2: Verification gates — agent prompts should include verification steps
+ */
+function checkVerificationGates(name: string, prompt: string): LintWarning[] {
+  if (!isAgentPrompt(name)) return [];
+
+  const warnings: LintWarning[] = [];
+  const hasVerification =
+    /verification|verify|gate|check|assert|validate|build.*pass|test.*pass/i.test(prompt);
+
+  if (!hasVerification) {
+    warnings.push({
+      rule: 'verification-gates',
+      message: `Agent prompt "${name}" has no verification steps. Agent may not validate its own output.`,
+    });
+  }
+  return warnings;
+}
+
+/**
+ * Rule 3: Scope discipline — agent prompts should constrain scope
+ */
+function checkScopeDiscipline(name: string, prompt: string): LintWarning[] {
+  if (!isAgentPrompt(name)) return [];
+
+  const warnings: LintWarning[] = [];
+  const hasScope = /scope|focus|only|do not|don't|never|limit|restrict|exactly what/i.test(prompt);
+
+  if (!hasScope) {
+    warnings.push({
+      rule: 'scope-discipline',
+      message: `Agent prompt "${name}" has no scope constraints. Agent may over-deliver or scope-creep.`,
+    });
+  }
+  return warnings;
+}
+
+/**
+ * Rule 4: Output format — prompts should specify expected output
+ */
+function checkOutputFormat(name: string, prompt: string): LintWarning[] {
+  const warnings: LintWarning[] = [];
+  const hasFormat =
+    /format|output|return|respond|response|json|xml|markdown|summary|structure/i.test(prompt);
+
+  if (!hasFormat && prompt.length > 200) {
+    warnings.push({
+      rule: 'output-format',
+      message: `Prompt "${name}" does not specify output format. LLM may produce inconsistent output shapes.`,
+    });
+  }
+  return warnings;
+}
+
+/**
+ * Rule 5: Anti-patterns — flag dangerous instructions
+ */
+function checkAntiPatterns(name: string, prompt: string): LintError[] {
+  const errors: LintError[] = [];
+
+  const dangerousPatterns: Array<{ pattern: RegExp; message: string }> = [
+    {
+      pattern: /skip\s+(all\s+)?tests/i,
+      message: 'Prompt instructs to skip tests',
+    },
+    {
+      pattern: /ignore\s+(all\s+)?errors/i,
+      message: 'Prompt instructs to ignore errors',
+    },
+    {
+      pattern: /rm\s+-rf\s+\//,
+      message: 'Prompt contains destructive rm -rf command',
+    },
+    {
+      pattern: /force\s+push\s+(to\s+)?main/i,
+      message: 'Prompt instructs force push to main',
+    },
+    {
+      pattern: /git\s+push\s+--force\s+origin\s+main/i,
+      message: 'Prompt contains force push to main',
+    },
+  ];
+
+  for (const { pattern, message } of dangerousPatterns) {
+    if (pattern.test(prompt)) {
+      errors.push({ rule: 'anti-pattern', message: `"${name}": ${message}` });
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Rule 6: Actionability — prompts should end with clear direction
+ */
+function checkActionability(name: string, prompt: string): LintWarning[] {
+  if (!isAgentPrompt(name)) return [];
+
+  const warnings: LintWarning[] = [];
+  // Check last 500 chars for action words
+  const tail = prompt.slice(-500);
+  const hasAction = /begin|start|implement|create|build|now|proceed|execute|do|run/i.test(tail);
+
+  if (!hasAction) {
+    warnings.push({
+      rule: 'actionability',
+      message: `Agent prompt "${name}" does not end with a clear action directive. Agent may not know what to do first.`,
+    });
+  }
+  return warnings;
+}
+
+/**
+ * Lint a single prompt against all rules.
+ */
+export function lintPrompt(name: string, prompt: string): LintResult {
+  const warnings: LintWarning[] = [
+    ...checkTokenBudget(name, prompt),
+    ...checkVerificationGates(name, prompt),
+    ...checkScopeDiscipline(name, prompt),
+    ...checkOutputFormat(name, prompt),
+    ...checkActionability(name, prompt),
+  ];
+
+  const errors: LintError[] = [...checkAntiPatterns(name, prompt)];
+
+  return {
+    name,
+    passed: errors.length === 0,
+    warnings,
+    errors,
+  };
+}
+
+/**
+ * Lint all registered default prompts.
+ * Returns a summary with pass/fail counts and individual results.
+ */
+export function lintAllPrompts(): LintSummary {
+  const results: LintResult[] = [];
+
+  // Flatten all prompt categories into name → prompt pairs
+  for (const [category, prompts] of Object.entries(DEFAULT_PROMPTS)) {
+    for (const [key, prompt] of Object.entries(prompts as unknown as Record<string, string>)) {
+      const name = `${category}.${key}`;
+      results.push(lintPrompt(name, prompt));
+    }
+  }
+
+  return {
+    total: results.length,
+    passed: results.filter((r) => r.passed).length,
+    failed: results.filter((r) => !r.passed).length,
+    warnings: results.reduce((sum, r) => sum + r.warnings.length, 0),
+    results,
+  };
+}

--- a/libs/prompts/tests/lint.test.ts
+++ b/libs/prompts/tests/lint.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Prompt Quality Linter Tests
+ *
+ * Tests the linter itself AND runs it against all default prompts
+ * to catch quality regressions in CI.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { lintPrompt, lintAllPrompts } from '../src/lint.js';
+
+describe('prompt linter', () => {
+  describe('lintPrompt — individual rules', () => {
+    it('warns on prompts exceeding token budget', () => {
+      const longPrompt = 'a'.repeat(20000); // ~5000 tokens
+      const result = lintPrompt('test.long', longPrompt);
+      expect(result.warnings.some((w) => w.rule === 'token-budget')).toBe(true);
+    });
+
+    it('does not warn on short prompts', () => {
+      const result = lintPrompt('test.short', 'Do this task.');
+      expect(result.warnings.some((w) => w.rule === 'token-budget')).toBe(false);
+    });
+
+    it('warns when agent prompt lacks verification gates', () => {
+      const result = lintPrompt('autoMode.noVerify', 'Just write some code.');
+      expect(result.warnings.some((w) => w.rule === 'verification-gates')).toBe(true);
+    });
+
+    it('does not warn when prompt has verification', () => {
+      const result = lintPrompt('autoMode.withVerify', 'Run build and verify exit code 0.');
+      expect(result.warnings.some((w) => w.rule === 'verification-gates')).toBe(false);
+    });
+
+    it('warns when agent prompt lacks scope discipline', () => {
+      const result = lintPrompt('taskExecution.noScope', 'Build everything you can.');
+      expect(result.warnings.some((w) => w.rule === 'scope-discipline')).toBe(true);
+    });
+
+    it('does not warn when prompt has scope constraints', () => {
+      const result = lintPrompt(
+        'taskExecution.withScope',
+        'Focus only on the requested changes. Do not modify other files.'
+      );
+      expect(result.warnings.some((w) => w.rule === 'scope-discipline')).toBe(false);
+    });
+
+    it('skips agent-only rules for non-agent prompts', () => {
+      const result = lintPrompt('enhancement.test', 'Improve the description.');
+      expect(result.warnings.some((w) => w.rule === 'verification-gates')).toBe(false);
+      expect(result.warnings.some((w) => w.rule === 'scope-discipline')).toBe(false);
+    });
+
+    it('errors on dangerous anti-patterns', () => {
+      const result = lintPrompt('test.danger', 'skip all tests and rm -rf /');
+      expect(result.errors.length).toBeGreaterThanOrEqual(2);
+      expect(result.passed).toBe(false);
+    });
+
+    it('passes clean prompts', () => {
+      const result = lintPrompt(
+        'autoMode.clean',
+        'Implement the feature. Verify the build passes. Focus only on the task. Return a JSON summary.'
+      );
+      expect(result.passed).toBe(true);
+      expect(result.errors.length).toBe(0);
+    });
+
+    it('warns on prompts without output format specification', () => {
+      // Long enough prompt without format keywords
+      const prompt =
+        'This is a long prompt that describes what to do but never says how the agent should shape its reply. ' +
+        'It goes on for a while without mentioning anything about the expected shape of the answer. '.repeat(
+          3
+        );
+      const result = lintPrompt('test.noFormat', prompt);
+      expect(result.warnings.some((w) => w.rule === 'output-format')).toBe(true);
+    });
+  });
+
+  describe('lintAllPrompts — regression gate', () => {
+    it('lints all 12 prompt categories', () => {
+      const summary = lintAllPrompts();
+      expect(summary.total).toBeGreaterThanOrEqual(30); // ~50 prompts across 12 categories
+    });
+
+    it('all prompts pass (no errors)', () => {
+      const summary = lintAllPrompts();
+      const failing = summary.results.filter((r) => !r.passed);
+
+      if (failing.length > 0) {
+        const details = failing
+          .map((r) => `  ${r.name}: ${r.errors.map((e) => e.message).join(', ')}`)
+          .join('\n');
+        expect.fail(`${failing.length} prompt(s) have errors:\n${details}`);
+      }
+    });
+
+    it('reports warnings without failing', () => {
+      const summary = lintAllPrompts();
+      // Warnings are informational — log them but don't fail
+      expect(summary.warnings).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/libs/prompts/tests/snapshot.test.ts
+++ b/libs/prompts/tests/snapshot.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Prompt Snapshot Tests
+ *
+ * Structural assertions for all default prompt categories.
+ * Verifies prompts contain required sections/patterns without
+ * asserting exact text (so prompts can evolve freely).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_PROMPTS } from '../src/defaults.js';
+
+describe('prompt snapshots — structural assertions', () => {
+  describe('autoMode prompts', () => {
+    const { autoMode } = DEFAULT_PROMPTS;
+
+    it('featurePromptTemplate contains feature context variables', () => {
+      expect(autoMode.featurePromptTemplate).toContain('{{featureId}}');
+      expect(autoMode.featurePromptTemplate).toContain('{{title}}');
+      expect(autoMode.featurePromptTemplate).toContain('{{description}}');
+    });
+
+    it('featurePromptTemplate includes conditional blocks', () => {
+      // Template uses Handlebars conditionals for optional sections
+      expect(autoMode.featurePromptTemplate).toContain('{{#if');
+    });
+
+    it('planningLite contains planning structure', () => {
+      expect(autoMode.planningLite.length).toBeGreaterThan(100);
+      expect(autoMode.planningLite).toMatch(/plan|approach|implement/i);
+    });
+
+    it('planningSpec is more detailed than planningLite', () => {
+      expect(autoMode.planningSpec.length).toBeGreaterThan(autoMode.planningLite.length);
+    });
+
+    it('planningFull is most detailed planning prompt', () => {
+      expect(autoMode.planningFull.length).toBeGreaterThan(autoMode.planningSpec.length);
+    });
+
+    it('followUpPromptTemplate references previous work', () => {
+      expect(autoMode.followUpPromptTemplate).toMatch(/previous|continue|follow.?up|remaining/i);
+    });
+
+    it('continuationPromptTemplate handles agent restart', () => {
+      expect(autoMode.continuationPromptTemplate).toMatch(/continu|resum|pick.?up/i);
+    });
+
+    it('pipelineStepPromptTemplate contains step context', () => {
+      expect(autoMode.pipelineStepPromptTemplate.length).toBeGreaterThan(50);
+    });
+  });
+
+  describe('taskExecution prompts', () => {
+    const { taskExecution } = DEFAULT_PROMPTS;
+
+    it('implementationInstructions has scope discipline section', () => {
+      expect(taskExecution.implementationInstructions).toMatch(/scope discipline/i);
+    });
+
+    it('implementationInstructions has turn budget', () => {
+      expect(taskExecution.implementationInstructions).toMatch(/turn budget/i);
+    });
+
+    it('implementationInstructions has verification gates', () => {
+      expect(taskExecution.implementationInstructions).toMatch(/verification gates/i);
+    });
+
+    it('implementationInstructions has risk awareness', () => {
+      expect(taskExecution.implementationInstructions).toMatch(/risk/i);
+    });
+
+    it('implementationInstructions has "when stuck" guidance', () => {
+      expect(taskExecution.implementationInstructions).toMatch(/when stuck/i);
+    });
+
+    it('implementationInstructions has red flags section', () => {
+      expect(taskExecution.implementationInstructions).toMatch(/red flag/i);
+    });
+
+    it('taskPromptTemplate contains task variables', () => {
+      expect(taskExecution.taskPromptTemplate).toContain('{{taskId}}');
+      expect(taskExecution.taskPromptTemplate).toContain('{{taskDescription}}');
+    });
+
+    it('learningExtractionSystemPrompt exists and is non-trivial', () => {
+      expect(taskExecution.learningExtractionSystemPrompt.length).toBeGreaterThan(50);
+    });
+
+    it('playwrightVerificationInstructions mentions browser testing', () => {
+      expect(taskExecution.playwrightVerificationInstructions).toMatch(
+        /playwright|browser|e2e|test/i
+      );
+    });
+  });
+
+  describe('agent prompts', () => {
+    const { agent } = DEFAULT_PROMPTS;
+
+    it('systemPrompt is non-trivial', () => {
+      expect(agent.systemPrompt.length).toBeGreaterThan(100);
+    });
+
+    it('systemPrompt contains role context', () => {
+      expect(agent.systemPrompt).toMatch(/implement|feature|task|code/i);
+    });
+  });
+
+  describe('backlogPlan prompts', () => {
+    const { backlogPlan } = DEFAULT_PROMPTS;
+
+    it('systemPrompt handles planning tasks', () => {
+      expect(backlogPlan.systemPrompt.length).toBeGreaterThan(50);
+    });
+
+    it('userPromptTemplate has placeholder for feature context', () => {
+      expect(backlogPlan.userPromptTemplate.length).toBeGreaterThan(50);
+    });
+  });
+
+  describe('enhancement prompts', () => {
+    const { enhancement } = DEFAULT_PROMPTS;
+
+    it('has all 5 enhancement modes', () => {
+      expect(enhancement.improveSystemPrompt).toBeDefined();
+      expect(enhancement.technicalSystemPrompt).toBeDefined();
+      expect(enhancement.simplifySystemPrompt).toBeDefined();
+      expect(enhancement.acceptanceSystemPrompt).toBeDefined();
+      expect(enhancement.uxReviewerSystemPrompt).toBeDefined();
+    });
+
+    it('each mode has non-trivial content', () => {
+      for (const [, prompt] of Object.entries(enhancement)) {
+        expect(prompt.length).toBeGreaterThan(50);
+      }
+    });
+  });
+
+  describe('commitMessage prompts', () => {
+    const { commitMessage } = DEFAULT_PROMPTS;
+
+    it('systemPrompt mentions commit conventions', () => {
+      expect(commitMessage.systemPrompt).toMatch(/commit|message|convention|format/i);
+    });
+  });
+
+  describe('titleGeneration prompts', () => {
+    const { titleGeneration } = DEFAULT_PROMPTS;
+
+    it('systemPrompt handles title generation', () => {
+      expect(titleGeneration.systemPrompt.length).toBeGreaterThan(50);
+    });
+  });
+
+  describe('issueValidation prompts', () => {
+    const { issueValidation } = DEFAULT_PROMPTS;
+
+    it('systemPrompt validates issues', () => {
+      expect(issueValidation.systemPrompt.length).toBeGreaterThan(50);
+    });
+  });
+
+  describe('ideation prompts', () => {
+    const { ideation } = DEFAULT_PROMPTS;
+
+    it('has ideation and suggestions system prompts', () => {
+      expect(ideation.ideationSystemPrompt).toBeDefined();
+      expect(ideation.suggestionsSystemPrompt).toBeDefined();
+    });
+  });
+
+  describe('appSpec prompts', () => {
+    const { appSpec } = DEFAULT_PROMPTS;
+
+    it('has generate, structured, and features prompts', () => {
+      expect(appSpec.generateSpecSystemPrompt).toBeDefined();
+      expect(appSpec.structuredSpecInstructions).toBeDefined();
+      expect(appSpec.generateFeaturesFromSpecPrompt).toBeDefined();
+    });
+
+    it('each is non-trivial', () => {
+      for (const [, prompt] of Object.entries(appSpec)) {
+        expect(prompt.length).toBeGreaterThan(50);
+      }
+    });
+  });
+
+  describe('contextDescription prompts', () => {
+    const { contextDescription } = DEFAULT_PROMPTS;
+
+    it('has file and image description prompts', () => {
+      expect(contextDescription.describeFilePrompt).toBeDefined();
+      expect(contextDescription.describeImagePrompt).toBeDefined();
+    });
+  });
+
+  describe('suggestions prompts', () => {
+    const { suggestions } = DEFAULT_PROMPTS;
+
+    it('has all suggestion categories', () => {
+      expect(suggestions.featuresPrompt).toBeDefined();
+      expect(suggestions.refactoringPrompt).toBeDefined();
+      expect(suggestions.securityPrompt).toBeDefined();
+      expect(suggestions.performancePrompt).toBeDefined();
+      expect(suggestions.baseTemplate).toBeDefined();
+    });
+  });
+
+  describe('all categories present', () => {
+    it('DEFAULT_PROMPTS has all 12 categories', () => {
+      const categories = Object.keys(DEFAULT_PROMPTS);
+      expect(categories).toContain('autoMode');
+      expect(categories).toContain('agent');
+      expect(categories).toContain('backlogPlan');
+      expect(categories).toContain('enhancement');
+      expect(categories).toContain('commitMessage');
+      expect(categories).toContain('titleGeneration');
+      expect(categories).toContain('issueValidation');
+      expect(categories).toContain('ideation');
+      expect(categories).toContain('appSpec');
+      expect(categories).toContain('contextDescription');
+      expect(categories).toContain('suggestions');
+      expect(categories).toContain('taskExecution');
+      expect(categories.length).toBe(12);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Prompt snapshot tests** — 32 structural assertions across all 12 prompt categories, verifying required sections (verification gates, scope discipline, turn budget, template variables) without brittle exact-text matching
- **Prompt quality linter** — static analysis with 6 rules: token budget (>4000 tokens), verification gates, scope discipline, output format, anti-patterns (rm -rf, skip tests, force push), actionability
- **CI-ready** — linter exported from `@automaker/prompts`, runs as part of `npm run test:packages` (118 tests pass)

## Test plan
- [x] `npm run build:packages` passes
- [x] `vitest run` in `libs/prompts/` — 118 tests, 4 files, all green
- [x] Linter catches dangerous anti-patterns (skip tests, rm -rf)
- [x] Linter passes all default prompts (no false positives)
- [x] Snapshot tests verify structural elements without exact text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prompt quality linting with automated checks for token limits, verification requirements, scope constraints, output formatting, safety patterns, and prompt clarity.

* **Tests**
  * Added comprehensive test coverage for linting functionality and prompt structure validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->