### PR TITLE
fix: reduce staging deploy downtime with force-recreate

### DIFF
--- a/scripts/setup-staging.sh
+++ b/scripts/setup-staging.sh
@@ -208,16 +208,18 @@ start_services() {
   info "Starting services..."
   cd "$PROJECT_ROOT"
 
-  stop_existing
-
   # Ensure named volumes exist (external: true in compose won't auto-create them)
   for vol in automaker-data automaker-claude-config automaker-cursor-config \
              automaker-opencode-data automaker-opencode-config automaker-opencode-cache; do
     docker volume create "$vol" >/dev/null
   done
 
-  # Start app services (server + UI)
-  docker compose -f "$COMPOSE_FILE" up -d server ui
+  # Use --force-recreate instead of down+up to minimize downtime.
+  # Docker Compose stops each old container and starts its replacement in quick
+  # succession (~2-3s gap per service) rather than stopping everything first.
+  # --remove-orphans cleans up containers from renamed/removed services.
+  info "Recreating app services (minimal downtime)..."
+  docker compose -f "$COMPOSE_FILE" up -d --force-recreate --remove-orphans server ui
 
   # Start docs independently (won't be affected by app restarts)
   # Remove old container first — it may belong to a different compose project


### PR DESCRIPTION
## Summary
- Replace `docker compose down` + `up -d` with `up -d --force-recreate --remove-orphans` in `start_services()`
- Docker Compose now replaces containers per-service (~2-3s gap each) instead of stopping everything first (~15-30s full downtime)
- Rollback step still uses `down` (appropriate for failure recovery)

## Before
```
stop ALL containers → wait → start ALL containers → health check
         ~~~~ 15-30s downtime ~~~~
```

## After
```
recreate server (~2-3s) → recreate ui (~2-3s) → health check
         ~~~~ 2-3s downtime ~~~~
```

## Test plan
- [ ] `./scripts/setup-staging.sh --start` recreates containers without full stop
- [ ] Health check passes after restart
- [ ] `--stop` and `--teardown` still work (use `stop_existing()` directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized staging deployment process to minimize downtime during service restarts, replacing sequential stop-and-start with an improved recreation approach that maintains system availability while updating services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->