### PR TITLE
feat: auto-detect file contention between project phases

### DIFF
--- a/apps/server/src/services/project-orchestration-service.ts
+++ b/apps/server/src/services/project-orchestration-service.ts
@@ -8,7 +8,7 @@
  * - Emits progress events for UI updates
  */
 
-import type { Feature, FeatureFactoryResult, Project } from '@protolabs-ai/types';
+import type { Feature, FeatureFactoryResult, Milestone, Phase, Project } from '@protolabs-ai/types';
 import { getProjectJsonPath } from '@protolabs-ai/platform';
 import { secureFs } from '@protolabs-ai/platform';
 import { phaseToFeatureDescription, slugify } from '@protolabs-ai/utils';
@@ -312,6 +312,90 @@ export async function orchestrateProjectFeatures(
               `Failed to set dependencies for phase ${phase.name}: ${getErrorMessage(err)}`
             );
           }
+        }
+      }
+    }
+
+    // Phase 2.5: Detect file contention and add sequential dependencies
+    events?.emit('project:features:progress', {
+      step: 'checking-file-contention',
+      message: 'Detecting file contention between phases',
+    });
+
+    // Build a list of all phases with their metadata
+    interface PhaseMetadata {
+      milestoneIndex: number;
+      milestone: Milestone;
+      phase: Phase;
+      featureId: string;
+      phaseKey: string;
+    }
+
+    const allPhases: PhaseMetadata[] = [];
+    for (let mi = 0; mi < project.milestones.length; mi++) {
+      const milestone = project.milestones[mi];
+      for (const phase of milestone.phases) {
+        const phaseKey = `${milestone.slug}:${phase.name}`;
+        const featureId = result.phaseFeatureMap[phaseKey];
+        if (featureId && phase.filesToModify && phase.filesToModify.length > 0) {
+          allPhases.push({
+            milestoneIndex: mi,
+            milestone,
+            phase,
+            featureId,
+            phaseKey,
+          });
+        }
+      }
+    }
+
+    // Check each pair of phases for file contention
+    for (let i = 0; i < allPhases.length; i++) {
+      for (let j = i + 1; j < allPhases.length; j++) {
+        const phaseA = allPhases[i];
+        const phaseB = allPhases[j];
+
+        // Check for file overlap
+        const filesA = phaseA.phase.filesToModify || [];
+        const filesB = phaseB.phase.filesToModify || [];
+        const sharedFiles = filesA.filter((file) => filesB.includes(file));
+
+        if (sharedFiles.length === 0) {
+          continue; // No overlap
+        }
+
+        // phaseA is always earlier than phaseB (since i < j in iteration order)
+        const earlierPhase = phaseA;
+        const laterPhase = phaseB;
+
+        // Check if there's already a dependency between them
+        const laterFeature = createdFeatures.get(laterPhase.phaseKey);
+        if (!laterFeature) continue;
+
+        const laterDeps = laterFeature.dependencies || [];
+        if (laterDeps.includes(earlierPhase.featureId)) {
+          continue; // Dependency already exists
+        }
+
+        // Add dependency: later phase depends on earlier phase
+        const updatedDeps = [...laterDeps, earlierPhase.featureId];
+        try {
+          await featureLoader.update(projectPath, laterPhase.featureId, {
+            dependencies: updatedDeps,
+          });
+
+          // Update in-memory feature
+          laterFeature.dependencies = updatedDeps;
+
+          // Log warning with the files that caused contention
+          const fileList = sharedFiles.join(', ');
+          console.warn(
+            `File contention detected: phase ${earlierPhase.phase.name} and phase ${laterPhase.phase.name} both modify ${fileList} — adding sequential dependency`
+          );
+        } catch (err) {
+          result.errors?.push(
+            `Failed to add file contention dependency between ${earlierPhase.phase.name} and ${laterPhase.phase.name}: ${getErrorMessage(err)}`
+          );
         }
       }
     }


### PR DESCRIPTION
## Summary

- After creating features from a project plan, scans `filesToModify` arrays across all phases for overlaps
- If two phases with no existing dependency share a file, automatically adds a sequential dependency (later → earlier)
- Logs a warning: `File contention detected: phase X and phase Y both modify <file> — adding sequential dependency`

## Context

During the Knowledge Hive pipeline, every feature touched `knowledge-store-service.ts`. Without explicit dependencies, auto-mode ran them in parallel causing merge conflicts. This phase detection catches that pattern at project creation time and prevents it.

This is Phase 3 of the Agent Workflow Reliability project (after #1027 dep gating and #1029 uncommitted guard).

## Test plan

- [ ] CI: build + test passes
- [ ] Create a project with two phases sharing a file and no dep → verify dep is auto-added
- [ ] Create a project with two phases sharing a file WITH existing dep → verify no duplicate dep

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic phase contention analysis to detect overlapping file modifications across project phases and intelligently establish sequential dependencies to prevent conflicts.

* **Improvements**
  * Enhanced error handling and logging for dependency management operations, providing better visibility into potential issues and dependency resolution failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->