### PR TITLE
fix: content pipeline Langfuse serialization crash

### DIFF
--- a/libs/flows/src/content/content-creation-flow.ts
+++ b/libs/flows/src/content/content-creation-flow.ts
@@ -24,6 +24,7 @@ import {
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { createLogger } from '@protolabs-ai/utils';
 import { LangfuseClient } from '@protolabs-ai/observability';
+import { isLangfuseReady } from './langfuse-guard.js';
 import { wrapSubgraph } from '../graphs/utils/subgraph-wrapper.js';
 import {
   createSectionWriterGraph,
@@ -194,7 +195,7 @@ Return ONLY a JSON array of strings, no markdown formatting. Example:
     const endTime = new Date();
 
     // Track generation in Langfuse
-    if (config.langfuseClient?.isAvailable() && state.traceId) {
+    if (isLangfuseReady(config.langfuseClient) && state.traceId) {
       config.langfuseClient.createGeneration({
         traceId: state.traceId,
         name: 'generate_queries',
@@ -338,7 +339,7 @@ Return ONLY the JSON object, no markdown formatting.`;
     const endTime = new Date();
 
     // Track generation in Langfuse
-    if (config.langfuseClient?.isAvailable() && state.traceId) {
+    if (isLangfuseReady(config.langfuseClient) && state.traceId) {
       config.langfuseClient.createGeneration({
         traceId: state.traceId,
         name: `research_delegate:${query.slice(0, 40)}`,
@@ -625,7 +626,7 @@ Return ONLY the JSON, no markdown formatting.`;
     const endTime = new Date();
 
     // Track generation in Langfuse
-    if (config.langfuseClient?.isAvailable() && state.traceId) {
+    if (isLangfuseReady(config.langfuseClient) && state.traceId) {
       config.langfuseClient.createGeneration({
         traceId: state.traceId,
         name: 'generate_outline',

--- a/libs/flows/src/content/langfuse-guard.ts
+++ b/libs/flows/src/content/langfuse-guard.ts
@@ -1,0 +1,14 @@
+/**
+ * Safe guard for LangfuseClient usage in LangGraph flows.
+ *
+ * LangGraph serializes state objects, which strips class prototype methods.
+ * When a LangfuseClient instance passes through graph state, `isAvailable()`
+ * becomes undefined. This guard checks both existence and callable-ness.
+ */
+import type { LangfuseClient } from '@protolabs-ai/observability';
+
+export function isLangfuseReady(
+  client: LangfuseClient | undefined | null
+): client is LangfuseClient {
+  return client != null && typeof client.isAvailable === 'function' && client.isAvailable();
+}

--- a/libs/flows/src/content/nodes/review-workers.ts
+++ b/libs/flows/src/content/nodes/review-workers.ts
@@ -11,6 +11,7 @@ import type { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import type { RunnableConfig } from '@langchain/core/runnables';
 import { createLogger } from '@protolabs-ai/utils';
 import { LangfuseClient } from '@protolabs-ai/observability';
+import { isLangfuseReady } from '../langfuse-guard.js';
 import { compilePrompt } from '../prompt-loader.js';
 import { extractAllTags, extractTag, extractRequiredEnum } from '../xml-parser.js';
 import { copilotkitEmitState, emitHeartbeat } from '../copilotkit-utils.js';
@@ -463,7 +464,7 @@ export async function technicalReviewerNode(
     const generationStartTime = new Date();
     let generationId: string | undefined;
 
-    if (langfuseClient?.isAvailable() && traceId) {
+    if (isLangfuseReady(langfuseClient) && traceId) {
       generationId = `gen-tech-review-${Date.now()}`;
       langfuseClient.createGeneration({
         traceId,
@@ -498,7 +499,7 @@ export async function technicalReviewerNode(
     }
 
     // Update Langfuse trace
-    if (langfuseClient?.isAvailable() && traceId && generationId) {
+    if (isLangfuseReady(langfuseClient) && traceId && generationId) {
       langfuseClient.createGeneration({
         traceId,
         id: generationId,
@@ -597,7 +598,7 @@ export async function styleReviewerNode(
     const generationStartTime = new Date();
     let generationId: string | undefined;
 
-    if (langfuseClient?.isAvailable() && traceId) {
+    if (isLangfuseReady(langfuseClient) && traceId) {
       generationId = `gen-style-review-${Date.now()}`;
       langfuseClient.createGeneration({
         traceId,
@@ -632,7 +633,7 @@ export async function styleReviewerNode(
     }
 
     // Update Langfuse trace
-    if (langfuseClient?.isAvailable() && traceId && generationId) {
+    if (isLangfuseReady(langfuseClient) && traceId && generationId) {
       langfuseClient.createGeneration({
         traceId,
         id: generationId,
@@ -774,7 +775,7 @@ export async function factCheckerNode(
     const generationStartTime = new Date();
     let generationId: string | undefined;
 
-    if (langfuseClient?.isAvailable() && traceId) {
+    if (isLangfuseReady(langfuseClient) && traceId) {
       generationId = `gen-fact-check-${Date.now()}`;
       langfuseClient.createGeneration({
         traceId,
@@ -810,7 +811,7 @@ export async function factCheckerNode(
     }
 
     // Update Langfuse trace
-    if (langfuseClient?.isAvailable() && traceId && generationId) {
+    if (isLangfuseReady(langfuseClient) && traceId && generationId) {
       langfuseClient.createGeneration({
         traceId,
         id: generationId,

--- a/libs/flows/src/content/prompt-loader.ts
+++ b/libs/flows/src/content/prompt-loader.ts
@@ -3,6 +3,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { LangfuseClient } from '@protolabs-ai/observability';
 import { createLogger } from '@protolabs-ai/utils';
+import { isLangfuseReady } from './langfuse-guard.js';
 
 const logger = createLogger('PromptLoader');
 
@@ -125,7 +126,7 @@ export async function compilePrompt(options: CompilePromptOptions): Promise<Comp
   let promptVersion: number | undefined;
 
   // Try Langfuse first if client provided
-  if (langfuseClient && langfuseClient.isAvailable()) {
+  if (isLangfuseReady(langfuseClient)) {
     try {
       logger.debug(`Attempting to fetch prompt from Langfuse: ${name}`, { version });
       const langfusePrompt = await langfuseClient.getPrompt(name, version);
@@ -243,7 +244,7 @@ export async function loadPromptTemplate(
   let version: number | undefined;
 
   // Try Langfuse first if client provided
-  if (langfuseClient && langfuseClient.isAvailable()) {
+  if (isLangfuseReady(langfuseClient)) {
     try {
       const langfusePrompt = await langfuseClient.getPrompt(name);
 

--- a/libs/flows/src/content/subgraphs/section-writer.ts
+++ b/libs/flows/src/content/subgraphs/section-writer.ts
@@ -13,6 +13,7 @@ import { StateGraph, Annotation } from '@langchain/langgraph';
 import { z } from 'zod';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { createLogger } from '@protolabs-ai/utils';
+import { isLangfuseReady } from '../langfuse-guard.js';
 import { LangfuseClient } from '@protolabs-ai/observability';
 import { extractTag, extractAllTags, extractRequiredTag } from '../xml-parser.js';
 
@@ -129,7 +130,7 @@ async function generateNode(
   const generationStartTime = new Date();
   let generationId: string | undefined;
 
-  if (langfuseClient?.isAvailable() && traceId) {
+  if (isLangfuseReady(langfuseClient) && traceId) {
     generationId = `gen-${Date.now()}`;
     langfuseClient.createGeneration({
       traceId,
@@ -173,7 +174,7 @@ async function generateNode(
     }
 
     // Update trace with successful generation
-    if (langfuseClient?.isAvailable() && traceId && generationId) {
+    if (isLangfuseReady(langfuseClient) && traceId && generationId) {
       langfuseClient.createGeneration({
         traceId,
         id: generationId,
@@ -214,7 +215,7 @@ async function generateNode(
     const generationEndTime = new Date();
 
     // Update trace with error
-    if (langfuseClient?.isAvailable() && traceId && generationId) {
+    if (isLangfuseReady(langfuseClient) && traceId && generationId) {
       langfuseClient.createGeneration({
         traceId,
         id: generationId,


### PR DESCRIPTION
## Summary
- LangGraph serializes state objects through its graph, stripping class prototype methods
- `LangfuseClient.isAvailable()` becomes `undefined` when the client passes through `ContentCreationState` annotation
- Adds `isLangfuseReady()` type guard that checks `typeof isAvailable === 'function'` before calling
- Fixes 14 call sites across 4 content pipeline files

## Root Cause
```
TypeError: config2.langfuseClient?.isAvailable is not a function
    at RunnableCallable.researchDelegateNode2 (content-creation-flow.ts:341)
```

`ContentCreationState` uses `config: Annotation<ContentConfig>` which includes `langfuseClient`. LangGraph's state management serializes this, losing the class prototype chain.

## Files Changed
- `libs/flows/src/content/langfuse-guard.ts` (new) — safe type guard
- `libs/flows/src/content/content-creation-flow.ts` — 3 call sites
- `libs/flows/src/content/subgraphs/section-writer.ts` — 3 call sites
- `libs/flows/src/content/nodes/review-workers.ts` — 6 call sites
- `libs/flows/src/content/prompt-loader.ts` — 2 call sites

## Test plan
- [ ] `npx tsc --project libs/flows/tsconfig.json --noEmit` passes
- [ ] Content pipeline `create_content` no longer crashes on Langfuse calls
- [ ] Pipeline works both with and without Langfuse configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized Langfuse service readiness validation across content creation modules, including prompt loading, generation, and review workflows, to improve internal robustness and ensure reliable operation tracking throughout content creation pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->