### PR TITLE
feat: ceremony audit log with Discord delivery tracking

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -649,9 +649,13 @@ const { linearSyncService } = await import('./services/linear-sync-service.js');
 linearSyncService.initialize(events, settingsService, featureLoader, projectService);
 linearSyncService.start();
 
-// Initialize Ceremony Service for milestone completion ceremonies
+// Initialize Ceremony Audit Log and Ceremony Service
+const { CeremonyAuditLogService } = await import('./services/ceremony-audit-service.js');
+const ceremonyAuditLog = new CeremonyAuditLogService();
+
 const { ceremonyService } = await import('./services/ceremony-service.js');
 ceremonyService.initialize(events, settingsService, featureLoader, projectService, metricsService);
+ceremonyService.setAuditLog(ceremonyAuditLog);
 
 // Listen for retro improvements and create Linear issues when configured
 events.subscribe(async (type, payload) => {
@@ -898,15 +902,33 @@ eventHookService.initialize(
 
 // Bridge integration:discord events to Discord bot service
 // CeremonyService, IntegrationService, and ChangelogService emit these events
-// with { action: 'send_message', channelId, content } payloads
+// with { action: 'send_message', channelId, content, correlationId? } payloads
 events.subscribe(async (type, payload) => {
   if (type !== 'integration:discord') return;
-  const p = payload as { channelId?: string; content?: string; action?: string };
+  const p = payload as {
+    channelId?: string;
+    content?: string;
+    action?: string;
+    correlationId?: string;
+  };
   if (p.action !== 'send_message' || !p.channelId || !p.content) return;
   try {
     await discordBotService.sendToChannel(p.channelId, p.content);
+    // Track delivery receipt for ceremony audit log
+    if (p.correlationId) {
+      ceremonyAuditLog.updateDeliveryStatus(p.correlationId, 'delivered');
+    }
   } catch (error) {
     logger.error('Failed to deliver integration:discord event:', error);
+    // Track delivery failure for ceremony audit log
+    if (p.correlationId) {
+      ceremonyAuditLog.updateDeliveryStatus(
+        p.correlationId,
+        'failed',
+        undefined,
+        error instanceof Error ? error.message : String(error)
+      );
+    }
   }
 });
 
@@ -1433,7 +1455,7 @@ app.use(
 );
 app.use(
   '/api/ceremonies',
-  createCeremoniesRoutes(events, featureLoader, projectService, ceremonyService)
+  createCeremoniesRoutes(events, featureLoader, projectService, ceremonyService, ceremonyAuditLog)
 );
 app.use('/api/issues', createIssuesRoutes(events));
 app.use('/api/deploy', createDeployRoutes(autoModeService));

--- a/apps/server/src/routes/ceremonies/index.ts
+++ b/apps/server/src/routes/ceremonies/index.ts
@@ -2,6 +2,9 @@
  * Ceremony Routes
  *
  * POST /api/ceremonies/trigger — manually trigger a ceremony for a project/milestone.
+ * GET  /api/ceremonies/status — ceremony observability endpoint with delivery summary.
+ * GET  /api/ceremonies/log — audit log entries for ceremony events.
+ *
  * Loads project data, aggregates stats, and emits the appropriate event so
  * CeremonyService picks it up naturally.
  */
@@ -12,6 +15,7 @@ import type { EventEmitter } from '../../lib/events.js';
 import type { FeatureLoader } from '../../services/feature-loader.js';
 import type { ProjectService } from '../../services/project-service.js';
 import type { CeremonyService } from '../../services/ceremony-service.js';
+import type { CeremonyAuditLogService } from '../../services/ceremony-audit-service.js';
 import { validatePathParams } from '../../middleware/validate-paths.js';
 import { createLogger } from '@protolabs-ai/utils';
 
@@ -30,21 +34,52 @@ export function createCeremoniesRoutes(
   events: EventEmitter,
   featureLoader: FeatureLoader,
   projectService: ProjectService,
-  ceremonyService: CeremonyService
+  ceremonyService: CeremonyService,
+  auditLog?: CeremonyAuditLogService
 ): Router {
   const router = Router();
 
-  // GET /status — ceremony observability endpoint
-  router.get('/status', (_req: Request, res: Response): void => {
+  // GET /status — ceremony observability endpoint with delivery summary
+  router.get('/status', (req: Request, res: Response): void => {
     const status = ceremonyService.getStatus();
     const reflection = ceremonyService.getReflectionStatus();
+
+    // Include delivery summary from audit log if available
+    const projectPath = req.query.projectPath as string | undefined;
+    const deliverySummary =
+      projectPath && auditLog ? auditLog.getDeliverySummary(projectPath) : null;
+
     res.json({
       success: true,
       ...status,
       activeReflection: reflection.active ? reflection.activeProject : null,
       reflectionCount: reflection.reflectionCount,
       lastReflection: reflection.lastReflection,
+      ...(deliverySummary ? { deliverySummary } : {}),
     });
+  });
+
+  // GET /log — ceremony audit log entries
+  router.get('/log', (req: Request, res: Response): void => {
+    const projectPath = req.query.projectPath as string | undefined;
+    const limit = parseInt(req.query.limit as string, 10) || 50;
+    const type = req.query.type as string | undefined;
+
+    if (!projectPath) {
+      res.status(400).json({ success: false, error: 'projectPath query parameter is required' });
+      return;
+    }
+
+    if (!auditLog) {
+      res.json({ success: true, entries: [], message: 'Audit log not initialized' });
+      return;
+    }
+
+    const entries = type
+      ? auditLog.getEntriesByType(projectPath, type, limit)
+      : auditLog.getRecentEntries(projectPath, limit);
+
+    res.json({ success: true, entries, total: entries.length });
   });
 
   // POST /retry — clear dedup guard and re-trigger project:completed

--- a/apps/server/src/services/ceremony-audit-service.ts
+++ b/apps/server/src/services/ceremony-audit-service.ts
@@ -1,0 +1,165 @@
+/**
+ * CeremonyAuditLogService — Persistent, append-only audit log for ceremony events.
+ *
+ * Every ceremony fire is recorded to `.automaker/ceremony-log.jsonl` regardless
+ * of whether Discord is configured. Discord delivery status is tracked via
+ * correlationId round-trips through the integration:discord event bridge.
+ */
+
+import { createLogger } from '@protolabs-ai/utils';
+import type { CeremonyAuditEntry, CeremonyDeliveryStatus } from '@protolabs-ai/types';
+import fs from 'fs';
+import path from 'path';
+
+const logger = createLogger('CeremonyAuditLog');
+
+export class CeremonyAuditLogService {
+  /** In-memory index of recent entries keyed by id for fast delivery status updates */
+  private entryIndex = new Map<string, { projectPath: string; line: number }>();
+
+  /**
+   * Record a new ceremony event to the audit log.
+   */
+  record(entry: CeremonyAuditEntry): void {
+    try {
+      const logPath = this.getLogPath(entry.projectPath);
+      const dir = path.dirname(logPath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      const line = JSON.stringify(entry) + '\n';
+      fs.appendFileSync(logPath, line, 'utf-8');
+
+      // Track in memory for fast delivery updates
+      this.entryIndex.set(entry.id, {
+        projectPath: entry.projectPath,
+        line: this.countLines(logPath) - 1,
+      });
+
+      logger.debug(`Recorded ceremony ${entry.ceremonyType} (${entry.id})`);
+    } catch (error) {
+      logger.error(`Failed to record ceremony audit entry:`, error);
+    }
+  }
+
+  /**
+   * Update delivery status for a ceremony entry (called after Discord delivery resolves).
+   */
+  updateDeliveryStatus(
+    id: string,
+    status: CeremonyDeliveryStatus,
+    messageId?: string,
+    error?: string
+  ): void {
+    const meta = this.entryIndex.get(id);
+    if (!meta) {
+      logger.debug(`No audit entry found for correlationId ${id}, skipping delivery update`);
+      return;
+    }
+
+    try {
+      const logPath = this.getLogPath(meta.projectPath);
+      const lines = fs.readFileSync(logPath, 'utf-8').split('\n').filter(Boolean);
+
+      // Find the entry by id (search from the end for efficiency)
+      for (let i = lines.length - 1; i >= 0; i--) {
+        try {
+          const entry = JSON.parse(lines[i]) as CeremonyAuditEntry;
+          if (entry.id === id) {
+            entry.deliveryStatus = status;
+            if (messageId) entry.discordMessageId = messageId;
+            if (error) entry.errorMessage = error;
+            lines[i] = JSON.stringify(entry);
+            break;
+          }
+        } catch {
+          // Skip malformed lines
+        }
+      }
+
+      fs.writeFileSync(logPath, lines.join('\n') + '\n', 'utf-8');
+      this.entryIndex.delete(id);
+      logger.debug(`Updated delivery status for ${id}: ${status}`);
+    } catch (err) {
+      logger.error(`Failed to update delivery status for ${id}:`, err);
+    }
+  }
+
+  /**
+   * Get recent audit log entries for a project.
+   */
+  getRecentEntries(projectPath: string, limit = 50): CeremonyAuditEntry[] {
+    try {
+      const logPath = this.getLogPath(projectPath);
+      if (!fs.existsSync(logPath)) return [];
+
+      const lines = fs.readFileSync(logPath, 'utf-8').split('\n').filter(Boolean);
+      const entries: CeremonyAuditEntry[] = [];
+
+      // Read from the end for most recent first
+      for (let i = lines.length - 1; i >= 0 && entries.length < limit; i--) {
+        try {
+          entries.push(JSON.parse(lines[i]) as CeremonyAuditEntry);
+        } catch {
+          // Skip malformed lines
+        }
+      }
+
+      return entries;
+    } catch (error) {
+      logger.error(`Failed to read ceremony audit log:`, error);
+      return [];
+    }
+  }
+
+  /**
+   * Get audit entries filtered by ceremony type.
+   */
+  getEntriesByType(projectPath: string, ceremonyType: string, limit = 50): CeremonyAuditEntry[] {
+    return this.getRecentEntries(projectPath, limit * 2)
+      .filter((e) => e.ceremonyType === ceremonyType)
+      .slice(0, limit);
+  }
+
+  /**
+   * Get summary stats for the ceremony status endpoint.
+   */
+  getDeliverySummary(projectPath: string): {
+    total: number;
+    delivered: number;
+    failed: number;
+    skipped: number;
+    pending: number;
+    lastFiredAt: string | null;
+  } {
+    const entries = this.getRecentEntries(projectPath, 200);
+    const summary = {
+      total: 0,
+      delivered: 0,
+      failed: 0,
+      skipped: 0,
+      pending: 0,
+      lastFiredAt: null as string | null,
+    };
+
+    for (const entry of entries) {
+      summary.total++;
+      summary[entry.deliveryStatus]++;
+    }
+
+    summary.lastFiredAt = entries[0]?.timestamp ?? null;
+    return summary;
+  }
+
+  private getLogPath(projectPath: string): string {
+    return path.join(projectPath, '.automaker', 'ceremony-log.jsonl');
+  }
+
+  private countLines(filePath: string): number {
+    try {
+      return fs.readFileSync(filePath, 'utf-8').split('\n').filter(Boolean).length;
+    } catch {
+      return 0;
+    }
+  }
+}

--- a/apps/server/src/services/ceremony-service.ts
+++ b/apps/server/src/services/ceremony-service.ts
@@ -18,12 +18,14 @@ import type { SettingsService } from './settings-service.js';
 import type { FeatureLoader } from './feature-loader.js';
 import type { ProjectService } from './project-service.js';
 import type { MetricsService } from './metrics-service.js';
-import type { Feature, CeremonySettings } from '@protolabs-ai/types';
+import type { Feature, CeremonySettings, CeremonyAuditType } from '@protolabs-ai/types';
 import { simpleQuery } from '../providers/simple-query-service.js';
 import { BeadsService } from './beads-service.js';
 import { LinearProjectUpdateService } from './linear-project-update-service.js';
+import type { CeremonyAuditLogService } from './ceremony-audit-service.js';
 import { secureFs } from '@protolabs-ai/platform';
 import path from 'path';
+import crypto from 'crypto';
 import fs from 'fs/promises';
 
 const logger = createLogger('CeremonyService');
@@ -106,6 +108,7 @@ export class CeremonyService {
   private metricsService: MetricsService | null = null;
   private beadsService: BeadsService | null = null;
   private linearProjectUpdateService: LinearProjectUpdateService | null = null;
+  private auditLog: CeremonyAuditLogService | null = null;
   private unsubscribe: (() => void) | null = null;
 
   /** Observability counters for engine status */
@@ -246,6 +249,65 @@ export class CeremonyService {
   }
 
   /**
+   * Set the audit log service for ceremony event tracking
+   */
+  setAuditLog(auditLog: CeremonyAuditLogService): void {
+    this.auditLog = auditLog;
+  }
+
+  /**
+   * Record a ceremony event to the audit log and emit ceremony:fired WebSocket event.
+   * Returns the correlationId for Discord delivery tracking.
+   */
+  private recordCeremony(
+    ceremonyType: CeremonyAuditType,
+    projectPath: string,
+    discordSuccess: boolean,
+    opts: {
+      id?: string;
+      projectSlug?: string;
+      milestoneSlug?: string;
+      featureId?: string;
+      channelId?: string;
+      title: string;
+      summary?: string;
+    }
+  ): string {
+    const id = opts.id ?? crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    if (this.auditLog) {
+      this.auditLog.record({
+        id,
+        timestamp: now,
+        ceremonyType,
+        projectPath,
+        projectSlug: opts.projectSlug,
+        milestoneSlug: opts.milestoneSlug,
+        featureId: opts.featureId,
+        discordChannelId: opts.channelId,
+        deliveryStatus: discordSuccess ? 'pending' : 'skipped',
+        payload: { title: opts.title, summary: opts.summary },
+      });
+    }
+
+    // Emit WebSocket event for live UI updates
+    if (this.emitter) {
+      this.emitter.emit('ceremony:fired', {
+        id,
+        timestamp: now,
+        ceremonyType,
+        projectPath,
+        projectSlug: opts.projectSlug,
+        title: opts.title,
+        deliveryStatus: discordSuccess ? 'pending' : 'skipped',
+      });
+    }
+
+    return id;
+  }
+
+  /**
    * Handle epic creation event — post kickoff announcement with scope and complexity
    */
   private async handleEpicCreated(payload: EpicCreatedEventPayload): Promise<void> {
@@ -277,16 +339,26 @@ export class CeremonyService {
 
       const messages = this.splitMessage(content, 2000);
 
+      const correlationId = crypto.randomUUID();
       let anySuccess = false;
       for (const message of messages) {
         const success = await this.emitDiscordEvent(
           projectPath,
           ceremonySettings.discordChannelId,
           message,
-          `Epic Kickoff: ${milestone.title}`
+          `Epic Kickoff: ${milestone.title}`,
+          correlationId
         );
         if (success) anySuccess = true;
       }
+
+      this.recordCeremony('epic_kickoff', projectPath, anySuccess, {
+        id: correlationId,
+        projectSlug,
+        milestoneSlug,
+        channelId: ceremonySettings.discordChannelId,
+        title: `Epic Kickoff: ${milestone.title}`,
+      });
 
       if (anySuccess) {
         this.ceremonyCounts.epicKickoff++;
@@ -323,16 +395,25 @@ export class CeremonyService {
 
       const messages = this.splitMessage(content, 2000);
 
+      const correlationId = crypto.randomUUID();
       let anySuccess = false;
       for (const message of messages) {
         const success = await this.emitDiscordEvent(
           projectPath,
           ceremonySettings.discordChannelId,
           message,
-          `Standup: Milestone ${milestoneNumber} — ${milestoneTitle}`
+          `Standup: Milestone ${milestoneNumber} — ${milestoneTitle}`,
+          correlationId
         );
         if (success) anySuccess = true;
       }
+
+      this.recordCeremony('standup', projectPath, anySuccess, {
+        id: correlationId,
+        projectSlug,
+        channelId: ceremonySettings.discordChannelId,
+        title: `Standup: Milestone ${milestoneNumber} — ${milestoneTitle}`,
+      });
 
       // Post to Linear project update if enabled
       if (ceremonySettings.enableLinearProjectUpdates && this.settingsService) {
@@ -387,6 +468,8 @@ export class CeremonyService {
       // Split into chunks if needed (Discord limit: 2000 chars)
       const messages = this.splitMessage(content, 2000);
 
+      const correlationId = crypto.randomUUID();
+
       // Emit Discord events for each message chunk
       let anySuccess = false;
       for (const message of messages) {
@@ -394,10 +477,18 @@ export class CeremonyService {
           projectPath,
           ceremonySettings.discordChannelId,
           message,
-          `Milestone ${milestoneNumber}: ${milestoneTitle}`
+          `Milestone ${milestoneNumber}: ${milestoneTitle}`,
+          correlationId
         );
         if (success) anySuccess = true;
       }
+
+      this.recordCeremony('milestone_retro', projectPath, anySuccess, {
+        id: correlationId,
+        projectSlug,
+        channelId: ceremonySettings.discordChannelId,
+        title: `Milestone ${milestoneNumber}: ${milestoneTitle}`,
+      });
 
       // Load milestone features to check for blockers
       const project = await this.projectService!.getProject(projectPath, projectSlug);
@@ -519,16 +610,26 @@ Keep it concise, actionable, and focused on what makes this milestone interestin
 
       // Post to the dedicated content-briefs channel
       const messages = this.splitMessage(formatted, 2000);
+
+      const correlationId = crypto.randomUUID();
       let anySuccess = false;
       for (const message of messages) {
         const success = await this.emitDiscordEvent(
           projectPath,
           channelId,
           message,
-          `Content Brief: ${milestoneTitle}`
+          `Content Brief: ${milestoneTitle}`,
+          correlationId
         );
         if (success) anySuccess = true;
       }
+
+      this.recordCeremony('content_brief', projectPath, anySuccess, {
+        id: correlationId,
+        projectSlug,
+        channelId,
+        title: `Content Brief: ${milestoneTitle}`,
+      });
 
       if (anySuccess) {
         this.ceremonyCounts.contentBrief++;
@@ -570,6 +671,8 @@ Keep it concise, actionable, and focused on what makes this milestone interestin
       // Split into chunks if needed (Discord limit: 2000 chars)
       const messages = this.splitMessage(content, 2000);
 
+      const correlationId = crypto.randomUUID();
+
       // Emit Discord events for each message chunk
       let anySuccess = false;
       for (const message of messages) {
@@ -577,10 +680,18 @@ Keep it concise, actionable, and focused on what makes this milestone interestin
           projectPath,
           ceremonySettings.discordChannelId,
           message,
-          `Epic Delivered: ${featureTitle}`
+          `Epic Delivered: ${featureTitle}`,
+          correlationId
         );
         if (success) anySuccess = true;
       }
+
+      this.recordCeremony('epic_delivery', projectPath, anySuccess, {
+        id: correlationId,
+        featureId,
+        channelId: ceremonySettings.discordChannelId,
+        title: `Epic Delivered: ${featureTitle}`,
+      });
 
       if (anySuccess) {
         this.ceremonyCounts.epicDelivery++;
@@ -708,6 +819,8 @@ ${dataSummary}`;
       // Split into chunks if needed (Discord limit: 2000 chars)
       const messages = this.splitMessage(formattedRetro, 2000);
 
+      const correlationId = crypto.randomUUID();
+
       // Post to Discord
       let anySuccess = false;
       for (const message of messages) {
@@ -715,10 +828,18 @@ ${dataSummary}`;
           projectPath,
           ceremonySettings.discordChannelId,
           message,
-          `Project Complete: ${projectTitle}`
+          `Project Complete: ${projectTitle}`,
+          correlationId
         );
         if (success) anySuccess = true;
       }
+
+      this.recordCeremony('project_retro', projectPath, anySuccess, {
+        id: correlationId,
+        projectSlug,
+        channelId: ceremonySettings.discordChannelId,
+        title: `Project Complete: ${projectTitle}`,
+      });
 
       if (anySuccess) {
         this.ceremonyCounts.projectRetro++;
@@ -1588,7 +1709,8 @@ ${summary}
     projectPath: string,
     channelId: string | undefined,
     content: string,
-    featureTitle: string
+    featureTitle: string,
+    correlationId?: string
   ): Promise<boolean> {
     if (!this.emitter) {
       return false;
@@ -1627,6 +1749,7 @@ ${summary}
       webhookToken: discordConfig.webhookToken,
       action: 'send_message',
       content,
+      correlationId,
     });
 
     return true;

--- a/libs/types/src/ceremony.ts
+++ b/libs/types/src/ceremony.ts
@@ -62,6 +62,55 @@ export interface MilestoneUpdateData {
  * - Key learnings for future projects
  * - Recommendations for process improvements
  */
+/**
+ * CeremonyAuditType - All ceremony event types fired by CeremonyService
+ */
+export type CeremonyAuditType =
+  | 'epic_kickoff'
+  | 'standup'
+  | 'milestone_retro'
+  | 'epic_delivery'
+  | 'content_brief'
+  | 'project_retro';
+
+/**
+ * CeremonyDeliveryStatus - Delivery state of a ceremony event
+ */
+export type CeremonyDeliveryStatus = 'pending' | 'delivered' | 'failed' | 'skipped';
+
+/**
+ * CeremonyAuditEntry - A single ceremony event in the audit log
+ */
+export interface CeremonyAuditEntry {
+  /** Unique ID for this audit entry (also used as correlationId for Discord delivery) */
+  id: string;
+  /** ISO timestamp when the ceremony fired */
+  timestamp: string;
+  /** Type of ceremony */
+  ceremonyType: CeremonyAuditType;
+  /** Project path */
+  projectPath: string;
+  /** Project slug */
+  projectSlug?: string;
+  /** Milestone slug (if applicable) */
+  milestoneSlug?: string;
+  /** Feature ID (if applicable) */
+  featureId?: string;
+  /** Discord channel ID that was targeted */
+  discordChannelId?: string;
+  /** Discord message ID after delivery */
+  discordMessageId?: string;
+  /** Current delivery status */
+  deliveryStatus: CeremonyDeliveryStatus;
+  /** Error message if delivery failed */
+  errorMessage?: string;
+  /** Summary payload */
+  payload: {
+    title: string;
+    summary?: string;
+  };
+}
+
 export interface ProjectRetroData {
   /** ID of the completed project */
   projectId: string;

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -254,6 +254,7 @@ export type EventType =
   | 'ceremony:milestone-update'
   | 'ceremony:project-retro'
   | 'ceremony:triggered'
+  | 'ceremony:fired'
   // Retro improvement events (reflection loop: REFLECT → REPEAT)
   | 'retro:improvements:created'
   | 'retro:improvement:linear-sync'

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -246,7 +246,7 @@ export type {
   // Discord integration types
   DiscordSettings,
   DiscordUserDMConfig,
-  // Ceremony types
+  // Ceremony types (CeremonySettings only — audit types from ceremony.ts)
   CeremonySettings,
   // Project integration types
   LinearIntegrationConfig,
@@ -612,7 +612,14 @@ export type {
 } from './beads.js';
 
 // Ceremony types (milestone updates and project retrospectives)
-export type { CeremonyType, MilestoneUpdateData, ProjectRetroData } from './ceremony.js';
+export type {
+  CeremonyType,
+  MilestoneUpdateData,
+  ProjectRetroData,
+  CeremonyAuditType,
+  CeremonyDeliveryStatus,
+  CeremonyAuditEntry,
+} from './ceremony.js';
 
 // Linear sync types (bidirectional sync metadata and payloads)
 export type {


### PR DESCRIPTION
## Summary
- Add `CeremonyAuditLogService` — persistent JSONL audit log for every ceremony event fired by CeremonyService
- Track Discord delivery status via correlationId round-trips through the `integration:discord` event bridge
- New `GET /api/ceremonies/log` endpoint for querying audit entries by project and type
- `GET /api/ceremonies/status` now includes delivery summary (total/delivered/failed/skipped/pending)
- `ceremony:fired` WebSocket event emitted for live UI updates
- New types: `CeremonyAuditEntry`, `CeremonyAuditType`, `CeremonyDeliveryStatus`

## Files Changed
- `libs/types/src/ceremony.ts` — new audit entry types
- `libs/types/src/event.ts` — add `ceremony:fired` event type
- `libs/types/src/index.ts` — export new types
- `apps/server/src/services/ceremony-audit-service.ts` — **new** audit log service
- `apps/server/src/services/ceremony-service.ts` — integrate audit log, add correlationId to Discord events
- `apps/server/src/routes/ceremonies/index.ts` — add log endpoint, delivery summary to status
- `apps/server/src/index.ts` — wire audit service, track delivery receipts in Discord bridge

## Test plan
- [x] `npm run build:packages` — all 14 packages compile
- [x] `npm run test:all` — all 2980 tests pass
- [x] TypeScript check passes (no new errors)
- [ ] Trigger a ceremony and verify `.automaker/ceremony-log.jsonl` is written
- [ ] Verify `GET /api/ceremonies/log?projectPath=...` returns entries
- [ ] Verify delivery status updates from Discord bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ceremony audit logging with delivery status tracking for all ceremony events
  * New observability endpoints to retrieve ceremony audit logs and delivery summaries per project
  * Discord ceremony deliveries now tracked with success/failure status and error details
  * Ceremonies assigned unique correlation IDs for cross-system tracking and monitoring
<!-- end of auto-generated comment: release notes by coderabbit.ai -->