### PR TITLE
fix(types): add teamId + prOwnershipStaleTtlHours to GlobalSettings

### DIFF
--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -563,6 +563,20 @@ export interface GlobalSettings {
   instanceId?: string;
 
   /**
+   * Team or organization identifier for grouping instances.
+   * Used in PR ownership watermarks to identify which org created a PR.
+   * Example: "proto-labs-ai"
+   */
+  teamId?: string;
+
+  /**
+   * Hours after which PR ownership is considered stale when both last commit age
+   * and last activity age exceed this threshold. Stale PRs can be taken over by
+   * other instances. Defaults to 24.
+   */
+  prOwnershipStaleTtlHours?: number;
+
+  /**
    * Maintenance scheduler settings.
    * @see MaintenanceSettings in project-settings.ts
    */


### PR DESCRIPTION
## Summary

Adds two missing fields to `GlobalSettings` in `libs/types/src/global-settings.ts`:

- `teamId?: string` — org identifier for PR ownership watermarks
- `prOwnershipStaleTtlHours?: number` — stale ownership TTL threshold

## Root cause

PR #1192 (multi-instance PR ownership) added these fields, but they were lost when the settings.ts split (#1186) decomposed the monolithic file into domain-specific files. The `global-settings.ts` generated by the split didn't include them.

## Impact

Without this fix, the merged state of dev→staging (PR #1254) fails TypeScript build:
- `check-pr-status.ts:110` — `prOwnershipStaleTtlHours` not on `GlobalSettings`
- `create-pr.ts:158` — `teamId` not on `GlobalSettings`

This is a blocker for PR #1254 merging. Needs to land on dev first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)