### PR TITLE
fix(infra): add dumb-init PID 1, right-size resources, fix subprocess exit race

### DIFF
--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,7 +5,7 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 238
+  loaded: 240
   referenced: 74
   successfulFeatures: 74
 ---

--- a/.automaker/memory/content-pipeline-validation.md
+++ b/.automaker/memory/content-pipeline-validation.md
@@ -5,7 +5,7 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 57
+  loaded: 58
   referenced: 3
   successfulFeatures: 3
 ---

--- a/.automaker/memory/documentation.md
+++ b/.automaker/memory/documentation.md
@@ -5,7 +5,7 @@ relevantTo: [documentation]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 93
+  loaded: 94
   referenced: 35
   successfulFeatures: 35
 ---

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,7 +5,7 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 656
+  loaded: 659
   referenced: 237
   successfulFeatures: 237
 ---

--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -5,7 +5,7 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 123
+  loaded: 125
   referenced: 23
   successfulFeatures: 23
 ---

--- a/.automaker/memory/monitoring.md
+++ b/.automaker/memory/monitoring.md
@@ -5,7 +5,7 @@ relevantTo: [monitoring]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 12
+  loaded: 13
   referenced: 2
   successfulFeatures: 2
 ---

--- a/.automaker/memory/pattern.md
+++ b/.automaker/memory/pattern.md
@@ -5,7 +5,7 @@ relevantTo: [pattern]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 125
+  loaded: 126
   referenced: 40
   successfulFeatures: 40
 ---

--- a/.automaker/memory/reliability.md
+++ b/.automaker/memory/reliability.md
@@ -5,7 +5,7 @@ relevantTo: [reliability]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 9
+  loaded: 10
   referenced: 3
   successfulFeatures: 3
 ---

--- a/.automaker/memory/testing.md
+++ b/.automaker/memory/testing.md
@@ -5,7 +5,7 @@ relevantTo: [testing]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 61
+  loaded: 62
   referenced: 25
   successfulFeatures: 25
 ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ ARG GID=1001
 # Install git, curl, bash (for terminal), gosu (for user switching), and GitHub CLI (pinned version, multi-arch)
 # Also install Playwright/Chromium system dependencies (aligns with playwright install-deps on Debian/Ubuntu)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git curl bash gosu ca-certificates openssh-client \
+    git curl bash gosu ca-certificates openssh-client dumb-init \
     # Playwright/Chromium dependencies
     libglib2.0-0 libnss3 libnspr4 libdbus-1-3 libatk1.0-0 libatk-bridge2.0-0 \
     libcups2 libdrm2 libxkbcommon0 libatspi2.0-0 libxcomposite1 libxdamage1 \
@@ -194,7 +194,7 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:3008/api/health || exit 1
 
 # Use entrypoint to fix permissions before starting
-ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/local/bin/docker-entrypoint.sh"]
 
 # Start server
 CMD ["node", "apps/server/dist/index.js"]

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -103,10 +103,10 @@ services:
       - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:3007}
 
       # Agent concurrency limit (system hard cap)
-      - AUTOMAKER_MAX_CONCURRENCY=${AUTOMAKER_MAX_CONCURRENCY:-8}
+      - AUTOMAKER_MAX_CONCURRENCY=${AUTOMAKER_MAX_CONCURRENCY:-6}
 
       # Node.js memory tuning for high-concurrency agent execution
-      - NODE_OPTIONS=--max-old-space-size=${NODE_MAX_OLD_SPACE:-32768}
+      - NODE_OPTIONS=--max-old-space-size=${NODE_MAX_OLD_SPACE:-4096} --max-semi-space-size=128
 
     volumes:
       # Persistent data
@@ -124,8 +124,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '${CPU_LIMIT:-8}'
-          memory: ${MEMORY_LIMIT:-48G}
+          cpus: '${CPU_LIMIT:-6}'
+          memory: ${MEMORY_LIMIT:-32G}
         reservations:
           cpus: '2'
           memory: 8G

--- a/libs/platform/src/subprocess.ts
+++ b/libs/platform/src/subprocess.ts
@@ -136,6 +136,20 @@ export async function* spawnJSONLProcess(options: SubprocessOptions): AsyncGener
     }
   };
 
+  // Pre-register exit promise to prevent race where process exits between
+  // stdout close and listener registration.
+  const exitPromise = new Promise<number | null>((resolve) => {
+    childProcess.on('exit', (code) => {
+      console.log(`[SubprocessManager] Process exited with code: ${code}`);
+      resolve(code);
+    });
+
+    childProcess.on('error', (error) => {
+      console.error('[SubprocessManager] Process error:', error);
+      resolve(null);
+    });
+  });
+
   // Parse stdout as JSONL (one JSON object per line)
   if (childProcess.stdout) {
     const rl = readline.createInterface({
@@ -176,18 +190,8 @@ export async function* spawnJSONLProcess(options: SubprocessOptions): AsyncGener
     cleanupAbortListener();
   }
 
-  // Wait for process to exit
-  const exitCode = await new Promise<number | null>((resolve) => {
-    childProcess.on('exit', (code) => {
-      console.log(`[SubprocessManager] Process exited with code: ${code}`);
-      resolve(code);
-    });
-
-    childProcess.on('error', (error) => {
-      console.error('[SubprocessManager] Process error:', error);
-      resolve(null);
-    });
-  });
+  // Wait for process to exit (promise was pre-registered before readline to avoid race)
+  const exitCode = await exitPromise;
 
   // Handle non-zero exit codes
   if (exitCode !== 0 && exitCode !== null) {


### PR DESCRIPTION
## Summary
- **Dockerfile**: installs `dumb-init` and wraps `ENTRYPOINT` so it runs as PID 1 — reaps all orphaned child processes (git, esbuild, bash) from agent subprocesses, eliminating the 57-zombie accumulation pattern
- **docker-compose.staging.yml**: heap cap 32768→4096 MB (GC instead of OOM kill), adds `--max-semi-space-size=128`, concurrency 8→6, CPU limit 8→6, memory limit 48G→32G — all overridable via env vars
- **libs/platform/src/subprocess.ts**: pre-registers `exitPromise` before the readline `for await` loop so the `'exit'` event cannot fire unobserved in the window between stdout close and listener registration

## Test plan
- [ ] CI passes (build + typecheck + server tests — all passed locally)
- [ ] After deploy: `docker exec automaker-server ps aux | grep -c 'Z'` → 0
- [ ] `docker stats automaker-server --no-stream` → server heap under 4 GB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential race condition in process exit handling to ensure deterministic cleanup and prevent resource leaks.

* **Chores**
  * Enhanced container stability through improved signal handling and graceful process cleanup mechanisms.
  * Optimized staging environment resource allocation, including memory configuration and concurrency limit adjustments for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->