### PR TITLE
feat: add quarantine gate to feature creation route

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -388,6 +388,10 @@ const events: EventEmitter = createEventEmitter();
 // Note: settingsService is created first so it can be injected into other services
 const settingsService = new SettingsService(DATA_DIR);
 const featureLoader = new FeatureLoader();
+
+// Trust Tier Service for quarantine pipeline
+import { TrustTierService } from './services/trust-tier-service.js';
+const trustTierService = new TrustTierService(DATA_DIR);
 const agentService = new AgentService(DATA_DIR, events, settingsService, undefined, featureLoader);
 const metricsService = new MetricsService(featureLoader);
 
@@ -1402,6 +1406,7 @@ app.use(
   '/api/features',
   createFeaturesRoutes(
     featureLoader,
+    trustTierService,
     settingsService,
     events,
     authorityService,

--- a/apps/server/src/routes/features/index.ts
+++ b/apps/server/src/routes/features/index.ts
@@ -21,9 +21,11 @@ import { createHealthHandler } from './routes/health.js';
 import { createAssignAgentHandler } from './routes/assign-agent.js';
 import type { FeatureHealthService } from '../../services/feature-health-service.js';
 import type { RoleRegistryService } from '../../services/role-registry-service.js';
+import type { TrustTierService } from '../../services/trust-tier-service.js';
 
 export function createFeaturesRoutes(
   featureLoader: FeatureLoader,
+  trustTierService: TrustTierService,
   settingsService?: SettingsService,
   events?: EventEmitter,
   authorityService?: AuthorityService,
@@ -37,7 +39,7 @@ export function createFeaturesRoutes(
   router.post(
     '/create',
     validatePathParams('projectPath'),
-    createCreateHandler(featureLoader, events)
+    createCreateHandler(featureLoader, trustTierService, events)
   );
   router.post(
     '/update',

--- a/apps/server/src/routes/features/routes/create.ts
+++ b/apps/server/src/routes/features/routes/create.ts
@@ -7,8 +7,40 @@ import { FeatureLoader } from '../../../services/feature-loader.js';
 import type { EventEmitter } from '../../../lib/events.js';
 import type { Feature } from '@protolabs-ai/types';
 import { getErrorMessage, logError } from '../common.js';
+import { TrustTierService } from '../../../services/trust-tier-service.js';
+import { QuarantineService } from '../../../services/quarantine-service.js';
+import type { QuarantineStage, SanitizationViolation } from '@protolabs-ai/types';
 
-export function createCreateHandler(featureLoader: FeatureLoader, events?: EventEmitter) {
+/**
+ * Determine the feature source from request headers and authentication method
+ */
+function determineSource(req: Request): Feature['source'] {
+  // Check for MCP client header
+  const mcpClient = req.headers['x-automaker-client'];
+  if (mcpClient === 'mcp') {
+    return 'mcp';
+  }
+
+  // Check authentication method
+  // X-API-Key header → 'api'
+  if (req.headers['x-api-key']) {
+    return 'api';
+  }
+
+  // Session token (X-Session-Token or cookie) → 'ui'
+  if (req.headers['x-session-token'] || req.cookies?.automaker_session) {
+    return 'ui';
+  }
+
+  // Default to 'internal' if no clear authentication method
+  return 'internal';
+}
+
+export function createCreateHandler(
+  featureLoader: FeatureLoader,
+  trustTierService: TrustTierService,
+  events?: EventEmitter
+) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
       const { projectPath, feature } = req.body as {
@@ -20,6 +52,15 @@ export function createCreateHandler(featureLoader: FeatureLoader, events?: Event
         res.status(400).json({
           success: false,
           error: 'projectPath and feature are required',
+        });
+        return;
+      }
+
+      // Validate that feature has title and description for quarantine processing
+      if (!feature.title || !feature.description) {
+        res.status(400).json({
+          success: false,
+          error: 'feature.title and feature.description are required',
         });
         return;
       }
@@ -37,7 +78,44 @@ export function createCreateHandler(featureLoader: FeatureLoader, events?: Event
         }
       }
 
-      const created = await featureLoader.create(projectPath, feature);
+      // Determine source from request context
+      const source = determineSource(req);
+
+      // Get trust tier from TrustTierService
+      const trustTier = trustTierService.classifyTrust(source);
+
+      // Process through quarantine pipeline
+      const quarantineService = new QuarantineService(trustTierService, projectPath);
+      const outcome = await quarantineService.process({
+        title: feature.title,
+        description: feature.description,
+        source,
+        trustTier,
+      });
+
+      // If quarantine failed, return HTTP 422
+      if (!outcome.approved) {
+        res.status(422).json({
+          error: 'quarantine_failed',
+          quarantineId: outcome.entry.id,
+          stage: outcome.entry.stage as QuarantineStage,
+          violations: outcome.entry.violations as SanitizationViolation[],
+        });
+        return;
+      }
+
+      // Use sanitized title and description from quarantine outcome
+      const sanitizedFeature: Partial<Feature> = {
+        ...feature,
+        title: outcome.sanitizedTitle,
+        description: outcome.sanitizedDescription,
+        source,
+        trustTier,
+        quarantineStatus: outcome.entry.result,
+        quarantineId: outcome.entry.id,
+      };
+
+      const created = await featureLoader.create(projectPath, sanitizedFeature);
 
       // Emit feature_created event for hooks
       if (events) {


### PR DESCRIPTION
## Summary
- Gate all feature creation through QuarantineService before saving
- Determine auth source from request context (API key → api, session → ui, MCP header → mcp)
- Assign trust tier via TrustTierService, bypass quarantine for tier >= 3
- Save sanitized title/description to features instead of raw input
- Return HTTP 422 with quarantine details when validation fails
- Set feature.source, feature.trustTier, feature.quarantineStatus on all new features

## Test plan
- [ ] Feature creation via UI (session auth) bypasses quarantine (tier 3)
- [ ] Feature creation via API key goes through full quarantine pipeline
- [ ] Quarantine failure returns 422 with violation details
- [ ] Sanitized content used for feature title/description
- [ ] Build passes: `npm run build:server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)