### PR TITLE
Fix orphaned features on worktree delete

### DIFF
--- a/apps/server/src/routes/worktree/index.ts
+++ b/apps/server/src/routes/worktree/index.ts
@@ -62,12 +62,14 @@ import { createStashDropHandler } from './routes/stash-drop.js';
 import type { SettingsService } from '../../services/settings-service.js';
 import type { WorktreeLifecycleService } from '../../services/worktree-lifecycle-service.js';
 import type { AutoModeService } from '../../services/auto-mode-service.js';
+import type { FeatureLoader } from '../../services/feature-loader.js';
 
 export function createWorktreeRoutes(
   events: EventEmitter,
   settingsService?: SettingsService,
   worktreeLifecycleService?: WorktreeLifecycleService,
-  autoModeService?: AutoModeService
+  autoModeService?: AutoModeService,
+  featureLoader?: FeatureLoader
 ): Router {
   const router = Router();
 
@@ -86,7 +88,7 @@ export function createWorktreeRoutes(
   router.post(
     '/delete',
     validatePathParams('projectPath', 'worktreePath'),
-    createDeleteHandler(autoModeService)
+    createDeleteHandler(autoModeService, featureLoader)
   );
   router.post('/create-pr', createCreatePRHandler(settingsService));
   router.post('/pr-info', createPRInfoHandler());

--- a/apps/server/src/routes/worktree/routes/delete.ts
+++ b/apps/server/src/routes/worktree/routes/delete.ts
@@ -9,11 +9,15 @@ import { isGitRepo } from '@protolabs-ai/git-utils';
 import { getErrorMessage, logError, isValidBranchName, execGitCommand } from '../common.js';
 import { createLogger } from '@protolabs-ai/utils';
 import type { AutoModeService } from '../../../services/auto-mode-service.js';
+import type { FeatureLoader } from '../../../services/feature-loader.js';
 
 const execAsync = promisify(exec);
 const logger = createLogger('Worktree');
 
-export function createDeleteHandler(autoModeService?: AutoModeService) {
+export function createDeleteHandler(
+  autoModeService?: AutoModeService,
+  featureLoader?: FeatureLoader
+) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
       const { projectPath, worktreePath, deleteBranch } = req.body as {
@@ -99,6 +103,32 @@ export function createDeleteHandler(autoModeService?: AutoModeService) {
         }
       }
 
+      // Migrate features referencing the deleted branch back to main (branchName: null)
+      let featuresMovedToMain = 0;
+      if (featureLoader && branchName) {
+        try {
+          const features = await featureLoader.getAll(projectPath);
+          const orphanedFeatures = features.filter((f) => f.branchName === branchName);
+
+          for (const feature of orphanedFeatures) {
+            await featureLoader.update(projectPath, feature.id, { branchName: undefined });
+          }
+
+          featuresMovedToMain = orphanedFeatures.length;
+          if (featuresMovedToMain > 0) {
+            logger.info(
+              `Migrated ${featuresMovedToMain} feature(s) from deleted branch "${branchName}" back to main worktree`
+            );
+          }
+        } catch (migrationError) {
+          // Feature migration errors must not block worktree deletion
+          logger.warn(
+            `Failed to migrate features for deleted branch "${branchName}":`,
+            migrationError
+          );
+        }
+      }
+
       res.json({
         success: true,
         deleted: {
@@ -106,6 +136,7 @@ export function createDeleteHandler(autoModeService?: AutoModeService) {
           branch: branchDeleted ? branchName : null,
           branchDeleted,
         },
+        featuresMovedToMain,
       });
     } catch (error) {
       logError(error, 'Delete worktree failed');

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -258,7 +258,13 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api/enhance-prompt', createEnhancePromptRoutes(settingsService));
   app.use(
     '/api/worktree',
-    createWorktreeRoutes(events, settingsService, worktreeLifecycleService, autoModeService)
+    createWorktreeRoutes(
+      events,
+      settingsService,
+      worktreeLifecycleService,
+      autoModeService,
+      featureLoader
+    )
   );
   app.use('/api/git', createGitRoutes());
   app.use('/api/suggestions', createSuggestionsRoutes(events, settingsService));


### PR DESCRIPTION
## Summary

**Origin:** Upstream Automaker PR #820 (AutoMaker-Org/automaker)

When a worktree is deleted via the delete route, features with `branchName` pointing to that deleted branch become orphaned — they still reference a non-existent branch and will fail to execute.

**Current behavior (`apps/server/src/routes/worktree/routes/delete.ts`):**
- Deletes worktree via `git worktree remove --force`
- Optionally deletes the branch if `deleteBranch === true`
- Checks for running agents before deletion
- Does ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worktree deletion now automatically migrates associated features to main, with a count of migrated features included in the deletion response.

* **Chores**
  * Updated route handler signatures to support feature management during worktree operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->