### PR TITLE
docs: UI standards enforcement strategy and agent context files

### DIFF
--- a/.automaker/context/CLAUDE.md
+++ b/.automaker/context/CLAUDE.md
@@ -35,7 +35,8 @@ automaker/
     ├── dependency-resolver/  # Feature dependency ordering
     ├── policy-engine/     # Trust-based policy checking
     ├── spec-parser/       # XML/markdown spec parsing
-    └── git-utils/    # Git operations & worktree management
+    ├── git-utils/    # Git operations & worktree management
+    └── ui/           # Shared UI components (atoms, molecules, theme)
 ```
 
 ## Package Dependency Chain (top = no deps)
@@ -70,6 +71,10 @@ import { resolveModelString } from '@protolabs-ai/model-resolver';
 // NEVER import from relative paths to other packages
 // ❌ import { Feature } from '../services/feature-loader';
 ```
+
+## Frontend UI Standards
+
+For all frontend work, follow the UI standards in `ui-standards.md`. Always use shared components from `@protolabs-ai/ui` -- never bare HTML elements (`<button>`, `<input>`, `<select>`, `<textarea>`, `<label>`). Never hardcode color classes (`bg-gray-*`, `text-blue-*`); always use semantic tokens (`bg-card`, `text-foreground`, `border-border`).
 
 ## Before Creating New Types
 

--- a/.automaker/context/ui-standards.md
+++ b/.automaker/context/ui-standards.md
@@ -1,0 +1,189 @@
+# UI Standards
+
+All frontend code MUST follow these rules. Violations break theming across 6+ themes.
+
+## 1. Shared Component Library
+
+ALWAYS import from `@protolabs-ai/ui`. NEVER use bare HTML elements for interactive UI.
+
+### Atoms (`@protolabs-ai/ui/atoms`)
+
+| Component | Notes |
+|-----------|-------|
+| `Button` | Supports `variant`, `size`, `loading`, `asChild` props |
+| `Badge` | Semantic variants: success, warning, error, info, muted, brand |
+| `Card, CardHeader, CardContent, CardFooter, CardTitle, CardAction, CardDescription` | |
+| `Input` | |
+| `Label` | |
+| `Checkbox` | |
+| `RadioGroup, RadioGroupItem` | |
+| `Select, SelectTrigger, SelectContent, SelectItem, SelectValue, SelectGroup, SelectLabel, SelectSeparator` | |
+| `Switch` | |
+| `Slider` | |
+| `Textarea` | |
+| `Accordion, AccordionItem, AccordionTrigger, AccordionContent` | |
+| `Breadcrumb, BreadcrumbList, BreadcrumbItem, BreadcrumbLink, BreadcrumbPage, BreadcrumbSeparator, BreadcrumbEllipsis` | |
+| `Collapsible, CollapsibleTrigger, CollapsibleContent` | |
+| `Kbd, KbdGroup` | Keyboard shortcut display |
+| `ScrollArea, ScrollBar` | |
+| `SkeletonPulse` | Loading placeholder |
+| `Spinner` | `size` prop: sm, md, lg, xl |
+| `Tabs, TabsList, TabsTrigger, TabsContent` | |
+| `Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogTrigger, DialogClose` | |
+| `DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSeparator, DropdownMenuLabel, DropdownMenuGroup, DropdownMenuSub, DropdownMenuSubTrigger, DropdownMenuSubContent, DropdownMenuCheckboxItem, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuShortcut` | |
+| `Popover, PopoverContent, PopoverTrigger` | |
+| `Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription, SheetFooter, SheetTrigger, SheetClose` | |
+| `Tooltip, TooltipContent, TooltipProvider, TooltipTrigger` | |
+| `Command, CommandDialog, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem, CommandSeparator, CommandShortcut` | |
+
+### Molecules (`@protolabs-ai/ui/molecules`)
+
+| Component | Purpose |
+|-----------|---------|
+| `HotkeyButton` | Button with keyboard shortcut support |
+| `ConfirmDialog` | Pre-built confirmation modal with hotkey confirm |
+| `Autocomplete` | Searchable combobox with create-new support |
+| `LoadingState` | Centered spinner with optional message |
+| `ErrorState` | Error display with optional retry button |
+| `Markdown` | Theme-aware markdown renderer |
+
+## 2. Forbidden HTML Elements
+
+| NEVER use | ALWAYS use instead |
+|-----------|--------------------|
+| `<button>` | `<Button>` from `@protolabs-ai/ui/atoms` |
+| `<input>` | `<Input>` from `@protolabs-ai/ui/atoms` |
+| `<select>` | `<Select>` + `<SelectTrigger>` + `<SelectContent>` + `<SelectItem>` |
+| `<textarea>` | `<Textarea>` from `@protolabs-ai/ui/atoms` |
+| `<input type="checkbox">` | `<Checkbox>` from `@protolabs-ai/ui/atoms` |
+| `<label>` | `<Label>` from `@protolabs-ai/ui/atoms` |
+
+## 3. Button Variants & Sizes
+
+**Variants:** `default`, `destructive`, `outline`, `secondary`, `ghost`, `link`, `animated-outline`
+
+**Sizes:** `default` (h-9), `sm` (h-8), `lg` (h-10), `icon` (9x9), `icon-sm` (8x8), `icon-lg` (10x10)
+
+**Props:** `loading={true}` shows spinner and disables. `asChild` for custom wrappers.
+
+## 4. Theme Token Mapping
+
+NEVER hardcode colors. NEVER use raw Tailwind color classes (gray-*, blue-*, red-*, etc.).
+
+### Backgrounds
+
+| NEVER | ALWAYS |
+|-------|--------|
+| `bg-white`, `bg-gray-900` | `bg-background` |
+| `bg-white` (card surface) | `bg-card` |
+| `bg-gray-50`, `bg-gray-800` | `bg-muted` |
+| `bg-gray-100`, `bg-gray-700` | `bg-accent` or `bg-secondary` |
+| `hover:bg-gray-100` | `hover:bg-accent` |
+| `bg-blue-500`, `bg-indigo-600` | `bg-primary` |
+| `bg-blue-50` | `bg-primary/10` |
+| `bg-red-500` | `bg-destructive` |
+| Inline `style={{ background: '#...' }}` | Tailwind token class or `var(--token)` |
+
+### Text
+
+| NEVER | ALWAYS |
+|-------|--------|
+| `text-black`, `text-white`, `text-gray-900` | `text-foreground` |
+| `text-gray-600`, `text-gray-700` | `text-foreground-secondary` |
+| `text-gray-400`, `text-gray-500` | `text-muted-foreground` |
+| `text-blue-600`, `text-blue-700` | `text-primary` |
+| `text-red-500`, `text-red-600` | `text-destructive` |
+
+### Borders
+
+| NEVER | ALWAYS |
+|-------|--------|
+| `border-gray-200`, `border-gray-700` | `border-border` |
+| `border-gray-300` (input borders) | `border-input` |
+| `ring-blue-500` | `ring-ring` |
+
+### Status Colors
+
+Use CSS variable syntax for status indicators:
+
+| Status | Background | Text |
+|--------|------------|------|
+| Success | `bg-status-success-bg` | `text-status-success` |
+| Warning | `bg-status-warning-bg` | `text-status-warning` |
+| Error | `bg-status-error-bg` | `text-status-error` |
+| Info | `bg-status-info-bg` | `text-status-info` |
+
+Or use Badge semantic variants: `<Badge variant="success">`, `<Badge variant="warning">`, etc.
+
+## 5. Text Hierarchy
+
+Three tiers only:
+
+1. **Primary** — `text-foreground` — headings, labels, important content
+2. **Secondary** — `text-foreground-secondary` — body text, descriptions
+3. **Muted** — `text-muted-foreground` — hints, timestamps, tertiary info
+
+## 6. Code Examples
+
+### Card Section
+
+```tsx
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@protolabs-ai/ui/atoms';
+
+<Card>
+  <CardHeader>
+    <CardTitle>Section Title</CardTitle>
+    <CardDescription>Brief explanation of this section.</CardDescription>
+  </CardHeader>
+  <CardContent className="space-y-4">
+    {/* content here */}
+  </CardContent>
+</Card>
+```
+
+### Form Field
+
+```tsx
+import { Label, Input } from '@protolabs-ai/ui/atoms';
+
+<div className="space-y-2">
+  <Label htmlFor="project-name">Project Name</Label>
+  <Input id="project-name" placeholder="my-project" value={name} onChange={(e) => setName(e.target.value)} />
+  <p className="text-sm text-muted-foreground">Used as the directory name.</p>
+</div>
+```
+
+### Button Group
+
+```tsx
+import { Button } from '@protolabs-ai/ui/atoms';
+import { Save, Trash2 } from 'lucide-react';
+
+<div className="flex items-center gap-2">
+  <Button variant="outline" onClick={onCancel}>Cancel</Button>
+  <Button variant="destructive" size="sm" onClick={onDelete}>
+    <Trash2 /> Delete
+  </Button>
+  <Button onClick={onSave} loading={isSaving}>
+    <Save /> Save Changes
+  </Button>
+</div>
+```
+
+## 7. Accessibility
+
+- Icon-only buttons MUST have `aria-label`: `<Button size="icon" aria-label="Delete item"><Trash2 /></Button>`
+- Every `<Input>` / `<Textarea>` / `<Select>` MUST have a paired `<Label>` with matching `htmlFor`/`id`
+- Keyboard navigation is handled by shared components -- do not override `onKeyDown` unless adding new shortcuts
+
+## 8. Exemptions
+
+- **Canvas/renderer internals** that draw user content (e.g., code editor buffers, terminal emulators) are exempt
+- **Application chrome** (toolbars, panels, sidebars, inspectors, settings, modals) is NEVER exempt
+
+## 9. Reference Views
+
+When building new UI, study these files as the gold standard:
+
+- **Board view** (Kanban): `apps/ui/src/components/views/board-view/` -- layout, cards, drag-and-drop
+- **Settings view** (forms): `apps/ui/src/components/views/settings-view/` -- form patterns, input groups, sections

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,9 +5,9 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 122
-  referenced: 64
-  successfulFeatures: 64
+  loaded: 130
+  referenced: 67
+  successfulFeatures: 67
 ---
 # api
 
