### PR TITLE
fix: add missing build:libs script breaking staging deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dev:docker:rebuild": "docker compose build --no-cache && docker compose up",
     "dev:full": "npm run build:packages && concurrently \"npm run _dev:server\" \"npm run _dev:web\"",
     "build": "npm run build:packages && npm run build --workspace=apps/ui",
+    "build:libs": "turbo run build --filter='./libs/*'",
     "build:packages": "turbo run build --filter='./libs/*' --filter='./packages/mcp-server'",
     "build:server": "npm run build:packages && npm run build --workspace=apps/server",
     "build:electron": "npm run build:packages && npm run build:electron --workspace=apps/ui",


### PR DESCRIPTION
## Summary
- **Staging deploys have been broken** since `build:libs` was removed during a refactor
- The Dockerfile uses `npm run build:libs` to build only shared libraries (excluding `packages/mcp-server` which isn't in the Docker context)
- Adds back the `build:libs` script: `turbo run build --filter='./libs/*'`

## Root cause
The Dockerfile references `npm run build:libs` (lines 60, 280) but the script was removed when `build:packages` was refactored. Docker builds fail with:
```
npm error Missing script: "build:libs"
```

## Key distinction
- `build:libs` — shared libraries only (for Docker builds, no MCP server)
- `build:packages` — libs + MCP server (for host development)

## Test plan
- [ ] Verify `npm run build:libs` succeeds
- [ ] Verify Docker build completes: `docker compose -f docker-compose.staging.yml build`
- [ ] Staging deploy triggers and succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)