### PR TITLE
feat: add quarantine types and trust tier fields to Feature interface

### DIFF
--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -421,6 +421,18 @@ export interface Feature {
   domain?: string;
   /** Instance ID that has claimed this feature for execution */
   claimedBy?: string;
+
+  // Quarantine fields
+  /** Source of this feature submission */
+  source?: 'internal' | 'ui' | 'api' | 'mcp' | 'github_issue' | 'github_discussion';
+  /** Trust tier of the submitter (0=anonymous, 1=github_user, 2=contributor, 3=maintainer, 4=system) */
+  trustTier?: import('./quarantine.js').TrustTier;
+  /** Current quarantine processing status */
+  quarantineStatus?: 'pending' | 'passed' | 'failed' | 'bypassed';
+  /** Links to QuarantineEntry record */
+  quarantineId?: string;
+  /** Reason for quarantine failure (if quarantineStatus === 'failed') */
+  quarantineFailureReason?: string;
 }
 
 /**

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -65,6 +65,16 @@ export type {
 } from './feature.js';
 export { normalizeFeatureStatus } from './feature.js';
 
+// Quarantine types
+export type {
+  TrustTier,
+  QuarantineStage,
+  QuarantineResult,
+  SanitizationViolation,
+  QuarantineEntry,
+  TrustTierRecord,
+} from './quarantine.js';
+
 // Feature store interface (pluggable storage abstraction)
 export type { FeatureStore } from './feature-store.js';
 

--- a/libs/types/src/quarantine.ts
+++ b/libs/types/src/quarantine.ts
@@ -1,0 +1,68 @@
+/**
+ * Quarantine and trust tier types for feature sanitization
+ */
+
+import type { Feature } from './feature.js';
+
+/**
+ * Trust tier levels for feature submission sources
+ * Higher numbers = more trust, higher privileges
+ */
+export type TrustTier = 0 | 1 | 2 | 3 | 4;
+// 0 = anonymous (external, unknown)
+// 1 = github_user (verified GitHub account, opened issue)
+// 2 = contributor (past merged contribution via idea)
+// 3 = maintainer (team member, bypasses quarantine)
+// 4 = system (internal/MCP/CLI, full trust)
+
+/**
+ * Stages in the quarantine process
+ */
+export type QuarantineStage = 'gate' | 'syntax' | 'content' | 'security';
+
+/**
+ * Possible outcomes of quarantine processing
+ */
+export type QuarantineResult = 'passed' | 'failed' | 'bypassed';
+
+/**
+ * Records a single rule violation during sanitization
+ */
+export interface SanitizationViolation {
+  stage: QuarantineStage;
+  rule: string;
+  severity: 'info' | 'warn' | 'block';
+  detail: string;
+  offset?: number; // character position in original text
+}
+
+/**
+ * Complete record of a feature's quarantine processing
+ */
+export interface QuarantineEntry {
+  id: string;
+  featureId?: string;
+  source: Feature['source'];
+  trustTier: TrustTier;
+  submittedAt: string; // ISO timestamp
+  reviewedAt?: string;
+  result: QuarantineResult;
+  stage?: QuarantineStage; // stage where failure occurred
+  violations: SanitizationViolation[];
+  originalTitle: string;
+  originalDescription: string;
+  sanitizedTitle?: string;
+  sanitizedDescription?: string;
+  reviewedBy?: string; // maintainer who approved/rejected if manual review
+}
+
+/**
+ * Records trust tier grants for GitHub users
+ */
+export interface TrustTierRecord {
+  githubUsername: string;
+  tier: TrustTier;
+  grantedAt: string;
+  grantedBy: string;
+  reason?: string;
+}


### PR DESCRIPTION
## Summary
- Added quarantine fields to `Feature` interface: `source`, `trustTier`, `quarantineStatus`, `quarantineId`, `quarantineFailureReason`
- Created `libs/types/src/quarantine.ts` with `TrustTier` (0-4), `QuarantineEntry`, `SanitizationViolation`, `QuarantineStage`, `QuarantineResult` types
- Exported all new types from `libs/types/src/index.ts`
- `build:packages` compiles successfully

## Test plan
- [ ] `npm run build:packages` succeeds
- [ ] Types correctly exported (import check from consuming packages)
- [ ] No TypeScript errors in existing code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a feature quarantine system for tracking submitted features with trust tier levels and validation status.
  * Features now include source origin, trust tier classification, and detailed quarantine status with violation records.
  * Added comprehensive tracking across multiple validation stages (gate, syntax, content, security) for feature sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->