### PR TITLE
test(ceremony): rewrite tests for LangGraph-based CeremonyService

### DIFF
--- a/apps/server/tests/unit/services/ceremony-service.test.ts
+++ b/apps/server/tests/unit/services/ceremony-service.test.ts
@@ -1,11 +1,13 @@
 /**
- * Ceremony Service Unit Tests
+ * CeremonyService Unit Tests
  *
- * Tests for milestone completion ceremony generation:
- * - Milestone update content generation
- * - Message splitting at 2000 character limit
- * - Config loading (enabled/disabled)
- * - Channel override functionality
+ * Tests for the LangGraph-based ceremony service:
+ * - Config gate checks (enabled/disabled, channel required)
+ * - Flow factory invocation with correct arguments
+ * - Discord adapter routing via integration:discord event
+ * - Observability counters and status methods
+ * - Project retro dedup guard and clearProcessedProject
+ * - Error handling (flow throws → discordPostFailures++)
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -15,84 +17,68 @@ import type { EventEmitter } from '../../../src/lib/events.js';
 import type { SettingsService } from '../../../src/services/settings-service.js';
 import type { FeatureLoader } from '../../../src/services/feature-loader.js';
 import type { ProjectService } from '../../../src/services/project-service.js';
-import type { Feature, Project, CeremonySettings, ProjectSettings } from '@protolabs-ai/types';
+import type { MetricsService } from '../../../src/services/metrics-service.js';
+import type { ProjectSettings } from '@protolabs-ai/types';
 
-// Mock dependencies
-const createMockSettingsService = (): SettingsService => {
-  return {
-    getProjectSettings: vi.fn(),
-  } as unknown as SettingsService;
-};
+// ---------------------------------------------------------------------------
+// Module mocks — prevent real LLM calls
+// ---------------------------------------------------------------------------
 
-const createMockFeatureLoader = (): FeatureLoader => {
-  return {
-    getAll: vi.fn(),
-  } as unknown as FeatureLoader;
-};
+vi.mock('@langchain/anthropic', () => ({
+  ChatAnthropic: vi.fn().mockImplementation(() => ({})),
+}));
 
-const createMockProjectService = (): ProjectService => {
-  return {
-    getProject: vi.fn(),
-  } as unknown as ProjectService;
-};
+vi.mock('@protolabs-ai/flows', () => ({
+  createStandupFlow: vi.fn(),
+  createRetroFlow: vi.fn(),
+  createProjectRetroFlow: vi.fn(),
+}));
 
-// Test data factories
-const createTestFeature = (overrides: Partial<Feature> = {}): Feature => ({
-  id: 'feature-123',
-  title: 'Test Feature',
-  description: 'A test feature',
-  status: 'done',
-  createdAt: '2026-02-10T00:00:00.000Z',
-  updatedAt: '2026-02-10T00:00:00.000Z',
-  prUrl: 'https://github.com/test/repo/pull/123',
-  prNumber: 123,
-  costUsd: 1.5,
-  startedAt: '2026-02-09T00:00:00.000Z',
-  milestoneSlug: 'milestone-1',
-  ...overrides,
+import { createStandupFlow, createRetroFlow, createProjectRetroFlow } from '@protolabs-ai/flows';
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+const createMockSettingsService = (): SettingsService =>
+  ({ getProjectSettings: vi.fn() }) as unknown as SettingsService;
+
+const createMockFeatureLoader = (): FeatureLoader =>
+  ({ getAll: vi.fn() }) as unknown as FeatureLoader;
+
+const createMockProjectService = (): ProjectService =>
+  ({ getProject: vi.fn() }) as unknown as ProjectService;
+
+const createMockMetricsService = (): MetricsService => ({}) as unknown as MetricsService;
+
+/** Settings with ceremonies enabled and a Discord channel configured. */
+const enabledSettings = (
+  overrides: Partial<NonNullable<ProjectSettings['ceremonySettings']>> = {}
+): ProjectSettings => ({
+  ceremonySettings: {
+    enabled: true,
+    enableMilestoneUpdates: true,
+    enableProjectRetros: true,
+    discordChannelId: 'channel-123',
+    ...overrides,
+  },
 });
 
