### PR TITLE
[linear] ux(ava-anywhere): polish the overlay as the primary Ava chat surface

### DIFF
--- a/apps/ui/src/components/shared/keyboard-map.tsx
+++ b/apps/ui/src/components/shared/keyboard-map.tsx
@@ -111,6 +111,7 @@ const SHORTCUT_LABELS: Record<keyof KeyboardShortcuts, string> = {
   splitTerminalDown: 'Split Down',
   closeTerminal: 'Close Terminal',
   newTerminalTab: 'New Tab',
+  avaAnywhere: 'Open Ava Anywhere',
 };
 
 // Categorize shortcuts for color coding
@@ -131,6 +132,7 @@ const SHORTCUT_CATEGORIES: Record<keyof KeyboardShortcuts, 'navigation' | 'ui' |
   githubIssues: 'navigation',
   githubPrs: 'navigation',
   toggleSidebar: 'ui',
+  avaAnywhere: 'ui',
   addFeature: 'action',
   addContextFile: 'action',
   startNext: 'action',

--- a/apps/ui/src/components/views/board-view/board-header.tsx
+++ b/apps/ui/src/components/views/board-view/board-header.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Switch } from '@protolabs-ai/ui/atoms';
-import { Label } from '@protolabs-ai/ui/atoms';
-import { Wand2, GitBranch, ClipboardCheck, DollarSign } from 'lucide-react';
+import { Label, Kbd, KbdGroup } from '@protolabs-ai/ui/atoms';
+import { Wand2, GitBranch, ClipboardCheck, DollarSign, Sparkles } from 'lucide-react';
 import { ConflictBadge } from './components/conflict-badge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@protolabs-ai/ui/atoms';
 import { UsagePopover } from '@/components/usage-popover';
@@ -18,6 +18,8 @@ import { BoardControls } from './board-controls';
 import { ViewToggle, type ViewMode } from './components';
 import { HeaderMobileMenu } from './header-mobile-menu';
 import { formatCostUsd } from '@/lib/format';
+import { isElectron, getOverlayAPI } from '@/lib/electron';
+import { formatShortcut } from '@/store/types';
 
 export type { ViewMode };
 
