### PR TITLE
docs: add Knowledge Store server reference page

### DIFF
--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,9 +5,9 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 95
-  referenced: 53
-  successfulFeatures: 53
+  loaded: 96
+  referenced: 54
+  successfulFeatures: 54
 ---
 # api
 

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -2608,3 +2608,42 @@ usageStats:
 - **Situation:** Confusion about dependency ownership in monorepo structure - types library is meant for TypeScript type exports only
 - **Root cause:** Separating types from runtime code prevents circular dependencies, allows types to be consumed by any package without pulling in database drivers. Types packages export type definitions, not executable code.
 - **How to avoid:** Gains: Clean separation of concerns, types can be installed without runtime dependencies. Losses: Need to manage dependencies in correct package
+
+#### [Gotcha] Fallback operators in disjunctive conditions create implicit permission pathways. The nullish coalescing operator (??) in `(feature.planSpec?.tasksCompleted ?? 0)` allowed stale planSpec data on terminal-status features to bypass the intended logic guard. (2026-02-24)
+- **Situation:** Features with status='done' but planSpec.tasksCompleted < planSpec.tasksTotal were incorrectly eligible for re-execution. The OR condition allowed any feature with an approved planSpec to pass through regardless of status.
+- **Root cause:** In systems using `condition1 OR (data.property ?? default)`, the fallback to default creates a state where invalid entities can pass through if the data property exists with certain values. The status guard alone is insufficient.
+- **How to avoid:** Explicit status exclusions add verbosity but prevent silent failures from stale data. Alternative of removing planSpec checks entirely would have broken the backlog-with-approved-plan fallback.
+
+#### [Pattern] Terminal state metadata staleness pattern: When features transition to terminal states (done, verified), their associated metadata (planSpec) is not invalidated/cleaned, creating a risk that stale metadata will influence eligibility logic in subsequent operations. (2026-02-24)
+- **Problem solved:** The bug manifested because planSpec could exist on done/verified features with tasksCompleted != tasksTotal, even though those features should never be eligible for auto-mode regardless of plan completion state.
+- **Why this works:** Cleaning up associated metadata on state transitions is often deferred. Systems using multiple data sources (status field + planSpec object) must protect against metadata outliving its validity.
+- **Trade-offs:** Defensive guards in eligibility logic are safer for backward compatibility with existing data but require developers to remember terminal states need special handling everywhere such metadata is checked.
+
+### Using explicit exclusion (blacklist of terminal statuses) rather than explicit inclusion (whitelist of allowed statuses) in OR-based eligibility logic when adding safety guards. (2026-02-24)
+- **Context:** The fix added status guards to the planSpec fallback condition by excluding terminal states rather than creating an allowedStatuses array.
+- **Why:** In a disjunctive eligibility check with multiple branches, adding new conditions via OR means new invalid cases can emerge if you only include known-good cases. Explicit exclusion of known-bad cases is more maintainable for the 'backlog OR (planSpec.approved AND ...) pattern because new statuses added to the system should naturally fall through unless explicitly allowed.
+- **Rejected:** Using `const ELIGIBLE_STATUSES = ['backlog']; if (!ELIGIBLE_STATUSES.includes(status) && planSpec.approved)...` - this inverts the logic and is harder to reason about in a disjunctive context.
+- **Trade-offs:** Explicit exclusion list is verbose (5 negation checks) but creates a clear firewall preventing unknown/future statuses from falling through. Inclusion would be more concise but risky for extensibility.
+- **Breaking if changed:** If new feature statuses are added (e.g., 'archived', 'cancelled') without adding them to the exclusion list, those features would incorrectly become eligible for auto-mode execution if they have approved planSpecs.
+
+### Rebase failures are non-blocking with graceful degradation - agents continue execution on stale base instead of failing (2026-02-24)
+- **Context:** Agent execution must rebase onto latest origin/main, but network/merge conflicts can prevent this
+- **Why:** Ensures agent execution resilience. A failed rebase is worse than executing on stale code (which still works). Preserves availability over consistency.
+- **Rejected:** Make rebase blocking - fail agent execution if rebase fails. This would improve consistency but reduce availability and cause cascading failures.
+- **Trade-offs:** Gained: High availability and resilience. Lost: Strict consistency guarantee - agents may execute against outdated code when rebase fails.
+- **Breaking if changed:** If changed to blocking: Agents will fail when merge conflicts exist instead of proceeding, causing outages during periods of rapid main merges.
+
+#### [Pattern] Rebase integrated at 3 execution points (executeFeature, executePipelineStep, followUpFeature) rather than single entry point (2026-02-24)
+- **Problem solved:** Multiple independent code paths trigger agent execution with different calling conventions
+- **Why this works:** Indicates execution paths don't converge at a common parent. Adding rebase at a single higher point would miss some paths. Three touchpoints guarantee all executions rebase regardless of entry point.
+- **Trade-offs:** Gained: Coverage of all paths. Lost: Code duplication (rebase logic appears 3 times). Maintenance burden if rebase logic changes.
+
+#### [Pattern] Detect merge conflicts specifically and abort rebase cleanly rather than treating all failures the same (2026-02-24)
+- **Problem solved:** Rebase can fail due to conflicts (merge required) or other reasons (network, permissions, etc)
+- **Why this works:** Conflicts are recoverable and expected during parallel development. Distinguishing them from hard failures allows proper logging and monitoring. Aborting cleans up worktree state automatically.
+- **Trade-offs:** Gained: Operational visibility into conflict frequency. Lost: Slightly more complex error handling code.
+
+#### [Pattern] Use emoji indicators (⚠️, ✓) and context tags in logs for quick visual parsing of rebase outcomes during agent execution (2026-02-24)
+- **Problem solved:** Rebase happens silently during agent execution in background processes/logs
+- **Why this works:** Non-blocking rebase means failures don't stop execution but become silent risks. Emoji + clear messages enable ops/developers to scan logs quickly for rebase health. Indicates this is expected to fail sometimes in production.
+- **Trade-offs:** Gained: Operational observability. Lost: Slightly more verbose logs. Assumes ops/developers actively monitor logs for rebase messages.

