### PR TITLE
[linear] feat(observability): implement TrajectoryStoreService — persist verified trajectories and feed Langf

### DIFF
--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -81,6 +81,7 @@ import { HeadsdownService } from '../services/headsdown-service.js';
 import { PRDService } from '../services/prd-service.js';
 import { AgentDiscordRouter } from '../services/agent-discord-router.js';
 import { FactStoreService } from '../services/fact-store-service.js';
+import { TrajectoryStoreService } from '../services/trajectory-store-service.js';
 import { LeadHandoffService } from '../services/lead-handoff-service.js';
 import { ChannelRouter } from '../services/channel-router.js';
 
@@ -216,6 +217,7 @@ export interface ServiceContainer {
   leadEngineerService: LeadEngineerService;
   pipelineCheckpointService: PipelineCheckpointService;
   factStoreService: FactStoreService;
+  trajectoryStoreService: TrajectoryStoreService;
   leadHandoffService: LeadHandoffService;
 
   // PR & worktree lifecycle
@@ -501,6 +503,9 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   // Fact Store Service — extracts and persists structured facts from agent output
   const factStoreService = new FactStoreService();
 
+  // Trajectory Store Service — persists verified trajectories and feeds Langfuse datasets
+  const trajectoryStoreService = new TrajectoryStoreService();
+
   // Lead Handoff Service — stores phase transition snapshots for LE continuity
   const leadHandoffService = new LeadHandoffService();
 
@@ -725,6 +730,7 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
     leadEngineerService,
     pipelineCheckpointService,
     factStoreService,
+    trajectoryStoreService,
     leadHandoffService,
     approvalBridge,
     intakeBridge,

--- a/apps/server/src/services/lead-engineer-escalation.ts
+++ b/apps/server/src/services/lead-engineer-escalation.ts
@@ -6,7 +6,7 @@
  */
 
 import { createLogger } from '@protolabs-ai/utils';
-import type { EventType } from '@protolabs-ai/types';
+import type { EventType, VerifiedTrajectory } from '@protolabs-ai/types';
 import { FailureClassifierService } from './failure-classifier-service.js';
 import type {
   ProcessorServiceContext,
@@ -163,6 +163,42 @@ export class EscalateProcessor implements StateProcessor {
       remediationAttempts: ctx.remediationAttempts,
       failureCategory: failureAnalysis.category,
     });
+
+    // Fire-and-forget: persist failure trajectory for the learning flywheel
+    if (this.serviceContext.trajectoryStoreService) {
+      try {
+        const existingTrajectories =
+          await this.serviceContext.trajectoryStoreService.loadTrajectories(
+            ctx.projectPath,
+            ctx.feature.id
+          );
+        const attemptNumber = existingTrajectories.length + 1;
+
+        const trajectory: VerifiedTrajectory = {
+          featureId: ctx.feature.id,
+          domain: 'fullstack',
+          complexity: (ctx.feature.complexity as VerifiedTrajectory['complexity']) || 'medium',
+          model: ctx.feature.model || 'sonnet',
+          planSummary: (ctx.planOutput || '').slice(0, 500),
+          executionSummary: ctx.escalationReason || 'Escalated without execution summary',
+          costUsd: ctx.feature.costUsd || 0,
+          durationMs: ctx.startedAt ? Date.now() - new Date(ctx.startedAt).getTime() : 0,
+          retryCount: ctx.retryCount,
+          escalationReason: ctx.escalationReason,
+          verified: false,
+          timestamp: new Date().toISOString(),
+          attemptNumber,
+        };
+
+        this.serviceContext.trajectoryStoreService.saveTrajectory(
+          ctx.projectPath,
+          ctx.feature.id,
+          trajectory
+        );
+      } catch (err) {
+        logger.warn('[ESCALATE] Failed to save trajectory (non-fatal):', err);
+      }
+    }
 
     return {
       nextState: null,

--- a/apps/server/src/services/lead-engineer-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-execute-processor.ts
@@ -18,6 +18,7 @@ import type {
   StateTransitionResult,
 } from './lead-engineer-types.js';
 import { EXECUTE_TIMEOUT_MS } from './lead-engineer-types.js';
+import type { VerifiedTrajectory } from '@protolabs-ai/types';
 
 const execAsync = promisify(exec);
 const logger = createLogger('LeadEngineerService');
@@ -344,6 +345,48 @@ export class ExecuteProcessor implements StateProcessor {
         });
       } catch (err) {
         logger.warn('[EXECUTE] Failed to save handoff (non-fatal):', err);
+      }
+    }
+
+    // Fire-and-forget: persist trajectory for the learning flywheel
+    if (this.serviceContext.trajectoryStoreService) {
+      try {
+        const existingTrajectories =
+          await this.serviceContext.trajectoryStoreService.loadTrajectories(
+            ctx.projectPath,
+            ctx.feature.id
+          );
+        const attemptNumber = existingTrajectories.length + 1;
+
+        const fs = await import('node:fs/promises');
+        const outputPath = path.join(
+          getFeatureDir(ctx.projectPath, ctx.feature.id),
+          'agent-output.md'
+        );
+        const agentOutput = await fs.readFile(outputPath, 'utf-8').catch(() => '');
+
+        const trajectory: VerifiedTrajectory = {
+          featureId: ctx.feature.id,
+          domain: 'fullstack',
+          complexity: (ctx.feature.complexity as VerifiedTrajectory['complexity']) || 'medium',
+          model: ctx.feature.model || 'sonnet',
+          planSummary: (ctx.planOutput || '').slice(0, 500),
+          executionSummary: agentOutput.slice(0, 500),
+          costUsd: ctx.feature.costUsd || 0,
+          durationMs: ctx.startedAt ? Date.now() - new Date(ctx.startedAt).getTime() : 0,
+          retryCount: ctx.retryCount,
+          verified: true,
+          timestamp: new Date().toISOString(),
+          attemptNumber,
+        };
+
+        this.serviceContext.trajectoryStoreService.saveTrajectory(
+          ctx.projectPath,
+          ctx.feature.id,
+          trajectory
+        );
+      } catch (err) {
+        logger.warn('[EXECUTE] Failed to save trajectory (non-fatal):', err);
       }
     }
 

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -25,6 +25,7 @@ import type { ContextFidelityService } from './context-fidelity-service.js';
 import type { KnowledgeStoreService } from './knowledge-store-service.js';
 import type { LeadHandoffService } from './lead-handoff-service.js';
 import type { FactStoreService } from './fact-store-service.js';
