### PR TITLE
feat: surface git workflow errors on feature data

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -2229,6 +2229,13 @@ export class AutoModeService {
         } catch (gitError) {
           logger.warn(`Git workflow failed for ${featureId}:`, gitError);
           // Don't fail the feature - git workflow is best-effort
+          // Store the error on the feature for UI visibility
+          await this.featureLoader.update(projectPath, featureId, {
+            gitWorkflowError: {
+              message: gitError instanceof Error ? gitError.message : String(gitError),
+              timestamp: new Date().toISOString(),
+            },
+          });
         }
       }
 
@@ -3142,6 +3149,13 @@ Complete the pipeline step instructions above. Review the previous work and appl
             message: `⚠️ Git workflow failed: ${error instanceof Error ? error.message : String(error)}`,
             projectPath,
           });
+          // Store the error on the feature for UI visibility
+          await this.featureLoader.update(projectPath, featureId, {
+            gitWorkflowError: {
+              message: error instanceof Error ? error.message : String(error),
+              timestamp: new Date().toISOString(),
+            },
+          });
         }
       }
 
@@ -3402,6 +3416,13 @@ Complete the pipeline step instructions above. Review the previous work and appl
           }
         } catch (gitError) {
           logger.warn(`Git workflow failed for ${featureId}:`, gitError);
+          // Store the error on the feature for UI visibility
+          await this.featureLoader.update(projectPath, featureId, {
+            gitWorkflowError: {
+              message: gitError instanceof Error ? gitError.message : String(gitError),
+              timestamp: new Date().toISOString(),
+            },
+          });
         }
       }
 
@@ -3838,6 +3859,13 @@ Address the follow-up instructions above. Review the previous work and make the 
           }
         } catch (gitError) {
           logger.warn(`Git workflow failed for ${featureId}:`, gitError);
+          // Store the error on the feature for UI visibility
+          await this.featureLoader.update(projectPath, featureId, {
+            gitWorkflowError: {
+              message: gitError instanceof Error ? gitError.message : String(gitError),
+              timestamp: new Date().toISOString(),
+            },
+          });
         }
       }
 

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -426,6 +426,16 @@ export interface Feature {
    */
   lastTraceId?: string;
 
+  /**
+   * Git workflow error details when git operations (commit, push, PR) fail.
+   * The feature status remains unchanged (e.g., verified), but this field
+   * surfaces the failure in the UI for visibility and debugging.
+   */
+  gitWorkflowError?: {
+    message: string;
+    timestamp: string; // ISO 8601 timestamp when the error occurred
+  };
+
   // Hivemind fields
   /** Domain this feature belongs to (e.g. "frontend", "server") for mesh routing */
   domain?: string;


### PR DESCRIPTION
## Summary
- Adds `gitWorkflowError` field to the `Feature` type (`libs/types/src/feature.ts`) with `message` and `timestamp` properties
- Updates all 4 git workflow catch blocks in `auto-mode-service.ts` to persist error details to `feature.json` via `featureLoader.update()`
- Feature status remains unchanged (e.g., stays `verified`) — the error field provides visibility without disrupting the state machine

## Context
Part of the Git Workflow Reliability project (M3: Crash Recovery & Observability). Previously, git workflow failures (commit, push, PR creation) were silently logged but invisible in the UI. This change makes them available for display.

## Test plan
- [ ] `npm run build:packages` succeeds (types compile)
- [ ] `npm run build:server` succeeds
- [ ] `npm run test:server` passes
- [ ] Manually verify: when a git push fails, `feature.json` contains `gitWorkflowError` with message and timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Git workflow errors are now automatically persisted with error messages and timestamps, providing better visibility into issues for troubleshooting and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->