### PR TITLE
feat: core frame and layout renderer for PEN designs

### DIFF
--- a/apps/ui/src/components/views/designs-view/designs-canvas.tsx
+++ b/apps/ui/src/components/views/designs-view/designs-canvas.tsx
@@ -1,0 +1,158 @@
+/**
+ * Zoomable and pannable canvas for rendering Pen designs
+ */
+
+import { useState, useRef, useEffect, useMemo, type MouseEvent } from 'react';
+import type { PenDocument as PenDocumentParsed } from '@protolabs-ai/types';
+import type { PenDocument } from '@/store/designs-store';
+import { PenNodeRenderer } from './renderer';
+
+interface DesignsCanvasProps {
+  penFile: PenDocument | null;
+}
+
+export function DesignsCanvas({ penFile }: DesignsCanvasProps) {
+  // Parse the raw PEN content into a structured document
+  const document = useMemo<PenDocumentParsed | null>(() => {
+    if (!penFile?.content) return null;
+    try {
+      const parsed = JSON.parse(penFile.content);
+      if (parsed.version && Array.isArray(parsed.children)) {
+        return parsed as PenDocumentParsed;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }, [penFile]);
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [isPanning, setIsPanning] = useState(false);
+  const [panStart, setPanStart] = useState({ x: 0, y: 0 });
+  const canvasRef = useRef<HTMLDivElement>(null);
+
+  // Handle mouse wheel for zoom
+  useEffect(() => {
+    const handleWheel = (e: WheelEvent) => {
+      if (e.ctrlKey || e.metaKey) {
+        e.preventDefault();
+        const delta = e.deltaY > 0 ? 0.9 : 1.1;
+        setZoom((prev) => Math.max(0.1, Math.min(5, prev * delta)));
+      }
+    };
+
+    const canvas = canvasRef.current;
+    if (canvas) {
+      canvas.addEventListener('wheel', handleWheel, { passive: false });
+      return () => canvas.removeEventListener('wheel', handleWheel);
+    }
+  }, []);
+
+  // Handle pan start
+  const handleMouseDown = (e: MouseEvent<HTMLDivElement>) => {
+    if (e.button === 0 && (e.ctrlKey || e.metaKey || e.shiftKey)) {
+      setIsPanning(true);
+      setPanStart({ x: e.clientX - pan.x, y: e.clientY - pan.y });
+      e.preventDefault();
+    }
+  };
+
+  // Handle pan move
+  const handleMouseMove = (e: MouseEvent<HTMLDivElement>) => {
+    if (isPanning) {
+      setPan({
+        x: e.clientX - panStart.x,
+        y: e.clientY - panStart.y,
+      });
+    }
+  };
+
+  // Handle pan end
+  const handleMouseUp = () => {
+    setIsPanning(false);
+  };
+
+  // Handle zoom controls
+  const handleZoomIn = () => {
+    setZoom((prev) => Math.min(5, prev * 1.2));
+  };
+
+  const handleZoomOut = () => {
+    setZoom((prev) => Math.max(0.1, prev / 1.2));
+  };
+
+  const handleResetView = () => {
+    setZoom(1);
+    setPan({ x: 0, y: 0 });
+  };
+
+  if (!document || !document.children || document.children.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        <p>No design to display</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={canvasRef}
+      className="relative h-full w-full overflow-hidden bg-gray-50"
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
+      style={{ cursor: isPanning ? 'grabbing' : 'default' }}
+    >
+      {/* Zoom controls */}
+      <div className="absolute right-4 top-4 z-10 flex flex-col gap-2 rounded-lg bg-white p-2 shadow-md">
+        <button
+          onClick={handleZoomIn}
+          className="rounded px-3 py-1 hover:bg-gray-100"
+          title="Zoom in (Ctrl + scroll)"
+        >
+          +
+        </button>
+        <div className="px-3 py-1 text-center text-sm">{Math.round(zoom * 100)}%</div>
+        <button
+          onClick={handleZoomOut}
+          className="rounded px-3 py-1 hover:bg-gray-100"
+          title="Zoom out (Ctrl + scroll)"
+        >
+          −
+        </button>
+        <button
+          onClick={handleResetView}
+          className="rounded px-3 py-1 hover:bg-gray-100"
+          title="Reset view"
+        >
+          ⟲
+        </button>
+      </div>
+
+      {/* Instructions */}
+      <div className="absolute left-4 top-4 z-10 rounded-lg bg-white p-3 text-sm shadow-md">
+        <div className="font-semibold">Controls:</div>
+        <div className="text-xs text-gray-600">
+          <div>Ctrl/Cmd + Scroll: Zoom</div>
+          <div>Ctrl/Cmd + Drag: Pan</div>
+        </div>
+      </div>
+
+      {/* Canvas content */}
+      <div
+        className="absolute left-1/2 top-1/2"
+        style={{
+          transform: `translate(-50%, -50%) translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+          transformOrigin: 'center',
+        }}
+      >
+        <div className="rounded-lg bg-white p-8 shadow-lg">
+          {document.children.map((node) => (
+            <PenNodeRenderer key={node.id} node={node} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/views/designs-view/designs-view.tsx
+++ b/apps/ui/src/components/views/designs-view/designs-view.tsx
@@ -3,6 +3,7 @@ import { useAppStore } from '@/store/app-store';
 import { useDesignsStore } from '@/store/designs-store';
 import { Spinner } from '@protolabs-ai/ui/atoms';
 import { DesignsTree } from './designs-tree';
+import { DesignsCanvas } from './designs-canvas';
 import { FileText } from 'lucide-react';
 
 export function DesignsView() {
@@ -48,22 +49,14 @@ export function DesignsView() {
           )}
 
           {/* Canvas content */}
-          <div className="flex-1 flex items-center justify-center p-8">
+          <div className="flex-1 flex items-center justify-center">
             {isLoadingDocument ? (
               <div className="flex flex-col items-center gap-3">
                 <Spinner size="lg" />
                 <p className="text-sm text-muted-foreground">Loading design...</p>
               </div>
             ) : selectedDocument ? (
-              <div className="text-center">
-                <FileText className="mx-auto h-12 w-12 text-muted-foreground/50" />
-                <p className="mt-4 text-sm text-muted-foreground">
-                  Canvas renderer will be implemented in a future milestone
-                </p>
-                <pre className="mt-4 text-xs text-left bg-muted p-4 rounded max-w-md overflow-auto">
-                  {JSON.stringify(selectedDocument, null, 2)}
-                </pre>
-              </div>
+              <DesignsCanvas penFile={selectedDocument} />
             ) : (
               <div className="text-center">
                 <FileText className="mx-auto h-12 w-12 text-muted-foreground/50" />

--- a/apps/ui/src/components/views/designs-view/renderer/index.ts
+++ b/apps/ui/src/components/views/designs-view/renderer/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Pen renderer exports
+ */
+
+export { PenNodeRenderer } from './pen-node-renderer';
+export { PenFrameRenderer } from './pen-frame-renderer';
+export { PenGroupRenderer } from './pen-group-renderer';
+export * from './style-utils';

--- a/apps/ui/src/components/views/designs-view/renderer/pen-frame-renderer.tsx
+++ b/apps/ui/src/components/views/designs-view/renderer/pen-frame-renderer.tsx
@@ -1,0 +1,99 @@
+/**
+ * Frame renderer with flexbox layout support
+ */
+
+import type { PenFrame } from '@protolabs-ai/types';
+import { PenNodeRenderer } from './pen-node-renderer';
+import { fillToCSS, strokeToCSS, paddingToCSS, layoutToFlexDirection } from './style-utils';
+import type { CSSProperties } from 'react';
+
+interface PenFrameRendererProps {
+  node: PenFrame;
+}
+
+/**
+ * Renders a frame node as a div with CSS flexbox layout
+ */
+export function PenFrameRenderer({ node }: PenFrameRendererProps) {
+  const style: CSSProperties = {
+    position: node.layoutMode === 'none' ? 'relative' : undefined,
+    display: node.layoutMode !== 'none' ? 'flex' : undefined,
+    boxSizing: 'border-box',
+  };
+
+  // Layout direction
+  const flexDirection = layoutToFlexDirection(node.layoutMode);
+  if (flexDirection) {
+    style.flexDirection = flexDirection as 'row' | 'column';
+  }
+
+  // Gap (itemSpacing)
+  if (node.itemSpacing !== undefined && node.layoutMode !== 'none') {
+    style.gap = `${node.itemSpacing}px`;
+  }
+
+  // Padding (handle both uniform and per-side)
+  const paddingTop = node.paddingTop ?? 0;
+  const paddingRight = node.paddingRight ?? 0;
+  const paddingBottom = node.paddingBottom ?? 0;
+  const paddingLeft = node.paddingLeft ?? 0;
+
+  if (paddingTop || paddingRight || paddingBottom || paddingLeft) {
+    style.padding = `${paddingTop}px ${paddingRight}px ${paddingBottom}px ${paddingLeft}px`;
+  }
+
+  // Width and height from bounds
+  if (node.bounds) {
+    style.width = `${node.bounds.width}px`;
+    style.height = `${node.bounds.height}px`;
+  }
+
+  // Corner radius
+  if (node.cornerRadius !== undefined) {
+    style.borderRadius = `${node.cornerRadius}px`;
+  }
+
+  // Fills (background)
+  if (node.fills && node.fills.length > 0) {
+    const fill = node.fills[0]; // Use first fill for now
+    style.background = fillToCSS(fill);
+    if (fill.opacity !== undefined && fill.opacity < 1) {
+      // Apply fill opacity to background
+      style.opacity = fill.opacity;
+    }
+  }
+
+  // Strokes (border)
+  if (node.strokes && node.strokes.length > 0) {
+    const stroke = node.strokes[0]; // Use first stroke for now
+    const borderStyle = strokeToCSS(stroke);
+    style.borderWidth = borderStyle.borderWidth;
+    style.borderStyle = borderStyle.borderStyle;
+    style.borderColor = borderStyle.borderColor;
+  }
+
+  // Opacity (node-level)
+  if (node.opacity !== undefined && node.opacity < 1) {
+    style.opacity = node.opacity;
+  }
+
+  // Clip content (overflow:hidden)
+  if (node.clipsContent) {
+    style.overflow = 'hidden';
+  }
+
+  // Transform
+  if (node.transform) {
+    const t = node.transform;
+    style.transform = `matrix(${t.a}, ${t.b}, ${t.c}, ${t.d}, ${t.tx}, ${t.ty})`;
+  }
+
+  // Render children recursively
+  return (
+    <div style={style} data-node-id={node.id} data-node-type="frame">
+      {node.children?.map((child) => (
+        <PenNodeRenderer key={child.id} node={child} />
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/src/components/views/designs-view/renderer/pen-group-renderer.tsx
+++ b/apps/ui/src/components/views/designs-view/renderer/pen-group-renderer.tsx
@@ -1,0 +1,65 @@
+/**
+ * Group renderer - layout only, no fill
+ */
+
+import type { PenGroup } from '@protolabs-ai/types';
+import { PenNodeRenderer } from './pen-node-renderer';
+import { layoutToFlexDirection } from './style-utils';
+import type { CSSProperties } from 'react';
+
+interface PenGroupRendererProps {
+  node: PenGroup;
+}
+
+/**
+ * Renders a group node as a div with layout only (no background/fill)
+ */
+export function PenGroupRenderer({ node }: PenGroupRendererProps) {
+  const style: CSSProperties = {
+    position: node.layoutMode === 'none' ? 'relative' : undefined,
+    display: node.layoutMode !== 'none' ? 'flex' : undefined,
+    boxSizing: 'border-box',
+  };
+
+  // Layout direction
+  const flexDirection = layoutToFlexDirection(node.layoutMode);
+  if (flexDirection) {
+    style.flexDirection = flexDirection as 'row' | 'column';
+  }
+
+  // Gap (itemSpacing)
+  if (node.itemSpacing !== undefined && node.layoutMode !== 'none') {
+    style.gap = `${node.itemSpacing}px`;
+  }
+
+  // Width and height from bounds
+  if (node.bounds) {
+    style.width = `${node.bounds.width}px`;
+    style.height = `${node.bounds.height}px`;
+  }
+
+  // Opacity (node-level)
+  if (node.opacity !== undefined && node.opacity < 1) {
+    style.opacity = node.opacity;
+  }
+
+  // Clip content (overflow:hidden)
+  if (node.clipsContent) {
+    style.overflow = 'hidden';
+  }
+
+  // Transform
+  if (node.transform) {
+    const t = node.transform;
+    style.transform = `matrix(${t.a}, ${t.b}, ${t.c}, ${t.d}, ${t.tx}, ${t.ty})`;
+  }
+
+  // Render children recursively
+  return (
+    <div style={style} data-node-id={node.id} data-node-type="group">
+      {node.children?.map((child) => (
+        <PenNodeRenderer key={child.id} node={child} />
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/src/components/views/designs-view/renderer/pen-node-renderer.tsx
+++ b/apps/ui/src/components/views/designs-view/renderer/pen-node-renderer.tsx
@@ -1,0 +1,56 @@
+/**
+ * Recursive node renderer that dispatches to specific node type renderers
+ */
+
+import type { PenNode } from '@protolabs-ai/types';
+import { PenFrameRenderer } from './pen-frame-renderer';
+import { PenGroupRenderer } from './pen-group-renderer';
+
+interface PenNodeRendererProps {
+  node: PenNode;
+}
+
+/**
+ * Main node renderer that dispatches based on node type
+ */
+export function PenNodeRenderer({ node }: PenNodeRendererProps) {
+  // Handle visibility
+  if (node.visible === false) {
+    return null;
+  }
+
+  // Dispatch to specific renderer based on type
+  switch (node.type) {
+    case 'frame':
+      return <PenFrameRenderer node={node} />;
+    case 'group':
+      return <PenGroupRenderer node={node} />;
+    case 'rectangle':
+    case 'ellipse':
+    case 'line':
+    case 'polygon':
+    case 'path':
+    case 'text':
+    case 'icon-font':
+    case 'ref':
+    case 'image':
+    case 'vector':
+    case 'instance':
+      // Placeholder for other node types - will be implemented in future features
+      return (
+        <div
+          style={{
+            padding: '8px',
+            background: '#f0f0f0',
+            border: '1px dashed #ccc',
+            borderRadius: '4px',
+          }}
+        >
+          {node.type} ({node.name || node.id})
+        </div>
+      );
+    default:
+      console.warn('Unknown node type:', (node as PenNode).type);
+      return null;
+  }
+}

--- a/apps/ui/src/components/views/designs-view/renderer/style-utils.ts
+++ b/apps/ui/src/components/views/designs-view/renderer/style-utils.ts
@@ -1,0 +1,161 @@
+/**
+ * Style utility functions for converting Pen node properties to CSS
+ */
+
+import type { PenFill, PenStroke, PenColor } from '@protolabs-ai/types';
+
+/**
+ * Convert PenColor to CSS rgba string
+ */
+export function colorToCSS(color: string | PenColor): string {
+  if (typeof color === 'string') {
+    // Handle CSS variables (e.g., $primary -> var(--primary))
+    if (color.startsWith('$')) {
+      return `var(--${color.slice(1)})`;
+    }
+    // Already a hex or CSS color string
+    return color;
+  }
+  // Convert RGBA object to CSS rgba()
+  return `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a})`;
+}
+
+/**
+ * Convert PenFill to CSS background
+ */
+export function fillToCSS(fill: PenFill): string {
+  switch (fill.type) {
+    case 'solid': {
+      const color = colorToCSS(fill.color);
+      const opacity = fill.opacity ?? 1;
+      if (opacity < 1) {
+        // Apply opacity to the color
+        if (color.startsWith('var(')) {
+          // For CSS variables, we need to use opacity on the element
+          return color;
+        }
+        return color; // Opacity will be handled separately
+      }
+      return color;
+    }
+    case 'gradient': {
+      const stops = fill.stops
+        .map((stop) => `${colorToCSS(stop.color)} ${stop.position * 100}%`)
+        .join(', ');
+
+      if (fill.gradientType === 'linear') {
+        // Default to top-to-bottom if no start/end specified
+        const angle = fill.start && fill.end ? calculateGradientAngle(fill.start, fill.end) : 180;
+        return `linear-gradient(${angle}deg, ${stops})`;
+      }
+      if (fill.gradientType === 'radial') {
+        return `radial-gradient(circle, ${stops})`;
+      }
+      if (fill.gradientType === 'angular') {
+        return `conic-gradient(from 0deg, ${stops})`;
+      }
+      return 'transparent';
+    }
+    case 'image': {
+      // Image fills would need asset resolution - for now return a placeholder
+      return `url(${fill.imageRef})`;
+    }
+    default:
+      return 'transparent';
+  }
+}
+
+/**
+ * Calculate gradient angle from start/end points
+ */
+function calculateGradientAngle(
+  start: { x: number; y: number },
+  end: { x: number; y: number }
+): number {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const angle = (Math.atan2(dy, dx) * 180) / Math.PI + 90;
+  return angle;
+}
+
+/**
+ * Convert PenStroke to CSS border
+ */
+export function strokeToCSS(stroke: PenStroke): {
+  borderWidth: string;
+  borderStyle: string;
+  borderColor: string;
+} {
+  const color = colorToCSS(stroke.color);
+  const width = `${stroke.width}px`;
+  const style = stroke.dashPattern ? 'dashed' : 'solid';
+
+  return {
+    borderWidth: width,
+    borderStyle: style,
+    borderColor: color,
+  };
+}
+
+/**
+ * Convert width/height to CSS size
+ * - number → 'Npx'
+ * - 'fill_container' → flex: 1
+ * - 'fit_content' → 'auto'
+ */
+export function sizeToCSS(
+  size: number | 'fill_container' | 'fit_content' | undefined,
+  isFlex: boolean
+): { size?: string; flex?: string } {
+  if (size === undefined) {
+    return {};
+  }
+
+  if (size === 'fill_container') {
+    return { flex: '1' };
+  }
+
+  if (size === 'fit_content') {
+    return { size: 'auto' };
+  }
+
+  if (typeof size === 'number') {
+    return { size: `${size}px` };
+  }
+
+  return {};
+}
+
+/**
+ * Convert padding to CSS
+ */
+export function paddingToCSS(
+  padding: number | { top?: number; right?: number; bottom?: number; left?: number } | undefined
+): string {
+  if (padding === undefined) {
+    return '0';
+  }
+
+  if (typeof padding === 'number') {
+    return `${padding}px`;
+  }
+
+  const top = padding.top ?? 0;
+  const right = padding.right ?? 0;
+  const bottom = padding.bottom ?? 0;
+  const left = padding.left ?? 0;
+
+  return `${top}px ${right}px ${bottom}px ${left}px`;
+}
+
+/**
+ * Get flexbox direction from layout mode
+ */
+export function layoutToFlexDirection(
+  layout: 'none' | 'horizontal' | 'vertical' | undefined
+): string | undefined {
+  if (!layout || layout === 'none') {
+    return undefined;
+  }
+  return layout === 'vertical' ? 'column' : 'row';
+}


### PR DESCRIPTION
## Summary
- Adds recursive PEN node rendering pipeline with CSS flexbox layout support
- `PenNodeRenderer` dispatches to type-specific renderers (frame, group, with placeholders for text/shapes)
- `PenFrameRenderer` handles fills, strokes, padding, corner radius, transforms, and clip content
- `style-utils.ts` converts PEN properties (colors, gradients, strokes, sizing) to CSS
- `DesignsCanvas` provides zoomable (Ctrl+Scroll) and pannable (Ctrl+Drag) canvas with controls
- Wires canvas into `DesignsView` with inline JSON parsing of raw PEN content

## Design Studio M3 Phase 1
Part of the Pen Renderer & Visual Canvas milestone.

## Test plan
- [ ] Verify PEN files render with correct layout (flexbox direction, gap, padding)
- [ ] Test zoom in/out with Ctrl+Scroll and zoom controls
- [ ] Test pan with Ctrl+Drag
- [ ] Verify invisible nodes (visible: false) are skipped
- [ ] Check that unsupported node types show placeholder with type label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added an interactive design canvas for viewing Pen design documents
* Integrated zoom controls with in/out buttons and reset view functionality
* Enabled keyboard-driven panning and mouse wheel zoom for flexible navigation
* Renders design frames and groups within a centered, pannable canvas

<!-- end of auto-generated comment: release notes by coderabbit.ai -->