### PR TITLE
feat: wire FailureClassifier into fast-path rules

### DIFF
--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -3102,3 +3102,37 @@ usageStats:
 - **Rejected:** Configurable parameter; dynamic based on chunk size; single question; five questions
 - **Trade-offs:** Simplicity and predictable cost; but inflexible if use cases need more diverse queries (search quality becomes architectural limit)
 - **Breaking if changed:** If operational needs change (need finer coverage), requires code change not config; if benchmarking shows 2 questions sufficient, still paying for 3
+
+### Replaced working directory heuristic with explicit project configuration scan from settingsService for crash recovery session discovery (2026-02-24)
+- **Context:** Multi-project environments where crash recovery sessions could exist in any project, not just the one where LE was started
+- **Why:** Working directory is unreliable in crash scenarios - user might have been in project A but LE restarted in project B. Explicit configuration covers all known projects and is deterministic
+- **Rejected:** Filesystem scanning (too slow, discovers unrelated projects), environment variables (not scalable), continuing to use single cwd (original approach - misses sessions)
+- **Trade-offs:** Requires projects to be registered in settings service, but gains multi-project coverage and deterministic behavior. More complex dependency tree.
+- **Breaking if changed:** If a project is not in settings, its sessions won't be discovered even if they exist on disk. Configuration drift becomes a failure mode.
+
+#### [Pattern] Multi-level fallback chain: configured projects → process.cwd() if unconfigured → process.cwd() on error (2026-02-24)
+- **Problem solved:** Crash recovery is critical path - cannot fail even if settings service is broken or returns empty config
+- **Why this works:** Defensive programming for resilience. Each level provides a safety net: explicit config, then working directory heuristic, then error recovery.
+- **Trade-offs:** More code paths to test, but guarantees service always restores sessions from somewhere. Hides misconfiguration - user might not realize missing projects.
+
+#### [Gotcha] Pattern matching order (first-match-wins) is critical to correctness but implicit and undocumented. Pattern ordering must follow specificity principle: more specific patterns before general ones. (2026-02-24)
+- **Situation:** FailureClassifierService executes 11 matchers sequentially. Patterns for 'timeout' (transient) and 'network error' (transient) could overlap; order determines classification.
+- **Root cause:** First-match prevents backtracking, keeping logic simple and predictable. But this makes ordering a silent requirement—no explicit priority mechanism.
+- **How to avoid:** Code is simple and fast. Dangerous to refactor—reordering patterns silently changes behavior for edge cases. Adding overlapping patterns breaks existing classifications without test visibility.
+
+### Synchronous, pure pattern-matching classifier instead of async LLM or ML-based classification. (2026-02-24)
+- **Context:** Recovery strategies are hardcoded in patterns, no external ML model or API call. Confidence scores are synthetic (0.8-0.95), not probabilistic.
+- **Why:** Eliminates non-determinism, latency, and external dependencies. Every failure is classifiable offline. Pure functions enable embedding directly in hot-path code (EscalateProcessor).
+- **Rejected:** Async LLM: high accuracy but introduces latency, cost, rate limits, non-determinism. ML classifier: requires labeled training data, retraining pipeline. Rules engine DSL: more flexible but harder to reason about.
+- **Trade-offs:** Gains: reliability, speed, simplicity, offline-capability. Loses: accuracy for novel failure modes, adaptability without redeployment. Patterns become domain knowledge that must be manually maintained.
+- **Breaking if changed:** If failure diversity exceeds pattern coverage, classification accuracy degrades and unknown category grows. No learning loop to auto-improve patterns. Manual pattern updates required for new tools/frameworks.
+
+#### [Pattern] Recovery strategies are tightly mapped to FailureCategory patterns, embedding tactical recovery in the classifier itself. (2026-02-24)
+- **Problem solved:** FailureAnalysis includes both category and recoveryStrategy. Each pattern matcher returns a strategy (e.g., rate_limit → exponential_backoff). Strategies are union type from shared @protolabs-ai/types.
+- **Why this works:** Keeps failure diagnosis and recovery strategy coupled—if a failure is rate-limited, retry with backoff is the correct recovery. Single source of truth per failure type prevents strategy mismatches.
+- **Trade-offs:** Simpler code (diagnosis + strategy together). Harder to evolve strategies independently. RecoveryStrategy changes require classifier updates. Strategy becomes an implementation detail of the classifier.
+
+#### [Gotcha] Confidence scores (0.8-0.95 for patterns, 0.5 for unknown) are synthetic, not Bayesian—they don't represent actual error rates or misclassification probability. (2026-02-24)
+- **Situation:** Downstream consumers may assume confidence score correlates to classification accuracy, but it's arbitrary: all matching patterns get 0.8-0.95, unmatched gets 0.5, regardless of pattern quality or false-positive rate.
+- **Root cause:** Synthetic scores are simple to assign without data. High confidence for patterns encourages escalation; 0.5 for unknown preserves optionality. Intent is signaling, not accuracy metrics.
+- **How to avoid:** Easy to assign without data vs misleading if consumers interpret as accuracy. Good for alerting logic vs bad for learning or auditing. Simpler than Bayesian scoring vs loses information about pattern quality.

