### PR TITLE
feat: Promotion API Routes — /api/promotions endpoints

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -193,6 +193,7 @@ import { createTwitchRoutes } from './routes/twitch.js';
 import { createVoiceRoutes } from './routes/voice/index.js';
 import { createKnowledgeRoutes } from './routes/knowledge/index.js';
 import { createDesignsRoutes } from './routes/designs/index.js';
+import { createPromotionsRoutes } from './routes/promotions/index.js';
 import { LinearAgentService } from './services/linear-agent-service.js';
 import { LinearAgentRouter } from './services/linear-agent-router.js';
 import { MAX_SYSTEM_CONCURRENCY } from '@protolabs-ai/types';
@@ -1572,6 +1573,10 @@ if (knowledgeStoreService) {
 // Designs routes (.pen file management)
 app.use('/api/designs', createDesignsRoutes());
 logger.info('Designs routes mounted at /api/designs');
+
+// Promotion orchestration routes
+app.use('/api/promotions', createPromotionsRoutes());
+logger.info('Promotion routes mounted at /api/promotions');
 
 // Note: Sentry v8 automatically captures Express errors - no manual error handler needed
 

--- a/apps/server/src/routes/promotions/index.ts
+++ b/apps/server/src/routes/promotions/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Promotions routes — public API surface
+ *
+ * Re-exports the router factory so index.ts can mount it cleanly:
+ *
+ *   import { createPromotionsRoutes } from './routes/promotions/index.js';
+ *   app.use('/api/promotions', createPromotionsRoutes());
+ */
+
+export { createPromotionsRouter as createPromotionsRoutes } from './routes.js';

--- a/apps/server/src/routes/promotions/routes.ts
+++ b/apps/server/src/routes/promotions/routes.ts
@@ -1,0 +1,284 @@
+/**
+ * Promotion Orchestration Routes
+ *
+ * GET  /api/promotions/candidates      — list candidates with optional ?status= filter
+ * POST /api/promotions/batch           — create a PromotionBatch from selected candidateIds
+ * GET  /api/promotions/batches         — list all batches
+ * POST /api/promotions/promote-to-staging — trigger git promotion for a batch
+ * POST /api/promotions/promote-to-main   — trigger staging→main PR creation
+ */
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { createLogger } from '@protolabs-ai/utils';
+import type { PromotionBatch, PromotionCandidate, PromotionStatus } from '@protolabs-ai/types';
+import { stagingPromotionService } from '../../services/staging-promotion-service.js';
+
+const logger = createLogger('PromotionRoutes');
+
+// ---------------------------------------------------------------------------
+// In-memory batch store (batches are ephemeral orchestration state;
+// candidates are persisted to disk by stagingPromotionService)
+// ---------------------------------------------------------------------------
+
+const batchesStore = new Map<string, PromotionBatch>();
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Router factory
+// ---------------------------------------------------------------------------
+
+export function createPromotionsRouter(): Router {
+  const router = Router();
+
+  /**
+   * GET /api/promotions/candidates
+   * Returns promotion candidates from disk, with optional ?status= filter.
+   */
+  router.get('/candidates', async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, status } = req.query as { projectPath?: string; status?: string };
+
+      if (!projectPath) {
+        res.status(400).json({ error: 'projectPath query parameter is required' });
+        return;
+      }
+
+      const validStatuses: PromotionStatus[] = [
+        'candidate',
+        'selected',
+        'promoted',
+        'held',
+        'rejected',
+      ];
+      if (status && !validStatuses.includes(status as PromotionStatus)) {
+        res.status(400).json({
+          error: `Invalid status filter "${status}". Valid values: ${validStatuses.join(', ')}`,
+        });
+        return;
+      }
+
+      const candidates = await stagingPromotionService.listCandidates(
+        projectPath,
+        status as PromotionStatus | undefined
+      );
+
+      res.json({ candidates });
+    } catch (error) {
+      logger.error('Failed to list promotion candidates:', error);
+      res.status(500).json({
+        error: error instanceof Error ? error.message : 'Failed to list candidates',
+      });
+    }
+  });
+
+  /**
+   * POST /api/promotions/batch
+   * Creates a PromotionBatch from a set of candidate IDs.
+   * Body: { projectPath: string, candidateIds: string[], batchId?: string }
+   */
+  router.post('/batch', async (req: Request, res: Response): Promise<void> => {
+    try {
+      const {
+        projectPath,
+        candidateIds,
+        batchId: requestedBatchId,
+      } = req.body as {
+        projectPath?: string;
+        candidateIds?: string[];
+        batchId?: string;
+      };
+
+      if (!projectPath) {
+        res.status(400).json({ error: 'projectPath is required' });
+        return;
+      }
+
+      if (!candidateIds || !Array.isArray(candidateIds) || candidateIds.length === 0) {
+        res.status(400).json({ error: 'candidateIds must be a non-empty array of strings' });
+        return;
+      }
+
+      const batchId =
+        requestedBatchId ?? `batch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+      if (batchesStore.has(batchId)) {
+        res.status(409).json({ error: `Batch with id "${batchId}" already exists` });
+        return;
+      }
+
+      // Resolve candidateIds → full PromotionCandidate objects from disk
+      const allCandidates = await stagingPromotionService.listCandidates(projectPath);
+      const candidates = allCandidates.filter((c: PromotionCandidate) =>
+        candidateIds.includes(c.featureId)
+      );
+
+      const missing = candidateIds.filter(
+        (id: string) => !candidates.some((c: PromotionCandidate) => c.featureId === id)
+      );
+      if (missing.length > 0) {
+        res.status(400).json({
+          error: `Candidate(s) not found: ${missing.join(', ')}`,
+        });
+        return;
+      }
+
+      const batch: PromotionBatch = {
+        batchId,
+        promotionBranchName: `promotion/${batchId}`,
+        candidates,
+        status: 'candidate',
+        createdAt: now(),
+      };
+
+      batchesStore.set(batchId, batch);
+      logger.info(`Created promotion batch ${batchId} with ${candidates.length} candidate(s)`);
+
+      res.status(201).json({ batch });
+    } catch (error) {
+      logger.error('Failed to create promotion batch:', error);
+      res.status(500).json({
+        error: error instanceof Error ? error.message : 'Failed to create batch',
+      });
+    }
+  });
+
+  /**
+   * GET /api/promotions/batches
+   * Returns all in-memory promotion batches.
+   */
+  router.get('/batches', (_req: Request, res: Response): void => {
+    try {
+      const batches = Array.from(batchesStore.values());
+      res.json({ batches });
+    } catch (error) {
+      logger.error('Failed to list promotion batches:', error);
+      res.status(500).json({
+        error: error instanceof Error ? error.message : 'Failed to list batches',
+      });
+    }
+  });
+
+  /**
+   * POST /api/promotions/promote-to-staging
+   * Triggers the git promotion workflow for a batch (dev → staging).
+   * Body: { batchId: string, projectPath: string }
+   */
+  router.post('/promote-to-staging', async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { batchId, projectPath } = req.body as {
+        batchId?: string;
+        projectPath?: string;
+      };
+
+      if (!batchId) {
+        res.status(400).json({ error: 'batchId is required' });
+        return;
+      }
+      if (!projectPath) {
+        res.status(400).json({ error: 'projectPath is required' });
+        return;
+      }
+
+      const batch = batchesStore.get(batchId);
+      if (!batch) {
+        res.status(404).json({ error: `Batch "${batchId}" not found` });
+        return;
+      }
+
+      if (batch.stagingPrUrl) {
+        res.status(409).json({
+          error: `Batch "${batchId}" has already been promoted to staging (PR: ${batch.stagingPrUrl})`,
+        });
+        return;
+      }
+
+      logger.info(
+        `Triggering git promotion to staging for batch ${batchId} with ${batch.candidates.length} candidate(s)`
+      );
+
+      // Delegate to StagingPromotionService (git ops + PR creation)
+      await stagingPromotionService.promoteToStaging(batch, projectPath);
+      batchesStore.set(batchId, batch);
+
+      res.json({
+        success: true,
+        batchId,
+        stagingPrUrl: batch.stagingPrUrl,
+        promoted: batch.candidates.filter((c) => c.status === 'promoted').length,
+        held: batch.candidates.filter((c) => c.status === 'held').length,
+      });
+    } catch (error) {
+      logger.error('Failed to promote batch to staging:', error);
+      res.status(500).json({
+        error: error instanceof Error ? error.message : 'Failed to promote to staging',
+      });
+    }
+  });
+
+  /**
+   * POST /api/promotions/promote-to-main
+   * Triggers staging→main PR creation for a batch.
+   * Body: { batchId: string, projectPath: string }
+   */
+  router.post('/promote-to-main', async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { batchId, projectPath } = req.body as {
+        batchId?: string;
+        projectPath?: string;
+      };
+
+      if (!batchId) {
+        res.status(400).json({ error: 'batchId is required' });
+        return;
+      }
+      if (!projectPath) {
+        res.status(400).json({ error: 'projectPath is required' });
+        return;
+      }
+
+      const batch = batchesStore.get(batchId);
+      if (!batch) {
+        res.status(404).json({ error: `Batch "${batchId}" not found` });
+        return;
+      }
+
+      if (!batch.stagingPrUrl) {
+        res.status(409).json({
+          error: `Batch "${batchId}" must be promoted to staging before promoting to main`,
+        });
+        return;
+      }
+
+      if (batch.mainPrUrl) {
+        res.status(409).json({
+          error: `Batch "${batchId}" already has a main PR: ${batch.mainPrUrl}`,
+        });
+        return;
+      }
+
+      logger.info(`Triggering staging→main PR creation for batch ${batchId}`);
+
+      // Delegate to StagingPromotionService (PR creation + HITL notification)
+      await stagingPromotionService.promoteToMain(batch, projectPath);
+      batchesStore.set(batchId, batch);
+
+      res.json({
+        success: true,
+        batchId,
+        mainPrUrl: batch.mainPrUrl,
+        message: 'staging→main PR created. Human review required before merging.',
+      });
+    } catch (error) {
+      logger.error('Failed to promote batch to main:', error);
+      res.status(500).json({
+        error: error instanceof Error ? error.message : 'Failed to promote to main',
+      });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/services/staging-promotion-service.ts
+++ b/apps/server/src/services/staging-promotion-service.ts
@@ -1,22 +1,48 @@
 /**
- * StagingPromotionService - Candidate tracking for the promotion pipeline
+ * StagingPromotionService — candidate tracking and git orchestration for the promotion pipeline.
  *
- * Detects when features are merged to dev and creates promotion candidates.
- * Candidates are persisted atomically to .automaker/promotions/candidates.json.
+ * Two responsibilities:
+ *  1. Candidate tracking: detects dev-merge events and persists promotion candidates
+ *     atomically to .automaker/promotions/candidates.json.
+ *  2. Promotion orchestration:
+ *     - promoteToStaging(): Ava-autonomous — cherry-picks features onto a promotion branch,
+ *       pushes it, creates a staging PR, and enables auto-merge.
+ *     - promoteToMain(): HITL-gated — creates a staging→main PR (NO auto-merge) and
+ *       notifies a human via HITLFormService.
  */
 
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import { createLogger, atomicWriteJson, readJsonWithRecovery } from '@protolabs-ai/utils';
 import { getAutomakerDir } from '@protolabs-ai/platform';
-import type { PromotionCandidate, PromotionStatus } from '@protolabs-ai/types';
+import type {
+  PromotionBatch,
+  PromotionCandidate,
+  PromotionStatus,
+  HITLFormRequestInput,
+} from '@protolabs-ai/types';
+import type { HITLFormService } from './hitl-form-service.js';
 
+const execFileAsync = promisify(execFile);
 const logger = createLogger('StagingPromotionService');
 
 const PROMOTIONS_DIR = 'promotions';
 const CANDIDATES_FILE = 'candidates.json';
 
 export class StagingPromotionService {
+  private hitlFormService?: HITLFormService;
+
+  /** Inject optional HITLFormService — same setter pattern as LeadEngineerService */
+  setHITLFormService(s: HITLFormService): void {
+    this.hitlFormService = s;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Candidate tracking
+  // ---------------------------------------------------------------------------
+
   /**
    * Detect whether a dev merge event should trigger promotion candidate creation.
    * Returns true when the feature is valid and a commit SHA is present.
@@ -145,6 +171,239 @@ export class StagingPromotionService {
 
   private getCandidatesPath(projectPath: string): string {
     return path.join(getAutomakerDir(projectPath), PROMOTIONS_DIR, CANDIDATES_FILE);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Promotion orchestration
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Ava-autonomous promotion to staging.
+   *
+   * 1. Fetches origin to ensure latest refs are available.
+   * 2. Creates the promotion branch off origin/staging HEAD.
+   * 3. Cherry-picks each candidate's commitSha in order.
+   *    On conflict: aborts the cherry-pick and marks the candidate status=held;
+   *    continues with remaining candidates.
+   * 4. Pushes the promotion branch to origin.
+   * 5. Creates a PR from the promotion branch into staging (via gh cli).
+   * 6. Enables auto-merge on the staging PR (--squash).
+   * 7. Updates each successfully cherry-picked candidate to status=promoted
+   *    and sets batch.stagingPrUrl.
+   */
+  async promoteToStaging(batch: PromotionBatch, projectPath: string): Promise<void> {
+    const branchName = batch.promotionBranchName;
+
+    // 1. Fetch origin so origin/staging is up to date
+    logger.info(`[batch=${batch.batchId}] Fetching origin...`);
+    await execFileAsync('git', ['fetch', 'origin'], { cwd: projectPath });
+
+    // 2. Create (or reset) the promotion branch off origin/staging HEAD
+    logger.info(`[batch=${batch.batchId}] Creating branch ${branchName} from origin/staging`);
+    await execFileAsync('git', ['checkout', '-B', branchName, 'origin/staging'], {
+      cwd: projectPath,
+    });
+
+    // 3. Cherry-pick each candidate sequentially
+    const promoted: PromotionCandidate[] = [];
+    for (const candidate of batch.candidates) {
+      try {
+        logger.info(
+          `[batch=${batch.batchId}] Cherry-picking ${candidate.commitSha} (${candidate.featureId})`
+        );
+        await execFileAsync('git', ['cherry-pick', candidate.commitSha], { cwd: projectPath });
+        promoted.push(candidate);
+      } catch (err) {
+        logger.warn(
+          `[batch=${batch.batchId}] Cherry-pick conflict for ${candidate.commitSha} ` +
+            `(${candidate.featureId}); aborting and marking as held`
+        );
+        // Abort the in-progress cherry-pick
+        try {
+          await execFileAsync('git', ['cherry-pick', '--abort'], { cwd: projectPath });
+        } catch (abortErr) {
+          logger.error(`[batch=${batch.batchId}] git cherry-pick --abort failed:`, abortErr);
+        }
+        candidate.status = 'held';
+        // Continue with remaining candidates
+      }
+    }
+
+    // 4. Push the promotion branch
+    logger.info(`[batch=${batch.batchId}] Pushing ${branchName} to origin`);
+    await execFileAsync('git', ['push', '-u', 'origin', branchName, '--force-with-lease'], {
+      cwd: projectPath,
+    });
+
+    // 5. Build PR body listing included features
+    const featureList =
+      promoted.length > 0
+        ? promoted
+            .map(
+              (c) =>
+                `- **${c.featureTitle}** (\`${c.featureId}\`) — commit \`${c.commitSha.slice(0, 8)}\``
+            )
+            .join('\n')
+        : '_No features were successfully cherry-picked._';
+
+    const heldList = batch.candidates
+      .filter((c) => c.status === 'held')
+      .map((c) => `- ${c.featureTitle} (\`${c.featureId}\`) — cherry-pick conflict`)
+      .join('\n');
+
+    const prBody = [
+      `## Promotion Batch: ${batch.batchId}`,
+      '',
+      '### Included Features',
+      featureList,
+      ...(heldList ? ['', '### Held (Cherry-Pick Conflicts)', heldList] : []),
+    ].join('\n');
+
+    const prTitle = `Promote ${batch.batchId} to staging`;
+
+    // 6. Create PR into staging via gh cli
+    logger.info(`[batch=${batch.batchId}] Creating staging PR: ${branchName} → staging`);
+    const { stdout: prOutput } = await execFileAsync(
+      'gh',
+      [
+        'pr',
+        'create',
+        '--base',
+        'staging',
+        '--head',
+        branchName,
+        '--title',
+        prTitle,
+        '--body',
+        prBody,
+      ],
+      { cwd: projectPath }
+    );
+    const prUrl = prOutput.trim();
+    logger.info(`[batch=${batch.batchId}] Staging PR created: ${prUrl}`);
+
+    // 7. Enable auto-merge on the staging PR
+    // gh pr create prints the PR URL; extract the PR number from the trailing path segment
+    const prNumber = prUrl.split('/').at(-1);
+    if (prNumber && /^\d+$/.test(prNumber)) {
+      logger.info(`[batch=${batch.batchId}] Enabling auto-merge on staging PR #${prNumber}`);
+      try {
+        await execFileAsync('gh', ['pr', 'merge', '--auto', '--squash', prNumber], {
+          cwd: projectPath,
+        });
+      } catch (err) {
+        logger.warn(
+          `[batch=${batch.batchId}] Failed to enable auto-merge on PR #${prNumber}:`,
+          err
+        );
+      }
+    } else {
+      logger.warn(
+        `[batch=${batch.batchId}] Could not parse PR number from URL "${prUrl}"; skipping auto-merge`
+      );
+    }
+
+    // 8. Update candidate statuses and batch metadata
+    for (const candidate of promoted) {
+      candidate.status = 'promoted';
+    }
+    batch.stagingPrUrl = prUrl;
+
+    logger.info(
+      `[batch=${batch.batchId}] promoteToStaging complete — ` +
+        `promoted=${promoted.length}, held=${batch.candidates.filter((c) => c.status === 'held').length}`
+    );
+  }
+
+  /**
+   * HITL-gated promotion to main.
+   *
+   * 1. Creates a PR from staging into main via gh cli (NO auto-merge).
+   * 2. Calls this.hitlFormService?.create() to notify a human reviewer.
+   * 3. Updates batch.mainPrUrl.
+   *
+   * Ava never merges this PR herself — she only creates it and notifies.
+   */
+  async promoteToMain(batch: PromotionBatch, projectPath: string): Promise<void> {
+    logger.info(`[batch=${batch.batchId}] Creating staging → main PR`);
+
+    const promotedCandidates = batch.candidates.filter((c) => c.status === 'promoted');
+    const featureList =
+      promotedCandidates.length > 0
+        ? promotedCandidates.map((c) => `- ${c.featureTitle} (\`${c.featureId}\`)`).join('\n')
+        : '_No promoted features in this batch._';
+
+    const prBody = [
+      `## Production Promotion: ${batch.batchId}`,
+      '',
+      '### Features',
+      featureList,
+      '',
+      '> ⚠️ **Human review and approval required before merging.**',
+      '> Ava does not merge this PR automatically.',
+    ].join('\n');
+
+    const prTitle = `Promote batch ${batch.batchId} to main`;
+
+    // Create the PR from staging into main — NO auto-merge
+    const { stdout: prOutput } = await execFileAsync(
+      'gh',
+      ['pr', 'create', '--base', 'main', '--head', 'staging', '--title', prTitle, '--body', prBody],
+      { cwd: projectPath }
+    );
+    const prUrl = prOutput.trim();
+    logger.info(`[batch=${batch.batchId}] Main PR created: ${prUrl}`);
+
+    // Update batch with the PR URL
+    batch.mainPrUrl = prUrl;
+
+    // Notify via HITLFormService — direct server-side call, NOT MCP tool
+    const hitlInput: HITLFormRequestInput = {
+      title: `Approve Promotion to Main: ${batch.batchId}`,
+      description: [
+        `A **staging → main** PR has been created for promotion batch **${batch.batchId}**.`,
+        '',
+        `**PR:** ${prUrl}`,
+        '',
+        `**Features (${promotedCandidates.length}):**`,
+        featureList,
+        '',
+        'Please review the PR and approve or reject the promotion.',
+      ].join('\n'),
+      steps: [
+        {
+          title: 'Promotion Approval',
+          description: `Batch ${batch.batchId} — ${promotedCandidates.length} feature(s) ready for main`,
+          schema: {
+            type: 'object',
+            properties: {
+              decision: {
+                type: 'string',
+                title: 'Decision',
+                enum: ['approve', 'reject'],
+              },
+              notes: {
+                type: 'string',
+                title: 'Notes (optional)',
+              },
+            },
+            required: ['decision'],
+          },
+          uiSchema: {
+            decision: { 'ui:widget': 'radio' },
+            notes: { 'ui:widget': 'textarea' },
+          },
+        },
+      ],
+      callerType: 'flow',
+      projectPath,
+    };
+
+    this.hitlFormService?.create(hitlInput);
+
+    logger.info(
+      `[batch=${batch.batchId}] promoteToMain complete — mainPrUrl=${prUrl}, HITL form created`
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

- **GET** `/api/promotions/candidates` — list candidates with optional `?status=` filter (candidate/selected/promoted/held/rejected)
- **POST** `/api/promotions/batch` — create a `PromotionBatch` from selected candidateIds (in-memory store)
- **GET** `/api/promotions/batches` — list all in-memory batches
- **POST** `/api/promotions/promote-to-staging` — trigger git promotion for a batch (delegates to `StagingPromotionService.promoteToStaging`)
- **POST** `/api/promotions/promote-to-main` — trigger staging→main PR creation (delegates to `StagingPromotionService.promoteToMain`, HITL-gated)

Uses canonical `@protolabs-ai/types` (`PromotionBatch`, `PromotionCandidate`, `PromotionStatus`).

**Depends on:** #1211 (Git Promotion Workflow — adds `promoteToStaging`/`promoteToMain` to `StagingPromotionService`)

## Test plan
- [ ] GET /api/promotions/candidates returns empty array for new project
- [ ] POST /api/promotions/batch creates batch from valid candidateIds
- [ ] POST /api/promotions/batch returns 400 for unknown candidateIds
- [ ] GET /api/promotions/batches lists all batches
- [ ] POST /api/promotions/promote-to-staging returns 409 if already promoted
- [ ] POST /api/promotions/promote-to-main returns 409 if no stagingPrUrl

🤖 Generated with [Claude Code](https://claude.com/claude-code)