### PR TITLE
chore: update CLAUDE.md and MCP tools reference docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ automaker/
     ├── model-resolver/    # Claude model alias resolution
     ├── dependency-resolver/  # Feature dependency ordering
     ├── spec-parser/       # XML/markdown spec parsing for project plans
+    ├── pen-parser/        # PEN file parser for Penpot design files
     ├── git-utils/    # Git operations & worktree management
     ├── tools/        # Unified tool definition and registry system
     ├── flows/        # LangGraph state graph primitives & flow orchestration
@@ -110,7 +111,7 @@ Packages can only depend on packages above them:
 ```
 @protolabs-ai/types (no dependencies)
     ↓
-@protolabs-ai/utils, @protolabs-ai/prompts, @protolabs-ai/platform, @protolabs-ai/model-resolver, @protolabs-ai/dependency-resolver, @protolabs-ai/spec-parser, @protolabs-ai/tools, @protolabs-ai/flows, @protolabs-ai/llm-providers, @protolabs-ai/observability
+@protolabs-ai/utils, @protolabs-ai/prompts, @protolabs-ai/platform, @protolabs-ai/model-resolver, @protolabs-ai/dependency-resolver, @protolabs-ai/spec-parser, @protolabs-ai/pen-parser, @protolabs-ai/tools, @protolabs-ai/flows, @protolabs-ai/llm-providers, @protolabs-ai/observability
     ↓
 @protolabs-ai/git-utils, @protolabs-ai/ui
     ↓
@@ -351,7 +352,7 @@ claude plugin install automaker
 
 ### Available MCP Tools
 
-The MCP server exposes 48+ tools organized by category:
+The MCP server exposes 135 tools organized by category:
 
 **Feature Management:** `list_features`, `get_feature`, `create_feature`, `update_feature`, `delete_feature`, `move_feature`
 

--- a/docs/integrations/mcp-tools-reference.md
+++ b/docs/integrations/mcp-tools-reference.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-Complete catalog of MCP tools exposed by the protoLabs server. See `packages/mcp-server/src/index.ts` for the full definitions.
+Complete catalog of **135 MCP tools** exposed by the protoLabs server. See `packages/mcp-server/src/index.ts` for the full definitions.
 
 For installation and configuration, see [Claude Plugin Setup](./claude-plugin.md). For commands and examples, see [Plugin Commands](./plugin-commands.md).
 


### PR DESCRIPTION
## Summary
- Minor updates to `CLAUDE.md` — model alias and documentation corrections
- Updates `docs/integrations/mcp-tools-reference.md` — reference doc alignment

Auto-committed agent progress from engine validation feature.

## Test plan
- [ ] Docs render correctly on docs site
- [ ] No broken links in updated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)