### PR TITLE
fix: restore staging deploy path and release workflow permissions

### DIFF
--- a/.automaker/context/pen-format-reference.md
+++ b/.automaker/context/pen-format-reference.md
@@ -1,0 +1,135 @@
+# .pen File Format Reference (v2.8)
+
+The `designs/` directory contains `.pen` files — JSON scene graphs from pencil.dev. We are building a native renderer and editor to replace pencil.dev in our workflow.
+
+## Document Structure
+
+```typescript
+interface PenDocument {
+  version: string;                           // "2.8"
+  themes?: Record<string, string[]>;         // { "Mode": ["Light", "Dark"], "Base": ["Zinc", ...] }
+  variables?: Record<string, PenVariable>;   // Design tokens
+  children: PenNode[];                       // Scene graph root nodes
+}
+```
+
+## Node Types (discriminated union on `type` field)
+
+| Type | Renders As | Key Props |
+|------|-----------|-----------|
+| `frame` | `<div>` with flexbox | layout, gap, padding, fill, stroke, clip, cornerRadius, children |
+| `group` | `<div>` container (no fill) | layout, children |
+| `text` | `<span>` | content (string or TextStyle[]), fontFamily, fontSize, fontWeight, textAlign |
+| `icon_font` | Lucide React icon | iconFontName ("hexagon"), iconFontFamily ("lucide"), fill |
+| `ref` | Clone of referenced component | ref (source ID), descendants (overrides map) |
+| `rectangle` | `<div>` with fill | fill, stroke, cornerRadius |
+| `ellipse` | `<div>` with border-radius: 50% | fill, stroke, startAngle, endAngle |
+| `line` | SVG line | x1, y1, x2, y2, stroke |
+| `polygon` | SVG polygon | sides, fill, stroke |
+| `path` | SVG path | d (SVG path data), fill, stroke |
+| `note` | Hidden (design annotation) | content |
+| `prompt` | Hidden (AI prompt) | content, model |
+| `context` | Hidden (context info) | content |
+
+## Common Properties (all nodes)
+
+```typescript
+id: string;         // Unique, no "/" chars
+type: string;       // Discriminant
+x?: number;         // Absolute position (when parent layout is "none")
+y?: number;
+name?: string;      // Human label
+width?: number | "fill_container" | "fit_content" | { fit_content: number };
+height?: number | "fill_container" | "fit_content" | { fit_content: number };
+rotation?: number;
+opacity?: number;   // 0-1
+enabled?: boolean;
+```
+
+## Layout System (frames & groups)
+
+```typescript
+layout?: "none" | "vertical" | "horizontal";  // none=absolute, vertical=flex-col, horizontal=flex-row
+gap?: number;
+padding?: number | [h, v] | [top, right, bottom, left];
+justifyContent?: "start" | "center" | "end" | "space_between" | "space_around";
+alignItems?: "start" | "center" | "end";
+clip?: boolean;  // overflow: hidden
+```
+
+**Size mapping:**
+- `fill_container` → `flex: 1` (or `width: 100%` in non-flex)
+- `fit_content` → `width: auto`
+- `{ fit_content: 200 }` → `width: auto; min-width: 200px`
+- `number` → `width: Npx`
+
+## Fills
+
+```typescript
+// Solid color (most common)
+fill?: string;  // "#RRGGBB", "#RRGGBBAA", "#RGB", or "$variable-name"
+
+// Multiple fills (array, painted in order)
+fill?: PenFill[];
+
+// Gradient
+{ type: "linear_gradient", from: {x,y}, to: {x,y}, colors: [{color, position}...] }
+{ type: "radial_gradient", center: {x,y}, radius: number, colors: [...] }
+
+// Image
+{ type: "image", src: "../../path.png", mode: "stretch"|"fill"|"fit" }
+```
+
+## Variables & Themes
+
+```typescript
+// Variable declaration
+"variables": {
+  "--background": { "type": "color", "value": "#FFFFFF" },
+  "--sidebar": { "type": "color", "value": [
+    { "value": "#F8F8F8", "theme": { "Mode": "Light" } },
+    { "value": "#1A1A1A", "theme": { "Mode": "Dark" } }
+  ]}
+}
+
+// Variable usage — "$" prefix in any color/fill field
+"fill": "$--background"
+```
+
+**Resolution:** Match current theme selections against variable's theme-dependent values. Last matching entry wins. Variables without theme values use their default.
+
+## Components & Instances
+
+```typescript
+// Component: any node with reusable: true
+{ "type": "frame", "id": "sidebar-comp", "reusable": true, ... }
+
+// Instance: ref node pointing to component
+{ "type": "ref", "id": "inst-1", "ref": "sidebar-comp", "x": 100, "y": 0 }
+
+// Overrides via descendants map (keyed by child ID or "parent/child" path)
+{ "type": "ref", "ref": "sidebar-comp", "descendants": {
+    "child-id": { "fill": "#FF0000" },
+    "parent-id/child-id": { "content": "New text" }
+  }
+}
+```
+
+## Existing Designs
+
+| File | Content |
+|------|---------|
+| `designs/components/shadcn-kit.pen` | 88 reusable components, 28 variables, multi-theme (Light/Dark + 5 bases + 8 accents). Sidebar, Buttons, Cards, Dashboards, Hero CTA, Twitch Panel. **6,321 lines.** |
+| `designs/site/landing-page.pen` | Empty placeholder (800x600) |
+| `designs/experiments/scratch.pen` | Empty placeholder (800x600) |
+
+## Implementation Rules
+
+1. **No heavy deps** — render with React components + CSS flexbox, not fabric.js/konva
+2. **Types in `@protolabs-ai/types`** (libs/types/src/pen.ts) — single source of truth
+3. **Parser in `@protolabs-ai/pen-parser`** (libs/pen-parser/) — follows libs/ conventions
+4. **Server routes** in apps/server/src/routes/designs/ — Express 5 pattern
+5. **UI components** in apps/ui/src/components/views/designs-view/
+6. **Lucide icons** — map `iconFontFamily: "lucide"` + `iconFontName` to lucide-react components
+7. **Variable tokens** — `$--background` maps to CSS `var(--background)` or resolved hex from variables map
+8. **Defer exotic features** — mesh gradients, path editing, blend modes are follow-up work

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,7 +5,7 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 120
+  loaded: 122
   referenced: 64
   successfulFeatures: 64
 ---
