### PR TITLE
chore: gitignore automaker runtime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,9 @@ docs/.vitepress/cache/
 .automaker/knowledge.db
 .automaker/knowledge.db-shm
 .automaker/knowledge.db-wal
+.automaker/knowledge-eval.jsonl
 .automaker/ceremony-log.jsonl
+.automaker/quarantine/
 
 # Instance-specific — each machine starts fresh
 .automaker/projects/


### PR DESCRIPTION
## Summary

- Add `.automaker/knowledge-eval.jsonl` — runtime search/eval log from the knowledge store service
- Add `.automaker/quarantine/` — runtime quarantine entries from the trust pipeline

These are server-generated at runtime and should never be tracked.

<!-- automaker:owner instance=local team=proto-labs-ai created=2026-02-25T23:59:00.000Z -->