### PR TITLE
feat(plugin): add hooks support to plugin.json format (v1.1.0)

### DIFF
--- a/packages/mcp-server/plugins/automaker/.claude-plugin/plugin.json
+++ b/packages/mcp-server/plugins/automaker/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "automaker",
   "description": "Automaker - AI Development Studio. Manage Kanban boards, AI agents, and feature orchestration.",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "author": {
     "name": "Proto Labs AI"
   },
@@ -38,5 +38,110 @@
         "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
       }
     }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/compaction-prime-directive.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-context.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/check-mcp-health.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-context.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/check-mcp-health.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-context.sh\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/block-dangerous.sh\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/auto-update-plugin.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__plugin_automaker_automaker__create_feature",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/auto-start-agent.sh\""
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact-save-state.sh\""
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-end-save.sh\""
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "mcp__plugin_automaker_automaker__",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/handle-mcp-failure.sh\""
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Bumps plugin version `1.0.7` → `1.1.0`
- Adds `hooks` section to `plugin.json` plugin format specification
- Demonstrates full hook lifecycle: SessionStart, PreToolUse, PostToolUse, PreCompact, SessionEnd, PostToolUseFailure

## Hook definitions added

| Event | Matcher | Hook |
|-------|---------|------|
| SessionStart | compact | compaction-prime-directive + session-context |
| SessionStart | startup | check-mcp-health + session-context |
| SessionStart | resume | check-mcp-health + session-context |
| PreToolUse | Bash | block-dangerous (safety guard) |
| PostToolUse | Edit\|Write | auto-update-plugin |
| PostToolUse | create_feature | auto-start-agent |
| PreCompact | (all) | pre-compact-save-state |
| SessionEnd | (all) | session-end-save |
| PostToolUseFailure | mcp__automaker | handle-mcp-failure |

## Test plan

- [ ] Plugin installs without errors
- [ ] Hooks fire correctly on respective events
- [ ] `CLAUDE_PLUGIN_ROOT` resolves hook script paths correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)