### PR TITLE
chore: insights-driven workflow improvements (CLAUDE.md + /ship skill)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,12 @@ This is a greenfield codebase. We are building the future, not maintaining the p
 - **No shortcuts.** Do it right the first time. If that means touching 10 files to propagate a type change, touch 10 files.
 - **Do things correctly or not at all.** Every line of code should be production-quality from day one.
 
+## Working Style
+
+- **Implementation first.** Unless explicitly asked to plan, start writing code. Don't spend the session on exploration and subtask creation without producing output. Read the specific files you need, then implement.
+- **Confirm the target upfront.** Before starting work, state which specific file/component/service/endpoint you'll modify. If it's ambiguous, ask — don't assume.
+- **Check for recent related work.** Before implementing anything, check open PRs and recent commits for work that overlaps. Running `gh pr list --state open` and `git log --oneline -10 origin/main` prevents duplicating what's already shipped.
+
 ## Planning & Approach
 
 - When creating plans, start with the minimal viable scope. Do NOT propose multi-phase plans unless explicitly asked. Default to the smallest, lowest-risk approach first.
@@ -37,10 +43,22 @@ See `docs/dev/branch-strategy.md` for the full strategy.
 - Agent feature PRs target `dev` by default (`prBaseBranch: 'dev'` in `DEFAULT_GIT_WORKFLOW_SETTINGS`).
 - Before committing, run `git status` and verify only intended files are staged. Watch for accidentally staged deletions from previously merged PRs.
 - `.automaker/memory/` files are updated by agents during autonomous work. Include memory changes in your commits alongside related code changes — don't leave them as unstaged drift.
+- **Before opening a PR**, check for concurrent open PRs that touch the same files (`gh pr list --state open`). Merge conflicts from uncoordinated PRs are avoidable.
+- **Always read `packageManager` from `package.json`** before assuming pnpm/npm/node versions in CI config. Never guess.
 
 ## Session Continuation
 
 - When continuing a previous session or autonomous loop, always check MCP server connectivity and board status FIRST before attempting any agent launches or API calls.
+
+## MCP & External Tools
+
+- Before building a workflow around an MCP tool, verify it's actually responding. If tools aren't loading, suggest restarting the session or checking that the backing service is running (dev server, Pencil desktop app, etc.).
+- All Automaker operations go through MCP tools (`mcp__plugin_automaker_automaker__*`). Never make direct HTTP calls to the server — the MCP plugin handles auth automatically.
+
+## Code Standards
+
+- This is a TypeScript-first codebase. All new code is TypeScript. When fixing type errors, grep for existing patterns before inventing new approaches.
+- `npm run build` (Vite) does NOT type-check. Always verify with `npx tsc --noEmit` when type correctness is in question.
 
 ## Project Overview
 

--- a/packages/mcp-server/plugins/automaker/commands/ship.md
+++ b/packages/mcp-server/plugins/automaker/commands/ship.md
@@ -1,0 +1,154 @@
+---
+name: ship
+description: Ship current changes — stage, commit, push, create PR, enable auto-merge. Handles conflicts automatically.
+argument-hint: (optional commit message or description)
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - Edit
+  - AskUserQuestion
+---
+
+# Ship Workflow
+
+You are the Ship agent. Your job is to take the user's current uncommitted changes and get them to main as cleanly as possible.
+
+## Process
+
+### 1. Assess Current State
+
+```bash
+git status --short
+git diff --stat HEAD
+gh pr list --state open --limit 10
+```
+
+Check:
+
+- What files are changed?
+- Are there already open PRs touching these files? (conflict risk)
+- Is there already a feature branch for this work?
+
+### 2. Confirm What to Ship
+
+Report to the user:
+
+- Files changed (brief list)
+- Any conflict risks from open PRs
+- Proposed branch name and commit message
+
+If the user provided arguments, use them as the commit message context.
+If not, infer the message from the diff.
+
+**Do NOT ask for permission before proceeding** — just ship. Only pause if:
+
+- Sensitive files are staged (`.env`, `credentials.json`, `secrets.*`)
+- There's a destructive deletion you want to flag
+
+### 3. Stage and Commit
+
+Stage files by name — never `git add -A`. Exclude:
+
+- `.automaker/` (runtime files)
+- `.env` / credentials
+- Any file matching `*.log`, `*.db`
+
+```bash
+git add <specific files>
+git status  # verify staging is clean
+git commit -m "$(cat <<'EOF'
+<concise message describing what and why>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 4. Push to Feature Branch
+
+Check current branch:
+
+```bash
+git branch --show-current
+```
+
+If on `main`: create a feature branch first
+
+```bash
+git checkout -b feat/<slug-from-commit-message>
+git push -u origin HEAD
+```
+
+If already on a feature branch:
+
+```bash
+git push origin HEAD
+```
+
+### 5. Create or Update PR
+
+Check if PR already exists:
+
+```bash
+gh pr view --json url,state 2>/dev/null
+```
+
+If no PR:
+
+```bash
+gh pr create --title "<commit message>" --body "$(cat <<'EOF'
+## Summary
+<2-3 bullet points from the diff>
+
+## Test plan
+- [ ] CI passes
+- [ ] Spot-check affected files
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+If PR exists: just push updates it. Report the PR URL.
+
+### 6. Enable Auto-Merge
+
+```bash
+gh pr merge --auto --squash
+```
+
+If auto-merge fails (no CI checks configured yet), note it and leave the PR open.
+
+### 7. Handle Conflicts
+
+If push fails due to conflicts:
+
+```bash
+git fetch origin
+git rebase origin/main
+# If rebase conflicts:
+git status  # identify conflicting files
+# Resolve by taking the version that makes more sense for the change
+git add <resolved files>
+git rebase --continue
+git push --force-with-lease origin HEAD
+```
+
+### 8. Report
+
+Confirm what shipped:
+
+- Branch name
+- PR URL
+- Auto-merge status
+- CI status (run `gh pr checks` to get current state)
+
+## What NOT to do
+
+- Don't run `git add -A` or `git add .`
+- Don't commit `.automaker/`, `.env`, or credential files
+- Don't force-push to main
+- Don't skip hooks (`--no-verify`)
+- Don't create a PR if there are unstaged conflicts


### PR DESCRIPTION
## Summary
- Add `## Working Style` section: implement-first default, confirm target before starting, check open PRs before implementing
- Add `## MCP & External Tools` section: verify tools respond before building workflows
- Add `## Code Standards` section: TypeScript-first, use `tsc --noEmit` for type checking
- Expand `## Git Workflow`: concurrent PR check + always read `packageManager` field
- New `/ship` skill: one-command commit → PR → auto-merge with conflict handling

From `/insights` analysis — wrong approach (13 instances), planning trap (6+ sessions), and CI breakages were the top three friction sources across 66 sessions.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated internal guidelines with new working style standards and code standards.
  * Added comprehensive Ship workflow documentation defining the automated process for moving changes to production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->