### PR TITLE
feat: add verdict system to agent templates

### DIFF
--- a/.automaker/context/CLAUDE.md
+++ b/.automaker/context/CLAUDE.md
@@ -195,3 +195,44 @@ npm run format:check
 ```
 
 **Never use** `prettier --write` without `--ignore-path /dev/null` in a worktree context.
+
+## Verdict System (All Feature Agents)
+
+All feature agents (kai, matt, sam, frank, and any future agents) **must** follow the Verdict System pattern when surfacing findings from analysis, review, or audit tasks.
+
+### Confidence Threshold
+
+Only surface findings with **>80% certainty**. If you cannot confirm an issue with high confidence, omit it or note it as "unverified — needs further investigation."
+
+### Consolidation Rule
+
+Consolidate similar findings into a single item. Do not list the same class of problem multiple times.
+
+> Example: Instead of listing 3 separate "missing error handling" findings, report: `3 files missing error handling` as one item.
+
+### Verdict Block Format
+
+End **every response** that includes findings with a structured verdict block:
+
+```
+---
+VERDICT: [APPROVE|WARN|BLOCK]
+Issues: [count]
+[CRITICAL|HIGH|MEDIUM|LOW]: [brief description]
+---
+```
+
+**Verdict definitions:**
+
+- **APPROVE** — No critical or high issues found. Safe to proceed.
+- **WARN** — Only medium or low issues found. Proceed with caution; remediation recommended but not blocking.
+- **BLOCK** — One or more critical issues present. Remediation required before proceeding.
+
+**Severity definitions:**
+
+- **CRITICAL** — System failure, data loss, security breach, or major regression likely
+- **HIGH** — Major functional breakage or significant risk
+- **MEDIUM** — Degraded experience or moderate risk
+- **LOW** — Minor issue, style, or technical debt
+
+If no issues are found, emit: `VERDICT: APPROVE` with `Issues: 0`.

--- a/packages/mcp-server/plugins/automaker/commands/frank.md
+++ b/packages/mcp-server/plugins/automaker/commands/frank.md
@@ -474,6 +474,47 @@ docs/infra/
 
 **When in doubt:** Post to Discord with your recommendation and wait for approval.
 
+## Verdict System
+
+After completing any analysis, review, or audit task, apply the following rules before responding:
+
+### Confidence Threshold
+
+Only surface findings with **>80% certainty**. If you cannot confirm an issue with high confidence, omit it or note it as "unverified — needs further investigation."
+
+### Consolidation Rule
+
+Consolidate similar findings into a single item. Do not list the same class of problem multiple times.
+
+> Example: Instead of listing 3 separate "container memory threshold exceeded" findings, report: `3 containers exceeding memory thresholds` as one item.
+
+### Verdict Block
+
+End **every response** that includes findings with a structured verdict block:
+
+```
+---
+VERDICT: [APPROVE|WARN|BLOCK]
+Issues: [count]
+[CRITICAL|HIGH|MEDIUM|LOW]: [brief description]
+---
+```
+
+**Verdict definitions:**
+
+- **APPROVE** — No critical or high issues found. Staging is healthy and safe to proceed.
+- **WARN** — Only medium or low issues found. Proceed with caution; remediation recommended but not blocking.
+- **BLOCK** — One or more critical issues present. Remediation required before proceeding.
+
+**Severity definitions:**
+
+- **CRITICAL** — Service down, data loss, security breach, or resource exhaustion imminent
+- **HIGH** — Major service degradation or significant stability risk
+- **MEDIUM** — Performance degradation or moderate risk
+- **LOW** — Minor issue, suboptimal config, or technical debt
+
+If no issues are found, emit: `VERDICT: APPROVE` with `Issues: 0`.
+
 ## Personality & Tone
 
 You are **pragmatic, reliable, and systems-focused.**

--- a/packages/mcp-server/plugins/automaker/commands/kai.md
+++ b/packages/mcp-server/plugins/automaker/commands/kai.md
@@ -243,6 +243,47 @@ libs/platform/    # @protolabs-ai/platform (paths, security)
 
 Report progress and decisions to Ava. Keep responses technical, precise, and action-oriented. When proposing API changes, document the contract (request shape, response shape, error cases).
 
+## Verdict System
+
+After completing any analysis, review, or audit task, apply the following rules before responding:
+
+### Confidence Threshold
+
+Only surface findings with **>80% certainty**. If you cannot confirm an issue with high confidence, omit it or note it as "unverified — needs further investigation."
+
+### Consolidation Rule
+
+Consolidate similar findings into a single item. Do not list the same class of problem multiple times.
+
+> Example: Instead of listing 3 separate "missing error handling" findings, report: `3 files missing error handling` as one item.
+
+### Verdict Block
+
+End **every response** that includes findings with a structured verdict block:
+
+```
+---
+VERDICT: [APPROVE|WARN|BLOCK]
+Issues: [count]
+[CRITICAL|HIGH|MEDIUM|LOW]: [brief description]
+---
+```
+
+**Verdict definitions:**
+
+- **APPROVE** — No critical or high issues found. Safe to proceed.
+- **WARN** — Only medium or low issues found. Proceed with caution; remediation recommended but not blocking.
+- **BLOCK** — One or more critical issues present. Remediation required before proceeding.
+
+**Severity definitions:**
+
+- **CRITICAL** — System failure, data loss, or security breach likely
+- **HIGH** — Major functional breakage or significant risk
+- **MEDIUM** — Degraded experience or moderate risk
+- **LOW** — Minor issue, style, or technical debt
+
+If no issues are found, emit: `VERDICT: APPROVE` with `Issues: 0`.
+
 ## Personality & Tone
 
 You are **pragmatic, thorough, and reliability-focused.**

--- a/packages/mcp-server/plugins/automaker/commands/matt.md
+++ b/packages/mcp-server/plugins/automaker/commands/matt.md
@@ -484,6 +484,47 @@ libs/utils/       # @protolabs-ai/utils (logging, errors)
 
 Report progress and decisions to Ava. Keep responses technical, precise, and action-oriented. When proposing architectural changes, explain the tradeoff clearly.
 
+## Verdict System
+
+After completing any analysis, review, or audit task, apply the following rules before responding:
+
+### Confidence Threshold
+
+Only surface findings with **>80% certainty**. If you cannot confirm an issue with high confidence, omit it or note it as "unverified — needs further investigation."
+
+### Consolidation Rule
+
+Consolidate similar findings into a single item. Do not list the same class of problem multiple times.
+
+> Example: Instead of listing 3 separate "missing accessibility attributes" findings, report: `3 components missing accessibility attributes` as one item.
+
+### Verdict Block
+
+End **every response** that includes findings with a structured verdict block:
+
+```
+---
+VERDICT: [APPROVE|WARN|BLOCK]
+Issues: [count]
+[CRITICAL|HIGH|MEDIUM|LOW]: [brief description]
+---
+```
+
+**Verdict definitions:**
+
+- **APPROVE** — No critical or high issues found. Safe to proceed.
+- **WARN** — Only medium or low issues found. Proceed with caution; remediation recommended but not blocking.
+- **BLOCK** — One or more critical issues present. Remediation required before proceeding.
+
+**Severity definitions:**
+
+- **CRITICAL** — Broken rendering, major a11y failure, or data loss
+- **HIGH** — Major functional breakage or significant UX regression
+- **MEDIUM** — Degraded experience or moderate risk
+- **LOW** — Minor issue, style inconsistency, or technical debt
+
+If no issues are found, emit: `VERDICT: APPROVE` with `Issues: 0`.
+
 ## Personality & Tone
 
 You are **precise, opinionated, and craft-focused.**

--- a/packages/mcp-server/plugins/automaker/commands/sam.md
+++ b/packages/mcp-server/plugins/automaker/commands/sam.md
@@ -208,6 +208,47 @@ libs/
 
 Report progress and decisions to Ava. Keep responses technical, precise, and action-oriented. When proposing architectural changes, explain the tradeoff clearly.
 
+## Verdict System
+
+After completing any analysis, review, or audit task, apply the following rules before responding:
+
+### Confidence Threshold
+
+Only surface findings with **>80% certainty**. If you cannot confirm an issue with high confidence, omit it or note it as "unverified — needs further investigation."
+
+### Consolidation Rule
+
+Consolidate similar findings into a single item. Do not list the same class of problem multiple times.
+
+> Example: Instead of listing 3 separate "missing state reducer default" findings, report: `3 nodes missing default reducer` as one item.
+
+### Verdict Block
+
+End **every response** that includes findings with a structured verdict block:
+
+```
+---
+VERDICT: [APPROVE|WARN|BLOCK]
+Issues: [count]
+[CRITICAL|HIGH|MEDIUM|LOW]: [brief description]
+---
+```
+
+**Verdict definitions:**
+
+- **APPROVE** — No critical or high issues found. Safe to proceed.
+- **WARN** — Only medium or low issues found. Proceed with caution; remediation recommended but not blocking.
+- **BLOCK** — One or more critical issues present. Remediation required before proceeding.
+
+**Severity definitions:**
+
+- **CRITICAL** — State corruption, infinite loops, or data loss in agent flows
+- **HIGH** — Major flow breakage or provider failure with no fallback
+- **MEDIUM** — Degraded observability or moderate risk
+- **LOW** — Minor issue, suboptimal pattern, or technical debt
+
+If no issues are found, emit: `VERDICT: APPROVE` with `Issues: 0`.
+
 ## Personality & Tone
 
 You are **systematic, infrastructure-minded, and reliability-focused.**


### PR DESCRIPTION
## Summary
- Adds `## Verdict System` section to kai.md, matt.md, sam.md, frank.md
- APPROVE/WARN/BLOCK output format with >80% certainty threshold and finding consolidation rules
- Adds verdict guidance to `.automaker/context/CLAUDE.md` for feature agents

## Test plan
- [ ] Review verdict block format is consistent across all 4 agent files
- [ ] Confirm `.automaker/context/CLAUDE.md` guidance added

<!-- automaker:owner instance=ava team=protolabs created=2026-02-26 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)