### PR TITLE
feat(discord): Reaction Abilities UI in Discord config dialog

### DIFF
--- a/apps/server/src/routes/discord/index.ts
+++ b/apps/server/src/routes/discord/index.ts
@@ -2,9 +2,12 @@
  * Discord routes - HTTP API for Discord channel management and DMs
  */
 
-import { Router } from 'express';
+import { Router, Request, Response } from 'express';
+import { createLogger } from '@protolabs-ai/utils';
 import { DiscordService } from '../../services/discord-service.js';
 import type { DiscordBotService } from '../../services/discord-bot-service.js';
+import type { SettingsService } from '../../services/settings-service.js';
+import type { ReactionAbility } from '@protolabs-ai/types';
 import {
   createReorganizeHandler,
   createUndoHandler,
@@ -13,7 +16,12 @@ import {
 import { createSendDMHandler } from './routes/send-dm.js';
 import { createReadDMsHandler } from './routes/read-dms.js';
 
-export function createDiscordRoutes(discordBotService?: DiscordBotService): Router {
+const logger = createLogger('DiscordRoutes');
+
+export function createDiscordRoutes(
+  discordBotService?: DiscordBotService,
+  settingsService?: SettingsService
+): Router {
   const router = Router();
   const discordService = new DiscordService();
 
@@ -26,6 +34,72 @@ export function createDiscordRoutes(discordBotService?: DiscordBotService): Rout
   if (discordBotService) {
     router.post('/send-dm', createSendDMHandler(discordBotService));
     router.post('/read-dms', createReadDMsHandler(discordBotService));
+  }
+
+  // Reaction abilities endpoints (require SettingsService)
+  if (settingsService) {
+    /**
+     * GET /api/discord/reaction-abilities?projectPath=...
+     * Returns the reaction abilities configured for a project
+     */
+    router.get('/reaction-abilities', async (req: Request, res: Response) => {
+      try {
+        const projectPath = req.query.projectPath as string;
+        if (!projectPath) {
+          res.status(400).json({ error: 'projectPath is required' });
+          return;
+        }
+
+        const projectSettings = await settingsService.getProjectSettings(projectPath);
+        const abilities: ReactionAbility[] =
+          projectSettings.integrations?.discord?.reactionAbilities ?? [];
+
+        res.json({ abilities });
+      } catch (error) {
+        logger.error('Failed to get reaction abilities:', error);
+        res.status(500).json({ error: 'Failed to get reaction abilities' });
+      }
+    });
+
+    /**
+     * PUT /api/discord/reaction-abilities
+     * Saves the full list of reaction abilities for a project
+     */
+    router.put('/reaction-abilities', async (req: Request, res: Response) => {
+      try {
+        const { projectPath, abilities } = req.body as {
+          projectPath: string;
+          abilities: ReactionAbility[];
+        };
+
+        if (!projectPath) {
+          res.status(400).json({ error: 'projectPath is required' });
+          return;
+        }
+        if (!Array.isArray(abilities)) {
+          res.status(400).json({ error: 'abilities must be an array' });
+          return;
+        }
+
+        const projectSettings = await settingsService.getProjectSettings(projectPath);
+        const discordConfig = projectSettings.integrations?.discord ?? { enabled: false };
+
+        await settingsService.updateProjectSettings(projectPath, {
+          integrations: {
+            ...projectSettings.integrations,
+            discord: {
+              ...discordConfig,
+              reactionAbilities: abilities,
+            },
+          },
+        });
+
+        res.json({ abilities });
+      } catch (error) {
+        logger.error('Failed to save reaction abilities:', error);
+        res.status(500).json({ error: 'Failed to save reaction abilities' });
+      }
+    });
   }
 
   return router;

--- a/apps/server/src/routes/integrations/index.ts
+++ b/apps/server/src/routes/integrations/index.ts
@@ -76,6 +76,10 @@ export function createIntegrationRoutes(
       }
 
       if (integrations.discord) {
+        // Preserve existing reactionAbilities when updating discord config
+        const existingSettings = await settingsService.getProjectSettings(projectPath);
+        const existingReactionAbilities = existingSettings.integrations?.discord?.reactionAbilities;
+
         validatedIntegrations.discord = {
           enabled: integrations.discord.enabled ?? false,
           serverId: integrations.discord.serverId,
@@ -88,6 +92,7 @@ export function createIntegrationRoutes(
           useWebhook: integrations.discord.useWebhook ?? false,
           webhookId: integrations.discord.webhookId,
           webhookToken: integrations.discord.webhookToken,
+          reactionAbilities: existingReactionAbilities,
         };
       }
 

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -328,7 +328,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   );
   app.use('/api/scheduler', createSchedulerRoutes(schedulerService, settingsService));
   app.use('/api/ava', createAvaRoutes(services));
-  app.use('/api/discord', createDiscordRoutes(discordBotService));
+  app.use('/api/discord', createDiscordRoutes(discordBotService, settingsService));
   app.use(
     '/api/agents',
     createAgentManagementRoutes(roleRegistryService, agentFactoryService, dynamicAgentExecutor)

--- a/apps/ui/src/components/views/settings-view/integrations/integration-config-dialog.tsx
+++ b/apps/ui/src/components/views/settings-view/integrations/integration-config-dialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Eye, EyeOff } from 'lucide-react';
+import { Eye, EyeOff, Pencil, Trash2, Plus, ChevronLeft } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -16,11 +16,21 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Badge,
   Spinner,
 } from '@protolabs-ai/ui/atoms';
 import { apiFetch } from '@/lib/api-fetch';
 import { useAppStore } from '@/store/app-store';
-import type { IntegrationDescriptor, ConfigField } from '@protolabs-ai/types';
+import {
+  useReactionAbilities,
+  useSaveReactionAbilities,
+} from '@/hooks/queries/use-reaction-abilities';
+import type {
+  IntegrationDescriptor,
+  ConfigField,
+  ReactionAbility,
+  ReactionAbilityIntent,
+} from '@protolabs-ai/types';
 
 interface IntegrationConfigDialogProps {
   integrationId: string | null;
@@ -42,6 +52,8 @@ export function IntegrationConfigDialog({
   const [saveError, setSaveError] = useState<string | null>(null);
   const [revealedSecrets, setRevealedSecrets] = useState<Set<string>>(new Set());
   const currentProject = useAppStore((s) => s.currentProject);
+
+  const isDiscord = integrationId === 'discord';
 
   // Fetch descriptor when opened
   useEffect(() => {
@@ -159,7 +171,13 @@ export function IntegrationConfigDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto">
+      <DialogContent
+        className={
+          isDiscord
+            ? 'max-w-2xl max-h-[80vh] overflow-y-auto'
+            : 'max-w-lg max-h-[80vh] overflow-y-auto'
+        }
+      >
         <DialogHeader>
           <DialogTitle>{descriptor?.name ?? 'Integration'} Configuration</DialogTitle>
           <DialogDescription>{descriptor?.description}</DialogDescription>
@@ -190,6 +208,10 @@ export function IntegrationConfigDialog({
                 </div>
               </div>
             ))}
+
+            {isDiscord && currentProject && (
+              <DiscordReactionAbilitiesSection projectPath={currentProject.path} />
+            )}
           </div>
         )}
 
@@ -316,4 +338,358 @@ function FieldRenderer({
         </div>
       );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Discord Reaction Abilities Section
+// ---------------------------------------------------------------------------
+
+const INTENT_LABELS: Record<ReactionAbilityIntent, string> = {
+  work_order: 'Work Order',
+  idea: 'Idea',
+  feedback: 'Feedback',
+  conversational: 'Conversational',
+};
+
+const INTENT_VARIANTS: Record<ReactionAbilityIntent, 'default' | 'secondary' | 'outline'> = {
+  work_order: 'default',
+  idea: 'secondary',
+  feedback: 'secondary',
+  conversational: 'outline',
+};
+
+function makeBlankAbility(): ReactionAbility {
+  return {
+    id: crypto.randomUUID(),
+    emoji: '',
+    label: '',
+    intent: 'feedback',
+    channels: [],
+    allowedRoles: [],
+    allowedUsers: [],
+    autoFeature: true,
+    enabled: true,
+  };
+}
+
+type FormMode = 'list' | 'add' | 'edit';
+
+interface AbilityFormDraft {
+  id: string;
+  emoji: string;
+  label: string;
+  intent: ReactionAbilityIntent;
+  channels: string;
+  allowedRoles: string;
+  allowedUsers: string;
+  autoFeature: boolean;
+  enabled: boolean;
+}
+
+function abilityToFormDraft(ability: ReactionAbility): AbilityFormDraft {
+  return {
+    id: ability.id,
+    emoji: ability.emoji,
+    label: ability.label,
+    intent: ability.intent,
+    channels: (ability.channels ?? []).join(', '),
+    allowedRoles: (ability.allowedRoles ?? []).join(', '),
+    allowedUsers: (ability.allowedUsers ?? []).join(', '),
+    autoFeature: ability.autoFeature ?? true,
+    enabled: ability.enabled,
+  };
+}
+
+function formDraftToAbility(draft: AbilityFormDraft): ReactionAbility {
+  const splitTrim = (s: string) =>
+    s
+      .split(',')
+      .map((v) => v.trim())
+      .filter(Boolean);
+
+  return {
+    id: draft.id,
+    emoji: draft.emoji.trim(),
+    label: draft.label.trim(),
+    intent: draft.intent,
+    channels: splitTrim(draft.channels),
+    allowedRoles: splitTrim(draft.allowedRoles),
+    allowedUsers: splitTrim(draft.allowedUsers),
+    autoFeature: draft.autoFeature,
+    enabled: draft.enabled,
+  };
+}
+
+function channelSummary(channels: string[] | undefined): string {
+  if (!channels || channels.length === 0) return 'All channels';
+  return `${channels.length} channel${channels.length === 1 ? '' : 's'}`;
+}
+
+function trustSummary(roles: string[] | undefined): string {
+  if (!roles || roles.length === 0) return 'All members';
+  return `${roles.length} role${roles.length === 1 ? '' : 's'}`;
+}
+
+function DiscordReactionAbilitiesSection({ projectPath }: { projectPath: string }) {
+  const { data: abilities = [], isLoading } = useReactionAbilities(projectPath);
+  const { mutate: saveAbilities, isPending: isSaving } = useSaveReactionAbilities(projectPath);
+
+  const [formMode, setFormMode] = useState<FormMode>('list');
+  const [formDraft, setFormDraft] = useState<AbilityFormDraft>(() =>
+    abilityToFormDraft(makeBlankAbility())
+  );
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const setDraftField = <K extends keyof AbilityFormDraft>(key: K, value: AbilityFormDraft[K]) => {
+    setFormDraft((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleAdd = () => {
+    setFormDraft(abilityToFormDraft(makeBlankAbility()));
+    setFormError(null);
+    setFormMode('add');
+  };
+
+  const handleEdit = (ability: ReactionAbility) => {
+    setFormDraft(abilityToFormDraft(ability));
+    setFormError(null);
+    setFormMode('edit');
+  };
+
+  const handleDelete = (id: string) => {
+    const updated = abilities.filter((a) => a.id !== id);
+    saveAbilities(updated);
+  };
+
+  const handleToggleEnabled = (id: string, enabled: boolean) => {
+    const updated = abilities.map((a) => (a.id === id ? { ...a, enabled } : a));
+    saveAbilities(updated);
+  };
+
+  const handleFormSubmit = () => {
+    if (!formDraft.emoji.trim()) {
+      setFormError('Emoji is required');
+      return;
+    }
+    if (!formDraft.label.trim()) {
+      setFormError('Label is required');
+      return;
+    }
+
+    const ability = formDraftToAbility(formDraft);
+    let updated: ReactionAbility[];
+
+    if (formMode === 'add') {
+      updated = [...abilities, ability];
+    } else {
+      updated = abilities.map((a) => (a.id === ability.id ? ability : a));
+    }
+
+    setFormError(null);
+    saveAbilities(updated, {
+      onSuccess: () => setFormMode('list'),
+    });
+  };
+
+  const handleFormCancel = () => {
+    setFormMode('list');
+    setFormError(null);
+  };
+
+  return (
+    <div className="space-y-3 border-t border-zinc-200 dark:border-zinc-700 pt-4">
+      <div className="flex items-center justify-between">
+        <h4 className="text-xs font-medium text-zinc-500 uppercase tracking-wider">
+          Reaction Abilities
+        </h4>
+        {formMode === 'list' && (
+          <Button variant="outline" size="sm" onClick={handleAdd} className="h-7 gap-1 text-xs">
+            <Plus className="w-3 h-3" />
+            Add
+          </Button>
+        )}
+        {formMode !== 'list' && (
+          <button
+            type="button"
+            onClick={handleFormCancel}
+            className="flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200"
+          >
+            <ChevronLeft className="w-3 h-3" />
+            Back to list
+          </button>
+        )}
+      </div>
+
+      {formMode === 'list' && (
+        <>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-4">
+              <Spinner />
+            </div>
+          ) : abilities.length === 0 ? (
+            <p className="text-sm text-zinc-500 py-3">
+              No reaction abilities configured. Add one to let trusted users tag messages with
+              reactions.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {abilities.map((ability) => (
+                <div
+                  key={ability.id}
+                  className="flex items-center gap-3 rounded-md border border-zinc-200 dark:border-zinc-700 px-3 py-2"
+                >
+                  <span className="text-2xl leading-none select-none">{ability.emoji}</span>
+                  <div className="flex-1 min-w-0 space-y-0.5">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium truncate">{ability.label}</span>
+                      <Badge variant={INTENT_VARIANTS[ability.intent]} className="text-xs shrink-0">
+                        {INTENT_LABELS[ability.intent]}
+                      </Badge>
+                    </div>
+                    <p className="text-xs text-zinc-500">
+                      {channelSummary(ability.channels)} &middot;{' '}
+                      {trustSummary(ability.allowedRoles)}
+                    </p>
+                  </div>
+                  <Switch
+                    checked={ability.enabled}
+                    onCheckedChange={(enabled) => handleToggleEnabled(ability.id, enabled)}
+                    disabled={isSaving}
+                    aria-label="Enable ability"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleEdit(ability)}
+                    className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+                    aria-label="Edit ability"
+                  >
+                    <Pencil className="w-4 h-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(ability.id)}
+                    disabled={isSaving}
+                    className="text-zinc-400 hover:text-red-500"
+                    aria-label="Delete ability"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {(formMode === 'add' || formMode === 'edit') && (
+        <div className="space-y-3 rounded-md border border-zinc-200 dark:border-zinc-700 p-3">
+          <h5 className="text-xs font-medium text-zinc-700 dark:text-zinc-300">
+            {formMode === 'add' ? 'New Reaction Ability' : 'Edit Reaction Ability'}
+          </h5>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label className="text-xs">Emoji</Label>
+              <Input
+                value={formDraft.emoji}
+                onChange={(e) => setDraftField('emoji', e.target.value)}
+                placeholder="e.g. \uD83D\uDC1B or :bug:123"
+                className="text-base"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-xs">Label</Label>
+              <Input
+                value={formDraft.label}
+                onChange={(e) => setDraftField('label', e.target.value)}
+                placeholder="e.g. Report Bug"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label className="text-xs">Intent</Label>
+            <Select
+              value={formDraft.intent}
+              onValueChange={(v) => setDraftField('intent', v as ReactionAbilityIntent)}
+            >
+              <SelectTrigger className="h-8 text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="work_order">Work Order</SelectItem>
+                <SelectItem value="idea">Idea</SelectItem>
+                <SelectItem value="feedback">Feedback</SelectItem>
+                <SelectItem value="conversational">Conversational</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label className="text-xs">Channels (comma-separated IDs, blank = all)</Label>
+            <Input
+              value={formDraft.channels}
+              onChange={(e) => setDraftField('channels', e.target.value)}
+              placeholder="123456789, 987654321"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label className="text-xs">Allowed Roles (comma-separated IDs, blank = any role)</Label>
+            <Input
+              value={formDraft.allowedRoles}
+              onChange={(e) => setDraftField('allowedRoles', e.target.value)}
+              placeholder="111111111, 222222222"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label className="text-xs">Allowed Users (comma-separated IDs)</Label>
+            <Input
+              value={formDraft.allowedUsers}
+              onChange={(e) => setDraftField('allowedUsers', e.target.value)}
+              placeholder="333333333"
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div>
+              <Label className="text-xs">Auto-create Feature</Label>
+              <p className="text-xs text-zinc-500">
+                Automatically create a board feature on reaction
+              </p>
+            </div>
+            <Switch
+              checked={formDraft.autoFeature}
+              onCheckedChange={(v) => setDraftField('autoFeature', v)}
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <Label className="text-xs">Enabled</Label>
+            <Switch
+              checked={formDraft.enabled}
+              onCheckedChange={(v) => setDraftField('enabled', v)}
+            />
+          </div>
+
+          {formError && <p className="text-xs text-red-600 dark:text-red-400">{formError}</p>}
+
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="outline" size="sm" onClick={handleFormCancel} className="h-7 text-xs">
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleFormSubmit}
+              disabled={isSaving}
+              className="h-7 text-xs"
+            >
+              {isSaving ? 'Saving...' : formMode === 'add' ? 'Add Ability' : 'Update Ability'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/apps/ui/src/hooks/queries/index.ts
+++ b/apps/ui/src/hooks/queries/index.ts
@@ -104,3 +104,6 @@ export {
 // Agent Templates
 export { useAgentTemplates } from './use-agent-templates';
 export type { AgentTemplateMetadata } from './use-agent-templates';
+
+// Discord
+export { useReactionAbilities, useSaveReactionAbilities } from './use-reaction-abilities';

--- a/apps/ui/src/hooks/queries/use-reaction-abilities.ts
+++ b/apps/ui/src/hooks/queries/use-reaction-abilities.ts
@@ -1,0 +1,75 @@
+/**
+ * Reaction Abilities Query Hooks
+ *
+ * React Query hooks for fetching and updating Discord reaction abilities.
+ * Reaction abilities are emoji-triggered workflow intents configured per project.
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiGet, apiPut } from '@/lib/api-fetch';
+import { queryKeys } from '@/lib/query-keys';
+import type { ReactionAbility } from '@protolabs-ai/types';
+
+const STALE_TIME = 30 * 1000; // 30 seconds
+
+interface ReactionAbilitiesResponse {
+  abilities: ReactionAbility[];
+}
+
+/**
+ * Fetch reaction abilities for a project
+ *
+ * @param projectPath - Path to the project
+ * @returns Query result with abilities array
+ *
+ * @example
+ * ```tsx
+ * const { data: abilities, isLoading } = useReactionAbilities(projectPath);
+ * ```
+ */
+export function useReactionAbilities(projectPath: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.discord.reactionAbilities(projectPath ?? ''),
+    queryFn: async (): Promise<ReactionAbility[]> => {
+      if (!projectPath) throw new Error('No project path');
+      const params = new URLSearchParams({ projectPath });
+      const result = await apiGet<ReactionAbilitiesResponse>(
+        `/api/discord/reaction-abilities?${params.toString()}`
+      );
+      return result.abilities ?? [];
+    },
+    enabled: !!projectPath,
+    staleTime: STALE_TIME,
+    refetchOnWindowFocus: false,
+  });
+}
+
+/**
+ * Mutation to save the full list of reaction abilities for a project
+ *
+ * @param projectPath - Path to the project
+ * @returns Mutation result
+ *
+ * @example
+ * ```tsx
+ * const { mutate: saveAbilities, isPending } = useSaveReactionAbilities(projectPath);
+ * saveAbilities(updatedAbilities);
+ * ```
+ */
+export function useSaveReactionAbilities(projectPath: string | undefined) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (abilities: ReactionAbility[]): Promise<ReactionAbility[]> => {
+      if (!projectPath) throw new Error('No project path');
+      const result = await apiPut<ReactionAbilitiesResponse>('/api/discord/reaction-abilities', {
+        projectPath,
+        abilities,
+      });
+      return result.abilities ?? [];
+    },
+    onSuccess: (abilities) => {
+      queryClient.setQueryData(queryKeys.discord.reactionAbilities(projectPath ?? ''), abilities);
+    },
+  });
+}

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -335,6 +335,15 @@ export const queryKeys = {
   },
 
   // ============================================
+  // Discord
+  // ============================================
+  discord: {
+    /** Reaction abilities for a project */
+    reactionAbilities: (projectPath: string) =>
+      ['discord', 'reaction-abilities', projectPath] as const,
+  },
+
+  // ============================================
   // System Health
   // ============================================
   system: {

--- a/libs/types/src/discord.ts
+++ b/libs/types/src/discord.ts
@@ -199,3 +199,39 @@ export interface DiscordUserMessageRoutedPayload {
   content: string;
   routedToAgent: string;
 }
+
+// ============================================================================
+// Reaction Abilities - Emoji-triggered workflow intents
+// ============================================================================
+
+/**
+ * The intent/action type associated with a reaction ability
+ */
+export type ReactionAbilityIntent = 'work_order' | 'idea' | 'feedback' | 'conversational';
+
+/**
+ * ReactionAbility - A configured emoji reaction that triggers a workflow
+ *
+ * When a trusted user reacts to a Discord message with the configured emoji,
+ * the system creates a work item or routes it according to the intent.
+ */
+export interface ReactionAbility {
+  /** Unique identifier for this ability */
+  id: string;
+  /** Unicode emoji (e.g. "🐛") or Discord custom emoji ID (e.g. ":bug:123456789") */
+  emoji: string;
+  /** Human-readable label (e.g. "Report Bug") */
+  label: string;
+  /** The intent/action this reaction triggers */
+  intent: ReactionAbilityIntent;
+  /** Channel IDs this ability applies to; empty array or undefined means all channels */
+  channels?: string[];
+  /** Role IDs allowed to trigger this ability; empty array or undefined means any role */
+  allowedRoles?: string[];
+  /** Specific user IDs allowed to trigger this ability */
+  allowedUsers?: string[];
+  /** Automatically create a feature when triggered (default: true) */
+  autoFeature?: boolean;
+  /** Whether this ability is currently active */
+  enabled: boolean;
+}

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -552,6 +552,8 @@ export type {
   DiscordReplyContext,
   DiscordRoutedMessage,
   DiscordUserMessageRoutedPayload,
+  ReactionAbilityIntent,
+  ReactionAbility,
 } from './discord.js';
 
 // Agent role types (headsdown agents)

--- a/libs/types/src/integration-settings.ts
+++ b/libs/types/src/integration-settings.ts
@@ -8,6 +8,7 @@
 
 import type { EventHookTrigger } from './event-settings.js';
 import type { SignalIntent } from './signal-intent.js';
+import type { ReactionAbility } from './discord.js';
 
 // ============================================================================
 // Discord Settings - Global Discord bot configuration


### PR DESCRIPTION
## Summary

- Adds a Reaction Abilities section to the Discord integration config dialog
- List view: emoji, label, intent badge, channel summary, trust summary, enabled toggle, edit/delete buttons
- Inline form: emoji input, label, intent dropdown, channel IDs, allowed roles, allowed users, autoFeature toggle, enabled toggle
- Empty state: "No reaction abilities configured" message
- `useReactionAbilities` React query hook — GET/PUT against `discord/reaction-abilities` endpoints
- Non-Discord integration dialogs unchanged

## Target

Targeting `feature/m4-discord-reaction-abilities` epic branch (M4: Discord Reaction Abilities)

## Test plan

- [ ] Reaction Abilities section appears in Discord config dialog
- [ ] Add/edit/delete/toggle abilities via the UI
- [ ] Changes persist via API after page refresh
- [ ] Empty state shown when no abilities configured
- [ ] `npm run build` passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)