### PR TITLE
feat(auto-mode): route content features to GTM execution path

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -1114,6 +1114,17 @@ export class AutoModeService {
             continue;
           }
 
+          // Guard: content features (featureType === 'content') must route through
+          // leadEngineerService to the GTM execution path. They must NOT be launched
+          // with the standard code agent. If leadEngineerService is not available, skip them.
+          if (nextFeature.featureType === 'content' && !this.leadEngineerService) {
+            logger.warn(
+              `[AutoLoop] Skipping content feature ${nextFeature.id} ("${nextFeature.title}") — LeadEngineerService required for GTM execution path`
+            );
+            await this.sleep(2000);
+            continue;
+          }
+
           // Mark feature as starting BEFORE calling executeFeature to prevent race conditions
           projectState.startingFeatures.add(nextFeature.id);
 
@@ -1132,8 +1143,10 @@ export class AutoModeService {
             }
           }, 30000);
 
-          // Start feature execution in background
-          // Delegate to Lead Engineer if available, otherwise use legacy executeFeature
+          // Start feature execution in background.
+          // Content features (featureType === 'content') always route through leadEngineerService
+          // to the GTM execution path (guarded above — leadEngineerService is non-null here).
+          // Code features use leadEngineerService if available, otherwise fall back to executeFeature.
           const featureModelResult = await this.getModelForFeature(nextFeature, projectPath);
           const executionPromise = this.leadEngineerService
             ? this.leadEngineerService.process(projectPath, nextFeature.id, {
@@ -1460,6 +1473,18 @@ export class AutoModeService {
         if (nextFeature) {
           // Reset idle event flag since we're doing work again
           this.hasEmittedIdleEvent = false;
+
+          // Guard: content features (featureType === 'content') require leadEngineerService
+          // for the GTM execution path and must not run via the legacy code agent.
+          // Skip them here — they will be picked up by runAutoLoopForProject.
+          if (nextFeature.featureType === 'content') {
+            logger.warn(
+              `[AutoLoop] Skipping content feature ${nextFeature.id} in legacy loop — GTM execution requires per-project auto mode`
+            );
+            await this.sleep(2000);
+            continue;
+          }
+
           // Start feature execution in background
           this.executeFeature(
             this.config!.projectPath,

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -197,6 +197,14 @@ export interface Feature {
    */
   complexity?: 'small' | 'medium' | 'large' | 'architectural';
   /**
+   * Feature type — determines the execution path in auto-mode and LeadEngineer.
+   * - 'code' (default): Standard engineering feature executed by the code agent.
+   * - 'content': GTM content piece executed via the GTM execution path (GtmExecuteProcessor).
+   *   Content features are routed through leadEngineerService and must not be launched
+   *   with the standard code agent.
+   */
+  featureType?: 'code' | 'content';
+  /**
    * Marks this feature as foundational infrastructure (e.g., package scaffold,
    * directory structure, base types). Features that depend on a foundation feature
    * will NOT start until the foundation reaches 'done' (PR merged to main).


### PR DESCRIPTION
## Summary

- Added `featureType?: 'code' | 'content'` field to `Feature` type in `libs/types`
- Added guards in both auto-mode loops to route content features through `leadEngineerService` → GtmExecuteProcessor
- Code features continue to use the standard agent launch path
- Content features now never accidentally launch the standard code agent

## Test plan

- [ ] `npm run build:server` passes (TypeScript compiles cleanly — pre-existing `@protolabs-ai/platform` p-limit DTS issue is unrelated)
- [ ] Code features continue to work normally via existing auto-mode path
- [ ] Content features with `featureType: 'content'` route through leadEngineerService when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)