### PR TITLE
docs: update MCP tool count to 135 and add pen-parser to structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ automaker/
     ├── model-resolver/    # Claude model alias resolution
     ├── dependency-resolver/  # Feature dependency ordering
     ├── spec-parser/       # XML/markdown spec parsing for project plans
+    ├── pen-parser/        # PEN file parser for Penpot design files
     ├── git-utils/    # Git operations & worktree management
     ├── tools/        # Unified tool definition and registry system
     ├── flows/        # LangGraph state graph primitives & flow orchestration
@@ -110,7 +111,7 @@ Packages can only depend on packages above them:
 ```
 @protolabs-ai/types (no dependencies)
     ↓
-@protolabs-ai/utils, @protolabs-ai/prompts, @protolabs-ai/platform, @protolabs-ai/model-resolver, @protolabs-ai/dependency-resolver, @protolabs-ai/spec-parser, @protolabs-ai/tools, @protolabs-ai/flows, @protolabs-ai/llm-providers, @protolabs-ai/observability
+@protolabs-ai/utils, @protolabs-ai/prompts, @protolabs-ai/platform, @protolabs-ai/model-resolver, @protolabs-ai/dependency-resolver, @protolabs-ai/spec-parser, @protolabs-ai/pen-parser, @protolabs-ai/tools, @protolabs-ai/flows, @protolabs-ai/llm-providers, @protolabs-ai/observability
     ↓
 @protolabs-ai/git-utils, @protolabs-ai/ui
     ↓
@@ -351,7 +352,7 @@ claude plugin install automaker
 
 ### Available MCP Tools
 
-The MCP server exposes 48+ tools organized by category:
+The MCP server exposes 135 tools organized by category:
 
 **Feature Management:** `list_features`, `get_feature`, `create_feature`, `update_feature`, `delete_feature`, `move_feature`
 

--- a/docs/integrations/mcp-tools-reference.md
+++ b/docs/integrations/mcp-tools-reference.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-Complete catalog of MCP tools exposed by the protoLabs server. See `packages/mcp-server/src/index.ts` for the full definitions.
+Complete catalog of **135 MCP tools** exposed by the protoLabs server. See `packages/mcp-server/src/index.ts` for the full definitions.
 
 For installation and configuration, see [Claude Plugin Setup](./claude-plugin.md). For commands and examples, see [Plugin Commands](./plugin-commands.md).
 


### PR DESCRIPTION
## Summary
- Updated MCP tool count from "48+" to **135** in CLAUDE.md and mcp-tools-reference.md
- Added `pen-parser` package to monorepo structure and dependency chain docs

## Test plan
- [ ] CLAUDE.md renders correctly
- [ ] No broken internal references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pen-parser library, expanding the monorepo's capabilities
  * Expanded MCP tools catalog from 48+ to 135 available tools

* **Documentation**
  * Updated MCP Tools Reference documentation and architecture diagrams to reflect new library and expanded tooling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->