### PR TITLE
promote: staging → main (v0.9.0 — chat routes, provider settings, deploy fixes)

### DIFF
--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,7 +5,7 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 183
+  loaded: 202
   referenced: 74
   successfulFeatures: 74
 ---

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,7 +5,7 @@ relevantTo: [architecture]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 55
+  loaded: 56
   referenced: 25
   successfulFeatures: 25
 ---

--- a/.automaker/memory/content-pipeline-validation.md
+++ b/.automaker/memory/content-pipeline-validation.md
@@ -5,7 +5,7 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 34
+  loaded: 37
   referenced: 2
   successfulFeatures: 2
 ---

--- a/.automaker/memory/cost-optimization.md
+++ b/.automaker/memory/cost-optimization.md
@@ -5,7 +5,7 @@ relevantTo: [cost-optimization]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 23
+  loaded: 24
   referenced: 11
   successfulFeatures: 11
 ---

--- a/.automaker/memory/documentation.md
+++ b/.automaker/memory/documentation.md
@@ -5,7 +5,7 @@ relevantTo: [documentation]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 70
+  loaded: 75
   referenced: 35
   successfulFeatures: 35
 ---

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,7 +5,7 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 559
+  loaded: 593
   referenced: 236
   successfulFeatures: 236
 ---

--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -5,7 +5,7 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 89
+  loaded: 108
   referenced: 23
   successfulFeatures: 23
 ---

--- a/.automaker/memory/pattern.md
+++ b/.automaker/memory/pattern.md
@@ -5,7 +5,7 @@ relevantTo: [pattern]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 95
+  loaded: 104
   referenced: 40
   successfulFeatures: 40
 ---

--- a/.automaker/memory/testing.md
+++ b/.automaker/memory/testing.md
@@ -5,11 +5,10 @@ relevantTo: [testing]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 52
+  loaded: 55
   referenced: 25
   successfulFeatures: 25
 ---
-
 # testing
 
 #### [Pattern] Test .gitignore patterns by creating actual files and running `git check-ignore`, then verify via integration test that the file appears in `git status` (2026-02-10)

