### PR TITLE
refactor: AntagonisticReviewService wiring and EM Agent guard

### DIFF
--- a/apps/server/src/server/wiring.ts
+++ b/apps/server/src/server/wiring.ts
@@ -74,6 +74,8 @@ export async function wireServices(services: ServiceContainer): Promise<void> {
     factStoreService,
     leadHandoffService,
     beadsService,
+    antagonisticReviewService,
+    emAgent,
   } = services;
 
   // Calendar service wiring
@@ -219,6 +221,10 @@ export async function wireServices(services: ServiceContainer): Promise<void> {
   leadEngineerService.setAgentFactory(agentFactoryService);
   leadEngineerService.setFactStoreService(factStoreService);
   leadEngineerService.setHandoffService(leadHandoffService);
+  leadEngineerService.setAntagonisticReviewService(antagonisticReviewService);
+
+  // EM Agent: yield lifecycle control to Lead Engineer when active
+  emAgent.setLeadEngineerService(leadEngineerService);
 
   // PR Feedback service wiring
   prFeedbackService.setAutoModeService(autoModeService);

--- a/apps/server/src/services/antagonistic-review-service.ts
+++ b/apps/server/src/services/antagonistic-review-service.ts
@@ -18,6 +18,7 @@ import { AntagonisticReviewAdapter } from './antagonistic-review-adapter.js';
 import { getLangfuseInstance } from '../lib/langfuse-singleton.js';
 import type { SettingsService } from './settings-service.js';
 import { resolveModelString } from '@protolabs-ai/model-resolver';
+import { simpleQuery } from '../providers/simple-query-service.js';
 
 const logger = createLogger('AntagonisticReview');
 
@@ -692,6 +693,67 @@ Be clear, concise, and actionable. This is the final PRD that will guide impleme
       concerns: concerns.length > 0 ? concerns : undefined,
       recommendations: recommendations.length > 0 ? recommendations : undefined,
     };
+  }
+
+  /**
+   * Verify an implementation plan using antagonistic review.
+   * Used by PlanProcessor to gate plan quality for large/architectural features.
+   *
+   * Returns { approved, reason } if a verdict was reached, or null if review was skipped/failed
+   * (callers should approve by default on null).
+   */
+  async verifyPlan(params: {
+    featureTitle: string;
+    featureDescription: string;
+    complexity: string;
+    planOutput: string;
+    projectPath: string;
+  }): Promise<{ approved: boolean; reason?: string } | null> {
+    const { featureTitle, featureDescription, complexity, planOutput, projectPath } = params;
+
+    logger.info('[verifyPlan] Running plan review', { featureTitle, complexity });
+
+    try {
+      const result = await simpleQuery({
+        prompt: `You are a critical code reviewer. Evaluate this implementation plan for a ${complexity}-complexity feature.
+
+**Feature:** ${featureTitle}
+**Description:** ${featureDescription}
+
+**Proposed Plan:**
+${planOutput}
+
+Review the plan for:
+1. Missing error handling or edge cases
+2. Architectural risks (circular dependencies, monolithic changes)
+3. Missing test strategy
+4. Files that should be modified but aren't mentioned
+5. Overly complex approach where simpler exists
+
+If the plan is solid, respond with: APPROVED
+If critical issues exist, respond with: REJECTED: [concise reason]
+Minor suggestions don't warrant rejection — only reject for issues that would cause implementation failure.`,
+        model: resolveModelString('haiku'),
+        cwd: projectPath,
+        systemPrompt:
+          'You are a senior architect reviewing implementation plans. Be critical but fair — only reject plans with genuine issues that would cause failure.',
+        maxTurns: 1,
+        allowedTools: [],
+      });
+
+      const response = result.text.trim();
+      if (response.startsWith('APPROVED')) {
+        logger.info('[verifyPlan] Plan approved');
+        return { approved: true };
+      }
+
+      const reason = response.startsWith('REJECTED:') ? response.slice(9).trim() : response;
+      logger.info('[verifyPlan] Plan rejected', { reason });
+      return { approved: false, reason };
+    } catch (err) {
+      logger.warn('[verifyPlan] Review failed, approving by default', err);
+      return null;
+    }
   }
 
   /**

--- a/apps/server/src/services/authority-agents/em-agent.ts
+++ b/apps/server/src/services/authority-agents/em-agent.ts
@@ -52,6 +52,7 @@ export class EMAuthorityAgent {
   private readonly auditService: AuditService;
   private readonly settingsService: SettingsService;
   private readonly hitlFormService: HITLFormService | null;
+  private leadEngineerService?: { isActive(projectPath: string): boolean };
 
   /** Agent state (agents, initialization, processing tracking, poll timers) */
   private readonly state: AgentState<EMCustomState>;
