### PR TITLE
Register ceremonies as Automations + inbox event routing

### DIFF
--- a/apps/server/src/routes/briefing/routes/digest.ts
+++ b/apps/server/src/routes/briefing/routes/digest.ts
@@ -38,29 +38,65 @@ type BriefingSeverity = 'critical' | 'high' | 'medium' | 'low';
  * Based on importance to Ava's briefing needs
  */
 const TRIGGER_SEVERITY_MAP: Record<EventHookTrigger, BriefingSeverity> = {
-  // Critical: System failures, auto-mode errors, critical health checks
+  // Critical: System failures, blocked features, health checks
   auto_mode_error: 'critical',
   health_check_critical: 'critical',
+  feature_permanently_blocked: 'critical',
+  feature_pr_closed_unmerged: 'critical',
+  headsdown_agent_work_failed: 'critical',
+  pr_ci_failure: 'critical',
 
-  // High: Feature failures, retries, recoveries
+  // High: Feature failures, completions, retries, recoveries, key successes
   feature_error: 'high',
   feature_retry: 'high',
   feature_recovery: 'high',
   pr_feedback_received: 'high',
+  feature_success: 'high',
+  feature_completed: 'high',
+  feature_pr_merged: 'high',
+  pr_approved: 'high',
+  headsdown_agent_work_completed: 'high',
+  pr_remediation_completed: 'high',
+  auto_mode_started: 'high',
 
-  // Medium: Feature successes, auto-mode completions, health checks
-  feature_success: 'medium',
+  // Medium: Routine state changes, completions, ceremonies
   auto_mode_complete: 'medium',
   auto_mode_health_check: 'medium',
+  auto_mode_stopped: 'medium',
   skill_created: 'medium',
   memory_learning: 'medium',
   project_scaffolded: 'medium',
-
-  // Low: Feature creation, project deletion, ceremony events
-  feature_created: 'low',
-  project_deleted: 'low',
   milestone_completed: 'medium',
   project_completed: 'medium',
+  feature_started: 'medium',
+  feature_stopped: 'medium',
+  feature_committed: 'medium',
+  feature_blocked: 'medium',
+  feature_unblocked: 'medium',
+  pr_changes_requested: 'medium',
+  pr_remediation_started: 'medium',
+  ceremony_triggered: 'medium',
+  ceremony_milestone_update: 'medium',
+  ceremony_project_retro: 'medium',
+  linear_approval_detected: 'medium',
+  linear_changes_requested_detected: 'medium',
+
+  // Low: Informational events, creation events, low-impact changes
+  feature_created: 'low',
+  project_deleted: 'low',
+  feature_status_changed: 'low',
+  feature_agent_suggested: 'low',
+  headsdown_agent_started: 'low',
+  headsdown_agent_stopped: 'low',
+  worktree_drift_detected: 'low',
+  coderabbit_review_received: 'low',
+  issue_created: 'low',
+  prd_created: 'low',
+  project_analysis_completed: 'low',
+  discord_message_detected: 'low',
+  project_status_changed: 'low',
+  pr_remediation_failed: 'low',
+  health_issue_detected: 'low',
 };
 
 /**

--- a/apps/server/src/services/automation-service.ts
+++ b/apps/server/src/services/automation-service.ts
@@ -478,6 +478,37 @@ export class AutomationService {
 
     logger.info(`Automation sync complete: ${registered} automations registered with scheduler`);
 
+    // Wire event-triggered automations: subscribe once and dispatch to matching automations at runtime
+    const eventsEmitter = deps.events as
+      | { subscribe?: (...args: unknown[]) => unknown }
+      | undefined;
+    if (eventsEmitter && typeof eventsEmitter.subscribe === 'function') {
+      eventsEmitter.subscribe((type: unknown, _payload: unknown) => {
+        void (async () => {
+          try {
+            const allAutomations = await this.readAutomations();
+            const matching = allAutomations.filter(
+              (a) =>
+                a.enabled &&
+                a.trigger.type === 'event' &&
+                (a.trigger as StoredEventTrigger).eventType === type
+            );
+            for (const automation of matching) {
+              this.executeAutomation(automation.id, 'scheduler').catch((err) => {
+                logger.error(
+                  `Event-triggered automation "${automation.name}" (${automation.id}) failed:`,
+                  err
+                );
+              });
+            }
+          } catch (err) {
+            logger.error('Error dispatching event-triggered automations:', err);
+          }
+        })();
+      });
+      logger.info('Event trigger wiring complete');
+    }
+
     // Apply per-task overrides from GlobalSettings.maintenance
     await this.applyMaintenanceSettingsOverrides(deps.settingsService);
   }
@@ -570,6 +601,32 @@ export class AutomationService {
       });
     }
 
+    // Ceremony automations (always seeded — event-triggered)
+    await this.upsertBuiltIn({
+      id: 'ceremony:standup',
+      name: 'Standup Ceremony',
+      description: 'Runs standup flow when a feature completes execution.',
+      trigger: { type: 'event', eventType: 'feature:completed' },
+      flowId: 'standup-flow',
+      enabled: true,
+    });
+    await this.upsertBuiltIn({
+      id: 'ceremony:retro',
+      name: 'Retrospective Ceremony',
+      description: 'Runs retro flow on milestone updates.',
+      trigger: { type: 'event', eventType: 'ceremony:milestone-update' },
+      flowId: 'retro-flow',
+      enabled: true,
+    });
+    await this.upsertBuiltIn({
+      id: 'ceremony:project-retro',
+      name: 'Project Retrospective Ceremony',
+      description: 'Runs project retro flow when a project retrospective is triggered.',
+      trigger: { type: 'event', eventType: 'ceremony:project-retro' },
+      flowId: 'project-retro-flow',
+      enabled: true,
+    });
+
     logger.info('Built-in automation records seeded');
   }
 
@@ -582,7 +639,7 @@ export class AutomationService {
     id: string;
     name: string;
     description: string;
-    trigger: { type: 'cron'; expression: string };
+    trigger: { type: 'cron'; expression: string } | { type: 'event'; eventType: string };
     flowId: string;
     enabled: boolean;
   }): Promise<void> {

--- a/apps/server/src/services/event-hook-service.ts
+++ b/apps/server/src/services/event-hook-service.ts
@@ -42,6 +42,60 @@ const execAsync = promisify(exec);
 const logger = createLogger('EventHooks');
 
 /**
+ * Mapping from EventType strings to EventHookTrigger for the expanded trigger set.
+ * Events handled by dedicated methods above are excluded to avoid double-firing.
+ */
+const GENERIC_EVENT_TYPE_TO_TRIGGER: Partial<Record<string, EventHookTrigger>> = {
+  // Feature lifecycle
+  'feature:started': 'feature_started',
+  'feature:completed': 'feature_completed',
+  'feature:stopped': 'feature_stopped',
+  'feature:committed': 'feature_committed',
+  'feature:pr-merged': 'feature_pr_merged',
+  'feature:pr-closed-unmerged': 'feature_pr_closed_unmerged',
+  'feature:blocked': 'feature_blocked',
+  'feature:unblocked': 'feature_unblocked',
+  'feature:status-changed': 'feature_status_changed',
+  'feature:permanently-blocked': 'feature_permanently_blocked',
+  'feature:agent-suggested': 'feature_agent_suggested',
+  // Auto-mode
+  'auto-mode:started': 'auto_mode_started',
+  'auto-mode:stopped': 'auto_mode_stopped',
+  // PR lifecycle
+  'pr:approved': 'pr_approved',
+  'pr:changes-requested': 'pr_changes_requested',
+  'pr:ci-failure': 'pr_ci_failure',
+  'pr:remediation-started': 'pr_remediation_started',
+  'pr:remediation-completed': 'pr_remediation_completed',
+  'pr:remediation-failed': 'pr_remediation_failed',
+  // Ceremony events
+  'ceremony:milestone-update': 'ceremony_milestone_update',
+  'ceremony:project-retro': 'ceremony_project_retro',
+  'ceremony:triggered': 'ceremony_triggered',
+  // Infrastructure / health
+  'worktree:drift-detected': 'worktree_drift_detected',
+  'health:issue-detected': 'health_issue_detected',
+  // Headsdown agents
+  'headsdown:agent:started': 'headsdown_agent_started',
+  'headsdown:agent:stopped': 'headsdown_agent_stopped',
+  'headsdown:agent:work-completed': 'headsdown_agent_work_completed',
+  'headsdown:agent:work-failed': 'headsdown_agent_work_failed',
+  // Integrations
+  'coderabbit:review-received': 'coderabbit_review_received',
+  'linear:approval:detected': 'linear_approval_detected',
+  'linear:changes-requested:detected': 'linear_changes_requested_detected',
+  'discord:message:detected': 'discord_message_detected',
+  // Project / planning
+  'issue:created': 'issue_created',
+  'prd:created': 'prd_created',
+  'project:analysis-completed': 'project_analysis_completed',
+  'project:status-changed': 'project_status_changed',
+  // Milestone / project completion (not handled via auto-mode:event)
+  'milestone:completed': 'milestone_completed',
+  'project:completed': 'project_completed',
+};
+
+/**
  * Classify event severity based on trigger type
  *
  * Classification rules:
@@ -55,13 +109,26 @@ function classifySeverity(trigger: EventHookTrigger): EventSeverity {
   if (
     trigger === 'feature_error' ||
     trigger === 'auto_mode_error' ||
-    trigger === 'health_check_critical'
+    trigger === 'health_check_critical' ||
+    trigger === 'feature_permanently_blocked' ||
+    trigger === 'feature_pr_closed_unmerged' ||
+    trigger === 'headsdown_agent_work_failed' ||
+    trigger === 'pr_ci_failure'
   ) {
     return 'critical';
   }
 
   // High priority events - important successes and completions
-  if (trigger === 'feature_success' || trigger === 'auto_mode_complete') {
+  if (
+    trigger === 'feature_success' ||
+    trigger === 'auto_mode_complete' ||
+    trigger === 'feature_completed' ||
+    trigger === 'feature_pr_merged' ||
+    trigger === 'pr_approved' ||
+    trigger === 'headsdown_agent_work_completed' ||
+    trigger === 'pr_remediation_completed' ||
+    trigger === 'auto_mode_started'
+  ) {
     return 'high';
   }
 
@@ -69,13 +136,25 @@ function classifySeverity(trigger: EventHookTrigger): EventSeverity {
   if (
     trigger === 'feature_created' ||
     trigger === 'feature_retry' ||
-    trigger === 'feature_recovery'
+    trigger === 'feature_recovery' ||
+    trigger === 'feature_started' ||
+    trigger === 'feature_stopped' ||
+    trigger === 'feature_committed' ||
+    trigger === 'feature_blocked' ||
+    trigger === 'feature_unblocked' ||
+    trigger === 'pr_changes_requested' ||
+    trigger === 'pr_remediation_started' ||
+    trigger === 'ceremony_triggered' ||
+    trigger === 'ceremony_milestone_update' ||
+    trigger === 'ceremony_project_retro' ||
+    trigger === 'auto_mode_stopped' ||
+    trigger === 'linear_approval_detected' ||
+    trigger === 'linear_changes_requested_detected'
   ) {
     return 'medium';
   }
 
   // Low priority - everything else (informational)
-  // auto_mode_health_check, skill_created, memory_learning, pr_feedback_received, project_scaffolded, project_deleted
   return 'low';
 }
 
@@ -274,6 +353,12 @@ export class EventHookService {
         this.handleProjectScaffoldedEvent(payload as ProjectScaffoldedPayload);
       } else if (type === 'project:deleted') {
         this.handleProjectDeletedEvent(payload as ProjectDeletedPayload);
+      } else {
+        // Handle expanded trigger set via generic mapping
+        const trigger = GENERIC_EVENT_TYPE_TO_TRIGGER[type];
+        if (trigger) {
+          void this.handleGenericEvent(trigger, payload as Record<string, unknown>);
+        }
       }
     });
 
@@ -516,6 +601,37 @@ export class EventHookService {
     };
 
     await this.executeHooksForTrigger('health_check_critical', context);
+  }
+
+  /**
+   * Handle generic events using the GENERIC_EVENT_TYPE_TO_TRIGGER mapping.
+   * Extracts common fields (featureId, projectPath, error) from the payload.
+   */
+  private async handleGenericEvent(
+    trigger: EventHookTrigger,
+    payload: Record<string, unknown>
+  ): Promise<void> {
+    const featureId = typeof payload.featureId === 'string' ? payload.featureId : undefined;
+    const featureName =
+      typeof payload.featureTitle === 'string'
+        ? payload.featureTitle
+        : typeof payload.featureName === 'string'
+          ? payload.featureName
+          : undefined;
+    const projectPath = typeof payload.projectPath === 'string' ? payload.projectPath : undefined;
+    const error = typeof payload.error === 'string' ? payload.error : undefined;
+
+    const hookContext: HookContext = {
+      featureId,
+      featureName,
+      projectPath,
+      projectName: projectPath ? this.extractProjectName(projectPath) : undefined,
+      error,
+      timestamp: new Date().toISOString(),
+      eventType: trigger,
+    };
+
+    await this.executeHooksForTrigger(trigger, hookContext);
   }
 
   /**

--- a/apps/server/tests/unit/services/automation-service.test.ts
+++ b/apps/server/tests/unit/services/automation-service.test.ts
@@ -399,9 +399,9 @@ describe('AutomationService', () => {
 
       vi.mocked(scheduler.registerTask).mockClear();
 
-      // Pass null for optional deps to keep seeding deterministic (3 always-on built-ins only)
+      // Pass a mock events with subscribe to support event-trigger wiring
       const mockDeps = {
-        events: {} as never,
+        events: { subscribe: vi.fn().mockReturnValue(() => {}) } as never,
         autoModeService: {} as never,
         featureHealthService: null as never,
         integrityWatchdogService: null as never,
@@ -413,9 +413,114 @@ describe('AutomationService', () => {
 
       expect(registerMaintenanceFlows).toHaveBeenCalledOnce();
       // 3 always-on built-ins + 1 enabled user automation; disabled user automation is skipped
+      // Ceremony automations are event-triggered and do NOT add to registerTask count
       expect(scheduler.registerTask).toHaveBeenCalledTimes(4);
       const taskIds = vi.mocked(scheduler.registerTask).mock.calls.map(([id]) => id);
       expect(taskIds.every((id) => id.startsWith('automation:'))).toBe(true);
+    });
+
+    it('seeds 3 ceremony automations with correct triggers and flowIds', async () => {
+      const mockDeps = {
+        events: { subscribe: vi.fn().mockReturnValue(() => {}) } as never,
+        autoModeService: {} as never,
+        featureHealthService: null as never,
+        integrityWatchdogService: null as never,
+        featureLoader: null as never,
+        settingsService: {} as never,
+      };
+
+      await service.syncWithScheduler(mockDeps);
+
+      const all = await service.list();
+      const standup = all.find((a) => a.id === 'ceremony:standup');
+      const retro = all.find((a) => a.id === 'ceremony:retro');
+      const projectRetro = all.find((a) => a.id === 'ceremony:project-retro');
+
+      expect(standup).toBeDefined();
+      expect(standup?.trigger).toEqual({ type: 'event', eventType: 'feature:completed' });
+      expect(standup?.flowId).toBe('standup-flow');
+      expect(standup?.enabled).toBe(true);
+
+      expect(retro).toBeDefined();
+      expect(retro?.trigger).toEqual({ type: 'event', eventType: 'ceremony:milestone-update' });
+      expect(retro?.flowId).toBe('retro-flow');
+
+      expect(projectRetro).toBeDefined();
+      expect(projectRetro?.trigger).toEqual({
+        type: 'event',
+        eventType: 'ceremony:project-retro',
+      });
+      expect(projectRetro?.flowId).toBe('project-retro-flow');
+    });
+
+    it('ceremony automations are idempotent — not duplicated on second sync', async () => {
+      const mockDeps = {
+        events: { subscribe: vi.fn().mockReturnValue(() => {}) } as never,
+        autoModeService: {} as never,
+        featureHealthService: null as never,
+        integrityWatchdogService: null as never,
+        featureLoader: null as never,
+        settingsService: {} as never,
+      };
+
+      await service.syncWithScheduler(mockDeps);
+      await service.syncWithScheduler(mockDeps);
+
+      const all = await service.list();
+      const standupCount = all.filter((a) => a.id === 'ceremony:standup').length;
+      expect(standupCount).toBe(1);
+    });
+
+    it('wires event subscription when events emitter is provided', async () => {
+      const subscribeSpy = vi.fn().mockReturnValue(() => {});
+
+      await service.syncWithScheduler({
+        events: { subscribe: subscribeSpy } as never,
+        autoModeService: {} as never,
+        featureHealthService: null as never,
+        integrityWatchdogService: null as never,
+        featureLoader: null as never,
+        settingsService: {} as never,
+      });
+
+      expect(subscribeSpy).toHaveBeenCalledOnce();
+    });
+
+    it('feature:completed event triggers standup-flow execution', async () => {
+      const flowFn = vi.fn().mockResolvedValue(undefined);
+      flowRegistry.register('standup-flow', flowFn);
+
+      let capturedCallback: ((type: string, payload: unknown) => void) | null = null;
+      const mockEvents = {
+        subscribe: vi.fn((cb: (type: string, payload: unknown) => void) => {
+          capturedCallback = cb;
+          return () => {};
+        }),
+      };
+
+      await service.syncWithScheduler({
+        events: mockEvents as never,
+        autoModeService: {} as never,
+        featureHealthService: null as never,
+        integrityWatchdogService: null as never,
+        featureLoader: null as never,
+        settingsService: {} as never,
+      });
+
+      expect(capturedCallback).not.toBeNull();
+
+      // Register the standup flow in flowRegistry so executeAutomation can find it
+      // (already registered above)
+
+      // Simulate feature:completed event
+      capturedCallback!('feature:completed', { featureId: 'f1', projectPath: '/test' });
+
+      // Wait for async chain to settle
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(flowFn).toHaveBeenCalledOnce();
+
+      flowRegistry.unregister('standup-flow');
     });
   });
 

--- a/libs/types/src/event-settings.ts
+++ b/libs/types/src/event-settings.ts
@@ -12,38 +12,135 @@
 /**
  * EventHookTrigger - Event types that can trigger custom hooks
  *
+ * Core feature lifecycle:
  * - feature_created: A new feature was created
- * - feature_success: Feature completed successfully
+ * - feature_started: A feature agent started running
+ * - feature_completed: A feature completed execution (maps to feature:completed)
+ * - feature_stopped: A feature was stopped
+ * - feature_committed: A feature committed its changes
+ * - feature_pr_merged: A feature PR was merged
+ * - feature_pr_closed_unmerged: A feature PR was closed without merging
+ * - feature_success: Feature completed successfully (via auto-mode event)
  * - feature_error: Feature failed with an error
  * - feature_retry: Feature is being retried after a failure
  * - feature_recovery: A recovery action was taken for a feature
+ * - feature_blocked: A feature was blocked
+ * - feature_unblocked: A feature was unblocked
+ * - feature_status_changed: A feature status changed
+ * - feature_permanently_blocked: A feature is permanently blocked
+ * - feature_agent_suggested: An agent was suggested for a feature
+ *
+ * Auto-mode:
+ * - auto_mode_started: Auto mode started
+ * - auto_mode_stopped: Auto mode stopped
  * - auto_mode_complete: Auto mode finished processing all features
  * - auto_mode_error: Auto mode encountered a critical error and paused
  * - auto_mode_health_check: Periodic health status check
+ *
+ * PR lifecycle:
+ * - pr_approved: A PR was approved
+ * - pr_changes_requested: Changes were requested on a PR
+ * - pr_ci_failure: CI checks failed on a PR
+ * - pr_remediation_started: PR remediation workflow began
+ * - pr_remediation_completed: PR remediation completed successfully
+ * - pr_remediation_failed: PR remediation failed
+ * - pr_feedback_received: Pull request received feedback that needs addressing
+ *
+ * Ceremony events:
+ * - ceremony_milestone_update: A milestone update ceremony was triggered
+ * - ceremony_project_retro: A project retrospective ceremony was triggered
+ * - ceremony_triggered: A ceremony was triggered
+ *
+ * Infrastructure / health:
+ * - worktree_drift_detected: Worktree drift was detected
+ * - health_issue_detected: A health issue was detected
+ * - health_check_critical: Health check detected critical or degraded status
+ *
+ * Headsdown agents:
+ * - headsdown_agent_started: A headsdown agent started
+ * - headsdown_agent_stopped: A headsdown agent stopped
+ * - headsdown_agent_work_completed: A headsdown agent completed work
+ * - headsdown_agent_work_failed: A headsdown agent failed
+ *
+ * Integrations:
+ * - coderabbit_review_received: CodeRabbit posted a review
+ * - linear_approval_detected: A Linear approval was detected
+ * - linear_changes_requested_detected: Linear changes-requested detected
+ * - discord_message_detected: A Discord message was detected
+ *
+ * Project / planning:
  * - skill_created: An agent created a new reusable skill
  * - memory_learning: A new learning was recorded from agent execution
- * - pr_feedback_received: Pull request received feedback that needs addressing
+ * - issue_created: An issue was created
+ * - prd_created: A PRD was created
  * - project_scaffolded: A project was scaffolded and features were created
  * - project_deleted: A project was deleted
- * - health_check_critical: Health check detected critical or degraded status
+ * - project_analysis_completed: Project analysis completed
+ * - project_status_changed: A project status changed
+ * - milestone_completed: A milestone was completed
+ * - project_completed: A project was completed
  */
 export type EventHookTrigger =
