### PR TITLE
fix(agent): patch pending tool calls on session resume

### DIFF
--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -130,7 +130,7 @@ export class AgentService {
     workingDirectory?: string;
   }) {
     if (!this.sessions.has(sessionId)) {
-      const messages = await this.loadSession(sessionId);
+      let messages = await this.loadSession(sessionId);
       const metadata = await this.loadMetadata();
       const sessionMetadata = metadata[sessionId];
 
@@ -143,6 +143,14 @@ export class AgentService {
 
       // Load persisted queue
       const promptQueue = await this.loadQueueState(sessionId);
+
+      // Recover in-flight tool calls from a previously interrupted session
+      const persistedPendingTools = await this.loadPendingToolsState(sessionId);
+      if (persistedPendingTools.length > 0) {
+        messages = this.patchInterruptedTools(messages, persistedPendingTools);
+        await this.saveSession(sessionId, messages);
+        await this.clearPendingToolsState(sessionId);
+      }
 
       this.sessions.set(sessionId, {
         messages,
@@ -558,6 +566,9 @@ export class AgentService {
                   startTime: Date.now(),
                 });
 
+                // Persist pending tools for crash recovery
+                await this.savePendingToolsState(sessionId, session.pendingTools);
+
                 this.emitAgentEvent(sessionId, {
                   type: 'tool_use',
                   tool: toolUse,
@@ -574,7 +585,7 @@ export class AgentService {
           }
 
           // Process completed tools and persist to feature state if applicable
-          await this.processCompletedTools(session, true);
+          await this.processCompletedTools(sessionId, session, true);
 
           this.emitAgentEvent(sessionId, {
             type: 'complete',
@@ -605,7 +616,7 @@ export class AgentService {
           });
 
           // Process pending tools as failed
-          await this.processCompletedTools(session, false);
+          await this.processCompletedTools(sessionId, session, false);
 
           // Mark session as no longer running so the UI and queue stay in sync
           session.isRunning = false;
@@ -649,7 +660,7 @@ export class AgentService {
       };
     } catch (error) {
       if (isAbortError(error)) {
-        await this.processCompletedTools(session, false);
+        await this.processCompletedTools(sessionId, session, false);
         session.isRunning = false;
         session.abortController = null;
         return { success: false, aborted: true };
@@ -658,7 +669,7 @@ export class AgentService {
       this.logger.error('Error:', error);
 
       // Process pending tools as failed
-      await this.processCompletedTools(session, false);
+      await this.processCompletedTools(sessionId, session, false);
 
       session.isRunning = false;
       session.abortController = null;
@@ -1068,7 +1079,11 @@ export class AgentService {
   /**
    * Process completed tools and persist to feature state if applicable
    */
-  private async processCompletedTools(session: Session, success: boolean): Promise<void> {
+  private async processCompletedTools(
+    sessionId: string,
+    session: Session,
+    success: boolean
+  ): Promise<void> {
     if (!session.pendingTools || session.pendingTools.length === 0) {
       return;
     }
@@ -1122,7 +1137,66 @@ export class AgentService {
       }
     }
 
-    // Clear pending tools
+    // Clear pending tools (memory + disk)
     session.pendingTools = [];
+    await this.clearPendingToolsState(sessionId);
+  }
+
+  private async savePendingToolsState(
+    sessionId: string,
+    tools: Array<{ name: string; startTime: number }>
+  ): Promise<void> {
+    const pendingFile = path.join(this.stateDir, `${sessionId}-pending.json`);
+    try {
+      await secureFs.writeFile(pendingFile, JSON.stringify(tools, null, 2), 'utf-8');
+    } catch (error) {
+      this.logger.error('Failed to save pending tools state:', error);
+    }
+  }
+
+  private async loadPendingToolsState(
+    sessionId: string
+  ): Promise<Array<{ name: string; startTime: number }>> {
+    const pendingFile = path.join(this.stateDir, `${sessionId}-pending.json`);
+    try {
+      const data = (await secureFs.readFile(pendingFile, 'utf-8')) as string;
+      return JSON.parse(data);
+    } catch {
+      return [];
+    }
+  }
+
+  private async clearPendingToolsState(sessionId: string): Promise<void> {
+    const pendingFile = path.join(this.stateDir, `${sessionId}-pending.json`);
+    try {
+      await secureFs.unlink(pendingFile);
+    } catch {
+      // File may not exist
+    }
+  }
+
+  private patchInterruptedTools(
+    messages: Message[],
+    pendingTools: Array<{ name: string; startTime: number }>
+  ): Message[] {
+    const result = [...messages];
+
+    for (const tool of pendingTools) {
+      const syntheticContent = `[Interrupted] Tool call '${tool.name}' was in-flight when the session was interrupted and did not complete.`;
+
+      // Idempotency: skip if this exact error message already exists
+      const alreadyPatched = result.some((m) => m.isError && m.content === syntheticContent);
+      if (alreadyPatched) continue;
+
+      result.push({
+        id: this.generateId(),
+        role: 'assistant',
+        content: syntheticContent,
+        timestamp: new Date().toISOString(),
+        isError: true,
+      });
+    }
+
+    return result;
   }
 }

--- a/apps/server/tests/unit/services/agent-service.test.ts
+++ b/apps/server/tests/unit/services/agent-service.test.ts
@@ -83,8 +83,14 @@ describe('agent-service.ts', () => {
           timestamp: '2024-01-01T00:00:00Z',
         },
       ];
+      const enoentError: any = new Error('ENOENT');
+      enoentError.code = 'ENOENT';
 
-      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(existingMessages));
+      vi.mocked(fs.readFile)
+        .mockResolvedValueOnce(JSON.stringify(existingMessages)) // session file
+        .mockResolvedValueOnce('{}') // metadata file
+        .mockRejectedValueOnce(enoentError) // queue file
+        .mockRejectedValueOnce(enoentError); // pending tools file
 
       const result = await service.startConversation({
         sessionId: 'session-1',
@@ -123,9 +129,124 @@ describe('agent-service.ts', () => {
       });
 
       expect(result.success).toBe(true);
-      // First call reads session file, metadata file, and queue state file (3 calls)
+      // First call reads session file, metadata file, queue state file, and pending tools file (4 calls)
       // Second call should reuse in-memory session (no additional calls)
-      expect(fs.readFile).toHaveBeenCalledTimes(3);
+      expect(fs.readFile).toHaveBeenCalledTimes(4);
+    });
+
+    it('should pass through unchanged on clean resume (no pending tools)', async () => {
+      const enoentError: any = new Error('ENOENT');
+      enoentError.code = 'ENOENT';
+      const existingMessages = [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: 'Hello',
+          timestamp: '2024-01-01T00:00:00Z',
+        },
+      ];
+
+      vi.mocked(fs.readFile)
+        .mockResolvedValueOnce(JSON.stringify(existingMessages)) // session file
+        .mockResolvedValueOnce('{}') // metadata file
+        .mockRejectedValueOnce(enoentError) // queue file
+        .mockRejectedValueOnce(enoentError); // pending tools file (none)
+
+      const result = await service.startConversation({
+        sessionId: 'session-clean',
+        workingDirectory: '/test/dir',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.messages).toEqual(existingMessages);
+      // No writeFile since no patching needed
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should inject synthetic error messages for pending tools on interrupted resume', async () => {
+      const enoentError: any = new Error('ENOENT');
+      enoentError.code = 'ENOENT';
+      const existingMessages = [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: 'Run a command',
+          timestamp: '2024-01-01T00:00:00Z',
+        },
+      ];
+      const pendingTools = [
+        { name: 'Bash', startTime: 1700000000000 },
+        { name: 'Read', startTime: 1700000001000 },
+      ];
+
+      vi.mocked(fs.readFile)
+        .mockResolvedValueOnce(JSON.stringify(existingMessages)) // session file
+        .mockResolvedValueOnce('{}') // metadata file
+        .mockRejectedValueOnce(enoentError) // queue file
+        .mockResolvedValueOnce(JSON.stringify(pendingTools)); // pending tools file
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+
+      const result = await service.startConversation({
+        sessionId: 'session-interrupted',
+        workingDirectory: '/test/dir',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.messages.length).toBe(3); // original user msg + 2 synthetic errors
+
+      const errorMessages = result.messages.filter((m: any) => m.isError);
+      expect(errorMessages.length).toBe(2);
+      expect(errorMessages[0].role).toBe('assistant');
+      expect(errorMessages[0].content).toContain('[Interrupted]');
+      expect(errorMessages[0].content).toContain("'Bash'");
+      expect(errorMessages[1].content).toContain("'Read'");
+
+      // Should save patched messages to disk
+      expect(fs.writeFile).toHaveBeenCalled();
+      // Should clear pending tools file
+      expect(fs.unlink).toHaveBeenCalled();
+    });
+
+    it('should not duplicate synthetic errors on idempotent replay', async () => {
+      const enoentError: any = new Error('ENOENT');
+      enoentError.code = 'ENOENT';
+      const pendingTools = [{ name: 'Bash', startTime: 1700000000000 }];
+      const syntheticContent = `[Interrupted] Tool call 'Bash' was in-flight when the session was interrupted and did not complete.`;
+      const existingMessages = [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: 'Run a command',
+          timestamp: '2024-01-01T00:00:00Z',
+        },
+        {
+          id: 'msg-2',
+          role: 'assistant',
+          content: syntheticContent,
+          timestamp: '2024-01-01T00:00:01Z',
+          isError: true,
+        },
+      ];
+
+      vi.mocked(fs.readFile)
+        .mockResolvedValueOnce(JSON.stringify(existingMessages)) // session (already patched)
+        .mockResolvedValueOnce('{}') // metadata
+        .mockRejectedValueOnce(enoentError) // queue
+        .mockResolvedValueOnce(JSON.stringify(pendingTools)); // pending tools (stale)
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+
+      const result = await service.startConversation({
+        sessionId: 'session-idempotent',
+        workingDirectory: '/test/dir',
+      });
+
+      expect(result.success).toBe(true);
+      // Should NOT add duplicate error - still just 2 messages
+      expect(result.messages.length).toBe(2);
+      const errorMessages = result.messages.filter((m: any) => m.isError);
+      expect(errorMessages.length).toBe(1); // only the pre-existing one
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `patchInterruptedSession()` to `AgentService.startConversation()` — scans `pendingTools` on session load and injects synthetic error messages for any tool calls in-flight when the session was interrupted
- Clears `pendingTools` after patching so resume is idempotent
- Unit tests: clean resume, interrupted resume, idempotent replay paths

## Why

When an agent session is interrupted mid-tool-call (crash, turn limit, cancel), the stored session has `pendingTools` entries with no corresponding result messages. Resumed sessions hand this malformed history to the LLM, causing hallucination or looping instead of clean recovery.

M1 of the DeerFlow Adoption project — ported from ByteDance DeerFlow v2.0's `DanglingToolCallMiddleware` pattern.

## Test plan
- [ ] `npm run test:server` passes (new agent-service tests)
- [ ] `npm run build:server` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)