--- a/.automaker/skills/mcp-integration-patterns.md
+++ b/.automaker/skills/mcp-integration-patterns.md
@@ -1,0 +1,199 @@
+---
+name: mcp-integration-patterns
+emoji: 🔌
+description: How to add MCP tools to the Automaker MCP server — tool definition, handler registration, error handling, and testing patterns.
+metadata:
+  author: agent
+  created: 2026-02-25T00:00:00.000Z
+  usageCount: 0
+  successRate: 0
+  tags: [mcp, api, tools, integration, typescript]
+  source: learned
+---
+
+# MCP Integration Patterns
+
+How to add, structure, and test MCP tools in the Automaker MCP server (`packages/mcp-server/`). Includes the NEVER direct API calls rule.
+
+---
+
+## ⛔ NEVER Make Direct API Calls
+
+**NEVER use `curl`, `fetch`, or `axios` directly against the Automaker server.** Always use MCP tools (`mcp__plugin_automaker_automaker__*`).
+
+```bash
+# ❌ WRONG — bypasses auth, error handling, and path resolution
+curl -X POST http://localhost:3008/features/list \
+  -H "Authorization: Bearer $AUTOMAKER_API_KEY" \
+  -d '{"projectPath": "/path/to/project"}'
+
+# ✅ CORRECT — use the MCP tool
+mcp__plugin_automaker_automaker__list_features({ projectPath: "/path/to/project" })
+```
+
+**Why?**
+- MCP handles `AUTOMAKER_API_KEY` automatically (from plugin's `.env`)
+- MCP returns structured responses; curl returns raw JSON/HTML
+- When the API key rotates, MCP picks it up; hardcoded curl breaks
+- If no MCP tool exists for an operation → that's a feature gap, create the tool
+
+---
+
+## MCP Tool Structure
+
+Each tool is defined as a `Tool` object (from `@modelcontextprotocol/sdk/types.js`) with a JSON Schema `inputSchema`.
+
+### Tool Definition (JSON Schema Format)
+
+```typescript
+// packages/mcp-server/src/tools/my-tools.ts
+
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+export const myTools: Tool[] = [
+  {
+    name: 'my_tool_name',
+    description:
+      'Clear description of what this tool does. Mention return shape. ' +
+      'Used by agents to do X, Y, Z.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        featureId: {
+          type: 'string',
+          description: 'The feature ID (UUID)',
+        },
+        options: {
+          type: 'object',
+          description: 'Optional configuration (optional)',
+          properties: {
+            dryRun: { type: 'boolean', description: 'Simulate without making changes' },
+          },
+        },
+      },
+      required: ['projectPath', 'featureId'],   // ← list ALL required fields
+    },
+  },
+];
+```
+
+### Handler Function
+
+The handler lives in `packages/mcp-server/src/index.ts` as a case in the `handleTool` switch:
+
+```typescript
+// In handleTool(name, args):
+case 'my_tool_name': {
+  const result = await apiCall('/my-endpoint/action', {
+    projectPath: args.projectPath as string,
+    featureId: args.featureId as string,
+    options: args.options as Record<string, unknown> | undefined,
+  });
+  return result;
+}
+```
+
+---
+
+## Error Handling Pattern
+
+All handlers must return a consistent error shape so callers can detect failures programmatically.
+
+### Standard Error Response
+
+```typescript
+// ✅ Correct error response
+return { success: false, error: 'Human-readable error description' };
+
+// ✅ Success with data
+return { success: true, featureId: 'abc-123', status: 'done' };
+
+// ✅ Richer error with context
+return {
+  success: false,
+  error: `Feature ${featureId} not found in project ${projectPath}`,
+  code: 'FEATURE_NOT_FOUND',
+};
+```
+
+> **Note:** `apiCall()` retries automatically (3× with backoff) for 5xx/network errors. Wrap in try/catch for non-retryable cases and return `{ success: false, error: e.message }`.
+
+---
+
+## How to Add a New Tool to the Registry
+
+Follow these 4 steps exactly:
+
+### Step 1 — Create or extend a tools file
+
+Create `packages/mcp-server/src/tools/my-tools.ts` (see [MCP Tool Structure](#mcp-tool-structure) above for the exact format).
+
+### Step 2 — Import + Register in index.ts
+
+```typescript
+// ~line 163 in packages/mcp-server/src/index.ts:
+import { myTools } from './tools/my-tools.js';
+
+// In the tools array:
+const tools: Tool[] = [...featureTools, ...agentTools, ...myTools];
+```
+
+### Step 3 — Add the handler case
+
+```typescript
+// In handleTool(name, args) switch statement:
+case 'my_new_tool':
+  return apiCall('/my-endpoint/action', {
+    projectPath: args.projectPath,
+    // ... other args
+  });
+```
+
+### Step 5 — Rebuild
+
+```bash
+# After modifying packages/mcp-server/src/:
+npm run build:packages
+```
+
+The new tool will appear as `mcp__plugin_automaker_automaker__my_new_tool` in Claude Code after the MCP server restarts.
+
+The `apiCall()` helper (defined in `index.ts`) calls the Automaker REST API. Base URL: `AUTOMAKER_API_URL` env var (default: `http://localhost:3008`). Auth: `Authorization: Bearer ${AUTOMAKER_API_KEY}`.
+
+> **Two .env files:** `automaker/.env` has dev server vars; `packages/mcp-server/plugins/automaker/.env` has MCP plugin vars (`AUTOMAKER_API_KEY`, `AUTOMAKER_API_URL`). Never reference `~/.secrets/`.
+
+---
+
+## Testing MCP Tools
+
+```bash
+# After changes: rebuild, start dev, then call in Claude Code:
+npm run build:packages && npm run dev
+mcp__plugin_automaker_automaker__my_new_tool({ projectPath: "/path/to/project" })
+
+# Debug underlying API directly (dev only):
+source packages/mcp-server/plugins/automaker/.env
+curl -s -X POST http://localhost:3008/my-endpoint/action \
+  -H "Authorization: Bearer $AUTOMAKER_API_KEY" -H "Content-Type: application/json" \
+  -d '{"projectPath": "/Users/kj/dev/automaker"}' | jq
+```
+
+Handler logic is thin (`apiCall` wrappers) — prefer integration testing via MCP. For complex logic, add unit tests in `packages/mcp-server/src/__tests__/`.
+
+---
+
+## Anti-Patterns Summary
+
+| Anti-Pattern | Consequence | Fix |
+|---|---|---|
+| Direct `curl`/`fetch` to Automaker API | Auth fails after key rotation; no retry | Use `mcp__plugin_automaker_automaker__*` tools |
+| No error response shape | Callers can't detect failure programmatically | Return `{ success: false, error: string }` |
+| Hardcoding `http://localhost:3008` in tools | Breaks in staging/production | Use `apiCall()` — it reads `AUTOMAKER_API_URL` |
+| Adding tool definition but not the handler case | Tool is listed but throws "Unknown tool" | Always add both definition + case in handleTool |
+| Forgetting `npm run build:packages` after changes | MCP client still sees old tool list | Rebuild + restart MCP server |
+| Accessing `~/.secrets/` for credentials | Path doesn't exist | Use `.env` files at project/plugin level |
+| Creating a new API route without an MCP wrapper | Feature accessible only via curl | Always pair new routes with an MCP tool |

--- a/.automaker/skills/monorepo-patterns.md
+++ b/.automaker/skills/monorepo-patterns.md
@@ -1,0 +1,197 @@
+---
+name: monorepo-patterns
+emoji: 🏗️
+description: Comprehensive monorepo patterns for the Automaker project — build order, import conventions, package dependency chain, and adding new packages.
+metadata:
+  author: agent
+  created: 2026-02-25T00:00:00.000Z
+  usageCount: 0
+  successRate: 0
+  tags: [build, monorepo, typescript, packages, imports]
+  source: learned
+---
+
+# Monorepo Patterns
+
+Complete reference for working in the Automaker monorepo. Covers build order, dependency chain, import conventions, TypeScript workspace resolution, and adding new packages.
+
+---
+
+## Package Dependency Chain
+
+Packages MUST only depend on packages above them in the chain. Violating this creates circular imports that break the build.
+
+```
+@protolabs-ai/types            ← no dependencies, foundation for everything
+         ↓
+@protolabs-ai/utils
+@protolabs-ai/prompts
+@protolabs-ai/platform
+@protolabs-ai/model-resolver
+@protolabs-ai/dependency-resolver
+@protolabs-ai/spec-parser
+         ↓
+@protolabs-ai/git-utils        ← depends on types + utils
+         ↓
+@protolabs-ai/mcp-server       ← depends on all above (lives in packages/)
+         ↓
+apps/server                    ← depends on all above
+apps/ui                        ← depends on @protolabs-ai/types only (browser-safe)
+```
+
+> **Note:** `@protolabs-ai/mcp-server` lives in `packages/` not `libs/`. It IS included in `build:packages`.
+
+---
+
+## Build Order
+
+**Always build packages before server.** Building out of order causes stale types, missing exports, and agent failures.
+
+```bash
+# Step 1 — build all shared packages (libs/* + packages/mcp-server)
+npm run build:packages
+
+# Step 2 — build server (requires packages to be built first)
+npm run build:server
+
+# Or build everything in one command (runs in correct order)
+npm run build
+```
+
+### When to Rebuild
+
+| Trigger | Required Action |
+|---------|----------------|
+| Modified any file in `libs/*` | `npm run build:packages` |
+| Modified `packages/mcp-server` | `npm run build:packages` |
+| Added/changed MCP tools | `npm run build:packages` |
+| Types PR merged | `npm run build:packages` immediately |
+| Agent reports wrong method signatures | Rebuild packages (stale dist) |
+| Before starting an agent | `npm run build:packages` (if packages changed recently) |
+
+---
+
+## Import Conventions
+
+**Always import from `@protolabs-ai/*` workspace packages. Never use relative paths that cross package boundaries.**
+
+### ✅ Correct Imports
+
+```typescript
+// Types from the shared types package
+import type { Feature, AgentStatus, BoardColumn } from '@protolabs-ai/types';
+
+// Utilities from shared utils
+import { createLogger, sleep, formatDate } from '@protolabs-ai/utils';
+
+// Git operations
+import { getChangedFiles, createWorktree } from '@protolabs-ai/git-utils';
+
+// Model resolution
+import { resolveModel } from '@protolabs-ai/model-resolver';
+
+// Prompts
+import { buildSystemPrompt } from '@protolabs-ai/prompts';
+```
+
+### ❌ Incorrect Imports (Anti-Patterns)
+
+```typescript
+// WRONG: relative path crossing package boundary
+import { Feature } from '../../libs/types/src/feature';
+import { createLogger } from '../../../libs/utils/src/logger';
+
+// WRONG: importing from another app's source
+import { featureLoader } from '../../server/src/services/feature-loader';
+
+// WRONG: importing from dist/ directly
+import { Feature } from '../../../libs/types/dist/index';
+
+// WRONG: bypassing workspace resolution
+import type { Feature } from '/Users/kj/dev/automaker/libs/types/src/types';
+```
+
+---
+
+## TypeScript Workspace Resolution
+
+The monorepo uses TypeScript project references (`tsconfig.json` with `composite: true`). This enables:
+- Incremental builds
+- Cross-package type checking
+- Go-to-definition across packages
+
+### How Resolution Works
+
+```
+apps/server/tsconfig.json
+  └── references: [{ path: "../../libs/types" }, { path: "../../libs/utils" }, ...]
+
+libs/types/tsconfig.json
+  └── compilerOptions.composite: true
+  └── compilerOptions.declarationMap: true   ← enables go-to-source (not dist)
+```
+
+Each shared package sets `"main": "./dist/index.js"` and `"exports"` in its `package.json`. When you `import from '@protolabs-ai/types'`, Node resolves to `dist/index.js`. **If dist is stale, you get old types.**
+
+---
+
+## Adding a New Shared Package
+
+Follow these steps exactly. Missing any step causes workspace link failures or build order issues.
+
+### Step 1 — Create the Package Directory: `mkdir -p libs/my-package/src`
+
+### Step 2 — Create package.json
+
+```json
+{
+  "name": "@protolabs-ai/my-package",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc --build",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@protolabs-ai/types": "*"
+  }
+}
+```
+
+### Step 3 — Create tsconfig.json
+
+Extend `../../tsconfig.base.json` with `composite: true`, `declarationMap: true`, `outDir: ./dist`, and reference any packages this one depends on.
+
+### Step 4 — Register in Root
+
+In root `package.json`:
+1. Add `"libs/my-package"` to the `workspaces` array
+2. Add `npm run build -w @protolabs-ai/my-package` to `build:packages` **after** its dependencies
+
+### Step 5 — Install and Verify
+
+```bash
+npm install          # links workspace symlinks
+npm run build:packages   # verify it builds
+```
+
+---
+
+## Anti-Patterns Summary
+
+| Anti-Pattern | Why It Fails | Fix |
+|---|---|---|
+| `build:server` without `build:packages` first | Stale types from old dist | Always run `build:packages` first |
+| Relative imports across package boundaries | Breaks when packages move; no workspace resolution | Use `@protolabs-ai/*` imports |
+| Adding `@protolabs-ai/server` dep to a lib | Circular dependency | Only depend on packages higher in the chain |
+| Forgetting `composite: true` in tsconfig | Project references break | Always add it to lib tsconfigs |
+| Not running `npm install` after adding package | Workspace symlink missing | Run `npm install` from root after adding a package |
+| `process.env` at module level in shared packages | Crashes browser (no `process` in browser) | Guard with `typeof process !== 'undefined'` |

--- a/.automaker/skills/worktree-patterns.md
+++ b/.automaker/skills/worktree-patterns.md
@@ -1,0 +1,200 @@
+---
+name: worktree-patterns
+emoji: 🌳
+description: Safe patterns for git worktrees — NEVER cd into worktrees, prettier fix, pre-flight rebase, stale detection and recovery.
+metadata:
+  author: agent
+  created: 2026-02-25T00:00:00.000Z
+  usageCount: 0
+  successRate: 0
+  tags: [git, worktree, safety, prettier, rebase]
+  source: learned
+---
+
+# Worktree Patterns
+
+Critical rules and exact commands for working safely with git worktrees in Automaker. Violating these rules can break the session, cause data loss, or corrupt worktree state.
+
+---
+
+## ⛔ NEVER `cd` Into a Worktree
+
+This is the most dangerous operation. If you `cd` into a worktree path and the worktree is later removed (`git worktree remove`), the **Bash tool permanently breaks for the entire session**. Every subsequent Bash call fails with:
+
+```
+ENOENT: no such file or directory, posix_spawn '/bin/sh'
+```
+
+This also kills: Task subagents, all hooks (stop hook, safety guard), any shell spawning.
+**Session restart is the ONLY fix.**
+
+### ✅ Use `git -C` Instead
+
+```bash
+# Check status in a worktree — SAFE
+git -C /Users/kj/dev/automaker/.worktrees/my-branch status --short
+
+# View recent commits — SAFE
+git -C /Users/kj/dev/automaker/.worktrees/my-branch log --oneline -5
+
+# View diff — SAFE
+git -C /Users/kj/dev/automaker/.worktrees/my-branch diff
+
+# Stage specific files — SAFE
+git -C /Users/kj/dev/automaker/.worktrees/my-branch add src/server/routes/foo.ts
+
+# Commit — SAFE
+git -C /Users/kj/dev/automaker/.worktrees/my-branch commit -m "feat: add foo route"
+```
+
+### ✅ Use Absolute Paths for Read/Write Tools
+
+The `Read`, `Write`, `Edit`, `Grep`, and `Glob` tools work fine with absolute paths — no `cd` needed:
+
+```bash
+# These work without any cd:
+# Read:  /Users/kj/dev/automaker/.worktrees/my-branch/src/server/index.ts
+# Write: /Users/kj/dev/automaker/.worktrees/my-branch/src/server/new-file.ts
+# Grep:  path=/Users/kj/dev/automaker/.worktrees/my-branch
+```
+
+---
+
+## Prettier in Worktrees
+
+Running `prettier` in a worktree directory fails to pick up the root `.prettierignore` (which references paths relative to the project root). This causes prettier to try formatting files it should skip.
+
+### ✅ Required Fix: `--ignore-path /dev/null`
+
+```bash
+# CORRECT: disable .prettierignore lookup when formatting worktree files
+cd /Users/kj/dev/automaker/.worktrees/my-branch && \
+  npx prettier --write --ignore-path /dev/null src/ && \
+  cd /Users/kj/dev/automaker
+
+# Format a single file in a worktree
+cd /Users/kj/dev/automaker/.worktrees/my-branch && \
+  npx prettier --write --ignore-path /dev/null src/server/routes/foo.ts && \
+  cd /Users/kj/dev/automaker
+```
+
+> **Why `--ignore-path /dev/null`?** The `.prettierignore` in the main repo has paths like `dist/`, `node_modules/`, `.automaker/`. When prettier runs from the worktree directory, those relative paths may resolve differently or fail. Using `/dev/null` skips the ignore file entirely — format exactly what you specify.
+
+> **Always `cd` back** to `/Users/kj/dev/automaker` immediately after running prettier in a worktree.
+
+---
+
+## Pre-Flight Rebase Before Agent Starts
+
+Before an agent begins work in a worktree, always sync it with the base branch to avoid merge conflicts mid-feature.
+
+### ✅ Standard Pre-Flight Sequence
+
+```bash
+# 1. Fetch latest from origin
+git -C /Users/kj/dev/automaker/.worktrees/my-branch fetch origin
+
+# 2. Rebase onto the base branch (usually dev or main)
+git -C /Users/kj/dev/automaker/.worktrees/my-branch rebase origin/dev
+
+# 3. Verify clean state
+git -C /Users/kj/dev/automaker/.worktrees/my-branch status --short
+```
+
+If there are no conflicts, status should show empty output (clean tree).
+
+### Handling Rebase Conflicts
+
+```bash
+# If rebase fails due to conflicts:
+git -C /Users/kj/dev/automaker/.worktrees/my-branch rebase --abort
+
+# Report the conflict — do NOT attempt to resolve automatically
+# The agent should surface this to the orchestrator as a blocker
+```
+
+---
+
+## Checking for Uncommitted Work
+
+Before creating, switching, or removing worktrees, always verify uncommitted work:
+
+```bash
+# Check for unstaged/staged/untracked changes — empty output = clean
+git -C /Users/kj/dev/automaker/.worktrees/my-branch status --short
+
+# Check if there are commits not pushed to remote
+git -C /Users/kj/dev/automaker/.worktrees/my-branch log origin/my-branch..HEAD --oneline
+
+# Check if worktree has ANY local changes vs base branch
+git -C /Users/kj/dev/automaker/.worktrees/my-branch diff origin/dev --stat
+```
+
+---
+
+## Stale Worktree Detection and Recovery
+
+A worktree becomes "stale" if its branch was deleted on the remote, or if the worktree directory was removed without `git worktree remove`.
+
+### Detect Stale Worktrees
+
+```bash
+# List all worktrees and their state
+git worktree list
+
+# Check for prunable (stale/orphan) worktrees
+git worktree prune --dry-run
+```
+
+Output showing `prunable` means the worktree is stale:
+```
+Removing worktrees/my-old-branch: gitdir file points to non-existent location
+```
+
+### Recover from Stale Worktree
+
+```bash
+# Remove stale entries from .git/worktrees/ metadata
+git worktree prune
+
+# Verify cleanup
+git worktree list
+```
+
+### Recover from Accidentally Deleted Worktree Directory
+
+If the worktree directory was deleted without `git worktree remove`:
+
+```bash
+# Prune the dangling ref
+git worktree prune
+
+# Re-create if needed
+git worktree add .worktrees/my-branch my-branch
+```
+
+---
+
+## Safe Worktree Lifecycle
+
+```bash
+git worktree add .worktrees/feature-foo feature/foo            # from existing branch
+git worktree add -b feature/new-thing .worktrees/x origin/dev  # new branch from dev
+git worktree list                                               # list all
+git worktree remove .worktrees/feature-foo                     # clean remove
+git worktree remove --force .worktrees/feature-foo             # force (uncommitted ok)
+```
+
+---
+
+## Anti-Patterns Summary
+
+| Anti-Pattern | Consequence | Fix |
+|---|---|---|
+| `cd .worktrees/my-branch` | Breaks Bash permanently if worktree removed | Use `git -C <path>` or absolute paths |
+| `npx prettier --write .` from worktree dir | Wrong ignore paths; may format dist/ or .automaker/ | Add `--ignore-path /dev/null` |
+| Starting agent without rebase | Mid-feature merge conflicts, wasted work | Always `fetch` + `rebase origin/dev` first |
+| `git worktree remove` with uncommitted work | Data loss | Check `git status --short` first |
+| `git checkout <branch>` in main repo | Modifies `.automaker/features/` on disk → data loss | Use worktrees or `git -C <wt> checkout` |
+| `git add -A` in main repo | Captures runtime files (.automaker/, .beads/) | Use `git add <specific-files>` |
+| Not `cd`-ing back after worktree commands | Next Bash call starts in wrong directory | Always return: `&& cd /Users/kj/dev/automaker` |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -13,7 +13,7 @@ jobs:
   deploy:
     runs-on: [self-hosted, staging]
     if: github.repository == 'proto-labs-ai/protoMaker'
-    timeout-minutes: 30
+    timeout-minutes: 60
     concurrency:
       group: staging-deploy
       cancel-in-progress: false
@@ -115,6 +115,8 @@ jobs:
         working-directory: ${{ env.DEPLOY_DIR }}
         env:
           GIT_COMMIT_SHA: ${{ github.sha }}
+          DOCKER_BUILDKIT: 1
+          COMPOSE_DOCKER_CLI_BUILD: 1
         run: |
           # setup-staging.sh --build isolates storybook from critical services.
           # If storybook fails to build, the script continues (non-fatal).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,18 @@ git -C /path/to/.worktrees/<branch> commit --no-verify -m "<feat/fix/refactor>: 
 
 Then use `create_pr_from_worktree` targeting `dev`, move feature to `review`, enable auto-merge on the PR.
 
+**Prettier check fails in CI but passes locally (worktree path masking):**
+Files in `.worktrees/` are excluded by `.prettierignore`. When you run `npx prettier --check` with an absolute path like `/path/to/.worktrees/branch/file.ts`, prettier silently skips the file due to the ignore pattern — reporting success even if the file has issues.
+
+To correctly check a file in a worktree, bypass the ignore file:
+
+```bash
+npx prettier --check /abs/path/to/worktree/file.ts --ignore-path /dev/null
+npx prettier --write /abs/path/to/worktree/file.ts --ignore-path /dev/null
+```
+
+Then commit and push the fix.
+
 **Self-improvement rule:** When you observe a recurring failure pattern that blocks agents, you MUST immediately:
 
 1. File a P1 bug feature on the board describing the root cause and fix

--- a/apps/server/src/lib/git-staging-utils.ts
+++ b/apps/server/src/lib/git-staging-utils.ts
@@ -1,0 +1,27 @@
+/**
+ * Git Staging Utilities — shared helpers for staging files in worktrees.
+ *
+ * Centralises the pathspec-safe "git add" command so that all call sites
+ * (worktree-guard, git-workflow-service, worktree-recovery-service) use
+ * the same logic and the behaviour is covered by a single test suite.
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Builds a git add command that stages all changes except .automaker/,
+ * then re-includes .automaker/memory/ and .automaker/skills/ only if those
+ * directories exist in the working tree. This prevents a fatal pathspec error
+ * when a directory is absent (e.g. in a fresh worktree).
+ */
+export function buildGitAddCommand(workDir: string): string {
+  const parts = ["git add -A -- ':!.automaker/'"];
+  if (existsSync(join(workDir, '.automaker/memory'))) {
+    parts.push("'.automaker/memory/'");
+  }
+  if (existsSync(join(workDir, '.automaker/skills'))) {
+    parts.push("'.automaker/skills/'");
+  }
+  return parts.join(' ');
+}

--- a/apps/server/src/lib/worktree-guard.ts
+++ b/apps/server/src/lib/worktree-guard.ts
@@ -7,30 +7,12 @@
  */
 
 import { exec } from 'child_process';
-import { existsSync } from 'fs';
-import { join } from 'path';
 import { promisify } from 'util';
 import { createLogger } from '@protolabs-ai/utils';
+import { buildGitAddCommand } from './git-staging-utils.js';
 
 const execAsync = promisify(exec);
 const logger = createLogger('WorktreeGuard');
-
-/**
- * Builds a git add command that stages all changes except .automaker/,
- * then re-includes .automaker/memory/ and .automaker/skills/ only if those
- * directories exist in the working tree. This prevents a fatal pathspec error
- * when a directory is absent (e.g. in a fresh worktree).
- */
-function buildGitAddCommand(workDir: string): string {
-  const parts = ["git add -A -- ':!.automaker/'"];
-  if (existsSync(join(workDir, '.automaker/memory'))) {
-    parts.push("'.automaker/memory/'");
-  }
-  if (existsSync(join(workDir, '.automaker/skills'))) {
-    parts.push("'.automaker/skills/'");
-  }
-  return parts.join(' ');
-}
 
 /**
  * Result of worktree cleanup operation

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -6,11 +6,10 @@
  */
 
 import { exec, execFile } from 'child_process';
-import { existsSync } from 'fs';
-import { join } from 'path';
 import { promisify } from 'util';
 import path from 'path';
 import { createLogger } from '@protolabs-ai/utils';
+import { buildGitAddCommand } from '../lib/git-staging-utils.js';
 import type {
   Feature,
   GitWorkflowSettings,
@@ -28,23 +27,6 @@ import type { EventEmitter } from '../lib/events.js';
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 const logger = createLogger('GitWorkflow');
-
-/**
- * Builds a git add command that stages all changes except .automaker/,
- * then re-includes .automaker/memory/ and .automaker/skills/ only if those
- * directories exist in the working tree. This prevents a fatal pathspec error
- * when a directory is absent (e.g. in a fresh worktree).
- */
-function buildGitAddCommand(workDir: string): string {
-  const parts = ["git add -A -- ':!.automaker/'"];
-  if (existsSync(join(workDir, '.automaker/memory'))) {
-    parts.push("'.automaker/memory/'");
-  }
-  if (existsSync(join(workDir, '.automaker/skills'))) {
-    parts.push("'.automaker/skills/'");
-  }
-  return parts.join(' ');
-}
 
 /**
  * Retry helper with exponential backoff.

--- a/apps/server/src/services/worktree-recovery-service.ts
+++ b/apps/server/src/services/worktree-recovery-service.ts
@@ -7,11 +7,10 @@
  */
 
 import { exec, execFile } from 'child_process';
-import { existsSync } from 'fs';
-import { join } from 'path';
 import { promisify } from 'util';
 import { createLogger } from '@protolabs-ai/utils';
 import type { Feature } from '@protolabs-ai/types';
+import { buildGitAddCommand } from '../lib/git-staging-utils.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -42,23 +41,6 @@ const extendedPath = [process.env.PATH, ...additionalPaths.filter(Boolean)]
   .join(pathSeparator);
 
 const execEnv = { ...process.env, PATH: extendedPath, HUSKY: '0' };
-
-/**
- * Builds a git add command that stages all changes except .automaker/,
- * then re-includes .automaker/memory/ and .automaker/skills/ only if those
- * directories exist in the working tree. This prevents a fatal pathspec error
- * when a directory is absent (e.g. in a fresh worktree).
- */
-function buildGitAddCommand(workDir: string): string {
-  const parts = ["git add -A -- ':!.automaker/'"];
-  if (existsSync(join(workDir, '.automaker/memory'))) {
-    parts.push("'.automaker/memory/'");
-  }
-  if (existsSync(join(workDir, '.automaker/skills'))) {
-    parts.push("'.automaker/skills/'");
-  }
-  return parts.join(' ');
-}
 
 export interface WorktreeRecoveryResult {
   /** Whether any uncommitted changes were detected */

--- a/apps/server/tests/unit/lib/git-staging-utils.test.ts
+++ b/apps/server/tests/unit/lib/git-staging-utils.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { buildGitAddCommand } from '../../../src/lib/git-staging-utils.js';
+
+describe('buildGitAddCommand', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'git-staging-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should return base exclude command when no .automaker dirs exist', () => {
+    expect(buildGitAddCommand(tempDir)).toBe("git add -A -- ':!.automaker/'");
+  });
+
+  it('should include .automaker/memory/ when that directory exists', () => {
+    mkdirSync(join(tempDir, '.automaker', 'memory'), { recursive: true });
+    expect(buildGitAddCommand(tempDir)).toBe("git add -A -- ':!.automaker/' '.automaker/memory/'");
+  });
+
+  it('should include .automaker/skills/ when that directory exists', () => {
+    mkdirSync(join(tempDir, '.automaker', 'skills'), { recursive: true });
+    expect(buildGitAddCommand(tempDir)).toBe("git add -A -- ':!.automaker/' '.automaker/skills/'");
+  });
+
+  it('should include both when both directories exist', () => {
+    mkdirSync(join(tempDir, '.automaker', 'memory'), { recursive: true });
+    mkdirSync(join(tempDir, '.automaker', 'skills'), { recursive: true });
+    expect(buildGitAddCommand(tempDir)).toBe(
+      "git add -A -- ':!.automaker/' '.automaker/memory/' '.automaker/skills/'"
+    );
+  });
+
+  it('should not include memory when only .automaker/ exists (no subdirs)', () => {
+    mkdirSync(join(tempDir, '.automaker'), { recursive: true });
+    expect(buildGitAddCommand(tempDir)).toBe("git add -A -- ':!.automaker/'");
+  });
+});

--- a/apps/ui/src/components/layout/mobile-bottom-nav.tsx
+++ b/apps/ui/src/components/layout/mobile-bottom-nav.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useRouterState } from '@tanstack/react-router';
-import { Grid, BarChart3, FileText, Settings } from 'lucide-react';
+import { Grid, BarChart3, FileText, Settings, MessageCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useIsMobile } from '@/hooks/use-media-query';
 
@@ -13,6 +13,7 @@ interface NavItem {
 const navItems: NavItem[] = [
   { id: 'board', icon: Grid, label: 'Board', path: '/board' },
   { id: 'analytics', icon: BarChart3, label: 'Analytics', path: '/analytics' },
+  { id: 'chat', icon: MessageCircle, label: 'Chat', path: '/chat' },
   { id: 'notes', icon: FileText, label: 'Notes', path: '/notes' },
   { id: 'settings', icon: Settings, label: 'Settings', path: '/settings' },
 ];

--- a/apps/ui/src/components/layout/sidebar/hooks/use-navigation.ts
+++ b/apps/ui/src/components/layout/sidebar/hooks/use-navigation.ts
@@ -16,6 +16,7 @@ import {
   Palette,
   CalendarDays,
   FolderOpen,
+  MessageCircle,
 } from 'lucide-react';
 import type { NavSection, NavItem } from '../types';
 import type { KeyboardShortcut } from '@/hooks/use-keyboard-shortcuts';
@@ -161,6 +162,11 @@ export function useNavigation({
 
     // Build project items - Terminal, Calendar, Designs are conditionally included
     const projectItems: NavItem[] = [
+      {
+        id: 'chat',
+        label: 'Ava',
+        icon: MessageCircle,
+      },
       {
         id: 'analytics',
         label: 'System View',

--- a/apps/ui/src/components/views/board-view/shared/model-constants.ts
+++ b/apps/ui/src/components/views/board-view/shared/model-constants.ts
@@ -122,13 +122,49 @@ export const OPENCODE_MODELS: ModelOption[] = OPENCODE_MODEL_CONFIGS.map((config
 }));
 
 /**
- * All available models (Claude + Cursor + Codex + OpenCode)
+ * Groq models with canonical prefixed IDs
+ * IDs use 'groq-' prefix matching the groq-provider getAvailableModels() output
+ */
+export const GROQ_MODELS: ModelOption[] = [
+  {
+    id: 'groq-llama-3.3-70b-versatile',
+    label: 'Llama 3.3 70B Versatile',
+    description: "Meta's most capable Llama 3.3 model, great for complex reasoning.",
+    badge: 'Balanced',
+    provider: 'groq',
+  },
+  {
+    id: 'groq-llama-3.1-8b-instant',
+    label: 'Llama 3.1 8B Instant',
+    description: 'Ultra-fast 8B model, ideal for low-latency tasks.',
+    badge: 'Speed',
+    provider: 'groq',
+  },
+  {
+    id: 'groq-mixtral-8x7b-32768',
+    label: 'Mixtral 8x7B',
+    description: "Mistral's mixture-of-experts model with 32k context window.",
+    badge: 'Balanced',
+    provider: 'groq',
+  },
+  {
+    id: 'groq-gemma2-9b-it',
+    label: 'Gemma 2 9B IT',
+    description: "Google's Gemma 2 instruction-tuned model.",
+    badge: 'Speed',
+    provider: 'groq',
+  },
+];
+
+/**
+ * All available models (Claude + Cursor + Codex + OpenCode + Groq)
  */
 export const ALL_MODELS: ModelOption[] = [
   ...CLAUDE_MODELS,
   ...CURSOR_MODELS,
   ...CODEX_MODELS,
   ...OPENCODE_MODELS,
+  ...GROQ_MODELS,
 ];
 
 export const THINKING_LEVELS: ThinkingLevel[] = ['none', 'low', 'medium', 'high', 'ultrathink'];

--- a/apps/ui/src/components/views/chat-overlay/ava-settings-panel.tsx
+++ b/apps/ui/src/components/views/chat-overlay/ava-settings-panel.tsx
@@ -1,0 +1,37 @@
+/**
+ * AvaSettingsPanel — Settings popover for the Ava chat overlay.
+ *
+ * Provides project-scoped configuration options for the Ava assistant.
+ * Displayed when the user clicks the gear icon in the chat overlay header.
+ */
+
+import { Settings } from 'lucide-react';
+
+export interface AvaSettingsPanelProps {
+  /** Absolute path of the current project */
+  projectPath?: string;
+}
+
+export function AvaSettingsPanel({ projectPath }: AvaSettingsPanelProps) {
+  return (
+    <div data-slot="ava-settings-panel" className="p-4 space-y-3">
+      <div className="flex items-center gap-2 border-b border-border pb-3">
+        <Settings className="size-4 text-muted-foreground" />
+        <span className="text-sm font-medium">Ava Settings</span>
+      </div>
+
+      {projectPath ? (
+        <div className="space-y-1">
+          <p className="text-xs text-muted-foreground font-medium uppercase tracking-wide">
+            Project
+          </p>
+          <p className="text-xs text-foreground truncate" title={projectPath}>
+            {projectPath}
+          </p>
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">No project selected.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
@@ -3,46 +3,57 @@
  *
  * Contains the header, message list, input, and conversation history.
  * Used by both the Electron overlay view and the web fallback modal.
+ *
+ * Reads currentProject from useAppStore and passes projectId/projectPath
+ * to useChatSession for project-scoped session management.
  */
 
 import { useState, useCallback } from 'react';
-import { History, X } from 'lucide-react';
+import { History, X, Settings } from 'lucide-react';
 import { ChatMessageList, ChatInput } from '@protolabs-ai/ui/ai';
 import { Button } from '@protolabs-ai/ui/atoms';
+import { Popover, PopoverContent, PopoverTrigger } from '@protolabs-ai/ui/atoms';
 import { cn } from '@/lib/utils';
 import { ChatModelSelect } from '@/components/views/chat/components/chat-model-select';
 import { ConversationList } from './conversation-list';
-import type { useChatSession } from '@/hooks/use-chat-session';
+import { AvaSettingsPanel } from './ava-settings-panel';
+import { useChatSession } from '@/hooks/use-chat-session';
+import { useAppStore } from '@/store/app-store';
 
-type ChatSessionReturn = ReturnType<typeof useChatSession>;
-
-export interface ChatOverlayContentProps extends ChatSessionReturn {
+export interface ChatOverlayContentProps {
   /** Called when the user wants to close/hide the overlay or modal */
   onHide: () => void;
   /** When true, renders in modal mode (no drag region, different hint text) */
   isModal?: boolean;
 }
 
-export function ChatOverlayContent({
-  messages,
-  sendMessage,
-  stop,
-  isStreaming,
-  error,
-  sessions,
-  currentSessionId,
-  modelAlias,
-  handleNewChat,
-  handleSwitchSession,
-  handleDeleteSession,
-  handleModelChange,
-  historyOpen,
-  toggleHistory,
-  setHistoryOpen,
-  onHide,
-  isModal = false,
-}: ChatOverlayContentProps) {
+export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayContentProps) {
+  const currentProject = useAppStore((s) => s.currentProject);
+
+  const {
+    messages,
+    sendMessage,
+    stop,
+    isStreaming,
+    error,
+    sessions,
+    currentSessionId,
+    modelAlias,
+    handleNewChat,
+    handleSwitchSession,
+    handleDeleteSession,
+    handleModelChange,
+    historyOpen,
+    toggleHistory,
+    setHistoryOpen,
+  } = useChatSession({
+    defaultModel: 'sonnet',
+    projectId: currentProject?.id,
+    projectPath: currentProject?.path,
+  });
+
   const [inputValue, setInputValue] = useState('');
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const handleSubmit = useCallback(() => {
     const text = inputValue.trim();
@@ -87,6 +98,22 @@ export function ChatOverlayContent({
           >
             <span className="text-xs">New</span>
           </Button>
+          <Popover open={settingsOpen} onOpenChange={setSettingsOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                title="Settings"
+                aria-label="Open settings"
+              >
+                <Settings className="size-3.5" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" sideOffset={6} className="w-72 p-0">
+              <AvaSettingsPanel projectPath={currentProject?.path} />
+            </PopoverContent>
+          </Popover>
           <Button
             variant="ghost"
             size="icon"

--- a/apps/ui/src/components/views/chat/chat-sidebar.tsx
+++ b/apps/ui/src/components/views/chat/chat-sidebar.tsx
@@ -58,6 +58,8 @@ export function ChatSidebar({ className }: { className?: string }) {
     handleModelChange,
   } = useChatSession({
     defaultModel: 'sonnet',
+    projectId: currentProject?.id,
+    projectPath: currentProject?.path,
     body: notesContext ? { context: notesContext } : undefined,
   });
 

--- a/apps/ui/src/components/views/settings-view/model-defaults/phase-model-selector.tsx
+++ b/apps/ui/src/components/views/settings-view/model-defaults/phase-model-selector.tsx
@@ -12,6 +12,7 @@ import type {
   ClaudeCompatibleProvider,
   ProviderModel,
   ClaudeModelAlias,
+  OpenAICompatibleConfig,
 } from '@protolabs-ai/types';
 import {
   STANDALONE_CURSOR_MODELS,
@@ -24,13 +25,14 @@ import {
   CLAUDE_MODELS,
   CURSOR_MODELS,
   OPENCODE_MODELS,
+  GROQ_MODELS,
   THINKING_LEVELS,
   THINKING_LEVEL_LABELS,
   REASONING_EFFORT_LEVELS,
   REASONING_EFFORT_LABELS,
   type ModelOption,
 } from '@/components/views/board-view/shared/model-constants';
-import { Check, ChevronsUpDown, Star, ChevronRight } from 'lucide-react';
+import { Check, ChevronsUpDown, Star, ChevronRight, Zap, Server } from 'lucide-react';
 import {
   AnthropicIcon,
   CursorIcon,
@@ -178,6 +180,7 @@ export function PhaseModelSelector({
     fetchOpencodeModels,
     disabledProviders,
     claudeCompatibleProviders,
+    openaiCompatibleProviders,
   } = useAIModelsStore();
 
   // Detect mobile devices to use inline expansion instead of nested popovers
@@ -193,6 +196,11 @@ export function PhaseModelSelector({
   const enabledProviders = useMemo(() => {
     return (claudeCompatibleProviders || []).filter((p) => p.enabled !== false);
   }, [claudeCompatibleProviders]);
+
+  // Get enabled OpenAI-compatible providers
+  const enabledOpenAICompatibleProviders = useMemo(() => {
+    return (openaiCompatibleProviders || []).filter((p) => p.enabled !== false);
+  }, [openaiCompatibleProviders]);
 
   // Fetch Codex models on mount
   useEffect(() => {
@@ -452,6 +460,20 @@ export function PhaseModelSelector({
       }
     }
 
+    // Check OpenAI-Compatible Provider models
+    for (const provider of enabledOpenAICompatibleProviders) {
+      const providerModel = provider.models?.find((m) => m.id === selectedModel);
+      if (providerModel) {
+        return {
+          id: selectedModel,
+          label: `${providerModel.displayName} (${provider.name})`,
+          description: provider.name,
+          provider: 'openai-compatible' as const,
+          icon: Server,
+        };
+      }
+    }
+
     return null;
   }, [
     selectedModel,
@@ -461,6 +483,7 @@ export function PhaseModelSelector({
     transformedCodexModels,
     dynamicOpencodeModels,
     enabledProviders,
+    enabledOpenAICompatibleProviders,
   ]);
 
   // Compute grouped vs standalone Cursor models
@@ -528,17 +551,20 @@ export function PhaseModelSelector({
     cursor: _cursor,
     codex,
     opencode,
+    groq,
   } = useMemo(() => {
     const favs: typeof CLAUDE_MODELS = [];
     const cModels: typeof CLAUDE_MODELS = [];
     const curModels: typeof CURSOR_MODELS = [];
     const codModels: typeof transformedCodexModels = [];
     const ocModels: ModelOption[] = [];
+    const groqModels: typeof GROQ_MODELS = [];
 
     const isClaudeDisabled = disabledProviders.includes('claude');
     const isCursorDisabled = disabledProviders.includes('cursor');
     const isCodexDisabled = disabledProviders.includes('codex');
     const isOpencodeDisabled = disabledProviders.includes('opencode');
+    const isGroqDisabled = disabledProviders.includes('groq');
 
     // Process Claude Models (skip if provider is disabled)
     if (!isClaudeDisabled) {
@@ -584,12 +610,24 @@ export function PhaseModelSelector({
       });
     }
 
+    // Process Groq Models (skip if provider is disabled)
+    if (!isGroqDisabled) {
+      GROQ_MODELS.forEach((model) => {
+        if (favoriteModels.includes(model.id)) {
+          favs.push(model);
+        } else {
+          groqModels.push(model);
+        }
+      });
+    }
+
     return {
       favorites: favs,
       claude: cModels,
       cursor: curModels,
       codex: codModels,
       opencode: ocModels,
+      groq: groqModels,
     };
   }, [
     favoriteModels,
@@ -1008,6 +1046,116 @@ export function PhaseModelSelector({
               {model.badge}
             </span>
           )}
+          <Button
+            variant="ghost"
+            size="icon"
+            className={cn(
+              'h-6 w-6 hover:bg-transparent hover:text-yellow-500 focus:ring-0',
+              isFavorite
+                ? 'text-yellow-500 opacity-100'
+                : 'opacity-0 group-hover:opacity-100 text-muted-foreground'
+            )}
+            onClick={(e) => {
+              e.stopPropagation();
+              toggleFavoriteModel(model.id);
+            }}
+          >
+            <Star className={cn('h-3.5 w-3.5', isFavorite && 'fill-current')} />
+          </Button>
+          {isSelected && <Check className="h-4 w-4 text-primary shrink-0" />}
+        </div>
+      </CommandItem>
+    );
+  };
+
+  const renderGroqModelItem = (model: (typeof GROQ_MODELS)[0]) => {
+    const isSelected = selectedModel === model.id;
+    const isFavorite = favoriteModels.includes(model.id);
+
+    return (
+      <CommandItem
+        key={model.id}
+        value={model.label}
+        onSelect={() => {
+          onChange({ model: model.id });
+          setOpen(false);
+        }}
+        className="group flex items-center justify-between py-2"
+      >
+        <div className="flex items-center gap-3 overflow-hidden">
+          <Zap
+            className={cn(
+              'h-4 w-4 shrink-0',
+              isSelected ? 'text-primary' : 'text-muted-foreground'
+            )}
+          />
+          <div className="flex flex-col truncate">
+            <span className={cn('truncate font-medium', isSelected && 'text-primary')}>
+              {model.label}
+            </span>
+            <span className="truncate text-xs text-muted-foreground">{model.description}</span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1 ml-2">
+          {model.badge && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground mr-1">
+              {model.badge}
+            </span>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            className={cn(
+              'h-6 w-6 hover:bg-transparent hover:text-yellow-500 focus:ring-0',
+              isFavorite
+                ? 'text-yellow-500 opacity-100'
+                : 'opacity-0 group-hover:opacity-100 text-muted-foreground'
+            )}
+            onClick={(e) => {
+              e.stopPropagation();
+              toggleFavoriteModel(model.id);
+            }}
+          >
+            <Star className={cn('h-3.5 w-3.5', isFavorite && 'fill-current')} />
+          </Button>
+          {isSelected && <Check className="h-4 w-4 text-primary shrink-0" />}
+        </div>
+      </CommandItem>
+    );
+  };
+
+  // Render OpenAI-Compatible provider model item (simple selection, no thinking levels)
+  const renderOpenAICompatModelItem = (provider: OpenAICompatibleConfig, model: ProviderModel) => {
+    const isSelected = selectedModel === model.id;
+    const isFavorite = favoriteModels.includes(model.id);
+
+    return (
+      <CommandItem
+        key={`${provider.id}-${model.id}`}
+        value={`${provider.name} ${model.displayName}`}
+        onSelect={() => {
+          onChange({ model: model.id });
+          setOpen(false);
+        }}
+        className="group flex items-center justify-between py-2"
+      >
+        <div className="flex items-center gap-3 overflow-hidden">
+          <Server
+            className={cn(
+              'h-4 w-4 shrink-0',
+              isSelected ? 'text-primary' : 'text-muted-foreground'
+            )}
+          />
+          <div className="flex flex-col truncate">
+            <span className={cn('truncate font-medium', isSelected && 'text-primary')}>
+              {model.displayName}
+            </span>
+            <span className="truncate text-xs text-muted-foreground">{model.id}</span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1 ml-2">
           <Button
             variant="ghost"
             size="icon"
@@ -1846,6 +1994,10 @@ export function PhaseModelSelector({
                     if (model.provider === 'opencode') {
                       return renderOpencodeModelItem(model);
                     }
+                    // Groq model
+                    if (model.provider === 'groq') {
+                      return renderGroqModelItem(model as (typeof GROQ_MODELS)[0]);
+                    }
                     // Claude model
                     return renderClaudeModelItem(model);
                   });
@@ -1919,6 +2071,22 @@ export function PhaseModelSelector({
               {codex.map((model) => renderCodexModelItem(model))}
             </CommandGroup>
           )}
+
+          {groq.length > 0 && (
+            <CommandGroup heading="Groq Models">
+              {groq.map((model) => renderGroqModelItem(model))}
+            </CommandGroup>
+          )}
+
+          {/* OpenAI-Compatible Provider Models - each provider as separate group */}
+          {enabledOpenAICompatibleProviders.map((provider) => {
+            if (!provider.models || provider.models.length === 0) return null;
+            return (
+              <CommandGroup key={provider.id} heading={provider.name}>
+                {provider.models.map((model) => renderOpenAICompatModelItem(provider, model))}
+              </CommandGroup>
+            );
+          })}
 
           {opencodeSections.length > 0 && (
             <CommandGroup heading={OPENCODE_CLI_GROUP_LABEL}>

--- a/apps/ui/src/components/views/settings-view/providers/groq-settings-tab/index.tsx
+++ b/apps/ui/src/components/views/settings-view/providers/groq-settings-tab/index.tsx
@@ -1,0 +1,408 @@
+import { useState, useCallback, useEffect } from 'react';
+import { toast } from 'sonner';
+import { Key, CheckCircle2, XCircle, Loader2, ExternalLink, Info } from 'lucide-react';
+import { Button } from '@protolabs-ai/ui/atoms';
+import { Switch } from '@protolabs-ai/ui/atoms';
+import { Label } from '@protolabs-ai/ui/atoms';
+import { Input } from '@protolabs-ai/ui/atoms';
+import { cn } from '@/lib/utils';
+import { getElectronAPI } from '@/lib/electron';
+import { createLogger } from '@protolabs-ai/utils/logger';
+import { ProviderToggle } from '../provider-toggle';
+
+const logger = createLogger('GroqSettings');
+
+/** Groq model definitions with display metadata */
+const GROQ_MODEL_DEFINITIONS = [
+  {
+    id: 'groq-llama-3.3-70b-versatile',
+    label: 'Llama 3.3 70B Versatile',
+    description: "Meta's most capable Llama 3.3 model, great for complex reasoning.",
+    badge: 'Balanced',
+  },
+  {
+    id: 'groq-llama-3.1-8b-instant',
+    label: 'Llama 3.1 8B Instant',
+    description: 'Ultra-fast 8B model, ideal for low-latency tasks.',
+    badge: 'Speed',
+  },
+  {
+    id: 'groq-mixtral-8x7b-32768',
+    label: 'Mixtral 8x7B',
+    description: "Mistral's mixture-of-experts model with 32k context window.",
+    badge: 'Balanced',
+  },
+  {
+    id: 'groq-gemma2-9b-it',
+    label: 'Gemma 2 9B IT',
+    description: "Google's Gemma 2 instruction-tuned model.",
+    badge: 'Speed',
+  },
+] as const;
+
+type GroqModelId = (typeof GROQ_MODEL_DEFINITIONS)[number]['id'];
+
+interface TestResult {
+  success: boolean;
+  message: string;
+}
+
+export function GroqSettingsTab() {
+  const [apiKey, setApiKey] = useState('');
+  const [showKey, setShowKey] = useState(false);
+  const [isTesting, setIsTesting] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [testResult, setTestResult] = useState<TestResult | null>(null);
+  const [enabledModels, setEnabledModels] = useState<Set<GroqModelId>>(
+    new Set(GROQ_MODEL_DEFINITIONS.map((m) => m.id))
+  );
+  const [hasStoredKey, setHasStoredKey] = useState(false);
+
+  // Load existing credentials on mount
+  useEffect(() => {
+    const loadCredentials = async () => {
+      try {
+        const api = getElectronAPI();
+        if (api?.settings?.getCredentials) {
+          const result = await api.settings.getCredentials();
+          if (result.success && result.credentials) {
+            // Check if groq key is configured (it comes back masked)
+            const groqCred = (
+              result.credentials as Record<string, { configured: boolean; masked: string }>
+            )['groq'];
+            if (groqCred?.configured) {
+              setHasStoredKey(true);
+              setApiKey(groqCred.masked || '');
+            }
+          }
+        }
+      } catch (error) {
+        logger.error('Failed to load Groq credentials:', error);
+      }
+    };
+    loadCredentials();
+  }, []);
+
+  const handleSaveApiKey = useCallback(async () => {
+    if (!apiKey.trim()) {
+      toast.error('Please enter an API key');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const api = getElectronAPI();
+      if (api?.settings?.updateCredentials) {
+        const result = await api.settings.updateCredentials({
+          apiKeys: { groq: apiKey.trim() } as Record<string, string>,
+        });
+        if (result.success) {
+          setHasStoredKey(true);
+          toast.success('Groq API key saved');
+        } else {
+          toast.error(result.error || 'Failed to save API key');
+        }
+      } else {
+        // Fallback: store via global settings
+        await api.settings.updateGlobal({ groqApiKey: apiKey.trim() });
+        setHasStoredKey(true);
+        toast.success('Groq API key saved');
+      }
+    } catch (error) {
+      logger.error('Failed to save Groq API key:', error);
+      toast.error('Failed to save API key');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [apiKey]);
+
+  const handleTestConnection = useCallback(async () => {
+    if (!apiKey.trim()) {
+      setTestResult({ success: false, message: 'Please enter an API key to test.' });
+      return;
+    }
+
+    setIsTesting(true);
+    setTestResult(null);
+
+    try {
+      const api = getElectronAPI();
+      // Call the Groq status/test endpoint if available
+      if (api?.setup?.testGroqConnection) {
+        const result = await api.setup.testGroqConnection(apiKey.trim());
+        if (result.success) {
+          setTestResult({ success: true, message: 'Connection successful! Groq API responded.' });
+        } else {
+          setTestResult({
+            success: false,
+            message: result.error || 'Failed to connect to Groq API.',
+          });
+        }
+      } else {
+        // Fallback: validate key format (Groq keys start with 'gsk_')
+        if (apiKey.trim().startsWith('gsk_') && apiKey.trim().length > 20) {
+          setTestResult({
+            success: true,
+            message: 'API key format looks valid. Save to confirm.',
+          });
+        } else {
+          setTestResult({
+            success: false,
+            message: 'Invalid key format. Groq API keys start with "gsk_".',
+          });
+        }
+      }
+    } catch {
+      setTestResult({ success: false, message: 'Network error. Please check your connection.' });
+    } finally {
+      setIsTesting(false);
+    }
+  }, [apiKey]);
+
+  const handleModelToggle = useCallback((modelId: GroqModelId, enabled: boolean) => {
+    setEnabledModels((prev) => {
+      const next = new Set(prev);
+      if (enabled) {
+        next.add(modelId);
+      } else {
+        next.delete(modelId);
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      {/* Provider Visibility Toggle */}
+      <ProviderToggle provider="groq" providerLabel="Groq" />
+
+      {/* Info Banner */}
+      <div className="flex items-start gap-3 p-4 rounded-xl bg-orange-500/10 border border-orange-500/20">
+        <Info className="w-5 h-5 text-orange-400 shrink-0 mt-0.5" />
+        <div className="text-sm text-orange-400/90">
+          <span className="font-medium">Fast LLM Inference</span>
+          <p className="text-xs text-orange-400/70 mt-1">
+            Groq provides ultra-fast inference for open-source models like Llama and Mixtral. Get a
+            free API key at{' '}
+            <a
+              href="https://console.groq.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-orange-300 inline-flex items-center gap-1"
+            >
+              console.groq.com
+              <ExternalLink className="w-3 h-3" />
+            </a>
+            .
+          </p>
+        </div>
+      </div>
+
+      {/* API Key Section */}
+      <div
+        className={cn(
+          'rounded-lg overflow-hidden',
+          'border border-border/50',
+          'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
+          'shadow-sm shadow-black/5'
+        )}
+      >
+        <div className="p-4 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-orange-500/20 to-orange-600/10 flex items-center justify-center border border-orange-500/20">
+              <Key className="w-5 h-5 text-orange-500" />
+            </div>
+            <h2 className="text-lg font-semibold text-foreground tracking-tight">API Key</h2>
+          </div>
+          <p className="text-sm text-muted-foreground/80 ml-12">
+            Your Groq API key is stored locally and used for model inference.
+          </p>
+        </div>
+
+        <div className="p-4 space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="groq-api-key" className="text-sm font-medium">
+              Groq API Key
+              {hasStoredKey && (
+                <span className="ml-2 text-xs text-green-500 font-normal">(key saved)</span>
+              )}
+            </Label>
+            <div className="relative">
+              <Input
+                id="groq-api-key"
+                type={showKey ? 'text' : 'password'}
+                placeholder="gsk_..."
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                className="pr-24 font-mono text-sm"
+                data-testid="groq-api-key-input"
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                className="absolute right-1 top-1 h-7 px-2 text-xs"
+                onClick={() => setShowKey((v) => !v)}
+                data-testid="toggle-groq-visibility"
+              >
+                {showKey ? 'Hide' : 'Show'}
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Get your free API key at{' '}
+              <a
+                href="https://console.groq.com/keys"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                console.groq.com/keys
+              </a>
+              .
+            </p>
+          </div>
+
+          {/* Test result */}
+          {testResult && (
+            <div
+              className={cn(
+                'flex items-center gap-2 p-3 rounded-lg text-sm',
+                testResult.success
+                  ? 'bg-green-500/10 text-green-600 border border-green-500/20'
+                  : 'bg-red-500/10 text-red-600 border border-red-500/20'
+              )}
+              data-testid="groq-test-connection-result"
+            >
+              {testResult.success ? (
+                <CheckCircle2 className="w-4 h-4 shrink-0" />
+              ) : (
+                <XCircle className="w-4 h-4 shrink-0" />
+              )}
+              <span data-testid="groq-test-connection-message">{testResult.message}</span>
+            </div>
+          )}
+
+          {/* Action buttons */}
+          <div className="flex items-center gap-3 pt-2">
+            <Button
+              onClick={handleSaveApiKey}
+              disabled={isSaving || !apiKey.trim()}
+              data-testid="save-groq-api-key"
+              className={cn(
+                'min-w-[120px] h-10',
+                'bg-gradient-to-r from-orange-500 to-orange-600',
+                'hover:from-orange-600 hover:to-orange-600',
+                'text-white font-medium border-0',
+                'shadow-md shadow-orange-500/20 hover:shadow-lg hover:shadow-orange-500/25',
+                'transition-all duration-200 ease-out',
+                'hover:scale-[1.02] active:scale-[0.98]'
+              )}
+            >
+              {isSaving ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                'Save Key'
+              )}
+            </Button>
+
+            <Button
+              variant="outline"
+              onClick={handleTestConnection}
+              disabled={isTesting || !apiKey.trim()}
+              data-testid="test-groq-connection"
+              className="h-10"
+            >
+              {isTesting ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Testing...
+                </>
+              ) : (
+                'Test Connection'
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Models Section */}
+      <div
+        className={cn(
+          'rounded-lg overflow-hidden',
+          'border border-border/50',
+          'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
+          'shadow-sm shadow-black/5'
+        )}
+      >
+        <div className="p-4 border-b border-border/50">
+          <h2 className="text-lg font-semibold text-foreground tracking-tight">Available Models</h2>
+          <p className="text-sm text-muted-foreground/80 mt-1">
+            Enable or disable Groq models for use in model selectors.
+          </p>
+        </div>
+
+        <div className="p-4 space-y-3">
+          {GROQ_MODEL_DEFINITIONS.map((model) => {
+            const isEnabled = enabledModels.has(model.id);
+            return (
+              <div
+                key={model.id}
+                className="flex items-center justify-between p-3 rounded-lg bg-accent/10 border border-border/20 hover:bg-accent/20 transition-colors"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-foreground truncate">
+                      {model.label}
+                    </span>
+                    {model.badge && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-500 font-medium shrink-0">
+                        {model.badge}
+                      </span>
+                    )}
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium shrink-0">
+                      Groq
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-0.5 truncate">
+                    {model.description}
+                  </p>
+                  <p className="text-[10px] font-mono text-muted-foreground/60 mt-0.5">
+                    {model.id.replace('groq-', '')}
+                  </p>
+                </div>
+                <Switch
+                  checked={isEnabled}
+                  onCheckedChange={(checked) => handleModelToggle(model.id, checked)}
+                  className="ml-4 shrink-0"
+                />
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Note about free tier */}
+        <div className="px-4 pb-4">
+          <div className="flex items-start gap-2 p-3 rounded-lg bg-blue-500/5 border border-blue-500/20">
+            <Info className="w-4 h-4 text-blue-500 flex-shrink-0 mt-0.5" />
+            <p className="text-xs text-muted-foreground">
+              Groq offers a generous free tier with rate limits. Upgrade at{' '}
+              <a
+                href="https://console.groq.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-500 hover:underline"
+              >
+                console.groq.com
+              </a>{' '}
+              for higher throughput.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default GroqSettingsTab;

--- a/apps/ui/src/components/views/settings-view/providers/openai-compatible-tab/index.tsx
+++ b/apps/ui/src/components/views/settings-view/providers/openai-compatible-tab/index.tsx
@@ -1,0 +1,664 @@
+import React, { useState, useCallback } from 'react';
+import { toast } from 'sonner';
+import {
+  Plus,
+  Trash2,
+  Pencil,
+  ChevronLeft,
+  Server,
+  Globe,
+  Key,
+  Check,
+  X,
+  Info,
+} from 'lucide-react';
+import { Button } from '@protolabs-ai/ui/atoms';
+import { Input } from '@protolabs-ai/ui/atoms';
+import { Label } from '@protolabs-ai/ui/atoms';
+import { Switch } from '@protolabs-ai/ui/atoms';
+import { type OpenAICompatibleConfig, type ProviderModel } from '@protolabs-ai/types';
+import { useAIModelsStore } from '@/store/ai-models-store';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// Local template definitions (mirrors @protolabs-ai/types OPENAI_COMPATIBLE_TEMPLATES)
+// Defined locally to avoid dependency on the built dist during development.
+// ============================================================================
+
+interface OpenAICompatibleTemplate {
+  templateId: string;
+  name: string;
+  baseUrl: string;
+  description: string;
+  apiKeyUrl?: string;
+  defaultModels: ProviderModel[];
+  requiresApiKey?: boolean;
+}
+
+const OPENAI_COMPATIBLE_TEMPLATES: OpenAICompatibleTemplate[] = [
+  {
+    templateId: 'ollama',
+    name: 'Ollama',
+    baseUrl: 'http://localhost:11434/v1',
+    description: 'Run open-source LLMs locally with Ollama',
+    requiresApiKey: false,
+    defaultModels: [
+      { id: 'llama3.2', displayName: 'Llama 3.2' },
+      { id: 'mistral', displayName: 'Mistral' },
+      { id: 'codellama', displayName: 'Code Llama' },
+    ],
+  },
+  {
+    templateId: 'lmstudio',
+    name: 'LM Studio',
+    baseUrl: 'http://localhost:1234/v1',
+    description: 'Run local LLMs with LM Studio',
+    requiresApiKey: false,
+    defaultModels: [{ id: 'local-model', displayName: 'Local Model' }],
+  },
+  {
+    templateId: 'together',
+    name: 'Together AI',
+    baseUrl: 'https://api.together.xyz/v1',
+    description: 'Access 200+ open-source models via Together AI',
+    apiKeyUrl: 'https://api.together.ai/settings/api-keys',
+    requiresApiKey: true,
+    defaultModels: [
+      { id: 'meta-llama/Llama-3.3-70B-Instruct-Turbo', displayName: 'Llama 3.3 70B Turbo' },
+      { id: 'mistralai/Mixtral-8x7B-Instruct-v0.1', displayName: 'Mixtral 8x7B' },
+    ],
+  },
+  {
+    templateId: 'custom',
+    name: 'Custom',
+    baseUrl: '',
+    description: 'Configure a custom OpenAI-compatible endpoint',
+    requiresApiKey: false,
+    defaultModels: [],
+  },
+];
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function generateId(): string {
+  return Math.random().toString(36).substring(2, 11) + Date.now().toString(36);
+}
+
+// ============================================================================
+// Model Row (in edit form)
+// ============================================================================
+
+interface ModelRowProps {
+  model: ProviderModel;
+  onUpdate: (updated: ProviderModel) => void;
+  onRemove: () => void;
+}
+
+function ModelRow({ model, onUpdate, onRemove }: ModelRowProps) {
+  return (
+    <div className="flex items-center gap-2 p-2 rounded-lg bg-accent/10 border border-border/20">
+      <div className="flex-1 grid grid-cols-2 gap-2">
+        <Input
+          placeholder="Model ID (e.g. llama3.2)"
+          value={model.id}
+          onChange={(e) => onUpdate({ ...model, id: e.target.value })}
+          className="text-sm h-8"
+        />
+        <Input
+          placeholder="Display Name"
+          value={model.displayName}
+          onChange={(e) => onUpdate({ ...model, displayName: e.target.value })}
+          className="text-sm h-8"
+        />
+      </div>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 text-destructive hover:text-destructive hover:bg-destructive/10 shrink-0"
+        onClick={onRemove}
+        aria-label="Remove model"
+      >
+        <X className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
+// ============================================================================
+// Provider Form (add / edit)
+// ============================================================================
+
+interface ProviderFormProps {
+  provider: OpenAICompatibleConfig | null;
+  template?: OpenAICompatibleTemplate;
+  onSave: (data: OpenAICompatibleConfig) => Promise<void>;
+  onBack: () => void;
+}
+
+function ProviderForm({ provider, template, onSave, onBack }: ProviderFormProps) {
+  const [name, setName] = useState(provider?.name ?? template?.name ?? '');
+  const [baseUrl, setBaseUrl] = useState(provider?.baseUrl ?? template?.baseUrl ?? '');
+  const [apiKey, setApiKey] = useState(provider?.apiKey ?? '');
+  const [showKey, setShowKey] = useState(false);
+  const [models, setModels] = useState<ProviderModel[]>(
+    provider?.models ?? template?.defaultModels ?? []
+  );
+  const [isSaving, setIsSaving] = useState(false);
+
+  const addModel = useCallback(() => {
+    setModels((prev) => [...prev, { id: '', displayName: '' }]);
+  }, []);
+
+  const updateModel = useCallback((index: number, updated: ProviderModel) => {
+    setModels((prev) => prev.map((m, i) => (i === index ? updated : m)));
+  }, []);
+
+  const removeModel = useCallback((index: number) => {
+    setModels((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!name.trim()) {
+      toast.error('Provider name is required');
+      return;
+    }
+    if (!baseUrl.trim()) {
+      toast.error('Base URL is required');
+      return;
+    }
+    const validModels = models.filter((m) => m.id.trim() && m.displayName.trim());
+
+    setIsSaving(true);
+    try {
+      await onSave({
+        id: provider?.id ?? generateId(),
+        name: name.trim(),
+        baseUrl: baseUrl.trim(),
+        apiKeySource: apiKey.trim() ? 'inline' : 'inline',
+        apiKey: apiKey.trim() || undefined,
+        enabled: provider?.enabled ?? true,
+        models: validModels,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [name, baseUrl, apiKey, models, provider, onSave]);
+
+  return (
+    <div className="space-y-6">
+      {/* Back button */}
+      <Button variant="ghost" size="sm" onClick={onBack} className="gap-1 text-muted-foreground">
+        <ChevronLeft className="h-4 w-4" />
+        Back to providers
+      </Button>
+
+      <div>
+        <h3 className="text-lg font-semibold text-foreground tracking-tight">
+          {provider ? 'Edit Provider' : 'Add Provider'}
+        </h3>
+        <p className="text-sm text-muted-foreground mt-0.5">
+          {provider
+            ? 'Update your OpenAI-compatible provider configuration.'
+            : 'Configure a new OpenAI-compatible API endpoint.'}
+        </p>
+      </div>
+
+      {/* Form card */}
+      <div
+        className={cn(
+          'rounded-lg overflow-hidden',
+          'border border-border/50',
+          'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
+          'shadow-sm shadow-black/5'
+        )}
+      >
+        <div className="p-4 space-y-4">
+          {/* Name */}
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium flex items-center gap-1.5">
+              <Server className="h-3.5 w-3.5 text-muted-foreground" />
+              Provider Name
+            </Label>
+            <Input
+              placeholder="e.g. Local Ollama"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              data-testid="openai-compat-provider-name"
+            />
+          </div>
+
+          {/* Base URL */}
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium flex items-center gap-1.5">
+              <Globe className="h-3.5 w-3.5 text-muted-foreground" />
+              Base URL
+            </Label>
+            <Input
+              placeholder="e.g. http://localhost:11434/v1"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              data-testid="openai-compat-base-url"
+            />
+            <p className="text-xs text-muted-foreground">
+              The base URL for the OpenAI-compatible API endpoint (without trailing slash).
+            </p>
+          </div>
+
+          {/* API Key */}
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium flex items-center gap-1.5">
+              <Key className="h-3.5 w-3.5 text-muted-foreground" />
+              API Key
+              <span className="text-xs font-normal text-muted-foreground">
+                (optional for local providers)
+              </span>
+            </Label>
+            <div className="relative">
+              <Input
+                type={showKey ? 'text' : 'password'}
+                placeholder="sk-..."
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                className="pr-20 font-mono text-sm"
+                data-testid="openai-compat-api-key"
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                className="absolute right-1 top-1 h-7 px-2 text-xs"
+                onClick={() => setShowKey((v) => !v)}
+              >
+                {showKey ? 'Hide' : 'Show'}
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        {/* Models section */}
+        <div className="border-t border-border/50">
+          <div className="p-4">
+            <div className="flex items-center justify-between mb-3">
+              <div>
+                <h4 className="text-sm font-medium text-foreground">Models</h4>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Add models exposed by this provider.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={addModel}
+                className="gap-1.5 text-xs"
+                data-testid="openai-compat-add-model"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Add Model
+              </Button>
+            </div>
+
+            <div className="space-y-2">
+              {models.length === 0 ? (
+                <div className="text-center py-6 text-sm text-muted-foreground">
+                  No models configured. Add at least one model to use this provider.
+                </div>
+              ) : (
+                <>
+                  <div className="grid grid-cols-2 gap-2 px-2 text-xs text-muted-foreground font-medium">
+                    <span>Model ID</span>
+                    <span>Display Name</span>
+                  </div>
+                  {models.map((model, index) => (
+                    <ModelRow
+                      key={index}
+                      model={model}
+                      onUpdate={(updated) => updateModel(index, updated)}
+                      onRemove={() => removeModel(index)}
+                    />
+                  ))}
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="p-4 border-t border-border/50 flex items-center gap-3">
+          <Button
+            onClick={handleSave}
+            disabled={isSaving}
+            data-testid="openai-compat-save-provider"
+            className={cn(
+              'min-w-[120px]',
+              'bg-gradient-to-r from-violet-500 to-violet-600',
+              'hover:from-violet-600 hover:to-violet-700',
+              'text-white font-medium border-0',
+              'shadow-md shadow-violet-500/20 hover:shadow-lg hover:shadow-violet-500/25',
+              'transition-all duration-200 ease-out'
+            )}
+          >
+            {isSaving ? 'Saving...' : provider ? 'Save Changes' : 'Add Provider'}
+          </Button>
+          <Button variant="outline" onClick={onBack}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Template Picker
+// ============================================================================
+
+const CUSTOM_TEMPLATE: OpenAICompatibleTemplate = {
+  templateId: 'custom',
+  name: 'Custom Provider',
+  baseUrl: '',
+  defaultApiKeySource: 'inline',
+  description: 'Configure a custom OpenAI-compatible endpoint',
+  defaultModels: [],
+};
+
+interface TemplatePickerProps {
+  onSelect: (template: OpenAICompatibleTemplate) => void;
+  onBack: () => void;
+}
+
+function TemplatePicker({ onSelect, onBack }: TemplatePickerProps) {
+  const templates = [...OPENAI_COMPATIBLE_TEMPLATES, CUSTOM_TEMPLATE];
+
+  return (
+    <div className="space-y-6">
+      <Button variant="ghost" size="sm" onClick={onBack} className="gap-1 text-muted-foreground">
+        <ChevronLeft className="h-4 w-4" />
+        Back to providers
+      </Button>
+
+      <div>
+        <h3 className="text-lg font-semibold text-foreground tracking-tight">Choose a Template</h3>
+        <p className="text-sm text-muted-foreground mt-0.5">
+          Select a pre-configured template or start from scratch.
+        </p>
+      </div>
+
+      <div className="grid gap-3">
+        {templates.map((template) => (
+          <button
+            key={template.templateId}
+            onClick={() => onSelect(template)}
+            data-testid={`openai-compat-template-${template.templateId}`}
+            className={cn(
+              'w-full text-left p-4 rounded-lg',
+              'border border-border/50 bg-card/80',
+              'hover:bg-accent/30 hover:border-violet-500/30',
+              'transition-all duration-150 cursor-pointer',
+              'group'
+            )}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-sm text-foreground">{template.name}</span>
+                  {template.apiKeyUrl && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-500 font-medium">
+                      API Key
+                    </span>
+                  )}
+                  {!template.apiKeyUrl && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-green-500/10 text-green-500 font-medium">
+                      Local
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">{template.description}</p>
+                {template.baseUrl && (
+                  <p className="text-[10px] font-mono text-muted-foreground/60 mt-1">
+                    {template.baseUrl}
+                  </p>
+                )}
+              </div>
+              <ChevronLeft className="h-4 w-4 text-muted-foreground rotate-180 shrink-0 mt-0.5 opacity-0 group-hover:opacity-100 transition-opacity" />
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Provider Card (list item)
+// ============================================================================
+
+interface ProviderCardProps {
+  provider: OpenAICompatibleConfig;
+  onEdit: () => void;
+  onDelete: () => void;
+  onToggle: () => void;
+}
+
+function ProviderCard({ provider, onEdit, onDelete, onToggle }: ProviderCardProps) {
+  const isEnabled = provider.enabled !== false;
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-3 p-3 rounded-lg',
+        'border transition-colors',
+        isEnabled
+          ? 'border-border/50 bg-card/60 hover:bg-accent/20'
+          : 'border-border/30 bg-card/30 opacity-60'
+      )}
+      data-testid={`openai-compat-provider-card-${provider.id}`}
+    >
+      {/* Icon */}
+      <div className="w-8 h-8 rounded-lg bg-violet-500/10 border border-violet-500/20 flex items-center justify-center shrink-0">
+        <Server className="w-4 h-4 text-violet-500" />
+      </div>
+
+      {/* Info */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-foreground truncate">{provider.name}</span>
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium shrink-0">
+            {provider.models.length} model{provider.models.length !== 1 ? 's' : ''}
+          </span>
+        </div>
+        <p className="text-xs text-muted-foreground truncate mt-0.5">{provider.baseUrl}</p>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-2 shrink-0">
+        <Switch
+          checked={isEnabled}
+          onCheckedChange={onToggle}
+          aria-label={`Toggle ${provider.name}`}
+          data-testid={`openai-compat-toggle-${provider.id}`}
+        />
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 text-muted-foreground hover:text-foreground"
+          onClick={onEdit}
+          aria-label={`Edit ${provider.name}`}
+          data-testid={`openai-compat-edit-${provider.id}`}
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+          onClick={onDelete}
+          aria-label={`Delete ${provider.name}`}
+          data-testid={`openai-compat-delete-${provider.id}`}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Empty State
+// ============================================================================
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+      <div className="w-12 h-12 rounded-xl bg-violet-500/10 border border-violet-500/20 flex items-center justify-center mb-4">
+        <Server className="w-6 h-6 text-violet-500" />
+      </div>
+      <h4 className="text-sm font-medium text-foreground mb-1">No providers configured</h4>
+      <p className="text-sm text-muted-foreground max-w-xs">
+        Add an OpenAI-compatible provider to use local models (Ollama, LM Studio) or cloud APIs.
+      </p>
+    </div>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+type ViewState =
+  | { mode: 'list' }
+  | { mode: 'template-picker' }
+  | {
+      mode: 'edit';
+      provider: OpenAICompatibleConfig | null;
+      template?: OpenAICompatibleTemplate;
+    };
+
+export function OpenAICompatibleTab() {
+  const [view, setView] = useState<ViewState>({ mode: 'list' });
+  const {
+    openaiCompatibleProviders,
+    addOpenAICompatibleProvider,
+    updateOpenAICompatibleProvider,
+    deleteOpenAICompatibleProvider,
+    toggleOpenAICompatibleProviderEnabled,
+  } = useAIModelsStore();
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      await deleteOpenAICompatibleProvider(id);
+      toast.success('Provider removed');
+    },
+    [deleteOpenAICompatibleProvider]
+  );
+
+  const handleSave = useCallback(
+    async (data: OpenAICompatibleConfig) => {
+      const isEditing = view.mode === 'edit' && view.provider !== null;
+      if (isEditing && view.mode === 'edit' && view.provider) {
+        await updateOpenAICompatibleProvider(view.provider.id, data);
+        toast.success('Provider updated');
+      } else {
+        await addOpenAICompatibleProvider(data);
+        toast.success('Provider added');
+      }
+      setView({ mode: 'list' });
+    },
+    [view, addOpenAICompatibleProvider, updateOpenAICompatibleProvider]
+  );
+
+  if (view.mode === 'template-picker') {
+    return (
+      <TemplatePicker
+        onSelect={(template) => setView({ mode: 'edit', provider: null, template })}
+        onBack={() => setView({ mode: 'list' })}
+      />
+    );
+  }
+
+  if (view.mode === 'edit') {
+    return (
+      <ProviderForm
+        provider={view.provider}
+        template={view.template}
+        onSave={handleSave}
+        onBack={() => setView({ mode: 'list' })}
+      />
+    );
+  }
+
+  // List view
+  return (
+    <div className="space-y-6">
+      {/* Info banner */}
+      <div className="flex items-start gap-3 p-4 rounded-xl bg-violet-500/10 border border-violet-500/20">
+        <Info className="w-5 h-5 text-violet-400 shrink-0 mt-0.5" />
+        <div className="text-sm text-violet-400/90">
+          <span className="font-medium">OpenAI-Compatible APIs</span>
+          <p className="text-xs text-violet-400/70 mt-1">
+            Connect local models (Ollama, LM Studio) or cloud APIs that implement the OpenAI Chat
+            Completions protocol. Models appear in all model selectors, grouped by provider name.
+          </p>
+        </div>
+      </div>
+
+      {/* Header with Add button */}
+      <div
+        className={cn(
+          'rounded-lg overflow-hidden',
+          'border border-border/50',
+          'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
+          'shadow-sm shadow-black/5'
+        )}
+      >
+        <div className="p-4 border-b border-border/50 flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground tracking-tight">
+              Configured Providers
+            </h2>
+            <p className="text-sm text-muted-foreground/80 mt-0.5">
+              {openaiCompatibleProviders.length === 0
+                ? 'No providers added yet.'
+                : `${openaiCompatibleProviders.length} provider${openaiCompatibleProviders.length !== 1 ? 's' : ''} configured.`}
+            </p>
+          </div>
+          <Button
+            onClick={() => setView({ mode: 'template-picker' })}
+            data-testid="openai-compat-add-provider"
+            className={cn(
+              'gap-1.5',
+              'bg-gradient-to-r from-violet-500 to-violet-600',
+              'hover:from-violet-600 hover:to-violet-700',
+              'text-white font-medium border-0',
+              'shadow-md shadow-violet-500/20 hover:shadow-lg hover:shadow-violet-500/25',
+              'transition-all duration-200 ease-out'
+            )}
+          >
+            <Plus className="h-4 w-4" />
+            Add Provider
+          </Button>
+        </div>
+
+        <div className="p-4">
+          {openaiCompatibleProviders.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <div className="space-y-3">
+              {openaiCompatibleProviders.map((provider) => (
+                <ProviderCard
+                  key={provider.id}
+                  provider={provider}
+                  onEdit={() => setView({ mode: 'edit', provider })}
+                  onDelete={() => handleDelete(provider.id)}
+                  onToggle={() => toggleOpenAICompatibleProviderEnabled(provider.id)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default OpenAICompatibleTab;

--- a/apps/ui/src/components/views/settings-view/providers/provider-tabs.tsx
+++ b/apps/ui/src/components/views/settings-view/providers/provider-tabs.tsx
@@ -1,20 +1,22 @@
 import React from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@protolabs-ai/ui/atoms';
 import { AnthropicIcon, CursorIcon, OpenAIIcon } from '@/components/shared/provider-icon';
-import { Cpu } from 'lucide-react';
+import { Cpu, Zap, Server } from 'lucide-react';
 import { CursorSettingsTab } from './cursor-settings-tab';
 import { ClaudeSettingsTab } from './claude-settings-tab';
 import { CodexSettingsTab } from './codex-settings-tab';
 import { OpencodeSettingsTab } from './opencode-settings-tab';
+import { GroqSettingsTab } from './groq-settings-tab';
+import { OpenAICompatibleTab } from './openai-compatible-tab';
 
 interface ProviderTabsProps {
-  defaultTab?: 'claude' | 'cursor' | 'codex' | 'opencode';
+  defaultTab?: 'claude' | 'cursor' | 'codex' | 'opencode' | 'groq' | 'openai-compatible';
 }
 
 export function ProviderTabs({ defaultTab = 'claude' }: ProviderTabsProps) {
   return (
     <Tabs defaultValue={defaultTab} className="w-full">
-      <TabsList className="grid w-full grid-cols-4 mb-6">
+      <TabsList className="grid w-full grid-cols-6 mb-6">
         <TabsTrigger value="claude" className="flex items-center gap-2">
           <AnthropicIcon className="w-4 h-4" />
           Claude
@@ -30,6 +32,18 @@ export function ProviderTabs({ defaultTab = 'claude' }: ProviderTabsProps) {
         <TabsTrigger value="opencode" className="flex items-center gap-2">
           <Cpu className="w-4 h-4" />
           OpenCode
+        </TabsTrigger>
+        <TabsTrigger value="groq" className="flex items-center gap-2">
+          <Zap className="w-4 h-4" />
+          Groq
+        </TabsTrigger>
+        <TabsTrigger
+          value="openai-compatible"
+          className="flex items-center gap-2"
+          data-testid="openai-compatible-tab-trigger"
+        >
+          <Server className="w-4 h-4" />
+          OpenAI-Compatible
         </TabsTrigger>
       </TabsList>
 
@@ -47,6 +61,14 @@ export function ProviderTabs({ defaultTab = 'claude' }: ProviderTabsProps) {
 
       <TabsContent value="opencode">
         <OpencodeSettingsTab />
+      </TabsContent>
+
+      <TabsContent value="groq">
+        <GroqSettingsTab />
+      </TabsContent>
+
+      <TabsContent value="openai-compatible">
+        <OpenAICompatibleTab />
       </TabsContent>
     </Tabs>
   );

--- a/apps/ui/src/hooks/use-settings-migration.ts
+++ b/apps/ui/src/hooks/use-settings-migration.ts
@@ -212,6 +212,9 @@ export function parseLocalStorageSettings(): Partial<GlobalSettings> | null {
       // Claude Compatible Providers (new system)
       claudeCompatibleProviders:
         (state.claudeCompatibleProviders as GlobalSettings['claudeCompatibleProviders']) ?? [],
+      // OpenAI Compatible Providers
+      openaiCompatibleProviders:
+        (state.openaiCompatibleProviders as GlobalSettings['openaiCompatibleProviders']) ?? [],
     };
   } catch (error) {
     logger.error('Failed to parse localStorage settings:', error);
@@ -354,6 +357,16 @@ export function mergeSettings(
     localSettings.claudeCompatibleProviders.length > 0
   ) {
     merged.claudeCompatibleProviders = localSettings.claudeCompatibleProviders;
+  }
+
+  // OpenAI Compatible Providers - preserve from localStorage if server is empty
+  if (
+    (!serverSettings.openaiCompatibleProviders ||
+      serverSettings.openaiCompatibleProviders.length === 0) &&
+    localSettings.openaiCompatibleProviders &&
+    localSettings.openaiCompatibleProviders.length > 0
+  ) {
+    merged.openaiCompatibleProviders = localSettings.openaiCompatibleProviders;
   }
 
   return merged;
@@ -757,6 +770,7 @@ export function hydrateStoreFromSettings(settings: GlobalSettings): void {
     claudeApiProfiles: settings.claudeApiProfiles ?? [],
     activeClaudeApiProfileId: settings.activeClaudeApiProfileId ?? null,
     claudeCompatibleProviders: settings.claudeCompatibleProviders ?? [],
+    openaiCompatibleProviders: settings.openaiCompatibleProviders ?? [],
   });
 
   useWorktreeStore.setState({
@@ -831,6 +845,7 @@ function buildSettingsUpdateFromStore(): Record<string, unknown> {
     claudeApiProfiles: aiState.claudeApiProfiles,
     activeClaudeApiProfileId: aiState.activeClaudeApiProfileId,
     claudeCompatibleProviders: aiState.claudeCompatibleProviders,
+    openaiCompatibleProviders: aiState.openaiCompatibleProviders,
     // Worktree store
     maxConcurrency: worktreeState.maxConcurrency,
     autoModeByWorktree: persistedAutoModeByWorktree,

--- a/apps/ui/src/routes/chat.tsx
+++ b/apps/ui/src/routes/chat.tsx
@@ -1,0 +1,29 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useAppStore } from '@/store/app-store';
+import { useChatSession } from '@/hooks/use-chat-session';
+import { ChatOverlayContent } from '@/components/views/chat-overlay/chat-overlay-content';
+
+function ChatPage() {
+  const navigate = useNavigate();
+  const currentProject = useAppStore((s) => s.currentProject);
+
+  const chatSession = useChatSession({
+    defaultModel: 'sonnet',
+    projectPath: currentProject?.path,
+    projectId: currentProject?.id,
+  });
+
+  const handleHide = () => {
+    navigate({ to: '/' });
+  };
+
+  return (
+    <div className="h-full">
+      <ChatOverlayContent {...chatSession} onHide={handleHide} />
+    </div>
+  );
+}
+
+export const Route = createFileRoute('/chat')({
+  component: ChatPage,
+});

--- a/apps/ui/src/store/ai-models-store.ts
+++ b/apps/ui/src/store/ai-models-store.ts
@@ -11,6 +11,7 @@ import type {
   ModelDefinition,
   ClaudeCompatibleProvider,
   ClaudeApiProfile,
+  OpenAICompatibleConfig,
 } from '@protolabs-ai/types';
 import {
   getAllCursorModelIds,
@@ -68,6 +69,8 @@ interface AIModelsState {
   skipSandboxWarning: boolean;
   // Claude-Compatible Providers
   claudeCompatibleProviders: ClaudeCompatibleProvider[];
+  // OpenAI-Compatible Providers
+  openaiCompatibleProviders: OpenAICompatibleConfig[];
   // Claude API Profiles (deprecated)
   claudeApiProfiles: ClaudeApiProfile[];
   activeClaudeApiProfileId: string | null;
@@ -138,6 +141,15 @@ interface AIModelsActions {
   // Claude Agent SDK Settings actions
   setAutoLoadClaudeMd: (enabled: boolean) => Promise<void>;
   setSkipSandboxWarning: (skip: boolean) => Promise<void>;
+  // OpenAI-Compatible Provider actions
+  addOpenAICompatibleProvider: (provider: OpenAICompatibleConfig) => Promise<void>;
+  updateOpenAICompatibleProvider: (
+    id: string,
+    updates: Partial<OpenAICompatibleConfig>
+  ) => Promise<void>;
+  deleteOpenAICompatibleProvider: (id: string) => Promise<void>;
+  setOpenAICompatibleProviders: (providers: OpenAICompatibleConfig[]) => Promise<void>;
+  toggleOpenAICompatibleProviderEnabled: (id: string) => Promise<void>;
   // Claude-Compatible Provider actions
   addClaudeCompatibleProvider: (provider: ClaudeCompatibleProvider) => Promise<void>;
   updateClaudeCompatibleProvider: (
@@ -203,6 +215,7 @@ const initialState: AIModelsState = {
   autoLoadClaudeMd: false,
   skipSandboxWarning: false,
   claudeCompatibleProviders: [],
+  openaiCompatibleProviders: [],
   claudeApiProfiles: [],
   activeClaudeApiProfileId: null,
   claudeRefreshInterval: 60,
@@ -372,6 +385,47 @@ export const useAIModelsStore = create<AIModelsState & AIModelsActions>()((set, 
       logger.error('Failed to sync skipSandboxWarning setting to server - reverting');
       set({ skipSandboxWarning: previous });
     }
+  },
+
+  // OpenAI-Compatible Provider actions
+  addOpenAICompatibleProvider: async (provider) => {
+    set({ openaiCompatibleProviders: [...get().openaiCompatibleProviders, provider] });
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  updateOpenAICompatibleProvider: async (id, updates) => {
+    set({
+      openaiCompatibleProviders: get().openaiCompatibleProviders.map((p) =>
+        p.id === id ? { ...p, ...updates } : p
+      ),
+    });
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  deleteOpenAICompatibleProvider: async (id) => {
+    set({
+      openaiCompatibleProviders: get().openaiCompatibleProviders.filter((p) => p.id !== id),
+    });
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  setOpenAICompatibleProviders: async (providers) => {
+    set({ openaiCompatibleProviders: providers });
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
+  },
+
+  toggleOpenAICompatibleProviderEnabled: async (id) => {
+    set({
+      openaiCompatibleProviders: get().openaiCompatibleProviders.map((p) =>
+        p.id === id ? { ...p, enabled: p.enabled === false ? true : false } : p
+      ),
+    });
+    const { syncSettingsToServer } = await import('@/hooks/use-settings-migration');
+    await syncSettingsToServer();
   },
 
   // Claude-Compatible Provider actions


### PR DESCRIPTION
## Promotion: staging → main

### Changes

- **fix(ci)**: bump deploy-staging timeout 30→60min + enable BuildKit (#1398) — prevents future staging timeouts
- **chore**: update CLAUDE.md + agent memory + skill files (#1397)
- **feat(ui)**: OpenAI-compatible provider settings tab with model selector (#1396)
- **refactor**: extract buildGitAddCommand to shared utility + regression tests (#1389)
- **feat(ui)**: full-screen /chat route + Chat nav in MobileBottomNav and Sidebar (#1394)
- **feat(ui)**: wire project context into ChatOverlayContent and ChatSidebar (#1393)
- **feat(ui)**: Groq Settings UI — provider tab, model selector, API key management (#1392)

### Merge strategy

Must use **merge commit** (`--merge`) to preserve DAG for next promotion cycle.