### PR TITLE
feat: add human-blocked dependency types and resolver

### DIFF
--- a/apps/server/src/services/escalation-channels/github-issue-channel.ts
+++ b/apps/server/src/services/escalation-channels/github-issue-channel.ts
@@ -59,6 +59,7 @@ function sourceToLabel(source: EscalationSource): string {
     board_anomaly: 'source:board-anomaly',
     human_mention: 'source:human-mention',
     agent_needs_input: 'source:agent-needs-input',
+    human_blocked_dependency: 'source:human-blocked-dependency',
   };
   return labelMap[source];
 }

--- a/libs/dependency-resolver/src/index.ts
+++ b/libs/dependency-resolver/src/index.ts
@@ -9,6 +9,7 @@ export {
   getBlockingDependencies,
   createFeatureMap,
   getBlockingDependenciesFromMap,
+  getBlockingInfo,
   wouldCreateCircularDependency,
   dependencyExists,
   getAncestors,
@@ -16,4 +17,5 @@ export {
   type DependencyResolutionResult,
   type DependencySatisfactionOptions,
   type AncestorContext,
+  type BlockingInfo,
 } from './resolver.js';

--- a/libs/dependency-resolver/src/resolver.ts
+++ b/libs/dependency-resolver/src/resolver.ts
@@ -308,6 +308,76 @@ export function getBlockingDependenciesFromMap(
 }
 
 /**
+ * Result type for getBlockingInfo function.
+ * Provides detailed information about why a feature is blocked.
+ */
+export interface BlockingInfo {
+  /** True if the feature is blocked by unsatisfied dependencies */
+  isBlocked: boolean;
+  /** Array of feature IDs that are blocking this feature and are assigned to humans */
+  humanBlockers: string[];
+  /** Array of feature IDs that are blocking this feature and are NOT assigned to humans */
+  agentBlockers: string[];
+}
+
+/**
+ * Gets detailed blocking information for a feature, identifying whether
+ * blocking dependencies are assigned to humans or agents.
+ *
+ * A dependency is considered "assigned to a human" if:
+ * - assignee field is set AND assignee !== 'agent'
+ *
+ * @param feature - Feature to check
+ * @param allFeatures - All features in the project
+ * @returns BlockingInfo with categorized blockers
+ */
+export function getBlockingInfo(feature: Feature, allFeatures: Feature[]): BlockingInfo {
+  if (!feature.dependencies || feature.dependencies.length === 0) {
+    return { isBlocked: false, humanBlockers: [], agentBlockers: [] };
+  }
+
+  const humanBlockers: string[] = [];
+  const agentBlockers: string[] = [];
+
+  for (const depId of feature.dependencies) {
+    const dep = allFeatures.find((f) => f.id === depId);
+    if (!dep) {
+      continue; // Missing dependency is not blocking (not found in feature list)
+    }
+
+    // Check if dependency is incomplete (blocking)
+    let isBlocking = false;
+
+    // Foundation deps require 'done' (merged) — 'review' is NOT sufficient
+    if (dep.isFoundation) {
+      isBlocking = dep.status !== 'done' && dep.status !== 'completed' && dep.status !== 'verified';
+    } else {
+      isBlocking = dep.status !== 'completed' && dep.status !== 'verified' && dep.status !== 'done';
+    }
+
+    if (isBlocking) {
+      // Categorize blocker: human-assigned vs agent-assigned
+      // A feature is human-assigned if assignee is set and NOT 'agent'
+      const isHumanAssigned = dep.assignee !== undefined && dep.assignee !== 'agent';
+
+      if (isHumanAssigned) {
+        humanBlockers.push(depId);
+      } else {
+        agentBlockers.push(depId);
+      }
+    }
+  }
+
+  const isBlocked = humanBlockers.length > 0 || agentBlockers.length > 0;
+
+  return {
+    isBlocked,
+    humanBlockers,
+    agentBlockers,
+  };
+}
+
+/**
  * Checks if adding a dependency from sourceId to targetId would create a circular dependency.
  * When we say "targetId depends on sourceId", we add sourceId to targetId.dependencies.
  * A cycle would occur if sourceId already depends on targetId (directly or transitively).

--- a/libs/types/src/escalation.ts
+++ b/libs/types/src/escalation.ts
@@ -43,6 +43,8 @@ export enum EscalationSource {
   human_mention = 'human_mention',
   /** Agent needs human input (elicitation) */
   agent_needs_input = 'agent_needs_input',
+  /** Feature blocked by dependency assigned to human */
+  human_blocked_dependency = 'human_blocked_dependency',
 }
 
 /**

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -141,6 +141,16 @@ export interface Feature {
   priority?: 0 | 1 | 2 | 3 | 4;
   status?: FeatureStatus | string; // Allow string for extensibility
   dependencies?: string[];
+  /**
+   * Reason why this feature is blocked by dependencies.
+   * Populated by dependency resolver when getBlockingInfo detects unsatisfied dependencies.
+   */
+  blockingReason?: string;
+  /**
+   * True if this feature is blocked by a dependency assigned to a human.
+   * Set by dependency resolver when human-assigned blockers are detected.
+   */
+  blockedByHuman?: boolean;
   spec?: string;
   model?: string;
   imagePaths?: Array<string | FeatureImagePath | { path: string; [key: string]: unknown }>;


### PR DESCRIPTION
## Summary
- Add `human_blocked_dependency` to `EscalationSource` enum
- Add optional `blockingReason` and `blockedByHuman` fields to `Feature` type
- Add `getBlockingInfo()` function to dependency resolver that categorizes blocking dependencies as human-assigned vs agent-assigned
- Export new `BlockingInfo` type from dependency-resolver package

## Test plan
- [ ] Verify `npm run build:packages` passes
- [ ] Verify `getBlockingInfo()` correctly identifies human vs agent blockers
- [ ] Verify `areDependenciesSatisfied()` behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detailed blocking info for features, separating human-assigned vs agent-assigned blockers.
  * New escalation source for features blocked by human-assigned dependencies.
  * Feature metadata now includes blocking reason and a human-blocker flag.
  * Blocking information is exposed for use across the system, and issue-label mapping updated to reflect the new escalation source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->