### PR TITLE
ci: restrict Electron build to PRs targeting dev/staging/main

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,7 +4,9 @@ name: PR Build Check
 on:
   pull_request:
     branches:
-      - '*'
+      - dev
+      - staging
+      - main
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

- Changed `pr-check.yml` trigger from `branches: '*'` to `branches: [dev, staging, main]`
- Feature PRs into `epic/*` branches no longer run the 20-40min Electron build
- Only epic→dev integration PRs (and promotion PRs) get the build gate

## Why

Stacked epic workflows generate many feature PRs targeting `epic/*` branches. Running `build:electron` on each one adds up and slows iteration. The real integration gate is the epic→dev PR.

**Before:** feature→epic PR triggers Electron build (~20-40 min, not useful)
**After:** feature→epic PRs get fast feedback (checks + tests only); Electron build runs once on the epic→dev PR

Supersedes #1253 (was based off main, not dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)