+  // Core feature lifecycle
   | 'feature_created'
+  | 'feature_started'
+  | 'feature_completed'
+  | 'feature_stopped'
+  | 'feature_committed'
+  | 'feature_pr_merged'
+  | 'feature_pr_closed_unmerged'
   | 'feature_success'
   | 'feature_error'
   | 'feature_retry'
   | 'feature_recovery'
+  | 'feature_blocked'
+  | 'feature_unblocked'
+  | 'feature_status_changed'
+  | 'feature_permanently_blocked'
+  | 'feature_agent_suggested'
+  // Auto-mode
+  | 'auto_mode_started'
+  | 'auto_mode_stopped'
   | 'auto_mode_complete'
   | 'auto_mode_error'
   | 'auto_mode_health_check'
+  // PR lifecycle
+  | 'pr_approved'
+  | 'pr_changes_requested'
+  | 'pr_ci_failure'
+  | 'pr_remediation_started'
+  | 'pr_remediation_completed'
+  | 'pr_remediation_failed'
+  | 'pr_feedback_received'
+  // Ceremony events
+  | 'ceremony_milestone_update'
+  | 'ceremony_project_retro'
+  | 'ceremony_triggered'
+  // Infrastructure / health
+  | 'worktree_drift_detected'
+  | 'health_issue_detected'
+  | 'health_check_critical'
+  // Headsdown agents
+  | 'headsdown_agent_started'
+  | 'headsdown_agent_stopped'
+  | 'headsdown_agent_work_completed'
+  | 'headsdown_agent_work_failed'
+  // Integrations
+  | 'coderabbit_review_received'
+  | 'linear_approval_detected'
+  | 'linear_changes_requested_detected'
+  | 'discord_message_detected'
+  // Project / planning
   | 'skill_created'
   | 'memory_learning'
