### PR TITLE
fix(hitl): gate all HITL form creation behind featureFlags.pipeline

### DIFF
--- a/apps/server/src/routes/hitl-forms/index.ts
+++ b/apps/server/src/routes/hitl-forms/index.ts
@@ -13,6 +13,7 @@
 
 import { Router } from 'express';
 import type { HITLFormService } from '../../services/hitl-form-service.js';
+import type { SettingsService } from '../../services/settings-service.js';
 import { createCreateHandler } from './routes/create.js';
 import { createGetHandler } from './routes/get.js';
 import { createListHandler } from './routes/list.js';
@@ -23,12 +24,16 @@ import { createCancelHandler } from './routes/cancel.js';
  * Create HITL forms router with all endpoints
  *
  * @param hitlFormService - Instance of HITLFormService
+ * @param settingsService - Optional SettingsService for feature flag checks
  * @returns Express Router configured with all HITL form endpoints
  */
-export function createHITLFormRoutes(hitlFormService: HITLFormService): Router {
+export function createHITLFormRoutes(
+  hitlFormService: HITLFormService,
+  settingsService?: SettingsService
+): Router {
   const router = Router();
 
-  router.post('/create', createCreateHandler(hitlFormService));
+  router.post('/create', createCreateHandler(hitlFormService, settingsService));
   router.post('/get', createGetHandler(hitlFormService));
   router.post('/list', createListHandler(hitlFormService));
   router.post('/submit', createSubmitHandler(hitlFormService));

--- a/apps/server/src/routes/hitl-forms/routes/create.ts
+++ b/apps/server/src/routes/hitl-forms/routes/create.ts
@@ -7,11 +7,38 @@
 
 import type { Request, Response } from 'express';
 import type { HITLFormService } from '../../../services/hitl-form-service.js';
+import type { SettingsService } from '../../../services/settings-service.js';
+import { createLogger } from '@protolabs-ai/utils';
 import { getErrorMessage, logError } from '../common.js';
 
-export function createCreateHandler(hitlFormService: HITLFormService) {
+const logger = createLogger('HITLFormCreateRoute');
+
+export function createCreateHandler(
+  hitlFormService: HITLFormService,
+  settingsService?: SettingsService
+) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
+      // Check feature flag: HITL forms only created when pipeline flag is enabled
+      let hitlEnabled = false;
+      if (settingsService) {
+        try {
+          const globalSettings = await settingsService.getGlobalSettings();
+          hitlEnabled = globalSettings.featureFlags?.pipeline ?? false;
+        } catch (err) {
+          logger.warn('Failed to read feature flags, HITL disabled:', err);
+        }
+      }
+      if (!hitlEnabled) {
+        logger.debug('HITL forms disabled (featureFlags.pipeline=false), rejecting create request');
+        res
+          .status(403)
+          .json({
+            error: 'HITL forms are disabled. Enable featureFlags.pipeline to use this feature.',
+          });
+        return;
+      }
+
       const {
         title,
         description,

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -313,7 +313,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api/pipeline', createPipelineRoutes(pipelineService));
   app.use('/api/metrics', createMetricsRoutes(metricsService, ledgerService));
   app.use('/api/notifications', createNotificationsRoutes(notificationService));
-  app.use('/api/hitl-forms', createHITLFormRoutes(hitlFormService));
+  app.use('/api/hitl-forms', createHITLFormRoutes(hitlFormService, settingsService));
   app.use(
     '/api/actionable-items',
     createActionableItemsRoutes(actionableItemService, settingsService)

--- a/apps/server/src/services/authority-agents/pm-agent.ts
+++ b/apps/server/src/services/authority-agents/pm-agent.ts
@@ -406,7 +406,25 @@ export class PMAuthorityAgent {
 
         // Ask user for clarification if triage says it's needed
         let clarificationContext = '';
+
+        // Check feature flag: HITL forms only created when pipeline flag is enabled
+        let hitlEnabled = false;
+        if (this.settingsService) {
+          try {
+            const globalSettings = await this.settingsService.getGlobalSettings();
+            hitlEnabled = globalSettings.featureFlags?.pipeline ?? false;
+          } catch (err) {
+            logger.warn('Failed to read feature flags, HITL disabled:', err);
+          }
+        }
+        if (!hitlEnabled) {
+          logger.debug(
+            'HITL forms disabled (featureFlags.pipeline=false), skipping clarifying questions'
+          );
+        }
+
         if (
+          hitlEnabled &&
           triage?.needsClarification &&
           triage.clarifyingQuestions?.length &&
           this.hitlFormService

--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -416,8 +416,24 @@ export class SignalIntakeService {
       if (intent === 'interrupt') {
         logger.info(`Interrupt signal received: "${title}" — creating HITL form for human triage`);
 
+        // Check feature flag: HITL forms only created when pipeline flag is enabled
+        let hitlEnabled = false;
+        if (this.settingsService) {
+          try {
+            const globalSettings = await this.settingsService.getGlobalSettings();
+            hitlEnabled = globalSettings.featureFlags?.pipeline ?? false;
+          } catch (err) {
+            logger.warn('Failed to read feature flags, HITL disabled:', err);
+          }
+        }
+        if (!hitlEnabled) {
+          logger.debug(
+            'HITL forms disabled (featureFlags.pipeline=false), skipping interrupt form'
+          );
+        }
+
         let hitlFormId: string | undefined;
-        if (this.hitlFormService) {
+        if (hitlEnabled && this.hitlFormService) {
           const form = this.hitlFormService.create({
             title: `Interrupt: ${title}`,
             description: `An urgent signal was received from ${signal.source} and requires immediate human attention.\n\n${description}`,
@@ -453,7 +469,7 @@ export class SignalIntakeService {
             ],
           });
           hitlFormId = form.id;
-        } else {
+        } else if (hitlEnabled && !this.hitlFormService) {
           logger.warn(
             'HITLFormService not wired into SignalIntakeService — interrupt signal will not create a form. Call setHITLFormService() during service initialization.'
           );

--- a/libs/tools/src/domains/hitl/request-user-input.ts
+++ b/libs/tools/src/domains/hitl/request-user-input.ts
@@ -64,6 +64,27 @@ export const requestUserInput = defineSharedTool({
     try {
       const typedInput = input as RequestUserInputInput;
 
+      // Check feature flag: HITL forms only created when pipeline flag is enabled
+      const settingsService = context.services?.settingsService as any;
+      if (settingsService) {
+        try {
+          const globalSettings = await settingsService.getGlobalSettings();
+          const hitlEnabled = globalSettings?.featureFlags?.pipeline ?? false;
+          if (!hitlEnabled) {
+            return {
+              success: false,
+              error: 'HITL forms are disabled. Enable featureFlags.pipeline to use this feature.',
+            };
+          }
+        } catch {
+          // If settings cannot be read, default to disabled
+          return {
+            success: false,
+            error: 'HITL forms are disabled. Enable featureFlags.pipeline to use this feature.',
+          };
+        }
+      }
+
       const hitlFormService = context.services?.hitlFormService as any;
       if (!hitlFormService) {
         return {


### PR DESCRIPTION
## Summary

Add `featureFlags.pipeline` guard to all 4 unguarded HITL form creation sites. Currently only EscalateProcessor checks the flag — PM Agent, Signal Intake, REST API route, and MCP tool all bypass it, causing HITL forms to fire even when pipeline is disabled.

## Files to modify

**1. `apps/server/src/services/authority-agents/pm-agent.ts` (line ~415)**
Before the block that checks `triage?.needsClarification` and creates a HITL form, add a flag check:
```typescript
const globalSettings = await th...

---
*Recovered automatically by Automaker post-agent hook*