### PR TITLE
feat(trajectory): TrajectoryFact type and FactStoreService for structured fact extraction

### DIFF
--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -82,6 +82,7 @@ import { DocsUpdateDetector } from '../services/docs-update-detector.js';
 import { HeadsdownService } from '../services/headsdown-service.js';
 import { PRDService } from '../services/prd-service.js';
 import { AgentDiscordRouter } from '../services/agent-discord-router.js';
+import { FactStoreService } from '../services/fact-store-service.js';
 
 // Services originally loaded via top-level dynamic imports — now static for proper typing
 import { ProjectLifecycleService } from '../services/project-lifecycle-service.js';
@@ -214,6 +215,7 @@ export interface ServiceContainer {
   // Lead Engineer
   leadEngineerService: LeadEngineerService;
   pipelineCheckpointService: PipelineCheckpointService;
+  factStoreService: FactStoreService;
 
   // PR & worktree lifecycle
   approvalBridge: LinearApprovalBridge;
@@ -484,6 +486,9 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   // Completion Detector Service — cascades feature done → epic → milestone → project
   const completionDetectorService = new CompletionDetectorService();
 
+  // Fact Store Service — extracts and persists structured facts from agent output
+  const factStoreService = new FactStoreService();
+
   // Lead Engineer Service — production-phase nerve center
   const leadEngineerService = new LeadEngineerService(
     events,
@@ -709,6 +714,7 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
     ceremonyService,
     leadEngineerService,
     pipelineCheckpointService,
+    factStoreService,
     approvalBridge,
     intakeBridge,
     prFeedbackService,

--- a/apps/server/src/server/wiring.ts
+++ b/apps/server/src/server/wiring.ts
@@ -66,6 +66,7 @@ export async function wireServices(services: ServiceContainer): Promise<void> {
     intakeBridge,
     graphiteSyncScheduler,
     eventStreamBuffer,
+    factStoreService,
   } = services;
 
   // Calendar service wiring
@@ -192,6 +193,7 @@ export async function wireServices(services: ServiceContainer): Promise<void> {
   leadEngineerService.setPRFeedbackService(prFeedbackService);
   leadEngineerService.setDiscordBot(discordBotService);
   leadEngineerService.setAgentFactory(agentFactoryService);
+  leadEngineerService.setFactStoreService(factStoreService);
 
   // PR Feedback service wiring
   prFeedbackService.setAutoModeService(autoModeService);

--- a/apps/server/src/services/fact-store-service.ts
+++ b/apps/server/src/services/fact-store-service.ts
@@ -1,0 +1,143 @@
+/**
+ * Fact Store Service
+ *
+ * Extracts structured TrajectoryFact objects from agent output using a Haiku
+ * model call and persists them to .automaker/trajectory/{featureId}/facts.json.
+ *
+ * Designed to be called fire-and-forget: extractAndSave() returns void and
+ * never throws — all errors are caught and logged.
+ */
+
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import Anthropic from '@anthropic-ai/sdk';
+import { createLogger, atomicWriteJson } from '@protolabs-ai/utils';
+import { resolveModelString } from '@protolabs-ai/model-resolver';
+import type { TrajectoryFact } from '@protolabs-ai/types';
+
+const logger = createLogger('FactStoreService');
+
+const EXTRACTION_PROMPT = `You are a knowledge extractor for an AI development system. Your job is to extract structured facts from an AI agent's execution output.
+
+Analyze the agent output below and extract discrete, reusable facts that would help future agents working on similar tasks. Focus on:
+- **patterns**: Repeatable implementation patterns or approaches that worked well
+- **gotchas**: Pitfalls, unexpected behaviors, or common mistakes to avoid
+- **constraints**: Hard rules or limitations discovered during implementation
+- **performance**: Observations about performance, efficiency, or scalability
+- **decision**: Key architectural or design decisions made and their rationale
+
+Return a JSON array of fact objects. Each object must have:
+- "content": string — a concise, actionable statement (1-3 sentences)
+- "category": one of "pattern" | "gotcha" | "constraint" | "performance" | "decision"
+- "confidence": number between 0 and 1 — your confidence this fact is accurate and generalizable
+
+Return ONLY valid JSON (an array). No markdown, no explanation.
+
+Example:
+[
+  {"content": "Always call atomicWriteJson with createDirs: true when writing to new directories.", "category": "pattern", "confidence": 0.95},
+  {"content": "The featureLoader.update() method does not create the feature directory — it must already exist.", "category": "gotcha", "confidence": 0.85}
+]
+
+Agent output to analyze:`;
+
+/**
+ * Fact Store Service — extracts and persists structured facts from agent output.
+ */
+export class FactStoreService {
+  private anthropic: Anthropic;
+
+  constructor() {
+    this.anthropic = new Anthropic();
+  }
+
+  /**
+   * Fire-and-forget: extract facts from agentOutput and write to facts.json.
+   * Never throws — all errors are caught and logged.
+   */
+  extractAndSave(projectPath: string, featureId: string, agentOutput: string): void {
+    void this._extractAndSave(projectPath, featureId, agentOutput).catch((err) => {
+      logger.error('[FactStore] Unexpected error in extractAndSave:', err);
+    });
+  }
+
+  private async _extractAndSave(
+    projectPath: string,
+    featureId: string,
+    agentOutput: string
+  ): Promise<void> {
+    if (!agentOutput.trim()) {
+      logger.debug('[FactStore] Empty agent output, skipping extraction');
+      return;
+    }
+
+    const model = resolveModelString('haiku');
+    const prompt = `${EXTRACTION_PROMPT}\n\n${agentOutput}`;
+
+    let responseText: string;
+    try {
+      const response = await this.anthropic.messages.create({
+        model,
+        max_tokens: 2048,
+        messages: [{ role: 'user', content: prompt }],
+      });
+
+      const content = response.content[0];
+      if (content.type !== 'text') {
+        logger.warn('[FactStore] Unexpected response type from model, skipping');
+        return;
+      }
+      responseText = content.text;
+    } catch (err) {
+      logger.error('[FactStore] LLM call failed:', err);
+      return;
+    }
+
+    let rawFacts: Array<{
+      content?: unknown;
+      category?: unknown;
+      confidence?: unknown;
+    }>;
+    try {
+      const parsed = JSON.parse(responseText);
+      rawFacts = Array.isArray(parsed) ? parsed : [];
+    } catch {
+      logger.warn('[FactStore] Failed to parse JSON from model response, skipping');
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const validCategories = new Set(['pattern', 'gotcha', 'constraint', 'performance', 'decision']);
+
+    const facts: TrajectoryFact[] = rawFacts
+      .filter((f) => {
+        const confidence = typeof f.confidence === 'number' ? f.confidence : 0;
+        return confidence >= 0.7 && validCategories.has(String(f.category));
+      })
+      .map(
+        (f): TrajectoryFact => ({
+          id: randomUUID(),
+          content: String(f.content || '').trim(),
+          category: f.category as TrajectoryFact['category'],
+          confidence: typeof f.confidence === 'number' ? f.confidence : 0,
+          featureId,
+          createdAt: now,
+        })
+      )
+      .filter((f) => f.content.length > 0);
+
+    if (facts.length === 0) {
+      logger.info('[FactStore] No high-confidence facts extracted for feature', { featureId });
+      return;
+    }
+
+    const factsPath = path.join(projectPath, '.automaker', 'trajectory', featureId, 'facts.json');
+
+    try {
+      await atomicWriteJson(factsPath, facts, { createDirs: true });
+      logger.info(`[FactStore] Saved ${facts.length} facts for feature ${featureId}`);
+    } catch (err) {
+      logger.error('[FactStore] Failed to write facts.json:', err);
+    }
+  }
+}

--- a/apps/server/src/services/lead-engineer-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-execute-processor.ts
@@ -242,6 +242,25 @@ export class ExecuteProcessor implements StateProcessor {
       };
     }
 
+    // Fire-and-forget: extract structured facts from agent output
+    if (this.serviceContext.factStoreService) {
+      try {
+        const fs = await import('node:fs/promises');
+        const outputPath = path.join(
+          getFeatureDir(ctx.projectPath, ctx.feature.id),
+          'agent-output.md'
+        );
+        const agentOutput = await fs.readFile(outputPath, 'utf-8').catch(() => '');
+        this.serviceContext.factStoreService.extractAndSave(
+          ctx.projectPath,
+          ctx.feature.id,
+          agentOutput
+        );
+      } catch (err) {
+        logger.warn('[EXECUTE] Failed to trigger fact extraction (non-fatal):', err);
+      }
+    }
+
     // Reload feature to capture updated costUsd, prNumber, etc.
     const updated = await this.serviceContext.featureLoader.get(ctx.projectPath, ctx.feature.id);
     if (updated) {

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -24,6 +24,7 @@ import type { PipelineCheckpointService } from './pipeline-checkpoint-service.js
 import type { ContextFidelityService } from './context-fidelity-service.js';
 import type { KnowledgeStoreService } from './knowledge-store-service.js';
 import type { LeadHandoffService } from './lead-handoff-service.js';
+import type { FactStoreService } from './fact-store-service.js';
 import { DEFAULT_RULES } from './lead-engineer-rules.js';
 import { getWorkflowSettings } from '../lib/settings-helpers.js';
 import { FeatureStateMachine } from './lead-engineer-state-machine.js';
@@ -62,6 +63,7 @@ export class LeadEngineerService {
   private knowledgeStoreService?: KnowledgeStoreService;
   private agentFactoryService?: AgentFactoryService;
   private handoffService?: LeadHandoffService;
+  private factStoreService?: FactStoreService;
 
   private worldStateBuilder: WorldStateBuilder;
   private sessionStore: LeadEngineerSessionStore;
@@ -108,6 +110,9 @@ export class LeadEngineerService {
   }
   setHandoffService(s: LeadHandoffService): void {
     this.handoffService = s;
+  }
+  setFactStoreService(s: FactStoreService): void {
+    this.factStoreService = s;
   }
 
   async initialize(): Promise<void> {
@@ -298,6 +303,7 @@ export class LeadEngineerService {
         contextFidelityService: this.contextFidelityService,
         knowledgeStoreService: this.knowledgeStoreService,
         settingsService: this.settingsService,
+        factStoreService: this.factStoreService,
       };
 
       const workflowSettings = await getWorkflowSettings(

--- a/apps/server/src/services/lead-engineer-types.ts
+++ b/apps/server/src/services/lead-engineer-types.ts
@@ -13,6 +13,7 @@ import type { PipelineCheckpointService } from './pipeline-checkpoint-service.js
 import type { ContextFidelityService } from './context-fidelity-service.js';
 import type { KnowledgeStoreService } from './knowledge-store-service.js';
 import type { SettingsService } from './settings-service.js';
+import type { FactStoreService } from './fact-store-service.js';
 
 // ────────────────────────── Budget / timing constants ──────────────────────────
 
@@ -37,6 +38,7 @@ export interface ProcessorServiceContext {
   contextFidelityService?: ContextFidelityService;
   knowledgeStoreService?: KnowledgeStoreService;
   settingsService?: SettingsService;
+  factStoreService?: FactStoreService;
 }
 
 // ────────────────────────── Feature State Machine Types ──────────────────────────

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -821,6 +821,14 @@ export type {
   RetrievalMode,
 } from './knowledge.js';
 
+// Trajectory types (execution learning flywheel)
+export type {
+  TrajectoryFact,
+  TrajectoryFactCategory,
+  VerifiedTrajectory,
+  TrajectoryDomain,
+} from './trajectory.js';
+
 // PenFile types (vector graphics format v2.8)
 export type {
   PenColor,

--- a/libs/types/src/trajectory.ts
+++ b/libs/types/src/trajectory.ts
@@ -6,6 +6,41 @@
  */
 
 /**
+ * Category of a trajectory fact
+ */
+export type TrajectoryFactCategory =
+  | 'pattern'
+  | 'gotcha'
+  | 'constraint'
+  | 'performance'
+  | 'decision';
+
+/**
+ * Structured fact extracted from agent output after a successful execution.
+ *
+ * Stored at: .automaker/trajectory/{featureId}/facts.json
+ */
+export interface TrajectoryFact {
+  /** Unique identifier (UUID) */
+  id: string;
+
+  /** The fact content extracted from agent output */
+  content: string;
+
+  /** Category classifying the type of knowledge */
+  category: TrajectoryFactCategory;
+
+  /** Confidence score (0-1); facts below 0.7 are filtered out before storage */
+  confidence: number;
+
+  /** Feature ID this fact belongs to */
+  featureId: string;
+
+  /** ISO timestamp when this fact was created */
+  createdAt: string;
+}
+
+/**
  * Feature domain categories for trajectory matching
  */
 export type TrajectoryDomain =


### PR DESCRIPTION
## Summary

- Adds `TrajectoryFact` interface and `TrajectoryFactCategory` union type to `@protolabs-ai/types` for structured knowledge representation
- Adds `TrajectoryDomain` type classifying features by domain (frontend/backend/devops/etc)
- Implements `FactStoreService`: fire-and-forget Haiku-powered extraction of structured facts from agent output, persisted to `.automaker/trajectory/{featureId}/facts.json`
- Wires `FactStoreService` into `lead-engineer-execute-processor` post-execution hook
- Registers service in server `services.ts` and `wiring.ts`

## Test plan

- [ ] Build compiles: `npm run build:packages && npm run build:server`
- [ ] `FactStoreService.extractAndSave()` fires after agent execution completes
- [ ] Facts are written to `.automaker/trajectory/{featureId}/facts.json`
- [ ] Low-confidence facts (< 0.7) are filtered before storage
- [ ] Service never throws — errors are caught and logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)