### PR TITLE
feat(utils): skill loader and initial skill files

### DIFF
--- a/.automaker/skills/git-workflow/SKILL.md
+++ b/.automaker/skills/git-workflow/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: git-workflow
+description: Three-branch strategy, worktree safety, and correct commit patterns
+triggers: [git, commit, branch, pr, push, merge, worktree, husky]
+---
+
+# Git Workflow Patterns
+
+## Three-Branch Strategy
+
+```
+feature/* → dev → staging → main
+```
+
+- **`dev`** — active development. Feature branches PR here.
+- **`staging`** — integration/QA. PR from `dev` only.
+- **`main`** — stable release. PR from `staging` only.
+
+Feature PRs always target `dev` (never `main` or `staging` directly).
+
+## Commit Patterns
+
+Skip Husky hooks when committing from within agents/scripts:
+
+```bash
+HUSKY=0 git commit -m "feat: implement X"
+```
+
+Before committing, verify only intended files are staged:
+
+```bash
+git status
+git diff --staged
+git add specific-file.ts  # Prefer specific files over git add -A
+```
+
+Never use `git add -A` without checking for `.automaker/` or `.beads/` drift:
+
+```bash
+# Safe pattern to exclude runtime files
+git add -A -- ':!.automaker/' ':!.beads/'
+```
+
+## Worktree Safety
+
+Never `cd` into a worktree directory. If the worktree is removed, Bash breaks for the entire session.
+
+```bash
+# ✅ Use git -C for operations in worktrees
+git -C /path/to/.worktrees/branch-name status
+git -C /path/to/.worktrees/branch-name log --oneline -5
+
+# ❌ Never do this
+cd /path/to/.worktrees/branch-name
+```
+
+## Branch Naming
+
+Feature branches use `feature/` prefix matching the feature ID or a short slug:
+
+```bash
+git checkout -b feature/my-feature-name
+```

--- a/.automaker/skills/testing-standards/SKILL.md
+++ b/.automaker/skills/testing-standards/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: testing-standards
+description: Vitest patterns, test isolation principles, and avoid hardcoded count assertions
+triggers: [test, vitest, unit, integration, spec, jest, assertion]
+---
+
+# Testing Standards
+
+## Vitest Patterns
+
+Server unit tests use Vitest. Run them with:
+
+```bash
+npm run test:server                                      # All server tests
+npm run test:server -- tests/unit/specific.test.ts      # Single file
+npm run test:packages                                    # All package tests
+```
+
+## Test Isolation
+
+Each test should set up and tear down its own state. Do not rely on test execution order:
+
+```typescript
+import { beforeEach, afterEach, describe, it, expect } from 'vitest';
+
+describe('MyService', () => {
+  let service: MyService;
+
+  beforeEach(() => {
+    service = new MyService();
+  });
+
+  afterEach(() => {
+    service.cleanup();
+  });
+
+  it('does the thing', () => {
+    expect(service.doThing()).toBe(true);
+  });
+});
+```
+
+## No Hardcoded Counts
+
+Avoid assertions that depend on exact list counts that may change over time:
+
+```typescript
+// ❌ Brittle — breaks when new items are added
+expect(results).toHaveLength(5);
+
+// ✅ Better — check behavior, not count
+expect(results.length).toBeGreaterThan(0);
+expect(results.find((r) => r.name === 'expected')).toBeDefined();
+```
+
+## Mocking
+
+Use `vi.mock()` for external dependencies. Mock at the module level, not inside tests:
+
+```typescript
+import { vi } from 'vitest';
+
+vi.mock('@protolabs-ai/git-utils', () => ({
+  getGitRepositoryDiffs: vi.fn().mockResolvedValue([]),
+}));
+```
+
+## Environment Variables
+
+Use `process.env` assignments inside `beforeEach`/`afterEach` for env var tests, and always restore:
+
+```typescript
+const originalKey = process.env.MY_KEY;
+beforeEach(() => {
+  process.env.MY_KEY = 'test-value';
+});
+afterEach(() => {
+  process.env.MY_KEY = originalKey;
+});
+```

