### PR TITLE
[linear] feat(maintenance): replace board-health merged-not-done poll with PR merge webhook hook

### DIFF
--- a/apps/server/src/routes/github/routes/webhook.ts
+++ b/apps/server/src/routes/github/routes/webhook.ts
@@ -149,7 +149,9 @@ async function handlePullRequestEvent(
     baseBranch: pull_request.base.ref,
   });
 
-  // Future: Update feature status when PR is merged/closed
+  // PR merge -> feature status transition is handled by the primary webhook router
+  // at apps/server/src/routes/webhooks/routes/github.ts (pull_request.closed + merged:true).
+  // Do not implement it here.
 }
 
 /**

--- a/apps/server/src/routes/webhooks/routes/github.ts
+++ b/apps/server/src/routes/webhooks/routes/github.ts
@@ -303,12 +303,15 @@ export function createGitHubWebhookHandler(events: EventEmitter, settingsService
         return;
       }
 
-      // Track whether the feature was already marked done before this event
-      const wasAlreadyDone = currentFeature.status === 'done';
+      // Idempotency guard: skip update if feature is already in a terminal status.
+      // Prevents double-updating completedAt or re-emitting feature:pr-merged on duplicate
+      // webhook deliveries.
+      const TERMINAL_STATUSES = new Set(['done', 'completed', 'verified']);
+      const wasAlreadyTerminal = TERMINAL_STATUSES.has(currentFeature.status ?? '');
 
-      if (wasAlreadyDone) {
-        logger.info(
-          `Feature "${feature.title}" is already in "done" status. PR #${prNumber} merge confirmed.`
+      if (wasAlreadyTerminal) {
+        logger.debug(
+          `Feature "${feature.title}" already in terminal status '${currentFeature.status}' — skipping merge update for PR #${prNumber}`
         );
       } else {
         // Update feature status to done
@@ -355,8 +358,8 @@ export function createGitHubWebhookHandler(events: EventEmitter, settingsService
 
       res.json({
         success: true,
-        message: wasAlreadyDone
-          ? `Feature already marked as done`
+        message: wasAlreadyTerminal
+          ? `Feature already in terminal status '${currentFeature.status}'`
           : `Feature "${feature.title}" moved to done`,
         featureId: feature.featureId,
       });

--- a/apps/server/src/services/feature-health-service.ts
+++ b/apps/server/src/services/feature-health-service.ts
@@ -3,29 +3,27 @@
  *
  * Checks for:
  * - Orphaned features (epicId references non-existent epic)
- * - Merged-but-not-done (branch merged to main but feature not marked done)
  * - Completed epics (all children done but epic still in-progress/backlog)
  * - Stale in-progress (features stuck in running with no active agent)
  * - Dangling dependencies (depend on deleted/non-existent features)
+ * - Stale pipeline gates (awaiting gate beyond timeout threshold)
  *
  * Provides dry-run and auto-fix modes.
+ * Note: merged-not-done detection was removed. PR merge -> done transitions are
+ * handled synchronously by the primary webhook handler at
+ * apps/server/src/routes/webhooks/routes/github.ts.
  */
 
 import { createLogger } from '@protolabs-ai/utils';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import type { Feature } from '@protolabs-ai/types';
 import type { FeatureLoader } from './feature-loader.js';
 import type { AutoModeService } from './auto-mode-service.js';
