### PR TITLE
Security: Parameterize hardcoded paths in staging compose

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -119,7 +119,7 @@ services:
 
       # Host project directories - mount at same path for MCP path compatibility
       - ${PROJECTS_MOUNT:-/home/josh/dev}:${PROJECTS_MOUNT:-/home/josh/dev}:rw
-      - /home/josh/labs:/home/josh/labs:rw
+      - ${LABS_MOUNT:-/home/josh/labs}:${LABS_MOUNT:-/home/josh/labs}:rw
 
     deploy:
       resources:

--- a/docs/infra/staging-deployment.md
+++ b/docs/infra/staging-deployment.md
@@ -154,6 +154,7 @@ GID=1000
 
 # Paths
 PROJECTS_MOUNT=/home/youruser/dev
+LABS_MOUNT=/home/youruser/labs
 ALLOWED_ROOT_DIRECTORY=/home/youruser/dev
 
 # Resources (auto-detected by setup-staging.sh if omitted)

--- a/scripts/setup-staging.sh
+++ b/scripts/setup-staging.sh
@@ -100,6 +100,7 @@ GID=$gid
 
 # ── Paths ────────────────────────────────────────────────────────────────────
 PROJECTS_MOUNT=/home/$(whoami)/dev
+LABS_MOUNT=/home/$(whoami)/labs
 ALLOWED_ROOT_DIRECTORY=/home/$(whoami)/dev
 EOF
 


### PR DESCRIPTION
## Summary\n\nReplace hardcoded user-specific paths in docker-compose.staging.yml with environment variables.\n\nFile: docker-compose.staging.yml lines 121-122\nThe second volume mount has a hardcoded path instead of using an env var like the first one.\n\nFix: Make both volume mounts use the same env var pattern (PROJECTS_MOUNT / LABS_MOUNT) so any user can configure their own paths.\n\nNote: The host mounts are BY DESIGN - Automaker agents need r/w access to project files on the host. This is just a config hygiene...\n\n---\n*Recovered automatically by Automaker post-agent hook*