### PR TITLE
feat: add ecc hooks, verdict system, and phase handoffs

### DIFF
--- a/.automaker/context/CLAUDE.md
+++ b/.automaker/context/CLAUDE.md
@@ -269,3 +269,22 @@ When available skills exist for this project, you will see an `<available_skills
 **Do NOT load all skills.** Only read the skill file when the task clearly matches. Skills are metadata-only in the prompt to minimize token usage — content is fetched on demand.
 
 **Skill location:** `.automaker/skills/{name}.md`
+
+## Verdict System
+
+At the end of every response, output a verdict block summarizing your confidence in the work:
+
+```
+---
+VERDICT: [APPROVE|WARN|BLOCK]
+Issues: [count]
+[CRITICAL|HIGH|MEDIUM|LOW]: [brief description]
+---
+```
+
+**Rules:**
+- Only surface findings with **>80% certainty**
+- Consolidate similar findings (e.g. "3 files missing error handling" → one item)
+- **APPROVE** — No critical or high issues. Work is solid.
+- **WARN** — Medium/low issues only. Proceed with caution.
+- **BLOCK** — Critical issues present. Remediation required before PR.

--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -83,6 +83,7 @@ import { HeadsdownService } from '../services/headsdown-service.js';
 import { PRDService } from '../services/prd-service.js';
 import { AgentDiscordRouter } from '../services/agent-discord-router.js';
 import { FactStoreService } from '../services/fact-store-service.js';
+import { LeadHandoffService } from '../services/lead-handoff-service.js';
 
 // Services originally loaded via top-level dynamic imports — now static for proper typing
 import { ProjectLifecycleService } from '../services/project-lifecycle-service.js';
@@ -216,6 +217,7 @@ export interface ServiceContainer {
   leadEngineerService: LeadEngineerService;
   pipelineCheckpointService: PipelineCheckpointService;
   factStoreService: FactStoreService;
+  leadHandoffService: LeadHandoffService;
 
   // PR & worktree lifecycle
   approvalBridge: LinearApprovalBridge;
@@ -489,6 +491,9 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   // Fact Store Service — extracts and persists structured facts from agent output
   const factStoreService = new FactStoreService();
 
+  // Lead Handoff Service — stores phase transition snapshots for LE continuity
+  const leadHandoffService = new LeadHandoffService();
+
   // Lead Engineer Service — production-phase nerve center
   const leadEngineerService = new LeadEngineerService(
     events,
@@ -716,6 +721,7 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
     leadEngineerService,
     pipelineCheckpointService,
     factStoreService,
+    leadHandoffService,
     approvalBridge,
     intakeBridge,
     prFeedbackService,

--- a/apps/server/src/server/wiring.ts
+++ b/apps/server/src/server/wiring.ts
@@ -67,6 +67,7 @@ export async function wireServices(services: ServiceContainer): Promise<void> {
     graphiteSyncScheduler,
     eventStreamBuffer,
     factStoreService,
+    leadHandoffService,
   } = services;
 
   // Calendar service wiring
@@ -193,6 +194,7 @@ export async function wireServices(services: ServiceContainer): Promise<void> {
   leadEngineerService.setDiscordBot(discordBotService);
   leadEngineerService.setAgentFactory(agentFactoryService);
   leadEngineerService.setFactStoreService(factStoreService);
+  leadEngineerService.setHandoffService(leadHandoffService);
 
   // PR Feedback service wiring
   prFeedbackService.setAutoModeService(autoModeService);

--- a/apps/server/src/services/lead-engineer-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-execute-processor.ts
@@ -308,6 +308,45 @@ export class ExecuteProcessor implements StateProcessor {
       if (updated.prNumber) ctx.prNumber = updated.prNumber;
     }
 
+    // Save EXECUTE handoff — parse modified files and questions from agent output
+    if (this.serviceContext.leadHandoffService) {
+      try {
+        const fs = await import('node:fs/promises');
+        const outputPath = path.join(
+          getFeatureDir(ctx.projectPath, ctx.feature.id),
+          'agent-output.md'
+        );
+        const agentOutput = await fs.readFile(outputPath, 'utf-8').catch(() => '');
+        const modifiedFiles = (
+          agentOutput.match(/^(?:Modified:|Create[d]?:|\+\+\+\s+)\s*(\S+\.tsx?)/gm) || []
+        )
+          .map((l) => l.replace(/^(?:Modified:|Create[d]?:|\+\+\+\s+)\s*/, '').trim())
+          .slice(0, 20);
+        const questions = agentOutput
+          .split('\n')
+          .filter((l) => l.trim().endsWith('?'))
+          .slice(0, 5);
+        const verdictMatch = agentOutput.match(/VERDICT:\s*(APPROVE|WARN|BLOCK)/);
+        const verdict = (verdictMatch?.[1] as 'APPROVE' | 'WARN' | 'BLOCK') ?? 'APPROVE';
+
+        await this.serviceContext.leadHandoffService.saveHandoff(ctx.projectPath, ctx.feature.id, {
+          phase: 'EXECUTE',
+          summary: `Agent completed execution. PR: ${ctx.prNumber ? `#${ctx.prNumber}` : 'pending'}`,
+          discoveries: [],
+          modifiedFiles,
+          outstandingQuestions: questions,
+          scopeLimits: [],
+          testCoverage: agentOutput.toLowerCase().includes('test')
+            ? 'Tests mentioned in output'
+            : 'Unknown',
+          verdict,
+          createdAt: new Date().toISOString(),
+        });
+      } catch (err) {
+        logger.warn('[EXECUTE] Failed to save handoff (non-fatal):', err);
+      }
+    }
+
     return {
       nextState: 'REVIEW',
       shouldContinue: true,

--- a/apps/server/src/services/lead-engineer-processors.ts
+++ b/apps/server/src/services/lead-engineer-processors.ts
@@ -249,6 +249,21 @@ Keep it focused and actionable. If the feature description is too vague or uncle
       logger.warn('[PLAN] Proceeding despite review rejection (max retries exceeded)');
     }
 
+    // Save PLAN handoff before transitioning to EXECUTE
+    if (this.serviceContext.leadHandoffService && ctx.planOutput) {
+      await this.serviceContext.leadHandoffService.saveHandoff(ctx.projectPath, ctx.feature.id, {
+        phase: 'PLAN',
+        summary: ctx.planOutput.slice(0, 500),
+        discoveries: [],
+        modifiedFiles: [],
+        outstandingQuestions: [],
+        scopeLimits: [],
+        testCoverage: 'N/A — plan phase',
+        verdict: reviewResult && !reviewResult.approved ? 'WARN' : 'APPROVE',
+        createdAt: new Date().toISOString(),
+      });
+    }
+
     return {
       nextState: 'EXECUTE',
       shouldContinue: true,

--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -94,6 +94,20 @@ export class ReviewProcessor implements StateProcessor {
     });
 
     if (reviewState === 'approved') {
+      // Save REVIEW handoff before transitioning to MERGE
+      if (this.serviceContext.leadHandoffService) {
+        await this.serviceContext.leadHandoffService.saveHandoff(ctx.projectPath, ctx.feature.id, {
+          phase: 'REVIEW',
+          summary: `PR #${ctx.prNumber} approved and CI passing. Ready to merge.`,
+          discoveries: [],
+          modifiedFiles: [],
+          outstandingQuestions: [],
+          scopeLimits: [],
+          testCoverage: 'CI passed',
+          verdict: 'APPROVE',
+          createdAt: new Date().toISOString(),
+        });
+      }
       return {
         nextState: 'MERGE',
         shouldContinue: true,

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -304,6 +304,7 @@ export class LeadEngineerService {
         knowledgeStoreService: this.knowledgeStoreService,
         settingsService: this.settingsService,
         factStoreService: this.factStoreService,
+        leadHandoffService: this.handoffService,
       };
 
       const workflowSettings = await getWorkflowSettings(

--- a/apps/server/src/services/lead-engineer-types.ts
+++ b/apps/server/src/services/lead-engineer-types.ts
@@ -14,6 +14,7 @@ import type { ContextFidelityService } from './context-fidelity-service.js';
 import type { KnowledgeStoreService } from './knowledge-store-service.js';
 import type { SettingsService } from './settings-service.js';
 import type { FactStoreService } from './fact-store-service.js';
+import type { LeadHandoffService } from './lead-handoff-service.js';
 
 // ────────────────────────── Budget / timing constants ──────────────────────────
 
@@ -39,6 +40,7 @@ export interface ProcessorServiceContext {
   knowledgeStoreService?: KnowledgeStoreService;
   settingsService?: SettingsService;
   factStoreService?: FactStoreService;
+  leadHandoffService?: LeadHandoffService;
 }
 
 // ────────────────────────── Feature State Machine Types ──────────────────────────

--- a/libs/types/src/lead-engineer.ts
+++ b/libs/types/src/lead-engineer.ts
@@ -268,31 +268,6 @@ export interface PersonaAssignment {
 // ────────────────────────── Phase Handoffs ──────────────────────────
 
 /**
- * Structured handoff document written by the Lead Engineer at the end of
- * each feature lifecycle phase. Enables continuity across agent boundaries.
- */
-export interface PhaseHandoff {
-  /** The lifecycle phase this handoff covers */
-  phase: FeatureState;
-  /** High-level summary of work completed in this phase */
-  summary: string;
-  /** Key discoveries made during this phase */
-  discoveries: string[];
-  /** Files that were created or modified */
-  modifiedFiles: string[];
-  /** Open questions that need resolution in subsequent phases */
-  outstandingQuestions: string[];
-  /** Intentional scope limits — what was NOT done and why */
-  scopeLimits: string[];
-  /** Description of test coverage added or verified */
-  testCoverage: string;
-  /** Overall verdict for this phase handoff */
-  verdict: 'APPROVE' | 'WARN' | 'BLOCK';
-  /** ISO 8601 timestamp when the handoff was created */
-  createdAt: string;
-}
-
-/**
  * Lead Engineer Service interface
  * Core orchestration service for managing feature lifecycle
  */
@@ -345,4 +320,31 @@ export interface LeadEngineerService {
    * Update world state from current system state
    */
   refreshWorldState(projectPath: string): Promise<LeadWorldState>;
+}
+
+// ────────────────────────── Phase Handoff ──────────────────────────
+
+/**
+ * Structured document capturing the state at the end of each Lead Engineer phase.
+ * Stored at .automaker/features/{featureId}/handoff-{phase}.json
+ */
+export interface PhaseHandoff {
+  /** The phase that just completed */
+  phase: string;
+  /** Human-readable summary of what was accomplished */
+  summary: string;
+  /** New discoveries made during this phase */
+  discoveries: string[];
+  /** Files that were created or modified */
+  modifiedFiles: string[];
+  /** Questions that remain open or need clarification */
+  outstandingQuestions: string[];
+  /** Scope boundaries — things explicitly excluded */
+  scopeLimits: string[];
+  /** Test coverage status */
+  testCoverage: string;
+  /** Agent's confidence verdict for the phase output */
+  verdict: 'APPROVE' | 'WARN' | 'BLOCK';
+  /** ISO timestamp when this handoff was created */
+  createdAt: string;
 }

--- a/packages/mcp-server/plugins/automaker/commands/frank.md
+++ b/packages/mcp-server/plugins/automaker/commands/frank.md
@@ -598,3 +598,21 @@ DISCORD_DEV_CHANNEL=1469080556720623699
 When you're activated, run the startup checklist and report status to Discord. Then enter monitoring loop with exponential backoff.
 
 Get to work! 🔧
+
+## Verdict System
+
+Only surface findings with **>80% certainty**. Consolidate similar findings (e.g. "3 containers with high memory usage" → one item, not three separate findings).
+
+End **every response** with a structured verdict block:
+
+```
+---
+VERDICT: [APPROVE|WARN|BLOCK]
+Issues: [count]
+[CRITICAL|HIGH|MEDIUM|LOW]: [brief description]
+---
+```
+
+- **APPROVE** — No critical or high issues. System is healthy, proceed.
+- **WARN** — Only medium/low issues. Proceed with caution, document the concerns.
+- **BLOCK** — One or more critical issues present. Remediation required before proceeding.

--- a/packages/mcp-server/plugins/automaker/commands/kai.md
+++ b/packages/mcp-server/plugins/automaker/commands/kai.md
@@ -303,3 +303,21 @@ You are **pragmatic, thorough, and reliability-focused.**
 5. Start working on the highest priority backend task
 
 Get to work!
+
+## Verdict System
+
+Only surface findings with **>80% certainty**. Consolidate similar findings (e.g. "3 files missing error handling" → one item, not three separate findings).
+
+End **every response** with a structured verdict block:
+
+```
+---
+VERDICT: [APPROVE|WARN|BLOCK]
+Issues: [count]
+[CRITICAL|HIGH|MEDIUM|LOW]: [brief description]
+---
+```
+
+- **APPROVE** — No critical or high issues. Work is solid, proceed.
+- **WARN** — Only medium/low issues. Proceed with caution, document the concerns.
+- **BLOCK** — One or more critical issues present. Remediation required before proceeding.

--- a/packages/mcp-server/plugins/automaker/commands/matt.md
+++ b/packages/mcp-server/plugins/automaker/commands/matt.md
@@ -544,3 +544,21 @@ You are **precise, opinionated, and craft-focused.**
 5. Start working on the highest priority frontend task
 
 Get to work!
+
+## Verdict System
+
+Only surface findings with **>80% certainty**. Consolidate similar findings (e.g. "3 components missing accessibility attributes" → one item, not three separate findings).
+
+End **every response** with a structured verdict block:
+
+```
+---
+VERDICT: [APPROVE|WARN|BLOCK]
+Issues: [count]
+[CRITICAL|HIGH|MEDIUM|LOW]: [brief description]
+---
+```
+
+- **APPROVE** — No critical or high issues. Work is solid, proceed.
+- **WARN** — Only medium/low issues. Proceed with caution, document the concerns.
+- **BLOCK** — One or more critical issues present. Remediation required before proceeding.

--- a/packages/mcp-server/plugins/automaker/commands/sam.md
+++ b/packages/mcp-server/plugins/automaker/commands/sam.md
@@ -268,3 +268,21 @@ You are **systematic, infrastructure-minded, and reliability-focused.**
 5. Start working on the highest priority agent infrastructure task
 
 Get to work!
+
+## Verdict System
+
+Only surface findings with **>80% certainty**. Consolidate similar findings (e.g. "3 flow nodes missing error handling" → one item, not three separate findings).
+
+End **every response** with a structured verdict block:
+
+```
+---
+VERDICT: [APPROVE|WARN|BLOCK]
+Issues: [count]
+[CRITICAL|HIGH|MEDIUM|LOW]: [brief description]
+---
+```
+
+- **APPROVE** — No critical or high issues. Work is solid, proceed.
+- **WARN** — Only medium/low issues. Proceed with caution, document the concerns.
+- **BLOCK** — One or more critical issues present. Remediation required before proceeding.

--- a/packages/mcp-server/plugins/automaker/hooks/hooks.json
+++ b/packages/mcp-server/plugins/automaker/hooks/hooks.json
@@ -60,6 +60,10 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/auto-update-plugin.sh\""
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post-edit-typecheck.js\""
           }
         ]
       },

