### PR TITLE
fix: TypedEventBus executeFeature throw contract and prettier format

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -1715,9 +1715,7 @@ export class AutoModeService {
       const runtime = existing ? Math.floor((Date.now() - existing.startTime) / 1000) : 0;
       // Undo the lease increment before throwing — we're not going to execute
       this.concurrencyManager.release(featureId);
-      throw new Error(
-        `Feature ${featureId} is already running (runtime: ${runtime}s)`
-      );
+      throw new Error(`Feature ${featureId} is already running (runtime: ${runtime}s)`);
     }
 
     // Add to running features immediately to prevent duplicate execution race condition


### PR DESCRIPTION
Replaces #1177 with a clean cherry-pick containing only the two fix commits.

**Why a new PR?** #1177 was retargeted to the epic branch after the TypedEventBus feature was squash-merged in. Because squash merges don't share commit ancestry, the PR diff showed the full TypedEventBus reimplementation (668 lines) even though the epic already contained those changes. This PR cherry-picks only the actual fixes.

## Changes

- **fix: throw on duplicate executeFeature** — `executeFeature` was silently returning when the ConcurrencyManager lease was already held. Unit test expected `rejects.toThrow`. Now releases the lease increment and throws.
- **fix: format auto-mode-service.ts** — Prettier violations flagged by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)