### PR TITLE
feat: headless claude subprocess tool + maintenance langgraph flow

### DIFF
--- a/libs/flows/src/index.ts
+++ b/libs/flows/src/index.ts
@@ -184,6 +184,14 @@ export {
   extractOptionalEnum,
 } from './content/xml-parser.js';
 
+// Maintenance flow (board health check → LLM analysis → Discord report)
+export {
+  createMaintenanceFlow,
+  type MaintenanceFlowDeps,
+  type MaintenanceFeatureLoader,
+  type MaintenanceDiscordBot,
+} from './maintenance/maintenance-flow.js';
+
 // Project planning flow (Linear-native HITL workflow)
 export {
   createProjectPlanningFlow,

--- a/libs/flows/src/maintenance/maintenance-flow.ts
+++ b/libs/flows/src/maintenance/maintenance-flow.ts
@@ -1,0 +1,187 @@
+/**
+ * Maintenance LangGraph flow — reference implementation for Automation-powered health checks.
+ *
+ * This is the first automation migrated from a hardcoded maintenance task to a real LangGraph
+ * StateGraph. It replaces the board-health cron task with a proper flow that can be
+ * composed, extended, and observed like any other flow in the system.
+ *
+ * Three sequential nodes:
+ *   START → loadBoardState → analyzeHealth → reportToDiscord → END
+ *
+ * Dependencies are injected via MaintenanceFlowDeps — structural interfaces only,
+ * so this flow has no hard dependencies on @protolabs-ai/tools or concrete service classes.
+ */
+
+import { StateGraph, Annotation, END, START } from '@langchain/langgraph';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import type { Feature } from '@protolabs-ai/types';
+
+// ---------------------------------------------------------------------------
+// Minimal structural interfaces (dependency injection without concrete imports)
+// ---------------------------------------------------------------------------
+
+/**
+ * Subset of FeatureLoader used by the maintenance flow.
+ * Any object with a matching getAll signature satisfies this interface.
+ */
+export interface MaintenanceFeatureLoader {
+  getAll: (projectPath: string) => Promise<Feature[]>;
+}
+
+/**
+ * Subset of DiscordBot used by the maintenance flow.
+ * Any object with a matching sendMessage signature satisfies this interface.
+ */
+export interface MaintenanceDiscordBot {
+  sendMessage: (channelId: string, content: string) => Promise<{ id: string }>;
+}
+
+/**
+ * All dependencies required to create a maintenance flow instance.
+ */
+export interface MaintenanceFlowDeps {
+  /** Feature loader for reading board state */
+  featureLoader: MaintenanceFeatureLoader;
+  /** LangChain BaseChatModel for board health analysis */
+  model: BaseChatModel;
+  /** Discord bot for sending the health report */
+  discordBot: MaintenanceDiscordBot;
+  /** Absolute path to the project directory */
+  projectPath: string;
+  /** Discord channel ID to send the report to */
+  discordChannelId: string;
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const MaintenanceStateAnnotation = Annotation.Root({
+  boardSummary: Annotation<string>,
+  analysis: Annotation<string>,
+  reportSent: Annotation<boolean>,
+  error: Annotation<string>,
+});
+
+type MaintenanceState = typeof MaintenanceStateAnnotation.State;
+
+// ---------------------------------------------------------------------------
+// Node factories
+// ---------------------------------------------------------------------------
+
+/**
+ * loadBoardState: Fetches all features and builds a concise board summary string.
+ * Groups features by status, lists blocked feature titles for quick triage.
+ */
+function createLoadBoardStateNode(deps: MaintenanceFlowDeps) {
+  return async (_state: MaintenanceState): Promise<Partial<MaintenanceState>> => {
+    const features = await deps.featureLoader.getAll(deps.projectPath);
+
+    const byStatus = features.reduce<Record<string, number>>((acc, f) => {
+      const status = f.status ?? 'unknown';
+      acc[status] = (acc[status] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    const statusLines = Object.entries(byStatus)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([status, count]) => `  ${status}: ${count}`)
+      .join('\n');
+
+    const blockedFeatures = features.filter((f) => f.status === 'blocked');
+    const blockedSection =
+      blockedFeatures.length > 0
+        ? `\n\nBlocked features (${blockedFeatures.length}):\n` +
+          blockedFeatures.map((f) => `  - ${f.title ?? f.id}`).join('\n')
+        : '';
+
+    const boardSummary =
+      `Board state — ${features.length} total features:\n${statusLines}` + blockedSection;
+
+    return { boardSummary };
+  };
+}
+
+/**
+ * analyzeHealth: Calls the LLM to analyze board health and produce a concise report
+ * suitable for posting to a Discord channel.
+ */
+function createAnalyzeHealthNode(deps: MaintenanceFlowDeps) {
+  return async (state: MaintenanceState): Promise<Partial<MaintenanceState>> => {
+    const prompt =
+      `You are a project health analyst. Review the following board state and provide a ` +
+      `concise health report (3–5 bullet points) suitable for a Discord channel update. ` +
+      `Flag any concerns (too many blocked features, large backlogs, stalled in-progress work). ` +
+      `Keep the response under 300 words and use markdown bullet points.\n\n` +
+      `Board state:\n${state.boardSummary}\n\nHealth report:`;
+
+    const response = await deps.model.invoke([{ role: 'user', content: prompt }]);
+    const analysis =
+      typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+
+    return { analysis };
+  };
+}
+
+/**
+ * reportToDiscord: Sends the health analysis to the configured Discord channel.
+ * Truncates to 2000 chars to stay within Discord's message limit.
+ */
+function createReportToDiscordNode(deps: MaintenanceFlowDeps) {
+  return async (state: MaintenanceState): Promise<Partial<MaintenanceState>> => {
+    const message = `**Board Health Report**\n\n${state.analysis}`;
+    const truncated = message.length > 2000 ? message.slice(0, 1997) + '...' : message;
+
+    await deps.discordBot.sendMessage(deps.discordChannelId, truncated);
+    return { reportSent: true };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates and compiles the maintenance LangGraph flow.
+ *
+ * Flow topology: START → loadBoardState → analyzeHealth → reportToDiscord → END
+ *
+ * Usage (server-side):
+ * ```typescript
+ * import { createMaintenanceFlow } from '@protolabs-ai/flows';
+ * import { createLangChainModel } from '@protolabs-ai/llm-providers';
+ *
+ * const flow = createMaintenanceFlow({
+ *   featureLoader,
+ *   model: createLangChainModel({ model: 'claude-haiku-4-5-20251001' }),
+ *   discordBot,
+ *   projectPath: '/path/to/project',
+ *   discordChannelId: '1469080556720623699',
+ * });
+ *
+ * await flow.invoke({});
+ * ```
+ *
+ * @param deps - Flow dependencies (featureLoader, LLM model, discordBot, projectPath, channelId)
+ * @returns Compiled StateGraph ready for .invoke()
+ */
+export function createMaintenanceFlow(deps: MaintenanceFlowDeps) {
+  const graph = new StateGraph(MaintenanceStateAnnotation);
+
+  graph.addNode('loadBoardState', createLoadBoardStateNode(deps));
+  graph.addNode('analyzeHealth', createAnalyzeHealthNode(deps));
+  graph.addNode('reportToDiscord', createReportToDiscordNode(deps));
+
+  // TypeScript's strict node-name literal inference requires casting here.
+  // The same pattern is used in coordinator-flow.ts and research-flow.ts.
+  const g = graph as unknown as {
+    addEdge: (from: string, to: string) => void;
+  };
+
+  g.addEdge(START as unknown as string, 'loadBoardState');
+  g.addEdge('loadBoardState', 'analyzeHealth');
+  g.addEdge('analyzeHealth', 'reportToDiscord');
+  g.addEdge('reportToDiscord', END as unknown as string);
+
+  return graph.compile();
+}

--- a/libs/flows/tests/unit/maintenance-flow.test.ts
+++ b/libs/flows/tests/unit/maintenance-flow.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Maintenance Flow Tests
+ *
+ * Unit tests for createMaintenanceFlow() — verifies the 3-node LangGraph flow
+ * runs successfully end-to-end with mock dependencies.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createMaintenanceFlow } from '../../src/maintenance/maintenance-flow.js';
+import type { MaintenanceFlowDeps } from '../../src/maintenance/maintenance-flow.js';
+
+describe('createMaintenanceFlow()', () => {
+  const mockFeatures = [
+    { id: 'feat-1', title: 'Feature A', status: 'backlog' },
+    { id: 'feat-2', title: 'Feature B', status: 'in_progress' },
+    { id: 'feat-3', title: 'Feature C', status: 'blocked' },
+    { id: 'feat-4', title: 'Feature D', status: 'done' },
+  ];
+
+  function makeDeps(overrides?: Partial<MaintenanceFlowDeps>): MaintenanceFlowDeps {
+    return {
+      featureLoader: {
+        getAll: vi.fn().mockResolvedValue(mockFeatures),
+      },
+      model: {
+        invoke: vi.fn().mockResolvedValue({
+          content: '- Board looks healthy\n- 1 blocked feature needs attention',
+        }),
+      } as unknown as MaintenanceFlowDeps['model'],
+      discordBot: {
+        sendMessage: vi.fn().mockResolvedValue({ id: 'msg-123' }),
+      },
+      projectPath: '/test/project',
+      discordChannelId: '1234567890',
+      ...overrides,
+    };
+  }
+
+  it('compiles without throwing', () => {
+    expect(() => createMaintenanceFlow(makeDeps())).not.toThrow();
+  });
+
+  it('invokes featureLoader.getAll with the configured projectPath', async () => {
+    const deps = makeDeps();
+    const flow = createMaintenanceFlow(deps);
+    await flow.invoke({});
+    expect(deps.featureLoader.getAll).toHaveBeenCalledWith('/test/project');
+  });
+
+  it('invokes model.invoke with a prompt containing the board summary', async () => {
+    const deps = makeDeps();
+    const flow = createMaintenanceFlow(deps);
+    await flow.invoke({});
+
+    const callArg = vi.mocked(deps.model.invoke).mock.calls[0][0] as unknown[];
+    const msg = callArg[0] as { role: string; content: string };
+    expect(msg.content).toContain('blocked');
+    expect(msg.content).toContain('Board state');
+  });
+
+  it('sends the analysis to Discord with the configured channelId', async () => {
+    const deps = makeDeps();
+    const flow = createMaintenanceFlow(deps);
+    await flow.invoke({});
+
+    expect(deps.discordBot.sendMessage).toHaveBeenCalledWith(
+      '1234567890',
+      expect.stringContaining('Board Health Report')
+    );
+  });
+
+  it('includes "blocked" features by name in the board summary', async () => {
+    const deps = makeDeps();
+    const flow = createMaintenanceFlow(deps);
+    await flow.invoke({});
+
+    const invokeCall = vi.mocked(deps.model.invoke).mock.calls[0][0] as unknown[];
+    const content = (invokeCall[0] as { content: string }).content;
+    expect(content).toContain('Feature C');
+  });
+
+  it('truncates Discord message to 2000 chars when analysis is very long', async () => {
+    const longAnalysis = 'x'.repeat(2100);
+    const deps = makeDeps({
+      model: {
+        invoke: vi.fn().mockResolvedValue({ content: longAnalysis }),
+      } as unknown as MaintenanceFlowDeps['model'],
+    });
+
+    const flow = createMaintenanceFlow(deps);
+    await flow.invoke({});
+
+    const [, sentMessage] = vi.mocked(deps.discordBot.sendMessage).mock.calls[0];
+    expect((sentMessage as string).length).toBeLessThanOrEqual(2000);
+    expect(sentMessage as string).toMatch(/\.\.\.$/);
+  });
+});

--- a/libs/tools/src/claude-code-tool.ts
+++ b/libs/tools/src/claude-code-tool.ts
@@ -1,0 +1,236 @@
+/**
+ * ClaudeCodeTool — runs `claude -p <prompt>` headlessly with lock file protection.
+ *
+ * Factory: createClaudeCodeTool(deps?) returns a SharedTool named 'claude-code'.
+ *
+ * Key features:
+ * - Per-invocationId lock file prevents concurrent runs of the same automation
+ * - Configurable timeout (default 300 s) terminates the process on expiry
+ * - Captures stdout and stderr; best-effort JSON cost parsing from claude output
+ * - Clean SIGTERM → 3 s grace → SIGKILL termination sequence
+ */
+
+import { spawn } from 'child_process';
+import { writeFileSync, unlinkSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { z } from 'zod';
+import { defineSharedTool } from './define-tool.js';
+import type { SharedTool } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Lock file helpers
+// ---------------------------------------------------------------------------
+
+const LOCK_DIR = join(tmpdir(), 'protolabs-claude-locks');
+
+function lockFilePath(invocationId: string): string {
+  return join(LOCK_DIR, `${invocationId}.lock`);
+}
+
+/**
+ * Attempts to acquire an exclusive lock file for the given invocation ID.
+ * Uses the 'wx' flag (exclusive create) so only one concurrent call succeeds.
+ * Returns true on success, false if the lock is already held.
+ */
+function acquireLock(invocationId: string): boolean {
+  try {
+    mkdirSync(LOCK_DIR, { recursive: true });
+    writeFileSync(lockFilePath(invocationId), String(process.pid), { flag: 'wx' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function releaseLock(invocationId: string): void {
+  try {
+    unlinkSync(lockFilePath(invocationId));
+  } catch {
+    // File may already be gone — safe to ignore
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cost parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Scans output lines for a JSON object containing a `cost_usd` number.
+ * The Claude CLI emits cost information in its JSON output when used with
+ * --output-format json. Returns undefined when no cost data is found.
+ */
+function parseCostUsd(text: string): number | undefined {
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{')) continue;
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      if (typeof parsed['cost_usd'] === 'number') return parsed['cost_usd'] as number;
+    } catch {
+      // Not JSON — skip line
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Deps + schemas
+// ---------------------------------------------------------------------------
+
+export interface ClaudeCodeDeps {
+  /** Path to the claude binary (default: 'claude' — relies on $PATH) */
+  claudePath?: string;
+  /** Default working directory for child processes (default: process.cwd()) */
+  cwd?: string;
+}
+
+const ClaudeCodeInputSchema = z.object({
+  prompt: z.string().describe('Prompt to send to claude -p'),
+  invocationId: z
+    .string()
+    .describe(
+      'Unique ID used for the lock file — prevents concurrent executions of the same automation job. ' +
+        'Use a stable identifier like "board-health-check" or "daily-report".'
+    ),
+  timeout: z
+    .number()
+    .int()
+    .positive()
+    .default(300_000)
+    .describe('Maximum runtime in milliseconds (default: 300 000 = 5 minutes)'),
+  cwd: z.string().optional().describe('Working directory override for this invocation'),
+});
+
+const ClaudeCodeOutputSchema = z.object({
+  output: z.string().describe('Captured stdout from the claude process'),
+  stderr: z.string().describe('Captured stderr from the claude process'),
+  exitCode: z.number().nullable().describe('Process exit code (null if killed by signal)'),
+  timedOut: z.boolean().describe('True if the process was terminated due to timeout'),
+  costUsd: z
+    .number()
+    .optional()
+    .describe('Estimated API cost parsed from JSON output lines, if available'),
+});
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a 'claude-code' SharedTool that spawns `claude -p <prompt>` headlessly.
+ *
+ * The tool manages the full subprocess lifecycle:
+ * 1. Acquires an exclusive lock file keyed by invocationId
+ * 2. Spawns `claude -p <prompt>` with stdout/stderr captured
+ * 3. Enforces a hard timeout (SIGTERM then SIGKILL after 3 s grace period)
+ * 4. Releases the lock file in all exit paths (success, error, timeout)
+ *
+ * @param deps - Optional configuration (claudePath, default cwd)
+ * @returns A SharedTool named 'claude-code' for use with ToolRegistry or toLangGraphTools()
+ */
+export function createClaudeCodeTool(deps?: ClaudeCodeDeps): SharedTool {
+  const claudeBin = deps?.claudePath ?? 'claude';
+  const defaultCwd = deps?.cwd ?? process.cwd();
+
+  return defineSharedTool({
+    name: 'claude-code',
+    description:
+      'Runs `claude -p <prompt>` as a headless subprocess. ' +
+      'Uses an exclusive lock file (keyed by invocationId) to prevent concurrent runs ' +
+      'of the same automation. Enforces a configurable timeout with clean process ' +
+      'termination (SIGTERM then SIGKILL after 3 s grace). Returns captured stdout, ' +
+      'stderr, exit code, and optional cost estimate.',
+    inputSchema: ClaudeCodeInputSchema,
+    outputSchema: ClaudeCodeOutputSchema,
+    metadata: { category: 'ai', tags: ['claude', 'subprocess', 'automation', 'headless'] },
+    execute: async (rawInput) => {
+      const input = rawInput as z.infer<typeof ClaudeCodeInputSchema>;
+
+      if (!acquireLock(input.invocationId)) {
+        return {
+          success: false,
+          error:
+            `Lock already held for invocationId '${input.invocationId}'. ` +
+            'Another instance of this automation is still running.',
+        };
+      }
+
+      let timedOut = false;
+      let timeoutHandle: NodeJS.Timeout | null = null;
+      let stdoutBuf = '';
+      let stderrBuf = '';
+
+      try {
+        const child = spawn(claudeBin, ['-p', input.prompt], {
+          cwd: input.cwd ?? defaultCwd,
+          stdio: ['ignore', 'pipe', 'pipe'],
+          env: { ...process.env },
+        });
+
+        // Pre-register exit promise BEFORE data listeners to eliminate the race
+        // where the process exits between stdout-close and listener attachment.
+        const exitPromise = new Promise<number | null>((resolve) => {
+          child.on('exit', resolve);
+          child.on('error', () => resolve(null));
+        });
+
+        // Arm timeout: SIGTERM first, then SIGKILL after 3 s grace period
+        timeoutHandle = setTimeout(() => {
+          timedOut = true;
+          child.kill('SIGTERM');
+          setTimeout(() => {
+            try {
+              child.kill('SIGKILL');
+            } catch {
+              // Process already dead — safe to ignore
+            }
+          }, 3_000);
+        }, input.timeout);
+
+        child.stdout?.on('data', (chunk: Buffer) => {
+          stdoutBuf += chunk.toString();
+        });
+        child.stderr?.on('data', (chunk: Buffer) => {
+          stderrBuf += chunk.toString();
+        });
+
+        const exitCode = await exitPromise;
+
+        // Clear timeout if process exited naturally before deadline
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+
+        const costUsd = parseCostUsd(stdoutBuf);
+
+        if (timedOut) {
+          return {
+            success: false,
+            error: `claude -p timed out after ${input.timeout} ms`,
+            data: { output: stdoutBuf, stderr: stderrBuf, exitCode, timedOut: true, costUsd },
+          };
+        }
+
+        if (exitCode !== 0) {
+          const errDetail = stderrBuf.slice(0, 500);
+          return {
+            success: false,
+            error: `claude -p exited with code ${exitCode}${errDetail ? `: ${errDetail}` : ''}`,
+            data: { output: stdoutBuf, stderr: stderrBuf, exitCode, timedOut: false, costUsd },
+          };
+        }
+
+        return {
+          success: true,
+          data: { output: stdoutBuf, stderr: stderrBuf, exitCode, timedOut: false, costUsd },
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to spawn claude process',
+        };
+      } finally {
+        releaseLock(input.invocationId);
+      }
+    },
+  });
+}

--- a/libs/tools/src/index.ts
+++ b/libs/tools/src/index.ts
@@ -26,3 +26,5 @@ export { createDiscordTools } from './discord-tools.js';
 export type { DiscordDeps, DiscordMessage } from './discord-tools.js';
 export { createGitHubTools } from './github-tools.js';
 export type { GitHubDeps, PullRequest } from './github-tools.js';
+export { createClaudeCodeTool } from './claude-code-tool.js';
+export type { ClaudeCodeDeps } from './claude-code-tool.js';

--- a/libs/tools/tests/claude-code-tool.test.ts
+++ b/libs/tools/tests/claude-code-tool.test.ts
@@ -1,0 +1,182 @@
+/**
+ * ClaudeCodeTool Tests
+ *
+ * Unit tests for lock file protection, tool registration, and subprocess output handling.
+ * Uses vi.mock to intercept Node's child_process.spawn so no actual `claude` binary is needed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createClaudeCodeTool } from '../src/claude-code-tool.js';
+import { ToolRegistry } from '../src/registry.js';
+
+// ─── Mock child_process.spawn ─────────────────────────────────────────────────
+
+// Minimal EventEmitter-like child process mock
+function makeMockProcess({
+  stdout = 'hello world\n',
+  stderr = '',
+  exitCode = 0,
+}: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+} = {}) {
+  const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+
+  const on = vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+    listeners[event] = listeners[event] ?? [];
+    listeners[event].push(cb);
+    return mock;
+  });
+
+  const kill = vi.fn();
+
+  const stdoutStream = {
+    on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+      if (event === 'data') {
+        // Emit data asynchronously so listeners are registered first
+        Promise.resolve().then(() => cb(Buffer.from(stdout)));
+      }
+    }),
+  };
+
+  const stderrStream = {
+    on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+      if (event === 'data' && stderr) {
+        Promise.resolve().then(() => cb(Buffer.from(stderr)));
+      }
+    }),
+  };
+
+  const mock = {
+    on,
+    kill,
+    stdout: stdoutStream,
+    stderr: stderrStream,
+    pid: 12345,
+    // Trigger exit after a microtask so that tests can await it
+    _resolveExit: () => {
+      Promise.resolve().then(() => {
+        listeners['exit']?.forEach((cb) => cb(exitCode));
+      });
+    },
+  };
+
+  return mock;
+}
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('createClaudeCodeTool()', () => {
+  let spawnMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const cp = await import('child_process');
+    spawnMock = vi.mocked(cp.spawn);
+    spawnMock.mockReset();
+  });
+
+  it('registers as "claude-code" in ToolRegistry', () => {
+    const tool = createClaudeCodeTool();
+    const registry = new ToolRegistry();
+    registry.register(tool as never);
+    expect(registry.has('claude-code')).toBe(true);
+  });
+
+  it('returns output on successful exit code 0', async () => {
+    const proc = makeMockProcess({ stdout: 'done!\n', exitCode: 0 });
+    spawnMock.mockReturnValue(proc);
+    proc._resolveExit();
+
+    const tool = createClaudeCodeTool({ claudePath: 'claude' });
+    const result = await tool.execute(
+      { prompt: 'hello', invocationId: 'test-success-1', timeout: 5000 },
+      {}
+    );
+
+    expect(result.success).toBe(true);
+    expect((result.data as { output: string }).output).toContain('done!');
+    expect((result.data as { timedOut: boolean }).timedOut).toBe(false);
+  });
+
+  it('returns failure with error message on non-zero exit code', async () => {
+    const proc = makeMockProcess({ stdout: '', stderr: 'fatal error', exitCode: 1 });
+    spawnMock.mockReturnValue(proc);
+    proc._resolveExit();
+
+    const tool = createClaudeCodeTool();
+    const result = await tool.execute(
+      { prompt: 'fail', invocationId: 'test-nonzero-1', timeout: 5000 },
+      {}
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/exited with code 1/);
+    expect(result.error).toContain('fatal error');
+  });
+
+  it('rejects duplicate invocationId when lock is already held', async () => {
+    // First call: lock acquired, process hangs (never exits)
+    const hanging = makeMockProcess();
+    spawnMock.mockReturnValue(hanging);
+    // Don't call _resolveExit so first call is still "in progress"
+
+    const tool = createClaudeCodeTool();
+
+    // Start first call (don't await — let it hang)
+    const firstCall = tool.execute(
+      { prompt: 'first', invocationId: 'duplicate-lock-test', timeout: 60_000 },
+      {}
+    );
+
+    // Second call should immediately see the lock
+    await new Promise((r) => setTimeout(r, 10)); // let first call acquire lock
+    const second = await tool.execute(
+      { prompt: 'second', invocationId: 'duplicate-lock-test', timeout: 5000 },
+      {}
+    );
+
+    expect(second.success).toBe(false);
+    expect(second.error).toMatch(/Lock already held/);
+    expect(second.error).toContain('duplicate-lock-test');
+
+    // Clean up: resolve first call
+    hanging._resolveExit();
+    await firstCall;
+  });
+
+  it('parses costUsd from JSON lines in stdout', async () => {
+    const jsonLine = JSON.stringify({ cost_usd: 0.0042 });
+    const proc = makeMockProcess({ stdout: `some text\n${jsonLine}\n`, exitCode: 0 });
+    spawnMock.mockReturnValue(proc);
+    proc._resolveExit();
+
+    const tool = createClaudeCodeTool();
+    const result = await tool.execute(
+      { prompt: 'cost-test', invocationId: 'test-cost-1', timeout: 5000 },
+      {}
+    );
+
+    expect(result.success).toBe(true);
+    expect((result.data as { costUsd?: number }).costUsd).toBeCloseTo(0.0042);
+  });
+
+  it('uses custom claudePath when provided', async () => {
+    const proc = makeMockProcess({ exitCode: 0 });
+    spawnMock.mockReturnValue(proc);
+    proc._resolveExit();
+
+    const tool = createClaudeCodeTool({ claudePath: '/usr/local/bin/claude-custom' });
+    await tool.execute({ prompt: 'test', invocationId: 'test-path-1', timeout: 5000 }, {});
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/usr/local/bin/claude-custom',
+      ['-p', 'test'],
+      expect.any(Object)
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **`createClaudeCodeTool()`** — new `SharedTool` in `@protolabs-ai/tools` that spawns `claude -p <prompt>` headlessly with:
  - Exclusive lock file per `invocationId` (prevents concurrent runs of the same automation)
  - Configurable timeout (default 5 min): SIGTERM then SIGKILL after 3 s grace
  - stdout/stderr capture + best-effort `cost_usd` parsing from JSON output lines
- **`createMaintenanceFlow()`** — first real LangGraph `StateGraph` in `@protolabs-ai/flows` replacing the board-health hardcoded maintenance task:
  - `loadBoardState` → `analyzeHealth` → `reportToDiscord` (sequential 3-node pipeline)
  - Accepts `BaseChatModel` (from `@langchain/core`) and structural interfaces for deps — no new package-level dependencies
- 11 new unit tests: 5 for `ClaudeCodeTool` (lock contention, exit codes, cost parsing, custom path), 6 for the maintenance flow (end-to-end with mocks, message truncation)

## Test plan
- [x] `npm run build:packages` — 16 packages, all successful
- [x] `npm run test:packages` — 1017/52 passing
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a maintenance flow that loads board state, analyzes health via AI, and sends reports to Discord
  * Added a Claude code tool with process locking, timeout management, and cost tracking capabilities

* **Tests**
  * Added comprehensive test coverage for the new maintenance flow and Claude code tool

<!-- end of auto-generated comment: release notes by coderabbit.ai -->