### PR TITLE
fix(intake): Linear issue creation bypasses intake state gate — routes to signal pipeline instead of linearApprovalHandler

### DIFF
--- a/apps/server/src/routes/linear/webhook.ts
+++ b/apps/server/src/routes/linear/webhook.ts
@@ -353,14 +353,37 @@ async function handleIssueEvent(
         title: data.title,
         state: data.state?.name,
       });
-      // Emit issue detected event for signal intake
-      events.emit('linear:issue:detected', {
-        issueId: data.id,
-        title: data.title,
-        description: data.description,
-        state: data.state,
-        createdAt: data.createdAt,
-      });
+      // Route through linearApprovalHandler to check intake trigger state.
+      // Only issues created directly in a trigger state (e.g., "Todo") will fire
+      // linear:intake:triggered. Issues created in "Backlog" or other states are ignored.
+      if (data.state?.name) {
+        const defaultPath = process.env.AUTOMAKER_PROJECT_PATH || repoRoot;
+        let projectPath = defaultPath;
+        if (data.team?.id) {
+          try {
+            const globalSettings = await settingsService.getGlobalSettings();
+            const mapped = globalSettings.linearTeamRoutes?.[data.team.id];
+            if (mapped) {
+              projectPath = mapped;
+              logger.info(`Routed team ${data.team.name} (${data.team.id}) to ${mapped}`);
+            }
+          } catch (err) {
+            logger.warn('Failed to resolve linearTeamRoutes, using default', {
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+        await linearApprovalHandler.onIssueStateChange(data.id, data.state.name, projectPath, {
+          title: data.title,
+          description: data.description,
+          priority: data.priority,
+          team: data.team,
+          project: data.project,
+          assignee: data.assignee ? { id: data.assignee.id, name: data.assignee.name } : undefined,
+        });
+      } else {
+        logger.debug(`Issue created without a state, skipping intake check: ${data.id}`);
+      }
       break;
     case 'update':
       await handleIssueUpdated(data, events, featureLoader, settingsService, repoRoot);

--- a/apps/server/src/services/integration-service.ts
+++ b/apps/server/src/services/integration-service.ts
@@ -1004,7 +1004,22 @@ export class IntegrationService {
     projectId?: string;
     createdAt: string;
   }): Promise<void> {
-    // All new Linear issues are treated as signals
+    // Secondary guard: skip issues not in an intake trigger state.
+    // The primary gate is in the webhook handler (linearApprovalHandler.onIssueStateChange),
+    // but this catch ensures the signal pipeline is not triggered even if the event
+    // arrives from another source (e.g., the polling monitor).
+    const intakeTriggerStates = ['Todo'];
+    if (
+      payload.state?.name &&
+      !intakeTriggerStates.some((s) => s.toLowerCase() === payload.state!.name.toLowerCase())
+    ) {
+      logger.debug(
+        `Skipping Linear issue signal: state "${payload.state.name}" is not an intake trigger state`,
+        { issueId: payload.issueId }
+      );
+      return;
+    }
+
     logger.info(`Signal detected from Linear issue: ${payload.title}`, {
       issueId: payload.issueId,
       labels: payload.labels,


### PR DESCRIPTION
## Summary

## Bug

Every new Linear issue creation triggers board feature creation, regardless of workflow state. Creating a tracking ticket (e.g. PRO-361, PRO-362 in 'Backlog') spawns unwanted board features and agents.

## Root Cause

Three-layer chain:

1. `apps/server/src/routes/linear/webhook.ts` lines 351-363: `case 'create'` unconditionally emits `linear:issue:detected` with no state check.

2. `apps/server/src/services/integration-service.ts` lines 998-1031: `handleLinearIssue()` has a hardcoded co...

---
*Recovered automatically by Automaker post-agent hook*