### PR TITLE
fix(board): show all features on main worktree when worktrees are loaded

### DIFF
--- a/apps/ui/src/components/views/board-view/hooks/use-board-column-features.ts
+++ b/apps/ui/src/components/views/board-view/hooks/use-board-column-features.ts
@@ -106,8 +106,19 @@ export function useBoardColumnFeatures({
           matchesWorktree = true;
         }
       } else {
-        // Match by branch name
-        matchesWorktree = featureBranch === effectiveBranch;
+        if (featureBranch === effectiveBranch) {
+          // Feature's branch is the current worktree's branch - show it
+          matchesWorktree = true;
+        } else if (currentWorktreePath === null && projectPath) {
+          // On the main worktree: show features that don't have their own dedicated worktree.
+          // Features checked out in a non-main worktree should stay pinned there, not leak onto main.
+          const allWorktrees = useWorktreeStore.getState().worktreesByProject[projectPath] ?? [];
+          const hasOwnWorktree = allWorktrees.some((w) => !w.isMain && w.branch === featureBranch);
+          matchesWorktree = !hasOwnWorktree;
+        } else {
+          // On a non-main worktree viewing a different branch - hide it
+          matchesWorktree = false;
+        }
       }
 
       // Normalize status to handle legacy values, but preserve pipeline_* statuses


### PR DESCRIPTION
## Summary

- Fixes Kanban board features flashing then disappearing after worktrees finish loading
- Root cause: strict `featureBranch === effectiveBranch` check hid all `feature/*` branches once `effectiveBranch` resolved to the main branch name (e.g. `"dev"`)
- Fix: on the main worktree, show a feature unless it has its own dedicated non-main worktree — features checked out in their own worktree stay pinned there, everything else is visible on main

## Test plan
- [ ] Open a project with worktrees enabled — all backlog/review/blocked/done features should remain visible after worktrees load (no flash/disappear)
- [ ] Features with active worktrees should still only appear in their worktree tab
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed feature visibility across worktrees. Features with dedicated worktrees no longer incorrectly appear on the main worktree. Features on non-main worktrees now correctly display only matching branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->