### PR TITLE
fix(deps): foundation vs non-foundation eligibility split in resolver + staleDeps rule

### DIFF
--- a/apps/server/src/services/lead-engineer-rules.ts
+++ b/apps/server/src/services/lead-engineer-rules.ts
@@ -133,7 +133,18 @@ export const staleDeps: LeadFastPathRule = {
 
       const allDepsDone = feature.dependencies!.every((depId) => {
         const dep = worldState.features[depId];
-        return dep && (dep.status === 'done' || dep.status === 'verified');
+        if (!dep) return false;
+        // Foundation deps require done (merged) — 'review' is NOT sufficient
+        if (dep.isFoundation) {
+          return dep.status === 'done' || dep.status === 'completed' || dep.status === 'verified';
+        }
+        // Non-foundation deps: 'review' is sufficient to unblock
+        return (
+          dep.status === 'done' ||
+          dep.status === 'completed' ||
+          dep.status === 'verified' ||
+          dep.status === 'review'
+        );
       });
 
       if (allDepsDone) {

--- a/libs/dependency-resolver/src/resolver.ts
+++ b/libs/dependency-resolver/src/resolver.ts
@@ -56,12 +56,17 @@ export function resolveDependencies(features: Feature[]): DependencyResolutionRe
 
         // Check if dependency is incomplete (blocking)
         const depFeature = featureMap.get(depId)!;
-        if (
-          depFeature.status !== 'completed' &&
-          depFeature.status !== 'verified' &&
-          depFeature.status !== 'done' &&
-          depFeature.status !== 'review'
-        ) {
+        // Foundation deps require 'done' (merged) — 'review' is NOT sufficient.
+        // Non-foundation deps can proceed when dep is in 'review'.
+        const isComplete = depFeature.isFoundation
+          ? depFeature.status === 'completed' ||
+            depFeature.status === 'verified' ||
+            depFeature.status === 'done'
+          : depFeature.status === 'completed' ||
+            depFeature.status === 'verified' ||
+            depFeature.status === 'done' ||
+            depFeature.status === 'review';
+        if (!isComplete) {
           if (!blockedFeatures.has(feature.id)) {
             blockedFeatures.set(feature.id, []);
           }
@@ -219,11 +224,17 @@ export function areDependenciesSatisfied(
       return dep.status === 'done' || dep.status === 'completed' || dep.status === 'verified';
     }
 
-    // Default: require 'completed', 'verified', or 'done' (PR merged)
+    // Default: require 'completed', 'verified', 'done', or 'review'
     // 'done' = PR merged, final state
     // 'completed' = agent finished, no PR workflow
     // 'verified' = manually verified by user
-    return dep.status === 'completed' || dep.status === 'verified' || dep.status === 'done';
+    // 'review' = PR created and under review — sufficient for non-foundation deps
+    return (
+      dep.status === 'completed' ||
+      dep.status === 'verified' ||
+      dep.status === 'done' ||
+      dep.status === 'review'
+    );
   });
 }
 
@@ -248,7 +259,13 @@ export function getBlockingDependencies(feature: Feature, allFeatures: Feature[]
       return dep.status !== 'done' && dep.status !== 'completed' && dep.status !== 'verified';
     }
 
-    return dep.status !== 'completed' && dep.status !== 'verified' && dep.status !== 'done';
+    // Non-foundation deps: 'review' is sufficient (dep has a PR, downstream can start)
+    return (
+      dep.status !== 'completed' &&
+      dep.status !== 'verified' &&
+      dep.status !== 'done' &&
+      dep.status !== 'review'
+    );
   });
 }
 
@@ -299,7 +316,13 @@ export function getBlockingDependenciesFromMap(
       continue;
     }
 
-    if (dep.status !== 'completed' && dep.status !== 'verified' && dep.status !== 'done') {
+    // Non-foundation deps: 'review' is sufficient (dep has a PR, downstream can start)
+    if (
+      dep.status !== 'completed' &&
+      dep.status !== 'verified' &&
+      dep.status !== 'done' &&
+      dep.status !== 'review'
+    ) {
       blockingDependencies.push(depId);
     }
   }
