### PR TITLE
Migrate git-diff-panel, log-viewer, and shared components

### DIFF
--- a/apps/ui/src/components/shared/git-diff-panel.tsx
+++ b/apps/ui/src/components/shared/git-diff-panel.tsx
@@ -48,15 +48,15 @@ const getFileIcon = (status: string) => {
   switch (status) {
     case 'A':
     case '?':
-      return <FilePlus className="w-4 h-4 text-green-500" />;
+      return <FilePlus className="w-4 h-4 text-status-success" />;
     case 'D':
-      return <FileX className="w-4 h-4 text-red-500" />;
+      return <FileX className="w-4 h-4 text-status-error" />;
     case 'M':
     case 'U':
-      return <FilePen className="w-4 h-4 text-amber-500" />;
+      return <FilePen className="w-4 h-4 text-status-warning" />;
     case 'R':
     case 'C':
-      return <File className="w-4 h-4 text-blue-500" />;
+      return <File className="w-4 h-4 text-status-info" />;
     default:
       return <FileText className="w-4 h-4 text-muted-foreground" />;
   }
@@ -66,15 +66,15 @@ const getStatusBadgeColor = (status: string) => {
   switch (status) {
     case 'A':
     case '?':
-      return 'bg-green-500/20 text-green-400 border-green-500/30';
+      return 'bg-status-success/20 text-status-success border-status-success/30';
     case 'D':
-      return 'bg-red-500/20 text-red-400 border-red-500/30';
+      return 'bg-status-error/20 text-status-error border-status-error/30';
     case 'M':
     case 'U':
-      return 'bg-amber-500/20 text-amber-400 border-amber-500/30';
+      return 'bg-status-warning/20 text-status-warning border-status-warning/30';
     case 'R':
     case 'C':
-      return 'bg-blue-500/20 text-blue-400 border-blue-500/30';
+      return 'bg-status-info/20 text-status-info border-status-info/30';
     default:
       return 'bg-muted text-muted-foreground border-border';
   }
@@ -224,16 +224,16 @@ function DiffLine({
 }) {
   const bgClass = {
     context: 'bg-transparent',
-    addition: 'bg-green-500/10',
-    deletion: 'bg-red-500/10',
-    header: 'bg-blue-500/10',
+    addition: 'bg-status-success/10',
+    deletion: 'bg-status-error/10',
+    header: 'bg-status-info/10',
   };
 
   const textClass = {
     context: 'text-foreground-secondary',
-    addition: 'text-green-400',
-    deletion: 'text-red-400',
-    header: 'text-blue-400',
+    addition: 'text-status-success',
+    deletion: 'text-status-error',
+    header: 'text-status-info',
   };
 
   const prefix = {
@@ -304,22 +304,22 @@ function FileDiffSection({
         </span>
         <div className="flex items-center gap-2 flex-shrink-0">
           {fileDiff.isNew && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">
+            <span className="text-xs px-1.5 py-0.5 rounded bg-status-success/20 text-status-success">
               new
             </span>
           )}
           {fileDiff.isDeleted && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400">
+            <span className="text-xs px-1.5 py-0.5 rounded bg-status-error/20 text-status-error">
               deleted
             </span>
           )}
           {fileDiff.isRenamed && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400">
+            <span className="text-xs px-1.5 py-0.5 rounded bg-status-info/20 text-status-info">
               renamed
             </span>
           )}
-          {additions > 0 && <span className="text-xs text-green-400">+{additions}</span>}
-          {deletions > 0 && <span className="text-xs text-red-400">-{deletions}</span>}
+          {additions > 0 && <span className="text-xs text-status-success">+{additions}</span>}
+          {deletions > 0 && <span className="text-xs text-status-error">-{deletions}</span>}
         </div>
       </button>
       {isExpanded && (
@@ -460,8 +460,8 @@ export function GitDiffPanel({
               <span className="text-muted-foreground">
                 {files.length} {files.length === 1 ? 'file' : 'files'}
               </span>
-              {totalAdditions > 0 && <span className="text-green-400">+{totalAdditions}</span>}
-              {totalDeletions > 0 && <span className="text-red-400">-{totalDeletions}</span>}
+              {totalAdditions > 0 && <span className="text-status-success">+{totalAdditions}</span>}
+              {totalDeletions > 0 && <span className="text-status-error">-{totalDeletions}</span>}
             </>
           )}
         </div>
@@ -477,7 +477,7 @@ export function GitDiffPanel({
             </div>
           ) : error ? (
             <div className="flex flex-col items-center justify-center gap-2 py-8 text-muted-foreground">
-              <AlertCircle className="w-5 h-5 text-amber-500" />
+              <AlertCircle className="w-5 h-5 text-status-warning" />
               <span className="text-sm">{error}</span>
               <Button variant="ghost" size="sm" onClick={() => loadDiffs()} className="mt-2">
                 <RefreshCw className="w-4 h-4 mr-2" />
@@ -568,10 +568,10 @@ export function GitDiffPanel({
                     {files.length} {files.length === 1 ? 'file' : 'files'} changed
                   </span>
                   {totalAdditions > 0 && (
-                    <span className="text-green-400">+{totalAdditions} additions</span>
+                    <span className="text-status-success">+{totalAdditions} additions</span>
                   )}
                   {totalDeletions > 0 && (
-                    <span className="text-red-400">-{totalDeletions} deletions</span>
+                    <span className="text-status-error">-{totalDeletions} deletions</span>
                   )}
                 </div>
               </div>

--- a/apps/ui/src/components/shared/keyboard-map.tsx
+++ b/apps/ui/src/components/shared/keyboard-map.tsx
@@ -162,21 +162,21 @@ const SHORTCUT_CATEGORIES: Record<keyof KeyboardShortcuts, 'navigation' | 'ui' |
 // Category colors
 const CATEGORY_COLORS = {
   navigation: {
-    bg: 'bg-blue-500/20',
-    border: 'border-blue-500/50',
-    text: 'text-blue-400',
+    bg: 'bg-status-info/20',
+    border: 'border-status-info/50',
+    text: 'text-status-info',
     label: 'Navigation',
   },
   ui: {
-    bg: 'bg-purple-500/20',
-    border: 'border-purple-500/50',
-    text: 'text-purple-400',
+    bg: 'bg-primary/20',
+    border: 'border-primary/50',
+    text: 'text-primary',
     label: 'UI Controls',
   },
   action: {
-    bg: 'bg-green-500/20',
-    border: 'border-green-500/50',
-    text: 'text-green-400',
+    bg: 'bg-status-success/20',
+    border: 'border-status-success/50',
+    text: 'text-status-success',
     label: 'Actions',
   },
 };
@@ -244,7 +244,7 @@ export function KeyboardMap({ onKeySelect, selectedKey, className }: KeyboardMap
           // Selected state
           isSelected && 'ring-2 ring-brand-500 ring-offset-2 ring-offset-background',
           // Modified indicator
-          isModified && 'ring-1 ring-yellow-500/50'
+          isModified && 'ring-1 ring-status-warning/50'
         )}
         data-testid={`keyboard-key-${keyDef.key}`}
       >
@@ -277,7 +277,7 @@ export function KeyboardMap({ onKeySelect, selectedKey, className }: KeyboardMap
           }
         </span>
         {isModified && (
-          <span className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-yellow-500" />
+          <span className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-status-warning" />
         )}
       </button>
     );
@@ -308,7 +308,7 @@ export function KeyboardMap({ onKeySelect, selectedKey, className }: KeyboardMap
                       {displayShortcut}
                     </kbd>
                     {mergedShortcuts[shortcut] !== DEFAULT_KEYBOARD_SHORTCUTS[shortcut] && (
-                      <span className="text-xs text-yellow-400">(custom)</span>
+                      <span className="text-xs text-status-warning">(custom)</span>
                     )}
                   </div>
                 );
@@ -338,8 +338,8 @@ export function KeyboardMap({ onKeySelect, selectedKey, className }: KeyboardMap
             <span className="text-muted-foreground">Available</span>
           </div>
           <div className="flex items-center gap-2">
-            <div className="w-2 h-2 rounded-full bg-yellow-500" />
-            <span className="text-yellow-400">Modified</span>
+            <div className="w-2 h-2 rounded-full bg-status-warning" />
+            <span className="text-status-warning">Modified</span>
           </div>
         </div>
 
@@ -628,7 +628,8 @@ export function ShortcutReferencePanel({ editable = false }: ShortcutReferencePa
                               onKeyDown={handleKeyDown}
                               className={cn(
                                 'w-12 h-7 text-center font-mono text-xs uppercase',
-                                shortcutError && 'border-red-500 focus-visible:ring-red-500'
+                                shortcutError &&
+                                  'border-status-error focus-visible:ring-status-error'
                               )}
                               placeholder="Key"
                               maxLength={1}
@@ -638,7 +639,7 @@ export function ShortcutReferencePanel({ editable = false }: ShortcutReferencePa
                             <Button
                               size="sm"
                               variant="ghost"
-                              className="h-7 w-7 p-0 hover:bg-green-500/20 hover:text-green-400"
+                              className="h-7 w-7 p-0 hover:bg-status-success/20 hover:text-status-success"
                               onClick={(e) => {
                                 e.stopPropagation();
                                 handleSaveShortcut();
@@ -651,7 +652,7 @@ export function ShortcutReferencePanel({ editable = false }: ShortcutReferencePa
                             <Button
                               size="sm"
                               variant="ghost"
-                              className="h-7 w-7 p-0 hover:bg-red-500/20 hover:text-red-400"
+                              className="h-7 w-7 p-0 hover:bg-status-error/20 hover:text-status-error"
                               onClick={(e) => {
                                 e.stopPropagation();
                                 handleCancelEdit();
@@ -679,7 +680,7 @@ export function ShortcutReferencePanel({ editable = false }: ShortcutReferencePa
                                   <Button
                                     size="sm"
                                     variant="ghost"
-                                    className="h-6 w-6 p-0 hover:bg-yellow-500/20 hover:text-yellow-400"
+                                    className="h-6 w-6 p-0 hover:bg-status-warning/20 hover:text-status-warning"
                                     onClick={(e) => {
                                       e.stopPropagation();
                                       handleResetShortcut(key);
@@ -695,7 +696,7 @@ export function ShortcutReferencePanel({ editable = false }: ShortcutReferencePa
                               </Tooltip>
                             )}
                             {isModified && !editable && (
-                              <span className="w-2 h-2 rounded-full bg-yellow-500" />
+                              <span className="w-2 h-2 rounded-full bg-status-warning" />
                             )}
                             {editable && !isModified && (
                               <Edit2 className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100" />
@@ -710,7 +711,7 @@ export function ShortcutReferencePanel({ editable = false }: ShortcutReferencePa
               {editingShortcut &&
                 shortcutError &&
                 SHORTCUT_CATEGORIES[editingShortcut] === category && (
-                  <p className="text-xs text-red-400 mt-1">{shortcutError}</p>
+                  <p className="text-xs text-status-error mt-1">{shortcutError}</p>
                 )}
             </div>
           );

--- a/apps/ui/src/components/shared/log-viewer.tsx
+++ b/apps/ui/src/components/shared/log-viewer.tsx
@@ -93,19 +93,19 @@ const getToolCategoryIcon = (category: ToolCategory | undefined) => {
 const getToolCategoryColor = (category: ToolCategory | undefined): string => {
   switch (category) {
     case 'read':
-      return 'text-blue-400 bg-blue-500/10 border-blue-500/30';
+      return 'text-status-info bg-status-info/10 border-status-info/30';
     case 'edit':
-      return 'text-amber-400 bg-amber-500/10 border-amber-500/30';
+      return 'text-status-warning bg-status-warning/10 border-status-warning/30';
     case 'write':
-      return 'text-emerald-400 bg-emerald-500/10 border-emerald-500/30';
+      return 'text-status-success bg-status-success/10 border-status-success/30';
     case 'bash':
-      return 'text-purple-400 bg-purple-500/10 border-purple-500/30';
+      return 'text-primary bg-primary/10 border-primary/30';
     case 'search':
-      return 'text-cyan-400 bg-cyan-500/10 border-cyan-500/30';
+      return 'text-status-info bg-status-info/10 border-status-info/30';
     case 'todo':
-      return 'text-green-400 bg-green-500/10 border-green-500/30';
+      return 'text-status-success bg-status-success/10 border-status-success/30';
     case 'task':
-      return 'text-indigo-400 bg-indigo-500/10 border-indigo-500/30';
+      return 'text-primary bg-primary/10 border-primary/30';
     default:
       return 'text-muted-foreground bg-muted/30 border-border';
   }
@@ -145,7 +145,7 @@ function TodoListRenderer({ todos }: { todos: TodoItem[] }) {
   const getStatusIcon = (status: TodoItem['status']) => {
     switch (status) {
       case 'completed':
-        return <CheckCircle2 className="w-4 h-4 text-emerald-400" />;
+        return <CheckCircle2 className="w-4 h-4 text-status-success" />;
       case 'in_progress':
         return <Spinner size="sm" />;
       case 'pending':
@@ -158,9 +158,9 @@ function TodoListRenderer({ todos }: { todos: TodoItem[] }) {
   const getStatusColor = (status: TodoItem['status']) => {
     switch (status) {
       case 'completed':
-        return 'text-emerald-300 line-through opacity-70';
+        return 'text-status-success line-through opacity-70';
       case 'in_progress':
-        return 'text-amber-300';
+        return 'text-status-warning';
       case 'pending':
         return 'text-muted-foreground';
       default:
@@ -172,13 +172,13 @@ function TodoListRenderer({ todos }: { todos: TodoItem[] }) {
     switch (status) {
       case 'completed':
         return (
-          <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-500/20 text-emerald-400 ml-auto">
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-status-success/20 text-status-success ml-auto">
             Done
           </span>
         );
       case 'in_progress':
         return (
-          <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400 ml-auto">
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-status-warning/20 text-status-warning ml-auto">
             In Progress
           </span>
         );
@@ -194,8 +194,8 @@ function TodoListRenderer({ todos }: { todos: TodoItem[] }) {
           key={index}
           className={cn(
             'flex items-start gap-2 p-2 rounded-md transition-colors',
-            todo.status === 'in_progress' && 'bg-amber-500/5 border border-amber-500/20',
-            todo.status === 'completed' && 'bg-emerald-500/5',
+            todo.status === 'in_progress' && 'bg-status-warning/5 border border-status-warning/20',
+            todo.status === 'completed' && 'bg-status-success/5',
             todo.status === 'pending' && 'bg-muted/30'
           )}
         >
@@ -203,7 +203,7 @@ function TodoListRenderer({ todos }: { todos: TodoItem[] }) {
           <div className="flex-1 min-w-0">
             <p className={cn('text-sm', getStatusColor(todo.status))}>{todo.content}</p>
             {todo.status === 'in_progress' && todo.activeForm && (
-              <p className="text-xs text-amber-400/70 mt-0.5 italic">{todo.activeForm}</p>
+              <p className="text-xs text-status-warning/70 mt-0.5 italic">{todo.activeForm}</p>
             )}
           </div>
           {getStatusBadge(todo.status)}
@@ -676,7 +676,7 @@ export function LogViewer({ output, className }: LogViewerProps) {
               );
             })}
             {stats.errors > 0 && (
-              <span className="text-xs px-2 py-0.5 rounded-full bg-red-500/10 text-red-400 border border-red-500/30 flex items-center gap-1">
+              <span className="text-xs px-2 py-0.5 rounded-full bg-status-error/10 text-status-error border border-status-error/30 flex items-center gap-1">
                 <AlertCircle className="w-3 h-3" />
                 {stats.errors}
               </span>


### PR DESCRIPTION
## Summary

**Milestone:** Semantic Color Migration

Replace raw palette colors in the shared domain components:

**Files:**
- `apps/ui/src/components/shared/git-diff-panel.tsx` — 20+ violations: bg-green-500/10 -> bg-status-success/10, bg-red-500/10 -> bg-status-error/10, text-green-400 -> text-status-success, text-red-400 -> text-status-error, bg-amber-500/* -> bg-status-warning/*, bg-blue-500/* -> bg-status-info/*
- `apps/ui/src/components/shared/log-viewer.tsx` — 14+ violations: text-blue-400 -> text-st...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated color scheme across UI components to use a unified status-based palette for improved visual consistency in diff panels, keyboard shortcuts, and log viewer.

* **New Features**
  * Added Todo parsing and rendering capabilities in log viewer to display structured task information.
  * Enhanced content formatting with JSON pretty-printing support in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->