### PR TITLE
feat(escalation): escalation dedup persistence and pipeline state drift fix

### DIFF
--- a/apps/server/src/services/escalation-router.ts
+++ b/apps/server/src/services/escalation-router.ts
@@ -11,6 +11,9 @@
  * - Audit log for signal history
  */
 
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
 import type { EscalationSignal, EscalationChannel } from '@protolabs-ai/types';
 import { EscalationSeverity } from '@protolabs-ai/types';
 import { createLogger } from '@protolabs-ai/utils';
@@ -49,6 +52,15 @@ interface DeduplicationEntry {
 }
 
 /**
+ * Persisted escalation store schema
+ */
+interface EscalationStoreData {
+  version: 1;
+  recentSignals: Array<{ key: string; timestamp: number }>;
+  savedAt: string;
+}
+
+/**
  * EscalationRouter manages signal routing and channel orchestration
  */
 export class EscalationRouter {
@@ -59,6 +71,69 @@ export class EscalationRouter {
   private events: EventEmitter | null = null;
   private deduplicationWindowMs: number = 30 * 60 * 1000; // 30 minutes
   private readonly MAX_LOG_ENTRIES = 1000;
+  private storePath: string | null = null;
+
+  /**
+   * Initialize the router with a file-backed dedup store.
+   * Loads previously persisted signals from disk so dedup windows survive restarts.
+   */
+  async initialize(storePath: string): Promise<void> {
+    this.storePath = storePath;
+    await this.loadStore();
+  }
+
+  /**
+   * Load persisted dedup state from disk.
+   */
+  private async loadStore(): Promise<void> {
+    if (!this.storePath) return;
+    try {
+      const content = await readFile(this.storePath, 'utf-8');
+      const data = JSON.parse(content) as EscalationStoreData;
+      if (data.version !== 1) {
+        logger.warn(`Escalation store version mismatch: expected 1, got ${data.version}`);
+        return;
+      }
+      const now = Date.now();
+      let loaded = 0;
+      for (const entry of data.recentSignals) {
+        if (now - entry.timestamp <= this.deduplicationWindowMs) {
+          this.recentSignals.set(entry.key, { key: entry.key, timestamp: entry.timestamp });
+          loaded++;
+        }
+      }
+      logger.info(`Escalation store loaded: ${loaded} active signals from ${this.storePath}`);
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        logger.info('No escalation store found at startup, starting fresh');
+      } else {
+        logger.error('Failed to load escalation store:', error);
+      }
+    }
+  }
+
+  /**
+   * Atomically persist current dedup state to disk.
+   */
+  private async persistStore(): Promise<void> {
+    if (!this.storePath) return;
+    const data: EscalationStoreData = {
+      version: 1,
+      recentSignals: Array.from(this.recentSignals.values()).map((e) => ({
+        key: e.key,
+        timestamp: e.timestamp,
+      })),
+      savedAt: new Date().toISOString(),
+    };
+    const tmpPath = `${this.storePath}.tmp`;
+    try {
+      await mkdir(dirname(this.storePath), { recursive: true });
+      await writeFile(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
+      await rename(tmpPath, this.storePath);
+    } catch (error) {
+      logger.error('Failed to persist escalation store:', error);
+    }
+  }
 
   /**
    * Set event emitter for listening to escalation signals
@@ -231,6 +306,7 @@ export class EscalationRouter {
       timestamp: Date.now(),
     });
     this.cleanupOldSignals();
+    void this.persistStore();
   }
 
   /**
@@ -322,6 +398,8 @@ export class EscalationRouter {
 
     logger.info(`Signal acknowledged: ${deduplicationKey} by ${acknowledgedBy}`);
 
+    void this.persistStore();
+
     if (this.events) {
       this.events.emit('escalation:acknowledged', {
         deduplicationKey,
@@ -391,11 +469,17 @@ export class EscalationRouter {
 let routerInstance: EscalationRouter | null = null;
 
 /**
- * Get or create the singleton escalation router instance
+ * Get or create the singleton escalation router instance.
+ * Auto-initializes the file-backed dedup store on first creation.
  */
 export function getEscalationRouter(): EscalationRouter {
   if (!routerInstance) {
     routerInstance = new EscalationRouter();
+    const dataDir = process.env.DATA_DIR || './data';
+    const storePath = join(dataDir, 'escalations.json');
+    routerInstance.initialize(storePath).catch((err) => {
+      logger.error('Failed to initialize escalation store:', err);
+    });
     logger.info('EscalationRouter instance created');
   }
   return routerInstance;

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -352,12 +352,33 @@ export class LeadEngineerService {
         );
         logger.info(`[LeadEngineer] Content feature routed to GtmReviewProcessor`, { featureId });
       }
-      const result = await stateMachine.processFeature(
-        feature,
-        projectPath,
-        options,
-        resumeFromCheckpoint
-      );
+      // Emit pipeline:phase-sync after each LE state transition so PipelineOrchestrator
+      // can keep the 9-phase model in sync with the Lead Engineer's actual progress.
+      const phaseSyncStates = new Set(['REVIEW', 'MERGE', 'DEPLOY', 'DONE']);
+      const unsubPipelineSync = this.events.subscribe((type: EventType, payload: unknown) => {
+        if (type !== ('pipeline:state-entered' as EventType)) return;
+        const p = payload as { featureId?: string; state?: string; fromState?: string } | null;
+        if (!p || p.featureId !== featureId || !p.state || !phaseSyncStates.has(p.state)) return;
+        this.events.emit('pipeline:phase-sync' as EventType, {
+          featureId,
+          projectPath,
+          fromState: p.fromState,
+          toState: p.state,
+          timestamp: new Date().toISOString(),
+        });
+      });
+
+      let result: Awaited<ReturnType<typeof stateMachine.processFeature>>;
+      try {
+        result = await stateMachine.processFeature(
+          feature,
+          projectPath,
+          options,
+          resumeFromCheckpoint
+        );
+      } finally {
+        unsubPipelineSync();
+      }
 
       logger.info(`[LeadEngineer] Feature processing completed`, {
         featureId,

--- a/apps/server/src/services/pipeline-orchestrator.ts
+++ b/apps/server/src/services/pipeline-orchestrator.ts
@@ -547,9 +547,41 @@ export class PipelineOrchestrator {
           logger.error('Error handling gtm-signal for pipeline:', err);
         });
       }
+
+      if (type === ('pipeline:phase-sync' as EventType)) {
+        this.handlePhaseSync(payload as Record<string, unknown>).catch((err) => {
+          logger.error('Error handling pipeline:phase-sync:', err);
+        });
+      }
     }) as EventCallback);
 
     this.unsubscribe = subscription.unsubscribe;
