### PR TITLE
feat: Handoff Document Type and Storage

### DIFF
--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -24,6 +24,7 @@ import type { PipelineCheckpointService } from './pipeline-checkpoint-service.js
 import type { ContextFidelityService } from './context-fidelity-service.js';
 import type { KnowledgeStoreService } from './knowledge-store-service.js';
 import type { TrajectoryStoreService } from './trajectory-store-service.js';
+import type { LeadHandoffService } from './lead-handoff-service.js';
 import { DEFAULT_RULES } from './lead-engineer-rules.js';
 import { getWorkflowSettings } from '../lib/settings-helpers.js';
 import { FeatureStateMachine } from './lead-engineer-state-machine.js';
@@ -62,6 +63,7 @@ export class LeadEngineerService {
   private knowledgeStoreService?: KnowledgeStoreService;
   private trajectoryStoreService?: TrajectoryStoreService;
   private agentFactoryService?: AgentFactoryService;
+  private handoffService?: LeadHandoffService;
 
   private worldStateBuilder: WorldStateBuilder;
   private sessionStore: LeadEngineerSessionStore;
@@ -108,6 +110,9 @@ export class LeadEngineerService {
   }
   setAgentFactory(s: AgentFactoryService): void {
     this.agentFactoryService = s;
+  }
+  setHandoffService(s: LeadHandoffService): void {
+    this.handoffService = s;
   }
 
   async initialize(): Promise<void> {

--- a/apps/server/src/services/lead-handoff-service.ts
+++ b/apps/server/src/services/lead-handoff-service.ts
@@ -1,0 +1,118 @@
+/**
+ * Lead Handoff Service
+ *
+ * Persists and retrieves PhaseHandoff documents for feature lifecycle phases.
+ * Handoffs are stored at:
+ *   {projectPath}/.automaker/features/{featureId}/handoff-{phase}.json
+ *
+ * Each file is written atomically (temp file → rename) to prevent partial reads.
+ */
+
+import fs from 'fs/promises';
+import { join } from 'path';
+import { createLogger } from '@protolabs-ai/utils';
+import type { PhaseHandoff, FeatureState } from '@protolabs-ai/types';
+
+const logger = createLogger('LeadHandoffService');
+
+export class LeadHandoffService {
+  /**
+   * Persist a phase handoff document to disk.
+   *
+   * @param projectPath - Absolute path to the project root
+   * @param featureId   - The feature ID
+   * @param handoff     - The PhaseHandoff record to store
+   */
+  async saveHandoff(projectPath: string, featureId: string, handoff: PhaseHandoff): Promise<void> {
+    const dir = join(projectPath, '.automaker', 'features', featureId);
+    const filePath = join(dir, `handoff-${handoff.phase}.json`);
+    const tempPath = `${filePath}.tmp.${Date.now()}`;
+
+    try {
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(tempPath, JSON.stringify(handoff, null, 2), 'utf-8');
+      await fs.rename(tempPath, filePath);
+      logger.info(
+        `Handoff saved: feature=${featureId} phase=${handoff.phase} verdict=${handoff.verdict}`
+      );
+    } catch (error) {
+      // Clean up temp file if rename failed
+      await fs.unlink(tempPath).catch(() => undefined);
+      logger.error(
+        `Failed to save handoff for feature=${featureId} phase=${handoff.phase}:`,
+        error
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Read a phase handoff document from disk.
+   *
+   * @param projectPath - Absolute path to the project root
+   * @param featureId   - The feature ID
+   * @param phase       - The lifecycle phase
+   * @returns The PhaseHandoff if it exists, or null
+   */
+  async getHandoff(
+    projectPath: string,
+    featureId: string,
+    phase: FeatureState
+  ): Promise<PhaseHandoff | null> {
+    const filePath = join(
+      projectPath,
+      '.automaker',
+      'features',
+      featureId,
+      `handoff-${phase}.json`
+    );
+
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      return JSON.parse(content) as PhaseHandoff;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return null;
+      }
+      logger.error(`Failed to read handoff for feature=${featureId} phase=${phase}:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Return the most recently created handoff across all phases for a feature.
+   *
+   * @param projectPath - Absolute path to the project root
+   * @param featureId   - The feature ID
+   * @returns The latest PhaseHandoff by createdAt, or null if none exist
+   */
+  async getLatestHandoff(projectPath: string, featureId: string): Promise<PhaseHandoff | null> {
+    const dir = join(projectPath, '.automaker', 'features', featureId);
+
+    let files: string[];
+    try {
+      const entries = await fs.readdir(dir);
+      files = entries.filter((f) => f.startsWith('handoff-') && f.endsWith('.json'));
+    } catch {
+      return null;
+    }
+
+    if (files.length === 0) return null;
+
+    let latest: PhaseHandoff | null = null;
+
+    for (const file of files) {
+      try {
+        const content = await fs.readFile(join(dir, file), 'utf-8');
+        const handoff = JSON.parse(content) as PhaseHandoff;
+        if (!latest || new Date(handoff.createdAt) > new Date(latest.createdAt)) {
+          latest = handoff;
+        }
+      } catch {
+        // Skip corrupt files
+      }
+    }
+
+    return latest;
+  }
+}

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -770,6 +770,7 @@ export type {
   EscalationTrigger,
   PersonaAssignment,
   LeadEngineerService,
+  PhaseHandoff,
 } from './lead-engineer.js';
 
 // Twitch integration types (chat suggestions)

--- a/libs/types/src/lead-engineer.ts
+++ b/libs/types/src/lead-engineer.ts
@@ -265,6 +265,33 @@ export interface PersonaAssignment {
   maxConcurrency?: number;
 }
 
+// ────────────────────────── Phase Handoffs ──────────────────────────
+
+/**
+ * Structured handoff document written by the Lead Engineer at the end of
+ * each feature lifecycle phase. Enables continuity across agent boundaries.
+ */
+export interface PhaseHandoff {
+  /** The lifecycle phase this handoff covers */
+  phase: FeatureState;
+  /** High-level summary of work completed in this phase */
+  summary: string;
+  /** Key discoveries made during this phase */
+  discoveries: string[];
+  /** Files that were created or modified */
+  modifiedFiles: string[];
+  /** Open questions that need resolution in subsequent phases */
+  outstandingQuestions: string[];
+  /** Intentional scope limits — what was NOT done and why */
+  scopeLimits: string[];
+  /** Description of test coverage added or verified */
+  testCoverage: string;
+  /** Overall verdict for this phase handoff */
+  verdict: 'APPROVE' | 'WARN' | 'BLOCK';
+  /** ISO 8601 timestamp when the handoff was created */
+  createdAt: string;
+}
+
 /**
  * Lead Engineer Service interface
  * Core orchestration service for managing feature lifecycle

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -180,6 +180,7 @@ import { fileOpsTools } from './tools/file-ops-tools.js';
 import { gitOpsTools } from './tools/git-ops-tools.js';
 import { worktreeGitTools } from './tools/worktree-git-tools.js';
 import { promotionTools } from './tools/promotion-tools.js';
+import { leadEngineerTools } from './tools/lead-engineer-tools.js';
 
 // Aggregate all tools
 const tools: Tool[] = [
@@ -203,6 +204,7 @@ const tools: Tool[] = [
   ...fileOpsTools,
   ...worktreeGitTools,
   ...promotionTools,
+  ...leadEngineerTools,
 ];
 
 // Tool implementations
@@ -1775,6 +1777,47 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
 
     case 'list_promotion_batches':
       return apiCall('/promotions/batches', {}, 'GET');
+
+    // Lead Engineer Handoffs
+    case 'get_feature_handoff': {
+      const fsModule = await import('fs/promises');
+      const pathModule = await import('path');
+
+      const projectPath = args.projectPath as string;
+      const featureId = args.featureId as string;
+      const handoffDir = pathModule.join(projectPath, '.automaker', 'features', featureId);
+
+      let files: string[] = [];
+      try {
+        const entries = await fsModule.readdir(handoffDir);
+        files = entries.filter((f: string) => f.startsWith('handoff-') && f.endsWith('.json'));
+      } catch {
+        return { success: true, handoff: null, message: 'No handoffs found for this feature' };
+      }
+
+      if (files.length === 0) {
+        return { success: true, handoff: null, message: 'No handoffs found for this feature' };
+      }
+
+      // Find the latest handoff by createdAt
+      let latest: Record<string, unknown> | null = null;
+      for (const file of files) {
+        try {
+          const content = await fsModule.readFile(pathModule.join(handoffDir, file), 'utf-8');
+          const handoff = JSON.parse(content) as Record<string, unknown>;
+          if (
+            !latest ||
+            new Date(handoff.createdAt as string) > new Date(latest.createdAt as string)
+          ) {
+            latest = handoff;
+          }
+        } catch {
+          // Skip corrupt files
+        }
+      }
+
+      return { success: true, handoff: latest };
+    }
 
     default:
       throw new Error(`Unknown tool: ${name}`);

--- a/packages/mcp-server/src/tools/lead-engineer-tools.ts
+++ b/packages/mcp-server/src/tools/lead-engineer-tools.ts
@@ -1,0 +1,33 @@
+/**
+ * Lead Engineer Tools
+ *
+ * MCP tools for interacting with Lead Engineer phase handoff documents.
+ * - get_feature_handoff: Retrieve the latest handoff document for a feature
+ */
+
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+export const leadEngineerTools: Tool[] = [
+  {
+    name: 'get_feature_handoff',
+    description:
+      'Get the latest Lead Engineer phase handoff document for a feature. ' +
+      'Handoff documents summarise what was done in each lifecycle phase (INTAKE, PLAN, EXECUTE, ' +
+      'REVIEW, MERGE, DEPLOY) including discoveries, modified files, outstanding questions, ' +
+      'scope limits, test coverage, and a verdict (APPROVE | WARN | BLOCK).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        featureId: {
+          type: 'string',
+          description: 'The feature ID to retrieve the handoff for',
+        },
+      },
+      required: ['projectPath', 'featureId'],
+    },
+  },
+];


### PR DESCRIPTION
Implements PhaseHandoff interface in lead-engineer types, LeadHandoffService for atomic read/write of handoff docs at `.automaker/features/{id}/handoff-{phase}.json`, and `get_feature_handoff` MCP tool. Part of ECC Pattern Integration - Lead Engineer Handoffs milestone.