### PR TITLE
feat(ui): ceremony feed page with audit log viewer

### DIFF
--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -6,6 +6,7 @@ const logger = createLogger('Sidebar');
 import { cn, isMac } from '@/lib/utils';
 import { useAppStore } from '@/store/app-store';
 import { useNotificationsStore } from '@/store/notifications-store';
+import { useCeremonyStore } from '@/store/ceremony-store';
 import { useKeyboardShortcuts, useKeyboardShortcutsConfig } from '@/hooks/use-keyboard-shortcuts';
 import { getElectronAPI, isElectron } from '@/lib/electron';
 import { initializeProject, hasAppSpec, hasAutomakerDir } from '@/lib/project-init';
@@ -96,6 +97,9 @@ export function Sidebar() {
 
   // Get unread notifications count
   const unreadNotificationsCount = useNotificationsStore((s) => s.unreadCount);
+
+  // Get unread ceremony event count
+  const unreadCeremonyCount = useCeremonyStore((s) => s.unreadCount);
 
   // State for delete project confirmation dialog
   const [showDeleteProjectDialog, setShowDeleteProjectDialog] = useState(false);
@@ -260,6 +264,7 @@ export function Sidebar() {
     cycleNextProject,
     unviewedValidationsCount,
     unreadNotificationsCount,
+    unreadCeremonyCount,
     isSpecGenerating: isCurrentProjectGeneratingSpec,
   });
 

--- a/apps/ui/src/components/layout/sidebar/hooks/use-navigation.ts
+++ b/apps/ui/src/components/layout/sidebar/hooks/use-navigation.ts
@@ -13,6 +13,7 @@ import {
   Inbox,
   Settings,
   NotebookPen,
+  PartyPopper,
 } from 'lucide-react';
 import type { NavSection, NavItem } from '../types';
 import type { KeyboardShortcut } from '@/hooks/use-keyboard-shortcuts';
@@ -55,6 +56,8 @@ interface UseNavigationProps {
   unviewedValidationsCount?: number;
   /** Count of unread notifications to show on Notifications nav item */
   unreadNotificationsCount?: number;
+  /** Count of unread ceremony events */
+  unreadCeremonyCount?: number;
   /** Whether spec generation is currently running for the current project */
   isSpecGenerating?: boolean;
 }