--- a/.automaker/skills/typescript-monorepo/SKILL.md
+++ b/.automaker/skills/typescript-monorepo/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: typescript-monorepo
+description: Package dependency chain, import conventions, and build order for the TypeScript monorepo
+triggers: [typescript, monorepo, packages, build, import, tsconfig]
+---
+
+# TypeScript Monorepo Patterns
+
+## Package Dependency Chain
+
+Packages can only depend on packages above them:
+
+```
+@protolabs-ai/types (no dependencies)
+    ↓
+@protolabs-ai/utils, @protolabs-ai/prompts, @protolabs-ai/platform,
+@protolabs-ai/model-resolver, @protolabs-ai/dependency-resolver,
+@protolabs-ai/spec-parser, @protolabs-ai/pen-parser, @protolabs-ai/tools,
+@protolabs-ai/flows, @protolabs-ai/llm-providers, @protolabs-ai/observability
+    ↓
+@protolabs-ai/git-utils, @protolabs-ai/ui
+    ↓
+apps/server, apps/ui
+```
+
+## Import Conventions
+
+Always import from shared packages, never from internal paths:
+
+```typescript
+// ✅ Correct
+import type { Feature } from '@protolabs-ai/types';
+import { createLogger } from '@protolabs-ai/utils';
+import { getFeatureDir } from '@protolabs-ai/platform';
+import { resolveModelString } from '@protolabs-ai/model-resolver';
+
+// ❌ Wrong
+import { Feature } from '../services/feature-loader';
+import { createLogger } from '../lib/logger';
+```
+
+## Build Order
+
+Always build packages before apps:
+
+```bash
+npm run build:packages   # Build all shared packages first
+npm run build:server     # Then build the server
+npm run build            # Or build everything (web app)
+```
+
+When adding a new export to a package, build that package before referencing it in other packages or apps.
+
+## TypeScript Path Aliases
+
+Each package uses `@/*` pointing to `./src/*` in tsconfig. The compiled output uses `.js` extensions in imports (even for `.ts` source files) because the packages compile to ESM.
+
+```typescript
+// In source: import from './my-module.js' (not .ts)
+import { foo } from './my-module.js';
+```

--- a/.automaker/skills/worktree-safety/SKILL.md
+++ b/.automaker/skills/worktree-safety/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: worktree-safety
+description: Never cd into worktrees, use git -C patterns, and prettier with --ignore-path
+triggers: [worktree, git, cd, bash, prettier, format]
+---
+
+# Worktree Safety Rules
+
+## NEVER `cd` Into Worktree Directories
+
+If you `cd` into a worktree path and the worktree is later removed, **Bash permanently breaks** for the entire session. Every subsequent Bash call fails with `ENOENT`.
+
+**Session restart is the only fix.**
+
+## Always Use `git -C` Instead
+
+```bash
+# ✅ Correct: operate in worktree without changing CWD
+git -C /path/to/.worktrees/branch-name status
+git -C /path/to/.worktrees/branch-name log --oneline -5
+git -C /path/to/.worktrees/branch-name diff
+git -C /path/to/.worktrees/branch-name add specific-file.ts
+git -C /path/to/.worktrees/branch-name commit -m "feat: X"
+
+# ❌ Wrong: never cd into the worktree
+cd /path/to/.worktrees/branch-name
+```
+
+## Running Commands That Require CWD (e.g., Prettier)
+
+When a tool must run from inside the worktree directory, cd in and back out in a single Bash call:
+
+```bash
+cd /absolute/path/to/.worktrees/branch-name && \
+  npx prettier --write src/ && \
+  cd /original/working/directory
+```
+
+## Prettier with `--ignore-path`
+
+When running prettier from outside the worktree, use `--ignore-path` to respect the project's `.prettierignore`:
+
+```bash
+npx prettier --write src/ --ignore-path /path/to/.worktrees/branch-name/.prettierignore
+```
+
+## Never Checkout Branches in the Main Repo
+
+`git checkout <branch>` in the main repo modifies `.automaker/features/` on disk, causing feature data loss when the server is running.
+
+Instead:
+
+- Use worktrees for isolated work
+- Create branches with `git branch` + `git push` (no switch)
+
+## CWD Persists Across Bash Calls
+
+If you use `cd` in one Bash call, the next call starts from that directory. Always use absolute paths when switching contexts.

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -172,6 +172,9 @@ export {
   type SkillsLoadResult,
 } from './skills-loader.js';
 
