### PR TITLE
docs: enforce merge commit strategy for promotion PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ See `docs/dev/branch-strategy.md` for the full strategy.
 
 - Never push directly to `main` or `staging`. Always use a PR.
 - Agent feature PRs target `dev` by default (`prBaseBranch: 'dev'` in `DEFAULT_GIT_WORKFLOW_SETTINGS`).
+- **Promotion PRs (`dev→staging`, `staging→main`) must use `--merge`, NEVER `--squash`.** Squash creates a synthetic commit with no DAG relationship to the source branch — the next promotion will conflict even though the code is identical. Feature PRs to `dev` may squash (branch is discarded). Promotion PRs must merge (branches live on).
 - Before committing, run `git status` and verify only intended files are staged. Watch for accidentally staged deletions from previously merged PRs.
 - `.automaker/memory/` files are updated by agents during autonomous work. Include memory changes in your commits alongside related code changes — don't leave them as unstaged drift.
 

--- a/docs/dev/branch-strategy.md
+++ b/docs/dev/branch-strategy.md
@@ -102,16 +102,46 @@ If a project needs agents to target a different base, override in project settin
 }
 ```
 
+## Promotion Merge Strategy
+
+> **Critical rule: promotion PRs must use `--merge` (merge commit), never `--squash`.**
+
+Squash-merging a promotion PR creates a synthetic commit with no DAG relationship to the source branch's commits. The next promotion will find that synthetic commit as a conflict — even though the code is identical — because git can't recognize what's already been integrated.
+
+```
+# What happens with squash (WRONG):
+dev:     A → B → C → D
+                       ← squash → staging: A → S   (S has no parent on dev)
+dev:     A → B → C → D → E → F
+                       ← merge: git finds A as base, sees S vs B+C+D+E+F → CONFLICT
+
+# What happens with merge commit (CORRECT):
+dev:     A → B → C → D
+                       ← merge commit → staging: A → B → C → D → M1
+dev:     A → B → C → D → E → F
+                       ← merge: git finds D as base, sees only E+F as new → CLEAN
+```
+
+**Rule of thumb:**
+
+- Feature PRs (`feature/*` → `dev`): squash ✅ (branch is discarded)
+- Promotion PRs (`dev` → `staging`, `staging` → `main`): merge commit ✅ (branch lives on)
+
 ## Promotion Commands
 
 ```bash
-# Promote dev → staging
-gh pr create --base staging --head dev --title "chore: promote dev to staging" \
+# Promote dev → staging (ALWAYS --merge)
+gh pr create --base staging --head dev --title "chore: promote dev → staging" \
   --body "Promoting dev to staging for user testing."
+gh pr merge <number> --merge   # NOT --squash
 
-# Promote staging → main (use the template)
+# Promote staging → main (ALWAYS --merge, use the template)
 gh pr create --base main --head staging \
   --template .github/PULL_REQUEST_TEMPLATE/promote-to-main.md
+gh pr merge <number> --merge   # NOT --squash
+
+# Enable auto-merge with merge strategy
+gh pr merge <number> --auto --merge
 ```
 
 ## Common Questions
@@ -127,3 +157,6 @@ Yes — make sure `dev` is up to date with `main` before opening a `dev → stag
 
 **What if CI fails on the staging promote PR?**
 Fix the failure on `dev`, push the fix, then the open PR to `staging` will re-run CI automatically.
+
+**What if dev → staging shows conflicts?**
+This means a previous promotion used `--squash`. To recover: create a new branch from `dev`, `git merge origin/staging` (take dev's version for all conflicts), push, and open a new PR. Going forward, always use `--merge`.

--- a/packages/mcp-server/plugins/automaker/commands/ava.md
+++ b/packages/mcp-server/plugins/automaker/commands/ava.md
@@ -463,12 +463,16 @@ When reviewing or creating PRs: feature branches target `dev`, not `main`. If yo
 **Promotion commands:**
 
 ```bash
-# dev → staging
-gh pr create --base staging --head dev --title "chore: promote dev to staging"
+# dev → staging (ALWAYS --merge, never --squash)
+gh pr create --base staging --head dev --title "chore: promote dev → staging"
+gh pr merge <number> --auto --merge
 
-# staging → main (use template — enforced by CI)
+# staging → main (ALWAYS --merge, use template — enforced by CI)
 gh pr create --base main --head staging --template .github/PULL_REQUEST_TEMPLATE/promote-to-main.md
+gh pr merge <number> --auto --merge
 ```
+
+> **Merge strategy rule**: Promotion PRs must use `--merge` (merge commit), NEVER `--squash` or `--rebase`. Both create new commit SHAs, breaking git's DAG — the next promotion shows conflicts even though the code is identical. Feature PRs to `dev` may squash (branch discarded). Promotion PRs must merge (branches live on).
 
 **Beads** (`bd` CLI) — Your operational brain and primary work queue.
 


### PR DESCRIPTION
## Summary

- Documents the root cause of promotion conflicts: squash/rebase create new commit SHAs, breaking git's DAG
- Adds diagram showing why merge commits are required for `dev→staging` and `staging→main`
- Updates CLAUDE.md git rules, `branch-strategy.md` (with before/after DAG diagram + recovery steps), and `ava.md` promotion commands

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established merge strategy guidelines requiring merge commits for promotion PRs; squash merges are prohibited to prevent merge conflicts
  * Added conflict resolution guidance and recovery steps for promotion workflows
  * Clarified promotion authority boundaries: dev→staging is autonomous; staging→main requires human approval
  * Introduced PR ownership checks and governance controls for automated promotions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->