### PR TITLE
feat: add Google Calendar sync service

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -109,6 +109,7 @@ import { createFlowsRoutes } from './routes/flows/index.js';
 import { createBacklogPlanRoutes } from './routes/backlog-plan/index.js';
 import { createCalendarRoutes } from './routes/calendar/index.js';
 import { createGoogleOAuthRoutes } from './routes/google-calendar/oauth.js';
+import { GoogleCalendarSyncService } from './services/google-calendar-sync-service.js';
 import { cleanupStaleValidations } from './routes/github/routes/validation-common.js';
 import { createMCPRoutes } from './routes/mcp/index.js';
 import { MCPTestService } from './services/mcp-test-service.js';
@@ -396,6 +397,7 @@ archivalService.start();
 // Calendar service
 calendarService.setFeatureLoader(featureLoader);
 calendarService.setSettingsService(settingsService);
+const googleCalendarSyncService = new GoogleCalendarSyncService(settingsService, calendarService);
 const autoModeService = new AutoModeService(events, settingsService);
 const hitlFormService = new HITLFormService({
   events,
@@ -1355,8 +1357,11 @@ app.use('/api/setup', createSetupRoutes(settingsService));
 app.use('/webhooks', createWebhooksRoutes(events, settingsService));
 // Linear agent routes (OAuth + webhook)
 app.use('/api/linear', createLinearRoutes(settingsService, events, featureLoader));
-// Google Calendar OAuth (unauthenticated — browser-initiated redirect flow)
-app.use('/api/google-calendar', createGoogleOAuthRoutes(settingsService));
+// Google Calendar OAuth + sync (unauthenticated — browser-initiated redirect flow)
+app.use(
+  '/api/google-calendar',
+  createGoogleOAuthRoutes(settingsService, googleCalendarSyncService)
+);
 
 // Apply authentication to all /api/* routes
 app.use('/api', authMiddleware);

--- a/apps/server/src/routes/google-calendar/oauth.ts
+++ b/apps/server/src/routes/google-calendar/oauth.ts
@@ -7,6 +7,7 @@ import { Router, type Request, type Response } from 'express';
 import { randomBytes } from 'node:crypto';
 import { createLogger } from '@protolabs-ai/utils';
 import type { SettingsService } from '../../services/settings-service.js';
+import type { GoogleCalendarSyncService } from '../../services/google-calendar-sync-service.js';
 
 const logger = createLogger('google-calendar:oauth');
 const SCOPES = ['https://www.googleapis.com/auth/calendar.readonly'];
@@ -19,7 +20,10 @@ function cleanExpiredStates(): void {
   }
 }
 
-export function createGoogleOAuthRoutes(settingsService: SettingsService): Router {
+export function createGoogleOAuthRoutes(
+  settingsService: SettingsService,
+  googleCalendarSyncService?: GoogleCalendarSyncService
+): Router {
   const router = Router();
 
   // GET /authorize — redirect to Google OAuth consent screen
@@ -203,6 +207,38 @@ export function createGoogleOAuthRoutes(settingsService: SettingsService): Route
     } catch (error) {
       logger.error('Failed to revoke Google token', { error });
       res.status(500).json({ error: 'Failed to revoke token' });
+    }
+  });
+
+  // POST /sync — trigger a one-time sync from Google Calendar
+  router.post('/sync', async (req: Request, res: Response) => {
+    try {
+      const { projectPath } = req.body;
+      if (!projectPath) {
+        res.status(400).json({ error: 'projectPath is required' });
+        return;
+      }
+
+      if (!googleCalendarSyncService) {
+        res.status(503).json({ error: 'Google Calendar sync service not available' });
+        return;
+      }
+
+      const settings = await settingsService.getProjectSettings(projectPath);
+      const google = settings.integrations?.google;
+      if (!google?.accessToken || !google?.refreshToken) {
+        res.status(400).json({ error: 'Google Calendar not connected. Complete OAuth first.' });
+        return;
+      }
+
+      const result = await googleCalendarSyncService.syncFromGoogle(projectPath);
+
+      logger.info('Google Calendar sync completed', { projectPath, ...result });
+      res.json({ synced: result.synced, created: result.created });
+    } catch (error) {
+      logger.error('Google Calendar sync failed', { error });
+      const message = error instanceof Error ? error.message : 'Sync failed';
+      res.status(500).json({ error: message });
     }
   });
 

