### PR TITLE
fix: handle malformed notifications.json in NotificationService

### DIFF
--- a/apps/server/src/services/notification-service.ts
+++ b/apps/server/src/services/notification-service.ts
@@ -13,7 +13,7 @@ import { createLogger } from '@protolabs-ai/utils';
 import * as secureFs from '../lib/secure-fs.js';
 import { getNotificationsPath, ensureAutomakerDir } from '@protolabs-ai/platform';
 import type { Notification, NotificationsFile, NotificationType } from '@protolabs-ai/types';
-import { DEFAULT_NOTIFICATIONS_FILE } from '@protolabs-ai/types';
+import { NOTIFICATIONS_VERSION } from '@protolabs-ai/types';
 import type { EventEmitter } from '../lib/events.js';
 import { randomUUID } from 'crypto';
 
@@ -40,6 +40,11 @@ async function atomicWriteJson(filePath: string, data: unknown): Promise<void> {
   }
 }
 
+/** Fresh copy of the default file — prevents shared mutable state */
+function emptyNotificationsFile(): NotificationsFile {
+  return { version: NOTIFICATIONS_VERSION, notifications: [] };
+}
+
 /**
  * Safely read notifications JSON file with fallback to default.
  * Validates the parsed shape — returns default if file contains
@@ -54,13 +59,13 @@ async function readNotificationsFile(filePath: string): Promise<NotificationsFil
       return parsed as NotificationsFile;
     }
     logger.warn(`Malformed notifications file at ${filePath}, using default`);
-    return { ...DEFAULT_NOTIFICATIONS_FILE };
+    return emptyNotificationsFile();
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return { ...DEFAULT_NOTIFICATIONS_FILE };
+      return emptyNotificationsFile();
     }
     logger.error(`Error reading ${filePath}:`, error);
-    return { ...DEFAULT_NOTIFICATIONS_FILE };
+    return emptyNotificationsFile();
   }
 }
 


### PR DESCRIPTION
## Summary

- `notifications.json` on disk contained `[]` (bare array) instead of `{ version: 1, notifications: [] }`
- `readJsonFile` parsed it as valid JSON but the array has no `.notifications` property → `TypeError: Cannot read properties of undefined (reading 'filter')` on every `/api/notifications/list` and `/api/notifications/unread-count` call
- Replaced generic `readJsonFile<T>` with `readNotificationsFile()` that validates the parsed shape before returning — falls back to default structure if malformed
- This hardens all 5 callsites (getNotifications, createNotification, markAsRead, markAllAsRead, dismissNotification, dismissAll)

## Test plan

- [x] Navigate to notifications panel — no more 500 errors
- [x] Unread count badge loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification system reliability with enhanced validation and error handling for corrupted or missing notification data.

* **Refactor**
  * Strengthened notification data processing with consistent validation and fallback mechanisms across all notification operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->