### PR TITLE
feat: TrajectoryStoreService — persist execution trajectories

### DIFF
--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -46,6 +46,10 @@ import { getWorkflowSettings } from '../lib/settings-helpers.js';
 import type { PipelineCheckpointService } from './pipeline-checkpoint-service.js';
 import type { ContextFidelityService } from './context-fidelity-service.js';
 import type { KnowledgeStoreService } from './knowledge-store-service.js';
+import type {
+  TrajectoryStoreService,
+  TrajectoryStateTransition,
+} from './trajectory-store-service.js';
 import { simpleQuery } from '../providers/simple-query-service.js';
 import { resolveModelString } from '@protolabs-ai/model-resolver';
 
@@ -74,6 +78,7 @@ export interface ProcessorServiceContext {
   checkpointService?: PipelineCheckpointService;
   contextFidelityService?: ContextFidelityService;
   knowledgeStoreService?: KnowledgeStoreService;
+  trajectoryStoreService?: TrajectoryStoreService;
 }
 
 // ────────────────────────── Feature State Machine ──────────────────────────
@@ -124,6 +129,11 @@ export interface StateContext {
   escalationReason?: string;
   reviewFeedback?: string;
   siblingReflections?: string[];
+  // Trajectory tracking fields
+  /** ISO 8601 timestamp when processing started */
+  startedAt?: string;
+  /** State transitions for trajectory recording */
+  stateTransitions?: TrajectoryStateTransition[];
 }
 
 /**
@@ -947,6 +957,24 @@ class DeployProcessor implements StateProcessor {
       remediationAttempts: ctx.remediationAttempts,
     });
 
+    // Fire-and-forget trajectory save (non-blocking)
+    if (this.serviceContext.trajectoryStoreService && ctx.startedAt) {
+      const completedAt = new Date().toISOString();
+      const durationMs = new Date(completedAt).getTime() - new Date(ctx.startedAt).getTime();
+      this.serviceContext.trajectoryStoreService.save({
+        feature: ctx.feature,
+        projectPath: ctx.projectPath,
+        outcome: 'success',
+        stateTransitions: ctx.stateTransitions || [],
+        startedAt: ctx.startedAt,
+        completedAt,
+        durationMs,
+        costUsd: finalCost,
+        model: ctx.options.model || 'sonnet',
+        prNumber: ctx.prNumber,
+      });
+    }
+
     // Fire-and-forget reflection (non-blocking)
     void this.generateReflection(ctx);
 
@@ -1071,6 +1099,30 @@ class EscalateProcessor implements StateProcessor {
       retryCount: ctx.retryCount,
       remediationAttempts: ctx.remediationAttempts,
     });
+
+    // Fire-and-forget trajectory save (non-blocking)
+    if (this.serviceContext.trajectoryStoreService && ctx.startedAt) {
+      const completedAt = new Date().toISOString();
+      const durationMs = new Date(completedAt).getTime() - new Date(ctx.startedAt).getTime();
+      this.serviceContext.trajectoryStoreService.save({
+        feature: ctx.feature,
+        projectPath: ctx.projectPath,
+        outcome: 'escalated',
+        stateTransitions: ctx.stateTransitions || [],
+        startedAt: ctx.startedAt,
+        completedAt,
+        durationMs,
+        costUsd: ctx.feature.costUsd || 0,
+        model: ctx.options.model || 'sonnet',
+        prNumber: ctx.prNumber,
+        failureAnalysis: {
+          reason: ctx.escalationReason || 'Unknown escalation reason',
+          retryCount: ctx.retryCount,
+          remediationAttempts: ctx.remediationAttempts,
+          reviewFeedback: ctx.reviewFeedback,
+        },
+      });
+    }
 
     return {
       nextState: null,
@@ -1220,6 +1272,9 @@ export class FeatureStateMachine {
       remediationAttempts: 0,
       mergeRetryCount: 0,
       planRetryCount: 0,
+      // Trajectory tracking
+      startedAt: new Date().toISOString(),
+      stateTransitions: [],
       // Merge any restored context from checkpoint
       ...resumeFromCheckpoint?.restoredContext,
     };
@@ -1329,6 +1384,14 @@ export class FeatureStateMachine {
         }
 
         completedStates.push(currentState);
+
+        // Track state transition for trajectory
+        ctx.stateTransitions?.push({
+          from: completedStates.length > 1 ? completedStates[completedStates.length - 2] : null,
+          to: currentState,
+          timestamp: new Date().toISOString(),
+          reason: result.reason,
+        });
 
         logger.info('State transition', {
           from: currentState,

--- a/apps/server/src/services/trajectory-store-service.ts
+++ b/apps/server/src/services/trajectory-store-service.ts
@@ -1,0 +1,242 @@
+/**
+ * Trajectory Store Service
+ *
+ * Persists structured execution trajectories to `.automaker/trajectory/{featureId}/attempt-{N}.json`.
+ * Each trajectory captures: attempt number, state transitions, duration, cost, model used,
+ * outcome (success/failure/escalation), and failure analysis if applicable.
+ *
+ * Writes are non-blocking (fire-and-forget) to avoid slowing down the main execution path.
+ */
+
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { getAutomakerDir } from '@protolabs-ai/platform';
+import { createLogger } from '@protolabs-ai/utils';
+import type { Feature } from '@protolabs-ai/types';
+
+const logger = createLogger('TrajectoryStoreService');
+
+/**
+ * Represents a state transition in the feature processing pipeline.
+ */
+export interface TrajectoryStateTransition {
+  /** Previous state (null if initial) */
+  from: string | null;
+  /** New state */
+  to: string;
+  /** ISO 8601 timestamp */
+  timestamp: string;
+  /** Optional reason for transition */
+  reason?: string;
+}
+
+/**
+ * Failure analysis data for escalated features.
+ */
+export interface TrajectoryFailureAnalysis {
+  /** Primary reason for escalation */
+  reason: string;
+  /** Number of retry attempts before escalation */
+  retryCount: number;
+  /** Number of remediation cycles attempted */
+  remediationAttempts: number;
+  /** Last error message if available */
+  lastError?: string;
+  /** PR feedback that may have contributed to failure */
+  reviewFeedback?: string;
+}
+
+/**
+ * A complete execution trajectory record.
+ */
+export interface ExecutionTrajectory {
+  /** Feature ID this trajectory belongs to */
+  featureId: string;
+  /** Feature title for human readability */
+  featureTitle: string;
+  /** Attempt number (1-indexed) */
+  attemptNumber: number;
+  /** Outcome of this attempt */
+  outcome: 'success' | 'escalated' | 'interrupted';
+  /** ISO 8601 timestamp when execution started */
+  startedAt: string;
+  /** ISO 8601 timestamp when execution completed */
+  completedAt: string;
+  /** Total duration in milliseconds */
+  durationMs: number;
+  /** Total cost in USD for this attempt */
+  costUsd: number;
+  /** Model used for this execution */
+  model: string;
+  /** State transitions during this attempt */
+  stateTransitions: TrajectoryStateTransition[];
+  /** PR number if one was created */
+  prNumber?: number;
+  /** Failure analysis (only present when outcome is 'escalated') */
+  failureAnalysis?: TrajectoryFailureAnalysis;
+}
+
+/**
+ * Input data for saving a trajectory.
+ */
+export interface SaveTrajectoryInput {
+  feature: Feature;
+  projectPath: string;
+  outcome: 'success' | 'escalated' | 'interrupted';
+  stateTransitions: TrajectoryStateTransition[];
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  costUsd: number;
+  model: string;
+  prNumber?: number;
+  failureAnalysis?: TrajectoryFailureAnalysis;
+}
+
+/**
+ * Get the trajectory directory for a feature.
+ */
+function getTrajectoryDir(projectPath: string, featureId: string): string {
+  return path.join(getAutomakerDir(projectPath), 'trajectory', featureId);
+}
+
+/**
+ * Get the next available attempt number by checking existing files.
+ */
+async function getNextAttemptNumber(trajectoryDir: string): Promise<number> {
+  try {
+    const files = await fs.readdir(trajectoryDir);
+    const attemptNumbers = files
+      .filter((f) => f.startsWith('attempt-') && f.endsWith('.json'))
+      .map((f) => {
+        const match = f.match(/^attempt-(\d+)\.json$/);
+        return match ? parseInt(match[1], 10) : 0;
+      })
+      .filter((n) => n > 0);
+
+    if (attemptNumbers.length === 0) {
+      return 1;
+    }
+    return Math.max(...attemptNumbers) + 1;
+  } catch {
+    // Directory doesn't exist yet
+    return 1;
+  }
+}
+
+/**
+ * Service for persisting execution trajectories.
+ */
+export class TrajectoryStoreService {
+  /**
+   * Save an execution trajectory to disk.
+   *
+   * This method is fire-and-forget - it does not block the caller.
+   * Errors are logged but not thrown.
+   *
+   * @param input - The trajectory data to save
+   */
+  save(input: SaveTrajectoryInput): void {
+    // Fire-and-forget: immediately return, process asynchronously
+    void this.saveAsync(input);
+  }
+
+  /**
+   * Internal async implementation for saving trajectories.
+   */
+  private async saveAsync(input: SaveTrajectoryInput): Promise<void> {
+    try {
+      const {
+        feature,
+        projectPath,
+        outcome,
+        stateTransitions,
+        startedAt,
+        completedAt,
+        durationMs,
+        costUsd,
+        model,
+        prNumber,
+        failureAnalysis,
+      } = input;
+
+      const trajectoryDir = getTrajectoryDir(projectPath, feature.id);
+
+      // Ensure directory exists
+      await fs.mkdir(trajectoryDir, { recursive: true });
+
+      // Get next attempt number
+      const attemptNumber = await getNextAttemptNumber(trajectoryDir);
+
+      // Build trajectory record
+      const trajectory: ExecutionTrajectory = {
+        featureId: feature.id,
+        featureTitle: feature.title || 'Untitled',
+        attemptNumber,
+        outcome,
+        startedAt,
+        completedAt,
+        durationMs,
+        costUsd,
+        model,
+        stateTransitions,
+      };
+
+      if (prNumber !== undefined) {
+        trajectory.prNumber = prNumber;
+      }
+
+      if (failureAnalysis) {
+        trajectory.failureAnalysis = failureAnalysis;
+      }
+
+      // Write trajectory file
+      const filePath = path.join(trajectoryDir, `attempt-${attemptNumber}.json`);
+      await fs.writeFile(filePath, JSON.stringify(trajectory, null, 2), 'utf-8');
+
+      logger.info(`[TrajectoryStore] Saved trajectory for feature ${feature.id}`, {
+        attemptNumber,
+        outcome,
+        durationMs,
+        costUsd,
+        filePath,
+      });
+    } catch (err) {
+      // Log error but don't throw - fire-and-forget semantics
+      logger.warn(`[TrajectoryStore] Failed to save trajectory:`, err);
+    }
+  }
+
+  /**
+   * Read all trajectories for a feature.
+   *
+   * @param projectPath - Project path
+   * @param featureId - Feature ID
+   * @returns Array of trajectories, sorted by attempt number
+   */
+  async getTrajectories(projectPath: string, featureId: string): Promise<ExecutionTrajectory[]> {
+    try {
+      const trajectoryDir = getTrajectoryDir(projectPath, featureId);
+      const files = await fs.readdir(trajectoryDir);
+
+      const trajectories: ExecutionTrajectory[] = [];
+
+      for (const file of files) {
+        if (file.startsWith('attempt-') && file.endsWith('.json')) {
+          try {
+            const content = await fs.readFile(path.join(trajectoryDir, file), 'utf-8');
+            trajectories.push(JSON.parse(content) as ExecutionTrajectory);
+          } catch {
+            // Skip invalid files
+          }
+        }
+      }
+
+      // Sort by attempt number
+      return trajectories.sort((a, b) => a.attemptNumber - b.attemptNumber);
+    } catch {
+      // Directory doesn't exist or other error
+      return [];
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `TrajectoryStoreService` that persists execution trajectories to `.automaker/trajectory/{featureId}/attempt-{N}.json`
- Each trajectory captures: attempt number, state transitions, duration, cost, model, outcome, and failure analysis
- Wires into `DeployProcessor` (success path) and `EscalateProcessor` (failure/escalation path)
- All writes are fire-and-forget (non-blocking) via `void this.saveAsync()`
- Adds trajectory tracking fields to `StateContext` (`startedAt`, `stateTransitions`)

**Note:** This PR depends on PR #1049 (FailureClassifierService). Will need rebase after #1049 merges.

## Test plan

- [ ] `npm run build:server` passes
- [ ] Verify trajectory JSON files are created in `.automaker/trajectory/` on feature completion
- [ ] Verify fire-and-forget semantics — failures in trajectory writing don't block execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented execution trajectory tracking system that records all workflow steps, state transitions, and outcomes during feature development. Each execution is automatically saved with comprehensive metadata including duration, cost, model details, and associated pull request numbers, enabling detailed audit trails and performance analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->