### PR TITLE
Chain of Thought Reasoning Component

### DIFF
--- a/apps/server/src/routes/chat/index.ts
+++ b/apps/server/src/routes/chat/index.ts
@@ -28,10 +28,18 @@ export type { AvaConfig };
 
 const logger = createLogger('ChatRoutes');
 
-/** Map our internal aliases to AI SDK model IDs */
-function resolveAISDKModel(modelAlias?: string) {
-  const resolved = resolveModelString(modelAlias, 'sonnet');
-  return anthropic(resolved);
+/**
+ * Budget tokens for extended thinking (Anthropic "extended thinking" feature).
+ * Chosen to allow meaningful multi-step reasoning without excessive cost.
+ */
+const THINKING_BUDGET_TOKENS = 10_000;
+
+/**
+ * Returns true when the resolved model ID supports Anthropic extended thinking.
+ * Currently all claude-opus and claude-sonnet models support this feature.
+ */
+function modelSupportsExtendedThinking(resolvedModelId: string): boolean {
+  return resolvedModelId.includes('opus') || resolvedModelId.includes('sonnet');
 }
 
 /**
@@ -109,7 +117,8 @@ export function createChatRoutes(services: ServiceContainer): Router {
       const modelAlias =
         avaConfig.model || (req.headers['x-model-alias'] as string) || bodyModel || 'sonnet';
 
-      const aiModel = resolveAISDKModel(modelAlias);
+      const resolvedModelId = resolveModelString(modelAlias, 'sonnet');
+      const aiModel = anthropic(resolvedModelId);
 
       // Conditionally load project context files
       let projectContext: string | undefined;
@@ -155,8 +164,13 @@ export function createChatRoutes(services: ServiceContainer): Router {
           )
         : {};
 
+      // Enable extended thinking for models that support it (opus / sonnet).
+      // The thinking budget caps how many tokens the model may use for internal
+      // reasoning before producing its visible response.
+      const extendedThinking = modelSupportsExtendedThinking(resolvedModelId);
+
       logger.info(
-        `Chat request: ${messages.length} messages, model=${modelAlias}, projectPath=${projectPath ?? 'none'}, contextInjection=${avaConfig.contextInjection}, sitrepInjection=${avaConfig.sitrepInjection}`
+        `Chat request: ${messages.length} messages, model=${modelAlias}, projectPath=${projectPath ?? 'none'}, contextInjection=${avaConfig.contextInjection}, sitrepInjection=${avaConfig.sitrepInjection}, extendedThinking=${extendedThinking}`
       );
 
       const result = streamText({
@@ -165,6 +179,13 @@ export function createChatRoutes(services: ServiceContainer): Router {
         system: systemPrompt,
         tools,
         stopWhen: stepCountIs(10),
+        ...(extendedThinking && {
+          providerOptions: {
+            anthropic: {
+              thinking: { type: 'enabled', budgetTokens: THINKING_BUDGET_TOKENS },
+            },
+          },
+        }),
         experimental_telemetry: {
           isEnabled: true,
           metadata: {

--- a/libs/ui/src/ai/chain-of-thought.tsx
+++ b/libs/ui/src/ai/chain-of-thought.tsx
@@ -1,0 +1,156 @@
+/**
+ * ChainOfThought — Step-by-step reasoning display for AI extended thinking.
+ *
+ * Parses reasoning text into logical steps (detected by newlines or numbered
+ * lists). Each step shows a spinner while streaming and a check icon when the
+ * next step starts. Auto-opens when Ava starts thinking and auto-collapses with
+ * a "Thought for Xs" summary when reasoning completes. Duration tracks from
+ * first render (reasoning start) to when state transitions to "done"
+ * (≈ first text token).
+ */
+
+import { useState, useEffect, useRef } from 'react';
+import { Brain, ChevronDown, Loader2, Check } from 'lucide-react';
+import { cn } from '../lib/utils.js';
+
+export interface ChainOfThoughtProps {
+  text: string;
+  state?: 'streaming' | 'done';
+  className?: string;
+}
+
+/**
+ * Parse reasoning text into an array of logical steps.
+ *
+ * Priority:
+ * 1. Numbered list items ("1. Step one\n2. Step two")
+ * 2. Double-newline-separated paragraphs
+ * 3. Single-newline-separated lines (fallback)
+ */
+function parseSteps(text: string): string[] {
+  if (!text.trim()) return [];
+
+  // Check for numbered list format (e.g. "1. First\n2. Second")
+  if (/^\d+\.\s+/m.test(text)) {
+    const steps = text
+      .split(/\n(?=\d+\.\s+)/)
+      .map((s) => s.replace(/^\d+\.\s+/, '').trim())
+      .filter(Boolean);
+    if (steps.length > 1) return steps;
+  }
+
+  // Paragraph-separated steps
+  const paragraphs = text
+    .split(/\n\n+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (paragraphs.length > 1) return paragraphs;
+
+  // Line-by-line fallback
+  return text
+    .split(/\n/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.round(ms / 1000);
+  return `${seconds}s`;
+}
+
+export function ChainOfThought({ text, state, className }: ChainOfThoughtProps) {
+  // Record when this component first mounts — that is the reasoning start time.
+  const startTimeRef = useRef<number>(Date.now());
+  const [durationMs, setDurationMs] = useState<number | undefined>();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const isStreaming = state === 'streaming';
+
+  // Auto-open as soon as streaming begins.
+  useEffect(() => {
+    if (isStreaming) {
+      setIsOpen(true);
+    }
+  }, [isStreaming]);
+
+  // Auto-collapse when streaming finishes and record duration.
+  useEffect(() => {
+    if (state === 'done' && durationMs === undefined) {
+      setDurationMs(Date.now() - startTimeRef.current);
+      setIsOpen(false);
+    }
+  }, [state, durationMs]);
+
+  const steps = parseSteps(text);
+
+  const summaryText =
+    state === 'done' && durationMs !== undefined
+      ? `Thought for ${formatDuration(durationMs)}`
+      : isStreaming
+        ? 'Thinking...'
+        : 'Reasoning';
+
+  return (
+    <div
+      data-slot="chain-of-thought"
+      className={cn('my-1 rounded-md border border-border/50 bg-muted/30 text-xs', className)}
+    >
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left"
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-expanded={isOpen}
+      >
+        <Brain
+          className={cn(
+            'size-3.5 shrink-0 text-muted-foreground',
+            isStreaming && 'animate-pulse text-primary'
+          )}
+        />
+        <span className="flex-1 truncate text-muted-foreground">{summaryText}</span>
+        <ChevronDown
+          className={cn(
+            'size-3 shrink-0 text-muted-foreground transition-transform',
+            isOpen && 'rotate-180'
+          )}
+        />
+      </button>
+
+      {isOpen && (
+        <div className="space-y-1.5 border-t border-border/50 px-2.5 py-2">
+          {steps.length === 0 && isStreaming ? (
+            /* Nothing parsed yet — show a generic "processing" row */
+            <div className="flex items-center gap-2 py-0.5">
+              <Loader2 className="size-3 shrink-0 animate-spin text-primary" />
+              <span className="italic text-muted-foreground">Processing…</span>
+            </div>
+          ) : (
+            steps.map((step, i) => {
+              const isCurrentStep = isStreaming && i === steps.length - 1;
+              return (
+                <div key={i} className="flex items-start gap-2 py-0.5">
+                  {isCurrentStep ? (
+                    <Loader2 className="mt-0.5 size-3 shrink-0 animate-spin text-primary" />
+                  ) : (
+                    <Check className="mt-0.5 size-3 shrink-0 text-green-500" />
+                  )}
+                  <span
+                    className={cn(
+                      'leading-relaxed',
+                      isCurrentStep ? 'text-foreground/90' : 'text-foreground/70'
+                    )}
+                  >
+                    {step}
+                  </span>
+                </div>
+              );
+            })
+          )}
+          {isStreaming && steps.length > 0 && (
+            <span className="inline-block animate-pulse text-muted-foreground">|</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/libs/ui/src/ai/chat-message.tsx
+++ b/libs/ui/src/ai/chat-message.tsx
@@ -12,7 +12,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { Bot, User } from 'lucide-react';
 import type { UIMessage } from 'ai';
 import { cn } from '../lib/utils.js';
-import { ReasoningPart } from './reasoning-part.js';
+import { ChainOfThought } from './chain-of-thought.js';
 import { ToolInvocationPart, type ToolInvocationPartProps } from './tool-invocation-part.js';
 import { ChatMessageMarkdown } from './chat-message-markdown.js';
 
@@ -143,7 +143,7 @@ function MessagePartRenderer({
 
   if (type === 'reasoning') {
     return (
-      <ReasoningPart
+      <ChainOfThought
         text={part.text as string}
         state={part.state as 'streaming' | 'done' | undefined}
       />

--- a/libs/ui/src/ai/index.ts
+++ b/libs/ui/src/ai/index.ts
@@ -21,6 +21,8 @@ export { PromptInputProvider, usePromptInput } from './prompt-input-context.js';
 
 export { SuggestionList, type SuggestionItem } from './suggestion.js';
 
+export { ChainOfThought, type ChainOfThoughtProps } from './chain-of-thought.js';
+
 export { ReasoningPart, type ReasoningPartProps } from './reasoning-part.js';
 
 export { ToolInvocationPart, type ToolInvocationPartProps } from './tool-invocation-part.js';

--- a/libs/ui/src/ai/reasoning-part.tsx
+++ b/libs/ui/src/ai/reasoning-part.tsx
@@ -1,62 +1,13 @@
 /**
- * ReasoningPart — Collapsible thinking/reasoning block for AI messages.
+ * ReasoningPart — Backward-compatible re-export of ChainOfThought.
  *
- * Renders the model's reasoning (extended thinking) as a collapsible section.
- * Shows a streaming indicator when the model is still thinking.
+ * The reasoning display has been replaced by the ChainOfThought component which
+ * parses the reasoning stream into logical step-by-step entries. This module
+ * re-exports ChainOfThought under the legacy ReasoningPart name so that
+ * existing imports continue to work without changes.
  */
 
-import { useState } from 'react';
-import { Brain, ChevronDown } from 'lucide-react';
-import { cn } from '../lib/utils.js';
-
-export interface ReasoningPartProps {
-  text: string;
-  state?: 'streaming' | 'done';
-  className?: string;
-}
-
-export function ReasoningPart({ text, state, className }: ReasoningPartProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const isStreaming = state === 'streaming';
-
-  // Show first line as preview when collapsed
-  const preview = text.split('\n')[0]?.slice(0, 80) || 'Thinking...';
-
-  return (
-    <div
-      data-slot="reasoning-part"
-      className={cn('my-1 rounded-md border border-border/50 bg-muted/30 text-xs', className)}
-    >
-      <button
-        type="button"
-        className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left"
-        onClick={() => setIsOpen(!isOpen)}
-        aria-expanded={isOpen}
-      >
-        <Brain
-          className={cn(
-            'size-3.5 shrink-0 text-muted-foreground',
-            isStreaming && 'animate-pulse text-primary'
-          )}
-        />
-        <span className="flex-1 truncate text-muted-foreground">
-          {isStreaming ? 'Thinking...' : preview}
-        </span>
-        <ChevronDown
-          className={cn(
-            'size-3 shrink-0 text-muted-foreground transition-transform',
-            isOpen && 'rotate-180'
-          )}
-        />
-      </button>
-      {isOpen && (
-        <div className="border-t border-border/50 px-2.5 py-2">
-          <pre className="whitespace-pre-wrap font-mono text-[11px] leading-relaxed text-muted-foreground">
-            {text}
-            {isStreaming && <span className="animate-pulse">|</span>}
-          </pre>
-        </div>
-      )}
-    </div>
-  );
-}
+export {
+  ChainOfThought as ReasoningPart,
+  type ChainOfThoughtProps as ReasoningPartProps,
+} from './chain-of-thought.js';


### PR DESCRIPTION
## Summary

**Milestone:** M3: Reasoning + Chain of Thought

Replace the current ReasoningPart with a ChainOfThought component that parses the reasoning text into logical steps. Steps are detected by newlines or numbered lists in the reasoning stream. Each step shows an icon (spinner while streaming, check when done), label, and expandable detail. The component auto-opens when Ava starts thinking and auto-collapses with a 'Thought for Xs' summary when done. Add duration tracking from stream start to first t...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Extended thinking support for compatible AI models, enabling deeper reasoning during conversations
- Chain of Thought panel now visualizes step-by-step AI reasoning with real-time streaming updates, per-step progress indicators, auto-collapsing behavior upon completion, and elapsed reasoning duration tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->