### PR TITLE
fix: auto-close GitHub issues when agent PRs merge

### DIFF
--- a/.automaker/context/github-issue-pr-linking.md
+++ b/.automaker/context/github-issue-pr-linking.md
@@ -1,0 +1,31 @@
+# GitHub Issue ↔ PR Linking
+
+When creating pull requests that address GitHub issues, you MUST include closing keywords in the PR body so that merging the PR auto-closes the linked issue.
+
+## Required Format
+
+Use one of these keywords followed by the issue reference:
+- `Closes #123`
+- `Fixes #123`
+- `Resolves #123`
+
+For cross-repo or full URL references:
+- `Closes https://github.com/proto-labs-ai/protoMaker/issues/123`
+
+## What Does NOT Work
+
+- A bare URL like `https://github.com/.../issues/123` — creates a visual link but does NOT auto-close
+- Mentioning `#123` without a closing keyword — links but does NOT auto-close
+- Putting the keyword only in the PR title — GitHub only parses the body and commit messages
+
+## When Creating PRs Manually
+
+If you use `gh pr create` or `gt submit`, always include the closing keyword in the `--body`:
+
+```bash
+gh pr create --title "fix: the thing" --body "## Summary\n\nFixed the thing.\n\nCloses #123"
+```
+
+## Automated PRs
+
+The `git-workflow-service.ts` `buildPRBody()` helper automatically appends closing keywords when features have `githubIssueNumber`, `githubIssueUrl`, or issue URLs in their title/description. No manual action needed for auto-mode PRs.

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -59,6 +59,59 @@ const execEnv = {
 };
 
 /**
+ * Build PR body with issue closing references.
+ * Appends "Closes #N" when the feature has a linked GitHub issue,
+ * so that merging the PR auto-closes the issue.
+ */
+function buildPRBody(feature: Feature): string {
+  const summary = feature.description.substring(0, 500);
+  const ellipsis = feature.description.length > 500 ? '...' : '';
+  let body = `## Summary\n\n${summary}${ellipsis}`;
+
+  // Append closing reference for linked GitHub issues
+  const issueRef = getGitHubIssueRef(feature);
+  if (issueRef) {
+    body += `\n\n${issueRef}`;
+  }
+
+  body += `\n\n---\n*Created automatically by Automaker*`;
+  return body;
+}
+
+/**
+ * Extract a GitHub issue closing reference from the feature.
+ * Checks explicit fields first, then parses URLs from title/description.
+ */
+function getGitHubIssueRef(feature: Feature): string | null {
+  // Explicit field takes priority
+  if (feature.githubIssueNumber) {
+    return `Closes #${feature.githubIssueNumber}`;
+  }
+  if (feature.githubIssueUrl) {
+    return `Closes ${feature.githubIssueUrl}`;
+  }
+
+  // Parse issue URLs from title and description
+  const text = `${feature.title || ''} ${feature.description || ''}`;
+  const issueUrlPattern = /https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/(\d+)/g;
+  const matches = [...text.matchAll(issueUrlPattern)];
+  if (matches.length > 0) {
+    // Deduplicate by issue number
+    const seen = new Set<string>();
+    const refs: string[] = [];
+    for (const match of matches) {
+      if (!seen.has(match[1])) {
+        seen.add(match[1]);
+        refs.push(`Closes ${match[0]}`);
+      }
+    }
+    return refs.join('\n');
+  }
+
+  return null;
+}
+
+/**
  * Check if gh CLI is available on the system
  */
 async function isGhCliAvailable(): Promise<boolean> {
@@ -799,7 +852,7 @@ export class GitWorkflowService {
     prCreatedAt?: string;
   }> {
     const title = feature.title || extractTitleFromDescription(feature.description);
-    const body = `## Summary\n\n${feature.description.substring(0, 500)}${feature.description.length > 500 ? '...' : ''}\n\n---\n*Created automatically by Automaker*`;
+    const body = buildPRBody(feature);
 
     const submitResult = await graphiteService.submit(workDir, title, body);
 
@@ -1161,7 +1214,7 @@ export class GitWorkflowService {
     }
 
     const title = feature.title || extractTitleFromDescription(feature.description);
-    const body = `## Summary\n\n${feature.description.substring(0, 500)}${feature.description.length > 500 ? '...' : ''}\n\n---\n*Created automatically by Automaker*`;
+    const body = buildPRBody(feature);
 
     // Detect repository info by checking remotes
     // We need to explicitly set --repo to avoid gh defaulting to wrong upstream


### PR DESCRIPTION
## Summary

- Agent-created PRs linked to GitHub issues via bare URLs, which doesn't trigger GitHub's auto-close on merge
- Added `buildPRBody()` and `getGitHubIssueRef()` helpers to `git-workflow-service.ts` that append `Closes #N` keywords to PR bodies
- Checks `feature.githubIssueNumber`, `feature.githubIssueUrl`, and falls back to parsing issue URLs from feature title/description
- Both PR creation paths updated (Graphite submit + gh CLI)

## Test plan

- [ ] Create a feature with `githubIssueNumber` set — verify PR body contains `Closes #N`
- [ ] Create a feature with a GitHub issue URL in the title — verify PR body parses and includes `Closes <url>`
- [ ] Verify existing features without issue references produce unchanged PR body format

🤖 Generated with [Claude Code](https://claude.com/claude-code)