### PR TITLE
createLangChainModel() adapter in libs/llm-providers

### DIFF
--- a/libs/llm-providers/package.json
+++ b/libs/llm-providers/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@protolabs-ai/llm-providers",
+  "version": "0.15.3",
+  "type": "module",
+  "description": "LangChain adapter for the protoLabs provider system",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "watch": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "build:check": "tsc --noEmit"
+  },
+  "keywords": [
+    "automaker",
+    "langchain",
+    "providers",
+    "llm"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "AutoMaker Team",
+  "license": "SEE LICENSE IN LICENSE",
+  "engines": {
+    "node": ">=22.0.0 <23.0.0"
+  },
+  "peerDependencies": {
+    "@langchain/core": ">=0.3.0"
+  },
+  "dependencies": {
+    "@langchain/anthropic": "^0.3.10",
+    "@protolabs-ai/types": "^0.15.3"
+  },
+  "devDependencies": {
+    "@langchain/core": "^0.3.33",
+    "@types/node": "22.19.3",
+    "tsup": "^8.5.1",
+    "typescript": "5.9.3",
+    "vitest": "4.0.16"
+  }
+}

--- a/libs/llm-providers/src/index.ts
+++ b/libs/llm-providers/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @protolabs-ai/llm-providers
+ *
+ * LangChain adapter for the protoLabs provider system.
+ * Provides createLangChainModel() to map PhaseModelEntry to BaseChatModel.
+ */
+
+export { createLangChainModel, ProviderFactory } from './langchain-adapter.js';
+export type { AdapterOptions } from './langchain-adapter.js';

--- a/libs/llm-providers/src/langchain-adapter.ts
+++ b/libs/llm-providers/src/langchain-adapter.ts
@@ -1,0 +1,74 @@
+/**
+ * LangChain adapter for the protoLabs provider system.
+ *
+ * Provides createLangChainModel() which maps a PhaseModelEntry to the
+ * appropriate LangChain BaseChatModel by routing through ProviderFactory.
+ */
+
+import type { PhaseModelEntry } from '@protolabs-ai/types';
+import { isClaudeModel } from '@protolabs-ai/types';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { ChatAnthropic } from '@langchain/anthropic';
+
+/**
+ * Options for the LangChain adapter.
+ */
+export interface AdapterOptions {
+  /** Sampling temperature (default: 0) */
+  temperature?: number;
+  /** Enable streaming (default: true) */
+  streaming?: boolean;
+  /** Maximum tokens in response */
+  maxTokens?: number;
+}
+
+/**
+ * Internal factory that maps a PhaseModelEntry to the correct LangChain model class.
+ * Mirrors the routing logic of the server-side ProviderFactory but returns
+ * LangChain BaseChatModel instances instead of BaseProvider instances.
+ */
+export class ProviderFactory {
+  /**
+   * Returns a LangChain BaseChatModel for the given model entry.
+   *
+   * @param entry - Model configuration including model ID and optional provider/thinking settings
+   * @param options - Adapter options (temperature, streaming, maxTokens)
+   * @returns A LangChain-compatible BaseChatModel
+   * @throws Error if the model ID is not supported by any registered LangChain provider
+   */
+  static getProviderForModel(entry: PhaseModelEntry, options?: AdapterOptions): BaseChatModel {
+    const { model } = entry;
+
+    if (isClaudeModel(model)) {
+      return new ChatAnthropic({
+        model,
+        temperature: options?.temperature ?? 0,
+        streaming: options?.streaming ?? true,
+        ...(options?.maxTokens !== undefined && { maxTokens: options.maxTokens }),
+      });
+    }
+
+    throw new Error(
+      `Unsupported model: "${model}". No LangChain adapter is available for this provider. ` +
+        `Supported providers: claude (claude-*, sonnet, haiku, opus).`
+    );
+  }
+}
+
+/**
+ * Creates a LangChain-compatible BaseChatModel for the given model configuration.
+ *
+ * Routes through ProviderFactory to select the appropriate LangChain model class
+ * based on the model ID in the PhaseModelEntry.
+ *
+ * @param entry - Model configuration (model ID, optional providerId, thinkingLevel)
+ * @param options - Adapter options (temperature, streaming, maxTokens)
+ * @returns A LangChain BaseChatModel with invoke, stream, and tool_call support
+ *
+ * @example
+ * const model = createLangChainModel({ model: 'claude-sonnet-4-6' });
+ * const response = await model.invoke([{ role: 'user', content: 'Hello' }]);
+ */
+export function createLangChainModel(entry: PhaseModelEntry, options?: AdapterOptions): BaseChatModel {
+  return ProviderFactory.getProviderForModel(entry, options);
+}

