### PR TITLE
fix: prevent duplicate agent launches when feature already has open PR

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -5114,6 +5114,23 @@ Format your response as a structured markdown document.`;
     // Used to identify orphaned features (features with branchNames but no worktrees)
     const worktreeBranches = await this.getAllWorktreeBranches(projectPath);
 
+    // Fetch all open PRs once — guards against re-executing features that already have open PRs.
+    // Prevents the SPEC_REVIEW gate (or dep-unblocking) from launching duplicate agents.
+    const openPrBranches = new Map<string, number>(); // branch → PR number
+    try {
+      const { stdout: prJson } = await execAsync(
+        'gh pr list --state open --json number,headRefName --limit 200',
+        { cwd: projectPath, timeout: 15000 }
+      );
+      const prs: { number: number; headRefName: string }[] = JSON.parse(prJson || '[]');
+      for (const pr of prs) openPrBranches.set(pr.headRefName, pr.number);
+      logger.debug(
+        `[loadPendingFeatures] Found ${openPrBranches.size} open PR(s) — these branches are excluded from re-execution`
+      );
+    } catch (err) {
+      logger.warn('[loadPendingFeatures] Could not fetch open PRs (non-fatal):', err);
+    }
+
     try {
       const entries = await secureFs.readdir(featuresDir, {
         withFileTypes: true,
@@ -5162,20 +5179,49 @@ Format your response as a structured markdown document.`;
       for (const feature of blockedWithDeps) {
         const satisfied = areDependenciesSatisfied(feature, allFeatures);
         if (satisfied) {
-          logger.info(
-            `[loadPendingFeatures] Unblocking feature ${feature.id} — all dependencies now satisfied`
-          );
-          feature.status = 'backlog';
-          try {
-            await this.featureLoader.update(projectPath, feature.id, { status: 'backlog' });
-            this.events.emit('feature:status-changed', {
-              projectPath,
-              featureId: feature.id,
-              previousStatus: 'blocked',
-              newStatus: 'backlog',
-            });
-          } catch (error) {
-            logger.error(`[loadPendingFeatures] Failed to unblock feature ${feature.id}:`, error);
+          // Guard: if deps are satisfied but feature already has an open PR, sync to 'review'
+          // rather than 'backlog' — this prevents duplicate agent launches after SPEC_REVIEW gate
+          const existingPr = feature.branchName
+            ? openPrBranches.get(feature.branchName)
+            : undefined;
+          if (existingPr) {
+            logger.info(
+              `[loadPendingFeatures] Feature ${feature.id} deps satisfied but has open PR #${existingPr} — syncing to review`
+            );
+            feature.status = 'review';
+            try {
+              await this.featureLoader.update(projectPath, feature.id, {
+                status: 'review',
+                prNumber: existingPr,
+              });
+              this.events.emit('feature:status-changed', {
+                projectPath,
+                featureId: feature.id,
+                previousStatus: 'blocked',
+                newStatus: 'review',
+              });
+            } catch (error) {
+              logger.error(
+                `[loadPendingFeatures] Failed to sync feature ${feature.id} to review:`,
+                error
+              );
+            }
+          } else {
+            logger.info(
+              `[loadPendingFeatures] Unblocking feature ${feature.id} — all dependencies now satisfied`
+            );
+            feature.status = 'backlog';
+            try {
+              await this.featureLoader.update(projectPath, feature.id, { status: 'backlog' });
+              this.events.emit('feature:status-changed', {
+                projectPath,
+                featureId: feature.id,
+                previousStatus: 'blocked',
+                newStatus: 'backlog',
+              });
+            } catch (error) {
+              logger.error(`[loadPendingFeatures] Failed to unblock feature ${feature.id}:`, error);
+            }
           }
         }
       }
@@ -5218,6 +5264,37 @@ Format your response as a structured markdown document.`;
             );
             continue;
           }
+
+          // Guard: if feature already has an open PR, sync it to 'review' and skip execution.
+          // Prevents duplicate agent launches when SPEC_REVIEW gate or dep-unblocking races
+          // with an existing in-flight PR.
+          const existingPr = feature.branchName
+            ? openPrBranches.get(feature.branchName)
+            : undefined;
+          if (existingPr) {
+            logger.info(
+              `[loadPendingFeatures] ⏭ Feature ${feature.id} has open PR #${existingPr} — syncing to review, skipping execution`
+            );
+            try {
+              await this.featureLoader.update(projectPath, feature.id, {
+                status: 'review',
+                prNumber: existingPr,
+              });
+              this.events.emit('feature:status-changed', {
+                projectPath,
+                featureId: feature.id,
+                previousStatus: feature.status,
+                newStatus: 'review',
+              });
+            } catch (error) {
+              logger.error(
+                `[loadPendingFeatures] Failed to sync feature ${feature.id} to review:`,
+                error
+              );
+            }
+            continue;
+          }
+
           // Filter by branchName:
           // - If branchName is null (main worktree), include features with:
           //   - branchName === null (unassigned), OR

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -511,6 +511,36 @@ class ExecuteProcessor implements StateProcessor {
       };
     }
 
