### PR TITLE
[linear] fix(observability): remove cost=0 stub in antagonistic review adapter — track actual LLM costs

### DIFF
--- a/apps/server/src/services/antagonistic-review-adapter.ts
+++ b/apps/server/src/services/antagonistic-review-adapter.ts
@@ -9,7 +9,7 @@
 import { createLogger } from '@protolabs-ai/utils';
 import { createAntagonisticReviewGraph } from '@protolabs-ai/flows';
 import type { SPARCPrd } from '@protolabs-ai/types';
-import { LangfuseClient } from '@protolabs-ai/observability';
+import { LangfuseClient, calculateCost } from '@protolabs-ai/observability';
 import { v4 as uuidv4 } from 'uuid';
 import { createFlowModel } from '../lib/flow-model-factory.js';
 import type { SettingsService } from './settings-service.js';
@@ -267,8 +267,27 @@ export class AntagonisticReviewAdapter {
         });
       }
 
-      // Calculate total cost (placeholder - will be populated by LLM callback tracking)
-      const totalCost = 0; // TODO: Track actual costs from LLM calls
+      // Calculate total cost from token usage collected across graph nodes
+      let totalCost = 0;
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const modelName: string = (smartModel as any).model ?? (smartModel as any).modelName ?? '';
+        const usages = [
+          result.avaTokenUsage,
+          result.jonTokenUsage,
+          result.consolidateTokenUsage,
+        ].filter(Boolean) as Array<{ inputTokens: number; outputTokens: number }>;
+        for (const usage of usages) {
+          const cost = calculateCost(modelName, {
+            promptTokens: usage.inputTokens,
+            completionTokens: usage.outputTokens,
+          });
+          totalCost += cost ?? 0;
+        }
+      } catch (err) {
+        logger.warn('Failed to compute antagonistic review cost', err);
+        totalCost = 0;
+      }
 
       // Flush Langfuse events
       await this.langfuse?.flush();

--- a/libs/flows/src/antagonistic-review/graph.ts
+++ b/libs/flows/src/antagonistic-review/graph.ts
@@ -256,6 +256,7 @@ async function avaReviewAdapter(
 
   return {
     avaReview: mapNodeReviewToGraphReview(result.avaReview, 'ava'),
+    avaTokenUsage: result.tokenUsage,
   };
 }
 
@@ -304,6 +305,7 @@ async function jonReviewAdapter(
 
   return {
     jonReview: mapNodeReviewToGraphReview(result.jonReview, 'jon'),
+    jonTokenUsage: result.tokenUsage,
   };
 }
 
@@ -361,7 +363,7 @@ async function consolidateAdapter(
     consolidatedPrd = { ...state.prd, generatedAt: new Date().toISOString() };
   }
 
-  return { consolidatedPrd, finalVerdict, hitlRequired };
+  return { consolidatedPrd, finalVerdict, hitlRequired, consolidateTokenUsage: result.tokenUsage };
 }
 
 // ─── Routing Functions ─────────────────────────────────────────────────────

--- a/libs/flows/src/antagonistic-review/nodes/ava-review.ts
+++ b/libs/flows/src/antagonistic-review/nodes/ava-review.ts
@@ -47,11 +47,20 @@ export const ReviewerPerspectiveSchema = z.object({
 export type ReviewerPerspective = z.infer<typeof ReviewerPerspectiveSchema>;
 
 /**
+ * Token usage from a single LLM call
+ */
+export interface NodeTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/**
  * State interface for ava-review node
  */
 export interface AvaReviewState {
   prd: string;
   avaReview?: ReviewerPerspective;
+  tokenUsage?: NodeTokenUsage;
   smartModel?: BaseChatModel;
   fastModel?: BaseChatModel;
 }
@@ -69,7 +78,7 @@ export async function avaReviewNode(state: AvaReviewState): Promise<Partial<AvaR
   console.log(`[${nodeName}] Starting Ava's operational review`);
 
   try {
-    // Execute with model fallback
+    // Execute with model fallback, capturing both content and token usage
     const result = await executeWithFallback(
       { primary: smartModel, fallback: fastModel },
       async (model) => {
@@ -113,19 +122,34 @@ Be direct, practical, and focus on execution realities. Return ONLY the JSON obj
           },
         ]);
 
-        return response.content.toString();
+        const usageMeta = response.usage_metadata;
+        const fallbackUsage = (response.response_metadata as any)?.usage;
+        let tokenUsage: NodeTokenUsage | undefined;
+        if (usageMeta) {
+          tokenUsage = {
+            inputTokens: usageMeta.input_tokens,
+            outputTokens: usageMeta.output_tokens,
+          };
+        } else if (fallbackUsage) {
+          tokenUsage = {
+            inputTokens: fallbackUsage.prompt_tokens ?? 0,
+            outputTokens: fallbackUsage.completion_tokens ?? 0,
+          };
+        }
+
+        return { content: response.content.toString(), tokenUsage };
       },
       nodeName
     );
 
     // Parse and validate the LLM response
