### PR TITLE
ci: skip full check suite for docs/markdown/site path-only PRs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,10 +7,20 @@ on:
       - dev
       - staging
       - main
+    paths-ignore:
+      - 'docs/**'
+      - 'site/**'
+      - '**.md'
+      - '.automaker/**'
   push:
     branches:
       - main
       - master
+    paths-ignore:
+      - 'docs/**'
+      - 'site/**'
+      - '**.md'
+      - '.automaker/**'
 
 permissions: read-all
 


### PR DESCRIPTION
## Summary
- Adds `paths-ignore` to `pr-check.yml` for both `pull_request` and `push` events
- Skips the full CI pipeline (format, lint, build, test, audit) when PRs only touch docs, site, markdown, or `.automaker/` files
- Reduces CI load and build time for documentation-only changes

## Trade-offs
- Branch protection must be configured to treat skipped checks as passing (GitHub: "Required status checks" → enable "Require status checks to pass"). If the check never runs, it counts as skipped/passing on GitHub Actions.
- Code changes still run the full suite — this only affects pure-docs PRs.

## Test plan
- [ ] A PR touching only `.md` files does not trigger the full CI suite
- [ ] A PR touching any `.ts` or `.yml` code file still triggers the full CI suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)