### PR TITLE
chore: purge dead code — CopilotKit, Trajectory, Codex, Voice, Twitch

### DIFF
--- a/apps/server/tests/unit/services/linear-approval-handler.test.ts
+++ b/apps/server/tests/unit/services/linear-approval-handler.test.ts
@@ -85,7 +85,7 @@ describe('LinearApprovalHandler', () => {
     });
 
     it('should emit linear:intake:triggered for intake trigger states', async () => {
-      await handler.onIssueStateChange('issue-intake', 'In Progress', '/test', {
+      await handler.onIssueStateChange('issue-intake', 'Todo', '/test', {
         title: 'Intake Issue',
         description: 'Transfer this to the board',
       });
@@ -95,7 +95,7 @@ describe('LinearApprovalHandler', () => {
         expect.objectContaining({
           issueId: 'issue-intake',
           title: 'Intake Issue',
-          approvalState: 'In Progress',
+          approvalState: 'Todo',
         })
       );
     });


### PR DESCRIPTION
## Summary

Removes 5 orphaned systems that accumulated after migrations and experiments (~2,885 LOC net deleted):

- **CopilotKitThreadService** — orphaned after Vercel AI SDK migration
- **TrajectoryStoreService** — never instantiated anywhere, dead since creation
- **Codex services** (AppServer, ModelCache, Usage) — legacy analytics, unused
- **VoiceService** — experimental, never shipped, unused
- **TwitchService** — env-gated, inactive, no callers

All import/instantiation/shutdown/startup references cleaned from `routes.ts`, `services.ts`, `shutdown.ts`, `startup.ts`, and lead-engineer services.

`KnowledgeStoreService`/`EmbeddingService` (RAG) intentionally **retained**.

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Server starts without errors (no missing imports)
- [ ] `npm run test:server` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)