### PR TITLE
fix: pwa title and tree-kill ESM bundle crash

### DIFF
--- a/apps/ui/src/hooks/use-browser-notifications.ts
+++ b/apps/ui/src/hooks/use-browser-notifications.ts
@@ -12,7 +12,7 @@ import { useAppStore } from '@/store/app-store';
 import { getHttpApiClient } from '@/lib/http-api-client';
 import type { ActionableItem } from '@protolabs-ai/types';
 
-const BASE_TITLE = 'Automaker';
+const BASE_TITLE = 'protoLabs.studio';
 
 /**
  * Mount at app root to enable browser-level notification channels.

--- a/libs/git-utils/tsup.config.ts
+++ b/libs/git-utils/tsup.config.ts
@@ -9,5 +9,5 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
-  external: [/^@automaker\//],
+  external: [/^@protolabs-ai\//, 'tree-kill'],
 });


### PR DESCRIPTION
## Summary

- Fix PWA install prompt showing "Install Automaker" instead of "Install protoLabs.studio" — `BASE_TITLE` in `use-browser-notifications.ts` was still "Automaker"
- Fix `Dynamic require of "child_process" is not supported` crash by marking `tree-kill` as external in git-utils tsup config (CJS package can't be bundled into ESM)
- Fix stale `@automaker` regex in git-utils tsup external pattern (missed by sed since regex patterns aren't string literals)

## Test plan

- [ ] Tab title shows "protoLabs.studio" (or "(N) protoLabs.studio" with pending items)
- [ ] PWA install prompt says "Install protoLabs.studio"
- [ ] Dev server starts without tree-kill crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)