### PR TITLE
fix: rebase before PR creation in non-Graphite path

### DIFF
--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -470,8 +470,48 @@ export class GitWorkflowService {
       this.trackOperation('commit', featureId, true);
       logger.info(`Committed changes for feature ${featureId}: ${commitHash}`);
 
-      // Step 1.5: Restack with Graphite before pushing (if enabled)
-      // This ensures the branch is up to date with trunk/main to prevent merge conflicts
+      // Step 1.5: Rebase/restack before push to prevent CONFLICTING PRs
+      // Graphite handles this via restack; without Graphite, rebase manually.
+      let needsForceWithLease = false;
+
+      if (!useGraphite && gitSettings.autoPush) {
+        try {
+          const targetBranch = `origin/${prBaseBranch}`;
+          logger.info(`Rebasing branch ${branchName} onto ${targetBranch} before push`);
+          await execAsync(`git fetch origin ${prBaseBranch}`, {
+            cwd: workDir,
+            env: execEnv,
+            timeout: 30_000,
+          });
+          await execAsync(`git rebase ${targetBranch}`, {
+            cwd: workDir,
+            env: execEnv,
+            timeout: 60_000,
+          });
+          needsForceWithLease = true;
+          logger.info(`Successfully rebased branch ${branchName} onto ${targetBranch}`);
+        } catch (rebaseError) {
+          const errorMsg = rebaseError instanceof Error ? rebaseError.message : String(rebaseError);
+          if (errorMsg.includes('conflict') || errorMsg.includes('CONFLICT')) {
+            logger.warn(
+              `Rebase conflicts for ${branchName}, aborting rebase — PR may need manual rebase`
+            );
+            try {
+              await execAsync('git rebase --abort', { cwd: workDir, env: execEnv });
+            } catch {
+              // Best-effort abort
+            }
+          } else {
+            logger.warn(`Rebase failed for ${branchName}: ${errorMsg} — continuing without rebase`);
+            try {
+              await execAsync('git rebase --abort', { cwd: workDir, env: execEnv });
+            } catch {
+              // Best-effort abort — may not be in rebase state
+            }
+          }
+        }
+      }
+
       if (useGraphite && gitSettings.autoPush) {
         try {
           logger.info(`Restacking branch ${branchName} before push`);
@@ -506,7 +546,7 @@ export class GitWorkflowService {
             // Graphite push handles force-push-with-lease for rebased stacks
             pushed = await graphiteService.push(workDir);
           } else {
-            pushed = await this.pushToRemote(workDir, branchName);
+            pushed = await this.pushToRemote(workDir, branchName, needsForceWithLease);
           }
           result.pushed = pushed;
           if (pushed) {
@@ -1207,17 +1247,22 @@ export class GitWorkflowService {
    * Uses exponential backoff retry (3 attempts with 2s/4s/8s delays).
    * @returns true if push succeeded
    */
-  private async pushToRemote(workDir: string, branchName: string): Promise<boolean> {
+  private async pushToRemote(
+    workDir: string,
+    branchName: string,
+    forceWithLease: boolean = false
+  ): Promise<boolean> {
+    const forceFlag = forceWithLease ? ' --force-with-lease' : '';
     return await retryWithExponentialBackoff(async () => {
       try {
-        await execAsync(`git push -u origin ${branchName}`, {
+        await execAsync(`git push${forceFlag} -u origin ${branchName}`, {
           cwd: workDir,
           env: execEnv,
         });
         return true;
       } catch {
         // Try with --set-upstream
-        await execAsync(`git push --set-upstream origin ${branchName}`, {
+        await execAsync(`git push${forceFlag} --set-upstream origin ${branchName}`, {
           cwd: workDir,
           env: execEnv,
         });

--- a/apps/server/src/services/worktree-recovery-service.ts
+++ b/apps/server/src/services/worktree-recovery-service.ts
@@ -141,8 +141,42 @@ export async function checkAndRecoverUncommittedWork(
 
     logger.info(`[PostAgentHook] Committed uncommitted work for feature ${feature.id}`);
 
+    // Step 3.5: Rebase onto origin/dev before push to prevent CONFLICTING PRs
+    let useForceWithLease = false;
+    try {
+      await execAsync('git fetch origin dev', {
+        cwd: worktreePath,
+        env: execEnv,
+        timeout: 30_000,
+      });
+      await execAsync('git rebase origin/dev', {
+        cwd: worktreePath,
+        env: execEnv,
+        timeout: 60_000,
+      });
+      useForceWithLease = true;
+    } catch (rebaseError) {
+      const msg = rebaseError instanceof Error ? rebaseError.message : String(rebaseError);
+      if (msg.includes('conflict') || msg.includes('CONFLICT')) {
+        try {
+          await execAsync('git rebase --abort', { cwd: worktreePath, env: execEnv });
+        } catch {
+          // Best-effort abort
+        }
+        logger.warn(`[PostAgentHook] Rebase conflicts for ${feature.id}, pushing without rebase`);
+      } else {
+        logger.warn(`[PostAgentHook] Rebase failed for ${feature.id}: ${msg}`);
+        try {
+          await execAsync('git rebase --abort', { cwd: worktreePath, env: execEnv });
+        } catch {
+          // Best-effort abort — may not be in rebase state
+        }
+      }
+    }
+
     // Step 4: Push to remote with -u
-    await execAsync(`git push -u origin "${branchName}"`, {
+    const forceFlag = useForceWithLease ? ' --force-with-lease' : '';
+    await execAsync(`git push${forceFlag} -u origin "${branchName}"`, {
       cwd: worktreePath,
       env: execEnv,
     });

--- a/apps/server/tests/unit/services/worktree-recovery-service.test.ts
+++ b/apps/server/tests/unit/services/worktree-recovery-service.test.ts
@@ -67,7 +67,11 @@ describe('worktree-recovery-service', () => {
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit (execFile)
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // git push
+      // git fetch origin dev (rebase step)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git rebase origin/dev (rebase step)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git push --force-with-lease
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // gh pr create
       mockExec.mockResolvedValueOnce({
@@ -111,6 +115,10 @@ describe('worktree-recovery-service', () => {
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit succeeds
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git fetch origin dev (rebase step)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git rebase origin/dev (rebase step)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git push fails
       mockExec.mockRejectedValueOnce(new Error('remote: Permission denied'));
 
@@ -132,7 +140,11 @@ describe('worktree-recovery-service', () => {
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit succeeds
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // git push succeeds
+      // git fetch origin dev (rebase step)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git rebase origin/dev (rebase step)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git push --force-with-lease succeeds
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // gh pr create succeeds
       mockExec.mockResolvedValueOnce({
@@ -146,6 +158,70 @@ describe('worktree-recovery-service', () => {
       expect(result.detected).toBe(true);
       expect(result.recovered).toBe(true);
       expect(result.prNumber).toBe(99);
+    });
+
+    it('recovers when rebase conflicts — pushes without force-with-lease', async () => {
+      // git status --short
+      mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
+      // git diff HEAD (for prettier formatting)
+      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      // npx prettier
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git add
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git commit (execFile)
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git fetch origin dev (rebase step)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git rebase origin/dev FAILS with CONFLICT
+      mockExec.mockRejectedValueOnce(
+        new Error('CONFLICT (content): Merge conflict in src/index.ts')
+      );
+      // git rebase --abort (best-effort)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git push (NO --force-with-lease since rebase was aborted)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // gh pr create
+      mockExec.mockResolvedValueOnce({
+        stdout: 'https://github.com/owner/repo/pull/55\n',
+        stderr: '',
+      });
+
+      const result = await checkAndRecoverUncommittedWork(baseFeature, '/mock/worktree');
+
+      expect(result.detected).toBe(true);
+      expect(result.recovered).toBe(true);
+      expect(result.prNumber).toBe(55);
+    });
+
+    it('recovers when rebase fails for non-conflict reason — aborts and pushes normally', async () => {
+      // git status --short
+      mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
+      // git diff HEAD
+      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      // npx prettier
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git add
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git commit (execFile)
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git fetch origin dev — fails (network error)
+      mockExec.mockRejectedValueOnce(new Error('fatal: unable to access remote'));
+      // git rebase --abort (best-effort after non-conflict failure)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git push (NO --force-with-lease)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // gh pr create
+      mockExec.mockResolvedValueOnce({
+        stdout: 'https://github.com/owner/repo/pull/77\n',
+        stderr: '',
+      });
+
+      const result = await checkAndRecoverUncommittedWork(baseFeature, '/mock/worktree');
+
+      expect(result.detected).toBe(true);
+      expect(result.recovered).toBe(true);
+      expect(result.prNumber).toBe(77);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add rebase step between commit and push for non-Graphite users in both `git-workflow-service` and `worktree-recovery-service`
- Without this, agent PRs are created against a stale base and immediately marked CONFLICTING by GitHub, requiring manual cherry-pick recovery
- Uses `--force-with-lease` on push after successful rebase; aborts rebase on any failure (conflict or otherwise) and falls back to pushing without rebase (no regression vs today)

## Test plan
- [x] `npm run build:server` compiles (no new errors)
- [x] `npm run test:server` -- 8/8 worktree recovery tests pass (2 new: conflict path, non-conflict failure path)
- [ ] CI passes
- [ ] Manual: create a feature, let agent run, verify PR is MERGEABLE (not CONFLICTING)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic rebasing during pre-push when autoPush is enabled
  * Enhanced conflict handling in recovery workflows with intelligent abort and retry logic

* **Bug Fixes**
  * Improved push operation resilience with conditional force-with-lease support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->