### PR TITLE
feat(ui): add Calendar route and sidebar navigation

### DIFF
--- a/apps/ui/src/components/layout/sidebar/hooks/use-navigation.ts
+++ b/apps/ui/src/components/layout/sidebar/hooks/use-navigation.ts
@@ -15,6 +15,7 @@ import {
   NotebookPen,
   PartyPopper,
   Palette,
+  CalendarDays,
 } from 'lucide-react';
 import type { NavSection, NavItem } from '../types';
 import type { KeyboardShortcut } from '@/hooks/use-keyboard-shortcuts';
@@ -163,6 +164,11 @@ export function useNavigation({
         id: 'designs',
         label: 'Designs',
         icon: Palette,
+      },
+      {
+        id: 'calendar',
+        label: 'Calendar',
+        icon: CalendarDays,
       },
     ];
 

--- a/apps/ui/src/routes/calendar.tsx
+++ b/apps/ui/src/routes/calendar.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { CalendarView } from '@/components/views/calendar-view';
+
+export const Route = createFileRoute('/calendar')({
+  component: CalendarView,
+});


### PR DESCRIPTION
## Summary
- Add `/calendar` route file using TanStack Router file-based routing convention, rendering the existing `CalendarView` component
- Add Calendar navigation item (with `CalendarDays` icon from lucide-react) to the sidebar's Project section, placed after Designs

## Test plan
- [ ] Start dev server (`npm run dev:web`) and verify the route tree regenerates with `/calendar`
- [ ] Navigate to `/calendar` directly in the browser and confirm `CalendarView` renders
- [ ] Verify the Calendar item appears in the sidebar under the Project section, after Designs
- [ ] Click the Calendar sidebar item and confirm it navigates to `/calendar`
- [ ] Verify no regressions on other sidebar navigation items

🤖 Generated with [Claude Code](https://claude.com/claude-code)