### PR TITLE
fix: emit feature lifecycle events from updateFeatureStatus()

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -4742,6 +4742,9 @@ Format your response as a structured markdown document.`;
         return;
       }
 
+      // Capture previous status before updating for event emission
+      const previousStatus = feature.status;
+
       feature.status = status;
       feature.updatedAt = new Date().toISOString();
       // Set justFinishedAt timestamp when moving to waiting_approval (agent just completed)
@@ -4759,6 +4762,35 @@ Format your response as a structured markdown document.`;
 
       // Use atomic write with backup support
       await atomicWriteJson(featurePath, feature, { backupCount: DEFAULT_BACKUP_COUNT });
+
+      // Emit feature:status-changed event for all status transitions
+      this.events.emit('feature:status-changed', {
+        projectPath,
+        featureId,
+        previousStatus,
+        newStatus: status,
+      });
+
+      // Emit feature:completed event when reaching terminal success states
+      // This allows Lead Engineer and other services to detect completion
+      if (status === 'verified' || status === 'done') {
+        this.events.emit('feature:completed', {
+          projectPath,
+          featureId,
+          featureTitle: feature.title,
+          status,
+        });
+      }
+
+      // Emit feature:error event when reaching error states
+      if (status === 'failed' || status === 'blocked') {
+        this.events.emit('feature:error', {
+          projectPath,
+          featureId,
+          error: feature.error || 'Feature execution failed',
+          status,
+        });
+      }
 
       // Create notifications for important status changes
       const notificationService = getNotificationService();


### PR DESCRIPTION
## Summary

- **Fixes 30-minute timeout** in Lead Engineer's `ExecuteProcessor.waitForCompletion()` which listens for `feature:completed` events that `updateFeatureStatus()` never emitted
- Adds three domain event emissions to `updateFeatureStatus()`:
  - `feature:status-changed` on every status transition (includes `previousStatus` and `newStatus`)
  - `feature:completed` when reaching terminal success states (`verified`, `done`)
  - `feature:error` when reaching error states (`failed`, `blocked`)

## Root Cause

`auto-mode-service.ts` used `emitAutoModeEvent('auto_mode_feature_complete', ...)` for its internal event bus, but `lead-engineer-service.ts` listens for domain events (`feature:completed`). The `updateFeatureStatus()` method—the single code path for all status changes—wrote to disk silently without emitting any events.

## Test plan

- [ ] Build passes (`npm run build:server`)
- [ ] Lead Engineer processes feature without 30-minute timeout
- [ ] `feature:status-changed` events visible in event stream after status transitions
- [ ] `feature:completed` fires when feature reaches `verified` or `done`
- [ ] Existing auto-mode behavior unchanged (emitAutoModeEvent still fires separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)