### PR TITLE
feat(onboarding): add optional user profile step to setup flow

### DIFF
--- a/apps/ui/src/components/views/setup-view.tsx
+++ b/apps/ui/src/components/views/setup-view.tsx
@@ -7,6 +7,7 @@ import {
   CompleteStep,
   ProvidersSetupStep,
   GitHubSetupStep,
+  UserProfileSetupStep,
 } from './setup-view/steps';
 import { useNavigate } from '@tanstack/react-router';
 
@@ -17,14 +18,15 @@ export function SetupView() {
   const { currentStep, setCurrentStep, completeSetup } = useSetupStore();
   const navigate = useNavigate();
 
-  // Simplified steps: welcome, theme, providers (combined), github, complete
-  const steps = ['welcome', 'theme', 'providers', 'github', 'complete'] as const;
+  // Steps: welcome, theme, user_profile, providers (combined), github, complete
+  const steps = ['welcome', 'theme', 'user_profile', 'providers', 'github', 'complete'] as const;
   type StepName = (typeof steps)[number];
 
   const getStepName = (): StepName => {
     // Map old step names to new consolidated steps
     if (currentStep === 'welcome') return 'welcome';
     if (currentStep === 'theme') return 'theme';
+    if (currentStep === 'user_profile') return 'user_profile';
     if (
       currentStep === 'claude_detect' ||
       currentStep === 'claude_auth' ||
@@ -49,6 +51,10 @@ export function SetupView() {
         setCurrentStep('theme');
         break;
       case 'theme':
+        logger.debug('[Setup Flow] Moving to user_profile step');
+        setCurrentStep('user_profile');
+        break;
+      case 'user_profile':
         logger.debug('[Setup Flow] Moving to providers step');
         setCurrentStep('providers');
         break;
@@ -69,8 +75,11 @@ export function SetupView() {
       case 'theme':
         setCurrentStep('welcome');
         break;
-      case 'providers':
+      case 'user_profile':
         setCurrentStep('theme');
+        break;
+      case 'providers':
+        setCurrentStep('user_profile');
         break;
       case 'github':
         setCurrentStep('providers');
@@ -114,6 +123,14 @@ export function SetupView() {
 
             {currentStep === 'theme' && (
               <ThemeStep onNext={() => handleNext('theme')} onBack={() => handleBack('theme')} />
+            )}
+
+            {currentStep === 'user_profile' && (
+              <UserProfileSetupStep
+                onNext={() => handleNext('user_profile')}
+                onBack={() => handleBack('user_profile')}
+                onSkip={() => handleNext('user_profile')}
+              />
             )}
 
             {(currentStep === 'providers' ||

--- a/apps/ui/src/components/views/setup-view/steps/index.ts
+++ b/apps/ui/src/components/views/setup-view/steps/index.ts
@@ -1,6 +1,7 @@
 // Re-export all setup step components for easier imports
 export { WelcomeStep } from './welcome-step';
 export { ThemeStep } from './theme-step';
+export { UserProfileSetupStep } from './user-profile-setup-step';
 export { CompleteStep } from './complete-step';
 export { ProvidersSetupStep } from './providers-setup-step';
 export { GitHubSetupStep } from './github-setup-step';

--- a/apps/ui/src/components/views/setup-view/steps/user-profile-setup-step.tsx
+++ b/apps/ui/src/components/views/setup-view/steps/user-profile-setup-step.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { Button, Input, Label, Textarea } from '@protolabs-ai/ui/atoms';
+import { useGlobalSettings } from '@/hooks/queries/use-settings';
+import { useUpdateGlobalSettings } from '@/hooks/mutations/use-settings-mutations';
+import type { UserProfile } from '@protolabs-ai/types';
+
+interface UserProfileSetupStepProps {
+  onNext: () => void;
+  onBack: () => void;
+  onSkip: () => void;
+}
+
+export function UserProfileSetupStep({ onNext, onBack, onSkip }: UserProfileSetupStepProps) {
+  const { data: settings } = useGlobalSettings();
+  const [profile, setProfile] = useState<UserProfile>(() => settings?.userProfile ?? {});
+
+  const { mutate: updateSettings } = useUpdateGlobalSettings({ showSuccessToast: false });
+
+  const handleNext = () => {
+    if (profile.name || profile.title || profile.bio) {
+      updateSettings({ userProfile: profile });
+    }
+    onNext();
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] px-6">
+      <div className="w-full max-w-md rounded-2xl border border-border bg-gradient-to-br from-card/80 via-card/70 to-card/80 backdrop-blur-xl p-8 space-y-6">
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold text-foreground">Tell us about yourself</h2>
+          <p className="text-sm text-muted-foreground">
+            This helps agents personalize their output. You can always update this in Settings.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="profile-name">Your name</Label>
+            <Input
+              id="profile-name"
+              placeholder="Jane Smith"
+              value={profile.name ?? ''}
+              onChange={(e) => setProfile((p) => ({ ...p, name: e.target.value }))}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="profile-title">Role or title</Label>
+            <Input
+              id="profile-title"
+              placeholder="Architect, founder"
+              value={profile.title ?? ''}
+              onChange={(e) => setProfile((p) => ({ ...p, title: e.target.value }))}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="profile-bio">
+              Brief bio <span className="text-muted-foreground font-normal">(optional)</span>
+            </Label>
+            <Textarea
+              id="profile-bio"
+              placeholder="Tell agents a bit about your background and working style…"
+              rows={3}
+              value={profile.bio ?? ''}
+              onChange={(e) => setProfile((p) => ({ ...p, bio: e.target.value }))}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between pt-2">
+          <Button variant="ghost" onClick={onBack}>
+            Back
+          </Button>
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" onClick={onSkip} className="text-muted-foreground">
+              Skip for now
+            </Button>
+            <Button onClick={handleNext}>Continue</Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/store/setup-store.ts
+++ b/apps/ui/src/store/setup-store.ts
@@ -114,6 +114,7 @@ export interface InstallProgress {
 export type SetupStep =
   | 'welcome'
   | 'theme'
+  | 'user_profile'
   | 'providers'
   | 'claude_detect'
   | 'claude_auth'


### PR DESCRIPTION
Adds an optional user profile setup step to the onboarding flow. Users can fill in name, role, and preferences during setup. Step is skippable and integrates with the existing setup-store state machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new User Profile setup step to the onboarding flow where users can enter their name, title, and bio during initial setup.
  * Users can skip the profile setup or navigate back to previous steps as needed; profile information is automatically saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->