### PR TITLE
feat(mcp): HITL form + actionable item MCP tools (M2.3)

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1360,6 +1360,34 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         formId: args.formId,
       });
 
+    case 'list_pending_forms':
+      return apiCall('/hitl-forms/list', {
+        projectPath: args.projectPath,
+      });
+
+    case 'submit_form_response':
+      return apiCall('/hitl-forms/submit', {
+        formId: args.formId,
+        response: args.response,
+      });
+
+    case 'cancel_form':
+      return apiCall('/hitl-forms/cancel', {
+        formId: args.formId,
+      });
+
+    case 'list_actionable_items':
+      return apiCall('/actionable-items/list', {
+        projectPath: args.projectPath,
+        category: args.category,
+      });
+
+    case 'act_on_actionable_item':
+      return apiCall('/actionable-items/update-status', {
+        itemId: args.itemId,
+        action: args.action,
+      });
+
     // Idea Processing
     case 'process_idea':
       return apiCall('/authority/inject-idea', {

--- a/packages/mcp-server/src/tools/integration-tools.ts
+++ b/packages/mcp-server/src/tools/integration-tools.ts
@@ -216,4 +216,100 @@ export const integrationTools: Tool[] = [
       required: ['formId'],
     },
   },
+
+  {
+    name: 'list_pending_forms',
+    description:
+      'List all pending HITL form requests for a project. Returns form summaries with formId, title, featureId, and expiresAt.',
+    _meta: { avaOnly: true },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+
+  {
+    name: 'submit_form_response',
+    description:
+      'Programmatically submit a response to a pending HITL form. Allows Ava to answer form questions on behalf of the user, which resumes the waiting agent.',
+    _meta: { avaOnly: true },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        formId: {
+          type: 'string',
+          description: 'The form ID to submit a response for',
+        },
+        response: {
+          type: 'object',
+          description: 'The response data matching the form schema',
+        },
+      },
+      required: ['formId', 'response'],
+    },
+  },
+
+  {
+    name: 'cancel_form',
+    description: 'Cancel a pending HITL form request, dismissing it without a response.',
+    _meta: { avaOnly: true },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        formId: {
+          type: 'string',
+          description: 'The form ID to cancel',
+        },
+      },
+      required: ['formId'],
+    },
+  },
+
+  {
+    name: 'list_actionable_items',
+    description:
+      'List actionable items requiring attention, with optional filtering by project and category.',
+    _meta: { avaOnly: true },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory (optional filter)',
+        },
+        category: {
+          type: 'string',
+          description: 'Category filter (optional)',
+        },
+      },
+    },
+  },
+
+  {
+    name: 'act_on_actionable_item',
+    description:
+      'Update the status of an actionable item by acting on it, dismissing, or snoozing.',
+    _meta: { avaOnly: true },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        itemId: {
+          type: 'string',
+          description: 'The actionable item ID to update',
+        },
+        action: {
+          type: 'string',
+          enum: ['acted', 'dismissed', 'snoozed'],
+          description: 'The action to take on the item',
+        },
+      },
+      required: ['itemId', 'action'],
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

- Adds 5 new MCP tools for programmatic HITL control: `list_pending_forms`, `submit_form_response`, `cancel_form`, `list_actionable_items`, `act_on_actionable_item`
- Tool definitions added to `integration-tools.ts`
- Handler cases wired in `index.ts` routing to existing HTTP endpoints (`/hitl-forms/*`, `/actionable-items/*`)

Part of M2.3 — HITL Re-trigger + Programmatic API epic.

---
*Rescued by Ava — agent work recovered after git commit failure (pre-deploy of split git-add fix)*