### PR TITLE
feat(server): HITL response triggers pipeline resume (M3.2)

### DIFF
--- a/apps/server/src/services/hitl-form-service.ts
+++ b/apps/server/src/services/hitl-form-service.ts
@@ -426,6 +426,16 @@ export class HITLFormService {
           // No-op — caller polls via get()
           break;
         }
+        case 'lead_engineer': {
+          this.events.emit('lead-engineer:hitl-response', {
+            formId: form.id,
+            featureId: form.featureId,
+            projectPath: form.projectPath,
+            response: form.response,
+          });
+          logger.info(`Routed form response to lead engineer: feature=${form.featureId}`);
+          break;
+        }
       }
     } catch (error) {
       logger.error(`Failed to route response for form ${form.id}:`, error);

--- a/apps/server/src/services/lead-engineer-action-executor.ts
+++ b/apps/server/src/services/lead-engineer-action-executor.ts
@@ -264,6 +264,20 @@ export class ActionExecutor {
         });
         break;
       }
+
+      case 'update_feature': {
+        try {
+          await this.deps.featureLoader.update(
+            session.projectPath,
+            action.featureId,
+            action.updates as Record<string, unknown>
+          );
+          logger.info(`Updated feature ${action.featureId}:`, action.updates);
+        } catch (err) {
+          logger.error(`Failed to update feature ${action.featureId}:`, err);
+        }
+        break;
+      }
     }
   }
 

--- a/apps/server/src/services/lead-engineer-rules.ts
+++ b/apps/server/src/services/lead-engineer-rules.ts
@@ -451,6 +451,90 @@ export const classifiedRecovery: LeadFastPathRule = {
   },
 };
 
+/**
+ * hitlFormResponse — Handle lead_engineer HITL form responses.
+ * Routes retry/provide_context/skip/close responses to the appropriate actions.
+ */
+export const hitlFormResponse: LeadFastPathRule = {
+  name: 'hitlFormResponse',
+  description: 'HITL form response from lead_engineer caller → retry/provide_context/skip/close',
+  triggers: ['lead-engineer:hitl-response'],
+
+  evaluate(worldState, _eventType, payload): LeadRuleAction[] {
+    const event = payload as Record<string, unknown> | null;
+    if (!event) return [];
+
+    const featureId = event.featureId as string | undefined;
+    if (!featureId) return [];
+
+    const feature = worldState.features[featureId];
+    if (!feature) return [];
+
+    const response = event.response as Record<string, unknown>[] | undefined;
+    if (!response?.length) return [];
+
+    const step0 = response[0];
+    const action = step0.action as string | undefined;
+    if (!action) return [];
+
+    const ruleActions: LeadRuleAction[] = [];
+
+    switch (action) {
+      case 'retry': {
+        ruleActions.push({
+          type: 'update_feature',
+          featureId,
+          updates: {
+            failureCount: 0,
+            statusChangeReason: 'Retried via HITL form',
+          },
+        });
+        ruleActions.push({ type: 'move_feature', featureId, toStatus: 'backlog' });
+        break;
+      }
+
+      case 'provide_context': {
+        const context = step0.context as string | undefined;
+        ruleActions.push({
+          type: 'update_feature',
+          featureId,
+          updates: {
+            ...(context ? { description: context } : {}),
+            failureCount: 0,
+            statusChangeReason: 'Retried with additional context via HITL form',
+          },
+        });
+        ruleActions.push({ type: 'move_feature', featureId, toStatus: 'backlog' });
+        break;
+      }
+
+      case 'skip': {
+        ruleActions.push({
+          type: 'update_feature',
+          featureId,
+          updates: { statusChangeReason: 'Skipped via HITL form' },
+        });
+        ruleActions.push({ type: 'move_feature', featureId, toStatus: 'done' });
+        break;
+      }
+
+      case 'close': {
+        ruleActions.push({
+          type: 'update_feature',
+          featureId,
+          updates: { awaitingGatePhase: null },
+        });
+        break;
+      }
+
+      default:
+        break;
+    }
+
+    return ruleActions;
+  },
+};
+
 // ────────────────────────── Exports ──────────────────────────
 
 /** Default set of fast-path rules */
