### PR TITLE
[linear] feat(maintenance): detect closed PRs linked to non-done features and recover automatically

### DIFF
--- a/apps/server/src/routes/webhooks/routes/github.ts
+++ b/apps/server/src/routes/webhooks/routes/github.ts
@@ -257,12 +257,55 @@ export function createGitHubWebhookHandler(events: EventEmitter, settingsService
         return;
       }
 
-      // Only handle merged PRs for pull_request events
-      if (payload.action !== 'closed' || !payload.pull_request.merged) {
-        logger.debug(
-          `Ignoring PR action: ${payload.action}, merged: ${payload.pull_request.merged}`
+      // Only handle closed pull_request events
+      if (payload.action !== 'closed') {
+        logger.debug(`Ignoring PR action: ${payload.action}`);
+        res.json({ success: true, message: 'Not a close event' });
+        return;
+      }
+
+      // PR closed WITHOUT merging — find linked feature and recover to backlog
+      if (!payload.pull_request.merged) {
+        const closedPrNumber = payload.pull_request.number;
+        const closedProject = settings.projects.find((p) => p.id === settings.currentProjectId);
+        const closedProjectPath = closedProject?.path || process.cwd();
+
+        const closedFeature = await featureLoader.findByPRNumber(closedProjectPath, closedPrNumber);
+
+        if (!closedFeature) {
+          logger.debug(`No feature found for closed PR #${closedPrNumber}`);
+          res.json({ success: true, message: 'No feature linked to this PR' });
+          return;
+        }
+
+        if (closedFeature.status !== 'review') {
+          logger.debug(
+            `Feature ${closedFeature.id} is not in review (status=${closedFeature.status}), skipping recovery`
+          );
+          res.json({ success: true, message: 'Feature not in review, no recovery needed' });
+          return;
+        }
+
+        logger.info(
+          `PR #${closedPrNumber} closed without merging — recovering feature ${closedFeature.id} to backlog`
         );
-        res.json({ success: true, message: 'PR not merged' });
+
+        await featureLoader.update(closedProjectPath, closedFeature.id, {
+          status: 'backlog',
+          statusChangeReason: `PR #${closedPrNumber} closed without merging — auto-recovering to backlog`,
+          prNumber: undefined,
+          prUrl: undefined,
+          reviewStartedAt: undefined,
+        });
+
+        events.emit('feature:pr-closed-unmerged', {
+          featureId: closedFeature.id,
+          projectPath: closedProjectPath,
+          prNumber: closedPrNumber,
+          prUrl: closedFeature.prUrl,
+        });
+
+        res.json({ success: true, message: `Feature ${closedFeature.id} recovered to backlog` });
         return;
       }
 

--- a/apps/server/src/services/feature-health-service.ts
+++ b/apps/server/src/services/feature-health-service.ts
@@ -29,7 +29,8 @@ export interface HealthIssue {
     | 'epic_children_done'
     | 'stale_running'
     | 'stale_gate'
-    | 'dangling_dependency';
+    | 'dangling_dependency'
+    | 'closed_pr_in_review';
   featureId: string;
   featureTitle: string;
   message: string;
@@ -71,6 +72,7 @@ export class FeatureHealthService {
     issues.push(...(await this.checkStaleRunning(features, projectPath)));
     issues.push(...this.checkStaleGates(features));
     issues.push(...(await this.checkMergedNotDone(features, projectPath)));
+    issues.push(...(await this.checkClosedPRsInReview(features)));
 
     // Auto-fix if requested
     if (autoFix) {
@@ -434,6 +436,58 @@ export class FeatureHealthService {
       case 'merged_not_done':
         await this.featureLoader.update(projectPath, issue.featureId, { status: 'done' });
         break;
+
+      case 'closed_pr_in_review': {
+        const feature = featureMap.get(issue.featureId);
+        await this.featureLoader.update(projectPath, issue.featureId, {
+          status: 'backlog',
+          statusChangeReason: `PR closed without merging (detected by board health audit) — auto-recovering to backlog`,
+          prNumber: undefined,
+          prUrl: undefined,
+          reviewStartedAt: undefined,
+        });
+        logger.info(
+          `Auto-fixed closed_pr_in_review: feature ${issue.featureId} recovered to backlog (was PR #${feature?.prNumber})`
+        );
+        break;
+      }
     }
+  }
+
+  /**
+   * Features in 'review' status whose linked PR has been closed without merging.
+   * Compensating control for missed webhooks (runs on 6-hour board health cycle).
+   */
+  private async checkClosedPRsInReview(features: Feature[]): Promise<HealthIssue[]> {
+    const issues: HealthIssue[] = [];
+    const reviewFeatures = features.filter((f) => f.status === 'review' && f.prNumber != null);
+
+    for (const feature of reviewFeatures) {
+      const prNumber = feature.prNumber!;
+      try {
+        const { stdout } = await execFileAsync(
+          'gh',
+          ['pr', 'view', String(prNumber), '--json', 'state,merged'],
+          { encoding: 'utf-8', timeout: 10_000 }
+        );
+        const prData = JSON.parse(stdout) as { state: string; merged: boolean };
+
+        if (prData.state === 'CLOSED' && !prData.merged) {
+          issues.push({
+            type: 'closed_pr_in_review',
+            featureId: feature.id,
+            featureTitle: feature.title ?? feature.id,
+            message: `PR #${prNumber} is closed without merging but feature status is 'review'`,
+            autoFixable: true,
+            fix: 'Reset status to backlog and clear PR fields',
+          });
+        }
+      } catch {
+        // gh CLI not available, PR not found, or network error — skip
+        logger.debug(`Skipping closed PR check for feature ${feature.id} PR #${prNumber}`);
+      }
+    }
+
+    return issues;
   }
 }

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -29,6 +29,7 @@ export type EventType =
   | 'feature:retry'
   | 'feature:recovery'
   | 'feature:pr-merged'
+  | 'feature:pr-closed-unmerged'
   | 'feature:verify-pending'
   | 'feature:blocked'
   | 'feature:unblocked'
@@ -537,6 +538,12 @@ export interface EventPayloadMap {
     featureTitle?: string;
     prNumber?: number;
     projectPath?: string;
+  };
+  'feature:pr-closed-unmerged': {
+    featureId: string;
+    projectPath: string;
+    prNumber: number;
+    prUrl?: string;
   };
   'feature:verify-pending': {
     featureId: string;


### PR DESCRIPTION
## Summary

# SPARC PRD: Detect Closed PRs Linked to Non-Done Features and Auto-Recover

**Feature ID:** feat/maintenance-closed-pr-recovery  
**Date:** 2026-02-28  
**Complexity:** Medium  
**Target Branch:** dev

---

## Situation

Automaker manages features through a lifecycle that includes a `review` status, representing features whose pull requests are open and awaiting merge. The GitHub webhook handler at `apps/server/src/routes/webhooks/routes/github.ts` currently handles two webhook scenarios:

- **...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health checks to detect closed pull requests that weren't merged, enabling automatic recovery workflows.
  * Improved pull request lifecycle handling to support both merged and unmerged closure events.

* **Bug Fixes**
  * Features in review status now automatically recover to backlog when their associated pull request is closed without merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->