### PR TITLE
[linear] feat(observability): add per-tool-call span tracing in TracedProvider

### DIFF
--- a/libs/observability/src/langfuse/middleware.ts
+++ b/libs/observability/src/langfuse/middleware.ts
@@ -3,6 +3,22 @@ import { createLogger } from '@protolabs-ai/utils';
 import { LangfuseClient } from './client.js';
 import type { CreateGenerationOptions } from './types.js';
 
+const TOOL_SPAN_MAX_BYTES = 2048;
+
+interface PendingToolCall {
+  toolName: string;
+  toolInput: unknown;
+  startTime: Date;
+  turnIndex: number;
+  toolCallIndex: number;
+}
+
+function truncateForSpan(value: unknown): { value: string; truncated?: true } {
+  const serialized = typeof value === 'string' ? value : (JSON.stringify(value) ?? '');
+  if (serialized.length <= TOOL_SPAN_MAX_BYTES) return { value: serialized };
+  return { value: serialized.slice(0, TOOL_SPAN_MAX_BYTES), truncated: true };
+}
+
 export const logger = createLogger('LangfuseMiddleware');
 
 /**
@@ -189,12 +205,65 @@ export async function* wrapProviderWithTracing<T>(
   // Collect all messages for usage tracking
   const messages: T[] = [];
   let error: Error | undefined;
+  let turnIndex = -1;
+  const pendingToolCalls = new Map<string, PendingToolCall>();
 
   try {
     // Yield all messages and collect them
     for await (const message of generator) {
       messages.push(message);
       yield message;
+
+      // Inspect for tool events to create per-tool-call spans
+      const msg = message as any;
+      if (msg?.type === 'assistant' && Array.isArray(msg?.message?.content)) {
+        turnIndex++;
+        let toolCallIndex = 0;
+        for (const block of msg.message.content) {
+          if (block?.type === 'tool_use' && block?.id) {
+            pendingToolCalls.set(block.id, {
+              toolName: block.name ?? 'unknown',
+              toolInput: block.input,
+              startTime: new Date(),
+              turnIndex,
+              toolCallIndex,
+            });
+            toolCallIndex++;
+          }
+        }
+      } else if (msg?.type === 'user' && Array.isArray(msg?.message?.content)) {
+        for (const block of msg.message.content) {
+          if (block?.type === 'tool_result' && block?.tool_use_id) {
+            const pending = pendingToolCalls.get(block.tool_use_id);
+            if (pending) {
+              pendingToolCalls.delete(block.tool_use_id);
+              const endTime = new Date();
+              const inputResult = truncateForSpan(pending.toolInput);
+              const outputResult = truncateForSpan(block.content);
+              client.createSpan({
+                traceId,
+                name: `tool:${pending.toolName}`,
+                input: {
+                  toolName: pending.toolName,
+                  toolInput: inputResult.value,
+                  ...(inputResult.truncated ? { truncated: true } : {}),
+                },
+                output: {
+                  result: outputResult.value,
+                  ...(outputResult.truncated ? { truncated: true } : {}),
+                },
+                metadata: {
+                  featureId: options.metadata?.featureId,
+                  turnIndex: pending.turnIndex,
+                  toolCallIndex: pending.toolCallIndex,
+                },
+                startTime: pending.startTime,
+                endTime,
+              });
+            }
+          }
+        }
+      }
     }
   } catch (err) {
     error = err as Error;

--- a/libs/observability/tests/integration/provider-tracing.test.ts
+++ b/libs/observability/tests/integration/provider-tracing.test.ts
@@ -316,6 +316,236 @@ describe('Provider Tracing Integration', () => {
     });
   });
 
+  describe('Per-Tool-Call Span Tracing', () => {
+    let enabledClient: LangfuseClient;
+    let enabledConfig: TracingConfig;
+
+    beforeEach(() => {
+      enabledClient = new LangfuseClient({ enabled: false });
+      vi.spyOn(enabledClient, 'isAvailable').mockReturnValue(true);
+      vi.spyOn(enabledClient, 'createTrace').mockReturnValue(null);
+      vi.spyOn(enabledClient, 'createGeneration').mockReturnValue(null);
+      vi.spyOn(enabledClient, 'updateTrace').mockReturnValue(undefined);
+      vi.spyOn(enabledClient, 'flush').mockResolvedValue(undefined);
+
+      enabledConfig = {
+        enabled: true,
+        client: enabledClient,
+      };
+    });
+
+    it('should create one span for a single tool call', async () => {
+      const createSpanSpy = vi.spyOn(enabledClient, 'createSpan').mockReturnValue(null);
+
+      const messages = [
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'tool_use', id: 'tool_1', name: 'Read', input: { path: '/foo.ts' } }],
+          },
+        },
+        {
+          type: 'user',
+          message: {
+            content: [{ type: 'tool_result', tool_use_id: 'tool_1', content: 'file content' }],
+          },
+        },
+      ];
+
+      const generator = mockProviderGenerator(messages);
+      const traced = wrapProviderWithTracing(generator, enabledConfig, {
+        model: 'claude-sonnet-4-6',
+        metadata: { featureId: 'feat-123' },
+      });
+
+      for await (const _ of traced) {
+        // consume
+      }
+
+      expect(createSpanSpy).toHaveBeenCalledTimes(1);
+      const spanCall = createSpanSpy.mock.calls[0][0];
+      expect(spanCall.name).toBe('tool:Read');
+      expect(spanCall.input.toolName).toBe('Read');
+      expect(spanCall.input.toolInput).toContain('/foo.ts');
+      expect(spanCall.output.result).toBe('file content');
+      expect(spanCall.metadata.featureId).toBe('feat-123');
+      expect(spanCall.metadata.turnIndex).toBe(0);
+      expect(spanCall.metadata.toolCallIndex).toBe(0);
+      expect(spanCall.startTime).toBeInstanceOf(Date);
+      expect(spanCall.endTime).toBeInstanceOf(Date);
+    });
+
+    it('should track turnIndex correctly across multi-turn runs', async () => {
+      const createSpanSpy = vi.spyOn(enabledClient, 'createSpan').mockReturnValue(null);
+
+      const messages = [
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'tool_use', id: 'tool_1', name: 'Read', input: {} }],
+          },
+        },
+        {
+          type: 'user',
+          message: {
+            content: [{ type: 'tool_result', tool_use_id: 'tool_1', content: 'result1' }],
+          },
+        },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'tool_use', id: 'tool_2', name: 'Write', input: {} }],
+          },
+        },
+        {
+          type: 'user',
+          message: {
+            content: [{ type: 'tool_result', tool_use_id: 'tool_2', content: 'result2' }],
+          },
+        },
+      ];
+
+      const generator = mockProviderGenerator(messages);
+      const traced = wrapProviderWithTracing(generator, enabledConfig, {
+        model: 'claude-sonnet-4-6',
+      });
+
+      for await (const _ of traced) {
+        // consume
+      }
+
+      expect(createSpanSpy).toHaveBeenCalledTimes(2);
+      expect(createSpanSpy.mock.calls[0][0].metadata.turnIndex).toBe(0);
+      expect(createSpanSpy.mock.calls[1][0].metadata.turnIndex).toBe(1);
+    });
+
+    it('should truncate tool input at 2KB and set truncated flag', async () => {
+      const createSpanSpy = vi.spyOn(enabledClient, 'createSpan').mockReturnValue(null);
+
+      const largeInput = 'x'.repeat(3000);
+      const messages = [
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'tool_use', id: 'tool_1', name: 'Bash', input: largeInput }],
+          },
+        },
+        {
+          type: 'user',
+          message: {
+            content: [{ type: 'tool_result', tool_use_id: 'tool_1', content: 'output' }],
+          },
+        },
+      ];
+
+      const generator = mockProviderGenerator(messages);
+      const traced = wrapProviderWithTracing(generator, enabledConfig, {
+        model: 'claude-sonnet-4-6',
+      });
+
+      for await (const _ of traced) {
+        // consume
+      }
+
+      expect(createSpanSpy).toHaveBeenCalledTimes(1);
+      const spanCall = createSpanSpy.mock.calls[0][0];
+      expect(spanCall.input.toolInput.length).toBe(2048);
+      expect(spanCall.input.truncated).toBe(true);
+    });
+
+    it('should truncate tool output at 2KB and set truncated flag', async () => {
+      const createSpanSpy = vi.spyOn(enabledClient, 'createSpan').mockReturnValue(null);
+
+      const largeOutput = 'y'.repeat(3000);
+      const messages = [
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'tool_use', id: 'tool_1', name: 'Read', input: {} }],
+          },
+        },
+        {
+          type: 'user',
+          message: {
+            content: [{ type: 'tool_result', tool_use_id: 'tool_1', content: largeOutput }],
+          },
+        },
+      ];
+
+      const generator = mockProviderGenerator(messages);
+      const traced = wrapProviderWithTracing(generator, enabledConfig, {
+        model: 'claude-sonnet-4-6',
+      });
+
+      for await (const _ of traced) {
+        // consume
+      }
+
+      expect(createSpanSpy).toHaveBeenCalledTimes(1);
+      const spanCall = createSpanSpy.mock.calls[0][0];
+      expect(spanCall.output.result.length).toBe(2048);
+      expect(spanCall.output.truncated).toBe(true);
+    });
+
+    it('should create no spans when tracing is disabled', async () => {
+      const createSpanSpy = vi.spyOn(enabledClient, 'createSpan').mockReturnValue(null);
+
+      const disabledConfig: TracingConfig = { enabled: false, client: enabledClient };
+
+      const messages = [
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'tool_use', id: 'tool_1', name: 'Read', input: {} }],
+          },
+        },
+        {
+          type: 'user',
+          message: {
+            content: [{ type: 'tool_result', tool_use_id: 'tool_1', content: 'result' }],
+          },
+        },
+      ];
+
+      const generator = mockProviderGenerator(messages);
+      const traced = wrapProviderWithTracing(generator, disabledConfig, {
+        model: 'claude-sonnet-4-6',
+      });
+
+      for await (const _ of traced) {
+        // consume
+      }
+
+      expect(createSpanSpy).not.toHaveBeenCalled();
+    });
+
+    it('should silently ignore tool_result with no matching tool_use', async () => {
+      const createSpanSpy = vi.spyOn(enabledClient, 'createSpan').mockReturnValue(null);
+
+      const messages = [
+        {
+          type: 'user',
+          message: {
+            content: [
+              { type: 'tool_result', tool_use_id: 'nonexistent_id', content: 'orphan result' },
+            ],
+          },
+        },
+      ];
+
+      const generator = mockProviderGenerator(messages);
+      const traced = wrapProviderWithTracing(generator, enabledConfig, {
+        model: 'claude-sonnet-4-6',
+      });
+
+      for await (const _ of traced) {
+        // consume
+      }
+
+      expect(createSpanSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Usage Extraction', () => {
     it('should extract usage from Anthropic format', async () => {
       const messages = [

--- a/libs/observability/tests/mocks/langfuse-api.ts
+++ b/libs/observability/tests/mocks/langfuse-api.ts
@@ -36,10 +36,22 @@ export interface MockGeneration {
   endTime?: Date;
 }
 
+export interface MockSpan {
+  id: string;
+  traceId: string;
+  name: string;
+  input?: any;
+  output?: any;
+  metadata?: Record<string, any>;
+  startTime?: Date;
+  endTime?: Date;
+}
+
 export class MockLangfuseAPI {
   private prompts: Map<string, MockPrompt[]> = new Map();
   private traces: Map<string, MockTrace> = new Map();
   private generations: Map<string, MockGeneration> = new Map();
+  private spans: Map<string, MockSpan> = new Map();
   private shouldFail = false;
 
   /**
@@ -94,6 +106,16 @@ export class MockLangfuseAPI {
   }
 
   /**
+   * Record a span
+   */
+  recordSpan(span: MockSpan): void {
+    if (this.shouldFail) {
+      throw new Error('Mock API failure');
+    }
+    this.spans.set(span.id, span);
+  }
+
+  /**
    * Get recorded trace by ID
    */
   getTrace(id: string): MockTrace | undefined {
@@ -122,12 +144,20 @@ export class MockLangfuseAPI {
   }
 
   /**
+   * Get all recorded spans
+   */
+  getAllSpans(): MockSpan[] {
+    return Array.from(this.spans.values());
+  }
+
+  /**
    * Clear all recorded data
    */
   clear(): void {
     this.prompts.clear();
     this.traces.clear();
     this.generations.clear();
+    this.spans.clear();
     this.shouldFail = false;
   }
 
@@ -166,6 +196,20 @@ export function createMockLangfuseClient(api: MockLangfuseAPI) {
         });
         return genOptions;
       },
