### PR TITLE
fix: make git workflow error persistence non-blocking

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -2237,13 +2237,15 @@ export class AutoModeService {
         } catch (gitError) {
           logger.warn(`Git workflow failed for ${featureId}:`, gitError);
           // Don't fail the feature - git workflow is best-effort
-          // Store the error on the feature for UI visibility
-          await this.featureLoader.update(projectPath, featureId, {
-            gitWorkflowError: {
-              message: gitError instanceof Error ? gitError.message : String(gitError),
-              timestamp: new Date().toISOString(),
-            },
-          });
+          // Store the error on the feature for UI visibility (non-blocking)
+          this.featureLoader
+            .update(projectPath, featureId, {
+              gitWorkflowError: {
+                message: gitError instanceof Error ? gitError.message : String(gitError),
+                timestamp: new Date().toISOString(),
+              },
+            })
+            .catch((e) => logger.warn(`Failed to persist git workflow error for ${featureId}:`, e));
         }
       }
 
@@ -3157,13 +3159,15 @@ Complete the pipeline step instructions above. Review the previous work and appl
             message: `⚠️ Git workflow failed: ${error instanceof Error ? error.message : String(error)}`,
             projectPath,
           });
-          // Store the error on the feature for UI visibility
-          await this.featureLoader.update(projectPath, featureId, {
-            gitWorkflowError: {
-              message: error instanceof Error ? error.message : String(error),
-              timestamp: new Date().toISOString(),
-            },
-          });
+          // Store the error on the feature for UI visibility (non-blocking)
+          this.featureLoader
+            .update(projectPath, featureId, {
+              gitWorkflowError: {
+                message: error instanceof Error ? error.message : String(error),
+                timestamp: new Date().toISOString(),
+              },
+            })
+            .catch((e) => logger.warn(`Failed to persist git workflow error for ${featureId}:`, e));
         }
       }
 
@@ -3424,13 +3428,15 @@ Complete the pipeline step instructions above. Review the previous work and appl
           }
         } catch (gitError) {
           logger.warn(`Git workflow failed for ${featureId}:`, gitError);
-          // Store the error on the feature for UI visibility
-          await this.featureLoader.update(projectPath, featureId, {
-            gitWorkflowError: {
-              message: gitError instanceof Error ? gitError.message : String(gitError),
-              timestamp: new Date().toISOString(),
-            },
-          });
+          // Store the error on the feature for UI visibility (non-blocking)
+          this.featureLoader
+            .update(projectPath, featureId, {
+              gitWorkflowError: {
+                message: gitError instanceof Error ? gitError.message : String(gitError),
+                timestamp: new Date().toISOString(),
+              },
+            })
+            .catch((e) => logger.warn(`Failed to persist git workflow error for ${featureId}:`, e));
         }
       }
 
@@ -3867,13 +3873,15 @@ Address the follow-up instructions above. Review the previous work and make the 
           }
         } catch (gitError) {
           logger.warn(`Git workflow failed for ${featureId}:`, gitError);
-          // Store the error on the feature for UI visibility
-          await this.featureLoader.update(projectPath, featureId, {
-            gitWorkflowError: {
-              message: gitError instanceof Error ? gitError.message : String(gitError),
-              timestamp: new Date().toISOString(),
-            },
-          });
+          // Store the error on the feature for UI visibility (non-blocking)
+          this.featureLoader
+            .update(projectPath, featureId, {
+              gitWorkflowError: {
+                message: gitError instanceof Error ? gitError.message : String(gitError),
+                timestamp: new Date().toISOString(),
+              },
+            })
+            .catch((e) => logger.warn(`Failed to persist git workflow error for ${featureId}:`, e));
         }
       }
 


### PR DESCRIPTION
## Summary
- Converts all 4 `gitWorkflowError` persistence calls in `auto-mode-service.ts` from blocking `await` to fire-and-forget with `.catch()` handler
- Prevents `featureLoader.update()` failures from escalating inside catch blocks that handle git workflow errors
- Follow-up fix for PR #1126 where the agent used blocking `await` inside catch blocks

## Test plan
- [ ] Verify build passes (`npm run build:server`)
- [ ] Verify git workflow errors are still logged when persistence fails
- [ ] Confirm no unhandled promise rejections in agent execution logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved application responsiveness during error conditions by making git workflow error updates non-blocking, ensuring uninterrupted system operation.
  * Enhanced error logging to better track when error persistence encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->