### PR TITLE
ci: harden and loosen GitHub Actions + branch protections

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Extract version from tag
         id: version
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Extract version from tag
         id: version
@@ -88,7 +88,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Extract version from tag
         id: version
@@ -122,7 +122,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup project
         uses: ./.github/actions/setup-project
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup project
         uses: ./.github/actions/setup-project
@@ -198,7 +198,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup project
         uses: ./.github/actions/setup-project

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,7 +4,6 @@ name: PR Build Check
 on:
   pull_request:
     branches:
-      - dev
       - staging
       - main
     paths-ignore:
@@ -15,7 +14,6 @@ on:
   push:
     branches:
       - main
-      - master
     paths-ignore:
       - 'docs/**'
       - 'site/**'


### PR DESCRIPTION
## Summary

- **Bug fix**: `deploy-staging.yml` was deploying `origin/main` to staging (not `origin/staging`)
- **Bug fix**: `pr-check.yml` had dead `master` branch trigger
- **Harden**: Pin `actions/checkout` to SHA in `build-electron.yml`
- **Harden**: `source-branch` check now in ruleset (was only in legacy protection, now deleted)
- **Loosen**: `pr-check` electron build only triggers on PRs to `staging`/`main` (not `dev`)
- **Loosen**: Staging `strict=false` — dev→staging no longer requires up-to-date head

## Context

Outcome of full CI/CD audit. The staging deploy bug meant staging was always running production code — critical fix.

## Test plan
- [ ] CI passes
- [ ] Verify deploy-staging.yml deploys origin/staging after next staging push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and CI/CD workflows to improve reliability and consistency across automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->