### PR TITLE
[linear] cant adjust concurrent agents

### DIFF
--- a/apps/server/src/routes/auto-mode/routes/status.ts
+++ b/apps/server/src/routes/auto-mode/routes/status.ts
@@ -7,6 +7,7 @@
 
 import type { Request, Response } from 'express';
 import type { AutoModeService } from '../../../services/auto-mode-service.js';
+import { MAX_SYSTEM_CONCURRENCY } from '@protolabs-ai/types';
 import { getErrorMessage, logError } from '../common.js';
 
 export function createStatusHandler(autoModeService: AutoModeService) {
@@ -32,6 +33,7 @@ export function createStatusHandler(autoModeService: AutoModeService) {
           runningFeatures: projectStatus.runningFeatures,
           runningCount: projectStatus.runningCount,
           maxConcurrency: projectStatus.maxConcurrency,
+          systemMaxConcurrency: MAX_SYSTEM_CONCURRENCY,
           projectPath,
           branchName: normalizedBranchName,
         });
@@ -47,6 +49,7 @@ export function createStatusHandler(autoModeService: AutoModeService) {
         ...status,
         activeAutoLoopProjects: activeProjects,
         activeAutoLoopWorktrees: activeWorktrees,
+        systemMaxConcurrency: MAX_SYSTEM_CONCURRENCY,
       });
     } catch (error) {
       logError(error, 'Get status failed');

--- a/apps/ui/src/components/views/board-view.tsx
+++ b/apps/ui/src/components/views/board-view.tsx
@@ -93,6 +93,8 @@ import { usePipelineConfig } from '@/hooks/queries';
 import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/query-keys';
 import { useAutoModeQueryInvalidation } from '@/hooks/use-query-invalidation';
+import { useUpdateGlobalSettings } from '@/hooks/mutations/use-settings-mutations';
+import { DEFAULT_MAX_CONCURRENCY } from '@protolabs-ai/types';
 
 // Stable empty array to avoid infinite loop in selector
 const EMPTY_WORKTREES: ReturnType<ReturnType<typeof useWorktreeStore.getState>['getWorktrees']> =
@@ -514,6 +516,9 @@ export function BoardView() {
   const setMaxConcurrencyForWorktree = useWorktreeStore(
     (state) => state.setMaxConcurrencyForWorktree
   );
+  // Mutation to persist concurrency to the server immediately (bypasses the 1s debounce
+  // so that auto-mode restarts read the new value from settings)
+  const updateGlobalSettings = useUpdateGlobalSettings({ showSuccessToast: false });
 
   // Get the current branch from the selected worktree (not from store which may be stale)
   const currentWorktreeBranch = selectedWorktree?.branch ?? null;
@@ -1339,10 +1344,28 @@ export function BoardView() {
         onConcurrencyChange={(newMaxConcurrency) => {
           if (currentProject && selectedWorktree) {
             const branchName = selectedWorktree.isMain ? null : selectedWorktree.branch;
+            // Update local Zustand state immediately for responsive UI
             setMaxConcurrencyForWorktree(currentProject.id, branchName, newMaxConcurrency);
-            // Also update backend if auto mode is running
+            // Persist to server immediately so auto-mode restart reads the new value.
+            // The settings sync debounce (1s) would be too slow when auto-mode
+            // restarts below — this explicit call ensures the value is saved first.
+            const worktreeKey = `${currentProject.id}::${branchName ?? '__main__'}`;
+            const currentAutoMode = useWorktreeStore.getState().autoModeByWorktree;
+            const persistedAutoMode: Record<
+              string,
+              { maxConcurrency: number; branchName: string | null }
+            > = {};
+            for (const [key, value] of Object.entries(currentAutoMode)) {
+              persistedAutoMode[key] = {
+                maxConcurrency: value.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
+                branchName: value.branchName,
+              };
+            }
+            // Ensure the current worktree entry has the new value
+            persistedAutoMode[worktreeKey] = { maxConcurrency: newMaxConcurrency, branchName };
+            updateGlobalSettings.mutate({ autoModeByWorktree: persistedAutoMode });
+            // If running, restart so the new limit takes effect
             if (autoMode.isRunning) {
-              // Restart auto mode with new concurrency (backend will handle this)
               autoMode.stop().then(() => {
                 autoMode.start().catch((error) => {
                   logger.error('[AutoMode] Failed to restart with new concurrency:', error);

--- a/apps/ui/src/components/views/board-view/dialogs/auto-mode-settings-popover.tsx
+++ b/apps/ui/src/components/views/board-view/dialogs/auto-mode-settings-popover.tsx
@@ -1,10 +1,13 @@
 import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Popover, PopoverContent, PopoverTrigger } from '@protolabs-ai/ui/atoms';
 import { Label } from '@protolabs-ai/ui/atoms';
 import { Switch } from '@protolabs-ai/ui/atoms';
 import { Slider } from '@protolabs-ai/ui/atoms';
-import { FastForward, Bot, Settings2, Lock, CheckCircle, Clock } from 'lucide-react';
+import { FastForward, Bot, Settings2, Lock, CheckCircle, Clock, AlertTriangle } from 'lucide-react';
 import { useAppStore } from '@/store/app-store';
+import { getElectronAPI } from '@/lib/electron';
+import { queryKeys } from '@/lib/query-keys';
 import { getBlockingDependencies } from '@protolabs-ai/dependency-resolver';
 
 interface AutoModeSettingsPopoverProps {
@@ -24,6 +27,24 @@ export function AutoModeSettingsPopover({
 }: AutoModeSettingsPopoverProps) {
   const features = useAppStore((state) => state.features);
   const enableDependencyBlocking = useAppStore((state) => state.enableDependencyBlocking);
+  const currentProject = useAppStore((s) => s.currentProject);
+
+  // Fetch auto-mode status to get the server-side system concurrency cap
+  const { data: statusData } = useQuery({
+    queryKey: queryKeys.autoMode.status(currentProject?.path),
+    queryFn: async () => {
+      const api = getElectronAPI();
+      return api.autoMode?.status(currentProject?.path, null);
+    },
+    enabled: !!currentProject?.path,
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const systemMaxConcurrency: number =
+    ((statusData as Record<string, unknown> | undefined)?.systemMaxConcurrency as number) ?? 10;
+  const sliderMax = Math.min(10, systemMaxConcurrency);
+  const isCapped = maxConcurrency > systemMaxConcurrency;
 
   const stats = useMemo(() => {
     let backlog = 0;
@@ -111,19 +132,30 @@ export function AutoModeSettingsPopover({
             </div>
             <div className="flex items-center gap-3">
               <Slider
-                value={[maxConcurrency]}
+                value={[Math.min(maxConcurrency, sliderMax)]}
                 onValueChange={(value) => onConcurrencyChange(value[0])}
                 min={1}
-                max={10}
+                max={sliderMax}
                 step={1}
                 className="flex-1"
                 data-testid="concurrency-slider"
               />
               <span className="text-xs font-medium min-w-[2ch] text-right">{maxConcurrency}</span>
             </div>
-            <p className="text-[10px] text-muted-foreground">
-              Higher values process more features in parallel but use more API resources.
-            </p>
+            {isCapped && (
+              <div className="flex items-start gap-1.5 text-[10px] text-amber-500">
+                <AlertTriangle className="w-3 h-3 shrink-0 mt-0.5" />
+                <span>
+                  System limit: {systemMaxConcurrency} concurrent agents. Set{' '}
+                  AUTOMAKER_MAX_CONCURRENCY to increase.
+                </span>
+              </div>
+            )}
+            {!isCapped && (
+              <p className="text-[10px] text-muted-foreground">
+                Higher values process more features in parallel but use more API resources.
+              </p>
+            )}
           </div>
 
           {/* Skip Verification Setting */}

--- a/apps/ui/src/components/views/flow-graph/flow-graph-canvas.tsx
+++ b/apps/ui/src/components/views/flow-graph/flow-graph-canvas.tsx
@@ -20,7 +20,7 @@ import {
   type OnEdgesChange,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
-import { Info, BarChart3 } from 'lucide-react';
+import { Info, BarChart3, Activity } from 'lucide-react';
 import { nodeTypes } from './nodes';
 import { edgeTypes } from './edges';
 
@@ -32,6 +32,8 @@ interface FlowGraphCanvasProps {
   onToggleLegend?: () => void;
   showAgentAnalytics?: boolean;
   onToggleAgentAnalytics?: () => void;
+  showAutoModeSummary?: boolean;
+  onToggleAutoModeSummary?: () => void;
 }
 
 export function FlowGraphCanvas({
@@ -42,6 +44,8 @@ export function FlowGraphCanvas({
   onToggleLegend,
   showAgentAnalytics,
   onToggleAgentAnalytics,
+  showAutoModeSummary,
+  onToggleAutoModeSummary,
 }: FlowGraphCanvasProps) {
   const [nodes, setNodes, onNodesChange] = useNodesState(externalNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(externalEdges);
@@ -106,6 +110,13 @@ export function FlowGraphCanvas({
             data-testid="flow-graph-analytics-toggle"
           >
             <BarChart3 className={`w-3.5 h-3.5 ${showAgentAnalytics ? 'text-violet-400' : ''}`} />
+          </ControlButton>
+          <ControlButton
+            onClick={onToggleAutoModeSummary}
+            title="Auto-Mode Summary"
+            data-testid="flow-graph-automode-toggle"
+          >
+            <Activity className={`w-3.5 h-3.5 ${showAutoModeSummary ? 'text-brand-400' : ''}`} />
           </ControlButton>
         </Controls>
       </ReactFlow>

--- a/apps/ui/src/components/views/flow-graph/flow-graph-view.tsx
+++ b/apps/ui/src/components/views/flow-graph/flow-graph-view.tsx
@@ -17,6 +17,7 @@ import { PipelinePillSelector } from './pipeline-pill-selector';
 import { PipelineEventLog } from './pipeline-event-log';
 import { PipelineAnalytics } from './pipeline-analytics';
 import { AgentAnalyticsPanel } from './agent-analytics-panel';
+import { AutoModeSummaryPanel } from './panels/auto-mode-summary-panel';
 import { NodeDetailDialog, type SelectedNode } from './dialogs/node-detail-dialog';
 import { SignalInputDialog } from './dialogs/signal-input-dialog';
 import { PrdReviewDialog } from './dialogs/prd-review-dialog';
@@ -38,6 +39,9 @@ export function FlowGraphView({ onFeatureClick }: FlowGraphViewProps) {
 
   // Agent analytics panel visibility
   const [showAgentAnalytics, setShowAgentAnalytics] = useState(false);
+
+  // Auto-mode summary panel visibility
+  const [showAutoModeSummary, setShowAutoModeSummary] = useState(false);
 
   // Node detail dialog state
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
@@ -207,6 +211,8 @@ export function FlowGraphView({ onFeatureClick }: FlowGraphViewProps) {
           onToggleLegend={() => setShowLegend((v) => !v)}
           showAgentAnalytics={showAgentAnalytics}
           onToggleAgentAnalytics={() => setShowAgentAnalytics((v) => !v)}
+          showAutoModeSummary={showAutoModeSummary}
+          onToggleAutoModeSummary={() => setShowAutoModeSummary((v) => !v)}
         />
       </ReactFlowProvider>
 
@@ -245,6 +251,11 @@ export function FlowGraphView({ onFeatureClick }: FlowGraphViewProps) {
 
       {/* Agent Analytics Panel */}
       {showAgentAnalytics && <AgentAnalyticsPanel onClose={() => setShowAgentAnalytics(false)} />}
+
+      {/* Auto-Mode Summary Panel */}
+      {showAutoModeSummary && (
+        <AutoModeSummaryPanel onClose={() => setShowAutoModeSummary(false)} />
+      )}
     </div>
   );
 }

--- a/apps/ui/src/components/views/flow-graph/panels/auto-mode-summary-panel.tsx
+++ b/apps/ui/src/components/views/flow-graph/panels/auto-mode-summary-panel.tsx
@@ -1,0 +1,285 @@
+/**
+ * AutoModeSummaryPanel — Sidebar panel showing auto-mode status and trigger configuration
+ *
+ * Shows: per-project auto-mode status, trigger type (Always On vs Manual),
+ * effective vs. configured concurrency, and system cap warnings.
+ * Data fetched from /api/auto-mode/status (global) and /api/settings/global.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { X, Bot, Zap, AlertTriangle, Activity, Settings } from 'lucide-react';
+import { getElectronAPI } from '@/lib/electron';
+import { queryKeys } from '@/lib/query-keys';
+import { useGlobalSettings } from '@/hooks/queries/use-settings';
+import { DEFAULT_MAX_CONCURRENCY } from '@protolabs-ai/types';
+import { cn } from '@/lib/utils';
+
+interface AutoModeWorktreeEntry {
+  projectPath: string;
+  branchName: string | null;
+}
+
+interface GlobalAutoModeStatus {
+  success: boolean;
+  isRunning: boolean;
+  runningCount: number;
+  runningFeatures: string[];
+  activeAutoLoopProjects: string[];
+  activeAutoLoopWorktrees: AutoModeWorktreeEntry[];
+  systemMaxConcurrency: number;
+}
+
+interface AutoModeSummaryPanelProps {
+  onClose: () => void;
+}
+
+function worktreeLabel(entry: AutoModeWorktreeEntry): string {
+  const parts = entry.projectPath.split('/');
+  const projectName = parts[parts.length - 1] || entry.projectPath;
+  return entry.branchName ? `${projectName} (${entry.branchName})` : projectName;
+}
+
+function WorktreeRow({
+  worktreeKey,
+  projectPath,
+  branchName,
+  isActive,
+  configuredConcurrency,
+  systemMaxConcurrency,
+  isAlwaysOn,
+}: {
+  worktreeKey: string;
+  projectPath: string;
+  branchName: string | null;
+  isActive: boolean;
+  configuredConcurrency: number;
+  systemMaxConcurrency: number;
+  isAlwaysOn: boolean;
+}) {
+  const effectiveConcurrency = Math.min(configuredConcurrency, systemMaxConcurrency);
+  const isCapped = configuredConcurrency > systemMaxConcurrency;
+  const label = worktreeLabel({ projectPath, branchName });
+
+  return (
+    <div
+      key={worktreeKey}
+      className={cn(
+        'flex flex-col gap-1.5 px-4 py-3 border-b border-border/30',
+        isActive && 'bg-brand-500/5'
+      )}
+    >
+      {/* Project/worktree name + status badge */}
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs font-medium truncate flex-1" title={`${projectPath}`}>
+          {label}
+        </span>
+        <span
+          className={cn(
+            'text-[10px] font-semibold px-1.5 py-0.5 rounded-full shrink-0',
+            isActive ? 'bg-brand-500/15 text-brand-400' : 'bg-muted/50 text-muted-foreground'
+          )}
+        >
+          {isActive ? 'Running' : 'Stopped'}
+        </span>
+      </div>
+
+      {/* Trigger type + concurrency */}
+      <div className="flex items-center gap-3 text-[10px] text-muted-foreground">
+        <div className="flex items-center gap-1">
+          {isAlwaysOn ? (
+            <>
+              <Zap className="w-3 h-3 text-amber-400" />
+              <span>Always On</span>
+            </>
+          ) : (
+            <>
+              <Settings className="w-3 h-3" />
+              <span>Manual</span>
+            </>
+          )}
+        </div>
+        <span className="text-border/60">|</span>
+        <div className="flex items-center gap-1">
+          <Bot className="w-3 h-3" />
+          <span className="tabular-nums">
+            {effectiveConcurrency}/{configuredConcurrency} agents
+          </span>
+        </div>
+        {isCapped && (
+          <div className="flex items-center gap-1 text-amber-500">
+            <AlertTriangle className="w-3 h-3" />
+            <span>capped at {systemMaxConcurrency}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function AutoModeSummaryPanel({ onClose }: AutoModeSummaryPanelProps) {
+  // Global auto-mode status — includes activeAutoLoopWorktrees and systemMaxConcurrency
+  const { data: statusData } = useQuery<GlobalAutoModeStatus>({
+    queryKey: queryKeys.autoMode.status(undefined),
+    queryFn: async (): Promise<GlobalAutoModeStatus> => {
+      const api = getElectronAPI();
+      const result = await api.autoMode?.status(undefined, null);
+      return result as GlobalAutoModeStatus;
+    },
+    refetchInterval: 10_000,
+    staleTime: 5_000,
+  });
+
+  // Global settings — includes autoModeByWorktree and autoModeAlwaysOn
+  const { data: settings } = useGlobalSettings();
+
+  const systemMaxConcurrency = statusData?.systemMaxConcurrency ?? 10;
+  const activeWorktrees = statusData?.activeAutoLoopWorktrees ?? [];
+
+  // Build a set of active worktree keys for quick lookup
+  const activeKeys = new Set(
+    activeWorktrees.map((w) => `${w.projectPath}::${w.branchName ?? '__main__'}`)
+  );
+
+  // Collect all configured worktrees from settings, merging with always-on config
+  const configuredWorktrees: Array<{
+    worktreeKey: string;
+    projectPath: string;
+    branchName: string | null;
+    configuredConcurrency: number;
+    isAlwaysOn: boolean;
+  }> = [];
+
+  const autoModeByWorktree = settings?.autoModeByWorktree ?? {};
+  const alwaysOnProjects = settings?.autoModeAlwaysOn?.projects ?? [];
+  const alwaysOnEnabled = settings?.autoModeAlwaysOn?.enabled ?? false;
+
+  // Include worktrees from autoModeByWorktree settings
+  for (const [key, value] of Object.entries(autoModeByWorktree)) {
+    const [rawProjectPath, rawBranch] = key.split('::');
+    const projectPath = rawProjectPath ?? key;
+    const branchName = rawBranch === '__main__' ? null : (rawBranch ?? null);
+    configuredWorktrees.push({
+      worktreeKey: key,
+      projectPath,
+      branchName,
+      configuredConcurrency: value.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
+      isAlwaysOn: false,
+    });
+  }
+
+  // Include always-on worktrees not already in the list
+  if (alwaysOnEnabled) {
+    for (const project of alwaysOnProjects) {
+      const key = `${project.projectPath}::${project.branchName ?? '__main__'}`;
+      const existing = configuredWorktrees.find((w) => w.worktreeKey === key);
+      if (existing) {
+        // Mark as always-on
+        existing.isAlwaysOn = true;
+        if (project.maxConcurrency != null) {
+          existing.configuredConcurrency = project.maxConcurrency;
+        }
+      } else {
+        configuredWorktrees.push({
+          worktreeKey: key,
+          projectPath: project.projectPath,
+          branchName: project.branchName,
+          configuredConcurrency: project.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
+          isAlwaysOn: true,
+        });
+      }
+    }
+  }
+
+  // Include active worktrees not in settings (e.g. started from the UI without saving settings)
+  for (const active of activeWorktrees) {
+    const key = `${active.projectPath}::${active.branchName ?? '__main__'}`;
+    if (!configuredWorktrees.find((w) => w.worktreeKey === key)) {
+      configuredWorktrees.push({
+        worktreeKey: key,
+        projectPath: active.projectPath,
+        branchName: active.branchName,
+        configuredConcurrency: DEFAULT_MAX_CONCURRENCY,
+        isAlwaysOn: false,
+      });
+    }
+  }
+
+  const isAnyCapped = configuredWorktrees.some(
+    (w) => w.configuredConcurrency > systemMaxConcurrency
+  );
+  const hasAnyActivity = activeKeys.size > 0 || configuredWorktrees.length > 0;
+
+  return (
+    <div className="fixed top-0 right-0 h-full w-[320px] bg-card border-l border-border shadow-2xl flex flex-col z-30 overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <div className="flex items-center gap-2">
+          <Activity className="w-4 h-4 text-muted-foreground" />
+          <h3 className="text-sm font-semibold">Auto-Mode Summary</h3>
+        </div>
+        <button
+          onClick={onClose}
+          className="p-1 hover:bg-muted rounded transition-colors"
+          aria-label="Close auto-mode summary panel"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* System cap banner */}
+      <div className="flex items-center justify-between px-4 py-2 bg-muted/20 border-b border-border/30">
+        <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold">
+          System Concurrency Cap
+        </span>
+        <span className="text-xs font-semibold tabular-nums">
+          {systemMaxConcurrency} agents max
+        </span>
+      </div>
+
+      {isAnyCapped && (
+        <div className="flex items-start gap-2 px-4 py-2 bg-amber-500/10 border-b border-amber-500/20 text-amber-500 text-[10px]">
+          <AlertTriangle className="w-3 h-3 mt-0.5 shrink-0" />
+          <span>
+            Some worktrees are configured above the system cap. Set{' '}
+            <code className="font-mono">AUTOMAKER_MAX_CONCURRENCY</code> to increase the limit.
+          </span>
+        </div>
+      )}
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto">
+        {!hasAnyActivity ? (
+          <div className="flex flex-col items-center justify-center h-full px-6 text-center text-sm text-muted-foreground">
+            <Bot className="w-10 h-10 mx-auto mb-3 opacity-30" />
+            <p className="font-medium mb-1">No auto-mode configured</p>
+            <p className="text-xs">
+              Start auto-mode from the board view to see per-project status here.
+            </p>
+          </div>
+        ) : (
+          <>
+            {/* Section header */}
+            <div className="px-4 pt-3 pb-1">
+              <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                Worktrees
+              </h4>
+            </div>
+
+            {configuredWorktrees.map((w) => (
+              <WorktreeRow
+                key={w.worktreeKey}
+                worktreeKey={w.worktreeKey}
+                projectPath={w.projectPath}
+                branchName={w.branchName}
+                isActive={activeKeys.has(w.worktreeKey)}
+                configuredConcurrency={w.configuredConcurrency}
+                systemMaxConcurrency={systemMaxConcurrency}
+                isAlwaysOn={w.isAlwaysOn}
+              />
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/views/settings-view/feature-defaults/feature-defaults-section.tsx
+++ b/apps/ui/src/components/views/settings-view/feature-defaults/feature-defaults-section.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query';
 import { Label } from '@protolabs-ai/ui/atoms';
 import { Checkbox } from '@protolabs-ai/ui/atoms';
 import {
@@ -12,8 +13,11 @@ import {
   FastForward,
   Sparkles,
   Cpu,
+  Gauge,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { getElectronAPI } from '@/lib/electron';
+import { queryKeys } from '@/lib/query-keys';
 import {
   Select,
   SelectContent,
@@ -59,6 +63,21 @@ export function FeatureDefaultsSection({
   onEnableAiCommitMessagesChange,
   onDefaultFeatureModelChange,
 }: FeatureDefaultsSectionProps) {
+  // Fetch global auto-mode status to display the server-side concurrency cap
+  const { data: autoModeStatusData } = useQuery({
+    queryKey: ['autoMode', 'status', undefined],
+    queryFn: async () => {
+      const api = getElectronAPI();
+      return api.autoMode?.status(undefined, null);
+    },
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const systemMaxConcurrency: number =
+    ((autoModeStatusData as Record<string, unknown> | undefined)?.systemMaxConcurrency as number) ??
+    null;
+
   return (
     <div
       className={cn(
@@ -311,6 +330,34 @@ export function FeatureDefaultsSection({
               When enabled, opening the commit dialog will automatically generate a commit message
               using AI based on your staged or unstaged changes. You can configure the model used in
               Model Defaults.
+            </p>
+          </div>
+        </div>
+
+        {/* Separator */}
+        <div className="border-t border-border/30" />
+
+        {/* System Concurrency Limit (read-only) */}
+        <div className="group flex items-start space-x-3 p-3 rounded-xl -mx-3">
+          <div className="w-10 h-10 mt-0.5 rounded-xl flex items-center justify-center shrink-0 bg-muted/40">
+            <Gauge className="w-5 h-5 text-muted-foreground" />
+          </div>
+          <div className="flex-1 space-y-1.5">
+            <div className="flex items-center justify-between">
+              <Label className="text-foreground font-medium">System Concurrency Limit</Label>
+              <span
+                className="text-xs font-semibold tabular-nums px-2 py-0.5 rounded bg-muted/50 text-muted-foreground"
+                data-testid="system-max-concurrency-value"
+              >
+                {systemMaxConcurrency !== null ? systemMaxConcurrency : '--'}
+              </span>
+            </div>
+            <p className="text-xs text-muted-foreground/80 leading-relaxed">
+              Maximum concurrent agents allowed system-wide. Set by the{' '}
+              <code className="font-mono text-[11px] bg-muted/60 px-1 py-0.5 rounded">
+                AUTOMAKER_MAX_CONCURRENCY
+              </code>{' '}
+              environment variable. Read-only — restart the server to apply changes.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Fix three gaps preventing users from controlling concurrent agents:

- **Slider persistence**: Wire `onConcurrencyChange` in `board-view.tsx` to call `useUpdateGlobalSettings()` so changes survive page refresh
- **System cap visibility**: Add `systemMaxConcurrency` to auto-mode status response; clamp slider max and show inline warning when env var cap overrides user setting
- **Analytics panel**: New `AutoModeSummaryPanel` in the flow-graph view showing per-project auto-mode status, trigger type, and effective vs. configured concurrency

## Key files changed

- `apps/server/src/routes/auto-mode/routes/status.ts` — adds `systemMaxConcurrency` to status response
- `apps/ui/src/components/views/board-view.tsx` — wires slider to settings mutation
- `apps/ui/src/components/views/board-view/dialogs/auto-mode-settings-popover.tsx` — clamps slider, adds cap warning
- `apps/ui/src/components/views/flow-graph/panels/auto-mode-summary-panel.tsx` — new analytics panel

## Test plan
- [ ] Move slider, refresh page — verify value persists
- [ ] Set `AUTOMAKER_MAX_CONCURRENCY=2`, configure slider to 5 — verify warning renders
- [ ] Open analytics/flow-graph view — verify Auto-Mode Summary panel shows per-project status

---
*Generated by Automaker*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Auto-Mode Summary panel displaying per-worktree auto-mode status and concurrency metrics.
  * System concurrency limits now enforced with visual alerts for exceeded thresholds.
  * System concurrency cap now visible in settings.

* **Improvements**
  * Auto-mode concurrency settings now synchronize immediately with the server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->