@@ -622,3 +622,27 @@ usageStats:
 - **Rejected:** Storing theme on parser instance or in document metadata - would require re-parsing to switch themes
 - **Trade-offs:** Easier: Flexibility, testability; Harder: Caller must manage theme context and pass it correctly
 - **Breaking if changed:** If theme was baked into document, couldn't generate multiple theme variants from single parsed file without re-parsing
+
+### VariableResolver type imported from @protolabs-ai/types rather than defined inline in style-utils.ts (2026-02-25)
+- **Context:** Style utilities need to accept a resolver function with specific signature for theme variable resolution
+- **Why:** Centralized type definition ensures consistency across the codebase; changes to resolver contract stay synchronized across all consumers
+- **Rejected:** Inline types or use 'any' would avoid the import but creates risk of signature drift between utils and context
+- **Trade-offs:** Requires monorepo type coordination but prevents silent breaking changes when resolver signature evolves
+- **Breaking if changed:** If types are changed in @protolabs-ai/types without updating callers, style-utils become type-incompatible at compile time (safe failure)
+
+#### [Gotcha] Environment variable interpolation in Grafana provisioned configs uses ${VAR_NAME} syntax, not $VAR_NAME or ${VAR_NAME} as bash/Docker (2026-02-25)
+- **Situation:** Discord webhook URL stored in DISCORD_WEBHOOK_INFRA environment variable, referenced in contactpoints.yml as ${DISCORD_WEBHOOK_INFRA}
+- **Root cause:** Grafana's provisioning system has its own variable interpolation layer separate from container runtime
+- **How to avoid:** ${VAR_NAME} syntax is Grafana-specific knowledge required. Benefit is that provisioning works consistently across deployment methods (K8s, Docker, manual).
+
+### Discord contact point template uses Go template syntax ({{ .GroupLabels.alertname }}) for message formatting, not Jinja or other template engines (2026-02-25)
+- **Context:** Alert messages need dynamic content: alert name, severity, dashboard links, timestamps - all embedded in single Discord message template
+- **Why:** Grafana unified alerting standardized on Go templates for all message templates. Using Go templates ensures consistency across contact point types (Discord, email, webhook).
+- **Rejected:** Custom Go template in webhook handler: Would require separate service, more infrastructure, harder to version control
+- **Trade-offs:** Go templates provide full expression power within Grafana. Benefit is templates are version-controlled with alerting config. Cost is Go template syntax is less intuitive than other template languages.
+- **Breaking if changed:** If someone uses Jinja syntax or other template language, template rendering fails silently and generic message gets sent to Discord instead of formatted alert details.
+
+#### [Gotcha] Linear API requires team-specific label IDs that aren't easily discoverable without additional API calls (2026-02-25)
+- **Situation:** Attempted to apply labels to created Linear issues using label names. Discovered Linear only accepts label IDs, which require querying the team's labels endpoint first.
+- **Root cause:** Linear labels are team-scoped resources. The API doesn't support name-based label lookups - you must know the ID beforehand or query the labels list.
+- **How to avoid:** Simplified to text-based label hints in issue description. Trade structured label filtering/querying capability for reduced API calls and complexity. Production may need to query labels upfront and cache.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -3226,3 +3226,172 @@ usageStats:
 - **Rejected:** Inline component definitions - would bloat file size by factor of component_count-1 for each component type
 - **Trade-offs:** Easier: Smaller file size, faster parsing; Harder: Requires reference resolution mechanism, circular ref checks, handling missing refs
 - **Breaking if changed:** If changed to inline definitions, parser doesn't need resolveRef, but file format becomes larger and updating component definition requires finding all instances
