### PR TITLE
feat: knowledge store startup init + context fidelity in auto-mode retries

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -799,6 +799,7 @@ autoModeService.setPipelineCheckpointService(pipelineCheckpointService);
 const { ContextFidelityService } = await import('./services/context-fidelity-service.js');
 const contextFidelityService = new ContextFidelityService();
 leadEngineerService.setContextFidelityService(contextFidelityService);
+autoModeService.setContextFidelityService(contextFidelityService);
 
 // Wire KnowledgeStoreService for FTS5-powered reflection search
 leadEngineerService.setKnowledgeStoreService(knowledgeStoreService);
@@ -1114,11 +1115,14 @@ specGenerationMonitor.startMonitoring();
   await agentService.initialize();
   logger.info('Agent service initialized');
 
-  // Initialize Knowledge Store Service for configured project paths
+  // Initialize Knowledge Store Service for all known projects
   if (knowledgeStoreService) {
     try {
       const settings = await settingsService.getGlobalSettings();
       const projectPaths = [
+        // All projects registered in the project list
+        ...(settings.projects?.map((p) => p.path) ?? []),
+        // Additionally, any autoModeAlwaysOn projects (may not be in project list)
         ...(settings.autoModeAlwaysOn?.projects?.map((p) => p.projectPath) ?? []),
       ];
       const uniquePaths = [...new Set(projectPaths)];

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -128,6 +128,7 @@ import type { LeadEngineerService } from './lead-engineer-service.js';
 import { gitWorkflowService } from './git-workflow-service.js';
 import { graphiteService } from './graphite-service.js';
 import type { KnowledgeStoreService } from './knowledge-store-service.js';
+import type { ContextFidelityService } from './context-fidelity-service.js';
 import type { PipelineCheckpointService } from './pipeline-checkpoint-service.js';
 import {
   AutoLoopCoordinator,
@@ -274,6 +275,8 @@ export class AutoModeService {
   private leadEngineerService: LeadEngineerService | null = null;
   // Knowledge Store service for learning deduplication (optional)
   private knowledgeStoreService: KnowledgeStoreService | null = null;
+  // Context Fidelity service for shaping prior agent output on retries (optional)
+  private contextFidelityService: ContextFidelityService | null = null;
   // Pipeline Checkpoint service for crash recovery checkpoint cleanup (optional)
   private pipelineCheckpointService: PipelineCheckpointService | null = null;
   // ExecutionService handles feature execution logic
@@ -385,6 +388,15 @@ export class AutoModeService {
    */
   setKnowledgeStoreService(service: KnowledgeStoreService): void {
     this.knowledgeStoreService = service;
+  }
+
+  /**
+   * Wire up the Context Fidelity service for shaping prior agent output on retries.
+   * When set, auto-mode retry paths will compact the previous agent output before
+   * passing it to the next agent, matching what Lead Engineer already does.
+   */
+  setContextFidelityService(service: ContextFidelityService): void {
+    this.contextFidelityService = service;
   }
 
   /**
@@ -2455,6 +2467,11 @@ export class AutoModeService {
       // No previous context
     }
 
+    // Shape prior context to compact form (matching Lead Engineer retry pattern)
+    if (previousContext && this.contextFidelityService) {
+      previousContext = await this.contextFidelityService.shape(previousContext, 'compact');
+    }
+
     // Load autoLoadClaudeMd setting to determine context loading strategy
     const autoLoadClaudeMd = await getAutoLoadClaudeMdSetting(
       projectPath,
@@ -4486,6 +4503,11 @@ You can use the Read tool to view these images at any time during implementation
       previousContext = (await secureFs.readFile(contextPath, 'utf-8')) as string;
     } catch {
       // No previous context, that's okay
+    }
+
+    // Shape prior context to compact form (matching Lead Engineer retry pattern)
+    if (previousContext && this.contextFidelityService) {
+      previousContext = await this.contextFidelityService.shape(previousContext, 'compact');
     }
 
     // Build continuation prompt with feedback


### PR DESCRIPTION
## Summary
- Initialize knowledge store for ALL registered projects at server startup (was only initializing `autoModeAlwaysOn` projects, leaving cold starts for everything else)
- Wire `ContextFidelityService` into `AutoModeService` retry paths — shapes prior agent output to `'compact'` before retry, matching Lead Engineer behavior

## Changes
- `apps/server/src/index.ts` — expand project path collection to include `settings.projects` + wire `autoModeService.setContextFidelityService()`
- `apps/server/src/services/auto-mode-service.ts` — add `ContextFidelityService` property + `setContextFidelityService()` + call `shape()` in both retry paths

## Test plan
- [ ] Server startup logs show knowledge store initialized for each known project
- [ ] Auto-mode retry agent receives compacted prior context (not raw dump)
- [ ] Build passes: `npm run build:server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)