### PR TITLE
[linear] fix(observability): extend Langfuse cost pricing table to cover Groq and OpenAI-compatible models

### DIFF
--- a/libs/observability/src/langfuse/middleware.ts
+++ b/libs/observability/src/langfuse/middleware.ts
@@ -3,7 +3,7 @@ import { createLogger } from '@protolabs-ai/utils';
 import { LangfuseClient } from './client.js';
 import type { CreateGenerationOptions } from './types.js';
 
-const logger = createLogger('LangfuseMiddleware');
+export const logger = createLogger('LangfuseMiddleware');
 
 /**
  * Configuration for provider tracing
@@ -82,12 +82,9 @@ function extractUsageFromMessages(messages: any[]):
   };
 }
 
-/**
- * Calculate cost based on model and token usage
- * Prices are per 1M tokens (as of 2025-01)
- */
-/** Default Claude pricing (per 1M tokens) */
+/** Default pricing per 1M tokens (as of 2026-02) */
 const DEFAULT_PRICING: Record<string, { input: number; output: number }> = {
+  // Claude
   'opus-4-6': { input: 15, output: 75 },
   'claude-opus-4-6': { input: 15, output: 75 },
   'opus-4-5': { input: 15, output: 75 },
@@ -98,9 +95,23 @@ const DEFAULT_PRICING: Record<string, { input: number; output: number }> = {
   'claude-sonnet-4-5': { input: 3, output: 15 },
   'haiku-4-5': { input: 0.8, output: 4 },
   'claude-haiku-4-5': { input: 0.8, output: 4 },
+
+  // Groq (per 1M tokens, 2026-02)
+  'llama-3.3-70b-versatile': { input: 0.59, output: 0.79 },
+  'llama-3.1-8b-instant': { input: 0.05, output: 0.08 },
+  // deprecated on Groq; retained for legacy trace cost reconstruction
+  'mixtral-8x7b-32768': { input: 0.24, output: 0.24 },
+  'gemma2-9b-it': { input: 0.2, output: 0.2 }, // verify: approximate as of 2026-02
+
+  // OpenAI (per 1M tokens, 2026-02)
+  // NOTE: 'gpt-4o-mini' MUST appear before 'gpt-4o' — substring match hits first entry
+  'gpt-4o-mini': { input: 0.15, output: 0.6 },
+  'gpt-4o': { input: 2.5, output: 10.0 },
+  'gpt-4-turbo': { input: 10.0, output: 30.0 },
+  'o3-mini': { input: 1.1, output: 4.4 },
 };
 
-function calculateCost(
+export function calculateCost(
   model: string,
   usage?: { promptTokens: number; completionTokens: number },
   customPricing?: Record<string, { input: number; output: number }>
@@ -121,7 +132,7 @@ function calculateCost(
   }
 
   if (!prices) {
-    // Unknown model, can't calculate cost
+    logger.debug('No pricing found for model, cost will be undefined', { model });
     return undefined;
   }
 

--- a/libs/observability/tests/integration/provider-tracing.test.ts
+++ b/libs/observability/tests/integration/provider-tracing.test.ts
@@ -5,7 +5,12 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { LangfuseClient } from '../../src/langfuse/client.js';
-import { wrapProviderWithTracing, type TracingConfig } from '../../src/langfuse/middleware.js';
+import {
+  wrapProviderWithTracing,
+  calculateCost,
+  logger,
+  type TracingConfig,
+} from '../../src/langfuse/middleware.js';
 
 // Mock async generator to simulate provider behavior
 async function* mockProviderGenerator(messages: any[]): AsyncGenerator<any> {
@@ -241,6 +246,73 @@ describe('Provider Tracing Integration', () => {
       expect(results).toEqual(messages);
       // Cost calculation happens in finally block
       // For 1M input + 1M output: 0.8 + 4 = $4.80
+    });
+
+    it('should calculate cost for llama-3.3-70b-versatile', () => {
+      const cost = calculateCost('llama-3.3-70b-versatile', {
+        promptTokens: 1_000_000,
+        completionTokens: 1_000_000,
+      });
+      // 0.59 + 0.79 = 1.38
+      expect(cost).toBeCloseTo(1.38);
+    });
+
+    it('should calculate cost for llama-3.1-8b-instant', () => {
+      const cost = calculateCost('llama-3.1-8b-instant', {
+        promptTokens: 1_000_000,
+        completionTokens: 1_000_000,
+      });
+      // 0.05 + 0.08 = 0.13
+      expect(cost).toBeCloseTo(0.13);
+    });
+
+    it('should calculate cost for gpt-4o', () => {
+      const cost = calculateCost('gpt-4o', {
+        promptTokens: 1_000_000,
+        completionTokens: 1_000_000,
+      });
+      // 2.50 + 10.00 = 12.50
+      expect(cost).toBeCloseTo(12.5);
+    });
+
+    it('should calculate cost for gpt-4o-mini', () => {
+      const cost = calculateCost('gpt-4o-mini', {
+        promptTokens: 1_000_000,
+        completionTokens: 1_000_000,
+      });
+      // 0.15 + 0.60 = 0.75
+      expect(cost).toBeCloseTo(0.75);
+    });
+
+    it('should not match gpt-4o pricing for gpt-4o-mini (substring guard)', () => {
+      const cost = calculateCost('gpt-4o-mini', {
+        promptTokens: 500_000,
+        completionTokens: 500_000,
+      });
+      // gpt-4o-mini at 500K each: (0.5 * 0.15) + (0.5 * 0.60) = 0.375
+      // gpt-4o at 500K each would be: (0.5 * 2.50) + (0.5 * 10.00) = 6.25
+      expect(cost).toBeCloseTo(0.375);
+      expect(cost).not.toBeCloseTo(6.25);
+    });
+
+    it('should return undefined for unknown models', () => {
+      const cost = calculateCost('unknown-model-xyz', {
+        promptTokens: 1_000_000,
+        completionTokens: 1_000_000,
+      });
+      expect(cost).toBeUndefined();
+    });
+
+    it('should emit logger.debug when model has no pricing', () => {
+      const debugSpy = vi.spyOn(logger, 'debug');
+      calculateCost('unknown-model-xyz', {
+        promptTokens: 1_000_000,
+        completionTokens: 1_000_000,
+      });
+      expect(debugSpy).toHaveBeenCalledWith('No pricing found for model, cost will be undefined', {
+        model: 'unknown-model-xyz',
+      });
+      debugSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary\n\n# SPARC PRD: Extend Langfuse Cost Pricing Table (Groq + OpenAI Models)\n\n**Feature ID:** fix/observability-langfuse-pricing-groq-openai  \n**Date:** 2026-02-28  \n**Complexity:** small  \n**Owner:** Observability  \n\n---\n\n## Situation\n\nThe  package provides cost-tracking middleware for Langfuse via . Inside that file, a  table (currently lines ~90–101) maps model-name substrings to per-1M-token input/output prices. A ...\n\n---\n*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cost calculation API is now publicly available for use.
  * Pricing database expanded with additional model support.

* **Improvements**
  * Enhanced handling for models without available pricing data.

* **Tests**
  * Added comprehensive test coverage for cost calculation across multiple models and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->