### PR TITLE
chore: promote staging → main (board reconciliation + chat UI)

### DIFF
--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,7 +5,7 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 256
+  loaded: 258
   referenced: 75
   successfulFeatures: 75
 ---

--- a/.automaker/memory/content-pipeline-validation.md
+++ b/.automaker/memory/content-pipeline-validation.md
@@ -5,7 +5,7 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 61
+  loaded: 63
   referenced: 3
   successfulFeatures: 3
 ---

--- a/.automaker/memory/documentation.md
+++ b/.automaker/memory/documentation.md
@@ -5,7 +5,7 @@ relevantTo: [documentation]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 110
+  loaded: 112
   referenced: 36
   successfulFeatures: 36
 ---

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,7 +5,7 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 683
+  loaded: 685
   referenced: 239
   successfulFeatures: 239
 ---

--- a/apps/server/src/routes/webhooks/routes/github.ts
+++ b/apps/server/src/routes/webhooks/routes/github.ts
@@ -97,6 +97,26 @@ function verifySignature(secret: string, signature: string | undefined, body: st
 }
 
 /**
+ * Scan all configured projects to find the one whose features satisfy `matcher`.
+ * Returns the project path on first match, or null if none match.
+ */
+async function findProjectPathForFeature(
+  featureLoader: FeatureLoader,
+  projects: Array<{ path?: string }>,
+  matcher: (path: string) => Promise<boolean>
+): Promise<string | null> {
+  for (const project of projects) {
+    if (!project.path) continue;
+    try {
+      if (await matcher(project.path)) return project.path;
+    } catch {
+      /* continue to next project */
+    }
+  }
+  return null;
+}
+
+/**
  * Find feature by branch name
  */
 async function findFeatureByBranch(
@@ -267,8 +287,10 @@ export function createGitHubWebhookHandler(events: EventEmitter, settingsService
       // PR closed WITHOUT merging — find linked feature and recover to backlog
       if (!payload.pull_request.merged) {
         const closedPrNumber = payload.pull_request.number;
-        const closedProject = settings.projects.find((p) => p.id === settings.currentProjectId);
-        const closedProjectPath = closedProject?.path || process.cwd();
+        const closedProjectPath =
+          (await findProjectPathForFeature(featureLoader, settings.projects, (path) =>
+            featureLoader.findByPRNumber(path, closedPrNumber).then(Boolean)
+          )) ?? process.cwd();
 
         const closedFeature = await featureLoader.findByPRNumber(closedProjectPath, closedPrNumber);
 
@@ -317,10 +339,11 @@ export function createGitHubWebhookHandler(events: EventEmitter, settingsService
 
       logger.info(`PR #${prNumber} merged: ${prTitle} (branch: ${branchName} → ${baseBranch})`);
 
-      // Get project path from settings or use current working directory
-      // In a real implementation, you might want to match the repository to a project
-      const currentProject = settings.projects.find((p) => p.id === settings.currentProjectId);
-      const projectPath = currentProject?.path || process.cwd();
+      // Search all configured projects for the one containing this branch's feature
+      const projectPath =
+        (await findProjectPathForFeature(featureLoader, settings.projects, (path) =>
+          findFeatureByBranch(featureLoader, path, branchName).then(Boolean)
+        )) ?? process.cwd();
 
       // Find feature by branch name
       const feature = await findFeatureByBranch(featureLoader, projectPath, branchName);
@@ -365,6 +388,28 @@ export function createGitHubWebhookHandler(events: EventEmitter, settingsService
         logger.info(
           `Feature "${feature.title}" moved from "${currentFeature.status}" to "done" after PR #${prNumber} was merged`
         );
+
+        // Epic auto-promotion: if all siblings are done/review, promote the parent epic immediately.
+        try {
+          const updatedFeature = await featureLoader.get(projectPath, feature.featureId);
+          if (updatedFeature?.epicId) {
+            const allFeatures = await featureLoader.getAll(projectPath);
+            const doneStatuses = new Set(['done', 'completed', 'verified', 'review']);
+            const siblings = allFeatures.filter((f) => f.epicId === updatedFeature.epicId);
+            const allSiblingsDone = siblings.every((s) => doneStatuses.has(s.status ?? ''));
+            if (allSiblingsDone) {
+              const epic = allFeatures.find((f) => f.id === updatedFeature.epicId);
+              if (epic && !doneStatuses.has(epic.status ?? '')) {
+                await featureLoader.update(projectPath, epic.id, { status: 'done' });
+                logger.info(
+                  `Epic "${epic.title}" auto-promoted to done (all ${siblings.length} children done after PR #${prNumber})`
+                );
+              }
+            }
+          }
+        } catch (epicErr) {
+          logger.warn('Epic auto-promotion check failed (non-fatal):', epicErr);
+        }
 
         // Emit event for UI notification
         events.emit('feature:pr-merged', {

--- a/apps/server/src/services/event-subscriptions.module.ts
+++ b/apps/server/src/services/event-subscriptions.module.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@protolabs-ai/utils';
+import type { Feature } from '@protolabs-ai/types';
 
 import type { ServiceContainer } from '../server/services.js';
 
@@ -10,7 +11,7 @@ const logger = createLogger('Server:Wiring');
  * Note: linear:comment:followup subscription lives in linear-agent.module.ts.
  */
 export function register(container: ServiceContainer): void {
-  const { events, settingsService } = container;
+  const { events, settingsService, featureLoader, autoModeService } = container;
 
   // Listen for retro improvements and create Linear issues when configured
   events.subscribe(async (type, payload) => {
@@ -89,5 +90,64 @@ export function register(container: ServiceContainer): void {
     } catch (error) {
       logger.warn('[Bugs] Failed to create Linear issue for bug:', error);
     }
+  });
+
+  // feature:stopped → reset stale in_progress features to backlog immediately
+  events.subscribe((type, payload) => {
+    if (type !== 'feature:stopped') return;
+    const p = payload as { featureId?: string; projectPath?: string };
+    if (!p.featureId || !p.projectPath) return;
+
+    void (async () => {
+      try {
+        const feature = await featureLoader.get(p.projectPath!, p.featureId!);
+        const staleStatuses = new Set(['running', 'in_progress', 'in-progress']);
+        if (!feature || !staleStatuses.has(feature.status ?? '')) return;
+
+        const runningAgents = await autoModeService.getRunningAgents();
+        const isActuallyRunning = runningAgents.some(
+          (a) => a.featureId === p.featureId && a.projectPath === p.projectPath
+        );
+        if (isActuallyRunning) return;
+
+        await featureLoader.update(p.projectPath!, p.featureId!, {
+          status: 'backlog',
+          statusChangeReason: 'Agent stopped — auto-recovering to backlog',
+        });
+        logger.info(
+          `[BoardReconcile] Reset stale in_progress feature ${p.featureId} to backlog after agent stop`
+        );
+      } catch (err) {
+        logger.warn('[BoardReconcile] Failed to reset stale feature on agent stop:', err);
+      }
+    })();
+  });
+
+  // feature:deleted → clean dangling epicId and dependency refs immediately
+  events.subscribe((type, payload) => {
+    if (type !== 'feature:deleted') return;
+    const p = payload as { featureId?: string; projectPath?: string };
+    if (!p.featureId || !p.projectPath) return;
+
+    void (async () => {
+      try {
+        const allFeatures = await featureLoader.getAll(p.projectPath!);
+        for (const feature of allFeatures) {
+          const updates: Partial<Feature> = {};
+          if (feature.epicId === p.featureId) updates.epicId = undefined;
+          if (feature.dependencies?.includes(p.featureId!)) {
+            updates.dependencies = feature.dependencies.filter((d) => d !== p.featureId);
+          }
+          if (Object.keys(updates).length > 0) {
+            await featureLoader.update(p.projectPath!, feature.id, updates);
+            logger.info(
+              `[BoardReconcile] Removed dangling ref to deleted feature ${p.featureId} from ${feature.id}`
+            );
+          }
+        }
+      } catch (err) {
+        logger.warn('[BoardReconcile] Failed to clean dangling refs after feature delete:', err);
+      }
+    })();
   });
 }

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -338,6 +338,7 @@ export function Sidebar() {
                 onDocs={() => getElectronAPI().openExternalLink('https://docs.protolabs.studio')}
                 onNewProject={() => setShowNewProjectModal(true)}
                 onOpenFolder={handleOpenFolder}
+                onSettings={() => navigate({ to: '/settings' })}
                 onClose={handleToggleSidebar}
               />
             </div>

--- a/apps/ui/src/components/layout/sidebar/components/quick-actions-bar.tsx
+++ b/apps/ui/src/components/layout/sidebar/components/quick-actions-bar.tsx
@@ -1,4 +1,4 @@
-import { Bug, BookOpen, Plus, FolderOpen, X } from 'lucide-react';
+import { Bug, BookOpen, Plus, FolderOpen, Settings, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface QuickActionsBarProps {
@@ -6,6 +6,7 @@ interface QuickActionsBarProps {
   onDocs: () => void;
   onNewProject: () => void;
   onOpenFolder: () => void;
+  onSettings: () => void;
   onClose: () => void;
 }
 
@@ -14,6 +15,7 @@ const actions = [
   { key: 'open', icon: FolderOpen, label: 'Open Folder', testId: 'quick-action-open' },
   { key: 'docs', icon: BookOpen, label: 'Documentation', testId: 'quick-action-docs' },
   { key: 'bug', icon: Bug, label: 'Report Bug', testId: 'quick-action-bug' },
+  { key: 'settings', icon: Settings, label: 'Global Settings', testId: 'quick-action-settings' },
 ] as const;
 
 export function QuickActionsBar({
@@ -21,6 +23,7 @@ export function QuickActionsBar({
   onDocs,
   onNewProject,
   onOpenFolder,
+  onSettings,
   onClose,
 }: QuickActionsBarProps) {
   const handlers: Record<string, () => void> = {
@@ -28,6 +31,7 @@ export function QuickActionsBar({
     docs: onDocs,
     new: onNewProject,
     open: onOpenFolder,
+    settings: onSettings,
   };
 
   return (

--- a/libs/ui/src/ai/index.ts
+++ b/libs/ui/src/ai/index.ts
@@ -66,3 +66,5 @@ export { AgentStatusCard } from './tool-results/agent-status-card.js';
 export { AgentOutputCard } from './tool-results/agent-output-card.js';
 export { AutoModeStatusCard } from './tool-results/auto-mode-status-card.js';
 export { ExecutionOrderCard } from './tool-results/execution-order-card.js';
+export { ArtifactCard } from './tool-results/artifact-card.js';
+export { ImageCard } from './tool-results/image-card.js';

--- a/libs/ui/src/ai/tool-invocation-part.tsx
+++ b/libs/ui/src/ai/tool-invocation-part.tsx
@@ -23,6 +23,8 @@ import { AgentStatusCard } from './tool-results/agent-status-card.js';
 import { AgentOutputCard } from './tool-results/agent-output-card.js';
 import { AutoModeStatusCard } from './tool-results/auto-mode-status-card.js';
 import { ExecutionOrderCard } from './tool-results/execution-order-card.js';
+import { ArtifactCard } from './tool-results/artifact-card.js';
+import { ImageCard } from './tool-results/image-card.js';
 
 // Register custom renderers for the boardRead tool group
 toolResultRegistry.register('get_board_summary', BoardSummaryCard);
@@ -44,6 +46,10 @@ toolResultRegistry.register('get_auto_mode_status', AutoModeStatusCard);
 
 // Register custom renderers for the orchestration tool group
 toolResultRegistry.register('get_execution_order', ExecutionOrderCard);
+
+// Register custom renderers for artifact and image generation tools
+toolResultRegistry.register('generate_artifact', ArtifactCard);
+toolResultRegistry.register('generate_image', ImageCard);
 
 type ToolState =
   | 'input-streaming'

--- a/libs/ui/src/ai/tool-results/artifact-card.tsx
+++ b/libs/ui/src/ai/tool-results/artifact-card.tsx
@@ -1,0 +1,123 @@
+/**
+ * ArtifactCard — Expandable panel for generated code or file content.
+ *
+ * Renders:
+ * - Filename header with language badge and line count
+ * - Collapsible body containing a syntax-highlighted CodeBlock
+ *
+ * Extracts { filename, language, content } from tool output.
+ */
+
+import { useState } from 'react';
+import { ChevronDown, FileCode2, Loader2 } from 'lucide-react';
+import * as Collapsible from '@radix-ui/react-collapsible';
+import { cn } from '../../lib/utils.js';
+import { CodeBlock } from '../code-block.js';
+import type { ToolResultRendererProps } from '../tool-result-registry.js';
+
+interface ArtifactData {
+  filename?: string;
+  language?: string;
+  content?: string;
+  [key: string]: unknown;
+}
+
+function extractData(output: unknown): ArtifactData | null {
+  if (!output || typeof output !== 'object') return null;
+  const o = output as Record<string, unknown>;
+  // Handle wrapped response: { success: true, data: { ... } }
+  if ('success' in o && 'data' in o && typeof o.data === 'object' && o.data !== null) {
+    return o.data as ArtifactData;
+  }
+  return o as ArtifactData;
+}
+
+function countLines(content: string): number {
+  return content.split('\n').length;
+}
+
+export function ArtifactCard({ output, state }: ToolResultRendererProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const isLoading =
+    state === 'input-streaming' || state === 'input-available' || state === 'approval-responded';
+
+  if (isLoading) {
+    return (
+      <div
+        data-slot="artifact-card"
+        className="flex items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+      >
+        <Loader2 className="size-3.5 animate-spin" />
+        <span>Generating artifact…</span>
+      </div>
+    );
+  }
+
+  const data = extractData(output);
+
+  if (!data || !data.content) {
+    return (
+      <div
+        data-slot="artifact-card"
+        className="rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+      >
+        No artifact content
+      </div>
+    );
+  }
+
+  const filename = data.filename ?? 'untitled';
+  const language = data.language ?? '';
+  const content = data.content;
+  const lineCount = countLines(content);
+
+  return (
+    <Collapsible.Root
+      data-slot="artifact-card"
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className="rounded-md border border-border/50 bg-muted/30 text-xs"
+    >
+      <Collapsible.Trigger asChild>
+        <button
+          type="button"
+          className="flex w-full items-center gap-2 px-3 py-2 text-left"
+          aria-expanded={isOpen}
+        >
+          <FileCode2 className="size-3.5 shrink-0 text-muted-foreground" />
+
+          {/* Filename */}
+          <span className="flex-1 truncate font-mono font-medium text-foreground/80">
+            {filename}
+          </span>
+
+          {/* Language badge */}
+          {language && (
+            <span className="shrink-0 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-primary/70">
+              {language}
+            </span>
+          )}
+
+          {/* Line count */}
+          <span className="shrink-0 text-[10px] text-muted-foreground">
+            {lineCount} {lineCount === 1 ? 'line' : 'lines'}
+          </span>
+
+          <ChevronDown
+            className={cn(
+              'size-3 shrink-0 text-muted-foreground transition-transform',
+              isOpen && 'rotate-180'
+            )}
+          />
+        </button>
+      </Collapsible.Trigger>
+
+      <Collapsible.Content>
+        <div className="border-t border-border/50 px-2 pb-2">
+          <CodeBlock code={content} language={language || undefined} />
+        </div>
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+}

--- a/libs/ui/src/ai/tool-results/image-card.tsx
+++ b/libs/ui/src/ai/tool-results/image-card.tsx
@@ -1,0 +1,196 @@
+/**
+ * ImageCard — Displays AI-generated images from tool output.
+ *
+ * Renders:
+ * - Loading skeleton while the image loads
+ * - Error fallback if the image fails to load
+ * - Image with alt text and optional metadata
+ * - Click-to-expand dialog for full-size view
+ *
+ * Extracts { url, alt, metadata } from tool output.
+ */
+
+import { useState } from 'react';
+import { ImageIcon, Loader2, AlertTriangle, ZoomIn, X } from 'lucide-react';
+import { cn } from '../../lib/utils.js';
+import type { ToolResultRendererProps } from '../tool-result-registry.js';
+
+interface ImageMetadata {
+  width?: number;
+  height?: number;
+  format?: string;
+  size?: number;
+  [key: string]: unknown;
+}
+
+interface ImageData {
+  url?: string;
+  alt?: string;
+  metadata?: ImageMetadata;
+  [key: string]: unknown;
+}
+
+function extractData(output: unknown): ImageData | null {
+  if (!output || typeof output !== 'object') return null;
+  const o = output as Record<string, unknown>;
+  // Handle wrapped response: { success: true, data: { ... } }
+  if ('success' in o && 'data' in o && typeof o.data === 'object' && o.data !== null) {
+    return o.data as ImageData;
+  }
+  return o as ImageData;
+}
+
+function ImageSkeleton() {
+  return (
+    <div
+      data-slot="image-skeleton"
+      className="flex h-40 w-full animate-pulse items-center justify-center rounded-md bg-muted/50"
+    >
+      <ImageIcon className="size-8 text-muted-foreground/30" />
+    </div>
+  );
+}
+
+function ImageError({ message }: { message?: string }) {
+  return (
+    <div
+      data-slot="image-error"
+      className="flex h-40 w-full flex-col items-center justify-center gap-2 rounded-md border border-destructive/20 bg-destructive/5 text-xs text-destructive"
+    >
+      <AlertTriangle className="size-5" />
+      <span>{message ?? 'Failed to load image'}</span>
+    </div>
+  );
+}
+
+function ExpandedImageDialog({
+  url,
+  alt,
+  onClose,
+}: {
+  url: string;
+  alt: string;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      data-slot="image-expand-overlay"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+      onClick={onClose}
+    >
+      <div className="relative max-h-[90vh] max-w-[90vw]" onClick={(e) => e.stopPropagation()}>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close expanded image"
+          className="absolute -right-3 -top-3 rounded-full bg-background p-1 shadow-md hover:bg-muted"
+        >
+          <X className="size-4" />
+        </button>
+        <img src={url} alt={alt} className="max-h-[85vh] max-w-[85vw] rounded-md object-contain" />
+      </div>
+    </div>
+  );
+}
+
+export function ImageCard({ output, state }: ToolResultRendererProps) {
+  const [imageStatus, setImageStatus] = useState<'loading' | 'loaded' | 'error'>('loading');
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const isLoading =
+    state === 'input-streaming' || state === 'input-available' || state === 'approval-responded';
+
+  if (isLoading) {
+    return (
+      <div
+        data-slot="image-card"
+        className="flex items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+      >
+        <Loader2 className="size-3.5 animate-spin" />
+        <span>Generating image…</span>
+      </div>
+    );
+  }
+
+  const data = extractData(output);
+
+  if (!data || !data.url) {
+    return (
+      <div
+        data-slot="image-card"
+        className="rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+      >
+        No image available
+      </div>
+    );
+  }
+
+  const url = data.url;
+  const alt = data.alt ?? 'AI-generated image';
+  const metadata = data.metadata;
+
+  return (
+    <>
+      <div
+        data-slot="image-card"
+        className="rounded-md border border-border/50 bg-muted/30 text-xs overflow-hidden"
+      >
+        {/* Image area */}
+        <div className="relative">
+          {/* Loading skeleton shown while image loads */}
+          {imageStatus === 'loading' && <ImageSkeleton />}
+
+          {/* Error fallback */}
+          {imageStatus === 'error' && <ImageError />}
+
+          {/* Actual image */}
+          <img
+            src={url}
+            alt={alt}
+            className={cn(
+              'w-full rounded-t-md object-contain',
+              imageStatus !== 'loaded' && 'hidden'
+            )}
+            onLoad={() => setImageStatus('loaded')}
+            onError={() => setImageStatus('error')}
+          />
+
+          {/* Click-to-expand overlay (only when loaded) */}
+          {imageStatus === 'loaded' && (
+            <button
+              type="button"
+              onClick={() => setIsExpanded(true)}
+              aria-label="Expand image"
+              className="absolute inset-0 flex items-center justify-center bg-transparent opacity-0 transition-opacity hover:bg-black/20 hover:opacity-100"
+            >
+              <ZoomIn className="size-6 text-white drop-shadow" />
+            </button>
+          )}
+        </div>
+
+        {/* Footer: alt text and metadata */}
+        <div className="px-3 py-2">
+          {alt && alt !== 'AI-generated image' && (
+            <p className="text-[11px] text-foreground/70 leading-snug">{alt}</p>
+          )}
+          {metadata && (
+            <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-muted-foreground">
+              {metadata.width && metadata.height && (
+                <span>
+                  {metadata.width}×{metadata.height}
+                </span>
+              )}
+              {metadata.format && <span>{metadata.format.toString().toUpperCase()}</span>}
+              {metadata.size && <span>{Math.round((metadata.size as number) / 1024)} KB</span>}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Expanded view dialog */}
+      {isExpanded && (
+        <ExpandedImageDialog url={url} alt={alt} onClose={() => setIsExpanded(false)} />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Promotion PR: `staging → main`

Includes two sets of changes since last promotion:

**fix(board): event-driven board reconciliation** (PR #1587)
- Multi-project PR webhook fix: scan all configured projects instead of only `currentProjectId`
- Epic auto-promotion on PR merge — eliminates 6h cron lag
- `feature:stopped` → immediate stale in_progress reset — eliminates 1h cron lag
- `feature:deleted` → immediate dangling ref cleanup — eliminates 6h cron lag

**feat(chat): step-split bubbles, table styling, docs + Matt ownership** (PR #1586)
- Chat message UI improvements

## Test plan
- [ ] CI passes on staging
- [ ] Deploy Staging healthy post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings action added to quick actions bar for configuration access
  * Automatic feature lifecycle management: stopped features reset to backlog; deleted features trigger dependent cleanup
  * AI artifact rendering with code display and syntax highlighting
  * AI image rendering with expandable viewer and metadata display (dimensions, format, size)
  * Epic auto-promotion when all sibling features reach completion
  * Enhanced webhook handling for improved cross-project feature lookup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->