@@ -113,6 +115,9 @@ export function BoardHeader({
   // Codex usage tracking visibility logic
   // Show if Codex is authenticated (CLI or API key)
   const showCodexUsage = !!codexAuthStatus?.authenticated;
+
+  // Ava Anywhere shortcut for discoverability hint
+  const avaAnywhereShortcut = useAppStore((state) => state.keyboardShortcuts.avaAnywhere);
 
   // Calculate cumulative project cost from all features
   const features = useAppStore((state) => state.features);
@@ -265,6 +270,21 @@ export function BoardHeader({
               onPlanUseSelectedWorktreeBranchChange={setPlanUseSelectedWorktreeBranch}
             />
           </div>
+        )}
+
+        {/* Ava Anywhere discoverability hint — Electron only */}
+        {isMounted && !isTablet && isElectron() && (
+          <button
+            onClick={() => getOverlayAPI()?.toggleOverlay?.()}
+            className="flex items-center gap-1.5 px-3 h-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+            title="Open Ava Anywhere"
+            data-testid="ava-anywhere-hint"
+          >
+            <Sparkles className="size-3.5" />
+            <KbdGroup>
+              <Kbd>{formatShortcut(avaAnywhereShortcut, true)}</Kbd>
+            </KbdGroup>
+          </button>
         )}
       </div>
     </div>

--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
@@ -8,9 +8,9 @@
  * to useChatSession for project-scoped session management.
  */
 
-import { useState, useCallback } from 'react';
-import { History, X, Settings } from 'lucide-react';
-import { ChatMessageList, ChatInput } from '@protolabs-ai/ui/ai';
+import { useState, useCallback, useEffect } from 'react';
+import { History, X, Settings, ChevronUp, ChevronDown } from 'lucide-react';
+import { ChatMessageList, ChatInput, SuggestionList } from '@protolabs-ai/ui/ai';
 import { Button } from '@protolabs-ai/ui/atoms';
 import { Popover, PopoverContent, PopoverTrigger } from '@protolabs-ai/ui/atoms';
 import { cn } from '@/lib/utils';
@@ -19,6 +19,11 @@ import { ConversationList } from './conversation-list';
 import { AvaSettingsPanel } from './ava-settings-panel';
 import { useChatSession } from '@/hooks/use-chat-session';
 import { useAppStore } from '@/store/app-store';
+import { useContextualSuggestions } from '@/hooks/use-contextual-suggestions';
+import { getOverlayAPI } from '@/lib/electron';
+
+const OVERLAY_HEIGHT_DEFAULT = 600;
+const OVERLAY_HEIGHT_EXPANDED = 900;
 
 export interface ChatOverlayContentProps {
   /** Called when the user wants to close/hide the overlay or modal */
@@ -29,6 +34,7 @@ export interface ChatOverlayContentProps {
 
 export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayContentProps) {
   const currentProject = useAppStore((s) => s.currentProject);
+  const features = useAppStore((s) => s.features);
 
   const {
     messages,
@@ -54,6 +60,9 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
 
   const [inputValue, setInputValue] = useState('');
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  const suggestions = useContextualSuggestions(features ?? []);
 
   const handleSubmit = useCallback(() => {
     const text = inputValue.trim();
@@ -62,7 +71,35 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
     setInputValue('');
   }, [inputValue, isStreaming, sendMessage]);
 
+  const handleSuggestionSelect = useCallback(
+    (value: string) => {
+      sendMessage({ text: value });
+    },
+    [sendMessage]
+  );
+
+  const handleExpand = useCallback(() => {
+    const next = !expanded;
+    setExpanded(next);
+    getOverlayAPI()?.resizeOverlay?.(next ? OVERLAY_HEIGHT_EXPANDED : OVERLAY_HEIGHT_DEFAULT);
+  }, [expanded]);
+
   const shortcutHint = isModal ? '\u2318K to close' : 'Esc to hide';
+
+  // Escape key: close history panel if open, otherwise hide the overlay
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (historyOpen) {
+          setHistoryOpen(false);
+        } else {
+          onHide();
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [historyOpen, setHistoryOpen, onHide]);
 
   return (
     <div data-slot="chat-overlay-content" className="flex h-full w-full flex-col overflow-hidden">
@@ -98,6 +135,18 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
           >
             <span className="text-xs">New</span>
           </Button>
+          {!isModal && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7"
+              onClick={handleExpand}
+              title={expanded ? 'Collapse' : 'Expand'}
+              aria-label={expanded ? 'Collapse overlay' : 'Expand overlay'}
+            >
+              {expanded ? <ChevronDown className="size-3.5" /> : <ChevronUp className="size-3.5" />}
+            </Button>
+          )}
           <Popover open={settingsOpen} onOpenChange={setSettingsOpen}>
             <PopoverTrigger asChild>
               <Button
@@ -158,6 +207,11 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
         {/* Chat area */}
         <div className="flex min-w-0 flex-1 flex-col">
           <ChatMessageList messages={messages} emptyMessage="Ask Ava anything..." />
+
+          {/* Contextual suggestions — shown only when no messages in current session */}
+          {messages.length === 0 && (
+            <SuggestionList suggestions={suggestions} onSelect={handleSuggestionSelect} />
+          )}
 
           <ChatInput
             value={inputValue}

--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-view.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-view.tsx
@@ -8,21 +8,53 @@
  * In web mode, this route is unused — ChatModal provides the equivalent.
  */
 
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
-import { getElectronAPI, isElectron } from '@/lib/electron';
-import { useChatSession } from '@/hooks/use-chat-session';
+import { getOverlayAPI } from '@/lib/electron';
 import { ChatOverlayContent } from './chat-overlay-content';
 
 export function ChatOverlayView() {
-  const chatSession = useChatSession({ defaultModel: 'sonnet' });
-  const { historyOpen, setHistoryOpen } = chatSession;
+  // animClass drives the CSS entrance/exit animation on the wrapper div
+  const [animClass, setAnimClass] = useState('');
+  const isHidingRef = useRef(false);
 
-  const handleHide = useCallback(() => {
-    if (isElectron()) {
-      getElectronAPI()?.hideOverlay?.();
-    }
+  const startHide = useCallback(() => {
+    if (isHidingRef.current) return;
+    isHidingRef.current = true;
+    const bridge = getOverlayAPI();
+    // Signal main process so blur handler won't race with our animation
+    bridge?.startHide?.();
+    setAnimClass('animate-out fade-out slide-out-to-top-2 duration-150 fill-mode-forwards');
+    setTimeout(() => {
+      bridge?.hideOverlay?.();
+      isHidingRef.current = false;
+    }, 150);
   }, []);
+
+  // Listen for overlay:did-show from main process to trigger entrance animation
+  useEffect(() => {
+    const bridge = getOverlayAPI();
+    if (!bridge?.onOverlayDidShow) {
+      // Web / non-Electron fallback: show immediately
+      setAnimClass('animate-in slide-in-from-top-2 fade-in duration-200');
+      return;
+    }
+    const cleanup = bridge.onOverlayDidShow(() => {
+      isHidingRef.current = false;
+      setAnimClass('animate-in slide-in-from-top-2 fade-in duration-200');
+    });
+    return cleanup;
+  }, []);
+
+  // Listen for overlay:hide-requested (triggered by window blur in main process)
+  useEffect(() => {
+    const bridge = getOverlayAPI();
+    if (!bridge?.onOverlayHideRequested) return;
+    const cleanup = bridge.onOverlayHideRequested(() => {
+      startHide();
+    });
+    return cleanup;
+  }, [startHide]);
 
   // When the Electron overlay window is shown again, focus the chat input
   useEffect(() => {
@@ -36,30 +68,17 @@ export function ChatOverlayView() {
     return () => window.removeEventListener('focus', handleWindowFocus);
   }, []);
 
-  // Escape key hides the overlay (or closes history panel first)
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        if (historyOpen) {
-          setHistoryOpen(false);
-        } else {
-          handleHide();
-        }
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [handleHide, historyOpen, setHistoryOpen]);
-
   return (
     <div
       data-slot="chat-overlay"
       className={cn(
         'flex h-screen w-screen flex-col bg-background',
-        'overflow-hidden rounded-xl border border-border'
+        'overflow-hidden rounded-xl border border-border',
+        'will-change-transform',
+        animClass
       )}
     >
-      <ChatOverlayContent {...chatSession} onHide={handleHide} />
+      <ChatOverlayContent onHide={startHide} />
     </div>
   );
 }

--- a/apps/ui/src/hooks/use-contextual-suggestions.ts
+++ b/apps/ui/src/hooks/use-contextual-suggestions.ts
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+import type { SuggestionItem } from '@protolabs-ai/ui/ai';
+import type { Feature } from '@/store/types';
+
+const DEFAULT_SUGGESTIONS: SuggestionItem[] = [
+  { label: 'Board status', value: 'What is the current board status?' },
+  { label: "What's running?", value: 'Which agents are currently running?' },
+  { label: 'Recent activity', value: 'Summarize recent activity on this project' },
+  { label: 'Any blockers?', value: 'Are there any blocked features I should know about?' },
+];
+
+/**
+ * Returns up to 4 contextual suggestion pills for the overlay empty state.
+ * Prioritizes board state (blocked, in-progress, failed features) when available,
+ * filling remaining slots from the default suggestions.
+ */
+export function useContextualSuggestions(features: Feature[]): SuggestionItem[] {
+  return useMemo(() => {
+    if (!features.length) return DEFAULT_SUGGESTIONS;
+
+    const suggestions: SuggestionItem[] = [];
+    const blocked = features.filter((f) => f.status === 'blocked');
+    const running = features.filter(
+      (f) => f.status === 'in_progress' || (f.status as string) === 'running'
+    );
+    const failed = features.filter((f) => (f.failureCount ?? 0) > 0);
+
+    if (blocked.length) {
+      suggestions.push({
+        label: `Why is "${blocked[0].title}" blocked?`,
+        value: `Why is the feature "${blocked[0].title}" blocked?`,
+      });
+    }
+    if (running.length) {
+      suggestions.push({
+        label: `What is "${running[0].title}" doing?`,
+        value: `What is the agent working on for "${running[0].title}"?`,
+      });
+    }
+    if (failed.length) {
+      suggestions.push({
+        label: `What failed on "${failed[0].title}"?`,
+        value: `Explain the last failure on "${failed[0].title}"`,
+      });
+    }
+
+    const remaining = DEFAULT_SUGGESTIONS.slice(0, Math.max(0, 4 - suggestions.length));
+    return [...suggestions, ...remaining].slice(0, 4);
+  }, [features]);
+}

--- a/apps/ui/src/lib/electron.ts
+++ b/apps/ui/src/lib/electron.ts
@@ -554,6 +554,11 @@ export interface ElectronAPI {
   toggleOverlay?: () => Promise<void>;
   hideOverlay?: () => Promise<void>;
   showOverlay?: () => Promise<void>;
+  startHide?: () => void;
+  resizeOverlay?: (height: number) => Promise<void>;
+  setOverlayShortcut?: (accelerator: string) => Promise<boolean>;
+  onOverlayDidShow?: (callback: () => void) => () => void;
+  onOverlayHideRequested?: (callback: () => void) => () => void;
 
   openExternalLink: (url: string) => Promise<{ success: boolean; error?: string }>;
   openDirectory: () => Promise<DialogResult>;
@@ -1043,6 +1048,27 @@ export const getElectronAPI = (): ElectronAPI => {
 // Async version (same as sync since HTTP client is synchronously instantiated)
 export const getElectronAPIAsync = async (): Promise<ElectronAPI> => {
   return getElectronAPI();
+};
+
+/**
+ * Access the Electron preload bridge directly for overlay IPC calls.
+ * These methods are only available in Electron renderer processes (not the HTTP API client).
+ */
+export const getOverlayAPI = ():
+  | Pick<
+      ElectronAPI,
+      | 'toggleOverlay'
+      | 'hideOverlay'
+      | 'showOverlay'
+      | 'startHide'
+      | 'resizeOverlay'
+      | 'setOverlayShortcut'
+      | 'onOverlayDidShow'
+      | 'onOverlayHideRequested'
+    >
+  | undefined => {
+  if (typeof window === 'undefined') return undefined;
+  return (window as unknown as { electronAPI?: ElectronAPI }).electronAPI;
 };
 
 // Check if backend is connected (for showing connection status in UI)

--- a/apps/ui/src/main.ts
+++ b/apps/ui/src/main.ts
@@ -796,6 +796,12 @@ function createWindow(): void {
 
 const OVERLAY_WIDTH = 420;
 const OVERLAY_HEIGHT = 600;
+const OVERLAY_HEIGHT_EXPANDED = 900;
+
+// Track current global shortcut accelerator so it can be re-registered dynamically
+let currentOverlayAccelerator = 'CommandOrControl+Shift+Space';
+// Flag set by renderer before exit animation; prevents blur from double-hiding
+let isOverlayAnimatingOut = false;
 
 /**
  * Create the pre-warmed overlay window (hidden until shortcut activates it).
@@ -838,9 +844,11 @@ function createOverlayWindow(): void {
   overlayWindow.loadURL(overlayUrl);
 
   overlayWindow.on('blur', () => {
-    // Hide on focus loss (click outside)
+    // If renderer is already running exit animation, skip — it will call overlay:hide when done
+    if (isOverlayAnimatingOut) return;
+    // Request renderer to animate out before hiding
     if (overlayWindow && !overlayWindow.isDestroyed()) {
-      overlayWindow.hide();
+      overlayWindow.webContents.send('overlay:hide-requested');
     }
   });
 
@@ -865,39 +873,42 @@ function toggleOverlay(): void {
     createOverlayWindow();
     overlayWindow?.show();
     overlayWindow?.focus();
+    overlayWindow?.webContents.send('overlay:did-show');
     return;
   }
 
   if (overlayWindow.isVisible()) {
-    overlayWindow.hide();
+    // Request renderer to animate out
+    if (!isOverlayAnimatingOut) {
+      overlayWindow.webContents.send('overlay:hide-requested');
+    }
   } else {
-    // Position near cursor's current screen
+    // Position near cursor's current screen, respecting work area origin
     const cursorPoint = screen.getCursorScreenPoint();
     const currentDisplay = screen.getDisplayNearestPoint(cursorPoint);
-    const { x: workX, width: workW } = currentDisplay.workArea;
+    const { x: workX, y: workY, width: workW } = currentDisplay.workArea;
 
-    overlayWindow.setPosition(Math.round(workX + workW / 2 - OVERLAY_WIDTH / 2), 80);
+    isOverlayAnimatingOut = false;
+    overlayWindow.setPosition(Math.round(workX + workW / 2 - OVERLAY_WIDTH / 2), workY + 80);
     overlayWindow.show();
     overlayWindow.focus();
+    overlayWindow.webContents.send('overlay:did-show');
   }
 }
 
 /**
  * Register the global shortcut for Ava Anywhere.
- * Cmd+Shift+Space on macOS, Ctrl+Shift+Space on Windows/Linux.
+ * Uses currentOverlayAccelerator (default: CommandOrControl+Shift+Space).
  */
 function registerOverlayShortcut(): void {
-  const accelerator =
-    process.platform === 'darwin' ? 'CommandOrControl+Shift+Space' : 'Ctrl+Shift+Space';
-
-  const registered = globalShortcut.register(accelerator, () => {
+  const registered = globalShortcut.register(currentOverlayAccelerator, () => {
     toggleOverlay();
   });
 
   if (registered) {
-    logger.info(`Global shortcut registered: ${accelerator}`);
+    logger.info(`Global shortcut registered: ${currentOverlayAccelerator}`);
   } else {
-    logger.warn(`Failed to register global shortcut: ${accelerator}`);
+    logger.warn(`Failed to register global shortcut: ${currentOverlayAccelerator}`);
   }
 }
 
@@ -1144,6 +1155,7 @@ ipcMain.handle('overlay:toggle', () => {
 });
 
 ipcMain.handle('overlay:hide', () => {
+  isOverlayAnimatingOut = false;
   if (overlayWindow && !overlayWindow.isDestroyed()) {
     overlayWindow.hide();
   }
@@ -1153,8 +1165,40 @@ ipcMain.handle('overlay:show', () => {
   if (!overlayWindow || overlayWindow.isDestroyed()) {
     createOverlayWindow();
   }
+  isOverlayAnimatingOut = false;
   overlayWindow?.show();
   overlayWindow?.focus();
+  overlayWindow?.webContents.send('overlay:did-show');
+});
+
+// Renderer signals that exit animation has started — suppress blur handler
+ipcMain.on('overlay:start-hide', () => {
+  isOverlayAnimatingOut = true;
+});
+
+// Dynamic shortcut re-registration
+ipcMain.handle('overlay:set-shortcut', (_event, accelerator: string) => {
+  globalShortcut.unregister(currentOverlayAccelerator);
+  const ok = globalShortcut.register(accelerator, () => toggleOverlay());
+  if (ok) {
+    currentOverlayAccelerator = accelerator;
+    logger.info(`Global shortcut updated: ${accelerator}`);
+  } else {
+    // Roll back to previous accelerator on failure
+    globalShortcut.register(currentOverlayAccelerator, () => toggleOverlay());
+    logger.warn(
+      `Failed to register shortcut: ${accelerator}, rolled back to ${currentOverlayAccelerator}`
+    );
+  }
+  return ok;
+});
+
+// Resize overlay window height
+ipcMain.handle('overlay:resize', (_event, height: number) => {
+  if (overlayWindow && !overlayWindow.isDestroyed()) {
+    const clampedHeight = Math.max(400, Math.min(height, 1200));
+    overlayWindow.setSize(OVERLAY_WIDTH, clampedHeight, true);
+  }
 });
 
 // Native file dialogs

--- a/apps/ui/src/preload.ts
+++ b/apps/ui/src/preload.ts
@@ -64,6 +64,20 @@ contextBridge.exposeInMainWorld('electronAPI', {
   toggleOverlay: (): Promise<void> => ipcRenderer.invoke('overlay:toggle'),
   hideOverlay: (): Promise<void> => ipcRenderer.invoke('overlay:hide'),
   showOverlay: (): Promise<void> => ipcRenderer.invoke('overlay:show'),
+  startHide: (): void => ipcRenderer.send('overlay:start-hide'),
+  resizeOverlay: (height: number): Promise<void> => ipcRenderer.invoke('overlay:resize', height),
+  setOverlayShortcut: (accelerator: string): Promise<boolean> =>
+    ipcRenderer.invoke('overlay:set-shortcut', accelerator),
+  onOverlayDidShow: (callback: () => void): (() => void) => {
+    const handler = () => callback();
+    ipcRenderer.on('overlay:did-show', handler);
+    return () => ipcRenderer.removeListener('overlay:did-show', handler);
+  },
+  onOverlayHideRequested: (callback: () => void): (() => void) => {
+    const handler = () => callback();
+    ipcRenderer.on('overlay:hide-requested', handler);
+    return () => ipcRenderer.removeListener('overlay:hide-requested', handler);
+  },
 
   // Auto-updater
   updater: {

--- a/apps/ui/src/store/app-store.ts
+++ b/apps/ui/src/store/app-store.ts
@@ -1038,6 +1038,19 @@ export const useAppStore = create<AppState & AppActions>()((set, get) => ({
         [key]: value,
       },
     });
+    // When avaAnywhere changes, re-register the global Electron shortcut.
+    // Convert app format (Cmd+Shift+X) to Electron accelerator format.
+    if (key === 'avaAnywhere' && typeof window !== 'undefined') {
+      const accelerator = value
+        .replace(/\bCmd\b/g, 'CommandOrControl')
+        .replace(/\bCtrl\b/g, 'CommandOrControl')
+        .replace(/\bOpt\b/g, 'Alt');
+      (
+        window as Window & {
+          electronAPI?: { setOverlayShortcut?: (acc: string) => Promise<boolean> };
+        }
+      ).electronAPI?.setOverlayShortcut?.(accelerator);
+    }
   },
 
   setKeyboardShortcuts: (shortcuts) => {

--- a/apps/ui/src/store/types.ts
+++ b/apps/ui/src/store/types.ts
@@ -151,6 +151,7 @@ export function parseShortcut(shortcut: string | undefined | null): ShortcutKey 
       modifier === 'ctrl' ||
       modifier === 'win' ||
       modifier === 'super' ||
+      modifier === 'commandorcontrol' ||
       modifier === '⌘' ||
       modifier === '^' ||
       modifier === '⊞' ||
@@ -249,6 +250,9 @@ export interface KeyboardShortcuts {
   splitTerminalDown: string;
   closeTerminal: string;
   newTerminalTab: string;
+
+  // Global overlay shortcut (Electron accelerator format, e.g. "CommandOrControl+Shift+Space")
+  avaAnywhere: string;
 }
 
 // Default keyboard shortcuts
@@ -291,6 +295,9 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcuts = {
   splitTerminalDown: 'Alt+S',
   closeTerminal: 'Alt+W',
   newTerminalTab: 'Alt+T',
+
+  // Global overlay shortcut
+  avaAnywhere: 'CommandOrControl+Shift+Space',
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary\n\n# SPARC PRD: Polish the Ava Anywhere Overlay as the Primary Chat Surface\n\n**Feature ID:** ux/ava-anywhere-polish  \n**Date:** 2026-02-28  \n**Complexity:** large  \n**Linear Label:** [linear] ux(ava-anywhere)\n\n---\n\n## Situation\n\nThe sidebar chat has been removed. The Ava Anywhere overlay () is now the **sole** Ava chat surface in the application. It is an Electron  ( on macOS) — 420×600 px, frameless, transparent, pre-warmed — that toggles visibility o...\n\n---\n*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ava Anywhere global keyboard shortcut (CommandOrControl+Shift+Space) to quickly open the overlay
  * Chat overlay now supports expand/collapse functionality for better visibility
  * Contextual suggestions appear when the overlay is empty, recommending relevant actions
  * Desktop users can discover Ava Anywhere via a new button in the header

* **Improvements**
  * Enhanced overlay animations with smoother entrance and exit transitions
  * Improved keyboard shortcut management with dynamic configuration support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->