### PR TITLE
feat: require a reason when blocking features

### DIFF
--- a/.automaker/context/event-type-registration.md
+++ b/.automaker/context/event-type-registration.md
@@ -1,0 +1,41 @@
+# EventType Registration (REQUIRED)
+
+## The Rule
+
+Every event string emitted via `createEventEmitter()` MUST be registered in the `EventType` union in `libs/types/src/event.ts`.
+
+If you add a new event (e.g., `ceremony:my-thing:complete`), you MUST add it to the `EventType` union. The build will fail with a TypeScript error if you don't.
+
+## How It Works
+
+`libs/types/src/event.ts` defines a discriminated string union:
+
+```typescript
+export type EventType =
+  | 'feature:created'
+  | 'feature:updated'
+  | 'ceremony:fired'
+  | 'ceremony:post-project-docs'
+  | 'ceremony:post-project-docs:complete'
+  | 'ceremony:post-project-docs:failed'
+  // ... etc
+```
+
+The `EventCallback` type enforces that all emitted events match this union. If your code emits an event string not in this union, `tsc` will reject it at compile time.
+
+## What To Do
+
+1. Open `libs/types/src/event.ts`
+2. Find the `EventType` union (it's a large `|`-separated string literal type)
+3. Add your new event string(s) to the union
+4. Run `npm run build:packages` to verify it compiles
+
+## Common Mistake
+
+Adding event emissions in a service file but forgetting to register the event name in `EventType`. This passes linting but fails the build.
+
+## Naming Convention
+
+Events follow a colon-separated namespace pattern:
+- `{domain}:{action}` — e.g., `feature:created`, `agent:started`
+- `{domain}:{sub}:{action}` — e.g., `ceremony:post-project-docs:complete`

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,9 +5,9 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 157
-  referenced: 73
-  successfulFeatures: 73
+  loaded: 162
+  referenced: 74
+  successfulFeatures: 74
 ---
 # api
 
@@ -647,6 +647,7 @@ usageStats:
 - **Root cause:** Linear labels are team-scoped resources. The API doesn't support name-based label lookups - you must know the ID beforehand or query the labels list.
 - **How to avoid:** Simplified to text-based label hints in issue description. Trade structured label filtering/querying capability for reduced API calls and complexity. Production may need to query labels upfront and cache.
 
+<<<<<<< Updated upstream
 ### Used two-tier severity classification ('warn' vs 'block') for violations instead of numeric scores (0-10) or detailed enum with many levels. (2026-02-25)
 - **Context:** Defining violation severity to help callers decide whether to reject or log
 - **Why:** Binary severity simplifies decision-making: 'block' violations should always be rejected (safety boundary), 'warn' violations are suspicious but might be legitimate (audit trail). More granular scoring (numeric 0-10) doesn't add value—callers still need a cutoff threshold and reasoning becomes arbitrary.
@@ -679,3 +680,38 @@ usageStats:
 - **Rejected:** Full user object: overkill, harder to serialize. JWT/session claim: requires auth system (out of scope). localStorage only: loses cloud sync.
 - **Trade-offs:** String is lightweight but doesn't scale if features need user ID, email, permissions. Filter logic must handle case sensitivity and exact matches.
 - **Breaking if changed:** If later needing user ID or other fields, must migrate stored string to object structure. Existing string identities need schema upgrade.
+=======
+### Changed PenThemeProvider API from `themes={...} variables={...}` pattern to `document={document}` signature (2026-02-25)
+- **Context:** Updating designs canvas theming infrastructure during brand compliance audit
+- **Why:** Simpler, more focused API surface with explicit document binding; cleaner separation between theme data and application context; reduces prop drilling complexity
+- **Rejected:** Maintaining backwards-compatible props with deprecation warnings; keeping themes/variables structure
+- **Trade-offs:** Easier to use and understand API vs. immediate breaking change for existing consumers; reduced flexibility (must pass document) vs. decoupled design
+- **Breaking if changed:** All existing code using PenThemeProvider with themes/variables props fails immediately; requires coordinated update across codebase
+
+### Changed function signature from `ensureCleanWorktree(workDir, featureId): void` to `ensureCleanWorktree(workDir, featureId, branchName): WorktreeGuardResult` with structured return type (2026-02-25)
+- **Context:** Callers need visibility into what cleanup actions were actually taken (did it commit? did it push?) but void return provides no feedback
+- **Why:** Structured return enables callers to understand operation state without re-querying git. Also documents contract: this function performs cleanup and reports results
+- **Rejected:** Keep void return and have callers check git state afterward (duplicates git queries). Or add separate status methods (more API surface).
+- **Trade-offs:** Observability gained: callers know exactly what happened. API burden gained: all call sites must change to pass branchName parameter.
+- **Breaking if changed:** Any code calling the old void signature will have type errors. The return value is now required information that some callers may not handle
+
+#### [Pattern] Used `setImmediate()` to defer scan execution after HTTP response completion (2026-02-25)
+- **Problem solved:** Scan must run after resume-interrupted endpoint responds, to avoid delaying client response
+- **Why this works:** Ensures non-blocking: HTTP response sends first, then background scan runs. Prevents timeout perception.
+- **Trade-offs:** Slightly more complex control flow vs. guaranteed fast responses. Scan runs asynchronously without visibility to caller.
+
+### Made gitWorkflowError field optional in Feature type rather than required-with-null default (2026-02-25)
+- **Context:** Need backward compatibility with existing features that don't have git workflow errors
+- **Why:** Optional field means existing feature.json files are valid without modification; only features that experience git errors need the field populated. Cleaner for data model - field only exists when relevant.
+- **Rejected:** Required field with null default - would force all serialized features to include the field even when empty, polluting JSON
+- **Trade-offs:** Two-state representation (field absent vs present with error) vs single-state (field always present, null when no error); requires null/undefined checks but lighter JSON
+- **Breaking if changed:** Type definitions without gitWorkflowError in older feature.json files are still valid; but code that does `if (feature.gitWorkflowError.message)` without existence check will error
+>>>>>>> Stashed changes
+
+
+### Extended DragData interface to support both 'component' and 'node' drag types, allowing single DND provider to handle both component instantiation and node reordering (2026-02-25)
+- **Context:** DndProvider collision detection + handleDragEnd event handling unified for two distinct operations
+- **Why:** Eliminates need for separate drag systems; reuses existing @dnd-kit infrastructure and DndProvider context
+- **Rejected:** Create separate DND contexts/handlers for component instantiation vs node reordering
+- **Trade-offs:** Simpler infrastructure but more complex handleDragEnd logic with type-based operation branching
+- **Breaking if changed:** If drag type discrimination fails (e.g., drag data not properly set), wrong operation executes silently—needs strict validation at drag start

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,9 +5,9 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 42
-  referenced: 25
-  successfulFeatures: 25
+  loaded: 43
+  referenced: 26
+  successfulFeatures: 26
 ---
 # architecture
 
@@ -3396,6 +3396,7 @@ usageStats:
 - **Why this works:** Core functionality (bug tracking) should not depend on secondary notification channel. Prevents cascading failures where one missing integration blocks the entire pipeline.
 - **Trade-offs:** Issues get created even if Discord is down (good). Operator might miss notifications but issue is still tracked (acceptable). Code must handle missing Discord gracefully with proper null checks.
 
+<<<<<<< Updated upstream
 #### [Pattern] Defensive quality gates prevent low-quality output generation by refusing to create content.md when antagonistic review scores fall below threshold (75%), rather than generating and filtering afterward. (2026-02-25)
 - **Problem solved:** Content pipeline completes end-to-end but produces zero output files because research scores consistently fail at ~10%. This appears to be a failure but is actually the quality gate system working as designed.
 - **Why this works:** Prevents propagation of low-quality content downstream. A refused generation is better than silently releasing substandard content. The architectural choice is: fail-safe (don't generate) not fail-open (generate and flag).
@@ -3518,3 +3519,200 @@ usageStats:
 - **Situation:** QuarantineEntry has optional stage and violations fields. create.ts needs to return these in HTTP 422 body. Compiler doesn't enforce non-null guarantee.
 - **Root cause:** QuarantineEntry type allows stage/violations to be undefined (accommodates different use cases). HTTP 422 response shape expects these fields. Gap between type definition and API contract.
 - **How to avoid:** Explicit casting documents that HTTP endpoint guarantees these fields (unlike internal service). Adds type safety at call site. Cost: boilerplate cast code.
+=======
+#### [Pattern] Epic branch targeting in PR generation: When feature belongs to epic, PR targets epic's branch instead of main branch (2026-02-25)
+- **Problem solved:** Feature completion workflow must handle multi-level hierarchy (features within epics)
+- **Why this works:** Preserves epic-based development isolation. PRs from features must merge to epic branches first, not directly to main, maintaining feature tree integrity
+- **Trade-offs:** Adds complexity of branch lookup, but enables structured feature hierarchies and prevents improper merges
+
+### Git workflow post-completion is non-blocking - failures emit warning events instead of failing feature completion (2026-02-25)
+- **Context:** Pipeline-step-removed path needed git workflow but couldn't block feature completion on git errors
+- **Why:** Separates concerns: feature completion is local/deterministic, git operations are external/unreliable. Feature is logically complete even if push/PR fails
+- **Rejected:** Blocking git failures would cascade upstream and fail the entire feature completion on network/auth issues
+- **Trade-offs:** Users see features marked complete without successful PR - requires event monitoring. But prevents deadlocks from git infrastructure issues
+- **Breaking if changed:** Making git workflow blocking would cause feature completions to fail on transient git/network errors, blocking pipelines
+
+### Conditional git workflow invocation gated by settingsService availability (2026-02-25)
+- **Context:** Git automation should be optional - not all environments/configurations want automatic commits/PRs
+- **Why:** Enables feature flags and configuration-driven behavior. Users can disable git automation entirely
+- **Rejected:** Unconditional invocation would force git workflow on all systems, breaking environments with different policies
+- **Trade-offs:** Code complexity increases with guards, but provides flexibility for different deployment contexts
+- **Breaking if changed:** Removing settingsService check would make git automation mandatory, breaking configurations that need it disabled
+
+### DndContext must wrap entire view at top level, creating global drag state container for all draggable/droppable descendants (2026-02-25)
+- **Context:** Implementing @dnd-kit drag-drop system with multiple draggable components and drop targets scattered across view hierarchy
+- **Why:** DndContext maintains singleton drag state (active drag, overlay position, etc). All useDraggable/useDroppable hooks must be descendants to access context. Local scopes would create isolated, non-communicating systems
+- **Rejected:** Wrapping individual component groups or drop zones locally - this breaks the global coordination needed for DragOverlay to know which item is being dragged and where
+- **Trade-offs:** Simpler: single context for whole feature. Harder: any state that needs drag awareness (disabled buttons, conditional renders) must use context from top-level view, creating dependency chain
+- **Breaking if changed:** Moving DndContext wrapper lower in tree breaks drag-overlay rendering and cross-component drag coordination; removing it makes hooks unusable
+
+#### [Pattern] Recursive helper function (addChildToNode) for tree mutation rather than direct array manipulation or lens-based updates (2026-02-25)
+- **Problem solved:** Drop handler needs to insert new ref node into nested frame's children array within immutable state structure
+- **Why this works:** PEN document is deeply nested tree (frame -> children -> nodes). Direct mutation violates Zustand immutability. Lenses are overkill for codebase not using functional updates. Recursive helper provides readable, maintainable traversal that returns new tree structure
+- **Trade-offs:** Gained: immutable updates, reusable helper for other mutations. Lost: brevity, performance cost of tree copy
+
+### Single updateDocument function with flags (isDirty, addToHistory) instead of separate functions for each mutation type (2026-02-25)
+- **Context:** Drop operation needs to simultaneously: update tree, mark document dirty, add to undo history
+- **Why:** These three concerns are logically coupled - you never want tree update without marking dirty, never want to skip history. Single function enforces invariant that mutations are always recorded. Multiple functions create risk of callers forgetting history or dirty flag
+- **Rejected:** Separate updateDocumentAndMarkDirty, updateDocumentWithHistory, etc. - spreads responsibility and creates combinatorial explosion of variants; Always auto-marking dirty - loses flexibility for internal batch operations
+- **Trade-offs:** Gained: invariant enforcement, single point of control. Lost: granular control for advanced scenarios (batch updates), slightly larger function signature
+- **Breaking if changed:** If caller marks dirty separately, concurrent updates could create inconsistent state. If store action doesn't call updateDocument, UI won't reflect changes
+
+### Per-frame drop zones rather than single canvas-level zone, tightly coupling drop target to frame's layout context (2026-02-25)
+- **Context:** User drops component onto canvas; system must insert ref node into correct frame's children array with correct layout constraints
+- **Why:** Each frame is independent layout container with own coordinate system and constraints. Dropping at canvas level would require separate frame-selection step or ambiguous frame detection. Per-frame zones make target unambiguous and allow frame-specific drop validation (e.g., reject layouts that can't accept children)
+- **Rejected:** Single canvas drop zone with frame detection: requires hit-testing or additional interaction; Frame selector then drop: adds friction to workflow; Global zones: loses frame-specific constraints and validation
+- **Trade-offs:** Gained: explicit frame context, frame-specific validation, no ambiguity. Lost: complexity of distributing drop zones, harder to implement canvas-level drag operations later
+- **Breaking if changed:** Centralizing to canvas-level zone loses frame context and requires redesign of drop handler to discover target frame
+
+#### [Pattern] Cohesive store actions that bundle tree mutation with side effects (dirty flag, history) rather than separating concerns (2026-02-25)
+- **Problem solved:** createRefNode action both modifies tree structure and manages document metadata (isDirty, history)
+- **Why this works:** Adding node to tree and marking dirty are logically inseparable operations in this domain. Separating them into different actions creates risk of inconsistent state. Actions should reflect domain semantics (create-ref-node-in-context), not technical layers
+- **Trade-offs:** Gained: semantic coherence, invariant enforcement, atomic updates. Lost: granular reusability (can't reuse tree mutation in isolation), larger action scope
+
+### Ref nodes (type: 'ref') with refId pointing to source component rather than duplicating component definition (2026-02-25)
+- **Context:** Drop operation creates new instance on canvas; system must decide between copying source component or creating reference
+- **Why:** References maintain link to source - changes to component definition could affect instances (or explicitly not, via overrides). Duplicates lose this connection and create maintenance burden. Ref pattern allows instance-specific overrides while inheriting base
+- **Rejected:** Full duplication: breaks future updates to source component, loses variant tracking; Immutable reference: prevents instance customization like property overrides
+- **Trade-offs:** Gained: maintainability, source-instance relationship, override capability. Lost: independence of instances, harder to track component usage across document
+- **Breaking if changed:** Changing to duplication strategy loses ability to update instances when source changes; changing to immutable refs removes override capability
+
+### Applied semantic tokens to native `<select>` elements instead of replacing with shadcn Select component (2026-02-25)
+- **Context:** Needed to upgrade form elements to be theme-compliant while standardizing on UI atoms
+- **Why:** shadcn Select is a complex controlled component requiring extensive state management refactoring; semantic token styling (border-border, bg-card) achieves the core goal of removing hardcoded colors with minimal risk. Selective refactoring reduces surface area of breaking changes.
+- **Rejected:** Full component library migration - replace all select with shadcn Select component for consistency
+- **Trade-offs:** Faster implementation and lower risk vs. incomplete design system adoption; if Select component needs variant system or controlled behavior, partial migration may require rework
+- **Breaking if changed:** If design tokens are not properly defined or if future Select component adoption requires different prop interfaces, this mixed approach may create migration debt
+
+#### [Pattern] Risk-mitigated partial UI atom migration strategy - complete refactoring for simple components (Button, Input, Textarea, Slider) while deferring complex ones (Select) (2026-02-25)
+- **Problem solved:** Balancing design system standardization against implementation risk in a large feature
+- **Why this works:** Simple replacements (button→Button, input→Input) have clear 1:1 mapping with minimal prop restructuring; complex components (Select) introduce state management overhead and higher regression risk; incremental approach allows learning and iteration
+- **Trade-offs:** Incremental progress with validated patterns vs. mixed component types in codebase; reduces blast radius of issues vs. delayed full standardization; allows parallel fix of blocking issues
+
+### Push failures are logged as errors but are non-blocking - verification proceeds even if remote sync fails (2026-02-25)
+- **Context:** ensureCleanWorktree now pushes commits to remote, but network/permission failures can occur during push operation
+- **Why:** Prevents temporary remote issues from blocking the entire pipeline. Local work is committed (persistent), so remote sync failure is a separate concern that should be visible but non-fatal
+- **Rejected:** Could throw on push failure (strict guarantees) or silently ignore (no visibility). Both miss the mark for resilience.
+- **Trade-offs:** Resilience gained: push failures don't block verification. Guarantee lost: pushing is not enforced, only attempted.
+- **Breaking if changed:** If changed to throw on push failure, it would block verification pipelines during remote connectivity issues, breaking CI/CD flow
+
+#### [Pattern] Separated detection of two distinct concerns: uncommitted changes vs unpushed commits. Each has its own detection, commit operation, and push operation. (2026-02-25)
+- **Problem solved:** Previously only handled uncommitted changes. New requirement is to ensure both local changes are committed AND commits are pushed to remote
+- **Why this works:** Two different states require different remediation (git add + commit vs git push). Separating them provides clear logic flow and allows returning visibility into each operation independently
+- **Trade-offs:** Clarity gained: each operation is explicit. Complexity gained: two separate operations instead of one.
+
+#### [Gotcha] Git add pattern must exactly match across services: `git add -A -- ':!.automaker/' '.automaker/memory/'` to exclude .automaker except its memory subdirectory (2026-02-25)
+- **Situation:** The pattern in auto-mode-service and git-workflow-service diverged initially. Using `git add -A` alone breaks the exclusion contract
+- **Root cause:** Different services handle worktree preparation and cleanup, but must maintain consistent git state. The .automaker directory needs selective exclusion to maintain the automation system's state isolation
+- **How to avoid:** Consistency gained: same exclusion logic everywhere. Complexity gained: pattern is non-obvious and must be maintained in multiple places.
+
+#### [Pattern] Fallback strategy for optional context: branchName parameter defaults to 'main' at call sites when the actual branch name is unavailable (2026-02-25)
+- **Problem solved:** Multiple call sites have different branch name availability (some have feature.branchName, others have local variable). Function requires branchName to push to correct remote branch
+- **Why this works:** Allows the function to work with incomplete information from callers. Falls back to safe default 'main' rather than failing or requiring all paths to have branch name available
+- **Trade-offs:** Robustness gained: works with partial information. Correctness risk gained: 'main' fallback may not be right branch in all cases.
+
+### Placed retry logic at operation level (push, PR creation) rather than wrapping individual git commands (2026-02-25)
+- **Context:** Multiple git operations need resilience to network/API failures, but retry placement could be granular (per-command) or coarse (per-operation)
+- **Why:** Operation-level placement provides better error context, cleaner control flow, and allows distinguishing between transient operation failures vs terminal git command failures
+- **Rejected:** Command-level wrapping would require retry at multiple git invocation points; harder to correlate retry attempts with user-facing operations
+- **Trade-offs:** Simpler to understand and maintain, but misses granular failures within a single operation; all-or-nothing retry per operation
+- **Breaking if changed:** If debugging required operation sub-steps to retry independently, this coarser approach prevents that
+
+### Selected specific operations for retry wrapping (push + PR creation) rather than comprehensive retry coverage (2026-02-25)
+- **Context:** Many git-related operations could theoretically fail; must prioritize which ones warrant automatic retry vs error escalation
+- **Why:** Push and PR creation are the highest-risk, highest-impact operations most prone to transient GitHub API/network failures; other operations like commits/checkouts are local and rarely fail transiently
+- **Rejected:** Wrapping all operations adds complexity and retry delays where unnecessary; only push would miss PR failures; no retry at all leaves users without resilience
+- **Trade-offs:** Focused approach keeps code simple but doesn't protect against transient failures in clone/checkout/merge operations; assumes git local operations are sufficiently reliable
+- **Breaking if changed:** If new remote operations (fetch, pull) are added to workflow without retry, they'll fail without the same protection; developers must remember to wrap new remote ops
+
+### Reused existing `runPostCompletionWorkflow()` function for recovery instead of implementing separate commit/push/PR logic (2026-02-25)
+- **Context:** Needed to auto-commit, push, and create PRs for recovered worktrees
+- **Why:** Centralizes post-completion logic in one place; ensures recovery follows the same workflow as manual completion
+- **Rejected:** Reimplementing commit, push, and PR creation directly in scan function
+- **Trade-offs:** Simpler code vs. tighter coupling to a complex workflow function. If workflow changes, recovery behavior changes automatically.
+- **Breaking if changed:** If runPostCompletionWorkflow() behavior changes, crash recovery behavior changes with it. No separate control.
+
+#### [Pattern] Selective recovery targeting only `verified` and `done` feature statuses, logging warnings for others (2026-02-25)
+- **Problem solved:** Crash recovery should only auto-push features that are truly complete, not in-progress work
+- **Why this works:** Respects feature lifecycle: only recovered features that passed review/verification gates. Prevents pushing incomplete work.
+- **Trade-offs:** More complex state checking vs. safer recovery. In-progress features stay local (user can push manually).
+
+### Passed EventEmitter as optional parameter through route creation chain rather than accessing from global context (2026-02-25)
+- **Context:** Scan needs to emit observability events but handler doesn't naturally have access to events emitter
+- **Why:** Explicit dependency injection makes code testable and decouples from globals; optional parameter allows graceful degradation if not provided
+- **Rejected:** Global variable access or importing events emitter directly into route module
+- **Trade-offs:** More boilerplate in route wiring vs. clearer dependency graph and easier testing
+- **Breaking if changed:** If dependency injection removed and global used instead, testing becomes harder and circular dependency risk increases.
+
+#### [Pattern] Used git `--porcelain` flags for consistent, parseable output instead of human-readable format (2026-02-25)
+- **Problem solved:** Parsing git output reliably for automation (worktree listing, status checking)
+- **Why this works:** Porcelain format is version-stable and designed for automation; human-readable output can change between git versions
+- **Trade-offs:** More robust output parsing vs. slightly harder to debug manually (raw output less obvious)
+
+### Added separate gitWorkflowError field to Feature type instead of modifying feature.status enum to include error states (2026-02-25)
+- **Context:** Needed to surface git workflow failures without conflating execution status with git operation status
+- **Why:** Maintains separation of concerns - feature execution lifecycle (created, in_progress, completed, etc.) is independent from git operation success. This prevents status explosion and allows features to have clean status while still tracking git failures.
+- **Rejected:** Adding new status values like 'git_error' or 'git_failed' - would couple git concerns to core feature lifecycle and require UI changes to handle mixed success/failure states
+- **Trade-offs:** Cleaner concerns but consumers must check two fields when determining overall feature health; enables more expressive state (feature can be 'completed' with a 'gitWorkflowError' simultaneously)
+- **Breaking if changed:** Monitoring/querying logic that assumes feature.status is the only failure indicator must be updated to check gitWorkflowError; dashboards need to be aware of the separate field
+>>>>>>> Stashed changes
+
+
+#### [Gotcha] Frames with layout: 'none' (absolute-positioned children) must be excluded from SortableContext wrapping, otherwise drag behavior becomes incorrect for absolute positioning (2026-02-25)
+- **Situation:** Conditional wrapping only when frame.layout !== 'none' in sortable-node.tsx
+- **Root cause:** SortableContext with layout strategies (vertical/horizontal) assumes flow layout. Absolute-positioned frames need free drag, not constrained sorting
+- **How to avoid:** Extra conditional check but ensures correct behavior for mixed layout types
+
+#### [Gotcha] Node structure lacks parent references, forcing O(n) recursive tree traversal to find parent frames during drag-drop detection (2026-02-25)
+- **Situation:** designs-view.tsx handleDragEnd requires recursive findParentFrame() to distinguish same-frame reordering from cross-frame moves
+- **Root cause:** Current node model is tree-structured but only maintains child relationships, not bidirectional parent-child links
+- **How to avoid:** Simpler node model but linear performance cost per drag operation; acceptable for current hierarchy depth but could degrade
+
+#### [Pattern] All DOM changes mediated through Zustand store actions (reorderChildren, moveNode) with addToHistory flag, guaranteeing undo/redo support without special history handling (2026-02-25)
+- **Problem solved:** designs-view.tsx handleDragEnd calls store actions rather than direct DOM manipulation
+- **Why this works:** Single source of truth prevents state drift between visual representation and document model; history flag leverages existing updateDocument history management
+- **Trade-offs:** Requires store action for each operation type but eliminates need for custom undo/redo logic
+
+### Auto-recovery uses GitHub API's native `reRunWorkflowFailedJobs` endpoint instead of manual cancel+retry or pushing commits (2026-02-25)
+- **Context:** Implementing auto-recovery for stuck workflow runs. Multiple approaches possible: push empty commit to trigger rebuild, manually cancel and call rerun API, or use GitHub's built-in rerun endpoint.
+- **Why:** Native API method is cleanest because it's atomic, doesn't pollute git history, and leverages GitHub's intended recovery mechanism. Avoids side effects of commit history manipulation.
+- **Rejected:** Pushing empty commits (creates noise in git history), manual cancel+separate rerun call (more complex state management, higher failure risk)
+- **Trade-offs:** Relies on GitHub API availability and rate limits. Simpler code, cleaner semantics, but dependency on external API.
+- **Breaking if changed:** If GitHub API rerun endpoint changes or is rate-limited differently, recovery behavior degrades. No fallback to alternative recovery methods.
+
+#### [Pattern] Conditional feature registration: maintenance task only registers scheduler if GitHub credentials exist in environment (GITHUB_TOKEN, GITHUB_REPO_OWNER, GITHUB_REPO_NAME) (2026-02-25)
+- **Problem solved:** Runner health checking requires GitHub API access. In some deployments (local dev, non-GitHub setups), these credentials won't exist.
+- **Why this works:** Graceful degradation allows monolithic application to work in multiple environments without runtime errors. Missing credentials don't crash the server.
+- **Trade-offs:** Adds initialization logic to check credentials before registration, but enables flexible deployments. Feature silently unavailable rather than erroring.
+
+#### [Pattern] Maintenance task emits typed events (maintenance:runner-health, cancel-stuck-run, congestion-alert, health-check, check-failed) rather than direct logging or UI updates (2026-02-25)
+- **Problem solved:** Multiple systems need awareness of runner health: UI dashboard, alert escalation to Discord/Linear, audit logging, metrics collection.
+- **Why this works:** Event-driven decouples maintenance logic from downstream concerns. Scheduler doesn't know or care about escalation/UI routing. Events are consumed by separate systems.
+- **Trade-offs:** Requires event infrastructure and subscription handlers, but enables flexible routing and better separation of concerns. Easier to add new consumer (e.g., metrics export) without modifying scheduler.
+
+#### [Gotcha] Social media crawlers cannot resolve relative URLs in OG meta tags. They operate from external context and require absolute, public-facing URLs (https://protolabs.studio/images/og-main.png not /images/og-main.png). Using relative paths fails silently—preview just doesn't show the image. (2026-02-25)
+- **Situation:** Implementation uses absolute URLs in both og:image and twitter:image tags. This is critical for social platforms (Twitter, LinkedIn, Facebook, Slack) to fetch and display preview images.
+- **Root cause:** Web crawlers for social platforms operate outside your website's context, so relative path resolution fails. Only absolute public URLs work across all platforms.
+- **How to avoid:** Slightly longer meta tag strings but guaranteed compatibility across all social platforms
+
+#### [Pattern] Generation scripts for version-controlled assets must be idempotent—producing bit-identical output every run. This was verified with 'git diff site/images/' showing zero changes after regeneration. (2026-02-25)
+- **Problem solved:** The generate-og-images.mjs script can be re-run safely without creating spurious git diffs. This is essential for asset maintenance workflows (e.g., 'regenerate images after rebranding').
+- **Why this works:** Git workflows require deterministic builds. Non-idempotent scripts create unwanted diffs on every run, breaking version control hygiene and making regeneration risky. Idempotent scripts integrate cleanly with deployment pipelines.
+- **Trade-offs:** Requires careful implementation (controlled fonts, fixed seed values, no timestamp metadata) but enables safe, repeatable asset generation
+
+#### [Gotcha] Different social platforms parse different OG meta tags. Facebook/LinkedIn use og:image + og:image:width/height. Twitter requires explicit twitter:image tag. LinkedIn may parse additional tags. Missing platform-specific tags causes preview to fail on that platform. (2026-02-25)
+- **Situation:** Implementation includes explicit og:image, og:image:width, og:image:height, AND twitter:image tags. Tests verify each tag's presence separately. Failure on one platform is invisible until you test that platform.
+- **Root cause:** Social platforms developed OG support independently and didn't fully standardize. Twitter added custom twitter: namespace. LinkedIn has its own preferences. Covering all variants ensures cross-platform reliability.
+- **How to avoid:** More meta tags in HTML but reliable preview appearance across all major platforms
+
+#### [Gotcha] OG image dimensions must be exactly 1200x630px (verified with Sharp metadata validation). This is the standard across Facebook, LinkedIn, Twitter specs. Incorrect dimensions cause squishing, cropping, or layout shift in social preview UI. (2026-02-25)
+- **Situation:** Implementation explicitly validates with Sharp: 'All images are 1200x630px PNG format (verified with Sharp)'. Any deviation breaks cross-platform compatibility.
+- **Root cause:** Social platforms expect this aspect ratio (1.904:1) which balances portrait/landscape display modes. Deviations trigger platform-specific layout algorithms that distort the image.
+- **How to avoid:** No flexibility on dimensions but follows established platform standards and ensures consistent appearance
+
+### Use programmatic Sharp-based generation instead of storing static pre-rendered images. Script regenerates all 5 OG images deterministically from a single source template. (2026-02-25)
+- **Context:** Implementation includes generate-og-images.mjs script that creates all images. Re-running produces identical output (verified with git diff). Follows pattern from existing apps/ui/scripts/generate-icons.mjs.
+- **Why:** Programmatic generation is reproducible and version-controllable. When branding changes, update the script template and regenerate—single source of truth. Follows proven pattern from icon generation system.
+- **Rejected:** Static images committed to repo (hard to maintain across versions), Figma export workflow (adds tool dependency), manual image creation (error-prone)
+- **Trade-offs:** Requires Node.js build environment but gains maintainability, consistency across multiple images, and version control integration
+- **Breaking if changed:** If Sharp or Node.js image libraries are removed, script breaks. But source code stays in git, making recovery straightforward. Static image approach hides dependencies.

--- a/.automaker/memory/database.md
+++ b/.automaker/memory/database.md
@@ -126,6 +126,7 @@ usageStats:
 - **Trade-offs:** Better query performance and simpler deployment vs limited horizontal scalability; schema version is immutable once data is written
 - **Breaking if changed:** Schema version must match across all Loki instances; changing schema requires data migration or reindexing
 
+<<<<<<< Updated upstream
 #### [Pattern] TrustTierService uses AtomicWriter (not direct fs.writeFile) for persisting trust-tiers.json. Data updates are atomic — partial writes cannot corrupt the file. Aligns with SettingsService and AnalyticsService pattern for security-critical persistent state. (2026-02-25)
 - **Problem solved:** Trust tier records are security-sensitive. Corruption or partial updates could grant unintended access. File-based storage chosen for simplicity and auditability.
 - **Why this works:** Atomic writes guarantee that trust state is always consistent. A crash or process kill during write cannot leave the file in a partially-updated state. Essential for security-related data where any corruption is a security breach.
@@ -135,3 +136,11 @@ usageStats:
 - **Problem solved:** Adding quarantine metadata to existing features requires migration or graceful degradation. No migration job was written.
 - **Why this works:** Implicit bypass via absence is safe default (old features continue working). Avoids complex migration logic. Clear data semantics: missing field means 'pre-quarantine era'.
 - **Trade-offs:** Simpler deployment (no migration) vs audit ambiguity (can't distinguish 'bypassed' from 'never validated'). Acceptable because quarantine is a new security feature, not a fix for existing data.
+=======
+### Persisted git workflow errors directly to feature.json via featureLoader.update() rather than separate error tracking/logging system (2026-02-25)
+- **Context:** Need to store git errors so they survive server restarts and are accessible to all clients querying feature state
+- **Why:** Colocates error data with feature data - single source of truth, no distributed state, errors immediately visible in feature snapshots, follows existing update patterns
+- **Rejected:** Separate error log file, database error table, or in-memory error registry - would require coordination with feature state and add potential sync issues
+- **Trade-offs:** feature.json includes error metadata (slightly larger JSON); error state travels with feature across systems; simplified debugging but feature.json schema now has optional error fields
+- **Breaking if changed:** Code that assumes feature.json only contains production-happy paths; serialization/deserialization must handle optional gitWorkflowError; migrations needed if schema versioning was strict
+>>>>>>> Stashed changes

--- a/.automaker/memory/documentation.md
+++ b/.automaker/memory/documentation.md
@@ -5,9 +5,15 @@ relevantTo: [documentation]
 importance: 0.7
 relatedFiles: []
 usageStats:
+<<<<<<< Updated upstream
   loaded: 65
   referenced: 35
   successfulFeatures: 35
+=======
+  loaded: 52
+  referenced: 32
+  successfulFeatures: 32
+>>>>>>> Stashed changes
 ---
 # documentation
 

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 452
-  referenced: 227
-  successfulFeatures: 227
+  loaded: 463
+  referenced: 230
+  successfulFeatures: 230
 ---
 # gotchas
 
@@ -383,6 +383,7 @@ usageStats:
 - **Root cause:** Prometheus ecosystem standardizes on seconds for duration histograms. Conversion ensures metrics are compatible with standard dashboards and alert thresholds.
 - **How to avoid:** Conversion required at metric ingestion point, but keeps internal timing logic unchanged; missing conversion creates 1000x inflated duration metrics
 
+<<<<<<< Updated upstream
 #### [Gotcha] LLM output regex parsing fails silently: patterns like `**dimension[:\s]*\*\*` that don't match LLM output format return default scores (50%) instead of the actual LLM score, making it impossible to detect parsing failures. (2026-02-25)
 - **Situation:** Antagonistic reviewer extracts review scores via regex. If pattern doesn't match actual LLM output format, the regex silently fails and a default score is assigned, causing all quality gates to fail incorrectly.
 - **Root cause:** The fix changed pattern to `**dimension\*\*:` (exact format matching) because LLM output format is inconsistent. Exact matching + subsequent validation would catch mismatches, but the code doesn't currently fail fast on non-match.
@@ -442,3 +443,25 @@ usageStats:
 - **Situation:** Dialog footer has disabled state on empty input, but no visual feedback if API call times out or returns error.
 - **Root cause:** Implementation focused on happy path. `.then(success => {})` pattern checks success bool but doesn't distinguish between network error, validation error, or permission error.
 - **How to avoid:** Current: clean code, but silent failures. With error handling: more verbose but better UX for failure cases.
+=======
+#### [Gotcha] Git worktrees do not automatically include node_modules - environment setup required for builds to work (2026-02-25)
+- **Situation:** Created worktree for feature branch but npm run build failed with 'Cannot find package' errors
+- **Root cause:** Worktrees are shallow copies of git state, not full environment clones. Dependencies are in .gitignore and not transferred
+- **How to avoid:** Must either npm install or use symlinks to parent node_modules. Choosing npm install doubles disk usage; symlinks risk conflicts
+
+#### [Gotcha] Git command `git rev-list origin/branch..branch --count` fails (non-zero exit) when remote branch doesn't exist yet (2026-02-25)
+- **Situation:** Checking for unpushed commits on new branches that haven't been pushed to remote
+- **Root cause:** Root cause: remote branch literally doesn't exist. Conservative handling: treat as 'unpushed' and proceed with push.
+- **How to avoid:** Graceful handling means new branches get pushed (desired) but silent failures could hide real git issues if not logged carefully.
+
+#### [Gotcha] Pre-existing platform package p-limit import error blocks build verification, even though implementation is correct and isolated (2026-02-25)
+- **Situation:** Full monorepo build fails on unrelated @protolabs-ai/platform package TypeScript compilation before reaching actual feature tests
+- **Root cause:** Root cause is broken dependency resolution in platform/secure-fs.ts, not caused by this feature. Discovered via baseline testing (stashing changes, building clean, restashing).
+- **How to avoid:** Requires extra diagnostic steps (stash-test-unstash) to verify isolation; creates false blocker on acceptance criteria checklist even though feature is correct
+>>>>>>> Stashed changes
+
+
+#### [Gotcha] Git worktree TypeScript compilation resolves to main repo's node_modules via symlinks, not worktree's own updates. Type changes must be applied to main repo for worktree build to pass, even though source code is only in worktree. (2026-02-25)
+- **Situation:** During implementation in worktree, added 'maintenance' event type to worktree's types/src/event.ts, but server build failed to find it. Discovery: worktree's TypeScript was resolving @protolabs-ai/types from main repo's symlinked node_modules.
+- **Root cause:** Worktrees inherit parent repo's node_modules symlink structure. TypeScript module resolution prefers symlinks over local files, causing version divergence between worktree source and resolved dependencies.
+- **How to avoid:** Added complexity where type changes must be made in two places, but simplifies maintenance (no duplicate node_modules). Both changes merge together when PR is integrated.

--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -5,9 +5,9 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 44
-  referenced: 21
-  successfulFeatures: 21
+  loaded: 49
+  referenced: 22
+  successfulFeatures: 22
 ---
 # GTM Signal Intelligence & Content Operations
 

--- a/.automaker/memory/monitoring.md
+++ b/.automaker/memory/monitoring.md
@@ -5,9 +5,9 @@ relevantTo: [monitoring]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 2
-  referenced: 1
-  successfulFeatures: 1
+  loaded: 7
+  referenced: 2
+  successfulFeatures: 2
 ---
 # monitoring
 

--- a/.automaker/memory/observability.md
+++ b/.automaker/memory/observability.md
@@ -18,7 +18,19 @@ usageStats:
 - **Trade-offs:** Metrics appear 'noisier' with failures included, but provide complete cost picture for billing and debugging
 - **Breaking if changed:** If failure tracking is removed, cost metrics become misleading (actual system cost higher than reported)
 
+<<<<<<< Updated upstream
 #### [Pattern] Langfuse traces are created and persisted even when quality gates fail and content generation is blocked, providing full observability into failed runs. (2026-02-25)
 - **Problem solved:** All 5 test runs created Langfuse traces with `traceId: content-content-{runId}` despite producing no content.md output. This was verified as successful even when pipeline didn't generate final output.
 - **Why this works:** When content generation fails due to quality gates, you need to inspect LLM reasoning and research findings to decide: is this a threshold problem or a genuine quality issue? Traces provide this visibility.
 - **Trade-offs:** Upside: Complete observability, enables root cause analysis. Downside: Requires access to Langfuse dashboard to debug failures (not available in CLI output). Adds Langfuse dependency to operations.
+=======
+#### [Pattern] Two-tier logging: warn-level per retry attempt with countdown; error-level only on final exhaustion (2026-02-25)
+- **Problem solved:** Need to distinguish between transient failures being recovered vs permanent failures while avoiding log spam
+- **Why this works:** Warn-level retries provide observability into transient issues without alarming—can be monitored for patterns; error-level final failure clearly signals operator intervention needed
+- **Trade-offs:** Cleaner signal processing but requires log analysis to correlate warn→error chains; naive log aggregation might miss the warn→error recovery pattern
+
+#### [Pattern] Emitting `maintenance:crash_recovery_scan_completed` event with detailed results instead of just logging (2026-02-25)
+- **Problem solved:** Need to communicate scan results to other parts of system and enable monitoring
+- **Why this works:** Decouples scan from consumers; enables multiple handlers (logging, metrics, alerts) to subscribe independently
+- **Trade-offs:** Requires EventEmitter wiring through multiple dependency layers vs. ability for downstream code to react without coupling.
+>>>>>>> Stashed changes

--- a/.automaker/memory/pattern.md
+++ b/.automaker/memory/pattern.md
@@ -5,9 +5,9 @@ relevantTo: [pattern]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 62
-  referenced: 37
-  successfulFeatures: 37
+  loaded: 68
+  referenced: 39
+  successfulFeatures: 39
 ---
 # pattern
 

--- a/.automaker/memory/patterns.md
+++ b/.automaker/memory/patterns.md
@@ -5,9 +5,15 @@ relevantTo: [patterns]
 importance: 0.7
 relatedFiles: []
 usageStats:
+<<<<<<< Updated upstream
   loaded: 28
   referenced: 15
   successfulFeatures: 15
+=======
+  loaded: 23
+  referenced: 12
+  successfulFeatures: 12
+>>>>>>> Stashed changes
 ---
 # patterns
 

--- a/.automaker/memory/performance.md
+++ b/.automaker/memory/performance.md
@@ -5,9 +5,9 @@ relevantTo: [performance]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 18
-  referenced: 10
-  successfulFeatures: 10
+  loaded: 19
+  referenced: 11
+  successfulFeatures: 11
 ---
 # performance
 
@@ -234,3 +234,20 @@ usageStats:
 - **Rejected:** Array with .includes() - adequate but degrades with many groups; Record - more verbose with no performance gain
 - **Trade-offs:** Better render performance and cleaner code vs. Set is less familiar and less serializable if state persistence added later
 - **Breaking if changed:** Switching to array search would degrade UX responsiveness with large component libraries; Set choice matters for performance-critical render path
+
+#### [Pattern] Exponential backoff with 2^(attempt-1) * 2s formula (2s, 4s, 8s delays) for transient failures (2026-02-25)
+- **Problem solved:** Git push and PR creation can fail transiently due to network blips or GitHub API rate limits; retry strategy must balance speed vs not overwhelming service
+- **Why this works:** Exponential backoff prevents thundering herd; starting fast (2s) provides quick recovery for brief network hiccups while escalating (4s, 8s) backs off from rapid-fire retries on persistent issues
+- **Trade-offs:** Fast initial retry but caps out at 8s—good for network blips but inadequate for sustained outages lasting >10s; simple formula vs more sophisticated jitter/deadline logic
+
+### Check interval set to 5 minutes, balancing stuck build detection speed against GitHub API rate limit constraints (2026-02-25)
+- **Context:** Scheduler can run checks more frequently (1 min) for faster detection, or less frequently (15+ min) to reduce API usage.
+- **Why:** 5 minutes provides reasonable responsiveness (10-15 min max delay for stuck build detection) while staying well within GitHub's API rate limits for typical deployments. Conservative approach avoids rate limit surprises.
+- **Rejected:** 1-minute interval (faster but risks hitting rate limits with multiple runners), 15+ minute interval (safer but stuck builds stay stuck longer)
+- **Trade-offs:** Slower detection than ideal, but safe operation. Stuck builds may remain stuck 5-10 minutes longer than minimum possible.
+- **Breaking if changed:** If interval is reduced to 1-minute without monitoring API usage, could hit GitHub rate limits and cause health checks to fail.
+
+#### [Pattern] OG images optimized to 9-12KB per image (25x smaller than 300KB estimate) through SVG-based composition + PNG optimization, not raster artwork. This pattern works because social preview images are simple graphics, not photographs. (2026-02-25)
+- **Problem solved:** Five images total to ~50KB instead of 1.5MB. Achieved through programmatic graphic design (logo, text overlays, colored backgrounds) rather than complex artwork.
+- **Why this works:** Social preview images have specific constraints: simple layouts, text-heavy, small display size (typically 120-200px in feeds). Vector/simple graphics compress exponentially better than photos. Reduced payload speeds social crawler fetches and improves page load.
+- **Trade-offs:** Constrains design to simple graphics/layouts but achieves extreme file size efficiency and fast regeneration

--- a/.automaker/memory/reliability.md
+++ b/.automaker/memory/reliability.md
@@ -5,9 +5,15 @@ relevantTo: [reliability]
 importance: 0.7
 relatedFiles: []
 usageStats:
+<<<<<<< Updated upstream
   loaded: 8
   referenced: 3
   successfulFeatures: 3
+=======
+  loaded: 6
+  referenced: 0
+  successfulFeatures: 0
+>>>>>>> Stashed changes
 ---
 # reliability
 

--- a/.automaker/memory/security.md
+++ b/.automaker/memory/security.md
@@ -5,9 +5,9 @@ relevantTo: [security]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 49
-  referenced: 21
-  successfulFeatures: 21
+  loaded: 33
+  referenced: 19
+  successfulFeatures: 19
 ---
 # security
 
@@ -350,98 +350,7 @@ usageStats:
 - **Why this works:** Prevents Grafana from accidentally or maliciously modifying its own provisioning configuration. Enforces separation between infrastructure configuration (external, version-controlled) and runtime state (container-internal).
 - **Trade-offs:** Slightly more secure but means Grafana UI edits don't persist (users must modify source JSON, not UI, for changes to stick)
 
-#### [Gotcha] Zero-width characters (U+200B-U+2060) and directional overrides (U+202A-U+2069) are invisible to humans but can be used for homograph attacks, code injection hiding, and social engineering. They must be explicitly stripped during normalization. (2026-02-25)
-- **Situation:** Implementing normalizeUnicode to sanitize user input for LLM processing
-- **Root cause:** Invisible Unicode can pass visual review but execute malicious intent. Stripping these prevents a class of attacks that Unicode normalization alone doesn't catch.
-- **How to avoid:** Slightly more aggressive sanitization (removes legitimate uses of these chars like ZWNJ in typography) but security-first approach is justified for LLM input
-
-### Used curated character-by-character homoglyph mapping (Cyrillic-to-Latin replacements) instead of Unicode property detection or algorithmic homoglyph discovery. (2026-02-25)
-- **Context:** Implementing normalizeUnicode to detect lookalike characters that could bypass visual inspection
-- **Why:** Homoglyph attacks are intent-driven—specific characters chosen by an attacker to look identical. A curated, explicit map is auditable and maintainable. Algorithmic approaches (Unicode confusables) either miss targeted attacks or have excessive false positives.
-- **Rejected:** Using Unicode.Confusable property (misses targeted Cyrillic attacks), machine learning classifier (non-deterministic, hard to audit), or algorithmic similarity detection (too broad, destroys legitimate text)
-- **Trade-offs:** Requires ongoing curation as new homoglyph attacks are discovered (maintenance burden), but provides exact control and zero false positives on mapped characters. Can't detect unknown homoglyph pairs until explicitly added.
-- **Breaking if changed:** If the homoglyph map is removed or simplified, targeted visual attacks using Cyrillic/Latin confusion become viable again. Callers relying on confidence that all homoglyphs are caught would get false negatives.
-
-### Used pattern-based prompt injection detection with severity levels ('warn' vs 'block') instead of probabilistic/ML or regex whitelisting approaches. (2026-02-25)
-- **Context:** Implementing detectPromptInjection to catch common prompt manipulation attempts
-- **Why:** Pattern-based detection is deterministic, auditable, and doesn't require training data or external models. Severity levels allow callers to choose whether to reject ('block') or alert ('warn') on suspicious patterns, giving flexibility without being overly restrictive.
-- **Rejected:** ML-based detection (non-deterministic, hard to audit, requires training data), regex-based whitelist of safe inputs (too restrictive, breaks legitimate uses), simple keyword matching without context (high false positives)
-- **Trade-offs:** Misses novel/obfuscated injection patterns unknown at implementation time, but catches the common, well-known attacks with zero false positives. Requires updating patterns as new attack vectors emerge.
-- **Breaking if changed:** If patterns are removed or made too generic, the detector becomes either useless or creates unacceptable false positives. The severity classification must remain—removal forces callers to either block all violations or ignore all.
-
-### Sanitization utilities library has zero external dependencies, using only built-in JavaScript/TypeScript features. (2026-02-25)
-- **Context:** Creating a foundational security utility used across the codebase (utils package that other packages depend on)
-- **Why:** Security-critical code at a low level of the dependency graph should minimize supply chain risk. Every external dependency is a potential attack surface and licensing liability. Built-in features are auditable and stable across Node/TypeScript versions.
-- **Rejected:** Using dedicated sanitization libraries (xss, sanitize-html, etc.), Unicode libraries (unidecode ports), or regex helpers (escapeRegExp from lodash)
-- **Trade-offs:** Slightly more verbose code (manual regex patterns, explicit character mappings), but eliminates transitive dependencies and keeps the library lightweight for bundling. Forced to maintain homoglyph map and injection patterns explicitly.
-- **Breaking if changed:** If dependencies are added, it changes the surface area for supply chain attacks and increases bundle size for consuming code. The library would no longer be self-contained and portable.
-
-### Set suspicious line length threshold at 2000 characters for sanitizeMarkdownForLLM, with a 'warn' severity classification. (2026-02-25)
-- **Context:** Detecting potential prompt injection or context window attacks in Markdown before feeding to LLM
-- **Why:** LLM context windows are typically 4K-100K tokens, and 2000 chars is a reasonable heuristic for 'unusually dense input that might be an attack pattern or data exfiltration attempt.' 'Warn' severity (not 'block') allows legitimate long-form content while flagging for review.
-- **Rejected:** No line length limit (misses some context flooding attacks), lower threshold like 500 chars (too many false positives on normal code blocks), 'block' severity (breaks legitimate use cases), per-window-size tuning (adds complexity)
-- **Trade-offs:** May not catch all context flooding attacks, but avoids rejecting legitimate long paragraphs. Callers can inspect 'warn' violations and decide if content is legitimate.
-- **Breaking if changed:** If threshold is removed, context flooding attacks become easier. If threshold is lowered to 500, legitimate code blocks and long lists get flagged. If changed to 'block', legitimate users get rejected.
-
-#### [Pattern] Environment variable AUTOMAKER_API_URL with localhost fallback (process.env.AUTOMAKER_API_URL || 'http://localhost:3001'). Enables local development without env setup while supporting multiple deployment environments. (2026-02-25)
-- **Problem solved:** Stats script runs in multiple contexts: local dev (no env vars), CI/CD (env vars configured), deployed (might be different URL).
-- **Why this works:** Reduces friction for local development (works out of box if server on default port). Supports staging/production (via env var). Single code path for all environments.
-- **Trade-offs:** Relies on convention (server on localhost:3001 in dev). If dev sets up server differently, must use env var. But convention is well-established.
-
-#### [Pattern] Event-specific fork protection strategies: pull_request events require explicit fork checks (github.event.pull_request.head.repo.full_name == github.repository), but push and release events have implicit fork protection since only maintainers can trigger them. (2026-02-25)
-- **Problem solved:** GitHub Actions workflows triggered by different events have different vulnerability profiles when using self-hosted runners.
-- **Why this works:** pull_request events can be triggered from forks with user-controlled code and metadata. push and release events are inherently restricted to maintainers. Treating them identically wastes security checks and complicates guards.
-- **Trade-offs:** Event-specific logic is more complex but more precise. Simpler to audit and understand the actual vulnerability profile of each event.
-
-#### [Gotcha] String processing from PR metadata (title, body, description) in shell scripts requires fork protection even in events that seem safe (pull_request: [closed]). Fork-controlled PR metadata can contain shell injection payloads. (2026-02-25)
-- **Situation:** linear-sync.yml processes PR title/body in bash scripts. Initial assessment: 'safe' because it only triggers on pull_request:closed. Actual risk: PR metadata is under fork control and can be weaponized.
-- **Root cause:** PR metadata fields are completely controlled by fork submitters. Even in bash scripts that don't directly execute user code, string interpolation into commands is vulnerable to injection. Examples: `PR_TITLE='$(malicious_command)'`
-- **How to avoid:** Adding fork checks to linear-sync.yml adds 1 line of guard logic. Alternative: avoid processing PR metadata entirely (much larger refactor). The guard is minimal cost for high security value.
-
-#### [Pattern] Permissions hierarchy: Workflow-level permissions: read-all with job-level elevation only where needed (e.g., contents:write, pull-requests:write for release jobs). Creates explicit security boundaries and makes privilege requirements auditable. (2026-02-25)
-- **Problem solved:** GitHub Actions workflows can declare permissions at workflow level (applies to all jobs) or job level (override for specific jobs). Many workflows use a single blanket permission.
-- **Why this works:** Setting minimal at workflow level means jobs without elevated permissions automatically fail safe. Job-level elevation makes it explicit which jobs need write access. Easier to audit and harder to accidentally leak permissions.
-- **Trade-offs:** More verbose YAML but much clearer security model. Debugging permission errors requires checking both levels, but this is a feature—forces explicit thinking about what each job needs.
-
-### Explicit fork checks (if: github.event.pull_request.head.repo.full_name == github.repository) instead of pull_request_target event. Trades automatic fork isolation for explicit, auditable guards. (2026-02-25)
-- **Context:** GitHub Actions provides pull_request_target event which runs workflow code from main branch even when triggered by fork PRs. Alternative approach is pull_request event with explicit fork checks.
-- **Why:** pull_request_target is opaque and harder to audit—developers don't see 'what is being protected' in the workflow file. Explicit fork checks make the security model visible and auditable. Also avoids the complexity of pull_request_target (requires separate fetch of PR code if needed).
-- **Rejected:** Using pull_request_target event (automatic fork isolation but less auditable), or using pull_request without any fork checks (vulnerable)
-- **Trade-offs:** Explicit checks require manual maintenance of the fork-detection logic. pull_request_target would be automatic but less visible. Current approach wins on auditability and clarity.
-- **Breaking if changed:** Removing the explicit fork check guard but keeping pull_request event would expose self-hosted runners to fork PR code execution. Using pull_request_target without understanding its security properties can lead to credential leaks (secrets are available in pull_request_target but isolated from PR code).
-
-#### [Pattern] SHA-pinned actions with version comments (e.g., @abc123def...40chars # v4) enable supply chain attack prevention while maintaining semantic versioning context. Comment serves as audit trail of what action version was intended. (2026-02-25)
-- **Problem solved:** GitHub actions can be referenced by tag (e.g., actions/checkout@v4) which is convenient but mutable, or by full commit SHA (immutable but opaque).
-- **Why this works:** Tags can be moved by action maintainers (intentionally or via compromise). Full SHAs are immutable and prevent malicious action maintainers from injecting code into existing version tags. Comments document intent and make it easier to track when a deliberate action upgrade occurred vs. when a SHA became stale.
-- **Trade-offs:** More verbose, requires occasional pinning updates. But updates are explicit and auditable (commit message shows 'upgraded actions/checkout to v4.2.0'). Vulnerability surface reduced significantly.
-
-#### [Pattern] Layered repository validation: combining fork check + explicit repository name check + event type check + merge status check creates multiple layers of defense. Each layer catches different attack vectors independently. (2026-02-25)
-- **Problem solved:** The implementation checks: (1) github.event.pull_request.head.repo.full_name == github.repository (fork check), (2) github.repository == 'proto-labs-ai/protoMaker' (explicit repo name), (3) github.event.pull_request.merged == true (merge status), (4) different checks for different event types.
-- **Why this works:** No single check is bulletproof. Fork check prevents fork attacks but doesn't verify this is the correct repo. Repo name check prevents workflows running in mirrors/forks of the codebase. Merge status check prevents accidental processing of open PRs. Layering makes exploitation harder—attacker would need to bypass multiple independent validations.
-- **Trade-offs:** More verbose guard logic (2-3 if conditions). But defense-in-depth is worth the verbosity for self-hosted runner workflows where compromise is costly.
-
-### Trust tier bypass logic embedded in QuarantineService.Gate stage (returns early if tier >= 3) rather than checked in create route handler before calling quarantine. (2026-02-25)
-- **Context:** Three sources with different trust levels: api-key (tier 1, full validation), ui-session (tier 3, bypass), mcp/internal (tier 4, bypass). Need to conditionally validate based on tier.
-- **Why:** Centralizing bypass logic in the validation service creates complete audit trail (quarantine entry marks stage='Gate', violations empty, status='bypassed') vs bypassing before validation (no audit record). Maintains separation of concerns: handler doesn't need to know about validation rules.
-- **Rejected:** Check tier in handler with `if (tier >= 3) { return create(feature) }`. This skips validation entirely and loses audit trail of who submitted what and why it was bypassed. Complicates future security audits.
-- **Trade-offs:** All submissions create quarantine entries (even bypassed ones) → more disk I/O. Benefit: complete submission history. Handler code simpler: always call quarantine, don't conditionally skip.
-- **Breaking if changed:** If bypass check moved to handler, bypassed features would have no quarantine entry record. Future 'show me all submissions from API keys' queries fail. Audit trail becomes incomplete, security forensics impossible.
-
-### Save quarantine-processed content (title/description from outcome) to feature, not raw request input. Example: save outcome.entry.title instead of req.body.feature.title. (2026-02-25)
-- **Context:** QuarantineService sanitizes content (removes prompts, normalizes unicode, escapes HTML). Raw input may contain injection vectors that sanitization removes.
-- **Why:** Ensures stored feature data matches what passed validation. If raw input stored, sanitization becomes theater (database contains unsanitized content). Prevents subtle bugs where UI renders sanitized content but database serves raw content on next load.
-- **Rejected:** Store raw input and sanitize on render. Problem: race condition between storage and query. Other services query features without going through render pipeline and see unsanitized content. Distributed sanitization is unreliable.
-- **Trade-offs:** Data loss: normalization may truncate or collapse content. Benefit: guaranteed consistency between validation and storage. Worth the trade-off for security-critical data.
-- **Breaking if changed:** If raw input stored instead of sanitized: sanitization bypass via feature.json download (auth to get raw data). Content injection attacks succeed if downstream code trusts database without re-sanitizing.
-
-#### [Pattern] Organize security utility tests by threat class, not just code structure. Utilities grouped by attack vector: Unicode attacks (normalizeUnicode), content injection (sanitizeMarkdownForLLM), LLM-specific attacks (detectPromptInjection), path manipulation (validateFilePaths). (2026-02-25)
-- **Problem solved:** 19 tests across 4 sanitization utilities required systematic test design to ensure threat coverage
-- **Why this works:** Threat-based organization makes coverage gaps visible and maps to actual security risk model rather than just code coverage
-- **Trade-offs:** Requires upfront threat modeling, but provides clearer verification that all attack classes are handled
-
-### Security violation severity levels (block vs warn) embedded in sanitization utilities. Different violations warrant different risk tolerance—some hard-fail execution, others log warnings for investigation. (2026-02-25)
-- **Context:** Multiple types of security violations in LLM context (prompt injection, path traversal, XSS) have different impact profiles
-- **Why:** Not all security risks are equally critical in the same context. Injected script tags may warrant block; zero-width Unicode characters warrant warn.
-- **Rejected:** Treating all violations as hard failures or warnings uniformly
-- **Trade-offs:** Adds state to security functions but enables nuanced policy enforcement without code changes
-- **Breaking if changed:** Removing severity levels collapses risk categories—downstream code can't differentiate response strategy
+#### [Pattern] Used instanceof Error check before accessing .message: `gitError instanceof Error ? gitError.message : String(gitError)` to defensively handle unknown error types (2026-02-25)
+- **Problem solved:** Catch blocks in JavaScript can receive any value type (Error objects, strings, null, etc.), not just Error instances
+- **Why this works:** Production robustness - JavaScript allows throwing non-Error values. Code that assumes only Error objects will crash if third-party or edge-case code throws a string/object. This pattern survives any throw without crashing.
+- **Trade-offs:** Adds null-coalescing complexity; protects against edge cases but makes code slightly more verbose

--- a/.automaker/memory/testing.md
+++ b/.automaker/memory/testing.md
@@ -5,9 +5,9 @@ relevantTo: [testing]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 42
-  referenced: 24
-  successfulFeatures: 24
+  loaded: 43
+  referenced: 25
+  successfulFeatures: 25
 ---
 # testing
 
@@ -870,59 +870,24 @@ usageStats:
 - **Why this works:** Real design file catches edge cases in schema - nested component structures, theme variations, variable reference chains that wouldn't appear in minimal examples; validates file format compatibility at scale
 - **Trade-offs:** Easier: Tests validate against real-world data; Harder: Test file must be maintained, tests are slower, test data is opaque (hard to debug what's being tested)
 
-### Used Playwright test suite (E2E browser automation framework) for JSON data validation and schema verification, despite semantic mismatch. (2026-02-25)
-- **Context:** Created test file to verify roadmap.json structure, stats.json prCount, changelog.json firstDate without any UI interaction.
-- **Why:** Playwright is already in project infrastructure; consistent test runner across E2E and data tests; familiar syntax for team. Avoids separate test framework.
-- **Rejected:** Jest, native Node assertions, or custom validation scripts would be semantically clearer and lightweight.
-- **Trade-offs:** Benefit: reuse infrastructure, single test runner. Cost: Playwright adds browser overhead for non-UI tests; semantic confusion (Playwright = UI automation); tight coupling between data validation and E2E framework.
-- **Breaking if changed:** If Playwright is removed from dependencies, data tests have no runner. If Playwright major version upgrades change assertion API, both E2E and data tests break. Heavy coupling.
+#### [Gotcha] Code pattern consistency across multiple completion paths - single missing invocation in one path is easy to overlook (2026-02-25)
+- **Situation:** Pipeline-step-removed path was missing git workflow call that existed in 3+ other completion paths
+- **Root cause:** When same pattern exists in multiple places, divergence indicates either oversight or intentional branch logic. No compile error flags missing optional invocation
+- **How to avoid:** Code review catches inconsistency, but tests for each path variant would prevent such gaps
 
-#### [Gotcha] Functional correctness of a service can be verified at ESM level without full server build. Created standalone Node.js test script that imports compiled ESM, runs operations, verifies behavior. All 10 tests passed despite TypeScript DTS build failures and unrelated server build issues (platform package). This proves the service works correctly in isolation. (2026-02-25)
-- **Situation:** Full server build blocked by unrelated platform package DTS failures. TypeScript build also failing. However, the service code itself is sound and needed verification before being marked complete.
-- **Root cause:** ESM (JavaScript runtime) is the actual code that runs. DTS build failures don't affect runtime correctness. By testing at the module level (compile ESM, import, run), you bypass build infrastructure issues and test the actual behavior.
-- **How to avoid:** ESM-level testing is lightweight and fast, but doesn't verify type safety. It catches logic bugs and API contract violations, but not TypeScript type errors. For security-critical code, both are needed eventually, but ESM testing unblocks faster.
+#### [Gotcha] E2E testing for drag-drop requires full dev server + browser context; unit testing limited by @dnd-kit's need for active drag state that only exists during user interaction (2026-02-25)
+- **Situation:** Feature has no failing tests but acceptance criteria verified only through code review and manual verification strategy
+- **Root cause:** @dnd-kit maintains drag state in DndContext only when pointer events fire; simulating events in JSDOM or Playwright requires full browser event pipeline. Type checking in TS catches structural issues but not runtime drag state management
+- **How to avoid:** Gained: confidence in real browser behavior. Lost: automated test coverage, ability to catch drag-drop bugs in CI without dev server
 
-#### [Gotcha] Event emitter mock initially used Map<eventType, handlers[]> with type-indexed routing, but actual EventEmitter.subscribe() is type-agnostic: single handler receives all events as (type, payload) tuple, not type-specific subscriptions. (2026-02-25)
-- **Situation:** Creating mock EventEmitter for signal-intake-service tests revealed interface contract mismatch in initial implementation.
-- **Root cause:** Easy to assume mock mirrors pub/sub type-routing, but this service uses a universal fan-out model where one handler gets all event notifications. Interface reading error.
-- **How to avoid:** Array-based simple list is less type-safe but correct. Type-indexed map adds structure but creates dead subscriptions.
+#### [Gotcha] Full build verification was blocked by pre-existing dependency issues in unrelated packages (platform p-limit import error, calendar-view missing react-day-picker), preventing runtime validation of changes (2026-02-25)
+- **Situation:** Attempting to verify changes don't break monorepo when running full build
+- **Root cause:** Monorepo has tight coupling through shared build process; broken dependencies in one package prevent verification of unrelated changes; calendar-view and platform are loaded during UI build even if not used by designs-view
+- **How to avoid:** Full end-to-end verification is ideal but impossible when dependencies are broken; fallback to import validation and static analysis misses runtime/bundler errors
 
-#### [Pattern] Unit tests for async event-driven service require 50-100ms timeouts to allow event handlers to complete before assertions. Async processing happens off the call stack. (2026-02-25)
-- **Problem solved:** signal-intake-service processes signals via event emission with async handlers; tests needed explicit waits.
-- **Why this works:** Events are fired synchronously but handlers may run async (e.g., awaiting mocked db calls, event propagation). Without delays, assertions run before handlers complete, causing false failures.
-- **Trade-offs:** Delays make tests slower but reliable. Missing delays cause flaky tests. Suggests service is inherently async/event-driven, not synchronous.
-
-#### [Pattern] Unit tests pass despite pre-existing TypeScript build errors in transitive dependencies (@protolabs-ai/platform). Test isolation via comprehensive mocking prevents build-time failures from blocking test-time verification. (2026-02-25)
-- **Problem solved:** secure-fs.ts has p-limit type error; test files compile and run successfully.
-- **Why this works:** Tests mock external dependencies (db, event emitter, services). They don't import the broken @protolabs-ai/platform code at runtime, only the service code being tested. Build-time type checking and runtime test execution are decoupled.
-- **Trade-offs:** Tests prove the service code is correct but don't catch errors in dependencies. Build will still fail. Good for iteration; bad for shipping without a passing build.
-
-#### [Gotcha] Mock return types must include ALL interface fields, not just primary data. readJsonWithRecovery mocks initially returned {data: T} but actual signature requires {data: T, recovered: boolean, source: string}. TypeScript compiled with partial mocks but tests failed at runtime when code accessed .recovered or .source. (2026-02-25)
-- **Situation:** Test setup discovered that structural typing in TypeScript allows incomplete mock objects to pass type checking if they contain the minimum needed properties.
-- **Root cause:** TypeScript's object literal type checking uses structural (duck) typing - it doesn't enforce that all interface properties are present, only that provided properties match. Mock code compiled because it had 'data', but runtime access to missing fields failed.
-- **How to avoid:** Full mock completeness (all fields) ensures test code matches real behavior and catches integration bugs early; partial mocks compile and run locally but fail mysteriously at runtime in CI.
-
-#### [Gotcha] Bulk sed replacements on repetitive mock data (CalendarEvent arrays) can create duplicates if the pattern already exists. Added projectPath to all CalendarEvent objects using sed, but some already had it from earlier edits, requiring a second cleanup pass. (2026-02-25)
-- **Situation:** Test fixtures used repetitive object literals across multiple test cases. CalendarEvent interface requires projectPath field, discovered during mock construction.
-- **Root cause:** Sed pattern matching doesn't know about object context - it matches lines and adds after them. Multiple CalendarEvent objects with the same structure meant the pattern matched multiple times, but idempotency wasn't guaranteed.
-- **How to avoid:** Sed bulk edits are fast for large changes but risk duplicates without post-validation; manual edits are slower but guaranteed correct.
-
-#### [Pattern] Test data (mock objects) must be as complete as real implementation objects, even for internal-only fields. CalendarEvent needed projectPath in tests even though the public API doesn't expose it - discovered by type errors during mock construction. (2026-02-25)
-- **Problem solved:** Tests discovered that the CalendarEvent interface requires projectPath for internal deduplication and storage logic, despite this not being part of the service's public API surface.
-- **Why this works:** The implementation uses projectPath internally to scope events to specific projects. Tests must instantiate objects exactly as the implementation expects, not as the API documentation suggests.
-- **Trade-offs:** Complete mock objects match reality and catch bugs early; simpler mocks are easier to write but miss real requirements and fail in production.
-
-#### [Pattern] Async state machines in services (like pause/resume loops) require timing-aware test patterns: delays to let state transitions complete, explicit cleanup between tests, and assertions on final state rather than intermediate state. (2026-02-25)
-- **Problem solved:** ralph-loop-service tests had to handle pauseLoop/resumeLoop functionality where internal state (paused, running, completed) changes asynchronously. Tests needed to wait for state changes before asserting.
-- **Why this works:** Async loops have internal timers and state flags that update asynchronously. Tests must either mock timers completely (using vi.useFakeTimers) or add delays to let real timers fire. Race conditions occur if tests assert before async operations complete.
-- **Trade-offs:** Explicit timing (delays + cleanup) tests real behavior but adds complexity and slight flakiness; fake timers eliminate timing but don't test actual timer implementation.
-
-#### [Pattern] Services aggregating data from multiple external sources need error mode testing for each source independently. calendar-service tests mock failure scenarios for FeatureLoader, LinearMCPClient, and Google Calendar separately to ensure graceful degradation. (2026-02-25)
-- **Problem solved:** Calendar service merges events from three sources (features, Linear milestones, Google Calendar). Tests needed to verify service behavior when each source fails independently.
-- **Why this works:** In production, one source failing (e.g., Linear API down) should not break the entire calendar. Tests must verify that partial data still returns successfully, not that the entire service crashes.
-- **Trade-offs:** Comprehensive error mocking ensures production resilience but adds significant test complexity (more mocked scenarios); simple happy-path tests are easy to write but miss critical failure cases.
-
-#### [Pattern] Security test data uses realistic attack patterns, not synthetic edge cases. Tests include actual zero-width space characters, genuine prompt injection phrasings, real path traversal sequences. (2026-02-25)
-- **Problem solved:** Security utilities can pass tests with made-up examples while failing against real attacks
-- **Why this works:** Synthetic test cases may exercise code paths without actually triggering threat detection logic. Real attack patterns verify the threat model itself.
-- **Trade-offs:** Requires research into real-world attack vectors, but provides confidence tests catch actual threats
+### Created temporary verification test with Playwright-style assertions then deleted it after validation (2026-02-25)
+- **Context:** New retry logic needed verification that backoff delays and retry counts were correct, but test wasn't meant to be permanent part of suite
+- **Why:** Temporary verification test allowed proving the implementation without adding maintenance burden; once confidence established through manual testing, cleanup prevents test sprawl
+- **Rejected:** Keeping test would require mocking/stubbing time delays (complex); integration test would add CI duration; no test at all would leave retry logic unverified
+- **Trade-offs:** Temporary verification trades off permanent safety net for reduced test infrastructure; relies on code review and staging verification instead
+- **Breaking if changed:** If future changes touch retry logic without test verification, regressions could slip through; subsequent developers can't see what was tested

--- a/.automaker/memory/ui.md
+++ b/.automaker/memory/ui.md
@@ -490,9 +490,17 @@ usageStats:
 - **Root cause:** PenNodeRenderer uses CSS variables injected by PenThemeProvider; context must be in component tree or variables silently fail to resolve
 - **How to avoid:** Required wrapper adds component hierarchy complexity vs. ensuring correct styling that works out-of-box
 
-### Replaced synchronous `window.prompt()` with asynchronous Dialog component + Promise-based saveIdentity(). (2026-02-25)
-- **Context:** Original UX was blocking prompt. Needed non-blocking, dismissible input that could fail gracefully.
-- **Why:** Dialog is non-blocking, allows escape/cancel flow, persists state across dismissals, better UX than modal prompt. Async allows API validation before confirm.
-- **Rejected:** Keep window.prompt (synchronous, blocks UI, bad UX). Or use inline input field without dialog (less modal clarity, harder to focus flow).
-- **Trade-offs:** Dialog UX better, but requires async state handling in component. `.then(success => {})` pattern is callback-heavy; could use async/await in event handler.
-- **Breaking if changed:** If changed back to prompt: lose non-blocking behavior and error handling capability. Revert to old UX degradation.
+#### [Gotcha] DragOverlay component must render outside normal component tree and use active.data.current for payload access, not direct closure/props (2026-02-25)
+- **Situation:** Ghost preview overlay needs to be visually on top of everything but receive data from scattered draggable components
+- **Root cause:** DragOverlay renders into portal at document level, outside reach of props passed to useDraggable. @dnd-kit separates draggable implementation (which stores data in context) from visual rendering (DragOverlay). Only access point is active.data.current in DndContext
+- **How to avoid:** Gained: clean visual layering, unclipped rendering. Lost: direct prop passing, need explicit data serialization in active.data
+
+#### [Pattern] Semantic token adoption as theming abstraction layer - replacing hardcoded color classes (bg-white, bg-gray-50, text-gray-600) with design tokens (bg-card, bg-muted, text-muted-foreground) (2026-02-25)
+- **Problem solved:** Need to support dark mode and brand compliance without changing component logic or rewriting JSX
+- **Why this works:** Decouples color values from component code at CSS level; enables theme switching without touching components; one change to token value updates all uses; supports arbitrary future themes
+- **Trade-offs:** Requires upfront semantic token infrastructure investment; components become less self-documenting; enables powerful theming at cost of indirection
+
+#### [Pattern] Leverage @dnd-kit's strategy selection based on layout direction (verticalListSortingStrategy vs horizontalListSortingStrategy) rather than generic collision detection (2026-02-25)
+- **Problem solved:** sortable-node.tsx selects strategy in SortableContext based on frame.layoutDirection
+- **Why this works:** Layout-specific strategies optimize drop targeting and visual feedback; closestCenter collision detection alone insufficient for constrained layouts
+- **Trade-offs:** More code but significantly better UX; drop zones more predictable and insertion indicators clearer

--- a/apps/server/src/routes/features/routes/update.ts
+++ b/apps/server/src/routes/features/routes/update.ts
@@ -126,6 +126,18 @@ export function createUpdateHandler(
         }
       }
 
+      // Require a reason when blocking a feature
+      if (newStatus === 'blocked' && previousStatus !== 'blocked') {
+        const reason = updates.statusChangeReason?.trim();
+        if (!reason) {
+          res.status(400).json({
+            success: false,
+            error: 'A reason is required when blocking a feature. Set statusChangeReason.',
+          });
+          return;
+        }
+      }
+
       const updated = await featureLoader.update(
         projectPath,
         featureId,

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -70,6 +70,7 @@ export type EventType =
   | 'scheduler:task_disabled'
   | 'scheduler:task_started'
   | 'scheduler:task_completed'
+  | 'maintenance'
   | 'recovery_analysis'
   | 'recovery_started'
   | 'recovery_completed'

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -264,6 +264,7 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
       if (args.dueDate !== undefined) updates.dueDate = args.dueDate;
       if (args.priority !== undefined) updates.priority = args.priority;
       if (args.isFoundation !== undefined) updates.isFoundation = args.isFoundation;
+      if (args.statusChangeReason) updates.statusChangeReason = args.statusChangeReason;
       return apiCall('/features/update', {
         projectPath: args.projectPath,
         featureId: args.featureId,

--- a/packages/mcp-server/src/tools/feature-tools.ts
+++ b/packages/mcp-server/src/tools/feature-tools.ts
@@ -194,6 +194,11 @@ export const featureTools: Tool[] = [
           description:
             'Mark as foundation feature (package scaffold, base types). Downstream features wait for this to be merged before starting.',
         },
+        statusChangeReason: {
+          type: 'string',
+          description:
+            "Required when setting status to 'blocked'. Explain why the feature is blocked (e.g., 'Waiting on PR #123 to merge', 'Blocked by API rate limits').",
+        },
       },
       required: ['projectPath', 'featureId'],
     },


### PR DESCRIPTION
## Summary

- **Server validation**: `POST /features/update` now returns HTTP 400 if `status: 'blocked'` is requested without a `statusChangeReason`. Catches silent, undocumented blocks at the API boundary.
- **MCP tool schema**: Added `statusChangeReason` field to `update_feature` — agents and LLM callers can now discover and use it.
- **MCP handler**: Passes `statusChangeReason` through to the API payload alongside other updates.
- **EventType**: Added generic `maintenance` type (companion to `maintenance:runner-health` in PR #1141).
- **Context file**: Added `.automaker/context/event-type-registration.md` to guide agents on registering new event types.

## Motivation

Discovered 13 features manually blocked with no recorded reason — made them impossible to triage. This PR makes blocking a feature a deliberate, documented act.

## Test plan

- [ ] Block a feature via UI without a reason → 400 error
- [ ] Block a feature with a reason → succeeds, reason appears in statusHistory
- [ ] Block via MCP `update_feature` tool without reason → 400 error
- [ ] Block via MCP with `statusChangeReason` → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional statusChangeReason field to feature update operations for documenting feature status changes.

* **Improvements**
  * A non-empty statusChangeReason is now required when blocking a feature for the first time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->