### PR TITLE
fix: parseSteps edge case for single numbered items

### DIFF
--- a/libs/ui/src/ai/chain-of-thought.tsx
+++ b/libs/ui/src/ai/chain-of-thought.tsx
@@ -36,7 +36,7 @@ function parseSteps(text: string): string[] {
       .split(/\n(?=\d+\.\s+)/)
       .map((s) => s.replace(/^\d+\.\s+/, '').trim())
       .filter(Boolean);
-    if (steps.length > 1) return steps;
+    if (steps.length > 0) return steps;
   }
 
   // Paragraph-separated steps
@@ -49,7 +49,7 @@ function parseSteps(text: string): string[] {
   // Line-by-line fallback
   return text
     .split(/\n/)
-    .map((s) => s.trim())
+    .map((s) => s.replace(/^\d+\.\s+/, '').trim())
     .filter(Boolean);
 }
 


### PR DESCRIPTION
## Summary
- Accept single numbered items in `parseSteps()` (change `steps.length > 1` to `> 0`)
- Strip number prefixes in the line-by-line fallback path
- Fixes edge case where "1. Analyze the problem" retained the "1." prefix

Addresses CodeRabbit review from PR #1561.

## Test plan
- [ ] Single numbered item renders without prefix
- [ ] Multi-item numbered lists still work correctly
- [ ] Plain text fallback unchanged

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Single-step numbered lists are now properly extracted in AI chain-of-thought analysis.
  * Enhanced parsing of numbered list item formatting for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->