### PR TITLE
promote: dev → staging (createFlowModel adapter)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -30,6 +30,8 @@
     "@anthropic-ai/sdk": "^0.65.0",
     "@langchain/anthropic": "^0.3.34",
     "@langchain/core": "^0.3.80",
+    "@langchain/groq": "^0.1.3",
+    "@langchain/openai": "^0.3.17",
     "@langfuse/otel": "^4.6.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@napi-rs/whisper": "^0.0.4",

--- a/apps/server/src/lib/flow-model-factory.ts
+++ b/apps/server/src/lib/flow-model-factory.ts
@@ -1,0 +1,154 @@
+/**
+ * Flow Model Factory
+ *
+ * Creates LangChain BaseChatModel instances for use in LangGraph flows.
+ * Reads model configuration from settings via getPhaseModelWithOverrides,
+ * supporting Claude (Anthropic), Groq, and OpenAI-compatible providers.
+ *
+ * Usage:
+ *   const model = await createFlowModel('specGenerationModel', projectPath, services);
+ */
+
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { ChatAnthropic } from '@langchain/anthropic';
+import { createLogger } from '@protolabs-ai/utils';
+import { resolvePhaseModel } from '@protolabs-ai/model-resolver';
+import type { PhaseModelKey, ClaudeCompatibleProvider, Credentials } from '@protolabs-ai/types';
+import { getPhaseModelWithOverrides } from './settings-helpers.js';
+import type { SettingsService } from '../services/settings-service.js';
+
+const logger = createLogger('FlowModelFactory');
+
+/**
+ * Groq model patterns — these model IDs are served via Groq's fast inference API.
+ * Matches llama-*, mixtral-*, gemma-* prefixes and the groq/ explicit prefix.
+ */
+const GROQ_MODEL_PREFIXES = ['llama-', 'mixtral-', 'gemma-'];
+
+function isGroqModel(model: string): boolean {
+  return (
+    model.startsWith('groq/') || GROQ_MODEL_PREFIXES.some((prefix) => model.startsWith(prefix))
+  );
+}
+
+/**
+ * Resolve the API key for a ClaudeCompatibleProvider based on its apiKeySource strategy.
+ */
+function resolveProviderApiKey(
+  provider: ClaudeCompatibleProvider,
+  credentials: Credentials | undefined
+): string | undefined {
+  switch (provider.apiKeySource) {
+    case 'inline':
+      return provider.apiKey;
+    case 'env':
+      return process.env.ANTHROPIC_API_KEY;
+    case 'credentials':
+      return credentials?.apiKeys?.anthropic || undefined;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Create a LangChain BaseChatModel for a given phase, resolved from settings.
+ *
+ * Resolution order:
+ * 1. Project-level phase model override (if projectPath provided)
+ * 2. Global phase model setting
+ * 3. Default phase model (from DEFAULT_PHASE_MODELS)
+ *
+ * Model routing:
+ * - claude-* models → ChatAnthropic (with optional provider baseURL/apiKey)
+ * - llama-*, mixtral-*, gemma-*, groq/* → ChatGroq
+ * - All other models with a provider → ChatOpenAI (OpenAI-compatible)
+ * - Unknown/no-provider fallback → ChatAnthropic with claude-sonnet
+ *
+ * @param phase - The phase key (e.g., 'specGenerationModel', 'fileDescriptionModel')
+ * @param projectPath - Optional project path for project-level overrides
+ * @param services - Services container providing settingsService
+ * @returns Resolved BaseChatModel instance
+ */
+export async function createFlowModel(
+  phase: PhaseModelKey,
+  projectPath: string | undefined,
+  services: { settingsService: SettingsService | null | undefined }
+): Promise<BaseChatModel> {
+  const { phaseModel, provider, credentials } = await getPhaseModelWithOverrides(
+    phase,
+    services.settingsService,
+    projectPath
+  );
+
+  const { model: resolvedModel } = resolvePhaseModel(phaseModel);
+
+  logger.debug(
+    `createFlowModel: phase=${phase}, resolvedModel=${resolvedModel}, provider=${provider?.name ?? 'none'}`
+  );
+
+  // Claude models (claude-* prefix) — use ChatAnthropic
+  if (resolvedModel.startsWith('claude-') || resolvedModel.startsWith('claude')) {
+    const config: {
+      model: string;
+      apiKey?: string;
+      anthropicApiUrl?: string;
+    } = { model: resolvedModel };
+
+    if (provider) {
+      const apiKey = resolveProviderApiKey(provider, credentials);
+      if (apiKey) {
+        config.apiKey = apiKey;
+      }
+      if (provider.baseUrl) {
+        config.anthropicApiUrl = provider.baseUrl;
+      }
+    }
+
+    logger.debug(`createFlowModel: using ChatAnthropic for model=${resolvedModel}`);
+    return new ChatAnthropic(config) as unknown as BaseChatModel;
+  }
+
+  // Groq models (llama-*, mixtral-*, gemma-*, groq/*) — use ChatGroq
+  if (isGroqModel(resolvedModel)) {
+    try {
+      const { ChatGroq } = await import('@langchain/groq');
+      const apiKey = process.env.GROQ_API_KEY;
+      logger.debug(`createFlowModel: using ChatGroq for model=${resolvedModel}`);
+      return new ChatGroq({ model: resolvedModel, apiKey }) as unknown as BaseChatModel;
+    } catch {
+      logger.warn(
+        `createFlowModel: @langchain/groq not available, falling back to ChatAnthropic for model=${resolvedModel}`
+      );
+    }
+  }
+
+  // OpenAI-compatible models (non-claude, non-groq) — use ChatOpenAI when provider is set
+  if (provider) {
+    try {
+      const { ChatOpenAI } = await import('@langchain/openai');
+      const apiKey = resolveProviderApiKey(provider, credentials);
+      logger.debug(
+        `createFlowModel: using ChatOpenAI for model=${resolvedModel}, baseURL=${provider.baseUrl}`
+      );
+      return new ChatOpenAI({
+        model: resolvedModel,
+        openAIApiKey: apiKey,
+        configuration: {
+          baseURL: provider.baseUrl,
+          apiKey: apiKey,
+        },
+      }) as unknown as BaseChatModel;
+    } catch {
+      logger.warn(
+        `createFlowModel: @langchain/openai not available, falling back to ChatAnthropic for model=${resolvedModel}`
+      );
+    }
+  }
+
+  // Fallback: use Claude Sonnet via ChatAnthropic
+  const fallbackModel = 'claude-sonnet-4-5-20250929';
+  logger.warn(
+    `createFlowModel: unknown model "${resolvedModel}" for phase "${phase}", falling back to ${fallbackModel}`
+  );
+  return new ChatAnthropic({ model: fallbackModel }) as unknown as BaseChatModel;
+}

--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -266,6 +266,8 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
 
   // Settings & identity (created first — injected into most other services)
   const settingsService = new SettingsService(dataDir);
+  // Wire settingsService into the contentFlowService singleton for model resolution
+  contentFlowService.setSettingsService(settingsService);
   const userIdentityService = new UserIdentityService(settingsService);
   const featureLoader = new FeatureLoader();
 
@@ -609,7 +611,7 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   try {
     const { createLLMProjectPlanningConfig } =
       await import('../services/project-planning-executors.js');
-    const planningFlowConfig = createLLMProjectPlanningConfig();
+    const planningFlowConfig = await createLLMProjectPlanningConfig({ settingsService });
     projectPlanningService = new ProjectPlanningService(
       events,
       linearAgentService,

--- a/apps/server/src/services/antagonistic-review-adapter.ts
+++ b/apps/server/src/services/antagonistic-review-adapter.ts
@@ -7,11 +7,12 @@
  */
 
 import { createLogger } from '@protolabs-ai/utils';
-import { ChatAnthropic } from '@langchain/anthropic';
 import { createAntagonisticReviewGraph } from '@protolabs-ai/flows';
 import type { SPARCPrd } from '@protolabs-ai/types';
 import { LangfuseClient } from '@protolabs-ai/observability';
 import { v4 as uuidv4 } from 'uuid';
+import { createFlowModel } from '../lib/flow-model-factory.js';
+import type { SettingsService } from './settings-service.js';
 
 const logger = createLogger('AntagonisticReviewAdapter');
 
@@ -75,9 +76,17 @@ export interface ReviewRequest {
  * Configuration for the adapter
  */
 export interface AdapterConfig {
+  /**
+   * @deprecated Model selection is now handled by createFlowModel() via specGenerationModel phase.
+   * This field is kept for backward compatibility but has no effect.
+   */
   smartModel?: string;
   enableHITL?: boolean;
   langfuseClient?: LangfuseClient;
+  /** Settings service for resolving the specGenerationModel phase model */
+  settingsService?: SettingsService | null;
+  /** Project path for project-level model overrides */
+  projectPath?: string;
 }
 
 /**
@@ -101,9 +110,10 @@ export class AntagonisticReviewAdapter {
 
   constructor(config: AdapterConfig = {}) {
     this.config = {
-      smartModel: config.smartModel || 'claude-sonnet-4-5-20250929',
       enableHITL: config.enableHITL || false,
       langfuseClient: config.langfuseClient,
+      settingsService: config.settingsService,
+      projectPath: config.projectPath,
     };
     this.langfuse = config.langfuseClient || null;
   }
@@ -145,11 +155,9 @@ export class AntagonisticReviewAdapter {
       // Create the flow graph (checkpointing enabled by default)
       const graph = createAntagonisticReviewGraph(true);
 
-      // Create LLM models for the review nodes
-      const smartModel = new ChatAnthropic({
-        model: this.config.smartModel || 'claude-sonnet-4-5-20250929',
-        temperature: 0.7,
-        maxTokens: 8192,
+      // Create LLM model for the review nodes via settings-aware factory
+      const smartModel = await createFlowModel('specGenerationModel', this.config.projectPath, {
+        settingsService: this.config.settingsService,
       });
 
       // Use thread ID for checkpointing (required for HITL resume)

--- a/apps/server/src/services/content-flow-service.ts
+++ b/apps/server/src/services/content-flow-service.ts
@@ -11,10 +11,11 @@ import fs from 'node:fs/promises';
 import { createLogger } from '@protolabs-ai/utils';
 import { getAutomakerDir } from '@protolabs-ai/platform';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
-import { ChatAnthropic } from '@langchain/anthropic';
 import { createContentCreationFlow } from '@protolabs-ai/flows';
 import type { EventEmitter } from '../lib/events.js';
 import { getLangfuseInstance } from '../lib/langfuse-singleton.js';
+import { createFlowModel } from '../lib/flow-model-factory.js';
+import type { SettingsService } from './settings-service.js';
 
 const logger = createLogger('ContentFlowService');
 
@@ -124,9 +125,11 @@ export interface HITLReview {
 export class ContentFlowService {
   private activeRuns: Map<string, ContentFlowStatus>;
   private events: EventEmitter | null = null;
+  private settingsService: SettingsService | null | undefined;
 
-  constructor() {
+  constructor(settingsService?: SettingsService | null) {
     this.activeRuns = new Map();
+    this.settingsService = settingsService;
   }
 
   /**
@@ -134,6 +137,14 @@ export class ContentFlowService {
    */
   setEventEmitter(emitter: EventEmitter): void {
     this.events = emitter;
+  }
+
+  /**
+   * Set settings service for model resolution.
+   * Can be called after construction to wire in the service.
+   */
+  setSettingsService(settingsService: SettingsService | null | undefined): void {
+    this.settingsService = settingsService;
   }
 
   /**
@@ -155,21 +166,18 @@ export class ContentFlowService {
   }
 
   /**
-   * Create models from config
+   * Create models from settings via createFlowModel().
+   * Uses specGenerationModel for heavy content generation (smart model)
+   * and fileDescriptionModel for fast auxiliary tasks.
    */
-  private createModels(): { smartModel: BaseChatModel; fastModel: BaseChatModel } {
-    // Cast needed: ChatAnthropic's type doesn't perfectly align with BaseChatModel
-    // due to LangChain version mismatch on the 'profile' property, but works at runtime
-    const smartModel = new ChatAnthropic({
-      model: 'claude-sonnet-4-5-20250929',
-      temperature: 0.7,
-    }) as unknown as BaseChatModel;
-
-    const fastModel = new ChatAnthropic({
-      model: 'claude-haiku-4-5-20251001',
-      temperature: 0.5,
-    }) as unknown as BaseChatModel;
-
+  private async createModels(
+    projectPath: string
+  ): Promise<{ smartModel: BaseChatModel; fastModel: BaseChatModel }> {
+    const services = { settingsService: this.settingsService };
+    const [smartModel, fastModel] = await Promise.all([
+      createFlowModel('specGenerationModel', projectPath, services),
+      createFlowModel('fileDescriptionModel', projectPath, services),
+    ]);
     return { smartModel, fastModel };
   }
 
@@ -197,7 +205,7 @@ export class ContentFlowService {
       `Starting content flow ${runId} for topic: ${topic} (autonomous=${!contentConfig?.enableHITL})`
     );
 
-    const { smartModel, fastModel } = this.createModels();
+    const { smartModel, fastModel } = await this.createModels(projectPath);
 
     // Initialize Langfuse tracing
     const langfuse = getLangfuseInstance();

--- a/apps/server/src/services/project-planning-executors.ts
+++ b/apps/server/src/services/project-planning-executors.ts
@@ -3,13 +3,12 @@
  *
  * Creates a ProjectPlanningFlowConfig with real LLM-powered executors.
  * This is the production wiring that replaces mock executors with actual
- * ChatAnthropic models.
+ * LangChain models resolved from settings.
  *
  * Used by: server index.ts when initializing ProjectPlanningService
  */
 
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
-import { ChatAnthropic } from '@langchain/anthropic';
 import {
   type ProjectPlanningFlowConfig,
   createLLMResearchExecutor,
@@ -19,43 +18,36 @@ import {
   createLLMMilestonePlanner,
 } from '@protolabs-ai/flows';
 import { createLogger } from '@protolabs-ai/utils';
+import { createFlowModel } from '../lib/flow-model-factory.js';
+import type { SettingsService } from './settings-service.js';
 
 const logger = createLogger('ProjectPlanningExecutors');
 
 /**
- * Create ChatAnthropic models for planning flow.
- *
- * Uses sonnet for all planning tasks (smart model).
- * The double cast is needed due to LangChain type mismatch on the 'profile' property
- * — same pattern used in ContentFlowService and AntagonisticReviewAdapter.
- */
-function createModels(): { smartModel: BaseChatModel; fastModel: BaseChatModel } {
-  const smartModel = new ChatAnthropic({
-    model: 'claude-sonnet-4-5-20250929',
-    temperature: 0.7,
-    maxTokens: 8192,
-  }) as unknown as BaseChatModel;
-
-  const fastModel = new ChatAnthropic({
-    model: 'claude-haiku-4-5-20251001',
-    temperature: 0.5,
-    maxTokens: 4096,
-  }) as unknown as BaseChatModel;
-
-  return { smartModel, fastModel };
-}
-
-/**
  * Creates a ProjectPlanningFlowConfig with real LLM executors.
  *
- * All 5 planning executors use the smart model (sonnet) by default.
+ * The model for all planning executors is resolved from the 'specGenerationModel'
+ * phase setting, applying project-level overrides when projectPath is provided.
+ *
+ * All 5 planning executors use the smart model by default.
  * The IssueCreator is NOT included here — it's injected separately
  * by ProjectPlanningService using the LinearMCPClient.
+ *
+ * @param services - Services container with settingsService for model resolution
+ * @param projectPath - Optional project path for per-project model overrides
+ * @returns Promise resolving to ProjectPlanningFlowConfig with LLM executors
  */
-export function createLLMProjectPlanningConfig(): ProjectPlanningFlowConfig {
-  const { smartModel } = createModels();
+export async function createLLMProjectPlanningConfig(
+  services?: { settingsService: SettingsService | null | undefined },
+  projectPath?: string
+): Promise<ProjectPlanningFlowConfig> {
+  const smartModel: BaseChatModel = await createFlowModel(
+    'specGenerationModel',
+    projectPath,
+    services ?? { settingsService: undefined }
+  );
 
-  logger.info('Created LLM-powered project planning executors (sonnet)');
+  logger.info('Created LLM-powered project planning executors (specGenerationModel)');
 
   return {
     researchExecutor: createLLMResearchExecutor(smartModel),

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,8 @@
         "@anthropic-ai/sdk": "^0.65.0",
         "@langchain/anthropic": "^0.3.34",
         "@langchain/core": "^0.3.80",
+        "@langchain/groq": "^0.1.3",
+        "@langchain/openai": "^0.3.17",
         "@langfuse/otel": "^4.6.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@napi-rs/whisper": "^0.0.4",
@@ -6561,6 +6563,33 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@langchain/groq": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@langchain/groq/-/groq-0.1.3.tgz",
+      "integrity": "sha512-dMzvBVaLf/0IQoHdAOAN8W/PbOcwgbvgUMCn02CqvCC90mxZ45LI0Tipzqnoaam0hiKALR5hLc3dNj1oCYV92w==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/openai": "~0.3.0",
+        "groq-sdk": "^0.5.0",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.2.21 <0.4.0"
+      }
+    },
+    "node_modules/@langchain/groq/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@langchain/langgraph": {
       "version": "0.2.74",
       "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-0.2.74.tgz",
@@ -6668,6 +6697,33 @@
       }
     },
     "node_modules/@langchain/langgraph/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@langchain/openai": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.3.17.tgz",
+      "integrity": "sha512-uw4po32OKptVjq+CYHrumgbfh4NuD7LqyE+ZgqY9I/LrLc6bHLMc+sisHmI17vgek0K/yqtarI0alPJbzrwyag==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tiktoken": "^1.0.12",
+        "openai": "^4.77.0",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.3.29 <0.4.0"
+      }
+    },
+    "node_modules/@langchain/openai/node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",


### PR DESCRIPTION
## Summary

Promotes 1 commit from dev to staging:

- feat: createFlowModel adapter — unified LangGraph flow model creation (#1401)

Replaces hardcoded ChatAnthropic in 3 LangGraph services with a unified createFlowModel() adapter that supports Claude, Groq, and OpenAI-compatible providers.

---
*Promotion PR — merge commit only, do not squash*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Groq and OpenAI as LLM providers alongside existing Claude support
  * Introduced flexible model configuration with project-level and global settings for LLM selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->