--- a/.automaker/memory/cost-optimization.md
+++ b/.automaker/memory/cost-optimization.md
@@ -5,7 +5,7 @@ relevantTo: [cost-optimization]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 6
+  loaded: 7
   referenced: 4
   successfulFeatures: 4
 ---

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 357
-  referenced: 192
-  successfulFeatures: 192
+  loaded: 359
+  referenced: 193
+  successfulFeatures: 193
 ---
 # gotchas
 
@@ -337,3 +337,8 @@ usageStats:
 - **Situation:** Claude Haiku returns JSON array of questions; sometimes wrapped as ```json [...]```
 - **Root cause:** Root cause: Claude interprets 'return JSON' as 'format as markdown code block' in certain contexts; had to handle both raw and wrapped formats
 - **How to avoid:** Regex approach is more fragile/loose but handles real-world LLM output variability
+
+#### [Gotcha] Configuration drift: project settings can reference deleted/moved projects. Solution validates existence before using each path. (2026-02-24)
+- **Situation:** Settings service persists project list, but filesystem state changes independently (projects deleted, moved, renamed)
+- **Root cause:** Stale configuration causes 'session not found' errors or attempts to restore from non-existent paths. Validation prevents these failures.
+- **How to avoid:** Slightly slower (stat calls per project), but prevents crash recovery feature itself from crashing. User doesn't get feedback that config is stale.

--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -5,9 +5,9 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 26
-  referenced: 13
-  successfulFeatures: 13
+  loaded: 28
+  referenced: 14
+  successfulFeatures: 14
 ---
 # GTM Signal Intelligence & Content Operations
 

--- a/.automaker/memory/pattern.md
+++ b/.automaker/memory/pattern.md
@@ -5,9 +5,9 @@ relevantTo: [pattern]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 47
-  referenced: 29
-  successfulFeatures: 29
+  loaded: 48
+  referenced: 30
+  successfulFeatures: 30
 ---
 # pattern
 

--- a/.automaker/memory/patterns.md
+++ b/.automaker/memory/patterns.md
@@ -5,9 +5,9 @@ relevantTo: [patterns]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 11
-  referenced: 8
-  successfulFeatures: 8
+  loaded: 13
+  referenced: 9
+  successfulFeatures: 9
 ---
 # patterns
 

--- a/.automaker/memory/persistence.md
+++ b/.automaker/memory/persistence.md
@@ -5,9 +5,9 @@ relevantTo: [persistence]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 4
-  referenced: 3
-  successfulFeatures: 3
+  loaded: 6
+  referenced: 4
+  successfulFeatures: 4
 ---
 # persistence
 

--- a/.automaker/memory/reliability.md
+++ b/.automaker/memory/reliability.md
@@ -1,0 +1,17 @@
+---
+tags: [reliability]
+summary: reliability implementation decisions and patterns
+relevantTo: [reliability]
+importance: 0.7
+relatedFiles: []
+usageStats:
+  loaded: 1
+  referenced: 0
+  successfulFeatures: 0
+---
+# reliability
+
+#### [Pattern] Individual checkpoint deletion errors are caught and logged as warnings without stopping overall reconciliation; errors do not propagate to halt the process (2026-02-24)
+- **Problem solved:** Checkpoint files may fail to delete due to file system issues, permissions, race conditions, or external file removal
+- **Why this works:** Partial cleanup success is preferable to startup failure. One checkpoint deletion failure should not block deletion of other checkpoints or prevent the system from coming online. Reconciliation is a recovery operation; best effort is sufficient.
+- **Trade-offs:** Some orphaned checkpoints might persist if deletion fails (incomplete cleanup), but system availability is preserved and operational

--- a/apps/server/src/services/lead-engineer-rules.ts
+++ b/apps/server/src/services/lead-engineer-rules.ts
@@ -78,11 +78,27 @@ export const orphanedInProgress: LeadFastPathRule = {
       const age = now - new Date(f.startedAt).getTime();
       if (age > ORPHANED_IN_PROGRESS_MS) {
         const hours = Math.round(age / (60 * 60 * 1000));
-        actions.push({
-          type: 'reset_feature',
-          featureId: f.id,
-          reason: `Orphaned in-progress for ${hours}h with no running agent`,
-        });
+
+        // Features with repeated failures get blocked instead of reset
+        // to prevent infinite retry loops
+        if (f.failureCount && f.failureCount >= 3) {
+          actions.push({
+            type: 'move_feature',
+            featureId: f.id,
+            toStatus: 'blocked',
+          });
+          actions.push({
+            type: 'log',
+            level: 'warn',
+            message: `orphanedInProgress: ${f.id} blocked after ${f.failureCount} failures (orphaned ${hours}h)`,
+          });
+        } else {
+          actions.push({
+            type: 'reset_feature',
+            featureId: f.id,
+            reason: `Orphaned in-progress for ${hours}h with no running agent`,
+          });
+        }
       }
     }
     return actions;
