### PR TITLE
chore: promote dev → staging (feature flags off by default)

### DIFF
--- a/apps/ui/src/hooks/use-settings-migration.ts
+++ b/apps/ui/src/hooks/use-settings-migration.ts
@@ -714,7 +714,7 @@ export function hydrateStoreFromSettings(settings: GlobalSettings): void {
     muteDoneSound: settings.muteDoneSound ?? false,
     serverLogLevel: settings.serverLogLevel ?? 'info',
     enableRequestLogging: settings.enableRequestLogging ?? true,
-    featureFlags: settings.featureFlags ?? { calendar: true, designs: true, docs: true },
+    featureFlags: settings.featureFlags ?? { calendar: false, designs: false, docs: false },
     keyboardShortcuts: {
       ...current.keyboardShortcuts,
       ...(settings.keyboardShortcuts as unknown as Partial<typeof current.keyboardShortcuts>),

--- a/apps/ui/src/hooks/use-settings-sync.ts
+++ b/apps/ui/src/hooks/use-settings-sync.ts
@@ -826,7 +826,7 @@ export async function refreshSettingsFromServer(): Promise<boolean> {
       lastProjectDir: serverSettings.lastProjectDir ?? '',
       recentFolders: serverSettings.recentFolders ?? [],
       eventHooks: serverSettings.eventHooks ?? [],
-      featureFlags: serverSettings.featureFlags ?? { calendar: true, designs: true, docs: true },
+      featureFlags: serverSettings.featureFlags ?? { calendar: false, designs: false, docs: false },
     });
 
     // Also refresh setup wizard state

--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -188,19 +188,19 @@ const DEFAULT_CODEX_ADDITIONAL_DIRS: string[] = [];
  * New features should start behind a flag until ready for general availability.
  */
 export interface FeatureFlags {
-  /** Calendar view in project sidebar (default: true in dev) */
+  /** Calendar view in project sidebar */
   calendar: boolean;
-  /** Designs/pen file viewer in project sidebar (default: true in dev) */
+  /** Designs/pen file viewer in project sidebar */
   designs: boolean;
-  /** Docs view in project sidebar (default: true in dev) */
+  /** Docs view in project sidebar */
   docs: boolean;
 }
 
-/** Default feature flags — all on in development, off in staging/production */
+/** Default feature flags — all off by default, opt-in per environment */
 export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
-  calendar: true,
-  designs: true,
-  docs: true,
+  calendar: false,
+  designs: false,
+  docs: false,
 };
 
 export interface GlobalSettings {


### PR DESCRIPTION
## Summary

- fix(settings): feature flags default to off (#1336) — calendar, designs, docs flags now default to `false` across all environments

## Merge strategy

Use `--merge` (merge commit). Do NOT squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default feature flag settings. Calendar, designs, and docs features are now disabled by default and can be enabled through user settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->