### PR TITLE
feat(hooks): post-edit TypeScript typecheck hook

### DIFF
--- a/packages/mcp-server/plugins/automaker/hooks/hooks.json
+++ b/packages/mcp-server/plugins/automaker/hooks/hooks.json
@@ -60,6 +60,10 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/auto-update-plugin.sh\""
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post-edit-typecheck.js\""
           }
         ]
       },

--- a/packages/mcp-server/plugins/automaker/hooks/scripts/post-edit-typecheck.js
+++ b/packages/mcp-server/plugins/automaker/hooks/scripts/post-edit-typecheck.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// post-edit-typecheck.js — PostToolUse hook for Edit/Write tool calls.
+// Runs TypeScript type checking on .ts/.tsx files after they are edited.
+// Fires on Edit and Write tool calls.
+//
+// Behavior:
+//   - Silent (exit 0) if file is not .ts/.tsx
+//   - Silent (exit 0) if no tsconfig.json found walking up from file
+//   - Silent (exit 0) if tsc passes with no errors
+//   - Exits non-zero with filtered error lines if type errors found (max 10 lines)
+
+import { execFileSync } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+
+// Read tool input from stdin (JSON payload from Claude hooks)
+let input;
+try {
+  const raw = fs.readFileSync(0, 'utf8');
+  input = JSON.parse(raw);
+} catch {
+  process.exit(0);
+}
+
+// Extract file_path from tool_input (PostToolUse hook format)
+const filePath = input?.tool_input?.file_path;
+if (!filePath) {
+  process.exit(0);
+}
+
+// Only process .ts/.tsx files
+if (!/\.(tsx?)$/.test(filePath)) {
+  process.exit(0);
+}
+
+// Walk up from the edited file's directory to find the nearest tsconfig.json
+function findTsConfig(startDir) {
+  let current = path.resolve(startDir);
+  while (true) {
+    const candidate = path.join(current, 'tsconfig.json');
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      // Reached filesystem root without finding tsconfig.json
+      return null;
+    }
+    current = parent;
+  }
+}
+
+const fileDir = path.dirname(path.resolve(filePath));
+const tsconfig = findTsConfig(fileDir);
+
+if (!tsconfig) {
+  process.exit(0);
+}
+
+const tsconfigDir = path.dirname(tsconfig);
+
+// Run tsc --noEmit using execFileSync (NOT shell: true) for security
+let tscOutput = '';
+try {
+  execFileSync('npx', ['tsc', '--noEmit', '--pretty', 'false'], {
+    cwd: tsconfigDir,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  // tsc passed — exit 0 silently
+  process.exit(0);
+} catch (err) {
+  // tsc failed — collect stdout and stderr
+  if (err.stdout) tscOutput += err.stdout.toString();
+  if (err.stderr) tscOutput += err.stderr.toString();
+}
+
+// Filter output to lines referencing the edited file (max 10 lines)
+const resolvedFile = path.resolve(filePath);
+const fileBasename = path.basename(filePath);
+
+const errorLines = tscOutput
+  .split('\n')
+  .filter(line => line.includes(resolvedFile) || line.includes(fileBasename))
+  .slice(0, 10);
+
+if (errorLines.length === 0) {
+  // No errors reference this file specifically — exit silently
+  process.exit(0);
+}
+
+process.stderr.write(errorLines.join('\n') + '\n');
+process.exit(1);


### PR DESCRIPTION
## Summary
- Adds `PostToolUse` hook that runs `tsc --noEmit` on `.ts/.tsx` files after Edit/Write
- Walks up directory tree from edited file to find nearest `tsconfig.json`
- Filters tsc output to lines referencing the edited file (max 10 lines) — keeps signal clean
- Silent exit 0 for non-TS files, missing tsconfig, or clean typecheck
- Uses `execFileSync` (not shell) for security, consistent with `post-edit-format.js` pattern

## Foundation
Foundation feature for the Agent Quality Hooks epic. Session Evaluate Hook and downstream features depend on this merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic TypeScript type checking for edited files, providing instant validation and immediate feedback on type errors during the editing workflow to help catch issues early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->