### PR TITLE
[linear] fix(hitl): gate all HITL form creation behind featureFlags.pipeline — PM Agent, Signal Intake, REST 

### DIFF
--- a/apps/server/src/routes/hitl-forms/index.ts
+++ b/apps/server/src/routes/hitl-forms/index.ts
@@ -13,6 +13,7 @@
 
 import { Router } from 'express';
 import type { HITLFormService } from '../../services/hitl-form-service.js';
+import type { SettingsService } from '../../services/settings-service.js';
 import { createCreateHandler } from './routes/create.js';
 import { createGetHandler } from './routes/get.js';
 import { createListHandler } from './routes/list.js';
@@ -23,12 +24,16 @@ import { createCancelHandler } from './routes/cancel.js';
  * Create HITL forms router with all endpoints
  *
  * @param hitlFormService - Instance of HITLFormService
+ * @param settingsService - Instance of SettingsService for feature flag checks
  * @returns Express Router configured with all HITL form endpoints
  */
-export function createHITLFormRoutes(hitlFormService: HITLFormService): Router {
+export function createHITLFormRoutes(
+  hitlFormService: HITLFormService,
+  settingsService?: SettingsService | null
+): Router {
   const router = Router();
 
-  router.post('/create', createCreateHandler(hitlFormService));
+  router.post('/create', createCreateHandler(hitlFormService, settingsService));
   router.post('/get', createGetHandler(hitlFormService));
   router.post('/list', createListHandler(hitlFormService));
   router.post('/submit', createSubmitHandler(hitlFormService));

--- a/apps/server/src/routes/hitl-forms/routes/create.ts
+++ b/apps/server/src/routes/hitl-forms/routes/create.ts
@@ -7,11 +7,37 @@
 
 import type { Request, Response } from 'express';
 import type { HITLFormService } from '../../../services/hitl-form-service.js';
+import type { SettingsService } from '../../../services/settings-service.js';
 import { getErrorMessage, logError } from '../common.js';
+import { createLogger } from '@protolabs-ai/utils';
 
-export function createCreateHandler(hitlFormService: HITLFormService) {
+const logger = createLogger('HITLCreateRoute');
+
+export function createCreateHandler(
+  hitlFormService: HITLFormService,
+  settingsService?: SettingsService | null
+) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
+      // Check featureFlags.pipeline — HITL form creation is gated behind this flag
+      let hitlEnabled = false;
+      if (settingsService) {
+        try {
+          const globalSettings = await settingsService.getGlobalSettings();
+          hitlEnabled = globalSettings.featureFlags?.pipeline ?? false;
+        } catch (err) {
+          logger.warn('Failed to read feature flags, HITL disabled:', err);
+        }
+      }
+
+      if (!hitlEnabled) {
+        logger.debug('HITL forms disabled (featureFlags.pipeline=false), skipping');
+        res
+          .status(403)
+          .json({ success: false, error: 'HITL forms are disabled (featureFlags.pipeline=false)' });
+        return;
+      }
+
       const {
         title,
         description,

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -313,7 +313,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api/pipeline', createPipelineRoutes(pipelineService));
   app.use('/api/metrics', createMetricsRoutes(metricsService, ledgerService));
   app.use('/api/notifications', createNotificationsRoutes(notificationService));
-  app.use('/api/hitl-forms', createHITLFormRoutes(hitlFormService));
+  app.use('/api/hitl-forms', createHITLFormRoutes(hitlFormService, settingsService));
   app.use(
     '/api/actionable-items',
     createActionableItemsRoutes(actionableItemService, settingsService)

--- a/apps/server/src/services/authority-agents/pm-agent.ts
+++ b/apps/server/src/services/authority-agents/pm-agent.ts
@@ -406,10 +406,20 @@ export class PMAuthorityAgent {
 
         // Ask user for clarification if triage says it's needed
         let clarificationContext = '';
+        let hitlEnabled = false;
+        if (this.settingsService) {
+          try {
+            const globalSettings = await this.settingsService.getGlobalSettings();
+            hitlEnabled = globalSettings.featureFlags?.pipeline ?? false;
+          } catch (err) {
+            logger.warn('[PMAgent] Failed to read feature flags, HITL disabled:', err);
+          }
+        }
         if (
           triage?.needsClarification &&
           triage.clarifyingQuestions?.length &&
-          this.hitlFormService
+          this.hitlFormService &&
+          hitlEnabled
         ) {
           const { schema, uiSchema } = this.convertQuestionsToSchema(triage.clarifyingQuestions);
           const form = this.hitlFormService.create({
@@ -440,6 +450,10 @@ export class PMAuthorityAgent {
               `No clarification received for ${featureId}, proceeding with original idea`
             );
           }
+        } else if (triage?.needsClarification && !hitlEnabled) {
+          logger.debug(
+            'HITL forms disabled (featureFlags.pipeline=false), skipping clarification form'
+          );
         }
 
         // Inject clarification answers into feature description before research

--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -416,8 +416,18 @@ export class SignalIntakeService {
       if (intent === 'interrupt') {
         logger.info(`Interrupt signal received: "${title}" — creating HITL form for human triage`);
 
+        let hitlEnabled = false;
+        if (this.settingsService) {
+          try {
+            const globalSettings = await this.settingsService.getGlobalSettings();
+            hitlEnabled = globalSettings.featureFlags?.pipeline ?? false;
+          } catch (err) {
+            logger.warn('[SignalIntake] Failed to read feature flags, HITL disabled:', err);
+          }
+        }
+
         let hitlFormId: string | undefined;
-        if (this.hitlFormService) {
+        if (this.hitlFormService && hitlEnabled) {
           const form = this.hitlFormService.create({
             title: `Interrupt: ${title}`,
             description: `An urgent signal was received from ${signal.source} and requires immediate human attention.\n\n${description}`,
@@ -453,6 +463,10 @@ export class SignalIntakeService {
             ],
           });
           hitlFormId = form.id;
+        } else if (!hitlEnabled) {
+          logger.debug(
+            'HITL forms disabled (featureFlags.pipeline=false), skipping interrupt form'
+          );
         } else {
           logger.warn(
             'HITLFormService not wired into SignalIntakeService — interrupt signal will not create a form. Call setHITLFormService() during service initialization.'

--- a/apps/server/tests/unit/routes/hitl-create-flag.test.ts
+++ b/apps/server/tests/unit/routes/hitl-create-flag.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for HITL create route featureFlags.pipeline guard
+ *
+ * Verifies that POST /api/hitl-forms/create returns 403 when
+ * featureFlags.pipeline=false, and creates the form when true.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import { createMockExpressContext } from '../../utils/mocks.js';
+
+vi.mock('@protolabs-ai/utils', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../src/routes/hitl-forms/common.js', () => ({
+  getErrorMessage: (e: unknown) => String(e),
+  logError: vi.fn(),
+}));
+
+import { createCreateHandler } from '@/routes/hitl-forms/routes/create.js';
+
+function makeSettingsService(pipelineEnabled: boolean) {
+  return {
+    getGlobalSettings: vi.fn().mockResolvedValue({
+      featureFlags: { pipeline: pipelineEnabled },
+    }),
+  } as any;
+}
+
+function makeHITLFormService() {
+  return {
+    create: vi.fn().mockReturnValue({ id: 'form-123', title: 'Test Form' }),
+  } as any;
+}
+
+const validBody = {
+  title: 'Test Form',
+  steps: [
+    {
+      schema: { type: 'object', properties: { name: { type: 'string' } } },
+      title: 'Step 1',
+    },
+  ],
+  callerType: 'api',
+};
+
+describe('HITL create route — featureFlags.pipeline guard', () => {
+  it('returns 403 when featureFlags.pipeline=false', async () => {
+    const { req, res } = createMockExpressContext();
+    req.body = validBody;
+
+    const settingsService = makeSettingsService(false);
+    const hitlFormService = makeHITLFormService();
+
+    const handler = createCreateHandler(hitlFormService, settingsService);
+    await handler(req as Request, res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false, error: expect.stringContaining('featureFlags.pipeline=false') })
+    );
+    expect(hitlFormService.create).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when no settingsService provided', async () => {
+    const { req, res } = createMockExpressContext();
+    req.body = validBody;
+
+    const hitlFormService = makeHITLFormService();
+
+    const handler = createCreateHandler(hitlFormService, null);
+    await handler(req as Request, res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(hitlFormService.create).not.toHaveBeenCalled();
+  });
+
+  it('creates the form when featureFlags.pipeline=true', async () => {
+    const { req, res } = createMockExpressContext();
+    req.body = validBody;
+
+    const settingsService = makeSettingsService(true);
+    const hitlFormService = makeHITLFormService();
+
+    const handler = createCreateHandler(hitlFormService, settingsService);
+    await handler(req as Request, res as Response);
+
+    expect(hitlFormService.create).toHaveBeenCalledOnce();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true })
+    );
+  });
+});

--- a/libs/tools/src/domains/hitl/request-user-input.ts
+++ b/libs/tools/src/domains/hitl/request-user-input.ts
@@ -64,6 +64,34 @@ export const requestUserInput = defineSharedTool({
     try {
       const typedInput = input as RequestUserInputInput;
 
+      // Check featureFlags.pipeline — HITL form creation is gated behind this flag
+      const settingsService = context.services?.settingsService as any;
+      if (settingsService) {
+        try {
+          const globalSettings = await settingsService.getGlobalSettings();
+          const hitlEnabled = globalSettings?.featureFlags?.pipeline ?? false;
+          if (!hitlEnabled) {
+            return {
+              success: false,
+              error:
+                'HITL forms are disabled (featureFlags.pipeline=false). Enable the pipeline feature flag to use this tool.',
+            };
+          }
+        } catch {
+          // If we can't read settings, default to disabled
+          return {
+            success: false,
+            error: 'HITL forms are disabled: could not read feature flags.',
+          };
+        }
+      } else {
+        // No settingsService available — HITL disabled by default
+        return {
+          success: false,
+          error: 'HITL forms are disabled: settings service not available.',
+        };
+      }
+
       const hitlFormService = context.services?.hitlFormService as any;
       if (!hitlFormService) {
         return {


### PR DESCRIPTION
## Summary

# [linear] fix(hitl): gate all HITL form creation behind featureFlags.pipeline — PM Agent, Signal Intake, REST 

## Situation
This feature was requested but PRD generation encountered an issue.

## Problem
fix(hitl): gate all HITL form creation behind featureFlags.pipeline — PM Agent, Signal Intake, REST API, MCP tool all bypass the flag

## Problem

HITL 'Clarifying Questions' forms are firing even when `featureFlags.pipeline = false`. Three duplicate forms appeared for 'Launch Readiness — Josh...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added feature flag control for human-in-the-loop (HITL) form creation; HITL functionality can now be toggled via global configuration.

* **Improvements**
  * HITL form requests now return a clear error when the feature is disabled.
  * Enhanced logging for debugging HITL enablement status.

* **Tests**
  * Added test coverage for HITL feature flag gating behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->