### PR TITLE
fix: auto-commit agent progress on turn limit before retry

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -2210,7 +2210,22 @@ export class AutoModeService {
           projectPath,
         });
       } else if (errorInfo.type === 'max_turns' && feature && tempRunningFeature) {
-        // Special handling for error_max_turns: escalate turns and retry with cap
+        // Special handling for error_max_turns: save progress, escalate turns, and retry with cap
+
+        // Save uncommitted work so the retry agent picks up where this one left off
+        if (tempRunningFeature.worktreePath && feature.branchName) {
+          const savedHash = await gitWorkflowService.saveAgentProgress(
+            tempRunningFeature.worktreePath,
+            feature,
+            feature.branchName
+          );
+          if (savedHash) {
+            logger.info(
+              `Saved agent progress checkpoint (${savedHash}) before max-turns retry for feature ${featureId}`
+            );
+          }
+        }
+
         const MAX_MAX_TURNS_RETRIES = 3;
         const currentFailures = feature.failureCount ?? 0;
         const newFailureCount = currentFailures + 1;

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -183,6 +183,102 @@ export class GitWorkflowService {
   }
 
   /**
+   * Save agent progress as a WIP commit when an agent is interrupted (e.g., turn limit).
+   * Commits and pushes any uncommitted work so the next retry agent can pick up where
+   * the previous one left off instead of starting from scratch.
+   *
+   * This is a lightweight operation — no PR creation, no merge, no changeset.
+   * Returns the commit hash if work was saved, null if there was nothing to commit.
+   */
+  async saveAgentProgress(
+    workDir: string,
+    feature: Feature,
+    branchName: string
+  ): Promise<string | null> {
+    try {
+      // Check for uncommitted changes
+      const { stdout: status } = await execAsync('git status --porcelain --untracked-files=all', {
+        cwd: workDir,
+        env: execEnv,
+      });
+
+      if (!status.trim()) {
+        logger.debug(`No uncommitted changes to save for feature ${feature.id}`);
+        return null;
+      }
+
+      logger.info(
+        `Saving agent progress for feature ${feature.id} (${status.trim().split('\n').length} files changed)`
+      );
+
+      // Stage all changes (same pattern as commitChanges)
+      await execAsync("git add -A -- ':!.automaker/' '.automaker/memory/'", {
+        cwd: workDir,
+        env: execEnv,
+      });
+
+      // Format staged files before committing
+      try {
+        const { stdout: stagedFiles } = await execAsync(
+          "git diff --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.json' '*.css' '*.md'",
+          { cwd: workDir, env: execEnv }
+        );
+        const files = stagedFiles.trim().split('\n').filter(Boolean);
+        if (files.length > 0) {
+          await execAsync(
+            `npx prettier --ignore-path /dev/null --write ${files.map((f) => `"${f}"`).join(' ')}`,
+            { cwd: workDir, env: execEnv }
+          );
+          await execAsync("git add -A -- ':!.automaker/' '.automaker/memory/'", {
+            cwd: workDir,
+            env: execEnv,
+          });
+        }
+      } catch {
+        // Non-fatal: formatting failure shouldn't block progress save
+      }
+
+      // Create WIP commit
+      const title = feature.title || 'agent work';
+      const commitMessage = `wip: ${title}\n\nAgent progress checkpoint — interrupted before completion.\nFeature ID: ${feature.id}`;
+      await execFileAsync('git', ['commit', '--no-verify', '-m', commitMessage], {
+        cwd: workDir,
+        env: execEnv,
+      });
+
+      // Get commit hash
+      const { stdout: hashOutput } = await execAsync('git rev-parse HEAD', {
+        cwd: workDir,
+        env: execEnv,
+      });
+      const hash = hashOutput.trim().substring(0, 8);
+
+      // Push to remote
+      try {
+        await execAsync(`git push origin ${branchName}`, {
+          cwd: workDir,
+          env: execEnv,
+        });
+        logger.info(
+          `Saved agent progress for feature ${feature.id}: commit ${hash}, pushed to ${branchName}`
+        );
+      } catch (pushError) {
+        logger.warn(
+          `Progress committed (${hash}) but push failed: ${pushError instanceof Error ? pushError.message : String(pushError)}`
+        );
+      }
+
+      this.trackOperation('commit', feature.id, true);
+      return hash;
+    } catch (error) {
+      logger.warn(
+        `Failed to save agent progress for feature ${feature.id}: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return null;
+    }
+  }
+
+  /**
    * Run the complete git workflow after feature completion.
    * Operations are best-effort: failures in later steps don't prevent earlier steps from succeeding.
    *


### PR DESCRIPTION
## Summary

- When agents hit `max_turns`, they left uncommitted work stranded in worktrees. Retry agents started from scratch, wasting all progress.
- Added `GitWorkflowService.saveAgentProgress()` — a lightweight WIP commit+push that runs before the retry logic
- Retry agents now inherit committed state and pick up mid-implementation instead of re-reading the entire codebase

This directly fixes the Knowledge Hive agents that kept hitting turn limits on cross-package features (types → utils → server). Previously needed manual intervention to commit worktree progress; now it's automatic.

## Test plan

- [ ] Build passes: `npm run build:server`
- [ ] Agent hitting max_turns creates a WIP commit in the worktree
- [ ] Retry agent starts with the committed progress visible
- [ ] No regression: successful completions still use the normal git workflow
- [ ] Progress save failure doesn't block the retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from turn limit errors: Agent progress is now automatically saved when maximum turn limits are reached, ensuring work is preserved before retry operations continue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->