### PR TITLE
fix(linear): replace hardcoded model IDs with resolveModelString() in LinearAgentRouter

### DIFF
--- a/apps/server/src/services/linear-agent-router.ts
+++ b/apps/server/src/services/linear-agent-router.ts
@@ -23,6 +23,7 @@
 
 import { createLogger } from '@protolabs-ai/utils';
 import type { AgentRole } from '@protolabs-ai/types';
+import { resolveModelString } from '@protolabs-ai/model-resolver';
 import type { EventEmitter } from '../lib/events.js';
 import type { RoleRegistryService } from './role-registry-service.js';
 import type { LinearAgentService } from './linear-agent-service.js';
@@ -88,11 +89,11 @@ const DEFAULT_TEAM_ROLE_MAP: Record<string, AgentRole> = {
  * Urgent/High get Opus for maximum quality.
  */
 const PRIORITY_MODEL_MAP: Record<number, string> = {
-  1: 'claude-opus-4-5-20251101', // Urgent
-  2: 'claude-opus-4-5-20251101', // High
-  3: 'claude-sonnet-4-5-20250929', // Medium (default)
-  4: 'claude-haiku-4-5-20251001', // Low
-  0: 'claude-sonnet-4-5-20250929', // No priority
+  1: resolveModelString('opus'), // Urgent
+  2: resolveModelString('opus'), // High
+  3: resolveModelString('sonnet'), // Medium (default)
+  4: resolveModelString('haiku'), // Low
+  0: resolveModelString('sonnet'), // No priority
 };
 
 export interface RoutingDecision {
@@ -464,7 +465,7 @@ export class LinearAgentRouter {
    * Higher priority issues get more powerful models.
    */
   private selectModel(priority: number): string {
-    return PRIORITY_MODEL_MAP[priority] || 'claude-sonnet-4-5-20250929';
+    return PRIORITY_MODEL_MAP[priority] || resolveModelString('sonnet');
   }
 
   // ─── Context Building ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Replaces 6 hardcoded version-dated model strings in `LinearAgentRouter.PRIORITY_MODEL_MAP` and `selectModel()` fallback with `resolveModelString()` aliases. All peer services already use this pattern — this is the last outlier.

**Before:** `'claude-opus-4-5-20251101'`, `'claude-sonnet-4-5-20250929'` (stale)  
**After:** `resolveModelString('opus')`, `resolveModelString('sonnet')`, `resolveModelString('haiku')`

## Changes

- `apps/server/src/services/linear-agent-router.ts` — 1 import + 6 string replacements

## Test plan

- [ ] `npm run build:server` passes with no TypeScript errors
- [ ] `PRIORITY_MODEL_MAP[1]` and `[2]` resolve to `claude-opus-4-6`
- [ ] `PRIORITY_MODEL_MAP[0]` and `[3]` resolve to `claude-sonnet-4-6`
- [ ] Grep for `claude-opus-4-5\|claude-sonnet-4-5` in `linear-agent-router.ts` returns zero results