### PR TITLE
fix: CodeRabbit review on branch strategy docs

### DIFF
--- a/.automaker/context/CLAUDE.md
+++ b/.automaker/context/CLAUDE.md
@@ -134,7 +134,7 @@ Key fields available on every feature:
 
 All agent PRs target **`dev`** by default. The promotion flow is:
 
-```
+```text
 feature/* ──▶ dev ──▶ staging ──▶ main
 ```
 

--- a/packages/mcp-server/plugins/automaker/commands/ava.md
+++ b/packages/mcp-server/plugins/automaker/commands/ava.md
@@ -455,7 +455,10 @@ LinearSyncService moves issue to "Done" + adds comment
 - `staging` — Integration / QA. Promoted from `dev` via PR. Auto-deploys to staging env.
 - `main` — Stable release. **Only PRs from `staging` are allowed** — enforced by `promotion-check` CI. Any PR from another branch fails the `source-branch` required check.
 
-When reviewing or creating PRs: feature branches target `dev`, not `main`. If you see a feature PR targeting `main`, rebase it to target `dev` instead.
+When reviewing or creating PRs: feature branches target `dev`, not `main`. If you see a feature PR targeting `main`, retarget it with two steps:
+
+1. `gh pr edit <number> --base dev` — update the PR metadata
+2. `git rebase --onto dev main <branch>` — rebase commits off main onto dev (only needed if main commits were merged into the branch)
 
 **Promotion commands:**
 


### PR DESCRIPTION
## Summary

Addresses two CodeRabbit findings from PR #1197:

- **CLAUDE.md**: Add `text` language tag to diagram code fence (MD040)
- **ava.md**: Expand ambiguous "rebase to target dev" into two explicit steps

<!-- automaker:owner instance=local team=proto-labs-ai created=2026-02-25T23:48:00.000Z -->