### PR TITLE
Conversation Container + Prompt Input Upgrade

### DIFF
--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
@@ -6,11 +6,19 @@
  *
  * Reads currentProject from useAppStore and passes projectId/projectPath
  * to useChatSession for project-scoped session management.
+ *
+ * Input state is managed via PromptInputProvider so ChatInput does not
+ * require value/onChange props to be threaded through the tree.
  */
 
 import { useState, useCallback, useEffect } from 'react';
 import { History, X, Settings, ChevronUp, ChevronDown } from 'lucide-react';
-import { ChatMessageList, ChatInput, SuggestionList } from '@protolabs-ai/ui/ai';
+import {
+  ChatMessageList,
+  ChatInput,
+  SuggestionList,
+  PromptInputProvider,
+} from '@protolabs-ai/ui/ai';
 import { Button } from '@protolabs-ai/ui/atoms';
 import { Popover, PopoverContent, PopoverTrigger } from '@protolabs-ai/ui/atoms';
 import { cn } from '@/lib/utils';
@@ -58,18 +66,20 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
     projectPath: currentProject?.path,
   });
 
-  const [inputValue, setInputValue] = useState('');
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
 
   const suggestions = useContextualSuggestions(features ?? []);
 
-  const handleSubmit = useCallback(() => {
-    const text = inputValue.trim();
-    if (!text || isStreaming) return;
-    sendMessage({ text });
-    setInputValue('');
-  }, [inputValue, isStreaming, sendMessage]);
+  // onSubmit receives the trimmed text from ChatInput (via PromptInputProvider).
+  // ChatInput clears the input immediately after calling this.
+  const handleSubmit = useCallback(
+    (text: string) => {
+      if (isStreaming) return;
+      sendMessage({ text });
+    },
+    [isStreaming, sendMessage]
+  );
 
   const handleSuggestionSelect = useCallback(
     (value: string) => {
@@ -213,23 +223,24 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
             <SuggestionList suggestions={suggestions} onSelect={handleSuggestionSelect} />
           )}
 
-          <ChatInput
-            value={inputValue}
-            onChange={setInputValue}
-            onSubmit={handleSubmit}
-            onStop={stop}
-            isStreaming={isStreaming}
-            placeholder="Ask Ava..."
-            autoFocus
-            actions={
-              <>
-                <ChatModelSelect value={modelAlias} onValueChange={handleModelChange} />
-                <span className="text-[10px] text-muted-foreground">
-                  {isStreaming ? 'Streaming...' : `Enter to send \u00B7 ${shortcutHint}`}
-                </span>
-              </>
-            }
-          />
+          {/* PromptInputProvider scopes input state to this chat area */}
+          <PromptInputProvider>
+            <ChatInput
+              onSubmit={handleSubmit}
+              onStop={stop}
+              isStreaming={isStreaming}
+              placeholder="Ask Ava..."
+              autoFocus
+              actions={
+                <>
+                  <ChatModelSelect value={modelAlias} onValueChange={handleModelChange} />
+                  <span className="text-[10px] text-muted-foreground">
+                    {isStreaming ? 'Streaming...' : `Enter to send \u00B7 ${shortcutHint}`}
+                  </span>
+                </>
+              }
+            />
+          </PromptInputProvider>
         </div>
       </div>
     </div>

--- a/libs/ui/src/ai/chat-input.tsx
+++ b/libs/ui/src/ai/chat-input.tsx
@@ -1,52 +1,57 @@
 /**
- * ChatInput — Auto-resizing prompt textarea with submit/stop controls.
+ * ChatInput — Auto-resizing prompt textarea with a bottom action toolbar.
  *
- * Handles Enter to submit (Shift+Enter for newline).
- * Pure presentational — no business logic, no API knowledge.
+ * Reads value from PromptInputProvider context (no prop drilling).
+ * Enter submits, Shift+Enter inserts a newline.
+ * Auto-resizes up to 8 lines; beyond that the textarea scrolls internally.
+ * The bottom toolbar houses the actions slot (e.g. model selector) on the
+ * left and the submit/stop button on the right.
  */
 
 import { useCallback, useEffect, useRef } from 'react';
 import { Send, Square } from 'lucide-react';
 import { cn } from '../lib/utils.js';
 import { Button } from '../atoms/button.js';
