### PR TITLE
fix: stage all files before commit in git workflow service

### DIFF
--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -306,11 +306,14 @@ export class GitWorkflowService {
         `Saving agent progress for feature ${feature.id} (${status.trim().split('\n').length} files changed)`
       );
 
-      // Stage all changes (same pattern as commitChanges)
-      await execAsync("git add -A -- ':!.automaker/' '.automaker/memory/' '.automaker/skills/'", {
+      // Stage all changes (same pattern as commitChanges).
+      // Split into two calls: a single combined exclude+include pathspec silently stages
+      // nothing when the include paths have no changes (they restrict the -A match set).
+      await execAsync("git add -A -- ':(exclude).automaker/'", { cwd: workDir, env: execEnv });
+      await execAsync("git add '.automaker/memory/' '.automaker/skills/'", {
         cwd: workDir,
         env: execEnv,
-      });
+      }).catch(() => {});
 
       // Format staged files before committing
       try {
@@ -324,13 +327,11 @@ export class GitWorkflowService {
             `npx prettier --ignore-path /dev/null --write ${files.map((f) => `"${f}"`).join(' ')}`,
             { cwd: workDir, env: execEnv }
           );
-          await execAsync(
-            "git add -A -- ':!.automaker/' '.automaker/memory/' '.automaker/skills/'",
-            {
-              cwd: workDir,
-              env: execEnv,
-            }
-          );
+          await execAsync("git add -A -- ':(exclude).automaker/'", { cwd: workDir, env: execEnv });
+          await execAsync("git add '.automaker/memory/' '.automaker/skills/'", {
+            cwd: workDir,
+            env: execEnv,
+          }).catch(() => {});
         }
       } catch {
         // Non-fatal: formatting failure shouldn't block progress save
@@ -967,11 +968,14 @@ export class GitWorkflowService {
     const title = feature.title || extractTitleFromDescription(feature.description);
     const commitMessage = `feat: ${title}\n\nImplemented by Automaker auto-mode\nFeature ID: ${feature.id}`;
 
-    // Stage all changes - include .automaker/memory/ but exclude other .automaker/ files
-    await execAsync("git add -A -- ':!.automaker/' '.automaker/memory/' '.automaker/skills/'", {
+    // Stage all changes - include .automaker/memory/ and skills/ but exclude other .automaker/.
+    // Split into two calls: a single combined exclude+include pathspec silently stages
+    // nothing when the include paths have no changes (they restrict the -A match set).
+    await execAsync("git add -A -- ':(exclude).automaker/'", { cwd: workDir, env: execEnv });
+    await execAsync("git add '.automaker/memory/' '.automaker/skills/'", {
       cwd: workDir,
       env: execEnv,
-    });
+    }).catch(() => {});
 
     // Auto-format staged files before committing (matches CI prettier behavior)
     try {
@@ -989,10 +993,11 @@ export class GitWorkflowService {
           }
         );
         // Re-stage after formatting
-        await execAsync("git add -A -- ':!.automaker/' '.automaker/memory/' '.automaker/skills/'", {
+        await execAsync("git add -A -- ':(exclude).automaker/'", { cwd: workDir, env: execEnv });
+        await execAsync("git add '.automaker/memory/' '.automaker/skills/'", {
           cwd: workDir,
           env: execEnv,
-        });
+        }).catch(() => {});
         logger.debug(`Auto-formatted ${files.length} staged files`);
       }
     } catch (fmtError) {
@@ -1202,10 +1207,11 @@ export class GitWorkflowService {
       if (!status.trim()) return; // No formatting changes needed
 
       // Stage and amend
-      await execAsync("git add -A -- ':!.automaker/' '.automaker/memory/' '.automaker/skills/'", {
+      await execAsync("git add -A -- ':(exclude).automaker/'", { cwd: workDir, env: execEnv });
+      await execAsync("git add '.automaker/memory/' '.automaker/skills/'", {
         cwd: workDir,
         env: execEnv,
-      });
+      }).catch(() => {});
       await execAsync('git commit --no-verify --amend --no-edit', { cwd: workDir, env: execEnv });
       logger.info(`Formatted and amended last commit (${files.length} files checked)`);
     } catch (error) {


### PR DESCRIPTION
## Summary

- Splits `git add -A -- ':!.automaker/'` into two separate calls to correctly stage all modified and untracked files
- Previously, pathspec exclusion was silently restricting `-A` rather than augmenting it, causing agents' new untracked files to never be committed
- Root cause of the blocked-feature retry storm (P1 bug automaker-4kj)

Replaces #1359 (which had unresolvable `.automaker/` conflicts from the original branch base).

## Test plan
- [ ] CI passes
- [ ] After merge, agents should correctly commit new untracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved git file staging logic in the workflow service with enhanced pathspec handling and error resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->