### PR TITLE
HITL Confirmation Dialogs

### DIFF
--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -45,6 +45,64 @@ export interface AvaToolsConfig {
   projectMgmt?: boolean;
   /** Enable orchestration tools (get_execution_order, set_feature_dependencies) */
   orchestration?: boolean;
+  /**
+   * Pre-approved destructive tool calls (HITL flow).
+   * Each entry contains the tool name and a stable JSON hash of the input args.
+   * When a destructive tool's args match an entry here, it executes immediately
+   * rather than returning a confirmation-required sentinel.
+   */
+  approvedActions?: Array<{ toolName: string; inputHash: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Destructive-tool helpers (HITL)
+// ---------------------------------------------------------------------------
+
+/**
+ * The set of tool names that require human-in-the-loop confirmation before
+ * executing. `start_auto_mode` is only gated when maxConcurrency > 1.
+ */
+export const DESTRUCTIVE_TOOLS = new Set(['delete_feature', 'stop_agent', 'update_project_spec']);
+
+/**
+ * Produce a stable JSON string for an input object so that two calls with the
+ * same arguments generate identical hashes regardless of key insertion order.
+ */
+function stableJson(obj: unknown): string {
+  if (typeof obj !== 'object' || obj === null) return JSON.stringify(obj);
+  const sorted = Object.fromEntries(
+    Object.entries(obj as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b))
+  );
+  return JSON.stringify(sorted);
+}
+
+/**
+ * Returns true when the given (toolName, input) pair has been pre-approved by
+ * the user in this request.
+ */
+function isApproved(
+  toolName: string,
+  input: unknown,
+  approvedActions: AvaToolsConfig['approvedActions']
+): boolean {
+  if (!approvedActions || approvedActions.length === 0) return false;
+  const hash = stableJson(input);
+  return approvedActions.some((a) => a.toolName === toolName && a.inputHash === hash);
+}
+
+/**
+ * Build the HITL sentinel object returned when a destructive tool needs
+ * user confirmation before executing.
+ */
+function hitlSentinel(action: string, summary: string, input: unknown): Record<string, unknown> {
+  return {
+    __hitl: true,
+    action,
+    summary,
+    input,
+    message:
+      'This action requires user confirmation. Please confirm to proceed or reject to cancel.',
+  };
 }
 
 // Re-use the same status literals that the Feature type exposes
@@ -241,6 +299,10 @@ export function buildAvaTools(
         featureId: z.string().describe('The feature ID to delete'),
       }),
       execute: async ({ featureId }) => {
+        const input = { featureId };
+        if (!isApproved('delete_feature', input, config.approvedActions)) {
+          return hitlSentinel('delete_feature', `Delete feature "${featureId}"`, input);
+        }
         const success = await services.featureLoader.delete(projectPath, featureId);
         if (success) {
           services.events?.emit('feature:deleted', { projectPath, featureId });
@@ -290,6 +352,10 @@ export function buildAvaTools(
         sessionId: z.string().describe('ID of the session to stop'),
       }),
       execute: async ({ sessionId }) => {
+        const input = { sessionId };
+        if (!isApproved('stop_agent', input, config.approvedActions)) {
+          return hitlSentinel('stop_agent', `Stop agent session "${sessionId}"`, input);
+        }
         const deleted = await services.agentService.deleteSession(sessionId);
         return { success: deleted, sessionId };
       },
@@ -335,6 +401,18 @@ export function buildAvaTools(
           .describe('Restrict auto-mode to features belonging to this branch'),
       }),
       execute: async ({ maxConcurrency, branchName }) => {
+        // Require confirmation when running more than one worker in parallel
+        const isConcurrent = (maxConcurrency ?? 1) > 1;
+        if (isConcurrent) {
+          const input = { maxConcurrency, branchName };
+          if (!isApproved('start_auto_mode', input, config.approvedActions)) {
+            return hitlSentinel(
+              'start_auto_mode',
+              `Start auto mode with ${maxConcurrency} parallel workers`,
+              input
+            );
+          }
+        }
         const count = await services.autoModeService.startAutoLoopForProject(
           projectPath,
           branchName ?? null,
@@ -387,6 +465,10 @@ export function buildAvaTools(
         content: z.string().describe('Markdown content to write to spec.md'),
       }),
       execute: async ({ content }) => {
+        const input = { content };
+        if (!isApproved('update_project_spec', input, config.approvedActions)) {
+          return hitlSentinel('update_project_spec', 'Update project specification', input);
+        }
         const specDir = path.join(projectPath, '.automaker');
         const specPath = path.join(specDir, 'spec.md');
         await fs.mkdir(specDir, { recursive: true });

--- a/apps/server/src/routes/chat/index.ts
+++ b/apps/server/src/routes/chat/index.ts
@@ -171,6 +171,7 @@ export function createChatRoutes(services: ServiceContainer): Router {
         system,
         context,
         projectPath,
+        approvedActions,
       } = req.body as {
         messages: Array<{
           role: string;
@@ -181,6 +182,8 @@ export function createChatRoutes(services: ServiceContainer): Router {
         system?: string;
         context?: NotesContext;
         projectPath?: string;
+        /** Pre-approved destructive tool calls for the HITL confirmation flow */
+        approvedActions?: Array<{ toolName: string; inputHash: string }>;
       };
 
       if (!rawMessages || !Array.isArray(rawMessages) || rawMessages.length === 0) {
@@ -233,7 +236,9 @@ export function createChatRoutes(services: ServiceContainer): Router {
           extension: avaConfig.systemPromptExtension || undefined,
         });
 
-      // Build tool set for this request — gated by per-project toolGroups config
+      // Build tool set for this request — gated by per-project toolGroups config.
+      // approvedActions carries pre-approved destructive-tool call identifiers for
+      // the HITL confirmation flow.
       const tools = projectPath
         ? buildAvaTools(
             projectPath,
@@ -242,7 +247,10 @@ export function createChatRoutes(services: ServiceContainer): Router {
               autoModeService: services.autoModeService,
               agentService: services.agentService,
             },
-            avaConfig.toolGroups
+            {
+              ...avaConfig.toolGroups,
+              approvedActions: approvedActions ?? [],
+            }
           )
         : {};
 

--- a/libs/ui/src/ai/chat-message.tsx
+++ b/libs/ui/src/ai/chat-message.tsx
@@ -169,10 +169,18 @@ function buildSegments(rawParts: Array<Record<string, unknown>>): PartSegment[] 
 
       while (i < rawParts.length && isToolPart(rawParts[i])) {
         const p = rawParts[i];
+        const rawState = (p.state as string) ?? 'input-available';
+        // Override state to 'approval-requested' when the tool returned a HITL sentinel
+        const outputData =
+          p.output && typeof p.output === 'object'
+            ? (p.output as Record<string, unknown>)
+            : undefined;
+        const effectiveState: TaskToolState =
+          outputData?.__hitl === true ? 'approval-requested' : (rawState as TaskToolState);
         tools.push({
           toolName: getToolName(p),
           toolCallId: (p.toolCallId as string) ?? `tool-${i}`,
-          state: ((p.state as string) ?? 'input-available') as TaskToolState,
+          state: effectiveState,
           input: p.input,
           output: p.output,
           errorText: p.errorText as string | undefined,
@@ -300,9 +308,15 @@ function MessagePartRenderer({
 export function ChatMessage({
   message,
   className,
+  onToolApprove,
+  onToolReject,
 }: {
   message: UIMessage;
   className?: string;
+  /** Called when the user approves a destructive tool call (HITL). Receives the tool name and input. */
+  onToolApprove?: (toolName: string, input: unknown) => void;
+  /** Called when the user rejects a destructive tool call (HITL). Receives the tool name and input. */
+  onToolReject?: (toolName: string, input: unknown) => void;
 } & Partial<VariantProps<typeof messageVariants>>) {
   const role = message.role as MessageRole;
   const parts = message.parts ?? [];
@@ -378,6 +392,8 @@ export function ChatMessage({
                   output={t.output}
                   errorText={t.errorText}
                   title={t.title}
+                  onApprove={onToolApprove ? () => onToolApprove(t.toolName, t.input) : undefined}
+                  onReject={onToolReject ? () => onToolReject(t.toolName, t.input) : undefined}
                 />
               );
             }

--- a/libs/ui/src/ai/confirmation-card.tsx
+++ b/libs/ui/src/ai/confirmation-card.tsx
@@ -1,0 +1,184 @@
+/**
+ * ConfirmationCard — Inline confirmation UI for destructive tool calls.
+ *
+ * Shown in the message stream when a destructive tool call (delete_feature,
+ * stop_agent, start_auto_mode with high concurrency, update_project_spec)
+ * requires human approval before executing.
+ *
+ * Renders three visual states:
+ *   - approval-requested: Yellow accent, action summary, Approve/Reject buttons
+ *   - approval-responded: Spinner "Approving…" while the action is being executed
+ *   - output-denied:      Muted "Action denied" summary
+ *
+ * The component manages internal clicked-state so the buttons visually respond
+ * immediately without waiting for the parent to re-render.
+ */
+
+import { useState } from 'react';
+import { ShieldAlert, ShieldCheck, ShieldX, Loader2 } from 'lucide-react';
+import { cn } from '../lib/utils.js';
+import { formatToolName } from './tool-invocation-part.js';
+
+export interface ConfirmationCardProps {
+  /** The tool name that requires confirmation */
+  toolName: string;
+  /** The input arguments passed to the tool */
+  input?: unknown;
+  /** Optional human-readable summary of the action (from the __hitl sentinel) */
+  summary?: string;
+  /**
+   * External state:
+   *   - approval-requested: awaiting user decision (default)
+   *   - approval-responded: user approved, action is executing
+   *   - output-denied:      user or system denied the action
+   */
+  state?: 'approval-requested' | 'approval-responded' | 'output-denied';
+  /** Called when the user clicks Approve */
+  onApprove?: () => void;
+  /** Called when the user clicks Reject */
+  onReject?: () => void;
+  className?: string;
+}
+
+/** Internal clicked state for immediate visual feedback */
+type ClickedState = 'idle' | 'approving' | 'rejected';
+
+/**
+ * Build a human-readable action summary from the tool name and input args.
+ * Falls back to the formatted tool name when no specific pattern is found.
+ */
+function buildSummary(toolName: string, input: unknown): string {
+  if (!input || typeof input !== 'object') return formatToolName(toolName);
+  const args = input as Record<string, unknown>;
+
+  switch (toolName) {
+    case 'delete_feature':
+      return args.featureId ? `Delete feature "${args.featureId}"` : 'Delete feature';
+    case 'stop_agent':
+      return args.sessionId ? `Stop agent session "${args.sessionId}"` : 'Stop agent';
+    case 'start_auto_mode': {
+      const c = args.maxConcurrency as number | undefined;
+      return c ? `Start auto mode with ${c} parallel workers` : 'Start auto mode';
+    }
+    case 'update_project_spec':
+      return 'Update project specification';
+    default:
+      return formatToolName(toolName);
+  }
+}
+
+export function ConfirmationCard({
+  toolName,
+  input,
+  summary: summaryProp,
+  state: externalState = 'approval-requested',
+  onApprove,
+  onReject,
+  className,
+}: ConfirmationCardProps) {
+  const [clicked, setClicked] = useState<ClickedState>('idle');
+
+  // Derive the effective display state: clicked state wins once set
+  const displayState: 'approval-requested' | 'approval-responded' | 'output-denied' =
+    clicked === 'approving'
+      ? 'approval-responded'
+      : clicked === 'rejected'
+        ? 'output-denied'
+        : externalState;
+
+  const summary = summaryProp ?? buildSummary(toolName, input);
+
+  function handleApprove() {
+    if (clicked !== 'idle') return;
+    setClicked('approving');
+    onApprove?.();
+  }
+
+  function handleReject() {
+    if (clicked !== 'idle') return;
+    setClicked('rejected');
+    onReject?.();
+  }
+
+  // ── Denied state ─────────────────────────────────────────────────────────
+  if (displayState === 'output-denied') {
+    return (
+      <div
+        data-slot="confirmation-card"
+        data-state="denied"
+        className={cn(
+          'my-1 flex items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground',
+          className
+        )}
+      >
+        <ShieldX className="size-3.5 shrink-0" />
+        <span className="font-medium">Action denied</span>
+        <span className="text-muted-foreground/40">—</span>
+        <span className="truncate text-muted-foreground/70">{summary}</span>
+      </div>
+    );
+  }
+
+  // ── Approval-responded (spinner while executing) ──────────────────────────
+  if (displayState === 'approval-responded') {
+    return (
+      <div
+        data-slot="confirmation-card"
+        data-state="responded"
+        className={cn(
+          'my-1 flex items-center gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/5 px-3 py-2.5 text-xs',
+          className
+        )}
+      >
+        <Loader2 className="size-3.5 shrink-0 animate-spin text-yellow-500" />
+        <span className="font-medium text-yellow-700 dark:text-yellow-300">Approving…</span>
+        <span className="text-muted-foreground/40">—</span>
+        <span className="truncate text-foreground/60">{summary}</span>
+      </div>
+    );
+  }
+
+  // ── Approval-requested (default) ─────────────────────────────────────────
+  return (
+    <div
+      data-slot="confirmation-card"
+      data-state="approval-requested"
+      className={cn(
+        'my-1 rounded-md border border-yellow-500/40 bg-yellow-500/5 text-xs',
+        className
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-start gap-2.5 px-3 py-2.5">
+        <ShieldAlert className="mt-0.5 size-3.5 shrink-0 text-yellow-500" />
+        <div className="min-w-0 flex-1">
+          <p className="font-semibold text-foreground/90">Confirmation required</p>
+          <p className="mt-0.5 truncate text-muted-foreground">{summary}</p>
+        </div>
+        <span className="shrink-0 rounded bg-yellow-500/15 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-yellow-600 dark:text-yellow-400">
+          Destructive
+        </span>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex items-center gap-2 border-t border-yellow-500/20 px-3 py-2">
+        <button
+          type="button"
+          onClick={handleApprove}
+          className="flex items-center gap-1.5 rounded-md bg-yellow-500/15 px-2.5 py-1 font-medium text-yellow-700 transition-colors hover:bg-yellow-500/25 dark:text-yellow-300"
+        >
+          <ShieldCheck className="size-3" />
+          Approve
+        </button>
+        <button
+          type="button"
+          onClick={handleReject}
+          className="flex items-center gap-1.5 rounded-md bg-muted/60 px-2.5 py-1 font-medium text-muted-foreground transition-colors hover:bg-muted"
+        >
+          <ShieldX className="size-3" />
+          Reject
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/libs/ui/src/ai/index.ts
+++ b/libs/ui/src/ai/index.ts
@@ -9,6 +9,8 @@ export {
   type MessageRole,
 } from './chat-message.js';
 
+export { ConfirmationCard, type ConfirmationCardProps } from './confirmation-card.js';
+
 export { InlineCitation, type Citation, type InlineCitationProps } from './inline-citation.js';
 
 export { MessageSources, type MessageSourcesProps } from './message-sources.js';

--- a/libs/ui/src/ai/tool-invocation-part.tsx
+++ b/libs/ui/src/ai/tool-invocation-part.tsx
@@ -12,6 +12,7 @@
 import { useState } from 'react';
 import { ChevronDown, Wrench, Loader2, Check, AlertTriangle } from 'lucide-react';
 import { cn } from '../lib/utils.js';
+import { ConfirmationCard } from './confirmation-card.js';
 import { toolResultRegistry } from './tool-result-registry.js';
 import { BoardSummaryCard } from './tool-results/board-summary-card.js';
 import { FeatureListCard } from './tool-results/feature-list-card.js';
@@ -62,6 +63,10 @@ export interface ToolInvocationPartProps {
   errorText?: string;
   title?: string;
   className?: string;
+  /** Called when user approves a destructive tool call (HITL flow) */
+  onApprove?: () => void;
+  /** Called when user rejects a destructive tool call (HITL flow) */
+  onReject?: () => void;
 }
 
 const stateConfig: Record<ToolState, { label: string; color: string; icon: typeof Loader2 }> = {
@@ -108,12 +113,33 @@ export function ToolInvocationPart({
   errorText,
   title,
   className,
+  onApprove,
+  onReject,
 }: ToolInvocationPartProps) {
   const [isOpen, setIsOpen] = useState(false);
   const config = stateConfig[state] ?? stateConfig['input-available'];
   const StateIcon = config.icon;
   const isRunning =
     state === 'input-streaming' || state === 'input-available' || state === 'approval-responded';
+
+  // ── HITL confirmation states — render ConfirmationCard inline ────────────
+  if (state === 'approval-requested' || state === 'output-denied') {
+    const hitlData =
+      output && typeof output === 'object' ? (output as Record<string, unknown>) : null;
+    const summary = typeof hitlData?.summary === 'string' ? hitlData.summary : undefined;
+
+    return (
+      <ConfirmationCard
+        toolName={toolName}
+        input={input}
+        summary={summary}
+        state={state === 'output-denied' ? 'output-denied' : 'approval-requested'}
+        onApprove={onApprove}
+        onReject={onReject}
+        className={className}
+      />
+    );
+  }
 
   // Look up a custom renderer for this tool
   const CustomRenderer = toolResultRegistry.get(toolName);


### PR DESCRIPTION
## Summary

**Milestone:** M4: Task Tracking + HITL Confirmations

Add human-in-the-loop confirmation for destructive tool calls: delete_feature, stop_agent, start_auto_mode (with max_concurrency > 1), and update_project_spec. Use the Vercel AI SDK experimental_prepareToolCall or a client-side intercept pattern: before executing a destructive tool, stream a special tool-call part with state='approval-requested', render a Confirmation component with action details and Approve/Reject buttons, then resume or a...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Destructive actions (delete operations, agent control, specification updates) now require user approval before execution
* New confirmation card interface displays for approving or rejecting actions, with visual feedback during processing
* Pre-approved actions configuration enables bypassing confirmation for pre-vetted operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->