### PR TITLE
fix: pass githubIssueNumber to features from GitHub issue webhooks

### DIFF
--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -284,6 +284,10 @@ export class SignalIntakeService {
         ...(signal.source === 'linear' && signal.channelContext?.issueId
           ? { linearIssueId: signal.channelContext.issueId as string }
           : {}),
+        // Store GitHub issue number for auto-close on PR merge
+        ...(signal.source === 'github' && signal.channelContext?.issueNumber
+          ? { githubIssueNumber: signal.channelContext.issueNumber as number }
+          : {}),
       });
 
       // Trigger PM Agent pipeline


### PR DESCRIPTION
## Summary

- Fixes the missing link in the GitHub issue → feature → PR → auto-close pipeline
- `SignalIntakeService` now sets `githubIssueNumber` on features created from GitHub issue webhooks
- `GitWorkflowService.buildPRBody()` already includes `Closes #X` when this field is present

The PR body builder worked correctly, but the field was never populated upstream. This one-line addition closes the loop so merged PRs auto-close their originating GitHub issues.

## Test plan

- [ ] Verify `SignalIntakeService` creates features with `githubIssueNumber` when signal source is `github`
- [ ] Verify PRs created for those features include `Closes #X` in the body
- [ ] Server type-checks: `npx tsc --project apps/server/tsconfig.json --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)