### PR TITLE
fix: resolve all lint warnings in knowledge services

### DIFF
--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -3136,3 +3136,32 @@ usageStats:
 - **Situation:** Downstream consumers may assume confidence score correlates to classification accuracy, but it's arbitrary: all matching patterns get 0.8-0.95, unmatched gets 0.5, regardless of pattern quality or false-positive rate.
 - **Root cause:** Synthetic scores are simple to assign without data. High confidence for patterns encourages escalation; 0.5 for unknown preserves optionality. Intent is signaling, not accuracy metrics.
 - **How to avoid:** Easy to assign without data vs misleading if consumers interpret as accuracy. Good for alerting logic vs bad for learning or auditing. Simpler than Bayesian scoring vs loses information about pattern quality.
+
+### Checkpoint cleanup split across two services using both active and passive mechanisms: AutoModeService deletes checkpoints during feature state transitions, while LeadEngineerService performs comprehensive orphaned-checkpoint scan at startup (2026-02-24)
+- **Context:** Crash recovery system must handle checkpoint files that become orphaned when features are reset or when crashes interrupt cleanup operations
+- **Why:** Defense in depth approach where active cleanup during state transitions is complemented by passive validation scan. Passive scan catches edge cases: checkpoints orphaned by crashes, missed active deletions, or features reset to backlog. Separates concerns—AutoModeService owns feature lifecycle consequences, LeadEngineerService owns system-wide consistency invariants
+- **Rejected:** Single centralized cleanup service; relying only on active deletion during state transitions; scan-only approach without active cleanup
+- **Trade-offs:** Increased code complexity and two separate deletion paths, but guarantees orphaned checkpoints are caught even after crash scenarios. Passive scan adds startup latency but provides safety net for active cleanup failures
+- **Breaking if changed:** Removing passive scan leaves system vulnerable to orphaned files after crashes. Removing active cleanup means relying only on less immediate periodic scans, increasing recovery time
+
+#### [Gotcha] Reconciliation order is a critical hidden dependency: reconcileFeatureStates() must execute before reconcileCheckpoints(). Reversed order causes orphaned checkpoints to be missed because features aren't yet in backlog state when scan runs (2026-02-24)
+- **Situation:** When reconcileFeatureStates resets a feature to backlog, that checkpoint becomes a candidate for orphaning. reconcileCheckpoints identifies checkpoints as orphaned by checking if corresponding features are in active states. If scan runs first, newly-reset features won't be seen as backlog yet
+- **Root cause:** State consistency requirement—the scan logic depends on seeing features in their final reconciled state. This is a temporal dependency that exists only due to the two-phase design
+- **How to avoid:** Requires maintaining implicit ordering constraint in startup sequence, creating subtle coupling between services that must be documented
+
+#### [Pattern] Non-blocking checkpoint deletion failures during startup recovery: errors are logged as warnings but don't halt system initialization. System prioritizes availability over perfect cleanup state (2026-02-24)
+- **Problem solved:** Crash recovery startup path must restore operational state. If cleanup failures block progress, partially-crashed system could become permanently stuck
+- **Why this works:** Recovery systems must separate concerns: checkpoint cleanup is a safety/consistency concern, but system availability is a liveness concern. Recovery paths must never allow safety work to block liveness
+- **Trade-offs:** Orphaned checkpoint files may accumulate on disk if cleanup repeatedly fails, but system remains operational. Increases risk of stale file accumulation but guarantees recovery completion
+
+#### [Pattern] Multi-level cascading fallback strategy implemented: (1) Use configured projects from global settings, (2) Fall back to process.cwd() if projects list is empty, (3) Fall back to cwd again if settings service read fails entirely (2026-02-24)
+- **Problem solved:** Recovering sessions across multiple projects requires discovering which projects exist, but this discovery can fail at different levels
+- **Why this works:** Handles two distinct failure modes: missing configuration (user hasn't set up projects) and runtime errors (settings service unavailable). Each level ensures some recovery capability works.
+- **Trade-offs:** Added complexity in error handling paths, but guarantees graceful degradation. Session recovery works even with partial system failures.
+
+### Project discovery driven by explicit global settings configuration (settingsService.getGlobalSettings().projects) rather than filesystem scanning or auto-discovery (2026-02-24)
+- **Context:** System needs to know which projects exist to recover their sessions during crash recovery
+- **Why:** Explicit configuration makes session recovery deterministic and auditable - exactly known projects are scanned. Filesystem scanning would be implicit and fragile (hidden dependencies on directory structure).
+- **Rejected:** Filesystem scanning (find all .ava/session files): creates hidden dependencies, inconsistent behavior across environments, harder to debug session recovery failures
+- **Trade-offs:** Requires users to explicitly configure projects (higher friction), but system behavior is predictable and debuggable. Easier to implement and test.
+- **Breaking if changed:** Unconfigured projects lose sessions entirely. Users must add projects to settings to enable session recovery. Changing to auto-discovery would require rearchitecting discovery mechanism.

--- a/.automaker/memory/documentation.md
+++ b/.automaker/memory/documentation.md
@@ -5,7 +5,7 @@ relevantTo: [documentation]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 42
+  loaded: 43
   referenced: 28
   successfulFeatures: 28
 ---

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 359
-  referenced: 193
-  successfulFeatures: 193
+  loaded: 362
+  referenced: 195
+  successfulFeatures: 195
 ---
 # gotchas
 
@@ -342,3 +342,8 @@ usageStats:
 - **Situation:** Settings service persists project list, but filesystem state changes independently (projects deleted, moved, renamed)
 - **Root cause:** Stale configuration causes 'session not found' errors or attempts to restore from non-existent paths. Validation prevents these failures.
 - **How to avoid:** Slightly slower (stat calls per project), but prevents crash recovery feature itself from crashing. User doesn't get feedback that config is stale.
+
+#### [Gotcha] Sessions for deleted projects are permanently lost because path validation (line 2174) prevents checking non-existent paths. Project paths must remain valid to recover their sessions. (2026-02-24)
+- **Situation:** Session discovery validates that project paths exist before attempting to read session files
+- **Root cause:** Prevents file read errors on deleted projects, keeps implementation simple and predictable. But creates data loss scenario.
+- **How to avoid:** Safety and simplicity gained, but session recovery completeness lost for any deleted project. Users lose work if they delete a project without archiving its session.

--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -5,9 +5,9 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 28
-  referenced: 14
-  successfulFeatures: 14
+  loaded: 30
+  referenced: 15
+  successfulFeatures: 15
 ---
 # GTM Signal Intelligence & Content Operations
 

--- a/.automaker/memory/pattern.md
+++ b/.automaker/memory/pattern.md
@@ -5,7 +5,7 @@ relevantTo: [pattern]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 48
+  loaded: 49
   referenced: 30
   successfulFeatures: 30
 ---

--- a/.automaker/memory/patterns.md
+++ b/.automaker/memory/patterns.md
@@ -5,7 +5,7 @@ relevantTo: [patterns]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 13
+  loaded: 14
   referenced: 9
   successfulFeatures: 9
 ---

--- a/apps/server/src/routes/knowledge/index.ts
+++ b/apps/server/src/routes/knowledge/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { Router } from 'express';
+import type { KnowledgeStoreService } from '../../services/knowledge-store-service.js';
 import { createSearchHandler } from './routes/search.js';
 import { createStatsHandler } from './routes/stats.js';
 import { createRebuildHandler } from './routes/rebuild.js';
@@ -12,7 +13,7 @@ import {
 } from './routes/ingest.js';
 import { createEvalStatsHandler } from './routes/eval-stats.js';
 
-export function createKnowledgeRoutes(knowledgeStoreService: any): Router {
+export function createKnowledgeRoutes(knowledgeStoreService: KnowledgeStoreService): Router {
   const router = Router();
 
   router.post('/search', createSearchHandler(knowledgeStoreService));

--- a/apps/server/src/routes/knowledge/routes/eval-stats.ts
+++ b/apps/server/src/routes/knowledge/routes/eval-stats.ts
@@ -4,6 +4,7 @@
 
 import type { Request, Response } from 'express';
 import { createLogger } from '@protolabs-ai/utils';
+import type { KnowledgeStoreService } from '../../../services/knowledge-store-service.js';
 
 const logger = createLogger('KnowledgeRoutes');
 
@@ -11,7 +12,7 @@ interface EvalStatsRequest {
   projectPath: string;
 }
 
-export function createEvalStatsHandler(knowledgeStoreService: any) {
+export function createEvalStatsHandler(knowledgeStoreService: KnowledgeStoreService) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
       const { projectPath } = req.body as EvalStatsRequest;

--- a/apps/server/src/routes/knowledge/routes/ingest.ts
+++ b/apps/server/src/routes/knowledge/routes/ingest.ts
@@ -4,6 +4,7 @@
 
 import type { Request, Response } from 'express';
 import { createLogger } from '@protolabs-ai/utils';
+import type { KnowledgeStoreService } from '../../../services/knowledge-store-service.js';
 
 const logger = createLogger('KnowledgeIngestRoutes');
 
@@ -14,7 +15,7 @@ interface IngestRequest {
 /**
  * POST /ingest/reflections - Ingest all reflection.md files from features
  */
-export function createIngestReflectionsHandler(knowledgeStoreService: any) {
+export function createIngestReflectionsHandler(knowledgeStoreService: KnowledgeStoreService) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
       const { projectPath } = req.body as IngestRequest;
@@ -45,7 +46,7 @@ export function createIngestReflectionsHandler(knowledgeStoreService: any) {
 /**
  * POST /ingest/agent-outputs - Ingest all agent-output.md files from features
  */
-export function createIngestAgentOutputsHandler(knowledgeStoreService: any) {
+export function createIngestAgentOutputsHandler(knowledgeStoreService: KnowledgeStoreService) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
       const { projectPath } = req.body as IngestRequest;

--- a/apps/server/src/routes/knowledge/routes/rebuild.ts
+++ b/apps/server/src/routes/knowledge/routes/rebuild.ts
@@ -4,6 +4,7 @@
 
 import type { Request, Response } from 'express';
 import { createLogger } from '@protolabs-ai/utils';
+import type { KnowledgeStoreService } from '../../../services/knowledge-store-service.js';
 
 const logger = createLogger('KnowledgeRoutes');
 
@@ -11,7 +12,7 @@ interface RebuildRequest {
   projectPath: string;
 }
 
-export function createRebuildHandler(knowledgeStoreService: any) {
+export function createRebuildHandler(knowledgeStoreService: KnowledgeStoreService) {
   return (req: Request, res: Response): void => {
     try {
       const { projectPath } = req.body as RebuildRequest;

--- a/apps/server/src/routes/knowledge/routes/search.ts
+++ b/apps/server/src/routes/knowledge/routes/search.ts
@@ -4,6 +4,8 @@
 
 import type { Request, Response } from 'express';
 import { createLogger } from '@protolabs-ai/utils';
+import type { KnowledgeSourceType } from '@protolabs-ai/types';
+import type { KnowledgeStoreService } from '../../../services/knowledge-store-service.js';
 
 const logger = createLogger('KnowledgeRoutes');
 
@@ -12,10 +14,10 @@ interface SearchRequest {
   query: string;
   maxResults?: number;
   maxTokens?: number;
-  sourceTypes?: string[];
+  sourceTypes?: KnowledgeSourceType[] | 'all';
 }
 
-export function createSearchHandler(knowledgeStoreService: any) {
+export function createSearchHandler(knowledgeStoreService: KnowledgeStoreService) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
       const { projectPath, query, maxResults, maxTokens, sourceTypes } = req.body as SearchRequest;

--- a/apps/server/src/routes/knowledge/routes/stats.ts
+++ b/apps/server/src/routes/knowledge/routes/stats.ts
@@ -4,6 +4,7 @@
 
 import type { Request, Response } from 'express';
 import { createLogger } from '@protolabs-ai/utils';
+import type { KnowledgeStoreService } from '../../../services/knowledge-store-service.js';
 
 const logger = createLogger('KnowledgeRoutes');
 
@@ -11,7 +12,7 @@ interface StatsRequest {
   projectPath: string;
 }
 
-export function createStatsHandler(knowledgeStoreService: any) {
+export function createStatsHandler(knowledgeStoreService: KnowledgeStoreService) {
   return (req: Request, res: Response): void => {
     try {
       const { projectPath } = req.body as StatsRequest;

--- a/apps/server/src/services/embedding-service.ts
+++ b/apps/server/src/services/embedding-service.ts
@@ -9,7 +9,6 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { EventEmitter } from 'node:events';
 import { createLogger } from '@protolabs-ai/utils';
-import type { Pipeline } from '@xenova/transformers';
 import type { FeatureExtractionPipeline } from '@xenova/transformers';
 
 const logger = createLogger('EmbeddingService');

--- a/apps/server/src/services/knowledge-ingestion-service.ts
+++ b/apps/server/src/services/knowledge-ingestion-service.ts
@@ -34,7 +34,7 @@ export class KnowledgeIngestionService {
    * @param db - Database instance
    * @param projectPath - Project path to rebuild index for
    */
-  rebuildIndex(db: BetterSqlite3.Database, projectPath: string): void {
+  rebuildIndex(db: BetterSqlite3.Database, _projectPath: string): void {
     try {
       // Rebuild FTS5 index from chunks table
       db.exec("INSERT INTO chunks_fts(chunks_fts) VALUES('rebuild')");

--- a/apps/server/src/services/knowledge-search-service.ts
+++ b/apps/server/src/services/knowledge-search-service.ts
@@ -522,7 +522,6 @@ export class KnowledgeSearchService {
       fs.appendFileSync(evalLogPath, JSON.stringify(logEntry) + '\n');
 
       // Rotate if file exceeds 10k lines
-      const stats = fs.statSync(evalLogPath);
       const lineCount = fs.readFileSync(evalLogPath, 'utf-8').split('\n').length;
       if (lineCount > 10000) {
         const backupPath = path.join(automakerDir, `knowledge-eval-${Date.now()}.jsonl`);

--- a/apps/server/src/services/knowledge-store-service.ts
+++ b/apps/server/src/services/knowledge-store-service.ts
@@ -13,7 +13,6 @@ import type {
   KnowledgeStoreStats,
   KnowledgeSearchOptions,
   KnowledgeSearchResult,
-  KnowledgeChunk,
   KnowledgeStoreSettings,
   RetrievalMode,
 } from '@protolabs-ai/types';
@@ -137,7 +136,7 @@ export class KnowledgeStoreService {
         ALTER TABLE chunks ADD COLUMN hype_queries TEXT
       `);
       logger.debug('Added hype_queries column to chunks table');
-    } catch (err) {
+    } catch (_err) {
       // Column already exists, ignore error
       logger.debug('hype_queries column already exists');
     }
@@ -148,7 +147,7 @@ export class KnowledgeStoreService {
         ALTER TABLE chunks ADD COLUMN hype_embeddings BLOB
       `);
       logger.debug('Added hype_embeddings column to chunks table');
-    } catch (err) {
+    } catch (_err) {
       // Column already exists, ignore error
       logger.debug('hype_embeddings column already exists');
     }


### PR DESCRIPTION
## Summary
- Replace `any` types with proper `KnowledgeStoreService` imports across all 6 knowledge route handler factories
- Fix unused variable/import warnings in `embedding-service.ts`, `knowledge-search-service.ts`, `knowledge-store-service.ts`, and `knowledge-ingestion-service.ts`
- Correct `sourceTypes` type from `string[]` to `KnowledgeSourceType[] | 'all'` in search route — a real type mismatch that `any` was hiding

## Test plan
- [x] `npm run lint` — zero warnings (was 13)
- [x] `npm run build:server` — clean compile
- [x] `npm run test:all` — 3,017 tests passing, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety across knowledge service handlers by enforcing proper type definitions for service parameters.
  * Added input validation and initialization checks to ingestion request handlers.
  * Removed unused imports and code references for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->