@@ -352,7 +375,12 @@ export function getBlockingInfo(feature: Feature, allFeatures: Feature[]): Block
     if (dep.isFoundation) {
       isBlocking = dep.status !== 'done' && dep.status !== 'completed' && dep.status !== 'verified';
     } else {
-      isBlocking = dep.status !== 'completed' && dep.status !== 'verified' && dep.status !== 'done';
+      // Non-foundation deps: 'review' is sufficient (dep has a PR, downstream can start)
+      isBlocking =
+        dep.status !== 'completed' &&
+        dep.status !== 'verified' &&
+        dep.status !== 'done' &&
+        dep.status !== 'review';
     }
 
     if (isBlocking) {

--- a/libs/dependency-resolver/tests/resolver.test.ts
+++ b/libs/dependency-resolver/tests/resolver.test.ts
@@ -343,32 +343,33 @@ describe('resolver.ts', () => {
         expect(areDependenciesSatisfied(feature, allFeatures)).toBe(true);
       });
 
-      it('should NOT allow review to satisfy non-foundation deps', () => {
+      it('should allow review to satisfy non-foundation deps', () => {
         const normalDep = createFeature('Config', { status: 'review' });
         const feature = createFeature('Phase2', { dependencies: ['Config'] });
         const allFeatures = [normalDep, feature];
 
-        expect(areDependenciesSatisfied(feature, allFeatures)).toBe(false);
+        // Non-foundation dep in review is sufficient
+        expect(areDependenciesSatisfied(feature, allFeatures)).toBe(true);
       });
 
-      it('should handle mixed foundation and non-foundation deps', () => {
+      it('should handle mixed foundation and non-foundation deps — foundation in review blocks', () => {
         const foundation = createFeature('Scaffold', { status: 'review', isFoundation: true });
         const normalDep = createFeature('Config', { status: 'review' });
         const feature = createFeature('Phase3', { dependencies: ['Scaffold', 'Config'] });
         const allFeatures = [foundation, normalDep, feature];
 
-        // Both foundation and normal dep in review block
+        // Foundation dep in review still blocks; non-foundation dep in review is ok
         expect(areDependenciesSatisfied(feature, allFeatures)).toBe(false);
       });
 
-      it('should NOT satisfy mixed deps when non-foundation dep is in review', () => {
+      it('should satisfy mixed deps when foundation is done and non-foundation dep is in review', () => {
         const foundation = createFeature('Scaffold', { status: 'done', isFoundation: true });
         const normalDep = createFeature('Config', { status: 'review' });
         const feature = createFeature('Phase3', { dependencies: ['Scaffold', 'Config'] });
         const allFeatures = [foundation, normalDep, feature];
 
-        // Foundation is done (satisfied), but Config in review is NOT satisfied
-        expect(areDependenciesSatisfied(feature, allFeatures)).toBe(false);
+        // Foundation is done (satisfied) + non-foundation in review is now sufficient
+        expect(areDependenciesSatisfied(feature, allFeatures)).toBe(true);
       });
 
       it('should NOT block foundation dep when skipVerification is true', () => {
@@ -381,6 +382,24 @@ describe('resolver.ts', () => {
           true
         );
       });
+    });
+  });
+
+  describe('review-eligible path — non-foundation deps', () => {
+    it('feature with standard dep in review status becomes eligible', () => {
+      const dep = createFeature('DepA', { status: 'review' });
+      const feature = createFeature('Feature1', { dependencies: ['DepA'] });
+      const allFeatures = [dep, feature];
+
+      expect(areDependenciesSatisfied(feature, allFeatures)).toBe(true);
+    });
+
+    it('feature with foundation dep in review status remains blocked', () => {
+      const dep = createFeature('Foundation1', { status: 'review', isFoundation: true });
+      const feature = createFeature('Feature2', { dependencies: ['Foundation1'] });
+      const allFeatures = [dep, feature];
+
+      expect(areDependenciesSatisfied(feature, allFeatures)).toBe(false);
     });
   });
 
@@ -461,12 +480,13 @@ describe('resolver.ts', () => {
       expect(getBlockingDependencies(feature, allFeatures)).toEqual([]);
     });
 
-    it('should treat non-foundation dep in review as blocking', () => {
+    it('should NOT treat non-foundation dep in review as blocking', () => {
       const normalDep = createFeature('Config', { status: 'review' });
       const feature = createFeature('Phase2', { dependencies: ['Config'] });
       const allFeatures = [normalDep, feature];
 
-      expect(getBlockingDependencies(feature, allFeatures)).toEqual(['Config']);
+      // Non-foundation dep in review is sufficient — not blocking
+      expect(getBlockingDependencies(feature, allFeatures)).toEqual([]);
     });
   });
 

--- a/libs/types/src/lead-engineer.ts
+++ b/libs/types/src/lead-engineer.ts
@@ -25,6 +25,7 @@ export interface LeadFeatureSnapshot {
   dependencies?: string[];
   epicId?: string;
   isEpic?: boolean;
+  isFoundation?: boolean;
   complexity?: 'small' | 'medium' | 'large' | 'architectural';
   startedAt?: string;
   completedAt?: string;


### PR DESCRIPTION
## Summary

- Fixes `resolveDependencies`, `areDependenciesSatisfied`, `getBlockingDependencies`, and `getBlockingInfo` in `libs/dependency-resolver` to accept `review` status for **non-foundation** deps (matching documented behaviour)
- Foundation deps (`isFoundation: true`) remain strict — require `done | completed | verified` only
- Fixes the `staleDeps` fast-path rule in `lead-engineer-rules.ts` — adds `completed` to the done check and mirrors the foundation/non-foundation split
- Adds `isFoundation?: boolean` to `LeadFeatureSnapshot` type so the rule can read the flag
- 2 new acceptance-criteria tests: standard dep in review → eligible ✅; foundation dep in review → blocked ✅

**Epic:** Critical & High Pipeline Bug Fixes

## Test Results

`npm run test:packages` — 54 test files, 1045 tests passed, 1 skipped
`dependency-resolver` specifically — 64 tests passed (including 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)