### PR TITLE
feat(ui): chat store and hook — project scoping

### DIFF
--- a/apps/ui/src/hooks/use-chat-session.ts
+++ b/apps/ui/src/hooks/use-chat-session.ts
@@ -15,9 +15,18 @@ interface UseChatSessionOptions {
   defaultModel?: string;
   /** Extra body data sent with every chat request (e.g. notes context) */
   body?: Record<string, unknown>;
+  /** Absolute path of the current project, sent in transport body */
+  projectPath?: string;
+  /** Project ID used to scope sessions */
+  projectId?: string;
 }
 
-export function useChatSession({ defaultModel = 'sonnet', body }: UseChatSessionOptions = {}) {
+export function useChatSession({
+  defaultModel = 'sonnet',
+  body,
+  projectPath,
+  projectId,
+}: UseChatSessionOptions = {}) {
   const {
     sessions,
     currentSessionId,
@@ -27,6 +36,7 @@ export function useChatSession({ defaultModel = 'sonnet', body }: UseChatSession
     saveMessages,
     updateModel,
     getCurrentSession,
+    getSessionsForProject,
     historyOpen,
     toggleHistory,
     setHistoryOpen,
@@ -35,8 +45,20 @@ export function useChatSession({ defaultModel = 'sonnet', body }: UseChatSession
   const currentSession = getCurrentSession();
   const modelAlias = currentSession?.modelAlias ?? defaultModel;
 
+  // Filter sessions by projectId when provided
+  const visibleSessions = useMemo(
+    () => (projectId ? getSessionsForProject(projectId) : sessions),
+    [projectId, getSessionsForProject, sessions]
+  );
+
   // Track session switch to avoid saving stale messages
   const activeSessionRef = useRef(currentSessionId);
+
+  // Merge projectPath into transport body
+  const transportBody = useMemo(
+    () => ({ ...body, ...(projectPath !== undefined ? { projectPath } : {}) }),
+    [body, projectPath]
+  );
 
   // AI SDK v6 requires transport instead of api/headers/body
   const transport = useMemo(
@@ -44,9 +66,9 @@ export function useChatSession({ defaultModel = 'sonnet', body }: UseChatSession
       new DefaultChatTransport({
         api: '/api/chat',
         headers: { 'x-model-alias': modelAlias },
-        body,
+        body: transportBody,
       }),
-    [modelAlias, body]
+    [modelAlias, transportBody]
   );
 
   const { messages, sendMessage, stop, status, setMessages, error } = useChat({
@@ -77,10 +99,10 @@ export function useChatSession({ defaultModel = 'sonnet', body }: UseChatSession
   }, [currentSessionId, getCurrentSession, setMessages]);
 
   const handleNewChat = useCallback(() => {
-    const session = createSession(modelAlias);
+    const session = createSession(modelAlias, projectId);
     setMessages([]);
     activeSessionRef.current = session.id;
-  }, [createSession, modelAlias, setMessages]);
+  }, [createSession, modelAlias, projectId, setMessages]);
 
   const handleSwitchSession = useCallback(
     (id: string) => {
@@ -109,16 +131,16 @@ export function useChatSession({ defaultModel = 'sonnet', body }: UseChatSession
     [currentSessionId, updateModel]
   );
 
-  // Ensure there's always a session
+  // Ensure there's always a session (scoped to project when projectId provided)
   useEffect(() => {
-    if (!currentSessionId || !sessions.find((s) => s.id === currentSessionId)) {
-      if (sessions.length > 0) {
-        switchSession(sessions[0].id);
+    if (!currentSessionId || !visibleSessions.find((s) => s.id === currentSessionId)) {
+      if (visibleSessions.length > 0) {
+        switchSession(visibleSessions[0].id);
       } else {
-        createSession(defaultModel);
+        createSession(defaultModel, projectId);
       }
     }
-  }, [currentSessionId, sessions, switchSession, createSession, defaultModel]);
+  }, [currentSessionId, visibleSessions, switchSession, createSession, defaultModel, projectId]);
 
   return {
     // Chat state
@@ -130,7 +152,7 @@ export function useChatSession({ defaultModel = 'sonnet', body }: UseChatSession
     setMessages,
 
     // Session management
-    sessions,
+    sessions: visibleSessions,
     currentSessionId,
     currentSession,
     modelAlias,

--- a/apps/ui/src/store/chat-store.ts
+++ b/apps/ui/src/store/chat-store.ts
@@ -18,6 +18,7 @@ export interface ChatSession {
   id: string;
   title: string;
   modelAlias: string;
+  projectId: string;
   messages: UIMessage[];
   createdAt: number; // epoch ms (serializable)
   updatedAt: number;
@@ -35,7 +36,7 @@ interface ChatStoreState {
 }
 
 interface ChatActions {
-  createSession: (modelAlias?: string) => ChatSession;
+  createSession: (modelAlias?: string, projectId?: string) => ChatSession;
   deleteSession: (id: string) => void;
   switchSession: (id: string) => void;
   saveMessages: (id: string, messages: UIMessage[]) => void;
@@ -45,6 +46,7 @@ interface ChatActions {
   toggleHistory: () => void;
   setChatModalOpen: (open: boolean) => void;
   getCurrentSession: () => ChatSession | null;
+  getSessionsForProject: (projectId: string) => ChatSession[];
 }
 
 // ============================================================================
@@ -83,12 +85,13 @@ export const useChatStore = create<ChatStoreState & ChatActions>()(
       historyOpen: false,
       chatModalOpen: false,
 
-      createSession: (modelAlias = 'sonnet') => {
+      createSession: (modelAlias = 'sonnet', projectId = 'default') => {
         const now = Date.now();
         const session: ChatSession = {
           id: generateId(),
           title: 'New chat',
           modelAlias,
+          projectId,
           messages: [],
           createdAt: now,
           updatedAt: now,
@@ -153,10 +156,25 @@ export const useChatStore = create<ChatStoreState & ChatActions>()(
         const state = get();
         return state.sessions.find((s) => s.id === state.currentSessionId) ?? null;
       },
+
+      getSessionsForProject: (projectId) => {
+        return get().sessions.filter((s) => s.projectId === projectId);
+      },
     }),
     {
       name: 'ava-chat-sessions',
-      version: 1,
+      version: 2,
+      migrate: (persistedState, version) => {
+        const state = persistedState as ChatStoreState;
+        if (version < 2) {
+          // Set projectId: 'default' on all existing sessions missing it
+          state.sessions = state.sessions.map((s) => ({
+            ...s,
+            projectId: s.projectId ?? 'default',
+          }));
+        }
+        return state;
+      },
       // Only persist sessions and currentSessionId, not UI state
       partialize: (state) => ({
         sessions: state.sessions,


### PR DESCRIPTION
## Summary

- Add  to  interface in chat-store.ts
-  now accepts optional , stored on the session
-  selector returns only sessions for a given project
- Zustand persist version bumped 1→2 with migration (existing sessions get )
-  options accept  and ;  forwarded in transport body; sessions filtered by  when provided

## Test plan
- [ ] CI passes
- [ ] Existing sessions in localStorage auto-migrate to 
- [ ] Switching projects shows only that project's sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-02-27T22:57:11.262Z -->