### PR TITLE
feat(skills): inject available_skills metadata block into agent system prompts

### DIFF
--- a/.automaker/context/CLAUDE.md
+++ b/.automaker/context/CLAUDE.md
@@ -246,3 +246,26 @@ Issues: [count]
 - **LOW** — Minor issue, style, or technical debt
 
 If no issues are found, emit: `VERDICT: APPROVE` with `Issues: 0`.
+
+## Skill System
+
+When available skills exist for this project, you will see an `<available_skills>` block in your system prompt listing each skill by name, description, and file path.
+
+**How to use skills:**
+
+1. Review the `<available_skills>` list at the start of your task
+2. If a skill name or description matches your current task, read the full skill file:
+   ```
+   read_file(".automaker/skills/{name}.md")
+   ```
+3. Follow the instructions in the skill file — they encode proven patterns for this project
+
+**When a skill applies:**
+
+- The skill name or description relates to what you are implementing
+- You are about to do something the skill explicitly covers (e.g., build order, PR creation, testing)
+- Following the skill avoids a known class of mistakes
+
+**Do NOT load all skills.** Only read the skill file when the task clearly matches. Skills are metadata-only in the prompt to minimize token usage — content is fetched on demand.
+
+**Skill location:** `.automaker/skills/{name}.md`

--- a/apps/server/src/services/dynamic-agent-executor.ts
+++ b/apps/server/src/services/dynamic-agent-executor.ts
@@ -6,7 +6,9 @@
  * prompt assembly, output capture, error classification, and event emission.
  */
 
-import { createLogger, classifyError } from '@protolabs-ai/utils';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { createLogger, classifyError, listSkills, type SkillsFsModule } from '@protolabs-ai/utils';
 import {
   simpleQuery,
   streamingQuery,
@@ -14,6 +16,18 @@ import {
 } from '../providers/simple-query-service.js';
 import type { AgentConfig } from './agent-factory-service.js';
 import type { EventEmitter } from '../lib/events.js';
+
+const fsModule: SkillsFsModule = {
+  readFile: (p, enc) => fsp.readFile(p, enc as BufferEncoding) as Promise<string>,
+  writeFile: (p, c) => fsp.writeFile(p, c),
+  readdir: (p) => fsp.readdir(p),
+  stat: (p) => fsp.stat(p),
+  mkdir: async (p, opts) => {
+    await fsp.mkdir(p, opts);
+  },
+  unlink: (p) => fsp.unlink(p),
+  access: (p) => fsp.access(p),
+};
 
 const logger = createLogger('DynamicAgentExecutor');
 
@@ -69,7 +83,7 @@ export class DynamicAgentExecutor {
   async execute(config: AgentConfig, options: ExecuteOptions): Promise<ExecutionResult> {
     const startTime = Date.now();
 
-    const systemPrompt = this.buildSystemPrompt(config, options.additionalSystemPrompt);
+    const systemPrompt = await this.buildSystemPrompt(config, options.additionalSystemPrompt);
     const allowedTools = this.resolveTools(config);
 
     logger.info(
@@ -175,7 +189,10 @@ export class DynamicAgentExecutor {
   /**
    * Build the system prompt from template config + optional additions.
    */
-  private buildSystemPrompt(config: AgentConfig, additional?: string): string | undefined {
+  private async buildSystemPrompt(
+    config: AgentConfig,
+    additional?: string
+  ): Promise<string | undefined> {
     const parts: string[] = [];
 
     // Template's inline system prompt
@@ -217,6 +234,31 @@ export class DynamicAgentExecutor {
 
     if (constraints.length > 0) {
       parts.push('## Restrictions\n' + constraints.join('\n'));
+    }
+
+    // Available skills block — metadata only, no content loaded
+    if (config.projectPath) {
+      try {
+        const skills = await listSkills(config.projectPath, fsModule);
+        if (skills.length > 0) {
+          const lines: string[] = ['<available_skills>'];
+          for (const skill of skills) {
+            const skillPath = path.join('.automaker', 'skills', `${skill.name}.md`);
+            lines.push('  <skill>');
+            lines.push(`    <name>${skill.name}</name>`);
+            lines.push(`    <description>${skill.description}</description>`);
+            lines.push(`    <path>${skillPath}</path>`);
+            lines.push('  </skill>');
+          }
+          lines.push(
+            '  <instruction>When your task matches a skill above, read the full skill file via read_file before proceeding. Skills contain proven patterns and techniques for this project.</instruction>'
+          );
+          lines.push('</available_skills>');
+          parts.push(lines.join('\n'));
+        }
+      } catch {
+        // Skills loading is non-critical; continue without them
+      }
     }
 
     return parts.length > 0 ? parts.join('\n\n') : undefined;


### PR DESCRIPTION
## Summary

- Makes `buildSystemPrompt()` async in `DynamicAgentExecutor`
- Calls `listSkills()` from `@protolabs-ai/utils` for the project path
- When skills exist, appends an `<available_skills>` XML block listing name, description, and `.automaker/skills/{name}.md` path for each skill
- Agents fetch skill content on demand via `read_file` — no content loaded into the prompt (metadata only)
- Projects with no `.automaker/skills/` directory are unaffected
- Documents the skill system in `.automaker/context/CLAUDE.md`

## Changes

- `apps/server/src/services/dynamic-agent-executor.ts` — async `buildSystemPrompt`, skill block injection
- `.automaker/context/CLAUDE.md` — skill system documentation for agents

## Test plan

- [ ] `npm run build:server` passes
- [ ] Projects with skills: system prompt contains `<available_skills>` block
- [ ] Projects without `.automaker/skills/`: system prompt unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic skill discovery that automatically includes available skills in the system prompt, allowing on-demand loading without loading all skill content at once.

* **Documentation**
  * Added comprehensive Skill System documentation detailing how skills are represented and utilized in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->