### PR TITLE
fix(ci): bump deploy-staging timeout to 60min + enable BuildKit [HOTFIX]

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -13,7 +13,7 @@ jobs:
   deploy:
     runs-on: [self-hosted, staging]
     if: github.repository == 'proto-labs-ai/protoMaker'
-    timeout-minutes: 30
+    timeout-minutes: 60
     concurrency:
       group: staging-deploy
       cancel-in-progress: false
@@ -115,6 +115,8 @@ jobs:
         working-directory: ${{ env.DEPLOY_DIR }}
         env:
           GIT_COMMIT_SHA: ${{ github.sha }}
+          DOCKER_BUILDKIT: 1
+          COMPOSE_DOCKER_CLI_BUILD: 1
         run: |
           # setup-staging.sh --build isolates storybook from critical services.
           # If storybook fails to build, the script continues (non-fatal).


### PR DESCRIPTION
Staging has been down 2h due to Docker build timing out at 30min.

- timeout-minutes: 30 → 60
- DOCKER_BUILDKIT=1 + COMPOSE_DOCKER_CLI_BUILD=1

Needs to reach staging ASAP to unblock the deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved staging deployment reliability by increasing deployment timeout allowance.
  * Optimized build performance through enhanced Docker build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->