### PR TITLE
feat: designs directory API routes for .pen file management

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -184,6 +184,7 @@ import { createLinearRoutes } from './routes/linear/index.js';
 import { createTwitchRoutes } from './routes/twitch.js';
 import { createVoiceRoutes } from './routes/voice/index.js';
 import { createKnowledgeRoutes } from './routes/knowledge/index.js';
+import { createDesignsRoutes } from './routes/designs/index.js';
 import { LinearAgentService } from './services/linear-agent-service.js';
 import { LinearAgentRouter } from './services/linear-agent-router.js';
 import { MAX_SYSTEM_CONCURRENCY } from '@protolabs-ai/types';
@@ -1524,6 +1525,10 @@ if (knowledgeStoreService) {
   app.use('/api/knowledge', createKnowledgeRoutes(knowledgeStoreService));
   logger.info('Knowledge store routes mounted at /api/knowledge');
 }
+
+// Designs routes (.pen file management)
+app.use('/api/designs', createDesignsRoutes());
+logger.info('Designs routes mounted at /api/designs');
 
 // Create HTTP server
 const server = createServer(app);

--- a/apps/server/src/routes/designs/index.ts
+++ b/apps/server/src/routes/designs/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Designs routes - HTTP API for .pen file management
+ *
+ * Provides endpoints for managing design files in the designs/ directory:
+ * - List all .pen files recursively
+ * - Read and parse a .pen file
+ * - Write (save) a .pen file
+ * - Create a new empty .pen file
+ */
+
+import { Router } from 'express';
+import { validatePathParams } from '../../middleware/validate-paths.js';
+import { createListHandler } from './routes/list.js';
+import { createReadHandler } from './routes/read.js';
+import { createWriteHandler } from './routes/write.js';
+import { createCreateHandler } from './routes/create.js';
+
+export function createDesignsRoutes(): Router {
+  const router = Router();
+
+  // All routes validate projectPath to prevent access outside allowed directories
+  router.post('/list', validatePathParams('projectPath'), createListHandler());
+  router.post('/read', validatePathParams('projectPath', 'filePath'), createReadHandler());
+  router.post('/write', validatePathParams('projectPath', 'filePath'), createWriteHandler());
+  router.post('/create', validatePathParams('projectPath', 'filePath'), createCreateHandler());
+
+  return router;
+}

