### PR TITLE
feat(epic): Discord Signal Wiring

### DIFF
--- a/apps/server/src/services/discord-monitor.ts
+++ b/apps/server/src/services/discord-monitor.ts
@@ -6,7 +6,11 @@
  */
 
 import type { EventEmitter } from '../lib/events.js';
-import type { DiscordMonitorConfig, WorkItem } from '@protolabs-ai/types';
+import type {
+  DiscordMonitorConfig,
+  DiscordChannelSignalConfig,
+  WorkItem,
+} from '@protolabs-ai/types';
 import { createLogger } from '@protolabs-ai/utils';
 
 const logger = createLogger('DiscordMonitor');
@@ -127,6 +131,86 @@ export class DiscordMonitor {
     }
     this.intervals.clear();
     this.lastMessageIds.clear();
+  }
+
+  /**
+   * Start monitoring Discord channels for signal intake.
+   *
+   * Unlike startMonitoring() (which filters by keywords for headsdown agents),
+   * this method emits discord:message:detected for ALL new messages in configured
+   * channels. Keyword filtering is handled downstream by IntegrationService.
+   */
+  async startChannelMonitoring(
+    configs: DiscordChannelSignalConfig[],
+    pollInterval = 30000
+  ): Promise<void> {
+    const enabledConfigs = configs.filter((c) => c.enabled);
+
+    for (const config of enabledConfigs) {
+      const { channelId } = config;
+
+      // Skip if already monitoring this channel
+      if (this.intervals.has(channelId)) {
+        logger.debug(`Channel ${channelId} already being monitored, skipping`);
+        continue;
+      }
+
+      // Establish baseline: record the latest message ID to avoid replaying history
+      try {
+        const messages = await this.fetchMessages(channelId, 1);
+        if (messages.length > 0) {
+          this.lastMessageIds.set(channelId, messages[0].id);
+        }
+      } catch (error) {
+        logger.error(`Failed to fetch initial messages for channel ${channelId}:`, error);
+      }
+
+      // Start polling loop
+      const interval = setInterval(async () => {
+        try {
+          await this.pollChannelForSignals(config);
+        } catch (error) {
+          logger.error(`Error polling Discord channel ${channelId} for signals:`, error);
+        }
+      }, pollInterval);
+
+      this.intervals.set(channelId, interval);
+      logger.info(
+        `Started signal monitoring for Discord channel ${channelId} (${config.channelName})`
+      );
+    }
+  }
+
+  /**
+   * Poll a channel for new messages and emit discord:message:detected for each.
+   * Emits the flat payload format expected by IntegrationService.handleDiscordMessage.
+   */
+  private async pollChannelForSignals(config: DiscordChannelSignalConfig): Promise<void> {
+    const { channelId, channelName } = config;
+    const messages = await this.fetchMessages(channelId, 10);
+
+    const lastId = this.lastMessageIds.get(channelId);
+    const newMessages = lastId ? messages.filter((m) => BigInt(m.id) > BigInt(lastId)) : messages;
+
+    if (newMessages.length === 0) {
+      return;
+    }
+
+    // Update last seen message ID (messages are newest-first)
+    this.lastMessageIds.set(channelId, newMessages[0].id);
+
+    for (const message of newMessages) {
+      this.events.emit('discord:message:detected', {
+        channelId,
+        channelName,
+        userId: message.authorId,
+        username: message.authorName,
+        content: message.content,
+        timestamp: message.timestamp,
+      });
+
+      logger.debug(`Emitted discord:message:detected for message ${message.id} in ${channelName}`);
+    }
   }
 
   /**

--- a/apps/server/src/services/discord.module.ts
+++ b/apps/server/src/services/discord.module.ts
@@ -3,6 +3,7 @@ import { createLogger } from '@protolabs-ai/utils';
 import type { ServiceContainer } from '../server/services.js';
 import { DiscordDMChannel } from './escalation-channels/discord-dm-channel.js';
 import { eventHookService } from './event-hook-service.js';
+import { DiscordMonitor } from './discord-monitor.js';
 
 const logger = createLogger('Server:Wiring');
 
@@ -25,6 +26,7 @@ export function register(container: ServiceContainer): void {
     headsdownService,
     eventHistoryService,
     ceremonyAuditLog,
+    integrationRegistryService,
   } = container;
 
   // Discord Bot Service initialization
@@ -80,4 +82,21 @@ export function register(container: ServiceContainer): void {
   escalationRouter.registerChannel(
     new DiscordDMChannel(discordBotService, events, undefined, escalationRouter)
   );
+
+  // Start Discord channel signal monitoring when DISCORD_TOKEN is configured.
+  // The monitor polls only channels registered in integrationRegistryService.
+  // Configs start empty and are populated at runtime via setChannelConfigs().
+  if (process.env.DISCORD_TOKEN) {
+    const discordMonitor = new DiscordMonitor(events);
+    discordMonitor.setDiscordBotService(discordBotService);
+
+    const configs = integrationRegistryService.getAllEnabledChannelConfigs();
+    void discordMonitor.startChannelMonitoring(configs).catch((err) => {
+      logger.error('Failed to start Discord channel signal monitoring:', err);
+    });
+
+    logger.info(`Discord channel signal monitor started (${configs.length} channel(s) configured)`);
+  } else {
+    logger.info('Discord channel signal monitor skipped (DISCORD_TOKEN not set)');
+  }
 }

--- a/apps/server/src/services/integration-registry-service.ts
+++ b/apps/server/src/services/integration-registry-service.ts
@@ -16,6 +16,7 @@ import {
   type IntegrationDescriptor,
   type IntegrationHealth,
   type IntegrationSummary,
+  type DiscordChannelSignalConfig,
 } from '@protolabs-ai/types';
 import { createLogger } from '@protolabs-ai/utils';
 import type { EventEmitter } from '../lib/events.js';
@@ -28,6 +29,9 @@ export class IntegrationRegistryService {
   private integrations = new Map<string, IntegrationDescriptor>();
   private healthCheckers = new Map<string, HealthCheckFn>();
   private events?: EventEmitter;
+
+  /** Per-project Discord channel signal configs, keyed by project path */
+  private channelConfigs = new Map<string, DiscordChannelSignalConfig[]>();
 
   constructor(events?: EventEmitter) {
     this.events = events;
@@ -232,5 +236,37 @@ export class IntegrationRegistryService {
    */
   get size(): number {
     return this.integrations.size;
+  }
+
+  // ============================================================================
+  // Discord Channel Signal Config — per-project channel monitoring registry
+  // ============================================================================
+
+  /**
+   * Store channel signal configs for a project.
+   * Replaces any previously stored configs for that project.
+   */
+  setChannelConfigs(projectPath: string, configs: DiscordChannelSignalConfig[]): void {
+    this.channelConfigs.set(projectPath, configs);
+    logger.info(`Stored ${configs.length} Discord channel config(s) for project "${projectPath}"`);
+  }
+
+  /**
+   * Get channel signal configs for a specific project.
+   */
+  getChannelConfigs(projectPath: string): DiscordChannelSignalConfig[] {
+    return this.channelConfigs.get(projectPath) ?? [];
+  }
+
+  /**
+   * Get all channel configs across all projects as a flat array of enabled configs.
+   * Used by the Discord monitor to determine which channels to poll.
+   */
+  getAllEnabledChannelConfigs(): DiscordChannelSignalConfig[] {
+    const all: DiscordChannelSignalConfig[] = [];
+    for (const configs of this.channelConfigs.values()) {
+      all.push(...configs.filter((c) => c.enabled));
+    }
+    return all;
   }
 }

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -278,6 +278,7 @@ export type {
   CeremonySettings,
   // Project integration types
   ReactionAbility,
+  DiscordChannelSignalConfig,
   LinearIntegrationConfig,
   DiscordIntegrationConfig,
   GoogleIntegrationConfig,

--- a/libs/types/src/integration-settings.ts
+++ b/libs/types/src/integration-settings.ts
@@ -202,6 +202,29 @@ export interface ReactionAbility {
 }
 
 // ============================================================================
+// Discord Channel Signal Config - Per-channel polling config for signal intake
+// ============================================================================
+
+/**
+ * DiscordChannelSignalConfig - Per-channel configuration for signal monitoring
+ *
+ * Defines which Discord channels the monitor polls for messages, and how those
+ * messages are routed through the signal intake pipeline.
+ */
+export interface DiscordChannelSignalConfig {
+  /** Discord channel ID to monitor */
+  channelId: string;
+  /** Human-readable channel name for logging and display */
+  channelName: string;
+  /** Override the auto-classified signal intent for messages from this channel */
+  intentOverride?: SignalIntent;
+  /** Automatically create a board feature when a signal is detected */
+  autoFeature: boolean;
+  /** Whether this channel config is active */
+  enabled: boolean;
+}
+
+// ============================================================================
 // Discord Integration - Per-project Discord communication integration
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Epic branch containing the Discord signal monitoring foundation:

- `DiscordChannelSignalConfig` type added to `@protolabs-ai/types`
- `DiscordMonitor.startChannelMonitoring()` polling loop with BigInt snowflake comparison
- Per-project channel config storage in `IntegrationRegistryService`
- Discord channel signal monitor wired into `discord.module.ts`

## Children

- PR #1452 — `feat(discord): complete discord-monitor + signal wiring` (merged)

## Unblocks

Once merged, unblocks:
- `[Epic] Integrations Tab — Signal Sources UI`
- `Signal channel config API`
- `Signal store + API endpoint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord channel monitoring now supports per-channel polling with customizable intervals for real-time message detection
  * Added configuration management system for Discord channel signal monitoring, including per-project storage and retrieval
  * Channel monitoring features selective enabling/disabling and intent-based configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->