### PR TITLE
feat: worktree stash push/list/apply/drop REST endpoints + MCP tools

### DIFF
--- a/apps/server/src/routes/worktree/index.ts
+++ b/apps/server/src/routes/worktree/index.ts
@@ -58,6 +58,10 @@ import { createPruneHandler } from './routes/prune.js';
 import { createCherryPickHandler } from './routes/cherry-pick.js';
 import { createAbortOperationHandler } from './routes/abort-operation.js';
 import { createContinueOperationHandler } from './routes/continue-operation.js';
+import { createStashPushHandler } from './routes/stash-push.js';
+import { createStashListHandler } from './routes/stash-list.js';
+import { createStashApplyHandler } from './routes/stash-apply.js';
+import { createStashDropHandler } from './routes/stash-drop.js';
 import type { SettingsService } from '../../services/settings-service.js';
 import type { WorktreeLifecycleService } from '../../services/worktree-lifecycle-service.js';
 import type { AutoModeService } from '../../services/auto-mode-service.js';
@@ -214,6 +218,12 @@ export function createWorktreeRoutes(
     validatePathParams('worktreePath'),
     createContinueOperationHandler()
   );
+
+  // Stash operations
+  router.post('/stash-push', validatePathParams('worktreePath'), createStashPushHandler());
+  router.post('/stash-list', validatePathParams('worktreePath'), createStashListHandler());
+  router.post('/stash-apply', validatePathParams('worktreePath'), createStashApplyHandler());
+  router.post('/stash-drop', validatePathParams('worktreePath'), createStashDropHandler());
 
   // Worktree health and recovery routes
   if (worktreeLifecycleService) {

--- a/apps/server/src/routes/worktree/routes/stash-apply.ts
+++ b/apps/server/src/routes/worktree/routes/stash-apply.ts
@@ -1,0 +1,30 @@
+/**
+ * POST /api/worktree/stash-apply endpoint
+ * Applies a stash to the worktree without removing it from the stash list
+ */
+
+import type { Request, Response } from 'express';
+import { getErrorMessage, logError } from '../common.js';
+import { stashService } from '../../../services/stash-service.js';
+
+export function createStashApplyHandler() {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { worktreePath, stashRef } = req.body as {
+        worktreePath: string;
+        stashRef: string;
+      };
+
+      if (!worktreePath || !stashRef) {
+        res.status(400).json({ success: false, error: 'worktreePath and stashRef required' });
+        return;
+      }
+
+      await stashService.apply(worktreePath, stashRef);
+      res.json({ success: true });
+    } catch (error) {
+      logError(error, 'Stash apply failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/apps/server/src/routes/worktree/routes/stash-drop.ts
+++ b/apps/server/src/routes/worktree/routes/stash-drop.ts
@@ -1,0 +1,30 @@
+/**
+ * POST /api/worktree/stash-drop endpoint
+ * Drops (removes) a specific stash entry from a worktree
+ */
+
+import type { Request, Response } from 'express';
+import { getErrorMessage, logError } from '../common.js';
+import { stashService } from '../../../services/stash-service.js';
+
+export function createStashDropHandler() {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { worktreePath, stashRef } = req.body as {
+        worktreePath: string;
+        stashRef: string;
+      };
+
+      if (!worktreePath || !stashRef) {
+        res.status(400).json({ success: false, error: 'worktreePath and stashRef required' });
+        return;
+      }
+
+      await stashService.drop(worktreePath, stashRef);
+      res.json({ success: true });
+    } catch (error) {
+      logError(error, 'Stash drop failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/apps/server/src/routes/worktree/routes/stash-list.ts
+++ b/apps/server/src/routes/worktree/routes/stash-list.ts
@@ -1,0 +1,27 @@
+/**
+ * POST /api/worktree/stash-list endpoint
+ * Returns structured stash entries for a worktree
+ */
+
+import type { Request, Response } from 'express';
+import { getErrorMessage, logError } from '../common.js';
+import { stashService } from '../../../services/stash-service.js';
+
+export function createStashListHandler() {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { worktreePath } = req.body as { worktreePath: string };
+
+      if (!worktreePath) {
+        res.status(400).json({ success: false, error: 'worktreePath required' });
+        return;
+      }
+
+      const entries = await stashService.list(worktreePath);
+      res.json({ success: true, entries });
+    } catch (error) {
+      logError(error, 'Stash list failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/apps/server/src/routes/worktree/routes/stash-push.ts
+++ b/apps/server/src/routes/worktree/routes/stash-push.ts
@@ -1,0 +1,31 @@
+/**
+ * POST /api/worktree/stash-push endpoint
+ * Stashes current changes in a worktree with optional message and file selection
+ */
+
+import type { Request, Response } from 'express';
+import { getErrorMessage, logError } from '../common.js';
+import { stashService } from '../../../services/stash-service.js';
+
+export function createStashPushHandler() {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { worktreePath, message, files } = req.body as {
+        worktreePath: string;
+        message?: string;
+        files?: string[];
+      };
+
+      if (!worktreePath) {
+        res.status(400).json({ success: false, error: 'worktreePath required' });
+        return;
+      }
+
+      const result = await stashService.push(worktreePath, message, files);
+      res.json({ success: true, ref: result.ref });
+    } catch (error) {
+      logError(error, 'Stash push failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/apps/server/src/services/stash-service.ts
+++ b/apps/server/src/services/stash-service.ts
@@ -1,0 +1,88 @@
+/**
+ * StashService — encapsulates git stash command logic for worktrees
+ */
+
+import { exec, execFile } from 'child_process';
+import { promisify } from 'util';
+import { createLogger } from '@protolabs-ai/utils';
+
+const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+const logger = createLogger('StashService');
+
+export interface StashEntry {
+  ref: string;
+  index: number;
+  message: string;
+  branch: string;
+  description: string;
+}
+
+export class StashService {
+  async push(worktreePath: string, message?: string, files?: string[]): Promise<{ ref: string }> {
+    const args = ['stash', 'push'];
+
+    if (message) {
+      args.push('-m', message);
+    }
+
+    if (files && files.length > 0) {
+      args.push('--');
+      args.push(...files);
+    }
+
+    await execFileAsync('git', args, { cwd: worktreePath });
+
+    // Get the stash ref just created
+    const { stdout } = await execAsync('git stash list --format="%gd" -1', {
+      cwd: worktreePath,
+    });
+    const ref = stdout.trim() || 'stash@{0}';
+
+    logger.debug(`Stash pushed at ${ref} in ${worktreePath}`);
+    return { ref };
+  }
+
+  async list(worktreePath: string): Promise<StashEntry[]> {
+    const { stdout } = await execAsync('git stash list --format="%gd%x00%gs%x00%gD"', {
+      cwd: worktreePath,
+    });
+
+    if (!stdout.trim()) return [];
+
+    const entries: StashEntry[] = [];
+    for (const line of stdout.trim().split('\n')) {
+      const parts = line.split('\0');
+      const ref = parts[0] ?? '';
+      const subject = parts[1] ?? '';
+      const indexMatch = ref.match(/stash@\{(\d+)\}/);
+      const index = indexMatch ? parseInt(indexMatch[1], 10) : 0;
+
+      // subject format: "WIP on <branch>: <hash> <message>" or "On <branch>: <message>"
+      const branchMatch = subject.match(/^(?:WIP on|On) ([^:]+):/);
+      const branch = branchMatch ? branchMatch[1] : '';
+
+      entries.push({
+        ref,
+        index,
+        message: subject,
+        branch,
+        description: subject,
+      });
+    }
+
+    return entries;
+  }
+
+  async apply(worktreePath: string, stashRef: string): Promise<void> {
+    await execFileAsync('git', ['stash', 'apply', stashRef], { cwd: worktreePath });
+    logger.debug(`Applied stash ${stashRef} in ${worktreePath}`);
+  }
+
+  async drop(worktreePath: string, stashRef: string): Promise<void> {
+    await execFileAsync('git', ['stash', 'drop', stashRef], { cwd: worktreePath });
+    logger.debug(`Dropped stash ${stashRef} in ${worktreePath}`);
+  }
+}
+
+export const stashService = new StashService();

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -178,6 +178,7 @@ import { calendarTools } from './tools/calendar-tools.js';
 import { quarantineTools } from './tools/quarantine-tools.js';
 import { fileOpsTools } from './tools/file-ops-tools.js';
 import { gitOpsTools } from './tools/git-ops-tools.js';
+import { worktreeGitTools } from './tools/worktree-git-tools.js';
 
 // Aggregate all tools
 const tools: Tool[] = [
@@ -199,6 +200,7 @@ const tools: Tool[] = [
   ...calendarTools,
   ...quarantineTools,
   ...fileOpsTools,
+  ...worktreeGitTools,
 ];
 
 // Tool implementations
@@ -860,6 +862,28 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
       return apiCall('/github/resolve-pr-comment', {
         projectPath: args.projectPath,
         threadId: args.threadId,
+      });
+
+    case 'worktree_stash_push':
+      return apiCall('/worktree/stash-push', {
+        worktreePath: args.worktreePath,
+        message: args.message,
+        files: args.files,
+      });
+
+    case 'worktree_stash_list':
+      return apiCall('/worktree/stash-list', { worktreePath: args.worktreePath });
+
+    case 'worktree_stash_apply':
+      return apiCall('/worktree/stash-apply', {
+        worktreePath: args.worktreePath,
+        stashRef: args.stashRef,
+      });
+
+    case 'worktree_stash_drop':
+      return apiCall('/worktree/stash-drop', {
+        worktreePath: args.worktreePath,
+        stashRef: args.stashRef,
       });
 
     // Observability

--- a/packages/mcp-server/src/tools/worktree-git-tools.ts
+++ b/packages/mcp-server/src/tools/worktree-git-tools.ts
@@ -1,0 +1,93 @@
+/**
+ * MCP tools for worktree git operations (stash push/list/apply/drop)
+ */
+
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+export const worktreeStashPushTool: Tool = {
+  name: 'worktree_stash_push',
+  description:
+    'Stash uncommitted changes in a worktree. Optionally provide a message or limit stashing to specific files.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      worktreePath: {
+        type: 'string',
+        description: 'Absolute path to the worktree directory',
+      },
+      message: {
+        type: 'string',
+        description: 'Optional stash message for easy identification',
+      },
+      files: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Optional array of specific file paths to stash (relative to worktreePath)',
+      },
+    },
+    required: ['worktreePath'],
+  },
+};
+
+export const worktreeStashListTool: Tool = {
+  name: 'worktree_stash_list',
+  description:
+    'List all stash entries for a worktree. Returns ref, message, branch, and index for each stash.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      worktreePath: {
+        type: 'string',
+        description: 'Absolute path to the worktree directory',
+      },
+    },
+    required: ['worktreePath'],
+  },
+};
+
+export const worktreeStashApplyTool: Tool = {
+  name: 'worktree_stash_apply',
+  description:
+    'Apply a stash to the worktree without removing it from the stash list. Use worktree_stash_list to get valid stash refs (e.g. "stash@{0}").',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      worktreePath: {
+        type: 'string',
+        description: 'Absolute path to the worktree directory',
+      },
+      stashRef: {
+        type: 'string',
+        description: 'Stash reference to apply (e.g. "stash@{0}")',
+      },
+    },
+    required: ['worktreePath', 'stashRef'],
+  },
+};
+
+export const worktreeStashDropTool: Tool = {
+  name: 'worktree_stash_drop',
+  description:
+    'Drop (remove) a specific stash entry from a worktree stash list. Use worktree_stash_list to get valid refs.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      worktreePath: {
+        type: 'string',
+        description: 'Absolute path to the worktree directory',
+      },
+      stashRef: {
+        type: 'string',
+        description: 'Stash reference to drop (e.g. "stash@{0}")',
+      },
+    },
+    required: ['worktreePath', 'stashRef'],
+  },
+};
+
+export const worktreeGitTools = [
+  worktreeStashPushTool,
+  worktreeStashListTool,
+  worktreeStashApplyTool,
+  worktreeStashDropTool,
+];


### PR DESCRIPTION
## Summary

Adds `StashService` and four stash route handlers under `/api/worktree/`:
- **POST /stash-push** `{ worktreePath, message?, files? }` — stash uncommitted changes with optional message and file selection
- **POST /stash-list** `{ worktreePath }` — returns structured stash entries (ref, index, branch, description)
- **POST /stash-apply** `{ worktreePath, stashRef }` — apply a stash without dropping it
- **POST /stash-drop** `{ worktreePath, stashRef }` — remove a stash entry

MCP tools: `worktree_stash_push`, `worktree_stash_list`, `worktree_stash_apply`, `worktree_stash_drop`

Part of the PR #810 upstream integration (Agent-Accessible File & Git Operations milestone).

## Test plan
- [ ] Push stash, verify ref returned
- [ ] List stash entries, verify structure
- [ ] Apply stash, verify changes restored
- [ ] Drop stash, verify stash removed
- [ ] `npm run build:server` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added git stash management for worktrees: create stashes, list saved changes, apply or drop specific stashes.
  * Updated Claude model versions: Sonnet and Opus now resolve to their latest 4.6 releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->