### PR TITLE
chore: add agent-learned patterns + fix patterns.md conflict markers

### DIFF
--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,7 +5,7 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 47
+  loaded: 49
   referenced: 25
   successfulFeatures: 25
 ---
@@ -3540,3 +3540,35 @@ usageStats:
 - **Rejected:** Direct app.use(router) at module level - tightly couples routes to server initialization, harder to test
 - **Trade-offs:** One extra function call to create router vs direct registration. Gain testability and modularity.
 - **Breaking if changed:** If routes are inlined directly into index.ts instead of returned from factory, tests can't import createDocsRoutes() separately, and circular dependencies may form if routes need to be shared across server instances.
+### GitHub-hosted runners for smoke tests, but self-hosted Linux runner retained for builds. Different tool for different job type (2026-02-25)
+- **Context:** Could use self-hosted for consistency (one infrastructure pattern) or GitHub-hosted for consistency (one runner type)
+- **Why:** GitHub-hosted provides clean, consistent environment for tests (no state accumulation). Self-hosted needed for builds because: complex build dependencies, caching requirements, longer execution time amortization. Smoke tests are stateless; builds are not
+- **Rejected:** All GitHub-hosted (tests too slow/expensive), or all self-hosted (tests have environmental entropy)
+- **Trade-offs:** Operational complexity of two runner types, but each type is optimized for its workload. Tests get clean environment; builds get fast caching
+- **Breaking if changed:** Moving tests to self-hosted would expose them to previous build artifacts causing flaky environment-dependent failures
+
+#### [Pattern] Commit compiled CSS to repository but regenerate in GitHub Actions - hybrid approach to generated files (2026-02-25)
+- **Problem solved:** CSS is generated from config/source (Tailwind) but needed to be available for deployment
+- **Why this works:** Committed CSS ensures: (1) deployment doesn't require build step on server, (2) git history shows what was deployed, (3) works in environments without Node/build tools. GitHub Actions regeneration ensures: (1) source of truth is config, (2) accidental manual edits get overwritten, (3) deploy always uses current config.
+- **Trade-offs:** Slightly larger repo (33KB CSS file) but fast deployments without build. Hybrid approach combines benefits of both worlds.
+
+### Created `@protolabs-ai/error-tracking` wrapper package instead of direct Sentry integration throughout codebase (2026-02-25)
+- **Context:** Abstraction layer over `@sentry/node` and `@sentry/electron` to provide unified API across server and Electron contexts
+- **Why:** Decouples application code from Sentry vendor; allows swapping error tracking provider (e.g., from Sentry to PostHog, DataDog) without changing app code everywhere. Single point of configuration and privacy enforcement
+- **Rejected:** Importing Sentry directly in every module that needs error tracking (tight coupling, vendor lock-in, inconsistent privacy controls)
+- **Trade-offs:** Extra package/indirection adds small performance cost but provides flexibility and consistent privacy enforcement across entire app
+- **Breaking if changed:** Without this wrapper, changing error tracking providers requires updating dozens of import statements and error handling patterns across codebase
+
+### Context set once per request/transaction, inherited by all subsequent errors in that scope via `setFeatureContext()` and `setSessionContext()` (2026-02-25)
+- **Context:** Attaching feature ID, session ID, and execution metadata to errors without manual inclusion in every capture call
+- **Why:** Avoids repetitive context passing; errors automatically know which feature/session they belong to. Follows distributed tracing principle where context propagates through execution
+- **Rejected:** Passing context as argument to every `captureException()` call (verbose, error-prone if context not passed, harder to add new context later)
+- **Trade-offs:** Automatic context inheritance is cleaner but requires careful context management in async/concurrent scenarios - context can leak between unrelated requests if not properly isolated
+- **Breaking if changed:** If context is not cleared between requests in a request pool, errors from request A will be tagged with context from request B
+
+### Progressive disclosure: README shows overview + links to detailed docs, not all content inline (2026-02-25)
+- **Context:** Project has complex architecture (13 shared packages, monorepo structure, multiple apps, integration requirements) that exceeds README readability
+- **Why:** Different users have different needs - some want quick overview, others want architecture details. Progressive disclosure serves both without overwhelming single document. Keeps README under usable length while supporting deep exploration
+- **Rejected:** Inline all architecture/contributing details (creates unmaintainable 3000+ line README). Separate architecture doc without README overview (users don't know it exists)
+- **Trade-offs:** Users must click for details instead of finding everything in one place. But enables maintainability and caters to scanning vs deep reading behaviors
+- **Breaking if changed:** Without external documentation structure, README becomes dumping ground for all complexity. Architecture details require dedicated documentation with proper structure and versioning

--- a/.automaker/memory/patterns.md
+++ b/.automaker/memory/patterns.md
@@ -5,15 +5,9 @@ relevantTo: [patterns]
 importance: 0.7
 relatedFiles: []
 usageStats:
-<<<<<<< Updated upstream
-  loaded: 28
+  loaded: 30
   referenced: 15
   successfulFeatures: 15
-=======
-  loaded: 23
-  referenced: 12
-  successfulFeatures: 12
->>>>>>> Stashed changes
 ---
 # patterns
 

--- a/.automaker/memory/security.md
+++ b/.automaker/memory/security.md
@@ -452,3 +452,14 @@ usageStats:
 - **Rejected:** Simple checks: if(path.includes('..')) or if(!path.startsWith('/')) - these fail on paths like 'docs/../../../.env' which normalize to '../../../.env'
 - **Trade-offs:** More code and two function calls per request vs false sense of security from naive checks. Worth the cost for file serving.
 - **Breaking if changed:** Removing normalize() allows paths like 'docs/../../.env' to bypass relative() check. Removing relative() check allows any path that doesn't contain raw '..' (e.g., after normalization).
+#### [Pattern] Privacy controls implemented in `beforeSend` hook before transmission, not post-capture - emails, API keys, tokens scrubbed at source (2026-02-25)
+- **Problem solved:** Sensitive PII redaction for GDPR compliance with explicit user opt-in
+- **Why this works:** Data cannot be recalled after transmission; privacy must be enforced at the last moment before sending. `beforeSend` is the final gate before Sentry receives data
+- **Trade-offs:** More complex initialization logic but guarantees sensitive data never leaves the application
+
+### Default `enabled: false` for error tracking in settings - explicit user opt-in required, no automatic data transmission (2026-02-25)
+- **Context:** GDPR compliance and privacy-respecting default behavior
+- **Why:** Privacy-by-default: users must make conscious choice to enable monitoring. Opposite of opt-out (more ethical, legally safer). Data doesn't flow without explicit consent
+- **Rejected:** Default `enabled: true` with opt-out option (assumes consent, requires users to find and disable, risky legally)
+- **Trade-offs:** Reduced telemetry coverage initially (only opt-in users tracked) but better user trust and legal compliance
+- **Breaking if changed:** If default changes to `enabled: true`, the app starts transmitting error data without user knowledge - GDPR violation

--- a/.automaker/memory/seo.md
+++ b/.automaker/memory/seo.md
@@ -1,0 +1,19 @@
+---
+tags: [seo]
+summary: seo implementation decisions and patterns
+relevantTo: [seo]
+importance: 0.7
+relatedFiles: []
+usageStats:
+  loaded: 0
+  referenced: 0
+  successfulFeatures: 0
+---
+# seo
+
+### Use JSON-LD structured data format over microdata or RDFa for schema markup (2026-02-25)
+- **Context:** Need to add structured data for rich results in Google Search - multiple valid formats exist
+- **Why:** JSON-LD is Google's recommended format. Key advantages: (1) doesn't require HTML attribute changes - isolated in script tag, (2) easier to validate and maintain - valid JSON, (3) cleaner separation of concerns, (4) no risk of breaking HTML rendering if syntax error occurs. Microdata would clutter attributes; RDFa requires custom prefixes.
+- **Rejected:** Microdata: requires data-* attributes throughout HTML, harder to maintain complex schemas, mingles data with presentation. RDFa: more complex prefix syntax, steeper learning curve, less commonly used in modern web.
+- **Trade-offs:** Gained maintainability and validation tooling (can validate JSON separately). Slightly larger file size vs inline microdata (negligible - ~2KB). More declarative approach at cost of less semantic HTML.
+- **Breaking if changed:** If schema structure changes, only JSON-LD needs update. With microdata, would need to update both HTML attributes and attributes. Rich results validation would fail if JSON-LD is removed - Google Search Console would report schema issues.

--- a/.automaker/memory/testing.md
+++ b/.automaker/memory/testing.md
@@ -5,7 +5,7 @@ relevantTo: [testing]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 45
+  loaded: 48
   referenced: 24
   successfulFeatures: 24
 ---
@@ -931,3 +931,36 @@ usageStats:
 - **Situation:** Updated model aliases (opus 4-5 → 4-6, sonnet 4-5 → 4-6), then had to update 13 test assertions to match new IDs
 - **Root cause:** Tests are tightly coupled to implementation constants. They verify behavior, not contracts.
 - **How to avoid:** String assertions are simple but brittle. Could use parameterized tests or test against a config file instead.
+### 90-second timeout configured specifically to account for multi-stage installation + launch + server startup sequence: ~10s installation + ~10s app launch + ~60s server startup with port scanning + ~10s test buffer (2026-02-25)
+- **Context:** Electron app smoke tests must wait for multiple async operations before validation can begin
+- **Why:** Arbitrary timeout (30s, 60s) would be unreliable. Analyzed each component's typical duration to set reliable threshold without unnecessary flakiness
+- **Rejected:** Using standard Playwright timeout (30s) which would frequently timeout on server startup phase
+- **Trade-offs:** Longer tests (slower feedback loop) vs more reliable CI that doesn't fail on transient delays
+- **Breaking if changed:** Reducing timeout below 90s causes intermittent failures on slower CI runners when server startup takes 60+ seconds
+
+#### [Gotcha] Installation smoke tests cannot run in parallel (workers: 1) because platform-specific scripts modify shared system directories (DMG mount points, Program Files, /tmp) (2026-02-25)
+- **Situation:** Attempted parallel test execution caused conflicts when multiple tests tried to mount same DMG or install to same directory
+- **Root cause:** Unlike unit tests, smoke tests have real side effects on the OS. Installation tests are inherently sequential operations competing for shared resources
+- **How to avoid:** Sequential execution adds ~2 minutes to test suite runtime but eliminates flaky race conditions and resource conflicts
+
+#### [Gotcha] TypeScript type checker (tsc --noEmit) reports JSX namespace and import style errors but Vite build succeeds. Pre-existing node_modules type definition conflicts don't affect build output (2026-02-25)
+- **Situation:** Running isolated type checking for validation appeared to fail, but actual build succeeded without errors
+- **Root cause:** Vite uses esbuild which has different type checking behavior and doesn't enforce the same strict type constraints as tsc. Type definition conflicts in node_modules are cosmetic for esbuild
+- **How to avoid:** Build succeeds despite type checker warnings, but developers running 'tsc --noEmit' locally see spurious errors. IDE TypeScript checking may show warnings that aren't actual failures
+
+#### [Pattern] Platform-specific installation scripts (bash for macOS/Linux, PowerShell for Windows) replicate realistic user installation flow rather than direct binary extraction (2026-02-25)
+- **Problem solved:** Could have simplified to: extract DMG/exe/AppImage and run binary directly, but this bypasses installer-specific code paths
+- **Why this works:** Smoke tests should catch installer-specific bugs (broken mount scripts, invalid NSIS configuration, missing permissions) before release
+- **Trade-offs:** Slightly more complex test setup (platform-specific scripts) but catches entire category of installer bugs that generic extraction would miss
+
+#### [Pattern] Mock mode isolation via AUTOMAKER_MOCK_AGENT=true environment variable allows smoke tests to run without API connectivity or credentials (2026-02-25)
+- **Problem solved:** Smoke tests run in CI on GitHub runners without access to external services
+- **Why this works:** Test reliability depends on not hitting external dependencies. Mock mode allows testing app startup, window rendering, and state persistence without API infrastructure
+- **Trade-offs:** Tests verify app can launch and setup flow completes, but don't verify API integration
+
+### Artifact retention: 30 days for builds, 7 days for test results (not symmetric). Different retention for different artifact types (2026-02-25)
+- **Context:** Could use uniform retention (14 days, 30 days, etc) for simplicity
+- **Why:** Builds are expensive to recreate and needed for emergency rollbacks. Test results are primarily for debugging the most recent failures. After 7 days, test logs are stale (new code landed)
+- **Rejected:** Uniform 14-day retention (wastes storage on old test logs, might not keep builds long enough)
+- **Trade-offs:** Slightly higher complexity in CI configuration, but optimizes storage costs for artifact pattern
+- **Breaking if changed:** Shortening build retention to 7 days causes problems when needing to rebuild patch on 10-day-old code


### PR DESCRIPTION
## Summary
- Adds unique agent-learned patterns from Sentry, desktop testing, SEO, and README feature agents that were not captured in main during the concurrent PR merge wave
- Fixes `patterns.md` which had git conflict markers accidentally committed to main (lines 8, 12, 16 in HEAD)

## Files
- **seo.md** (new): JSON-LD vs microdata/RDFa structured data decision
- **architecture.md**: Sentry error-tracking wrapper, GitHub-hosted vs self-hosted runner strategy, hybrid CSS commit, README progressive disclosure pattern
- **testing.md**: Electron smoke test 90s timeout rationale, parallel installation test isolation, tsc vs Vite type checking discrepancy, platform-specific installer scripts, mock mode isolation, asymmetric artifact retention (30d builds / 7d tests)
- **security.md**: Privacy-by-default opt-in, `beforeSend` PII scrubbing at transmission gate
- **patterns.md**: Fix `<<<<<<< Updated upstream` / `=======` / `>>>>>>> Stashed changes` conflict markers in YAML frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)