### PR TITLE
chore: promote dev → staging (runner pin fix)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -11,7 +11,7 @@ permissions: read-all
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: [self-hosted, staging]
     if: github.repository == 'proto-labs-ai/protoMaker'
     timeout-minutes: 30
     concurrency:


### PR DESCRIPTION
## Promotion: dev → staging

Single commit follow-up to the main promotion (#1332):

- `fix(ci)`: pin deploy-staging to [self-hosted, staging] runner label (#1333)
  — without this, deploys that land on `protolabs-main` fail immediately with
  `ERROR: No .env found`. Gets the runner fix onto staging so the *next* deploy
  after this promotion uses the pinned runner.

**Merge strategy**: `--merge` (merge commit, not squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure configuration to enhance deployment handling and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->