### PR TITLE
fix(auto-mode): branch worktrees from origin/dev, not HEAD

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3629,8 +3629,10 @@ Format your response as a structured markdown document.`;
           env: gitEnv,
         });
       } else {
-        // Determine base branch: use epic branch if feature belongs to an epic
-        let baseBranch = 'HEAD';
+        // Determine base branch: use epic branch if feature belongs to an epic,
+        // otherwise use origin/dev as the canonical base (never HEAD which would
+        // inherit whatever branch is currently checked out in the main repo).
+        let baseBranch = 'origin/dev';
         if (feature?.epicId && !feature.isEpic) {
           try {
             const epicFeature = await this.featureLoader.get(projectPath, feature.epicId);

--- a/apps/server/src/services/worktree-recovery-service.ts
+++ b/apps/server/src/services/worktree-recovery-service.ts
@@ -159,7 +159,7 @@ export async function checkAndRecoverUncommittedWork(
       );
 
     const { stdout: prOutput } = await execAsync(
-      `gh pr create --base main --head "${branchName}" --title "${prTitle}" --body "${prBody.replace(/\n/g, '\\n')}"`,
+      `gh pr create --base dev --head "${branchName}" --title "${prTitle}" --body "${prBody.replace(/\n/g, '\\n')}"`,
       { cwd: worktreePath, env: execEnv }
     );
 


### PR DESCRIPTION
## Summary

Two root-cause fixes for the recurring "uncommitted work in worktree" agent failures and PR history divergence.

**Fix 1: Worktree base branch** (`auto-mode-service.ts`)
- Changed `let baseBranch = 'HEAD'` → `let baseBranch = 'origin/dev'`
- New worktrees were inheriting commits from whatever branch was checked out in the main repo (often a session branch with diverged history), causing agents to find files already in the expected state and produce nothing-to-commit failures
- All feature branches must base from `origin/dev`

**Fix 2: Recovery PR target** (`worktree-recovery-service.ts`)  
- Changed `--base main` → `--base dev` in `gh pr create` call
- Recovery PRs must target `dev` per our three-branch strategy; targeting `main` directly would bypass CI and promotion gates

## Test plan
- [ ] New worktrees created by auto-mode should base from `origin/dev` commit
- [ ] Recovery PRs (post-agent uncommitted work) target `dev`, not `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)