### PR TITLE
promote: staging → main (PRO-335 plugin new-install fix)

### DIFF
--- a/docs/integrations/claude-plugin.md
+++ b/docs/integrations/claude-plugin.md
@@ -9,19 +9,29 @@ Setup guide for the Claude Code plugin and MCP server. For commands and examples
 Install directly from the GitHub repository:
 
 ```bash
-# 1. Add the protoLabs plugin marketplace from GitHub
-claude plugin marketplace add https://github.com/proto-labs-ai/protomaker/tree/main/packages/mcp-server/plugins
-
-# 2. Install the plugin
-claude plugin install automaker
-
-# 3. Start protoLabs server (in a separate terminal)
+# 1. Clone the repo (needed for the MCP server binary)
 git clone https://github.com/proto-labs-ai/protomaker.git
 cd protomaker
+
+# 2. Add the protoLabs plugin marketplace
+claude plugin marketplace add https://github.com/proto-labs-ai/protomaker/tree/main/packages/mcp-server/plugins
+
+# 3. Install the plugin
+claude plugin install automaker
+
+# 4. Configure the plugin — AUTOMAKER_ROOT is required
+#    The plugin needs to know where your local clone lives
+PLUGIN_DIR=~/.claude/plugins/automaker
+cp "$PLUGIN_DIR/.env.example" "$PLUGIN_DIR/.env"
+# Edit .env and set AUTOMAKER_ROOT to the absolute path of this repo
+echo "AUTOMAKER_ROOT=$(pwd)" >> "$PLUGIN_DIR/.env"
+echo "AUTOMAKER_API_KEY=your-dev-key-2026" >> "$PLUGIN_DIR/.env"
+
+# 5. Start protoLabs server (in a separate terminal)
 npm install
 npm run dev:web
 
-# 4. Verify it works
+# 6. Verify it works
 claude
 > /board
 ```
@@ -39,14 +49,20 @@ npm install
 # 2. Build the MCP server
 npm run build:packages
 
-# 3. Start protoLabs server
-npm run dev:web
-
-# 4. In a new terminal, add the plugin marketplace and install
+# 3. Add the plugin marketplace and install
 claude plugin marketplace add $(pwd)/packages/mcp-server/plugins
 claude plugin install automaker
 
-# 5. Verify it works
+# 4. Configure the plugin — AUTOMAKER_ROOT is required
+PLUGIN_DIR=~/.claude/plugins/automaker
+cp "$PLUGIN_DIR/.env.example" "$PLUGIN_DIR/.env"
+echo "AUTOMAKER_ROOT=$(pwd)" > "$PLUGIN_DIR/.env"
+echo "AUTOMAKER_API_KEY=your-dev-key-2026" >> "$PLUGIN_DIR/.env"
+
+# 5. Start protoLabs server (in a separate terminal)
+npm run dev:web
+
+# 6. Verify it works
 claude
 > /board
 ```
@@ -153,12 +169,19 @@ You should see your Kanban board or a message to start the protoLabs server.
 
 ### Environment Variables
 
-Configure these in your shell or the plugin's `plugin.json`:
+Configure these in the plugin's `.env` file (`~/.claude/plugins/automaker/.env`).
+Copy `.env.example` in that directory to get started.
 
-| Variable            | Description                | Default                 |
-| ------------------- | -------------------------- | ----------------------- |
-| `AUTOMAKER_API_URL` | protoLabs API base URL     | `http://localhost:3008` |
-| `AUTOMAKER_API_KEY` | API key for authentication | (required)              |
+| Variable            | Description                                                   | Default                 |
+| ------------------- | ------------------------------------------------------------- | ----------------------- |
+| `AUTOMAKER_ROOT`    | Absolute path to your local protomaker repo clone             | (required)              |
+| `AUTOMAKER_API_KEY` | API key matching the one the protoLabs server is started with | (required)              |
+| `AUTOMAKER_API_URL` | protoLabs API base URL                                        | `http://localhost:3008` |
+| `GH_TOKEN`          | GitHub token for PR operations (`gh auth token` to get it)    | (optional)              |
+| `DISCORD_BOT_TOKEN` | Discord bot token for Discord MCP tools                       | (optional)              |
+| `LINEAR_API_KEY`    | Linear API key for Linear MCP tools                           | (optional)              |
+
+`AUTOMAKER_ROOT` is the most common cause of a new install failing silently. Without it, the plugin cannot locate the MCP server executable and no tools will be available.
 
 ### Plugin Configuration
 
@@ -326,10 +349,13 @@ Each project maintains its own `.automaker/` directory with independent features
 
 ### Plugin Not Loading
 
-1. Verify the MCP server is built: `cd packages/mcp-server && npm run build`
-2. Check the plugin is installed: `ls ~/.claude/plugins/`
-3. Verify the symlink or marketplace entry is correct
-4. Restart Claude Code
+The most common cause is a missing or misconfigured `AUTOMAKER_ROOT`:
+
+1. Check that `~/.claude/plugins/automaker/.env` exists and contains `AUTOMAKER_ROOT`
+2. Verify `AUTOMAKER_ROOT` points to the correct repo: `ls "$AUTOMAKER_ROOT/packages/mcp-server/dist/index.js"`
+3. Rebuild the MCP server if that file is missing: `cd "$AUTOMAKER_ROOT" && npm run build:packages`
+4. Verify the plugin is installed: `ls ~/.claude/plugins/`
+5. Restart Claude Code
 
 ### Connection Errors
 

