### PR TITLE
feat: DocsView — file tree and markdown panel

### DIFF
--- a/apps/ui/src/components/views/docs-view.tsx
+++ b/apps/ui/src/components/views/docs-view.tsx
@@ -1,8 +1,12 @@
+import { useState } from 'react';
 import { Library } from 'lucide-react';
 import { useAppStore } from '@/store/app-store';
+import { DocsFileTree } from './docs-view/docs-file-tree';
+import { DocsContentPanel } from './docs-view/docs-content-panel';
 
 export function DocsView() {
   const currentProject = useAppStore((s) => s.currentProject);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
 
   if (!currentProject) {
     return (
@@ -20,9 +24,17 @@ export function DocsView() {
         <h1 className="text-sm font-medium">Docs</h1>
       </div>
 
-      {/* Placeholder content */}
-      <div className="flex flex-1 items-center justify-center text-muted-foreground">
-        <p>Docs view - Coming soon</p>
+      {/* Two-panel layout */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Left panel: file tree, fixed width */}
+        <div className="w-56 shrink-0 overflow-y-auto border-r border-border">
+          <DocsFileTree selectedPath={selectedPath} onSelect={setSelectedPath} />
+        </div>
+
+        {/* Right panel: content, fills remaining space */}
+        <div className="flex-1 overflow-hidden">
+          <DocsContentPanel selectedPath={selectedPath} />
+        </div>
       </div>
     </div>
   );

--- a/apps/ui/src/components/views/docs-view/docs-content-panel.tsx
+++ b/apps/ui/src/components/views/docs-view/docs-content-panel.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+import { Loader2, FileText } from 'lucide-react';
+import Markdown from 'react-markdown';
+
+interface DocContent {
+  path: string;
+  title: string;
+  content: string;
+}
+
+interface DocsContentPanelProps {
+  selectedPath: string | null;
+}
+
+export function DocsContentPanel({ selectedPath }: DocsContentPanelProps) {
+  const [doc, setDoc] = useState<DocContent | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedPath) {
+      setDoc(null);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchDoc() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(`/api/docs/file?path=${encodeURIComponent(selectedPath!)}`);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch doc: ${response.status}`);
+        }
+        const data = await response.json();
+        if (!cancelled) {
+          setDoc({ path: data.path, title: data.title, content: data.content });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load document');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    fetchDoc();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedPath]);
+
+  if (!selectedPath) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
+        <FileText className="size-8 opacity-30" />
+        <p className="text-sm">Select a file to view its contents</p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2">
+        <p className="text-sm text-destructive">Failed to load document</p>
+        <p className="text-xs text-muted-foreground">{error}</p>
+      </div>
+    );
+  }
+
+  if (!doc) {
+    return null;
+  }
+
+  return (
+    <div className="h-full overflow-y-auto p-6">
+      <div className="prose prose-sm prose-invert max-w-none prose-p:text-foreground/90 prose-headings:text-foreground prose-li:text-foreground/90 prose-strong:text-foreground prose-code:text-violet-300 prose-code:bg-muted/50 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-pre:bg-muted/30 prose-pre:border prose-pre:border-border/20 prose-table:text-foreground/90 prose-th:text-foreground prose-td:border-border/20 prose-th:border-border/20">
+        <Markdown>{doc.content}</Markdown>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/views/docs-view/docs-file-tree.tsx
+++ b/apps/ui/src/components/views/docs-view/docs-file-tree.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react';
+import { FileText, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface DocFile {
+  path: string;
+  title: string;
+  slug: string;
+}
+
+interface DocsFileTreeProps {
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+}
+
+/**
+ * Infer a section label from the file's slug.
+ * Looks for common prefixes like "brand-", "process-", etc.
+ * Falls back to "General" for ungrouped files.
+ */
+function inferSection(slug: string): string {
+  const prefixes: Record<string, string> = {
+    brand: 'Brand',
+    process: 'Process',
+    workflow: 'Workflow',
+    guide: 'Guides',
+    guidelines: 'Guidelines',
+    architecture: 'Architecture',
+    setup: 'Setup',
+    api: 'API',
+    spec: 'Specs',
+    dev: 'Development',
+    development: 'Development',
+    test: 'Testing',
+    deploy: 'Deployment',
+  };
+
+  for (const [prefix, section] of Object.entries(prefixes)) {
+    if (slug.startsWith(prefix + '-') || slug === prefix) {
+      return section;
+    }
+  }
+
+  return 'General';
+}
+
+export function DocsFileTree({ selectedPath, onSelect }: DocsFileTreeProps) {
+  const [docs, setDocs] = useState<DocFile[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchDocs() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await fetch('/api/docs/list');
+        if (!response.ok) {
+          throw new Error(`Failed to fetch docs list: ${response.status}`);
+        }
+        const data = await response.json();
+        if (!cancelled) {
+          setDocs(data.docs ?? []);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load docs');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    fetchDocs();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="size-4 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-3 text-xs text-destructive">
+        <p>Failed to load docs</p>
+        <p className="mt-1 text-muted-foreground">{error}</p>
+      </div>
+    );
+  }
+
+  if (docs.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-xs text-muted-foreground">No docs found</p>
+      </div>
+    );
+  }
+
+  // Group docs by inferred section
+  const sections: Record<string, DocFile[]> = {};
+  for (const doc of docs) {
+    const section = inferSection(doc.slug);
+    if (!sections[section]) {
+      sections[section] = [];
+    }
+    sections[section].push(doc);
+  }
+
+  const sectionNames = Object.keys(sections).sort();
+
+  return (
+    <div className="flex flex-col gap-4 p-3">
+      {sectionNames.map((section) => (
+        <div key={section}>
+          <div className="mb-1 px-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            {section}
+          </div>
+          <div className="flex flex-col gap-0.5">
+            {sections[section].map((doc) => (
+              <button
+                key={doc.path}
+                onClick={() => onSelect(doc.path)}
+                className={cn(
+                  'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors',
+                  selectedPath === doc.path
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                )}
+              >
+                <FileText
+                  className={cn(
+                    'size-3 shrink-0',
+                    selectedPath === doc.path ? 'text-primary' : 'text-muted-foreground'
+                  )}
+                />
+                <span className="truncate">{doc.title}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Replaces the placeholder `DocsView` with a real two-panel implementation
- **Left panel**: file list from `GET /api/docs/list` — grouped by slug prefix (Brand, Process, etc.), highlights selected item
- **Right panel**: fetches `GET /api/docs/file?path=` and renders markdown via `react-markdown` with prose styles

## Files changed

- `apps/ui/src/components/views/docs-view.tsx` — wires two panels, manages `selectedPath` state
- `apps/ui/src/components/views/docs-view/docs-file-tree.tsx` — new file tree component
- `apps/ui/src/components/views/docs-view/docs-content-panel.tsx` — new markdown content component

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced documentation view with a two-panel layout: browse documentation files in a left panel and view content in the right panel
  * Documentation files are automatically organized by section for intuitive navigation
  * Integrated loading states and error handling for a polished experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->