### PR TITLE
fix: deploy timeout 15→30min + tag rollback head-1 guard

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -13,7 +13,7 @@ jobs:
   deploy:
     runs-on: self-hosted
     if: github.repository == 'proto-labs-ai/protoMaker'
-    timeout-minutes: 15
+    timeout-minutes: 30
     concurrency:
       group: staging-deploy
       cancel-in-progress: false
@@ -101,7 +101,7 @@ jobs:
           # Save current working images so we can restore on failure.
           # Only tag app services — docs runs independently and is never rolled back.
           for svc in server ui; do
-            img=$(docker compose -f docker-compose.staging.yml images -q "$svc" 2>/dev/null || true)
+            img=$(docker compose -f docker-compose.staging.yml images -q "$svc" 2>/dev/null | head -1 || true)
             if [ -n "$img" ]; then
               docker tag "$img" "automaker-staging-${svc}:rollback"
               echo "Tagged ${svc} image ${img} as rollback"


### PR DESCRIPTION
## Summary

Staging deploys have been failing in two different ways. Both fixed here.

**Fix 1 — `timeout-minutes: 15 → 30`**
The Docker build hits >15min when the layer cache is cold (triggered by adding `@sentry/node` in PR #1151). The timeout fired mid-build, left `automaker-server` in `Created` state, and the whole deploy failed before the server could start.

**Fix 2 — `docker compose images -q | head -1`**
When a previous failed deploy leaves a ghost container (`25a472cefc99_automaker-ui`), `docker compose images -q ui` returns two image IDs separated by a newline. `docker tag` then gets passed both as a single argument and fails with `"invalid reference format"` — crashing the deploy at the "Tag rollback images" step, before any code is built.

## Impact

Both issues compound: first deploy times out → leaves ghost container → second deploy crashes at tag step. Net result: server down, rollback not performed.

## Test plan

- [ ] Deploy runs past "Tag rollback images" without error
- [ ] Build completes within 30 minutes (warm cache: ~5min, cold: ~20min)
- [ ] `automaker-server` comes up healthy after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rollback mechanism to correctly identify and tag the primary image.

* **Chores**
  * Extended deployment timeout to 30 minutes for improved stability during longer deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->