### PR TITLE
feat: AvaConfig and Sitrep Modules

### DIFF
--- a/apps/server/src/routes/chat/ava-config.ts
+++ b/apps/server/src/routes/chat/ava-config.ts
@@ -1,0 +1,182 @@
+/**
+ * Ava Configuration — per-project config for Ava chat behaviour
+ *
+ * AvaConfig controls which capabilities are available, which model is used,
+ * and whether contextual data (sitrep, project context) is injected.
+ *
+ * Stored at {projectPath}/.automaker/ava-config.json.
+ * loadAvaConfig returns merged defaults when the file does not exist — no
+ * file is written on first load.  saveAvaConfig deep-merges a partial
+ * config and persists it.
+ */
+
+import path from 'path';
+import { createLogger } from '@protolabs-ai/utils';
+import { getAutomakerDir, ensureAutomakerDir } from '@protolabs-ai/platform';
+import * as secureFs from '../../lib/secure-fs.js';
+
+const logger = createLogger('AvaConfig');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Per-tool enable/disable flags for Ava.
+ * Each key represents a named tool capability.
+ */
+export interface AvaToolsConfig {
+  /** Full-text search across the project knowledge base */
+  knowledgeSearch: boolean;
+  /** Board / feature read access (list features, check status) */
+  readBoard: boolean;
+  /** Sitrep generation (generate and display a situation report) */
+  sitrep: boolean;
+  /** Web search capability */
+  webSearch: boolean;
+}
+
+/**
+ * Ava chat configuration stored per-project.
+ */
+export interface AvaConfig {
+  /** Claude model alias to use for Ava (e.g. "sonnet", "opus", "haiku") */
+  model: string;
+  /** Per-tool enable/disable flags */
+  tools: AvaToolsConfig;
+  /** When true, inject a situation report into the system prompt */
+  injectSitrep: boolean;
+  /** When true, inject project context (CLAUDE.md, context files) into the prompt */
+  injectContext: boolean;
+  /** Additional text appended to Ava's base system prompt (empty = no extension) */
+  systemPromptExtension: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Defaults
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Default configuration used when no per-project config file exists.
+ * All tools are enabled; model defaults to sonnet.
+ */
+export const DEFAULT_AVA_CONFIG: AvaConfig = {
+  model: 'sonnet',
+  tools: {
+    knowledgeSearch: true,
+    readBoard: true,
+    sitrep: true,
+    webSearch: true,
+  },
+  injectSitrep: true,
+  injectContext: true,
+  systemPromptExtension: '',
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// File path helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+function getAvaConfigPath(projectPath: string): string {
+  return path.join(getAutomakerDir(projectPath), 'ava-config.json');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Load AvaConfig for a project.
+ *
+ * Returns DEFAULT_AVA_CONFIG merged with any overrides present in the config
+ * file.  If the file does not exist the defaults are returned directly — the
+ * function never writes a file.
+ *
+ * @param projectPath - Absolute path to the project root
+ * @returns Resolved AvaConfig (always a complete object)
+ */
+export async function loadAvaConfig(projectPath: string): Promise<AvaConfig> {
+  const configPath = getAvaConfigPath(projectPath);
+
+  try {
+    const content = await secureFs.readFile(configPath, 'utf-8');
+    const parsed = JSON.parse(content as string) as Partial<AvaConfig>;
+
+    // Deep-merge: tools are merged separately to preserve all default keys
+    const mergedTools: AvaToolsConfig = {
+      ...DEFAULT_AVA_CONFIG.tools,
+      ...(parsed.tools ?? {}),
+    };
+
+    const merged: AvaConfig = {
+      ...DEFAULT_AVA_CONFIG,
+      ...parsed,
+      tools: mergedTools,
+    };
+
+    logger.debug(`Loaded ava-config from ${configPath}`);
+    return merged;
+  } catch (error: unknown) {
+    // File not found — return defaults without writing anything
+    if (isEnoentError(error)) {
+      logger.debug(`No ava-config at ${configPath}, using defaults`);
+      return { ...DEFAULT_AVA_CONFIG, tools: { ...DEFAULT_AVA_CONFIG.tools } };
+    }
+
+    // JSON parse errors or other I/O issues — log and fall back to defaults
+    logger.warn(`Failed to read ava-config at ${configPath}, using defaults:`, error);
+    return { ...DEFAULT_AVA_CONFIG, tools: { ...DEFAULT_AVA_CONFIG.tools } };
+  }
+}
+
+/**
+ * Save a (partial) AvaConfig for a project.
+ *
+ * The provided partial config is merged with the current on-disk config (or
+ * defaults if the file does not exist) and the result is written to disk.
+ *
+ * @param projectPath - Absolute path to the project root
+ * @param partial     - Partial config overrides to apply
+ * @returns The fully-resolved config that was written
+ */
+export async function saveAvaConfig(
+  projectPath: string,
+  partial: Partial<AvaConfig>
+): Promise<AvaConfig> {
+  // Ensure the .automaker directory exists before writing
+  await ensureAutomakerDir(projectPath);
+
+  // Load current config (may return defaults if file absent)
+  const current = await loadAvaConfig(projectPath);
+
+  // Merge tools separately for deep merge semantics
+  const mergedTools: AvaToolsConfig = {
+    ...current.tools,
+    ...(partial.tools ?? {}),
+  };
+
+  const merged: AvaConfig = {
+    ...current,
+    ...partial,
+    tools: mergedTools,
+  };
+
+  const configPath = getAvaConfigPath(projectPath);
+  await secureFs.writeFile(configPath, JSON.stringify(merged, null, 2), 'utf-8');
+  logger.info(`Saved ava-config to ${configPath}`);
+
+  return merged;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function isEnoentError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}

--- a/apps/server/src/routes/chat/sitrep.ts
+++ b/apps/server/src/routes/chat/sitrep.ts
@@ -1,0 +1,200 @@
+/**
+ * Sitrep — Situation Report generator for Ava
+ *
+ * getSitrep() produces a markdown situation report containing:
+ *   - Board counts by status (backlog / in_progress / review / done / blocked / interrupted)
+ *   - List of features currently in_progress or review
+ *   - Running agent feature IDs (from the persisted execution state)
+ *   - Auto-mode enabled / disabled status
+ *
+ * Results are cached per-projectPath with a 5-minute TTL.
+ * invalidateSitrep() clears the cache entry for a given projectPath immediately.
+ */
+
+import { createLogger } from '@protolabs-ai/utils';
+import { getExecutionStatePath } from '@protolabs-ai/platform';
+import type { ExecutionState, Feature } from '@protolabs-ai/types';
+import { FeatureLoader } from '../../services/feature-loader.js';
+import * as secureFs from '../../lib/secure-fs.js';
+
+const logger = createLogger('Sitrep');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cache
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface SitrepCacheEntry {
+  markdown: string;
+  /** Unix timestamp (ms) when the entry was populated */
+  cachedAt: number;
+}
+
+/** Module-level cache keyed by projectPath */
+const cache = new Map<string, SitrepCacheEntry>();
+
+/** TTL: 5 minutes */
+const TTL_MS = 5 * 60 * 1000;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Attempt to load the persisted execution state for a project.
+ * Returns null when the file does not exist or cannot be parsed.
+ */
+async function loadExecutionState(projectPath: string): Promise<ExecutionState | null> {
+  try {
+    const statePath = getExecutionStatePath(projectPath);
+    const content = await secureFs.readFile(statePath, 'utf-8');
+    return JSON.parse(content as string) as ExecutionState;
+  } catch {
+    // File absent or corrupt — not a fatal error
+    return null;
+  }
+}
+
+/**
+ * Build the markdown situation report string.
+ */
+async function buildSitrep(projectPath: string): Promise<string> {
+  // ── 1. Load features ──────────────────────────────────────────────────────
+  const loader = new FeatureLoader();
+  let features: Feature[] = [];
+
+  try {
+    features = await loader.getAll(projectPath);
+  } catch (error) {
+    logger.warn(`Failed to load features for sitrep (${projectPath}):`, error);
+  }
+
+  // ── 2. Board counts by status ─────────────────────────────────────────────
+  type StatusKey = 'backlog' | 'in_progress' | 'review' | 'done' | 'blocked' | 'interrupted';
+
+  const counts: Record<StatusKey, number> = {
+    backlog: 0,
+    in_progress: 0,
+    review: 0,
+    done: 0,
+    blocked: 0,
+    interrupted: 0,
+  };
+
+  for (const feature of features) {
+    const s = feature.status as string;
+    if (s && s in counts) {
+      counts[s as StatusKey]++;
+    }
+  }
+
+  // ── 3. Active features (in_progress + review) ─────────────────────────────
+  const activeFeatures = features.filter(
+    (f) => f.status === 'in_progress' || f.status === 'review'
+  );
+
+  // ── 4. Running agents + auto-mode from execution state ────────────────────
+  const executionState = await loadExecutionState(projectPath);
+  const runningFeatureIds: string[] = executionState?.runningFeatureIds ?? [];
+  const autoModeActive: boolean = executionState?.autoLoopWasRunning ?? false;
+
+  // ── 5. Compose markdown ───────────────────────────────────────────────────
+  const lines: string[] = [];
+
+  lines.push('# Situation Report');
+  lines.push('');
+
+  // Board counts table
+  lines.push('## Board');
+  lines.push('');
+  lines.push('| Status | Count |');
+  lines.push('|--------|------:|');
+  lines.push(`| Backlog | ${counts.backlog} |`);
+  lines.push(`| In Progress | ${counts.in_progress} |`);
+  lines.push(`| Review | ${counts.review} |`);
+  lines.push(`| Done | ${counts.done} |`);
+  if (counts.blocked > 0) {
+    lines.push(`| Blocked | ${counts.blocked} |`);
+  }
+  if (counts.interrupted > 0) {
+    lines.push(`| Interrupted | ${counts.interrupted} |`);
+  }
+  lines.push('');
+
+  // In-progress / review feature list
+  lines.push('## Active Features');
+  lines.push('');
+  if (activeFeatures.length === 0) {
+    lines.push('_No features currently in progress or review._');
+  } else {
+    for (const feature of activeFeatures) {
+      const statusLabel = feature.status === 'in_progress' ? '🔄 In Progress' : '👀 Review';
+      const title = feature.title ?? feature.id;
+      lines.push(`- **${title}** — ${statusLabel}`);
+    }
+  }
+  lines.push('');
+
+  // Running agents
+  lines.push('## Running Agents');
+  lines.push('');
+  if (runningFeatureIds.length === 0) {
+    lines.push('_No agents currently running._');
+  } else {
+    for (const featureId of runningFeatureIds) {
+      const feature = features.find((f) => f.id === featureId);
+      const title = feature?.title ?? featureId;
+      lines.push(`- **${title}** (\`${featureId}\`)`);
+    }
+  }
+  lines.push('');
+
+  // Auto-mode status
+  lines.push('## Auto-Mode');
+  lines.push('');
+  lines.push(`**Status:** ${autoModeActive ? '🟢 Running' : '⚪ Stopped'}`);
+
+  return lines.join('\n');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Return a markdown situation report for the given project.
+ *
+ * Results are cached per-projectPath with a 5-minute TTL.
+ *
+ * @param projectPath - Absolute path to the project root
+ * @returns Markdown string
+ */
+export async function getSitrep(projectPath: string): Promise<string> {
+  const now = Date.now();
+  const cached = cache.get(projectPath);
+
+  if (cached !== undefined && now - cached.cachedAt < TTL_MS) {
+    logger.debug(`Sitrep cache hit for ${projectPath}`);
+    return cached.markdown;
+  }
+
+  logger.debug(`Generating sitrep for ${projectPath}`);
+  const markdown = await buildSitrep(projectPath);
+
+  cache.set(projectPath, { markdown, cachedAt: now });
+  return markdown;
+}
+
+/**
+ * Invalidate (clear) the cached sitrep for a project.
+ *
+ * Call this whenever features or auto-mode state change so the next
+ * getSitrep() call returns fresh data.
+ *
+ * @param projectPath - Absolute path to the project root
+ */
+export function invalidateSitrep(projectPath: string): void {
+  const had = cache.delete(projectPath);
+  if (had) {
+    logger.debug(`Invalidated sitrep cache for ${projectPath}`);
+  }
+}


### PR DESCRIPTION
Creates per-project Ava configuration persistence and live board sitrep generation.

- :  interface,  (all tools enabled, sonnet),  (returns defaults when no file exists),  (merges partial config)
- :  with 5-min TTL module-level cache,  for event-driven invalidation. Generates markdown with board counts by status, in-progress/review feature titles, running agents, and auto-mode status.

Part of: Project-Scoped Ava Chat with Tool Execution

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-02-27T19:58:21.320Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-project Ava chat configuration system enabling customization of model selection, tool toggles (knowledge search, board reading, situation reports, web search), and system prompt extensions
  * Added Situation Report generator providing cached markdown summaries of project board status, active features, running agents, and auto-mode state
<!-- end of auto-generated comment: release notes by coderabbit.ai -->