### PR TITLE
fix(ci): install build-essential when make is missing on self-hosted runners

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -73,6 +73,18 @@ runs:
       # Build shared packages (types, utils, platform, etc.) before apps can use them
       run: npm run build:packages
 
+    - name: Install native build tools
+      if: inputs.skip-native-rebuild != 'true' && runner.os == 'Linux'
+      shell: bash
+      # Ensure make/g++ are available for node-gyp native compilation.
+      # Some self-hosted runner containers (especially lightweight ones) omit
+      # build-essential. node-pty falls back to compiling from source when
+      # prebuilds are missing, which requires make.
+      run: |
+        if ! command -v make &>/dev/null; then
+          sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends build-essential
+        fi
+
     - name: Rebuild native modules (root)
       if: inputs.skip-native-rebuild != 'true' && inputs.rebuild-node-pty-path == ''
       shell: bash


### PR DESCRIPTION
## Problem

`npm rebuild node-pty` fails with `gyp ERR! not found: make` on some self-hosted runner containers. node-pty falls back to compiling from source (via node-gyp) when prebuilds don't exist for the current Node version — this requires `make` from `build-essential`, which is missing on our lightweight runner containers.

Affected builds: #1260, #1261, and any PR whose build job lands on an underpowered runner.

## Fix

Add a defensive step before `npm rebuild node-pty` that checks if `make` exists and only installs `build-essential` if it's missing. No-op on runners that already have it installed.

```bash
if ! command -v make &>/dev/null; then
  sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends build-essential
fi
```

## Why not just install it on the runners?

Runner containers are ephemeral — changes don't persist. CI self-heal is the right approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system configuration to ensure native module compilation requirements are properly met on Linux environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->