### PR TITLE
Migrate status color violations (usage popovers, terminal, board)

### DIFF
--- a/apps/ui/src/components/claude-usage-popover.tsx
+++ b/apps/ui/src/components/claude-usage-popover.tsx
@@ -38,10 +38,10 @@ export function ClaudeUsagePopover() {
 
   // Derived status color/icon helper
   const getStatusInfo = (percentage: number) => {
-    if (percentage >= 75) return { color: 'text-red-500', icon: XCircle, bg: 'bg-red-500' };
+    if (percentage >= 75) return { color: 'text-red-500', icon: XCircle, bg: 'bg-status-error' };
     if (percentage >= 50)
-      return { color: 'text-orange-500', icon: AlertTriangle, bg: 'bg-orange-500' };
-    return { color: 'text-green-500', icon: CheckCircle, bg: 'bg-green-500' };
+      return { color: 'text-orange-500', icon: AlertTriangle, bg: 'bg-status-warning' };
+    return { color: 'text-green-500', icon: CheckCircle, bg: 'bg-status-success' };
   };
 
   // Helper component for the progress bar
@@ -128,9 +128,9 @@ export function ClaudeUsagePopover() {
     : 0;
 
   const getProgressBarColor = (percentage: number) => {
-    if (percentage >= 80) return 'bg-red-500';
-    if (percentage >= 50) return 'bg-yellow-500';
-    return 'bg-green-500';
+    if (percentage >= 80) return 'bg-status-error';
+    if (percentage >= 50) return 'bg-status-warning';
+    return 'bg-status-success';
   };
 
   const trigger = (

--- a/apps/ui/src/components/codex-usage-popover.tsx
+++ b/apps/ui/src/components/codex-usage-popover.tsx
@@ -94,10 +94,10 @@ export function CodexUsagePopover() {
 
   // Derived status color/icon helper
   const getStatusInfo = (percentage: number) => {
-    if (percentage >= 75) return { color: 'text-red-500', icon: XCircle, bg: 'bg-red-500' };
+    if (percentage >= 75) return { color: 'text-red-500', icon: XCircle, bg: 'bg-status-error' };
     if (percentage >= 50)
-      return { color: 'text-orange-500', icon: AlertTriangle, bg: 'bg-orange-500' };
-    return { color: 'text-green-500', icon: CheckCircle, bg: 'bg-green-500' };
+      return { color: 'text-orange-500', icon: AlertTriangle, bg: 'bg-status-warning' };
+    return { color: 'text-green-500', icon: CheckCircle, bg: 'bg-status-success' };
   };
 
   // Helper component for the progress bar
@@ -187,9 +187,9 @@ export function CodexUsagePopover() {
     : 0;
 
   const getProgressBarColor = (percentage: number) => {
-    if (percentage >= 80) return 'bg-red-500';
-    if (percentage >= 50) return 'bg-yellow-500';
-    return 'bg-green-500';
+    if (percentage >= 80) return 'bg-status-error';
+    if (percentage >= 50) return 'bg-status-warning';
+    return 'bg-status-success';
   };
 
   const trigger = (

--- a/apps/ui/src/components/usage-popover.tsx
+++ b/apps/ui/src/components/usage-popover.tsx
@@ -138,10 +138,10 @@ export function UsagePopover() {
 
   // Derived status color/icon helper
   const getStatusInfo = (percentage: number) => {
-    if (percentage >= 75) return { color: 'text-red-500', icon: XCircle, bg: 'bg-red-500' };
+    if (percentage >= 75) return { color: 'text-red-500', icon: XCircle, bg: 'bg-status-error' };
     if (percentage >= 50)
-      return { color: 'text-orange-500', icon: AlertTriangle, bg: 'bg-orange-500' };
-    return { color: 'text-green-500', icon: CheckCircle, bg: 'bg-green-500' };
+      return { color: 'text-orange-500', icon: AlertTriangle, bg: 'bg-status-warning' };
+    return { color: 'text-green-500', icon: CheckCircle, bg: 'bg-status-success' };
   };
 
   // Helper component for the progress bar
@@ -235,9 +235,9 @@ export function UsagePopover() {
     : 0;
 
   const getProgressBarColor = (percentage: number) => {
-    if (percentage >= 80) return 'bg-red-500';
-    if (percentage >= 50) return 'bg-yellow-500';
-    return 'bg-green-500';
+    if (percentage >= 80) return 'bg-status-error';
+    if (percentage >= 50) return 'bg-status-warning';
+    return 'bg-status-success';
   };
 
   // Determine which provider icon and percentage to show based on active tab

--- a/apps/ui/src/components/views/board-view/components/kanban-card/epic-badge.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/epic-badge.tsx
@@ -30,7 +30,7 @@ export function EpicBadge({ feature, className }: EpicBadgeProps) {
   const epicTitle = epicFeature.title?.replace(/^\[Epic\]\s*/i, '') || 'Epic';
 
   // Use epic's color or default to a neutral color
-  const badgeColor = feature.epicColor || epicFeature.epicColor || '#6366f1';
+  const badgeColor = feature.epicColor || epicFeature.epicColor || 'var(--primary)';
 
   return (
     <Badge

--- a/apps/ui/src/components/views/terminal-view/terminal-panel.tsx
+++ b/apps/ui/src/components/views/terminal-view/terminal-panel.tsx
@@ -1737,8 +1737,8 @@ export function TerminalPanel({
     >
       {/* Drop indicator overlay */}
       {isOver && isDropTarget && (
-        <div className="absolute inset-0 bg-green-500/10 z-10 pointer-events-none flex items-center justify-center">
-          <div className="px-3 py-2 bg-green-500/90 rounded-md text-white text-sm font-medium">
+        <div className="absolute inset-0 bg-status-success/10 z-10 pointer-events-none flex items-center justify-center">
+          <div className="px-3 py-2 bg-status-success/90 rounded-md text-white text-sm font-medium">
             Drop to swap
           </div>
         </div>
@@ -1746,8 +1746,8 @@ export function TerminalPanel({
 
       {/* Image drop overlay */}
       {isImageDragOver && (
-        <div className="absolute inset-0 bg-blue-500/20 z-20 pointer-events-none flex items-center justify-center border-2 border-dashed border-blue-400 rounded">
-          <div className="flex flex-col items-center gap-2 px-4 py-3 bg-blue-500/90 rounded-md text-white">
+        <div className="absolute inset-0 bg-status-info/20 z-20 pointer-events-none flex items-center justify-center border-2 border-dashed border-blue-400 rounded">
+          <div className="flex flex-col items-center gap-2 px-4 py-3 bg-status-info/90 rounded-md text-white">
             {isProcessingImage ? (
               <>
                 <Spinner size="lg" />
@@ -1804,7 +1804,7 @@ export function TerminalPanel({
             </button>
           )}
           {connectionStatus === 'reconnecting' && (
-            <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-500 flex items-center gap-1">
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-status-warning/20 text-yellow-500 flex items-center gap-1">
               <Spinner size="xs" />
               Reconnecting...
             </span>
@@ -1824,8 +1824,8 @@ export function TerminalPanel({
               className={cn(
                 'text-[10px] px-1.5 py-0.5 rounded flex items-center gap-1',
                 processExitCode === 0
-                  ? 'bg-green-500/20 text-green-500'
-                  : 'bg-yellow-500/20 text-yellow-500'
+                  ? 'bg-status-success/20 text-green-500'
+                  : 'bg-status-warning/20 text-yellow-500'
               )}
             >
               Exited ({processExitCode})


### PR DESCRIPTION
## Summary

**Milestone:** Semantic Color Migration

Replace raw palette status colors in the highest-traffic files:

**Files:**
- `apps/ui/src/components/usage-popover.tsx` — bg-red-500 -> bg-status-error, bg-green-500 -> bg-status-success, bg-orange-500 -> bg-status-warning, bg-yellow-500 -> bg-status-warning
- `apps/ui/src/components/claude-usage-popover.tsx` — same pattern
- `apps/ui/src/components/codex-usage-popover.tsx` — same pattern
- `apps/ui/src/components/views/terminal-view/terminal-panel.tsx` ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated status color scheme across usage indicators and terminal components with centralized color tokens for improved visual consistency
  * Progress bars and status badges now use standardized status-based color system instead of generic color utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->