### PR TITLE
fix: increment failureCount on git workflow failure to prevent retry storm

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3974,17 +3974,16 @@ Format your response as a structured markdown document.`;
             }
           } else {
             // Guard: if the feature was blocked due to a git commit / workflow failure,
-            // don't immediately re-enqueue it — that would recreate the retry storm.
-            // After MAX_GIT_COMMIT_RETRIES repeated failures, leave it blocked and require
-            // human intervention to fix the hook issue (e.g. .prettierignore, Husky config).
+            // don't re-enqueue it — that would recreate the retry storm. A git workflow
+            // failure is not a transient dependency issue, so satisfying deps doesn't fix it.
+            // Human intervention is required (e.g. fix .prettierignore, Husky config).
             const changeReason = feature.statusChangeReason ?? '';
             const isGitWorkflowBlock =
               changeReason.includes('git commit') || changeReason.includes('git workflow failed');
-            const MAX_GIT_COMMIT_RETRIES = 3;
-            if (isGitWorkflowBlock && (feature.failureCount ?? 0) >= MAX_GIT_COMMIT_RETRIES) {
+            if (isGitWorkflowBlock) {
               logger.warn(
                 `[loadPendingFeatures] Feature ${feature.id} skipping dep-unblock — ` +
-                  `blocked after ${feature.failureCount} git commit failures. Requires human intervention.`
+                  `blocked after ${feature.failureCount ?? 0} git workflow failure(s). Requires human intervention.`
               );
               continue;
             }

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -753,6 +753,7 @@ export class ExecutionService {
             await this.featureLoader.update(projectPath, featureId, {
               status: 'blocked',
               statusChangeReason: reason,
+              failureCount: (feature.failureCount ?? 0) + 1,
             });
             this.events.emit('feature:error', {
               projectPath,


### PR DESCRIPTION
## Summary

- Increments `failureCount` when blocking a feature due to git workflow failure
- Auto-mode dep-unblock guard now fires on first git failure (not after 3)
- Prevents the blocked→backlog→in_progress loop (80+ transitions/min observed 2026-02-27)

Replaces #1364 (conflicting base). Companion to #1362 (root cause fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)