### PR TITLE
feat: knowledge API routes for search, stats, and rebuild

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -181,6 +181,7 @@ import { createAvaRoutes } from './routes/ava/index.js';
 import { createLinearRoutes } from './routes/linear/index.js';
 import { createTwitchRoutes } from './routes/twitch.js';
 import { createVoiceRoutes } from './routes/voice/index.js';
+import { createKnowledgeRoutes } from './routes/knowledge/index.js';
 import { LinearAgentService } from './services/linear-agent-service.js';
 import { LinearAgentRouter } from './services/linear-agent-router.js';
 import { MAX_SYSTEM_CONCURRENCY } from '@automaker/types';
@@ -424,6 +425,10 @@ const twitchSettings = {
   botUsername: process.env.TWITCH_BOT_USERNAME,
 };
 const twitchService = new TwitchService(twitchSettings, REPO_ROOT);
+
+// Initialize Knowledge Store Service for chunked retrieval
+import { KnowledgeStoreService } from './services/knowledge-store-service.js';
+const knowledgeStoreService = new KnowledgeStoreService();
 
 // Initialize Escalation Router
 const escalationRouter = getEscalationRouter();
@@ -1052,6 +1057,35 @@ specGenerationMonitor.startMonitoring();
   await agentService.initialize();
   logger.info('Agent service initialized');
 