+// Skill list loader
+export { loadSkillList, type SkillEntry } from './skill-loader.js';
+
 // Memory chunking
 export { chunkMarkdownFile, type MemoryChunk } from './memory-chunker.js';
 

--- a/libs/utils/src/skill-loader.ts
+++ b/libs/utils/src/skill-loader.ts
@@ -1,0 +1,102 @@
+/**
+ * Skill List Loader
+ *
+ * Simple loader for the progressive skill system.
+ * Scans .automaker/skills/{skill-name}/SKILL.md files and returns
+ * a list of skill entries with basic metadata parsed from YAML frontmatter.
+ */
+
+import { readdir, readFile } from 'fs/promises';
+import path from 'path';
+
+/**
+ * A single skill entry returned by loadSkillList
+ */
+export interface SkillEntry {
+  /** Skill name from YAML frontmatter */
+  name: string;
+  /** Human-readable description from YAML frontmatter */
+  description: string;
+  /** Optional trigger keywords for automatic skill selection */
+  triggers?: string[];
+  /** Absolute path to the SKILL.md file */
+  path: string;
+}
+
+/**
+ * Parse simple YAML frontmatter from skill markdown content.
+ * Extracts name, description, and triggers fields only.
+ */
+function parseFrontmatter(content: string): {
+  name?: string;
+  description?: string;
+  triggers?: string[];
+} | null {
+  const match = content.match(/^---\s*\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+
+  const yaml = match[1];
+  const result: { name?: string; description?: string; triggers?: string[] } = {};
+
+  for (const line of yaml.split(/\r?\n/)) {
+    const kv = line.match(/^([a-zA-Z_]+):\s*(.+)$/);
+    if (!kv) continue;
+
+    const key = kv[1];
+    const value = kv[2].trim();
+
+    if (key === 'name') {
+      result.name = value.replace(/^["']|["']$/g, '');
+    } else if (key === 'description') {
+      result.description = value.replace(/^["']|["']$/g, '');
+    } else if (key === 'triggers') {
+      if (value.startsWith('[') && value.endsWith(']')) {
+        result.triggers = value
+          .slice(1, -1)
+          .split(',')
+          .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+          .filter(Boolean);
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Load the list of skills from .automaker/skills/{skill-name}/SKILL.md files.
+ * Returns an empty array if the skills directory does not exist or has no valid skills.
+ */
+export async function loadSkillList(projectPath: string): Promise<SkillEntry[]> {
+  const skillsDir = path.join(projectPath, '.automaker', 'skills');
+  const entries: SkillEntry[] = [];
+
+  let names: string[];
+  try {
+    names = await readdir(skillsDir);
+  } catch {
+    return [];
+  }
+
+  for (const name of names) {
+    const skillFilePath = path.join(skillsDir, name, 'SKILL.md');
+
+    try {
+      const content = await readFile(skillFilePath, 'utf-8');
+      const parsed = parseFrontmatter(content);
+
+      if (parsed?.name) {
+        entries.push({
+          name: parsed.name,
+          description: parsed.description ?? '',
+          triggers: parsed.triggers,
+          path: skillFilePath,
+        });
+      }
+    } catch {
+      // Skip entries without a valid SKILL.md (plain files, empty dirs, etc.)
+    }
+  }
+
+  return entries;
+}


### PR DESCRIPTION
## Summary

- Add `loadSkillList(projectPath)` to `@protolabs-ai/utils` — scans `.automaker/skills/{name}/SKILL.md`, parses YAML frontmatter, returns `SkillEntry[]`
- Returns empty array gracefully if `.automaker/skills/` doesn't exist
- Create four initial skill files: `typescript-monorepo`, `git-workflow`, `testing-standards`, `worktree-safety`
- Export `loadSkillList` and `SkillEntry` from `@protolabs-ai/utils` index

Part of [Epic] Progressive Skill System — `isFoundation: true`, downstream features unlock after merge.

## Test plan
- [ ] `loadSkillList('/path/to/project')` returns all 4 skills from initial files
- [ ] Returns `[]` when `.automaker/skills/` does not exist
- [ ] Each entry has `name`, `description`, `path` fields
- [ ] `npm run build:packages` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- automaker:feature:feature-1772083392421-sviuz519l -->