### PR TITLE
feat: Promotion Types & Feature Schema

### DIFF
--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -453,6 +453,18 @@ export interface Feature {
   quarantineId?: string;
   /** Reason for quarantine failure (if quarantineStatus === 'failed') */
   quarantineFailureReason?: string;
+
+  // Promotion tracking fields
+  /**
+   * ID of the PromotionCandidate record for this feature.
+   * Set when this feature is detected as a promotion candidate after merging to dev.
+   */
+  stagingCandidateId?: string;
+  /**
+   * ID of the PromotionBatch this feature has been included in.
+   * Set when this feature is added to a promotion batch targeting staging/main.
+   */
+  promotionBatchId?: string;
 }
 
 /**

--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -48,6 +48,7 @@ import type { EventHook } from './event-settings.js';
 import type { DiscordSettings, ErrorTrackingSettings } from './integration-settings.js';
 import type { MaintenanceSettings, ProjectRef, TrashedProjectRef } from './project-settings.js';
 import type { TrustBoundaryConfig } from './workflow-settings.js';
+import type { PromotionConfig } from './promotion.js';
 
 // Re-export ModelAlias for convenience (settings.ts historically re-exported this)
 export type { ModelAlias };
@@ -581,6 +582,13 @@ export interface GlobalSettings {
 
   /** Per-persona system prompt overrides, keyed by template name (e.g., 'ava', 'frank') */
   personaOverrides?: Record<string, CustomPrompt>;
+
+  /**
+   * Promotion pipeline configuration for staging/production candidate tracking.
+   * Controls how features are detected as promotion candidates and batched for release.
+   * @see PromotionConfig in promotion.ts
+   */
+  promotion?: PromotionConfig;
 }
 
 /** Default global settings used when no settings file exists */

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -78,6 +78,14 @@ export type {
   TrustTierRecord,
 } from './quarantine.js';
 
+// Promotion pipeline types (Detection & Candidate Tracking)
+export type {
+  PromotionStatus,
+  PromotionCandidate,
+  PromotionBatch,
+  PromotionConfig,
+} from './promotion.js';
+
 // Feature store interface (pluggable storage abstraction)
 export type { FeatureStore } from './feature-store.js';
 

--- a/libs/types/src/promotion.ts
+++ b/libs/types/src/promotion.ts
@@ -1,0 +1,72 @@
+/**
+ * Promotion types for feature promotion pipeline tracking
+ *
+ * These types support the Detection & Candidate Tracking milestone,
+ * enabling features to be tracked from dev merge through staging/main promotion.
+ */
+
+/**
+ * Status of a promotion candidate or batch in the promotion pipeline.
+ * - candidate: Feature has been merged to dev and is eligible for promotion
+ * - selected: Feature has been selected for inclusion in a promotion batch
+ * - promoted: Feature has been successfully promoted to main
+ * - held: Feature promotion is intentionally deferred
+ * - rejected: Feature has been rejected from the promotion batch
+ */
+export type PromotionStatus = 'candidate' | 'selected' | 'promoted' | 'held' | 'rejected';
+
+/**
+ * Represents a single feature that is a candidate for promotion to staging/production.
+ * Created when a feature branch is merged to the dev branch.
+ */
+export interface PromotionCandidate {
+  /** ID of the feature being promoted */
+  featureId: string;
+  /** Human-readable title of the feature */
+  featureTitle: string;
+  /** Name of the feature branch that was merged */
+  branchName: string;
+  /** Git commit SHA of the merge commit on dev */
+  commitSha: string;
+  /** ISO 8601 timestamp when the feature was merged to dev */
+  mergedAt: string;
+  /** Linear issue ID linked to this feature (if synced to Linear) */
+  linearIssueId?: string;
+  /** Current status of this candidate in the promotion pipeline */
+  status: PromotionStatus;
+}
+
+/**
+ * A batch of promotion candidates being promoted together as a single release unit.
+ * A batch groups multiple candidates and tracks the full lifecycle from
+ * branch creation through staging PR and final main PR.
+ */
+export interface PromotionBatch {
+  /** Unique identifier for this promotion batch */
+  batchId: string;
+  /** List of promotion candidates included in this batch */
+  candidates: PromotionCandidate[];
+  /** Name of the promotion branch created for this batch (e.g., "release-2024-01-15") */
+  promotionBranchName: string;
+  /** URL of the staging PR (dev → staging), set when the staging PR is created */
+  stagingPrUrl?: string;
+  /** URL of the main PR (staging → main), set when the main PR is created */
+  mainPrUrl?: string;
+  /** Current status of this batch */
+  status: PromotionStatus;
+  /** ISO 8601 timestamp when this batch was created */
+  createdAt: string;
+}
+
+/**
+ * Promotion configuration stored in GlobalSettings.
+ * Controls how the promotion pipeline detects and tracks candidates.
+ */
+export interface PromotionConfig {
+  /** Linear project ID for creating/tracking promotion candidate issues */
+  linearProjectId?: string;
+  /** Prefix used when naming promotion batches (e.g., "release-", "promo-") */
+  batchPrefix?: string;
+  /** When true, automatically create a promotion candidate when a feature is merged to dev */
+  autoCandidateOnDevMerge?: boolean;
+}


### PR DESCRIPTION
## Summary

- New `libs/types/src/promotion.ts` — `PromotionCandidate`, `PromotionBatch`, `PromotionStatus`, `PromotionConfig` types
- `Feature` gets optional `stagingCandidateId` and `promotionBatchId` fields  
- `GlobalSettings` gets `PromotionConfig` (linearProjectId, batchPrefix, autoCandidateOnDevMerge)
- All types exported from `libs/types/src/index.ts`

Foundation for the Linear-driven staging promotion pipeline.

<!-- automaker:owner instance=local team=proto-labs-ai created=2026-02-26T00:00:00.000Z -->