### PR TITLE
Migrate Discord profile fields → Integrations tab

### DIFF
--- a/apps/ui/src/components/views/settings-view/integrations/integration-config-dialog.tsx
+++ b/apps/ui/src/components/views/settings-view/integrations/integration-config-dialog.tsx
@@ -21,10 +21,13 @@ import {
 import { apiFetch } from '@/lib/api-fetch';
 import { useAppStore } from '@/store/app-store';
 import { useSignalChannels } from '@/hooks/use-signal-channels';
+import { useGlobalSettings } from '@/hooks/queries/use-settings';
+import { useUpdateGlobalSettings } from '@/hooks/mutations/use-settings-mutations';
 import type {
   IntegrationDescriptor,
   ConfigField,
   DiscordChannelSignalConfig,
+  UserProfile,
 } from '@protolabs-ai/types';
 import type { SignalIntent } from '@protolabs-ai/types';
 
@@ -216,6 +219,8 @@ export function IntegrationConfigDialog({
                 onChange={signalChannels.setChannels}
               />
             )}
+
+            {isDiscord && <DiscordProfileSection />}
           </div>
         )}
 
@@ -423,6 +428,180 @@ function SignalSourcesSection({
         </Button>
       )}
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Discord profile section — reads/writes userProfile.discord.* and additionalAllowedUsers
+// ---------------------------------------------------------------------------
+
+function DiscordProfileSection() {
+  const { data: settings } = useGlobalSettings();
+  const updateSettings = useUpdateGlobalSettings({ showSuccessToast: false });
+  const [local, setLocal] = useState<UserProfile>({});
+  const [allowedUsersText, setAllowedUsersText] = useState('');
+
+  useEffect(() => {
+    if (settings?.userProfile) {
+      setLocal(settings.userProfile);
+      setAllowedUsersText((settings.userProfile.additionalAllowedUsers ?? []).join(', '));
+    }
+  }, [settings?.userProfile]);
+
+  const save = useCallback(
+    (overrides?: Partial<UserProfile>) => {
+      const toSave = overrides ? { ...local, ...overrides } : local;
+      updateSettings.mutate({ userProfile: toSave });
+    },
+    [local, updateSettings]
+  );
+
+  const saveAllowedUsers = useCallback(() => {
+    const users = allowedUsersText
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const updated = { ...local, additionalAllowedUsers: users };
+    setLocal(updated);
+    updateSettings.mutate({ userProfile: updated });
+  }, [allowedUsersText, local, updateSettings]);
+
+  return (
+    <>
+      <div className="space-y-3">
+        <h4 className="text-xs font-medium text-zinc-500 uppercase tracking-wider">Bot Identity</h4>
+        <div className="space-y-1.5">
+          <Label className="text-sm">Discord username</Label>
+          <Input
+            value={local.discord?.username ?? ''}
+            onChange={(e) =>
+              setLocal((p) => ({
+                ...p,
+                discord: { ...p.discord, username: e.target.value },
+              }))
+            }
+            onBlur={() => save()}
+            placeholder="Discord username"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <h4 className="text-xs font-medium text-zinc-500 uppercase tracking-wider">
+          Notification Channels
+        </h4>
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label className="text-sm">Primary</Label>
+            <Input
+              className="font-mono"
+              value={local.discord?.channels?.primary ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  discord: {
+                    ...p.discord,
+                    channels: { ...p.discord?.channels, primary: e.target.value },
+                  },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="Channel ID"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm">Dev</Label>
+            <Input
+              className="font-mono"
+              value={local.discord?.channels?.dev ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  discord: {
+                    ...p.discord,
+                    channels: { ...p.discord?.channels, dev: e.target.value },
+                  },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="Channel ID"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm">Infra</Label>
+            <Input
+              className="font-mono"
+              value={local.discord?.channels?.infra ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  discord: {
+                    ...p.discord,
+                    channels: { ...p.discord?.channels, infra: e.target.value },
+                  },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="Channel ID"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm">Deployments</Label>
+            <Input
+              className="font-mono"
+              value={local.discord?.channels?.deployments ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  discord: {
+                    ...p.discord,
+                    channels: { ...p.discord?.channels, deployments: e.target.value },
+                  },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="Channel ID"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm">Alerts</Label>
+            <Input
+              className="font-mono"
+              value={local.discord?.channels?.alerts ?? ''}
+              onChange={(e) =>
+                setLocal((p) => ({
+                  ...p,
+                  discord: {
+                    ...p.discord,
+                    channels: { ...p.discord?.channels, alerts: e.target.value },
+                  },
+                }))
+              }
+              onBlur={() => save()}
+              placeholder="Channel ID"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <h4 className="text-xs font-medium text-zinc-500 uppercase tracking-wider">
+          Trusted Users
+        </h4>
+        <div className="space-y-1.5">
+          <Label className="text-sm">Trusted Discord users (comma-separated usernames)</Label>
+          <Input
+            value={allowedUsersText}
+            onChange={(e) => setAllowedUsersText(e.target.value)}
+            onBlur={() => saveAllowedUsers()}
+            placeholder="username1, username2"
+          />
+          <p className="text-xs text-zinc-500">
+            These users can interact with agents and trigger reaction abilities.
+          </p>
+        </div>
+      </div>
+    </>
   );
 }
 

--- a/apps/ui/src/components/views/settings-view/profile/profile-section.tsx
+++ b/apps/ui/src/components/views/settings-view/profile/profile-section.tsx
@@ -28,13 +28,11 @@ export function ProfileSection() {
   const updateSettings = useUpdateGlobalSettings({ showSuccessToast: false });
 
   const [local, setLocal] = useState<UserProfile>({});
-  const [allowedUsersText, setAllowedUsersText] = useState('');
 
   // Sync server data to local state
   useEffect(() => {
     if (settings?.userProfile) {
       setLocal(settings.userProfile);
-      setAllowedUsersText((settings.userProfile.additionalAllowedUsers ?? []).join(', '));
     }
   }, [settings?.userProfile]);
 
@@ -45,16 +43,6 @@ export function ProfileSection() {
     },
     [local, updateSettings]
   );
-
-  const saveAllowedUsers = useCallback(() => {
-    const users = allowedUsersText
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean);
-    const updated = { ...local, additionalAllowedUsers: users };
-    setLocal(updated);
-    updateSettings.mutate({ userProfile: updated });
-  }, [allowedUsersText, local, updateSettings]);
 
   return (
     <div
@@ -73,7 +61,7 @@ export function ProfileSection() {
           <h2 className="text-lg font-semibold text-foreground tracking-tight">User Profile</h2>
         </div>
         <p className="text-sm text-muted-foreground/80 ml-12">
-          Configure your identity, brand, and integrations for agent personalization.
+          Configure your identity and brand information for agent personalization.
         </p>
       </div>
 
@@ -104,109 +92,6 @@ export function ProfileSection() {
               onBlur={() => save()}
               rows={3}
               placeholder="Short bio for content agents"
-            />
-          </FieldRow>
-        </div>
-
-        {/* Discord */}
-        <div className="space-y-4">
-          <GroupHeader>Discord</GroupHeader>
-          <FieldRow label="Username">
-            <Input
-              value={local.discord?.username ?? ''}
-              onChange={(e) =>
-                setLocal((p) => ({
-                  ...p,
-                  discord: { ...p.discord, username: e.target.value },
-                }))
-              }
-              onBlur={() => save()}
-              placeholder="Discord username"
-            />
-          </FieldRow>
-          <FieldRow label="Primary Channel ID">
-            <Input
-              className="font-mono"
-              value={local.discord?.channels?.primary ?? ''}
-              onChange={(e) =>
-                setLocal((p) => ({
-                  ...p,
-                  discord: {
-                    ...p.discord,
-                    channels: { ...p.discord?.channels, primary: e.target.value },
-                  },
-                }))
-              }
-              onBlur={() => save()}
-              placeholder="Channel ID"
-            />
-          </FieldRow>
-          <FieldRow label="Dev Channel ID">
-            <Input
-              className="font-mono"
-              value={local.discord?.channels?.dev ?? ''}
-              onChange={(e) =>
-                setLocal((p) => ({
-                  ...p,
-                  discord: {
-                    ...p.discord,
-                    channels: { ...p.discord?.channels, dev: e.target.value },
-                  },
-                }))
-              }
-              onBlur={() => save()}
-              placeholder="Channel ID"
-            />
-          </FieldRow>
-          <FieldRow label="Infra Channel ID">
-            <Input
-              className="font-mono"
-              value={local.discord?.channels?.infra ?? ''}
-              onChange={(e) =>
-                setLocal((p) => ({
-                  ...p,
-                  discord: {
-                    ...p.discord,
-                    channels: { ...p.discord?.channels, infra: e.target.value },
-                  },
-                }))
-              }
-              onBlur={() => save()}
-              placeholder="Channel ID"
-            />
-          </FieldRow>
-          <FieldRow label="Deployments Channel ID">
-            <Input
-              className="font-mono"
-              value={local.discord?.channels?.deployments ?? ''}
-              onChange={(e) =>
-                setLocal((p) => ({
-                  ...p,
-                  discord: {
-                    ...p.discord,
-                    channels: { ...p.discord?.channels, deployments: e.target.value },
-                  },
-                }))
-              }
-              onBlur={() => save()}
-              placeholder="Channel ID"
-            />
-          </FieldRow>
-          <FieldRow label="Alerts Channel ID">
-            <Input
-              className="font-mono"
-              value={local.discord?.channels?.alerts ?? ''}
-              onChange={(e) =>
-                setLocal((p) => ({
-                  ...p,
-                  discord: {
-                    ...p.discord,
-                    channels: { ...p.discord?.channels, alerts: e.target.value },
-                  },
-                }))
-              }
-              onBlur={() => save()}
-              placeholder="Channel ID"
             />
           </FieldRow>
         </div>
@@ -349,22 +234,6 @@ export function ProfileSection() {
               onBlur={() => save()}
               placeholder="e.g. 192.168.1.100"
             />
-          </FieldRow>
-        </div>
-
-        {/* Access Control */}
-        <div className="space-y-4">
-          <GroupHeader>Access Control</GroupHeader>
-          <FieldRow label="Additional Allowed Users">
-            <Input
-              value={allowedUsersText}
-              onChange={(e) => setAllowedUsersText(e.target.value)}
-              onBlur={() => saveAllowedUsers()}
-              placeholder="Comma-separated Discord usernames"
-            />
-            <p className="text-xs text-muted-foreground/70">
-              Discord usernames allowed to interact with agents, separated by commas.
-            </p>
           </FieldRow>
         </div>
       </div>


### PR DESCRIPTION
## Summary\n\nMove all Discord-related fields from the User Profile settings tab into the Discord integration config dialog in the Integrations tab. The profile tab should only contain identity information (name, title, bio, brand). Discord coordination config belongs in the integrations surface.\n\n## What moves\n\nFrom apps/ui/src/components/views/settings-view/profile/profile-section.tsx:\n\n**Discord section (lines 111-212)** — remove entirely from profile:\n- discord.username — moves to Discord config dialog as...\n\n---\n*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord integration now supports configuration of username, channel IDs (primary, dev, infra, deployments, alerts), and trusted users management.

* **Changes**
  * Discord and Access Control settings moved from profile section to integration configuration dialog.
  * Profile section description updated to reflect simplified focus on identity and brand configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->