### PR TITLE
Assignee Badge Removal

### DIFF
--- a/apps/ui/src/components/views/board-view/components/kanban-card/card-badges.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/card-badges.tsx
@@ -8,7 +8,6 @@ import {
   Lock,
   Hand,
   Sparkles,
-  User,
   Calendar,
   DollarSign,
   Lightbulb,
@@ -149,7 +148,6 @@ interface CardBadgesProps {
 export const CardBadges = memo(function CardBadges({ feature, onPRDClick }: CardBadgesProps) {
   const hasEpic = !!feature.epicId;
   const hasError = !!feature.error;
-  const hasAssignee = !!feature.assignee;
   const hasDueDate = !!feature.dueDate;
   const hasWorkItemState = !!feature.workItemState;
   const isContent = feature.featureType === 'content';
@@ -157,15 +155,7 @@ export const CardBadges = memo(function CardBadges({ feature, onPRDClick }: Card
   const costUsd = typeof feature.costUsd === 'number' ? feature.costUsd : undefined;
   const hasCost = costUsd != null && costUsd > 0;
 
-  if (
-    !hasError &&
-    !hasEpic &&
-    !hasAssignee &&
-    !hasDueDate &&
-    !hasCost &&
-    !hasWorkItemState &&
-    !isContent
-  ) {
+  if (!hasError && !hasEpic && !hasDueDate && !hasCost && !hasWorkItemState && !isContent) {
     return null;
   }
 
@@ -224,14 +214,6 @@ export const CardBadges = memo(function CardBadges({ feature, onPRDClick }: Card
         >
           <FileType className="w-3 h-3" />
           Content
-        </div>
-      )}
-
-      {/* Assignee badge */}
-      {hasAssignee && (
-        <div className="inline-flex items-center gap-1 px-1.5 h-5 rounded text-[10px] font-medium bg-blue-500/15 text-blue-400 border border-blue-500/30">
-          <User className="w-3 h-3" />
-          {feature.assignee}
         </div>
       )}
 


### PR DESCRIPTION
## Summary\n\n**Milestone:** Remove Assignee UI\n\nRemove the blue assignee badge from card-badges.tsx. Remove the hasAssignee check and User icon import if no longer used. Verify use-user-identity.ts is still needed elsewhere or can be removed.\n\n**Files to Modify:**\n- apps/ui/src/components/views/board-view/components/kanban-card/card-badges.tsx\n\n**Acceptance Criteria:**\n- [ ] No blue assignee badge on any card\n- [ ] User icon import removed if unused\n- [ ] Typecheck passes\n\n**Complexity:** small\n\n**Guardrails...\n\n---\n*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed assignee badge display from kanban card badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->