### PR TITLE
fix: quote FTS5 tokens to prevent column-filter misparse in searchReflections

### DIFF
--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -5,7 +5,7 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 46
+  loaded: 47
   referenced: 21
   successfulFeatures: 21
 ---

--- a/apps/server/src/services/knowledge-search-service.ts
+++ b/apps/server/src/services/knowledge-search-service.ts
@@ -463,14 +463,23 @@ export class KnowledgeSearchService {
     query: string,
     maxResults: number = 5
   ): Promise<KnowledgeSearchResult[]> {
-    // Sanitize for FTS5 — strip operators that break MATCH syntax
+    // Sanitize for FTS5 — strip operators that break MATCH syntax, then quote
+    // each token individually so FTS5 never treats a word as a column filter.
     const sanitized = query
       .replace(/['"*(){}[\]:^~!@#$%&\\|<>]/g, ' ')
       .replace(/\s+/g, ' ')
       .trim();
     if (!sanitized) return [];
 
-    const { results } = await this.search(projectPath, sanitized, {
+    // Wrap each token in double quotes to prevent FTS5 column-filter interpretation.
+    // e.g. "Save" alone would otherwise trigger "no such column: Save".
+    const ftsQuery = sanitized
+      .split(' ')
+      .filter((t) => t.length > 0)
+      .map((t) => `"${t}"`)
+      .join(' ');
+
+    const { results } = await this.search(projectPath, ftsQuery, {
       sourceTypes: ['reflection', 'agent_output'],
       maxResults,
       maxTokens: 3000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/sdk-node": "^0.212.0",
         "@protolabs-ai/dependency-resolver": "0.4.0",
+        "@protolabs-ai/error-tracking": "0.4.0",
         "@protolabs-ai/flows": "0.4.0",
         "@protolabs-ai/git-utils": "0.4.0",
         "@protolabs-ai/llm-providers": "0.4.0",


### PR DESCRIPTION
## Problem

`KnowledgeSearchService.searchReflections` builds an FTS5 MATCH query directly from the feature title+description. When the first word happens to be one that FTS5 could interpret as a column filter (e.g. `Save`, or any word if there's a residual `:` nearby), SQLite throws:

```
SqliteError: no such column: Save
```

The existing sanitizer removes `:`, `{`, `}`, quotes, etc., but individual bare tokens can still trigger this if the FTS5 tokenizer parses them in context (e.g. as column-prefix specifiers in some SQLite builds).

## Fix

After sanitization, wrap each token in double-quotes before passing to FTS5:

```
"Save" "current" "file" "state"
```

FTS5 double-quoted tokens are treated as exact term matches and never parsed as column filters.

## Test

Reproduce: create a feature with title `Save current file state` and let `LeadEngineerService` execute it with `knowledgeStoreService` active. Before fix: crashes. After fix: returns BM25 results normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search query handling to deliver more accurate and reliable results across search operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->