### PR TITLE
feat(ui): full-screen /chat route + Chat nav in MobileBottomNav and Sidebar

### DIFF
--- a/apps/ui/src/components/layout/mobile-bottom-nav.tsx
+++ b/apps/ui/src/components/layout/mobile-bottom-nav.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useRouterState } from '@tanstack/react-router';
-import { Grid, BarChart3, FileText, Settings } from 'lucide-react';
+import { Grid, BarChart3, FileText, Settings, MessageCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useIsMobile } from '@/hooks/use-media-query';
 
@@ -13,6 +13,7 @@ interface NavItem {
 const navItems: NavItem[] = [
   { id: 'board', icon: Grid, label: 'Board', path: '/board' },
   { id: 'analytics', icon: BarChart3, label: 'Analytics', path: '/analytics' },
+  { id: 'chat', icon: MessageCircle, label: 'Chat', path: '/chat' },
   { id: 'notes', icon: FileText, label: 'Notes', path: '/notes' },
   { id: 'settings', icon: Settings, label: 'Settings', path: '/settings' },
 ];

--- a/apps/ui/src/components/layout/sidebar/hooks/use-navigation.ts
+++ b/apps/ui/src/components/layout/sidebar/hooks/use-navigation.ts
@@ -16,6 +16,7 @@ import {
   Palette,
   CalendarDays,
   FolderOpen,
+  MessageCircle,
 } from 'lucide-react';
 import type { NavSection, NavItem } from '../types';
 import type { KeyboardShortcut } from '@/hooks/use-keyboard-shortcuts';
@@ -161,6 +162,11 @@ export function useNavigation({
 
     // Build project items - Terminal, Calendar, Designs are conditionally included
     const projectItems: NavItem[] = [
+      {
+        id: 'chat',
+        label: 'Ava',
+        icon: MessageCircle,
+      },
       {
         id: 'analytics',
         label: 'System View',

--- a/apps/ui/src/routes/chat.tsx
+++ b/apps/ui/src/routes/chat.tsx
@@ -1,0 +1,29 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useAppStore } from '@/store/app-store';
+import { useChatSession } from '@/hooks/use-chat-session';
+import { ChatOverlayContent } from '@/components/views/chat-overlay/chat-overlay-content';
+
+function ChatPage() {
+  const navigate = useNavigate();
+  const currentProject = useAppStore((s) => s.currentProject);
+
+  const chatSession = useChatSession({
+    defaultModel: 'sonnet',
+    projectPath: currentProject?.path,
+    projectId: currentProject?.id,
+  });
+
+  const handleHide = () => {
+    navigate({ to: '/' });
+  };
+
+  return (
+    <div className="h-full">
+      <ChatOverlayContent {...chatSession} onHide={handleHide} />
+    </div>
+  );
+}
+
+export const Route = createFileRoute('/chat')({
+  component: ChatPage,
+});


### PR DESCRIPTION
## Summary
- Add  TanStack Router route rendering  fullscreen, wired to  with  for project-scoped sessions
- Add Chat tab (MessageCircle icon) to  navigating to 
- Add Ava nav item (MessageCircle icon) to sidebar via  hook; auto-highlights on  route

## Test plan
- [ ] CI passes
- [ ]  route renders ChatOverlayContent without error
- [ ] MobileBottomNav shows Chat tab on mobile viewports
- [ ] Sidebar shows Ava nav item, highlights when on /chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-02-28T00:39:18.818Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat option has been added to the mobile bottom navigation menu
  * New Chat navigation item integrated into the sidebar's Project section
  * New dedicated chat page is now accessible through the updated application navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->