### PR TITLE
feat(server): Lead Engineer GTM Routing + GtmExecuteProcessor

### DIFF
--- a/apps/server/src/services/lead-engineer-gtm-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-gtm-execute-processor.ts
@@ -1,0 +1,117 @@
+/**
+ * Lead Engineer — GTM Execute State Processor
+ *
+ * Handles content features (featureType === 'content') at the EXECUTE stage.
+ * Delegates to ContentFlowService instead of the standard code agent.
+ *
+ * Flow:
+ *   1. Calls contentFlowService.startFlow() with the feature's topic
+ *   2. Polls contentFlowService.getStatus() every 30 seconds
+ *   3. On completion → transitions to REVIEW
+ *   4. On failure or timeout → transitions to ESCALATE
+ */
+
+import { createLogger } from '@protolabs-ai/utils';
+import type { StateContext, StateProcessor, StateTransitionResult } from './lead-engineer-types.js';
+import { contentFlowService } from './content-flow-service.js';
+
+const logger = createLogger('LeadEngineerService');
+
+const POLL_INTERVAL_MS = 30_000; // 30 seconds
+const TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+
+export class GtmExecuteProcessor implements StateProcessor {
+  async enter(ctx: StateContext): Promise<void> {
+    logger.info(`[GTM_EXECUTE] Starting content flow for feature: ${ctx.feature.id}`, {
+      topic: ctx.feature.contentConfig?.topic,
+    });
+  }
+
+  async process(ctx: StateContext): Promise<StateTransitionResult> {
+    const topic = ctx.feature.contentConfig?.topic;
+    if (!topic) {
+      ctx.escalationReason = 'Content feature missing contentConfig.topic';
+      return {
+        nextState: 'ESCALATE',
+        shouldContinue: true,
+        reason: ctx.escalationReason,
+      };
+    }
+
+    let runId: string;
+    try {
+      const result = await contentFlowService.startFlow(ctx.projectPath, topic, {
+        format: 'guide',
+        tone: 'conversational',
+        audience: 'intermediate',
+      });
+      runId = result.runId;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.escalationReason = `Content flow failed to start: ${message}`;
+      return {
+        nextState: 'ESCALATE',
+        shouldContinue: true,
+        reason: ctx.escalationReason,
+      };
+    }
+
+    logger.info(`[GTM_EXECUTE] Content flow started: ${runId}`, { featureId: ctx.feature.id });
+
+    const startTime = Date.now();
+    while (Date.now() - startTime < TIMEOUT_MS) {
+      await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+
+      const status = contentFlowService.getStatus(runId);
+      if (!status) {
+        ctx.escalationReason = `Content flow ${runId} status lost`;
+        return {
+          nextState: 'ESCALATE',
+          shouldContinue: true,
+          reason: ctx.escalationReason,
+        };
+      }
+
+      if (status.status === 'completed') {
+        logger.info(`[GTM_EXECUTE] Content flow ${runId} completed`, {
+          featureId: ctx.feature.id,
+          progress: status.progress,
+        });
+        return {
+          nextState: 'REVIEW',
+          shouldContinue: true,
+          reason: 'Content flow completed successfully',
+        };
+      }
+
+      if (status.status === 'failed') {
+        ctx.escalationReason = `Content flow failed: ${status.error ?? 'unknown error'}`;
+        logger.warn(`[GTM_EXECUTE] Content flow ${runId} failed`, {
+          featureId: ctx.feature.id,
+          error: status.error,
+        });
+        return {
+          nextState: 'ESCALATE',
+          shouldContinue: true,
+          reason: ctx.escalationReason,
+        };
+      }
+
+      logger.debug(`[GTM_EXECUTE] Polling content flow ${runId}`, {
+        status: status.status,
+        progress: status.progress,
+      });
+    }
+
+    ctx.escalationReason = 'Content flow timed out after 30 minutes';
+    return {
+      nextState: 'ESCALATE',
+      shouldContinue: true,
+      reason: ctx.escalationReason,
+    };
+  }
+
+  async exit(_ctx: StateContext): Promise<void> {
+    logger.info('[GTM_EXECUTE] Content execution phase completed');
+  }
+}

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -31,6 +31,7 @@ import { WorldStateBuilder } from './lead-engineer-world-state.js';
 import { ActionExecutor } from './lead-engineer-action-executor.js';
 import { CeremonyOrchestrator } from './lead-engineer-ceremonies.js';
 import { LeadEngineerSessionStore } from './lead-engineer-session-store.js';
+import { GtmExecuteProcessor } from './lead-engineer-gtm-execute-processor.js';
 import type { FeatureProcessingState, StateContext } from './lead-engineer-types.js';
 
 export type { FeatureProcessingState, StateContext };
@@ -299,13 +300,19 @@ export class LeadEngineerService {
         this.settingsService,
         '[LeadEngineer]'
       );
+      const isContentFeature = feature.featureType === 'content';
       const stateMachine = new FeatureStateMachine(serviceContext, {
         checkpointService: workflowSettings.pipeline.checkpointEnabled
           ? this.checkpointService
           : undefined,
         events: this.events,
-        goalGatesEnabled: workflowSettings.pipeline.goalGatesEnabled,
+        // Content features bypass PR-centric goal gates (no PR is created)
+        goalGatesEnabled: isContentFeature ? false : workflowSettings.pipeline.goalGatesEnabled,
       });
+      if (isContentFeature) {
+        stateMachine.registerProcessor('EXECUTE', new GtmExecuteProcessor());
+        logger.info(`[LeadEngineer] Content feature ${featureId} routed to GtmExecuteProcessor`);
+      }
       const result = await stateMachine.processFeature(
         feature,
         projectPath,


### PR DESCRIPTION
## Summary

- Detects content features (`featureType === 'content'`) at the EXECUTE stage in `LeadEngineerService`
- Routes them to the new `GtmExecuteProcessor` instead of the standard code agent
- `GtmExecuteProcessor` calls `contentFlowService.startFlow()`, polls every 30s, transitions to REVIEW on completion or ESCALATE on failure/timeout

## Changes

- `apps/server/src/services/lead-engineer-gtm-execute-processor.ts` — new state processor for content feature execution
- `apps/server/src/services/lead-engineer-service.ts` — import + routing logic, goal gates disabled for content features

## Test plan

- [ ] `npm run build:server` passes
- [ ] Content features (`featureType: 'content'`) skip code agent and call `contentFlowService.startFlow()`
- [ ] Code features (`featureType: 'code'` or unset) continue to use standard `ExecuteProcessor`
- [ ] Missing `contentConfig.topic` transitions to ESCALATE with descriptive reason
- [ ] Content flow timeout after 30 minutes transitions to ESCALATE

🤖 Generated with [Claude Code](https://claude.com/claude-code)