### PR TITLE
fix: get_board_summary serves stale in-memory counts after status transitions

### DIFF
--- a/apps/server/src/routes/features/index.ts
+++ b/apps/server/src/routes/features/index.ts
@@ -19,6 +19,7 @@ import { createAgentOutputHandler, createRawOutputHandler } from './routes/agent
 import { createGenerateTitleHandler } from './routes/generate-title.js';
 import { createHealthHandler } from './routes/health.js';
 import { createAssignAgentHandler } from './routes/assign-agent.js';
+import { createSummaryHandler } from './routes/summary.js';
 import type { FeatureHealthService } from '../../services/feature-health-service.js';
 import type { RoleRegistryService } from '../../services/role-registry-service.js';
 import type { TrustTierService } from '../../services/trust-tier-service.js';
@@ -61,6 +62,7 @@ export function createFeaturesRoutes(
     validatePathParams('projectPath'),
     createDeleteHandler(featureLoader, events)
   );
+  router.post('/summary', validatePathParams('projectPath'), createSummaryHandler(featureLoader));
   router.post('/agent-output', createAgentOutputHandler(featureLoader));
   router.post('/raw-output', createRawOutputHandler(featureLoader));
   router.post('/generate-title', createGenerateTitleHandler(settingsService));

--- a/apps/server/src/routes/features/routes/summary.ts
+++ b/apps/server/src/routes/features/routes/summary.ts
@@ -1,0 +1,71 @@
+/**
+ * POST /summary endpoint - Board summary with status counts, always read from disk
+ */
+
+import type { Request, Response } from 'express';
+import type { FeatureLoader } from '../../../services/feature-loader.js';
+import { getErrorMessage, logError } from '../common.js';
+
+export interface BoardSummary {
+  total: number;
+  backlog: number;
+  inProgress: number;
+  review: number;
+  blocked: number;
+  done: number;
+  verified: number;
+}
+
+export function createSummaryHandler(featureLoader: FeatureLoader) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath } = req.body as { projectPath: string };
+
+      if (!projectPath) {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+
+      // Always read from disk to avoid stale in-memory state
+      const features = await featureLoader.getAll(projectPath);
+
+      const summary: BoardSummary = {
+        total: features.length,
+        backlog: 0,
+        inProgress: 0,
+        review: 0,
+        blocked: 0,
+        done: 0,
+        verified: 0,
+      };
+
+      for (const feature of features) {
+        switch (feature.status) {
+          case 'backlog':
+            summary.backlog++;
+            break;
+          case 'in_progress':
+            summary.inProgress++;
+            break;
+          case 'review':
+            summary.review++;
+            break;
+          case 'blocked':
+            summary.blocked++;
+            break;
+          case 'done':
+            summary.done++;
+            break;
+          case 'verified':
+            summary.verified++;
+            break;
+        }
+      }
+
+      res.json({ success: true, summary });
+    } catch (error) {
+      logError(error, 'Board summary failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -722,20 +722,10 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
     }
 
     case 'get_board_summary': {
-      const result = (await apiCall('/features/list', {
+      const result = (await apiCall('/features/summary', {
         projectPath: args.projectPath,
-      })) as { features?: Array<{ status: string }> };
-      const features = result.features || [];
-      const summary = {
-        total: features.length,
-        backlog: features.filter((f) => f.status === 'backlog').length,
-        inProgress: features.filter((f) => f.status === 'in_progress').length,
-        review: features.filter((f) => f.status === 'review').length,
-        blocked: features.filter((f) => f.status === 'blocked').length,
-        done: features.filter((f) => f.status === 'done').length,
-        verified: features.filter((f) => f.status === 'verified').length,
-      };
-      return summary;
+      })) as { summary?: Record<string, number> };
+      return result.summary ?? result;
     }
 
     case 'graphite_restack':


### PR DESCRIPTION
## Summary
- Add dedicated `/api/features/summary` route (`apps/server/src/routes/features/routes/summary.ts`) that reads fresh data from `featureLoader` on each request
- Register route in `apps/server/src/routes/features/index.ts`
- Update `packages/mcp-server/src/index.ts` to use the new endpoint

## Test plan
- [ ] `npm run build:server` exits 0
- [ ] `get_board_summary` MCP tool returns accurate counts after feature status transitions (no stale cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)