--- a/apps/server/src/routes/designs/routes/create.ts
+++ b/apps/server/src/routes/designs/routes/create.ts
@@ -1,0 +1,127 @@
+/**
+ * POST /create endpoint - Create a new empty .pen file
+ */
+
+import type { Request, Response } from 'express';
+import { join, relative, dirname } from 'node:path';
+import { writeFile, mkdir, access } from 'node:fs/promises';
+import { createLogger } from '@protolabs-ai/utils';
+import { validatePath } from '@protolabs-ai/platform';
+import type { PenDocument } from './read.js';
+
+const logger = createLogger('DesignsRoutes');
+
+interface CreateRequest {
+  projectPath: string;
+  filePath: string; // Relative path from projectPath (e.g., "designs/components/new-design.pen")
+}
+
+/**
+ * Validate that a file path is within the designs/ directory and doesn't traverse up
+ */
+function validateDesignPath(projectPath: string, filePath: string): string {
+  // Ensure filePath starts with designs/
+  if (!filePath.startsWith('designs/') && !filePath.startsWith('designs\\')) {
+    throw new Error('File path must be within designs/ directory');
+  }
+
+  // Construct full path
+  const fullPath = join(projectPath, filePath);
+
+  // Validate against ALLOWED_ROOT_DIRECTORY
+  validatePath(fullPath);
+
+  // Additional check: ensure the resolved path is still within designs/
+  const designsPath = join(projectPath, 'designs');
+  const relativePath = relative(designsPath, fullPath);
+
+  if (relativePath.startsWith('..') || relativePath.includes('..')) {
+    throw new Error('Path traversal detected');
+  }
+
+  return fullPath;
+}
+
+/**
+ * Create an empty PenDocument with version 2.8
+ */
+function createEmptyDocument(): PenDocument {
+  return {
+    version: '2.8',
+    children: [],
+  };
+}
+
+export function createCreateHandler() {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, filePath } = req.body as CreateRequest;
+
+      if (!projectPath) {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+
+      if (!filePath) {
+        res.status(400).json({ success: false, error: 'filePath is required' });
+        return;
+      }
+
+      // Validate and construct full path
+      let fullPath: string;
+      try {
+        fullPath = validateDesignPath(projectPath, filePath);
+      } catch (error) {
+        res.status(403).json({
+          success: false,
+          error: error instanceof Error ? error.message : 'Path validation failed',
+        });
+        return;
+      }
+
+      // Ensure file has .pen extension
+      if (!fullPath.endsWith('.pen')) {
+        res.status(400).json({
+          success: false,
+          error: 'File must have .pen extension',
+        });
+        return;
+      }
+
+      // Check if file already exists
+      try {
+        await access(fullPath);
+        res.status(409).json({
+          success: false,
+          error: 'File already exists',
+        });
+        return;
+      } catch {
+        // File doesn't exist, which is what we want
+      }
+
+      // Ensure parent directory exists
+      const dir = dirname(fullPath);
+      await mkdir(dir, { recursive: true });
+
+      // Create empty document with version 2.8
+      const document = createEmptyDocument();
+      const content = JSON.stringify(document, null, 2);
+      await writeFile(fullPath, content, 'utf-8');
+
+      logger.debug(`Created new .pen file: ${filePath}`);
+
+      res.json({
+        success: true,
+        filePath,
+        document,
+      });
+    } catch (error) {
+      logger.error('Create failed:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}

--- a/apps/server/src/routes/designs/routes/list.ts
+++ b/apps/server/src/routes/designs/routes/list.ts
@@ -1,0 +1,116 @@
+/**
+ * POST /list endpoint - Recursively list all .pen files in designs/ directory
+ */
+
+import type { Request, Response } from 'express';
+import { join, relative } from 'node:path';
+import { readdir, stat } from 'node:fs/promises';
+import { createLogger } from '@protolabs-ai/utils';
+import { validatePath } from '@protolabs-ai/platform';
+
+const logger = createLogger('DesignsRoutes');
+
+interface ListRequest {
+  projectPath: string;
+}
+
+interface DesignFileEntry {
+  path: string; // Relative path from designs/
+  name: string;
+  size: number;
+  modified: string;
+}
+
+/**
+ * Recursively find all .pen files in a directory
+ */
+async function findPenFiles(dirPath: string, basePath: string): Promise<DesignFileEntry[]> {
+  const results: DesignFileEntry[] = [];
+
+  try {
+    const entries = await readdir(dirPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = join(dirPath, entry.name);
+
+      if (entry.isDirectory()) {
+        // Recursively search subdirectories
+        const subResults = await findPenFiles(fullPath, basePath);
+        results.push(...subResults);
+      } else if (entry.isFile() && entry.name.endsWith('.pen')) {
+        const stats = await stat(fullPath);
+        const relativePath = relative(basePath, fullPath);
+
+        results.push({
+          path: relativePath,
+          name: entry.name,
+          size: stats.size,
+          modified: stats.mtime.toISOString(),
+        });
+      }
+    }
+  } catch (error) {
+    logger.warn(`Failed to read directory ${dirPath}:`, error);
+  }
+
+  return results;
+}
+
+export function createListHandler() {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath } = req.body as ListRequest;
+
+      if (!projectPath) {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+
+      // Construct path to designs/ directory
+      const designsPath = join(projectPath, 'designs');
+
+      // Validate the designs path is within allowed directories
+      try {
+        validatePath(designsPath);
+      } catch (error) {
+        res.status(403).json({
+          success: false,
+          error: `Access to designs directory not allowed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        });
+        return;
+      }
+
+      // Check if designs directory exists
+      try {
+        const stats = await stat(designsPath);
+        if (!stats.isDirectory()) {
+          res.status(400).json({
+            success: false,
+            error: 'designs/ is not a directory',
+          });
+          return;
+        }
+      } catch (error) {
+        // Directory doesn't exist - return empty list
+        res.json({ success: true, files: [] });
+        return;
+      }
+
+      // Recursively find all .pen files
+      const files = await findPenFiles(designsPath, designsPath);
+
+      // Sort by path for consistent ordering
+      files.sort((a, b) => a.path.localeCompare(b.path));
+
+      logger.debug(`Found ${files.length} .pen files in ${designsPath}`);
+
+      res.json({ success: true, files });
+    } catch (error) {
+      logger.error('List failed:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}

--- a/apps/server/src/routes/designs/routes/read.ts
+++ b/apps/server/src/routes/designs/routes/read.ts
@@ -1,0 +1,129 @@
+/**
+ * POST /read endpoint - Read and parse a .pen file
+ */
+
+import type { Request, Response } from 'express';
+import { join, relative, dirname } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { createLogger } from '@protolabs-ai/utils';
+import { validatePath } from '@protolabs-ai/platform';
+
+const logger = createLogger('DesignsRoutes');
+
+interface ReadRequest {
+  projectPath: string;
+  filePath: string; // Relative path from projectPath (e.g., "designs/components/shadcn-kit.pen")
+}
+
+/**
+ * PenDocument represents the structure of a .pen file
+ * Based on the Penpot/similar design tool format
+ */
+export interface PenDocument {
+  version: string;
+  children?: unknown[];
+  [key: string]: unknown;
+}
+
+/**
+ * Validate that a file path is within the designs/ directory and doesn't traverse up
+ */
+function validateDesignPath(projectPath: string, filePath: string): string {
+  // Ensure filePath starts with designs/
+  if (!filePath.startsWith('designs/') && !filePath.startsWith('designs\\')) {
+    throw new Error('File path must be within designs/ directory');
+  }
+
+  // Construct full path
+  const fullPath = join(projectPath, filePath);
+
+  // Validate against ALLOWED_ROOT_DIRECTORY
+  validatePath(fullPath);
+
+  // Additional check: ensure the resolved path is still within designs/
+  const designsPath = join(projectPath, 'designs');
+  const relativePath = relative(designsPath, fullPath);
+
+  if (relativePath.startsWith('..') || relativePath.includes('..')) {
+    throw new Error('Path traversal detected');
+  }
+
+  return fullPath;
+}
+
+export function createReadHandler() {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, filePath } = req.body as ReadRequest;
+
+      if (!projectPath) {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+
+      if (!filePath) {
+        res.status(400).json({ success: false, error: 'filePath is required' });
+        return;
+      }
+
+      // Validate and construct full path
+      let fullPath: string;
+      try {
+        fullPath = validateDesignPath(projectPath, filePath);
+      } catch (error) {
+        res.status(403).json({
+          success: false,
+          error: error instanceof Error ? error.message : 'Path validation failed',
+        });
+        return;
+      }
+
+      // Ensure file has .pen extension
+      if (!fullPath.endsWith('.pen')) {
+        res.status(400).json({
+          success: false,
+          error: 'File must have .pen extension',
+        });
+        return;
+      }
+
+      // Read and parse the file
+      try {
+        const content = await readFile(fullPath, 'utf-8');
+        const document = JSON.parse(content) as PenDocument;
+
+        logger.debug(`Read .pen file: ${filePath}`);
+
+        res.json({
+          success: true,
+          document,
+          filePath,
+        });
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          res.status(404).json({
+            success: false,
+            error: 'File not found',
+          });
+          return;
+        }
+
+        if (error instanceof SyntaxError) {
+          res.status(400).json({
+            success: false,
+            error: 'Invalid JSON in .pen file',
+          });
+          return;
+        }
+
+        throw error;
+      }
+    } catch (error) {
+      logger.error('Read failed:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}

--- a/apps/server/src/routes/designs/routes/write.ts
+++ b/apps/server/src/routes/designs/routes/write.ts
@@ -1,0 +1,118 @@
+/**
+ * POST /write endpoint - Save a PenDocument to a .pen file
+ */
+
+import type { Request, Response } from 'express';
+import { join, relative, dirname } from 'node:path';
+import { writeFile, mkdir } from 'node:fs/promises';
+import { createLogger } from '@protolabs-ai/utils';
+import { validatePath } from '@protolabs-ai/platform';
+import type { PenDocument } from './read.js';
+
+const logger = createLogger('DesignsRoutes');
+
+interface WriteRequest {
+  projectPath: string;
+  filePath: string; // Relative path from projectPath (e.g., "designs/components/my-design.pen")
+  document: PenDocument;
+}
+
+/**
+ * Validate that a file path is within the designs/ directory and doesn't traverse up
+ */
+function validateDesignPath(projectPath: string, filePath: string): string {
+  // Ensure filePath starts with designs/
+  if (!filePath.startsWith('designs/') && !filePath.startsWith('designs\\')) {
+    throw new Error('File path must be within designs/ directory');
+  }
+
+  // Construct full path
+  const fullPath = join(projectPath, filePath);
+
+  // Validate against ALLOWED_ROOT_DIRECTORY
+  validatePath(fullPath);
+
+  // Additional check: ensure the resolved path is still within designs/
+  const designsPath = join(projectPath, 'designs');
+  const relativePath = relative(designsPath, fullPath);
+
+  if (relativePath.startsWith('..') || relativePath.includes('..')) {
+    throw new Error('Path traversal detected');
+  }
+
+  return fullPath;
+}
+
+export function createWriteHandler() {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, filePath, document } = req.body as WriteRequest;
+
+      if (!projectPath) {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+
+      if (!filePath) {
+        res.status(400).json({ success: false, error: 'filePath is required' });
+        return;
+      }
+
+      if (!document) {
+        res.status(400).json({ success: false, error: 'document is required' });
+        return;
+      }
+
+      // Validate document has required fields
+      if (typeof document !== 'object' || !document.version) {
+        res.status(400).json({
+          success: false,
+          error: 'document must be a valid PenDocument with a version field',
+        });
+        return;
+      }
+
+      // Validate and construct full path
+      let fullPath: string;
+      try {
+        fullPath = validateDesignPath(projectPath, filePath);
+      } catch (error) {
+        res.status(403).json({
+          success: false,
+          error: error instanceof Error ? error.message : 'Path validation failed',
+        });
+        return;
+      }
+
+      // Ensure file has .pen extension
+      if (!fullPath.endsWith('.pen')) {
+        res.status(400).json({
+          success: false,
+          error: 'File must have .pen extension',
+        });
+        return;
+      }
+
+      // Ensure parent directory exists
+      const dir = dirname(fullPath);
+      await mkdir(dir, { recursive: true });
+
+      // Write the document as formatted JSON
+      const content = JSON.stringify(document, null, 2);
+      await writeFile(fullPath, content, 'utf-8');
+
+      logger.debug(`Wrote .pen file: ${filePath}`);
+
+      res.json({
+        success: true,
+        filePath,
+      });
+    } catch (error) {
+      logger.error('Write failed:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Add `POST /api/designs/list` — recursive directory listing of `designs/`
- Add `POST /api/designs/read` — parse and return PenDocument
- Add `POST /api/designs/write` — save PenDocument to disk
- Add `POST /api/designs/create` — create new empty .pen file
- Path traversal protection prevents reading outside designs/
- Routes registered in main server router

## Design Studio Project
Phase: M2 Designs Panel — Server API Routes

## Test plan
- [ ] `npm run build:server` succeeds
- [ ] All 4 endpoints respond correctly
- [ ] Path traversal attempts are rejected
- [ ] No lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)