### PR TITLE
AutomationService + flow node OTel instrumentation

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -38,6 +38,7 @@
     "@octokit/rest": "^22.0.1",
     "@openai/codex-sdk": "^0.98.0",
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api-logs": "^0.212.0",
     "@opentelemetry/auto-instrumentations-node": "^0.70.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.212.0",
     "@opentelemetry/sdk-node": "^0.212.0",

--- a/apps/server/src/services/automation-service.ts
+++ b/apps/server/src/services/automation-service.ts
@@ -11,6 +11,8 @@
 
 import { randomUUID } from 'crypto';
 import path from 'path';
+import { trace, context, SpanStatusCode } from '@opentelemetry/api';
+import { logs, SeverityNumber } from '@opentelemetry/api-logs';
 import { createLogger } from '@protolabs-ai/utils';
 import { secureFs } from '@protolabs-ai/platform';
 import type { Automation, AutomationRunRecord, AutomationRunStatus } from '@protolabs-ai/types';
@@ -307,6 +309,7 @@ export class AutomationService {
   /**
    * Execute an automation by ID.
    * Looks up the flow by flowId in the FlowRegistry and runs it with modelConfig injected.
+   * Creates a root OTel span for the run and emits a log record on completion.
    */
   async executeAutomation(
     id: string,
@@ -324,6 +327,7 @@ export class AutomationService {
 
     const runId = randomUUID();
     const startedAt = new Date().toISOString();
+    const startMs = Date.now();
 
     logger.info(
       `Executing automation "${automation.name}" (${id}), flow: ${automation.flowId}, triggered by: ${triggeredBy}`
@@ -331,9 +335,26 @@ export class AutomationService {
 
     let status: AutomationRunStatus = 'running';
     let error: string | undefined;
+    let traceId: string | undefined;
+
+    const tracer = trace.getTracer('automation-service');
+    const otelLogger = logs.getLogger('automation-service');
+
+    const span = tracer.startSpan(`automation:${id}`, {
+      attributes: {
+        automationId: id,
+        flowId: automation.flowId,
+        'trigger.type': automation.trigger.type,
+        'modelConfig.model': String(automation.modelConfig?.model ?? ''),
+      },
+    });
+
+    const ctx = trace.setSpan(context.active(), span);
 
     try {
-      await factory(automation.modelConfig);
+      await context.with(ctx, async () => {
+        await factory(automation.modelConfig);
+      });
       status = 'success';
     } catch (err) {
       status = 'failure';
@@ -341,7 +362,35 @@ export class AutomationService {
       logger.error(`Automation "${automation.name}" (${id}) failed:`, err);
     }
 
+    const durationMs = Date.now() - startMs;
     const completedAt = new Date().toISOString();
+
+    span.setAttributes({
+      success: status === 'success',
+      durationMs,
+      ...(error ? { errorMessage: error } : {}),
+    });
+
+    if (status === 'success') {
+      span.setStatus({ code: SpanStatusCode.OK });
+    } else {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: error });
+    }
+
+    traceId = span.spanContext().traceId;
+    span.end();
+
+    otelLogger.emit({
+      body: status === 'success' ? 'Automation run completed' : 'Automation run failed',
+      severityNumber: status === 'success' ? SeverityNumber.INFO : SeverityNumber.ERROR,
+      attributes: {
+        'event.name': status === 'success' ? 'automation.run.complete' : 'automation.run.failed',
+        automationId: id,
+        flowId: automation.flowId,
+        durationMs,
+        ...(error ? { errorMessage: error } : {}),
+      },
+    });
 
     const run: AutomationRunRecord = {
       id: runId,
@@ -350,6 +399,7 @@ export class AutomationService {
       startedAt,
       completedAt,
       error,
+      traceId,
     };
 
     await this.appendRun(run);

--- a/libs/flows/package.json
+++ b/libs/flows/package.json
@@ -36,6 +36,7 @@
     "node": ">=22.0.0 <23.0.0"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "@protolabs-ai/model-resolver": "^0.20.1",
     "@protolabs-ai/observability": "^0.20.1",
     "@protolabs-ai/prompts": "^0.20.1",

--- a/libs/flows/src/graphs/builder.ts
+++ b/libs/flows/src/graphs/builder.ts
@@ -1,5 +1,6 @@
 import { StateGraph, END, START, MemorySaver } from '@langchain/langgraph';
 import type { BaseCheckpointSaver } from '@langchain/langgraph';
+import { trace, SpanStatusCode } from '@opentelemetry/api';
 import type { ConditionalEdgeFunction, NodeName } from './routing.js';
 
 /**
@@ -26,6 +27,11 @@ export interface GraphBuilderConfig<TState> {
    * Custom checkpointer (if not provided, uses MemorySaver)
    */
   checkpointer?: Checkpointer;
+
+  /**
+   * Flow ID used as an OTel span attribute on each node span (default: 'unknown')
+   */
+  flowId?: string;
 }
 
 /**
@@ -39,9 +45,11 @@ export type NodeFunction<TState> = (state: TState) => Promise<Partial<TState>> |
 export class GraphBuilder<TState> {
   private graph: StateGraph<any>;
   private checkpointer?: Checkpointer;
+  private flowId: string;
 
   constructor(config: GraphBuilderConfig<TState>) {
     this.graph = new StateGraph(config.stateAnnotation) as any;
+    this.flowId = config.flowId ?? 'unknown';
 
     if (config.enableCheckpointing) {
       this.checkpointer = config.checkpointer || new MemorySaver();
@@ -49,10 +57,35 @@ export class GraphBuilder<TState> {
   }
 
   /**
-   * Adds a node to the graph
+   * Adds a node to the graph, wrapping it with an OTel child span named flow-node:{name}.
    */
   addNode(name: string, fn: NodeFunction<TState>): this {
-    this.graph.addNode(name, fn);
+    const flowId = this.flowId;
+    const wrappedFn = async (state: TState): Promise<Partial<TState>> => {
+      const tracer = trace.getTracer('flows');
+      const inputKeys = Object.keys(state as object);
+      const span = tracer.startSpan(`flow-node:${name}`, {
+        attributes: {
+          flowId,
+          nodeId: name,
+          inputKeys: inputKeys.join(','),
+        },
+      });
+      try {
+        const result = await fn(state);
+        const outputKeys = Object.keys((result ?? {}) as object);
+        span.setAttribute('outputKeys', outputKeys.join(','));
+        span.setStatus({ code: SpanStatusCode.OK });
+        return result;
+      } catch (err) {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: String(err) });
+        span.recordException(err as Error);
+        throw err;
+      } finally {
+        span.end();
+      }
+    };
+    this.graph.addNode(name, wrappedFn);
     return this;
   }
 

--- a/libs/types/src/automation.ts
+++ b/libs/types/src/automation.ts
@@ -45,6 +45,8 @@ export interface AutomationRunRecord {
   completedAt?: string; // ISO 8601
   error?: string;
   output?: unknown;
+  /** OTel trace ID for deep-linking to the Langfuse trace */
+  traceId?: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

**Milestone:** OTel Pipeline

Instrument AutomationService.executeAutomation() to create a root OTel span per run: span name = automation:{id}, attributes = {automationId, flowId, trigger.type, modelConfig.model, success, durationMs, errorMessage}. Add OTel span creation to the LangGraph flow runner: before each node executes, create a child span named flow-node:{nodeId} with {flowId, nodeId, inputKeys, outputKeys}. Emit an OTel Log Record (event.name = 'automation.run.complete' or 'automation.r...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automation runs now capture and record trace IDs for improved tracking and debugging.
  * Flow execution includes detailed span-level tracing with input/output tracking and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->