-
-const execFileAsync = promisify(execFile);
 
 const logger = createLogger('FeatureHealth');
 
 export interface HealthIssue {
   type:
     | 'orphaned_epic_ref'
-    | 'merged_not_done'
     | 'epic_children_done'
     | 'stale_running'
     | 'stale_gate'
@@ -70,7 +68,6 @@ export class FeatureHealthService {
     issues.push(...this.checkEpicChildrenDone(features, featureMap));
     issues.push(...(await this.checkStaleRunning(features, projectPath)));
     issues.push(...this.checkStaleGates(features));
-    issues.push(...(await this.checkMergedNotDone(features, projectPath)));
 
     // Auto-fix if requested
     if (autoFix) {
@@ -274,128 +271,6 @@ export class FeatureHealthService {
   }
 
   /**
-   * Features with branches that are merged to main (or their epic branch) but not marked done.
-   * Uses execFileAsync with argument arrays to prevent command injection.
-   */
-  private async checkMergedNotDone(
-    features: Feature[],
-    projectPath: string
-  ): Promise<HealthIssue[]> {
-    const issues: HealthIssue[] = [];
-    const doneStatuses = new Set(['done', 'completed', 'verified', 'review']);
-
-    // Detect default branch (try main first, then master)
-    let defaultBranch = 'main';
-    try {
-      await execFileAsync('git', ['rev-parse', '--verify', 'main'], {
-        cwd: projectPath,
-        encoding: 'utf-8',
-        timeout: 5_000,
-      });
-    } catch {
-      try {
-        await execFileAsync('git', ['rev-parse', '--verify', 'master'], {
-          cwd: projectPath,
-          encoding: 'utf-8',
-          timeout: 5_000,
-        });
-        defaultBranch = 'master';
-      } catch {
-        // Neither main nor master exist, skip this check
-        return issues;
-      }
-    }
-
-    // Get list of branches merged into the default branch
-    let mergedBranches: Set<string>;
-    try {
-      const { stdout: output } = await execFileAsync('git', ['branch', '--merged', defaultBranch], {
-        cwd: projectPath,
-        encoding: 'utf-8',
-        timeout: 10_000,
-      });
-      mergedBranches = new Set(
-        output
-          .split('\n')
-          .map((line) => line.trim().replace(/^\*\s*/, ''))
-          .filter((b) => b && b !== 'main' && b !== 'master')
-      );
-    } catch {
-      // Git command failed, skip this check
-      return issues;
-    }
-
-    // Build a map of epic branches for checking child features
-    const epicBranchMap = new Map<string, string>();
-    for (const f of features) {
-      if (f.isEpic && f.branchName) {
-        epicBranchMap.set(f.id, f.branchName);
-      }
-    }
-
-    // Cache epic branch --merged results to avoid redundant git calls
-    const epicMergedCache = new Map<string, Set<string>>();
-
-    for (const feature of features) {
-      if (!feature.branchName) continue;
-      if (doneStatuses.has(feature.status ?? '')) continue;
-      if (feature.isEpic) continue; // Epics are handled separately
-
-      let isMerged = mergedBranches.has(feature.branchName);
-
-      // For features with an epicId, also check if branch is merged into the epic branch
-      if (!isMerged && feature.epicId) {
-        const epicBranch = epicBranchMap.get(feature.epicId);
-        if (epicBranch) {
-          let epicMergedBranches = epicMergedCache.get(epicBranch);
-          if (!epicMergedBranches) {
-            try {
-              const { stdout: epicMergedOutput } = await execFileAsync(
-                'git',
-                ['branch', '--merged', epicBranch],
-                {
-                  cwd: projectPath,
-                  encoding: 'utf-8',
-                  timeout: 5_000,
-                }
-              );
-              epicMergedBranches = new Set(
-                epicMergedOutput
-                  .split('\n')
-                  .map((line) => line.trim().replace(/^\*\s*/, ''))
-                  .filter((b) => b)
-              );
-              epicMergedCache.set(epicBranch, epicMergedBranches);
-            } catch {
-              // Epic branch check failed, cache empty set to avoid retrying
-              epicMergedBranches = new Set();
-              epicMergedCache.set(epicBranch, epicMergedBranches);
-            }
-          }
-          isMerged = epicMergedBranches.has(feature.branchName);
-        }
-      }
-
-      if (isMerged) {
-        const targetBranch =
-          feature.epicId && epicBranchMap.get(feature.epicId)
-            ? epicBranchMap.get(feature.epicId)!
-            : defaultBranch;
-        issues.push({
-          type: 'merged_not_done',
-          featureId: feature.id,
-          featureTitle: feature.title ?? feature.id,
-          message: `Branch '${feature.branchName}' is merged to ${targetBranch} but feature status is '${feature.status}'`,
-          autoFixable: true,
-          fix: 'Set status to done',
-        });
-      }
-    }
-
-    return issues;
-  }
-
-  /**
    * Apply an auto-fix for a given issue.
    */
   private async applyFix(
@@ -429,10 +304,6 @@ export class FeatureHealthService {
 
       case 'stale_gate':
         await this.featureLoader.update(projectPath, issue.featureId, { status: 'blocked' });
-        break;
-
-      case 'merged_not_done':
-        await this.featureLoader.update(projectPath, issue.featureId, { status: 'done' });
         break;
     }
   }

--- a/apps/server/src/services/maintenance-tasks.ts
+++ b/apps/server/src/services/maintenance-tasks.ts
@@ -754,7 +754,7 @@ async function checkMergedBranches(events: EventEmitter, projectPaths: string[])
 
 /**
  * Run board health audit with auto-fix enabled.
- * Finds and fixes: orphaned epic refs, dangling deps, completed epics, stale running, merged-not-done.
+ * Finds and fixes: orphaned epic refs, dangling deps, completed epics, stale running, stale gates.
  * Runs against all known project paths rather than relying on process.cwd().
  */
 async function runBoardHealthAudit(


### PR DESCRIPTION
## Summary

# feat(maintenance): Replace board-health merged-not-done poll with PR merge webhook hook

**Date:** 2026-02-28  
**Complexity:** medium  
**Epic:** Maintenance / Compensating Control Elimination  
**Labels:** `maintenance`, `webhooks`, `board-health`

---

## Situation

The `maintenance:board-health` cron task runs every 6 hours (`0 */6 * * *`) via `apps/server/src/services/maintenance-tasks.ts`. One of its six sub-checks — `checkMergedNotDone` in `apps/server/src/services/feature-health-servic...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of merged pull requests to prevent duplicate feature status updates
  * Removed the "merged_not_done" health check from feature health audits, streamlining the audit process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->