@@ -467,6 +551,7 @@ export const DEFAULT_RULES: LeadFastPathRule[] = [
   threadsBlocking,
   remediationStalled,
   classifiedRecovery,
+  hitlFormResponse,
 ];
 
 /**

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -317,6 +317,7 @@ export type EventType =
   | 'lead-engineer:rule-evaluated'
   | 'lead-engineer:project-completing'
   | 'lead-engineer:project-completed'
+  | 'lead-engineer:hitl-response'
   // Notes workspace events (agent-initiated tab mutations)
   | 'notes:tab-created'
   | 'notes:tab-deleted'
@@ -599,6 +600,12 @@ export interface EventPayloadMap {
   };
   'lead-engineer:project-completing': { projectPath: string; projectSlug: string };
   'lead-engineer:project-completed': { projectPath: string; projectSlug: string };
+  'lead-engineer:hitl-response': {
+    formId: string;
+    featureId?: string;
+    projectPath?: string;
+    response?: Record<string, unknown>[];
+  };
 
   // Linear sync conflict event (manual resolution required)
   'linear:sync:conflict': {

--- a/libs/types/src/hitl-form.ts
+++ b/libs/types/src/hitl-form.ts
@@ -8,7 +8,7 @@
 import type { SignalChannel, SignalMetadata } from './signal-channel.js';
 
 /** Who initiated the form request */
-export type HITLFormCallerType = 'agent' | 'flow' | 'api';
+export type HITLFormCallerType = 'agent' | 'flow' | 'api' | 'lead_engineer';
 
 /** Form lifecycle status */
 export type HITLFormStatus = 'pending' | 'submitted' | 'cancelled' | 'expired';

--- a/libs/types/src/lead-engineer.ts
+++ b/libs/types/src/lead-engineer.ts
@@ -115,7 +115,17 @@ export type LeadRuleAction =
   | { type: 'post_discord'; channelId: string; message: string }
   | { type: 'log'; level: 'info' | 'warn' | 'error'; message: string }
   | { type: 'escalate_llm'; reason: string; context: Record<string, unknown> }
-  | { type: 'project_completing' };
+  | { type: 'project_completing' }
+  | {
+      type: 'update_feature';
+      featureId: string;
+      updates: {
+        description?: string;
+        statusChangeReason?: string;
+        failureCount?: number;
+        awaitingGatePhase?: null;
+      };
+    };
 
 // ────────────────────────── Fast-Path Rules ──────────────────────────
 


### PR DESCRIPTION
## Summary
- New lead engineer rule handles `hitl:form-responded` events where `callerType='lead_engineer'`
- Routes HITL resolution options back into the pipeline: retry / provide_context / skip / close
- `HITLFormService` updated to accept `'lead_engineer'` callerType and emit `lead-engineer:hitl-response` on the event bus
- Completes the loop: EscalateProcessor (M3.1) creates the form, this PR handles the response

## Resolution Options Wired
- **retry** — resets feature to backlog, clears failure count
- **provide_context** — injects user text into feature description, resets to backlog
- **skip** — moves feature to done with a note
- **close** — keeps blocked, clears `awaitingGatePhase`

## Changes
- `apps/server/src/services/lead-engineer-rules.ts` — new `HitlResponseRule`
- `apps/server/src/services/lead-engineer-action-executor.ts` — action handlers for all 4 resolution paths
- `apps/server/src/services/hitl-form-service.ts` — accept `lead_engineer` callerType + event emission
- `libs/types/src/hitl-form.ts` — `lead_engineer` added to callerType union
- `libs/types/src/lead-engineer.ts` — new event type `lead-engineer:hitl-response`
- `libs/types/src/event.ts` — new event registration

## Part of
Epic: ESCALATE to Structured HITL — M3.2