### PR TITLE
chore: promote staging → main (v0.24.0)

### DIFF
--- a/.automaker/context/hitl-forms.md
+++ b/.automaker/context/hitl-forms.md
@@ -1,0 +1,228 @@
+# HITL Form System — Quick Reference
+
+Use `request_user_input` to collect structured information from the user via JSON Schema forms. Forms render as dialogs in the UI with full validation.
+
+**Feature flag:** Requires `featureFlags.pipeline = true` in global settings.
+
+## Creating a Form
+
+```
+mcp__plugin_protolabs_studio__request_user_input({
+  projectPath: "/path/to/project",
+  title: "Form Title",
+  description: "Optional subtitle",
+  featureId: "optional-feature-id",
+  ttlSeconds: 3600,  // 60-86400, default 3600
+  steps: [
+    {
+      title: "Step Title",        // shown in wizard header (multi-step only)
+      description: "Step desc",
+      schema: { ... },            // JSON Schema draft-07
+      uiSchema: { ... }          // @rjsf layout hints (optional)
+    }
+  ]
+})
+```
+
+Returns `{ formId }`. Poll with `get_form_response({ formId })` to check status and retrieve the response.
+
+## JSON Schema Patterns
+
+### Radio Selection (enum + uiSchema)
+
+```json
+{
+  "schema": {
+    "type": "object",
+    "properties": {
+      "decision": {
+        "type": "string",
+        "title": "Your Decision",
+        "enum": ["approve", "deny"],
+        "enumNames": ["Approve this change", "Deny this change"]
+      }
+    },
+    "required": ["decision"]
+  },
+  "uiSchema": {
+    "decision": { "ui:widget": "radio" }
+  }
+}
+```
+
+### Radio with Descriptions (oneOf)
+
+```json
+{
+  "schema": {
+    "type": "object",
+    "properties": {
+      "action": {
+        "type": "string",
+        "title": "What should we do?",
+        "oneOf": [
+          { "const": "retry", "title": "Retry", "description": "Reset and re-run" },
+          { "const": "skip", "title": "Skip", "description": "Mark as done without implementing" },
+          { "const": "escalate", "title": "Escalate", "description": "Flag for manual review" }
+        ]
+      }
+    },
+    "required": ["action"]
+  }
+}
+```
+
+### Free Text Input
+
+```json
+{
+  "schema": {
+    "type": "object",
+    "properties": {
+      "feedback": {
+        "type": "string",
+        "title": "Your Feedback",
+        "description": "Tell us what you think"
+      }
+    }
+  }
+}
+```
+
+### Textarea (multiline)
+
+```json
+{
+  "schema": {
+    "type": "object",
+    "properties": {
+      "notes": { "type": "string", "title": "Notes" }
+    }
+  },
+  "uiSchema": {
+    "notes": { "ui:widget": "textarea", "ui:options": { "rows": 5 } }
+  }
+}
+```
+
+### Number Input
+
+```json
+{
+  "schema": {
+    "type": "object",
+    "properties": {
+      "count": { "type": "integer", "title": "How many?", "minimum": 1, "maximum": 10 }
+    },
+    "required": ["count"]
+  }
+}
+```
+
+### Checkbox (boolean)
+
+```json
+{
+  "schema": {
+    "type": "object",
+    "properties": {
+      "confirmed": { "type": "boolean", "title": "I confirm this action" }
+    },
+    "required": ["confirmed"]
+  }
+}
+```
+
+### Select Dropdown
+
+```json
+{
+  "schema": {
+    "type": "object",
+    "properties": {
+      "priority": {
+        "type": "string",
+        "title": "Priority",
+        "enum": ["urgent", "high", "normal", "low"],
+        "default": "normal"
+      }
+    }
+  }
+}
+```
+
+### Multi-Step Wizard
+
+Pass multiple steps. Each step gets its own page with Back/Next/Submit navigation:
+
+```json
+{
+  "steps": [
+    {
+      "title": "Step 1: Choose Action",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "action": { "type": "string", "enum": ["create", "update", "delete"] }
+        },
+        "required": ["action"]
+      }
+    },
+    {
+      "title": "Step 2: Provide Details",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "details": { "type": "string", "title": "Details" }
+        }
+      },
+      "uiSchema": {
+        "details": { "ui:widget": "textarea" }
+      }
+    }
+  ]
+}
+```
+
+### Dynamic Questions
+
+Build schemas at runtime from data:
+
+```json
+{
+  "schema": {
+    "type": "object",
+    "properties": {
+      "q1": { "type": "string", "title": "What is the target audience?" },
+      "q2": { "type": "string", "title": "What integrations are needed?" }
+    }
+  }
+}
+```
+
+## Polling for Response
+
+```
+mcp__plugin_protolabs_studio__get_form_response({ formId: "hitl-abc12345" })
+```
+
+Returns:
+- `status: "pending"` — user hasn't responded yet
+- `status: "submitted"` — `response` contains an object with the field values
+- `status: "cancelled"` — user cancelled
+- `status: "expired"` — TTL elapsed
+
+## Other Tools
+
+- `list_pending_forms({ projectPath })` — List all pending forms
+- `submit_form_response({ formId, response: {...} })` — Answer a form programmatically (Ava only)
+- `cancel_form({ formId })` — Cancel a pending form
+
+## Best Practices
+
+- Keep forms focused — 1-3 fields per step, 1-2 steps max
+- Use `oneOf` with descriptions for complex choices (renders as rich radio cards)
+- Use `enum` + `enumNames` for simple labeled options
+- Set reasonable TTL — 600s for quick decisions, 3600s for review tasks, 86400s for async approval
+- Always include `required` for mandatory fields
+- Use `uiSchema` to control widget types (radio, textarea, etc.)

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,7 +5,7 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 258
+  loaded: 259
   referenced: 75
   successfulFeatures: 75
 ---

--- a/.automaker/memory/content-pipeline-validation.md
+++ b/.automaker/memory/content-pipeline-validation.md
@@ -5,7 +5,7 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 63
+  loaded: 64
   referenced: 3
   successfulFeatures: 3
 ---

