### PR TITLE
Update all existing flows to use createLangChainModel()

### DIFF
--- a/libs/flows/src/content/content-creation-flow.ts
+++ b/libs/flows/src/content/content-creation-flow.ts
@@ -1396,7 +1396,7 @@ export function createContentCreationFlow(options?: ContentCreationFlowOptions) 
   // When HITL is enabled, compile with checkpointer + interruptBefore so the
   // graph can pause and resume at HITL gate nodes.
   // NOTE: HITL mode requires models to be removed from state before checkpointing
-  // works fully (ChatAnthropic instances aren't serializable by MemorySaver).
+  // works fully (LangChain model instances aren't serializable by MemorySaver).
   if (enableHITL) {
     const checkpointer = new MemorySaver();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1408,6 +1408,6 @@ export function createContentCreationFlow(options?: ContentCreationFlowOptions) 
 
   // Autonomous mode: no checkpointer needed since the flow runs end-to-end
   // without interrupts. Avoids MemorySaver serialization issues with
-  // non-serializable ChatAnthropic model instances in state.
+  // non-serializable LangChain model instances in state.
   return graph.compile();
 }

--- a/libs/flows/src/project-planning/executors/llm-executors.ts
+++ b/libs/flows/src/project-planning/executors/llm-executors.ts
@@ -9,7 +9,7 @@
  *   4. Return the typed result
  *
  * Usage (server-side):
- *   const model = new ChatAnthropic({ model: 'claude-sonnet-4-5-20250929' });
+ *   const model = createLangChainModel({ model: 'claude-sonnet' });
  *   const flow = createProjectPlanningFlow({
  *     researchExecutor: createLLMResearchExecutor(model),
  *     planningDocGenerator: createLLMPlanningDocGenerator(model),


### PR DESCRIPTION
## Summary

**Milestone:** Provider–LangGraph Bridge

Replace all hardcoded ChatAnthropic({ model: '...' }) and ChatOpenAI instantiations in libs/flows/src/ with createLangChainModel(). Affected files: content-creation-flow.ts, project-planning/executors/llm-executors.ts, antagonistic-review/graph.ts, coordinator-flow.ts, and any other flow files. Model strings become PhaseModelEntry objects (start with { model: 'claude-sonnet' } equivalents). Run npm run build:packages and npm run test:packages to verify n...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code documentation and usage examples to reflect current model integration practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->