### PR TITLE
Server-side plan streaming chunk + AvaConfig plan tool

### DIFF
--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -21,6 +21,24 @@ import type { AutoModeService } from '../../services/auto-mode-service.js';
 import type { AgentService } from '../../services/agent-service.js';
 
 // ---------------------------------------------------------------------------
+// Plan types
+// ---------------------------------------------------------------------------
+
+/** A single step within a PlanData card */
+export interface PlanStep {
+  id: string;
+  title: string;
+  status: 'pending' | 'running' | 'done' | 'error';
+  detail?: string;
+}
+
+/** Structured plan data sent to the client as a data-plan stream chunk */
+export interface PlanData {
+  steps: PlanStep[];
+  status: 'pending' | 'running' | 'done';
+}
+
+// ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 
@@ -206,6 +224,33 @@ export function buildAvaTools(
           return { error: `Feature '${featureId}' not found` };
         }
         return feature;
+      },
+    });
+
+    tools['create_plan'] = makeTool({
+      description:
+        'Create a structured plan card with titled steps. Use this to present a multi-step execution plan to the user as a visual card rather than plain text.',
+      inputSchema: z.object({
+        title: z.string().describe('Title of the plan'),
+        steps: z
+          .array(
+            z.object({
+              id: z.string().describe('Unique step identifier'),
+              title: z.string().describe('Short step title'),
+              status: z
+                .enum(['pending', 'running', 'done', 'error'])
+                .describe('Current status of the step'),
+              detail: z.string().optional().describe('Optional detail or description for the step'),
+            })
+          )
+          .describe('Ordered list of plan steps'),
+      }),
+      execute: async ({ title, steps }) => {
+        const planData: PlanData = {
+          steps,
+          status: 'pending',
+        };
+        return { title, ...planData };
       },
     });
   }

--- a/apps/server/src/routes/chat/index.ts
+++ b/apps/server/src/routes/chat/index.ts
@@ -35,6 +35,7 @@ import { buildAvaSystemPrompt, type NotesContext } from './personas.js';
 import { loadAvaConfig, DEFAULT_AVA_CONFIG, type AvaConfig } from './ava-config.js';
 import { getSitrep } from './sitrep.js';
 import { buildAvaTools } from './ava-tools.js';
+import type { PlanData } from './ava-tools.js';
 import type { ServiceContainer } from '../../server/services.js';
 import type { FeatureLoader } from '../../services/feature-loader.js';
 
@@ -147,6 +148,30 @@ async function extractAndResolveCitations(
   }
 
   return citations;
+}
+
+// ── Plan extraction ───────────────────────────────────────────────────────────
+
+/** Matches a fenced ```plan ... ``` block in the assistant response text */
+const PLAN_BLOCK_PATTERN = /```plan\s*([\s\S]*?)```/;
+
+/**
+ * Scan the assistant response text for a ```plan JSON block.
+ * Returns a PlanData object when a valid plan block is found, or null otherwise.
+ * Gracefully ignores malformed JSON without throwing.
+ */
+function extractPlan(text: string): PlanData | null {
+  const match = text.match(PLAN_BLOCK_PATTERN);
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[1].trim()) as Record<string, unknown>;
+    if (parsed && Array.isArray(parsed['steps'])) {
+      return parsed as unknown as PlanData;
+    }
+  } catch {
+    // Invalid JSON in plan block — ignore silently
+  }
+  return null;
 }
 
 // ── Route factory ─────────────────────────────────────────────────────────────
@@ -322,6 +347,21 @@ export function createChatRoutes(services: ServiceContainer): Router {
               }
             } catch (err) {
               logger.warn('Citation extraction failed:', err);
+            }
+          }
+
+          // Extract and stream a plan block when the response contains one
+          if (fullText) {
+            try {
+              const plan = extractPlan(fullText);
+              if (plan) {
+                writer.write({
+                  type: 'data-plan',
+                  data: plan,
+                } as UIMessageChunk);
+              }
+            } catch (err) {
+              logger.warn('Plan extraction failed:', err);
             }
           }
         },


### PR DESCRIPTION
## Summary

**Milestone:** Plan Part

Add plan streaming support to the chat route. In apps/server/src/routes/chat/index.ts: after streamText() completes each step, scan assistant text for a plan marker pattern (e.g. a JSON block tagged with ```plan). Extract it and write as a data chunk: streamText data chunks via dataStreamResponse.writeData({ type: 'plan', steps: [...], status: 'pending'|'running'|'done' }). Add a PlanData type to the shared types or inline in the chat route. The plan steps should have: ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Introduced structured planning functionality enabling multi-step plan creation
  - Plan steps now display status tracking (pending, running, done, or error) and optional detail descriptions
  - Assistant-generated plans are automatically detected and displayed in conversations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->