### PR TITLE
fix: OpenCode CLI stuck on 'not authenticated' — remove hardcoded auth gate

### DIFF
--- a/apps/server/src/providers/opencode-provider.ts
+++ b/apps/server/src/providers/opencode-provider.ts
@@ -37,9 +37,10 @@ const opencodeLogger = createLogger('OpencodeProvider');
 
 export interface OpenCodeAuthStatus {
   authenticated: boolean;
-  method: 'api_key' | 'oauth' | 'none';
+  method: 'api_key' | 'oauth' | 'env_api_key' | 'free_tier' | 'none';
   hasOAuthToken?: boolean;
   hasApiKey?: boolean;
+  hasEnvApiKey?: boolean;
 }
 
 // =============================================================================
@@ -1139,32 +1140,68 @@ export class OpencodeProvider extends CliProvider {
   // ==========================================================================
 
   /**
+   * Environment variables that indicate API key auth for OpenCode-compatible providers
+   */
+  private static readonly ENV_API_KEY_VARS = [
+    'OPENAI_API_KEY',
+    'ANTHROPIC_API_KEY',
+    'OPENCODE_API_KEY',
+    'GOOGLE_API_KEY',
+    'OPENROUTER_API_KEY',
+    'GROQ_API_KEY',
+    'MISTRAL_API_KEY',
+    'TOGETHER_API_KEY',
+    'FIREWORKS_API_KEY',
+    'DEEPSEEK_API_KEY',
+    'XAI_API_KEY',
+  ] as const;
+
+  /**
    * Check authentication status for OpenCode CLI
    *
-   * Checks for authentication via:
-   * - OAuth token in auth file
-   * - API key in auth file
+   * Checks for authentication via (in priority order):
+   * 1. OAuth token in auth file
+   * 2. API key in auth file
+   * 3. Environment variable API keys
+   *
+   * Note: Even without any auth, OpenCode provides free tier models.
+   * The `detectInstallation()` method handles that case by marking
+   * installed CLIs as authenticated with method 'free_tier'.
    */
   async checkAuth(): Promise<OpenCodeAuthStatus> {
     const authIndicators = await getOpenCodeAuthIndicators();
+    const hasEnvApiKey = OpencodeProvider.ENV_API_KEY_VARS.some((v) => !!process.env[v]?.trim());
 
-    // Check for OAuth token
+    // Check for OAuth token in auth file
     if (authIndicators.hasOAuthToken) {
       return {
         authenticated: true,
         method: 'oauth',
         hasOAuthToken: true,
         hasApiKey: authIndicators.hasApiKey,
+        hasEnvApiKey,
       };
     }
 
-    // Check for API key
+    // Check for API key in auth file
     if (authIndicators.hasApiKey) {
       return {
         authenticated: true,
         method: 'api_key',
         hasOAuthToken: false,
         hasApiKey: true,
+        hasEnvApiKey,
+      };
+    }
+
+    // Check for environment variable API keys
+    if (hasEnvApiKey) {
+      return {
+        authenticated: true,
+        method: 'env_api_key',
+        hasOAuthToken: false,
+        hasApiKey: false,
+        hasEnvApiKey: true,
       };
     }
 
@@ -1173,6 +1210,7 @@ export class OpencodeProvider extends CliProvider {
       method: 'none',
       hasOAuthToken: false,
       hasApiKey: false,
+      hasEnvApiKey: false,
     };
   }
 
@@ -1187,6 +1225,9 @@ export class OpencodeProvider extends CliProvider {
    * - Direct installation (npm global)
    * - NPX (fallback on Windows)
    * Also checks authentication status.
+   *
+   * If the CLI is installed, it's always considered authenticated at minimum
+   * because OpenCode provides free tier models without any auth.
    */
   async detectInstallation(): Promise<InstallationStatus> {
     this.ensureCliDetected();
@@ -1198,9 +1239,12 @@ export class OpencodeProvider extends CliProvider {
       installed,
       path: this.cliPath || undefined,
       method: this.detectedStrategy === 'npx' ? 'npm' : 'cli',
-      authenticated: auth.authenticated,
+      // If CLI is installed, it's at minimum authenticated for free tier models
+      authenticated: installed || auth.authenticated,
+      authMethod: installed && !auth.authenticated ? 'free_tier' : auth.method,
       hasApiKey: auth.hasApiKey,
       hasOAuthToken: auth.hasOAuthToken,
+      hasEnvApiKey: auth.hasEnvApiKey,
     };
   }
 }

--- a/apps/server/src/routes/setup/routes/opencode-status.ts
+++ b/apps/server/src/routes/setup/routes/opencode-status.ts
@@ -19,12 +19,6 @@ export function createOpencodeStatusHandler() {
       const provider = new OpencodeProvider();
       const status = await provider.detectInstallation();
 
-      // Derive auth method from authenticated status and API key presence
-      let authMethod = 'none';
-      if (status.authenticated) {
-        authMethod = status.hasApiKey ? 'api_key_env' : 'cli_authenticated';
-      }
-
       res.json({
         success: true,
         installed: status.installed,
@@ -32,9 +26,9 @@ export function createOpencodeStatusHandler() {
         path: status.path || null,
         auth: {
           authenticated: status.authenticated || false,
-          method: authMethod,
+          method: status.authMethod || 'none',
           hasApiKey: status.hasApiKey || false,
-          hasEnvApiKey: !!process.env.ANTHROPIC_API_KEY || !!process.env.OPENAI_API_KEY,
+          hasEnvApiKey: status.hasEnvApiKey || false,
           hasOAuthToken: status.hasOAuthToken || false,
         },
         recommendation: status.installed

--- a/apps/ui/src/components/views/settings-view/cli-status/opencode-cli-status.tsx
+++ b/apps/ui/src/components/views/settings-view/cli-status/opencode-cli-status.tsx
@@ -38,10 +38,12 @@ function getProviderDisplayName(provider: OpenCodeProviderInfo): string {
 }
 
 export type OpencodeAuthMethod =
-  | 'api_key_env' // ANTHROPIC_API_KEY or other provider env vars
-  | 'api_key' // Manually stored API key
+  | 'api_key_env' // Legacy: ANTHROPIC_API_KEY or other provider env vars
+  | 'env_api_key' // Environment variable API keys
+  | 'api_key' // API key in auth file
   | 'oauth' // OAuth authentication
   | 'config_file' // Config file with credentials
+  | 'free_tier' // CLI installed, free tier models available
   | 'none';
 
 export interface OpencodeAuthStatus {
@@ -58,11 +60,14 @@ function getAuthMethodLabel(method: OpencodeAuthMethod): string {
     case 'api_key':
       return 'API Key';
     case 'api_key_env':
+    case 'env_api_key':
       return 'API Key (Environment)';
     case 'oauth':
       return 'OAuth Authentication';
     case 'config_file':
       return 'Configuration File';
+    case 'free_tier':
+      return 'Free Tier';
     default:
       return method || 'Unknown';
   }

--- a/apps/ui/src/components/views/setup-view/steps/opencode-setup-step.tsx
+++ b/apps/ui/src/components/views/setup-view/steps/opencode-setup-step.tsx
@@ -150,16 +150,18 @@ export function OpencodeSetupStep({ onNext, onBack, onSkip }: OpencodeSetupStepP
   };
 
   const isReady = opencodeCliStatus?.installed && opencodeCliStatus?.auth?.authenticated;
+  const authMethod = opencodeCliStatus?.auth?.method;
+  const isFreeTierOnly = authMethod === 'free_tier';
 
   const getStatusBadge = () => {
     if (isChecking) {
       return <StatusBadge status="checking" label="Checking..." />;
     }
     if (opencodeCliStatus?.auth?.authenticated) {
-      return <StatusBadge status="authenticated" label="Ready" />;
+      return <StatusBadge status="authenticated" label={isFreeTierOnly ? 'Free Tier' : 'Ready'} />;
     }
     if (opencodeCliStatus?.installed) {
-      return <StatusBadge status="unverified" label="Not Logged In" />;
+      return <StatusBadge status="authenticated" label="Free Tier" />;
     }
     return <StatusBadge status="not_installed" label="Not Installed" />;
   };
@@ -211,7 +213,9 @@ export function OpencodeSetupStep({ onNext, onBack, onSkip }: OpencodeSetupStepP
           <CardDescription>
             {opencodeCliStatus?.installed
               ? opencodeCliStatus.auth?.authenticated
-                ? `Authenticated via ${opencodeCliStatus.auth.method === 'api_key' ? 'API Key' : 'Browser Login'}${opencodeCliStatus.version ? ` (v${opencodeCliStatus.version})` : ''}`
+                ? authMethod === 'free_tier'
+                  ? `Free tier models available${opencodeCliStatus.version ? ` (v${opencodeCliStatus.version})` : ''}`
+                  : `Authenticated via ${authMethod === 'api_key' ? 'API Key' : authMethod === 'env_api_key' ? 'Environment Variable' : 'Browser Login'}${opencodeCliStatus.version ? ` (v${opencodeCliStatus.version})` : ''}`
                 : 'Installed but not authenticated'
               : 'Not installed on your system'}
           </CardDescription>
@@ -219,17 +223,44 @@ export function OpencodeSetupStep({ onNext, onBack, onSkip }: OpencodeSetupStepP
         <CardContent className="space-y-4">
           {/* Success State */}
           {isReady && (
-            <div className="flex items-center gap-3 p-4 rounded-lg bg-green-500/10 border border-green-500/20">
-              <CheckCircle2 className="w-5 h-5 text-green-500" />
-              <div>
-                <p className="font-medium text-foreground">OpenCode CLI is ready!</p>
-                <p className="text-sm text-muted-foreground">
-                  You can use OpenCode models for AI tasks.
-                  {opencodeCliStatus?.version && (
-                    <span className="ml-1">Version: {opencodeCliStatus.version}</span>
-                  )}
-                </p>
+            <div className="space-y-3">
+              <div className="flex items-center gap-3 p-4 rounded-lg bg-green-500/10 border border-green-500/20">
+                <CheckCircle2 className="w-5 h-5 text-green-500" />
+                <div>
+                  <p className="font-medium text-foreground">
+                    {isFreeTierOnly ? 'Free Tier Ready' : 'OpenCode CLI is ready!'}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {isFreeTierOnly
+                      ? 'Free models available. Log in to unlock additional providers.'
+                      : 'You can use OpenCode models for AI tasks.'}
+                    {opencodeCliStatus?.version && (
+                      <span className="ml-1">Version: {opencodeCliStatus.version}</span>
+                    )}
+                  </p>
+                </div>
               </div>
+              {isFreeTierOnly && (
+                <div className="space-y-3 p-4 rounded-lg bg-muted/30 border border-border">
+                  <p className="text-sm text-muted-foreground">
+                    Optional: Log in for access to premium models from connected providers:
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <code className="flex-1 bg-muted px-3 py-2 rounded text-sm font-mono text-foreground">
+                      {opencodeCliStatus?.loginCommand || 'opencode auth login'}
+                    </code>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() =>
+                        copyCommand(opencodeCliStatus?.loginCommand || 'opencode auth login')
+                      }
+                    >
+                      <Copy className="w-4 h-4" />
+                    </Button>
+                  </div>
+                </div>
+              )}
             </div>
           )}
 

--- a/apps/ui/src/components/views/setup-view/steps/providers-setup-step.tsx
+++ b/apps/ui/src/components/views/setup-view/steps/providers-setup-step.tsx
@@ -1070,6 +1070,25 @@ function OpencodeContent() {
   };
 
   const isReady = opencodeCliStatus?.installed && opencodeCliStatus?.auth?.authenticated;
+  const authMethod = opencodeCliStatus?.auth?.method;
+  const isFreeTierOnly = authMethod === 'free_tier';
+
+  const getAuthDescription = () => {
+    if (!opencodeCliStatus?.installed) return 'Not installed on your system';
+    if (!opencodeCliStatus?.auth?.authenticated) return 'Installed but not authenticated';
+    switch (authMethod) {
+      case 'oauth':
+        return `Authenticated via login${opencodeCliStatus.version ? ` (v${opencodeCliStatus.version})` : ''}`;
+      case 'api_key':
+        return `Authenticated via API key${opencodeCliStatus.version ? ` (v${opencodeCliStatus.version})` : ''}`;
+      case 'env_api_key':
+        return `Authenticated via environment variable${opencodeCliStatus.version ? ` (v${opencodeCliStatus.version})` : ''}`;
+      case 'free_tier':
+        return `Free tier models available${opencodeCliStatus.version ? ` (v${opencodeCliStatus.version})` : ''}`;
+      default:
+        return `Ready${opencodeCliStatus.version ? ` (v${opencodeCliStatus.version})` : ''}`;
+    }
+  };
 
   return (
     <Card className="bg-card border-border">
@@ -1083,13 +1102,7 @@ function OpencodeContent() {
             {isChecking ? <Spinner size="sm" /> : <RefreshCw className="w-4 h-4" />}
           </Button>
         </div>
-        <CardDescription>
-          {opencodeCliStatus?.installed
-            ? opencodeCliStatus.auth?.authenticated
-              ? `Authenticated${opencodeCliStatus.version ? ` (v${opencodeCliStatus.version})` : ''}`
-              : 'Installed but not authenticated'
-            : 'Not installed on your system'}
-        </CardDescription>
+        <CardDescription>{getAuthDescription()}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         {isReady && (
@@ -1105,7 +1118,20 @@ function OpencodeContent() {
             </div>
             <div className="flex items-center gap-3 p-4 rounded-lg bg-green-500/10 border border-green-500/20">
               <CheckCircle2 className="w-5 h-5 text-green-500" />
-              <p className="font-medium text-foreground">Authenticated</p>
+              <div>
+                <p className="font-medium text-foreground">
+                  {isFreeTierOnly ? 'Free Tier Ready' : 'Authenticated'}
+                </p>
+                {isFreeTierOnly && (
+                  <p className="text-sm text-muted-foreground">
+                    Free models available. Run{' '}
+                    <code className="text-xs bg-muted px-1 py-0.5 rounded">
+                      opencode auth login
+                    </code>{' '}
+                    to unlock additional providers.
+                  </p>
+                )}
+              </div>
             </div>
           </div>
         )}
@@ -1141,61 +1167,6 @@ function OpencodeContent() {
                   <Copy className="w-4 h-4" />
                 </Button>
               </div>
-            </div>
-          </div>
-        )}
-
-        {opencodeCliStatus?.installed && !opencodeCliStatus?.auth?.authenticated && !isChecking && (
-          <div className="space-y-4">
-            {/* Show CLI installed toast */}
-            <div className="flex items-center gap-3 p-4 rounded-lg bg-green-500/10 border border-green-500/20">
-              <CheckCircle2 className="w-5 h-5 text-green-500" />
-              <div>
-                <p className="font-medium text-foreground">CLI Installed</p>
-                <p className="text-sm text-muted-foreground">
-                  {opencodeCliStatus?.version && `Version: ${opencodeCliStatus.version}`}
-                </p>
-              </div>
-            </div>
-
-            <div className="flex items-start gap-3 p-4 rounded-lg bg-amber-500/10 border border-amber-500/20">
-              <AlertTriangle className="w-5 h-5 text-amber-500 shrink-0 mt-0.5" />
-              <div className="flex-1">
-                <p className="font-medium text-foreground">OpenCode CLI not authenticated</p>
-                <p className="text-sm text-muted-foreground mt-1">
-                  Run the login command to authenticate.
-                </p>
-              </div>
-            </div>
-            <div className="space-y-3 p-4 rounded-lg bg-muted/30 border border-border">
-              <div className="flex items-center gap-2">
-                <code className="flex-1 bg-muted px-3 py-2 rounded text-sm font-mono text-foreground">
-                  {opencodeCliStatus?.loginCommand || 'opencode auth login'}
-                </code>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() =>
-                    copyCommand(opencodeCliStatus?.loginCommand || 'opencode auth login')
-                  }
-                >
-                  <Copy className="w-4 h-4" />
-                </Button>
-              </div>
-              <Button
-                onClick={handleLogin}
-                disabled={isLoggingIn}
-                className="w-full bg-brand-500 hover:bg-brand-600 text-white"
-              >
-                {isLoggingIn ? (
-                  <>
-                    <Spinner size="sm" className="mr-2" />
-                    Waiting for login...
-                  </>
-                ) : (
-                  'Copy Command & Wait for Login'
-                )}
-              </Button>
             </div>
           </div>
         )}

--- a/libs/platform/src/system-paths.ts
+++ b/libs/platform/src/system-paths.ts
@@ -1223,6 +1223,16 @@ const OPENCODE_PROVIDERS = [
   'amazon-bedrock',
   'github-copilot',
   'copilot',
+  'openrouter',
+  'ollama',
+  'lmstudio',
+  'xai',
+  'deepseek',
+  'azure',
+  'groq',
+  'mistral',
+  'together',
+  'fireworks',
 ] as const;
 
 function getOpenCodeNestedTokens(record: Record<string, unknown>): Record<string, unknown> | null {

--- a/libs/types/src/provider.ts
+++ b/libs/types/src/provider.ts
@@ -284,7 +284,17 @@ export interface InstallationStatus {
   method?: 'cli' | 'wsl' | 'npm' | 'brew' | 'sdk';
   hasApiKey?: boolean;
   hasOAuthToken?: boolean;
+  hasEnvApiKey?: boolean;
   authenticated?: boolean;
+  /**
+   * How the user is authenticated:
+   * - oauth: OpenCode OAuth login
+   * - api_key: API key in auth file
+   * - env_api_key: API key from environment variable
+   * - free_tier: CLI installed, free tier models available (no auth needed)
+   * - none: Not authenticated
+   */
+  authMethod?: 'oauth' | 'api_key' | 'env_api_key' | 'free_tier' | 'none';
   error?: string;
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `checkAuth()` only read `~/.local/share/opencode/auth.json` against 7 hardcoded providers. Users with env vars, local models, or fresh CLI installs got stuck on "not authenticated"
- **Fix**: Installed CLI = authenticated (free tier). OpenCode provides 5 free models without any auth. Login is now optional for unlocking premium providers.
- Expanded `OPENCODE_PROVIDERS` from 7 to 17 entries (added ollama, lmstudio, openrouter, xai, deepseek, azure, groq, mistral, together, fireworks)
- `checkAuth()` now detects 11 environment variable API keys as valid auth
- UI shows "Free Tier Ready" instead of blocking "not authenticated" warning

## Test plan

- [x] 105 OpenCode provider unit tests pass
- [x] Server type-checks clean
- [x] Packages build clean
- [ ] Manual: Install OpenCode CLI without running `opencode auth login` — should show "Free Tier Ready"
- [ ] Manual: Set `OPENAI_API_KEY` env var — should show "Authenticated via Environment Variable"
- [ ] Manual: Run `opencode auth login` — should show "Authenticated via Browser Login"

🤖 Generated with [Claude Code](https://claude.com/claude-code)