### PR TITLE
fix(ci): auto-install build-essential on Linux runners missing make

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -50,6 +50,17 @@ runs:
       # Use --force to allow platform-specific dev dependencies like dmg-license on non-darwin platforms
       run: npm install --ignore-scripts --force
 
+    - name: Install build tools (Linux)
+      if: inputs.skip-native-rebuild != 'true' && runner.os == 'Linux'
+      shell: bash
+      # Ensure make, gcc, and python3 are present for node-gyp native rebuilds.
+      # Some self-hosted runners (e.g. Proxmox LXC) ship without build-essential.
+      run: |
+        if ! command -v make &>/dev/null; then
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends build-essential python3-dev
+        fi
+
     - name: Install Linux native bindings
       if: inputs.skip-native-rebuild != 'true'
       shell: bash

--- a/docs/infra/runners.md
+++ b/docs/infra/runners.md
@@ -36,7 +36,10 @@ Each runner registers independently with GitHub. They appear as separate runners
 
 - Node.js v20+ (install via nvm: `nvm install --lts`)
 - `git`, `gh` CLI, `docker` installed on the host
+- `build-essential` (provides `make`, `gcc`, `g++`) — required for node-gyp native module compilation: `sudo apt-get install -y build-essential python3-dev`
 - A GitHub registration token from **Settings → Actions → Runners → New self-hosted runner**
+
+> **Note:** If `make` is missing the CI `setup-project` action will attempt to install `build-essential` automatically via `apt-get`, but this requires the runner user to have passwordless `sudo` access. It is strongly recommended to pre-install `build-essential` on every runner host to avoid per-job package installation overhead.
 
 ### Install a single runner
 


### PR DESCRIPTION
## Summary
- Adds a conditional `apt-get install build-essential python3-dev` step to the `setup-project` action
- Only runs on Linux runners when `make` is not found (self-hosted Proxmox LXC runners may lack it)
- Updates `docs/infra/runners.md` to document the `build-essential` requirement and sudo note

## Why
Self-hosted Proxmox LXC runners ship without `build-essential`, causing `node-pty` native rebuild failures during CI. This adds a graceful fallback without requiring manual runner provisioning.

## Test plan
- [ ] CI passes on self-hosted Linux runners (no `make` error)
- [ ] Step is skipped when `make` is already present (no overhead)
- [ ] Step is skipped on macOS/Windows runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Linux build pipeline automation to ensure required build tools are available during CI builds.

* **Documentation**
  * Clarified build tool prerequisites and automated installation details for Linux runner environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->