### PR TITLE
feat(ui): add custom event creation and management UI

### DIFF
--- a/apps/ui/src/components/views/calendar-view/calendar-view.tsx
+++ b/apps/ui/src/components/views/calendar-view/calendar-view.tsx
@@ -128,11 +128,7 @@ interface DayEventsPopoverContentProps {
   onEventClick: (event: CalendarEvent) => void;
 }
 
-function DayEventsPopoverContent({
-  dateStr,
-  events,
-  onEventClick,
-}: DayEventsPopoverContentProps) {
+function DayEventsPopoverContent({ dateStr, events, onEventClick }: DayEventsPopoverContentProps) {
   return (
     <div className="space-y-1">
       <p className="text-xs font-medium text-muted-foreground mb-2">{formatDateLabel(dateStr)}</p>
@@ -147,7 +143,7 @@ function DayEventsPopoverContent({
             <span
               className={cn(
                 'mt-1 inline-block h-2 w-2 rounded-full shrink-0',
-                getEventDotClass(event),
+                getEventDotClass(event)
               )}
               style={getEventDotStyle(event)}
             />
@@ -228,7 +224,7 @@ export function CalendarView() {
 
   const now = new Date();
   const [displayMonth, setDisplayMonth] = useState<Date>(
-    new Date(now.getFullYear(), now.getMonth()),
+    new Date(now.getFullYear(), now.getMonth())
   );
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
 
@@ -296,7 +292,7 @@ export function CalendarView() {
         toast.error(err instanceof Error ? err.message : 'Failed to create event');
       }
     },
-    [createEvent],
+    [createEvent]
   );
 
   const handleUpdateEvent = useCallback(
@@ -308,7 +304,7 @@ export function CalendarView() {
         toast.error(err instanceof Error ? err.message : 'Failed to update event');
       }
     },
-    [updateEvent],
+    [updateEvent]
   );
 
   const handleDeleteEvent = useCallback(
@@ -322,7 +318,7 @@ export function CalendarView() {
         toast.error(err instanceof Error ? err.message : 'Failed to delete event');
       }
     },
-    [deleteEvent],
+    [deleteEvent]
   );
 
   // No project selected state
@@ -440,7 +436,7 @@ export function CalendarView() {
                         'flex flex-col items-center gap-0.5',
                         isSelected && hasEvents && 'bg-accent text-accent-foreground',
                         modifiers.today && 'font-bold text-primary',
-                        modifiers.outside && 'text-muted-foreground/40',
+                        modifiers.outside && 'text-muted-foreground/40'
                       )}
                       onClick={(e) => {
                         handleDayClick(date);

--- a/apps/ui/src/components/views/calendar-view/create-event-dialog.tsx
+++ b/apps/ui/src/components/views/calendar-view/create-event-dialog.tsx
@@ -199,7 +199,7 @@ export function CreateEventDialog({
                   'bg-emerald-500/20',
                   !color
                     ? 'border-foreground ring-2 ring-foreground/20'
-                    : 'border-transparent hover:border-muted-foreground/40',
+                    : 'border-transparent hover:border-muted-foreground/40'
                 )}
                 title="Default"
                 data-testid="event-color-default"
@@ -213,7 +213,7 @@ export function CreateEventDialog({
                     'h-6 w-6 rounded-full border-2 transition-all',
                     color === preset.value
                       ? 'border-foreground ring-2 ring-foreground/20'
-                      : 'border-transparent hover:border-muted-foreground/40',
+                      : 'border-transparent hover:border-muted-foreground/40'
                   )}
                   style={{ backgroundColor: preset.value }}
                   title={preset.label}

--- a/apps/ui/src/components/views/calendar-view/event-detail-panel.tsx
+++ b/apps/ui/src/components/views/calendar-view/event-detail-panel.tsx
@@ -342,7 +342,7 @@ function EditableEventDetail({
               'bg-emerald-500/20',
               !color
                 ? 'border-foreground ring-2 ring-foreground/20'
-                : 'border-transparent hover:border-muted-foreground/40',
+                : 'border-transparent hover:border-muted-foreground/40'
             )}
             title="Default"
           />
@@ -355,7 +355,7 @@ function EditableEventDetail({
                 'h-6 w-6 rounded-full border-2 transition-all',
                 color === preset.value
                   ? 'border-foreground ring-2 ring-foreground/20'
-                  : 'border-transparent hover:border-muted-foreground/40',
+                  : 'border-transparent hover:border-muted-foreground/40'
               )}
               style={{ backgroundColor: preset.value }}
               title={preset.label}

--- a/apps/ui/src/components/views/calendar-view/use-calendar-events.ts
+++ b/apps/ui/src/components/views/calendar-view/use-calendar-events.ts
@@ -173,7 +173,7 @@ export function useCalendarEvents({
         setIsMutating(false);
       }
     },
-    [projectPath, fetchEvents],
+    [projectPath, fetchEvents]
   );
 
   const updateEvent = useCallback(
@@ -197,7 +197,7 @@ export function useCalendarEvents({
         setIsMutating(false);
       }
     },
-    [projectPath, fetchEvents],
+    [projectPath, fetchEvents]
   );
 
   const deleteEvent = useCallback(
@@ -220,7 +220,7 @@ export function useCalendarEvents({
         setIsMutating(false);
       }
     },
-    [projectPath, fetchEvents],
+    [projectPath, fetchEvents]
   );
 
   return {


### PR DESCRIPTION
## Summary
- Add `CreateEventDialog` component for creating custom calendar events with title, date range, description, and color picker (8 preset colors)
- Add `EventDetailPanel` component that shows read-only details for feature/milestone/google/linear events and editable details for custom events (with inline edit mode and delete confirmation)
- Wire both components into `CalendarView` with a "New Event" header button, clickable event rows in day popovers, and toast notifications for all mutations
- Extend `useCalendarEvents` hook with `createEvent`, `updateEvent`, and `deleteEvent` mutation functions that auto-refetch after success

## Files Changed
- `apps/ui/src/components/views/calendar-view/create-event-dialog.tsx` (new) — Dialog form for creating custom events
- `apps/ui/src/components/views/calendar-view/event-detail-panel.tsx` (new) — Event detail panel with read-only and editable modes
- `apps/ui/src/components/views/calendar-view/calendar-view.tsx` — Added New Event button, event click handlers, dialog/panel wiring
- `apps/ui/src/components/views/calendar-view/use-calendar-events.ts` — Added CRUD mutation functions and exported input types

## Test plan
- [ ] Open calendar view and click "New Event" button — create dialog opens
- [ ] Fill in title and date, submit — event appears on calendar, success toast shown
- [ ] Click an existing custom event in day popover — detail panel opens in view mode
- [ ] Click Edit on custom event — inline edit mode with pre-filled form
- [ ] Modify fields and save — event updates, success toast shown
- [ ] Click Delete on custom event — confirmation dialog appears, confirm deletes event
- [ ] Click a feature/milestone event — read-only detail panel with source link
- [ ] Verify Cmd+Enter hotkey works for both create and save

🤖 Generated with [Claude Code](https://claude.com/claude-code)