### PR TITLE
fix(ui): correct Kiro CLI icon mapping + document editor utilities

### DIFF
--- a/apps/ui/src/components/icons/editor-icons.tsx
+++ b/apps/ui/src/components/icons/editor-icons.tsx
@@ -175,7 +175,7 @@ export function getEditorIcon(command: string): IconComponent {
     cursor: CursorIcon,
     code: VSCodeIcon,
     'code-insiders': VSCodeInsidersIcon,
-    kido: KiroIcon,
+    kiro: KiroIcon,
     zed: ZedIcon,
     subl: SublimeTextIcon,
     windsurf: WindsurfIcon,

--- a/docs/dev/shared-packages.md
+++ b/docs/dev/shared-packages.md
@@ -104,7 +104,7 @@ if (isValidEnhancementMode('improve')) {
 
 ### @protolabs-ai/platform
 
-**Use when:** You need to work with AutoMaker's directory structure or spawn processes.
+**Use when:** You need to work with AutoMaker's directory structure, spawn processes, or detect/launch code editors.
 
 **Import for:**
 
@@ -114,11 +114,29 @@ if (isValidEnhancementMode('improve')) {
 - `ensureprotoLabsDir(projectPath)` - Create .automaker if needed
 - `spawnJSONLProcess()` - Spawn process with JSONL output
 - `initAllowedPaths()` - Security path validation
+- `detectAllEditors()` - Detect all installed editors on the system (cached 5 min)
+- `detectDefaultEditor()` - Get the highest-priority installed editor
+- `openInEditor(path, editorCommand?)` - Open a path in the specified (or default) editor
+- `openInFileManager(path)` - Open a path in the platform file manager
+- `openInTerminal(path)` - Open a terminal in the specified directory
+- `clearEditorCache()` - Invalidate the editor detection cache
+- `commandExists(cmd)` - Check if a CLI command is in PATH
+
+**Supported editors** (in priority order): Cursor, VS Code, VS Code Insiders, Kiro, Zed, Sublime Text, Windsurf, Trae (ByteDance), Rider, WebStorm, Xcode, Android Studio, Antigravity. Falls back to Finder/Explorer/xdg-open.
+
+**Adding a new editor:** Add an entry to `SUPPORTED_EDITORS` in `libs/platform/src/editor.ts`, add an icon component to `apps/ui/src/components/icons/editor-icons.tsx`, and register it in `getEditorIcon()`.
 
 **Example:**
 
 ```typescript
 import { getFeatureDir, ensureprotoLabsDir } from '@protolabs-ai/platform';
+import { detectAllEditors, openInEditor } from '@protolabs-ai/platform';
+
+// Detect all installed editors
+const editors = await detectAllEditors();
+
+// Open a path in the user's preferred editor
+await openInEditor('/path/to/project', 'cursor');
 ```
 
 **Never import from:** `lib/automaker-paths`, `lib/subprocess-manager`, `lib/security`


### PR DESCRIPTION
## Summary

- **Bug fix**: `editor-icons.tsx` had `kido: KiroIcon` — a typo left over from before `cbca9b68` fixed the Kiro CLI command in `editor.ts`. Kiro users with the `kiro` CLI were getting `FolderOpen` instead of the Kiro icon.
- **Docs**: Added editor utilities to the `@protolabs-ai/platform` section of `shared-packages.md`, including all exports, the supported editors list (Trae/ByteDance noted), and how to add a new editor.

## What this is NOT

Not related to Trae — Trae was correctly wired from the start: `cliCommand: 'trae'`, `TraeIcon`, `getEditorIcon('trae')` all consistent. This just caught the adjacent Kiro bug during the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-instance PR coordination with ownership tracking prevents concurrent actions across instances.
  * Ship workflow for automated change management and PR creation.
  * Enhanced PR status checks now include ownership and staleness information.

* **Bug Fixes**
  * Corrected editor icon mapping for Kiro editor.

* **Documentation**
  * Multi-instance coordination guide with configuration examples.
  * Platform editor detection and management capabilities.
  * Ship workflow command documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->