### PR TITLE
feat: wire agent execution metrics into Prometheus counters

### DIFF
--- a/apps/server/src/lib/prometheus.ts
+++ b/apps/server/src/lib/prometheus.ts
@@ -82,6 +82,36 @@ export const agentCostTotal = new Counter({
 });
 
 /**
+ * Agent input tokens counter
+ */
+export const agentTokensInputTotal = new Counter({
+  name: 'agent_tokens_input_total',
+  help: 'Total input tokens consumed by agents',
+  labelNames: ['model'],
+  registers: [register],
+});
+
+/**
+ * Agent output tokens counter
+ */
+export const agentTokensOutputTotal = new Counter({
+  name: 'agent_tokens_output_total',
+  help: 'Total output tokens produced by agents',
+  labelNames: ['model'],
+  registers: [register],
+});
+
+/**
+ * Agent executions counter
+ */
+export const agentExecutionsTotal = new Counter({
+  name: 'agent_executions_total',
+  help: 'Total number of agent executions',
+  labelNames: ['model', 'complexity', 'success'],
+  registers: [register],
+});
+
+/**
  * Node.js heap used gauge in bytes
  */
 export const nodeJsHeapUsedBytes = new Gauge({

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -86,6 +86,14 @@ import * as secureFs from '../lib/secure-fs.js';
 import type { EventEmitter } from '../lib/events.js';
 import { ensureCleanWorktree } from '../lib/worktree-guard.js';
 import {
+  agentCostTotal,
+  agentExecutionDuration,
+  activeAgentsCount,
+  agentTokensInputTotal,
+  agentTokensOutputTotal,
+  agentExecutionsTotal,
+} from '../lib/prometheus.js';
+import {
   createAutoModeOptions,
   createCustomOptions,
   validateWorkingDirectory,
@@ -1650,6 +1658,7 @@ export class AutoModeService {
       recoveryContext: options?.recoveryContext,
     };
     this.runningFeatures.set(featureId, tempRunningFeature);
+    activeAgentsCount.set(this.runningFeatures.size);
 
     // Save execution state when feature starts
     if (isAutoMode) {
@@ -2082,6 +2091,28 @@ export class AutoModeService {
         await this.featureLoader.update(projectPath, featureId, {
           executionHistory: [...history, record],
         });
+
+        // Increment Prometheus metrics
+        if (record.costUsd) {
+          agentCostTotal.inc({ feature_id: featureId, model: record.model }, record.costUsd);
+        }
+        if (record.durationMs) {
+          agentExecutionDuration.observe(
+            { feature_id: featureId, complexity: currentFeature?.complexity || 'medium' },
+            record.durationMs / 1000
+          );
+        }
+        if (record.inputTokens) {
+          agentTokensInputTotal.inc({ model: record.model }, record.inputTokens);
+        }
+        if (record.outputTokens) {
+          agentTokensOutputTotal.inc({ model: record.model }, record.outputTokens);
+        }
+        agentExecutionsTotal.inc({
+          model: record.model,
+          complexity: currentFeature?.complexity || 'medium',
+          success: 'true',
+        });
       } catch (recordError) {
         logger.warn(`Failed to save execution record for ${featureId}:`, recordError);
       }
@@ -2243,6 +2274,28 @@ export class AutoModeService {
           const history = currentFeature?.executionHistory ?? [];
           await this.featureLoader.update(projectPath, featureId, {
             executionHistory: [...history, record],
+          });
+
+          // Increment Prometheus metrics
+          if (record.costUsd) {
+            agentCostTotal.inc({ feature_id: featureId, model: record.model }, record.costUsd);
+          }
+          if (record.durationMs) {
+            agentExecutionDuration.observe(
+              { feature_id: featureId, complexity: currentFeature?.complexity || 'medium' },
+              record.durationMs / 1000
+            );
+          }
+          if (record.inputTokens) {
+            agentTokensInputTotal.inc({ model: record.model }, record.inputTokens);
+          }
+          if (record.outputTokens) {
+            agentTokensOutputTotal.inc({ model: record.model }, record.outputTokens);
+          }
+          agentExecutionsTotal.inc({
+            model: record.model,
+            complexity: currentFeature?.complexity || 'medium',
+            success: 'false',
           });
         } catch (recordError) {
           logger.warn(`Failed to save execution record for ${featureId}:`, recordError);
@@ -2501,6 +2554,7 @@ export class AutoModeService {
       const current = this.runningFeatures.get(featureId);
       if (current === tempRunningFeature) {
         this.runningFeatures.delete(featureId);
+        activeAgentsCount.set(this.runningFeatures.size);
       }
 
       // Update execution state after feature completes
@@ -2683,6 +2737,7 @@ Complete the pipeline step instructions above. Review the previous work and appl
     // Remove from running features immediately to allow resume
     // The abort signal will still propagate to stop any ongoing execution
     this.runningFeatures.delete(featureId);
+    activeAgentsCount.set(this.runningFeatures.size);
 
     // Cancel retry timer to prevent zombie restart loop
     const retryTimer = this.retryTimers.get(featureId);
@@ -3117,6 +3172,7 @@ Complete the pipeline step instructions above. Review the previous work and appl
       previousErrors: [],
     };
     this.runningFeatures.set(featureId, pipelineRunningFeature);
+    activeAgentsCount.set(this.runningFeatures.size);
 
     try {
       // Validate project path
@@ -3361,6 +3417,7 @@ Complete the pipeline step instructions above. Review the previous work and appl
       const current = this.runningFeatures.get(featureId);
       if (current === pipelineRunningFeature) {
         this.runningFeatures.delete(featureId);
+        activeAgentsCount.set(this.runningFeatures.size);
       }
     }
   }
@@ -3524,6 +3581,7 @@ Address the follow-up instructions above. Review the previous work and make the 
       previousErrors: [],
     };
     this.runningFeatures.set(featureId, followUpRunningFeature);
+    activeAgentsCount.set(this.runningFeatures.size);
 
     try {
       // Update feature status to in_progress BEFORE emitting event
@@ -3774,6 +3832,7 @@ Address the follow-up instructions above. Review the previous work and make the 
       const current = this.runningFeatures.get(featureId);
       if (current === followUpRunningFeature) {
         this.runningFeatures.delete(featureId);
+        activeAgentsCount.set(this.runningFeatures.size);
       }
     }
   }

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -33,6 +33,7 @@ import {
 import { addImplementedFeature, type ImplementedFeature } from '../lib/xml-extractor.js';
 import { debugLog } from '../lib/debug-log.js';
 import type { DataIntegrityWatchdogService } from './data-integrity-watchdog-service.js';
+import { featuresByStatus } from '../lib/prometheus.js';
 
 const logger = createLogger('FeatureLoader');
 
@@ -310,6 +311,36 @@ export class FeatureLoader implements FeatureStore {
   }
 
   /**
+   * Sync Prometheus metrics with current feature state
+   * Call this during server initialization to ensure gauges reflect reality
+   */
+  async syncMetrics(projectPath: string): Promise<void> {
+    try {
+      const features = await this.getAll(projectPath);
+      const statusCounts = new Map<string, number>();
+
+      // Count features by status
+      for (const feature of features) {
+        const status = feature.status || 'backlog';
+        statusCounts.set(status, (statusCounts.get(status) || 0) + 1);
+      }
+
+      // Reset gauge and set correct values
+      featuresByStatus.reset();
+      for (const [status, count] of statusCounts.entries()) {
+        featuresByStatus.set({ status }, count);
+      }
+
+      logger.info('Synced Prometheus metrics with feature state', {
+        totalFeatures: features.length,
+        statusCounts: Object.fromEntries(statusCounts),
+      });
+    } catch (error) {
+      logger.error('Failed to sync Prometheus metrics:', error);
+    }
+  }
+
+  /**
    * Normalize a title for comparison (case-insensitive, trimmed)
    */
   private normalizeTitle(title: string): string {
@@ -524,6 +555,9 @@ export class FeatureLoader implements FeatureStore {
       backupDir,
     });
 
+    // Update Prometheus gauge for new feature
+    featuresByStatus.inc({ status: initialStatus });
+
     logger.info(`Created feature ${featureId}`);
     return feature;
   }
@@ -615,6 +649,12 @@ export class FeatureLoader implements FeatureStore {
       };
       updatedStatusHistory = [...updatedStatusHistory, transition];
 
+      // Update Prometheus gauge for status change
+      if (feature.status) {
+        featuresByStatus.dec({ status: feature.status });
+      }
+      featuresByStatus.inc({ status: updates.status });
+
       // Set lifecycle timestamps based on status
       if (updates.status === 'review' && !feature.reviewStartedAt) {
         lifecycleUpdates = { ...lifecycleUpdates, reviewStartedAt: timestamp };
@@ -653,9 +693,18 @@ export class FeatureLoader implements FeatureStore {
    */
   async delete(projectPath: string, featureId: string): Promise<boolean> {
     try {
+      // Get feature status before deleting for metrics
+      const feature = await this.get(projectPath, featureId);
+      const featureStatus = feature?.status;
+
       const featureDir = this.getFeatureDir(projectPath, featureId);
       await secureFs.rm(featureDir, { recursive: true, force: true });
       logger.info(`Deleted feature ${featureId}`);
+
+      // Update Prometheus gauge for deleted feature
+      if (featureStatus) {
+        featuresByStatus.dec({ status: featureStatus });
+      }
 
       // Notify integrity watchdog so it doesn't flag this as data loss
       if (this.integrityWatchdog) {


### PR DESCRIPTION
## Summary
- Wires real agent execution data into Prometheus metrics that were previously declared but never populated
- Adds `agent_tokens_input_total`, `agent_tokens_output_total`, and `agent_executions_total` counters
- Updates `active_agents_count` gauge on agent start/stop in auto-mode service
- Wires `features_by_status` gauge to update dynamically on feature status changes
- Bridges the gap between Langfuse (LLM cost tracking) and Prometheus (Grafana dashboards)

## Changed Files
- `apps/server/src/lib/prometheus.ts` — new metric declarations
- `apps/server/src/services/auto-mode-service.ts` — agent lifecycle metric updates
- `apps/server/src/services/feature-loader.ts` — feature status metric updates

## Test plan
- [ ] `npm run build:server` succeeds
- [ ] `/api/metrics/prometheus` returns non-zero values after agent execution
- [ ] Grafana Agent Performance dashboard shows real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced system monitoring and observability with new metrics tracking agent token usage, execution counts, operational costs, and feature lifecycle events across multiple execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->