### PR TITLE
feat: add GitHub Actions workflows for community automation

### DIFF
--- a/.github/workflows/idea-accepted.yml
+++ b/.github/workflows/idea-accepted.yml
@@ -1,0 +1,22 @@
+name: Idea Accepted Notification
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  notify-acceptance:
+    runs-on: ubuntu-latest
+    if: "github.event.label.name == 'status: accepted'"
+    steps:
+      - name: Post acceptance comment
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --body "This idea has been accepted and queued for implementation by our AI agents. We will link the PR here when work begins." \
+            --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: Close Stale Issues
+
+on:
+  schedule:
+    # Run daily at 1:00 AM UTC
+    - cron: '0 1 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark stale issues and close inactive ones
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-message: 'This issue has been inactive for 60 days and will be closed in 14 days if there is no further activity. If you believe this issue is still relevant, please comment to keep it open.'
+          close-issue-message: 'This issue has been closed due to inactivity. If you believe this should be reopened, please create a new issue and reference this one.'
+          stale-issue-label: 'status: stale'
+          exempt-issue-labels: 'status: accepted,type: in-progress'
+          exempt-pr-labels: 'status: accepted,type: in-progress'
+          operations-per-run: 100

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,38 @@
+name: Triage New Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add needs-triage label
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --add-label "status: needs-triage" \
+            --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post welcome comment
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --body "👋 Thank you for submitting this idea!
+
+          Your issue has been added to our ideas pipeline. Here's what happens next:
+
+          1. **Triage** (1-3 days): Our team will review and label your idea
+          2. **Discussion** (ongoing): We may ask clarifying questions or gather community feedback
+          3. **Acceptance** (varies): If accepted, we'll add the \`status: accepted\` label
+          4. **Implementation** (varies): Our AI agents will implement accepted ideas and link the PR here
+
+          We appreciate your contribution to making this project better! 🚀" \
+            --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `triage.yml` workflow that auto-labels new issues with `status: needs-triage` and posts a welcome comment explaining the ideas pipeline
- Adds `stale.yml` workflow using SHA-pinned `actions/stale@v9` to mark issues stale after 60 days and close after 14 more days
- Adds `idea-accepted.yml` workflow that posts a notification comment when the `status: accepted` label is applied

All workflows use explicit `permissions:` blocks with minimum required access. Third-party actions are SHA-pinned.

**Part of: protoMaker Open-Source Launch (M1P2)**

## Test plan
- [ ] Verify triage.yml YAML syntax is valid
- [ ] Verify stale.yml uses SHA-pinned action reference
- [ ] Verify idea-accepted.yml triggers on label event with correct condition
- [ ] All workflows have explicit permissions blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automatic issue triaging that labels new issues as "needs-triage" and posts a welcome message explaining the triage process
  * Implemented automatic stale issue management that marks issues inactive for 60 days as stale and closes them after 14 additional days without activity
  * Implemented automatic notification for issues labeled as accepted

<!-- end of auto-generated comment: release notes by coderabbit.ai -->