### PR TITLE
Content Badge Removal

### DIFF
--- a/apps/ui/src/components/views/board-view/components/kanban-card/card-badges.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/card-badges.tsx
@@ -21,7 +21,6 @@ import {
   Loader2,
   FileText,
   XCircle,
-  FileType,
 } from 'lucide-react';
 import { getBlockingDependencies } from '@protolabs-ai/dependency-resolver';
 import { useShallow } from 'zustand/react/shallow';
@@ -150,12 +149,11 @@ export const CardBadges = memo(function CardBadges({ feature, onPRDClick }: Card
   const hasError = !!feature.error;
   const hasDueDate = !!feature.dueDate;
   const hasWorkItemState = !!feature.workItemState;
-  const isContent = feature.featureType === 'content';
   // costUsd is typed as unknown on the Feature interface; narrow with typeof guard
   const costUsd = typeof feature.costUsd === 'number' ? feature.costUsd : undefined;
   const hasCost = costUsd != null && costUsd > 0;
 
-  if (!hasError && !hasEpic && !hasDueDate && !hasCost && !hasWorkItemState && !isContent) {
+  if (!hasError && !hasEpic && !hasDueDate && !hasCost && !hasWorkItemState) {
     return null;
   }
 
@@ -204,17 +202,6 @@ export const CardBadges = memo(function CardBadges({ feature, onPRDClick }: Card
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
-      )}
-
-      {/* Content type badge */}
-      {isContent && (
-        <div
-          className="inline-flex items-center gap-1 px-1.5 h-5 rounded text-[10px] font-medium bg-violet-500/15 text-violet-400 border border-violet-500/30"
-          data-testid={`content-badge-${feature.id}`}
-        >
-          <FileType className="w-3 h-3" />
-          Content
-        </div>
       )}
 
       {/* Due date badge */}


### PR DESCRIPTION
## Summary\n\n**Milestone:** Remove Content Type UI\n\nRemove the violet Content badge from card-badges.tsx. Remove isContent check and FileType icon import if no longer used after assignee badge also removed.\n\n**Files to Modify:**\n- apps/ui/src/components/views/board-view/components/kanban-card/card-badges.tsx\n\n**Acceptance Criteria:**\n- [ ] No violet Content badge on any card\n- [ ] FileType import removed\n- [ ] Typecheck passes\n\n**Complexity:** small\n\n**Guardrails:** If this phase involves new or changed beha...\n\n---\n*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord reaction-abilities API endpoints for managing emoji-based reaction controls
  * Grafana monitoring configuration with customizable admin credentials

* **Bug Fixes**
  * Enhanced API key security masking in deployment logs
  * Improved worktree recovery with verification fallbacks, error capture, and rebase support
  * Feature dependencies normalization and various UX improvements

* **Chores**
  * Version 0.13.0 release with synchronized dependency updates across all packages

* **Refactor**
  * Removed Discord slash-command workflow; transitioned to message and reaction-based operations
  * Removed board assignee and username filters
  * Removed content-type badges from board cards
  * Removed voice activation and sidebar chat systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->