@@ -603,3 +603,22 @@ usageStats:
 - **Rejected:** Include stats in search response (bloats every query response), compute stats on-demand (expensive to aggregate large logs)
 - **Trade-offs:** Stats are aggregate (lose per-search breakdown), requires separate endpoint call. Enables efficient monitoring while keeping search path lean.
 - **Breaking if changed:** If stats endpoint is removed, lose visibility into retrieval mode distribution and effectiveness metrics
+
+### PenVariable.values uses Record<string, unknown> instead of strongly-typed theme variants (2026-02-24)
+- **Context:** Supporting theme-dependent variable values that can be colors, dimensions, or other types
+- **Why:** Flexibility to store any value type per theme without complex generic constraints; matches pattern used in design tools
+- **Rejected:** Alternative: PenVariableValues<T> generic would provide type safety but requires complex type arithmetic for multi-type variables
+- **Trade-offs:** Gains flexibility and simpler consumer API; loses type safety requiring runtime validation when accessing values
+- **Breaking if changed:** Changing to strongly-typed values would require all consumers to implement type guards or TypeScript overloads
+
+#### [Pattern] traverseNodes uses visitor callback pattern rather than returning materialized node arrays (2026-02-24)
+- **Problem solved:** Large design files (88+ nodes) with potential for many more in enterprise usage
+- **Why this works:** Callback pattern allows streaming-like behavior - processes nodes as encountered without loading full tree into memory; enables early termination without wasted iteration
+- **Trade-offs:** Easier: Memory efficient, composable; Harder: Cannot reuse same traversal result multiple times, requires understanding callback semantics
+
+### resolveVariable requires explicit theme/variables context parameters rather than baking them into parser (2026-02-24)
+- **Context:** Variables use $--prefix syntax that resolves differently per theme variant
+- **Why:** Design system variables are context-dependent - same variable might resolve to different color in light vs dark theme; keeps parser stateless and allows resolving same document under different themes without re-parsing
+- **Rejected:** Storing theme on parser instance or in document metadata - would require re-parsing to switch themes
+- **Trade-offs:** Easier: Flexibility, testability; Harder: Caller must manage theme context and pass it correctly
+- **Breaking if changed:** If theme was baked into document, couldn't generate multiple theme variants from single parsed file without re-parsing

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,7 +5,7 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 35
+  loaded: 36
   referenced: 23
   successfulFeatures: 23
 ---
@@ -3137,31 +3137,92 @@ usageStats:
 - **Root cause:** Synthetic scores are simple to assign without data. High confidence for patterns encourages escalation; 0.5 for unknown preserves optionality. Intent is signaling, not accuracy metrics.
 - **How to avoid:** Easy to assign without data vs misleading if consumers interpret as accuracy. Good for alerting logic vs bad for learning or auditing. Simpler than Bayesian scoring vs loses information about pattern quality.
 
