### PR TITLE
fix(ui): auto-focus chat input when chat overlay opens

### DIFF
--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
@@ -166,6 +166,7 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
             onStop={stop}
             isStreaming={isStreaming}
             placeholder="Ask Ava..."
+            autoFocus
             actions={
               <>
                 <ChatModelSelect value={modelAlias} onValueChange={handleModelChange} />

--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-view.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-view.tsx
@@ -24,6 +24,18 @@ export function ChatOverlayView() {
     }
   }, []);
 
+  // When the Electron overlay window is shown again, focus the chat input
+  useEffect(() => {
+    const handleWindowFocus = () => {
+      const textarea = document.querySelector<HTMLTextAreaElement>(
+        '[data-slot="chat-input"] textarea'
+      );
+      textarea?.focus();
+    };
+    window.addEventListener('focus', handleWindowFocus);
+    return () => window.removeEventListener('focus', handleWindowFocus);
+  }, []);
+
   // Escape key hides the overlay (or closes history panel first)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/libs/ui/src/ai/chat-input.tsx
+++ b/libs/ui/src/ai/chat-input.tsx
@@ -20,6 +20,7 @@ export function ChatInput({
   placeholder = 'Ask anything...',
   actions,
   className,
+  autoFocus,
 }: {
   value: string;
   onChange: (value: string) => void;
@@ -31,6 +32,8 @@ export function ChatInput({
   /** Optional slot for extra controls (e.g. model selector) rendered below the input */
   actions?: React.ReactNode;
   className?: string;
+  /** Focus the input on mount */
+  autoFocus?: boolean;
 }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isDisabled = disabled || isStreaming;
@@ -42,6 +45,15 @@ export function ChatInput({
     el.style.height = 'auto';
     el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
   }, [value]);
+
+  // Re-focus after streaming ends so user can type the next message immediately
+  const prevStreamingRef = useRef(false);
+  useEffect(() => {
+    if (prevStreamingRef.current && !isStreaming) {
+      textareaRef.current?.focus();
+    }
+    prevStreamingRef.current = !!isStreaming;
+  }, [isStreaming]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -67,6 +79,7 @@ export function ChatInput({
           placeholder={placeholder}
           disabled={isDisabled}
           rows={1}
+          autoFocus={autoFocus}
           className="flex-1 resize-none bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none disabled:opacity-50"
         />
         {isStreaming && onStop ? (


### PR DESCRIPTION
Fixes the ask-Ava chat window not focusing the input field on open. Updates chat-overlay-content, chat-overlay-view, and the shared chat-input component to auto-focus on mount/open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat input now auto-focuses when the chat overlay appears for improved user experience.
  * Chat input automatically regains focus when the application window is brought back into focus.
  * Chat input refocuses after a message finishes streaming, keeping focus in the right place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->