### PR TITLE
feat(ci): add GH_PAT validation step to auto-release.yml

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -32,6 +32,17 @@ jobs:
       DISCORD_DEV_WEBHOOK: ${{ secrets.DISCORD_DEV_WEBHOOK }}
 
     steps:
+      - name: Verify GH_PAT is set
+        run: |
+          if [ -z "${{ secrets.GH_PAT }}" ]; then
+            echo "WARNING: GH_PAT secret is not set."
+            echo "The v* tag push will fall back to GITHUB_TOKEN."
+            echo "build-electron.yml will NOT fire automatically."
+            echo "Set GH_PAT in repository secrets to enable the release → Electron build chain."
+          else
+            echo "GH_PAT is configured — release → Electron build chain is active."
+          fi
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:


### PR DESCRIPTION
## Summary

- Adds a `Verify GH_PAT is set` step as the **first step** in the `release` job of `auto-release.yml`, before the Checkout step
- Emits a structured warning (not failure) when `GH_PAT` is absent, surfacing the release → Electron build chain gap immediately without wasting runner time on git ops
- Confirms chain is active when `GH_PAT` is present

## Why before Checkout

Fast-fail principle: surfacing a misconfiguration at step 1 costs seconds, not the 2+ minutes consumed by checkout + npm install before the tag push would silently fail.

## Test plan

- [ ] Verify step appears first in the release job in GitHub Actions UI
- [ ] Confirm no other steps in `auto-release.yml` were modified
- [ ] On next release: confirm the step logs the correct message based on `GH_PAT` presence

Part of project: Production CI/CD Reliability Hardening (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow with additional verification checks for deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->