--- a/packages/mcp-server/plugins/automaker/hooks/check-mcp-health.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/check-mcp-health.sh
@@ -7,11 +7,50 @@
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENV_FILE="${PLUGIN_DIR}/.env"
 
-# Load AUTOMAKER_API_KEY from plugin .env
+# Load plugin env vars
 if [ -f "$ENV_FILE" ]; then
-  export $(grep -v '^#' "$ENV_FILE" | grep AUTOMAKER_API_KEY | xargs)
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE" 2>/dev/null || true
+  set +a
 fi
 
+# ── AUTOMAKER_ROOT check ──────────────────────────────────────────────────────
+# Without AUTOMAKER_ROOT the MCP server binary cannot be located and all tools
+# will silently fail. Surface a clear actionable error immediately.
+if [ -z "${AUTOMAKER_ROOT:-}" ]; then
+  echo ""
+  echo "## Plugin Setup Required: AUTOMAKER_ROOT not set"
+  echo ""
+  echo "The plugin cannot locate the protoLabs MCP server. \`AUTOMAKER_ROOT\` must be"
+  echo "set to the absolute path of your local protomaker repo clone."
+  echo ""
+  echo "**Fix:**"
+  echo "1. Open \`${ENV_FILE}\` (copy from \`.env.example\` if it doesn't exist)"
+  echo "2. Add: \`AUTOMAKER_ROOT=/absolute/path/to/protomaker\`"
+  echo "3. Add: \`AUTOMAKER_API_KEY=your-dev-key-2026\`"
+  echo "4. Restart Claude Code"
+  echo ""
+  echo "**Note:** All MCP tools (mcp__plugin_automaker_automaker__*) will be unavailable until this is fixed."
+  exit 0
+fi
+
+MCP_BINARY="${AUTOMAKER_ROOT}/packages/mcp-server/dist/index.js"
+if [ ! -f "$MCP_BINARY" ]; then
+  echo ""
+  echo "## Plugin Setup Required: MCP server not built"
+  echo ""
+  echo "AUTOMAKER_ROOT is set to \`${AUTOMAKER_ROOT}\` but the MCP server binary is missing."
+  echo "Expected: \`${MCP_BINARY}\`"
+  echo ""
+  echo "**Fix:**"
+  echo "  cd \"${AUTOMAKER_ROOT}\" && npm run build:packages"
+  echo ""
+  echo "**Note:** All MCP tools will be unavailable until the server is built."
+  exit 0
+fi
+
+# ── Server reachability check ─────────────────────────────────────────────────
 # Default to localhost:3008 (standard dev server)
 API_BASE="${AUTOMAKER_API_URL:-http://localhost:3008}"
 HEALTH_ENDPOINT="${API_BASE}/api/health"
@@ -24,20 +63,14 @@ HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
 # If server is unreachable or unhealthy, inject diagnostic context
 if [ "$HTTP_CODE" != "200" ]; then
   echo ""
-  echo "## ⚠️ MCP Server Health Check"
+  echo "## MCP Server Unreachable"
   echo "Automaker server at ${API_BASE} is unreachable (HTTP ${HTTP_CODE:-timeout})."
   echo ""
   echo "**Common causes:**"
-  echo "- Dev server not running (check terminal where \`npm run dev:server\` should be running)"
+  echo "- Dev server not running — start it: \`cd ${AUTOMAKER_ROOT} && npm run dev:web\`"
   echo "- Server crashed or restarting"
-  echo "- Wrong API_BASE URL (check AUTOMAKER_API_URL in plugin .env)"
-  echo "- Auth failure (verify AUTOMAKER_API_KEY in plugin .env matches server)"
-  echo ""
-  echo "**Recovery steps:**"
-  echo "1. Check if server is running: \`ps aux | grep 'node.*automaker'\`"
-  echo "2. If not running, ask user to start it: \`npm run dev:server\` in /Users/kj/dev/automaker"
-  echo "3. If running, check logs for crashes or errors"
-  echo "4. Verify plugin .env has correct AUTOMAKER_API_KEY"
+  echo "- Wrong API URL (check AUTOMAKER_API_URL in \`${ENV_FILE}\`)"
+  echo "- Auth failure (verify AUTOMAKER_API_KEY in \`${ENV_FILE}\` matches server)"
   echo ""
   echo "**Note:** All MCP tools (mcp__plugin_automaker_automaker__*) will fail until server is reachable."
   exit 0


### PR DESCRIPTION
Promotes PRO-335 fix to main, triggering auto-release.

**Changes from staging:**
- `fix(plugin)`: surface AUTOMAKER_ROOT missing error on new installs (PRO-335)

New installs of the plugin will now see a clear actionable message at session start if AUTOMAKER_ROOT is missing or MCP binary not built, instead of silently failing with no tools available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized plugin setup flow with clearer environment configuration steps
  * Expanded troubleshooting guidance highlighting common configuration issues
  * Enhanced environment variables documentation with configuration requirements
  * Improved Docker deployment path-mapping guidance

* **Bug Fixes**
  * Improved health check script with enhanced error messaging and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->