### PR TITLE
feat(knowledge): add Langfuse spans to search and embedding operations

### DIFF
--- a/apps/server/src/services/knowledge-embedding-orchestrator.ts
+++ b/apps/server/src/services/knowledge-embedding-orchestrator.ts
@@ -12,6 +12,7 @@ import * as BetterSqlite3 from 'better-sqlite3';
 import Anthropic from '@anthropic-ai/sdk';
 import { createLogger } from '@protolabs-ai/utils';
 import { EmbeddingService } from './embedding-service.js';
+import { getLangfuseInstance } from '../lib/langfuse-singleton.js';
 
 const logger = createLogger('KnowledgeEmbeddingOrchestrator');
 
@@ -54,45 +55,69 @@ export class KnowledgeEmbeddingOrchestrator {
         return;
       }
 
+      // Langfuse span for embedding batch observability
+      const _spanStartTime = new Date();
+      const _langfuse = getLangfuseInstance();
+      const _spanTraceId = `knowledge-embedding-${Date.now()}`;
+      const _embeddingModel = 'all-MiniLM-L6-v2';
+      _langfuse.createTrace({
+        id: _spanTraceId,
+        name: 'knowledge:embedding_batch',
+        tags: ['knowledge-embedding'],
+      });
+      const _span = _langfuse.createSpan({
+        traceId: _spanTraceId,
+        name: 'knowledge:embedding_batch',
+        input: { chunk_count: chunksToEmbed.length, model: _embeddingModel },
+        startTime: _spanStartTime,
+      });
+
       logger.info(`Starting background embedding for ${chunksToEmbed.length} chunks`);
 
       // Process chunks one by one
       let processed = 0;
