### PR TITLE
fix: correct pr-ownership doc and ava.md

### DIFF
--- a/.automaker/context/pr-ownership.md
+++ b/.automaker/context/pr-ownership.md
@@ -78,7 +78,7 @@ If you create a PR directly (not through auto-mode), include the watermark manua
 
 ```bash
 INSTANCE_ID="$(cat data/settings.json | jq -r '.instanceId // "local"')"
-gh pr create --title "..." --body "$(cat <<'EOF'
+gh pr create --title "..." --body "$(cat <<EOF
 ## Summary
 ...
 

--- a/packages/mcp-server/plugins/automaker/commands/ava.md
+++ b/packages/mcp-server/plugins/automaker/commands/ava.md
@@ -453,7 +453,7 @@ LinearSyncService moves issue to "Done" + adds comment
 
 **Worktree safety** — NEVER `cd` into worktree directories. Always use `git -C <worktree-path>` or absolute paths.
 
-**PR Ownership** — Every Automaker-created PR has a hidden watermark: `<!-- automaker:owner instance=X team=Y created=Z -->`. Before acting on any PR, call `POST /api/github/check-pr-status` and check the `ownership` field:
+**PR Ownership** — Every Automaker-created PR has a hidden watermark: `<!-- automaker:owner instance=X team=Y created=Z -->`. Before acting on any PR, call `mcp__plugin_automaker_automaker__check_pr_status` and check the `ownership` field:
 
 - `isOwnedByThisInstance: true` → act freely
 - `isOwnedByThisInstance: false`, `isStale: false` → **skip** — another live instance owns it


### PR DESCRIPTION
## Summary

Two verified fixes from code review. The `ship.md` finding was skipped — that file does not exist.

- **`.automaker/context/pr-ownership.md`**: Unquote heredoc delimiter (`<<'EOF'` → `<<EOF`) in the manual watermark snippet so `${INSTANCE_ID}` and `$(date ...)` interpolate at runtime instead of being printed literally
- **`ava.md`**: Replace raw `POST /api/github/check-pr-status` guidance with the MCP tool name `mcp__plugin_automaker_automaker__check_pr_status` — verified the tool exists in `packages/mcp-server/src/tools/git-tools.ts`

## Test plan

- [ ] Docs-only changes — no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced PR ownership detection and management for multi-instance deployments.
  * Added automatic reclamation of unowned pull requests after 24 hours of inactivity.
  * Improved decision logic to properly handle ownership conflicts and stale PR scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->