### PR TITLE
fix(test): prevent quarantine test dir collisions in parallel Vitest workers

### DIFF
--- a/apps/server/tests/unit/services/quarantine-service.test.ts
+++ b/apps/server/tests/unit/services/quarantine-service.test.ts
@@ -13,8 +13,9 @@ describe('QuarantineService', () => {
   let quarantineService: QuarantineService;
 
   beforeEach(async () => {
-    testProjectDir = path.join(os.tmpdir(), `quarantine-test-${Date.now()}`);
-    testDataDir = path.join(os.tmpdir(), `trust-tier-test-${Date.now()}`);
+    const uid = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    testProjectDir = path.join(os.tmpdir(), `quarantine-test-${uid}`);
+    testDataDir = path.join(os.tmpdir(), `trust-tier-test-${uid}`);
     await fs.mkdir(testProjectDir, { recursive: true });
     await fs.mkdir(testDataDir, { recursive: true });
     trustTierService = new TrustTierService(testDataDir);


### PR DESCRIPTION
## Summary
- Adds random suffix to tmpdir names in quarantine test `beforeEach` to prevent `Date.now()` collisions on fast parallel Vitest workers
- Fixes flaky: `expected 3 but got 6` in `listPending() - Filtering > should handle multiple pending entries`

## Root Cause
Two concurrent test workers both call `beforeEach` at the same millisecond, getting identical `quarantine-test-${Date.now()}` paths. They share the same tmpdir and entries accumulate across tests.

## Test Plan
- [ ] quarantine-service.test.ts passes consistently on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)