### PR TITLE
fix: add git workflow to pipeline-step-removed completion path

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3086,6 +3086,65 @@ Complete the pipeline step instructions above. Review the previous work and appl
 
       await this.updateFeatureStatus(projectPath, featureId, finalStatus);
 
+      // Run git workflow (commit, push, PR) if enabled
+      let gitWorkflowResult: Awaited<
+        ReturnType<typeof gitWorkflowService.runPostCompletionWorkflow>
+      > = null;
+      if (this.settingsService) {
+        try {
+          const settings = await this.settingsService.getGlobalSettings();
+
+          // Look up epic branch name if feature belongs to an epic
+          let epicBranchName: string | undefined;
+          if (feature.epicId && !feature.isEpic) {
+            const epicFeature = await this.featureLoader.get(projectPath, feature.epicId);
+            epicBranchName = epicFeature?.branchName;
+            if (epicBranchName) {
+              logger.info(`Feature ${featureId} belongs to epic, PR will target ${epicBranchName}`);
+            }
+          }
+
+          gitWorkflowResult = await gitWorkflowService.runPostCompletionWorkflow(
+            projectPath,
+            featureId,
+            feature,
+            pipelineWorkDir,
+            settings,
+            epicBranchName,
+            this.events
+          );
+          if (gitWorkflowResult) {
+            // Check if git workflow encountered conflicts
+            if (gitWorkflowResult.error && gitWorkflowResult.error.includes('conflict')) {
+              this.emitAutoModeEvent('auto_mode_progress', {
+                featureId,
+                featureName: feature.title,
+                message: `⚠️ Git workflow warning: ${gitWorkflowResult.error}`,
+                projectPath,
+              });
+            }
+
+            this.emitAutoModeEvent('auto_mode_git_workflow', {
+              featureId,
+              committed: gitWorkflowResult.commitHash,
+              pushed: gitWorkflowResult.pushed,
+              prUrl: gitWorkflowResult.prUrl,
+              prNumber: gitWorkflowResult.prNumber,
+              error: gitWorkflowResult.error,
+              projectPath,
+            });
+          }
+        } catch (error) {
+          logger.error('Error running post-completion git workflow:', error);
+          this.emitAutoModeEvent('auto_mode_progress', {
+            featureId,
+            featureName: feature.title,
+            message: `⚠️ Git workflow failed: ${error instanceof Error ? error.message : String(error)}`,
+            projectPath,
+          });
+        }
+      }
+
       this.emitAutoModeEvent('auto_mode_feature_complete', {
         featureId,
         featureName: feature.title,


### PR DESCRIPTION
## Summary

- The pipeline-step-removed completion path (lines 3070-3099 of `auto-mode-service.ts`) called `ensureCleanWorktree()` and `updateFeatureStatus()` but **never called `runPostCompletionWorkflow()`** — stranding agent work without a PR
- Adds the full git workflow invocation matching the pattern used in normal completion paths: commit, push, PR creation, epic branch targeting, conflict detection, and error event emission

## Root Cause

When a feature's pipeline step is deleted mid-execution (e.g., after project restructure), the code takes an early-return path that skips the git workflow entirely. This was the second of two gaps identified in the git workflow reliability deep dive.

## Test plan

- [ ] Build passes (`npm run build:server`)
- [ ] Features completing via pipeline-step-removed path get committed, pushed, and PR'd
- [ ] Epic branch targeting works for features in epics
- [ ] Git workflow errors are logged and emitted as events (not swallowed)
- [ ] Existing normal completion path behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)