+  }
+
+  /**
+   * Handle a phase-sync event from the Lead Engineer state machine.
+   * Called when the LE transitions to REVIEW, MERGE, DEPLOY, or DONE.
+   * Advances the 9-phase pipeline model to stay in sync with actual progress.
+   */
+  private async handlePhaseSync(payload: Record<string, unknown>): Promise<void> {
+    const featureId = payload.featureId as string | undefined;
+    const projectPath = payload.projectPath as string | undefined;
+
+    if (!featureId || !projectPath) {
+      logger.warn('pipeline:phase-sync: missing featureId or projectPath, ignoring');
+      return;
+    }
+
+    const feature = await this.featureLoader.get(projectPath, featureId);
+    if (!feature?.pipelineState) {
+      logger.debug(`pipeline:phase-sync: feature ${featureId} has no pipeline state, skipping`);
+      return;
+    }
+
+    logger.info(
+      `pipeline:phase-sync: advancing pipeline for feature ${featureId} (LE→${payload.toState})`
+    );
+    await this.advancePhase(projectPath, featureId);
   }
 
   private async handleIdeaInjected(payload: Record<string, unknown>): Promise<void> {


### PR DESCRIPTION
## Summary

Part of the **Wiring, Escalation & Hardening** epic.

- **EscalationRouter file-backed dedup store** — replaces in-memory `Map` with `DATA_DIR/escalations.json`. Atomic write (tmp → rename) prevents corruption on crash. `initialize()` loads signals on startup, filtering expired ones — so a 30-min dedup window survives server restarts. `recordSignal()` and `acknowledgeSignal()` persist on every change (fire-and-forget, non-blocking).
- **LeadEngineerService pipeline:phase-sync** — during `processFeature()`, subscribes to `pipeline:state-entered` events from the state machine. Filters REVIEW/MERGE/DEPLOY/DONE transitions and re-emits as `pipeline:phase-sync`. Subscription is cleaned up in `finally` block.
- **PipelineOrchestrator handlePhaseSync** — listens for `pipeline:phase-sync` and calls `advancePhase()`, keeping the 9-phase UI model in sync with Lead Engineer actual progress.

## Test plan

- [x] TypeScript check on 3 modified files: zero errors
- [x] Pre-existing build errors (`@protolabs-ai/platform` p-limit) confirmed not introduced by this change
- [ ] Restart server mid-escalation — verify dedup window survives restart
- [ ] Trigger Lead Engineer EXECUTE→REVIEW transition — verify UI flow graph advances to correct phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Escalation deduplication state now persists across server restarts, improving consistency and reliability.
  * Pipeline phase synchronization enhanced to ensure features advance reliably through processing stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->