+import { usePromptInput } from './prompt-input-context.js';
+
+/** Maximum textarea height — 8 lines × ~24 px line-height. */
+const MAX_HEIGHT_PX = 192;
 
 export function ChatInput({
-  value,
-  onChange,
   onSubmit,
   onStop,
   isStreaming,
   disabled,
   placeholder = 'Ask anything...',
+  /** Slot for the left side of the bottom toolbar (e.g. model selector). */
   actions,
   className,
   autoFocus,
 }: {
-  value: string;
-  onChange: (value: string) => void;
-  onSubmit: () => void;
+  /** Called with the trimmed message text when the user submits. */
+  onSubmit: (text: string) => void;
   onStop?: () => void;
   isStreaming?: boolean;
   disabled?: boolean;
   placeholder?: string;
-  /** Optional slot for extra controls (e.g. model selector) rendered below the input */
   actions?: React.ReactNode;
   className?: string;
-  /** Focus the input on mount */
   autoFocus?: boolean;
 }) {
+  const { value, setValue, clear } = usePromptInput();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isDisabled = disabled || isStreaming;
   const canSubmit = value.trim().length > 0 && !isDisabled;
 
+  // Auto-resize up to MAX_HEIGHT_PX; textarea handles its own overflow beyond that.
   useEffect(() => {
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = 'auto';
-    el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
+    el.style.height = `${Math.min(el.scrollHeight, MAX_HEIGHT_PX)}px`;
   }, [value]);
 
-  // Re-focus after streaming ends so user can type the next message immediately
+  // Re-focus after streaming ends so the user can type the next message immediately.
   const prevStreamingRef = useRef(false);
   useEffect(() => {
     if (prevStreamingRef.current && !isStreaming) {
@@ -55,14 +60,21 @@ export function ChatInput({
     prevStreamingRef.current = !!isStreaming;
   }, [isStreaming]);
 
+  const handleSubmitInternal = useCallback(() => {
+    const text = value.trim();
+    if (!text || isDisabled) return;
+    onSubmit(text);
+    clear();
+  }, [value, isDisabled, onSubmit, clear]);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
-        if (canSubmit) onSubmit();
+        handleSubmitInternal();
       }
     },
-    [canSubmit, onSubmit]
+    [handleSubmitInternal]
   );
 
   return (
@@ -70,42 +82,47 @@ export function ChatInput({
       data-slot="chat-input"
       className={cn('border-t border-border bg-background p-3', className)}
     >
-      <div className="flex items-end gap-2">
-        <textarea
-          ref={textareaRef}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder={placeholder}
-          disabled={isDisabled}
-          rows={1}
-          autoFocus={autoFocus}
-          className="flex-1 resize-none bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none disabled:opacity-50"
-        />
+      {/* Textarea row */}
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={isDisabled}
+        rows={1}
+        autoFocus={autoFocus}
+        className="w-full resize-none bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none disabled:opacity-50"
+        style={{ maxHeight: MAX_HEIGHT_PX, overflowY: 'auto' }}
+      />
+
+      {/* Bottom toolbar: actions left, submit/stop right */}
+      <div className="mt-1 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1">{actions}</div>
+
         {isStreaming && onStop ? (
           <Button
             variant="ghost"
             size="icon"
-            className="size-8 shrink-0"
+            className="size-7 shrink-0"
             onClick={onStop}
             aria-label="Stop generating"
           >
-            <Square className="size-4" />
+            <Square className="size-3.5" />
           </Button>
         ) : (
           <Button
             variant="ghost"
             size="icon"
-            className="size-8 shrink-0"
-            onClick={onSubmit}
+            className="size-7 shrink-0"
+            onClick={handleSubmitInternal}
             disabled={!canSubmit}
             aria-label="Send message"
           >
-            <Send className="size-4" />
+            <Send className="size-3.5" />
           </Button>
         )}
       </div>
-      {actions && <div className="mt-1 flex items-center justify-between">{actions}</div>}
     </div>
   );
 }

--- a/libs/ui/src/ai/chat-message-list.tsx
+++ b/libs/ui/src/ai/chat-message-list.tsx
@@ -1,8 +1,15 @@
 /**
- * ChatMessageList — Scrollable message container with auto-scroll.
+ * ChatMessageList — Scrollable message container with stick-to-bottom behaviour.
  *
- * Uses MutationObserver to auto-scroll on new content unless user has scrolled up.
- * Shows a "scroll to bottom" button when not at bottom.
+ * Automatically follows new content while the user is at the bottom.
+ * When the user scrolls up, auto-scroll pauses without interruption.
+ * A "scroll to bottom" button re-appears whenever the view is not at the bottom.
+ *
+ * Implementation notes:
+ *  - MutationObserver watches the content node for any DOM changes (streaming
+ *    tokens) and scrolls only when the user has NOT manually scrolled away.
+ *  - The messages.length effect only scrolls when the user is still at the
+ *    bottom, so a manually-scrolled-up view is never hijacked.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -24,14 +31,7 @@ export function ChatMessageList({
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const [isAtBottom, setIsAtBottom] = useState(true);
-  const [userScrolled, setUserScrolled] = useState(false);
-
-  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
-    const el = scrollRef.current;
-    if (!el) return;
-    el.scrollTo({ top: el.scrollHeight, behavior });
-    setUserScrolled(false);
-  }, []);
+  const userScrolledRef = useRef(false);
 
   const checkIfAtBottom = useCallback(() => {
     const el = scrollRef.current;
@@ -39,6 +39,16 @@ export function ChatMessageList({
     return el.scrollHeight - el.scrollTop - el.clientHeight < 50;
   }, []);
 
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior });
+    userScrolledRef.current = false;
+    setIsAtBottom(true);
+  }, []);
+
+  // Track scroll position to show/hide the scroll-to-bottom button
+  // and determine whether auto-scroll should fire.
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -46,23 +56,46 @@ export function ChatMessageList({
     const handleScroll = () => {
       const atBottom = checkIfAtBottom();
       setIsAtBottom(atBottom);
-      if (!atBottom) {
-        setUserScrolled(true);
-      } else {
-        setUserScrolled(false);
+      if (atBottom) {
+        userScrolledRef.current = false;
       }
+      // Only mark as "user scrolled" when moving away from bottom.
+      // We detect this by checking if the user is NOT at bottom; the ref
+      // is cleared whenever we scroll back to the bottom programmatically
+      // or the user scrolls back themselves.
     };
 
     el.addEventListener('scroll', handleScroll, { passive: true });
     return () => el.removeEventListener('scroll', handleScroll);
   }, [checkIfAtBottom]);
 
+  // Detect scroll-up gestures via wheel/touch to set the userScrolled flag.
+  // This ensures we can distinguish user intent from programmatic scrolling.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const markUserScrolled = () => {
+      if (!checkIfAtBottom()) {
+        userScrolledRef.current = true;
+      }
+    };
+
+    el.addEventListener('wheel', markUserScrolled, { passive: true });
+    el.addEventListener('touchmove', markUserScrolled, { passive: true });
+    return () => {
+      el.removeEventListener('wheel', markUserScrolled);
+      el.removeEventListener('touchmove', markUserScrolled);
+    };
+  }, [checkIfAtBottom]);
+
+  // Auto-scroll on streaming content changes (MutationObserver).
   useEffect(() => {
     const el = contentRef.current;
     if (!el) return;
 
     const observer = new MutationObserver(() => {
-      if (!userScrolled) {
+      if (!userScrolledRef.current) {
         scrollToBottom('smooth');
       }
     });
@@ -74,11 +107,17 @@ export function ChatMessageList({
     });
 
     return () => observer.disconnect();
-  }, [userScrolled, scrollToBottom]);
+  }, [scrollToBottom]);
 
+  // When a new message is appended, scroll to bottom only if the user
+  // has not manually scrolled away. This prevents hijacking reading position
+  // during long conversations / streaming.
   useEffect(() => {
-    scrollToBottom('instant');
-  }, [messages.length, scrollToBottom]);
+    if (!userScrolledRef.current) {
+      scrollToBottom('instant');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messages.length]);
 
   return (
     <div data-slot="chat-message-list" className={cn('relative flex-1 overflow-hidden', className)}>

--- a/libs/ui/src/ai/index.ts
+++ b/libs/ui/src/ai/index.ts
@@ -13,6 +13,8 @@ export { ChatMessageList } from './chat-message-list.js';
 
 export { ChatInput } from './chat-input.js';
 
+export { PromptInputProvider, usePromptInput } from './prompt-input-context.js';
+
 export { SuggestionList, type SuggestionItem } from './suggestion.js';
 
 export { ReasoningPart, type ReasoningPartProps } from './reasoning-part.js';

--- a/libs/ui/src/ai/prompt-input-context.tsx
+++ b/libs/ui/src/ai/prompt-input-context.tsx
@@ -1,0 +1,36 @@
+/**
+ * PromptInputProvider — Context for managing chat input value.
+ *
+ * Eliminates prop drilling of value/onChange between ChatInput
+ * and its parent. Wrap the chat area with PromptInputProvider;
+ * ChatInput reads and clears the value via usePromptInput().
+ */
+
+import { createContext, useCallback, useContext, useState } from 'react';
+
+interface PromptInputContextValue {
+  value: string;
+  setValue: (v: string) => void;
+  clear: () => void;
+}
+
+const PromptInputContext = createContext<PromptInputContextValue | null>(null);
+
+export function PromptInputProvider({ children }: { children: React.ReactNode }) {
+  const [value, setValue] = useState('');
+  const clear = useCallback(() => setValue(''), []);
+
+  return (
+    <PromptInputContext.Provider value={{ value, setValue, clear }}>
+      {children}
+    </PromptInputContext.Provider>
+  );
+}
+
+export function usePromptInput(): PromptInputContextValue {
+  const ctx = useContext(PromptInputContext);
+  if (!ctx) {
+    throw new Error('usePromptInput must be used within <PromptInputProvider>');
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Summary

**Milestone:** M1: Core UI Primitives

Replace the current manual scroll logic in chat-overlay-content.tsx with a proper stick-to-bottom Conversation container. Upgrade the Prompt Input to auto-resize, support Shift+Enter for newlines, add a bottom action toolbar with model selector and submit button. Extract ChatInput as a standalone composable component. Wire PromptInputProvider so the input clears after send without prop drilling.

**Files to Modify:**
- apps/ui/src/components/views/chat-over...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat input actions now display in a bottom toolbar for improved layout organization
  * Message list auto-scroll behavior enhanced: intelligently scrolls to bottom when you're positioned at the bottom; pauses when you manually scroll up to preserve your reading position

<!-- end of auto-generated comment: release notes by coderabbit.ai -->