+
+### Used host.docker.internal:3008 to reach Automaker server from Prometheus container instead of Docker network linking (2026-02-25)
+- **Context:** Prometheus container needs to scrape metrics from host-running Automaker server on port 3008
+- **Why:** host.docker.internal is DNS name that resolves to host IP from inside container; simplest approach when app runs outside Docker without requiring custom bridge networks or host network mode
+- **Rejected:** Docker bridge network (would require app to join monitoring network), host network mode (reduces container isolation), localhost (fails - container localhost ≠ host localhost)
+- **Trade-offs:** Simpler setup vs reduced network flexibility; works across platforms (Mac/Linux/Windows) vs platform-specific solutions
+- **Breaking if changed:** If changed to localhost or removed port mapping, Prometheus loses access to metrics endpoint; deployment on systems without host.docker.internal support would fail
+
+#### [Pattern] Prometheus configured to scrape 3 separate targets: application metrics, node-exporter system metrics, and self-monitoring - not just application metrics (2026-02-25)
+- **Problem solved:** Observability stack needs visibility into both application behavior and infrastructure health
+- **Why this works:** Separating targets enforces single-responsibility; allows independent alerting/dashboarding on infrastructure vs application concerns; self-scraping enables Prometheus uptime monitoring
+- **Trade-offs:** More complex scrape config vs better separation of concerns; separate targets enable independent failure domains
+
+#### [Pattern] Grafana datasource auto-provisioned via external provisioning file (monitoring/grafana/provisioning/datasources/prometheus.yml) instead of manual UI configuration (2026-02-25)
+- **Problem solved:** Grafana needs to know about Prometheus datasource on startup
+- **Why this works:** Provisioning files make infrastructure immutable and version-controllable; eliminates manual post-deploy configuration step; stack can be recreated identically from files alone
+- **Trade-offs:** Extra file/directory structure vs reproducibility and IaC; harder to discover vs easier to automate
+
+#### [Gotcha] Prometheus scrapes specific endpoint /api/metrics/prometheus on Automaker server - requires server implementation and version compatibility (2026-02-25)
+- **Situation:** Stack documentation says 'existing /api/metrics/prometheus endpoint is already implemented' - but this creates hard dependency
+- **Root cause:** Prometheus requires specific metrics format (OpenMetrics/Prometheus text format); cannot use arbitrary JSON endpoints without custom exporters
+- **How to avoid:** Tight coupling to server implementation vs simpler Prometheus config
+
+### Grafana port remapped to 3010 instead of standard internal port 3000 (2026-02-25)
+- **Context:** Docker port mapping decision for external access
+- **Why:** Avoids port conflicts with potential dev services already using 3000 (React apps, etc.); indicates intentional port allocation strategy in deployment environment
+- **Rejected:** Using standard 3000 (risks conflicts with other services), using random port (harder to remember and document)
+- **Trade-offs:** Non-standard port slightly harder to remember vs eliminates common port conflicts
+- **Breaking if changed:** If changed back to 3000, external access must change; documentation and scripts become invalid; developers must know to use :3010 not :3000
+
+#### [Pattern] Configuration managed via external YAML/INI files mounted into containers rather than environment variables in docker-compose (2026-02-25)
+- **Problem solved:** Complex configurations (Prometheus scrape jobs, Grafana auth settings) need to be managed and versioned
+- **Why this works:** YAML/INI files preserve structure and comments better than flattened env vars; easier to diff/version control complex configs; external files enable secrets injection without modifying docker-compose
+- **Trade-offs:** More files to manage vs better readability, version control, and security (can use .gitignore on sensitive files)
+
+#### [Pattern] Using Promtail relabel_configs to extract Docker metadata (container_name, service, compose_project) as Loki labels rather than parsing log content or relying on application instrumentation (2026-02-25)
+- **Problem solved:** Making logs searchable by meaningful identifiers without modifying application code or parsing log lines
+- **Why this works:** Prometheus relabel syntax allows powerful extraction from Docker service discovery API; decouples infrastructure concerns from application logic; labels become immutable at ingestion time for efficient indexing
+- **Trade-offs:** Centralized, scalable label management vs requires understanding Prometheus relabel syntax; fixed label cardinality from start
+
+### Configuring two separate Promtail Docker scrape jobs: one filtered to compose project containers, one collecting from all Docker containers (2026-02-25)
+- **Context:** Handling mixed deployment scenarios with both compose-managed and potentially standalone containers
+- **Why:** Compose-filtered job provides logical application-level isolation; all-containers job acts as safety net for non-compose workloads; allows selective relabeling strategies per job
+- **Rejected:** Single catch-all job for all containers; single compose-only job that misses non-compose containers
+- **Trade-offs:** Flexibility and coverage vs potential for duplicate log ingestion if filters overlap; added configuration complexity
+- **Breaking if changed:** Removing either job reduces scope coverage; duplicates would inflate retention period impact and costs
+
+### Resolver function passed as parameter through style utilities instead of accessing PenThemeContext directly within utils (2026-02-25)
+- **Context:** Need to resolve theme variables in style-utils.ts functions (colorToCSS, fillToCSS, strokeToCSS) while keeping utilities pure and testable
+- **Why:** Dependency injection pattern keeps utilities decoupled from React Context, enables testing utils without mocking context, and maintains single responsibility
+- **Rejected:** Direct context access in utils via useContext hook would couple utils to React and make unit testing impossible
+- **Trade-offs:** Easier to test style utilities but requires threading resolver through multiple function calls; more explicit dependencies
+- **Breaking if changed:** Removing resolver parameter causes all variable tokens ($--variable-name) to pass through unresolved, rendering literal strings instead of computed values
+
+#### [Gotcha] Variable resolution falls back to default value when no theme-specific value exists, but silently succeeds if default is also missing (2026-02-25)
+- **Situation:** resolveVariable() function has no error handling for missing defaults; returns undefined without indicating resolution failure
+- **Root cause:** Graceful degradation approach avoids crashes, but makes bugs harder to catch—unresolved variables render as actual values rather than throwing
+- **How to avoid:** Robust against incomplete data but unresolved variable bugs become silent failures only visible in visual inspection
+
+### Theme selections not persisted to localStorage; context value resets on page refresh (2026-02-25)
+- **Context:** Users switch themes via context state, which lives only in component memory during current session
+- **Why:** Scope boundary decision—feature focused on rendering system, not UX workflow; avoids adding state persistence complexity
+- **Rejected:** localStorage persistence would remember user selections but adds sync complexity and storage API dependency
+- **Trade-offs:** Simpler implementation but users lose theme preference on navigation; future feature would require refactoring
+- **Breaking if changed:** Adding persistence later requires state sync between context updates and localStorage, plus handling stale data scenarios
+
+#### [Pattern] PenThemeProvider uses render props pattern with React context instead of exposing useContext hook only (2026-02-25)
+- **Problem solved:** Components need theme context value AND a way to update theme selections while maintaining composition
+- **Why this works:** Render props gives consumers explicit control over what gets rendered; avoids HOC wrapper hell; keeps theme logic centralized while allowing flexible UI layer
+- **Trade-offs:** More boilerplate in consumers (render function callback) but enables theme logic to be isolated and testable independently of component tree
+
+#### [Pattern] Dashboard provisioning via YAML config + JSON definitions instead of manual Grafana UI configuration (2026-02-25)
+- **Problem solved:** Dashboards must be reproducible across deployments and persist in version control
+- **Why this works:** Enables Infrastructure as Code, GitOps workflows, and eliminates manual configuration drift. Provisioning ensures dashboards auto-load on Grafana startup without user intervention.
+- **Trade-offs:** Added complexity of maintaining separate provisioning YAML + JSON structures, but gained complete reproducibility and elimination of configuration drift
+
+#### [Pattern] Dashboard-level templating variables (time_range) instead of hardcoded time ranges in individual panels (2026-02-25)
+- **Problem solved:** Users need to filter dashboard data across multiple panels simultaneously without editing dashboard configuration
+- **Why this works:** Dashboard variables propagate to all panels sharing that variable, enabling single-click time range changes across the entire dashboard. Alternative (per-panel configuration) would require users to edit each panel individually.
+- **Trade-offs:** Adds JSON complexity to dashboard structure but dramatically improves operational usability and user experience
+
+### Dashboards defined assuming Prometheus datasource with UID 'prometheus' exists, without enforcing or validating this dependency at provisioning time (2026-02-25)
+- **Context:** Dashboards reference specific datasource UID in all panel queries but don't validate the datasource exists
+- **Why:** Loose coupling allows dashboard provisioning independent of datasource setup. Tighter coupling would require orchestrated initialization sequence. Grafana can provision dashboards before datasources are created (though they'll appear empty).
+- **Rejected:** Fail-fast validation that datasource exists (creates ordering dependency, complicates deployment)
+- **Trade-offs:** Looser coupling enables flexible deployment, but datasource misconfiguration silently fails with empty dashboards
+- **Breaking if changed:** If Prometheus datasource UID changes or datasource name differs, all dashboard queries fail silently without showing datasource error.
+
+#### [Gotcha] Dashboards can be successfully provisioned before their required Prometheus metrics are instrumented in the application code (2026-02-25)
+- **Situation:** Dashboard configurations reference metrics like automaker_deploys_total, automaker_agents_active that may not exist yet in Prometheus
+- **Root cause:** Grafana doesn't validate metric existence at dashboard load time. This loose coupling allows config-driven development but creates potential for silent data absence.
+- **How to avoid:** Enables parallel development of monitoring infrastructure and metrics instrumentation, but causes confusing 'empty dashboard' state until metrics are emitted
+
+#### [Pattern] UID-based semantic naming convention for dashboards (automaker-*) instead of auto-generated GUIDs (2026-02-25)
+- **Problem solved:** Grafana dashboards need stable, identifiable UIDs across deployments for linking and dashboard relationships
+- **Why this works:** Semantic UIDs survive dashboard reimports/reprovisioning and enable reliable linking between dashboards. Auto-generated UIDs change with each reimport, breaking saved links.
+- **Trade-offs:** Requires manual UID planning but provides stable dashboard identity across deployments
+
+#### [Pattern] Real-time state tracking via push-based gauge updates at 7 collection mutation points (add/remove from runningFeatures map) vs calculated from counters (2026-02-25)
+- **Problem solved:** Could have incremented a counter on agent start and decremented on agent end, then calculated active count = start_total - end_total
+- **Why this works:** Gauge updated at mutation time gives accurate real-time snapshot of concurrent agent activity. Counter approach would require query-time calculation and lose precision on agent lifecycle events.
+- **Trade-offs:** More frequent metric updates (7 points) but accurate real-time concurrency visibility on dashboards; alternative would trade update overhead for stale data
+
+### Used recursive findNodeById tree traversal instead of pre-indexing nodes in store (2026-02-25)
+- **Context:** Need to locate selected node by ID anywhere in nested PEN document tree to display properties
+- **Why:** PEN documents are small UI editor trees (typically <1000 nodes). O(n) search is negligible. Pre-indexing adds memory overhead and requires maintaining index on every document mutation.
+- **Rejected:** Pre-building ID->node Map on document load would be O(1) lookup but requires index maintenance complexity
+- **Trade-offs:** Slightly slower search (microseconds) vs significantly simpler code and less state to manage. Scales poorly above ~10k nodes.
+- **Breaking if changed:** If document trees grow to 100k+ nodes, performance degrades. If tree structure changes, search logic must adapt.
+
+#### [Pattern] Selection state auto-clears when switching files to prevent stale references to nodes no longer in document (2026-02-25)
+- **Problem solved:** User selects node in File A, then switches to File B. Selected node ID no longer exists in new document.
+- **Why this works:** Prevents inspector from showing properties for a node that doesn't exist in current view. Maintains consistency between selection state and visible content.
+- **Trade-offs:** Less selection persistence vs data consistency. Users must reselect after file switch but always see valid data.
+
+#### [Gotcha] Datasource UID must match exactly between alert rules and datasource provisioning. Alert rules reference datasourceUid internally, not datasource names. (2026-02-25)
+- **Situation:** Alert rules define Prometheus queries with a datasourceUid field that must match the UID assigned in provisioning/datasources/prometheus.yml
+- **Root cause:** Grafana stores datasource references by internal UUID. If UUIDs don't match, alerts silently fail without error messages.
+- **How to avoid:** UUID coupling makes config less readable but ensures deterministic datasource binding across environments
+
+### Notification policies use matchers (severity = critical/warning) to route alerts to different batch windows, not separate contact points per severity (2026-02-25)
+- **Context:** Need to send critical alerts immediately (0s wait) and batch warnings every 5 minutes (30s wait, 5m interval) without duplicate notifications
+- **Why:** Matchers in notification policies are the Grafana unified alerting native pattern. Single contact point (Discord) with routing logic is more maintainable than multiple contact points.
+- **Rejected:** Alternative: Create separate contact points and manual rules for each severity. Would be more flexible but harder to modify routing logic later.
+- **Trade-offs:** Centralized routing in policies is easier to modify and audit. Less flexible for complex multi-dimensional routing (though that can be added via additional matchers).
+- **Breaking if changed:** If matchers are removed or naming changes, all alerts route to default policy. Removing severity-based routing loses batching strategy entirely.
+
+### Critical alerts configured with 0s group_wait and 1m repeat interval vs warnings with 30s group_wait and 5m interval to balance responsiveness with notification fatigue (2026-02-25)
+- **Context:** Grafana alert grouping window (group_wait) determines how long to wait before sending first notification, repeat interval controls how often to re-notify
+- **Why:** 0s for critical means immediate Discord notification (maximizes MTTR), 30s for warnings allows grouping multiple related alerts into single message (reduces noise)
+- **Rejected:** Uniform batching (e.g., all 5m): Would reduce critical alert latency. Uniform immediate (e.g., all 0s): Would cause Discord spam for warning storms.
+- **Trade-offs:** Immediate critical notification means faster response but potential for alert fatigue if too many criticals. Batched warnings reduce noise at cost of up to 5m detection delay.
+- **Breaking if changed:** Setting critical group_wait to > 0 introduces alert latency that could impact incident response. Removing batching for warnings causes Discord notification storms.
+
+#### [Pattern] Grouped alerting by alertname + severity in notification policies reduces Discord notification volume for correlated failures (e.g., multiple disk mount points failing simultaneously) (2026-02-25)
+- **Problem solved:** Alert rules configured to fire independently; notification policy groups related alerts to prevent notification explosion during cascading failures
+- **Why this works:** When infrastructure degrades, multiple alerts often fire simultaneously (e.g., CPU spike → disk thrashing → memory pressure). Grouping by alertname ensures single Discord message per alert type per severity level.
+- **Trade-offs:** Grouping reduces notification noise and makes Discord channel readable. Trade-off: Requires checking Grafana UI to see individual alert instances within the group.
+
+#### [Pattern] Group components using name prefix with '/' delimiter (e.g., 'Button/Primary' → 'Button' group) instead of explicit group metadata (2026-02-25)
+- **Problem solved:** Need hierarchical component organization without requiring additional properties on every node
+- **Why this works:** Leverages existing naming convention in design systems for automatic hierarchy; zero metadata overhead; scales as components are added
+- **Trade-offs:** Automatic convenience and clean UI vs. strict naming discipline requirement and inability to reorganize without renaming
+
+### Mark reusable components with optional boolean flag (reusable?: boolean) on PenNodeBase instead of maintaining separate component registry (2026-02-25)
+- **Context:** Need to identify which nodes can be instantiated as library components without external configuration
+- **Why:** Single source of truth - metadata lives with node; enables any node to opt-in without ceremony; no synchronization required between node tree and registry
+- **Rejected:** Separate registry - would require manual registration, duplicate storage, and out-of-sync risk when nodes are deleted or moved
+- **Trade-offs:** Simpler, decentralized design vs. inability to externally mark nodes as reusable without modifying the document
+- **Breaking if changed:** Removing the flag means losing component-level reusability control; switching to registry would require migrating all marked nodes and complex tree scanning logic
+
+### Separate webhook routes outside /api/* paths to avoid authentication middleware (2026-02-25)
+- **Context:** Grafana webhooks must be unauthenticated. Initial attempt put alerts at /api/alerts which failed because API routes had auth middleware applied.
+- **Why:** Webhook services like Grafana cannot provide credentials in their outbound HTTP requests. Mixing webhooks with authenticated API routes creates a permission model conflict where valid webhooks get rejected.
+- **Rejected:** Conditional auth middleware to whitelist webhook paths, or embedding API key requirements in webhook URLs (less secure)
+- **Trade-offs:** Requires separate route files and mounting points (slightly more code organization) but prevents hard-to-debug authentication failures. Cleaner permission model.
+- **Breaking if changed:** Moving webhooks back under /api/* will cause Grafana (and other webhook services) to receive 401/403 responses and fail silently to POST alerts.
+
+### Use simple exact title matching for deduplication instead of fingerprint hashing (2026-02-25)
+- **Context:** Multiple Grafana alert firing events for the same underlying condition could create multiple Linear issues. Needed deduplication strategy.
+- **Why:** MVP speed - exact matching is trivial to implement (single Linear search API call). Described as 'simple but effective'. Fingerprint hashing would require additional logic to normalize alert data.
+- **Rejected:** Fingerprint-based deduplication using MD5 of normalized alert state (more robust but adds complexity and requires determining which fields constitute uniqueness)
+- **Trade-offs:** Simple implementation now vs. false negative risk later. Will create duplicate issues if alert name changes slightly (e.g., 'HighCPU_prod' vs 'HighCPU_prod_instance2'). Production may need fingerprinting.
+- **Breaking if changed:** Deduplication stops working if alert names are variations on same condition. Also fails if same issue is resolved+recreated - exact title match won't find the closed issue.
+
+#### [Pattern] Graceful degradation for optional services - Discord notifications are non-blocking relative to Linear issue creation (2026-02-25)
+- **Problem solved:** Implementation creates Linear issues and posts Discord notifications. Discord service might be unavailable or unconfigured.
+- **Why this works:** Core functionality (bug tracking) should not depend on secondary notification channel. Prevents cascading failures where one missing integration blocks the entire pipeline.
+- **Trade-offs:** Issues get created even if Discord is down (good). Operator might miss notifications but issue is still tracked (acceptable). Code must handle missing Discord gracefully with proper null checks.

--- a/.automaker/memory/cost-optimization.md
+++ b/.automaker/memory/cost-optimization.md
@@ -5,9 +5,9 @@ relevantTo: [cost-optimization]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 8
-  referenced: 5
-  successfulFeatures: 5
+  loaded: 17
+  referenced: 9
+  successfulFeatures: 9
 ---
 # cost-optimization
 

--- a/.automaker/memory/database.md
+++ b/.automaker/memory/database.md
@@ -118,3 +118,10 @@ usageStats:
 - **Problem solved:** DeployProcessor and EscalateProcessor both call save() but with different outcome values and different supplemental fields (failureAnalysis only on escalation)
 - **Why this works:** Discriminated union pattern: single schema with outcome tag determines which optional fields are present, avoiding multiple schema variants
 - **Trade-offs:** Gains: Single schema evolution point, flexible for new outcomes. Loses: Schema validation must be conditional on outcome field
+
+### Using TSDB schema with filesystem storage in Loki configuration instead of older BoltDB-based schemas or cloud storage backends (2026-02-25)
+- **Context:** Selecting storage architecture for self-hosted log aggregation in Loki v3.x
+- **Why:** TSDB schema in Loki v3.x is optimized for performance and recommended upstream; filesystem backend enables self-hosted deployment without cloud dependencies
+- **Rejected:** Older schema versions (legacy); cloud storage (S3, GCS) which adds operational complexity and latency
+- **Trade-offs:** Better query performance and simpler deployment vs limited horizontal scalability; schema version is immutable once data is written
+- **Breaking if changed:** Schema version must match across all Loki instances; changing schema requires data migration or reindexing

--- a/.automaker/memory/documentation.md
+++ b/.automaker/memory/documentation.md
@@ -5,9 +5,9 @@ relevantTo: [documentation]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 46
-  referenced: 31
-  successfulFeatures: 31
+  loaded: 47
+  referenced: 32
+  successfulFeatures: 32
 ---
 # documentation
 

--- a/.automaker/memory/gotcha.md
+++ b/.automaker/memory/gotcha.md
@@ -45,3 +45,8 @@ usageStats:
 - **Situation:** Three functions (areDependenciesSatisfied, getBlockingDependencies, getBlockingDependenciesFromMap) each had their own copy of which statuses count as 'satisfied'
 - **Root cause:** Each function may have evolved independently to solve different caller needs. Extracting to constant might seem premature optimization until a change reveals the cost.
 - **How to avoid:** Explicit local context (understand status list in each function) vs DRY principle (maintenance burden of 3 copies)
+
+#### [Gotcha] Pre-existing build issues in monorepo blocked full verification: platform package (p-limit import error) and UI app (react-day-picker dependency) (2026-02-25)
+- **Situation:** Could verify types package builds and types export correctly, but couldn't verify full app build or runtime behavior
+- **Root cause:** Monorepo with multiple interdependent packages. One package's build failure cascades. Implementation is likely correct but unverifiable in broken build state.
+- **How to avoid:** Could implement feature but couldn't prove it works end-to-end. Partial verification still valuable (types correct, no compilation errors in changed files)

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 365
-  referenced: 198
-  successfulFeatures: 198
+  loaded: 394
+  referenced: 209
+  successfulFeatures: 209
 ---
 # gotchas
 
@@ -362,3 +362,23 @@ usageStats:
 - **Situation:** Implementation added hook declarations to plugin.json, but success depends on hooks/compaction-prime-directive.sh, hooks/session-context.sh, etc. already being present in the plugin package.
 - **Root cause:** Plugin.json is declarative configuration; it doesn't create hooks, only references them. The executable scripts are the real implementation.
 - **How to avoid:** Plugin.json stays lightweight and declarative (+) but requires coordinated file management between config and script implementations (-)
+
+#### [Gotcha] Loki retention_period configuration requires compactor service to be enabled; setting retention alone does not delete old data (2026-02-25)
+- **Situation:** Attempting to manage disk usage by setting retention_period: 168h (7 days)
+- **Root cause:** Loki v3.x separates log writing from log cleanup; compactor runs asynchronously to find and delete chunks exceeding retention period; without compactor, chunks are never deleted despite retention setting
+- **How to avoid:** Explicit compactor configuration prevents accidental data loss vs easy to forget this requirement; results in silent disk space leaks
+
+#### [Gotcha] Promtail requires both Docker socket mount (/var/run/docker.sock) for service discovery AND container log directory mount (/var/lib/docker/containers) for actual log file access (2026-02-25)
+- **Situation:** Setting up Promtail to collect logs from Docker containers
+- **Root cause:** Docker socket provides service discovery and metadata (container names, labels); actual log files are filesystem-based; Promtail must read from filesystem but needs socket API for dynamic container detection
+- **How to avoid:** Dual mount provides automatic container discovery plus actual log access vs increased container privileges and attack surface
+
+#### [Gotcha] Volume mount path in docker-compose must exactly match where dashboard files actually exist. Mismatch causes silent failure - Grafana starts successfully but dashboards don't load. (2026-02-25)
+- **Situation:** Implementation created dashboards in monitoring/grafana/provisioning/dashboards/ but initial docker-compose pointed to ./grafana-dashboards/
+- **Root cause:** Docker volume mounts don't validate path existence; Grafana logs the mount but doesn't fail loudly if path is wrong, making the failure nearly invisible until dashboards don't appear
+- **How to avoid:** Silent failure is difficult to debug but avoids hard deployment failures. Requires careful path documentation and testing.
+
+#### [Gotcha] Duration unit conversion: durationMs from execution record must be divided by 1000 for Prometheus histogram (expects seconds per standard) (2026-02-25)
+- **Situation:** Code captures execution time in milliseconds internally, but Prometheus convention uses seconds. Conversion point is easy to miss or misapply.
+- **Root cause:** Prometheus ecosystem standardizes on seconds for duration histograms. Conversion ensures metrics are compatible with standard dashboards and alert thresholds.
+- **How to avoid:** Conversion required at metric ingestion point, but keeps internal timing logic unchanged; missing conversion creates 1000x inflated duration metrics

--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -5,9 +5,9 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 30
-  referenced: 17
-  successfulFeatures: 17
+  loaded: 31
+  referenced: 18
+  successfulFeatures: 18
 ---
 # GTM Signal Intelligence & Content Operations
 

--- a/.automaker/memory/monitoring.md
+++ b/.automaker/memory/monitoring.md
@@ -1,0 +1,17 @@
+---
+tags: [monitoring]
+summary: monitoring implementation decisions and patterns
+relevantTo: [monitoring]
+importance: 0.7
+relatedFiles: []
+usageStats:
+  loaded: 2
+  referenced: 1
+  successfulFeatures: 1
+---
+# monitoring
+
+#### [Pattern] Gauge state synchronization: Added syncMetrics() method to reset and rebuild features_by_status gauge from authoritative database source (2026-02-25)
+- **Problem solved:** Server restarts leave Prometheus gauges at their last value (not persistent). Without recovery, features_by_status would remain at old values until first feature mutation occurs.
+- **Why this works:** Gauges represent point-in-time state and must match reality. Need explicit initialization from truth source (feature database) to handle process restarts gracefully.
+- **Trade-offs:** Adds startup latency (need to query all features), but ensures metrics accuracy from server boot time

--- a/.automaker/memory/observability.md
+++ b/.automaker/memory/observability.md
@@ -1,0 +1,19 @@
+---
+tags: [observability]
+summary: observability implementation decisions and patterns
+relevantTo: [observability]
+importance: 0.7
+relatedFiles: []
+usageStats:
+  loaded: 0
+  referenced: 0
+  successfulFeatures: 0
+---
+# observability
+
+### Failure-path metric instrumentation: Incrementing agent_cost_usd_total, execution duration, and token counters on BOTH success and failure execution paths (2026-02-25)
+- **Context:** Could have only tracked successful executions to show 'profitable' activity, but chose to include failures
+- **Why:** Need visibility into full system cost including failed attempts. Failures still consume tokens/compute. Critical for debugging why total cost exceeds expected.
+- **Rejected:** Could have only instrumented success path to show cleaner metrics, but would hide failure costs
+- **Trade-offs:** Metrics appear 'noisier' with failures included, but provide complete cost picture for billing and debugging
+- **Breaking if changed:** If failure tracking is removed, cost metrics become misleading (actual system cost higher than reported)

--- a/.automaker/memory/patterns.md
+++ b/.automaker/memory/patterns.md
@@ -5,7 +5,7 @@ relevantTo: [patterns]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 17
+  loaded: 18
   referenced: 12
   successfulFeatures: 12
 ---

--- a/.automaker/memory/performance.md
+++ b/.automaker/memory/performance.md
@@ -5,9 +5,9 @@ relevantTo: [performance]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 13
-  referenced: 8
-  successfulFeatures: 8
+  loaded: 17
+  referenced: 10
+  successfulFeatures: 10
 ---
 # performance
 
@@ -215,3 +215,22 @@ usageStats:
 - **Rejected:** Direct tree search on each resolveRef call - would be O(n*m) for m references in doc
 - **Trade-offs:** Easier: Fast ref resolution; Harder: Map must be rebuilt if document modified, adds memory overhead for index
 - **Breaking if changed:** If map removed, downstream code doing performance analysis wouldn't catch the O(n*m) scaling problem until large files
+
+#### [Pattern] Health checks on all 3 services with setup script polling until healthy (30 retries) before declaring success (2026-02-25)
+- **Problem solved:** Automated scripts need to run after monitoring stack starts - must wait for readiness, not just container start
+- **Why this works:** Container running ≠ service ready; prevents race conditions where dependent operations fail; polling approach survives temporary startup delays
+- **Trade-offs:** Slightly slower startup (waiting for health) vs guaranteed reliable automation; script complexity vs automation robustness
+
+### Strategic label cardinality management: feature_id labels only on cost/duration metrics, but omitted from tokens/executions metrics to prevent combinatorial explosion (2026-02-25)
+- **Context:** Each unique label combination creates separate metric series. Using feature_id + model + complexity on all metrics would create O(features × models × complexity) = potentially 10,000s of series.
+- **Why:** Prometheus cardinality explosion degrades query performance and storage. Keeping cardinality bounded by limiting high-cardinality label combinations.
+- **Rejected:** Could have used consistent labeling scheme (feature_id everywhere) for uniformity, but would hit cardinality limits in production
+- **Trade-offs:** Lose per-feature token granularity (can only see global totals by model), but maintain sub-second query latency on metrics dashboard
+- **Breaking if changed:** If high-cardinality labels are added later (e.g., feature_id to all metrics), could cause Prometheus scrape failures or dropped series
+
+### Use Set<string> for tracking expanded groups instead of Array or Record<string, boolean> (2026-02-25)
+- **Context:** Group expanded state checked on every render to conditionally show/hide group contents and icons
+- **Why:** Set provides O(1) containment checking vs O(n) for array.includes() or verbose Record syntax; critical when filtering/rendering many groups
+- **Rejected:** Array with .includes() - adequate but degrades with many groups; Record - more verbose with no performance gain
+- **Trade-offs:** Better render performance and cleaner code vs. Set is less familiar and less serializable if state persistence added later
+- **Breaking if changed:** Switching to array search would degrade UX responsiveness with large component libraries; Set choice matters for performance-critical render path

--- a/.automaker/memory/security.md
+++ b/.automaker/memory/security.md
@@ -332,3 +332,20 @@ usageStats:
 - **Rejected:** Listing licenses without analyzing compatibility; trusting developers to spot issues
 - **Trade-offs:** Requires systematic review overhead but prevents subtle license contamination that's hard to detect later
 - **Breaking if changed:** Missing compatibility check could result in GPL dependency requiring full codebase release under GPL, completely changing project licensing
+
+### Grafana configured with anonymous read-only access (Viewer role) instead of requiring authentication (2026-02-25)
+- **Context:** Need to balance dashboard accessibility with security
+- **Why:** Viewer role provides granular access control (read-only); anonymous access removes barrier to viewing dashboards without requiring credential distribution; assumes dashboards don't expose sensitive data
+- **Rejected:** Admin-only access (less accessible), fully open with edit permissions (security risk), authentication-only (operational overhead)
+- **Trade-offs:** Lower friction for users vs potential exposure if dashboards contain sensitive metrics
+- **Breaking if changed:** If Viewer role is removed or auth.anonymous disabled, all access requires credentials; requires admin password management if changed to auth-only model
+
+#### [Gotcha] Ingestion rate limits (10MB/s, 20MB burst) in Loki silently drop excess logs without alerting operator when limits are exceeded (2026-02-25)
+- **Situation:** Protecting Loki server from being overwhelmed by log traffic from noisy containers
+- **Root cause:** Ingestion limits provide QoS and prevent single container from consuming all resources; but failure mode is silent data loss rather than explicit error
+- **How to avoid:** System stability vs debugging difficulty when logs mysteriously disappear; dropped logs are not typically logged
+
+#### [Pattern] Provisioning directory mounted as read-only (:ro) in docker-compose despite being provisioned into container (2026-02-25)
+- **Problem solved:** Grafana receives pre-configured dashboards that should not be modified at runtime
+- **Why this works:** Prevents Grafana from accidentally or maliciously modifying its own provisioning configuration. Enforces separation between infrastructure configuration (external, version-controlled) and runtime state (container-internal).
+- **Trade-offs:** Slightly more secure but means Grafana UI edits don't persist (users must modify source JSON, not UI, for changes to stick)

--- a/.automaker/memory/ui.md
+++ b/.automaker/memory/ui.md
@@ -462,3 +462,30 @@ usageStats:
 - **Rejected:** Single primary CTA - would force all users through one path, losing conversions from users who want alternative entry points
 - **Trade-offs:** More visual clutter and potential distraction from primary goal, but captures broader audience and improves overall conversion rate
 - **Breaking if changed:** If you remove secondary/tertiary CTAs, users primarily interested in learning or docs would have no clear next step.
+
+#### [Pattern] Theme axes dynamically parsed from naming convention 'Axis: Value' to auto-generate theme switcher buttons (2026-02-25)
+- **Problem solved:** Theme structure not known at compile time; needed flexible UI that adapts to any theme definition in .pen files
+- **Why this works:** Eliminates hardcoded UI for specific axes (Mode, Base, Accent); allows theme switcher to work with any future theme structure without code changes
+- **Trade-offs:** Simpler theme addition but fragile if naming convention isn't followed; no validation that names match expected pattern
+
+#### [Gotcha] Event propagation requires e.stopPropagation() in node click handlers to prevent immediate deselection when clicking nodes (2026-02-25)
+- **Situation:** Canvas background has deselection handler; nodes also have selection handlers. Both listen to clicks on the same hierarchy.
+- **Root cause:** Without stopping propagation, node clicks bubble to canvas handler which immediately deselects. Event flows up the DOM chain by default.
+- **How to avoid:** Simple implementation vs potential confusion about event flow; makes click behavior less predictable if developers don't understand propagation
+
+#### [Pattern] Type guards on discriminated unions to conditionally render inspector sections based on node type (2026-02-25)
+- **Problem solved:** Different PEN node types (text, frame, group, icon) have different properties. Inspector should only show relevant sections.
+- **Why this works:** Avoids runtime errors from accessing undefined properties. TypeScript catches type mismatches at compile time with proper guards like `node.type === 'text'` or `'strokes' in node`
+- **Trade-offs:** More verbose conditional logic vs type safety and clarity. Each new node type requires updating multiple conditionals.
+
+### External style prop merging pattern: pass style from parent to merge with component's internal styles rather than prop-drilling a 'selected' flag (2026-02-25)
+- **Context:** Need to add blue outline to selected nodes. Don't want to modify every renderer component's internal styling logic.
+- **Why:** Decouples selection UI from renderer internals. Parent (canvas) controls selection outline, component just applies the merged style. Scales to many node types.
+- **Rejected:** Alternatively: pass `selected={true}` prop and have each renderer add outline logic (duplicates code) or use CSS class (less flexible)
+- **Trade-offs:** Clean separation of concerns vs requires understanding style merging pattern. Makes styling less obvious from component inspection.
+- **Breaking if changed:** If style prop is removed or not merged properly, selection outline completely disappears with no obvious cause
+
+#### [Gotcha] PenThemeProvider context wrapper is REQUIRED around PenNodeRenderer for thumbnails - theme CSS variables won't resolve without it (2026-02-25)
+- **Situation:** Thumbnail renderer uses existing PenNodeRenderer component which depends on theme context for styling variables
+- **Root cause:** PenNodeRenderer uses CSS variables injected by PenThemeProvider; context must be in component tree or variables silently fail to resolve
+- **How to avoid:** Required wrapper adds component hierarchy complexity vs. ensuring correct styling that works out-of-box

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,7 @@ DevOps documentation in [`docs/infra/`](./infra/):
 | [Design Philosophy](./dev/design-philosophy.md)           | UI design direction (Linear, Vercel, shadcn/ui)      |
 | [Frontend Philosophy](./dev/frontend-philosophy.md)       | Gold standard frontend decisions                     |
 | [UI Architecture](./dev/ui-architecture.md)               | Frontend structure and patterns                      |
+| [UI Standards](./dev/ui-standards.md)                     | Component library, forbidden patterns, enforcement   |
 | [Hivemind Interfaces](./dev/hivemind-interfaces.md)       | Service abstractions for multi-instance architecture |
 | [Testing Patterns](./dev/testing-patterns.md)             | Test patterns and anti-patterns                      |
 | [Clean Code](./dev/clean-code.md)                         | Code quality standards and patterns                  |

--- a/docs/dev/ui-standards.md
+++ b/docs/dev/ui-standards.md
@@ -1,0 +1,203 @@
+# UI standards enforcement
+
+How we ensure AI agents and human contributors follow the design system. This page covers the shared component library, forbidden patterns, and enforcement mechanisms.
+
+> **Related docs:** [Design Philosophy](./design-philosophy) for visual decisions, [Frontend Philosophy](./frontend-philosophy) for implementation architecture, [Design System](../internal/design-system) for brand identity.
+
+## The problem
+
+AI agents don't instinctively know about our component library. Without explicit guidance, they default to bare HTML elements and hardcoded Tailwind colors — the path of least resistance. This produces code that:
+
+- Breaks across 6+ themes (hardcoded `bg-gray-800` is invisible on light themes)
+- Duplicates solved problems (re-implementing buttons, inputs, modals from scratch)
+- Misses accessibility (no aria labels, no keyboard navigation, no focus management)
+- Creates visual inconsistency (different border radii, spacing, typography per view)
+
+## Enforcement strategy
+
+Four layers of defense, ordered by impact:
+
+```
+Layer 1: Context injection (highest leverage)
+  └── .automaker/context/ui-standards.md → injected into every agent prompt
+  └── .automaker/context/CLAUDE.md → cross-references ui-standards.md
+
+Layer 2: ESLint rules (planned)
+  └── Ban bare HTML elements in application chrome
+  └── Ban hardcoded color classes (bg-gray-*, text-blue-*, etc.)
+
+Layer 3: Post-agent verification (planned)
+  └── Automated grep for forbidden patterns after agent completes
+  └── Fail-fast before PR creation if violations detected
+
+Layer 4: Code review (CodeRabbit + human)
+  └── Catches what automation misses
+```
+
+Layer 1 is active today. Layers 2-3 are planned future work.
+
+## Shared component library
+
+All interactive UI elements must come from `@protolabs-ai/ui`. The package lives at `libs/ui/` and exports through two entry points:
+
+```typescript
+import { Button, Card, Input, Badge } from '@protolabs-ai/ui/atoms';
+import { ConfirmDialog, Autocomplete, Markdown } from '@protolabs-ai/ui/molecules';
+```
+
+### Atoms (26+ components)
+
+Primitive building blocks. Each wraps a Radix UI headless component with Tailwind styling and CVA variants.
+
+| Component                                                                                                                                       | Notes                                                                                                                                                           |
+| ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Button`                                                                                                                                        | Variants: default, destructive, outline, secondary, ghost, link, animated-outline. Sizes: default, sm, lg, icon, icon-sm, icon-lg. Props: `loading`, `asChild`. |
+| `Badge`                                                                                                                                         | Semantic variants: success, warning, error, info, muted, brand                                                                                                  |
+| `Card`, `CardHeader`, `CardContent`, `CardFooter`, `CardTitle`, `CardAction`, `CardDescription`                                                 | Composable card system                                                                                                                                          |
+| `Input`                                                                                                                                         | Standard text input with theme tokens                                                                                                                           |
+| `Label`                                                                                                                                         | Paired with inputs via `htmlFor`/`id`                                                                                                                           |
+| `Checkbox`                                                                                                                                      | Radix-based checkbox                                                                                                                                            |
+| `RadioGroup`, `RadioGroupItem`                                                                                                                  | Radix-based radio group                                                                                                                                         |
+| `Select`, `SelectTrigger`, `SelectContent`, `SelectItem`, `SelectValue`                                                                         | Full select system (also: `SelectGroup`, `SelectLabel`, `SelectSeparator`)                                                                                      |
+| `Switch`                                                                                                                                        | Toggle switch                                                                                                                                                   |
+| `Slider`                                                                                                                                        | Range input                                                                                                                                                     |
+| `Textarea`                                                                                                                                      | Multi-line text input                                                                                                                                           |
+| `Tabs`, `TabsList`, `TabsTrigger`, `TabsContent`                                                                                                | Tab navigation                                                                                                                                                  |
+| `Accordion`, `AccordionItem`, `AccordionTrigger`, `AccordionContent`                                                                            | Collapsible sections                                                                                                                                            |
+| `Dialog`, `DialogContent`, `DialogHeader`, `DialogTitle`, `DialogDescription`, `DialogFooter`, `DialogTrigger`, `DialogClose`                   | Modal dialogs                                                                                                                                                   |
+| `DropdownMenu`, `DropdownMenuContent`, `DropdownMenuItem`, `DropdownMenuTrigger`                                                                | Full dropdown system (also: Separator, Label, Group, Sub, SubTrigger, SubContent, CheckboxItem, RadioGroup, RadioItem, Shortcut)                                |
+| `Popover`, `PopoverContent`, `PopoverTrigger`                                                                                                   | Floating content                                                                                                                                                |
+| `Sheet`, `SheetContent`, `SheetHeader`, `SheetTitle`, `SheetDescription`, `SheetFooter`, `SheetTrigger`, `SheetClose`                           | Slide-out panels                                                                                                                                                |
+| `Tooltip`, `TooltipContent`, `TooltipProvider`, `TooltipTrigger`                                                                                | Hover tooltips                                                                                                                                                  |
+| `Command`, `CommandDialog`, `CommandInput`, `CommandList`, `CommandEmpty`, `CommandGroup`, `CommandItem`, `CommandSeparator`, `CommandShortcut` | Command palette                                                                                                                                                 |
+| `Breadcrumb`, `BreadcrumbList`, `BreadcrumbItem`, `BreadcrumbLink`, `BreadcrumbPage`, `BreadcrumbSeparator`, `BreadcrumbEllipsis`               | Navigation breadcrumbs                                                                                                                                          |
+| `Collapsible`, `CollapsibleTrigger`, `CollapsibleContent`                                                                                       | Simple collapsible                                                                                                                                              |
+| `Kbd`, `KbdGroup`                                                                                                                               | Keyboard shortcut display                                                                                                                                       |
+| `ScrollArea`, `ScrollBar`                                                                                                                       | Custom scrollbars                                                                                                                                               |
+| `SkeletonPulse`                                                                                                                                 | Loading placeholder                                                                                                                                             |
+| `Spinner`                                                                                                                                       | Loading spinner (sizes: sm, md, lg, xl)                                                                                                                         |
+
+### Molecules (6+ components)
+
+Composed patterns that combine atoms with behavior:
+
+| Component       | Purpose                                          |
+| --------------- | ------------------------------------------------ |
+| `HotkeyButton`  | Button with keyboard shortcut support            |
+| `ConfirmDialog` | Pre-built confirmation modal with hotkey confirm |
+| `Autocomplete`  | Searchable combobox with create-new support      |
+| `LoadingState`  | Centered spinner with optional message           |
+| `ErrorState`    | Error display with optional retry button         |
+| `Markdown`      | Theme-aware markdown renderer                    |
+
+## Forbidden patterns
+
+### Bare HTML elements
+
+Application chrome (toolbars, panels, sidebars, inspectors, settings, modals) must never use bare HTML for interactive elements:
+
+| Never use                 | Always use instead                                                  |
+| ------------------------- | ------------------------------------------------------------------- |
+| `<button>`                | `<Button>` from `@protolabs-ai/ui/atoms`                            |
+| `<input>`                 | `<Input>` from `@protolabs-ai/ui/atoms`                             |
+| `<select>`                | `<Select>` + `<SelectTrigger>` + `<SelectContent>` + `<SelectItem>` |
+| `<textarea>`              | `<Textarea>` from `@protolabs-ai/ui/atoms`                          |
+| `<input type="checkbox">` | `<Checkbox>` from `@protolabs-ai/ui/atoms`                          |
+| `<label>`                 | `<Label>` from `@protolabs-ai/ui/atoms`                             |
+
+**Exemption:** Canvas/renderer internals (code editor buffers, terminal emulators, design canvas) are exempt because they render user content, not application chrome.
+
+### Hardcoded colors
+
+Never use raw Tailwind color classes. Always use semantic tokens:
+
+| Never                                       | Always                                 |
+| ------------------------------------------- | -------------------------------------- |
+| `bg-white`, `bg-gray-900`                   | `bg-background`                        |
+| `bg-white` (card surface)                   | `bg-card`                              |
+| `bg-gray-50`, `bg-gray-800`                 | `bg-muted`                             |
+| `bg-gray-100`, `bg-gray-700`                | `bg-accent` or `bg-secondary`          |
+| `hover:bg-gray-100`                         | `hover:bg-accent`                      |
+| `bg-blue-500`, `bg-indigo-600`              | `bg-primary`                           |
+| `bg-red-500`                                | `bg-destructive`                       |
+| `text-black`, `text-white`, `text-gray-900` | `text-foreground`                      |
+| `text-gray-600`, `text-gray-700`            | `text-foreground-secondary`            |
+| `text-gray-400`, `text-gray-500`            | `text-muted-foreground`                |
+| `text-blue-600`                             | `text-primary`                         |
+| `text-red-500`                              | `text-destructive`                     |
+| `border-gray-200`, `border-gray-700`        | `border-border`                        |
+| `border-gray-300`                           | `border-input`                         |
+| `ring-blue-500`                             | `ring-ring`                            |
+| Inline `style={{ background: '#...' }}`     | Tailwind token class or `var(--token)` |
+
+### Status colors
+
+Use semantic status tokens, not raw colors:
+
+| Status  | Background             | Text                  | Badge variant               |
+| ------- | ---------------------- | --------------------- | --------------------------- |
+| Success | `bg-status-success-bg` | `text-status-success` | `<Badge variant="success">` |
+| Warning | `bg-status-warning-bg` | `text-status-warning` | `<Badge variant="warning">` |
+| Error   | `bg-status-error-bg`   | `text-status-error`   | `<Badge variant="error">`   |
+| Info    | `bg-status-info-bg`    | `text-status-info`    | `<Badge variant="info">`    |
+
+## Text hierarchy
+
+Three tiers only. No exceptions:
+
+| Tier      | Token                       | Usage                               |
+| --------- | --------------------------- | ----------------------------------- |
+| Primary   | `text-foreground`           | Headings, labels, important content |
+| Secondary | `text-foreground-secondary` | Body text, descriptions             |
+| Muted     | `text-muted-foreground`     | Hints, timestamps, tertiary info    |
+
+## Accessibility requirements
+
+- Icon-only buttons must have `aria-label`: `<Button size="icon" aria-label="Delete item"><Trash2 /></Button>`
+- Every `<Input>`, `<Textarea>`, `<Select>` must have a paired `<Label>` with matching `htmlFor`/`id`
+- Keyboard navigation is handled by shared components. Do not override `onKeyDown` unless adding new shortcuts.
+- Color must never be the sole indicator of state. Use icons or text labels alongside colors.
+
+## Context file system
+
+The enforcement mechanism works through the `.automaker/context/` directory. Files placed here are automatically injected into every agent's system prompt via `loadContextFiles()` from `@protolabs-ai/utils`.
+
+**Active context files for UI standards:**
+
+| File                                 | Purpose                                                                             |
+| ------------------------------------ | ----------------------------------------------------------------------------------- |
+| `.automaker/context/CLAUDE.md`       | References `ui-standards.md`, lists `libs/ui/` in monorepo structure                |
+| `.automaker/context/ui-standards.md` | Complete component inventory, forbidden patterns, theme tokens, accessibility rules |
+
+The `ui-standards.md` context file is kept under 200 lines to fit within agent context budgets. It contains the actionable rules — the tables above are extracted from it.
+
+**How it works:**
+
+```
+Agent starts
+  → loadContextFiles({ projectPath })
+  → Reads ALL files from .automaker/context/
+  → Injects as system prompt section
+  → Agent sees: "ALWAYS use <Button> from @protolabs-ai/ui/atoms, NEVER use <button>"
+  → Agent follows the rules in generated code
+```
+
+This is the highest-leverage enforcement point because it reaches every agent on every execution without any code changes or CI pipeline modifications.
+
+## Reference views
+
+When building new UI, study these implementations as the gold standard:
+
+- **Board view** (Kanban): `apps/ui/src/components/views/board-view/` — layout, cards, drag-and-drop
+- **Settings view** (forms): `apps/ui/src/components/views/settings-view/` — form patterns, input groups, sections
+
+## Adding new standards
+
+To add a new UI standard:
+
+1. **Update the context file** (`.automaker/context/ui-standards.md`) — agents see this immediately
+2. **Update this doc** (`docs/dev/ui-standards.md`) — humans reference this
+3. **Add ESLint rule** (when available) — automated enforcement
+4. **Update reference views** if the new standard affects existing patterns
+
+Keep the context file and this doc in sync. The context file is the agent-facing version (concise, actionable). This doc is the human-facing version (explains the why, includes context).


### PR DESCRIPTION
## Summary
- Create `.automaker/context/ui-standards.md` — injected into every agent prompt with shared component inventory, forbidden patterns (bare HTML, hardcoded colors), theme token tables, and accessibility rules
- Update `.automaker/context/CLAUDE.md` to reference `libs/ui/` in the monorepo structure and cross-reference `ui-standards.md`
- Add `docs/dev/ui-standards.md` — human-facing documentation covering the enforcement philosophy, 4-layer defense strategy, and context injection system
- Include accumulated `.automaker/memory/` updates from recent agent work

## Context
AI agents were producing UI code with 50+ hardcoded colors, bare HTML elements, and zero imports from `@protolabs-ai/ui`. Root cause: agents had no idea the shared component library existed because it was omitted from context files. This PR establishes the enforcement layer.

## Test plan
- [ ] Verify `docs/dev/ui-standards.md` renders correctly in VitePress
- [ ] Verify `.automaker/context/ui-standards.md` is loaded by `loadContextFiles()`
- [ ] Run next agent on a UI feature and confirm it uses shared components

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a shared UI component library providing reusable Atom and Molecule components for consistent styling across the application.

* **Documentation**
  * Established comprehensive UI standards documentation covering component usage, forbidden patterns, semantic tokens, accessibility requirements, and enforcement guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->