### PR TITLE
fix(server): normalize HUSKY=0 in worktree-recovery-service execEnv

### DIFF
--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -3697,3 +3697,15 @@ usageStats:
 - **Problem solved:** Some features are created via UI, not Linear, so have no linearIssueId. Gate approval still works but comments don't post to Linear.
 - **Why this works:** Ensures robustness: all features support gate holds regardless of source. Handler interface abstracts this difference. Prevents special-case logic throughout codebase.
 - **Trade-offs:** Silent failure for non-Linear features (no error, no comment). Benefits: clean abstraction, no caller logic needed.
+
+### Environment variables for git hooks must be set via the `env` object in execAsync/execFileAsync, not as shell command prefixes (2026-02-27)
+- **Context:** Setting HUSKY=0 to disable Husky hook execution in worktree commits
+- **Why:** The env object parameter ensures proper isolation and consistent behavior across different execution contexts (especially worktrees where shell behavior diverges from standard repos)
+- **Rejected:** Shell-based prefix approach: `HUSKY=0 git commit` in the command string itself
+- **Trade-offs:** env object is more verbose but more reliable; shell prefix is simpler syntactically but fails in worktree contexts
+- **Breaking if changed:** Switching back to shell prefix will cause hook execution to fail in worktrees because the variable won't propagate correctly
+
+#### [Pattern] Git commit operations from multiple code paths must all synchronize the same hook-disabling environment variable (HUSKY=0) (2026-02-27)
+- **Problem solved:** Three separate execution paths make commits: worktree-guard.ts, git-workflow-service.ts, and create-pr route in common.ts
+- **Why this works:** Any git commit path that misses HUSKY=0 will trigger hook failures; the inconsistency propagates as silent failures in specific workflows
+- **Trade-offs:** Distributed pattern is less refactorable but requires less code reorganization; the trade-off is higher maintenance cost when adding new commit paths

--- a/.automaker/memory/content-pipeline-validation.md
+++ b/.automaker/memory/content-pipeline-validation.md
@@ -5,7 +5,7 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 28
+  loaded: 30
   referenced: 2
   successfulFeatures: 2
 ---

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 545
-  referenced: 235
-  successfulFeatures: 235
+  loaded: 549
+  referenced: 236
+  successfulFeatures: 236
 ---
 # gotchas
 
@@ -467,3 +467,9 @@ usageStats:
 - **Situation:** GtmReviewProcessor.buildReviewPrompt() expects Cindi to output 'SCORE: N' but there's no enforcement that the template actually does this
 - **Root cause:** LLM outputs are inherently unstructured; parsing strings is simplest immediate approach but creates hidden dependency
 - **How to avoid:** Simple regex parsing vs brittleness; no executor changes needed vs fails silently if template format changes
+
+
+#### [Gotcha] Worktrees have different git hook semantics than regular repositories—standard git flags like --no-verify are not respected by Husky in worktrees (2026-02-27)
+- **Situation:** Initial attempts to use `git commit --no-verify` failed in worktrees; only HUSKY=0 environment variable worked
+- **Root cause:** Worktrees appear to use different git process execution or hook invocation mechanisms than standard repos, causing Husky to ignore standard git flags
+- **How to avoid:** Using HUSKY=0 is a complete hook disable rather than a selective bypass, but it's the only approach that works reliably in worktrees

--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -5,7 +5,7 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 83
+  loaded: 86
   referenced: 23
   successfulFeatures: 23
 ---

--- a/.automaker/memory/pattern.md
+++ b/.automaker/memory/pattern.md
@@ -5,7 +5,7 @@ relevantTo: [pattern]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 94
+  loaded: 95
   referenced: 40
   successfulFeatures: 40
 ---

--- a/.automaker/memory/persistence.md
+++ b/.automaker/memory/persistence.md
@@ -5,7 +5,7 @@ relevantTo: [persistence]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 8
+  loaded: 10
   referenced: 4
   successfulFeatures: 4
 ---

--- a/apps/server/src/services/worktree-recovery-service.ts
+++ b/apps/server/src/services/worktree-recovery-service.ts
@@ -39,7 +39,7 @@ const extendedPath = [process.env.PATH, ...additionalPaths.filter(Boolean)]
   .filter(Boolean)
   .join(pathSeparator);
 
-const execEnv = { ...process.env, PATH: extendedPath };
+const execEnv = { ...process.env, PATH: extendedPath, HUSKY: '0' };
 
 export interface WorktreeRecoveryResult {
   /** Whether any uncommitted changes were detected */


### PR DESCRIPTION
## Summary

- Adds `HUSKY: '0'` to the module-level `execEnv` constant in `worktree-recovery-service.ts` (line 42)
- Brings this file into line with `git-workflow-service.ts`, `worktree-guard.ts`, and `common.ts`, which all centralize `HUSKY: '0'` in their shared exec environment
- The existing per-call-site spread at line 138 remains as belt-and-suspenders documentation of intent

**Why this matters:** Three consecutive features (`k5yo1ccaq`, `dwtmmw3za`, `sl35xd5t4`) required manual rescue because git commits in worktrees silently fail without `HUSKY=0` (lint-staged tries to format `.worktrees/` which is excluded by `.prettierignore`, returns non-zero, reverts all staged changes). `WorktreeRecoveryService` is the last-resort rescue path — it must reliably bypass Husky to avoid leaving features in `blocked` with no automated recovery.

This was identified during investigation of Linear PRO-329 (filed 2026-02-27).

## Test plan

- [ ] `npm run build:server` passes (TypeScript only, no runtime change)
- [ ] No new lint errors in `worktree-recovery-service.ts`
- [ ] Agent commit flow in worktrees succeeds without manual intervention on next feature run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated worktree recovery service environment configuration to optimize git hook handling during command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->