### PR TITLE
feat: component library panel for PEN design editor

### DIFF
--- a/apps/ui/src/components/views/designs-view/designs-view.tsx
+++ b/apps/ui/src/components/views/designs-view/designs-view.tsx
@@ -5,12 +5,20 @@ import { Spinner } from '@protolabs-ai/ui/atoms';
 import { DesignsTree } from './designs-tree';
 import { DesignsCanvas } from './designs-canvas';
 import { PropertyInspector } from './inspector/property-inspector';
-import { FileText } from 'lucide-react';
+import { ComponentLibrary } from './library';
+import { FileText, Package } from 'lucide-react';
 
 export function DesignsView() {
   const { currentProject } = useAppStore();
-  const { selectedFilePath, selectedDocument, isLoadingDocument, isDirty, reset } =
-    useDesignsStore();
+  const {
+    selectedFilePath,
+    selectedDocument,
+    isLoadingDocument,
+    isDirty,
+    isLibraryVisible,
+    toggleLibraryVisibility,
+    reset,
+  } = useDesignsStore();
 
   // Reset store when project changes or component unmounts
   useEffect(() => {
@@ -47,12 +55,33 @@ export function DesignsView() {
 
   return (
     <div className="flex h-full flex-col">
+      {/* Toolbar */}
+      <div className="border-b border-border bg-muted/30 px-4 py-2 flex items-center gap-2">
+        <button
+          onClick={toggleLibraryVisibility}
+          className={`flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+            isLibraryVisible ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
+          }`}
+          title={isLibraryVisible ? 'Hide component library' : 'Show component library'}
+        >
+          <Package className="h-4 w-4" />
+          Components
+        </button>
+      </div>
+
       {/* Main content area */}
       <div className="flex flex-1 overflow-hidden">
         {/* Left sidebar - File tree */}
         <div className="w-64 border-r border-border bg-background overflow-y-auto">
           <DesignsTree projectPath={currentProject.path} />
         </div>
+
+        {/* Component library panel */}
+        {isLibraryVisible && (
+          <div className="w-80 border-r border-border bg-background overflow-hidden">
+            <ComponentLibrary penFile={selectedDocument} />
+          </div>
+        )}
 
         {/* Middle pane - Canvas/Document viewer */}
         <div className="flex-1 flex flex-col">

--- a/apps/ui/src/components/views/designs-view/library/component-library.tsx
+++ b/apps/ui/src/components/views/designs-view/library/component-library.tsx
@@ -1,0 +1,225 @@
+/**
+ * Component library panel
+ * Displays all reusable components from the current .pen file, grouped by category
+ */
+
+import { useMemo } from 'react';
+import type { PenNode, PenDocument as PenDocumentParsed } from '@protolabs-ai/types';
+import type { PenDocument } from '@/store/designs-store';
+import { useDesignsStore } from '@/store/designs-store';
+import { ComponentThumbnail } from './component-thumbnail';
+import { Search, ChevronDown, ChevronRight, Package } from 'lucide-react';
+
+interface ComponentGroup {
+  name: string;
+  components: PenNode[];
+}
+
+/**
+ * Recursively find all reusable nodes in the document tree
+ */
+function findReusableNodes(nodes: PenNode[]): PenNode[] {
+  const reusable: PenNode[] = [];
+
+  for (const node of nodes) {
+    if (node.reusable === true) {
+      reusable.push(node);
+    }
+    // Recursively search children
+    if ('children' in node && Array.isArray(node.children)) {
+      reusable.push(...findReusableNodes(node.children));
+    }
+  }
+
+  return reusable;
+}
+
+/**
+ * Group components by name prefix (e.g., "Button/Default" → "Button")
+ */
+function groupComponents(components: PenNode[]): ComponentGroup[] {
+  const groups = new Map<string, PenNode[]>();
+
+  for (const component of components) {
+    const name = component.name || 'Unnamed';
+    const slashIndex = name.indexOf('/');
+    const groupName = slashIndex !== -1 ? name.slice(0, slashIndex) : 'Other';
+
+    if (!groups.has(groupName)) {
+      groups.set(groupName, []);
+    }
+    groups.get(groupName)!.push(component);
+  }
+
+  return Array.from(groups.entries())
+    .map(([name, components]) => ({ name, components }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+interface ComponentLibraryProps {
+  penFile: PenDocument | null;
+}
+
+export function ComponentLibrary({ penFile }: ComponentLibraryProps) {
+  const {
+    librarySearchFilter,
+    expandedLibraryGroups,
+    setLibrarySearchFilter,
+    toggleLibraryGroup,
+    setSelectedNode,
+  } = useDesignsStore();
+
+  // Parse the document
+  const document = useMemo<PenDocumentParsed | null>(() => {
+    if (!penFile?.content) return null;
+    try {
+      const parsed = JSON.parse(penFile.content);
+      if (parsed.version && Array.isArray(parsed.children)) {
+        return parsed as PenDocumentParsed;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }, [penFile]);
+
+  // Extract reusable components
+  const reusableComponents = useMemo(() => {
+    if (!document?.children) return [];
+    return findReusableNodes(document.children);
+  }, [document]);
+
+  // Group components
+  const groups = useMemo(() => {
+    return groupComponents(reusableComponents);
+  }, [reusableComponents]);
+
+  // Filter groups by search
+  const filteredGroups = useMemo(() => {
+    if (!librarySearchFilter) return groups;
+
+    const lowerFilter = librarySearchFilter.toLowerCase();
+    return groups
+      .map((group) => ({
+        ...group,
+        components: group.components.filter((component) => {
+          const name = component.name || '';
+          return name.toLowerCase().includes(lowerFilter);
+        }),
+      }))
+      .filter((group) => group.components.length > 0);
+  }, [groups, librarySearchFilter]);
+
+  // Handle component click
+  const handleComponentClick = (component: PenNode) => {
+    setSelectedNode(component.id);
+  };
+
+  // Show empty state if no file loaded
+  if (!penFile) {
+    return (
+      <div className="flex h-full flex-col">
+        <div className="border-b border-border bg-muted/30 px-4 py-3">
+          <h2 className="text-sm font-medium">Components</h2>
+        </div>
+        <div className="flex flex-1 items-center justify-center p-4">
+          <div className="text-center text-sm text-muted-foreground">
+            <Package className="mx-auto h-8 w-8 mb-2 opacity-50" />
+            <p>No file loaded</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Show empty state if no reusable components
+  if (reusableComponents.length === 0) {
+    return (
+      <div className="flex h-full flex-col">
+        <div className="border-b border-border bg-muted/30 px-4 py-3">
+          <h2 className="text-sm font-medium">Components</h2>
+        </div>
+        <div className="flex flex-1 items-center justify-center p-4">
+          <div className="text-center text-sm text-muted-foreground">
+            <Package className="mx-auto h-8 w-8 mb-2 opacity-50" />
+            <p>No reusable components</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="border-b border-border bg-muted/30 px-4 py-3">
+        <h2 className="text-sm font-medium">Components</h2>
+      </div>
+
+      {/* Search input */}
+      <div className="border-b border-border p-3">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder="Search components..."
+            value={librarySearchFilter}
+            onChange={(e) => setLibrarySearchFilter(e.target.value)}
+            className="w-full rounded-md border border-input bg-background pl-9 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+      </div>
+
+      {/* Component groups */}
+      <div className="flex-1 overflow-y-auto">
+        {filteredGroups.length === 0 ? (
+          <div className="flex items-center justify-center p-8">
+            <p className="text-sm text-muted-foreground">No components match your search</p>
+          </div>
+        ) : (
+          <div className="space-y-2 p-3">
+            {filteredGroups.map((group) => {
+              const isExpanded = expandedLibraryGroups.has(group.name);
+
+              return (
+                <div key={group.name} className="space-y-2">
+                  {/* Group header */}
+                  <button
+                    onClick={() => toggleLibraryGroup(group.name)}
+                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium hover:bg-muted/50 transition-colors"
+                  >
+                    {isExpanded ? (
+                      <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                    )}
+                    <span className="flex-1 text-left">{group.name}</span>
+                    <span className="text-xs text-muted-foreground">{group.components.length}</span>
+                  </button>
+
+                  {/* Group components */}
+                  {isExpanded && (
+                    <div className="space-y-2 pl-6">
+                      {group.components.map((component) => (
+                        <div key={component.id} className="space-y-1">
+                          <ComponentThumbnail
+                            node={component}
+                            document={document}
+                            onClick={() => handleComponentClick(component)}
+                          />
+                          <p className="text-xs text-muted-foreground truncate px-1">
+                            {component.name || component.id}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/views/designs-view/library/component-thumbnail.tsx
+++ b/apps/ui/src/components/views/designs-view/library/component-thumbnail.tsx
@@ -1,0 +1,42 @@
+/**
+ * Component thumbnail renderer
+ * Renders a scaled-down preview of a reusable component
+ */
+
+import type { PenNode, PenDocument } from '@protolabs-ai/types';
+import { PenNodeRenderer } from '../renderer/pen-node-renderer';
+import { PenThemeProvider } from '../renderer/pen-theme-context';
+
+interface ComponentThumbnailProps {
+  node: PenNode;
+  document: PenDocument | null;
+  onClick?: () => void;
+}
+
+/**
+ * Renders a thumbnail preview of a component at reduced scale
+ */
+export function ComponentThumbnail({ node, document, onClick }: ComponentThumbnailProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="group relative h-16 w-full overflow-hidden rounded-lg border border-border bg-muted/30 hover:border-primary hover:bg-muted/50 transition-colors"
+      title={node.name || node.id}
+    >
+      <div className="absolute inset-0 flex items-center justify-center p-2">
+        <div
+          className="origin-center"
+          style={{
+            transform: 'scale(0.5)',
+            maxWidth: '200%',
+            maxHeight: '200%',
+          }}
+        >
+          <PenThemeProvider document={document}>
+            <PenNodeRenderer node={node} />
+          </PenThemeProvider>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/apps/ui/src/components/views/designs-view/library/index.ts
+++ b/apps/ui/src/components/views/designs-view/library/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Component library exports
+ */
+
+export { ComponentLibrary } from './component-library';
+export { ComponentThumbnail } from './component-thumbnail';

--- a/apps/ui/src/store/designs-store.ts
+++ b/apps/ui/src/store/designs-store.ts
@@ -39,6 +39,11 @@ export interface DesignsState {
   history: HistoryEntry[];
   historyIndex: number;
 
+  // Component library state
+  isLibraryVisible: boolean;
+  librarySearchFilter: string;
+  expandedLibraryGroups: Set<string>;
+
   // Loading states
   isLoadingTree: boolean;
   isLoadingDocument: boolean;
@@ -72,6 +77,11 @@ export interface DesignsActions {
   saveDocument: () => Promise<void>;
   setDirty: (dirty: boolean) => void;
 
+  // Component library actions
+  toggleLibraryVisibility: () => void;
+  setLibrarySearchFilter: (filter: string) => void;
+  toggleLibraryGroup: (groupName: string) => void;
+
   // Loading state actions
   setLoadingTree: (loading: boolean) => void;
   setLoadingDocument: (loading: boolean) => void;
@@ -90,6 +100,9 @@ const initialState: DesignsState = {
   isSaving: false,
   history: [],
   historyIndex: -1,
+  isLibraryVisible: true,
+  librarySearchFilter: '',
+  expandedLibraryGroups: new Set(),
   isLoadingTree: false,
   isLoadingDocument: false,
 };
@@ -269,6 +282,21 @@ export const useDesignsStore = create<DesignsState & DesignsActions>()((set, get
   },
 
   setDirty: (dirty) => set({ isDirty: dirty }),
+
+  // Component library actions
+  toggleLibraryVisibility: () => set((state) => ({ isLibraryVisible: !state.isLibraryVisible })),
+
+  setLibrarySearchFilter: (filter) => set({ librarySearchFilter: filter }),
+
+  toggleLibraryGroup: (groupName) => {
+    const expanded = new Set(get().expandedLibraryGroups);
+    if (expanded.has(groupName)) {
+      expanded.delete(groupName);
+    } else {
+      expanded.add(groupName);
+    }
+    set({ expandedLibraryGroups: expanded });
+  },
 
   // Loading state actions
   setLoadingTree: (loading) => set({ isLoadingTree: loading }),

--- a/libs/types/src/pen.ts
+++ b/libs/types/src/pen.ts
@@ -194,6 +194,7 @@ export interface PenNodeBase {
   transform?: PenTransform;
   bounds?: PenBounds;
   effects?: PenEffect[];
+  reusable?: boolean; // Marks node as a reusable component
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Adds a collapsible component library panel to the PEN designs view, positioned between the file tree and canvas
- Components are extracted from the active `.pen` file, grouped by category with search/filter support
- Zustand store extended with library visibility, search filter, and expanded group state
- `PenNodeBase.reusable` field added to types for marking components as library-eligible

## Test plan
- [ ] Open a `.pen` file in the designs view
- [ ] Toggle the "Components" button in the toolbar to show/hide the library panel
- [ ] Verify component thumbnails render from the active document
- [ ] Search for components by name using the filter input
- [ ] Expand/collapse component groups
- [ ] Verify panel state persists across file selections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a component library panel displaying all reusable components from your current design file, organized in searchable collapsible groups
  * Search and filter components by name with case-insensitive matching
  * View component previews as interactive thumbnails
  * Select components directly from the library to use in your designs
  * Toggle the library panel visibility with a toolbar button

<!-- end of auto-generated comment: release notes by coderabbit.ai -->