+import type { TrajectoryStoreService } from './trajectory-store-service.js';
 import { DEFAULT_RULES } from './lead-engineer-rules.js';
 import { getWorkflowSettings } from '../lib/settings-helpers.js';
 import { FeatureStateMachine } from './lead-engineer-state-machine.js';
@@ -69,6 +70,7 @@ export class LeadEngineerService {
   private agentFactoryService?: AgentFactoryService;
   private handoffService?: LeadHandoffService;
   private factStoreService?: FactStoreService;
+  private trajectoryStoreService?: TrajectoryStoreService;
   private antagonisticReviewService?: IPlanReviewService;
   private hitlFormService?: HITLFormService;
 
@@ -120,6 +122,9 @@ export class LeadEngineerService {
   }
   setFactStoreService(s: FactStoreService): void {
     this.factStoreService = s;
+  }
+  setTrajectoryStoreService(s: TrajectoryStoreService): void {
+    this.trajectoryStoreService = s;
   }
   setAntagonisticReviewService(s: IPlanReviewService): void {
     this.antagonisticReviewService = s;
@@ -329,6 +334,7 @@ export class LeadEngineerService {
         leadHandoffService: this.handoffService,
         antagonisticReviewService: this.antagonisticReviewService,
         hitlFormService: this.hitlFormService,
+        trajectoryStoreService: this.trajectoryStoreService,
       };
 
       const workflowSettings = await getWorkflowSettings(

--- a/apps/server/src/services/lead-engineer-types.ts
+++ b/apps/server/src/services/lead-engineer-types.ts
@@ -16,6 +16,7 @@ import type { SettingsService } from './settings-service.js';
 import type { FactStoreService } from './fact-store-service.js';
 import type { LeadHandoffService } from './lead-handoff-service.js';
 import type { HITLFormService } from './hitl-form-service.js';
+import type { TrajectoryStoreService } from './trajectory-store-service.js';
 
 // ────────────────────────── Budget / timing constants ──────────────────────────
 
@@ -57,6 +58,7 @@ export interface ProcessorServiceContext {
   leadHandoffService?: LeadHandoffService;
   antagonisticReviewService?: IPlanReviewService;
   hitlFormService?: HITLFormService;
+  trajectoryStoreService?: TrajectoryStoreService;
 }
 
 // ────────────────────────── Feature State Machine Types ──────────────────────────

--- a/apps/server/src/services/lead-engineer.module.ts
+++ b/apps/server/src/services/lead-engineer.module.ts
@@ -14,6 +14,7 @@ export function register(container: ServiceContainer): void {
     discordBotService,
     agentFactoryService,
     factStoreService,
+    trajectoryStoreService,
     leadHandoffService,
     antagonisticReviewService,
   } = container;
@@ -24,6 +25,7 @@ export function register(container: ServiceContainer): void {
   leadEngineerService.setDiscordBot(discordBotService);
   leadEngineerService.setAgentFactory(agentFactoryService);
   leadEngineerService.setFactStoreService(factStoreService);
+  leadEngineerService.setTrajectoryStoreService(trajectoryStoreService);
   leadEngineerService.setHandoffService(leadHandoffService);
   leadEngineerService.setAntagonisticReviewService(antagonisticReviewService);
 

--- a/apps/server/src/services/trajectory-store-service.ts
+++ b/apps/server/src/services/trajectory-store-service.ts
@@ -1,0 +1,143 @@
+/**
+ * Trajectory Store Service
+ *
+ * Persists verified agent execution trajectories to
+ * .automaker/trajectory/{featureId}/attempt-{N}.json and feeds successful
+ * trajectories into a Langfuse evaluation dataset.
+ *
+ * All public methods are fire-and-forget (non-blocking) or return data
+ * on read. saveTrajectory() never throws or blocks the caller.
+ */
+
+import path from 'node:path';
+import { createLogger, atomicWriteJson } from '@protolabs-ai/utils';
+import type { VerifiedTrajectory } from '@protolabs-ai/types';
+import { getLangfuseInstance } from '../lib/langfuse-singleton.js';
+
+const logger = createLogger('TrajectoryStoreService');
+
+const TRAJECTORY_DATASET = 'agent-trajectories';
+
+/**
+ * Service for persisting and retrieving agent execution trajectories.
+ */
+export class TrajectoryStoreService {
+  /**
+   * Save a trajectory to disk in a fire-and-forget manner.
+   * Never throws — all errors are caught and logged.
+   */
+  saveTrajectory(projectPath: string, featureId: string, trajectory: VerifiedTrajectory): void {
+    void this._saveTrajectory(projectPath, featureId, trajectory).catch((err) => {
+      logger.error('[TrajectoryStore] Unexpected error in saveTrajectory:', err);
+    });
+  }
+
+  /**
+   * Load all trajectory attempts for a feature.
+   * Returns an empty array if none exist or on error.
+   */
+  async loadTrajectories(projectPath: string, featureId: string): Promise<VerifiedTrajectory[]> {
+    const trajectoryDir = path.join(projectPath, '.automaker', 'trajectory', featureId);
+
+    try {
+      const fs = await import('node:fs/promises');
+      const entries = await fs.readdir(trajectoryDir).catch(() => [] as string[]);
+
+      const attemptFiles = entries
+        .filter((f) => f.startsWith('attempt-') && f.endsWith('.json'))
+        .sort();
+
+      const trajectories: VerifiedTrajectory[] = [];
+      for (const file of attemptFiles) {
+        try {
+          const filePath = path.join(trajectoryDir, file);
+          const raw = await fs.readFile(filePath, 'utf-8');
+          trajectories.push(JSON.parse(raw) as VerifiedTrajectory);
+        } catch (err) {
+          logger.warn(`[TrajectoryStore] Failed to read trajectory file ${file}:`, err);
+        }
+      }
+
+      return trajectories;
+    } catch (err) {
+      logger.warn('[TrajectoryStore] Failed to load trajectories:', err);
+      return [];
+    }
+  }
+
+  /**
+   * Feed a trajectory to the Langfuse agent-trajectories dataset.
+   * No-op if Langfuse is not configured. Never throws.
+   */
+  async feedToLangfuse(
+    trajectory: VerifiedTrajectory,
+    datasetName: string = TRAJECTORY_DATASET
+  ): Promise<void> {
+    const langfuse = getLangfuseInstance();
+    if (!langfuse.isAvailable()) {
+      logger.debug('[TrajectoryStore] Langfuse unavailable, skipping dataset feed');
+      return;
+    }
+
+    try {
+      await langfuse.createDatasetItem({
+        datasetName,
+        input: {
+          featureId: trajectory.featureId,
+          complexity: trajectory.complexity,
+          domain: trajectory.domain,
+          planSummary: trajectory.planSummary,
+        },
+        expectedOutput: {
+          success: trajectory.verified,
+          retryCount: trajectory.retryCount,
+          executionSummary: trajectory.executionSummary,
+        },
+        metadata: {
+          featureId: trajectory.featureId,
+          model: trajectory.model,
+          costUsd: trajectory.costUsd,
+          durationMs: trajectory.durationMs,
+          escalationReason: trajectory.escalationReason,
+          attemptNumber: trajectory.attemptNumber,
+          timestamp: trajectory.timestamp,
+        },
+      });
+
+      logger.info(
+        `[TrajectoryStore] Fed trajectory to Langfuse dataset "${datasetName}" (feature: ${trajectory.featureId}, attempt: ${trajectory.attemptNumber})`
+      );
+    } catch (err) {
+      logger.error('[TrajectoryStore] Failed to feed trajectory to Langfuse:', err);
+    }
+  }
+
+  /**
+   * Internal implementation — writes trajectory JSON and optionally feeds to Langfuse.
+   */
+  private async _saveTrajectory(
+    projectPath: string,
+    featureId: string,
+    trajectory: VerifiedTrajectory
+  ): Promise<void> {
+    const trajectoryDir = path.join(projectPath, '.automaker', 'trajectory', featureId);
+    const filePath = path.join(trajectoryDir, `attempt-${trajectory.attemptNumber}.json`);
+
+    try {
+      await atomicWriteJson(filePath, trajectory, { createDirs: true });
+      logger.info(
+        `[TrajectoryStore] Saved trajectory for feature ${featureId} (attempt ${trajectory.attemptNumber})`
+      );
+    } catch (err) {
+      logger.error('[TrajectoryStore] Failed to write trajectory file:', err);
+      return;
+    }
+
+    // Feed successful trajectories to Langfuse dataset (fire-and-forget within _saveTrajectory)
+    if (trajectory.verified) {
+      void this.feedToLangfuse(trajectory).catch((err) => {
+        logger.error('[TrajectoryStore] Unexpected error in feedToLangfuse:', err);
+      });
+    }
+  }
+}

--- a/libs/observability/src/langfuse/client.ts
+++ b/libs/observability/src/langfuse/client.ts
@@ -285,6 +285,37 @@ export class LangfuseClient {
   }
 
   /**
+   * Create or upsert a dataset item in Langfuse.
+   * Creates the dataset if it doesn't exist, then adds the item.
+   */
+  async createDatasetItem(options: {
+    datasetName: string;
+    input?: Record<string, unknown>;
+    expectedOutput?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
+    sourceTraceId?: string;
+  }): Promise<void> {
+    if (!this.isAvailable()) {
+      logger.debug('Langfuse unavailable, skipping dataset item creation');
+      return;
+    }
+
+    try {
+      await this.client!.createDatasetItem({
+        datasetName: options.datasetName,
+        input: options.input,
+        expectedOutput: options.expectedOutput,
+        metadata: options.metadata,
+        sourceTraceId: options.sourceTraceId,
+      });
+      logger.debug('Created dataset item in Langfuse', { datasetName: options.datasetName });
+    } catch (error) {
+      logger.error('Failed to create dataset item in Langfuse', error);
+      throw error;
+    }
+  }
+
+  /**
    * Flush pending events to Langfuse
    */
   async flush(): Promise<void> {


### PR DESCRIPTION
## Summary\n\n# SPARC PRD: TrajectoryStoreService — Persist Verified Trajectories & Feed Langfuse Datasets\n\n**Feature ID:** feat(observability)/trajectory-store-service  \n**Date:** 2026-02-28  \n**Complexity:** Large  \n**Target Branch:** dev  \n\n---\n\n## Situation\n\nAutomaker's architecture documents and  describe a **learning flywheel** — a feedback loop where verified agent execution trajectories are persisted locally and fed into Langfuse evaluation datasets to continuously improve model quality. Th...\n\n---\n*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent execution trajectories are now automatically persisted, capturing execution steps, performance metrics, and context data for analysis and learning.
  * Enhanced monitoring and observability capabilities enable better visibility into agent behavior and performance across execution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->