-    const avaReview = parseAndValidateReview(result, nodeName);
+    const avaReview = parseAndValidateReview(result.content, nodeName);
 
     console.log(
       `[${nodeName}] Review complete: ${avaReview.verdict} (${avaReview.sections.length} sections)`
     );
 
-    return { avaReview };
+    return { avaReview, tokenUsage: result.tokenUsage };
   } catch (error) {
     console.error(`[${nodeName}] Failed:`, error);
     throw error;

--- a/libs/flows/src/antagonistic-review/nodes/consolidate.ts
+++ b/libs/flows/src/antagonistic-review/nodes/consolidate.ts
@@ -20,7 +20,7 @@
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { z } from 'zod';
 import { executeWithFallback } from './classify-topic.js';
-import { type ReviewerPerspective } from './ava-review.js';
+import { type ReviewerPerspective, type NodeTokenUsage } from './ava-review.js';
 
 /**
  * Final verdict schema for consolidated review
@@ -59,6 +59,7 @@ export interface ConsolidateState {
   jonReview?: ReviewerPerspective;
   pairReviews?: ReviewerPerspective[];
   consolidatedReview?: ConsolidatedReview;
+  tokenUsage?: NodeTokenUsage;
   smartModel?: BaseChatModel;
   fastModel?: BaseChatModel;
 }
@@ -109,7 +110,7 @@ Summary: ${review.comments}
       )
       .join('\n---\n');
 
-    // Execute with model fallback
+    // Execute with model fallback, capturing both content and token usage
     const result = await executeWithFallback(
       { primary: smartModel, fallback: fastModel },
       async (model) => {
@@ -156,19 +157,34 @@ Be thorough, fair, and prioritize both customer value (Jon's focus) and executio
           },
         ]);
 
-        return response.content.toString();
+        const usageMeta = response.usage_metadata;
+        const fallbackUsage = (response.response_metadata as any)?.usage;
+        let tokenUsage: NodeTokenUsage | undefined;
+        if (usageMeta) {
+          tokenUsage = {
+            inputTokens: usageMeta.input_tokens,
+            outputTokens: usageMeta.output_tokens,
+          };
+        } else if (fallbackUsage) {
+          tokenUsage = {
+            inputTokens: fallbackUsage.prompt_tokens ?? 0,
+            outputTokens: fallbackUsage.completion_tokens ?? 0,
+          };
+        }
+
+        return { content: response.content.toString(), tokenUsage };
       },
       nodeName
     );
 
     // Parse and validate the LLM response
-    const consolidatedReview = parseAndValidateConsolidation(result, nodeName);
+    const consolidatedReview = parseAndValidateConsolidation(result.content, nodeName);
 
     console.log(
       `[${nodeName}] Consolidation complete: ${consolidatedReview.verdict} (${allReviews.length} reviews merged)`
     );
 
-    return { consolidatedReview };
+    return { consolidatedReview, tokenUsage: result.tokenUsage };
   } catch (error) {
     console.error(`[${nodeName}] Failed:`, error);
     throw error;

--- a/libs/flows/src/antagonistic-review/nodes/jon-review.ts
+++ b/libs/flows/src/antagonistic-review/nodes/jon-review.ts
@@ -17,7 +17,11 @@
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { z } from 'zod';
 import { executeWithFallback } from './classify-topic.js';
-import { ReviewerPerspectiveSchema, type ReviewerPerspective } from './ava-review.js';
+import {
+  ReviewerPerspectiveSchema,
+  type ReviewerPerspective,
+  type NodeTokenUsage,
+} from './ava-review.js';
 
 /**
  * State interface for jon-review node
@@ -26,6 +30,7 @@ export interface JonReviewState {
   prd: string;
   avaReview?: ReviewerPerspective;
   jonReview?: ReviewerPerspective;
+  tokenUsage?: NodeTokenUsage;
   smartModel?: BaseChatModel;
   fastModel?: BaseChatModel;
 }
@@ -60,7 +65,7 @@ Ava's Summary: ${avaReview.comments}
 `
       : '';
 
-    // Execute with model fallback
+    // Execute with model fallback, capturing both content and token usage
     const result = await executeWithFallback(
       { primary: smartModel, fallback: fastModel },
       async (model) => {
@@ -111,19 +116,34 @@ Be strategic, business-focused, and consider customer impact above all. Return O
           },
         ]);
 
-        return response.content.toString();
+        const usageMeta = response.usage_metadata;
+        const fallbackUsage = (response.response_metadata as any)?.usage;
+        let tokenUsage: NodeTokenUsage | undefined;
+        if (usageMeta) {
+          tokenUsage = {
+            inputTokens: usageMeta.input_tokens,
+            outputTokens: usageMeta.output_tokens,
+          };
+        } else if (fallbackUsage) {
+          tokenUsage = {
+            inputTokens: fallbackUsage.prompt_tokens ?? 0,
+            outputTokens: fallbackUsage.completion_tokens ?? 0,
+          };
+        }
+
+        return { content: response.content.toString(), tokenUsage };
       },
       nodeName
     );
 
     // Parse and validate the LLM response
-    const jonReview = parseAndValidateReview(result, nodeName);
+    const jonReview = parseAndValidateReview(result.content, nodeName);
 
     console.log(
       `[${nodeName}] Review complete: ${jonReview.verdict} (${jonReview.sections.length} sections)`
     );
 
-    return { jonReview };
+    return { jonReview, tokenUsage: result.tokenUsage };
   } catch (error) {
     console.error(`[${nodeName}] Failed:`, error);
     throw error;

--- a/libs/flows/src/antagonistic-review/state.ts
+++ b/libs/flows/src/antagonistic-review/state.ts
@@ -18,6 +18,14 @@ import {
 } from '@protolabs-ai/types';
 
 /**
+ * Token usage captured from a single LLM node invocation
+ */
+export interface NodeTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/**
  * Zod schema for AntagonisticReviewState
  * Validates the review state structure
  */
@@ -44,6 +52,11 @@ export const AntagonisticReviewStateSchema = z.object({
   // HITL (Human-in-the-Loop) integration
   hitlRequired: z.boolean().optional(),
   hitlFeedback: z.string().optional(),
+
+  // Token usage per LLM node (for cost tracking)
+  avaTokenUsage: z.object({ inputTokens: z.number(), outputTokens: z.number() }).optional(),
+  jonTokenUsage: z.object({ inputTokens: z.number(), outputTokens: z.number() }).optional(),
+  consolidateTokenUsage: z.object({ inputTokens: z.number(), outputTokens: z.number() }).optional(),
 });
 
 /**
@@ -83,6 +96,15 @@ export interface AntagonisticReviewState {
 
   /** Feedback from human reviewer if HITL was triggered */
   hitlFeedback?: string;
+
+  /** Token usage from ava-review LLM call (for cost tracking) */
+  avaTokenUsage?: NodeTokenUsage;
+
+  /** Token usage from jon-review LLM call (for cost tracking) */
+  jonTokenUsage?: NodeTokenUsage;
+
+  /** Token usage from consolidate LLM call (for cost tracking) */
+  consolidateTokenUsage?: NodeTokenUsage;
 
   /** Smart LLM model for review nodes (injected by adapter) */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -126,6 +148,11 @@ export const AntagonisticReviewStateAnnotation = Annotation.Root({
   // HITL integration (replace semantics)
   hitlRequired: Annotation<boolean | undefined>,
   hitlFeedback: Annotation<string | undefined>,
+
+  // Token usage per LLM node (replace semantics)
+  avaTokenUsage: Annotation<NodeTokenUsage | undefined>,
+  jonTokenUsage: Annotation<NodeTokenUsage | undefined>,
+  consolidateTokenUsage: Annotation<NodeTokenUsage | undefined>,
 
   // LLM models (injected by adapter, replace semantics)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary\n\n# SPARC PRD: fix(observability): Remove  Stub in Antagonistic Review Adapter — Track Actual LLM Costs\n\n**Feature ID:** TBD (Linear)\n**Date:** 2026-02-28\n**Complexity:** medium\n**Owner:** Engineering\n\n---\n\n## Situation\n\nThe antagonistic review pipeline is a multi-node LangGraph flow that runs three distinct LLM calls:\n\n1. **Classify Topic Node** — determines whether to use a 'senior' or 'architect' review persona\n2. **Ava Review Node** — first LLM reviewer generating structured feedback\n3...\n\n---\n*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Antagonistic reviews now track and report token usage (input/output tokens) from all LLM calls throughout the review process
  * Automatic cost calculation system implemented to compute total expenses by aggregating token usage data from all review stages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->