### PR TITLE
fix: exclude non-backlog features from planSpec eligibility fallback

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -4742,7 +4742,12 @@ Format your response as a structured markdown document.`;
         // Those features have completed execution and should not be picked up again
         const isEligibleStatus =
           canonicalStatus === 'backlog' ||
-          (feature.planSpec?.status === 'approved' &&
+          (canonicalStatus !== 'done' &&
+            canonicalStatus !== 'verified' &&
+            canonicalStatus !== 'review' &&
+            canonicalStatus !== 'in_progress' &&
+            canonicalStatus !== 'blocked' &&
+            feature.planSpec?.status === 'approved' &&
             (feature.planSpec.tasksCompleted ?? 0) < (feature.planSpec.tasksTotal ?? 0));
 
         // Log ALL features with their eligibility status for debugging


### PR DESCRIPTION
## Summary
- Fixes auto-mode respawning agents on `done`/`verified` features when `planSpec.tasksCompleted < planSpec.tasksTotal`
- Adds explicit status exclusions (`done`, `verified`, `review`, `in_progress`, `blocked`) before the planSpec fallback check in `loadPendingFeatures()`
- Root cause: the `planSpec` eligibility OR-branch had no status guard, bypassing the `backlog` gate entirely

## Test plan
- [x] Standalone logic verification test (7 cases, all pass)
- [ ] CI: `npm run build:server` passes
- [ ] CI: `npm run format:check` passes
- [ ] Verify auto-mode no longer picks up done features in mythxengine project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the auto-mode feature selection logic to ensure only eligible pending features are automatically processed, preventing unintended execution of features in certain advanced states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->