### PR TITLE
feat: add quarantine API routes and MCP tools

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -201,6 +201,7 @@ import { LinearIntakeBridge } from './services/linear-intake-bridge.js';
 import { createDeployRoutes } from './routes/deploy/index.js';
 import { createIntegrityRoutes } from './routes/integrity.js';
 import { createAnalyticsRoutes } from './routes/analytics.js';
+import { createQuarantineRoutes } from './routes/quarantine.js';
 import { createAlertsRoutes } from './routes/alerts/index.js';
 import { createEngineRoutes } from './routes/engine/index.js';
 import { EventStreamBuffer } from './lib/event-stream-buffer.js';
@@ -1508,6 +1509,7 @@ app.use('/api/deploy', createDeployRoutes(autoModeService));
 app.use('/api/integrity', createIntegrityRoutes(integrityWatchdogService));
 app.use('/api/escalation', createEscalationRoutes(escalationRouter));
 app.use('/api/analytics', createAnalyticsRoutes());
+app.use('/api/quarantine', createQuarantineRoutes());
 
 // Lead Engineer routes (production-phase nerve center)
 const { createLeadEngineerRoutes } = await import('./routes/lead-engineer/index.js');

--- a/apps/server/src/routes/quarantine.ts
+++ b/apps/server/src/routes/quarantine.ts
@@ -1,0 +1,350 @@
+/**
+ * Quarantine API Routes
+ *
+ * Exposes quarantine management through REST API:
+ * - POST /api/quarantine/list - List all quarantine entries (with optional filtering)
+ * - POST /api/quarantine/get - Get single entry by id
+ * - POST /api/quarantine/approve - Approve a pending entry
+ * - POST /api/quarantine/reject - Reject with reason
+ * - POST /api/quarantine/trust-tiers/list - List all TrustTierRecords
+ * - POST /api/quarantine/trust-tiers/set - Grant/upgrade tier
+ * - POST /api/quarantine/trust-tiers/revoke - Revoke tier
+ *
+ * All routes require valid auth (handled by global authMiddleware).
+ */
+
+import { Router } from 'express';
+import { createLogger } from '@protolabs-ai/utils';
+import { QuarantineService } from '../services/quarantine-service.js';
+import { TrustTierService } from '../services/trust-tier-service.js';
+import type { QuarantineResult, TrustTier } from '@protolabs-ai/types';
+import { secureFs } from '@protolabs-ai/platform';
+import path from 'path';
+
+const logger = createLogger('QuarantineRoutes');
+const DATA_DIR = process.env.DATA_DIR || './data';
+
+export function createQuarantineRoutes(): Router {
+  const router = Router();
+
+  /**
+   * POST /api/quarantine/list
+   * List all quarantine entries (filter by result: pending/passed/failed/bypassed)
+   */
+  router.post('/list', async (req, res) => {
+    try {
+      const { projectPath, result } = req.body as {
+        projectPath: string;
+        result?: QuarantineResult;
+      };
+
+      if (!projectPath) {
+        res.status(400).json({ error: 'projectPath is required' });
+        return;
+      }
+
+      const trustTierService = new TrustTierService(DATA_DIR);
+      const quarantineService = new QuarantineService(trustTierService, projectPath);
+
+      // Read all quarantine entries
+      const quarantineDir = path.join(projectPath, '.automaker', 'quarantine');
+      let files: string[];
+      try {
+        files = (await secureFs.readdir(quarantineDir)) as string[];
+      } catch (error) {
+        // If directory doesn't exist, return empty array
+        res.json({
+          success: true,
+          projectPath,
+          result: result || 'all',
+          count: 0,
+          entries: [],
+        });
+        return;
+      }
+
+      const entries = [];
+      for (const file of files) {
+        if (!file.endsWith('.json')) continue;
+
+        const entryId = file.replace('.json', '');
+        const entry = await quarantineService.getEntry(entryId);
+
+        if (entry) {
+          // Filter by result if specified
+          if (!result || entry.result === result) {
+            entries.push(entry);
+          }
+        }
+      }
+
+      // Sort by submittedAt (newest first)
+      entries.sort((a, b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime());
+
+      res.json({
+        success: true,
+        projectPath,
+        result: result || 'all',
+        count: entries.length,
+        entries,
+      });
+    } catch (error) {
+      logger.error('Failed to list quarantine entries:', error);
+      res.status(500).json({
+        error: 'Failed to list quarantine entries',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  /**
+   * POST /api/quarantine/get
+   * Get single quarantine entry by id
+   */
+  router.post('/get', async (req, res) => {
+    try {
+      const { projectPath, quarantineId } = req.body as {
+        projectPath: string;
+        quarantineId: string;
+      };
+
+      if (!projectPath) {
+        res.status(400).json({ error: 'projectPath is required' });
+        return;
+      }
+
+      if (!quarantineId) {
+        res.status(400).json({ error: 'quarantineId is required' });
+        return;
+      }
+
+      const trustTierService = new TrustTierService(DATA_DIR);
+      const quarantineService = new QuarantineService(trustTierService, projectPath);
+
+      const entry = await quarantineService.getEntry(quarantineId);
+
+      if (!entry) {
+        res.status(404).json({
+          error: 'Quarantine entry not found',
+          quarantineId,
+        });
+        return;
+      }
+
+      res.json({
+        success: true,
+        entry,
+      });
+    } catch (error) {
+      logger.error('Failed to get quarantine entry:', error);
+      res.status(500).json({
+        error: 'Failed to get quarantine entry',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  /**
+   * POST /api/quarantine/approve
+   * Approve a pending entry (creates feature from sanitized input)
+   */
+  router.post('/approve', async (req, res) => {
+    try {
+      const { projectPath, quarantineId, reviewedBy } = req.body as {
+        projectPath: string;
+        quarantineId: string;
+        reviewedBy: string;
+      };
+
+      if (!projectPath) {
+        res.status(400).json({ error: 'projectPath is required' });
+        return;
+      }
+
+      if (!quarantineId) {
+        res.status(400).json({ error: 'quarantineId is required' });
+        return;
+      }
+
+      if (!reviewedBy) {
+        res.status(400).json({ error: 'reviewedBy is required' });
+        return;
+      }
+
+      const trustTierService = new TrustTierService(DATA_DIR);
+      const quarantineService = new QuarantineService(trustTierService, projectPath);
+
+      const entry = await quarantineService.approve(quarantineId, reviewedBy);
+
+      res.json({
+        success: true,
+        entry,
+        message: `Quarantine entry ${quarantineId} approved by ${reviewedBy}`,
+      });
+    } catch (error) {
+      logger.error('Failed to approve quarantine entry:', error);
+      res.status(500).json({
+        error: 'Failed to approve quarantine entry',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  /**
+   * POST /api/quarantine/reject
+   * Reject with reason
+   */
+  router.post('/reject', async (req, res) => {
+    try {
+      const { projectPath, quarantineId, reviewedBy, reason } = req.body as {
+        projectPath: string;
+        quarantineId: string;
+        reviewedBy: string;
+        reason: string;
+      };
+
+      if (!projectPath) {
+        res.status(400).json({ error: 'projectPath is required' });
+        return;
+      }
+
+      if (!quarantineId) {
+        res.status(400).json({ error: 'quarantineId is required' });
+        return;
+      }
+
+      if (!reviewedBy) {
+        res.status(400).json({ error: 'reviewedBy is required' });
+        return;
+      }
+
+      if (!reason) {
+        res.status(400).json({ error: 'reason is required' });
+        return;
+      }
+
+      const trustTierService = new TrustTierService(DATA_DIR);
+      const quarantineService = new QuarantineService(trustTierService, projectPath);
+
+      const entry = await quarantineService.reject(quarantineId, reviewedBy, reason);
+
+      res.json({
+        success: true,
+        entry,
+        message: `Quarantine entry ${quarantineId} rejected by ${reviewedBy}`,
+      });
+    } catch (error) {
+      logger.error('Failed to reject quarantine entry:', error);
+      res.status(500).json({
+        error: 'Failed to reject quarantine entry',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  /**
+   * POST /api/quarantine/trust-tiers/list
+   * List all TrustTierRecords
+   */
+  router.post('/trust-tiers/list', async (req, res) => {
+    try {
+      const trustTierService = new TrustTierService(DATA_DIR);
+      const records = await trustTierService.getAll();
+
+      res.json({
+        success: true,
+        count: records.length,
+        records,
+      });
+    } catch (error) {
+      logger.error('Failed to list trust tiers:', error);
+      res.status(500).json({
+        error: 'Failed to list trust tiers',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  /**
+   * POST /api/quarantine/trust-tiers/set
+   * Grant/upgrade tier
+   */
+  router.post('/trust-tiers/set', async (req, res) => {
+    try {
+      const { githubUsername, tier, grantedBy, reason } = req.body as {
+        githubUsername: string;
+        tier: TrustTier;
+        grantedBy: string;
+        reason?: string;
+      };
+
+      if (!githubUsername) {
+        res.status(400).json({ error: 'githubUsername is required' });
+        return;
+      }
+
+      if (tier === undefined || tier === null) {
+        res.status(400).json({ error: 'tier is required' });
+        return;
+      }
+
+      if (typeof tier !== 'number' || tier < 0 || tier > 4) {
+        res.status(400).json({ error: 'tier must be a number between 0 and 4' });
+        return;
+      }
+
+      if (!grantedBy) {
+        res.status(400).json({ error: 'grantedBy is required' });
+        return;
+      }
+
+      const trustTierService = new TrustTierService(DATA_DIR);
+      const record = await trustTierService.setTier(githubUsername, tier, grantedBy, reason);
+
+      res.json({
+        success: true,
+        record,
+        message: `Trust tier ${tier} granted to ${githubUsername} by ${grantedBy}`,
+      });
+    } catch (error) {
+      logger.error('Failed to set trust tier:', error);
+      res.status(500).json({
+        error: 'Failed to set trust tier',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  /**
+   * POST /api/quarantine/trust-tiers/revoke
+   * Revoke tier
+   */
+  router.post('/trust-tiers/revoke', async (req, res) => {
+    try {
+      const { githubUsername } = req.body as {
+        githubUsername: string;
+      };
+
+      if (!githubUsername) {
+        res.status(400).json({ error: 'githubUsername is required' });
+        return;
+      }
+
+      const trustTierService = new TrustTierService(DATA_DIR);
+      await trustTierService.revokeTier(githubUsername);
+
+      res.json({
+        success: true,
+        message: `Trust tier revoked for ${githubUsername}`,
+      });
+    } catch (error) {
+      logger.error('Failed to revoke trust tier:', error);
+      res.status(500).json({
+        error: 'Failed to revoke trust tier',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  return router;
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -175,6 +175,7 @@ import { setupTools } from './tools/setup-tools.js';
 import { utilityTools } from './tools/utility-tools.js';
 import { schedulerTools } from './tools/scheduler-tools.js';
 import { calendarTools } from './tools/calendar-tools.js';
+import { quarantineTools } from './tools/quarantine-tools.js';
 
 // Aggregate all tools
 const tools: Tool[] = [
@@ -193,6 +194,7 @@ const tools: Tool[] = [
   ...utilityTools,
   ...schedulerTools,
   ...calendarTools,
+  ...quarantineTools,
 ];
 
 // Tool implementations
@@ -1598,6 +1600,52 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
 
       return { success: true, ...results };
     }
+
+    // Quarantine Management
+    case 'list_quarantine_entries':
+      return apiCall('/quarantine/list', {
+        projectPath: args.projectPath,
+        result: args.result,
+      });
+
+    case 'approve_quarantine_entry':
+      return apiCall('/quarantine/approve', {
+        projectPath: args.projectPath,
+        quarantineId: args.quarantineId,
+        reviewedBy: args.reviewedBy,
+      });
+
+    case 'reject_quarantine_entry':
+      return apiCall('/quarantine/reject', {
+        projectPath: args.projectPath,
+        quarantineId: args.quarantineId,
+        reviewedBy: args.reviewedBy,
+        reason: args.reason,
+      });
+
+    case 'get_trust_tier': {
+      const tierResult = (await apiCall('/quarantine/trust-tiers/list', {})) as {
+        success?: boolean;
+        records?: Array<{ githubUsername: string; tier: number }>;
+      };
+      if (tierResult.success && tierResult.records) {
+        const record = tierResult.records.find((r) => r.githubUsername === args.githubUsername);
+        return {
+          success: true,
+          githubUsername: args.githubUsername,
+          tier: record ? record.tier : 0,
+        };
+      }
+      return { success: false, error: 'Failed to get trust tier' };
+    }
+
+    case 'set_trust_tier':
+      return apiCall('/quarantine/trust-tiers/set', {
+        githubUsername: args.githubUsername,
+        tier: args.tier,
+        grantedBy: args.grantedBy,
+        reason: args.reason,
+      });
 
     default:
       throw new Error(`Unknown tool: ${name}`);

--- a/packages/mcp-server/src/tools/quarantine-tools.ts
+++ b/packages/mcp-server/src/tools/quarantine-tools.ts
@@ -1,0 +1,131 @@
+/**
+ * Quarantine Management Tools
+ *
+ * Tools for managing quarantine entries and trust tiers:
+ * - list_quarantine_entries: List quarantine entries (with optional filtering)
+ * - approve_quarantine_entry: Approve a pending entry
+ * - reject_quarantine_entry: Reject with reason
+ * - get_trust_tier: Get trust tier for a GitHub username
+ * - set_trust_tier: Grant/upgrade tier
+ */
+
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+export const quarantineTools: Tool[] = [
+  {
+    name: 'list_quarantine_entries',
+    description:
+      'List all quarantine entries in a project. Can filter by result (pending, passed, failed, bypassed). Returns entries with violation details, trust tier, and sanitization information.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        result: {
+          type: 'string',
+          enum: ['pending', 'passed', 'failed', 'bypassed'],
+          description:
+            'Filter by result (optional). "pending" means entries that failed validation and are awaiting manual review.',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+  {
+    name: 'approve_quarantine_entry',
+    description:
+      'Approve a quarantine entry after manual review. This marks the entry as passed and allows the feature to be created from the sanitized input.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        quarantineId: {
+          type: 'string',
+          description: 'The quarantine entry ID (UUID)',
+        },
+        reviewedBy: {
+          type: 'string',
+          description: 'Username of the reviewer approving this entry',
+        },
+      },
+      required: ['projectPath', 'quarantineId', 'reviewedBy'],
+    },
+  },
+  {
+    name: 'reject_quarantine_entry',
+    description:
+      'Reject a quarantine entry after manual review. This marks the entry as failed with a rejection reason.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        quarantineId: {
+          type: 'string',
+          description: 'The quarantine entry ID (UUID)',
+        },
+        reviewedBy: {
+          type: 'string',
+          description: 'Username of the reviewer rejecting this entry',
+        },
+        reason: {
+          type: 'string',
+          description: 'Reason for rejection (e.g., "Contains malicious content")',
+        },
+      },
+      required: ['projectPath', 'quarantineId', 'reviewedBy', 'reason'],
+    },
+  },
+  {
+    name: 'get_trust_tier',
+    description:
+      'Get the trust tier for a GitHub username. Returns tier level (0-4) where 0=anonymous, 1=github_user, 2=contributor, 3=maintainer, 4=system.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        githubUsername: {
+          type: 'string',
+          description: 'GitHub username to query',
+        },
+      },
+      required: ['githubUsername'],
+    },
+  },
+  {
+    name: 'set_trust_tier',
+    description:
+      'Grant or upgrade a trust tier for a GitHub username. Trust tiers: 0=anonymous, 1=github_user, 2=contributor, 3=maintainer, 4=system. Higher tiers bypass more validation stages.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        githubUsername: {
+          type: 'string',
+          description: 'GitHub username to grant tier to',
+        },
+        tier: {
+          type: 'number',
+          enum: [0, 1, 2, 3, 4],
+          description:
+            'Trust tier level: 0=anonymous, 1=github_user, 2=contributor, 3=maintainer, 4=system',
+        },
+        grantedBy: {
+          type: 'string',
+          description: 'Username of the person granting this tier',
+        },
+        reason: {
+          type: 'string',
+          description:
+            'Optional reason for granting this tier (e.g., "Consistent high-quality contributions")',
+        },
+      },
+      required: ['githubUsername', 'tier', 'grantedBy'],
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- Add REST API routes at `/api/quarantine/` for quarantine entry management (list, get, approve, reject) and trust tier management (list, set, revoke)
- Add 5 MCP tools: `list_quarantine_entries`, `approve_quarantine_entry`, `reject_quarantine_entry`, `get_trust_tier`, `set_trust_tier`
- Register routes in server index.ts with TrustTierService instantiation

## Files Changed
- `apps/server/src/routes/quarantine.ts` — New: 7 REST endpoints
- `apps/server/src/index.ts` — Route registration
- `packages/mcp-server/src/tools/quarantine-tools.ts` — New: 5 MCP tool definitions
- `packages/mcp-server/src/index.ts` — MCP tool handler routing

## Test plan
- [ ] POST /api/quarantine/list returns entries filtered by result
- [ ] POST /api/quarantine/approve marks entry passed
- [ ] POST /api/quarantine/reject adds rejection violation
- [ ] Trust tier CRUD routes work correctly
- [ ] MCP tools route to correct API endpoints
- [ ] TypeScript build passes

Closes #M3P3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Quarantine feature for comprehensive entry management, including review, approval, and rejection workflows
  * Reviewer tracking and audit information for all quarantine operations
  * Trust tier system (levels 0-4) for managing user authorization and access control
  * Extended functionality integrated with development tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->