### PR TITLE
WebPreviewCard tool result card

### DIFF
--- a/docs/dev/ava-chat-system.md
+++ b/docs/dev/ava-chat-system.md
@@ -168,6 +168,9 @@ UIMessage.parts[]
 | `AgentOutputCard`    | `get_agent_output`          | `tool-results/agent-output-card.tsx`     |
 | `AutoModeStatusCard` | `get_auto_mode_status`      | `tool-results/auto-mode-status-card.tsx` |
 | `ExecutionOrderCard` | `get_execution_order`       | `tool-results/execution-order-card.tsx`  |
+| `ArtifactCard`       | `generate_artifact`         | `tool-results/artifact-card.tsx`         |
+| `ImageCard`          | `generate_image`            | `tool-results/image-card.tsx`            |
+| `WebPreviewCard`     | `generate_html`             | `tool-results/web-preview-card.tsx`      |
 
 ### Adding a New Tool Result Card
 

--- a/libs/ui/src/ai/index.ts
+++ b/libs/ui/src/ai/index.ts
@@ -68,3 +68,4 @@ export { AutoModeStatusCard } from './tool-results/auto-mode-status-card.js';
 export { ExecutionOrderCard } from './tool-results/execution-order-card.js';
 export { ArtifactCard } from './tool-results/artifact-card.js';
 export { ImageCard } from './tool-results/image-card.js';
+export { WebPreviewCard } from './tool-results/web-preview-card.js';

--- a/libs/ui/src/ai/tool-invocation-part.tsx
+++ b/libs/ui/src/ai/tool-invocation-part.tsx
@@ -25,6 +25,7 @@ import { AutoModeStatusCard } from './tool-results/auto-mode-status-card.js';
 import { ExecutionOrderCard } from './tool-results/execution-order-card.js';
 import { ArtifactCard } from './tool-results/artifact-card.js';
 import { ImageCard } from './tool-results/image-card.js';
+import { WebPreviewCard } from './tool-results/web-preview-card.js';
 
 // Register custom renderers for the boardRead tool group
 toolResultRegistry.register('get_board_summary', BoardSummaryCard);
@@ -50,6 +51,7 @@ toolResultRegistry.register('get_execution_order', ExecutionOrderCard);
 // Register custom renderers for artifact and image generation tools
 toolResultRegistry.register('generate_artifact', ArtifactCard);
 toolResultRegistry.register('generate_image', ImageCard);
+toolResultRegistry.register('generate_html', WebPreviewCard);
 
 type ToolState =
   | 'input-streaming'

--- a/libs/ui/src/ai/tool-results/web-preview-card.tsx
+++ b/libs/ui/src/ai/tool-results/web-preview-card.tsx
@@ -1,0 +1,133 @@
+/**
+ * WebPreviewCard — Expandable iframe panel for generated HTML content.
+ *
+ * Renders:
+ * - Collapsible header with title and a globe/link icon
+ * - Sandboxed iframe using the srcdoc attribute (no allow-same-origin)
+ * - "Open in new tab" button that creates a Blob URL for safe viewing
+ *
+ * Extracts { html, title } from tool output.
+ * Registered for tool name: generate_html
+ */
+
+import { useState } from 'react';
+import { ChevronDown, Globe, ExternalLink, Loader2 } from 'lucide-react';
+import * as Collapsible from '@radix-ui/react-collapsible';
+import { cn } from '../../lib/utils.js';
+import type { ToolResultRendererProps } from '../tool-result-registry.js';
+
+interface WebPreviewData {
+  html?: string;
+  title?: string;
+  [key: string]: unknown;
+}
+
+function extractData(output: unknown): WebPreviewData | null {
+  if (!output || typeof output !== 'object') return null;
+  const o = output as Record<string, unknown>;
+  // Handle wrapped response: { success: true, data: { ... } }
+  if ('success' in o && 'data' in o && typeof o.data === 'object' && o.data !== null) {
+    return o.data as WebPreviewData;
+  }
+  return o as WebPreviewData;
+}
+
+function openInNewTab(html: string): void {
+  const blob = new Blob([html], { type: 'text/html' });
+  const url = URL.createObjectURL(blob);
+  window.open(url, '_blank', 'noopener,noreferrer');
+  // Revoke after a short delay to allow the browser to load it
+  setTimeout(() => URL.revokeObjectURL(url), 10_000);
+}
+
+export function WebPreviewCard({ output, state }: ToolResultRendererProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const isLoading =
+    state === 'input-streaming' || state === 'input-available' || state === 'approval-responded';
+
+  if (isLoading) {
+    return (
+      <div
+        data-slot="web-preview-card"
+        className="flex items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+      >
+        <Loader2 className="size-3.5 animate-spin" />
+        <span>Generating HTML…</span>
+      </div>
+    );
+  }
+
+  const data = extractData(output);
+
+  if (!data || !data.html) {
+    return (
+      <div
+        data-slot="web-preview-card"
+        className="rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+      >
+        No HTML content
+      </div>
+    );
+  }
+
+  const html = data.html;
+  const title = data.title ?? 'Web Preview';
+
+  return (
+    <Collapsible.Root
+      data-slot="web-preview-card"
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className="rounded-md border border-border/50 bg-muted/30 text-xs"
+    >
+      <div className="flex items-center gap-2 px-3 py-2">
+        <Collapsible.Trigger asChild>
+          <button
+            type="button"
+            className="flex flex-1 items-center gap-2 text-left"
+            aria-expanded={isOpen}
+          >
+            <Globe className="size-3.5 shrink-0 text-muted-foreground" />
+
+            {/* Title */}
+            <span className="flex-1 truncate font-medium text-foreground/80">{title}</span>
+
+            <ChevronDown
+              className={cn(
+                'size-3 shrink-0 text-muted-foreground transition-transform',
+                isOpen && 'rotate-180'
+              )}
+            />
+          </button>
+        </Collapsible.Trigger>
+
+        {/* Open in new tab button */}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            openInNewTab(html);
+          }}
+          aria-label="Open in new tab"
+          title="Open in new tab"
+          className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        >
+          <ExternalLink className="size-3.5" />
+        </button>
+      </div>
+
+      <Collapsible.Content>
+        <div className="border-t border-border/50">
+          <iframe
+            srcDoc={html}
+            sandbox="allow-scripts"
+            title={title}
+            className="h-64 w-full rounded-b-md bg-white"
+            data-slot="web-preview-iframe"
+          />
+        </div>
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+}


### PR DESCRIPTION
## Summary

**Milestone:** Foundation UI Components

Create WebPreviewCard (libs/ui/src/ai/tool-results/web-preview-card.tsx): expandable iframe panel for generated HTML. Shows a collapsible header with title and URL icon, renders an iframe with srcdoc attribute set to the HTML content, sandboxed with sandbox='allow-scripts' (no allow-same-origin to prevent escaping). Includes a 'Open in new tab' button that creates a Blob URL. Extracts { html, title } from tool output. Register for tool name 'generate_html...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebPreviewCard component enabling users to generate and preview HTML content in an expandable panel with an "Open in new tab" action.

* **Documentation**
  * Updated documentation to register new tool result cards for artifact and image generation alongside HTML generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->