--- a/packages/mcp-server/plugins/automaker/hooks/scripts/post-edit-typecheck.js
+++ b/packages/mcp-server/plugins/automaker/hooks/scripts/post-edit-typecheck.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse Hook: TypeScript type-check on edited files
+ *
+ * Fires after Edit or Write tool calls. For .ts/.tsx files, walks up to find
+ * the nearest tsconfig.json and runs tsc --noEmit. Filters output to lines
+ * mentioning the edited file (max 10 lines). Silent for non-TS files or when
+ * no tsconfig is found.
+ *
+ * Receives tool input via stdin as JSON. Exits non-zero with filtered errors
+ * if type errors are found.
+ */
+
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { existsSync } from 'node:fs';
+
+async function main() {
+  // Read stdin to get hook input JSON
+  let stdinData = '';
+  try {
+    for await (const chunk of process.stdin) {
+      stdinData += chunk;
+    }
+  } catch {
+    process.exit(0);
+  }
+
+  let hookInput;
+  try {
+    hookInput = JSON.parse(stdinData || '{}');
+  } catch {
+    process.exit(0);
+  }
+
+  // Claude Code provides tool_input for PostToolUse hooks
+  const toolInput = hookInput.tool_input || hookInput;
+  const filePath = toolInput.file_path || '';
+
+  // Only process .ts/.tsx files
+  if (!filePath || !/\.(tsx?)$/.test(filePath)) {
+    process.exit(0);
+  }
+
+  // Walk up to find nearest tsconfig.json
+  let dir = path.dirname(path.resolve(filePath));
+  let tsconfig = null;
+  while (true) {
+    const candidate = path.join(dir, 'tsconfig.json');
+    if (existsSync(candidate)) {
+      tsconfig = candidate;
+      break;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+
+  if (!tsconfig) {
+    process.exit(0);
+  }
+
+  try {
+    execFileSync('npx', ['tsc', '--noEmit', '--pretty', 'false', '--project', tsconfig], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 30000,
+    });
+    // tsc passed cleanly
+    process.exit(0);
+  } catch (err) {
+    const output = (err.stdout || '') + (err.stderr || '');
+    // Filter to lines mentioning the edited file (max 10 lines)
+    const basename = path.basename(filePath);
+    const normalizedPath = filePath.replace(/\\/g, '/');
+    const lines = output
+      .split('\n')
+      .filter((line) => line.includes(basename) || line.includes(normalizedPath));
+    const trimmed = lines.slice(0, 10).join('\n').trim();
+    if (trimmed) {
+      process.stdout.write(trimmed + '\n');
+      process.exit(1);
+    }
+    // No matching lines — type errors in other files, not the one we edited
+    process.exit(0);
+  }
+}
+
+main().catch(() => process.exit(0));


### PR DESCRIPTION
## Summary

- **PostToolUse typecheck hook** (`post-edit-typecheck.js`): fires on Edit/Write for `.ts`/`.tsx` files, walks up to find `tsconfig.json`, runs `tsc --noEmit`, surfaces errors scoped to the edited file (max 10 lines) — registered in `hooks.json`
- **Verdict system** (APPROVE/WARN/BLOCK): added `## Verdict System` section to `kai.md`, `matt.md`, `sam.md`, `frank.md` agent commands and `.automaker/context/CLAUDE.md` so all agents emit structured verdicts with >80% certainty threshold
- **Phase handoffs**: `PhaseHandoff` type wired into `ProcessorServiceContext`, `ServiceContainer`, and `wireServices()`; `saveHandoff()` called at end of PLAN, EXECUTE, and REVIEW processors to leave structured artifacts for subsequent phases

## Test plan
- [ ] CI passes (build + typecheck)
- [ ] `tsc --noEmit` on server passes
- [ ] Hooks fire correctly on `.ts` file edits
- [ ] Agent commands contain verdict system section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a verdict system for structured response evaluation with APPROVE/WARN/BLOCK categorization.
  * Added phase-based handoff tracking throughout the workflow.
  * Implemented automatic type-checking validation after edits.

* **Documentation**
  * Updated guidance documentation with verdict system standards and requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->