--- a/libs/llm-providers/tests/langchain-adapter.test.ts
+++ b/libs/llm-providers/tests/langchain-adapter.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Use vi.hoisted so the spy is available inside vi.mock (which is hoisted)
+const mocks = vi.hoisted(() => ({
+  chatAnthropicSpy: vi.fn(),
+}));
+
+// Mock @langchain/anthropic to avoid requiring ANTHROPIC_API_KEY in unit tests
+vi.mock('@langchain/anthropic', () => ({
+  ChatAnthropic: class MockChatAnthropic {
+    _options: unknown;
+    constructor(options: unknown) {
+      mocks.chatAnthropicSpy(options);
+      this._options = options;
+    }
+  },
+}));
+
+import { createLangChainModel, ProviderFactory } from '../src/langchain-adapter.js';
+
+describe('createLangChainModel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('adapter returns correct model instance', () => {
+    it('returns an object for claude-sonnet model', () => {
+      const model = createLangChainModel({ model: 'claude-sonnet-4-6' });
+      expect(model).toBeDefined();
+      expect(mocks.chatAnthropicSpy).toHaveBeenCalledOnce();
+      expect(mocks.chatAnthropicSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'claude-sonnet-4-6' })
+      );
+    });
+
+    it('returns an object for claude-haiku model', () => {
+      const model = createLangChainModel({ model: 'claude-haiku-4-5-20251001' });
+      expect(model).toBeDefined();
+      expect(mocks.chatAnthropicSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'claude-haiku-4-5-20251001' })
+      );
+    });
+
+    it('returns an object for claude-opus model', () => {
+      const model = createLangChainModel({ model: 'claude-opus-4-6' });
+      expect(model).toBeDefined();
+      expect(mocks.chatAnthropicSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'claude-opus-4-6' })
+      );
+    });
+
+    it('passes adapter options to the model constructor', () => {
+      createLangChainModel({ model: 'claude-sonnet-4-6' }, {
+        temperature: 0.7,
+        streaming: false,
+        maxTokens: 1024,
+      });
+      expect(mocks.chatAnthropicSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'claude-sonnet-4-6',
+          temperature: 0.7,
+          streaming: false,
+          maxTokens: 1024,
+        })
+      );
+    });
+
+    it('uses default temperature 0 and streaming true when no options provided', () => {
+      createLangChainModel({ model: 'claude-sonnet-4-6' });
+      expect(mocks.chatAnthropicSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          temperature: 0,
+          streaming: true,
+        })
+      );
+    });
+  });
+
+  describe('routes to correct provider', () => {
+    it('routes claude models through ProviderFactory.getProviderForModel', () => {
+      const spy = vi.spyOn(ProviderFactory, 'getProviderForModel');
+      const entry = { model: 'claude-sonnet-4-6' } as const;
+
+      createLangChainModel(entry);
+
+      expect(spy).toHaveBeenCalledOnce();
+      expect(spy).toHaveBeenCalledWith(entry, undefined);
+      expect(mocks.chatAnthropicSpy).toHaveBeenCalledOnce();
+    });
+
+    it('passes options through ProviderFactory.getProviderForModel', () => {
+      const spy = vi.spyOn(ProviderFactory, 'getProviderForModel');
+      const entry = { model: 'claude-sonnet-4-6' } as const;
+      const options = { temperature: 0.5 };
+
+      createLangChainModel(entry, options);
+
+      expect(spy).toHaveBeenCalledWith(entry, options);
+    });
+  });
+
+  describe('throws on unknown model', () => {
+    it('throws for an unrecognized model ID', () => {
+      expect(() => createLangChainModel({ model: 'unknown-model-xyz' as never })).toThrow(
+        /Unsupported model: "unknown-model-xyz"/
+      );
+    });
+
+    it('throws for a cursor model (not yet supported in LangChain adapter)', () => {
+      expect(() => createLangChainModel({ model: 'cursor-auto' as never })).toThrow(
+        /Unsupported model/
+      );
+    });
+
+    it('throws for a groq model (not yet supported in LangChain adapter)', () => {
+      expect(() => createLangChainModel({ model: 'groq/llama3' as never })).toThrow(
+        /Unsupported model/
+      );
+    });
+  });
+});

--- a/libs/llm-providers/tsconfig.json
+++ b/libs/llm-providers/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/libs/llm-providers/tsup.config.ts
+++ b/libs/llm-providers/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: {
+    resolve: true,
+  },
+  clean: true,
+  sourcemap: true,
+  treeshake: true,
+  external: [/^@langchain\//, /^@automaker\//],
+});

--- a/libs/llm-providers/vitest.config.ts
+++ b/libs/llm-providers/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'llm-providers',
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.d.ts', 'src/index.ts'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

**Milestone:** Provider–LangGraph Bridge

Add a createLangChainModel(entry: PhaseModelEntry, options?: AdapterOptions) function to libs/llm-providers/src/ that returns a BaseChatModel. Internally calls ProviderFactory.getProviderForModel() and wraps the result in a LangChain-compatible BaseChatModel adapter (streaming, tool_call, invoke support). Export from libs/llm-providers/src/index.ts. Add the langchain/core peer dependency if not already present. Write unit tests: adapter returns correct m...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced new LangChain adapter package enabling Claude model integration with configurable temperature, streaming, and token limit options.
  * Support for multiple Claude model variants (Sonnet, Haiku, Opus).

* **Tests**
  * Added comprehensive test suite validating model instantiation, option propagation, and error handling for unsupported models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->