### PR TITLE
fix: wire KnowledgeStoreService into LeadEngineerService

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -764,6 +764,9 @@ const { ContextFidelityService } = await import('./services/context-fidelity-ser
 const contextFidelityService = new ContextFidelityService();
 leadEngineerService.setContextFidelityService(contextFidelityService);
 
+// Wire KnowledgeStoreService for FTS5-powered reflection search
+leadEngineerService.setKnowledgeStoreService(knowledgeStoreService);
+
 await leadEngineerService.initialize();
 
 // Wire Lead Engineer service into auto-mode for delegated feature execution

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -1456,6 +1456,7 @@ export class LeadEngineerService {
   private prFeedbackService?: PRFeedbackService;
   private checkpointService?: PipelineCheckpointService;
   private contextFidelityService?: ContextFidelityService;
+  private knowledgeStoreService?: KnowledgeStoreService;
 
   constructor(
     private events: EventEmitter,
@@ -1479,6 +1480,13 @@ export class LeadEngineerService {
    */
   setContextFidelityService(service: ContextFidelityService): void {
     this.contextFidelityService = service;
+  }
+
+  /**
+   * Set knowledge store service for FTS5-powered reflection search.
+   */
+  setKnowledgeStoreService(service: KnowledgeStoreService): void {
+    this.knowledgeStoreService = service;
   }
 
   /**
@@ -1755,6 +1763,7 @@ export class LeadEngineerService {
         prFeedbackService: this.prFeedbackService,
         checkpointService: this.checkpointService,
         contextFidelityService: this.contextFidelityService,
+        knowledgeStoreService: this.knowledgeStoreService,
       };
 
       // Read workflow settings to control pipeline features


### PR DESCRIPTION
## Summary
- Add `setKnowledgeStoreService()` setter on `LeadEngineerService`
- Wire `knowledgeStoreService` into `ProcessorServiceContext` for processor access
- Connect the service in `index.ts` during initialization

The squash merge of #1016 missed the final wiring commit — without this, the FTS5 reflection search path in `ExecuteProcessor` is dead code.

## Test plan
- [ ] `npm run build:packages && npm run build:server` compiles cleanly
- [ ] Verify `knowledgeStoreService` is available in `ProcessorServiceContext` at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated knowledge store service to enable enhanced reflection search capabilities with FTS5-powered search and fallback to legacy methods when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->