### PR TITLE
feat: wire antagonistic review into PlanProcessor

### DIFF
--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -277,7 +277,7 @@ class IntakeProcessor implements StateProcessor {
 class PlanProcessor implements StateProcessor {
   private readonly MAX_PLAN_RETRIES = 2;
 
-  constructor(private _serviceContext: ProcessorServiceContext) {}
+  constructor(private serviceContext: ProcessorServiceContext) {}
 
   async enter(ctx: StateContext): Promise<void> {
     logger.info(`[PLAN] Starting planning phase for feature: ${ctx.feature.id}`, {
@@ -348,6 +348,25 @@ Keep it focused and actionable. If the feature description is too vague or uncle
 
     logger.info(`[PLAN] Plan approved (${ctx.planOutput.length} chars)`);
 
+    // Antagonistic review gate for large/architectural features
+    const reviewResult = await this.antagonisticReview(ctx);
+    if (reviewResult && !reviewResult.approved) {
+      logger.warn('[PLAN] Antagonistic review rejected plan', { reason: reviewResult.reason });
+
+      if (ctx.planRetryCount < this.MAX_PLAN_RETRIES) {
+        ctx.planRetryCount++;
+        return {
+          nextState: 'PLAN',
+          shouldContinue: true,
+          reason: `Plan rejected by review: ${reviewResult.reason}`,
+          context: { reviewFeedback: reviewResult.reason },
+        };
+      }
+
+      // Max retries exceeded — proceed anyway with a warning
+      logger.warn('[PLAN] Proceeding despite review rejection (max retries exceeded)');
+    }
+
     return {
       nextState: 'EXECUTE',
       shouldContinue: true,
@@ -357,6 +376,72 @@ Keep it focused and actionable. If the feature description is too vague or uncle
 
   async exit(_ctx: StateContext): Promise<void> {
     logger.info('[PLAN] Planning phase completed');
+  }
+
+  /**
+   * Run antagonistic review on large/architectural plans.
+   * Returns null if review is skipped (small/medium features or disabled).
+   */
+  private async antagonisticReview(
+    ctx: StateContext
+  ): Promise<{ approved: boolean; reason?: string } | null> {
+    const complexity = ctx.feature.complexity || 'medium';
+    if (complexity !== 'large' && complexity !== 'architectural') {
+      return null; // Skip for small/medium features
+    }
+
+    // Check if antagonistic review is enabled in workflow settings
+    const workflowSettings = await getWorkflowSettings(ctx.projectPath);
+    if (workflowSettings.pipeline.antagonisticPlanReview === false) {
+      return null; // Disabled by settings
+    }
+
+    logger.info('[PLAN] Running antagonistic review for complex feature', {
+      featureId: ctx.feature.id,
+      complexity,
+    });
+
+    try {
+      const result = await simpleQuery({
+        prompt: `You are a critical code reviewer. Evaluate this implementation plan for a ${complexity}-complexity feature.
+
+**Feature:** ${ctx.feature.title || 'Untitled'}
+**Description:** ${ctx.feature.description || 'No description'}
+
+**Proposed Plan:**
+${ctx.planOutput}
+
+Review the plan for:
+1. Missing error handling or edge cases
+2. Architectural risks (circular dependencies, monolithic changes)
+3. Missing test strategy
+4. Files that should be modified but aren't mentioned
+5. Overly complex approach where simpler exists
+
+If the plan is solid, respond with: APPROVED
+If critical issues exist, respond with: REJECTED: [concise reason]
+Minor suggestions don't warrant rejection — only reject for issues that would cause implementation failure.`,
+        model: resolveModelString('haiku'),
+        cwd: ctx.projectPath,
+        systemPrompt:
+          'You are a senior architect reviewing implementation plans. Be critical but fair — only reject plans with genuine issues that would cause failure.',
+        maxTurns: 1,
+        allowedTools: [],
+      });
+
+      const response = result.text.trim();
+      if (response.startsWith('APPROVED')) {
+        logger.info('[PLAN] Antagonistic review approved');
+        return { approved: true };
+      }
+
+      const reason = response.startsWith('REJECTED:') ? response.slice(9).trim() : response;
+      return { approved: false, reason };
+    } catch (err) {
+      // Review failure shouldn't block the pipeline — log and approve
+      logger.warn('[PLAN] Antagonistic review failed, approving by default', err);
+      return null;
+    }
   }
 
   private validatePlan(ctx: StateContext): {

--- a/libs/types/src/settings.ts
+++ b/libs/types/src/settings.ts
@@ -2361,6 +2361,8 @@ export interface WorkflowSettings {
     maxAgentRuntimeMinutes: number;
     /** Max agent cost in USD before supervisor abort (default: 15) */
     maxAgentCostUsd: number;
+    /** Enable antagonistic plan review for large/architectural features (default: true) */
+    antagonisticPlanReview?: boolean;
   };
   retro: {
     /** Enable automatic retrospective generation on project completion (default: true) */
@@ -2405,6 +2407,7 @@ export const DEFAULT_WORKFLOW_SETTINGS: WorkflowSettings = {
     supervisorEnabled: true,
     maxAgentRuntimeMinutes: 45,
     maxAgentCostUsd: 15,
+    antagonisticPlanReview: true,
   },
   retro: {
     enabled: true,


### PR DESCRIPTION
## Summary

- Adds antagonistic plan review gate for large/architectural features in PlanProcessor
- After haiku plan generation passes basic validation, complex features get an adversarial review checking for architectural risks, missing error handling, and overly complex approaches
- Rejected plans retry with review feedback (up to 2 retries), then proceed with a warning
- Gate controlled by `WorkflowSettings.pipeline.antagonisticPlanReview` (default: `true`)
- Small/medium features skip review entirely — zero overhead for simple tasks

## Test plan

- [ ] `npm run build:packages && npm run build:server` passes
- [ ] Verify large/architectural features trigger antagonistic review after plan generation
- [ ] Verify small/medium features skip review
- [ ] Verify rejected plans retry with feedback
- [ ] Verify `antagonisticPlanReview: false` disables the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automated quality review for large and architectural plans with feedback-based retry capability to improve plan robustness.
  * New workflow setting enables/disables plan review behavior (enabled by default).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->