### PR TITLE
feat(server+ui): server-side agent output summary extraction and persistence

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -24,6 +24,7 @@ import type {
   Feature,
   ExecutionRecord,
   PipelineStep,
+  PipelineSummary,
   ThinkingLevel,
   PlanningMode,
   ExecutionContext,
@@ -855,6 +856,23 @@ export class ExecutionService {
           // Agent output might not exist yet
         }
 
+        // Extract and save summary to feature for real-time display on kanban cards
+        if (agentOutput) {
+          const extractedSummary = this.extractSummaryFromOutput(agentOutput);
+          if (extractedSummary) {
+            try {
+              await this.featureLoader.update(projectPath, featureId, {
+                summary: extractedSummary,
+              });
+              logger.info(
+                `Saved summary for feature ${featureId} (${extractedSummary.length} chars)`
+              );
+            } catch (summaryError) {
+              logger.warn(`Failed to save summary for feature ${featureId}:`, summaryError);
+            }
+          }
+        }
+
         // Record memory usage if we loaded any memory files
         if (contextResult.memoryFiles.length > 0 && agentOutput) {
           await recordMemoryUsage(
@@ -1539,6 +1557,32 @@ export class ExecutionService {
       updatedContext = (await secureFs.readFile(contextPath, 'utf-8')) as string;
     } catch {
       // No context update
+    }
+
+    // Extract and accumulate pipeline step summary
+    if (updatedContext) {
+      const stepSummary = this.extractSummaryFromOutput(updatedContext);
+      if (stepSummary) {
+        try {
+          const currentFeature = await this.featureLoader.get(projectPath, featureId);
+          if (currentFeature) {
+            const existingSummaries = currentFeature.pipelineSummaries ?? [];
+            await this.featureLoader.update(projectPath, featureId, {
+              pipelineSummaries: [
+                ...existingSummaries,
+                {
+                  stepId: step.id,
+                  stepName: step.name,
+                  summary: stepSummary,
+                  completedAt: new Date().toISOString(),
+                },
+              ],
+            });
+          }
+        } catch (summaryError) {
+          logger.warn(`Failed to save pipeline step summary for ${featureId}:`, summaryError);
+        }
+      }
     }
 
     this.callbacks.emitAutoModeEvent('pipeline_step_complete', {
@@ -2804,6 +2848,40 @@ You can use the Read tool to view these images at any time during implementation
     prompt = prompt.replace(/\{\{planContent\}\}/g, planContent);
 
     return prompt;
+  }
+
+  /**
+   * Extract summary text from agent output using common patterns.
+   * Mirrors the client-side extractSummary() logic in log-parser.ts.
+   */
+  private extractSummaryFromOutput(output: string): string | null {
+    if (!output?.trim()) return null;
+
+    // Try <summary> tags first (preferred format from agent system prompt)
+    const summaryTagMatch = output.match(/<summary>([\s\S]*?)<\/summary>/);
+    if (summaryTagMatch) return summaryTagMatch[1].trim();
+
+    // Try markdown ## Summary section
+    const summaryHeaderMatch = output.match(/^##\s+Summary\s*\n([\s\S]*?)(?=\n##\s+|$)/m);
+    if (summaryHeaderMatch) return summaryHeaderMatch[1].trim();
+
+    // Try other summary headers (Feature, Changes, Implementation)
+    const otherHeaderMatch = output.match(
+      /^##\s+(Feature|Changes|Implementation)\s*\n([\s\S]*?)(?=\n##\s+|$)/m
+    );
+    if (otherHeaderMatch) return `## ${otherHeaderMatch[1]}\n${otherHeaderMatch[2].trim()}`;
+
+    // Try "All tasks completed..." intro lines
+    const introMatch = output.match(/(^|\n)(All tasks completed[\s\S]*?)(?=\n🔧|\n📋|\n⚡|\n❌|$)/);
+    if (introMatch) return introMatch[2].trim();
+
+    // Try "I've/I have successfully completed..." intro lines
+    const completionMatch = output.match(
+      /(^|\n)((I've|I have) (successfully |now )?(completed|finished|implemented)[\s\S]*?)(?=\n🔧|\n📋|\n⚡|\n❌|$)/
+    );
+    if (completionMatch) return completionMatch[2].trim();
+
+    return null;
   }
 
   /**

--- a/apps/ui/src/components/views/board-view.tsx
+++ b/apps/ui/src/components/views/board-view.tsx
@@ -1685,6 +1685,7 @@ export function BoardView() {
         featureStatus={outputFeature?.status}
         onNumberKeyPress={handleOutputModalNumberKeyPress}
         branchName={outputFeature?.branchName}
+        featureSummary={outputFeature?.summary}
       />
 
       {/* Archive All Verified Dialog */}

--- a/apps/ui/src/components/views/board-view/components/kanban-card/summary-dialog.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/summary-dialog.tsx
@@ -1,4 +1,5 @@
 // @ts-nocheck -- Feature index signature causes property access type errors
+import { useState } from 'react';
 import { Feature } from '@/store/types';
 import { AgentTaskInfo } from '@/lib/agent-context-parser';
 import {
@@ -11,7 +12,7 @@ import {
 } from '@protolabs-ai/ui/atoms';
 import { Button } from '@protolabs-ai/ui/atoms';
 import { Markdown } from '@protolabs-ai/ui/molecules';
-import { Sparkles } from 'lucide-react';
+import { Sparkles, ChevronLeft, ChevronRight } from 'lucide-react';
 
 interface SummaryDialogProps {
   feature: Feature;
@@ -28,6 +29,22 @@ export function SummaryDialog({
   isOpen,
   onOpenChange,
 }: SummaryDialogProps) {
+  const [stepIndex, setStepIndex] = useState(0);
+
+  const pipelineSummaries = feature.pipelineSummaries;
+  const hasPipelineSteps = pipelineSummaries && pipelineSummaries.length > 0;
+  const mainSummary = feature.summary || summary || agentInfo?.summary;
+
+  // Build the list of phases: main summary + pipeline step summaries
+  const phases = [
+    ...(mainSummary ? [{ label: 'Implementation', content: mainSummary }] : []),
+    ...(hasPipelineSteps
+      ? pipelineSummaries.map((s) => ({ label: s.stepName, content: s.summary }))
+      : []),
+  ];
+
+  const currentPhase = phases[stepIndex] ?? null;
+
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
@@ -52,10 +69,46 @@ export function SummaryDialog({
             })()}
           </DialogDescription>
         </DialogHeader>
+
+        {/* Phase navigation when multiple phases are available */}
+        {phases.length > 1 && (
+          <div className="flex items-center justify-between gap-2 px-1 shrink-0">
+            <button
+              onClick={() => setStepIndex((i) => Math.max(0, i - 1))}
+              disabled={stepIndex === 0}
+              className="p-1 rounded hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              aria-label="Previous phase"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <div className="flex items-center gap-1.5 overflow-x-auto">
+              {phases.map((phase, idx) => (
+                <button
+                  key={idx}
+                  onClick={() => setStepIndex(idx)}
+                  className={`px-2.5 py-1 rounded-md text-xs font-medium whitespace-nowrap transition-colors ${
+                    idx === stepIndex
+                      ? 'bg-primary/20 text-primary'
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                  }`}
+                >
+                  {phase.label}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={() => setStepIndex((i) => Math.min(phases.length - 1, i + 1))}
+              disabled={stepIndex === phases.length - 1}
+              className="p-1 rounded hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              aria-label="Next phase"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+
         <div className="flex-1 overflow-y-auto p-4 bg-card rounded-lg border border-border/50">
-          <Markdown>
-            {feature.summary || summary || agentInfo?.summary || 'No summary available'}
-          </Markdown>
+          <Markdown>{currentPhase?.content ?? 'No summary available'}</Markdown>
         </div>
         <DialogFooter>
           <Button

--- a/apps/ui/src/components/views/board-view/dialogs/agent-output-modal.tsx
+++ b/apps/ui/src/components/views/board-view/dialogs/agent-output-modal.tsx
@@ -14,7 +14,7 @@ import { GitDiffPanel } from '@/components/shared/git-diff-panel';
 import { TaskProgressPanel } from '@/components/shared/task-progress-panel';
 import { Markdown } from '@protolabs-ai/ui/molecules';
 import { useWorktreeStore } from '@/store/worktree-store';
-import { extractSummary } from '@/lib/log-parser';
+import { selectSummary } from '@/lib/summary-selection';
 import { useAgentOutput } from '@/hooks/queries';
 import type { AutoModeEvent } from '@/types/electron';
 
@@ -31,6 +31,8 @@ interface AgentOutputModalProps {
   projectPath?: string;
   /** Branch name for the feature worktree - used when viewing changes */
   branchName?: string;
+  /** Server-side saved summary (preferred over client-extracted summary) */
+  featureSummary?: string;
 }
 
 type ViewMode = 'summary' | 'parsed' | 'raw' | 'changes';
@@ -44,6 +46,7 @@ export function AgentOutputModal({
   onNumberKeyPress,
   projectPath: projectPathProp,
   branchName,
+  featureSummary,
 }: AgentOutputModalProps) {
   const isBacklogPlan = featureId.startsWith('backlog-plan:');
 
@@ -76,8 +79,8 @@ export function AgentOutputModal({
   // Combine initial output from query with streamed content from WebSocket
   const output = initialOutput + streamedContent;
 
-  // Extract summary from output
-  const summary = useMemo(() => extractSummary(output), [output]);
+  // Prefer server-side saved summary; fall back to client-side extraction from output
+  const summary = useMemo(() => selectSummary(featureSummary, output), [featureSummary, output]);
 
   // Determine the effective view mode - default to summary if available, otherwise parsed
   const effectiveViewMode = viewMode ?? (summary ? 'summary' : 'parsed');

--- a/apps/ui/src/lib/summary-selection.ts
+++ b/apps/ui/src/lib/summary-selection.ts
@@ -1,0 +1,33 @@
+/**
+ * Summary selection utility — determines the best available summary for a feature.
+ *
+ * Priority order:
+ * 1. Server-side accumulated summary (feature.summary) — most authoritative
+ * 2. Client-side extraction from raw agent output — fallback
+ */
+
+import { extractSummary } from './log-parser';
+import type { PipelineSummary } from '@protolabs-ai/types';
+
+/**
+ * Returns the effective summary for a feature.
+ * Prefers server-saved summary over client-extracted summary.
+ */
+export function selectSummary(
+  featureSummary: string | undefined,
+  agentOutput: string | undefined
+): string | null {
+  if (featureSummary) return featureSummary;
+  if (agentOutput) return extractSummary(agentOutput);
+  return null;
+}
+
+/**
+ * Returns the latest pipeline step summary, or null if none exist.
+ */
+export function getLatestPipelineSummary(
+  pipelineSummaries: PipelineSummary[] | undefined
+): PipelineSummary | null {
+  if (!pipelineSummaries?.length) return null;
+  return pipelineSummaries[pipelineSummaries.length - 1];
+}

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -8,6 +8,7 @@ import type { AgentRole } from './agent-roles.js';
 import type { WorkItemState } from './authority.js';
 import type { ReviewThreadFeedback, PendingFeedback } from './coderabbit.js';
 import type { PipelineState } from './pipeline-phase.js';
+import type { PipelineSummary } from './pipeline.js';
 import type { SignalChannel, SignalMetadata } from './signal-channel.js';
 
 /**
@@ -181,6 +182,8 @@ export interface Feature {
   };
   error?: string;
   summary?: string;
+  /** Per-pipeline-step summaries accumulated during execution. Enables phase-structured output display. */
+  pipelineSummaries?: PipelineSummary[];
   startedAt?: string;
   descriptionHistory?: DescriptionHistoryEntry[]; // History of description changes
   /** Override global git workflow settings for this specific feature */

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -437,6 +437,7 @@ export type {
   PipelineStep,
   PipelineConfig,
   PipelineStatus,
+  PipelineSummary,
   FeatureStatusWithPipeline,
 } from './pipeline.js';
 

--- a/libs/types/src/pipeline.ts
+++ b/libs/types/src/pipeline.ts
@@ -17,6 +17,17 @@ export interface PipelineConfig {
   steps: PipelineStep[];
 }
 
+/**
+ * Summary captured from a single pipeline step execution.
+ * Accumulated on the feature to provide phase-structured output history.
+ */
+export interface PipelineSummary {
+  stepId: string;
+  stepName: string;
+  summary: string;
+  completedAt: string;
+}
+
 export type PipelineStatus = `pipeline_${string}`;
 
 export type FeatureStatusWithPipeline =


### PR DESCRIPTION
## Summary

- Adds `PipelineSummary` type to `libs/types/src/pipeline.ts` for structured phase summaries
- `execution-service.ts`: extracts summary from agent output on success, persists to feature JSON
- `summary-selection.ts`: new utility — prefer server-extracted summary over client-side parse
- `summary-dialog.tsx`: renders phase-structured summaries with step context
- `agent-output-modal.tsx`: wires summary-selection utility for consistent display
- Updates `Feature` type with `pipelineSummaries` field

Addresses upstream PR #812.

## Test plan
- [ ] Run an agent to completion — feature JSON should contain `pipelineSummaries`
- [ ] Summary dialog shows phase summaries in correct order
- [ ] Falls back to log-parser extraction when no server summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execution summaries are now automatically extracted from feature and pipeline step completions and persisted.
  * Enhanced UI with multi-phase navigation enables users to review detailed pipeline step outcomes.
  * Real-time kanban card updates display saved feature execution summaries.
  * Server-provided summaries are prioritized for display when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->