### PR TITLE
feat(ui): docs flag, ceremonies inbox, sidebar badge, notes move

### DIFF
--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -5,7 +5,7 @@ import { useNavigate, useLocation } from '@tanstack/react-router';
 const logger = createLogger('Sidebar');
 import { cn, isMac } from '@/lib/utils';
 import { useAppStore } from '@/store/app-store';
-import { useNotificationsStore } from '@/store/notifications-store';
+import { useActionableItemsStore } from '@/store/actionable-items-store';
 import { useCeremonyStore } from '@/store/ceremony-store';
 import { useKeyboardShortcuts, useKeyboardShortcutsConfig } from '@/hooks/use-keyboard-shortcuts';
 import { getElectronAPI, isElectron } from '@/lib/electron';
@@ -96,8 +96,8 @@ export function Sidebar() {
   // Get customizable keyboard shortcuts
   const shortcuts = useKeyboardShortcutsConfig();
 
-  // Get unread notifications count
-  const unreadNotificationsCount = useNotificationsStore((s) => s.unreadCount);
+  // Get pending actionable items count (drives the inbox badge)
+  const unreadNotificationsCount = useActionableItemsStore((s) => s.pendingCount);
 
   // Get unread ceremony event count
   const unreadCeremonyCount = useCeremonyStore((s) => s.unreadCount);
@@ -257,6 +257,7 @@ export function Sidebar() {
     hideTerminal,
     hideCalendar: !featureFlags.calendar,
     hideDesigns: !featureFlags.designs,
+    hideDocs: !featureFlags.docs,
     currentProject,
     projects,
     projectHistory,

--- a/apps/ui/src/components/layout/sidebar/hooks/use-navigation.ts
+++ b/apps/ui/src/components/layout/sidebar/hooks/use-navigation.ts
@@ -48,6 +48,7 @@ interface UseNavigationProps {
   hideTerminal: boolean;
   hideCalendar: boolean;
   hideDesigns: boolean;
+  hideDocs: boolean;
   currentProject: Project | null;
   projects: Project[];
   projectHistory: string[];
@@ -73,6 +74,7 @@ export function useNavigation({
   hideTerminal,
   hideCalendar,
   hideDesigns,
+  hideDocs,
   currentProject,
   projects,
   projectHistory,
@@ -133,12 +135,6 @@ export function useNavigation({
         shortcut: shortcuts.memory,
       },
       {
-        id: 'notes',
-        label: 'Notes',
-        icon: NotebookPen,
-        shortcut: shortcuts.notes,
-      },
-      {
         id: 'docs',
         label: 'Docs',
         icon: Library,
@@ -152,6 +148,9 @@ export function useNavigation({
         return false;
       }
       if (item.id === 'context' && hideContext) {
+        return false;
+      }
+      if (item.id === 'docs' && hideDocs) {
         return false;
       }
       return true;
@@ -169,6 +168,12 @@ export function useNavigation({
         label: 'Kanban Board',
         icon: LayoutGrid,
         shortcut: shortcuts.board,
+      },
+      {
+        id: 'notes',
+        label: 'Notes',
+        icon: NotebookPen,
+        shortcut: shortcuts.notes,
       },
     ];
 
@@ -257,6 +262,9 @@ export function useNavigation({
     hideSpecEditor,
     hideContext,
     hideTerminal,
+    hideCalendar,
+    hideDesigns,
+    hideDocs,
     hasGitHubRemote,
     unviewedValidationsCount,
     unreadNotificationsCount,

--- a/apps/ui/src/components/views/inbox-view.tsx
+++ b/apps/ui/src/components/views/inbox-view.tsx
@@ -1,15 +1,17 @@
 /**
  * Inbox View - Full page view for unified actionable items.
  *
- * Displays HITL forms, approvals, notifications, escalations, and pipeline gates
- * with category filtering, status tabs, snooze, and bulk actions.
+ * Displays HITL forms, approvals, notifications, escalations, pipeline gates,
+ * and ceremony audit log with category filtering, status tabs, snooze, and bulk actions.
  */
 
 import { useCallback, useMemo, useState } from 'react';
 import { useAppStore } from '@/store/app-store';
 import { useActionableItemsStore } from '@/store/actionable-items-store';
 import { useHITLFormStore } from '@/store/hitl-form-store';
+import { useCeremonyStore } from '@/store/ceremony-store';
 import { useLoadActionableItems, useActionableItemEvents } from '@/hooks/use-actionable-items';
+import { useLoadCeremonyEntries, useCeremonyEventStream } from '@/hooks/use-ceremony-events';
 import { getHttpApiClient } from '@/lib/http-api-client';
 import { Button } from '@protolabs-ai/ui/atoms';
 import { Spinner } from '@protolabs-ai/ui/atoms';
@@ -26,11 +28,19 @@ import {
   BellOff,
   Filter,
   X,
+  PartyPopper,
+  CalendarCheck,
+  BarChart2,
+  Trophy,
+  CheckCircle2,
+  XCircle,
+  HelpCircle,
 } from 'lucide-react';
 import type {
   ActionableItem,
   ActionableItemActionType,
   ActionableItemPriority,
+  CeremonyAuditEntry,
 } from '@protolabs-ai/types';
 import type { Feature } from '@/store/types';
 import { getEffectivePriority } from '@protolabs-ai/types';
@@ -44,7 +54,8 @@ type CategoryFilter =
   | 'notification'
   | 'escalation'
   | 'gate'
-  | 'review';
+  | 'review'
+  | 'ceremony';
 type StatusFilter = 'pending' | 'snoozed' | 'acted' | 'dismissed' | 'all';
 
 const CATEGORY_TABS: { value: CategoryFilter; label: string; icon: React.ReactNode }[] = [
@@ -54,6 +65,7 @@ const CATEGORY_TABS: { value: CategoryFilter; label: string; icon: React.ReactNo
   { value: 'notification', label: 'Notifications', icon: <Bell className="h-3.5 w-3.5" /> },
   { value: 'escalation', label: 'Escalations', icon: <AlertTriangle className="h-3.5 w-3.5" /> },
   { value: 'gate', label: 'Gates', icon: <CircleDot className="h-3.5 w-3.5" /> },
+  { value: 'ceremony', label: 'Ceremonies', icon: <PartyPopper className="h-3.5 w-3.5" /> },
 ];
 
 const STATUS_TABS: { value: StatusFilter; label: string }[] = [
@@ -69,6 +81,30 @@ const SNOOZE_OPTIONS = [
   { label: '4 hours', ms: 4 * 60 * 60 * 1000 },
   { label: 'Tomorrow', ms: 24 * 60 * 60 * 1000 },
 ];
+
+const CEREMONY_META: Record<
+  string,
+  { label: string; icon: React.ReactNode; color: string; bg: string }
+> = {
+  standup: {
+    label: 'Standup',
+    icon: <CalendarCheck className="h-4 w-4" />,
+    color: 'text-blue-500',
+    bg: 'bg-blue-500/10',
+  },
+  retro: {
+    label: 'Milestone Retro',
+    icon: <BarChart2 className="h-4 w-4" />,
+    color: 'text-purple-500',
+    bg: 'bg-purple-500/10',
+  },
+  'project-retro': {
+    label: 'Project Retro',
+    icon: <Trophy className="h-4 w-4" />,
+    color: 'text-amber-500',
+    bg: 'bg-amber-500/10',
+  },
+};
 
 function formatRelativeTime(date: Date): string {
   const now = new Date();
@@ -123,12 +159,50 @@ function getPriorityBadge(priority: ActionableItemPriority) {
   );
 }
 
+function CeremonyDeliveryBadge({ status }: { status: CeremonyAuditEntry['deliveryStatus'] }) {
+  const config = {
+    pending: {
+      icon: <HelpCircle className="h-3 w-3" />,
+      label: 'Pending',
+      cls: 'text-yellow-500 bg-yellow-500/10',
+    },
+    success: {
+      icon: <CheckCircle2 className="h-3 w-3" />,
+      label: 'Delivered',
+      cls: 'text-green-500 bg-green-500/10',
+    },
+    failed: {
+      icon: <XCircle className="h-3 w-3" />,
+      label: 'Failed',
+      cls: 'text-red-500 bg-red-500/10',
+    },
+  };
+  const { icon, label, cls } = config[status] ?? config.pending;
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium',
+        cls
+      )}
+    >
+      {icon}
+      {label}
+    </span>
+  );
+}
+
 export function InboxView() {
   const { currentProject } = useAppStore();
   const projectPath = currentProject?.path ?? null;
   const { items, isLoading, dismissItem, markAsRead, markAllAsRead, dismissAll } =
     useActionableItemsStore();
   const openForm = useHITLFormStore((s) => s.openForm);
+  const {
+    entries: ceremonyEntries,
+    isLoading: ceremoniesLoading,
+    unreadCount: ceremonyUnreadCount,
+    markAllRead: markCeremoniesRead,
+  } = useCeremonyStore();
 
   const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>('all');
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('pending');
@@ -139,6 +213,8 @@ export function InboxView() {
 
   useLoadActionableItems(projectPath);
   useActionableItemEvents(projectPath);
+  useLoadCeremonyEntries(projectPath);
+  useCeremonyEventStream(projectPath);
 
   const filteredItems = useMemo(() => {
     let filtered = items;
@@ -149,8 +225,13 @@ export function InboxView() {
     }
 
     // Category filter
-    if (categoryFilter !== 'all') {
+    if (categoryFilter !== 'all' && categoryFilter !== 'ceremony') {
       filtered = filtered.filter((i) => i.actionType === categoryFilter);
+    }
+
+    // Hide all actionable items when ceremony tab is active
+    if (categoryFilter === 'ceremony') {
+      return [];
     }
 
     // Sort by effective priority then by date
@@ -163,6 +244,15 @@ export function InboxView() {
     });
   }, [items, categoryFilter, statusFilter]);
 
+  // Ceremonies sorted newest-first
+  const sortedCeremonies = useMemo(
+    () =>
+      [...ceremonyEntries].sort(
+        (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+      ),
+    [ceremonyEntries]
+  );
+
   const handleGateAction = useCallback(
     async (e: React.MouseEvent, item: ActionableItem, action: 'advance' | 'reject') => {
       e.stopPropagation();
@@ -172,7 +262,6 @@ export function InboxView() {
       try {
         const api = getHttpApiClient();
         await api.engine.pipelineGateResolve(projectPath, featureId, action);
-        // Mark the item as acted and dismiss it
         useActionableItemsStore.getState().dismissItem(item.id);
         await api.actionableItems.dismiss(projectPath, item.id);
         toast.success(
@@ -191,12 +280,10 @@ export function InboxView() {
     async (item: ActionableItem) => {
       if (!projectPath) return;
 
-      // Mark as read
       markAsRead(item.id);
       const api = getHttpApiClient();
       await api.actionableItems.markRead(projectPath, item.id);
 
-      // Open approval preview dialog
       if (item.actionType === 'approval' && item.actionPayload?.featureId) {
         try {
           setApprovalLoading(true);
@@ -212,10 +299,9 @@ export function InboxView() {
         } finally {
           setApprovalLoading(false);
         }
-        return; // Don't fall through to HITL form handling
+        return;
       }
 
-      // Open HITL form if applicable
       if (item.actionType === 'hitl_form' && item.actionPayload?.formId) {
         try {
           const res = await api.hitlForms.get(item.actionPayload.formId as string);
@@ -262,9 +348,10 @@ export function InboxView() {
   const handleMarkAllRead = useCallback(async () => {
     if (!projectPath) return;
     markAllAsRead();
+    markCeremoniesRead();
     const api = getHttpApiClient();
     await api.actionableItems.markRead(projectPath);
-  }, [projectPath, markAllAsRead]);
+  }, [projectPath, markAllAsRead, markCeremoniesRead]);
 
   const handleDismissAll = useCallback(async () => {
     if (!projectPath) return;
@@ -281,8 +368,9 @@ export function InboxView() {
       counts[item.actionType] = (counts[item.actionType] ?? 0) + 1;
     }
     counts.all = items.filter((i) => i.status === 'pending').length;
+    counts.ceremony = ceremonyUnreadCount;
     return counts;
-  }, [items]);
+  }, [items, ceremonyUnreadCount]);
 
   if (!projectPath) {
     return (
@@ -292,6 +380,8 @@ export function InboxView() {
       </div>
     );
   }
+
+  const isCeremonyView = categoryFilter === 'ceremony';
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
@@ -310,10 +400,17 @@ export function InboxView() {
           <Button variant="ghost" size="sm" onClick={handleMarkAllRead}>
             Mark all read
           </Button>
-          <Button variant="ghost" size="sm" onClick={handleDismissAll} className="text-destructive">
-            <Trash2 className="mr-1 h-3.5 w-3.5" />
-            Dismiss all
-          </Button>
+          {!isCeremonyView && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleDismissAll}
+              className="text-destructive"
+            >
+              <Trash2 className="mr-1 h-3.5 w-3.5" />
+              Dismiss all
+            </Button>
+          )}
         </div>
       </div>
 
@@ -348,158 +445,228 @@ export function InboxView() {
         ))}
       </div>
 
-      {/* Status tabs */}
-      <div className="flex items-center gap-1 px-6 py-2 border-b">
-        <Filter className="h-3.5 w-3.5 text-muted-foreground mr-1" />
-        {STATUS_TABS.map((tab) => (
-          <button
-            key={tab.value}
-            onClick={() => setStatusFilter(tab.value)}
-            className={cn(
-              'rounded-md px-2 py-1 text-xs font-medium transition-colors',
-              statusFilter === tab.value
-                ? 'bg-accent text-foreground'
-                : 'text-muted-foreground hover:text-foreground'
-            )}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-
-      {/* Items list */}
-      <div className="flex-1 overflow-y-auto">
-        {isLoading ? (
-          <div className="flex items-center justify-center py-16">
-            <Spinner className="h-6 w-6" />
-          </div>
-        ) : filteredItems.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16">
-            <BellOff className="h-10 w-10 text-muted-foreground/30 mb-3" />
-            <p className="text-sm text-muted-foreground">No items match your filters</p>
-          </div>
-        ) : (
-          <div className="divide-y">
-            {filteredItems.map((item) => {
-              const effectivePriority = getEffectivePriority(item);
-              const isSnoozed = item.status === 'snoozed';
-
-              return (
-                <div
-                  key={item.id}
-                  className={cn(
-                    'flex items-start gap-4 px-6 py-4 cursor-pointer hover:bg-accent/50 transition-colors',
-                    !item.read && item.status === 'pending' && 'bg-primary/5',
-                    effectivePriority === 'urgent' && 'border-l-2 border-l-red-500',
-                    effectivePriority === 'high' && 'border-l-2 border-l-orange-500'
-                  )}
-                  onClick={() => handleItemClick(item)}
-                >
-                  <div className="flex-shrink-0 mt-1">{getActionIcon(item.actionType)}</div>
-
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-0.5">
-                      <p className="text-sm font-medium truncate">{item.title}</p>
-                      {!item.read && item.status === 'pending' && (
-                        <span className="h-2 w-2 rounded-full bg-primary flex-shrink-0" />
+      {isCeremonyView ? (
+        /* Ceremony view — no status tabs, different list */
+        <div className="flex-1 overflow-y-auto">
+          {ceremoniesLoading ? (
+            <div className="flex items-center justify-center py-16">
+              <Spinner className="h-6 w-6" />
+            </div>
+          ) : sortedCeremonies.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16">
+              <PartyPopper className="h-10 w-10 text-muted-foreground/30 mb-3" />
+              <p className="text-sm text-muted-foreground">No ceremonies yet</p>
+            </div>
+          ) : (
+            <div className="divide-y">
+              {sortedCeremonies.map((entry) => {
+                const meta = CEREMONY_META[entry.ceremonyType] ?? CEREMONY_META['standup'];
+                return (
+                  <div key={entry.id} className="flex items-start gap-4 px-6 py-4">
+                    {/* Icon */}
+                    <div
+                      className={cn(
+                        'flex-shrink-0 mt-0.5 flex h-8 w-8 items-center justify-center rounded-lg',
+                        meta.bg,
+                        meta.color
                       )}
-                      {getPriorityBadge(effectivePriority)}
+                    >
+                      {meta.icon}
                     </div>
-                    <p className="text-xs text-muted-foreground line-clamp-2">{item.message}</p>
-                    <div className="flex items-center gap-3 mt-1.5">
-                      <span className="text-[11px] text-muted-foreground">
-                        {formatRelativeTime(new Date(item.createdAt))}
-                      </span>
-                      {isSnoozed && item.snoozedUntil && (
-                        <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
-                          <Clock className="h-3 w-3" />
-                          until {new Date(item.snoozedUntil).toLocaleString()}
+
+                    {/* Content */}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-0.5">
+                        <p className="text-sm font-medium truncate">{entry.payload.title}</p>
+                        <span
+                          className={cn(
+                            'inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium',
+                            meta.color,
+                            meta.bg
+                          )}
+                        >
+                          {meta.label}
                         </span>
+                      </div>
+                      {entry.payload.summary && (
+                        <p className="text-xs text-muted-foreground line-clamp-2 mb-1.5">
+                          {entry.payload.summary}
+                        </p>
                       )}
-                      <span className="text-[11px] text-muted-foreground/60">
-                        {item.actionType.replace('_', ' ')}
-                      </span>
-                      {item.category && (
-                        <span className="text-[11px] text-muted-foreground/60">
-                          {item.category}
+                      <div className="flex items-center gap-3">
+                        <span className="text-[11px] text-muted-foreground">
+                          {formatRelativeTime(new Date(entry.timestamp))}
                         </span>
-                      )}
+                        {entry.milestoneSlug && (
+                          <span className="text-[11px] text-muted-foreground/60">
+                            {entry.milestoneSlug}
+                          </span>
+                        )}
+                        <CeremonyDeliveryBadge status={entry.deliveryStatus} />
+                      </div>
                     </div>
                   </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      ) : (
+        <>
+          {/* Status tabs */}
+          <div className="flex items-center gap-1 px-6 py-2 border-b">
+            <Filter className="h-3.5 w-3.5 text-muted-foreground mr-1" />
+            {STATUS_TABS.map((tab) => (
+              <button
+                key={tab.value}
+                onClick={() => setStatusFilter(tab.value)}
+                className={cn(
+                  'rounded-md px-2 py-1 text-xs font-medium transition-colors',
+                  statusFilter === tab.value
+                    ? 'bg-accent text-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
 
-                  <div className="flex items-center gap-1 flex-shrink-0">
-                    {/* Gate actions */}
-                    {item.actionType === 'gate' && item.status === 'pending' && (
-                      <>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="h-7 text-xs px-2 text-green-600 border-green-600/30 hover:bg-green-600/10"
-                          onClick={(e) => handleGateAction(e, item, 'advance')}
-                          title="Advance gate"
-                        >
-                          Advance
-                        </Button>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="h-7 text-xs px-2 text-red-500 border-red-500/30 hover:bg-red-500/10"
-                          onClick={(e) => handleGateAction(e, item, 'reject')}
-                          title="Reject gate"
-                        >
-                          Reject
-                        </Button>
-                      </>
-                    )}
+          {/* Items list */}
+          <div className="flex-1 overflow-y-auto">
+            {isLoading ? (
+              <div className="flex items-center justify-center py-16">
+                <Spinner className="h-6 w-6" />
+              </div>
+            ) : filteredItems.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-16">
+                <BellOff className="h-10 w-10 text-muted-foreground/30 mb-3" />
+                <p className="text-sm text-muted-foreground">No items match your filters</p>
+              </div>
+            ) : (
+              <div className="divide-y">
+                {filteredItems.map((item) => {
+                  const effectivePriority = getEffectivePriority(item);
+                  const isSnoozed = item.status === 'snoozed';
 
-                    {/* Snooze */}
-                    {item.status === 'pending' && (
-                      <div className="relative">
+                  return (
+                    <div
+                      key={item.id}
+                      className={cn(
+                        'flex items-start gap-4 px-6 py-4 cursor-pointer hover:bg-accent/50 transition-colors',
+                        !item.read && item.status === 'pending' && 'bg-primary/5',
+                        effectivePriority === 'urgent' && 'border-l-2 border-l-red-500',
+                        effectivePriority === 'high' && 'border-l-2 border-l-orange-500'
+                      )}
+                      onClick={() => handleItemClick(item)}
+                    >
+                      <div className="flex-shrink-0 mt-1">{getActionIcon(item.actionType)}</div>
+
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-0.5">
+                          <p className="text-sm font-medium truncate">{item.title}</p>
+                          {!item.read && item.status === 'pending' && (
+                            <span className="h-2 w-2 rounded-full bg-primary flex-shrink-0" />
+                          )}
+                          {getPriorityBadge(effectivePriority)}
+                        </div>
+                        <p className="text-xs text-muted-foreground line-clamp-2">{item.message}</p>
+                        <div className="flex items-center gap-3 mt-1.5">
+                          <span className="text-[11px] text-muted-foreground">
+                            {formatRelativeTime(new Date(item.createdAt))}
+                          </span>
+                          {isSnoozed && item.snoozedUntil && (
+                            <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+                              <Clock className="h-3 w-3" />
+                              until {new Date(item.snoozedUntil).toLocaleString()}
+                            </span>
+                          )}
+                          <span className="text-[11px] text-muted-foreground/60">
+                            {item.actionType.replace('_', ' ')}
+                          </span>
+                          {item.category && (
+                            <span className="text-[11px] text-muted-foreground/60">
+                              {item.category}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="flex items-center gap-1 flex-shrink-0">
+                        {/* Gate actions */}
+                        {item.actionType === 'gate' && item.status === 'pending' && (
+                          <>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="h-7 text-xs px-2 text-green-600 border-green-600/30 hover:bg-green-600/10"
+                              onClick={(e) => handleGateAction(e, item, 'advance')}
+                              title="Advance gate"
+                            >
+                              Advance
+                            </Button>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="h-7 text-xs px-2 text-red-500 border-red-500/30 hover:bg-red-500/10"
+                              onClick={(e) => handleGateAction(e, item, 'reject')}
+                              title="Reject gate"
+                            >
+                              Reject
+                            </Button>
+                          </>
+                        )}
+
+                        {/* Snooze */}
+                        {item.status === 'pending' && (
+                          <div className="relative">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-7 w-7"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setSnoozeMenuOpen(snoozeMenuOpen === item.id ? null : item.id);
+                              }}
+                              title="Snooze"
+                            >
+                              <Clock className="h-3.5 w-3.5" />
+                            </Button>
+                            {snoozeMenuOpen === item.id && (
+                              <div className="absolute right-0 top-full mt-1 z-10 bg-popover border rounded-md shadow-md py-1 min-w-[120px]">
+                                {SNOOZE_OPTIONS.map((opt) => (
+                                  <button
+                                    key={opt.label}
+                                    className="w-full text-left px-3 py-1.5 text-xs hover:bg-accent transition-colors"
+                                    onClick={(e) => handleSnooze(e, item.id, opt.ms)}
+                                  >
+                                    {opt.label}
+                                  </button>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        )}
+
+                        {/* Dismiss */}
                         <Button
                           variant="ghost"
                           size="icon"
                           className="h-7 w-7"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setSnoozeMenuOpen(snoozeMenuOpen === item.id ? null : item.id);
-                          }}
-                          title="Snooze"
+                          onClick={(e) => handleDismiss(e, item.id)}
+                          title="Dismiss"
                         >
-                          <Clock className="h-3.5 w-3.5" />
+                          <Trash2 className="h-3.5 w-3.5" />
                         </Button>
-                        {snoozeMenuOpen === item.id && (
-                          <div className="absolute right-0 top-full mt-1 z-10 bg-popover border rounded-md shadow-md py-1 min-w-[120px]">
-                            {SNOOZE_OPTIONS.map((opt) => (
-                              <button
-                                key={opt.label}
-                                className="w-full text-left px-3 py-1.5 text-xs hover:bg-accent transition-colors"
-                                onClick={(e) => handleSnooze(e, item.id, opt.ms)}
-                              >
-                                {opt.label}
-                              </button>
-                            ))}
-                          </div>
-                        )}
                       </div>
-                    )}
-
-                    {/* Dismiss */}
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-7 w-7"
-                      onClick={(e) => handleDismiss(e, item.id)}
-                      title="Dismiss"
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </Button>
-                  </div>
-                </div>
-              );
-            })}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
           </div>
-        )}
-      </div>
+        </>
+      )}
 
       {/* Approval Preview Dialog */}
       {approvalItem && (

--- a/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
+++ b/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
@@ -21,6 +21,10 @@ const FEATURE_FLAG_LABELS: Record<string, { label: string; description: string }
     label: 'Designs',
     description: 'Show the Designs (pen file) viewer in the project sidebar.',
   },
+  docs: {
+    label: 'Docs',
+    description: 'Show the Docs viewer in the project sidebar.',
+  },
 };
 
 export function DeveloperSection() {

--- a/apps/ui/src/hooks/use-settings-migration.ts
+++ b/apps/ui/src/hooks/use-settings-migration.ts
@@ -714,7 +714,7 @@ export function hydrateStoreFromSettings(settings: GlobalSettings): void {
     muteDoneSound: settings.muteDoneSound ?? false,
     serverLogLevel: settings.serverLogLevel ?? 'info',
     enableRequestLogging: settings.enableRequestLogging ?? true,
-    featureFlags: settings.featureFlags ?? { calendar: true, designs: true },
+    featureFlags: settings.featureFlags ?? { calendar: true, designs: true, docs: true },
     keyboardShortcuts: {
       ...current.keyboardShortcuts,
       ...(settings.keyboardShortcuts as unknown as Partial<typeof current.keyboardShortcuts>),

--- a/apps/ui/src/hooks/use-settings-sync.ts
+++ b/apps/ui/src/hooks/use-settings-sync.ts
@@ -88,6 +88,7 @@ const SETTINGS_FIELDS_TO_SYNC = [
   'worktreePanelCollapsed',
   'lastProjectDir',
   'recentFolders',
+  'featureFlags',
 ] as const;
 
 // Fields from setup store to sync
@@ -825,6 +826,7 @@ export async function refreshSettingsFromServer(): Promise<boolean> {
       lastProjectDir: serverSettings.lastProjectDir ?? '',
       recentFolders: serverSettings.recentFolders ?? [],
       eventHooks: serverSettings.eventHooks ?? [],
+      featureFlags: serverSettings.featureFlags ?? { calendar: true, designs: true, docs: true },
     });
 
     // Also refresh setup wizard state

--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -192,12 +192,15 @@ export interface FeatureFlags {
   calendar: boolean;
   /** Designs/pen file viewer in project sidebar (default: true in dev) */
   designs: boolean;
+  /** Docs view in project sidebar (default: true in dev) */
+  docs: boolean;
 }
 
 /** Default feature flags — all on in development, off in staging/production */
 export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   calendar: true,
   designs: true,
+  docs: true,
 };
 
 export interface GlobalSettings {


### PR DESCRIPTION
## Summary
- Add \`docs\` feature flag (joins \`calendar\` + \`designs\`) with toggle in Developer settings; fix persistence for all flags (add to \`SETTINGS_FIELDS_TO_SYNC\` + hydration) and fix \`useMemo\` deps so toggles reactively hide/show sidebar items
- Move Notes nav item from Tools section to Project section (under Kanban Board)
- Add Ceremonies tab to inbox view — loads historical entries, streams live \`ceremony:fired\` events, renders per-type icons (Standup/Milestone Retro/Project Retro) with delivery status badges
- Fix sidebar inbox badge: switch from stale \`notifications-store.unreadCount\` to \`actionable-items-store.pendingCount\` so the count reflects actual pending inbox items in both collapsed and expanded states

## Test plan
- [ ] Toggle Docs/Calendar/Designs flags in Settings → Developer; verify sidebar items appear/disappear
- [ ] Refresh app; verify flags persisted correctly
- [ ] Open Inbox → Ceremonies tab; verify entries load and ceremony types display correctly
- [ ] Sidebar badge shows pending count when there are actionable items
- [ ] Notes appears under Kanban Board in the Project nav section
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ceremony entries now appear in the inbox with delivery status badges
  * Added Docs toggle in settings to control sidebar visibility

* **Refactor**
  * Inbox badge now displays pending actionable items instead of unread notifications
  * Notes navigation item moved from Tools to Project section
  * Feature flag settings now sync with the server

<!-- end of auto-generated comment: release notes by coderabbit.ai -->