--- a/.automaker/memory/cost-optimization.md
+++ b/.automaker/memory/cost-optimization.md
@@ -1,0 +1,19 @@
+---
+tags: [cost-optimization]
+summary: cost-optimization implementation decisions and patterns
+relevantTo: [cost-optimization]
+importance: 0.7
+relatedFiles: []
+usageStats:
+  loaded: 0
+  referenced: 0
+  successfulFeatures: 0
+---
+# cost-optimization
+
+### Use Anthropic Haiku model (cheapest tier) for knowledge summarization instead of Claude 3.5 Sonnet or other capable models (2026-02-24)
+- **Context:** Compacting knowledge categories by summarizing their content when they exceed size threshold
+- **Why:** Summarization is a one-time-per-category operation, not latency-critical, and Haiku is sufficient quality for lossy compression of knowledge. At scale with many categories, cost difference is significant (Haiku ~7x cheaper than Sonnet)
+- **Rejected:** More capable models (better summary quality, but 7-10x higher cost per operation; doesn't justify ROI for lossy compression)
+- **Trade-offs:** Slightly lower summary quality, but acceptable since goal is aggressive compression not fidelity; dramatic cost savings
+- **Breaking if changed:** Using a much cheaper model could produce summaries too lossy (losing critical details); using a much more expensive model wastes budget on an operation where summary quality is secondary to compression ratio

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 311
-  referenced: 163
-  successfulFeatures: 163
+  loaded: 312
+  referenced: 165
+  successfulFeatures: 165
 ---
 # gotchas
 
@@ -277,3 +277,8 @@ usageStats:
 - **Situation:** Initial import attempt using default import failed - required investigation and switch to namespace import pattern
 - **Root cause:** better-sqlite3 uses named exports, not a default export. The library's actual module structure doesn't match the typical CommonJS default pattern.
 - **How to avoid:** Namespace import is more verbose but matches library's actual exports. Using wrong pattern causes runtime or type errors.
+
+#### [Gotcha] Turbo's shared cache references package paths from different worktrees, causing 'Cannot find module' errors that don't reflect actual code problems (2026-02-24)
+- **Situation:** Build fails with TypeScript dependency resolution errors when running in a feature worktree after another worktree has built
+- **Root cause:** Turbo's cache layer stores absolute paths but git worktrees are separate checkout locations. Cache from one worktree path becomes invalid in another.
+- **How to avoid:** None - this is a blocker. Workaround: force builds, clear cache, or build from main branch.

--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -6,8 +6,8 @@ importance: 0.5
 relatedFiles: []
 usageStats:
   loaded: 22
-  referenced: 10
-  successfulFeatures: 10
+  referenced: 11
+  successfulFeatures: 11
 ---
 # GTM Signal Intelligence & Content Operations
 

--- a/.automaker/memory/testing.md
+++ b/.automaker/memory/testing.md
@@ -783,3 +783,10 @@ usageStats:
 - **Situation:** Test manually set localStorage data but expected it to be immediately reflected in store state; localStorage write != store hydration
 - **Root cause:** localStorage.setItem() writes to browser storage, but Zustand's persist middleware only reads and hydrates on first store access (hook or getState()). Writing to storage doesn't retroactively hydrate already-instantiated stores.
 - **How to avoid:** Test must use Playwright page.evaluate() to set localStorage before any component mounts, then verify via component or direct store access after mount. Simpler test would be: mount component → localStorage auto-hydrates via middleware.
+
+### Verification through comprehensive unit tests rather than full build validation when worktree environment has dependency resolution issues. (2026-02-24)
+- **Context:** The fix couldn't be verified via `npm run build:server` due to pre-existing TypeScript module resolution issues with `@protolabs-ai/*` packages in the worktree, but logic correctness was proven through 7 test cases covering all eligibility scenarios.
+- **Why:** Eligibility logic is stateless and deterministic - it can be verified independently of the build environment. Unit tests on pure functions provide stronger confidence for logic correctness than environment-dependent builds would.
+- **Rejected:** Waiting for or attempting to fix the worktree build environment, or assuming the code is correct without explicit test coverage.
+- **Trade-offs:** Unit test verification is faster and more reliable for logic changes but doesn't catch integration issues or type-system problems. The worktree's build issues masked a potential type safety problem.
+- **Breaking if changed:** If you remove the unit tests and rely only on build verification, you lose visibility into logic correctness when environments are unstable. However, build verification should still be required before merging.

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,7 @@ DevOps documentation in [`docs/infra/`](./infra/):
 | [Route Organization](./server/route-organization.md) | Express route structure and patterns             |
 | [Providers](./server/providers.md)                   | AI provider architecture (Claude, Cursor, Codex) |
 | [Utilities](./server/utilities.md)                   | Server utility functions reference               |
+| [Knowledge Store](./server/knowledge-store.md)       | SQLite FTS5 knowledge base for agent context     |
 
 ## Authority System
 

--- a/docs/server/index.md
+++ b/docs/server/index.md
@@ -12,6 +12,7 @@ The server is an Express 5 application with WebSocket streaming, organized into 
 - **[Providers](./providers)** — AI provider abstraction (Claude, Cursor, Codex, OpenCode)
 - **[Utilities](./utilities)** — Server utility functions and helpers
 - **[Maintenance Scheduler](./maintenance-scheduler)** — Background task scheduling, cron overrides, and API
+- **[Knowledge Store](./knowledge-store)** — SQLite FTS5 knowledge base for agent context retrieval
 
 ## Key Technologies
 

--- a/docs/server/knowledge-store.md
+++ b/docs/server/knowledge-store.md
@@ -1,0 +1,294 @@
+# Knowledge store
+
+The Knowledge Store is a persistent SQLite-based full-text search engine that indexes project documentation, agent reflections, and execution outputs. It enables agents to retrieve relevant context from previous work before executing features.
+
+## Overview
+
+Each project gets its own SQLite database at `.automaker/knowledge.db`. The store uses FTS5 (Full-Text Search 5) with BM25 ranking to provide fast, relevance-scored search across all indexed content.
+
+**Key characteristics:**
+
+- **Per-project isolation** — Each project has its own database
+- **WAL mode** — Write-Ahead Logging for safe concurrent reads during agent execution
+- **Automatic FTS5 sync** — Triggers keep the search index in sync with source data
+- **Token-budgeted results** — Search results are trimmed to fit within configurable token limits
+- **Usage tracking** — Retrieval counts and timestamps enable future pruning
+
+## API endpoints
+
+All endpoints use `POST` with JSON bodies. Base path: `/api/knowledge`.
+
+### POST /api/knowledge/search
+
+Search the knowledge store using FTS5 BM25 ranking.
+
+**Request:**
+
+| Field         | Type                | Default  | Description              |
+| ------------- | ------------------- | -------- | ------------------------ |
+| `projectPath` | `string`            | required | Absolute path to project |
+| `query`       | `string`            | required | FTS5 search query        |
+| `maxResults`  | `number`            | `20`     | Maximum chunks to return |
+| `maxTokens`   | `number`            | `8000`   | Token budget for results |
+| `sourceTypes` | `string[] \| 'all'` | `'all'`  | Filter by source type    |
+
+**Response:**
+
+```typescript
+{
+  success: boolean;
+  results: Array<{
+    chunk: KnowledgeChunk;
+    score: number; // BM25 score (lower = more relevant)
+  }>;
+}
+```
+
+**FTS5 query syntax:**
+
+```
+"exact phrase"         // Phrase search
+word1 AND word2        // Boolean AND
+word1 OR word2         // Boolean OR
+NOT word1              // Negation
+word*                  // Prefix matching
+```
+
+### POST /api/knowledge/stats
+
+Get knowledge store statistics.
+
+**Request:**
+
+| Field         | Type     | Description              |
+| ------------- | -------- | ------------------------ |
+| `projectPath` | `string` | Absolute path to project |
+
+**Response:**
+
+```typescript
+{
+  success: boolean;
+  stats: {
+    totalChunks: number;
+    totalSizeBytes: number;     // Database file size
+    uniqueSources: number;
+    sourceTypeBreakdown: Record<KnowledgeSourceType, number>;
+    lastUpdated?: string;       // ISO 8601
+    dbPath: string;
+  };
+}
+```
+
+### POST /api/knowledge/rebuild
+
+Rebuild the FTS5 index from source data.
+
+**Request:**
+
+| Field         | Type     | Description              |
+| ------------- | -------- | ------------------------ |
+| `projectPath` | `string` | Absolute path to project |
+
+**Response:** Same shape as `/stats`.
+
+## Source types
+
+The store indexes 6 types of knowledge chunks:
+
+| Source Type    | Importance | Status  | Description                          |
+| -------------- | ---------- | ------- | ------------------------------------ |
+| `reflection`   | 0.8        | Active  | Feature `reflection.md` files        |
+| `agent_output` | 0.6        | Active  | Last 2000 chars of `agent-output.md` |
+| `file`         | 0.5        | Planned | Project documentation files          |
+| `url`          | 0.5        | Planned | External documentation links         |
+| `manual`       | 0.5        | Planned | Manually added knowledge             |
+| `generated`    | 0.5        | Planned | LLM-generated summaries              |
+
+## SQLite schema
+
+### chunks table
+
+```sql
+CREATE TABLE chunks (
+  id TEXT PRIMARY KEY,
+  source_type TEXT NOT NULL,
+  source_file TEXT NOT NULL,
+  project_path TEXT NOT NULL,
+  chunk_index INTEGER NOT NULL,
+  heading TEXT,
+  content TEXT NOT NULL,
+  tags TEXT,                     -- JSON array
+  importance REAL NOT NULL DEFAULT 0.5,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  last_retrieved_at TEXT,
+  retrieval_count INTEGER NOT NULL DEFAULT 0
+)
+```
+
+### FTS5 virtual table
+
+```sql
+CREATE VIRTUAL TABLE chunks_fts USING fts5(
+  heading,
+  content,
+  content=chunks,
+  content_rowid=rowid
+)
+```
+
+Three automatic triggers (`chunks_ai`, `chunks_au`, `chunks_ad`) keep the FTS5 index in sync on every INSERT, UPDATE, and DELETE.
+
+## Service methods
+
+### Initialization
+
+```typescript
+initialize(projectPath: string): void
+```
+
+Creates `.automaker/knowledge.db` if missing, opens connection, creates schema on first run. Called automatically by search and stats operations.
+
+### Search
+
+**`search(projectPath, query, options?)`** — General FTS5 search with token budget.
+
+```typescript
+search(
+  projectPath: string,
+  query: string,
+  opts?: {
+    maxResults?: number;               // Default: 20
+    maxTokens?: number;                // Default: 8000
+    sourceTypes?: KnowledgeSourceType[] | 'all';
+  }
+): KnowledgeSearchResult[]
+```
+
+**`searchReflections(projectPath, query, maxResults?)`** — Convenience wrapper filtering to `reflection` and `agent_output` types with 3000 token budget. Sanitizes FTS5 special characters automatically.
+
+**`findSimilarChunks(projectPath, text, sourceFile?, maxResults?)`** — Deduplication search. Sanitizes input, truncates to first 20 words, does not update retrieval metrics.
+
+### Ingestion
+
+**`ingestReflections(projectPath)`** — Scans `.automaker/features/{id}/reflection.md`, creates chunks with importance 0.8. Returns count indexed.
+
+**`ingestAgentOutputs(projectPath)`** — Scans `.automaker/features/{id}/agent-output.md`, indexes last 2000 characters with importance 0.6. Returns count indexed.
+
+### Maintenance
+
+**`rebuildIndex(projectPath)`** — Executes FTS5 rebuild command. Makes newly ingested content searchable.
+
+**`compactCategory(projectPath, categoryFile, threshold?)`** — Reads `.automaker/memory/{categoryFile}.md`, summarizes with Haiku if over 50,000 tokens. Used by auto-mode after learning extraction.
+
+**`pruneStaleChunks(projectPath)`** — Deletes chunks with zero retrievals older than 90 days. Returns count deleted.
+
+## Integration with agents
+
+### LeadEngineerService (EXECUTE state)
+
+When a feature enters the EXECUTE state, the Lead Engineer searches for relevant prior work:
+
+```
+Feature enters EXECUTE state
+  → Build query from feature title + description
+  → searchReflections(projectPath, query, 5)
+  → Inject results as "Lessons from Similar Features" in agent prompt
+  → Fallback: legacy same-epic sibling search if FTS5 returns empty
+```
+
+This gives agents context from previous solutions across the entire project, not just the current epic.
+
+### AutoModeService (post-execution)
+
+After feature completion, auto-mode extracts learnings and checks memory file sizes:
+
+```
+Feature completes
+  → Extract learnings into .automaker/memory/{category}.md
+  → compactCategory() if category exceeds 50,000 tokens
+  → Haiku summarizes while preserving key patterns
+```
+
+### Server wiring
+
+In `apps/server/src/index.ts`:
+
+```typescript
+const knowledgeStoreService = new KnowledgeStoreService();
+app.use('/api/knowledge', createKnowledgeRoutes(knowledgeStoreService));
+leadEngineerService.setKnowledgeStoreService(knowledgeStoreService);
+```
+
+## Types
+
+All types are defined in `libs/types/src/knowledge.ts`:
+
+```typescript
+type KnowledgeSourceType = 'file' | 'url' | 'manual' | 'generated' | 'reflection' | 'agent_output';
+
+interface KnowledgeChunk {
+  id: string;
+  sourceType: KnowledgeSourceType;
+  sourceFile: string;
+  projectPath: string;
+  chunkIndex: number;
+  heading?: string;
+  content: string;
+  tags?: string[];
+  importance: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface KnowledgeSearchResult {
+  chunk: KnowledgeChunk;
+  score: number;
+}
+
+interface KnowledgeStoreStats {
+  totalChunks: number;
+  totalSizeBytes: number;
+  uniqueSources: number;
+  sourceTypeBreakdown: Record<KnowledgeSourceType, number>;
+  lastUpdated?: string;
+  dbPath: string;
+}
+```
+
+## Database files
+
+```
+{projectPath}/.automaker/knowledge.db       # Main database
+{projectPath}/.automaker/knowledge.db-wal   # Write-ahead log
+{projectPath}/.automaker/knowledge.db-shm   # Shared memory
+```
+
+The WAL and SHM files are created automatically when WAL mode is enabled. They are safe to delete when the database is not in use — SQLite recreates them on next open.
+
+## Configuration
+
+All settings are currently hard-coded:
+
+| Setting                 | Default                   | Location                     |
+| ----------------------- | ------------------------- | ---------------------------- |
+| Database path           | `.automaker/knowledge.db` | `knowledge-store-service.ts` |
+| WAL mode                | Enabled                   | `knowledge-store-service.ts` |
+| Compaction threshold    | 50,000 tokens             | `knowledge-store-service.ts` |
+| Prune window            | 90 days                   | `knowledge-store-service.ts` |
+| Default max results     | 20                        | `knowledge-store-service.ts` |
+| Default max tokens      | 8,000                     | `knowledge-store-service.ts` |
+| Reflection importance   | 0.8                       | `knowledge-store-service.ts` |
+| Agent output importance | 0.6                       | `knowledge-store-service.ts` |
+
+## Key files
+
+| File                                                  | Purpose            |
+| ----------------------------------------------------- | ------------------ |
+| `apps/server/src/services/knowledge-store-service.ts` | Main service       |
+| `libs/types/src/knowledge.ts`                         | Type definitions   |
+| `apps/server/src/routes/knowledge/index.ts`           | Route registration |
+| `apps/server/src/routes/knowledge/routes/search.ts`   | Search endpoint    |
+| `apps/server/src/routes/knowledge/routes/stats.ts`    | Stats endpoint     |
+| `apps/server/src/routes/knowledge/routes/rebuild.ts`  | Rebuild endpoint   |


### PR DESCRIPTION
## Summary
- Adds `docs/server/knowledge-store.md` documenting the SQLite FTS5 knowledge base
- Covers API endpoints, schema, source types, service methods, and agent integration
- Updates server index and docs README with the new page
- Includes memory file updates from agent work

## Test plan
- [ ] VitePress build passes (docs page renders)
- [ ] Links in server index and README resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the Knowledge Store feature, including API reference, query syntax, configuration details, and integration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->