### PR TITLE
docs: update Project Overview to protoMaker + blocked feature recovery

### DIFF
--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,7 +5,7 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 54
+  loaded: 55
   referenced: 25
   successfulFeatures: 25
 ---

--- a/.automaker/memory/documentation.md
+++ b/.automaker/memory/documentation.md
@@ -5,7 +5,7 @@ relevantTo: [documentation]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 69
+  loaded: 70
   referenced: 35
   successfulFeatures: 35
 ---

--- a/.automaker/memory/seo.md
+++ b/.automaker/memory/seo.md
@@ -5,7 +5,7 @@ relevantTo: [seo]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 2
+  loaded: 3
   referenced: 1
   successfulFeatures: 1
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,33 @@ See `docs/dev/branch-strategy.md` for the full strategy.
 
 - When continuing a previous session or autonomous loop, always check MCP server connectivity and board status FIRST before attempting any agent launches or API calls.
 
+## Blocked Feature Recovery
+
+When a feature blocks, check `statusChangeReason` immediately. Common patterns and fixes:
+
+**"uncommitted work in worktree" / commit failed:**
+The agent completed its work but the git workflow ran `git commit` without staging first. New files show as `??` (untracked) and modified files as ` M` in `git status`.
+
+Recovery:
+
+```bash
+git -C /path/to/.worktrees/<branch> add -A
+git -C /path/to/.worktrees/<branch> commit --no-verify -m "<feat/fix/refactor>: <title>"
+```
+
+Then use `create_pr_from_worktree` targeting `dev`, move feature to `review`, enable auto-merge on the PR.
+
+**Self-improvement rule:** When you observe a recurring failure pattern that blocks agents, you MUST immediately:
+
+1. File a P1 bug feature on the board describing the root cause and fix
+2. Add the pattern to `ops-lessons.md` in memory
+3. Add recovery steps here in CLAUDE.md
+
+Do not just recover and move on. The flywheel only improves if failures are captured.
+
 ## Project Overview
 
-Automaker is an autonomous AI development studio built as an npm workspace monorepo. It provides a Kanban-based workflow where AI agents (powered by Claude Agent SDK) implement features in isolated git worktrees.
+protoMaker is an autonomous AI development studio built as an npm workspace monorepo. It provides a Kanban-based workflow where AI agents (powered by Claude Agent SDK) implement features in isolated git worktrees. This repo is a fork of Automaker by protoLabs.studio — internal package names (`@protolabs-ai/*`), directory paths (`.automaker/`), and the internal codename "Automaker" are preserved in code and config.
 
 ## Brand Identity
 


### PR DESCRIPTION
## Summary

- Renames "Automaker" to "protoMaker" in the Project Overview section of CLAUDE.md (internal package/path references like `@protolabs-ai/*` and `.automaker/` remain unchanged)
- Adds `## Blocked Feature Recovery` section documenting the recurring git workflow bug (unstaged files = blocked feature) and the self-improvement rule requiring a P1 bug ticket when the pattern is observed
- Updates ops-lessons.md memory with the unstaged files pattern and bug ticket reference

## Test plan

- [ ] CLAUDE.md Project Overview reads "protoMaker" not "Automaker"
- [ ] Blocked Feature Recovery section present with recovery commands
- [ ] ops-lessons.md updated with ticket reference feature-1772222613583-kevenxfsk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Blocked Feature Recovery section with step-by-step recovery patterns and guidance for handling git-related "uncommitted work" situations.
  * Updated project naming and branding to reflect protoLabs Studio / protoMaker distinctions and clarified internal vs external naming.
  * Clarified that changes are documentation-only; no behavioral or API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->