### PR TITLE
[linear] fix(agent): git-workflow-service PR body backtick shell error — use --body-file to escape special ch

### DIFF
--- a/apps/server/src/routes/worktree/routes/create-pr.ts
+++ b/apps/server/src/routes/worktree/routes/create-pr.ts
@@ -165,8 +165,6 @@ export function createCreatePRHandler(settingsService?: SettingsService) {
         }
       }
 
-      const draftFlag = draft ? '--draft' : '';
-
       let prUrl: string | null = null;
       let prError: string | null = null;
       let browserUrl: string | null = null;
@@ -311,23 +309,24 @@ export function createCreatePRHandler(settingsService?: SettingsService) {
         // Only create a new PR if one doesn't already exist
         if (!prUrl) {
           try {
-            // Build gh pr create command
-            let prCmd = `gh pr create --base "${base}"`;
+            // Build gh pr create args - use array to avoid shell injection
+            // with backticks, $(), !, and other special chars in LLM-generated PR bodies
+            const prArgs = ['pr', 'create', '--base', base];
 
             // If this is a fork (has upstream remote), specify the repo and head
             if (upstreamRepo && originOwner) {
               // For forks: --repo specifies where to create PR, --head specifies source
-              prCmd += ` --repo "${upstreamRepo}" --head "${originOwner}:${branchName}"`;
+              prArgs.push('--repo', upstreamRepo, '--head', `${originOwner}:${branchName}`);
             } else {
               // Not a fork, just specify the head branch
-              prCmd += ` --head "${branchName}"`;
+              prArgs.push('--head', branchName);
             }
 
-            prCmd += ` --title "${title.replace(/"/g, '\\"')}" --body "${body.replace(/"/g, '\\"')}" ${draftFlag}`;
-            prCmd = prCmd.trim();
+            prArgs.push('--title', title, '--body', body);
+            if (draft) prArgs.push('--draft');
 
-            logger.debug(`Creating PR with command: ${prCmd}`);
-            const { stdout: prOutput } = await execAsync(prCmd, {
+            logger.debug(`Creating PR with args: gh ${prArgs.join(' ')}`);
+            const { stdout: prOutput } = await execFileAsync('gh', prArgs, {
               cwd: worktreePath,
               env: execEnv,
             });

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -1162,21 +1162,29 @@ export class GitWorkflowService {
       // No existing PR found, continue to create
     }
 
-    // Create new PR - always use explicit --repo to target correct repository
-    let prCmd = `gh pr create --base "${baseBranch}"`;
+    // Create new PR - use execFileAsync array args to avoid shell injection
+    // with backticks, $(), !, and other special chars in LLM-generated PR bodies
+    const prArgs = [
+      'pr',
+      'create',
+      '--base',
+      baseBranch,
+      '--head',
+      branchName,
+      '--title',
+      title,
+      '--body',
+      body,
+    ];
 
     if (targetRepo) {
-      prCmd += ` --repo "${targetRepo}"`;
+      prArgs.push('--repo', targetRepo);
     }
-
-    // Use simple branch name since we're targeting our own repo (origin)
-    prCmd += ` --head "${branchName}"`;
-    prCmd += ` --title "${title.replace(/"/g, '\\"')}" --body "${body.replace(/"/g, '\\"')}"`;
 
     try {
       // Use retry logic for PR creation
       const { prUrl, prNumber, prCreatedAt } = await retryWithExponentialBackoff(async () => {
-        const { stdout: prOutput } = await execAsync(prCmd, {
+        const { stdout: prOutput } = await execFileAsync('gh', prArgs, {
           cwd: workDir,
           env: execEnv,
         });

--- a/apps/server/src/services/worktree-recovery-service.ts
+++ b/apps/server/src/services/worktree-recovery-service.ts
@@ -232,8 +232,9 @@ export async function checkAndRecoverUncommittedWork(
         "'"
       );
 
-    const { stdout: prOutput } = await execAsync(
-      `gh pr create --base dev --head "${branchName}" --title "${prTitle}" --body "${prBody.replace(/\n/g, '\\n')}"`,
+    const { stdout: prOutput } = await execFileAsync(
+      'gh',
+      ['pr', 'create', '--base', 'dev', '--head', branchName, '--title', prTitle, '--body', prBody],
       { cwd: worktreePath, env: execEnv }
     );
 


### PR DESCRIPTION
## Summary\n\n# fix(agent): git-workflow-service PR Body Shell Injection — Switch to  Array Args\n\n## Situation\n\n, , and  all create GitHub PRs by building a shell command string and passing it to . The PR body is interpolated directly into the string using  with only double-quote escaping applied.\n\nTwo other se...\n\n---\n*Recovered automatically by Automaker post-agent hook*