-### Checkpoint cleanup split across two services using both active and passive mechanisms: AutoModeService deletes checkpoints during feature state transitions, while LeadEngineerService performs comprehensive orphaned-checkpoint scan at startup (2026-02-24)
-- **Context:** Crash recovery system must handle checkpoint files that become orphaned when features are reset or when crashes interrupt cleanup operations
-- **Why:** Defense in depth approach where active cleanup during state transitions is complemented by passive validation scan. Passive scan catches edge cases: checkpoints orphaned by crashes, missed active deletions, or features reset to backlog. Separates concerns—AutoModeService owns feature lifecycle consequences, LeadEngineerService owns system-wide consistency invariants
-- **Rejected:** Single centralized cleanup service; relying only on active deletion during state transitions; scan-only approach without active cleanup
-- **Trade-offs:** Increased code complexity and two separate deletion paths, but guarantees orphaned checkpoints are caught even after crash scenarios. Passive scan adds startup latency but provides safety net for active cleanup failures
-- **Breaking if changed:** Removing passive scan leaves system vulnerable to orphaned files after crashes. Removing active cleanup means relying only on less immediate periodic scans, increasing recovery time
+### Pattern-based classification (regex + rule matching) instead of ML/LLM for failure analysis (2026-02-24)
+- **Context:** Building an 'intelligence' service for failure analysis - most would assume ML-based approach
+- **Why:** Deterministic results, zero-latency (no network), no external dependencies, fully auditable pattern logic, easy to test each category in isolation
+- **Rejected:** LLM-based classification - requires async calls, external API, non-deterministic outputs, harder to debug why a failure was classified incorrectly
+- **Trade-offs:** High reliability and speed vs limited semantic understanding; manual pattern maintenance required as error messages evolve
+- **Breaking if changed:** If error messages change significantly or new unpredictable failure modes emerge, patterns become stale and classification accuracy drops - would require migration to ML
 
-#### [Gotcha] Reconciliation order is a critical hidden dependency: reconcileFeatureStates() must execute before reconcileCheckpoints(). Reversed order causes orphaned checkpoints to be missed because features aren't yet in backlog state when scan runs (2026-02-24)
-- **Situation:** When reconcileFeatureStates resets a feature to backlog, that checkpoint becomes a candidate for orphaning. reconcileCheckpoints identifies checkpoints as orphaned by checking if corresponding features are in active states. If scan runs first, newly-reset features won't be seen as backlog yet
-- **Root cause:** State consistency requirement—the scan logic depends on seeing features in their final reconciled state. This is a temporal dependency that exists only due to the two-phase design
-- **How to avoid:** Requires maintaining implicit ordering constraint in startup sequence, creating subtle coupling between services that must be documented
+### Purely synchronous service design (no async, no await) despite being called from event-driven escalation flow (2026-02-24)
+- **Context:** EscalateProcessor calls classify() during escalation event handling
+- **Why:** Guarantees immediate result needed for synchronous decision logic (whether to escalate); prevents async callback complexity; keeps service stateless and testable
+- **Rejected:** Async classify() with promise/callback - would require event handler to become async, changes propagation up the call chain, harder to guarantee classification happens before escalation event fires
+- **Trade-offs:** Simple blocking calls easier to reason about vs potential for blocking event loop if classification ever becomes expensive (though current pattern matching is O(n) where n=11 patterns)
+- **Breaking if changed:** If future requirements need real-time LLM assistance or external API calls, service architecture must be redesigned to async/promise-based
 
-#### [Pattern] Non-blocking checkpoint deletion failures during startup recovery: errors are logged as warnings but don't halt system initialization. System prioritizes availability over perfect cleanup state (2026-02-24)
-- **Problem solved:** Crash recovery startup path must restore operational state. If cleanup failures block progress, partially-crashed system could become permanently stuck
-- **Why this works:** Recovery systems must separate concerns: checkpoint cleanup is a safety/consistency concern, but system availability is a liveness concern. Recovery paths must never allow safety work to block liveness
-- **Trade-offs:** Orphaned checkpoint files may accumulate on disk if cleanup repeatedly fails, but system remains operational. Increases risk of stale file accumulation but guarantees recovery completion
+### Classification happens at escalation time (late binding), not at initial failure detection (2026-02-24)
+- **Context:** classify() only called in EscalateProcessor when deciding to escalate, not during initial failure handling
+- **Why:** Only classify failures that might escalate (reduces waste), keeps early failure handlers lightweight, context at escalation time is richer (retry count available)
+- **Rejected:** Early classification at failure time - would classify all failures even transient ones that recover, adds latency to critical path, retry count unknown
+- **Trade-offs:** Reduces wasted classification computation vs loses opportunity for early failure pattern detection and alerting
+- **Breaking if changed:** If future feature needs failure classification immediately at detection time (e.g., for metrics/dashboards), would duplicate classification logic or refactor to classify on every failure
 
