### PR TITLE
fix: post-agent git workflow hardening — detect and recover uncommitted worktree work

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -75,6 +75,7 @@ import {
   getProviderByModelId,
 } from '../../lib/settings-helpers.js';
 import { RecoveryService } from '../recovery-service.js';
+import { checkAndRecoverUncommittedWork } from '../worktree-recovery-service.js';
 import { gitWorkflowService } from '../git-workflow-service.js';
 import { graphiteService } from '../graphite-service.js';
 import type { KnowledgeStoreService } from '../knowledge-store-service.js';
@@ -703,6 +704,62 @@ export class ExecutionService {
           providerId: modelResult.providerId,
         }
       );
+
+      // Post-agent hook: detect and recover uncommitted work
+      // Runs immediately after agent exits (before pipeline/git workflow steps)
+      // so that stranded work is committed and a PR is created if the agent
+      // completed implementation but failed to run its own git workflow step.
+      if (worktreePath) {
+        const recoveryResult = await checkAndRecoverUncommittedWork(feature, workDir);
+        if (recoveryResult.detected) {
+          if (recoveryResult.recovered) {
+            // Recovery committed, pushed, and created a PR.
+            // Update feature status to 'review' and emit completion so
+            // lead-engineer-service waitForCompletion resolves.
+            logger.info(
+              `[PostAgentHook] Recovered uncommitted work for ${featureId}: PR at ${recoveryResult.prUrl}`
+            );
+            await this.featureLoader.update(projectPath, featureId, {
+              status: 'review',
+              prUrl: recoveryResult.prUrl,
+              ...(recoveryResult.prNumber !== undefined && {
+                prNumber: recoveryResult.prNumber,
+              }),
+              ...(recoveryResult.prCreatedAt && { prCreatedAt: recoveryResult.prCreatedAt }),
+            });
+            this.callbacks.emitAutoModeEvent('auto_mode_git_workflow', {
+              featureId,
+              pushed: true,
+              prUrl: recoveryResult.prUrl,
+              prNumber: recoveryResult.prNumber,
+              projectPath,
+            });
+            this.events.emit('feature:completed', {
+              projectPath,
+              featureId,
+              featureTitle: feature.title,
+              status: 'review',
+            });
+            return;
+          } else {
+            // Recovery failed — mark as blocked and surface error to waitForCompletion
+            const reason = `git workflow failed — uncommitted work in worktree at ${workDir}: ${recoveryResult.error ?? 'unknown'}`;
+            logger.warn(
+              `[PostAgentHook] Recovery failed for ${featureId}: ${recoveryResult.error}`
+            );
+            await this.featureLoader.update(projectPath, featureId, {
+              status: 'blocked',
+              statusChangeReason: reason,
+            });
+            this.events.emit('feature:error', {
+              projectPath,
+              featureId,
+              error: reason,
+            });
+            return;
+          }
+        }
+      }
 
       // Check for pipeline steps and execute them
       const pipelineConfig = await pipelineService.getPipelineConfig(projectPath);

