### PR TITLE
docs: document --ignore-path /dev/null requirement for worktree prettier formatting

### DIFF
--- a/.automaker/context/CLAUDE.md
+++ b/.automaker/context/CLAUDE.md
@@ -54,6 +54,7 @@ apps/server, apps/ui
 ## CRITICAL: Build Order
 
 If you modify ANY file in `libs/`:
+
 1. `npm run build:packages` FIRST
 2. Then `npm run build:server`
 
@@ -92,6 +93,7 @@ If a type exists, import it from `@protolabs-ai/types`. Do NOT recreate it.
 ## Server Service Pattern
 
 Services are classes in `apps/server/src/services/`:
+
 ```typescript
 import { createLogger } from '@protolabs-ai/utils';
 import { FeatureLoader } from './feature-loader.js';
@@ -122,6 +124,7 @@ npm run format:check        # Prettier check
 ## Feature Data Fields (Feature interface)
 
 Key fields available on every feature:
+
 - `executionHistory?: ExecutionRecord[]` — per-execution timing, cost, tokens
 - `costUsd?: number` — total cost
 - `createdAt?, completedAt?, startedAt?, reviewStartedAt?` — lifecycle timestamps
@@ -165,7 +168,8 @@ When implementing features, every PR created by Automaker contains a hidden owne
 This is appended automatically by `create-pr.ts` via `buildPROwnershipWatermark()`. You do not need to add it manually.
 
 **WorktreeRecoveryService** runs after every agent exit. If you leave uncommitted changes in the worktree, it will:
-1. Format changed files
+
+1. Format changed files with `npx prettier --ignore-path /dev/null --write <files>`
 2. Stage (excluding `.automaker/`)
 3. Commit with `HUSKY=0`
 4. Push and create a PR
@@ -173,3 +177,21 @@ This is appended automatically by `create-pr.ts` via `buildPROwnershipWatermark(
 If recovery fails, the feature is marked `blocked` with a `statusChangeReason`. The Lead Engineer will escalate rather than retry — retrying the agent won't resolve a git or network failure.
 
 **Implication**: Commit your work before exiting. The recovery service is a safety net, not a substitute for proper commits.
+
+## CRITICAL: Prettier Formatting — Always Pass `--ignore-path`
+
+Prettier 3.x respects `.gitignore` by default. Since `.worktrees/` is gitignored, running `npx prettier --write` (without `--ignore-path`) silently skips ALL files in `.worktrees/` — no formatting, no error. This causes CI format failures on every agent PR.
+
+**Always use this exact command when formatting manually:**
+
+```bash
+npx prettier --ignore-path /dev/null --write <files>
+```
+
+Or to check before committing:
+
+```bash
+npm run format:check
+```
+
+**Never use** `prettier --write` without `--ignore-path /dev/null` in a worktree context.

--- a/.automaker/context/pr-ownership.md
+++ b/.automaker/context/pr-ownership.md
@@ -27,6 +27,7 @@ Every PR created by Automaker contains a hidden HTML comment in the body:
 This is invisible in rendered GitHub markdown but parseable by `gh pr view --json body`.
 
 Utility functions in `apps/server/src/routes/github/utils/pr-ownership.ts`:
+
 - `buildPROwnershipWatermark(instanceId, teamId)` — creates the comment string
 - `parsePROwnershipWatermark(body)` — parses it back to `{ instanceId, teamId, createdAt }`
 - `isPRStale(lastCommitAgeHours, lastActivityAgeHours, staleTtlHours)` — true when **both** ages exceed TTL
@@ -48,12 +49,12 @@ Utility functions in `apps/server/src/routes/github/utils/pr-ownership.ts`:
 
 ## Nudge Rules — When to Act
 
-| Scenario | Action |
-|----------|--------|
-| `isOwnedByThisInstance: true` | Act freely (rebase, fix, comment, merge) |
-| `isOwnedByThisInstance: false`, `isStale: false` | **Skip** — another live instance owns this PR |
-| `isOwnedByThisInstance: false`, `isStale: true` | May act — original owner appears inactive |
-| `instanceId: null` | PR not created by Automaker — apply project policy |
+| Scenario                                         | Action                                             |
+| ------------------------------------------------ | -------------------------------------------------- |
+| `isOwnedByThisInstance: true`                    | Act freely (rebase, fix, comment, merge)           |
+| `isOwnedByThisInstance: false`, `isStale: false` | **Skip** — another live instance owns this PR      |
+| `isOwnedByThisInstance: false`, `isStale: true`  | May act — original owner appears inactive          |
+| `instanceId: null`                               | PR not created by Automaker — apply project policy |
 
 Stale = BOTH last commit AND last activity older than `prOwnershipStaleTtlHours` (default 24h).
 
@@ -63,7 +64,7 @@ After every agent exits (success or failure), `WorktreeRecoveryService` checks f
 
 ```
 detect uncommitted work
-  → format (prettier stdin pipe)
+  → format (npx prettier --ignore-path /dev/null --write)
   → selective stage (exclude .automaker/)
   → HUSKY=0 git commit
   → git push

--- a/docs/dev/git-workflow.md
+++ b/docs/dev/git-workflow.md
@@ -477,7 +477,7 @@ For the full reference, see [Multi-Instance PR Coordination](./multi-instance-pr
 
 `WorktreeRecoveryService` runs after every agent exit (success or failure). It detects uncommitted changes in the worktree and automatically:
 
-1. Formats changed files via prettier stdin pipe
+1. Formats changed files with `npx prettier --ignore-path /dev/null --write <files>`
 2. Stages selectively (excludes `.automaker/`)
 3. Commits with `HUSKY=0` to skip hooks
 4. Pushes the branch


### PR DESCRIPTION
## Summary

- Adds CRITICAL prettier section to `.automaker/context/CLAUDE.md` explaining that Prettier 3.x respects `.gitignore` by default, silently skipping files in `.worktrees/` — always pass `--ignore-path /dev/null` when formatting from within a worktree
- Updates `.automaker/context/pr-ownership.md` to document WorktreeRecoveryService flow with correct prettier command
- Fixes `docs/dev/git-workflow.md` recovery service command example to use `--ignore-path /dev/null`

## Test plan

- [ ] Verify context files load correctly into agent prompts
- [ ] Verify docs page renders without errors
- [ ] CI format:check passes

## Notes

This is the SPEC phase output for the prettier investigation feature. The EXECUTE phase will implement the full fix: standardizing `commitChanges()` and `formatAndAmendLastCommit()` in `git-workflow-service.ts` to use `--ignore-path /dev/null`, adding error logging to catch blocks, and updating the PR Maintainer agent prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)