### PR TITLE
fix: delete pipeline checkpoints when features reset to backlog

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -762,6 +762,7 @@ const leadEngineerService = new LeadEngineerService(
 );
 const pipelineCheckpointService = new PipelineCheckpointService();
 leadEngineerService.setCheckpointService(pipelineCheckpointService);
+autoModeService.setPipelineCheckpointService(pipelineCheckpointService);
 
 // Wire ContextFidelityService for shaping prior context on retries
 const { ContextFidelityService } = await import('./services/context-fidelity-service.js');
@@ -1147,6 +1148,20 @@ specGenerationMonitor.startMonitoring();
         }
       } catch (err) {
         logger.warn(`[STARTUP] Failed to reconcile features for ${projectPath}:`, err);
+      }
+    }
+
+    // Reconcile orphaned checkpoints (runs after feature state reconciliation)
+    for (const projectPath of uniquePaths) {
+      try {
+        const result = await leadEngineerService.reconcileCheckpoints(projectPath);
+        if (result.deleted.length > 0) {
+          logger.info(
+            `[STARTUP] Deleted ${result.deleted.length} orphaned checkpoint(s) for ${projectPath}`
+          );
+        }
+      } catch (err) {
+        logger.warn(`[STARTUP] Failed to reconcile checkpoints for ${projectPath}:`, err);
       }
     }
   } catch (err) {

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -109,6 +109,7 @@ import type { LeadEngineerService } from './lead-engineer-service.js';
 import { gitWorkflowService } from './git-workflow-service.js';
 import { graphiteService } from './graphite-service.js';
 import type { KnowledgeStoreService } from './knowledge-store-service.js';
+import type { PipelineCheckpointService } from './pipeline-checkpoint-service.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -423,6 +424,8 @@ export class AutoModeService {
   private leadEngineerService: LeadEngineerService | null = null;
   // Knowledge Store service for learning deduplication (optional)
   private knowledgeStoreService: KnowledgeStoreService | null = null;
+  // Pipeline Checkpoint service for crash recovery checkpoint cleanup (optional)
+  private pipelineCheckpointService: PipelineCheckpointService | null = null;
   // Track which projects have already been checked for interrupted features this server lifecycle.
   // Prevents the UI from re-triggering resumeInterruptedFeatures on every board mount.
   private resumeCheckedProjects = new Set<string>();
@@ -490,6 +493,14 @@ export class AutoModeService {
    */
   setKnowledgeStoreService(service: KnowledgeStoreService): void {
     this.knowledgeStoreService = service;
+  }
+
+  /**
+   * Wire up the Pipeline Checkpoint service for crash recovery checkpoint cleanup.
+   * When set, reconcileFeatureStates() will also delete checkpoints for reset features.
+   */
+  setPipelineCheckpointService(service: PipelineCheckpointService): void {
+    this.pipelineCheckpointService = service;
   }
 
   /**
@@ -2842,6 +2853,17 @@ Complete the pipeline step instructions above. Review the previous work and appl
           status: 'backlog',
           startedAt: undefined,
         });
+
+        // Delete checkpoint for this feature (crash recovery cleanup)
+        if (this.pipelineCheckpointService) {
+          try {
+            await this.pipelineCheckpointService.delete(projectPath, feature.id);
+            logger.debug(`[RECONCILE] Deleted checkpoint for feature ${feature.id}`);
+          } catch (cpError) {
+            // Checkpoint deletion should not block reconciliation
+            logger.warn(`[RECONCILE] Failed to delete checkpoint for ${feature.id}:`, cpError);
+          }
+        }
 
         reconciled.push({
           featureId: feature.id,

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -1540,6 +1540,69 @@ export class LeadEngineerService {
   }
 
   /**
+   * Reconcile orphaned checkpoints after server restart.
+   * Scans for checkpoint files with no matching active feature and deletes them.
+   * Should be called after autoModeService.reconcileFeatureStates() to clean up
+   * any checkpoints that were left behind when features were reset to backlog.
+   */
+  async reconcileCheckpoints(projectPath: string): Promise<{ deleted: string[] }> {
+    if (!this.checkpointService) {
+      logger.debug('[RECONCILE-CP] No checkpoint service configured, skipping');
+      return { deleted: [] };
+    }
+
+    const deleted: string[] = [];
+
+    try {
+      // Get all checkpoints for the project
+      const checkpoints = await this.checkpointService.listAll(projectPath);
+      if (checkpoints.length === 0) {
+        logger.debug(`[RECONCILE-CP] No checkpoints found for ${projectPath}`);
+        return { deleted };
+      }
+
+      // Get all features
+      const features = await this.featureLoader.getAll(projectPath);
+      const featureMap = new Map(features.map((f) => [f.id, f]));
+
+      // Find orphaned checkpoints:
+      // - Feature no longer exists
+      // - Feature is in backlog status (was reset and shouldn't have a checkpoint)
+      for (const checkpoint of checkpoints) {
+        const feature = featureMap.get(checkpoint.featureId);
+        const isOrphaned = !feature || feature.status === 'backlog';
+
+        if (isOrphaned) {
+          try {
+            await this.checkpointService.delete(projectPath, checkpoint.featureId);
+            deleted.push(checkpoint.featureId);
+            logger.info(
+              `[RECONCILE-CP] Deleted orphaned checkpoint for ${checkpoint.featureId}` +
+                (feature ? ` (feature status: ${feature.status})` : ' (feature not found)')
+            );
+          } catch (err) {
+            logger.warn(
+              `[RECONCILE-CP] Failed to delete checkpoint for ${checkpoint.featureId}:`,
+              err
+            );
+          }
+        }
+      }
+
+      if (deleted.length > 0) {
+        logger.info(
+          `[RECONCILE-CP] Deleted ${deleted.length} orphaned checkpoint(s) for ${projectPath}`
+        );
+      }
+
+      return { deleted };
+    } catch (err) {
+      logger.error(`[RECONCILE-CP] Failed to reconcile checkpoints for ${projectPath}:`, err);
+      return { deleted };
+    }
+  }
+
+  /**
    * Clean up subscriptions and stop all sessions.
    */
   destroy(): void {


### PR DESCRIPTION
## Summary
- When `reconcileFeatureStates()` resets interrupted features to backlog on server restart, also deletes their checkpoint files via `PipelineCheckpointService.delete()`
- Adds `reconcileCheckpoints()` to `LeadEngineerService` that scans for orphaned checkpoints (feature deleted or in backlog)
- Wires checkpoint reconciliation into the startup sequence in `index.ts`, running after feature state reconciliation

## Test plan
- [ ] Server builds cleanly (`npm run build:server`)
- [ ] Unit tests pass (`npm run test:server`)
- [ ] Server startup runs checkpoint reconciliation without errors
- [ ] Features reset to backlog have their checkpoints cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)