### PR TITLE
chore: extend CodeRabbit reviews to dev and staging branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,6 +8,16 @@ reviews:
     - '!.automaker/memory/**'
     - '!.automaker/projects/**'
     - '!data/**'
+  # Post a GitHub commit status check ("CodeRabbit") so it can be
+  # added as a required check in branch protection.
+  commit_status: true
   auto_review:
     enabled: true
     drafts: false
+    # Review PRs targeting dev and staging in addition to the default branch (main).
+    # - dev: granular inline review on every feature/epic PR (fast feedback, not required)
+    # - staging: required check on dev→staging promotion PRs
+    # - main: required check on staging→main final pass
+    base_branches:
+      - '^dev$'
+      - '^staging$'


### PR DESCRIPTION
## Summary

Configures CodeRabbit to review PRs at every level of the three-branch flow, not just on the default branch (main).

### `.coderabbit.yaml` changes

- **`commit_status: true`** — CodeRabbit posts a GitHub status check (`CodeRabbit`) that can be gated in branch protection
- **`base_branches: ['^dev$', '^staging$']`** — Auto-reviews PRs targeting dev and staging in addition to main

### Branch protection changes (applied directly via API)

| Branch | CodeRabbit | Role |
|--------|-----------|------|
| `dev` | Reviews but NOT required | Granular inline feedback on every feature/epic PR |
| `staging` | **Required** | dev→staging promotion must pass review |
| `main` | **Required** | Final comprehensive pass on staging→main |

### Why

Previously CodeRabbit only ran on PRs targeting `main`. With stacked epic workflows, most code review was happening at the last moment. Now:
- Feature PRs get inline feedback early (dev)
- Promotion to staging is gated on review (staging)
- The final merge to main requires a full pass (main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)