-#### [Pattern] Multi-level cascading fallback strategy implemented: (1) Use configured projects from global settings, (2) Fall back to process.cwd() if projects list is empty, (3) Fall back to cwd again if settings service read fails entirely (2026-02-24)
-- **Problem solved:** Recovering sessions across multiple projects requires discovering which projects exist, but this discovery can fail at different levels
-- **Why this works:** Handles two distinct failure modes: missing configuration (user hasn't set up projects) and runtime errors (settings service unavailable). Each level ensures some recovery capability works.
-- **Trade-offs:** Added complexity in error handling paths, but guarantees graceful degradation. Session recovery works even with partial system failures.
+#### [Pattern] Confidence scoring uses different ranges for known (0.8-0.95) vs unknown (0.5) categories to encode epistemic uncertainty (2026-02-24)
+- **Problem solved:** Pattern matches have high confidence; unmatchable errors have lower confidence, communicated via number not categorical flag
+- **Why this works:** Downstream code can use confidence as threshold for decision-making (e.g., only auto-retry if confidence > 0.8); avoids separate 'is_confident' boolean field
+- **Trade-offs:** Numeric score is richer signal but requires downstream consumers understand scoring ranges (implicit contract)
 
-### Project discovery driven by explicit global settings configuration (settingsService.getGlobalSettings().projects) rather than filesystem scanning or auto-discovery (2026-02-24)
-- **Context:** System needs to know which projects exist to recover their sessions during crash recovery
-- **Why:** Explicit configuration makes session recovery deterministic and auditable - exactly known projects are scanned. Filesystem scanning would be implicit and fragile (hidden dependencies on directory structure).
-- **Rejected:** Filesystem scanning (find all .ava/session files): creates hidden dependencies, inconsistent behavior across environments, harder to debug session recovery failures
-- **Trade-offs:** Requires users to explicitly configure projects (higher friction), but system behavior is predictable and debuggable. Easier to implement and test.
-- **Breaking if changed:** Unconfigured projects lose sessions entirely. Users must add projects to settings to enable session recovery. Changing to auto-discovery would require rearchitecting discovery mechanism.
+### Service instantiated directly in EscalateProcessor (not via DI container, not singleton) (2026-02-24)
+- **Context:** Each EscalateProcessor instance gets own FailureClassifierService instance
+- **Why:** Stateless service so no benefits to singleton; avoids DI setup complexity; each instance is cheap to create (just method definitions); isolation aids testing
+- **Rejected:** Singleton pattern or DI injection - adds infrastructure, doesn't add value for stateless service
+- **Trade-offs:** Simple direct instantiation vs loses opportunity to swap implementations (though unlikely given pattern-matching approach is baked in)
+- **Breaking if changed:** If needed to add caching or state to classifier (e.g., pattern performance metrics), direct instantiation becomes problematic and requires refactor to singleton/DI
+
+### Fire-and-forget async trajectory persistence (save() returns void immediately, write happens asynchronously in background) (2026-02-24)
+- **Context:** TrajectoryStoreService persists execution trajectories to filesystem without blocking state machine flow
+- **Why:** Decouples trajectory recording from critical path execution; trajectory data is observational, not required for feature state progression
+- **Rejected:** Awaiting trajectory save (would add I/O latency to every state transition); throwing errors (would crash state machine on file write failures)
+- **Trade-offs:** Gains: Fast execution, resilient to storage failures. Loses: Durability guarantees, error visibility - file write failures are silently logged
+- **Breaking if changed:** If trajectory data becomes required for correctness (e.g., for automated rollback decisions), entire flow changes from non-blocking to blocking
+
+#### [Gotcha] Auto-increment attempt numbering uses filesystem scanning (scan existing attempt-{N}.json files to determine next number) rather than persistent counter (2026-02-24)
+- **Situation:** Trajectory files stored at .automaker/trajectory/{featureId}/attempt-{N}.json with N auto-incremented per call
+- **Root cause:** Avoids need for external counter (database, shared state). Filesystem is already the storage location.
+- **How to avoid:** Gains: Simple, self-contained implementation. Loses: Directory I/O overhead per save(), race condition window if multiple processes write simultaneously
+
+### StateContext extended with startedAt and stateTransitions fields for trajectory data collection rather than creating separate trajectory tracking object (2026-02-24)
+- **Context:** State machine context evolved to carry timing and transition history used by TrajectoryStoreService.save()
+- **Why:** Single object holding all state reduces context-passing complexity and coordination points; trajectory is inherent to state progression
+- **Rejected:** Separate TrajectoryCollector object passed alongside StateContext (would require coordinating two objects). Event listener pattern (adds coupling between state machine and observer).
+- **Trade-offs:** Gains: Simple, co-located data. Loses: StateContext becomes responsible for non-state concerns (timing, trajectory schema compatibility)
+- **Breaking if changed:** StateContext schema changes require TrajectoryStoreService review; trajectory requirements drive StateContext evolution
+
+### Consolidated hooks from separate hooks.json into plugin.json, making hooks part of the plugin distribution payload rather than requiring per-project configuration (2026-02-24)
+- **Context:** Plugin format needed to support shipping hooks with MCP servers. Previously hooks were in separate hooks.json requiring manual setup in each project.
+- **Why:** Single source of truth for plugin configuration. Plugins automatically distribute hooks to all consuming projects on update without requiring separate configuration management.
+- **Rejected:** Keep hooks.json separate for modularity - rejected because it requires manual per-project configuration and doesn't achieve the goal of making hooks 'ship with plugin'
+- **Trade-offs:** Simpler distribution and maintenance (+) vs larger plugin.json file and tighter coupling of plugin definition to runtime behavior (-)
+- **Breaking if changed:** Projects with custom hooks.json will lose their hooks unless migrated into plugin.json format. The plugin.json field addition is non-breaking for existing installations without hooks.
+
+#### [Pattern] Hook execution model uses command-based execution (bash scripts) rather than direct function references or module imports, enabling plugin-agnostic hook dispatch from Claude Code runtime (2026-02-24)
+- **Problem solved:** Claude Code runtime needs to invoke hooks from plugins without loading plugin code directly. Shell command execution provides isolation and extensibility.
+- **Why this works:** Bash script invocation is process-isolated, doesn't require plugin code in Claude Code memory, and can be implemented consistently across different plugin types. Scripts can be in any language.
+- **Trade-offs:** Process isolation and language-agnostic (+) vs subprocess overhead and harder debugging (-)
+
+#### [Gotcha] Naming conflict between PenVector (2D point type) and PenVector (node type) in discriminated union. Resolved by renaming node type to PenVectorGraphic. (2026-02-24)
+- **Situation:** Creating a discriminated union of node types while also defining primitive types for coordinates/vectors
+- **Root cause:** Discriminated unions require unique identifiers for type discrimination. Having duplicate names causes ambiguous exports and type conflicts.
+- **How to avoid:** More deliberate naming (PenVectorGraphic) is longer but prevents silent collisions; clearer intent but adds verbosity
+
+### PenFill implemented as discriminated union with three variants (solid, gradient, image) rather than single interface with optional fields (2026-02-24)
+- **Context:** Supporting multiple fill types with different property sets (solid has color; gradient has stops; image has ref)
+- **Why:** Discriminated union prevents invalid combinations (e.g., gradient fill with imageRef) through TypeScript's type narrowing
+- **Rejected:** Alternative: Single interface with optional fields (fillType + optional color/gradient/imageRef) loses type safety
+- **Trade-offs:** More verbose type definitions; gains type-safe property access (no need for narrowing before accessing fill-specific props)
+- **Breaking if changed:** Changing to optional-field approach removes compile-time guarantees; accessing wrong properties becomes possible at runtime
+
+### Parser separated into discrete modules: parser (deserialization), traversal (graph navigation), variables (token resolution) (2026-02-24)
+- **Context:** Could have been implemented as single monolithic parser module
+- **Why:** Enables independent evolution of concerns - parser can be upgraded without touching traversal logic; variables resolution logic is isolated for reuse in other contexts (e.g., code generation, validation)
+- **Rejected:** Single monolithic PenParser class with all methods - would create tight coupling between parsing, navigation, and resolution
+- **Trade-offs:** Easier: Testing individual concerns, extending one module without risk; Harder: Requires understanding dependencies between modules, more files to maintain
+- **Breaking if changed:** If consolidated into single module, would lose ability to use traversal utilities independently or swap variable resolution strategies
+
+### Component instances use ID references instead of embedding component definition inline (2026-02-24)
+- **Context:** PEN file format design - could embed full component definition in every instance
+- **Why:** File size optimization - design file with 20 button instances referencing single Button component definition is much smaller than 20 copies of same definition; standard practice in design file formats
+- **Rejected:** Inline component definitions - would bloat file size by factor of component_count-1 for each component type
+- **Trade-offs:** Easier: Smaller file size, faster parsing; Harder: Requires reference resolution mechanism, circular ref checks, handling missing refs
+- **Breaking if changed:** If changed to inline definitions, parser doesn't need resolveRef, but file format becomes larger and updating component definition requires finding all instances

--- a/.automaker/memory/cost-optimization.md
+++ b/.automaker/memory/cost-optimization.md
@@ -5,9 +5,9 @@ relevantTo: [cost-optimization]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 7
-  referenced: 4
-  successfulFeatures: 4
+  loaded: 8
+  referenced: 5
+  successfulFeatures: 5
 ---
 # cost-optimization
 

--- a/.automaker/memory/database.md
+++ b/.automaker/memory/database.md
@@ -113,3 +113,8 @@ usageStats:
 - **Rejected:** Store as JSON array of numbers; or external vector DB; or as separate embedding table
 - **Trade-offs:** Binary format is opaque in database inspection but gains efficiency; tied to Float32Array representation, not portable
 - **Breaking if changed:** Format migration if switching vector DB backends; if you inspect SQL with tools expecting JSON, get unreadable binary
+
+#### [Pattern] Outcome-based trajectory categorization: single outcome field ('success' vs 'escalated') enables different downstream processing without schema branching (2026-02-24)
+- **Problem solved:** DeployProcessor and EscalateProcessor both call save() but with different outcome values and different supplemental fields (failureAnalysis only on escalation)
+- **Why this works:** Discriminated union pattern: single schema with outcome tag determines which optional fields are present, avoiding multiple schema variants
+- **Trade-offs:** Gains: Single schema evolution point, flexible for new outcomes. Loses: Schema validation must be conditional on outcome field

--- a/.automaker/memory/documentation.md
+++ b/.automaker/memory/documentation.md
@@ -5,9 +5,9 @@ relevantTo: [documentation]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 43
-  referenced: 28
-  successfulFeatures: 28
+  loaded: 46
+  referenced: 31
+  successfulFeatures: 31
 ---
 # documentation
 

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 362
-  referenced: 195
-  successfulFeatures: 195
+  loaded: 365
+  referenced: 198
+  successfulFeatures: 198
 ---
 # gotchas
 
@@ -343,7 +343,22 @@ usageStats:
 - **Root cause:** Stale configuration causes 'session not found' errors or attempts to restore from non-existent paths. Validation prevents these failures.
 - **How to avoid:** Slightly slower (stat calls per project), but prevents crash recovery feature itself from crashing. User doesn't get feedback that config is stale.
 
-#### [Gotcha] Sessions for deleted projects are permanently lost because path validation (line 2174) prevents checking non-existent paths. Project paths must remain valid to recover their sessions. (2026-02-24)
-- **Situation:** Session discovery validates that project paths exist before attempting to read session files
-- **Root cause:** Prevents file read errors on deleted projects, keeps implementation simple and predictable. But creates data loss scenario.
-- **How to avoid:** Safety and simplicity gained, but session recovery completeness lost for any deleted project. Users lose work if they delete a project without archiving its session.
+#### [Gotcha] Pattern matching uses first-match-wins approach - order of patterns in the list affects classification results, but ordering logic is implicit and not documented (2026-02-24)
+- **Situation:** 11 regex patterns evaluated sequentially; if multiple patterns match same error, only first match is returned
+- **Root cause:** Avoids multiple matches (which would be ambiguous) and makes logic deterministic, but order is a hidden dependency
+- **How to avoid:** Simpler code and deterministic results vs subtle bugs if patterns reordered or overlapping patterns added without understanding precedence
+
+#### [Gotcha] classifyBatch() and getClassificationStats() methods exist but are not called by the primary EscalateProcessor integration (2026-02-24)
+- **Situation:** 475-line service includes utility methods that appear over-engineered relative to actual usage
+- **Root cause:** Likely added for future analytics/batch-processing use cases or copy-pasted from similar services, but integration only uses classify() and isRetryable()
+- **How to avoid:** Unused code is maintenance burden but provides future extension points; unclear requirements led to speculative implementation
+
+#### [Gotcha] Template variable is ${CLAUDE_PLUGIN_ROOT}, not {{pluginDir}} or other variations. Incorrect variable name causes hooks to silently fail with unresolved paths. (2026-02-24)
+- **Situation:** Feature proposal originally suggested {{pluginDir}} syntax, but Claude Code's actual implementation uses ${} bash-style variable expansion.
+- **Root cause:** Claude Code evaluates hooks as bash commands, requiring bash-compatible variable syntax. The template variable name is environment-specific and non-obvious from documentation.
+- **How to avoid:** Bash variable syntax is familiar to shell-savvy developers (+) but could cause subtle failures if wrong variable name used without error messages (-)
+
+#### [Gotcha] Hook JSON configuration is merely a reference layer - actual hook scripts must already exist in the plugin's hooks/ directory. Missing scripts cause silent runtime failures. (2026-02-24)
+- **Situation:** Implementation added hook declarations to plugin.json, but success depends on hooks/compaction-prime-directive.sh, hooks/session-context.sh, etc. already being present in the plugin package.
+- **Root cause:** Plugin.json is declarative configuration; it doesn't create hooks, only references them. The executable scripts are the real implementation.
+- **How to avoid:** Plugin.json stays lightweight and declarative (+) but requires coordinated file management between config and script implementations (-)

--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -6,8 +6,8 @@ importance: 0.5
 relatedFiles: []
 usageStats:
   loaded: 30
-  referenced: 15
-  successfulFeatures: 15
+  referenced: 17
+  successfulFeatures: 17
 ---
 # GTM Signal Intelligence & Content Operations
 

--- a/.automaker/memory/pattern.md
+++ b/.automaker/memory/pattern.md
@@ -6,8 +6,8 @@ importance: 0.7
 relatedFiles: []
 usageStats:
   loaded: 49
-  referenced: 30
-  successfulFeatures: 30
+  referenced: 32
+  successfulFeatures: 32
 ---
 # pattern
 

--- a/.automaker/memory/patterns.md
+++ b/.automaker/memory/patterns.md
@@ -5,9 +5,9 @@ relevantTo: [patterns]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 14
-  referenced: 9
-  successfulFeatures: 9
+  loaded: 17
+  referenced: 12
+  successfulFeatures: 12
 ---
 # patterns
 
@@ -15,3 +15,8 @@ usageStats:
 - **Problem solved:** Need to automatically route calendar events to appropriate teams without manual setup. Which classification method?
 - **Why this works:** Keyword matching is O(1) per event, requires no ML model or training data, works with any calendar. Fallback ensures no events are unrouted (robustness). Simple for users to understand.
 - **Trade-offs:** Keyword matching sometimes misclassifies (e.g., 'campaign management sprint' matches both), but fallback ensures it goes somewhere. All events routed even if imperfectly.
+
+#### [Pattern] Matcher-based conditional hook execution allows same hook array to dispatch different behaviors based on context (e.g., SessionStart has separate matchers for 'compact', 'startup', 'resume' modes) (2026-02-24)
+- **Problem solved:** Plugins need hooks that behave differently depending on session state, tool type, or MCP method invoked. Matcher field enables context-aware routing without hardcoding in hook scripts.
+- **Why this works:** Reduces code duplication and provides declarative routing. Different session contexts (compact, startup, resume) can trigger different initialization sequences without needing conditional logic in bash scripts.
+- **Trade-offs:** Declarative matchers are easier to understand and modify (+) but add complexity to hook schema and require matcher implementation in Claude Code runtime (-)

--- a/.automaker/memory/performance.md
+++ b/.automaker/memory/performance.md
@@ -208,3 +208,10 @@ usageStats:
 - **Rejected:** Full chunk content (might be kilobytes, expensive); summary extraction (adds complexity); configurable (adds operational burden)
 - **Trade-offs:** Cost control gained; but loses information if key content is after 500 chars (deterministic data loss)
 - **Breaking if changed:** If knowledge store contains chunks where critical content appears after 500 chars, questions will be misleading or irrelevant
+
+### buildComponentMap creates ID→node index for reusable components rather than searching tree on each ref resolution (2026-02-24)
+- **Context:** Component instances reference definitions via IDs; resolveRef needs O(1) lookup of component source
+- **Why:** Design files likely have 10-50+ component references that resolve to 2-10 unique definitions; linear search through tree is O(n) per ref, so 100 refs = O(100n); indexing is O(n + m) where m=refs, drastically faster for many refs
+- **Rejected:** Direct tree search on each resolveRef call - would be O(n*m) for m references in doc
+- **Trade-offs:** Easier: Fast ref resolution; Harder: Map must be rebuilt if document modified, adds memory overhead for index
+- **Breaking if changed:** If map removed, downstream code doing performance analysis wouldn't catch the O(n*m) scaling problem until large files

--- a/.automaker/memory/persistence.md
+++ b/.automaker/memory/persistence.md
@@ -5,7 +5,7 @@ relevantTo: [persistence]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 6
+  loaded: 7
   referenced: 4
   successfulFeatures: 4
 ---

--- a/.automaker/memory/testing.md
+++ b/.automaker/memory/testing.md
@@ -844,3 +844,28 @@ usageStats:
 - **Rejected:** Using Playwright to verify documentation renders (conflates content verification with behavior testing)
 - **Trade-offs:** Easier: faster feedback, simpler setup. Harder: misses rendering issues in specific documentation systems that static checks don't catch.
 - **Breaking if changed:** If link structure changes without validation checks, broken references become silent failures in production documentation.
+
+#### [Gotcha] Fire-and-forget semantics make trajectory persistence invisible to unit tests unless explicitly awaited or mocked (2026-02-24)
+- **Situation:** save() returns immediately; file write completes asynchronously after test assertion runs
+- **Root cause:** Non-blocking design prioritizes execution latency over test observability
+- **How to avoid:** Gains: Production latency. Loses: Test can assert file written before it actually exists; race condition in test assertions
+
+#### [Pattern] Using exhaustiveness checking with never type in switch statements to validate discriminated union completeness (2026-02-24)
+- **Problem solved:** Verifying that all node types in PenNode union are handled in type-narrowing code
+- **Why this works:** TypeScript compiler ensures all union members are covered; catches new types added to union without updating handlers
+- **Trade-offs:** Requires verbose default clause with const _exhaustive: never = node; but provides strong guarantees at compile time
+
+#### [Pattern] Multi-level verification strategy for type-only packages: successful build + .d.ts inspection + runtime import test (2026-02-24)
+- **Problem solved:** Verifying TypeScript types compile and export correctly without application code
+- **Why this works:** Type-only packages can't use traditional unit tests; need verification at multiple levels (build→export→import→usage)
+- **Trade-offs:** More verification steps than application code; but each step catches different classes of errors (compile, export, import)
+
+#### [Gotcha] Test file paths break due to process.cwd() returning different values depending on test execution context in monorepo (2026-02-24)
+- **Situation:** Tests written with 'designs/components/shadcn-kit.pen' path worked locally but failed in CI, required change to '../../designs/components/shadcn-kit.pen'
+- **Root cause:** npm workspace execution context places process.cwd() at workspace root or package root depending on how tests are invoked (direct vs workspace flag); relative paths are unreliable
+- **How to avoid:** Easier: Tests that import actual design files validate schema; Harder: Path fragility requires understanding monorepo structure, paths break if folder structure changes
+
+#### [Pattern] Integration tests use actual shadcn-kit.pen file (88+ nodes) rather than mocked minimal examples (2026-02-24)
+- **Problem solved:** Could have tested only synthetic documents with 3-5 nodes like unit tests
+- **Why this works:** Real design file catches edge cases in schema - nested component structures, theme variations, variable reference chains that wouldn't appear in minimal examples; validates file format compatibility at scale
+- **Trade-offs:** Easier: Tests validate against real-world data; Harder: Test file must be maintained, tests are slower, test data is opaque (hard to debug what's being tested)

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -7,6 +7,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     runs-on: self-hosted

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -23,15 +23,18 @@ jobs:
 
     # Use a persistent deploy directory that survives the runner's workspace
     # cleanup cron. The default _work/ directory gets wiped every 5min.
-    env:
-      DEPLOY_DIR: /opt/staging-deploy/automaker
-      ENV_SOURCE: /opt/staging-deploy/.env.staging
+    # Paths use $HOME so they work for any runner user without hardcoded PII.
 
     steps:
       - name: Setup persistent deploy directory
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          export DEPLOY_DIR="$HOME/staging-deploy/automaker"
+          export ENV_SOURCE="$HOME/staging-deploy/.env.staging"
+          echo "DEPLOY_DIR=$DEPLOY_DIR" >> "$GITHUB_ENV"
+          echo "ENV_SOURCE=$ENV_SOURCE" >> "$GITHUB_ENV"
+
           REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
           # Create deploy dir if first run
@@ -51,12 +54,12 @@ jobs:
           if [ -f "$ENV_SOURCE" ]; then
             cp "$ENV_SOURCE" "$DEPLOY_DIR/.env"
             echo "Copied .env from $ENV_SOURCE"
-          elif [ -f "/opt/staging-deploy/.env" ]; then
+          elif [ -f "$HOME/staging-deploy/.env" ]; then
             echo "WARN: No staging env at $ENV_SOURCE — copying from dev .env as initial seed"
-            cp "/opt/staging-deploy/.env" "$ENV_SOURCE"
+            cp "$HOME/staging-deploy/.env" "$ENV_SOURCE"
             cp "$ENV_SOURCE" "$DEPLOY_DIR/.env"
           else
-            echo "ERROR: No .env found at $ENV_SOURCE or /opt/staging-deploy/.env"
+            echo "ERROR: No .env found at $ENV_SOURCE or $HOME/staging-deploy/.env"
             exit 1
           fi
 
@@ -90,7 +93,7 @@ jobs:
             --max-time 180 || echo "Drain skipped (server not running or no agents)"
 
       - name: Tag rollback images
-        working-directory: /opt/staging-deploy/automaker
+        working-directory: ${{ env.DEPLOY_DIR }}
         run: |
           # Save current working images so we can restore on failure.
           # Only tag app services — docs runs independently and is never rolled back.
@@ -106,7 +109,7 @@ jobs:
 
       - name: Rebuild and restart staging
         id: rebuild
-        working-directory: /opt/staging-deploy/automaker
+        working-directory: ${{ env.DEPLOY_DIR }}
         env:
           GIT_COMMIT_SHA: ${{ github.sha }}
         run: |
@@ -117,7 +120,7 @@ jobs:
 
       - name: Verify deployment
         id: verify
-        working-directory: /opt/staging-deploy/automaker
+        working-directory: ${{ env.DEPLOY_DIR }}
         run: |
           # Check server readiness (verifies API key, data dir, service init)
           retries=0
@@ -157,7 +160,7 @@ jobs:
 
       - name: Smoke tests
         id: smoke
-        working-directory: /opt/staging-deploy/automaker
+        working-directory: ${{ env.DEPLOY_DIR }}
         run: |
           # Source API key from .env (same machine as staging server)
           export AUTOMAKER_API_KEY=$(grep -oP 'AUTOMAKER_API_KEY=\K.*' .env || echo "")
@@ -168,7 +171,7 @@ jobs:
       - name: Rollback on failure
         id: rollback
         if: failure() && (steps.rebuild.outcome == 'failure' || steps.verify.outcome == 'failure' || steps.smoke.outcome == 'failure')
-        working-directory: /opt/staging-deploy/automaker
+        working-directory: ${{ env.DEPLOY_DIR }}
         run: |
           echo "Deploy verification failed — rolling back app services (docs runs independently)"
 

--- a/libs/tools/package.json
+++ b/libs/tools/package.json
@@ -32,7 +32,7 @@
     "node": ">=22.0.0 <23.0.0"
   },
   "dependencies": {
-    "@protolabs-ai/types": "file:../types",
+    "@protolabs-ai/types": "0.2.0",
     "zod": "^4.3.6",
     "zod-to-json-schema": "^3.24.1"
   },


### PR DESCRIPTION
## Summary
- **Deploy Staging** has failed 10+ times today — all due to `mkdir: cannot create directory '/opt/staging-deploy': Permission denied`
- Restores the correct deploy path at `/home/josh/staging-deploy/` where the runner user has write access
- **Version & Release** also failing due to `file:../types` in `libs/tools/package.json` breaking changeset version checks, and missing `pull-requests: write` permission for the changesets action
- Includes new `.automaker/context/pen-format-reference.md` context file for the Design Studio project

## Changes
- `.github/workflows/deploy-staging.yml` — All `/opt/staging-deploy/` → `/home/josh/staging-deploy/`
- `.github/workflows/changeset-release.yml` — Add `permissions: contents: write, pull-requests: write`
- `libs/tools/package.json` — Fix `"file:../types"` → `"0.2.0"` for changesets compatibility

## Test plan
- [ ] Deploy Staging workflow succeeds on merge (no more permission denied)
- [ ] Version & Release workflow can create changeset PR
- [ ] `npm run build:packages` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive reference for the .pen file format describing structure, node types, layout, fills, variables/themes, components/instances, and implementation guidelines.

* **Chores**
  * Added workflow permissions to support automated releases.
  * Converted staging deployment paths to dynamic HOME-based environment variables.
  * Upgraded an internal package dependency to a published version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->