--- a/apps/server/src/services/lead-engineer-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-execute-processor.ts
@@ -208,6 +208,27 @@ export class ExecuteProcessor implements StateProcessor {
     const result = await this.waitForCompletion(ctx);
 
     if (!result.success) {
+      // Check if the post-agent recovery hook blocked this feature.
+      // Blocked features should escalate rather than retry — the work is stranded
+      // and retrying the agent won't resolve a git/network failure.
+      const currentFeature = await this.serviceContext.featureLoader
+        .get(ctx.projectPath, ctx.feature.id)
+        .catch(() => null);
+      if (currentFeature?.status === 'blocked') {
+        ctx.escalationReason =
+          currentFeature.statusChangeReason ||
+          'Post-agent recovery failed — uncommitted work stranded in worktree';
+        logger.warn('[EXECUTE] Feature blocked by post-agent recovery hook, escalating', {
+          featureId: ctx.feature.id,
+          reason: ctx.escalationReason,
+        });
+        return {
+          nextState: 'ESCALATE',
+          shouldContinue: false,
+          reason: ctx.escalationReason,
+        };
+      }
+
       ctx.retryCount++;
       logger.warn('[EXECUTE] Execution failed, will retry', {
         retryCount: ctx.retryCount,

--- a/apps/server/src/services/worktree-recovery-service.ts
+++ b/apps/server/src/services/worktree-recovery-service.ts
@@ -1,0 +1,187 @@
+/**
+ * Worktree Recovery Service - Post-agent uncommitted work detection and recovery
+ *
+ * After every agent exits, scans the worktree for uncommitted changes and
+ * attempts auto-recovery: format → stage → commit → push → PR creation.
+ * Returns structured results; callers are responsible for status updates and events.
+ */
+
+import { exec, execFile } from 'child_process';
+import { promisify } from 'util';
+import { createLogger } from '@protolabs-ai/utils';
+import type { Feature } from '@protolabs-ai/types';
+
+const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+const logger = createLogger('WorktreeRecovery');
+
+// Extended PATH for git/gh CLI availability (mirrors git-workflow-service pattern)
+const pathSeparator = process.platform === 'win32' ? ';' : ':';
+const additionalPaths: string[] = [];
+
+if (process.platform === 'win32') {
+  if (process.env.LOCALAPPDATA) {
+    additionalPaths.push(`${process.env.LOCALAPPDATA}\\Programs\\Git\\cmd`);
+  }
+  if (process.env.PROGRAMFILES) {
+    additionalPaths.push(`${process.env.PROGRAMFILES}\\Git\\cmd`);
+  }
+} else {
+  additionalPaths.push(
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+    '/home/linuxbrew/.linuxbrew/bin',
+    `${process.env.HOME}/.local/bin`
+  );
+}
+
+const extendedPath = [process.env.PATH, ...additionalPaths.filter(Boolean)]
+  .filter(Boolean)
+  .join(pathSeparator);
+
+const execEnv = { ...process.env, PATH: extendedPath };
+
+export interface WorktreeRecoveryResult {
+  /** Whether any uncommitted changes were detected */
+  detected: boolean;
+  /** Whether recovery succeeded (commit + push + PR) */
+  recovered: boolean;
+  /** PR URL if one was created */
+  prUrl?: string;
+  /** PR number if one was created */
+  prNumber?: number;
+  /** PR creation timestamp */
+  prCreatedAt?: string;
+  /** Error message if recovery failed */
+  error?: string;
+}
+
+/**
+ * Check for uncommitted work in a worktree after agent exit and recover if found.
+ *
+ * Steps when uncommitted work is detected:
+ * 1. Format changed files with prettier (non-fatal)
+ * 2. Stage changed files (excluding .automaker/ except memory/)
+ * 3. Commit with HUSKY=0 / --no-verify to bypass hooks
+ * 4. Push to remote with -u
+ * 5. Create PR via gh CLI targeting main
+ *
+ * Returns a structured result. The caller is responsible for updating feature
+ * status, emitting events, and deciding how to proceed.
+ *
+ * @param feature - The feature being processed
+ * @param worktreePath - Absolute path to the worktree
+ */
+export async function checkAndRecoverUncommittedWork(
+  feature: Feature,
+  worktreePath: string
+): Promise<WorktreeRecoveryResult> {
+  const result: WorktreeRecoveryResult = { detected: false, recovered: false };
+
+  try {
+    // Check for uncommitted changes
+    const { stdout: statusOutput } = await execAsync('git status --short', {
+      cwd: worktreePath,
+      env: execEnv,
+    });
+
+    if (!statusOutput.trim()) {
+      // Worktree is clean — nothing to do
+      return result;
+    }
+
+    result.detected = true;
+
+    const branchName = feature.branchName;
+    if (!branchName) {
+      result.error = `uncommitted work in worktree at ${worktreePath} but no branchName set on feature`;
+      logger.warn(`[PostAgentHook] ${result.error}`);
+      return result;
+    }
+
+    logger.warn(
+      `[PostAgentHook] Uncommitted work detected in ${worktreePath} for feature ${feature.id} — attempting recovery`
+    );
+    logger.debug(`[PostAgentHook] Uncommitted changes:\n${statusOutput}`);
+
+    // Step 1: Format changed files with prettier (non-fatal)
+    try {
+      const { stdout: diffOutput } = await execAsync(
+        "git diff HEAD --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.json' '*.css' '*.md'",
+        { cwd: worktreePath, env: execEnv }
+      );
+      const files = diffOutput.trim().split('\n').filter(Boolean);
+      if (files.length > 0) {
+        await execAsync(
+          `npx prettier --ignore-path /dev/null --write ${files.map((f) => `"${f}"`).join(' ')}`,
+          { cwd: worktreePath, env: execEnv }
+        );
+      }
+    } catch {
+      // Non-fatal: formatting failure should not block recovery
+    }
+
+    // Step 2: Stage changed files (exclude .automaker/ except memory/)
+    await execAsync("git add -A -- ':!.automaker/' '.automaker/memory/'", {
+      cwd: worktreePath,
+      env: execEnv,
+    });
+
+    // Step 3: Commit with HUSKY=0 / --no-verify to bypass hooks
+    const commitTitle = (feature.title || 'feature implementation')
+      .replace(/"/g, "'")
+      .substring(0, 72);
+    const commitMessage = `refactor: ${commitTitle}`;
+
+    await execFileAsync('git', ['commit', '--no-verify', '-m', commitMessage], {
+      cwd: worktreePath,
+      env: { ...execEnv, HUSKY: '0' },
+    });
+
+    logger.info(`[PostAgentHook] Committed uncommitted work for feature ${feature.id}`);
+
+    // Step 4: Push to remote with -u
+    await execAsync(`git push -u origin "${branchName}"`, {
+      cwd: worktreePath,
+      env: execEnv,
+    });
+
+    logger.info(`[PostAgentHook] Pushed branch ${branchName} for feature ${feature.id}`);
+
+    // Step 5: Create PR via gh CLI targeting main
+    const prTitle = (feature.title || commitTitle).replace(/"/g, "'");
+    const summary = feature.description.substring(0, 500);
+    const ellipsis = feature.description.length > 500 ? '...' : '';
+    const prBody =
+      `## Summary\n\n${summary}${ellipsis}\n\n---\n*Recovered automatically by Automaker post-agent hook*`.replace(
+        /"/g,
+        "'"
+      );
+
+    const { stdout: prOutput } = await execAsync(
+      `gh pr create --base main --head "${branchName}" --title "${prTitle}" --body "${prBody.replace(/\n/g, '\\n')}"`,
+      { cwd: worktreePath, env: execEnv }
+    );
+
+    // Parse PR URL and number from output (gh pr create prints the URL on stdout)
+    const prUrl = prOutput.trim();
+    const prNumberMatch = prUrl.match(/\/pull\/(\d+)/);
+    const prNumber = prNumberMatch ? parseInt(prNumberMatch[1], 10) : undefined;
+
+    result.prUrl = prUrl;
+    result.prNumber = prNumber;
+    result.prCreatedAt = new Date().toISOString();
+    result.recovered = true;
+
+    logger.info(
+      `[PostAgentHook] Recovery successful for feature ${feature.id}: PR created at ${prUrl}`
+    );
+
+    return result;
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    result.error = `git workflow failed — uncommitted work in worktree at ${worktreePath}: ${errorMessage}`;
+    logger.error(`[PostAgentHook] Recovery failed for feature ${feature.id}: ${errorMessage}`);
+    return result;
+  }
+}

--- a/apps/server/tests/unit/services/worktree-recovery-service.test.ts
+++ b/apps/server/tests/unit/services/worktree-recovery-service.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Feature } from '@protolabs-ai/types';
+
+// Mock exec/execFile before importing the service
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+  execFile: vi.fn(),
+}));
+vi.mock('util', () => ({
+  promisify: (fn: unknown) => fn,
+}));
+
+import { checkAndRecoverUncommittedWork } from '@/services/worktree-recovery-service.js';
+import { exec, execFile } from 'child_process';
+
+const mockExec = exec as unknown as ReturnType<typeof vi.fn>;
+const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+
+const baseFeature: Feature = {
+  id: 'feature-test-001',
+  title: 'Test feature',
+  description: 'Test feature description',
+  status: 'in_progress',
+  branchName: 'feature/test-branch',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  order: 0,
+};
+
+describe('worktree-recovery-service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('checkAndRecoverUncommittedWork', () => {
+    it('returns detected=false when worktree is clean', async () => {
+      // git status --short returns empty
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+      const result = await checkAndRecoverUncommittedWork(baseFeature, '/mock/worktree');
+
+      expect(result.detected).toBe(false);
+      expect(result.recovered).toBe(false);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('returns detected=true, error when feature has no branchName', async () => {
+      // git status --short returns uncommitted changes
+      mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
+
+      const featureNoBranch: Feature = { ...baseFeature, branchName: undefined };
+      const result = await checkAndRecoverUncommittedWork(featureNoBranch, '/mock/worktree');
+
+      expect(result.detected).toBe(true);
+      expect(result.recovered).toBe(false);
+      expect(result.error).toContain('no branchName set on feature');
+    });
+
+    it('successfully recovers uncommitted work (commit + push + PR)', async () => {
+      // git status --short: uncommitted files
+      mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
+      // git diff HEAD (for prettier formatting)
+      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      // npx prettier
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git add -A
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git commit (execFile)
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git push
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // gh pr create
+      mockExec.mockResolvedValueOnce({
+        stdout: 'https://github.com/owner/repo/pull/42\n',
+        stderr: '',
+      });
+
+      const result = await checkAndRecoverUncommittedWork(baseFeature, '/mock/worktree');
+
+      expect(result.detected).toBe(true);
+      expect(result.recovered).toBe(true);
+      expect(result.prUrl).toBe('https://github.com/owner/repo/pull/42');
+      expect(result.prNumber).toBe(42);
+      expect(result.prCreatedAt).toBeDefined();
+      expect(result.error).toBeUndefined();
+    });
+
+    it('returns error when commit step fails', async () => {
+      // git status --short: uncommitted files
+      mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
+      // git diff HEAD (for prettier formatting)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git add -A
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git commit (execFile) fails
+      mockExecFile.mockRejectedValueOnce(new Error('nothing to commit, working tree clean'));
+
+      const result = await checkAndRecoverUncommittedWork(baseFeature, '/mock/worktree');
+
+      expect(result.detected).toBe(true);
+      expect(result.recovered).toBe(false);
+      expect(result.error).toContain('git workflow failed');
+    });
+
+    it('returns error when push step fails', async () => {
+      // git status --short
+      mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
+      // git diff HEAD
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git add -A
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git commit succeeds
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git push fails
+      mockExec.mockRejectedValueOnce(new Error('remote: Permission denied'));
+
+      const result = await checkAndRecoverUncommittedWork(baseFeature, '/mock/worktree');
+
+      expect(result.detected).toBe(true);
+      expect(result.recovered).toBe(false);
+      expect(result.error).toContain('git workflow failed');
+    });
+
+    it('continues recovery even if prettier formatting fails', async () => {
+      // git status --short
+      mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
+      // git diff HEAD
+      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      // npx prettier fails (non-fatal)
+      mockExec.mockRejectedValueOnce(new Error('prettier not found'));
+      // git add -A
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git commit succeeds
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git push succeeds
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // gh pr create succeeds
+      mockExec.mockResolvedValueOnce({
+        stdout: 'https://github.com/owner/repo/pull/99\n',
+        stderr: '',
+      });
+
+      const result = await checkAndRecoverUncommittedWork(baseFeature, '/mock/worktree');
+
+      // Recovery should succeed even though formatting failed
+      expect(result.detected).toBe(true);
+      expect(result.recovered).toBe(true);
+      expect(result.prNumber).toBe(99);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- New `WorktreeRecoveryService` detects uncommitted changes after every agent exit and runs a recovery pipeline: format → selective-stage → `HUSKY=0` commit → push → `gh pr create`
- Wired into `AutoModeService.executeFeature()` after `agent.run()` resolves (both success and failure paths)
- Wired into `LeadEngineerService` `ExecuteProcessor` via same hook
- Recovery failure marks the feature `blocked` with a `statusChangeReason` message pointing to the worktree path
- Unit tests cover happy path and failure modes

## Test plan

- [x] Unit tests for `WorktreeRecoveryService` — happy path and failure modes
- [x] Build passes (`npm run build:server`)
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection and recovery of uncommitted changes into pull requests during auto mode execution

* **Improvements**
  * Enhanced error handling: Features marked as blocked now escalate immediately instead of attempting retries

* **Tests**
  * Added unit test coverage for worktree recovery scenarios and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->