### PR TITLE
feat: automation registry REST API and scheduler wiring

### DIFF
--- a/apps/server/src/routes/automations/index.ts
+++ b/apps/server/src/routes/automations/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Automation routes - REST API for the Automation Registry
+ *
+ * GET  /list           - List all automations
+ * GET  /:id            - Get a single automation
+ * POST /create         - Create a new automation
+ * PUT  /:id            - Update an automation (enable/disable, schedule, etc.)
+ * DELETE /:id          - Delete an automation
+ * GET  /:id/history    - Get run history for an automation
+ * POST /:id/run        - Manually trigger an automation
+ */
+
+import { Router } from 'express';
+import type { AutomationService } from '../../services/automation-service.js';
+import { createListHandler } from './routes/list.js';
+import { createGetHandler } from './routes/get.js';
+import { createCreateHandler } from './routes/create.js';
+import { createUpdateHandler } from './routes/update.js';
+import { createDeleteHandler } from './routes/delete.js';
+import { createHistoryHandler } from './routes/history.js';
+import { createRunHandler } from './routes/run.js';
+
+export function createAutomationsRoutes(automationService: AutomationService): Router {
+  const router = Router();
+
+  router.get('/list', createListHandler(automationService));
+  router.post('/create', createCreateHandler(automationService));
+  router.get('/:id/history', createHistoryHandler(automationService));
+  router.post('/:id/run', createRunHandler(automationService));
+  router.get('/:id', createGetHandler(automationService));
+  router.put('/:id', createUpdateHandler(automationService));
+  router.delete('/:id', createDeleteHandler(automationService));
+
+  return router;
+}

--- a/apps/server/src/routes/automations/routes/create.ts
+++ b/apps/server/src/routes/automations/routes/create.ts
@@ -1,0 +1,33 @@
+/**
+ * POST /api/automations/create - Create a new automation
+ */
+
+import type { Request, Response } from 'express';
+import type {
+  AutomationService,
+  CreateAutomationInput,
+} from '../../../services/automation-service.js';
+
+export function createCreateHandler(automationService: AutomationService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const input = req.body as CreateAutomationInput;
+
+      if (!input.name || typeof input.name !== 'string') {
+        res.status(400).json({ error: 'name is required' });
+        return;
+      }
+      if (!input.flowId || typeof input.flowId !== 'string') {
+        res.status(400).json({ error: 'flowId is required' });
+        return;
+      }
+
+      const automation = await automationService.create(input);
+      res.status(201).json(automation);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const status = message.includes('Invalid cron') ? 400 : 500;
+      res.status(status).json({ error: message });
+    }
+  };
+}

--- a/apps/server/src/routes/automations/routes/delete.ts
+++ b/apps/server/src/routes/automations/routes/delete.ts
@@ -1,0 +1,23 @@
+/**
+ * DELETE /api/automations/:id - Delete an automation
+ */
+
+import type { Request, Response } from 'express';
+import type { AutomationService } from '../../../services/automation-service.js';
+
+export function createDeleteHandler(automationService: AutomationService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const id = req.params['id'] as string;
+      const deleted = await automationService.delete(id);
+      if (!deleted) {
+        res.status(404).json({ error: `Automation not found: ${id}` });
+        return;
+      }
+      res.json({ success: true, id });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.status(500).json({ error: message });
+    }
+  };
+}

--- a/apps/server/src/routes/automations/routes/get.ts
+++ b/apps/server/src/routes/automations/routes/get.ts
@@ -1,0 +1,23 @@
+/**
+ * GET /api/automations/:id - Get a single automation by ID
+ */
+
+import type { Request, Response } from 'express';
+import type { AutomationService } from '../../../services/automation-service.js';
+
+export function createGetHandler(automationService: AutomationService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const id = req.params['id'] as string;
+      const automation = await automationService.get(id);
+      if (!automation) {
+        res.status(404).json({ error: `Automation not found: ${id}` });
+        return;
+      }
+      res.json(automation);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.status(500).json({ error: message });
+    }
+  };
+}

--- a/apps/server/src/routes/automations/routes/history.ts
+++ b/apps/server/src/routes/automations/routes/history.ts
@@ -1,0 +1,27 @@
+/**
+ * GET /api/automations/:id/history - Get run history for an automation
+ */
+
+import type { Request, Response } from 'express';
+import type { AutomationService } from '../../../services/automation-service.js';
+
+export function createHistoryHandler(automationService: AutomationService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const id = req.params['id'] as string;
+
+      // Verify automation exists
+      const automation = await automationService.get(id);
+      if (!automation) {
+        res.status(404).json({ error: `Automation not found: ${id}` });
+        return;
+      }
+
+      const runs = await automationService.getHistory(id);
+      res.json({ runs });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.status(500).json({ error: message });
+    }
+  };
+}

--- a/apps/server/src/routes/automations/routes/list.ts
+++ b/apps/server/src/routes/automations/routes/list.ts
@@ -1,0 +1,18 @@
+/**
+ * GET /api/automations/list - List all automations
+ */
+
+import type { Request, Response } from 'express';
+import type { AutomationService } from '../../../services/automation-service.js';
+
+export function createListHandler(automationService: AutomationService) {
+  return async (_req: Request, res: Response): Promise<void> => {
+    try {
+      const automations = await automationService.list();
+      res.json({ automations });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.status(500).json({ error: message });
+    }
+  };
+}

--- a/apps/server/src/routes/automations/routes/run.ts
+++ b/apps/server/src/routes/automations/routes/run.ts
@@ -1,0 +1,28 @@
+/**
+ * POST /api/automations/:id/run - Manually trigger an automation
+ */
+
+import type { Request, Response } from 'express';
+import type { AutomationService } from '../../../services/automation-service.js';
+
+export function createRunHandler(automationService: AutomationService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const id = req.params['id'] as string;
+
+      // Verify automation exists before attempting execution
+      const automation = await automationService.get(id);
+      if (!automation) {
+        res.status(404).json({ error: `Automation not found: ${id}` });
+        return;
+      }
+
+      const run = await automationService.executeAutomation(id, 'manual');
+      res.json(run);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const status = message.includes('not found') ? 404 : 500;
+      res.status(status).json({ error: message });
+    }
+  };
+}

--- a/apps/server/src/routes/automations/routes/update.ts
+++ b/apps/server/src/routes/automations/routes/update.ts
@@ -1,0 +1,29 @@
+/**
+ * PUT /api/automations/:id - Update an automation (enable/disable, change schedule, etc.)
+ */
+
+import type { Request, Response } from 'express';
+import type {
+  AutomationService,
+  UpdateAutomationInput,
+} from '../../../services/automation-service.js';
+
+export function createUpdateHandler(automationService: AutomationService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const id = req.params['id'] as string;
+      const input = req.body as UpdateAutomationInput;
+
+      const updated = await automationService.update(id, input);
+      if (!updated) {
+        res.status(404).json({ error: `Automation not found: ${id}` });
+        return;
+      }
+      res.json(updated);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const status = message.includes('Invalid cron') ? 400 : 500;
+      res.status(status).json({ error: message });
+    }
+  };
+}

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -84,6 +84,7 @@ import { createNotesRoutes } from '../routes/notes/index.js';
 import { createLeadEngineerRoutes } from '../routes/lead-engineer/index.js';
 import { createPrometheusRoute } from '../routes/metrics/prometheus.js';
 import { createBeadsRoutes } from '../routes/beads/index.js';
+import { createAutomationsRoutes } from '../routes/automations/index.js';
 
 const logger = createLogger('Server:Routes');
 
@@ -122,6 +123,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
     projectService,
     projectLifecycleService,
     schedulerService,
+    automationService,
     avaGatewayService,
     discordBotService,
     agentFactoryService,
@@ -328,6 +330,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
     createProjectsRoutes(featureLoader, events, projectService, projectLifecycleService)
   );
   app.use('/api/scheduler', createSchedulerRoutes(schedulerService, settingsService));