-const createTestProject = (overrides: Partial<Project> = {}): Project => ({
-  title: 'Test Project',
-  slug: 'test-project',
-  goal: 'Test project goal',
-  status: 'active',
-  createdAt: '2026-02-01T00:00:00.000Z',
-  updatedAt: '2026-02-10T00:00:00.000Z',
-  milestones: [
-    {
-      number: 1,
-      slug: 'milestone-1',
-      title: 'Foundation',
-      description: 'Core infrastructure',
-      phases: [
-        {
-          title: 'Phase 1',
-          description: 'First phase',
-          filesToModify: [],
-          acceptanceCriteria: [],
-          complexity: 'small',
-        },
-      ],
-    },
-    {
-      number: 2,
-      slug: 'milestone-2',
-      title: 'Features',
-      description: 'Main features',
-      phases: [
-        {
-          title: 'Phase 2',
-          description: 'Second phase',
-          filesToModify: [],
-          acceptanceCriteria: [],
-          complexity: 'medium',
-        },
-      ],
-    },
-  ],
-  ...overrides,
+/** A mock flow that calls discordBot.sendMessage when invoked. */
+const makeFlow = (
+  discordBot?: { sendMessage: (channelId: string, content: string) => Promise<{ id: string }> },
+  channelId = 'channel-123'
+) => ({
+  invoke: vi.fn(async () => {
+    if (discordBot) {
+      await discordBot.sendMessage(channelId, 'mock ceremony message');
+    }
+  }),
 });
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
 
 describe('CeremonyService', () => {
   let ceremonyService: CeremonyService;
@@ -100,6 +86,7 @@ describe('CeremonyService', () => {
   let mockSettingsService: SettingsService;
   let mockFeatureLoader: FeatureLoader;
   let mockProjectService: ProjectService;
+  let mockMetricsService: MetricsService;
 
   beforeEach(() => {
     ceremonyService = new CeremonyService();
@@ -107,1004 +94,579 @@ describe('CeremonyService', () => {
     mockSettingsService = createMockSettingsService();
     mockFeatureLoader = createMockFeatureLoader();
     mockProjectService = createMockProjectService();
+    mockMetricsService = createMockMetricsService();
     vi.clearAllMocks();
   });
 
+  // -------------------------------------------------------------------------
+  // Initialization
+  // -------------------------------------------------------------------------
+
   describe('initialization', () => {
-    it('should initialize with dependencies', () => {
-      expect(() => {
+    it('initializes without throwing', () => {
+      expect(() =>
         ceremonyService.initialize(
           emitter,
           mockSettingsService,
           mockFeatureLoader,
-          mockProjectService
-        );
-      }).not.toThrow();
+          mockProjectService,
+          mockMetricsService
+        )
+      ).not.toThrow();
     });
 
-    it('should subscribe to milestone:completed events on initialization', () => {
-      const subscribeSpy = vi.spyOn(emitter, 'subscribe');
-
+    it('subscribes to the emitter on initialization', () => {
+      const spy = vi.spyOn(emitter, 'subscribe');
       ceremonyService.initialize(
         emitter,
         mockSettingsService,
         mockFeatureLoader,
-        mockProjectService
+        mockProjectService,
+        mockMetricsService
       );
-
-      expect(subscribeSpy).toHaveBeenCalledOnce();
+      expect(spy).toHaveBeenCalledOnce();
     });
 
-    it('should cleanup subscriptions on destroy', () => {
+    it('unsubscribes on destroy', () => {
       ceremonyService.initialize(
         emitter,
         mockSettingsService,
         mockFeatureLoader,
-        mockProjectService
+        mockProjectService,
+        mockMetricsService
       );
+      expect(() => ceremonyService.destroy()).not.toThrow();
+    });
 
-      expect(() => {
-        ceremonyService.destroy();
-      }).not.toThrow();
+    it('getStatus returns zeroed counts before any ceremonies', () => {
+      const { counts, total } = ceremonyService.getStatus();
+      expect(total).toBe(0);
+      expect(counts.standup).toBe(0);
+      expect(counts.milestoneRetro).toBe(0);
+      expect(counts.projectRetro).toBe(0);
     });
   });
 
-  describe('config loading', () => {
-    it('should skip ceremony when config is disabled', async () => {
-      // Setup: ceremonies disabled
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: false,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: true,
-        },
-      };
+  // -------------------------------------------------------------------------
+  // Config gates — standup (milestone:started)
+  // -------------------------------------------------------------------------
 
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
+  describe('standup config gates', () => {
+    it('skips standup when ceremonies are disabled', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(
+        enabledSettings({ enabled: false })
+      );
+      vi.mocked(createStandupFlow).mockReturnValue(makeFlow() as any);
 
       ceremonyService.initialize(
         emitter,
         mockSettingsService,
         mockFeatureLoader,
-        mockProjectService
+        mockProjectService,
+        mockMetricsService
       );
 
-      // Trigger milestone:completed event
-      emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        milestoneTitle: 'Foundation',
+      emitter.emit('milestone:started', {
+        projectPath: '/test',
+        projectTitle: 'T',
+        projectSlug: 'test',
+        milestoneTitle: 'M1',
         milestoneNumber: 1,
       });
 
-      // Allow async handlers to run
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      // Should not emit integration:discord event
-      expect(emitSpy).toHaveBeenCalledWith('milestone:completed', expect.any(Object));
-      expect(emitSpy).not.toHaveBeenCalledWith('integration:discord', expect.any(Object));
+      await new Promise((r) => setTimeout(r, 20));
+      expect(createStandupFlow).not.toHaveBeenCalled();
     });
 
-    it('should skip ceremony when enableMilestoneUpdates is false', async () => {
-      // Setup: milestone updates disabled
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: false,
-          enableProjectRetros: true,
-        },
-      };
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
+    it('skips standup when discordChannelId is not set', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(
+        enabledSettings({ discordChannelId: undefined })
+      );
 
       ceremonyService.initialize(
         emitter,
         mockSettingsService,
         mockFeatureLoader,
-        mockProjectService
+        mockProjectService,
+        mockMetricsService
       );
 
-      // Trigger milestone:completed event
-      emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        milestoneTitle: 'Foundation',
+      emitter.emit('milestone:started', {
+        projectPath: '/test',
+        projectTitle: 'T',
+        projectSlug: 'test',
+        milestoneTitle: 'M1',
         milestoneNumber: 1,
       });
 
-      // Allow async handlers to run
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      // Should not emit integration:discord event
-      expect(emitSpy).not.toHaveBeenCalledWith('integration:discord', expect.any(Object));
+      await new Promise((r) => setTimeout(r, 20));
+      expect(createStandupFlow).not.toHaveBeenCalled();
     });
 
-    it('should process ceremony when config is enabled', async () => {
-      // Setup: ceremonies enabled
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: true,
-        },
-        integrations: {
-          discord: {
-            enabled: true,
-            serverId: 'server-123',
-            channelId: 'channel-123',
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
-
-      const mockProject = createTestProject();
-      const mockFeatures = [createTestFeature()];
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-      vi.mocked(mockProjectService.getProject).mockResolvedValue(mockProject);
-      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue(mockFeatures);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
+    it('invokes standup flow with correct arguments when enabled', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(enabledSettings());
+      vi.mocked(createStandupFlow).mockReturnValue(makeFlow() as any);
 
       ceremonyService.initialize(
         emitter,
         mockSettingsService,
         mockFeatureLoader,
-        mockProjectService
+        mockProjectService,
+        mockMetricsService
       );
 
-      // Trigger milestone:completed event
-      emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        milestoneTitle: 'Foundation',
+      emitter.emit('milestone:started', {
+        projectPath: '/test',
+        projectTitle: 'My Project',
+        projectSlug: 'my-project',
+        milestoneTitle: 'Milestone One',
         milestoneNumber: 1,
       });
 
-      // Allow async handlers to run
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await new Promise((r) => setTimeout(r, 20));
 
-      // Should emit integration:discord event
-      expect(emitSpy).toHaveBeenCalledWith(
-        'integration:discord',
+      expect(createStandupFlow).toHaveBeenCalledWith(
         expect.objectContaining({
-          projectPath: '/test/path',
-          action: 'send_message',
+          projectPath: '/test',
+          projectSlug: 'my-project',
+          milestoneSlug: 'milestone-one',
+          discordChannelId: 'channel-123',
         })
       );
+      expect(ceremonyService.getStatus().counts.standup).toBe(1);
     });
   });
 
-  describe('milestone update generation', () => {
-    it('should generate milestone update with features shipped', async () => {
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: true,
-        },
-        integrations: {
-          discord: {
-            enabled: true,
-            serverId: 'server-123',
-            channelId: 'channel-123',
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
+  // -------------------------------------------------------------------------
+  // Config gates — retro (milestone:completed)
+  // -------------------------------------------------------------------------
 
-      const mockProject = createTestProject();
-      const mockFeatures = [
-        createTestFeature({ title: 'Feature A', prNumber: 101 }),
-        createTestFeature({ title: 'Feature B', prNumber: 102 }),
-      ];
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-      vi.mocked(mockProjectService.getProject).mockResolvedValue(mockProject);
-      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue(mockFeatures);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
+  describe('retro config gates', () => {
+    it('skips retro when ceremonies are disabled', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(
+        enabledSettings({ enabled: false })
+      );
 
       ceremonyService.initialize(
         emitter,
         mockSettingsService,
         mockFeatureLoader,
-        mockProjectService
+        mockProjectService,
+        mockMetricsService
       );
 
       emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        milestoneTitle: 'Foundation',
+        projectPath: '/test',
+        projectTitle: 'T',
+        projectSlug: 'test',
+        milestoneTitle: 'M1',
         milestoneNumber: 1,
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Verify Discord event was emitted with content
-      const discordCalls = emitSpy.mock.calls.filter((call) => call[0] === 'integration:discord');
-      expect(discordCalls.length).toBeGreaterThan(0);
-
-      const discordPayload = discordCalls[0][1] as any;
-      expect(discordPayload.content).toContain('Test Project');
-      expect(discordPayload.content).toContain('Foundation');
-      expect(discordPayload.content).toContain('**Features Shipped:** 2');
-      expect(discordPayload.content).toContain('Feature A');
-      expect(discordPayload.content).toContain('Feature B');
+      await new Promise((r) => setTimeout(r, 20));
+      expect(createRetroFlow).not.toHaveBeenCalled();
     });
 
-    it('should include cost metrics in milestone update', async () => {
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: true,
-        },
-        integrations: {
-          discord: {
-            enabled: true,
-            serverId: 'server-123',
-            channelId: 'channel-123',
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
-
-      const mockProject = createTestProject();
-      const mockFeatures = [
-        createTestFeature({ costUsd: 2.5 }),
-        createTestFeature({ costUsd: 3.5 }),
-      ];
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-      vi.mocked(mockProjectService.getProject).mockResolvedValue(mockProject);
-      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue(mockFeatures);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
+    it('skips retro when enableMilestoneUpdates is false', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(
+        enabledSettings({ enableMilestoneUpdates: false })
+      );
 
       ceremonyService.initialize(
         emitter,
         mockSettingsService,
         mockFeatureLoader,
-        mockProjectService
+        mockProjectService,
+        mockMetricsService
       );
 
       emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        milestoneTitle: 'Foundation',
+        projectPath: '/test',
+        projectTitle: 'T',
+        projectSlug: 'test',
+        milestoneTitle: 'M1',
         milestoneNumber: 1,
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      const discordCalls = emitSpy.mock.calls.filter((call) => call[0] === 'integration:discord');
-      const discordPayload = discordCalls[0][1] as any;
-
-      expect(discordPayload.content).toContain('**Total Cost:** $6.00');
-      expect(discordPayload.content).toContain('**Avg per Feature:** $3.00');
+      await new Promise((r) => setTimeout(r, 20));
+      expect(createRetroFlow).not.toHaveBeenCalled();
     });
 
-    it('should include blockers in milestone update', async () => {
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: true,
-        },
-        integrations: {
-          discord: {
-            enabled: true,
-            serverId: 'server-123',
-            channelId: 'channel-123',
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
-
-      const mockProject = createTestProject();
-      const mockFeatures = [
-        createTestFeature({ title: 'Feature A' }),
-        createTestFeature({
-          title: 'Feature B',
-          status: 'blocked',
-          error: 'Test failed',
-        }),
-      ];
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-      vi.mocked(mockProjectService.getProject).mockResolvedValue(mockProject);
-      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue(mockFeatures);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
+    it('skips retro when discordChannelId is not set', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(
+        enabledSettings({ discordChannelId: undefined })
+      );
 
       ceremonyService.initialize(
         emitter,
         mockSettingsService,
         mockFeatureLoader,
-        mockProjectService
+        mockProjectService,
+        mockMetricsService
       );
 
       emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        milestoneTitle: 'Foundation',
+        projectPath: '/test',
+        projectTitle: 'T',
+        projectSlug: 'test',
+        milestoneTitle: 'M1',
         milestoneNumber: 1,
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      const discordCalls = emitSpy.mock.calls.filter((call) => call[0] === 'integration:discord');
-      const discordPayload = discordCalls[0][1] as any;
-
-      expect(discordPayload.content).toContain('**Blockers Encountered:** 1');
-      expect(discordPayload.content).toContain('Feature B');
+      await new Promise((r) => setTimeout(r, 20));
+      expect(createRetroFlow).not.toHaveBeenCalled();
     });
 
-    it('should include next milestone info', async () => {
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: true,
-        },
-        integrations: {
-          discord: {
-            enabled: true,
-            serverId: 'server-123',
-            channelId: 'channel-123',
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
-
-      const mockProject = createTestProject();
-      const mockFeatures = [createTestFeature()];
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-      vi.mocked(mockProjectService.getProject).mockResolvedValue(mockProject);
-      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue(mockFeatures);
+    it('invokes retro flow and routes discord via integration:discord event', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(enabledSettings());
 
       const emitSpy = vi.spyOn(emitter, 'emit');
+
+      // Flow captures discordBot and calls sendMessage when invoked
+      vi.mocked(createRetroFlow).mockImplementation(
+        ({ discordBot, discordChannelId }) => makeFlow(discordBot, discordChannelId) as any
+      );
 
       ceremonyService.initialize(
         emitter,
         mockSettingsService,
         mockFeatureLoader,
-        mockProjectService
+        mockProjectService,
+        mockMetricsService
       );
 
       emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
+        projectPath: '/test',
+        projectTitle: 'My Project',
+        projectSlug: 'my-project',
         milestoneTitle: 'Foundation',
         milestoneNumber: 1,
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await new Promise((r) => setTimeout(r, 20));
 
-      const discordCalls = emitSpy.mock.calls.filter((call) => call[0] === 'integration:discord');
-      const discordPayload = discordCalls[0][1] as any;
-
-      expect(discordPayload.content).toContain("**What's Next:** Milestone 2 — Features");
-      expect(discordPayload.content).toContain('1 phases planned');
-    });
-
-    it('should indicate project completion when no more milestones', async () => {
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: true,
-        },
-        integrations: {
-          discord: {
-            enabled: true,
-            serverId: 'server-123',
-            channelId: 'channel-123',
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
-
-      const mockProject = createTestProject({
-        milestones: [
-          {
-            number: 1,
-            slug: 'milestone-1',
-            title: 'Foundation',
-            description: 'Core infrastructure',
-            phases: [],
-          },
-        ],
-      });
-      const mockFeatures = [createTestFeature()];
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-      vi.mocked(mockProjectService.getProject).mockResolvedValue(mockProject);
-      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue(mockFeatures);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
-
-      ceremonyService.initialize(
-        emitter,
-        mockSettingsService,
-        mockFeatureLoader,
-        mockProjectService
+      expect(createRetroFlow).toHaveBeenCalledWith(
+        expect.objectContaining({ projectPath: '/test', discordChannelId: 'channel-123' })
       );
 
-      emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        milestoneTitle: 'Foundation',
-        milestoneNumber: 1,
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      const discordCalls = emitSpy.mock.calls.filter((call) => call[0] === 'integration:discord');
-      const discordPayload = discordCalls[0][1] as any;
-
-      expect(discordPayload.content).toContain('All milestones complete!');
+      // Discord adapter emits integration:discord when flow calls sendMessage
+      expect(emitSpy).toHaveBeenCalledWith(
+        'integration:discord',
+        expect.objectContaining({ channelId: 'channel-123', action: 'send_message' })
+      );
+      expect(ceremonyService.getStatus().counts.milestoneRetro).toBe(1);
     });
   });
 
-  describe('message splitting', () => {
-    it('should not split messages under 2000 characters', async () => {
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: true,
-        },
-        integrations: {
-          discord: {
-            enabled: true,
-            serverId: 'server-123',
-            channelId: 'channel-123',
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
+  // -------------------------------------------------------------------------
+  // Config gates — project retro (project:completed)
+  // -------------------------------------------------------------------------
 
-      const mockProject = createTestProject();
-      const mockFeatures = [createTestFeature()];
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-      vi.mocked(mockProjectService.getProject).mockResolvedValue(mockProject);
-      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue(mockFeatures);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
-
-      ceremonyService.initialize(
-        emitter,
-        mockSettingsService,
-        mockFeatureLoader,
-        mockProjectService
+  describe('project retro config gates', () => {
+    it('skips project retro when enableProjectRetros is false', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(
+        enabledSettings({ enableProjectRetros: false })
       );
 
-      emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        milestoneTitle: 'Foundation',
-        milestoneNumber: 1,
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Should emit only one Discord event (message not split)
-      const discordCalls = emitSpy.mock.calls.filter((call) => call[0] === 'integration:discord');
-      expect(discordCalls.length).toBe(1);
-    });
-
-    it('should split messages over 2000 characters into multiple chunks', async () => {
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: true,
-        },
-        integrations: {
-          discord: {
-            enabled: true,
-            serverId: 'server-123',
-            channelId: 'channel-123',
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
-
-      const mockProject = createTestProject();
-
-      // Create many features to exceed 2000 chars
-      const mockFeatures: Feature[] = [];
-      for (let i = 0; i < 100; i++) {
-        mockFeatures.push(
-          createTestFeature({
-            title: `Feature ${i} with a very long description that takes up space`,
-            prNumber: 1000 + i,
-            costUsd: i * 0.5,
-          })
-        );
-      }
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-      vi.mocked(mockProjectService.getProject).mockResolvedValue(mockProject);
-      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue(mockFeatures);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
-
       ceremonyService.initialize(
         emitter,
         mockSettingsService,
         mockFeatureLoader,
-        mockProjectService
-      );
-
-      emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        milestoneTitle: 'Foundation',
-        milestoneNumber: 1,
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Should emit multiple Discord events (message split)
-      const discordCalls = emitSpy.mock.calls.filter((call) => call[0] === 'integration:discord');
-      expect(discordCalls.length).toBeGreaterThan(1);
-
-      // Each message should be under 2000 chars
-      for (const call of discordCalls) {
-        const payload = call[1] as any;
-        expect(payload.content.length).toBeLessThanOrEqual(2000);
-      }
-    });
-
-    it('should preserve line boundaries when splitting', async () => {
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: true,
-        },
-        integrations: {
-          discord: {
-            enabled: true,
-            serverId: 'server-123',
-            channelId: 'channel-123',
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
-
-      const mockProject = createTestProject();
-
-      // Create many features
-      const mockFeatures: Feature[] = [];
-      for (let i = 0; i < 100; i++) {
-        mockFeatures.push(
-          createTestFeature({
-            title: `Feature ${i} with description`,
-            prNumber: 1000 + i,
-          })
-        );
-      }
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-      vi.mocked(mockProjectService.getProject).mockResolvedValue(mockProject);
-      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue(mockFeatures);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
-
-      ceremonyService.initialize(
-        emitter,
-        mockSettingsService,
-        mockFeatureLoader,
-        mockProjectService
-      );
-
-      emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        milestoneTitle: 'Foundation',
-        milestoneNumber: 1,
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      const discordCalls = emitSpy.mock.calls.filter((call) => call[0] === 'integration:discord');
-
-      // Each chunk should contain complete lines (no mid-line splits)
-      for (const call of discordCalls) {
-        const payload = call[1] as any;
-        const content = payload.content;
-
-        // Should not start or end with partial lines
-        // (Lines starting with "- " should be complete)
-        const lines = content.split('\n');
-        for (const line of lines) {
-          if (line.startsWith('- ')) {
-            // Feature list item should have complete format
-            expect(line).toMatch(/- .+ — \[PR#\d+\]\(https:\/\/.+\)/);
-          }
-        }
-      }
-    });
-  });
-
-  describe('channel override', () => {
-    it('should use channel override from ceremony settings', async () => {
-      const customChannelId = 'custom-channel-456';
-
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: true,
-          discordChannelId: customChannelId,
-        },
-        integrations: {
-          discord: {
-            enabled: true,
-            serverId: 'server-123',
-            channelId: 'default-channel-123',
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
-
-      const mockProject = createTestProject();
-      const mockFeatures = [createTestFeature()];
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-      vi.mocked(mockProjectService.getProject).mockResolvedValue(mockProject);
-      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue(mockFeatures);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
-
-      ceremonyService.initialize(
-        emitter,
-        mockSettingsService,
-        mockFeatureLoader,
-        mockProjectService
-      );
-
-      emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        milestoneTitle: 'Foundation',
-        milestoneNumber: 1,
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      const discordCalls = emitSpy.mock.calls.filter((call) => call[0] === 'integration:discord');
-      const discordPayload = discordCalls[0][1] as any;
-
-      // Should use custom channel, not default
-      expect(discordPayload.channelId).toBe(customChannelId);
-    });
-
-    it('should use default channel when no override specified', async () => {
-      const defaultChannelId = 'default-channel-123';
-
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: true,
-          // No discordChannelId override
-        },
-        integrations: {
-          discord: {
-            enabled: true,
-            serverId: 'server-123',
-            channelId: defaultChannelId,
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
-
-      const mockProject = createTestProject();
-      const mockFeatures = [createTestFeature()];
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-      vi.mocked(mockProjectService.getProject).mockResolvedValue(mockProject);
-      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue(mockFeatures);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
-
-      ceremonyService.initialize(
-        emitter,
-        mockSettingsService,
-        mockFeatureLoader,
-        mockProjectService
-      );
-
-      emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        milestoneTitle: 'Foundation',
-        milestoneNumber: 1,
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      const discordCalls = emitSpy.mock.calls.filter((call) => call[0] === 'integration:discord');
-      const discordPayload = discordCalls[0][1] as any;
-
-      // Should use default channel
-      expect(discordPayload.channelId).toBe(defaultChannelId);
-    });
-  });
-
-  describe('project retro config gate', () => {
-    it('should skip project retro when enableProjectRetros is false', async () => {
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: false, // retros disabled
-        },
-        integrations: {
-          discord: {
-            enabled: true,
-            serverId: 'server-123',
-            channelId: 'channel-123',
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
-
-      ceremonyService.initialize(
-        emitter,
-        mockSettingsService,
-        mockFeatureLoader,
-        mockProjectService
+        mockProjectService,
+        mockMetricsService
       );
 
       emitter.emit('project:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        totalMilestones: 2,
-        totalFeatures: 5,
-        totalCostUsd: 10.0,
-        failureCount: 1,
-        milestoneSummaries: [],
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Should NOT emit integration:discord for retro
-      const discordCalls = emitSpy.mock.calls.filter((call) => call[0] === 'integration:discord');
-      expect(discordCalls.length).toBe(0);
-    });
-
-    it('should pass config gate when enableProjectRetros is true even if enableMilestoneUpdates is false', async () => {
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: false, // milestone updates off
-          enableProjectRetros: true, // but retros on
-        },
-        integrations: {
-          discord: {
-            enabled: true,
-            serverId: 'server-123',
-            channelId: 'channel-123',
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
-
-      const mockFeatures = [createTestFeature({ projectSlug: 'test-project' })];
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue(mockFeatures);
-
-      ceremonyService.initialize(
-        emitter,
-        mockSettingsService,
-        mockFeatureLoader,
-        mockProjectService
-      );
-
-      emitter.emit('project:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
+        projectPath: '/test',
+        projectTitle: 'T',
+        projectSlug: 'test',
         totalMilestones: 1,
-        totalFeatures: 1,
-        totalCostUsd: 1.5,
+        totalFeatures: 2,
+        totalCostUsd: 5,
         failureCount: 0,
         milestoneSummaries: [],
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await new Promise((r) => setTimeout(r, 20));
+      expect(createProjectRetroFlow).not.toHaveBeenCalled();
+    });
 
-      // The config gate passed — featureLoader.getAll was called (happens after the gate)
-      // The retro may fail later due to unmocked LLM call, but the gate used enableProjectRetros
-      expect(mockFeatureLoader.getAll).toHaveBeenCalledWith('/test/path');
+    it('skips project retro when discordChannelId is not set', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(
+        enabledSettings({ discordChannelId: undefined })
+      );
+
+      ceremonyService.initialize(
+        emitter,
+        mockSettingsService,
+        mockFeatureLoader,
+        mockProjectService,
+        mockMetricsService
+      );
+
+      emitter.emit('project:completed', {
+        projectPath: '/test',
+        projectTitle: 'T',
+        projectSlug: 'test',
+        totalMilestones: 1,
+        totalFeatures: 2,
+        totalCostUsd: 5,
+        failureCount: 0,
+        milestoneSummaries: [],
+      });
+
+      await new Promise((r) => setTimeout(r, 20));
+      expect(createProjectRetroFlow).not.toHaveBeenCalled();
+    });
+
+    it('runs project retro independently of enableMilestoneUpdates', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(
+        enabledSettings({ enableMilestoneUpdates: false })
+      );
+      vi.mocked(createProjectRetroFlow).mockReturnValue(makeFlow() as any);
+
+      ceremonyService.initialize(
+        emitter,
+        mockSettingsService,
+        mockFeatureLoader,
+        mockProjectService,
+        mockMetricsService
+      );
+
+      emitter.emit('project:completed', {
+        projectPath: '/test',
+        projectTitle: 'My Project',
+        projectSlug: 'my-project',
+        totalMilestones: 2,
+        totalFeatures: 5,
+        totalCostUsd: 10,
+        failureCount: 0,
+        milestoneSummaries: [],
+      });
+
+      await new Promise((r) => setTimeout(r, 20));
+      expect(createProjectRetroFlow).toHaveBeenCalled();
     });
   });
 
+  // -------------------------------------------------------------------------
+  // Dedup guard
+  // -------------------------------------------------------------------------
+
+  describe('project retro dedup guard', () => {
+    it('skips project retro if already processed', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(enabledSettings());
+      vi.mocked(createProjectRetroFlow).mockReturnValue(makeFlow() as any);
+
+      ceremonyService.initialize(
+        emitter,
+        mockSettingsService,
+        mockFeatureLoader,
+        mockProjectService,
+        mockMetricsService
+      );
+
+      const payload = {
+        projectPath: '/test',
+        projectTitle: 'My Project',
+        projectSlug: 'my-project',
+        totalMilestones: 1,
+        totalFeatures: 2,
+        totalCostUsd: 5,
+        failureCount: 0,
+        milestoneSummaries: [],
+      };
+
+      emitter.emit('project:completed', payload);
+      await new Promise((r) => setTimeout(r, 20));
+
+      // Second emission — should be deduped
+      emitter.emit('project:completed', payload);
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(createProjectRetroFlow).toHaveBeenCalledTimes(1);
+    });
+
+    it('clearProcessedProject allows re-running the retro', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(enabledSettings());
+      vi.mocked(createProjectRetroFlow).mockReturnValue(makeFlow() as any);
+
+      ceremonyService.initialize(
+        emitter,
+        mockSettingsService,
+        mockFeatureLoader,
+        mockProjectService,
+        mockMetricsService
+      );
+
+      const payload = {
+        projectPath: '/test',
+        projectTitle: 'My Project',
+        projectSlug: 'my-project',
+        totalMilestones: 1,
+        totalFeatures: 2,
+        totalCostUsd: 5,
+        failureCount: 0,
+        milestoneSummaries: [],
+      };
+
+      emitter.emit('project:completed', payload);
+      await new Promise((r) => setTimeout(r, 20));
+
+      // Clear dedup and re-emit
+      ceremonyService.clearProcessedProject('/test', 'my-project');
+      emitter.emit('project:completed', payload);
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(createProjectRetroFlow).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Observability
+  // -------------------------------------------------------------------------
+
+  describe('observability', () => {
+    it('increments lastCeremonyAt after a standup', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(enabledSettings());
+      vi.mocked(createStandupFlow).mockReturnValue(makeFlow() as any);
+
+      const before = ceremonyService.getStatus().lastCeremonyAt;
+      expect(before).toBeNull();
+
+      ceremonyService.initialize(
+        emitter,
+        mockSettingsService,
+        mockFeatureLoader,
+        mockProjectService,
+        mockMetricsService
+      );
+      emitter.emit('milestone:started', {
+        projectPath: '/test',
+        projectTitle: 'T',
+        projectSlug: 'test',
+        milestoneTitle: 'M',
+        milestoneNumber: 1,
+      });
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(ceremonyService.getStatus().lastCeremonyAt).not.toBeNull();
+    });
+
+    it('tracks active reflection during project retro', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(enabledSettings());
+
+      let resolveFlow!: () => void;
+      const flowPromise = new Promise<void>((res) => {
+        resolveFlow = res;
+      });
+
+      vi.mocked(createProjectRetroFlow).mockReturnValue({
+        invoke: vi.fn(() => flowPromise),
+      } as any);
+
+      ceremonyService.initialize(
+        emitter,
+        mockSettingsService,
+        mockFeatureLoader,
+        mockProjectService,
+        mockMetricsService
+      );
+
+      emitter.emit('project:completed', {
+        projectPath: '/test',
+        projectTitle: 'My Project',
+        projectSlug: 'my-project',
+        totalMilestones: 1,
+        totalFeatures: 2,
+        totalCostUsd: 5,
+        failureCount: 0,
+        milestoneSummaries: [],
+      });
+
+      // While flow is running, reflection should be active
+      await new Promise((r) => setTimeout(r, 10));
+      const status = ceremonyService.getReflectionStatus();
+      expect(status.active).toBe(true);
+      expect(status.activeProject).toBe('My Project');
+
+      // Complete the flow
+      resolveFlow();
+      await new Promise((r) => setTimeout(r, 10));
+
+      const after = ceremonyService.getReflectionStatus();
+      expect(after.active).toBe(false);
+      expect(after.reflectionCount).toBe(1);
+      expect(after.lastReflection?.projectSlug).toBe('my-project');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling
+  // -------------------------------------------------------------------------
+
   describe('error handling', () => {
-    it('should handle missing project gracefully', async () => {
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: true,
-        },
-        integrations: {
-          discord: {
-            enabled: true,
-            serverId: 'server-123',
-            channelId: 'channel-123',
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-      vi.mocked(mockProjectService.getProject).mockResolvedValue(null);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
+    it('increments discordPostFailures when a flow throws', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(enabledSettings());
+      vi.mocked(createRetroFlow).mockReturnValue({
+        invoke: vi.fn().mockRejectedValue(new Error('LLM error')),
+      } as any);
 
       ceremonyService.initialize(
         emitter,
         mockSettingsService,
         mockFeatureLoader,
-        mockProjectService
+        mockProjectService,
+        mockMetricsService
       );
 
       emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        milestoneTitle: 'Foundation',
+        projectPath: '/test',
+        projectTitle: 'T',
+        projectSlug: 'test',
+        milestoneTitle: 'M',
         milestoneNumber: 1,
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Should not emit Discord event on error
-      const discordCalls = emitSpy.mock.calls.filter((call) => call[0] === 'integration:discord');
-      expect(discordCalls.length).toBe(0);
+      await new Promise((r) => setTimeout(r, 20));
+      expect(ceremonyService.getStatus().counts.discordPostFailures).toBe(1);
     });
 
-    it('should handle missing milestone gracefully', async () => {
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: true,
-        },
-        integrations: {
-          discord: {
-            enabled: true,
-            serverId: 'server-123',
-            channelId: 'channel-123',
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
+    it('does not throw when destroyed before any event', () => {
+      ceremonyService.initialize(
+        emitter,
+        mockSettingsService,
+        mockFeatureLoader,
+        mockProjectService,
+        mockMetricsService
+      );
+      expect(() => ceremonyService.destroy()).not.toThrow();
+    });
 
-      const mockProject = createTestProject();
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-      vi.mocked(mockProjectService.getProject).mockResolvedValue(mockProject);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
+    it('safely no-ops on events after destroy', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(enabledSettings());
 
       ceremonyService.initialize(
         emitter,
         mockSettingsService,
         mockFeatureLoader,
-        mockProjectService
+        mockProjectService,
+        mockMetricsService
       );
+      ceremonyService.destroy();
 
-      // Request non-existent milestone
-      emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        milestoneTitle: 'NonExistent',
-        milestoneNumber: 999,
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Should not emit Discord event on error
-      const discordCalls = emitSpy.mock.calls.filter((call) => call[0] === 'integration:discord');
-      expect(discordCalls.length).toBe(0);
-    });
-
-    it('should skip ceremony when Discord integration is disabled', async () => {
-      const mockSettings: ProjectSettings = {
-        ceremonySettings: {
-          enabled: true,
-          enableMilestoneUpdates: true,
-          enableProjectRetros: true,
-        },
-        integrations: {
-          discord: {
-            enabled: false, // Discord disabled
-            serverId: 'server-123',
-            channelId: 'channel-123',
-            webhookId: 'webhook-123',
-            webhookToken: 'token-123',
-          },
-        },
-      };
-
-      const mockProject = createTestProject();
-      const mockFeatures = [createTestFeature()];
-
-      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue(mockSettings);
-      vi.mocked(mockProjectService.getProject).mockResolvedValue(mockProject);
-      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue(mockFeatures);
-
-      const emitSpy = vi.spyOn(emitter, 'emit');
-
-      ceremonyService.initialize(
-        emitter,
-        mockSettingsService,
-        mockFeatureLoader,
-        mockProjectService
-      );
-
-      emitter.emit('milestone:completed', {
-        projectPath: '/test/path',
-        projectTitle: 'Test Project',
-        projectSlug: 'test-project',
-        milestoneTitle: 'Foundation',
+      // emitter still has subscribers from before — but service's unsubscribe was called
+      emitter.emit('milestone:started', {
+        projectPath: '/test',
+        projectTitle: 'T',
+        projectSlug: 'test',
+        milestoneTitle: 'M',
         milestoneNumber: 1,
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Should not emit Discord event when integration is disabled
-      const discordCalls = emitSpy.mock.calls.filter((call) => call[0] === 'integration:discord');
-      expect(discordCalls.length).toBe(0);
+      await new Promise((r) => setTimeout(r, 20));
+      // No flow should have been called
+      expect(createStandupFlow).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Replaces 1110-line test file written for old class hierarchy with 672-line tests matching the new `CeremonyService` implementation (PR #1558)
- Mocks `@protolabs-ai/flows` factories to prevent real LLM calls in tests
- Tests: config gates, flow invocation args, discord adapter routing, observability counters, dedup guard, error handling

## Why

The old tests tested implementation details (specific message content strings, message splitting) tied to the old `CeremonyBase → StandupCeremony → RetroCeremony → ProjectRetroCeremony` hierarchy that generated content in-process. The new flat `CeremonyService` delegates all content generation to LangGraph flows — so tests verify the service's orchestration behavior, not the flow's output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)