+      span: (spanOptions: any) => {
+        api.recordSpan({
+          id: spanOptions.id ?? Math.random().toString(36).slice(2),
+          traceId: options.id,
+          name: spanOptions.name,
+          input: spanOptions.input,
+          output: spanOptions.output,
+          metadata: spanOptions.metadata,
+          startTime: spanOptions.startTime,
+          endTime: spanOptions.endTime,
+        });
+        return spanOptions;
+      },
+      update: (_data: any) => {},
     }),
     flushAsync: async () => {
       // No-op for mock

--- a/libs/observability/tests/mocks/langfuse-stub.ts
+++ b/libs/observability/tests/mocks/langfuse-stub.ts
@@ -59,7 +59,11 @@ export class Langfuse {
   }
 
   trace(_body: LangfuseTraceBody): any {
-    return {};
+    return {
+      span: (_spanBody: any) => ({}),
+      update: (_data: any) => {},
+      generation: (_genBody: any) => ({}),
+    };
   }
 
   generation(_body: LangfuseGenerationBody): any {


### PR DESCRIPTION
## Summary

- Adds per-tool-call Langfuse spans inside `wrapProviderWithTracing()` in `libs/observability/src/langfuse/middleware.ts`
- Correlates `tool_use` blocks (assistant messages) with `tool_result` blocks (user messages) via a `Map<tool_use_id, PendingToolCall>`
- Each completed pair produces a `tool:{toolName}` span with input/output truncated to 2KB
- Tracks `turnIndex` and `toolCallIndex` in span metadata for ordering
- Zero blocking overhead — `createSpan()` is fire-and-forget; flushed in the existing `finally` block
- Full no-op when Langfuse is disabled
- Updates `langfuse-stub.ts` mock to support `span()` method

## Test plan

- [ ] Single tool call produces one span with correct name/input/output/metadata
- [ ] Multi-turn run produces spans with correct `turnIndex` values
- [ ] Input truncation at 2KB with `truncated: true` flag
- [ ] Output truncation at 2KB with `truncated: true` flag
- [ ] No spans created when Langfuse disabled
- [ ] Unmatched `tool_result` silently ignored
- [ ] `npm run typecheck` passes
- [ ] `npm run test:packages` passes

Closes PRO-351

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool calls are now tracked individually with spans capturing execution data, input/output, and metadata including turn indices and feature identifiers.

* **Tests**
  * Added comprehensive tests for tool-call span tracing including truncation behavior for large inputs/outputs, metadata propagation, multi-turn conversation handling, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->