### PR TITLE
fix: run resumeInterruptedFeatures once per server lifecycle

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -423,6 +423,9 @@ export class AutoModeService {
   private leadEngineerService: LeadEngineerService | null = null;
   // Knowledge Store service for learning deduplication (optional)
   private knowledgeStoreService: KnowledgeStoreService | null = null;
+  // Track which projects have already been checked for interrupted features this server lifecycle.
+  // Prevents the UI from re-triggering resumeInterruptedFeatures on every board mount.
+  private resumeCheckedProjects = new Set<string>();
   // Rate-limiting for auto_mode_progress events (per feature)
   private lastProgressEventTime = new Map<string, number>();
   private readonly PROGRESS_EVENT_MIN_INTERVAL_MS = 100; // Max 1 event per 100ms per feature
@@ -6687,6 +6690,14 @@ After generating the revised spec, output:
    * This should be called during server initialization
    */
   async resumeInterruptedFeatures(projectPath: string): Promise<void> {
+    // Only run once per project per server lifecycle.
+    // The UI calls this on every board mount — subsequent calls are no-ops.
+    if (this.resumeCheckedProjects.has(projectPath)) {
+      logger.debug(`Already checked interrupted features for ${projectPath}, skipping`);
+      return;
+    }
+    this.resumeCheckedProjects.add(projectPath);
+
     logger.info('Checking for interrupted features to resume...');
 
     // Clean up any stale running features from previous session


### PR DESCRIPTION
## Summary
- **Root cause fix** for agent respawning bug: the UI board hook calls `resumeInterrupted` on every mount/navigation, causing stopped agents to immediately respawn
- Adds a `resumeCheckedProjects` Set to `AutoModeService` so the server only processes interrupted features **once per project per server lifecycle** — subsequent UI calls become no-ops
- Companion to #1042 (terminal-status guards) which was defense-in-depth on the server side

## Context
The respawning loop was:
1. UI mounts board → calls `POST /api/auto-mode/resume-interrupted`
2. Server finds `in_progress` features without running agents → resumes them
3. User stops agent → feature stays `in_progress` (by design)
4. UI re-mounts → step 1 again → infinite respawn loop

This fix breaks the loop at step 2 by tracking which projects have already been checked.

## Test plan
- [x] `npm run build:server` — compiles clean
- [x] `npm run test:server` — 2033 tests pass
- [ ] CI pipeline (build, test, lint, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)