### PR TITLE
fix: add exponential backoff retry to git push and PR creation

### DIFF
--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -47,9 +47,7 @@ async function retryWithExponentialBackoff<T>(
       if (attempt === maxRetries) {
         // Final failure after all retries
         const errorMessage = error instanceof Error ? error.message : String(error);
-        logger.error(
-          `${operationName} failed after ${maxRetries} retries: ${errorMessage}`
-        );
+        logger.error(`${operationName} failed after ${maxRetries} retries: ${errorMessage}`);
         throw error;
       }
 
@@ -351,15 +349,12 @@ export class GitWorkflowService {
 
       // Push to remote with retry logic
       try {
-        await retryWithExponentialBackoff(
-          async () => {
-            await execAsync(`git push origin ${branchName}`, {
-              cwd: workDir,
-              env: execEnv,
-            });
-          },
-          `Push agent progress for ${branchName}`
-        );
+        await retryWithExponentialBackoff(async () => {
+          await execAsync(`git push origin ${branchName}`, {
+            cwd: workDir,
+            env: execEnv,
+          });
+        }, `Push agent progress for ${branchName}`);
         logger.info(
           `Saved agent progress for feature ${feature.id}: commit ${hash}, pushed to ${branchName}`
         );
@@ -1351,26 +1346,23 @@ export class GitWorkflowService {
 
     try {
       // Use retry logic for PR creation
-      const { prUrl, prNumber, prCreatedAt } = await retryWithExponentialBackoff(
-        async () => {
-          const { stdout: prOutput } = await execAsync(prCmd, {
-            cwd: workDir,
-            env: execEnv,
-          });
-          const prUrl = prOutput.trim();
+      const { prUrl, prNumber, prCreatedAt } = await retryWithExponentialBackoff(async () => {
+        const { stdout: prOutput } = await execAsync(prCmd, {
+          cwd: workDir,
+          env: execEnv,
+        });
+        const prUrl = prOutput.trim();
 
-          // Extract PR number
-          let prNumber: number | undefined;
-          const prCreatedAt = new Date().toISOString();
-          const prMatch = prUrl.match(/\/pull\/(\d+)/);
-          if (prMatch) {
-            prNumber = parseInt(prMatch[1], 10);
-          }
+        // Extract PR number
+        let prNumber: number | undefined;
+        const prCreatedAt = new Date().toISOString();
+        const prMatch = prUrl.match(/\/pull\/(\d+)/);
+        if (prMatch) {
+          prNumber = parseInt(prMatch[1], 10);
+        }
 
-          return { prUrl, prNumber, prCreatedAt };
-        },
-        `Create PR for ${branchName}`
-      );
+        return { prUrl, prNumber, prCreatedAt };
+      }, `Create PR for ${branchName}`);
 
       // Store metadata after successful creation
       if (prNumber) {


### PR DESCRIPTION
## Summary

- Adds `retryWithExponentialBackoff<T>()` generic helper to `git-workflow-service.ts` — 3 retries with 2s/4s/8s delays
- Wraps `pushToRemote()` with retry — transient network failures no longer cause permanent work loss
- Wraps agent progress push with retry
- Wraps `gh pr create` with retry — GitHub API rate limits or blips no longer strand PRs
- Retry attempts logged at warn level, final failures at error level

## Root Cause

A single network blip during push or PR creation would cause the entire git workflow to silently fail, stranding agent work. This was identified as GAP 5 in the git workflow reliability deep dive.

## Test plan

- [ ] Build passes
- [ ] Push failures retry 3 times before failing
- [ ] PR creation failures retry 3 times before failing
- [ ] Retry delays follow 2s → 4s → 8s exponential pattern
- [ ] Warn-level logs on each retry attempt
- [ ] Error-level log after final failure
- [ ] Successful operations on first attempt are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced reliability of git operations with automatic retry logic and exponential backoff for transient failures.
  * Improved PR creation flow with better fallback handling and error recovery.
  * Strengthened agent workflow resilience during remote operations with enhanced logging for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->