-  | 'pr_feedback_received'
+  | 'issue_created'
+  | 'prd_created'
   | 'project_scaffolded'
   | 'project_deleted'
+  | 'project_analysis_completed'
+  | 'project_status_changed'
   | 'milestone_completed'
-  | 'project_completed'
-  | 'health_check_critical';
+  | 'project_completed';
 
 /** HTTP methods supported for webhook requests */
 export type EventHookHttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH';
@@ -142,20 +239,64 @@ export interface EventHook {
 
 /** Human-readable labels for event hook triggers */
 export const EVENT_HOOK_TRIGGER_LABELS: Record<EventHookTrigger, string> = {
+  // Core feature lifecycle
   feature_created: 'Feature created',
+  feature_started: 'Feature agent started',
+  feature_completed: 'Feature execution completed',
+  feature_stopped: 'Feature stopped',
+  feature_committed: 'Feature changes committed',
+  feature_pr_merged: 'Feature PR merged',
+  feature_pr_closed_unmerged: 'Feature PR closed without merging',
   feature_success: 'Feature completed successfully',
   feature_error: 'Feature failed with error',
   feature_retry: 'Feature retry initiated',
   feature_recovery: 'Feature recovery action taken',
+  feature_blocked: 'Feature blocked',
+  feature_unblocked: 'Feature unblocked',
+  feature_status_changed: 'Feature status changed',
+  feature_permanently_blocked: 'Feature permanently blocked',
+  feature_agent_suggested: 'Agent suggested for feature',
+  // Auto-mode
+  auto_mode_started: 'Auto mode started',
+  auto_mode_stopped: 'Auto mode stopped',
   auto_mode_complete: 'Auto mode completed all features',
   auto_mode_error: 'Auto mode paused due to error',
   auto_mode_health_check: 'Auto mode health check',
+  // PR lifecycle
+  pr_approved: 'PR approved',
+  pr_changes_requested: 'PR changes requested',
+  pr_ci_failure: 'PR CI checks failed',
+  pr_remediation_started: 'PR remediation started',
+  pr_remediation_completed: 'PR remediation completed',
+  pr_remediation_failed: 'PR remediation failed',
+  pr_feedback_received: 'PR feedback received',
+  // Ceremony events
+  ceremony_milestone_update: 'Milestone update ceremony triggered',
+  ceremony_project_retro: 'Project retrospective ceremony triggered',
+  ceremony_triggered: 'Ceremony triggered',
+  // Infrastructure / health
+  worktree_drift_detected: 'Worktree drift detected',
+  health_issue_detected: 'Health issue detected',
+  health_check_critical: 'Health check critical',
+  // Headsdown agents
+  headsdown_agent_started: 'Headsdown agent started',
+  headsdown_agent_stopped: 'Headsdown agent stopped',
+  headsdown_agent_work_completed: 'Headsdown agent work completed',
+  headsdown_agent_work_failed: 'Headsdown agent work failed',
+  // Integrations
+  coderabbit_review_received: 'CodeRabbit review received',
+  linear_approval_detected: 'Linear approval detected',
+  linear_changes_requested_detected: 'Linear changes requested detected',
+  discord_message_detected: 'Discord message detected',
+  // Project / planning
   skill_created: 'New skill created by agent',
   memory_learning: 'New learning recorded',
-  pr_feedback_received: 'PR feedback received',
+  issue_created: 'Issue created',
+  prd_created: 'PRD created',
   project_scaffolded: 'Project scaffolded with features',
   project_deleted: 'Project deleted',
+  project_analysis_completed: 'Project analysis completed',
+  project_status_changed: 'Project status changed',
   milestone_completed: 'Milestone completed',
   project_completed: 'Project completed',
-  health_check_critical: 'Health check critical',
 };


### PR DESCRIPTION
## Summary

**Milestone:** Ceremony + Inbox Migration

Seed 3 ceremony Automations in seedBuiltInAutomations(): standup (trigger: event feature:completed, flowId: standup-flow), retro (trigger: event ceremony:milestone-update, flowId: retro-flow), project-retro (trigger: event ceremony:project-retro, flowId: project-retro-flow). Update AutomationService event trigger wiring to subscribe to the EventType triggers and call executeAutomation(). For the inbox: identify the top 20 most-used EventTypes that have ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event-triggered automations now supported, enabling workflows to execute based on system events rather than schedules alone.
  * Added ceremony-based automations for milestone updates and project retrospectives.
  * Expanded event type coverage across feature lifecycle, PR management, automation modes, and project planning.

* **Improvements**
  * Enhanced event severity classification for more granular event prioritization and handling.
  * Improved generic event dispatching to support a broader range of system events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->