### PR TITLE
fix(ava-chat): wire real tool/sitrep/config implementations + docs

### DIFF
--- a/apps/server/src/routes/ava/index.ts
+++ b/apps/server/src/routes/ava/index.ts
@@ -3,52 +3,16 @@
  */
 
 import { Router, type Request, type Response } from 'express';
-import { promises as fs } from 'node:fs';
-import { join } from 'node:path';
 import { createLogger } from '@protolabs-ai/utils';
 
 import type { ServiceContainer } from '../../server/services.js';
 import { createStatusHandler } from './routes/status.js';
+import { loadAvaConfig, saveAvaConfig } from '../chat/ava-config.js';
+import type { AvaConfig } from '../chat/ava-config.js';
+
+export type { AvaConfig };
 
 const logger = createLogger('AvaRoutes');
-
-/**
- * Per-project Ava configuration stored in {projectPath}/.automaker/ava-config.json
- */
-export interface AvaConfig {
-  projectPath: string;
-  enabled: boolean;
-  infraChannelId?: string;
-  heartbeatIntervalMs?: number;
-}
-
-const DEFAULT_AVA_CONFIG: Omit<AvaConfig, 'projectPath'> = {
-  enabled: false,
-  infraChannelId: undefined,
-  heartbeatIntervalMs: 60000,
-};
-
-function getAvaConfigPath(projectPath: string): string {
-  return join(projectPath, '.automaker', 'ava-config.json');
-}
-
-async function readAvaConfig(projectPath: string): Promise<AvaConfig> {
-  const configPath = getAvaConfigPath(projectPath);
-  try {
-    const raw = await fs.readFile(configPath, 'utf-8');
-    const parsed = JSON.parse(raw) as Partial<AvaConfig>;
-    return { ...DEFAULT_AVA_CONFIG, projectPath, ...parsed };
-  } catch {
-    return { ...DEFAULT_AVA_CONFIG, projectPath };
-  }
-}
-
-async function writeAvaConfig(config: AvaConfig): Promise<void> {
-  const configPath = getAvaConfigPath(config.projectPath);
-  const dir = join(config.projectPath, '.automaker');
-  await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8');
-}
 
 export function createAvaRoutes(services: ServiceContainer): Router {
   const router = Router();
@@ -59,7 +23,7 @@ export function createAvaRoutes(services: ServiceContainer): Router {
   /**
    * POST /api/ava/config/get
    * Body: { projectPath: string }
-   * Returns: AvaConfig
+   * Returns: { success: true, config: AvaConfig }
    */
   router.post('/config/get', async (req: Request, res: Response): Promise<void> => {
     try {
@@ -73,9 +37,8 @@ export function createAvaRoutes(services: ServiceContainer): Router {
         return;
       }
 
-      const config = await readAvaConfig(projectPath);
-
-      res.json({ success: true, data: config });
+      const config = await loadAvaConfig(projectPath);
+      res.json({ success: true, config });
     } catch (error) {
       logger.error('Failed to get Ava config:', error);
       res.status(500).json({
@@ -91,7 +54,7 @@ export function createAvaRoutes(services: ServiceContainer): Router {
   /**
    * POST /api/ava/config/update
    * Body: { projectPath: string, config: Partial<AvaConfig> }
-   * Returns: updated AvaConfig
+   * Returns: { success: true, config: AvaConfig }
    */
   router.post('/config/update', async (req: Request, res: Response): Promise<void> => {
     try {
@@ -116,17 +79,8 @@ export function createAvaRoutes(services: ServiceContainer): Router {
         return;
       }
 
-      const existing = await readAvaConfig(projectPath);
-      const updated: AvaConfig = { ...existing, ...configUpdate, projectPath };
-
-      await writeAvaConfig(updated);
-
-      // Reflect config changes in the live gateway service if applicable
-      if (updated.infraChannelId) {
-        services.avaGatewayService.setInfraChannelId(updated.infraChannelId);
-      }
-
-      res.json({ success: true, data: updated });
+      const config = await saveAvaConfig(projectPath, configUpdate);
+      res.json({ success: true, config });
     } catch (error) {
       logger.error('Failed to update Ava config:', error);
       res.status(500).json({

--- a/apps/server/src/routes/chat/ava-config.ts
+++ b/apps/server/src/routes/chat/ava-config.ts
@@ -14,6 +14,9 @@ import path from 'path';
 import { createLogger } from '@protolabs-ai/utils';
 import { getAutomakerDir, ensureAutomakerDir } from '@protolabs-ai/platform';
 import * as secureFs from '../../lib/secure-fs.js';
+import type { AvaToolsConfig } from './ava-tools.js';
+
+export type { AvaToolsConfig };
 
 const logger = createLogger('AvaConfig');
 
@@ -22,32 +25,20 @@ const logger = createLogger('AvaConfig');
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Per-tool enable/disable flags for Ava.
- * Each key represents a named tool capability.
- */
-export interface AvaToolsConfig {
-  /** Full-text search across the project knowledge base */
-  knowledgeSearch: boolean;
-  /** Board / feature read access (list features, check status) */
-  readBoard: boolean;
-  /** Sitrep generation (generate and display a situation report) */
-  sitrep: boolean;
-  /** Web search capability */
-  webSearch: boolean;
-}
-
-/**
  * Ava chat configuration stored per-project.
+ *
+ * Field names intentionally match the frontend AvaConfig in ava-client.ts
+ * so the /api/ava/config endpoints can pass through without transformation.
  */
 export interface AvaConfig {
-  /** Claude model alias to use for Ava (e.g. "sonnet", "opus", "haiku") */
-  model: string;
-  /** Per-tool enable/disable flags */
-  tools: AvaToolsConfig;
-  /** When true, inject a situation report into the system prompt */
-  injectSitrep: boolean;
+  /** Claude model alias to use for Ava ("haiku" | "sonnet" | "opus") */
+  model: 'haiku' | 'sonnet' | 'opus';
+  /** Per-tool-group enable/disable flags */
+  toolGroups: AvaToolsConfig;
+  /** When true, inject a live situation report into the system prompt */
+  sitrepInjection: boolean;
   /** When true, inject project context (CLAUDE.md, context files) into the prompt */
-  injectContext: boolean;
+  contextInjection: boolean;
   /** Additional text appended to Ava's base system prompt (empty = no extension) */
   systemPromptExtension: string;
 }
@@ -62,14 +53,16 @@ export interface AvaConfig {
  */
 export const DEFAULT_AVA_CONFIG: AvaConfig = {
   model: 'sonnet',
-  tools: {
-    knowledgeSearch: true,
-    readBoard: true,
-    sitrep: true,
-    webSearch: true,
+  toolGroups: {
+    boardRead: true,
+    boardWrite: true,
+    agentControl: true,
+    autoMode: true,
+    projectMgmt: true,
+    orchestration: true,
   },
-  injectSitrep: true,
-  injectContext: true,
+  sitrepInjection: true,
+  contextInjection: true,
   systemPromptExtension: '',
 };
 
@@ -102,16 +95,16 @@ export async function loadAvaConfig(projectPath: string): Promise<AvaConfig> {
     const content = await secureFs.readFile(configPath, 'utf-8');
     const parsed = JSON.parse(content as string) as Partial<AvaConfig>;
 
-    // Deep-merge: tools are merged separately to preserve all default keys
-    const mergedTools: AvaToolsConfig = {
-      ...DEFAULT_AVA_CONFIG.tools,
-      ...(parsed.tools ?? {}),
+    // Deep-merge: toolGroups are merged separately to preserve all default keys
+    const mergedToolGroups: AvaToolsConfig = {
+      ...DEFAULT_AVA_CONFIG.toolGroups,
+      ...(parsed.toolGroups ?? {}),
     };
 
     const merged: AvaConfig = {
       ...DEFAULT_AVA_CONFIG,
       ...parsed,
-      tools: mergedTools,
+      toolGroups: mergedToolGroups,
     };
 
     logger.debug(`Loaded ava-config from ${configPath}`);
@@ -120,12 +113,12 @@ export async function loadAvaConfig(projectPath: string): Promise<AvaConfig> {
     // File not found — return defaults without writing anything
     if (isEnoentError(error)) {
       logger.debug(`No ava-config at ${configPath}, using defaults`);
-      return { ...DEFAULT_AVA_CONFIG, tools: { ...DEFAULT_AVA_CONFIG.tools } };
+      return { ...DEFAULT_AVA_CONFIG, toolGroups: { ...DEFAULT_AVA_CONFIG.toolGroups } };
     }
 
     // JSON parse errors or other I/O issues — log and fall back to defaults
     logger.warn(`Failed to read ava-config at ${configPath}, using defaults:`, error);
-    return { ...DEFAULT_AVA_CONFIG, tools: { ...DEFAULT_AVA_CONFIG.tools } };
+    return { ...DEFAULT_AVA_CONFIG, toolGroups: { ...DEFAULT_AVA_CONFIG.toolGroups } };
   }
 }
 
@@ -149,16 +142,16 @@ export async function saveAvaConfig(
   // Load current config (may return defaults if file absent)
   const current = await loadAvaConfig(projectPath);
 
-  // Merge tools separately for deep merge semantics
-  const mergedTools: AvaToolsConfig = {
-    ...current.tools,
-    ...(partial.tools ?? {}),
+  // Merge toolGroups separately for deep merge semantics
+  const mergedToolGroups: AvaToolsConfig = {
+    ...current.toolGroups,
+    ...(partial.toolGroups ?? {}),
   };
 
   const merged: AvaConfig = {
     ...current,
     ...partial,
-    tools: mergedTools,
+    toolGroups: mergedToolGroups,
   };
 
   const configPath = getAvaConfigPath(projectPath);

--- a/apps/server/src/routes/chat/index.ts
+++ b/apps/server/src/routes/chat/index.ts
@@ -7,72 +7,26 @@
  *
  * Per-request enrichment:
  * - Loads AvaConfig from <projectPath>/.automaker/ava-config.json
- * - Injects project context via loadContextFiles when injectContext is true
- * - Injects sitrep from <projectPath>/.automaker/sitrep.md when injectSitrep is true
- * - Passes tools from buildAvaTools with maxSteps: 10
+ * - Injects project context via loadContextFiles when contextInjection is true
+ * - Fetches a live sitrep via getSitrep() when sitrepInjection is true
+ * - Builds tool set from buildAvaTools() gated by config.toolGroups
+ * - Passes tools to streamText with maxSteps: 10
  */
 
-import { promises as fs } from 'node:fs';
-import path from 'node:path';
 import { Router, type Request, type Response } from 'express';
-import { streamText, stepCountIs, type ModelMessage, type ToolSet } from 'ai';
+import { streamText, stepCountIs, type ModelMessage } from 'ai';
 import { anthropic } from '@ai-sdk/anthropic';
-import { createLogger } from '@protolabs-ai/utils';
-import { loadContextFiles } from '@protolabs-ai/utils';
+import { createLogger, loadContextFiles } from '@protolabs-ai/utils';
 import { resolveModelString } from '@protolabs-ai/model-resolver';
 import { buildAvaSystemPrompt, type NotesContext } from './personas.js';
+import { loadAvaConfig, DEFAULT_AVA_CONFIG, type AvaConfig } from './ava-config.js';
+import { getSitrep } from './sitrep.js';
+import { buildAvaTools } from './ava-tools.js';
 import type { ServiceContainer } from '../../server/services.js';
 
+export type { AvaConfig };
+
 const logger = createLogger('ChatRoutes');
-
-/**
- * Per-project Ava configuration loaded from .automaker/ava-config.json.
- * All fields are optional with sensible defaults.
- */
-export interface AvaConfig {
-  /** Override the model for this project (haiku | sonnet | opus) */
-  model?: string;
-  /** Whether to inject project context files into the system prompt */
-  injectContext?: boolean;
-  /** Whether to inject the current sitrep into the system prompt */
-  injectSitrep?: boolean;
-}
-
-/**
- * Load AvaConfig from <projectPath>/.automaker/ava-config.json.
- * Returns an empty config if the file does not exist or is invalid JSON.
- * Errors are silently swallowed so a missing config is a no-op.
- */
-async function loadAvaConfig(projectPath: string): Promise<AvaConfig> {
-  try {
-    const configPath = path.join(projectPath, '.automaker', 'ava-config.json');
-    const content = await fs.readFile(configPath, 'utf-8');
-    return JSON.parse(content) as AvaConfig;
-  } catch {
-    return {};
-  }
-}
-
-/**
- * Read the sitrep from <projectPath>/.automaker/sitrep.md.
- * Returns null if the file does not exist.
- */
-async function getSitrep(projectPath: string): Promise<string | null> {
-  try {
-    const sitrepPath = path.join(projectPath, '.automaker', 'sitrep.md');
-    return await fs.readFile(sitrepPath, 'utf-8');
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Build the tool set available to Ava during chat.
- * Currently returns an empty set; extend as Ava tools are added in future features.
- */
-export function buildAvaTools(_services: ServiceContainer): ToolSet {
-  return {};
-}
 
 /** Map our internal aliases to AI SDK model IDs */
 function resolveAISDKModel(modelAlias?: string) {
@@ -146,8 +100,10 @@ export function createChatRoutes(services: ServiceContainer): Router {
 
       const messages = toModelMessages(rawMessages);
 
-      // Load AvaConfig when a projectPath is available (cached read from disk)
-      const avaConfig: AvaConfig = projectPath ? await loadAvaConfig(projectPath) : {};
+      // Load AvaConfig when a projectPath is available; fall back to defaults
+      const avaConfig: AvaConfig = projectPath
+        ? await loadAvaConfig(projectPath)
+        : { ...DEFAULT_AVA_CONFIG, toolGroups: { ...DEFAULT_AVA_CONFIG.toolGroups } };
 
       // Model selection: AvaConfig.model > header > body > default (sonnet)
       const modelAlias =
@@ -157,7 +113,7 @@ export function createChatRoutes(services: ServiceContainer): Router {
 
       // Conditionally load project context files
       let projectContext: string | undefined;
-      if (avaConfig.injectContext && projectPath) {
+      if (avaConfig.contextInjection && projectPath) {
         try {
           const contextResult = await loadContextFiles({ projectPath });
           projectContext = contextResult.formattedPrompt || undefined;
@@ -166,27 +122,41 @@ export function createChatRoutes(services: ServiceContainer): Router {
         }
       }
 
-      // Conditionally fetch sitrep
+      // Conditionally fetch live sitrep
       let sitrep: string | undefined;
-      if (avaConfig.injectSitrep && projectPath) {
-        const sitrepText = await getSitrep(projectPath);
-        sitrep = sitrepText ?? undefined;
+      if (avaConfig.sitrepInjection && projectPath) {
+        try {
+          sitrep = await getSitrep(projectPath);
+        } catch (err) {
+          logger.warn('Failed to generate sitrep:', err);
+        }
       }
 
-      // Build Ava system prompt — enriched with project context and sitrep when available
+      // Build Ava system prompt — enriched with project context, sitrep, and extension
       const systemPrompt =
         system ??
         buildAvaSystemPrompt({
           ctx: context,
           projectContext,
           sitrep,
+          extension: avaConfig.systemPromptExtension || undefined,
         });
 
-      // Build tool set for this request
-      const tools = buildAvaTools(services);
+      // Build tool set for this request — gated by per-project toolGroups config
+      const tools = projectPath
+        ? buildAvaTools(
+            projectPath,
+            {
+              featureLoader: services.featureLoader,
+              autoModeService: services.autoModeService,
+              agentService: services.agentService,
+            },
+            avaConfig.toolGroups
+          )
+        : {};
 
       logger.info(
-        `Chat request: ${messages.length} messages, model=${modelAlias}, projectPath=${projectPath ?? 'none'}, injectContext=${avaConfig.injectContext ?? false}, injectSitrep=${avaConfig.injectSitrep ?? false}`
+        `Chat request: ${messages.length} messages, model=${modelAlias}, projectPath=${projectPath ?? 'none'}, contextInjection=${avaConfig.contextInjection}, sitrepInjection=${avaConfig.sitrepInjection}`
       );
 
       const result = streamText({

--- a/docs/server/ava-chat.md
+++ b/docs/server/ava-chat.md
@@ -1,0 +1,91 @@
+# Ava Chat System
+
+Project-scoped AI chat with live board context, tool execution, and per-project configuration.
+
+## Overview
+
+The Ava chat system extends the base chat endpoint with:
+
+- **Project context injection** — CLAUDE.md and `.automaker/context/` files injected into the system prompt
+- **Live sitrep** — board counts, running agents, and auto-mode status injected at request time
+- **Tool execution** — Ava can read and write the board, control agents, and manage auto-mode
+- **Per-project config** — model, tool groups, injection toggles, and system prompt extensions stored in `.automaker/ava-config.json`
+- **Project-scoped sessions** — chat history filtered by `projectId`
+
+## Architecture
+
+```
+POST /api/chat
+  ├── loadAvaConfig(projectPath)       → AvaConfig (from .automaker/ava-config.json)
+  ├── loadContextFiles(projectPath)    → projectContext string (if contextInjection: true)
+  ├── getSitrep(projectPath)           → sitrep markdown (if sitrepInjection: true, cached 5min)
+  ├── buildAvaSystemPrompt(opts)       → enriched system prompt
+  ├── buildAvaTools(projectPath, ...)  → tool set gated by toolGroups flags
+  └── streamText({ tools, maxSteps: 10 })
+
+GET/POST /api/ava/config/get
+POST     /api/ava/config/update
+  └── loadAvaConfig / saveAvaConfig   → .automaker/ava-config.json
+```
+
+## AvaConfig
+
+Stored at `{projectPath}/.automaker/ava-config.json`. Defaults are used when the file does not exist — no file is written on first load.
+
+```typescript
+interface AvaConfig {
+  model: 'haiku' | 'sonnet' | 'opus';
+  toolGroups: {
+    boardRead: boolean; // get_board_summary, list_features, get_feature
+    boardWrite: boolean; // create_feature, update_feature, move_feature, delete_feature
+    agentControl: boolean; // list_running_agents, start_agent, stop_agent, get_agent_output
+    autoMode: boolean; // get_auto_mode_status, start_auto_mode, stop_auto_mode
+    projectMgmt: boolean; // get_project_spec, update_project_spec
+    orchestration: boolean; // get_execution_order, set_feature_dependencies
+  };
+  sitrepInjection: boolean;
+  contextInjection: boolean;
+  systemPromptExtension: string;
+}
+```
+
+All tool groups default to `true`. Model defaults to `sonnet`.
+
+## Key Files
+
+| File                                                       | Role                                                                   |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `apps/server/src/routes/chat/index.ts`                     | Main chat route — wires config, sitrep, tools, streamText              |
+| `apps/server/src/routes/chat/ava-config.ts`                | `loadAvaConfig` / `saveAvaConfig` with deep-merge defaults             |
+| `apps/server/src/routes/chat/ava-tools.ts`                 | `buildAvaTools(projectPath, services, config)` — all 6 tool groups     |
+| `apps/server/src/routes/chat/sitrep.ts`                    | `getSitrep(projectPath)` — 5-min TTL cache, `invalidateSitrep()`       |
+| `apps/server/src/routes/chat/personas.ts`                  | `buildAvaSystemPrompt({ ctx, projectContext, sitrep, extension })`     |
+| `apps/server/src/routes/ava/index.ts`                      | `/api/ava/config/get` and `/api/ava/config/update` HTTP endpoints      |
+| `apps/ui/src/components/views/chat/ava-settings-panel.tsx` | Settings UI — model, tool toggles, injection toggles, prompt extension |
+| `apps/ui/src/hooks/use-chat-session.ts`                    | Sends `projectPath` in request body, scopes sessions by `projectId`    |
+| `apps/ui/src/store/chat-store.ts`                          | `ChatSession.projectId`, `getSessionsForProject()`, v1→v2 migration    |
+
+## Tool Execution
+
+Tools are defined in `ava-tools.ts` using the AI SDK `tool()` helper. They call `FeatureLoader`, `AutoModeService`, and `AgentService` directly (no HTTP roundtrip). `maxSteps: 10` allows Ava to chain multiple tool calls per response.
+
+Tool availability is gated per-request by `AvaConfig.toolGroups`. Disabling `boardWrite` prevents feature creation/deletion even if Ava attempts it.
+
+## Sitrep
+
+`getSitrep(projectPath)` generates a markdown document containing:
+
+- Feature counts by status (backlog / in_progress / review / done / blocked)
+- Titles of features currently in_progress or review
+- Running agent feature IDs and start times
+- Auto-mode enabled/disabled status
+
+Results are cached for 5 minutes per project path. Call `invalidateSitrep(projectPath)` to force a refresh on the next request (called automatically after board-write tool calls).
+
+## Session Scoping
+
+Sessions are stored in Zustand (`chat-store.ts`) keyed by `projectId`. Switching projects shows only that project's history. Sessions created before v2 (project scoping) are assigned `projectId: 'default'` via the store migration.
+
+## Settings UI
+
+The gear icon in the chat header opens `AvaSettingsPanel`, which loads config via `GET /api/ava/config/get` and saves via `POST /api/ava/config/update`. Changes take effect on the next chat request — no server restart required.


### PR DESCRIPTION
## Summary

Audit found that `ava-tools.ts`, `ava-config.ts`, and `sitrep.ts` were fully implemented but dead code — `chat/index.ts` had stubs that returned empty tools, read sitrep from a static file, and used a minimal local schema. The settings UI was wired to `/api/ava` endpoints that returned a gateway config, not the chat config.

- **`chat/index.ts`**: Replace stubs with real `buildAvaTools()`, `getSitrep()`, and `loadAvaConfig()` imports. Ava now has all 6 tool groups available.
- **`ava-config.ts`**: Align schema with frontend — `toolGroups` (6 flags), `sitrepInjection`, `contextInjection`. Import `AvaToolsConfig` from `ava-tools.ts` instead of defining a divergent local type.
- **`routes/ava/index.ts`**: `config/get` and `config/update` now use `loadAvaConfig`/`saveAvaConfig` (chat config) instead of the gateway schema the `AvaSettingsPanel` could never read.
- **`docs/server/ava-chat.md`**: New reference page documenting the Ava chat system.

## Test plan
- [ ] Ask Ava "what features are in backlog?" — should call `list_features` tool and return real data
- [ ] Open gear icon → settings panel loads model/tool toggles correctly
- [ ] Toggle a tool group off → Ava no longer uses that tool
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-project configuration and settings management for AI assistant features

* **Documentation**
  * Added comprehensive Ava Chat System documentation covering architecture, API endpoints, and configuration structure

* **Improvements**
  * Standardized API response formats for configuration endpoints
  * Enhanced validation for configuration requests
  * Improved error handling with standardized error responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->