--- a/apps/server/src/services/calendar-service.ts
+++ b/apps/server/src/services/calendar-service.ts
@@ -26,7 +26,8 @@ export type CalendarEventType =
   | 'feature' // Feature due dates
   | 'milestone' // Project milestone dates
   | 'meeting' // Scheduled meetings
-  | 'deadline'; // Hard deadlines
+  | 'deadline' // Hard deadlines
+  | 'google'; // Synced from Google Calendar
 
 /**
  * A calendar event
@@ -40,6 +41,7 @@ export interface CalendarEvent {
   description?: string;
   color?: string; // Hex color for display
   url?: string; // Optional link (e.g., to feature, PR, Linear issue)
+  sourceId?: string; // External source ID (e.g., Google Calendar event ID) for dedup
   createdAt: string;
   updatedAt: string;
 }
@@ -337,6 +339,50 @@ export class CalendarService {
     await this.writeCalendarFile(projectPath, events);
 
     logger.info(`Deleted calendar event ${id}`);
+  }
+
+  /**
+   * Upsert a calendar event by sourceId. If an event with the same sourceId exists,
+   * update it; otherwise create a new one. Returns the upserted event and whether it was new.
+   */
+  async upsertBySourceId(
+    projectPath: string,
+    sourceId: string,
+    data: Omit<CalendarEvent, 'id' | 'createdAt' | 'updatedAt'>
+  ): Promise<{ event: CalendarEvent; created: boolean }> {
+    const events = await this.readCalendarFile(projectPath);
+    const existingIndex = events.findIndex((e) => e.sourceId === sourceId);
+    const now = new Date().toISOString();
+
+    if (existingIndex !== -1) {
+      // Update existing event
+      const existing = events[existingIndex];
+      const updated: CalendarEvent = {
+        ...existing,
+        ...data,
+        id: existing.id,
+        sourceId,
+        createdAt: existing.createdAt,
+        updatedAt: now,
+      };
+      events[existingIndex] = updated;
+      await this.writeCalendarFile(projectPath, events);
+      return { event: updated, created: false };
+    }
+
+    // Create new event
+    const id = `google-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+    const newEvent: CalendarEvent = {
+      ...data,
+      id,
+      sourceId,
+      createdAt: now,
+      updatedAt: now,
+    };
+    events.push(newEvent);
+    await this.writeCalendarFile(projectPath, events);
+    logger.info(`Created synced calendar event ${id} (sourceId: ${sourceId})`);
+    return { event: newEvent, created: true };
   }
 }
 

--- a/apps/server/src/services/google-calendar-sync-service.ts
+++ b/apps/server/src/services/google-calendar-sync-service.ts
@@ -1,0 +1,258 @@
+/**
+ * Google Calendar Sync Service — syncs events from Google Calendar into CalendarService.
+ *
+ * Uses plain fetch against Google Calendar API v3. Reads OAuth tokens from project
+ * settings (stored by the Google Calendar OAuth flow). Handles automatic token refresh
+ * when the access token is expired or about to expire.
+ */
+
+import { createLogger } from '@protolabs-ai/utils';
+import type { SettingsService } from './settings-service.js';
+import type { CalendarService, CalendarEvent } from './calendar-service.js';
+
+const logger = createLogger('GoogleCalendarSync');
+
+const GOOGLE_CALENDAR_API = 'https://www.googleapis.com/calendar/v3';
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+
+/** Minimum remaining lifetime before we proactively refresh (5 minutes) */
+const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+/**
+ * Shape of a Google Calendar event from the API (subset of fields we use)
+ */
+interface GoogleCalendarEvent {
+  id: string;
+  summary?: string;
+  description?: string;
+  status?: string;
+  htmlLink?: string;
+  colorId?: string;
+  start?: {
+    date?: string; // All-day event: YYYY-MM-DD
+    dateTime?: string; // Timed event: RFC 3339
+  };
+  end?: {
+    date?: string;
+    dateTime?: string;
+  };
+  created?: string;
+  updated?: string;
+}
+
+/**
+ * Google Calendar API list response
+ */
+interface GoogleCalendarListResponse {
+  items?: GoogleCalendarEvent[];
+  nextPageToken?: string;
+}
+
+/**
+ * Google token refresh response
+ */
+interface GoogleTokenResponse {
+  access_token: string;
+  expires_in: number;
+  token_type: string;
+  refresh_token?: string;
+}
+
+export class GoogleCalendarSyncService {
+  constructor(
+    private settingsService: SettingsService,
+    private calendarService: CalendarService
+  ) {}
+
+  /**
+   * Refresh the access token if it is expired or about to expire.
+   * Updates project settings with the new token on success.
+   */
+  async refreshTokenIfNeeded(projectPath: string): Promise<string> {
+    const settings = await this.settingsService.getProjectSettings(projectPath);
+    const google = settings.integrations?.google;
+
+    if (!google?.accessToken || !google?.refreshToken) {
+      throw new Error('Google Calendar not connected — missing OAuth tokens');
+    }
+
+    const now = Date.now();
+    const expiry = google.tokenExpiry ?? 0;
+
+    // Token still valid with buffer
+    if (now < expiry - TOKEN_REFRESH_BUFFER_MS) {
+      return google.accessToken;
+    }
+
+    logger.info('Access token expired or expiring soon, refreshing...');
+
+    const clientId = process.env.GOOGLE_CLIENT_ID;
+    const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+
+    if (!clientId || !clientSecret) {
+      throw new Error('GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET must be set for token refresh');
+    }
+
+    const response = await fetch(GOOGLE_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: google.refreshToken,
+        grant_type: 'refresh_token',
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      logger.error('Token refresh failed', { status: response.status, error: errorText });
+      throw new Error(`Google token refresh failed (${response.status}): ${errorText}`);
+    }
+
+    const tokenData = (await response.json()) as GoogleTokenResponse;
+    const newExpiry = now + tokenData.expires_in * 1000;
+
+    // Persist new tokens (refresh token may or may not be returned)
+    await this.settingsService.updateProjectSettings(projectPath, {
+      integrations: {
+        google: {
+          ...google,
+          accessToken: tokenData.access_token,
+          tokenExpiry: newExpiry,
+          ...(tokenData.refresh_token ? { refreshToken: tokenData.refresh_token } : {}),
+        },
+      },
+    });
+
+    logger.info('Access token refreshed successfully');
+    return tokenData.access_token;
+  }
+
+  /**
+   * Fetch events from Google Calendar API within a time range.
+   * Handles pagination to retrieve all matching events.
+   */
+  async listGoogleEvents(
+    projectPath: string,
+    timeMin: string,
+    timeMax: string
+  ): Promise<GoogleCalendarEvent[]> {
+    const accessToken = await this.refreshTokenIfNeeded(projectPath);
+
+    const settings = await this.settingsService.getProjectSettings(projectPath);
+    const calendarId = settings.integrations?.google?.calendarId || 'primary';
+
+    const allEvents: GoogleCalendarEvent[] = [];
+    let pageToken: string | undefined;
+
+    do {
+      const params = new URLSearchParams({
+        timeMin,
+        timeMax,
+        singleEvents: 'true',
+        orderBy: 'startTime',
+        maxResults: '250',
+      });
+
+      if (pageToken) {
+        params.set('pageToken', pageToken);
+      }
+
+      const url = `${GOOGLE_CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events?${params.toString()}`;
+
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        logger.error('Google Calendar API request failed', {
+          status: response.status,
+          error: errorText,
+        });
+        throw new Error(`Google Calendar API error (${response.status}): ${errorText}`);
+      }
+
+      const data = (await response.json()) as GoogleCalendarListResponse;
+
+      if (data.items) {
+        allEvents.push(...data.items);
+      }
+
+      pageToken = data.nextPageToken;
+    } while (pageToken);
+
+    return allEvents;
+  }
+
+  /**
+   * Sync events from Google Calendar into CalendarService.
+   * Fetches events for a 90-day window (30 days back, 60 days forward) and
+   * upserts them as 'google' type CalendarEvent records keyed by sourceId.
+   *
+   * Returns the count of events synced (created + updated).
+   */
+  async syncFromGoogle(projectPath: string): Promise<{ synced: number; created: number }> {
+    const now = new Date();
+    const timeMin = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    const timeMax = new Date(now.getTime() + 60 * 24 * 60 * 60 * 1000).toISOString();
+
+    logger.info('Starting Google Calendar sync', { projectPath, timeMin, timeMax });
+
+    const googleEvents = await this.listGoogleEvents(projectPath, timeMin, timeMax);
+    let synced = 0;
+    let created = 0;
+
+    for (const gEvent of googleEvents) {
+      // Skip cancelled events
+      if (gEvent.status === 'cancelled') {
+        continue;
+      }
+
+      // Determine start date
+      const startDate = gEvent.start?.date || gEvent.start?.dateTime;
+      if (!startDate) {
+        logger.warn('Skipping Google Calendar event with no start date', { id: gEvent.id });
+        continue;
+      }
+
+      // Normalize to YYYY-MM-DD for all-day events or keep ISO for timed events
+      const date = startDate.length === 10 ? startDate : startDate.substring(0, 10);
+
+      // Determine end date (optional)
+      const endRaw = gEvent.end?.date || gEvent.end?.dateTime;
+      const endDate = endRaw
+        ? endRaw.length === 10
+          ? endRaw
+          : endRaw.substring(0, 10)
+        : undefined;
+
+      const eventData: Omit<CalendarEvent, 'id' | 'createdAt' | 'updatedAt'> = {
+        title: gEvent.summary || '(No title)',
+        date,
+        endDate: endDate !== date ? endDate : undefined,
+        type: 'google',
+        description: gEvent.description?.substring(0, 500) || undefined,
+        url: gEvent.htmlLink || undefined,
+        sourceId: gEvent.id,
+      };
+
+      const result = await this.calendarService.upsertBySourceId(projectPath, gEvent.id, eventData);
+      synced++;
+      if (result.created) {
+        created++;
+      }
+    }
+
+    logger.info('Google Calendar sync complete', {
+      projectPath,
+      total: googleEvents.length,
+      synced,
+      created,
+      updated: synced - created,
+    });
+
+    return { synced, created };
+  }
+}


### PR DESCRIPTION
## Summary
- Add `GoogleCalendarSyncService` that fetches events from Google Calendar API v3 and syncs them into Automaker's CalendarService using upsert-by-sourceId dedup
- Add `POST /api/google-calendar/sync` endpoint to trigger a one-time sync from Google Calendar
- Extend `CalendarEvent` with `sourceId` field and `CalendarEventType` with `'google'` variant
- Add `upsertBySourceId` method to `CalendarService` for idempotent sync operations
- Automatic OAuth token refresh when access token is expired or about to expire

## Test plan
- [x] TypeScript build passes (`tsc` clean)
- [x] All 84 server test files pass (2033 tests)
- [x] Prettier formatting verified
- [ ] Manual test: connect Google Calendar via OAuth, then POST `/api/google-calendar/sync` with `{ projectPath }` to verify events appear in calendar list

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented Google Calendar synchronization allowing users to sync their Google Calendar events into the local calendar system.
  * Added manual sync trigger for on-demand event synchronization with automatic token refresh.
  * Events are created or updated with source tracking to prevent duplication and preserve data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->