@@ -363,6 +379,67 @@ export const remediationStalled: LeadFastPathRule = {
   },
 };
 
+/**
+ * classifiedRecovery — Escalated feature with retryable failure → auto-retry.
+ * Uses FailureClassifier analysis from the escalation event payload.
+ */
+export const classifiedRecovery: LeadFastPathRule = {
+  name: 'classifiedRecovery',
+  description: 'Escalated feature with retryable failure → auto-retry',
+  triggers: ['escalation:signal-received'],
+
+  evaluate(worldState, _eventType, payload): LeadRuleAction[] {
+    const event = payload as Record<string, unknown> | null;
+    if (!event) return [];
+
+    // Only handle feature_escalated events from the state machine
+    if (event.type !== 'feature_escalated') return [];
+
+    const inner = event.payload as Record<string, unknown> | undefined;
+    if (!inner) return [];
+
+    const featureId = inner.featureId as string | undefined;
+    if (!featureId) return [];
+
+    // Verify feature exists in world state
+    const feature = worldState.features[featureId];
+    if (!feature) return [];
+
+    const failureAnalysis = inner.failureAnalysis as
+      | {
+          category: string;
+          isRetryable: boolean;
+          suggestedDelay: number;
+          maxRetries: number;
+          explanation: string;
+          confidence: number;
+        }
+      | undefined;
+
+    if (!failureAnalysis) return [];
+
+    const retryCount = (inner.retryCount as number) || 0;
+
+    // Auto-retry if: retryable + under max retries + high confidence
+    if (
+      failureAnalysis.isRetryable &&
+      retryCount < failureAnalysis.maxRetries &&
+      failureAnalysis.confidence >= 0.7
+    ) {
+      return [
+        {
+          type: 'reset_feature',
+          featureId,
+          reason: `Auto-retry: ${failureAnalysis.category} — ${failureAnalysis.explanation} (retry ${retryCount + 1}/${failureAnalysis.maxRetries})`,
+        },
+      ];
+    }
+
+    // Non-retryable or max retries exceeded — leave blocked
+    return [];
+  },
+};
+
 // ────────────────────────── Exports ──────────────────────────
 
 /** Default set of fast-path rules */
@@ -378,6 +455,7 @@ export const DEFAULT_RULES: LeadFastPathRule[] = [
   prApproved,
   threadsBlocking,
   remediationStalled,
+  classifiedRecovery,
 ];
 
 /**

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -2218,7 +2218,10 @@ export class LeadEngineerService {
    */
   private onEvent(type: EventType, payload: unknown): void {
     const p = payload as Record<string, unknown> | null;
-    const projectPath = p?.projectPath as string | undefined;
+    const nested = p?.payload as Record<string, unknown> | null;
+
+    // Check projectPath at top level or inside nested payload
+    const projectPath = (p?.projectPath ?? nested?.projectPath) as string | undefined;
 
     if (projectPath) {
       const session = this.sessions.get(projectPath);
@@ -2229,8 +2232,8 @@ export class LeadEngineerService {
       return;
     }
 
-    // For events without projectPath (e.g., auto-mode events), try to match by featureId
-    const featureId = p?.featureId as string | undefined;
+    // Check featureId at top level or inside nested payload
+    const featureId = (p?.featureId ?? nested?.featureId) as string | undefined;
     if (featureId) {
       for (const session of this.sessions.values()) {
         if (session.flowState !== 'running') continue;


### PR DESCRIPTION
## Summary

- Adds `classifiedRecovery` fast-path rule: auto-retries features when FailureClassifier identifies a recoverable failure (transient, rate_limit, test_failure, tool_error, dependency) with >=0.7 confidence and retries remaining
- Updates `orphanedInProgress` rule: features with 3+ failures get moved to `blocked` instead of reset to backlog, preventing infinite retry loops
- Fixes event routing in `onEvent()`: checks nested `payload.featureId` and `payload.projectPath`, enabling escalation events from the state machine to actually reach fast-path rules (previously silently dropped)

## Test plan

- [ ] `npm run build:server` passes
- [ ] Verify `classifiedRecovery` rule fires on `escalation:signal-received` events with `type: 'feature_escalated'`
- [ ] Verify retryable failures (rate_limit, transient) trigger `reset_feature` action
- [ ] Verify non-retryable failures (merge_conflict, auth) don't trigger auto-retry
- [ ] Verify `orphanedInProgress` blocks features with `failureCount >= 3` instead of resetting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented automatic recovery system that intelligently retries failed features when triggered by escalation events, using confidence-based analysis

* **Bug Fixes**
  * Enhanced handling of orphaned in-progress features by blocking them after repeated failures instead of resetting
  * Improved event processing to support nested payload structures for better feature and session identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->