### PR TITLE
promote: dev -> staging

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -30,9 +30,9 @@ CURSOR_AUTH_TOKEN=
 # OPTIONAL - Security
 # ============================================
 
-# API key for authenticating requests (leave empty to disable auth)
-# If set, all API requests must include X-API-Key header
-AUTOMAKER_API_KEY=
+# API key for authenticating requests (default: protoLabs_studio_key)
+# Override for production/Docker deployments
+# AUTOMAKER_API_KEY=your-secure-key
 
 # Root directory for projects and file operations
 # If set, users can only create/open projects and files within this directory

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -5,7 +5,7 @@
  * 1. Header-based (X-API-Key) - Used by Electron mode
  * 2. Cookie-based (HTTP-only session cookie) - Used by web mode
  *
- * Auto-generates an API key on first run if none is configured.
+ * Uses a known default key (override via AUTOMAKER_API_KEY env var).
  */
 
 import type { Request, Response, NextFunction } from 'express';
@@ -17,7 +17,7 @@ import { createLogger } from '@protolabs-ai/utils';
 const logger = createLogger('Auth');
 
 const DATA_DIR = process.env.DATA_DIR || './data';
-const API_KEY_FILE = path.join(DATA_DIR, '.api-key');
+const DEFAULT_API_KEY = 'protoLabs_studio_key';
 const SESSIONS_FILE = path.join(DATA_DIR, '.sessions');
 const SESSION_COOKIE_NAME = 'automaker_session';
 const SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -109,96 +109,10 @@ async function saveSessions(): Promise<void> {
 // Load existing sessions on startup
 loadSessions();
 
-/**
- * Ensure an API key exists - either from env var, file, or generate new one.
- * This provides CSRF protection by requiring a secret key for all API requests.
- */
-function ensureApiKey(): string {
-  // First check environment variable (Electron passes it this way)
-  if (process.env.AUTOMAKER_API_KEY) {
-    logger.info('Using API key from environment variable');
-    return process.env.AUTOMAKER_API_KEY;
-  }
+// API key — env override or default. Electron passes AUTOMAKER_API_KEY at launch.
+const API_KEY = process.env.AUTOMAKER_API_KEY || DEFAULT_API_KEY;
 
-  // Try to read from file
-  try {
-    if (secureFs.existsSync(API_KEY_FILE)) {
-      const key = (secureFs.readFileSync(API_KEY_FILE, 'utf-8') as string).trim();
-      if (key) {
-        logger.info('Loaded API key from file');
-        return key;
-      }
-    }
-  } catch (error) {
-    logger.warn('Error reading API key file:', error);
-  }
-
-  // Generate new key
-  const newKey = crypto.randomUUID();
-  try {
-    secureFs.mkdirSync(path.dirname(API_KEY_FILE), { recursive: true });
-    secureFs.writeFileSync(API_KEY_FILE, newKey, { encoding: 'utf-8', mode: 0o600 });
-    logger.info('Generated new API key');
-  } catch (error) {
-    logger.error('Failed to save API key:', error);
-  }
-  return newKey;
-}
-
-// API key - always generated/loaded on startup for CSRF protection
-const API_KEY = ensureApiKey();
-
-// Width for log box content (excluding borders)
-const BOX_CONTENT_WIDTH = 67;
-
-// Mask API key for safe logging (show first 4 + last 4 chars)
-function maskApiKey(key: string): string {
-  if (key.length <= 8) return '****';
-  return `${key.slice(0, 4)}${'*'.repeat(key.length - 8)}${key.slice(-4)}`;
-}
-
-// Print API key info to console (masked by default, full key only with AUTOMAKER_SHOW_API_KEY=true)
-{
-  const showFullKey = isEnvTrue(process.env.AUTOMAKER_SHOW_API_KEY);
-  const displayKey = showFullKey ? API_KEY : maskApiKey(API_KEY);
-  const autoLoginEnabled = isEnvTrue(process.env.AUTOMAKER_AUTO_LOGIN);
-  const autoLoginStatus = autoLoginEnabled ? 'enabled (auto-login active)' : 'disabled';
-
-  // Build box lines with exact padding
-  const header = 'API Key for Web Mode Authentication'.padEnd(BOX_CONTENT_WIDTH);
-  const line1 = "When accessing via browser, you'll be prompted to enter this key:".padEnd(
-    BOX_CONTENT_WIDTH
-  );
-  const line2 = displayKey.padEnd(BOX_CONTENT_WIDTH);
-  const line3 = 'In Electron mode, authentication is handled automatically.'.padEnd(
-    BOX_CONTENT_WIDTH
-  );
-  const line4 = `Auto-login (AUTOMAKER_AUTO_LOGIN): ${autoLoginStatus}`.padEnd(BOX_CONTENT_WIDTH);
-  const tipHeader = 'Tips'.padEnd(BOX_CONTENT_WIDTH);
-  const line5 = 'Set AUTOMAKER_SHOW_API_KEY=true to reveal the full key'.padEnd(BOX_CONTENT_WIDTH);
-  const line6 = 'Set AUTOMAKER_AUTO_LOGIN=true to skip the login prompt'.padEnd(BOX_CONTENT_WIDTH);
-
-  logger.info(`
-╔═════════════════════════════════════════════════════════════════════╗
-║  ${header}║
-╠═════════════════════════════════════════════════════════════════════╣
-║                                                                     ║
-║  ${line1}║
-║                                                                     ║
-║  ${line2}║
-║                                                                     ║
-║  ${line3}║
-║                                                                     ║
-║  ${line4}║
-║                                                                     ║
-╠═════════════════════════════════════════════════════════════════════╣
-║  ${tipHeader}║
-╠═════════════════════════════════════════════════════════════════════╣
-║  ${line5}║
-║  ${line6}║
-╚═════════════════════════════════════════════════════════════════════╝
-`);
-}
+logger.info(`API key: ${API_KEY}${process.env.AUTOMAKER_API_KEY ? ' (from env)' : ' (default)'}`);
 
 /**
  * Generate a cryptographically secure session token

--- a/apps/server/src/routes/health/routes/ready.ts
+++ b/apps/server/src/routes/health/routes/ready.ts
@@ -55,19 +55,10 @@ function checkDataDir(): { accessible: boolean; writable: boolean; error?: strin
  * Check if API key is configured
  */
 function checkApiKey(): { configured: boolean; source?: string } {
-  // Check environment variable
   if (process.env.AUTOMAKER_API_KEY) {
     return { configured: true, source: 'environment' };
   }
-
-  // Check file
-  const dataDir = process.env.DATA_DIR || './data';
-  const apiKeyFile = path.join(dataDir, '.api-key');
-  if (existsSync(apiKeyFile)) {
-    return { configured: true, source: 'file' };
-  }
-
-  return { configured: false };
+  return { configured: true, source: 'default' };
 }
 
 export function createReadyHandler() {

--- a/apps/server/tests/unit/lib/auth.test.ts
+++ b/apps/server/tests/unit/lib/auth.test.ts
@@ -11,7 +11,7 @@ describe('auth.ts', () => {
   beforeEach(() => {
     vi.resetModules();
     delete process.env.AUTOMAKER_API_KEY;
-    delete process.env.AUTOMAKER_SHOW_API_KEY;
+
     delete process.env.NODE_ENV;
   });
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -58,25 +58,25 @@ Features: gradient ASCII art, pre-flight dependency checks, remembers your last 
 
 protoLabs integrates with your authenticated Claude Code CLI. Install and authenticate following the [official quickstart](https://code.claude.com/docs/en/quickstart), then protoLabs detects your credentials automatically.
 
-### Fixed API Key (Development)
+### API Key
 
-By default, the server generates a random API key on each restart. For MCP integration or scripts, use a fixed key:
+The server uses `protoLabs_studio_key` as the default API key. To override, set the env var:
 
 ```bash
-AUTOMAKER_API_KEY=your-dev-key npm run dev --workspace=apps/server
+AUTOMAKER_API_KEY=your-custom-key npm run dev --workspace=apps/server
 ```
 
 ## Environment Variables
 
 ### Server
 
-| Variable            | Default     | Description                   |
-| ------------------- | ----------- | ----------------------------- |
-| `PORT`              | `3008`      | Server port                   |
-| `HOST`              | `0.0.0.0`   | Host to bind to               |
-| `HOSTNAME`          | `localhost` | Hostname for user-facing URLs |
-| `DATA_DIR`          | `./data`    | Data storage directory        |
-| `AUTOMAKER_API_KEY` | _(random)_  | Fixed API key for server auth |
+| Variable            | Default                | Description                   |
+| ------------------- | ---------------------- | ----------------------------- |
+| `PORT`              | `3008`                 | Server port                   |
+| `HOST`              | `0.0.0.0`              | Host to bind to               |
+| `HOSTNAME`          | `localhost`            | Hostname for user-facing URLs |
+| `DATA_DIR`          | `./data`               | Data storage directory        |
+| `AUTOMAKER_API_KEY` | `protoLabs_studio_key` | API key for server auth       |
 
 ### Security
 

--- a/docs/infra/deployment.md
+++ b/docs/infra/deployment.md
@@ -257,13 +257,13 @@ sudo systemctl disable automaker
 
 ### Authentication
 
-| Variable                   | Required | Description                                 |
-| -------------------------- | -------- | ------------------------------------------- |
-| `ANTHROPIC_API_KEY`        | Yes\*    | Anthropic API key                           |
-| `CLAUDE_OAUTH_CREDENTIALS` | Yes\*    | Claude CLI OAuth JSON                       |
-| `AUTOMAKER_API_KEY`        | No       | protoLabs API key (auto-generated if blank) |
-| `CURSOR_AUTH_TOKEN`        | No       | Cursor CLI OAuth token                      |
-| `GH_TOKEN`                 | No       | GitHub CLI token                            |
+| Variable                   | Required | Description                                         |
+| -------------------------- | -------- | --------------------------------------------------- |
+| `ANTHROPIC_API_KEY`        | Yes\*    | Anthropic API key                                   |
+| `CLAUDE_OAUTH_CREDENTIALS` | Yes\*    | Claude CLI OAuth JSON                               |
+| `AUTOMAKER_API_KEY`        | No       | protoLabs API key (default: `protoLabs_studio_key`) |
+| `CURSOR_AUTH_TOKEN`        | No       | Cursor CLI OAuth token                              |
+| `GH_TOKEN`                 | No       | GitHub CLI token                                    |
 
 \*At least one of `ANTHROPIC_API_KEY` or `CLAUDE_OAUTH_CREDENTIALS` is required.
 
@@ -280,12 +280,11 @@ sudo systemctl disable automaker
 
 ### Feature Flags
 
-| Variable                 | Default | Description                                           |
-| ------------------------ | ------- | ----------------------------------------------------- |
-| `IS_CONTAINERIZED`       | `false` | Skip sandbox confirmation dialogs                     |
-| `AUTOMAKER_MOCK_AGENT`   | `false` | Use mock agent (for testing)                          |
-| `AUTOMAKER_AUTO_LOGIN`   | `false` | Skip login prompt (dev only)                          |
-| `AUTOMAKER_SHOW_API_KEY` | `false` | Show full API key in startup logs (masked by default) |
+| Variable               | Default | Description                       |
+| ---------------------- | ------- | --------------------------------- |
+| `IS_CONTAINERIZED`     | `false` | Skip sandbox confirmation dialogs |
+| `AUTOMAKER_MOCK_AGENT` | `false` | Use mock agent (for testing)      |
+| `AUTOMAKER_AUTO_LOGIN` | `false` | Skip login prompt (dev only)      |
 
 ### Integrations
 

--- a/docs/integrations/claude-plugin.md
+++ b/docs/integrations/claude-plugin.md
@@ -116,19 +116,12 @@ The plugin consists of:
 - Claude Code CLI installed and authenticated
 - Node.js 22+
 
-### Step 1: Start protoLabs with a Fixed API Key
+### Step 1: Start protoLabs
 
-By default, protoLabs generates a random API key on each restart. For Claude Code integration, use a fixed key:
-
-```bash
-# Start protoLabs with a fixed API key
-AUTOMAKER_API_KEY=your-dev-key-2026 npm run dev
-```
-
-Or add it to your `.env` file:
+The server uses `protoLabs_studio_key` as the default API key. To override, set it in your `.env` or shell:
 
 ```bash
-AUTOMAKER_API_KEY=your-dev-key-2026
+AUTOMAKER_API_KEY=your-custom-key npm run dev
 ```
 
 ### Step 2: Build the MCP Server (if not already built)


### PR DESCRIPTION
## Summary
- fix(auth): use default API key (`protoLabs_studio_key`) instead of random generation

Hotfix promotion for v0.18.1.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ALLOWED_ROOT_DIRECTORY` configuration option for directory access control.

* **Improvements**
  * Simplified API key management with a sensible default value, eliminating file-based persistence.
  * Enhanced documentation for installation, deployment, and plugin configuration with clearer setup instructions.

* **Documentation**
  * Updated environment variable references and configuration guides across multiple deployment and integration docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->