### PR TITLE
fix: content pipeline review scoring regex and research fallback

### DIFF
--- a/apps/server/src/services/content-flow-service.ts
+++ b/apps/server/src/services/content-flow-service.ts
@@ -711,6 +711,36 @@ export class ContentFlowService {
       const fallbackPath = path.join(contentDir, 'content.md');
       await fs.writeFile(fallbackPath, finalState.assembledContent, 'utf-8');
       logger.info(`Saved assembled content fallback to ${fallbackPath}`);
+      contentWritten = true;
+    }
+
+    // Additional fallback: if no content was written but research results exist,
+    // save them as a draft for validation/debugging purposes
+    if (!contentWritten) {
+      const researchResults = finalState.researchResults as
+        | Array<{
+            query: string;
+            findings: { facts: string[]; examples: string[]; references: string[] };
+          }>
+        | undefined;
+      if (researchResults && researchResults.length > 0) {
+        const draftContent =
+          `# Research Results (Draft - Quality Gates Not Passed)\n\n` +
+          `This content did not pass quality review gates but is saved for validation.\n\n` +
+          researchResults
+            .map(
+              (r) =>
+                `## Query: ${r.query}\n\n` +
+                `### Facts\n${r.findings.facts.map((f) => `- ${f}`).join('\n')}\n\n` +
+                `### Examples\n${r.findings.examples.map((e) => `- ${e}`).join('\n')}\n\n` +
+                `### References\n${r.findings.references.map((ref) => `- ${ref}`).join('\n')}\n`
+            )
+            .join('\n\n');
+
+        const draftPath = path.join(contentDir, 'content.md');
+        await fs.writeFile(draftPath, draftContent, 'utf-8');
+        logger.info(`Saved research results draft to ${draftPath}`);
+      }
     }
 
     // Save metadata including review scores and trace ID

--- a/libs/flows/src/content/subgraphs/antagonistic-reviewer.ts
+++ b/libs/flows/src/content/subgraphs/antagonistic-reviewer.ts
@@ -452,7 +452,7 @@ function parseDimensionScores(output: string, expectedDimensions: string[]): Dim
 
   for (const dimension of expectedDimensions) {
     // Match pattern: **DimensionName:** X/10
-    const scoreRegex = new RegExp(`\\*\\*${dimension}[:\\s]*\\*\\*[\\s]*(\\d+)/10`, 'i');
+    const scoreRegex = new RegExp(`\\*\\*${dimension}\\*\\*:\\s*(\\d+)/10`, 'i');
     const evidenceRegex = new RegExp(`Evidence:[\\s]*([^\\n]+)`, 'i');
     const suggestionRegex = new RegExp(`Suggestion:[\\s]*([^\\n]+)`, 'i');
 
@@ -461,7 +461,7 @@ function parseDimensionScores(output: string, expectedDimensions: string[]): Dim
 
     // Find the section for this dimension
     const dimensionSectionRegex = new RegExp(
-      `\\*\\*${dimension}[:\\s]*\\*\\*[\\s]*\\d+/10[\\s\\S]*?(?=\\*\\*|##|$)`,
+      `\\*\\*${dimension}\\*\\*:\\s*\\d+/10[\\s\\S]*?(?=\\*\\*|##|$)`,
       'i'
     );
     const sectionMatch = output.match(dimensionSectionRegex);


### PR DESCRIPTION
## Summary
- **Fixed antagonistic reviewer regex** — dimension score parsing (`**Dimension**: X/10`) had the colon placement wrong, causing all review scores to default to 5/10 (50%). Both `scoreRegex` and `dimensionSectionRegex` patterns corrected.
- **Added research draft fallback** — when content pipeline quality gates fail and no assembled content exists, research findings are now persisted to `content.md` as a draft for debugging/validation.

## Files Changed
- `libs/flows/src/content/subgraphs/antagonistic-reviewer.ts` — 2-line regex fix
- `apps/server/src/services/content-flow-service.ts` — 23-line research fallback block

## Test plan
- [ ] Run content pipeline E2E — verify review scores now parse correctly from LLM output
- [ ] Trigger pipeline with a topic that fails quality gates — verify `content.md` gets written with research draft
- [ ] Existing content pipeline tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content generation fallback mechanism to ensure draft content is reliably created when automatic generation does not produce final content, enhancing overall content availability.
  * Refined parsing patterns for content analysis to improve accuracy in dimension score extraction and evaluation, ensuring more reliable content review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->