### PR TITLE
fix(tests): prevent settings-service test dir collision in parallel CI

### DIFF
--- a/apps/server/tests/unit/services/settings-service.test.ts
+++ b/apps/server/tests/unit/services/settings-service.test.ts
@@ -21,8 +21,9 @@ describe('settings-service.ts', () => {
   let settingsService: SettingsService;
 
   beforeEach(async () => {
-    testDataDir = path.join(os.tmpdir(), `settings-test-${Date.now()}`);
-    testProjectDir = path.join(os.tmpdir(), `project-test-${Date.now()}`);
+    const uid = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    testDataDir = path.join(os.tmpdir(), `settings-test-${uid}`);
+    testProjectDir = path.join(os.tmpdir(), `project-test-${uid}`);
     await fs.mkdir(testDataDir, { recursive: true });
     await fs.mkdir(testProjectDir, { recursive: true });
     settingsService = new SettingsService(testDataDir);


### PR DESCRIPTION
## Summary

- `beforeEach` in `settings-service.test.ts` used `Date.now()` alone for temp dir uniqueness
- Vitest's parallel worker threads can hit the same millisecond, causing two tests to share a directory and bleed state
- Adds a `Math.random()` suffix to guarantee uniqueness under concurrent execution

This fixes the intermittent CI failure pattern: `expected 'dark' to be 'light'` / `expected 'K' to be 'B'` depending on run order.

## Test plan
- [ ] CI passes consistently across multiple runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)