-      for (const chunk of chunksToEmbed) {
-        try {
-          // Combine heading and content
-          const text = chunk.heading ? `${chunk.heading} ${chunk.content}` : chunk.content;
+      try {
+        for (const chunk of chunksToEmbed) {
+          try {
+            // Combine heading and content
+            const text = chunk.heading ? `${chunk.heading} ${chunk.content}` : chunk.content;
 
-          // Generate embedding
-          const embedding = await this.embeddingService.embed(text);
+            // Generate embedding
+            const embedding = await this.embeddingService.embed(text);
 
-          // Convert Float32Array to Buffer for BLOB storage
-          const buffer = Buffer.from(embedding.buffer);
+            // Convert Float32Array to Buffer for BLOB storage
+            const buffer = Buffer.from(embedding.buffer);
 
-          // Insert or replace embedding in the embeddings table
-          db.prepare(
-            `INSERT OR REPLACE INTO embeddings (chunk_id, embedding, model, created_at)
+            // Insert or replace embedding in the embeddings table
+            db.prepare(
+              `INSERT OR REPLACE INTO embeddings (chunk_id, embedding, model, created_at)
              VALUES (?, ?, ?, datetime('now'))`
-          ).run(chunk.id, buffer, 'all-MiniLM-L6-v2');
+            ).run(chunk.id, buffer, _embeddingModel);
 
-          processed++;
+            processed++;
 
-          // Log progress every 10 chunks
-          if (processed % 10 === 0) {
-            logger.debug(`Embedded ${processed}/${chunksToEmbed.length} chunks`);
+            // Log progress every 10 chunks
+            if (processed % 10 === 0) {
+              logger.debug(`Embedded ${processed}/${chunksToEmbed.length} chunks`);
+            }
+          } catch (error) {
+            logger.warn(`Failed to embed chunk ${chunk.id}:`, error);
+            // Continue with next chunk
           }
-        } catch (error) {
-          logger.warn(`Failed to embed chunk ${chunk.id}:`, error);
-          // Continue with next chunk
         }
+
+        logger.info(
+          `Background embedding completed: ${processed}/${chunksToEmbed.length} chunks embedded`
+        );
+
+        // Start HyPE background worker after embeddings complete
+        void this.runBackgroundHype(db);
+      } finally {
+        _span?.end({
+          output: { processed_count: processed, total_count: chunksToEmbed.length },
+          metadata: { model: _embeddingModel, duration_ms: Date.now() - _spanStartTime.getTime() },
+        });
       }
-
-      logger.info(
-        `Background embedding completed: ${processed}/${chunksToEmbed.length} chunks embedded`
-      );
-
-      // Start HyPE background worker after embeddings complete
-      void this.runBackgroundHype(db);
     } catch (error) {
       logger.error('Background embedding failed:', error);
     }

--- a/apps/server/src/services/knowledge-search-service.ts
+++ b/apps/server/src/services/knowledge-search-service.ts
@@ -17,6 +17,7 @@ import type {
   RetrievalMode,
 } from '@protolabs-ai/types';
 import type { EmbeddingService } from './embedding-service.js';
+import { getLangfuseInstance } from '../lib/langfuse-singleton.js';
 
 const logger = createLogger('KnowledgeSearchService');
 
@@ -62,15 +63,35 @@ export class KnowledgeSearchService {
   ): Promise<{ results: KnowledgeSearchResult[]; retrieval_mode: RetrievalMode }> {
     const { maxResults = 20, maxTokens = 8000, sourceTypes = 'all' } = opts;
 
-    // Determine if we can use hybrid retrieval
-    const canUseHybrid = this.settings.hybridRetrieval && this.embeddingService.isReady();
+    // Langfuse span for search observability
+    const _spanStartTime = new Date();
+    const _langfuse = getLangfuseInstance();
+    const _spanTraceId = `knowledge-search-${Date.now()}`;
+    _langfuse.createTrace({
+      id: _spanTraceId,
+      name: 'knowledge:search',
+      tags: ['knowledge-search'],
+    });
+    const _span = _langfuse.createSpan({
+      traceId: _spanTraceId,
+      name: 'knowledge:search',
+      input: { query },
+      startTime: _spanStartTime,
+    });
+    let _spanResultCount = 0;
+    let _spanTop1Score: number | undefined;
+    let _spanMode: RetrievalMode = 'bm25';
 
-    let retrievalMode: RetrievalMode = 'bm25';
+    try {
+      // Determine if we can use hybrid retrieval
+      const canUseHybrid = this.settings.hybridRetrieval && this.embeddingService.isReady();
 
-    // Step 1: Run BM25 FTS5 search to get top-50 candidates
-    const candidateLimit = canUseHybrid ? 50 : maxResults;
+      let retrievalMode: RetrievalMode = 'bm25';
 
-    let sql = `
+      // Step 1: Run BM25 FTS5 search to get top-50 candidates
+      const candidateLimit = canUseHybrid ? 50 : maxResults;
+
+      let sql = `
       SELECT
         c.id,
         c.source_type,
@@ -89,277 +110,295 @@ export class KnowledgeSearchService {
       WHERE chunks_fts MATCH ?
     `;
 
-    const params: unknown[] = [query];
-    if (sourceTypes !== 'all' && sourceTypes.length > 0) {
-      const placeholders = sourceTypes.map(() => '?').join(', ');
-      sql += ` AND c.source_type IN (${placeholders})`;
-      params.push(...sourceTypes);
-    }
+      const params: unknown[] = [query];
+      if (sourceTypes !== 'all' && sourceTypes.length > 0) {
+        const placeholders = sourceTypes.map(() => '?').join(', ');
+        sql += ` AND c.source_type IN (${placeholders})`;
+        params.push(...sourceTypes);
+      }
 
-    sql += ' ORDER BY score LIMIT ?';
-    params.push(candidateLimit);
+      sql += ' ORDER BY score LIMIT ?';
+      params.push(candidateLimit);
 
-    logger.debug(`Executing FTS5 search: query="${query}", candidateLimit=${candidateLimit}`);
+      logger.debug(`Executing FTS5 search: query="${query}", candidateLimit=${candidateLimit}`);
 
-    const stmt = this.db.prepare(sql);
-    const rows = stmt.all(...params) as Array<{
-      id: string;
-      source_type: string;
-      source_file: string;
-      project_path: string;
-      chunk_index: number;
-      heading: string | null;
-      content: string;
-      tags: string | null;
-      importance: number;
-      created_at: string;
-      updated_at: string;
-      score: number;
-    }>;
+      const stmt = this.db.prepare(sql);
+      const rows = stmt.all(...params) as Array<{
+        id: string;
+        source_type: string;
+        source_file: string;
+        project_path: string;
+        chunk_index: number;
+        heading: string | null;
+        content: string;
+        tags: string | null;
+        importance: number;
+        created_at: string;
+        updated_at: string;
+        score: number;
+      }>;
 
-    // Step 2: If hybrid retrieval is enabled, compute RRF merge (triple-mode fusion if HyPE available)
-    let rankedRows = rows;
+      // Step 2: If hybrid retrieval is enabled, compute RRF merge (triple-mode fusion if HyPE available)
+      let rankedRows = rows;
 
-    if (canUseHybrid && rows.length > 0) {
-      try {
-        // Embed the query
-        const queryEmbedding = await this.embeddingService.embed(query);
+      if (canUseHybrid && rows.length > 0) {
+        try {
+          // Embed the query
+          const queryEmbedding = await this.embeddingService.embed(query);
 
-        if (queryEmbedding) {
-          // Load direct embeddings for candidates
-          const chunkIds = rows.map((r) => r.id);
-          const placeholders = chunkIds.map(() => '?').join(', ');
-          const embeddingSql = `
+          if (queryEmbedding) {
+            // Load direct embeddings for candidates
+            const chunkIds = rows.map((r) => r.id);
+            const placeholders = chunkIds.map(() => '?').join(', ');
+            const embeddingSql = `
             SELECT chunk_id, embedding
             FROM embeddings
             WHERE chunk_id IN (${placeholders})
           `;
 
-          const embeddingRows = this.db.prepare(embeddingSql).all(...chunkIds) as Array<{
-            chunk_id: string;
-            embedding: Buffer;
-          }>;
+            const embeddingRows = this.db.prepare(embeddingSql).all(...chunkIds) as Array<{
+              chunk_id: string;
+              embedding: Buffer;
+            }>;
 
-          // Build a map of chunk_id -> direct embedding
-          const embeddingMap = new Map<string, Float32Array>();
-          for (const row of embeddingRows) {
-            // Convert Buffer to Float32Array
-            const floatArray = new Float32Array(
-              row.embedding.buffer,
-              row.embedding.byteOffset,
-              row.embedding.byteLength / Float32Array.BYTES_PER_ELEMENT
-            );
-            embeddingMap.set(row.chunk_id, floatArray);
-          }
+            // Build a map of chunk_id -> direct embedding
+            const embeddingMap = new Map<string, Float32Array>();
+            for (const row of embeddingRows) {
+              // Convert Buffer to Float32Array
+              const floatArray = new Float32Array(
+                row.embedding.buffer,
+                row.embedding.byteOffset,
+                row.embedding.byteLength / Float32Array.BYTES_PER_ELEMENT
+              );
+              embeddingMap.set(row.chunk_id, floatArray);
+            }
 
-          // Load HyPE embeddings for candidates (from chunks table)
-          const hypeEmbeddingSql = `
+            // Load HyPE embeddings for candidates (from chunks table)
+            const hypeEmbeddingSql = `
             SELECT id, hype_embeddings
             FROM chunks
             WHERE id IN (${placeholders}) AND hype_embeddings IS NOT NULL
           `;
 
-          const hypeEmbeddingRows = this.db.prepare(hypeEmbeddingSql).all(...chunkIds) as Array<{
-            id: string;
-            hype_embeddings: Buffer;
-          }>;
+            const hypeEmbeddingRows = this.db.prepare(hypeEmbeddingSql).all(...chunkIds) as Array<{
+              id: string;
+              hype_embeddings: Buffer;
+            }>;
 
-          // Build a map of chunk_id -> HyPE embedding
-          const hypeEmbeddingMap = new Map<string, Float32Array>();
-          for (const row of hypeEmbeddingRows) {
-            // Convert Buffer to Float32Array
-            const floatArray = new Float32Array(
-              row.hype_embeddings.buffer,
-              row.hype_embeddings.byteOffset,
-              row.hype_embeddings.byteLength / Float32Array.BYTES_PER_ELEMENT
-            );
-            hypeEmbeddingMap.set(row.id, floatArray);
-          }
-
-          // Compute cosine similarity for direct embeddings
-          const directCosineSimilarities = new Map<string, number>();
-          for (const row of rows) {
-            const embedding = embeddingMap.get(row.id);
-            if (embedding) {
-              const similarity = this.embeddingService.cosineSimilarity(queryEmbedding, embedding);
-              directCosineSimilarities.set(row.id, similarity);
-            }
-          }
-
-          // Compute cosine similarity for HyPE embeddings
-          const hypeCosineSimilarities = new Map<string, number>();
-          for (const row of rows) {
-            const hypeEmbedding = hypeEmbeddingMap.get(row.id);
-            if (hypeEmbedding) {
-              const similarity = this.embeddingService.cosineSimilarity(
-                queryEmbedding,
-                hypeEmbedding
+            // Build a map of chunk_id -> HyPE embedding
+            const hypeEmbeddingMap = new Map<string, Float32Array>();
+            for (const row of hypeEmbeddingRows) {
+              // Convert Buffer to Float32Array
+              const floatArray = new Float32Array(
+                row.hype_embeddings.buffer,
+                row.hype_embeddings.byteOffset,
+                row.hype_embeddings.byteLength / Float32Array.BYTES_PER_ELEMENT
               );
-              hypeCosineSimilarities.set(row.id, similarity);
+              hypeEmbeddingMap.set(row.id, floatArray);
             }
-          }
 
-          // Determine retrieval mode based on available embeddings
-          const hasDirectEmbeddings = directCosineSimilarities.size > 0;
-          const hasHypeEmbeddings = hypeCosineSimilarities.size > 0;
-
-          if (hasDirectEmbeddings || hasHypeEmbeddings) {
-            // Step 3: Rank by BM25 (ascending order - lower score is better)
-            const bm25Ranked = [...rows].sort((a, b) => a.score - b.score);
-            const bm25RankMap = new Map<string, number>();
-            bm25Ranked.forEach((row, index) => {
-              bm25RankMap.set(row.id, index + 1);
-            });
-
-            // Step 4: Rank by direct cosine similarity (descending - higher is better)
-            const directCosineRanked = [...rows]
-              .filter((r) => directCosineSimilarities.has(r.id))
-              .sort((a, b) => {
-                const simA = directCosineSimilarities.get(a.id) || 0;
-                const simB = directCosineSimilarities.get(b.id) || 0;
-                return simB - simA;
-              });
-            const directCosineRankMap = new Map<string, number>();
-            directCosineRanked.forEach((row, index) => {
-              directCosineRankMap.set(row.id, index + 1);
-            });
-
-            // Step 5: Rank by HyPE cosine similarity (descending - higher is better)
-            const hypeRanked = [...rows]
-              .filter((r) => hypeCosineSimilarities.has(r.id))
-              .sort((a, b) => {
-                const simA = hypeCosineSimilarities.get(a.id) || 0;
-                const simB = hypeCosineSimilarities.get(b.id) || 0;
-                return simB - simA;
-              });
-            const hypeRankMap = new Map<string, number>();
-            hypeRanked.forEach((row, index) => {
-              hypeRankMap.set(row.id, index + 1);
-            });
-
-            // Step 6: RRF merge with k=60, equal weights for all three modes
-            const k = 60;
-            const rrfScores = new Map<string, number>();
-
+            // Compute cosine similarity for direct embeddings
+            const directCosineSimilarities = new Map<string, number>();
             for (const row of rows) {
-              const bm25Rank = bm25RankMap.get(row.id) || rows.length + 1;
-              const directCosineRank = directCosineRankMap.get(row.id) || rows.length + 1;
-              const hypeRank = hypeRankMap.get(row.id) || rows.length + 1;
-
-              let rrfScore = 1 / (k + bm25Rank);
-
-              // Add direct cosine if available
-              if (hasDirectEmbeddings) {
-                rrfScore += 1 / (k + directCosineRank);
+              const embedding = embeddingMap.get(row.id);
+              if (embedding) {
+                const similarity = this.embeddingService.cosineSimilarity(
+                  queryEmbedding,
+                  embedding
+                );
+                directCosineSimilarities.set(row.id, similarity);
               }
-
-              // Add HyPE cosine if available
-              if (hasHypeEmbeddings) {
-                rrfScore += 1 / (k + hypeRank);
-              }
-
-              rrfScores.set(row.id, rrfScore);
             }
 
-            // Step 7: Sort by RRF score (higher is better)
-            rankedRows = [...rows].sort((a, b) => {
-              const scoreA = rrfScores.get(a.id) || 0;
-              const scoreB = rrfScores.get(b.id) || 0;
-              return scoreB - scoreA;
-            });
+            // Compute cosine similarity for HyPE embeddings
+            const hypeCosineSimilarities = new Map<string, number>();
+            for (const row of rows) {
+              const hypeEmbedding = hypeEmbeddingMap.get(row.id);
+              if (hypeEmbedding) {
+                const similarity = this.embeddingService.cosineSimilarity(
+                  queryEmbedding,
+                  hypeEmbedding
+                );
+                hypeCosineSimilarities.set(row.id, similarity);
+              }
+            }
 
-            // Set retrieval mode based on what was used
-            if (hasHypeEmbeddings) {
-              retrievalMode = 'hybrid_hype';
-              logger.info(
-                `Triple-mode retrieval: ${directCosineSimilarities.size} direct, ${hypeCosineSimilarities.size} HyPE embeddings`
-              );
+            // Determine retrieval mode based on available embeddings
+            const hasDirectEmbeddings = directCosineSimilarities.size > 0;
+            const hasHypeEmbeddings = hypeCosineSimilarities.size > 0;
+
+            if (hasDirectEmbeddings || hasHypeEmbeddings) {
+              // Step 3: Rank by BM25 (ascending order - lower score is better)
+              const bm25Ranked = [...rows].sort((a, b) => a.score - b.score);
+              const bm25RankMap = new Map<string, number>();
+              bm25Ranked.forEach((row, index) => {
+                bm25RankMap.set(row.id, index + 1);
+              });
+
+              // Step 4: Rank by direct cosine similarity (descending - higher is better)
+              const directCosineRanked = [...rows]
+                .filter((r) => directCosineSimilarities.has(r.id))
+                .sort((a, b) => {
+                  const simA = directCosineSimilarities.get(a.id) || 0;
+                  const simB = directCosineSimilarities.get(b.id) || 0;
+                  return simB - simA;
+                });
+              const directCosineRankMap = new Map<string, number>();
+              directCosineRanked.forEach((row, index) => {
+                directCosineRankMap.set(row.id, index + 1);
+              });
+
+              // Step 5: Rank by HyPE cosine similarity (descending - higher is better)
+              const hypeRanked = [...rows]
+                .filter((r) => hypeCosineSimilarities.has(r.id))
+                .sort((a, b) => {
+                  const simA = hypeCosineSimilarities.get(a.id) || 0;
+                  const simB = hypeCosineSimilarities.get(b.id) || 0;
+                  return simB - simA;
+                });
+              const hypeRankMap = new Map<string, number>();
+              hypeRanked.forEach((row, index) => {
+                hypeRankMap.set(row.id, index + 1);
+              });
+
+              // Step 6: RRF merge with k=60, equal weights for all three modes
+              const k = 60;
+              const rrfScores = new Map<string, number>();
+
+              for (const row of rows) {
+                const bm25Rank = bm25RankMap.get(row.id) || rows.length + 1;
+                const directCosineRank = directCosineRankMap.get(row.id) || rows.length + 1;
+                const hypeRank = hypeRankMap.get(row.id) || rows.length + 1;
+
+                let rrfScore = 1 / (k + bm25Rank);
+
+                // Add direct cosine if available
+                if (hasDirectEmbeddings) {
+                  rrfScore += 1 / (k + directCosineRank);
+                }
+
+                // Add HyPE cosine if available
+                if (hasHypeEmbeddings) {
+                  rrfScore += 1 / (k + hypeRank);
+                }
+
+                rrfScores.set(row.id, rrfScore);
+              }
+
+              // Step 7: Sort by RRF score (higher is better)
+              rankedRows = [...rows].sort((a, b) => {
+                const scoreA = rrfScores.get(a.id) || 0;
+                const scoreB = rrfScores.get(b.id) || 0;
+                return scoreB - scoreA;
+              });
+
+              // Set retrieval mode based on what was used
+              if (hasHypeEmbeddings) {
+                retrievalMode = 'hybrid_hype';
+                logger.info(
+                  `Triple-mode retrieval: ${directCosineSimilarities.size} direct, ${hypeCosineSimilarities.size} HyPE embeddings`
+                );
+              } else {
+                retrievalMode = 'hybrid';
+                logger.info(
+                  `Hybrid retrieval: ${directCosineSimilarities.size}/${rows.length} chunks with direct embeddings`
+                );
+              }
             } else {
-              retrievalMode = 'hybrid';
-              logger.info(
-                `Hybrid retrieval: ${directCosineSimilarities.size}/${rows.length} chunks with direct embeddings`
-              );
+              logger.debug('No embeddings found for candidates, falling back to BM25');
             }
           } else {
-            logger.debug('No embeddings found for candidates, falling back to BM25');
+            logger.debug('Query embedding failed, falling back to BM25');
           }
-        } else {
-          logger.debug('Query embedding failed, falling back to BM25');
+        } catch (error) {
+          logger.warn('Hybrid retrieval error, falling back to BM25:', error);
         }
-      } catch (error) {
-        logger.warn('Hybrid retrieval error, falling back to BM25:', error);
-      }
-    }
-
-    // Apply token budget enforcement
-    const results: KnowledgeSearchResult[] = [];
-    let totalTokens = 0;
-
-    for (const row of rankedRows) {
-      if (results.length >= maxResults) {
-        break;
       }
 
-      // Estimate tokens: ~4 chars per token
-      const contentTokens = Math.ceil(row.content.length / 4);
-      const headingTokens = row.heading ? Math.ceil(row.heading.length / 4) : 0;
-      const chunkTokens = contentTokens + headingTokens;
+      // Apply token budget enforcement
+      const results: KnowledgeSearchResult[] = [];
+      let totalTokens = 0;
 
-      // Check if adding this chunk would exceed the budget
-      if (totalTokens + chunkTokens > maxTokens) {
-        logger.debug(
-          `Token budget exhausted: ${totalTokens}/${maxTokens} tokens used, skipping ${rankedRows.length - results.length} remaining chunks`
-        );
-        break;
+      for (const row of rankedRows) {
+        if (results.length >= maxResults) {
+          break;
+        }
+
+        // Estimate tokens: ~4 chars per token
+        const contentTokens = Math.ceil(row.content.length / 4);
+        const headingTokens = row.heading ? Math.ceil(row.heading.length / 4) : 0;
+        const chunkTokens = contentTokens + headingTokens;
+
+        // Check if adding this chunk would exceed the budget
+        if (totalTokens + chunkTokens > maxTokens) {
+          logger.debug(
+            `Token budget exhausted: ${totalTokens}/${maxTokens} tokens used, skipping ${rankedRows.length - results.length} remaining chunks`
+          );
+          break;
+        }
+
+        // Parse tags from JSON string
+        const tags = row.tags ? (JSON.parse(row.tags) as string[]) : undefined;
+
+        const chunk: KnowledgeChunk = {
+          id: row.id,
+          sourceType: row.source_type as KnowledgeChunk['sourceType'],
+          sourceFile: row.source_file,
+          projectPath: row.project_path,
+          chunkIndex: row.chunk_index,
+          heading: row.heading || undefined,
+          content: row.content,
+          tags,
+          importance: row.importance,
+          createdAt: row.created_at,
+          updatedAt: row.updated_at,
+        };
+
+        results.push({
+          chunk,
+          score: row.score,
+        });
+
+        totalTokens += chunkTokens;
       }
 
-      // Parse tags from JSON string
-      const tags = row.tags ? (JSON.parse(row.tags) as string[]) : undefined;
+      logger.info(
+        `Search completed (${retrievalMode}): ${results.length} chunks returned, ${totalTokens}/${maxTokens} tokens used`
+      );
 
-      const chunk: KnowledgeChunk = {
-        id: row.id,
-        sourceType: row.source_type as KnowledgeChunk['sourceType'],
-        sourceFile: row.source_file,
-        projectPath: row.project_path,
-        chunkIndex: row.chunk_index,
-        heading: row.heading || undefined,
-        content: row.content,
-        tags,
-        importance: row.importance,
-        createdAt: row.created_at,
-        updatedAt: row.updated_at,
-      };
-
-      results.push({
-        chunk,
-        score: row.score,
-      });
-
-      totalTokens += chunkTokens;
-    }
-
-    logger.info(
-      `Search completed (${retrievalMode}): ${results.length} chunks returned, ${totalTokens}/${maxTokens} tokens used`
-    );
-
-    // Update usage tracking for returned chunks
-    if (results.length > 0) {
-      const chunkIds = results.map((r) => r.chunk.id);
-      const placeholders = chunkIds.map(() => '?').join(', ');
-      const updateSql = `
+      // Update usage tracking for returned chunks
+      if (results.length > 0) {
+        const chunkIds = results.map((r) => r.chunk.id);
+        const placeholders = chunkIds.map(() => '?').join(', ');
+        const updateSql = `
         UPDATE chunks
         SET retrieval_count = retrieval_count + 1,
             last_retrieved_at = datetime('now')
         WHERE id IN (${placeholders})
       `;
-      this.db.prepare(updateSql).run(...chunkIds);
-      logger.debug(`Updated usage tracking for ${chunkIds.length} chunks`);
+        this.db.prepare(updateSql).run(...chunkIds);
+        logger.debug(`Updated usage tracking for ${chunkIds.length} chunks`);
+      }
+
+      // Log top-5 results for evaluation (append-only, rotate at 10k entries)
+      void this.logEvaluation(projectPath, query, results.slice(0, 5), retrievalMode);
+
+      // Capture span data before returning
+      _spanResultCount = results.length;
+      _spanTop1Score = results[0]?.score;
+      _spanMode = retrievalMode;
+
+      return { results, retrieval_mode: retrievalMode };
+    } finally {
+      _span?.end({
+        output: {
+          result_count: _spanResultCount,
+          top1_score: _spanTop1Score,
+          retrieval_mode: _spanMode,
+        },
+        metadata: { duration_ms: Date.now() - _spanStartTime.getTime() },
+      });
     }
-
-    // Log top-5 results for evaluation (append-only, rotate at 10k entries)
-    void this.logEvaluation(projectPath, query, results.slice(0, 5), retrievalMode);
-
-    return { results, retrieval_mode: retrievalMode };
   }
 
   /**


### PR DESCRIPTION
## Summary

- Added Langfuse tracing spans to `KnowledgeSearchService.search()` with query, retrieval mode, result count, top-1 score, and duration
- Added Langfuse tracing spans to `KnowledgeEmbeddingOrchestrator.runBackgroundEmbedding()` with chunk count, model name, and processed count
- Both use try/finally to guarantee spans always close even on error
- Uses existing `getLangfuseInstance()` singleton pattern (gracefully no-ops when no Langfuse credentials)

## Test plan

- [ ] `npm run build --workspace=apps/server` passes
- [ ] Knowledge search calls appear in Langfuse traces (when credentials present)
- [ ] Background embedding batches appear as spans with chunk count
- [ ] Spans close correctly on error path (try/finally pattern verified in code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)