### PR TITLE
fix: p0 ceremony data integrity and observability fixes

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1089,6 +1089,24 @@ specGenerationMonitor.startMonitoring();
     }
   }
 
+  // Wire reflection completion → knowledge store reindex (keeps FTS5 search up-to-date)
+  if (knowledgeStoreService) {
+    events.subscribe((type, payload) => {
+      if (type === 'feature:reflection:complete') {
+        const data = payload as { projectPath?: string };
+        if (data.projectPath) {
+          try {
+            knowledgeStoreService.ingestReflections(data.projectPath);
+            knowledgeStoreService.rebuildIndex(data.projectPath);
+            logger.info(`[KNOWLEDGE] Reindexed reflections for ${data.projectPath}`);
+          } catch (err) {
+            logger.warn('[KNOWLEDGE] Failed to reindex reflections:', err);
+          }
+        }
+      }
+    });
+  }
+
   // Reconcile stuck features (in_progress, interrupted, pipeline_* with no running agent)
   try {
     const settings = await settingsService.getGlobalSettings();

--- a/apps/server/src/services/agent-scoring-service.ts
+++ b/apps/server/src/services/agent-scoring-service.ts
@@ -33,7 +33,7 @@ export class AgentScoringService {
       if (type === 'feature:status-changed') {
         const data = payload as {
           featureId: string;
-          oldStatus?: string;
+          previousStatus?: string;
           newStatus?: string;
           projectPath?: string;
         };
@@ -41,7 +41,7 @@ export class AgentScoringService {
           void this.handleStatusChanged(
             data.projectPath,
             data.featureId,
-            data.oldStatus,
+            data.previousStatus,
             data.newStatus
           );
         }

--- a/apps/server/src/services/ceremony-service.ts
+++ b/apps/server/src/services/ceremony-service.ts
@@ -464,9 +464,11 @@ export class CeremonyService {
       return;
     }
 
-    const channelId = ceremonySettings.contentBriefChannelId;
+    const channelId = ceremonySettings.contentBriefChannelId || ceremonySettings.discordChannelId;
     if (!channelId) {
-      logger.debug('No contentBriefChannelId configured, skipping content brief');
+      logger.debug(
+        'No contentBriefChannelId or discordChannelId configured, skipping content brief'
+      );
       return;
     }
 
@@ -1575,7 +1577,7 @@ ${summary}
     } catch {
       // No projects dir
     }
-    throw new Error('No Linear project ID found for this project');
+    return '';
   }
 
   /**

--- a/apps/server/src/services/completion-detector-service.ts
+++ b/apps/server/src/services/completion-detector-service.ts
@@ -203,6 +203,7 @@ export class CompletionDetectorService {
     milestone.status = 'completed';
     await this.projectService!.updateProject(projectPath, projectSlug, {
       status: project.status,
+      milestones: project.milestones,
     });
 
     // Aggregate stats

--- a/libs/utils/src/memory-loader.ts
+++ b/libs/utils/src/memory-loader.ts
@@ -10,6 +10,9 @@
  */
 
 import path from 'path';
+import { createLogger } from './logger.js';
+
+const logger = createLogger('MemoryLoader');
 
 /**
  * File system module interface (compatible with secureFs)
@@ -589,9 +592,7 @@ export async function appendLearning(
   dedupChecker?: DedupChecker,
   indexRebuilder?: IndexRebuilder
 ): Promise<void> {
-  console.log(
-    `[MemoryLoader] appendLearning called: category=${learning.category}, type=${learning.type}`
-  );
+  logger.debug(`appendLearning called: category=${learning.category}, type=${learning.type}`);
   const memoryDir = getMemoryDir(projectPath);
   // Sanitize category name: lowercase, replace spaces with hyphens, remove special chars
   const sanitizedCategory = learning.category
@@ -605,9 +606,7 @@ export async function appendLearning(
   if (dedupChecker) {
     const isDuplicate = await dedupChecker(projectPath, learning, fileName);
     if (isDuplicate) {
-      console.log(
-        `[MemoryLoader] Deduplicated learning: similar entry already exists in ${fileName}`
-      );
+      logger.debug(`Deduplicated learning: similar entry already exists in ${fileName}`);
       return;
     }
   }
@@ -620,10 +619,10 @@ export async function appendLearning(
       // File exists, append to it
       const formatted = formatLearning(learning);
       await fsModule.appendFile(filePath, '\n' + formatted);
-      console.log(`[MemoryLoader] Appended learning to existing file: ${fileName}`);
+      logger.debug(`Appended learning to existing file: ${fileName}`);
     } catch {
       // File doesn't exist, create it with frontmatter
-      console.log(`[MemoryLoader] Creating new memory file: ${fileName}`);
+      logger.debug(`Creating new memory file: ${fileName}`);
       const metadata: MemoryMetadata = {
         tags: [sanitizedCategory || 'general'],
         summary: `${learning.category} implementation decisions and patterns`,
@@ -719,6 +718,6 @@ Mistakes and edge cases to avoid. These are lessons learned from past issues.
 
     await fsModule.writeFile(path.join(memoryDir, 'gotchas.md'), gotchasContent);
 
-    console.log(`[MemoryLoader] Initialized memory folder at ${memoryDir}`);
+    logger.debug(`Initialized memory folder at ${memoryDir}`);
   }
 }


### PR DESCRIPTION
## Summary
- Fix milestone status persistence (in-memory only → persisted to project.json)
- Wire `feature:reflection:complete` → knowledge store reindex (FTS5 was stale all session)
- Fix AgentScoringService field name mismatch (`oldStatus` → `previousStatus`)
- `getLinearProjectId()` returns empty string instead of throwing (noisy logs)
- Content brief channel falls back to `discordChannelId` when no separate channel configured
- Replace 5 raw `console.log` calls in memory-loader with proper logger

## Test plan
- [x] `npm run build:packages` — 14/14 packages pass
- [x] `npm run test:server` — 1992 tests pass, 0 failures
- [ ] Trigger a ceremony via MCP and verify Discord delivery
- [ ] Verify milestone completion persists across server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic knowledge store indexing now triggers when reflections are completed

* **Improvements**
  * More flexible channel configuration for content briefs with fallback support
  * Enhanced error resilience for Linear project integration
  * Proper milestone list updates during completion workflows
  * Better logging visibility for memory operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->