@@ -74,6 +77,7 @@ export function useNavigation({
   cycleNextProject,
   unviewedValidationsCount,
   unreadNotificationsCount,
+  unreadCeremonyCount,
   isSpecGenerating,
 }: UseNavigationProps) {
   // Track if current project has a GitHub remote
@@ -209,6 +213,12 @@ export function useNavigation({
           icon: Inbox,
         },
         {
+          id: 'ceremonies',
+          label: 'Ceremonies',
+          icon: PartyPopper,
+          count: unreadCeremonyCount,
+        },
+        {
           id: 'notifications',
           label: 'Notifications',
           icon: Bell,
@@ -233,6 +243,7 @@ export function useNavigation({
     hasGitHubRemote,
     unviewedValidationsCount,
     unreadNotificationsCount,
+    unreadCeremonyCount,
     isSpecGenerating,
   ]);
 

--- a/apps/ui/src/components/views/ceremonies-view.tsx
+++ b/apps/ui/src/components/views/ceremonies-view.tsx
@@ -1,0 +1,329 @@
+/**
+ * Ceremonies View — Full-page ceremony audit log with delivery status tracking.
+ *
+ * Shows ceremony events (standups, retros, kickoffs, etc.) with their Discord
+ * delivery status. Subscribes to live ceremony:fired WebSocket events.
+ */
+
+import { useMemo, useState } from 'react';
+import { useAppStore } from '@/store/app-store';
+import { useCeremonyStore } from '@/store/ceremony-store';
+import { useLoadCeremonyEntries, useCeremonyEventStream } from '@/hooks/use-ceremony-events';
+import { Spinner } from '@protolabs-ai/ui/atoms';
+import {
+  PartyPopper,
+  Megaphone,
+  Flag,
+  Rocket,
+  FileText,
+  Trophy,
+  CheckCircle,
+  XCircle,
+  Clock,
+  SkipForward,
+  Filter,
+} from 'lucide-react';
+import type { CeremonyAuditEntry, CeremonyAuditType } from '@protolabs-ai/types';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type TypeFilter = 'all' | CeremonyAuditType;
+type StatusFilter = 'all' | 'pending' | 'delivered' | 'failed' | 'skipped';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const TYPE_TABS: { value: TypeFilter; label: string; icon: React.ReactNode }[] = [
+  { value: 'all', label: 'All', icon: <PartyPopper className="h-3.5 w-3.5" /> },
+  { value: 'epic_kickoff', label: 'Kickoffs', icon: <Rocket className="h-3.5 w-3.5" /> },
+  { value: 'standup', label: 'Standups', icon: <Megaphone className="h-3.5 w-3.5" /> },
+  { value: 'milestone_retro', label: 'Retros', icon: <Flag className="h-3.5 w-3.5" /> },
+  { value: 'epic_delivery', label: 'Deliveries', icon: <Trophy className="h-3.5 w-3.5" /> },
+  { value: 'content_brief', label: 'Briefs', icon: <FileText className="h-3.5 w-3.5" /> },
+  { value: 'project_retro', label: 'Project', icon: <PartyPopper className="h-3.5 w-3.5" /> },
+];
+
+const STATUS_TABS: { value: StatusFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'delivered', label: 'Delivered' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'skipped', label: 'Skipped' },
+];
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  if (diffSec < 60) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHour < 24) return `${diffHour}h ago`;
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return date.toLocaleDateString();
+}
+
+function getCeremonyIcon(type: CeremonyAuditType) {
+  switch (type) {
+    case 'epic_kickoff':
+      return <Rocket className="h-4 w-4 text-blue-500" />;
+    case 'standup':
+      return <Megaphone className="h-4 w-4 text-green-500" />;
+    case 'milestone_retro':
+      return <Flag className="h-4 w-4 text-purple-500" />;
+    case 'epic_delivery':
+      return <Trophy className="h-4 w-4 text-yellow-500" />;
+    case 'content_brief':
+      return <FileText className="h-4 w-4 text-orange-500" />;
+    case 'project_retro':
+      return <PartyPopper className="h-4 w-4 text-pink-500" />;
+    default:
+      return <PartyPopper className="h-4 w-4 text-muted-foreground" />;
+  }
+}
+
+function getCeremonyLabel(type: CeremonyAuditType): string {
+  switch (type) {
+    case 'epic_kickoff':
+      return 'Epic Kickoff';
+    case 'standup':
+      return 'Standup';
+    case 'milestone_retro':
+      return 'Milestone Retro';
+    case 'epic_delivery':
+      return 'Epic Delivery';
+    case 'content_brief':
+      return 'Content Brief';
+    case 'project_retro':
+      return 'Project Retro';
+    default:
+      return type;
+  }
+}
+
+function getDeliveryBadge(status: CeremonyAuditEntry['deliveryStatus']) {
+  switch (status) {
+    case 'delivered':
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full border border-green-500/20 bg-green-500/10 px-1.5 py-0.5 text-[10px] font-medium text-green-500">
+          <CheckCircle className="h-3 w-3" />
+          Delivered
+        </span>
+      );
+    case 'failed':
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full border border-red-500/20 bg-red-500/10 px-1.5 py-0.5 text-[10px] font-medium text-red-500">
+          <XCircle className="h-3 w-3" />
+          Failed
+        </span>
+      );
+    case 'pending':
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full border border-blue-500/20 bg-blue-500/10 px-1.5 py-0.5 text-[10px] font-medium text-blue-500">
+          <Clock className="h-3 w-3" />
+          Pending
+        </span>
+      );
+    case 'skipped':
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+          <SkipForward className="h-3 w-3" />
+          Skipped
+        </span>
+      );
+  }
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function CeremoniesView() {
+  const { currentProject } = useAppStore();
+  const projectPath = currentProject?.path ?? null;
+  const { entries, isLoading, unreadCount, markAllRead } = useCeremonyStore();
+
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+
+  // Load historical entries + subscribe to live events
+  useLoadCeremonyEntries(projectPath);
+  useCeremonyEventStream(projectPath);
+
+  const filteredEntries = useMemo(() => {
+    let filtered = entries;
+
+    if (typeFilter !== 'all') {
+      filtered = filtered.filter((e) => e.ceremonyType === typeFilter);
+    }
+    if (statusFilter !== 'all') {
+      filtered = filtered.filter((e) => e.deliveryStatus === statusFilter);
+    }
+
+    // Already sorted newest-first from API
+    return filtered;
+  }, [entries, typeFilter, statusFilter]);
+
+  // Counts per type for badges
+  const typeCounts = useMemo(() => {
+    const counts: Record<string, number> = { all: entries.length };
+    for (const entry of entries) {
+      counts[entry.ceremonyType] = (counts[entry.ceremonyType] ?? 0) + 1;
+    }
+    return counts;
+  }, [entries]);
+
+  if (!projectPath) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full">
+        <PartyPopper className="h-12 w-12 text-muted-foreground/30 mb-4" />
+        <p className="text-muted-foreground">Select a project to view ceremonies</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 py-4 border-b">
+        <div className="flex items-center gap-3">
+          <PartyPopper className="h-5 w-5" />
+          <h1 className="text-lg font-semibold">Ceremonies</h1>
+          {unreadCount > 0 && (
+            <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-xs font-medium text-primary-foreground">
+              {unreadCount}
+            </span>
+          )}
+        </div>
+        {unreadCount > 0 && (
+          <button
+            onClick={markAllRead}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Mark all read
+          </button>
+        )}
+      </div>
+
+      {/* Type filter tabs */}
+      <div className="flex items-center gap-1 px-6 py-2 border-b overflow-x-auto">
+        {TYPE_TABS.map((tab) => (
+          <button
+            key={tab.value}
+            onClick={() => setTypeFilter(tab.value)}
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors whitespace-nowrap',
+              typeFilter === tab.value
+                ? 'bg-primary text-primary-foreground'
+                : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+            )}
+          >
+            {tab.icon}
+            {tab.label}
+            {(typeCounts[tab.value] ?? 0) > 0 && (
+              <span
+                className={cn(
+                  'ml-0.5 rounded-full px-1.5 py-0 text-[10px]',
+                  typeFilter === tab.value
+                    ? 'bg-primary-foreground/20 text-primary-foreground'
+                    : 'bg-muted text-muted-foreground'
+                )}
+              >
+                {typeCounts[tab.value]}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Status filter */}
+      <div className="flex items-center gap-1 px-6 py-2 border-b">
+        <Filter className="h-3.5 w-3.5 text-muted-foreground mr-1" />
+        {STATUS_TABS.map((tab) => (
+          <button
+            key={tab.value}
+            onClick={() => setStatusFilter(tab.value)}
+            className={cn(
+              'rounded-md px-2 py-1 text-xs font-medium transition-colors',
+              statusFilter === tab.value
+                ? 'bg-accent text-foreground'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Entries list */}
+      <div className="flex-1 overflow-y-auto">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <Spinner className="h-6 w-6" />
+          </div>
+        ) : filteredEntries.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16">
+            <PartyPopper className="h-10 w-10 text-muted-foreground/30 mb-3" />
+            <p className="text-sm text-muted-foreground">
+              {entries.length === 0
+                ? 'No ceremonies have fired yet'
+                : 'No ceremonies match your filters'}
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y">
+            {filteredEntries.map((entry) => (
+              <div
+                key={entry.id}
+                className="flex items-start gap-4 px-6 py-4 hover:bg-accent/50 transition-colors"
+              >
+                <div className="flex-shrink-0 mt-1">{getCeremonyIcon(entry.ceremonyType)}</div>
+
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-0.5">
+                    <p className="text-sm font-medium truncate">{entry.payload.title}</p>
+                    {getDeliveryBadge(entry.deliveryStatus)}
+                  </div>
+                  {entry.payload.summary && (
+                    <p className="text-xs text-muted-foreground line-clamp-2">
+                      {entry.payload.summary}
+                    </p>
+                  )}
+                  <div className="flex items-center gap-3 mt-1.5">
+                    <span className="text-[11px] text-muted-foreground">
+                      {formatRelativeTime(new Date(entry.timestamp))}
+                    </span>
+                    <span className="text-[11px] text-muted-foreground/60">
+                      {getCeremonyLabel(entry.ceremonyType)}
+                    </span>
+                    {entry.milestoneSlug && (
+                      <span className="text-[11px] text-muted-foreground/60">
+                        {entry.milestoneSlug}
+                      </span>
+                    )}
+                    {entry.errorMessage && (
+                      <span className="text-[11px] text-red-500 truncate max-w-[200px]">
+                        {entry.errorMessage}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/hooks/use-ceremony-events.ts
+++ b/apps/ui/src/hooks/use-ceremony-events.ts
@@ -1,0 +1,96 @@
+/**
+ * Hook to load ceremony audit entries and subscribe to live ceremony:fired events.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useCeremonyStore } from '@/store/ceremony-store';
+import { getHttpApiClient } from '@/lib/http-api-client';
+import { apiGet } from '@/lib/api-fetch';
+import type { CeremonyAuditEntry, EventType } from '@protolabs-ai/types';
+
+interface CeremonyLogResponse {
+  success: boolean;
+  entries: CeremonyAuditEntry[];
+  total: number;
+}
+
+/**
+ * Load historical ceremony entries for a project.
+ */
+export function useLoadCeremonyEntries(projectPath: string | null) {
+  const { setEntries, setLoading, setError, reset } = useCeremonyStore();
+  const loadedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!projectPath) {
+      reset();
+      loadedRef.current = null;
+      return;
+    }
+
+    // Avoid re-fetching for the same project
+    if (loadedRef.current === projectPath) return;
+    loadedRef.current = projectPath;
+
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await apiGet<CeremonyLogResponse>(
+          `/api/ceremonies/log?projectPath=${encodeURIComponent(projectPath!)}&limit=100`
+        );
+        if (!cancelled && res.success) {
+          setEntries(res.entries);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load ceremony log');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectPath, setEntries, setLoading, setError, reset]);
+}
+
+/**
+ * Subscribe to live ceremony:fired WebSocket events.
+ */
+export function useCeremonyEventStream(projectPath: string | null) {
+  const addEntry = useCeremonyStore((s) => s.addEntry);
+
+  useEffect(() => {
+    if (!projectPath) return;
+
+    const api = getHttpApiClient();
+    const unsubscribe = api.subscribeToEvents((type: EventType, payload: unknown) => {
+      if (type !== 'ceremony:fired') return;
+
+      const p = payload as Record<string, unknown>;
+      // Filter to current project
+      if (p.projectPath && p.projectPath !== projectPath) return;
+
+      const entry: CeremonyAuditEntry = {
+        id: (p.id as string) ?? '',
+        timestamp: (p.timestamp as string) ?? new Date().toISOString(),
+        ceremonyType: p.ceremonyType as CeremonyAuditEntry['ceremonyType'],
+        projectPath: (p.projectPath as string) ?? projectPath,
+        projectSlug: p.projectSlug as string | undefined,
+        milestoneSlug: p.milestoneSlug as string | undefined,
+        deliveryStatus: (p.deliveryStatus as CeremonyAuditEntry['deliveryStatus']) ?? 'pending',
+        payload: (p.payload as { title: string; summary?: string }) ?? { title: 'Ceremony' },
+      };
+
+      addEntry(entry);
+    });
+
+    return unsubscribe;
+  }, [projectPath, addEntry]);
+}

--- a/apps/ui/src/routes/ceremonies.tsx
+++ b/apps/ui/src/routes/ceremonies.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { CeremoniesView } from '@/components/views/ceremonies-view';
+
+export const Route = createFileRoute('/ceremonies')({
+  component: CeremoniesView,
+});

--- a/apps/ui/src/store/ceremony-store.ts
+++ b/apps/ui/src/store/ceremony-store.ts
@@ -1,0 +1,77 @@
+/**
+ * Ceremony Store - State management for ceremony audit log entries
+ *
+ * Tracks ceremony events (fired via ceremony:fired WebSocket events)
+ * and loads historical entries from the GET /api/ceremonies/log endpoint.
+ */
+
+import { create } from 'zustand';
+import type { CeremonyAuditEntry, CeremonyDeliveryStatus } from '@protolabs-ai/types';
+
+// ============================================================================
+// State Interface
+// ============================================================================
+
+interface CeremonyState {
+  entries: CeremonyAuditEntry[];
+  unreadCount: number;
+  isLoading: boolean;
+  error: string | null;
+}
+
+// ============================================================================
+// Actions Interface
+// ============================================================================
+
+interface CeremonyActions {
+  setEntries: (entries: CeremonyAuditEntry[]) => void;
+  addEntry: (entry: CeremonyAuditEntry) => void;
+  updateDeliveryStatus: (id: string, status: CeremonyDeliveryStatus) => void;
+  markAllRead: () => void;
+  setLoading: (loading: boolean) => void;
+  setError: (error: string | null) => void;
+  reset: () => void;
+}
+
+// ============================================================================
+// Initial State
+// ============================================================================
+
+const initialState: CeremonyState = {
+  entries: [],
+  unreadCount: 0,
+  isLoading: false,
+  error: null,
+};
+
+// ============================================================================
+// Store
+// ============================================================================
+
+export const useCeremonyStore = create<CeremonyState & CeremonyActions>((set) => ({
+  ...initialState,
+
+  setEntries: (entries) =>
+    set({
+      entries,
+      // Historical entries are all "read" — unread count stays as-is for live events
+    }),
+
+  addEntry: (entry) =>
+    set((state) => ({
+      entries: [entry, ...state.entries],
+      unreadCount: state.unreadCount + 1,
+    })),
+
+  updateDeliveryStatus: (id, status) =>
+    set((state) => ({
+      entries: state.entries.map((e) => (e.id === id ? { ...e, deliveryStatus: status } : e)),
+    })),
+
+  markAllRead: () => set({ unreadCount: 0 }),
+
+  setLoading: (loading) => set({ isLoading: loading }),
+  setError: (error) => set({ error }),
+
+  reset: () => set(initialState),
+}));


### PR DESCRIPTION
## Summary
- Adds `/ceremonies` route with full-page ceremony audit log viewer
- Zustand store + WebSocket hook for live `ceremony:fired` event streaming
- Type filter tabs (Kickoffs, Standups, Retros, Deliveries, Briefs, Project) and status filter (Delivered, Pending, Failed, Skipped)
- Delivery status badges (green/red/blue/gray) on each ceremony entry
- Sidebar nav item with `PartyPopper` icon and unread count badge

## Test plan
- [ ] Navigate to `/ceremonies` — shows empty state when no ceremonies exist
- [ ] Trigger a ceremony via `POST /api/ceremonies/trigger` — entry appears in real-time via WebSocket
- [ ] Filter by type and delivery status
- [ ] Unread badge appears in sidebar on new ceremony events, clears on "Mark all read"
- [ ] Verify no TypeScript regressions (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Ceremonies section accessible from the sidebar navigation with unread count display.
  * Introduced a live-updating ceremony audit log displaying events with delivery status indicators.
  * Added filtering capabilities by ceremony type and delivery status.
  * Implemented "Mark all read" functionality to manage ceremony notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->