### PR TITLE
feat(providers): wire Groq and OpenAI-Compatible settings tabs to UI

### DIFF
--- a/apps/ui/src/components/views/settings-view.tsx
+++ b/apps/ui/src/components/views/settings-view.tsx
@@ -30,6 +30,8 @@ import {
   CursorSettingsTab,
   CodexSettingsTab,
   OpencodeSettingsTab,
+  GroqSettingsTab,
+  OpenAICompatibleTab,
 } from './settings-view/providers';
 import { MCPServersSection } from './settings-view/mcp-servers';
 import { PromptCustomizationSection } from './settings-view/prompts';
@@ -104,6 +106,10 @@ export function SettingsView() {
         return <CodexSettingsTab />;
       case 'opencode-provider':
         return <OpencodeSettingsTab />;
+      case 'groq-provider':
+        return <GroqSettingsTab />;
+      case 'openai-compatible-provider':
+        return <OpenAICompatibleTab />;
       case 'providers':
       case 'claude': // Backwards compatibility - redirect to claude-provider
         return <ClaudeSettingsTab />;

--- a/apps/ui/src/components/views/settings-view/config/navigation.ts
+++ b/apps/ui/src/components/views/settings-view/config/navigation.ts
@@ -20,6 +20,7 @@ import {
   Timer,
   UserCog,
   Users,
+  Zap,
 } from 'lucide-react';
 import {
   AnthropicIcon,
@@ -61,6 +62,8 @@ export const GLOBAL_NAV_GROUPS: NavigationGroup[] = [
           { id: 'cursor-provider', label: 'Cursor', icon: CursorIcon },
           { id: 'codex-provider', label: 'Codex', icon: OpenAIIcon },
           { id: 'opencode-provider', label: 'OpenCode', icon: OpenCodeIcon },
+          { id: 'groq-provider', label: 'Groq', icon: Zap },
+          { id: 'openai-compatible-provider', label: 'OpenAI-Compatible', icon: Server },
         ],
       },
       { id: 'mcp-servers', label: 'MCP Servers', icon: Server },

--- a/apps/ui/src/components/views/settings-view/hooks/use-settings-view.ts
+++ b/apps/ui/src/components/views/settings-view/hooks/use-settings-view.ts
@@ -8,6 +8,8 @@ export type SettingsViewId =
   | 'cursor-provider'
   | 'codex-provider'
   | 'opencode-provider'
+  | 'groq-provider'
+  | 'openai-compatible-provider'
   | 'mcp-servers'
   | 'integrations'
   | 'prompts'

--- a/apps/ui/src/components/views/settings-view/providers/index.ts
+++ b/apps/ui/src/components/views/settings-view/providers/index.ts
@@ -3,3 +3,5 @@ export { ClaudeSettingsTab } from './claude-settings-tab';
 export { CursorSettingsTab } from './cursor-settings-tab';
 export { CodexSettingsTab } from './codex-settings-tab';
 export { OpencodeSettingsTab } from './opencode-settings-tab';
+export { GroqSettingsTab } from './groq-settings-tab';
+export { OpenAICompatibleTab } from './openai-compatible-tab';


### PR DESCRIPTION
## Summary
- Adds Groq and OpenAI-Compatible entries to the providers navigation
- Routes `groq-provider` and `openai-compatible-provider` view IDs to their tab components
- Exports the two new tab components from the providers barrel

The tab components (`groq-settings-tab` and `openai-compatible-tab`) were already implemented. This PR completes the wiring that the agent left uncommitted in a stale worktree.

## Test plan
- [ ] Open Settings → AI Providers → Groq nav item loads the Groq tab
- [ ] Open Settings → AI Providers → OpenAI-Compatible loads the tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Groq is now available as a new AI provider option in the settings, allowing users to configure and use it
  * OpenAI-Compatible is now available as a new AI provider option, enabling integration with compatible services
  * Both new providers are accessible through the AI Providers navigation menu for streamlined configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->