@@ -75,6 +76,10 @@ export class EMAuthorityAgent {
     this.state = createAgentState<EMCustomState>({
       pollTimers: new Map(),
     });
+  }
+
+  setLeadEngineerService(s: { isActive(projectPath: string): boolean }): void {
+    this.leadEngineerService = s;
   }
 
   /**
@@ -290,6 +295,11 @@ export class EMAuthorityAgent {
    * Scan for features in 'ready' state and process them.
    */
   private async scanForReadyFeatures(projectPath: string): Promise<void> {
+    // Skip when Lead Engineer owns the lifecycle for this project
+    if (this.leadEngineerService?.isActive(projectPath)) {
+      logger.debug(`[EMAgent] Lead Engineer is active for ${projectPath}, skipping EM scan`);
+      return;
+    }
     try {
       const features = await this.featureLoader.getAll(projectPath);
 

--- a/apps/server/src/services/lead-engineer-processors.ts
+++ b/apps/server/src/services/lead-engineer-processors.ts
@@ -277,7 +277,9 @@ Keep it focused and actionable. If the feature description is too vague or uncle
 
   /**
    * Run antagonistic review on large/architectural plans.
-   * Returns null if review is skipped (small/medium features or disabled).
+   * Delegates to AntagonisticReviewService.verifyPlan() when available;
+   * falls back to inline simpleQuery() otherwise.
+   * Returns null if review is skipped (small/medium features, disabled, or failure).
    */
   private async antagonisticReview(
     ctx: StateContext
@@ -302,6 +304,18 @@ Keep it focused and actionable. If the feature description is too vague or uncle
       complexity,
     });
 
+    // Prefer AntagonisticReviewService.verifyPlan() when wired
+    if (this.serviceContext.antagonisticReviewService) {
+      return this.serviceContext.antagonisticReviewService.verifyPlan({
+        featureTitle: ctx.feature.title || 'Untitled',
+        featureDescription: ctx.feature.description || 'No description',
+        complexity,
+        planOutput: ctx.planOutput ?? '',
+        projectPath: ctx.projectPath,
+      });
+    }
+
+    // Fallback: inline simpleQuery() when AntagonisticReviewService is not available
     try {
       const result = await simpleQuery({
         prompt: `You are a critical code reviewer. Evaluate this implementation plan for a ${complexity}-complexity feature.

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -33,7 +33,11 @@ import { ActionExecutor } from './lead-engineer-action-executor.js';
 import { CeremonyOrchestrator } from './lead-engineer-ceremonies.js';
 import { LeadEngineerSessionStore } from './lead-engineer-session-store.js';
 import { GtmExecuteProcessor } from './lead-engineer-gtm-execute-processor.js';
-import type { FeatureProcessingState, StateContext } from './lead-engineer-types.js';
+import type {
+  FeatureProcessingState,
+  StateContext,
+  IPlanReviewService,
+} from './lead-engineer-types.js';
 import type { AgentFactoryService } from './agent-factory-service.js';
 import { GtmReviewProcessor } from './lead-engineer-gtm-review-processor.js';
 
@@ -64,6 +68,7 @@ export class LeadEngineerService {
   private agentFactoryService?: AgentFactoryService;
   private handoffService?: LeadHandoffService;
   private factStoreService?: FactStoreService;
+  private antagonisticReviewService?: IPlanReviewService;
 
   private worldStateBuilder: WorldStateBuilder;
   private sessionStore: LeadEngineerSessionStore;
@@ -113,6 +118,18 @@ export class LeadEngineerService {
   }
   setFactStoreService(s: FactStoreService): void {
     this.factStoreService = s;
+  }
+  setAntagonisticReviewService(s: IPlanReviewService): void {
+    this.antagonisticReviewService = s;
+  }
+
+  /**
+   * Returns true when the Lead Engineer has an active (running) session for the given project.
+   * Used by EM Agent to skip execution when Lead Engineer owns the lifecycle.
+   */
+  isActive(projectPath: string): boolean {
+    const session = this.sessions.get(projectPath);
+    return session?.flowState === 'running';
   }
 
   async initialize(): Promise<void> {
@@ -305,6 +322,7 @@ export class LeadEngineerService {
         settingsService: this.settingsService,
         factStoreService: this.factStoreService,
         leadHandoffService: this.handoffService,
+        antagonisticReviewService: this.antagonisticReviewService,
       };
 
       const workflowSettings = await getWorkflowSettings(

--- a/apps/server/src/services/lead-engineer-types.ts
+++ b/apps/server/src/services/lead-engineer-types.ts
@@ -27,6 +27,19 @@ export const REVIEW_POLL_DELAY_MS = 30 * 1000; // 30 seconds
 // ────────────────────────── Service Context ──────────────────────────
 
 /**
+ * Minimal interface for plan review — avoids circular imports with AntagonisticReviewService.
+ */
+export interface IPlanReviewService {
+  verifyPlan(params: {
+    featureTitle: string;
+    featureDescription: string;
+    complexity: string;
+    planOutput: string;
+    projectPath: string;
+  }): Promise<{ approved: boolean; reason?: string } | null>;
+}
+
+/**
  * Service context injected into state processors.
  * Provides access to real services without circular dependencies.
  */
@@ -41,6 +54,7 @@ export interface ProcessorServiceContext {
   settingsService?: SettingsService;
   factStoreService?: FactStoreService;
   leadHandoffService?: LeadHandoffService;
+  antagonisticReviewService?: IPlanReviewService;
 }
 
 // ────────────────────────── Feature State Machine Types ──────────────────────────


### PR DESCRIPTION
## Summary

Part of the **Wiring, Escalation & Hardening** epic.

- Adds `verifyPlan()` to `AntagonisticReviewService` with `IPlanReviewService` interface (decoupled injection, avoids circular imports)
- `PlanProcessor` now delegates to `antagonisticReviewService.verifyPlan()` with `simpleQuery()` fallback when service unavailable
- `LeadEngineerService`: adds `setAntagonisticReviewService()` setter and `isActive(projectPath)` method
- `EMAgent`: guards `scanForReadyFeatures()` — skips polling when Lead Engineer owns the lifecycle for the project
- Wires both in `wiring.ts`

## Test plan

- [x] `npm run build:server` — 0 new TS errors (2 pre-existing in wiring.ts unrelated to this feature)
- [x] `npm run test:server` — 2200 passed, 23 skipped
- [ ] Verify EM Agent skips scan when Lead Engineer session is active
- [ ] Verify PlanProcessor falls back to `simpleQuery()` when `antagonisticReviewService` not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced plan verification system with improved review workflow integration.
  * Better coordination between automated agent components to prevent duplicate processing during active sessions.
  * Strengthened review delegation mechanism for more intelligent plan evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->