### PR TITLE
feat: designs page HTTP fallback for web mode

### DIFF
--- a/apps/server/src/routes/designs/index.ts
+++ b/apps/server/src/routes/designs/index.ts
@@ -14,6 +14,7 @@ import { createListHandler } from './routes/list.js';
 import { createReadHandler } from './routes/read.js';
 import { createWriteHandler } from './routes/write.js';
 import { createCreateHandler } from './routes/create.js';
+import { createDirectoryHandler, createStatHandler } from './routes/directory.js';
 
 export function createDesignsRoutes(): Router {
   const router = Router();
@@ -23,6 +24,10 @@ export function createDesignsRoutes(): Router {
   router.post('/read', validatePathParams('projectPath', 'filePath'), createReadHandler());
   router.post('/write', validatePathParams('projectPath', 'filePath'), createWriteHandler());
   router.post('/create', validatePathParams('projectPath', 'filePath'), createCreateHandler());
+
+  // Directory operations for web mode (HTTP fallback for Electron IPC)
+  router.post('/directory', createDirectoryHandler());
+  router.post('/stat', createStatHandler());
 
   return router;
 }

--- a/apps/server/src/routes/designs/routes/directory.ts
+++ b/apps/server/src/routes/designs/routes/directory.ts
@@ -1,0 +1,142 @@
+/**
+ * POST /directory endpoint - Read directory contents for designs view
+ * Provides HTTP fallback for Electron IPC in web mode
+ */
+
+import type { Request, Response } from 'express';
+import { join } from 'node:path';
+import { readdir, stat } from 'node:fs/promises';
+import { createLogger } from '@protolabs-ai/utils';
+import { validatePath } from '@protolabs-ai/platform';
+
+const logger = createLogger('DesignsDirectoryRoute');
+
+interface DirectoryRequest {
+  path: string;
+}
+
+interface DirectoryResult {
+  success: boolean;
+  files?: string[];
+  error?: string;
+}
+
+interface StatResult {
+  success: boolean;
+  isDirectory?: boolean;
+  isFile?: boolean;
+  error?: string;
+}
+
+/**
+ * Read directory contents and return file/folder names
+ * Mimics Electron IPC readDirectory behavior
+ */
+async function readDirectory(dirPath: string): Promise<DirectoryResult> {
+  try {
+    const entries = await readdir(dirPath, { withFileTypes: true });
+    const files = entries.map((entry) => entry.name);
+
+    return {
+      success: true,
+      files,
+    };
+  } catch (error) {
+    logger.warn(`Failed to read directory ${dirPath}:`, error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+/**
+ * Get file/directory stats
+ * Mimics Electron IPC statFile behavior
+ */
+async function statFile(filePath: string): Promise<StatResult> {
+  try {
+    const stats = await stat(filePath);
+
+    return {
+      success: true,
+      isDirectory: stats.isDirectory(),
+      isFile: stats.isFile(),
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+export function createDirectoryHandler() {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { path: dirPath } = req.body as DirectoryRequest;
+
+      if (!dirPath) {
+        res.status(400).json({ success: false, error: 'path is required' });
+        return;
+      }
+
+      // Validate the path is within allowed directories (security check)
+      try {
+        validatePath(dirPath);
+      } catch (error) {
+        res.status(403).json({
+          success: false,
+          error: `Access to directory not allowed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        });
+        return;
+      }
+
+      // Read the directory
+      const result = await readDirectory(dirPath);
+
+      res.json(result);
+    } catch (error) {
+      logger.error('Directory read failed:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}
+
+export function createStatHandler() {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { path: filePath } = req.body as DirectoryRequest;
+
+      if (!filePath) {
+        res.status(400).json({ success: false, error: 'path is required' });
+        return;
+      }
+
+      // Validate the path is within allowed directories (security check)
+      try {
+        validatePath(filePath);
+      } catch (error) {
+        res.status(403).json({
+          success: false,
+          error: `Access to file not allowed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        });
+        return;
+      }
+
+      // Get file stats
+      const result = await statFile(filePath);
+
+      res.json(result);
+    } catch (error) {
+      logger.error('Stat failed:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}

--- a/apps/ui/src/components/views/designs-view/designs-tree.tsx
+++ b/apps/ui/src/components/views/designs-view/designs-tree.tsx
@@ -30,16 +30,54 @@ export function DesignsTree({ projectPath }: DesignsTreeProps) {
     loadFileTree();
   }, [projectPath]);
 
+  // Check if Electron API is available
+  const isElectronMode = typeof window !== 'undefined' && window.electronAPI;
+
+  // HTTP API fallback for web mode
+  const readDirectoryHttp = async (path: string) => {
+    const response = await fetch('/api/designs/directory', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path }),
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to read directory');
+    }
+
+    return await response.json();
+  };
+
+  const statFileHttp = async (path: string) => {
+    const response = await fetch('/api/designs/stat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path }),
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to stat file');
+    }
+
+    return await response.json();
+  };
+
   const loadFileTree = useCallback(async () => {
     setLoadingTree(true);
     setError(null);
 
     try {
-      const api = getElectronAPI();
       const designsPath = `${projectPath}/designs`;
 
       // Check if designs directory exists
-      const dirResult = await api.readDirectory(designsPath);
+      let dirResult;
+      if (isElectronMode) {
+        const api = getElectronAPI();
+        dirResult = await api.readDirectory(designsPath);
+      } else {
+        dirResult = await readDirectoryHttp(designsPath);
+      }
+
       if (!dirResult.success) {
         setFileTree([]);
         setError('No designs directory found');
@@ -57,54 +95,69 @@ export function DesignsTree({ projectPath }: DesignsTreeProps) {
     } finally {
       setLoadingTree(false);
     }
-  }, [projectPath, setFileTree, setLoadingTree]);
+  }, [projectPath, setFileTree, setLoadingTree, isElectronMode]);
 
-  const buildFileTree = async (basePath: string, relativePath: string): Promise<FileTreeNode[]> => {
-    const api = getElectronAPI();
-    const fullPath = relativePath ? `${basePath}/${relativePath}` : basePath;
+  const buildFileTree = useCallback(
+    async (basePath: string, relativePath: string): Promise<FileTreeNode[]> => {
+      const fullPath = relativePath ? `${basePath}/${relativePath}` : basePath;
 
-    const result = await api.readDirectory(fullPath);
-    if (!result.success || !result.files) {
-      return [];
-    }
-
-    const nodes: FileTreeNode[] = [];
-
-    for (const file of result.files) {
-      const filePath = relativePath ? `${relativePath}/${file}` : file;
-      const fileFullPath = `${basePath}/${filePath}`;
-
-      // Check if it's a directory
-      const statResult = await api.statFile(fileFullPath);
-      const isDirectory = statResult.success && statResult.isDirectory;
-
-      if (isDirectory) {
-        // Recursively build subtree
-        const children = await buildFileTree(basePath, filePath);
-        nodes.push({
-          name: file,
-          path: filePath,
-          type: 'folder',
-          children,
-        });
-      } else if (file.endsWith('.pen')) {
-        // Only include .pen files
-        nodes.push({
-          name: file,
-          path: filePath,
-          type: 'file',
-        });
+      let result;
+      if (isElectronMode) {
+        const api = getElectronAPI();
+        result = await api.readDirectory(fullPath);
+      } else {
+        result = await readDirectoryHttp(fullPath);
       }
-    }
 
-    // Sort: folders first, then files, alphabetically
-    return nodes.sort((a, b) => {
-      if (a.type !== b.type) {
-        return a.type === 'folder' ? -1 : 1;
+      if (!result.success || !result.files) {
+        return [];
       }
-      return a.name.localeCompare(b.name);
-    });
-  };
+
+      const nodes: FileTreeNode[] = [];
+
+      for (const file of result.files) {
+        const filePath = relativePath ? `${relativePath}/${file}` : file;
+        const fileFullPath = `${basePath}/${filePath}`;
+
+        // Check if it's a directory
+        let statResult;
+        if (isElectronMode) {
+          const api = getElectronAPI();
+          statResult = await api.statFile(fileFullPath);
+        } else {
+          statResult = await statFileHttp(fileFullPath);
+        }
+        const isDirectory = statResult.success && statResult.isDirectory;
+
+        if (isDirectory) {
+          // Recursively build subtree
+          const children = await buildFileTree(basePath, filePath);
+          nodes.push({
+            name: file,
+            path: filePath,
+            type: 'folder',
+            children,
+          });
+        } else if (file.endsWith('.pen')) {
+          // Only include .pen files
+          nodes.push({
+            name: file,
+            path: filePath,
+            type: 'file',
+          });
+        }
+      }
+
+      // Sort: folders first, then files, alphabetically
+      return nodes.sort((a, b) => {
+        if (a.type !== b.type) {
+          return a.type === 'folder' ? -1 : 1;
+        }
+        return a.name.localeCompare(b.name);
+      });
+    },
+    [isElectronMode]
+  );
 
   const handleFileClick = useCallback(
     async (node: FileTreeNode) => {
@@ -116,10 +169,30 @@ export function DesignsTree({ projectPath }: DesignsTreeProps) {
       // Load the .pen file
       setLoadingDocument(true);
       try {
-        const api = getElectronAPI();
         const fullPath = `${projectPath}/designs/${node.path}`;
 
-        const result = await api.readFile(fullPath);
+        let result;
+        if (isElectronMode) {
+          const api = getElectronAPI();
+          result = await api.readFile(fullPath);
+        } else {
+          // Use existing HTTP API endpoint for reading files
+          const response = await fetch('/api/designs/read', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              projectPath,
+              filePath: node.path,
+            }),
+          });
+
+          if (!response.ok) {
+            throw new Error('Failed to load design file');
+          }
+
+          result = await response.json();
+        }
+
         if (!result.success || !result.content) {
           toast.error('Failed to load design file');
           return;
@@ -138,7 +211,7 @@ export function DesignsTree({ projectPath }: DesignsTreeProps) {
         setLoadingDocument(false);
       }
     },
-    [projectPath, toggleFolder, setSelectedFile, setLoadingDocument]
+    [projectPath, toggleFolder, setSelectedFile, setLoadingDocument, isElectronMode]
   );
 
   return (


### PR DESCRIPTION
## Summary
- Adds `POST /api/designs/directory` and `POST /api/designs/stat` HTTP endpoints as web-mode fallbacks for Electron IPC
- Updates `designs-tree.tsx` to detect web mode (`!window.electronAPI`) and use HTTP API instead of crashing
- Path traversal protection via `validatePath` from `@protolabs-ai/platform`
- Zero regression for Electron mode — IPC path preserved when `electronAPI` is available

## Files Changed
- `apps/server/src/routes/designs/routes/directory.ts` (new) — directory listing + stat endpoints
- `apps/server/src/routes/designs/index.ts` — route registration
- `apps/ui/src/components/views/designs-view/designs-tree.tsx` — web mode detection + HTTP fallback
- `apps/ui/src/components/views/designs-view/library/` — minor component adjustments

## Test plan
- [ ] `npm run dev:web` — designs page loads without crash
- [ ] `curl -X POST http://localhost:3008/api/designs/directory -H 'Content-Type: application/json' -d '{"path": "/tmp"}'` returns file listing
- [ ] Path traversal blocked: `{"path": "/etc/passwd"}` returns 403
- [ ] Electron mode still uses IPC (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added web-based file system operations enabling directory browsing and file inspection via HTTP endpoints.
  * Introduced dual-mode support allowing the application to function in both desktop and web environments seamlessly.
  * File navigation and metadata retrieval now work across both modes without requiring Electron runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->