### PR TITLE
fix(tests): update provider-factory test count for Groq (4 → 5)

### DIFF
--- a/apps/server/tests/unit/providers/provider-factory.test.ts
+++ b/apps/server/tests/unit/providers/provider-factory.test.ts
@@ -166,9 +166,9 @@ describe('provider-factory.ts', () => {
       expect(hasClaudeProvider).toBe(true);
     });
 
-    it('should return exactly 4 providers', () => {
+    it('should return exactly 5 providers', () => {
       const providers = ProviderFactory.getAllProviders();
-      expect(providers).toHaveLength(4);
+      expect(providers).toHaveLength(5);
     });
 
     it('should include CursorProvider', () => {
@@ -206,7 +206,8 @@ describe('provider-factory.ts', () => {
       expect(keys).toContain('cursor');
       expect(keys).toContain('codex');
       expect(keys).toContain('opencode');
-      expect(keys).toHaveLength(4);
+      expect(keys).toContain('groq');
+      expect(keys).toHaveLength(5);
     });
 
     it('should include cursor status', async () => {


### PR DESCRIPTION
## Summary

- Updates hardcoded provider count assertions from 4 → 5 to account for `GroqProvider` added in PR #1352
- Adds `groq` to the expected provider name keys assertion
- Unblocks PR #1362, #1365, #1366 which are failing CI due to this stale test

## Root Cause

`provider-factory.test.ts` hardcoded exact counts that weren't updated when Groq was registered in `provider-factory.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for groq as an additional provider option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->