### PR TITLE
[linear] P1: HITL form system is brittle — repeated popups blocking alpha testing

### DIFF
--- a/apps/server/src/services/lead-engineer-escalation.ts
+++ b/apps/server/src/services/lead-engineer-escalation.ts
@@ -84,76 +84,96 @@ export class EscalateProcessor implements StateProcessor {
     const maxRetriesHit = ctx.retryCount >= failureAnalysis.maxRetries;
     const needsHumanInput = !failureAnalysis.isRetryable || maxRetriesHit;
 
-    if (needsHumanInput && this.serviceContext.hitlFormService) {
+    // Check featureFlags.pipeline to see if HITL is enabled
+    let hitlEnabled = false;
+    if (this.serviceContext.settingsService) {
       try {
-        const confidencePct = Math.round(failureAnalysis.confidence * 100);
-        this.serviceContext.hitlFormService.create({
-          title: `Agent blocked: ${ctx.feature.title}`,
-          description: `Failure category: ${failureAnalysis.category}\nRoot cause: ${failureAnalysis.explanation}\nConfidence: ${confidencePct}%`,
-          steps: [
-            {
-              title: 'How would you like to proceed?',
-              schema: {
-                type: 'object',
-                properties: {
-                  resolution: {
-                    type: 'string',
-                    title: 'Resolution',
-                    oneOf: [
-                      {
-                        const: 'retry',
-                        title: 'Retry',
-                        description: 'Reset and re-run the agent',
-                      },
-                      {
-                        const: 'provide_context',
-                        title: 'Provide context',
-                        description: 'Give the agent additional information',
-                      },
-                      {
-                        const: 'skip',
-                        title: 'Skip this feature',
-                        description: 'Mark as done without implementing',
-                      },
-                      {
-                        const: 'close',
-                        title: 'Close as blocked',
-                        description: 'Keep blocked for manual handling',
-                      },
-                    ],
-                  },
-                },
-                required: ['resolution'],
-              },
-            },
-            {
-              title: 'Additional context',
-              description:
-                'Provide additional information for the agent (only required if you selected "Provide context")',
-              schema: {
-                type: 'object',
-                properties: {
-                  context: {
-                    type: 'string',
-                    title: 'Context',
-                    description: 'Additional information to help the agent proceed',
-                  },
-                },
-              },
-            },
-          ],
-          callerType: 'lead_engineer',
-          featureId: ctx.feature.id,
-          projectPath: ctx.projectPath,
-        });
-
-        logger.info(`[ESCALATE] Created HITL form for feature ${ctx.feature.id}`, {
-          category: failureAnalysis.category,
-          isRetryable: failureAnalysis.isRetryable,
-          maxRetriesHit,
-        });
+        const globalSettings = await this.serviceContext.settingsService.getGlobalSettings();
+        hitlEnabled = globalSettings.featureFlags?.pipeline ?? false;
       } catch (err) {
-        logger.error(`[ESCALATE] Failed to create HITL form for feature ${ctx.feature.id}:`, err);
+        logger.warn('[ESCALATE] Failed to read feature flags, HITL disabled:', err);
+      }
+    }
+
+    if (needsHumanInput && hitlEnabled && this.serviceContext.hitlFormService) {
+      // Deduplicate: skip if a pending form already exists for this feature
+      const existingForms = this.serviceContext.hitlFormService.listPending();
+      const existingForm = existingForms.find((f) => f.featureId === ctx.feature.id);
+      if (existingForm) {
+        logger.info(
+          `[ESCALATE] Form ${existingForm.id} already exists for feature ${ctx.feature.id}, skipping`
+        );
+      } else {
+        try {
+          const confidencePct = Math.round(failureAnalysis.confidence * 100);
+          this.serviceContext.hitlFormService.create({
+            title: `Agent blocked: ${ctx.feature.title}`,
+            description: `Failure category: ${failureAnalysis.category}\nRoot cause: ${failureAnalysis.explanation}\nConfidence: ${confidencePct}%`,
+            steps: [
+              {
+                title: 'How would you like to proceed?',
+                schema: {
+                  type: 'object',
+                  properties: {
+                    resolution: {
+                      type: 'string',
+                      title: 'Resolution',
+                      oneOf: [
+                        {
+                          const: 'retry',
+                          title: 'Retry',
+                          description: 'Reset and re-run the agent',
+                        },
+                        {
+                          const: 'provide_context',
+                          title: 'Provide context',
+                          description: 'Give the agent additional information',
+                        },
+                        {
+                          const: 'skip',
+                          title: 'Skip this feature',
+                          description: 'Mark as done without implementing',
+                        },
+                        {
+                          const: 'close',
+                          title: 'Close as blocked',
+                          description: 'Keep blocked for manual handling',
+                        },
+                      ],
+                    },
+                  },
+                  required: ['resolution'],
+                },
+              },
+              {
+                title: 'Additional context',
+                description:
+                  'Provide additional information for the agent (only required if you selected "Provide context")',
+                schema: {
+                  type: 'object',
+                  properties: {
+                    context: {
+                      type: 'string',
+                      title: 'Context',
+                      description: 'Additional information to help the agent proceed',
+                    },
+                  },
+                },
+              },
+            ],
+            callerType: 'lead_engineer',
+            featureId: ctx.feature.id,
+            projectPath: ctx.projectPath,
+          });
+
+          logger.info(`[ESCALATE] Created HITL form for feature ${ctx.feature.id}`, {
+            category: failureAnalysis.category,
+            isRetryable: failureAnalysis.isRetryable,
+            maxRetriesHit,
+          });
+        } catch (err) {
+          logger.error(`[ESCALATE] Failed to create HITL form for feature ${ctx.feature.id}:`, err);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary\n\nP1: HITL form system is brittle — repeated popups blocking alpha testing\n\n## Summary\n\nHITL (Human-In-The-Loop) forms are repeatedly appearing even though they should be disabled, causing system failures in alpha testing.\n\n## Root Causes (5 Issues)\n\n1. **Feature Flag Broken** —  documents that it controls HITL, but Lead Engineer ESCALATE processor doesn't check it\n2. **No Deduplication** — ESCALATE processor creates new forms every time it runs, even for already-blocked fea...\n\n---\n*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HITL escalations can now be controlled via feature flags.

* **Bug Fixes**
  * Prevented duplicate HITL form creation for the same feature.
  * Improved error handling for settings retrieval.
  * Updated HITL form structure with required resolution field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->