--- a/.automaker/memory/documentation.md
+++ b/.automaker/memory/documentation.md
@@ -5,7 +5,7 @@ relevantTo: [documentation]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 112
+  loaded: 113
   referenced: 36
   successfulFeatures: 36
 ---

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,7 +5,7 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 685
+  loaded: 686
   referenced: 239
   successfulFeatures: 239
 ---

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3011,15 +3011,33 @@ Address the follow-up instructions above. Review the previous work and make the 
   }
 
   /**
-   * Check if context exists for a feature
+   * Check if context exists for a feature.
+   *
+   * Guards against the stale context trap: if agent-output.md exists but
+   * hasn't been written to in over 2 hours, the session that created it is
+   * gone. Rename it to .stale so the next run starts fresh instead of trying
+   * to resume a dead Claude session (which handshakes, fails silently, and
+   * exits immediately).
    */
   async contextExists(projectPath: string, featureId: string): Promise<boolean> {
-    // Context is stored in .automaker directory
     const featureDir = getFeatureDir(projectPath, featureId);
     const contextPath = path.join(featureDir, 'agent-output.md');
 
     try {
       await secureFs.access(contextPath);
+
+      const stats = await secureFs.stat(contextPath);
+      const ageMs = Date.now() - stats.mtime.getTime();
+      const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
+
+      if (ageMs > TWO_HOURS_MS) {
+        logger.warn(
+          `[contextExists] agent-output.md for ${featureId} is ${Math.round(ageMs / 60000)}m old — stale session, renaming to .stale`
+        );
+        await secureFs.rename(contextPath, `${contextPath}.stale`);
+        return false;
+      }
+
       return true;
     } catch {
       return false;
@@ -3932,7 +3950,9 @@ Format your response as a structured markdown document.`;
             // Human intervention is required (e.g. fix .prettierignore, Husky config).
             const changeReason = feature.statusChangeReason ?? '';
             const isGitWorkflowBlock =
-              changeReason.includes('git commit') || changeReason.includes('git workflow failed');
+              changeReason.includes('git commit') ||
+              changeReason.includes('git workflow failed') ||
+              changeReason.includes('plan validation failed');
             if (isGitWorkflowBlock) {
               logger.warn(
                 `[loadPendingFeatures] Feature ${feature.id} skipping dep-unblock — ` +

--- a/apps/server/src/services/lead-engineer-processors.ts
+++ b/apps/server/src/services/lead-engineer-processors.ts
@@ -220,7 +220,10 @@ Keep it focused and actionable. If the feature description is too vague or uncle
         };
       }
 
-      ctx.escalationReason = `Plan rejected after ${ctx.planRetryCount} retries: ${gateResult.reason}`;
+      // Prefix with "plan validation failed:" so auto-mode's requeue guard
+      // can recognise this as a human-intervention-required block (not a
+      // transient dep issue) and prevent retry storms.
+      ctx.escalationReason = `plan validation failed: Plan rejected after ${ctx.planRetryCount} retries: ${gateResult.reason}`;
       return {
         nextState: 'ESCALATE',
         shouldContinue: true,

--- a/apps/ui/src/components/layout/chat-modal.tsx
+++ b/apps/ui/src/components/layout/chat-modal.tsx
@@ -10,16 +10,20 @@ import { useCallback, useEffect } from 'react';
 import { Dialog, DialogContent, DialogTitle } from '@protolabs-ai/ui/atoms';
 import { useChatSession } from '@/hooks/use-chat-session';
 import { useChatStore } from '@/store/chat-store';
+import { useAppStore } from '@/store/app-store';
 import { ChatOverlayContent } from '@/components/views/chat-overlay/chat-overlay-content';
 
 export function ChatModal() {
   const chatModalOpen = useChatStore((s) => s.chatModalOpen);
   const setChatModalOpen = useChatStore((s) => s.setChatModalOpen);
+  const avaChat = useAppStore((s) => s.featureFlags.avaChat);
   const chatSession = useChatSession({ defaultModel: 'sonnet' });
 
   const handleClose = useCallback(() => {
     setChatModalOpen(false);
   }, [setChatModalOpen]);
+
+  if (!avaChat) return null;
 
   return (
     <Dialog open={chatModalOpen} onOpenChange={setChatModalOpen}>
@@ -43,8 +47,11 @@ export function ChatModal() {
 export function useChatModalShortcut() {
   const chatModalOpen = useChatStore((s) => s.chatModalOpen);
   const setChatModalOpen = useChatStore((s) => s.setChatModalOpen);
+  const avaChat = useAppStore((s) => s.featureFlags.avaChat);
 
   useEffect(() => {
+    if (!avaChat) return;
+
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault();
@@ -54,5 +61,5 @@ export function useChatModalShortcut() {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [chatModalOpen, setChatModalOpen]);
+  }, [chatModalOpen, setChatModalOpen, avaChat]);
 }

--- a/apps/ui/src/components/layout/mobile-bottom-nav.tsx
+++ b/apps/ui/src/components/layout/mobile-bottom-nav.tsx
@@ -13,10 +13,16 @@ interface NavItem {
 
 const baseNavItems: NavItem[] = [
   { id: 'board', icon: Grid, label: 'Board', path: '/board' },
-  { id: 'chat', icon: MessageCircle, label: 'Chat', path: '/chat' },
   { id: 'notes', icon: FileText, label: 'Notes', path: '/notes' },
   { id: 'settings', icon: Settings, label: 'Settings', path: '/settings' },
 ];
+
+const chatNavItem: NavItem = {
+  id: 'chat',
+  icon: MessageCircle,
+  label: 'Chat',
+  path: '/chat',
+};
 
 const systemViewItem: NavItem = {
   id: 'system-view',
@@ -36,9 +42,13 @@ export function MobileBottomNav() {
     return null;
   }
 
-  const navItems = featureFlags.systemView
-    ? [baseNavItems[0], systemViewItem, ...baseNavItems.slice(1)]
-    : baseNavItems;
+  let navItems = [...baseNavItems];
+  if (featureFlags.avaChat) {
+    navItems.splice(1, 0, chatNavItem);
+  }
+  if (featureFlags.systemView) {
+    navItems.splice(1, 0, systemViewItem);
+  }
 
   const currentPath = routerState.location.pathname;
 

--- a/apps/ui/src/components/views/board-view/components/kanban-card/card-badges.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/card-badges.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@protolabs-ai/ui/atoms';
 import {
   AlertCircle,
+  AlertTriangle,
   Lock,
   Hand,
   Sparkles,
@@ -135,6 +136,18 @@ function getWorkItemStateBadge(state: WorkItemState): {
   }
 }
 
+/**
+ * Returns true when a blocked feature's statusChangeReason indicates it needs
+ * human intervention (will not be auto-requeued by auto-mode).
+ */
+function isHumanInterventionRequired(reason: string): boolean {
+  return (
+    reason.includes('git commit') ||
+    reason.includes('git workflow failed') ||
+    reason.includes('plan validation failed')
+  );
+}
+
 interface CardBadgesProps {
   feature: Feature;
   onPRDClick?: () => void;
@@ -152,8 +165,10 @@ export const CardBadges = memo(function CardBadges({ feature, onPRDClick }: Card
   // costUsd is typed as unknown on the Feature interface; narrow with typeof guard
   const costUsd = typeof feature.costUsd === 'number' ? feature.costUsd : undefined;
   const hasCost = costUsd != null && costUsd > 0;
+  const isNeedsAction =
+    feature.status === 'blocked' && isHumanInterventionRequired(feature.statusChangeReason ?? '');
 
-  if (!hasError && !hasEpic && !hasDueDate && !hasCost && !hasWorkItemState) {
+  if (!hasError && !hasEpic && !hasDueDate && !hasCost && !hasWorkItemState && !isNeedsAction) {
     return null;
   }
 
@@ -253,6 +268,27 @@ export const CardBadges = memo(function CardBadges({ feature, onPRDClick }: Card
             </TooltipTrigger>
             <TooltipContent side="bottom" className="text-xs max-w-[250px]">
               <p>{feature.error}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
+
+      {/* Needs Action badge — blocked features that won't auto-recover */}
+      {isNeedsAction && (
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className="inline-flex items-center gap-1 px-1.5 h-5 rounded text-[10px] font-medium bg-amber-500/15 text-amber-400 border border-amber-500/30"
+                data-testid={`needs-action-badge-${feature.id}`}
+              >
+                <AlertTriangle className="w-3 h-3" />
+                Needs Action
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs max-w-[280px]">
+              <p className="font-medium mb-0.5">Requires human intervention</p>
+              <p className="text-muted-foreground">{feature.statusChangeReason}</p>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
@@ -12,12 +12,14 @@
  */
 
 import { useState, useCallback, useEffect } from 'react';
-import { History, X, Settings, ChevronUp, ChevronDown, SquarePen } from 'lucide-react';
+import { History, X, Settings, ChevronUp, ChevronDown, SquarePen, ListOrdered } from 'lucide-react';
 import {
   ChatMessageList,
   ChatInput,
   SuggestionList,
   PromptInputProvider,
+  QueueView,
+  type QueueItem,
 } from '@protolabs-ai/ui/ai';
 import { Button } from '@protolabs-ai/ui/atoms';
 import { Popover, PopoverContent, PopoverTrigger } from '@protolabs-ai/ui/atoms';
@@ -68,6 +70,8 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
 
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
+  const [queueOpen, setQueueOpen] = useState(false);
+  const [queuePaused, setQueuePaused] = useState(false);
 
   const suggestions = useContextualSuggestions(features ?? []);
 
@@ -93,6 +97,27 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
     setExpanded(next);
     getOverlayAPI()?.resizeOverlay?.(next ? OVERLAY_HEIGHT_EXPANDED : OVERLAY_HEIGHT_DEFAULT);
   }, [expanded]);
+
+  // Regenerate: re-send the last user message text
+  const handleRegenerate = useCallback(() => {
+    const lastUserMsg = [...messages].reverse().find((m) => m.role === 'user');
+    if (lastUserMsg) {
+      const text = (lastUserMsg.parts ?? [])
+        .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+        .map((p) => p.text)
+        .join('');
+      if (text) sendMessage({ text });
+    }
+  }, [messages, sendMessage]);
+
+  // Thumbs up/down — no-op placeholders; wire to telemetry or feedback API as needed
+  const handleThumbsUp = useCallback(() => {
+    // Positive feedback placeholder
+  }, []);
+
+  const handleThumbsDown = useCallback(() => {
+    // Negative feedback placeholder
+  }, []);
 
   const shortcutHint = isModal ? '\u2318K to close' : 'Esc to hide';
 
@@ -134,6 +159,17 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
             aria-label="Toggle conversation history"
           >
             <History className="size-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            onClick={() => setQueueOpen((v) => !v)}
+            title="Feature queue"
+            aria-label="Toggle feature queue"
+            data-testid="queue-panel-toggle"
+          >
+            <ListOrdered className="size-3.5" />
           </Button>
           <Button
             variant="ghost"
@@ -195,6 +231,17 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
 
       {/* Main content area */}
       <div className="flex min-h-0 flex-1">
+        {/* Queue panel — slide in from left */}
+        {queueOpen && (
+          <div className="w-56 shrink-0 border-r border-border overflow-y-auto p-2 animate-in slide-in-from-left duration-200">
+            <QueueView
+              items={[]}
+              paused={queuePaused}
+              onTogglePause={() => setQueuePaused((v) => !v)}
+            />
+          </div>
+        )}
+
         {/* Conversation list panel — slide in from left */}
         {historyOpen && (
           <ConversationList
@@ -216,7 +263,14 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
 
         {/* Chat area */}
         <div className="flex min-w-0 flex-1 flex-col">
-          <ChatMessageList messages={messages} emptyMessage="Ask Ava anything..." />
+          <ChatMessageList
+            messages={messages}
+            emptyMessage="Ask Ava anything..."
+            isStreaming={isStreaming}
+            onRegenerate={handleRegenerate}
+            onThumbsUp={handleThumbsUp}
+            onThumbsDown={handleThumbsDown}
+          />
 
           {/* Contextual suggestions — shown only when no messages in current session */}
           {messages.length === 0 && (

--- a/apps/ui/src/components/views/chat/components/chat-model-select.tsx
+++ b/apps/ui/src/components/views/chat/components/chat-model-select.tsx
@@ -1,28 +1,84 @@
 /**
- * ChatModelSelect — Model selector dropdown for chat.
+ * ChatModelSelect — Enhanced model selector combobox for chat.
  *
- * Allows switching between haiku/sonnet/opus.
- * Persists selection in localStorage.
+ * Uses Radix Popover + cmdk Command for a rich combobox experience.
+ * Shows three models with tier badges: haiku (fast, blue), sonnet (balanced,
+ * purple), opus (powerful, gold). Each option shows model name, tier badge,
+ * and brief description. Keyboard navigation is supported (arrow keys, enter,
+ * escape). Trigger shows current model with a tier-color dot.
+ *
+ * Preserves backward compatibility: same value / onValueChange props.
  */
 
 import { useState, useEffect } from 'react';
-import { Cpu } from 'lucide-react';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@protolabs-ai/ui/atoms';
+import { Command } from 'cmdk';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import { Cpu, Check } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-const MODELS = [
-  { value: 'haiku', label: 'Haiku', description: 'Fast & light' },
-  { value: 'sonnet', label: 'Sonnet', description: 'Balanced' },
-  { value: 'opus', label: 'Opus', description: 'Most capable' },
-] as const;
+// ---------------------------------------------------------------------------
+// Model definitions
+// ---------------------------------------------------------------------------
+
+type TierColor = 'blue' | 'purple' | 'gold';
+
+interface ModelDefinition {
+  value: string;
+  label: string;
+  tier: string;
+  description: string;
+  tierColor: TierColor;
+  shortcut: string;
+}
+
+const MODELS: ModelDefinition[] = [
+  {
+    value: 'haiku',
+    label: 'Haiku',
+    tier: 'Fast',
+    description: 'Fastest responses, great for quick tasks',
+    tierColor: 'blue',
+    shortcut: '⌘1',
+  },
+  {
+    value: 'sonnet',
+    label: 'Sonnet',
+    tier: 'Balanced',
+    description: 'Best balance of speed and intelligence',
+    tierColor: 'purple',
+    shortcut: '⌘2',
+  },
+  {
+    value: 'opus',
+    label: 'Opus',
+    tier: 'Powerful',
+    description: 'Most capable model for complex tasks',
+    tierColor: 'gold',
+    shortcut: '⌘3',
+  },
+];
 
 const STORAGE_KEY = 'chat-model-alias';
+
+// ---------------------------------------------------------------------------
+// Tier badge styles
+// ---------------------------------------------------------------------------
+
+const TIER_DOT_CLASSES: Record<TierColor, string> = {
+  blue: 'bg-blue-500',
+  purple: 'bg-purple-500',
+  gold: 'bg-yellow-500',
+};
+
+const TIER_BADGE_CLASSES: Record<TierColor, string> = {
+  blue: 'bg-blue-500/15 text-blue-600 dark:text-blue-400',
+  purple: 'bg-purple-500/15 text-purple-600 dark:text-purple-400',
+  gold: 'bg-yellow-500/15 text-yellow-600 dark:text-yellow-400',
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
 
 export function ChatModelSelect({
   value,
@@ -33,29 +89,158 @@ export function ChatModelSelect({
   onValueChange: (value: string) => void;
   className?: string;
 }) {
+  const [open, setOpen] = useState(false);
+
+  const currentModel = MODELS.find((m) => m.value === value) ?? MODELS[1];
+
+  const handleSelect = (modelValue: string) => {
+    onValueChange(modelValue);
+    setOpen(false);
+  };
+
+  // Keyboard shortcut: ⌘1/2/3 (or Ctrl+1/2/3) to switch models directly
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!e.metaKey && !e.ctrlKey) return;
+      if (e.key === '1') {
+        e.preventDefault();
+        handleSelect('haiku');
+      } else if (e.key === '2') {
+        e.preventDefault();
+        handleSelect('sonnet');
+      } else if (e.key === '3') {
+        e.preventDefault();
+        handleSelect('opus');
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
   return (
-    <Select value={value} onValueChange={onValueChange}>
-      <SelectTrigger
-        data-slot="chat-model-select"
-        className={cn(
-          'h-7 w-auto gap-1 border-none bg-transparent px-2 text-xs text-muted-foreground hover:text-foreground',
-          className
-        )}
-      >
-        <Cpu className="size-3" />
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        {MODELS.map((model) => (
-          <SelectItem key={model.value} value={model.value}>
-            <span className="font-medium">{model.label}</span>
-            <span className="ml-1 text-muted-foreground">— {model.description}</span>
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+      {/* ------------------------------------------------------------------ */}
+      {/* Trigger button                                                       */}
+      {/* ------------------------------------------------------------------ */}
+      <PopoverPrimitive.Trigger asChild>
+        <button
+          data-slot="chat-model-select"
+          type="button"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          aria-label={`Model: ${currentModel.label} (${currentModel.tier})`}
+          className={cn(
+            'inline-flex h-7 items-center gap-1.5 rounded-md border-none bg-transparent px-2 text-xs text-muted-foreground',
+            'hover:text-foreground hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+            'transition-colors cursor-pointer select-none',
+            className
+          )}
+        >
+          <Cpu className="size-3 shrink-0" />
+          {/* Tier color dot indicates current model tier */}
+          <span
+            className={cn(
+              'size-1.5 rounded-full shrink-0',
+              TIER_DOT_CLASSES[currentModel.tierColor]
+            )}
+            aria-hidden="true"
+          />
+          <span className="font-medium">{currentModel.label}</span>
+        </button>
+      </PopoverPrimitive.Trigger>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Popover content with cmdk Command combobox                          */}
+      {/* ------------------------------------------------------------------ */}
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          align="start"
+          sideOffset={6}
+          onEscapeKeyDown={() => setOpen(false)}
+          className={cn(
+            'z-50 w-72 rounded-lg border border-border bg-popover p-1 shadow-md',
+            'animate-in fade-in-0 zoom-in-95',
+            'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+            'data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2'
+          )}
+        >
+          <Command loop>
+            {/* Header label */}
+            <div className="px-2 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Select Model
+            </div>
+
+            <Command.List role="listbox" aria-label="Available models">
+              {MODELS.map((model) => {
+                const isSelected = model.value === value;
+                return (
+                  <Command.Item
+                    key={model.value}
+                    value={model.value}
+                    onSelect={handleSelect}
+                    role="option"
+                    aria-selected={isSelected}
+                    className={cn(
+                      'relative flex cursor-pointer select-none items-start gap-3 rounded-md px-2 py-2',
+                      'text-sm outline-none',
+                      'data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground',
+                      'hover:bg-accent hover:text-accent-foreground',
+                      isSelected && 'bg-accent/50'
+                    )}
+                  >
+                    {/* Tier color dot */}
+                    <span
+                      className={cn(
+                        'mt-0.5 size-2 shrink-0 rounded-full',
+                        TIER_DOT_CLASSES[model.tierColor]
+                      )}
+                      aria-hidden="true"
+                    />
+
+                    {/* Model info */}
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-foreground">{model.label}</span>
+                        {/* Tier badge */}
+                        <span
+                          className={cn(
+                            'inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold leading-none',
+                            TIER_BADGE_CLASSES[model.tierColor]
+                          )}
+                        >
+                          {model.tier}
+                        </span>
+                        {/* Keyboard shortcut indicator */}
+                        <span className="ml-auto shrink-0 font-mono text-[10px] text-muted-foreground">
+                          {model.shortcut}
+                        </span>
+                      </div>
+                      <p className="text-[11px] leading-snug text-muted-foreground">
+                        {model.description}
+                      </p>
+                    </div>
+
+                    {/* Selected checkmark */}
+                    {isSelected && (
+                      <Check
+                        className="mt-0.5 size-3.5 shrink-0 text-foreground"
+                        aria-hidden="true"
+                      />
+                    )}
+                  </Command.Item>
+                );
+              })}
+            </Command.List>
+          </Command>
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Hook — unchanged from original for backward compatibility
+// ---------------------------------------------------------------------------
 
 /** Hook for persisting model selection in localStorage */
 export function useChatModelSelection(defaultModel = 'sonnet') {

--- a/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
+++ b/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
@@ -14,6 +14,10 @@ const LOG_LEVEL_OPTIONS: { value: ServerLogLevel; label: string; description: st
 ];
 
 const FEATURE_FLAG_LABELS: Record<keyof FeatureFlags, { label: string; description: string }> = {
+  avaChat: {
+    label: 'Ava Anywhere',
+    description: 'Chat overlay, Cmd+K modal, /chat route, and mobile chat tab.',
+  },
   calendar: {
     label: 'Calendar',
     description: 'Show the Calendar view in the project sidebar.',

--- a/apps/ui/src/routes/chat-overlay.tsx
+++ b/apps/ui/src/routes/chat-overlay.tsx
@@ -1,6 +1,15 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { useAppStore } from '@/store/app-store';
 import { ChatOverlayView } from '@/components/views/chat-overlay/chat-overlay-view';
 
+function ChatOverlayPage() {
+  const avaChat = useAppStore((s) => s.featureFlags.avaChat);
+
+  if (!avaChat) return null;
+
+  return <ChatOverlayView />;
+}
+
 export const Route = createFileRoute('/chat-overlay')({
-  component: ChatOverlayView,
+  component: ChatOverlayPage,
 });

--- a/apps/ui/src/routes/chat.tsx
+++ b/apps/ui/src/routes/chat.tsx
@@ -6,6 +6,7 @@ import { ChatOverlayContent } from '@/components/views/chat-overlay/chat-overlay
 function ChatPage() {
   const navigate = useNavigate();
   const currentProject = useAppStore((s) => s.currentProject);
+  const avaChat = useAppStore((s) => s.featureFlags.avaChat);
 
   const chatSession = useChatSession({
     defaultModel: 'sonnet',
@@ -16,6 +17,11 @@ function ChatPage() {
   const handleHide = () => {
     navigate({ to: '/' });
   };
+
+  if (!avaChat) {
+    navigate({ to: '/' });
+    return null;
+  }
 
   return (
     <div className="h-full">

--- a/apps/ui/tests/chat-model-select-verification.spec.ts
+++ b/apps/ui/tests/chat-model-select-verification.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * Temporary verification test for enhanced ChatModelSelect feature.
+ *
+ * Uses the /chat-overlay route which renders ChatOverlayContent in a
+ * minimal chromeless container — this is the Electron overlay route.
+ *
+ * Verifies:
+ * 1. Model selector uses Popover (not native select) — checks for [data-slot="chat-model-select"] button
+ * 2. Clicking opens a popover/combobox with three model options
+ * 3. Each model shows tier badge (Fast/Balanced/Powerful)
+ * 4. Trigger shows current model name with tier color dot
+ * 5. Selecting a model closes the popover and updates the trigger
+ * 6. Escape closes the popover
+ * 7. Keyboard navigation works (arrow keys)
+ *
+ * Delete after verification.
+ */
+
+import { test, expect } from '@playwright/test';
+import { authenticateForTests } from './utils';
+
+test.describe('ChatModelSelect — Enhanced combobox verification', () => {
+  /**
+   * Single comprehensive test combining all verifications to avoid
+   * hitting the auth rate limit from multiple beforeEach calls.
+   */
+  test('all acceptance criteria pass on /chat-overlay', async ({ page }) => {
+    await authenticateForTests(page);
+    await page.goto('/chat-overlay');
+    await page.waitForLoadState('networkidle');
+
+    const trigger = page.locator('[data-slot="chat-model-select"]').first();
+    await expect(trigger).toBeVisible({ timeout: 10000 });
+
+    // ── Criterion 1: Trigger is a button (not native select) ─────────────────
+    const tagName = await trigger.evaluate((el) => el.tagName.toLowerCase());
+    expect(tagName).toBe('button');
+
+    // ── Criterion 2: Trigger shows current model with tier color dot ──────────
+    await expect(trigger).toContainText('Sonnet'); // default model
+    // Verify the trigger aria-label includes the tier info
+    const ariaLabel = await trigger.getAttribute('aria-label');
+    expect(ariaLabel).toMatch(/Sonnet/i);
+
+    // ── Criterion 3: Opens as popover/combobox (not native select) ───────────
+    // Use JS click to bypass TanStack Query DevTools overlay intercepting pointer events
+    await trigger.evaluate((el) => (el as HTMLElement).click());
+    // cmdk Command.List renders with its default aria-label "Suggestions"
+    const listbox = page.getByRole('listbox', { name: 'Suggestions' });
+    await expect(listbox).toBeVisible({ timeout: 5000 });
+
+    // ── Criterion 4: Three models shown with tier badges ─────────────────────
+    const haikuOption = page.getByRole('option', { name: /haiku/i });
+    const sonnetOption = page.getByRole('option', { name: /sonnet/i });
+    const opusOption = page.getByRole('option', { name: /opus/i });
+    await expect(haikuOption).toBeVisible();
+    await expect(sonnetOption).toBeVisible();
+    await expect(opusOption).toBeVisible();
+    // Verify tier badges scoped to each option
+    await expect(haikuOption.getByText('Fast', { exact: true })).toBeVisible();
+    await expect(sonnetOption.getByText('Balanced', { exact: true })).toBeVisible();
+    await expect(opusOption.getByText('Powerful', { exact: true })).toBeVisible();
+
+    // ── Criterion 5: Escape closes the popover ──────────────────────────────
+    await page.keyboard.press('Escape');
+    await expect(listbox).not.toBeVisible();
+
+    // ── Criterion 6: Re-open and keyboard navigation works ───────────────────
+    await trigger.evaluate((el) => (el as HTMLElement).click());
+    await expect(listbox).toBeVisible();
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+    await expect(listbox).not.toBeVisible();
+
+    // ── Criterion 7: Selecting a model updates trigger ───────────────────────
+    await trigger.evaluate((el) => (el as HTMLElement).click());
+    await page
+      .getByRole('option', { name: /haiku/i })
+      .evaluate((el) => (el as HTMLElement).click());
+    await expect(listbox).not.toBeVisible();
+    await expect(trigger).toContainText('Haiku');
+  });
+});

--- a/docs/dev/ava-chat-system.md
+++ b/docs/dev/ava-chat-system.md
@@ -168,6 +168,9 @@ UIMessage.parts[]
 | `AgentOutputCard`    | `get_agent_output`          | `tool-results/agent-output-card.tsx`     |
 | `AutoModeStatusCard` | `get_auto_mode_status`      | `tool-results/auto-mode-status-card.tsx` |
 | `ExecutionOrderCard` | `get_execution_order`       | `tool-results/execution-order-card.tsx`  |
+| `ArtifactCard`       | `generate_artifact`         | `tool-results/artifact-card.tsx`         |
+| `ImageCard`          | `generate_image`            | `tool-results/image-card.tsx`            |
+| `WebPreviewCard`     | `generate_html`             | `tool-results/web-preview-card.tsx`      |
 
 ### Adding a New Tool Result Card
 

--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -189,6 +189,8 @@ const DEFAULT_CODEX_ADDITIONAL_DIRS: string[] = [];
  * New features should start behind a flag until ready for general availability.
  */
 export interface FeatureFlags {
+  /** Ava Anywhere — chat overlay, Cmd+K modal, /chat route, mobile chat tab */
+  avaChat: boolean;
   /** Calendar view in project sidebar */
   calendar: boolean;
   /** Designs/pen file viewer in project sidebar */
@@ -209,6 +211,7 @@ export interface FeatureFlags {
 
 /** Default feature flags — all off by default, opt-in per environment */
 export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
+  avaChat: false,
   calendar: false,
   designs: false,
   docs: false,

--- a/libs/ui/src/ai/chat-message-list.tsx
+++ b/libs/ui/src/ai/chat-message-list.tsx
@@ -18,15 +18,28 @@ import type { UIMessage } from 'ai';
 import { cn } from '../lib/utils.js';
 import { Button } from '../atoms/button.js';
 import { ChatMessage } from './chat-message.js';
+import { ShimmerLoader } from './shimmer.js';
 
 export function ChatMessageList({
   messages,
   emptyMessage = 'Start a conversation...',
   className,
+  isStreaming,
+  onRegenerate,
+  onThumbsUp,
+  onThumbsDown,
 }: {
   messages: UIMessage[];
   emptyMessage?: string;
   className?: string;
+  /** When true, shows a ShimmerLoader at the bottom if the last message has no text yet. */
+  isStreaming?: boolean;
+  /** Called when the user clicks Regenerate on an assistant message. */
+  onRegenerate?: () => void;
+  /** Called when the user clicks Thumbs Up on an assistant message. */
+  onThumbsUp?: () => void;
+  /** Called when the user clicks Thumbs Down on an assistant message. */
+  onThumbsDown?: () => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -119,6 +132,17 @@ export function ChatMessageList({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messages.length]);
 
+  // Determine if ShimmerLoader should be shown:
+  // Show when streaming and the last message has no text content yet (pending response).
+  const lastMessage = messages[messages.length - 1];
+  const lastMessageHasNoText =
+    !lastMessage ||
+    !(lastMessage.parts ?? []).some(
+      (p): p is { type: 'text'; text: string } =>
+        p.type === 'text' && !!(p as { type: 'text'; text: string }).text
+    );
+  const showShimmer = !!isStreaming && lastMessageHasNoText;
+
   return (
     <div data-slot="chat-message-list" className={cn('relative flex-1 overflow-hidden', className)}>
       <div ref={scrollRef} className="h-full overflow-y-auto">
@@ -128,8 +152,17 @@ export function ChatMessageList({
               <p className="text-sm text-muted-foreground">{emptyMessage}</p>
             </div>
           ) : (
-            messages.map((message) => <ChatMessage key={message.id} message={message} />)
+            messages.map((message) => (
+              <ChatMessage
+                key={message.id}
+                message={message}
+                onRegenerate={onRegenerate}
+                onThumbsUp={onThumbsUp}
+                onThumbsDown={onThumbsDown}
+              />
+            ))
           )}
+          {showShimmer && <ShimmerLoader />}
         </div>
       </div>
 

--- a/libs/ui/src/ai/chat-message.tsx
+++ b/libs/ui/src/ai/chat-message.tsx
@@ -18,7 +18,7 @@
  */
 
 import { cva, type VariantProps } from 'class-variance-authority';
-import { Bot, Loader2, User } from 'lucide-react';
+import { Bot, User } from 'lucide-react';
 import type { UIMessage } from 'ai';
 import { cn } from '../lib/utils.js';
 import { ChainOfThought } from './chain-of-thought.js';
@@ -27,6 +27,8 @@ import { TaskBlock, type ToolInvocationItem, type TaskToolState } from './task-b
 import { ChatMessageMarkdown } from './chat-message-markdown.js';
 import { MessageSources } from './message-sources.js';
 import type { Citation } from './inline-citation.js';
+import { AILoader } from './loader.js';
+import { MessageActions } from './message-actions.js';
 
 const messageVariants = cva('flex gap-3 px-4 py-2', {
   variants: {
@@ -211,38 +213,6 @@ function isMessageStreaming(rawParts: Array<Record<string, unknown>>): boolean {
   return rawParts.some((p) => isToolPart(p) && !TERMINAL_TOOL_STATES.has(p.state as string));
 }
 
-// ---------------------------------------------------------------------------
-// Step progress indicator
-// ---------------------------------------------------------------------------
-
-/**
- * Shown at the top of the assistant bubble during long-running streaming
- * operations (multiple agentic steps or many tool calls).  Disappears once
- * the message finishes streaming.
- */
-function MessageProgressIndicator({
-  stepCount,
-  toolCount,
-  streaming,
-}: {
-  stepCount: number;
-  toolCount: number;
-  streaming: boolean;
-}) {
-  if (!streaming || stepCount < 1 || toolCount < 1) return null;
-  return (
-    <div
-      data-slot="message-progress-indicator"
-      className="mb-1.5 flex items-center gap-1.5 text-[10px] text-muted-foreground"
-    >
-      <Loader2 className="size-2.5 animate-spin" />
-      <span>
-        Step {stepCount} · {toolCount} tool{toolCount !== 1 ? 's' : ''} called
-      </span>
-    </div>
-  );
-}
-
 /**
  * Extract resolved citations from message parts.
  * The server writes these as `data-citations` UIMessageChunks; the AI SDK
@@ -255,6 +225,20 @@ function extractCitations(parts: Array<Record<string, unknown>>): Citation[] {
     }
   }
   return [];
+}
+
+/**
+ * Extract plain text from a group's 'other' segments (text parts only).
+ * Used for the copy-to-clipboard action in MessageActions.
+ */
+function extractGroupText(group: PartSegment[]): string {
+  return group
+    .filter(
+      (seg): seg is { kind: 'other'; part: Record<string, unknown>; partIndex: number } =>
+        seg.kind === 'other' && seg.part.type === 'text'
+    )
+    .map((seg) => seg.part.text as string)
+    .join('');
 }
 
 /**
@@ -329,6 +313,9 @@ export function ChatMessage({
   className,
   onToolApprove,
   onToolReject,
+  onRegenerate,
+  onThumbsUp,
+  onThumbsDown,
 }: {
   message: UIMessage;
   className?: string;
@@ -336,6 +323,12 @@ export function ChatMessage({
   onToolApprove?: (toolName: string, input: unknown) => void;
   /** Called when the user rejects a destructive tool call (HITL). Receives the tool name and input. */
   onToolReject?: (toolName: string, input: unknown) => void;
+  /** Called when the user clicks the Regenerate button on an assistant message. */
+  onRegenerate?: () => void;
+  /** Called when the user clicks Thumbs Up on an assistant message. */
+  onThumbsUp?: () => void;
+  /** Called when the user clicks Thumbs Down on an assistant message. */
+  onThumbsDown?: () => void;
 } & Partial<VariantProps<typeof messageVariants>>) {
   const role = message.role as MessageRole;
   const parts = message.parts ?? [];
@@ -379,65 +372,86 @@ export function ChatMessage({
 
   // Stats for the progress indicator
   const stepCount = rawParts.filter((p) => p.type === 'step-start').length;
-  const toolCount = rawParts.filter((p) => isToolPart(p)).length;
   const streaming = isMessageStreaming(rawParts);
+
+  // Build onFeedback handler from separate thumbs up/down callbacks
+  const onFeedback =
+    onThumbsUp || onThumbsDown
+      ? (rating: 'up' | 'down') => {
+          if (rating === 'up') onThumbsUp?.();
+          else onThumbsDown?.();
+        }
+      : undefined;
 
   return (
     <div data-slot="chat-message" className={cn('flex flex-col gap-1', className)}>
-      {stepGroups.map((group, groupIdx) => (
-        <div key={groupIdx} className={cn(messageVariants({ role }))}>
-          {/* Avatar only on first bubble; spacer div on subsequent for alignment */}
-          {groupIdx === 0 ? (
-            <ChatMessageAvatar role={role} />
-          ) : (
-            <div className="size-7 shrink-0" aria-hidden />
-          )}
-          <ChatMessageBubble role={role}>
-            {/* Progress indicator only on the last (active) bubble while streaming */}
-            {groupIdx === stepGroups.length - 1 && (
-              <MessageProgressIndicator
-                stepCount={stepCount}
-                toolCount={toolCount}
-                streaming={streaming}
-              />
+      {stepGroups.map((group, groupIdx) => {
+        const bubbleText = extractGroupText(group);
+        return (
+          <div key={groupIdx} className={cn(messageVariants({ role }))}>
+            {/* Avatar only on first bubble; spacer div on subsequent for alignment */}
+            {groupIdx === 0 ? (
+              <ChatMessageAvatar role={role} />
+            ) : (
+              <div className="size-7 shrink-0" aria-hidden />
             )}
+            <div className="flex flex-col">
+              <ChatMessageBubble role={role}>
+                {/* AILoader only on the last (active) bubble while streaming */}
+                {groupIdx === stepGroups.length - 1 && streaming && stepCount >= 1 && (
+                  <AILoader stepCount={stepCount} className="mb-1.5" />
+                )}
 
-            {group.map((seg, i) => {
-              // step-start segments are filtered out by groupByStep
-              if (seg.kind === 'step-start') return null;
+                {group.map((seg, i) => {
+                  // step-start segments are filtered out by groupByStep
+                  if (seg.kind === 'step-start') return null;
 
-              if (seg.kind === 'tool-group') {
-                if (seg.tools.length === 1) {
-                  const t = seg.tools[0];
-                  return (
-                    <ToolInvocationPart
-                      key={t.toolCallId}
-                      toolName={t.toolName}
-                      toolCallId={t.toolCallId}
-                      state={t.state as ToolInvocationPartProps['state']}
-                      input={t.input}
-                      output={t.output}
-                      errorText={t.errorText}
-                      title={t.title}
-                      onApprove={
-                        onToolApprove ? () => onToolApprove(t.toolName, t.input) : undefined
-                      }
-                      onReject={onToolReject ? () => onToolReject(t.toolName, t.input) : undefined}
-                    />
-                  );
-                }
-                return <TaskBlock key={seg.segKey} tools={seg.tools} />;
-              }
+                  if (seg.kind === 'tool-group') {
+                    if (seg.tools.length === 1) {
+                      const t = seg.tools[0];
+                      return (
+                        <ToolInvocationPart
+                          key={t.toolCallId}
+                          toolName={t.toolName}
+                          toolCallId={t.toolCallId}
+                          state={t.state as ToolInvocationPartProps['state']}
+                          input={t.input}
+                          output={t.output}
+                          errorText={t.errorText}
+                          title={t.title}
+                          onApprove={
+                            onToolApprove ? () => onToolApprove(t.toolName, t.input) : undefined
+                          }
+                          onReject={
+                            onToolReject ? () => onToolReject(t.toolName, t.input) : undefined
+                          }
+                        />
+                      );
+                    }
+                    return <TaskBlock key={seg.segKey} tools={seg.tools} />;
+                  }
 
-              // 'other': text, reasoning, source-url, data-citations, etc.
-              return <MessagePartRenderer key={i} part={seg.part} citations={citations} />;
-            })}
+                  // 'other': text, reasoning, source-url, data-citations, etc.
+                  return <MessagePartRenderer key={i} part={seg.part} citations={citations} />;
+                })}
 
-            {/* Sources section — only on the last bubble */}
-            {groupIdx === stepGroups.length - 1 && <MessageSources citations={citations} />}
-          </ChatMessageBubble>
-        </div>
-      ))}
+                {/* Sources section — only on the last bubble */}
+                {groupIdx === stepGroups.length - 1 && <MessageSources citations={citations} />}
+              </ChatMessageBubble>
+
+              {/* MessageActions toolbar — assistant bubbles only */}
+              {role === 'assistant' && (
+                <MessageActions
+                  text={bubbleText}
+                  onRegenerate={onRegenerate}
+                  onFeedback={onFeedback}
+                  className="mt-0.5 ml-1"
+                />
+              )}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/libs/ui/src/ai/confirmation-card.stories.tsx
+++ b/libs/ui/src/ai/confirmation-card.stories.tsx
@@ -1,0 +1,146 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { ConfirmationCard } from './confirmation-card.js';
+
+const meta = {
+  title: 'AI/ConfirmationCard',
+  component: ConfirmationCard,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Inline confirmation card for destructive tool calls. Renders in the chat message stream when a tool call requires human approval. Three states: approval-requested, approval-responded, output-denied.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-md space-y-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ConfirmationCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ── States ─────────────────────────────────────────────────────────────────
+
+export const ApprovalRequested: Story = {
+  args: {
+    toolName: 'delete_feature',
+    input: { featureId: 'feature-abc123' },
+    state: 'approval-requested',
+  },
+};
+
+export const ApprovalResponded: Story = {
+  args: {
+    toolName: 'delete_feature',
+    input: { featureId: 'feature-abc123' },
+    state: 'approval-responded',
+  },
+};
+
+export const OutputDenied: Story = {
+  args: {
+    toolName: 'delete_feature',
+    input: { featureId: 'feature-abc123' },
+    state: 'output-denied',
+  },
+};
+
+// ── Tool Variants ──────────────────────────────────────────────────────────
+
+export const StopAgent: Story = {
+  args: {
+    toolName: 'stop_agent',
+    input: { sessionId: 'session-xyz789' },
+    state: 'approval-requested',
+  },
+};
+
+export const StartAutoMode: Story = {
+  args: {
+    toolName: 'start_auto_mode',
+    input: { maxConcurrency: 3 },
+    state: 'approval-requested',
+  },
+};
+
+export const UpdateSpec: Story = {
+  args: {
+    toolName: 'update_project_spec',
+    state: 'approval-requested',
+  },
+};
+
+export const CustomSummary: Story = {
+  args: {
+    toolName: 'custom_tool',
+    summary: 'Deploy 5 features to production',
+    state: 'approval-requested',
+  },
+};
+
+export const UnknownTool: Story = {
+  args: {
+    toolName: 'some_unknown_destructive_tool',
+    state: 'approval-requested',
+  },
+};
+
+// ── Interactive ────────────────────────────────────────────────────────────
+
+export const Interactive: Story = {
+  render: () => {
+    const [state, setState] = useState<
+      'approval-requested' | 'approval-responded' | 'output-denied'
+    >('approval-requested');
+
+    const handleReset = () => setState('approval-requested');
+
+    return (
+      <div className="space-y-4">
+        <ConfirmationCard
+          toolName="delete_feature"
+          input={{ featureId: 'feature-important-123' }}
+          state={state}
+          onApprove={() => setState('approval-responded')}
+          onReject={() => setState('output-denied')}
+        />
+        {state !== 'approval-requested' && (
+          <button
+            onClick={handleReset}
+            className="rounded bg-muted px-3 py-1 text-xs text-muted-foreground hover:bg-muted/80"
+          >
+            Reset
+          </button>
+        )}
+      </div>
+    );
+  },
+};
+
+// ── In Context ─────────────────────────────────────────────────────────────
+
+export const InChatStream: Story = {
+  render: () => (
+    <div className="space-y-2">
+      <div className="rounded-lg bg-muted/30 px-3 py-2 text-sm">
+        I need to delete the stale feature blocking the pipeline.
+      </div>
+      <ConfirmationCard
+        toolName="delete_feature"
+        input={{ featureId: 'feature-stale-456' }}
+        state="approval-requested"
+      />
+      <div className="rounded-lg bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+        Waiting for approval...
+      </div>
+    </div>
+  ),
+};

--- a/libs/ui/src/ai/index.ts
+++ b/libs/ui/src/ai/index.ts
@@ -11,6 +11,12 @@ export {
 
 export { ConfirmationCard, type ConfirmationCardProps } from './confirmation-card.js';
 
+export {
+  InlineFormCard,
+  type InlineFormCardProps,
+  type InlineFormCardState,
+} from './inline-form-card.js';
+
 export { InlineCitation, type Citation, type InlineCitationProps } from './inline-citation.js';
 
 export { MessageSources, type MessageSourcesProps } from './message-sources.js';
@@ -68,3 +74,12 @@ export { AutoModeStatusCard } from './tool-results/auto-mode-status-card.js';
 export { ExecutionOrderCard } from './tool-results/execution-order-card.js';
 export { ArtifactCard } from './tool-results/artifact-card.js';
 export { ImageCard } from './tool-results/image-card.js';
+export { WebPreviewCard } from './tool-results/web-preview-card.js';
+
+export {
+  QueueView,
+  type QueueViewProps,
+  type QueueItem,
+  type QueueItemStatus,
+  type QueueItemComplexity,
+} from './queue-view.js';

--- a/libs/ui/src/ai/inline-form-card.stories.tsx
+++ b/libs/ui/src/ai/inline-form-card.stories.tsx
@@ -1,0 +1,263 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { InlineFormCard } from './inline-form-card.js';
+
+const meta = {
+  title: 'AI/InlineFormCard',
+  component: InlineFormCard,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Chat-stream-sized card for collecting structured input inline. Wraps arbitrary form content (e.g. RJSF) with title, description, and submit/cancel actions. Three states: pending, submitted, cancelled.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-md space-y-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof InlineFormCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ── States ─────────────────────────────────────────────────────────────────
+
+export const Pending: Story = {
+  args: {
+    title: 'Choose deployment target',
+    description: 'Select where this feature should be deployed.',
+    state: 'pending',
+    children: (
+      <div className="space-y-2">
+        <label className="flex items-center gap-2 text-sm">
+          <input type="radio" name="target" value="staging" defaultChecked />
+          <span>Staging</span>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input type="radio" name="target" value="production" />
+          <span>Production</span>
+        </label>
+      </div>
+    ),
+  },
+};
+
+export const Submitted: Story = {
+  args: {
+    title: 'Choose deployment target',
+    state: 'submitted',
+  },
+};
+
+export const Cancelled: Story = {
+  args: {
+    title: 'Choose deployment target',
+    state: 'cancelled',
+  },
+};
+
+export const Submitting: Story = {
+  args: {
+    title: 'Confirm feature priority',
+    description: 'Set the priority level for this feature.',
+    state: 'pending',
+    isSubmitting: true,
+    children: (
+      <select className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm">
+        <option>Urgent</option>
+        <option>High</option>
+        <option selected>Normal</option>
+        <option>Low</option>
+      </select>
+    ),
+  },
+};
+
+// ── Variants ───────────────────────────────────────────────────────────────
+
+export const WithTextInput: Story = {
+  args: {
+    title: 'Provide additional context',
+    description: 'Help the agent understand the requirement better.',
+    state: 'pending',
+    children: (
+      <textarea
+        className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm placeholder:text-muted-foreground"
+        rows={3}
+        placeholder="Describe what you need..."
+      />
+    ),
+  },
+};
+
+export const WithMultipleFields: Story = {
+  args: {
+    title: 'Feature configuration',
+    description: 'Set up the feature before the agent starts.',
+    state: 'pending',
+    submitLabel: 'Start Agent',
+    children: (
+      <div className="space-y-3">
+        <div>
+          <label className="mb-1 block text-xs font-medium text-foreground">Feature name</label>
+          <input
+            type="text"
+            className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
+            defaultValue="Add search bar"
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium text-foreground">Complexity</label>
+          <select className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm">
+            <option>Small (Haiku)</option>
+            <option selected>Medium (Sonnet)</option>
+            <option>Large (Sonnet)</option>
+            <option>Architectural (Opus)</option>
+          </select>
+        </div>
+        <div>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" defaultChecked />
+            <span>Auto-create PR on completion</span>
+          </label>
+        </div>
+      </div>
+    ),
+  },
+};
+
+export const CustomSubmitLabel: Story = {
+  args: {
+    title: 'Approve deployment',
+    description: 'Review and approve the staging deployment.',
+    state: 'pending',
+    submitLabel: 'Approve',
+    children: (
+      <div className="rounded bg-muted/50 p-2 text-xs text-muted-foreground">
+        <p className="font-medium text-foreground">Deployment summary:</p>
+        <ul className="mt-1 list-inside list-disc space-y-0.5">
+          <li>3 features merged</li>
+          <li>12 files changed</li>
+          <li>All CI checks passing</li>
+        </ul>
+      </div>
+    ),
+  },
+};
+
+export const NoDescription: Story = {
+  args: {
+    title: 'Quick confirmation',
+    state: 'pending',
+    children: (
+      <p className="text-sm text-muted-foreground">
+        Are you sure you want to reset the board to its default state?
+      </p>
+    ),
+  },
+};
+
+// ── Interactive ────────────────────────────────────────────────────────────
+
+export const Interactive: Story = {
+  render: () => {
+    const [state, setState] = useState<'pending' | 'submitted' | 'cancelled'>('pending');
+    const [submitting, setSubmitting] = useState(false);
+
+    const handleSubmit = () => {
+      setSubmitting(true);
+      setTimeout(() => {
+        setSubmitting(false);
+        setState('submitted');
+      }, 1500);
+    };
+
+    const handleReset = () => {
+      setState('pending');
+      setSubmitting(false);
+    };
+
+    return (
+      <div className="space-y-4">
+        <InlineFormCard
+          title="Select resolution"
+          description="How should we handle this blocked feature?"
+          state={state}
+          isSubmitting={submitting}
+          onSubmit={handleSubmit}
+          onCancel={() => setState('cancelled')}
+        >
+          <div className="space-y-2">
+            <label className="flex items-center gap-2 text-sm">
+              <input type="radio" name="resolution" value="retry" defaultChecked />
+              <div>
+                <span className="font-medium">Retry</span>
+                <p className="text-xs text-muted-foreground">Reset and re-run the agent</p>
+              </div>
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input type="radio" name="resolution" value="skip" />
+              <div>
+                <span className="font-medium">Skip</span>
+                <p className="text-xs text-muted-foreground">Mark as done without implementing</p>
+              </div>
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input type="radio" name="resolution" value="escalate" />
+              <div>
+                <span className="font-medium">Escalate</span>
+                <p className="text-xs text-muted-foreground">Flag for manual review</p>
+              </div>
+            </label>
+          </div>
+        </InlineFormCard>
+        {state !== 'pending' && (
+          <button
+            onClick={handleReset}
+            className="rounded bg-muted px-3 py-1 text-xs text-muted-foreground hover:bg-muted/80"
+          >
+            Reset
+          </button>
+        )}
+      </div>
+    );
+  },
+};
+
+// ── In Context ─────────────────────────────────────────────────────────────
+
+export const InChatStream: Story = {
+  render: () => (
+    <div className="space-y-2">
+      <div className="rounded-lg bg-muted/30 px-3 py-2 text-sm">
+        I found a blocked feature that needs your input to proceed.
+      </div>
+      <InlineFormCard
+        title="Feature blocked: Authentication flow"
+        description="The agent encountered an error and needs guidance."
+        state="pending"
+      >
+        <div className="space-y-2">
+          <label className="flex items-center gap-2 text-sm">
+            <input type="radio" name="action" value="retry" defaultChecked />
+            <span>Retry with more context</span>
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="radio" name="action" value="skip" />
+            <span>Skip this feature</span>
+          </label>
+        </div>
+      </InlineFormCard>
+      <div className="rounded-lg bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+        Waiting for your response before continuing...
+      </div>
+    </div>
+  ),
+};

--- a/libs/ui/src/ai/inline-form-card.tsx
+++ b/libs/ui/src/ai/inline-form-card.tsx
@@ -1,0 +1,150 @@
+/**
+ * InlineFormCard — Chat-stream-sized card for collecting structured input.
+ *
+ * Renders inline in the message stream (like ConfirmationCard) but wraps
+ * arbitrary form content passed via `children`. Three visual states:
+ *   - pending:   Blue accent, form fields visible, Submit/Cancel buttons
+ *   - submitted: Green accent, "Response submitted" summary
+ *   - cancelled: Muted, "Form cancelled" summary
+ *
+ * The actual form fields (e.g. RJSF) are composed in `apps/ui/` and passed
+ * as children. This component handles the card chrome only.
+ */
+
+import { useState, type ReactNode } from 'react';
+import { ClipboardList, CheckCircle2, XCircle, Loader2, Send } from 'lucide-react';
+import { cn } from '../lib/utils.js';
+
+export type InlineFormCardState = 'pending' | 'submitted' | 'cancelled';
+
+export interface InlineFormCardProps {
+  /** Form title displayed in the card header */
+  title: string;
+  /** Optional description below the title */
+  description?: string;
+  /** Visual state of the form card */
+  state?: InlineFormCardState;
+  /** Form content — pass RJSF or any form elements here */
+  children?: ReactNode;
+  /** Called when the user clicks Submit */
+  onSubmit?: () => void;
+  /** Called when the user clicks Cancel */
+  onCancel?: () => void;
+  /** Whether submission is in progress (shows spinner) */
+  isSubmitting?: boolean;
+  /** Optional label for the submit button (default: "Submit") */
+  submitLabel?: string;
+  className?: string;
+}
+
+export function InlineFormCard({
+  title,
+  description,
+  state = 'pending',
+  children,
+  onSubmit,
+  onCancel,
+  isSubmitting = false,
+  submitLabel = 'Submit',
+  className,
+}: InlineFormCardProps) {
+  const [localCancelled, setLocalCancelled] = useState(false);
+
+  const effectiveState = localCancelled ? 'cancelled' : state;
+
+  function handleCancel() {
+    setLocalCancelled(true);
+    onCancel?.();
+  }
+
+  // ── Submitted state ──────────────────────────────────────────────────────
+  if (effectiveState === 'submitted') {
+    return (
+      <div
+        data-slot="inline-form-card"
+        data-state="submitted"
+        className={cn(
+          'my-1 flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/5 px-3 py-2.5 text-xs',
+          className
+        )}
+      >
+        <CheckCircle2 className="size-3.5 shrink-0 text-emerald-500" />
+        <span className="font-medium text-emerald-700 dark:text-emerald-300">
+          Response submitted
+        </span>
+        <span className="text-muted-foreground/40">&mdash;</span>
+        <span className="truncate text-foreground/60">{title}</span>
+      </div>
+    );
+  }
+
+  // ── Cancelled state ──────────────────────────────────────────────────────
+  if (effectiveState === 'cancelled') {
+    return (
+      <div
+        data-slot="inline-form-card"
+        data-state="cancelled"
+        className={cn(
+          'my-1 flex items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground',
+          className
+        )}
+      >
+        <XCircle className="size-3.5 shrink-0" />
+        <span className="font-medium">Form cancelled</span>
+        <span className="text-muted-foreground/40">&mdash;</span>
+        <span className="truncate text-muted-foreground/70">{title}</span>
+      </div>
+    );
+  }
+
+  // ── Pending state (default) ──────────────────────────────────────────────
+  return (
+    <div
+      data-slot="inline-form-card"
+      data-state="pending"
+      className={cn('my-1 rounded-md border border-blue-500/40 bg-blue-500/5 text-sm', className)}
+    >
+      {/* Header */}
+      <div className="flex items-start gap-2.5 px-3 py-2.5">
+        <ClipboardList className="mt-0.5 size-3.5 shrink-0 text-blue-500" />
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-semibold text-foreground/90">{title}</p>
+          {description && <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>}
+        </div>
+      </div>
+
+      {/* Form content slot */}
+      {children && <div className="border-t border-blue-500/20 px-3 py-3">{children}</div>}
+
+      {/* Action buttons */}
+      <div className="flex items-center gap-2 border-t border-blue-500/20 px-3 py-2">
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={isSubmitting}
+          className={cn(
+            'flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+            'bg-blue-500/15 text-blue-700 hover:bg-blue-500/25 dark:text-blue-300',
+            'disabled:opacity-50 disabled:cursor-not-allowed'
+          )}
+        >
+          {isSubmitting ? <Loader2 className="size-3 animate-spin" /> : <Send className="size-3" />}
+          {isSubmitting ? 'Submitting...' : submitLabel}
+        </button>
+        <button
+          type="button"
+          onClick={handleCancel}
+          disabled={isSubmitting}
+          className={cn(
+            'flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+            'bg-muted/60 text-muted-foreground hover:bg-muted',
+            'disabled:opacity-50 disabled:cursor-not-allowed'
+          )}
+        >
+          <XCircle className="size-3" />
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/libs/ui/src/ai/queue-view.tsx
+++ b/libs/ui/src/ai/queue-view.tsx
@@ -1,0 +1,162 @@
+/**
+ * QueueView — Visualizes the auto-mode feature pipeline.
+ *
+ * Shows features ordered by execution priority with status badges.
+ * Each queue item shows: feature title, status, complexity badge,
+ * estimated position in queue.
+ *
+ * Props:
+ *   items: QueueItem[]         — ordered list of queued features
+ *   paused: boolean            — current pause state
+ *   onTogglePause: () => void  — callback to pause/resume the queue
+ */
+
+import { Pause, Play, ListOrdered } from 'lucide-react';
+import { cn } from '../lib/utils.js';
+import { Button } from '../atoms/button.js';
+
+export type QueueItemStatus = 'backlog' | 'in_progress' | 'review';
+export type QueueItemComplexity = 'small' | 'medium' | 'large' | 'architectural';
+
+export interface QueueItem {
+  id: string;
+  title: string;
+  status: QueueItemStatus;
+  complexity?: QueueItemComplexity;
+  /** 1-based position in execution queue */
+  position: number;
+}
+
+export interface QueueViewProps {
+  items: QueueItem[];
+  /** Whether the queue is currently paused */
+  paused?: boolean;
+  /** Called when the user clicks pause/resume */
+  onTogglePause?: () => void;
+  className?: string;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Status config
+// ────────────────────────────────────────────────────────────────────────────
+
+const STATUS_CONFIG: Record<QueueItemStatus, { label: string; color: string; dot: string }> = {
+  backlog: {
+    label: 'Backlog',
+    color: 'text-muted-foreground',
+    dot: 'bg-muted-foreground/60',
+  },
+  in_progress: {
+    label: 'In Progress',
+    color: 'text-blue-500',
+    dot: 'bg-blue-500',
+  },
+  review: {
+    label: 'Review',
+    color: 'text-amber-500',
+    dot: 'bg-amber-500',
+  },
+};
+
+const COMPLEXITY_CONFIG: Record<QueueItemComplexity, { label: string; color: string }> = {
+  small: { label: 'S', color: 'text-green-500' },
+  medium: { label: 'M', color: 'text-amber-500' },
+  large: { label: 'L', color: 'text-orange-500' },
+  architectural: { label: 'A', color: 'text-red-500' },
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// QueueItemRow
+// ────────────────────────────────────────────────────────────────────────────
+
+function QueueItemRow({ item }: { item: QueueItem }) {
+  const statusCfg = STATUS_CONFIG[item.status];
+  const complexityCfg = item.complexity ? COMPLEXITY_CONFIG[item.complexity] : null;
+
+  return (
+    <div
+      className="flex items-center gap-2 rounded px-2 py-1.5 hover:bg-muted/40"
+      data-queue-item-id={item.id}
+    >
+      {/* Position number */}
+      <span className="w-4 shrink-0 text-center text-[10px] text-muted-foreground/60">
+        {item.position}
+      </span>
+
+      {/* Status dot */}
+      <span
+        className={cn('size-1.5 shrink-0 rounded-full', statusCfg.dot)}
+        title={statusCfg.label}
+      />
+
+      {/* Title */}
+      <span className="flex-1 truncate text-[11px] text-foreground/80">{item.title}</span>
+
+      {/* Status badge */}
+      <span className={cn('shrink-0 text-[10px]', statusCfg.color)}>{statusCfg.label}</span>
+
+      {/* Complexity badge */}
+      {complexityCfg && (
+        <span
+          className={cn(
+            'shrink-0 rounded border border-current px-1 font-mono text-[9px]',
+            complexityCfg.color
+          )}
+          title={`Complexity: ${item.complexity}`}
+        >
+          {complexityCfg.label}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// QueueView
+// ────────────────────────────────────────────────────────────────────────────
+
+export function QueueView({ items, paused = false, onTogglePause, className }: QueueViewProps) {
+  return (
+    <div
+      data-slot="queue-view"
+      className={cn('rounded-md border border-border/50 bg-muted/30 text-xs', className)}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-1.5 border-b border-border/50 px-3 py-1.5">
+        <ListOrdered className="size-3.5 text-muted-foreground" />
+        <span className="font-medium text-foreground/80">Queue</span>
+        <span
+          className="ml-1 text-muted-foreground"
+          data-testid="queue-depth-count"
+          aria-label={`${items.length} item${items.length !== 1 ? 's' : ''} in queue`}
+        >
+          ({items.length})
+        </span>
+
+        {/* Pause / resume toggle */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="ml-auto size-6"
+          onClick={onTogglePause}
+          title={paused ? 'Resume queue' : 'Pause queue'}
+          aria-label={paused ? 'Resume queue' : 'Pause queue'}
+          data-testid="queue-pause-toggle"
+        >
+          {paused ? <Play className="size-3" /> : <Pause className="size-3" />}
+        </Button>
+      </div>
+
+      {/* Item list */}
+      {items.length === 0 ? (
+        <div className="px-3 py-2 text-muted-foreground">No items in queue</div>
+      ) : (
+        <div className="max-h-48 overflow-y-auto p-1">
+          {items.map((item) => (
+            <QueueItemRow key={item.id} item={item} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/libs/ui/src/ai/tool-invocation-part.tsx
+++ b/libs/ui/src/ai/tool-invocation-part.tsx
@@ -25,6 +25,7 @@ import { AutoModeStatusCard } from './tool-results/auto-mode-status-card.js';
 import { ExecutionOrderCard } from './tool-results/execution-order-card.js';
 import { ArtifactCard } from './tool-results/artifact-card.js';
 import { ImageCard } from './tool-results/image-card.js';
+import { WebPreviewCard } from './tool-results/web-preview-card.js';
 
 // Register custom renderers for the boardRead tool group
 toolResultRegistry.register('get_board_summary', BoardSummaryCard);
@@ -50,6 +51,7 @@ toolResultRegistry.register('get_execution_order', ExecutionOrderCard);
 // Register custom renderers for artifact and image generation tools
 toolResultRegistry.register('generate_artifact', ArtifactCard);
 toolResultRegistry.register('generate_image', ImageCard);
+toolResultRegistry.register('generate_html', WebPreviewCard);
 
 type ToolState =
   | 'input-streaming'

--- a/libs/ui/src/ai/tool-results/web-preview-card.tsx
+++ b/libs/ui/src/ai/tool-results/web-preview-card.tsx
@@ -1,0 +1,133 @@
+/**
+ * WebPreviewCard — Expandable iframe panel for generated HTML content.
+ *
+ * Renders:
+ * - Collapsible header with title and a globe/link icon
+ * - Sandboxed iframe using the srcdoc attribute (no allow-same-origin)
+ * - "Open in new tab" button that creates a Blob URL for safe viewing
+ *
+ * Extracts { html, title } from tool output.
+ * Registered for tool name: generate_html
+ */
+
+import { useState } from 'react';
+import { ChevronDown, Globe, ExternalLink, Loader2 } from 'lucide-react';
+import * as Collapsible from '@radix-ui/react-collapsible';
+import { cn } from '../../lib/utils.js';
+import type { ToolResultRendererProps } from '../tool-result-registry.js';
+
+interface WebPreviewData {
+  html?: string;
+  title?: string;
+  [key: string]: unknown;
+}
+
+function extractData(output: unknown): WebPreviewData | null {
+  if (!output || typeof output !== 'object') return null;
+  const o = output as Record<string, unknown>;
+  // Handle wrapped response: { success: true, data: { ... } }
+  if ('success' in o && 'data' in o && typeof o.data === 'object' && o.data !== null) {
+    return o.data as WebPreviewData;
+  }
+  return o as WebPreviewData;
+}
+
+function openInNewTab(html: string): void {
+  const blob = new Blob([html], { type: 'text/html' });
+  const url = URL.createObjectURL(blob);
+  window.open(url, '_blank', 'noopener,noreferrer');
+  // Revoke after a short delay to allow the browser to load it
+  setTimeout(() => URL.revokeObjectURL(url), 10_000);
+}
+
+export function WebPreviewCard({ output, state }: ToolResultRendererProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const isLoading =
+    state === 'input-streaming' || state === 'input-available' || state === 'approval-responded';
+
+  if (isLoading) {
+    return (
+      <div
+        data-slot="web-preview-card"
+        className="flex items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+      >
+        <Loader2 className="size-3.5 animate-spin" />
+        <span>Generating HTML…</span>
+      </div>
+    );
+  }
+
+  const data = extractData(output);
+
+  if (!data || !data.html) {
+    return (
+      <div
+        data-slot="web-preview-card"
+        className="rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+      >
+        No HTML content
+      </div>
+    );
+  }
+
+  const html = data.html;
+  const title = data.title ?? 'Web Preview';
+
+  return (
+    <Collapsible.Root
+      data-slot="web-preview-card"
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className="rounded-md border border-border/50 bg-muted/30 text-xs"
+    >
+      <div className="flex items-center gap-2 px-3 py-2">
+        <Collapsible.Trigger asChild>
+          <button
+            type="button"
+            className="flex flex-1 items-center gap-2 text-left"
+            aria-expanded={isOpen}
+          >
+            <Globe className="size-3.5 shrink-0 text-muted-foreground" />
+
+            {/* Title */}
+            <span className="flex-1 truncate font-medium text-foreground/80">{title}</span>
+
+            <ChevronDown
+              className={cn(
+                'size-3 shrink-0 text-muted-foreground transition-transform',
+                isOpen && 'rotate-180'
+              )}
+            />
+          </button>
+        </Collapsible.Trigger>
+
+        {/* Open in new tab button */}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            openInNewTab(html);
+          }}
+          aria-label="Open in new tab"
+          title="Open in new tab"
+          className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        >
+          <ExternalLink className="size-3.5" />
+        </button>
+      </div>
+
+      <Collapsible.Content>
+        <div className="border-t border-border/50">
+          <iframe
+            srcDoc={html}
+            sandbox="allow-scripts"
+            title={title}
+            className="h-64 w-full rounded-b-md bg-white"
+            data-slot="web-preview-iframe"
+          />
+        </div>
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+}

--- a/packages/mcp-server/plugins/automaker/commands/ava.md
+++ b/packages/mcp-server/plugins/automaker/commands/ava.md
@@ -352,6 +352,7 @@ Execute on every activation. Focus on what only Ava can decide — crew members 
 
 **Ava monitors directly:**
 
+- **Needs Action features** (blocked, requires human intervention) — Highest priority. These features will NOT auto-recover. Check `statusChangeReason` for patterns: `git commit`, `git workflow failed`, `plan validation failed`. Fix the root cause yourself (rebase, reformat, clarify requirements), then reset the feature to backlog with `failureCount: 0`.
 - **Stuck agents** (running > 30min with no progress) — Decide: stop, send context, or let continue
 - **Blocked features** (3+ blocked) — Identify root cause, unblock
 - **Auto-mode health** — Features in backlog but auto-mode not running? Start it.

--- a/packages/mcp-server/plugins/automaker/commands/board.md
+++ b/packages/mcp-server/plugins/automaker/commands/board.md
@@ -67,6 +67,14 @@ Display format:
 - Review: X features
 - Done: X features
 
+### [!] Needs Action (blocked — requires human intervention)
+| ID | Title | Reason |
+|----|-------|--------|
+| ghi-789 | Auth service | plan validation failed: Plan too short (<100 chars) |
+
+> These features carry an amber "Needs Action" badge in the UI. They will NOT auto-recover.
+> Fix the root cause (git issue, bad plan, unclear spec), reset failureCount to 0, move to backlog.
+
 ### Backlog
 | ID | Title | Dependencies |
 |----|-------|--------------|
@@ -79,6 +87,8 @@ Display format:
 
 ...
 ```
+
+**Detecting "Needs Action" features**: After `list_features`, filter for `status: "blocked"` where `statusChangeReason` contains any of: `git commit`, `git workflow failed`, `plan validation failed`. Always display this section first if any such features exist.
 
 ### Creating Features
 

--- a/packages/mcp-server/plugins/automaker/commands/headsdown.md
+++ b/packages/mcp-server/plugins/automaker/commands/headsdown.md
@@ -171,6 +171,12 @@ Display a unified dashboard:
 
 - PR #N: [title] ([status]: mergeable/conflicting/pending review)
 
+### Needs Action (blocked, requires human intervention)
+
+- [Feature] - [statusChangeReason]
+
+> These features will NOT auto-recover. Fix the root cause before continuing.
+
 ### Stale Features (no activity > 24h)
 
 - [Feature] - last updated [time ago]
@@ -321,6 +327,23 @@ PRs not updated in >7 days are stale. Log them and decide: close, rebase, or pin
 ## Phase 5: Board Grooming
 
 Keep the board clean and consistent. Act autonomously — don't present menus.
+
+### 5.0 Needs Action Features
+
+Scan all blocked features. For each, check `statusChangeReason`. Features with any of these patterns require **direct human or Ava intervention** — auto-mode will NOT retry them:
+
+- `git commit` — git workflow failure (format, hook, or staging issue)
+- `git workflow failed` — pipeline-level git failure
+- `plan validation failed` — plan too short or feature requirements unclear
+
+For each "Needs Action" feature:
+
+1. Read the full `statusChangeReason` to understand the root cause
+2. Fix it: rebase the worktree, fix formatting, clarify the feature description, or resolve the underlying issue
+3. Reset `failureCount: 0` and move back to `backlog`
+4. **Do NOT simply reset status and let auto-mode retry** — that will reproduce the same failure
+
+These are surfaced with an amber "Needs Action" badge in the UI. Never leave them sitting blocked.
 
 ### 5.1 Stale Feature Remediation
 


### PR DESCRIPTION
## Promotion: staging → main

QA-verified batch from staging. Changes since v0.23.0:

### Reliability fixes
- **fix: stale context trap auto-detection** — `agent-output.md` files >2h old auto-renamed to `.stale`, preventing dead session resumes
- **fix: plan-loop guard** — `plan validation failed:` prefix stops auto-mode from retrying un-plannable features indefinitely

### UX
- **feat: Needs Action badge** — amber badge on blocked cards that require human intervention (git failures, plan rejections). Tooltip shows exact reason.
- **feat: Needs Action surfacing in skills** — ava, headsdown, board skills now surface these as top priority on activation

### UI components
- **feat: Enhanced ChatModelSelect** — popover/combobox with keyboard shortcuts
- **refactor: QueueView panel component** — extracted to shared `@protolabs-ai/ui`
- **refactor: WebPreviewCard, ChatMessage, ChatMessageList** — component cleanup
- **feat: inline form card, HITL context, Storybook stories**
- **feat: avaChat feature flag** — gates Ava Anywhere

## Merge instructions
Use **merge commit** (not squash): `gh pr merge --merge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched Ava Anywhere—chat overlay with keyboard shortcuts and mobile navigation support.
  * Enhanced model selection UI with searchable list, tier indicators, and direct keyboard switching.
  * Added message regeneration and feedback controls (thumbs up/down).
  * Introduced queue visualization for auto-mode feature pipeline.
  * New inline form components for dynamic form interactions.
  * Visual indicators for features requiring human intervention.

* **Bug Fixes**
  * Improved detection of stale agent sessions.
  * Enhanced plan validation failure handling in automation workflows.

* **Documentation**
  * Added HITL Forms quick reference guide.
  * Expanded auto-mode management guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->