+    // Guard: if the feature's branch already has an open PR, skip execution and advance to REVIEW.
+    // Prevents the state machine from launching a duplicate agent when the feature was already
+    // submitted (e.g., blocked at SPEC_REVIEW gate, then requeued by dep-unblocking).
+    if (ctx.feature.branchName) {
+      try {
+        const { stdout: prJson } = await execAsync(
+          `gh pr list --head "${ctx.feature.branchName}" --state open --json number,headRefName --limit 1`,
+          { cwd: ctx.projectPath, timeout: 10000 }
+        );
+        const prs: { number: number }[] = JSON.parse(prJson || '[]');
+        if (prs.length > 0) {
+          ctx.prNumber = prs[0].number;
+          logger.info(
+            `[EXECUTE] Feature ${ctx.feature.id} already has open PR #${ctx.prNumber} — skipping execution, transitioning to REVIEW`
+          );
+          await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
+            status: 'review',
+            prNumber: ctx.prNumber,
+          });
+          return {
+            nextState: 'REVIEW',
+            shouldContinue: true,
+            reason: `Existing open PR #${ctx.prNumber} found — skipping re-execution`,
+          };
+        }
+      } catch (err) {
+        logger.warn('[EXECUTE] Could not check for existing PR (non-fatal):', err);
+      }
+    }
+
     // Shape prior context via ContextFidelityService (if available)
     if (
       this.serviceContext.contextFidelityService &&

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/sdk-node": "^0.212.0",
         "@protolabs-ai/dependency-resolver": "0.4.0",
+        "@protolabs-ai/error-tracking": "0.4.0",
         "@protolabs-ai/flows": "0.4.0",
         "@protolabs-ai/git-utils": "0.4.0",
         "@protolabs-ai/llm-providers": "0.4.0",


### PR DESCRIPTION
## Summary

- **Layer 1 — `loadPendingFeatures()` in `auto-mode-service.ts`**: Fetches all open PRs once at function start. The blocked→backlog dependency-unblocking loop now syncs to `review` (instead of `backlog`) when the feature branch already has an open PR. The eligibility filter also skips those features, syncing them to `review` instead of queueing them for execution.

- **Layer 2 — `ExecuteProcessor.process()` in `lead-engineer-service.ts`**: Before launching an agent, checks GitHub for an existing open PR on the feature's branch. If found, sets `ctx.prNumber` and returns a `REVIEW` transition immediately — no agent is ever started.

- **`npm install`**: Brings `@sentry/node` and related packages into `node_modules` after PR #1151 merged the error-tracking package. Without this, `build:server` was failing.

## Root Cause

The Lead Engineer pipeline puts features in `blocked` status at the `SPEC_REVIEW` gate. When dependencies are later satisfied, `loadPendingFeatures` converts `blocked → backlog`, which auto-mode immediately picks up for execution — even if the feature's branch already has an open PR from a prior run. This caused $5–6 of duplicate agent spend per affected feature.

## Test plan

- [ ] Start auto-mode with a feature whose branch already has an open PR — verify it gets synced to `review` without launching an agent
- [ ] Verify blocked features with open PRs are synced to `review` by the dep-unblocking loop rather than `backlog`
- [ ] Verify the EXECUTE processor fast-paths to `REVIEW` when an existing PR is detected
- [ ] Verify normal backlog features (no existing PR) still execute as before
- [ ] `npm run build:server` passes cleanly ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented duplicate pull request creation for features with existing open PRs
  * Resolved race conditions between simultaneous PR submissions and feature execution workflows

* **Improvements**
  * Features with open PRs automatically transition to review status instead of re-executing
  * Enhanced error handling for pull request lookups with fallback to standard behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->