### PR TITLE
feat: Linear milestone targetDate sync and webhook dueDate propagation

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -393,6 +393,7 @@ archivalService.start();
 
 // Calendar service
 calendarService.setFeatureLoader(featureLoader);
+calendarService.setSettingsService(settingsService);
 const autoModeService = new AutoModeService(events, settingsService);
 const hitlFormService = new HITLFormService({
   events,

--- a/apps/server/src/routes/linear/webhook.ts
+++ b/apps/server/src/routes/linear/webhook.ts
@@ -107,6 +107,8 @@ interface LinearIssueWebhookPayload extends LinearWebhookPayload {
       /** When SLA breach is expected */
       breachesAt?: string;
     };
+    /** Due date (YYYY-MM-DD format, set when issue has a due date in Linear) */
+    dueDate?: string;
     /** Timestamps */
     createdAt: string;
     updatedAt: string;
@@ -421,6 +423,7 @@ async function handleIssueUpdated(
   await linearSyncService.onLinearIssueUpdated(data.id, stateName, projectPath, {
     title: data.title,
     priority: data.priority,
+    dueDate: data.dueDate,
   });
 
   // Also emit event for other listeners (UI, logging, etc.)

--- a/apps/server/src/services/calendar-service.ts
+++ b/apps/server/src/services/calendar-service.ts
@@ -12,6 +12,8 @@ import { createLogger, atomicWriteJson, readJsonWithRecovery } from '@protolabs-
 import { getAutomakerDir } from '@protolabs-ai/platform';
 import * as secureFs from '../lib/secure-fs.js';
 import type { FeatureLoader } from './feature-loader.js';
+import type { SettingsService } from './settings-service.js';
+import { LinearMCPClient } from './linear-mcp-client.js';
 import type { Feature } from '@protolabs-ai/types';
 
 const logger = createLogger('CalendarService');
@@ -57,6 +59,7 @@ export interface CalendarQueryOptions {
 export class CalendarService {
   private static instance: CalendarService;
   private featureLoader: FeatureLoader | null = null;
+  private settingsService: SettingsService | null = null;
 
   private constructor() {}
 
@@ -72,6 +75,13 @@ export class CalendarService {
    */
   setFeatureLoader(featureLoader: FeatureLoader): void {
     this.featureLoader = featureLoader;
+  }
+
+  /**
+   * Set the SettingsService instance for reading Linear integration config
+   */
+  setSettingsService(settingsService: SettingsService): void {
+    this.settingsService = settingsService;
   }
 
   /**
@@ -185,9 +195,38 @@ export class CalendarService {
       }
     }
 
-    // 3. Aggregate from project milestones (targetDate)
-    // TODO: Implement when targetDate is added to Milestone type
-    // For now, this is a placeholder for future enhancement
+    // 3. Aggregate from Linear project milestones (targetDate)
+    if (this.settingsService && (!types || types.includes('milestone'))) {
+      try {
+        const settings = await this.settingsService.getProjectSettings(projectPath);
+        const linearProjectId = settings.integrations?.linear?.projectId;
+
+        if (linearProjectId) {
+          const linearClient = new LinearMCPClient(this.settingsService, projectPath);
+          const milestones = await linearClient.listProjectMilestones(linearProjectId);
+
+          for (const milestone of milestones) {
+            if (!milestone.targetDate) continue;
+
+            const event: CalendarEvent = {
+              id: `milestone-${milestone.id}`,
+              title: milestone.name,
+              date: milestone.targetDate,
+              type: 'milestone',
+              description: milestone.description || undefined,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            };
+
+            if (this.isDateInRange(event.date, startDate, endDate)) {
+              allEvents.push(event);
+            }
+          }
+        }
+      } catch (error) {
+        logger.warn('Failed to load Linear milestones for calendar aggregation:', error);
+      }
+    }
 
     // Filter by date range
     let filteredEvents = allEvents;

--- a/apps/server/src/services/linear-mcp-client.ts
+++ b/apps/server/src/services/linear-mcp-client.ts
@@ -1440,9 +1440,15 @@ export class LinearMCPClient {
    * @returns Array of milestones with id and name
    * @throws {LinearAPIError} On API errors
    */
-  async listProjectMilestones(
-    projectId: string
-  ): Promise<Array<{ id: string; name: string; description?: string; sortOrder: number }>> {
+  async listProjectMilestones(projectId: string): Promise<
+    Array<{
+      id: string;
+      name: string;
+      description?: string;
+      sortOrder: number;
+      targetDate?: string;
+    }>
+  > {
     const query = `
       query ListProjectMilestones($projectId: String!) {
         project(id: $projectId) {
@@ -1452,6 +1458,7 @@ export class LinearMCPClient {
               name
               description
               sortOrder
+              targetDate
             }
           }
         }
@@ -1466,6 +1473,7 @@ export class LinearMCPClient {
             name: string;
             description?: string;
             sortOrder: number;
+            targetDate?: string;
           }>;
         };
       };

--- a/apps/server/src/services/linear-sync-service.ts
+++ b/apps/server/src/services/linear-sync-service.ts
@@ -2940,7 +2940,7 @@ ${prdContent}
     linearIssueId: string,
     newStateName: string,
     projectPath: string,
-    options?: { title?: string; priority?: number }
+    options?: { title?: string; priority?: number; dueDate?: string }
   ): Promise<void> {
     const startTime = Date.now();
     let featureId = 'unknown';
@@ -3013,6 +3013,12 @@ ${prdContent}
       if (options?.priority !== undefined && options.priority !== feature.priority) {
         featureUpdates.priority = options.priority as Feature['priority'];
         changeDescriptions.push(`priority: ${feature.priority ?? 'none'} → ${options.priority}`);
+      }
+
+      // --- Due date sync (Linear dueDate → Automaker dueDate) ---
+      if (options?.dueDate !== undefined && options.dueDate !== feature.dueDate) {
+        featureUpdates.dueDate = options.dueDate;
+        changeDescriptions.push(`dueDate: ${feature.dueDate ?? 'none'} → ${options.dueDate}`);
       }
 
       // --- Dependency sync (Linear issue relations → Automaker dependencies) ---


### PR DESCRIPTION
## Summary
- Add `targetDate` to the `listProjectMilestones()` GraphQL query in `LinearMCPClient`, so milestone dates are returned from the Linear API
- Add `dueDate` field to the Linear webhook Issue payload and propagate it through the sync service to update Automaker feature due dates
- Replace the TODO placeholder in `CalendarService.listEvents()` with real milestone aggregation: reads the Linear project ID from settings, fetches milestones via `LinearMCPClient`, and includes milestones with `targetDate` as `type='milestone'` calendar events

## Test plan
- [ ] Verify `npm run build:packages && npm run build:server` passes (confirmed locally)
- [ ] Verify Linear milestone `targetDate` appears in `listProjectMilestones()` response
- [ ] Verify webhook dueDate updates propagate to Automaker feature dueDate
- [ ] Verify `/api/calendar/list` returns milestone events from Linear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated Linear project milestones into calendar views with target date support
  * Added due date synchronization from Linear issues to Automaker features
  * Milestones are now filtered and displayed alongside other calendar events by date range and type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->