+  // Initialize Knowledge Store Service for configured project paths
+  if (knowledgeStoreService) {
+    try {
+      const settings = await settingsService.getGlobalSettings();
+      const projectPaths = [
+        ...(settings.autoModeAlwaysOn?.projects?.map((p) => p.projectPath) ?? []),
+      ];
+      const uniquePaths = [...new Set(projectPaths)];
+
+      for (const projectPath of uniquePaths) {
+        try {
+          knowledgeStoreService.initialize(projectPath);
+          logger.info(`[KNOWLEDGE] Initialized knowledge store for ${projectPath}`);
+
+          const stats = knowledgeStoreService.getStats();
+          if (stats.totalChunks === 0) {
+            logger.info(`[KNOWLEDGE] Rebuilding index for ${projectPath} (no existing data)`);
+            knowledgeStoreService.rebuildIndex(projectPath);
+            logger.info(`[KNOWLEDGE] Index rebuild complete for ${projectPath}`);
+          }
+        } catch (err) {
+          logger.warn(`[KNOWLEDGE] Failed to initialize knowledge store for ${projectPath}:`, err);
+        }
+      }
+    } catch (err) {
+      logger.warn('[KNOWLEDGE] Failed to initialize knowledge stores:', err);
+    }
+  }
+
   // Reconcile stuck features (in_progress, interrupted, pipeline_* with no running agent)
   try {
     const settings = await settingsService.getGlobalSettings();
@@ -1420,6 +1454,12 @@ app.use('/api/ai', createAIRoutes());
 app.use('/api/notes', createNotesRoutes(events));
 app.use('/api/twitch', createTwitchRoutes(twitchService, events, featureLoader));
 app.use('/api/voice', createVoiceRoutes(voiceService, events));
+
+// Knowledge store routes (chunked retrieval)
+if (knowledgeStoreService) {
+  app.use('/api/knowledge', createKnowledgeRoutes(knowledgeStoreService));
+  logger.info('Knowledge store routes mounted at /api/knowledge');
+}
 
 // Create HTTP server
 const server = createServer(app);

--- a/apps/server/src/routes/knowledge/index.ts
+++ b/apps/server/src/routes/knowledge/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Knowledge routes - HTTP API for knowledge store management
+ */
+
+import { Router } from 'express';
+import { createSearchHandler } from './routes/search.js';
+import { createStatsHandler } from './routes/stats.js';
+import { createRebuildHandler } from './routes/rebuild.js';
+
+export function createKnowledgeRoutes(knowledgeStoreService: any): Router {
+  const router = Router();
+
+  router.post('/search', createSearchHandler(knowledgeStoreService));
+  router.post('/stats', createStatsHandler(knowledgeStoreService));
+  router.post('/rebuild', createRebuildHandler(knowledgeStoreService));
+
+  return router;
+}

--- a/apps/server/src/routes/knowledge/routes/rebuild.ts
+++ b/apps/server/src/routes/knowledge/routes/rebuild.ts
@@ -1,0 +1,41 @@
+/**
+ * POST /rebuild endpoint - Rebuild knowledge store index
+ */
+
+import type { Request, Response } from 'express';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('KnowledgeRoutes');
+
+interface RebuildRequest {
+  projectPath: string;
+}
+
+export function createRebuildHandler(knowledgeStoreService: any) {
+  return (req: Request, res: Response): void => {
+    try {
+      const { projectPath } = req.body as RebuildRequest;
+
+      if (!projectPath) {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+
+      logger.info('Rebuild index request', { projectPath });
+
+      // Initialize for this project path (re-initializes if different)
+      knowledgeStoreService.initialize(projectPath);
+
+      knowledgeStoreService.rebuildIndex(projectPath);
+      const stats = knowledgeStoreService.getStats();
+
+      res.json({ success: true, stats });
+    } catch (error) {
+      logger.error('Rebuild index failed:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}

--- a/apps/server/src/routes/knowledge/routes/search.ts
+++ b/apps/server/src/routes/knowledge/routes/search.ts
@@ -1,0 +1,53 @@
+/**
+ * POST /search endpoint - Search knowledge store
+ */
+
+import type { Request, Response } from 'express';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('KnowledgeRoutes');
+
+interface SearchRequest {
+  projectPath: string;
+  query: string;
+  maxResults?: number;
+  maxTokens?: number;
+  sourceTypes?: string[];
+}
+
+export function createSearchHandler(knowledgeStoreService: any) {
+  return (req: Request, res: Response): void => {
+    try {
+      const { projectPath, query, maxResults, maxTokens, sourceTypes } = req.body as SearchRequest;
+
+      if (!projectPath) {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+
+      if (!query) {
+        res.status(400).json({ success: false, error: 'query is required' });
+        return;
+      }
+
+      logger.debug('Search request', { projectPath, query, maxResults, maxTokens, sourceTypes });
+
+      // Initialize for this project path (re-initializes if different)
+      knowledgeStoreService.initialize(projectPath);
+
+      const results = knowledgeStoreService.search(projectPath, query, {
+        maxResults,
+        maxTokens,
+        sourceTypes: sourceTypes ?? 'all',
+      });
+
+      res.json({ success: true, results });
+    } catch (error) {
+      logger.error('Search failed:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}

--- a/apps/server/src/routes/knowledge/routes/stats.ts
+++ b/apps/server/src/routes/knowledge/routes/stats.ts
@@ -1,0 +1,40 @@
+/**
+ * POST /stats endpoint - Get knowledge store statistics
+ */
+
+import type { Request, Response } from 'express';
+import { createLogger } from '@automaker/utils';
+
+const logger = createLogger('KnowledgeRoutes');
+
+interface StatsRequest {
+  projectPath: string;
+}
+
+export function createStatsHandler(knowledgeStoreService: any) {
+  return (req: Request, res: Response): void => {
+    try {
+      const { projectPath } = req.body as StatsRequest;
+
+      if (!projectPath) {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+
+      logger.debug('Stats request', { projectPath });
+
+      // Initialize for this project path (re-initializes if different)
+      knowledgeStoreService.initialize(projectPath);
+
+      const stats = knowledgeStoreService.getStats();
+
+      res.json({ success: true, stats });
+    } catch (error) {
+      logger.error('Get stats failed:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `POST /api/knowledge/search` — BM25 FTS5 search with token budget enforcement
- Adds `POST /api/knowledge/stats` — chunk counts by source type and db file size
- Adds `POST /api/knowledge/rebuild` — trigger full re-ingestion, returns updated stats
- Wires knowledge routes into server `index.ts`
- Initializes `KnowledgeStoreService` on server startup

## Test plan

- [ ] `npm run build:server` passes
- [ ] `npm run test:server` passes
- [ ] `npm run format:check` passes
- [ ] POST /api/knowledge/search returns ranked chunks
- [ ] POST /api/knowledge/stats returns db metrics
- [ ] POST /api/knowledge/rebuild triggers re-ingestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Knowledge store API endpoints available at /api/knowledge:
    * Search indexed content with customizable parameters (query, result limits, token limits, source filtering)
    * Retrieve indexing statistics for projects
    * Manually trigger index rebuilds
  * Automatic per-project index initialization and rebuilding on server startup, with per-project status and error logging
  * Endpoints validate inputs and return clear success/error responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->