### PR TITLE
fix(tests): sync CI test expectations with current service behavior

### DIFF
--- a/apps/server/tests/unit/providers/provider-factory.test.ts
+++ b/apps/server/tests/unit/providers/provider-factory.test.ts
@@ -4,6 +4,7 @@ import { ClaudeProvider } from '@/providers/claude-provider.js';
 import { CursorProvider } from '@/providers/cursor-provider.js';
 import { CodexProvider } from '@/providers/codex-provider.js';
 import { OpencodeProvider } from '@/providers/opencode-provider.js';
+import { GroqProvider } from '@/providers/groq-provider.js';
 
 describe('provider-factory.ts', () => {
   let consoleSpy: any;
@@ -11,6 +12,7 @@ describe('provider-factory.ts', () => {
   let detectCursorSpy: any;
   let detectCodexSpy: any;
   let detectOpencodeSpy: any;
+  let detectGroqSpy: any;
 
   beforeEach(() => {
     consoleSpy = {
@@ -30,6 +32,9 @@ describe('provider-factory.ts', () => {
     detectOpencodeSpy = vi
       .spyOn(OpencodeProvider.prototype, 'detectInstallation')
       .mockResolvedValue({ installed: true });
+    detectGroqSpy = vi
+      .spyOn(GroqProvider.prototype, 'detectInstallation')
+      .mockResolvedValue({ installed: true });
   });
 
   afterEach(() => {
@@ -38,6 +43,7 @@ describe('provider-factory.ts', () => {
     detectCursorSpy.mockRestore();
     detectCodexSpy.mockRestore();
     detectOpencodeSpy.mockRestore();
+    detectGroqSpy.mockRestore();
   });
 
   describe('getProviderForModel', () => {
@@ -166,9 +172,9 @@ describe('provider-factory.ts', () => {
       expect(hasClaudeProvider).toBe(true);
     });
 
-    it('should return exactly 4 providers', () => {
+    it('should return exactly 5 providers', () => {
       const providers = ProviderFactory.getAllProviders();
-      expect(providers).toHaveLength(4);
+      expect(providers).toHaveLength(5);
     });
 
     it('should include CursorProvider', () => {
@@ -206,7 +212,8 @@ describe('provider-factory.ts', () => {
       expect(keys).toContain('cursor');
       expect(keys).toContain('codex');
       expect(keys).toContain('opencode');
-      expect(keys).toHaveLength(4);
+      expect(keys).toContain('groq');
+      expect(keys).toHaveLength(5);
     });
 
     it('should include cursor status', async () => {

--- a/apps/server/tests/unit/services/worktree-recovery-service.test.ts
+++ b/apps/server/tests/unit/services/worktree-recovery-service.test.ts
@@ -63,9 +63,7 @@ describe('worktree-recovery-service', () => {
       mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
       // npx prettier
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // git add -A -- ':(exclude).automaker/'
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // git add '.automaker/memory/' (non-fatal second call)
+      // git add -A -- ':!.automaker/' '.automaker/memory/' '.automaker/skills/'
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit (execFile)
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
@@ -92,9 +90,7 @@ describe('worktree-recovery-service', () => {
       mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
       // git diff HEAD (for prettier formatting)
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // git add -A -- ':(exclude).automaker/'
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // git add '.automaker/memory/' (non-fatal second call)
+      // git add -A -- ':!.automaker/' '.automaker/memory/' '.automaker/skills/'
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit (execFile) fails
       mockExecFile.mockRejectedValueOnce(new Error('nothing to commit, working tree clean'));
@@ -111,9 +107,7 @@ describe('worktree-recovery-service', () => {
       mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
       // git diff HEAD
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // git add -A -- ':(exclude).automaker/'
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // git add '.automaker/memory/' (non-fatal second call)
+      // git add -A -- ':!.automaker/' '.automaker/memory/' '.automaker/skills/'
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit succeeds
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
@@ -134,9 +128,7 @@ describe('worktree-recovery-service', () => {
       mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
       // npx prettier fails (non-fatal)
       mockExec.mockRejectedValueOnce(new Error('prettier not found'));
-      // git add -A -- ':(exclude).automaker/'
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // git add '.automaker/memory/' (non-fatal second call)
+      // git add -A -- ':!.automaker/' '.automaker/memory/' '.automaker/skills/'
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit succeeds
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });


### PR DESCRIPTION
## Summary

- **provider-factory.test.ts**: Groq provider was added (commit d5aaf0fc) but test still expected 4 providers. Updated to expect 5, added GroqProvider spy and `'groq'` key assertion.
- **worktree-recovery-service.test.ts**: Dev test had 2 git-add mocks but the service only makes 1 combined `git add` call. Extra mock shifted all subsequent mocks by one, causing `gh pr create` to receive `''` instead of the PR URL.

## Impact

Fixes CI failures that block the `dev → staging` promotion (PR #1360) and all other PRs based on `dev`.

## Test plan
- [ ] CI passes (both failing test suites now match service behavior)
- [ ] PR #1360 (dev → staging) can be re-run and should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)