+  app.use('/api/automations', createAutomationsRoutes(automationService));
   app.use('/api/ava', createAvaRoutes(services));
   app.use('/api/discord', createDiscordRoutes(discordBotService));
   app.use(

--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -28,6 +28,7 @@ import { ActionableItemBridgeService } from '../services/actionable-item-bridge-
 import { getEventHistoryService } from '../services/event-history-service.js';
 import { getBriefingCursorService } from '../services/briefing-cursor-service.js';
 import { getSchedulerService } from '../services/scheduler-service.js';
+import { AutomationService } from '../services/automation-service.js';
 import { getHealthMonitorService } from '../services/health-monitor-service.js';
 import { integrationService } from '../services/integration-service.js';
 import { SignalIntakeService } from '../services/signal-intake-service.js';
@@ -138,6 +139,7 @@ export interface ServiceContainer {
   googleCalendarSyncService: GoogleCalendarSyncService;
   calendarService: typeof calendarService;
   schedulerService: ReturnType<typeof getSchedulerService>;
+  automationService: AutomationService;
 
   // Auto-mode
   autoModeService: AutoModeService;
@@ -598,6 +600,9 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   // Scheduler Service with event emitter and data directory
   const schedulerService = getSchedulerService();
 
+  // Automation Service — manages automation registry and cron/manual execution
+  const automationService = new AutomationService(schedulerService, dataDir);
+
   // Spec Generation Monitor for detecting and cleaning up stalled spec regeneration jobs
   const specGenerationMonitor = getSpecGenerationMonitor(events, {
     checkIntervalMs: 30000, // Check every 30 seconds
@@ -687,6 +692,7 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
     googleCalendarSyncService,
     calendarService,
     schedulerService,
+    automationService,
     autoModeService,
     hitlFormService,
     claudeUsageService,

--- a/apps/server/src/services/automation-service.ts
+++ b/apps/server/src/services/automation-service.ts
@@ -1,265 +1,446 @@
 /**
- * AutomationService - CRUD and persistence for automation definitions
+ * Automation Service
  *
- * Automations are stored as individual JSON files under:
- *   {projectPath}/.automaker/automations/{id}.json
+ * Manages the automation registry: stores automation definitions, tracks run history,
+ * wires cron automations into the SchedulerService, and executes flows on demand.
  *
- * Run history is stored alongside each automation at:
- *   {projectPath}/.automaker/automations/{id}.history.json
+ * Integrates with the FlowRegistry (a simple Map<string, FlowFactory>) so that
+ * each automation references a named flow that is executed with the automation's
+ * modelConfig injected.
  */
 
-import path from 'path';
 import { randomUUID } from 'crypto';
-import { createLogger, atomicWriteJson, readJsonWithRecovery } from '@protolabs-ai/utils';
-import { getAutomakerDir } from '@protolabs-ai/platform';
-import type { Automation, AutomationRunRecord } from '@protolabs-ai/types';
-import * as secureFs from '../lib/secure-fs.js';
+import path from 'path';
+import { createLogger } from '@protolabs-ai/utils';
+import { secureFs } from '@protolabs-ai/platform';
+import type { Automation, AutomationRunRecord, AutomationRunStatus } from '@protolabs-ai/types';
+import type { SchedulerService } from './scheduler-service.js';
+import type { EventEmitter } from '../lib/events.js';
+import type { AutoModeService } from './auto-mode-service.js';
+import type { FeatureHealthService } from './feature-health-service.js';
+import type { DataIntegrityWatchdogService } from './data-integrity-watchdog-service.js';
+import type { FeatureLoader } from './feature-loader.js';
+import type { SettingsService } from './settings-service.js';
+import { registerMaintenanceTasks } from './maintenance-tasks.js';
 
 const logger = createLogger('AutomationService');
 
-export interface ListAutomationsFilter {
-  enabled?: boolean;
-  tags?: string[];
-  triggerType?: 'cron' | 'event' | 'webhook';
+const AUTOMATIONS_FILE = 'automations.json';
+const AUTOMATION_RUNS_FILE = 'automation-runs.json';
+const MAX_RUNS_PER_AUTOMATION = 50;
+
+/**
+ * Scheduler task ID prefix for automations
+ */
+const AUTOMATION_TASK_PREFIX = 'automation:';
+
+/**
+ * Dependencies required for syncing with the scheduler (same as registerMaintenanceTasks)
+ */
+export interface SyncWithSchedulerDeps {
+  events: EventEmitter;
+  autoModeService: AutoModeService;
+  featureHealthService: FeatureHealthService;
+  integrityWatchdogService: DataIntegrityWatchdogService;
+  featureLoader: FeatureLoader;
+  settingsService: SettingsService;
 }
 
+/**
+ * Input for creating an automation via POST /api/automations/create
+ */
 export interface CreateAutomationInput {
   name: string;
   description?: string;
-  enabled?: boolean;
-  trigger: Automation['trigger'];
   flowId: string;
-  modelConfig: Automation['modelConfig'];
-  inputSchema?: Automation['inputSchema'];
-  tags?: string[];
-  metadata?: Record<string, unknown>;
+  trigger:
+    | { type: 'cron'; expression: string }
+    | { type: 'event'; eventType: string }
+    | { type: 'webhook'; path: string };
+  enabled?: boolean;
+  modelConfig?: Record<string, unknown>;
 }
 
+/**
+ * Input for updating an automation via PUT /api/automations/:id
+ */
 export interface UpdateAutomationInput {
   name?: string;
   description?: string;
-  enabled?: boolean;
-  trigger?: Automation['trigger'];
   flowId?: string;
-  modelConfig?: Automation['modelConfig'];
-  inputSchema?: Automation['inputSchema'];
-  tags?: string[];
-  metadata?: Record<string, unknown>;
-  lastRunAt?: string;
-  nextRunAt?: string;
-  lastRunStatus?: Automation['lastRunStatus'];
+  trigger?:
+    | { type: 'cron'; expression: string }
+    | { type: 'event'; eventType: string }
+    | { type: 'webhook'; path: string };
+  enabled?: boolean;
+  modelConfig?: Record<string, unknown>;
 }
 
+/**
+ * Type for a flow factory function stored in the FlowRegistry.
+ * Receives the automation's modelConfig and executes the flow.
+ */
+export type FlowFactory = (modelConfig?: Record<string, unknown>) => Promise<void>;
+
+/**
+ * Stored trigger types — mirrors @protolabs-ai/types AutomationTrigger but with
+ * a relaxed eventType (string instead of strict EventType union) so that users
+ * can persist event-based automations without needing a compile-time EventType match.
+ */
+type StoredCronTrigger = { type: 'cron'; expression: string };
+type StoredEventTrigger = { type: 'event'; eventType: string };
+type StoredWebhookTrigger = { type: 'webhook'; path: string };
+type StoredTrigger = StoredCronTrigger | StoredEventTrigger | StoredWebhookTrigger;
+
+/**
+ * Stored automation record — all fields from @protolabs-ai/types Automation except
+ * modelConfig (flexible Record) and trigger (relaxed eventType).
+ */
+type StoredAutomation = Omit<Automation, 'modelConfig' | 'trigger'> & {
+  trigger: StoredTrigger;
+  modelConfig?: Record<string, unknown>;
+};
+
+/**
+ * Global FlowRegistry: maps flowId -> FlowFactory
+ *
+ * Flows are registered at startup by services that own specific flows.
+ * AutomationService.executeAutomation() looks up the factory here.
+ */
+class FlowRegistry {
+  private flows: Map<string, FlowFactory> = new Map();
+
+  register(flowId: string, factory: FlowFactory): void {
+    this.flows.set(flowId, factory);
+    logger.info(`Registered flow: ${flowId}`);
+  }
+
+  unregister(flowId: string): void {
+    this.flows.delete(flowId);
+  }
+
+  get(flowId: string): FlowFactory | undefined {
+    return this.flows.get(flowId);
+  }
+
+  list(): string[] {
+    return Array.from(this.flows.keys());
+  }
+
+  has(flowId: string): boolean {
+    return this.flows.has(flowId);
+  }
+}
+
+/**
+ * Singleton FlowRegistry instance — shared across the process
+ */
+export const flowRegistry = new FlowRegistry();
+
+/**
+ * AutomationService
+ *
+ * Provides CRUD for automations, run history, cron scheduling, and manual execution.
+ */
 export class AutomationService {
-  private static instance: AutomationService;
+  private readonly schedulerService: SchedulerService;
+  private readonly dataDir: string;
 
-  private constructor() {}
-
-  static getInstance(): AutomationService {
-    if (!AutomationService.instance) {
-      AutomationService.instance = new AutomationService();
-    }
-    return AutomationService.instance;
+  constructor(schedulerService: SchedulerService, dataDir: string) {
+    this.schedulerService = schedulerService;
+    this.dataDir = dataDir;
   }
 
-  // ============================================================================
-  // Path helpers
-  // ============================================================================
+  // ---------------------------------------------------------------------------
+  // Storage helpers
+  // ---------------------------------------------------------------------------
 
-  private getAutomationsDir(projectPath: string): string {
-    return path.join(getAutomakerDir(projectPath), 'automations');
+  private automationsPath(): string {
+    return path.join(this.dataDir, AUTOMATIONS_FILE);
   }
 
-  private getAutomationPath(projectPath: string, id: string): string {
-    return path.join(this.getAutomationsDir(projectPath), `${id}.json`);
+  private runsPath(): string {
+    return path.join(this.dataDir, AUTOMATION_RUNS_FILE);
   }
 
-  private getHistoryPath(projectPath: string, id: string): string {
-    return path.join(this.getAutomationsDir(projectPath), `${id}.history.json`);
-  }
-
-  // ============================================================================
-  // Private I/O helpers
-  // ============================================================================
-
-  private async ensureAutomationsDir(projectPath: string): Promise<void> {
-    const dir = this.getAutomationsDir(projectPath);
+  private async readAutomations(): Promise<StoredAutomation[]> {
     try {
-      await secureFs.access(dir);
+      await secureFs.access(this.automationsPath());
+      const raw = (await secureFs.readFile(this.automationsPath(), 'utf-8')) as string;
+      return JSON.parse(raw) as StoredAutomation[];
     } catch {
-      await secureFs.mkdir(dir, { recursive: true });
+      return [];
     }
   }
 
-  private async readAutomation(projectPath: string, id: string): Promise<Automation | null> {
-    const filePath = this.getAutomationPath(projectPath, id);
+  private async writeAutomations(automations: StoredAutomation[]): Promise<void> {
+    await secureFs.mkdir(this.dataDir, { recursive: true });
+    await secureFs.writeFile(this.automationsPath(), JSON.stringify(automations, null, 2), 'utf-8');
+  }
+
+  private async readRuns(): Promise<AutomationRunRecord[]> {
     try {
-      await secureFs.access(filePath);
+      await secureFs.access(this.runsPath());
+      const raw = (await secureFs.readFile(this.runsPath(), 'utf-8')) as string;
+      return JSON.parse(raw) as AutomationRunRecord[];
     } catch {
-      return null;
+      return [];
     }
-    const result = await readJsonWithRecovery<Automation>(filePath, null as unknown as Automation, {
-      autoRestore: true,
-    });
-    return result.data ?? null;
   }
 
-  private async writeAutomation(projectPath: string, automation: Automation): Promise<void> {
-    await this.ensureAutomationsDir(projectPath);
-    await atomicWriteJson(this.getAutomationPath(projectPath, automation.id), automation, {
-      backupCount: 3,
-    });
+  private async writeRuns(runs: AutomationRunRecord[]): Promise<void> {
+    await secureFs.mkdir(this.dataDir, { recursive: true });
+    await secureFs.writeFile(this.runsPath(), JSON.stringify(runs, null, 2), 'utf-8');
   }
 
-  // ============================================================================
+  // ---------------------------------------------------------------------------
   // CRUD
-  // ============================================================================
+  // ---------------------------------------------------------------------------
 
-  async create(projectPath: string, input: CreateAutomationInput): Promise<Automation> {
+  async list(): Promise<StoredAutomation[]> {
+    return this.readAutomations();
+  }
+
+  async get(id: string): Promise<StoredAutomation | undefined> {
+    const automations = await this.readAutomations();
+    return automations.find((a) => a.id === id);
+  }
+
+  async create(input: CreateAutomationInput): Promise<StoredAutomation> {
+    const automations = await this.readAutomations();
     const now = new Date().toISOString();
-    const automation: Automation = {
+    const automation: StoredAutomation = {
       id: randomUUID(),
       name: input.name,
       description: input.description,
-      enabled: input.enabled ?? true,
-      trigger: input.trigger,
       flowId: input.flowId,
+      trigger: input.trigger,
+      enabled: input.enabled ?? true,
       modelConfig: input.modelConfig,
-      inputSchema: input.inputSchema,
-      tags: input.tags,
-      metadata: input.metadata,
       createdAt: now,
       updatedAt: now,
     };
+    automations.push(automation);
+    await this.writeAutomations(automations);
 
-    await this.writeAutomation(projectPath, automation);
-    logger.info(`Created automation ${automation.id} (${automation.name})`);
+    // If enabled and has a cron trigger, register with scheduler immediately
+    if (automation.enabled && automation.trigger.type === 'cron') {
+      await this.registerWithScheduler(automation);
+    }
+
+    logger.info(`Created automation "${automation.name}" (${automation.id})`);
     return automation;
   }
 
-  async get(projectPath: string, id: string): Promise<Automation | null> {
-    return this.readAutomation(projectPath, id);
-  }
+  async update(id: string, input: UpdateAutomationInput): Promise<StoredAutomation | undefined> {
+    const automations = await this.readAutomations();
+    const index = automations.findIndex((a) => a.id === id);
+    if (index === -1) return undefined;
 
-  async update(projectPath: string, id: string, input: UpdateAutomationInput): Promise<Automation> {
-    const existing = await this.readAutomation(projectPath, id);
-    if (!existing) {
-      throw new Error(`Automation ${id} not found`);
-    }
-
-    const updated: Automation = {
+    const existing = automations[index];
+    const updated: StoredAutomation = {
       ...existing,
       ...input,
-      id: existing.id,
-      createdAt: existing.createdAt,
+      id,
       updatedAt: new Date().toISOString(),
     };
+    automations[index] = updated;
+    await this.writeAutomations(automations);
 
-    await this.writeAutomation(projectPath, updated);
-    logger.info(`Updated automation ${id}`);
+    // Sync scheduler registration
+    const taskId = `${AUTOMATION_TASK_PREFIX}${id}`;
+    const existingTask = this.schedulerService.getTask(taskId);
+
+    if (updated.enabled && updated.trigger.type === 'cron') {
+      const cronExpression = (updated.trigger as StoredCronTrigger).expression;
+      if (existingTask) {
+        if (existingTask.cronExpression !== cronExpression) {
+          await this.schedulerService.updateTaskSchedule(taskId, cronExpression);
+        }
+        if (!existingTask.enabled) {
+          await this.schedulerService.enableTask(taskId);
+        }
+      } else {
+        await this.registerWithScheduler(updated);
+      }
+    } else if (!updated.enabled && existingTask) {
+      await this.schedulerService.disableTask(taskId);
+    } else if (updated.trigger.type !== 'cron' && existingTask) {
+      // Changed from cron to non-cron trigger — unregister from scheduler
+      await this.schedulerService.unregisterTask(taskId);
+    }
+
+    logger.info(`Updated automation "${updated.name}" (${id})`);
     return updated;
   }
 
-  async delete(projectPath: string, id: string): Promise<void> {
-    const filePath = this.getAutomationPath(projectPath, id);
-    try {
-      await secureFs.access(filePath);
-    } catch {
-      throw new Error(`Automation ${id} not found`);
-    }
+  async delete(id: string): Promise<boolean> {
+    const automations = await this.readAutomations();
+    const index = automations.findIndex((a) => a.id === id);
+    if (index === -1) return false;
 
-    await secureFs.unlink(filePath);
+    automations.splice(index, 1);
+    await this.writeAutomations(automations);
 
-    // Also remove history file if it exists
-    const historyPath = this.getHistoryPath(projectPath, id);
-    try {
-      await secureFs.access(historyPath);
-      await secureFs.unlink(historyPath);
-    } catch {
-      // History file may not exist — that's fine
-    }
+    // Unregister from scheduler
+    await this.schedulerService.unregisterTask(`${AUTOMATION_TASK_PREFIX}${id}`);
 
     logger.info(`Deleted automation ${id}`);
+    return true;
   }
 
-  async list(projectPath: string, filter?: ListAutomationsFilter): Promise<Automation[]> {
-    const dir = this.getAutomationsDir(projectPath);
+  // ---------------------------------------------------------------------------
+  // Run history
+  // ---------------------------------------------------------------------------
 
-    try {
-      await secureFs.access(dir);
-    } catch {
-      return [];
+  async getHistory(automationId: string): Promise<AutomationRunRecord[]> {
+    const runs = await this.readRuns();
+    return runs
+      .filter((r) => r.automationId === automationId)
+      .sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Execution
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Execute an automation by ID.
+   * Looks up the flow by flowId in the FlowRegistry and runs it with modelConfig injected.
+   */
+  async executeAutomation(
+    id: string,
+    triggeredBy: 'scheduler' | 'manual' = 'scheduler'
+  ): Promise<AutomationRunRecord> {
+    const automation = await this.get(id);
+    if (!automation) {
+      throw new Error(`Automation not found: ${id}`);
     }
 
-    const entries = await secureFs.readdir(dir);
-    const automationFiles = entries.filter(
-      (entry) => entry.endsWith('.json') && !entry.endsWith('.history.json')
+    const factory = flowRegistry.get(automation.flowId);
+    if (!factory) {
+      throw new Error(`Flow not registered: ${automation.flowId}`);
+    }
+
+    const runId = randomUUID();
+    const startedAt = new Date().toISOString();
+
+    logger.info(
+      `Executing automation "${automation.name}" (${id}), flow: ${automation.flowId}, triggered by: ${triggeredBy}`
     );
 
-    const automations: Automation[] = [];
+    let status: AutomationRunStatus = 'running';
+    let error: string | undefined;
 
-    for (const file of automationFiles) {
-      const id = file.replace(/\.json$/, '');
-      const automation = await this.readAutomation(projectPath, id);
-      if (!automation) continue;
+    try {
+      await factory(automation.modelConfig);
+      status = 'success';
+    } catch (err) {
+      status = 'failure';
+      error = err instanceof Error ? err.message : String(err);
+      logger.error(`Automation "${automation.name}" (${id}) failed:`, err);
+    }
 
-      if (filter) {
-        if (filter.enabled !== undefined && automation.enabled !== filter.enabled) continue;
-        if (filter.triggerType && automation.trigger.type !== filter.triggerType) continue;
-        if (filter.tags && filter.tags.length > 0) {
-          const autoTags = automation.tags ?? [];
-          const hasAll = filter.tags.every((t) => autoTags.includes(t));
-          if (!hasAll) continue;
+    const completedAt = new Date().toISOString();
+
+    const run: AutomationRunRecord = {
+      id: runId,
+      automationId: id,
+      status,
+      startedAt,
+      completedAt,
+      error,
+    };
+
+    await this.appendRun(run);
+
+    return run;
+  }
+
+  private async appendRun(run: AutomationRunRecord): Promise<void> {
+    const allRuns = await this.readRuns();
+    allRuns.push(run);
+
+    // Cap history per automation
+    const automationRuns = allRuns.filter((r) => r.automationId === run.automationId);
+    if (automationRuns.length > MAX_RUNS_PER_AUTOMATION) {
+      const toRemove = automationRuns
+        .sort((a, b) => a.startedAt.localeCompare(b.startedAt))
+        .slice(0, automationRuns.length - MAX_RUNS_PER_AUTOMATION)
+        .map((r) => r.id);
+
+      const pruned = allRuns.filter((r) => !toRemove.includes(r.id));
+      await this.writeRuns(pruned);
+    } else {
+      await this.writeRuns(allRuns);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scheduler integration
+  // ---------------------------------------------------------------------------
+
+  private async registerWithScheduler(automation: StoredAutomation): Promise<void> {
+    if (automation.trigger.type !== 'cron') return;
+
+    const cronExpression = (automation.trigger as StoredCronTrigger).expression;
+    const taskId = `${AUTOMATION_TASK_PREFIX}${automation.id}`;
+    await this.schedulerService.registerTask(
+      taskId,
+      automation.name,
+      cronExpression,
+      async () => {
+        await this.executeAutomation(automation.id, 'scheduler');
+      },
+      automation.enabled
+    );
+  }
+
+  /**
+   * Load all automations and sync enabled cron automations with the scheduler.
+   * Also registers built-in maintenance tasks.
+   *
+   * Called from scheduler.module.ts after the scheduler has started, replacing
+   * the direct call to registerMaintenanceTasks().
+   */
+  async syncWithScheduler(deps: SyncWithSchedulerDeps): Promise<void> {
+    // Register built-in maintenance tasks (preserves existing scheduled behavior)
+    await registerMaintenanceTasks(
+      this.schedulerService,
+      deps.events,
+      deps.autoModeService,
+      deps.featureHealthService,
+      deps.integrityWatchdogService,
+      deps.featureLoader,
+      deps.settingsService
+    );
+
+    // Register user-defined cron automations
+    const automations = await this.readAutomations();
+    let registered = 0;
+    for (const automation of automations) {
+      if (automation.enabled && automation.trigger.type === 'cron') {
+        try {
+          await this.registerWithScheduler(automation);
+          registered++;
+        } catch (err) {
+          logger.error(
+            `Failed to register automation "${automation.name}" (${automation.id}):`,
+            err
+          );
         }
       }
-
-      automations.push(automation);
     }
 
-    return automations;
+    logger.info(
+      `Automation sync complete: ${registered} user automations registered with scheduler`
+    );
   }
 
-  // ============================================================================
-  // Run History
-  // ============================================================================
-
-  async getHistory(projectPath: string, id: string): Promise<AutomationRunRecord[]> {
-    // Ensure the automation exists
-    const automation = await this.readAutomation(projectPath, id);
-    if (!automation) {
-      throw new Error(`Automation ${id} not found`);
-    }
-
-    const historyPath = this.getHistoryPath(projectPath, id);
-    try {
-      await secureFs.access(historyPath);
-    } catch {
-      return [];
-    }
-
-    const result = await readJsonWithRecovery<AutomationRunRecord[]>(historyPath, [], {
-      autoRestore: true,
-    });
-    return result.data ?? [];
-  }
-
-  async appendRunRecord(projectPath: string, record: AutomationRunRecord): Promise<void> {
-    await this.ensureAutomationsDir(projectPath);
-
-    const historyPath = this.getHistoryPath(projectPath, record.automationId);
-    const existing = await (async () => {
-      try {
-        await secureFs.access(historyPath);
-        const result = await readJsonWithRecovery<AutomationRunRecord[]>(historyPath, [], {
-          autoRestore: true,
-        });
-        return result.data ?? [];
-      } catch {
-        return [];
-      }
-    })();
-
-    existing.push(record);
-    await atomicWriteJson(historyPath, existing, { backupCount: 2 });
+  /**
+   * Alias for loadAll() semantics — returns all stored automations.
+   */
+  async loadAll(): Promise<StoredAutomation[]> {
+    return this.readAutomations();
   }
 }

--- a/apps/server/src/services/scheduler.module.ts
+++ b/apps/server/src/services/scheduler.module.ts
@@ -1,12 +1,15 @@
 import { createLogger } from '@protolabs-ai/utils';
 
-import { registerMaintenanceTasks } from './maintenance-tasks.js';
 import type { ServiceContainer } from '../server/services.js';
 
 const logger = createLogger('Server:Wiring');
 
 /**
- * Wires scheduler service initialization and registers maintenance tasks.
+ * Wires scheduler service initialization and registers automations + maintenance tasks.
+ *
+ * Delegates to automationService.syncWithScheduler() which:
+ * 1. Registers built-in maintenance tasks
+ * 2. Registers any user-defined cron automations from storage
  */
 export function register(container: ServiceContainer): void {
   const {
@@ -14,28 +17,28 @@ export function register(container: ServiceContainer): void {
     dataDir,
     settingsService,
     schedulerService,
+    automationService,
     autoModeService,
     featureHealthService,
     integrityWatchdogService,
     featureLoader,
   } = container;
 
-  // Scheduler Service initialization and maintenance task registration
+  // Scheduler Service initialization and task registration via AutomationService
   schedulerService.initialize(events, dataDir);
   void schedulerService
     .start()
     .then(() => {
-      return registerMaintenanceTasks(
-        schedulerService,
+      return automationService.syncWithScheduler({
         events,
         autoModeService,
         featureHealthService,
         integrityWatchdogService,
         featureLoader,
-        settingsService
-      );
+        settingsService,
+      });
     })
     .catch((err) => {
-      logger.error('Scheduler startup or maintenance task registration failed:', err);
+      logger.error('Scheduler startup or automation sync failed:', err);
     });
 }

--- a/apps/server/tests/unit/services/automation-service.test.ts
+++ b/apps/server/tests/unit/services/automation-service.test.ts
@@ -1,364 +1,436 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { AutomationService } from '@/services/automation-service.js';
-import * as secureFs from '@/lib/secure-fs.js';
-import { atomicWriteJson, readJsonWithRecovery } from '@protolabs-ai/utils';
-import type { Automation, AutomationRunRecord } from '@protolabs-ai/types';
+/**
+ * Unit tests for AutomationService
+ */
 
-vi.mock('@/lib/secure-fs.js');
-vi.mock('@protolabs-ai/utils', async () => {
-  const actual = await vi.importActual<typeof import('@protolabs-ai/utils')>('@protolabs-ai/utils');
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+// Mock @protolabs-ai/platform secureFs — use real fs in a temp dir
+vi.mock('@protolabs-ai/platform', () => {
   return {
-    ...actual,
-    atomicWriteJson: vi.fn(),
-    readJsonWithRecovery: vi.fn(),
-    createLogger: vi.fn(() => ({
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
-    })),
+    secureFs: {
+      access: async (p: string) => {
+        await fs.promises.access(p);
+      },
+      readFile: async (p: string, enc: string) => {
+        return fs.promises.readFile(p, enc as BufferEncoding);
+      },
+      writeFile: async (p: string, data: string, enc: string) => {
+        return fs.promises.writeFile(p, data, enc as BufferEncoding);
+      },
+      mkdir: async (p: string, opts?: { recursive?: boolean }) => {
+        return fs.promises.mkdir(p, opts);
+      },
+    },
   };
 });
 
-const projectPath = '/test/project';
+// Mock @protolabs-ai/utils
+vi.mock('@protolabs-ai/utils', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
 
-const baseModelConfig: Automation['modelConfig'] = {
-  model: 'claude-sonnet-4-6',
-  thinkingLevel: 'none',
-};
+// Mock maintenance-tasks
+vi.mock('../../../src/services/maintenance-tasks.js', () => ({
+  registerMaintenanceTasks: vi.fn().mockResolvedValue(undefined),
+}));
 
-function makeAutomation(overrides: Partial<Automation> = {}): Automation {
+import { AutomationService, flowRegistry } from '../../../src/services/automation-service.js';
+import type { SchedulerService } from '../../../src/services/scheduler-service.js';
+
+function createMockScheduler(): SchedulerService {
   return {
-    id: 'auto-123',
-    name: 'Test Automation',
-    enabled: true,
-    trigger: { type: 'cron', expression: '0 * * * *' },
-    flowId: 'flow-abc',
-    modelConfig: baseModelConfig,
-    createdAt: '2026-01-01T00:00:00Z',
-    updatedAt: '2026-01-01T00:00:00Z',
-    ...overrides,
-  };
+    registerTask: vi.fn().mockResolvedValue(undefined),
+    unregisterTask: vi.fn().mockResolvedValue(undefined),
+    enableTask: vi.fn().mockResolvedValue(undefined),
+    disableTask: vi.fn().mockResolvedValue(undefined),
+    updateTaskSchedule: vi.fn().mockResolvedValue(undefined),
+    getTask: vi.fn().mockReturnValue(undefined),
+    initialize: vi.fn(),
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    listTasks: vi.fn().mockReturnValue([]),
+    triggerTask: vi.fn().mockResolvedValue(undefined),
+  } as unknown as SchedulerService;
 }
 
 describe('AutomationService', () => {
   let service: AutomationService;
+  let scheduler: ReturnType<typeof createMockScheduler>;
+  let tempDir: string;
 
   beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'automation-test-'));
+    scheduler = createMockScheduler();
+    service = new AutomationService(scheduler, tempDir);
     vi.clearAllMocks();
-
-    // Reset singleton for each test
-    // @ts-expect-error accessing private static for test isolation
-    AutomationService.instance = undefined;
-    service = AutomationService.getInstance();
-
-    vi.mocked(secureFs.access).mockResolvedValue(undefined);
-    vi.mocked(secureFs.mkdir).mockResolvedValue(undefined);
-    vi.mocked(secureFs.unlink).mockResolvedValue(undefined);
-    vi.mocked(atomicWriteJson).mockResolvedValue(undefined);
-    vi.mocked(readJsonWithRecovery).mockResolvedValue({
-      data: null,
-      recovered: false,
-      source: 'default',
-    });
   });
 
-  describe('getInstance', () => {
-    it('should return the same instance', () => {
-      const a = AutomationService.getInstance();
-      const b = AutomationService.getInstance();
-      expect(a).toBe(b);
-    });
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  describe('create', () => {
-    it('should create automation with generated id and timestamps', async () => {
-      const result = await service.create(projectPath, {
-        name: 'My Automation',
-        trigger: { type: 'cron', expression: '0 0 * * *' },
-        flowId: 'flow-1',
-        modelConfig: baseModelConfig,
-      });
-
-      expect(result.id).toBeDefined();
-      expect(result.name).toBe('My Automation');
-      expect(result.enabled).toBe(true);
-      expect(result.trigger).toEqual({ type: 'cron', expression: '0 0 * * *' });
-      expect(result.createdAt).toBeDefined();
-      expect(result.updatedAt).toBeDefined();
-    });
-
-    it('should persist automation via atomicWriteJson', async () => {
-      await service.create(projectPath, {
-        name: 'My Automation',
-        trigger: { type: 'event', eventType: 'feature:created' },
-        flowId: 'flow-1',
-        modelConfig: baseModelConfig,
-      });
-
-      expect(atomicWriteJson).toHaveBeenCalledWith(
-        expect.stringContaining('.automaker/automations/'),
-        expect.objectContaining({ name: 'My Automation' }),
-        expect.any(Object)
-      );
-    });
-
-    it('should set enabled=false when passed explicitly', async () => {
-      const result = await service.create(projectPath, {
-        name: 'Disabled',
-        enabled: false,
-        trigger: { type: 'webhook', path: '/my-hook' },
-        flowId: 'flow-2',
-        modelConfig: baseModelConfig,
-      });
-
-      expect(result.enabled).toBe(false);
-    });
-
-    it('should store optional fields when provided', async () => {
-      const result = await service.create(projectPath, {
-        name: 'Full',
-        description: 'A full automation',
-        trigger: { type: 'cron', expression: '* * * * *' },
-        flowId: 'flow-full',
-        modelConfig: baseModelConfig,
-        tags: ['alpha', 'beta'],
-        metadata: { owner: 'team-a' },
-        inputSchema: { type: 'object', properties: {} },
-      });
-
-      expect(result.description).toBe('A full automation');
-      expect(result.tags).toEqual(['alpha', 'beta']);
-      expect(result.metadata).toEqual({ owner: 'team-a' });
-      expect(result.inputSchema).toEqual({ type: 'object', properties: {} });
-    });
-  });
-
-  describe('get', () => {
-    it('should return automation when file exists', async () => {
-      const automation = makeAutomation();
-      vi.mocked(readJsonWithRecovery).mockResolvedValue({
-        data: automation,
-        recovered: false,
-        source: 'main',
-      });
-
-      const result = await service.get(projectPath, 'auto-123');
-      expect(result).toEqual(automation);
-    });
-
-    it('should return null when file does not exist', async () => {
-      vi.mocked(secureFs.access).mockRejectedValue(new Error('ENOENT'));
-
-      const result = await service.get(projectPath, 'missing-id');
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('update', () => {
-    it('should update fields and bump updatedAt', async () => {
-      const original = makeAutomation();
-      vi.mocked(readJsonWithRecovery).mockResolvedValue({
-        data: original,
-        recovered: false,
-        source: 'main',
-      });
-
-      const updated = await service.update(projectPath, 'auto-123', { name: 'New Name' });
-
-      expect(updated.name).toBe('New Name');
-      expect(updated.id).toBe('auto-123');
-      expect(updated.createdAt).toBe('2026-01-01T00:00:00Z');
-      expect(updated.updatedAt).not.toBe('2026-01-01T00:00:00Z');
-    });
-
-    it('should throw if automation not found', async () => {
-      vi.mocked(secureFs.access).mockRejectedValue(new Error('ENOENT'));
-
-      await expect(service.update(projectPath, 'missing-id', { name: 'x' })).rejects.toThrow(
-        'Automation missing-id not found'
-      );
-    });
-
-    it('should persist updated automation', async () => {
-      const original = makeAutomation();
-      vi.mocked(readJsonWithRecovery).mockResolvedValue({
-        data: original,
-        recovered: false,
-        source: 'main',
-      });
-
-      await service.update(projectPath, 'auto-123', { enabled: false });
-
-      expect(atomicWriteJson).toHaveBeenCalledWith(
-        expect.stringContaining('auto-123.json'),
-        expect.objectContaining({ enabled: false }),
-        expect.any(Object)
-      );
-    });
-  });
-
-  describe('delete', () => {
-    it('should delete the automation file', async () => {
-      await service.delete(projectPath, 'auto-123');
-
-      expect(secureFs.unlink).toHaveBeenCalledWith(expect.stringContaining('auto-123.json'));
-    });
-
-    it('should also delete history file if it exists', async () => {
-      await service.delete(projectPath, 'auto-123');
-
-      // unlink called for main file and history file
-      expect(secureFs.unlink).toHaveBeenCalledTimes(2);
-    });
-
-    it('should throw if automation file does not exist', async () => {
-      vi.mocked(secureFs.access).mockRejectedValue(new Error('ENOENT'));
-
-      await expect(service.delete(projectPath, 'missing')).rejects.toThrow(
-        'Automation missing not found'
-      );
-    });
-
-    it('should not throw if history file is missing during delete', async () => {
-      // First access (automation file) succeeds; second (history file) fails
-      vi.mocked(secureFs.access)
-        .mockResolvedValueOnce(undefined)
-        .mockRejectedValueOnce(new Error('ENOENT'));
-
-      await expect(service.delete(projectPath, 'auto-123')).resolves.not.toThrow();
-      expect(secureFs.unlink).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('list', () => {
-    it('should return empty array when directory does not exist', async () => {
-      vi.mocked(secureFs.access).mockRejectedValue(new Error('ENOENT'));
-
-      const result = await service.list(projectPath);
+  describe('list()', () => {
+    it('returns empty array when no automations exist', async () => {
+      const result = await service.list();
       expect(result).toEqual([]);
     });
+  });
 
-    it('should list all automations', async () => {
-      const auto1 = makeAutomation({ id: 'auto-1', name: 'First' });
-      const auto2 = makeAutomation({ id: 'auto-2', name: 'Second' });
-
-      vi.mocked(secureFs.readdir).mockResolvedValue(['auto-1.json', 'auto-2.json'] as any);
-      vi.mocked(readJsonWithRecovery)
-        .mockResolvedValueOnce({ data: auto1, recovered: false, source: 'main' })
-        .mockResolvedValueOnce({ data: auto2, recovered: false, source: 'main' });
-
-      const result = await service.list(projectPath);
-      expect(result).toHaveLength(2);
-    });
-
-    it('should filter by enabled status', async () => {
-      const enabledAuto = makeAutomation({ id: 'auto-enabled', enabled: true });
-      const disabledAuto = makeAutomation({ id: 'auto-disabled', enabled: false });
-
-      vi.mocked(secureFs.readdir).mockResolvedValue([
-        'auto-enabled.json',
-        'auto-disabled.json',
-      ] as any);
-      vi.mocked(readJsonWithRecovery)
-        .mockResolvedValueOnce({ data: enabledAuto, recovered: false, source: 'main' })
-        .mockResolvedValueOnce({ data: disabledAuto, recovered: false, source: 'main' });
-
-      const result = await service.list(projectPath, { enabled: true });
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe('auto-enabled');
-    });
-
-    it('should filter by trigger type', async () => {
-      const cronAuto = makeAutomation({
-        id: 'cron-auto',
+  describe('create()', () => {
+    it('creates a cron automation and persists it', async () => {
+      const automation = await service.create({
+        name: 'Test Cron',
+        flowId: 'my-flow',
         trigger: { type: 'cron', expression: '0 * * * *' },
-      });
-      const eventAuto = makeAutomation({
-        id: 'event-auto',
-        trigger: { type: 'event', eventType: 'feature:created' },
+        enabled: true,
       });
 
-      vi.mocked(secureFs.readdir).mockResolvedValue(['cron-auto.json', 'event-auto.json'] as any);
-      vi.mocked(readJsonWithRecovery)
-        .mockResolvedValueOnce({ data: cronAuto, recovered: false, source: 'main' })
-        .mockResolvedValueOnce({ data: eventAuto, recovered: false, source: 'main' });
-
-      const result = await service.list(projectPath, { triggerType: 'cron' });
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe('cron-auto');
+      expect(automation.id).toBeTruthy();
+      expect(automation.name).toBe('Test Cron');
+      expect(automation.flowId).toBe('my-flow');
+      expect(automation.trigger.type).toBe('cron');
+      expect(automation.enabled).toBe(true);
+      expect(automation.createdAt).toBeTruthy();
+      expect(automation.updatedAt).toBeTruthy();
     });
 
-    it('should filter by tags', async () => {
-      const tagged = makeAutomation({ id: 'tagged', tags: ['alpha', 'beta'] });
-      const untagged = makeAutomation({ id: 'untagged', tags: ['gamma'] });
-
-      vi.mocked(secureFs.readdir).mockResolvedValue(['tagged.json', 'untagged.json'] as any);
-      vi.mocked(readJsonWithRecovery)
-        .mockResolvedValueOnce({ data: tagged, recovered: false, source: 'main' })
-        .mockResolvedValueOnce({ data: untagged, recovered: false, source: 'main' });
-
-      const result = await service.list(projectPath, { tags: ['alpha'] });
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe('tagged');
-    });
-
-    it('should exclude history files from listing', async () => {
-      const auto1 = makeAutomation({ id: 'auto-1' });
-
-      vi.mocked(secureFs.readdir).mockResolvedValue(['auto-1.json', 'auto-1.history.json'] as any);
-      vi.mocked(readJsonWithRecovery).mockResolvedValue({
-        data: auto1,
-        recovered: false,
-        source: 'main',
+    it('registers cron automation with scheduler on create', async () => {
+      await service.create({
+        name: 'Cron Auto',
+        flowId: 'flow-x',
+        trigger: { type: 'cron', expression: '*/5 * * * *' },
+        enabled: true,
       });
 
-      const result = await service.list(projectPath);
-      expect(result).toHaveLength(1);
+      expect(scheduler.registerTask).toHaveBeenCalledOnce();
+      const [taskId, name, cron] = vi.mocked(scheduler.registerTask).mock.calls[0];
+      expect(taskId).toMatch(/^automation:/);
+      expect(name).toBe('Cron Auto');
+      expect(cron).toBe('*/5 * * * *');
+    });
+
+    it('does not register disabled automation with scheduler', async () => {
+      await service.create({
+        name: 'Disabled',
+        flowId: 'flow-x',
+        trigger: { type: 'cron', expression: '0 * * * *' },
+        enabled: false,
+      });
+
+      expect(scheduler.registerTask).not.toHaveBeenCalled();
+    });
+
+    it('does not register event automation with scheduler', async () => {
+      await service.create({
+        name: 'Event Auto',
+        flowId: 'flow-y',
+        trigger: { type: 'event', eventType: 'feature.done' },
+        enabled: true,
+      });
+
+      expect(scheduler.registerTask).not.toHaveBeenCalled();
+    });
+
+    it('defaults enabled to true', async () => {
+      const auto = await service.create({
+        name: 'Default Enabled',
+        flowId: 'flow-z',
+        trigger: { type: 'webhook', path: '/hook' },
+      });
+
+      expect(auto.enabled).toBe(true);
     });
   });
 
-  describe('getHistory', () => {
-    it('should return empty array when no history file exists', async () => {
-      const automation = makeAutomation();
-      vi.mocked(readJsonWithRecovery)
-        .mockResolvedValueOnce({ data: automation, recovered: false, source: 'main' }) // get automation
-        .mockResolvedValueOnce({ data: [], recovered: false, source: 'default' }); // history
-      // history file access fails
-      vi.mocked(secureFs.access)
-        .mockResolvedValueOnce(undefined) // automation file exists
-        .mockRejectedValueOnce(new Error('ENOENT')); // history file missing
+  describe('get()', () => {
+    it('returns automation by id', async () => {
+      const created = await service.create({
+        name: 'Get Test',
+        flowId: 'f1',
+        trigger: { type: 'cron', expression: '0 0 * * *' },
+        enabled: false,
+      });
 
-      const result = await service.getHistory(projectPath, 'auto-123');
-      expect(result).toEqual([]);
+      const fetched = await service.get(created.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.id).toBe(created.id);
+      expect(fetched!.name).toBe('Get Test');
     });
 
-    it('should return history records when file exists', async () => {
-      const automation = makeAutomation();
-      const records: AutomationRunRecord[] = [
-        {
-          id: 'run-1',
-          automationId: 'auto-123',
-          status: 'success',
-          startedAt: '2026-01-01T00:00:00Z',
-          completedAt: '2026-01-01T00:01:00Z',
-        },
-      ];
+    it('returns undefined for unknown id', async () => {
+      const result = await service.get('nonexistent');
+      expect(result).toBeUndefined();
+    });
+  });
 
-      vi.mocked(readJsonWithRecovery)
-        .mockResolvedValueOnce({ data: automation, recovered: false, source: 'main' })
-        .mockResolvedValueOnce({ data: records, recovered: false, source: 'main' });
+  describe('list() after creates', () => {
+    it('returns all created automations', async () => {
+      await service.create({
+        name: 'A1',
+        flowId: 'f1',
+        trigger: { type: 'cron', expression: '0 * * * *' },
+        enabled: false,
+      });
+      await service.create({
+        name: 'A2',
+        flowId: 'f2',
+        trigger: { type: 'event', eventType: 'test' },
+        enabled: true,
+      });
 
-      const result = await service.getHistory(projectPath, 'auto-123');
-      expect(result).toEqual(records);
+      const all = await service.list();
+      expect(all).toHaveLength(2);
+      expect(all.map((a) => a.name)).toContain('A1');
+      expect(all.map((a) => a.name)).toContain('A2');
+    });
+  });
+
+  describe('update()', () => {
+    it('returns undefined for unknown id', async () => {
+      const result = await service.update('nonexistent', { enabled: false });
+      expect(result).toBeUndefined();
     });
 
-    it('should throw if automation not found', async () => {
-      vi.mocked(secureFs.access).mockRejectedValue(new Error('ENOENT'));
+    it('updates fields and persists', async () => {
+      const created = await service.create({
+        name: 'Original',
+        flowId: 'f1',
+        trigger: { type: 'cron', expression: '0 0 * * *' },
+        enabled: false,
+      });
 
-      await expect(service.getHistory(projectPath, 'missing')).rejects.toThrow(
-        'Automation missing not found'
+      const updated = await service.update(created.id, { name: 'Updated', enabled: true });
+      expect(updated).toBeDefined();
+      expect(updated!.name).toBe('Updated');
+      expect(updated!.enabled).toBe(true);
+
+      // Verify persistence
+      const fetched = await service.get(created.id);
+      expect(fetched!.name).toBe('Updated');
+    });
+
+    it('enables scheduler task when enabling cron automation', async () => {
+      const created = await service.create({
+        name: 'Toggle',
+        flowId: 'f1',
+        trigger: { type: 'cron', expression: '0 0 * * *' },
+        enabled: false,
+      });
+
+      vi.mocked(scheduler.registerTask).mockClear();
+
+      await service.update(created.id, { enabled: true });
+
+      // Should register since there was no existing task
+      expect(scheduler.registerTask).toHaveBeenCalledOnce();
+    });
+
+    it('disables scheduler task when disabling cron automation', async () => {
+      const created = await service.create({
+        name: 'Disable Test',
+        flowId: 'f1',
+        trigger: { type: 'cron', expression: '0 0 * * *' },
+        enabled: true,
+      });
+
+      // Simulate existing task in scheduler
+      vi.mocked(scheduler.getTask).mockReturnValue({
+        id: `automation:${created.id}`,
+        name: 'Disable Test',
+        cronExpression: '0 0 * * *',
+        enabled: true,
+      } as ReturnType<SchedulerService['getTask']>);
+
+      await service.update(created.id, { enabled: false });
+
+      expect(scheduler.disableTask).toHaveBeenCalledWith(`automation:${created.id}`);
+    });
+  });
+
+  describe('delete()', () => {
+    it('returns false for unknown id', async () => {
+      const result = await service.delete('nonexistent');
+      expect(result).toBe(false);
+    });
+
+    it('deletes automation and unregisters from scheduler', async () => {
+      const created = await service.create({
+        name: 'To Delete',
+        flowId: 'f1',
+        trigger: { type: 'cron', expression: '0 * * * *' },
+        enabled: false,
+      });
+
+      const result = await service.delete(created.id);
+      expect(result).toBe(true);
+
+      const fetched = await service.get(created.id);
+      expect(fetched).toBeUndefined();
+
+      expect(scheduler.unregisterTask).toHaveBeenCalledWith(`automation:${created.id}`);
+    });
+  });
+
+  describe('getHistory()', () => {
+    it('returns empty array for automation with no runs', async () => {
+      const created = await service.create({
+        name: 'No Runs',
+        flowId: 'f1',
+        trigger: { type: 'cron', expression: '0 * * * *' },
+        enabled: false,
+      });
+
+      const runs = await service.getHistory(created.id);
+      expect(runs).toEqual([]);
+    });
+  });
+
+  describe('executeAutomation()', () => {
+    it('throws for unknown automation id', async () => {
+      await expect(service.executeAutomation('nonexistent')).rejects.toThrow(
+        'Automation not found: nonexistent'
       );
+    });
+
+    it('throws when flow is not registered', async () => {
+      const created = await service.create({
+        name: 'No Flow',
+        flowId: 'unregistered-flow',
+        trigger: { type: 'cron', expression: '0 * * * *' },
+        enabled: false,
+      });
+
+      await expect(service.executeAutomation(created.id)).rejects.toThrow(
+        'Flow not registered: unregistered-flow'
+      );
+    });
+
+    it('executes the flow and returns a run record', async () => {
+      const flowFn = vi.fn().mockResolvedValue(undefined);
+      flowRegistry.register('test-execute-flow', flowFn);
+
+      const created = await service.create({
+        name: 'Exec Test',
+        flowId: 'test-execute-flow',
+        trigger: { type: 'cron', expression: '0 * * * *' },
+        enabled: true,
+        modelConfig: { model: 'sonnet' },
+      });
+
+      const run = await service.executeAutomation(created.id, 'manual');
+
+      expect(flowFn).toHaveBeenCalledOnce();
+      expect(flowFn).toHaveBeenCalledWith({ model: 'sonnet' });
+      expect(run.automationId).toBe(created.id);
+      expect(run.status).toBe('success');
+      expect(run.startedAt).toBeTruthy();
+      expect(run.completedAt).toBeTruthy();
+      expect(run.error).toBeUndefined();
+
+      flowRegistry.unregister('test-execute-flow');
+    });
+
+    it('records failure when flow throws', async () => {
+      const flowFn = vi.fn().mockRejectedValue(new Error('flow error'));
+      flowRegistry.register('fail-flow', flowFn);
+
+      const created = await service.create({
+        name: 'Fail Test',
+        flowId: 'fail-flow',
+        trigger: { type: 'cron', expression: '0 * * * *' },
+        enabled: true,
+      });
+
+      const run = await service.executeAutomation(created.id, 'manual');
+
+      expect(run.status).toBe('failure');
+      expect(run.error).toBe('flow error');
+
+      flowRegistry.unregister('fail-flow');
+    });
+
+    it('persists run in history', async () => {
+      const flowFn = vi.fn().mockResolvedValue(undefined);
+      flowRegistry.register('history-flow', flowFn);
+
+      const created = await service.create({
+        name: 'History Test',
+        flowId: 'history-flow',
+        trigger: { type: 'cron', expression: '0 * * * *' },
+        enabled: true,
+      });
+
+      await service.executeAutomation(created.id, 'manual');
+      await service.executeAutomation(created.id, 'scheduler');
+
+      const runs = await service.getHistory(created.id);
+      expect(runs).toHaveLength(2);
+
+      flowRegistry.unregister('history-flow');
+    });
+  });
+
+  describe('syncWithScheduler()', () => {
+    it('registers maintenance tasks and user cron automations', async () => {
+      const { registerMaintenanceTasks } =
+        await import('../../../src/services/maintenance-tasks.js');
+
+      // Create one enabled cron automation and one disabled
+      await service.create({
+        name: 'Active Cron',
+        flowId: 'f1',
+        trigger: { type: 'cron', expression: '0 * * * *' },
+        enabled: true,
+      });
+      await service.create({
+        name: 'Disabled Cron',
+        flowId: 'f2',
+        trigger: { type: 'cron', expression: '0 * * * *' },
+        enabled: false,
+      });
+
+      vi.mocked(scheduler.registerTask).mockClear();
+
+      const mockDeps = {
+        events: {} as never,
+        autoModeService: {} as never,
+        featureHealthService: {} as never,
+        integrityWatchdogService: {} as never,
+        featureLoader: {} as never,
+        settingsService: {} as never,
+      };
+
+      await service.syncWithScheduler(mockDeps);
+
+      expect(registerMaintenanceTasks).toHaveBeenCalledOnce();
+      // Only the enabled automation should be registered
+      expect(scheduler.registerTask).toHaveBeenCalledOnce();
+      const [taskId] = vi.mocked(scheduler.registerTask).mock.calls[0];
+      expect(taskId).toMatch(/^automation:/);
+    });
+  });
+
+  describe('loadAll()', () => {
+    it('is an alias for list()', async () => {
+      await service.create({
+        name: 'Load All Test',
+        flowId: 'f1',
+        trigger: { type: 'cron', expression: '0 * * * *' },
+        enabled: false,
+      });
+
+      const listResult = await service.list();
+      const loadAllResult = await service.loadAll();
+
+      expect(loadAllResult).toEqual(listResult);
     });
   });
 });

--- a/docs/server/automation-registry.md
+++ b/docs/server/automation-registry.md
@@ -1,0 +1,176 @@
+# Automation Registry
+
+The Automation Registry provides a REST API and service layer for defining, scheduling, and manually triggering automation flows. Automations reference named flows in a FlowRegistry and can run on cron schedules or on demand.
+
+## Architecture
+
+```
+REST API (/api/automations)
+    |
+AutomationService
+    |-- FlowRegistry (Map<flowId, FlowFactory>)
+    |-- SchedulerService (cron task registration)
+    |-- JSON storage (automations.json, automation-runs.json)
+```
+
+**AutomationService** (`apps/server/src/services/automation-service.ts`):
+
+- Stores automation definitions in `{DATA_DIR}/automations.json`
+- Stores run history in `{DATA_DIR}/automation-runs.json`
+- Registers enabled cron automations with `SchedulerService` at startup via `syncWithScheduler()`
+- Executes flows by looking up the `flowId` in the global `flowRegistry`
+
+**FlowRegistry**: A process-scoped `Map<string, FlowFactory>` (singleton). Services register flows at startup using `flowRegistry.register(flowId, factory)`. The factory receives the automation's `modelConfig` at execution time.
+
+## REST API
+
+Base path: `/api/automations`
+
+All requests require the standard `X-API-Key` header.
+
+### Endpoints
+
+| Method   | Path           | Description                       |
+| -------- | -------------- | --------------------------------- |
+| `GET`    | `/list`        | List all automations              |
+| `GET`    | `/:id`         | Get a single automation by ID     |
+| `POST`   | `/create`      | Create a new automation           |
+| `PUT`    | `/:id`         | Update an automation              |
+| `DELETE` | `/:id`         | Delete an automation              |
+| `GET`    | `/:id/history` | Get run history for an automation |
+| `POST`   | `/:id/run`     | Manually trigger an automation    |
+
+### GET /list
+
+Returns all automations.
+
+```json
+{
+  "automations": [
+    {
+      "id": "uuid",
+      "name": "Nightly Cleanup",
+      "flowId": "cleanup-flow",
+      "trigger": { "type": "cron", "expression": "0 3 * * *" },
+      "enabled": true,
+      "modelConfig": { "model": "haiku" },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+### POST /create
+
+Creates a new automation. The automation is immediately registered with the scheduler if it has a cron trigger and `enabled: true`.
+
+**Request body:**
+
+```json
+{
+  "name": "Nightly Cleanup",
+  "flowId": "cleanup-flow",
+  "trigger": {
+    "type": "cron",
+    "expression": "0 3 * * *"
+  },
+  "enabled": true,
+  "description": "Optional description",
+  "modelConfig": { "model": "haiku" }
+}
+```
+
+**Trigger types:**
+
+| Type      | Fields                             | Notes                                      |
+| --------- | ---------------------------------- | ------------------------------------------ |
+| `cron`    | `expression` (5-field cron string) | Registered with SchedulerService           |
+| `event`   | `eventType` (string)               | Stored only; event routing not yet wired   |
+| `webhook` | `path` (string)                    | Stored only; webhook routing not yet wired |
+
+Returns `201` with the created automation object.
+
+### PUT /:id
+
+Updates any field on an automation. Scheduler registration is synced automatically:
+
+- Enabling a cron automation registers it with the scheduler
+- Disabling a cron automation calls `disableTask()` on the scheduler
+- Changing the cron expression calls `updateTaskSchedule()` on the scheduler
+- Switching from cron to another trigger type unregisters the scheduler task
+
+**Request body (all fields optional):**
+
+```json
+{
+  "enabled": false,
+  "trigger": { "type": "cron", "expression": "0 4 * * *" }
+}
+```
+
+### GET /:id/history
+
+Returns run records sorted newest-first. History is capped at 50 runs per automation.
+
+```json
+{
+  "runs": [
+    {
+      "id": "run-uuid",
+      "automationId": "automation-uuid",
+      "status": "success",
+      "startedAt": "2026-01-01T03:00:00.000Z",
+      "completedAt": "2026-01-01T03:00:01.234Z",
+      "error": null
+    }
+  ]
+}
+```
+
+Run status values: `running`, `success`, `failure`.
+
+### POST /:id/run
+
+Manually triggers the automation, bypassing the cron schedule. The flow referenced by `flowId` must be registered in the FlowRegistry. Returns the run record.
+
+```json
+{
+  "id": "run-uuid",
+  "automationId": "automation-uuid",
+  "status": "success",
+  "startedAt": "...",
+  "completedAt": "...",
+  "error": null
+}
+```
+
+## Registering Flows
+
+Flows must be registered in the FlowRegistry before automations can execute them. Register flows at server startup:
+
+```typescript
+import { flowRegistry } from '../services/automation-service.js';
+
+flowRegistry.register('my-flow', async (modelConfig) => {
+  const model = (modelConfig?.model as string) ?? 'sonnet';
+  // ... run the flow
+});
+```
+
+## Startup Integration
+
+`scheduler.module.ts` calls `automationService.syncWithScheduler(deps)` after the scheduler starts. This method:
+
+1. Registers all built-in maintenance tasks (same as before)
+2. Loads all stored automations from disk
+3. Registers enabled cron automations with the scheduler
+
+## Data Storage
+
+| File                              | Contents                                     |
+| --------------------------------- | -------------------------------------------- |
+| `{DATA_DIR}/automations.json`     | Array of automation definitions              |
+| `{DATA_DIR}/automation-runs.json` | Array of run records (capped per automation) |
+
+`DATA_DIR` defaults to `./data`. See [Environment Variables](/getting-started/env-vars.md).

--- a/libs/types/src/automation.ts
+++ b/libs/types/src/automation.ts
@@ -80,3 +80,55 @@ export interface Automation {
   createdAt: string; // ISO 8601
   updatedAt: string; // ISO 8601
 }
+
+// ============================================================================
+// API Input Types — supplementary types for REST API layer
+// ============================================================================
+
+/**
+ * Input for creating a new automation via POST /api/automations/create
+ */
+export interface CreateAutomationInput {
+  name: string;
+  description?: string;
+  flowId: string;
+  trigger: CronTriggerInput | EventTriggerInput | WebhookTriggerInput;
+  enabled?: boolean;
+  modelConfig?: Record<string, unknown>;
+}
+
+/** Cron trigger input */
+export interface CronTriggerInput {
+  type: 'cron';
+  expression: string;
+}
+
+/** Event trigger input */
+export interface EventTriggerInput {
+  type: 'event';
+  eventType: string;
+}
+
+/** Webhook trigger input */
+export interface WebhookTriggerInput {
+  type: 'webhook';
+  path: string;
+}
+
+/**
+ * Input for updating an automation via PUT /api/automations/:id
+ */
+export interface UpdateAutomationInput {
+  name?: string;
+  description?: string;
+  flowId?: string;
+  trigger?: CronTriggerInput | EventTriggerInput | WebhookTriggerInput;
+  enabled?: boolean;
+  modelConfig?: Record<string, unknown>;
+}
+
+/**
+ * Type for a flow factory function stored in the FlowRegistry.
+ * Receives optional model config and executes the flow.
+ */
+export type FlowFactory = (modelConfig?: Record<string, unknown>) => Promise<void>;

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -3,6 +3,17 @@
  * Shared type definitions for AutoMaker
  */
 
+// Automation registry supplementary types (CreateAutomationInput, UpdateAutomationInput, FlowFactory)
+// Core types (Automation, AutomationRunRecord, etc.) are already exported from the base workspace types
+export type {
+  CreateAutomationInput,
+  UpdateAutomationInput,
+  FlowFactory,
+  CronTriggerInput,
+  EventTriggerInput,
+  WebhookTriggerInput,
+} from './automation.js';
+
 // Provider types
 export type {
   ProviderConfig,

--- a/tests/verification/automations-api.spec.ts
+++ b/tests/verification/automations-api.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Verification test for Automation Registry REST API
+ *
+ * Tests all /api/automations endpoints:
+ * - GET  /api/automations/list
+ * - GET  /api/automations/:id
+ * - POST /api/automations/create
+ * - PUT  /api/automations/:id
+ * - DELETE /api/automations/:id
+ * - GET  /api/automations/:id/history
+ * - POST /api/automations/:id/run
+ */
+
+import { test, expect } from '@playwright/test';
+
+const API_BASE_URL = process.env.AUTOMAKER_API_URL || 'http://localhost:3008';
+const API_KEY = process.env.AUTOMAKER_API_KEY || 'test-key';
+
+const headers = {
+  'Content-Type': 'application/json',
+  'X-API-Key': API_KEY,
+};
+
+async function get(path: string) {
+  return fetch(`${API_BASE_URL}${path}`, { headers });
+}
+
+async function post(path: string, body: unknown) {
+  return fetch(`${API_BASE_URL}${path}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+async function put(path: string, body: unknown) {
+  return fetch(`${API_BASE_URL}${path}`, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+async function del(path: string) {
+  return fetch(`${API_BASE_URL}${path}`, { method: 'DELETE', headers });
+}
+
+test.describe('Automation Registry REST API', () => {
+  let createdId: string;
+
+  test('GET /api/automations/list returns an array', async () => {
+    const res = await get('/api/automations/list');
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { automations: unknown[] };
+    expect(Array.isArray(data.automations)).toBe(true);
+  });
+
+  test('POST /api/automations/create requires name and flowId', async () => {
+    const res = await post('/api/automations/create', {});
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(typeof data.error).toBe('string');
+  });
+
+  test('POST /api/automations/create creates a cron automation', async () => {
+    const res = await post('/api/automations/create', {
+      name: 'Test Verification Automation',
+      flowId: 'test-flow',
+      trigger: { type: 'cron', expression: '0 * * * *' },
+      enabled: false,
+    });
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as {
+      id: string;
+      name: string;
+      enabled: boolean;
+      trigger: { type: string; expression: string };
+    };
+    expect(data.id).toBeTruthy();
+    expect(data.name).toBe('Test Verification Automation');
+    expect(data.enabled).toBe(false);
+    expect(data.trigger.type).toBe('cron');
+    createdId = data.id;
+  });
+
+  test('GET /api/automations/list includes the created automation', async () => {
+    const res = await get('/api/automations/list');
+    const data = (await res.json()) as { automations: Array<{ id: string }> };
+    expect(data.automations.some((a) => a.id === createdId)).toBe(true);
+  });
+
+  test('GET /api/automations/:id returns the automation', async () => {
+    const res = await get(`/api/automations/${createdId}`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { id: string; name: string };
+    expect(data.id).toBe(createdId);
+    expect(data.name).toBe('Test Verification Automation');
+  });
+
+  test('GET /api/automations/:id returns 404 for unknown id', async () => {
+    const res = await get('/api/automations/nonexistent-id-000');
+    expect(res.status).toBe(404);
+  });
+
+  test('PUT /api/automations/:id updates automation fields', async () => {
+    const res = await put(`/api/automations/${createdId}`, { enabled: true });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { id: string; enabled: boolean };
+    expect(data.id).toBe(createdId);
+    expect(data.enabled).toBe(true);
+  });
+
+  test('PUT /api/automations/:id returns 404 for unknown id', async () => {
+    const res = await put('/api/automations/nonexistent-id-000', { enabled: true });
+    expect(res.status).toBe(404);
+  });
+
+  test('GET /api/automations/:id/history returns run array', async () => {
+    const res = await get(`/api/automations/${createdId}/history`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { runs: unknown[] };
+    expect(Array.isArray(data.runs)).toBe(true);
+  });
+
+  test('GET /api/automations/:id/history returns 404 for unknown id', async () => {
+    const res = await get('/api/automations/nonexistent-id-000/history');
+    expect(res.status).toBe(404);
+  });
+
+  test('POST /api/automations/:id/run returns 404 for unknown id', async () => {
+    const res = await post('/api/automations/nonexistent-id-000/run', {});
+    expect(res.status).toBe(404);
+  });
+
+  test('DELETE /api/automations/:id deletes the automation', async () => {
+    const res = await del(`/api/automations/${createdId}`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { success: boolean; id: string };
+    expect(data.success).toBe(true);
+    expect(data.id).toBe(createdId);
+  });
+
+  test('DELETE /api/automations/:id returns 404 for unknown id', async () => {
+    const res = await del('/api/automations/nonexistent-id-000');
+    expect(res.status).toBe(404);
+  });
+
+  test('GET /api/automations/:id returns 404 after deletion', async () => {
+    const res = await get(`/api/automations/${createdId}`);
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `AutomationService` with full CRUD, `FlowRegistry` singleton, run history (capped at 50/automation), and `syncWithScheduler()` for boot-time wiring
- Add 8 REST routes at `/api/automations` — list, get, create, update, delete, history, run — wired into `ServiceContainer` and `routes.ts`
- Wire `automationService.syncWithScheduler(deps)` into `scheduler.module.ts`, replacing the direct `registerMaintenanceTasks()` call (backward-compatible: `syncWithScheduler` calls it internally first)
- Add supplementary API input types (`CreateAutomationInput`, `UpdateAutomationInput`, `FlowFactory`, trigger input types) to `@protolabs-ai/types`
- 23 unit tests for `AutomationService` + docs at `docs/server/automation-registry.md`

## Notes

- `FlowRegistry` is empty by default. Flows register at server startup via `flowRegistry.register(id, factory)`.
- `POST /api/automations/:id/run` returns 500 `"Flow not registered: <flowId>"` until flows are wired — by design, no stubs.
- Event and webhook trigger types are stored/returned by API but routing is future work.

## Test plan

- [x] TypeScript typecheck: 0 errors
- [x] Server unit tests: 2249 passed (96 files), including 23 new automation service tests
- [ ] E2E: verify CRUD lifecycle via Playwright spec at `tests/verification/automations-api.spec.ts` after server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automation Registry API: REST endpoints for creating, updating, deleting, and listing automations.
  * Schedule automations with cron, event, and webhook triggers.
  * Track automation run history and manually execute automations on demand.

* **Documentation**
  * Comprehensive Automation Registry documentation added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->