### PR TITLE
Adaptive notification routing + get_presence_state Ava tool

### DIFF
--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -19,6 +19,7 @@ import type { EventEmitter } from 'events';
 import type { FeatureLoader } from '../../services/feature-loader.js';
 import type { AutoModeService } from '../../services/auto-mode-service.js';
 import type { AgentService } from '../../services/agent-service.js';
+import type { SensorRegistryService } from '../../services/sensor-registry-service.js';
 
 // ---------------------------------------------------------------------------
 // Plan types
@@ -48,6 +49,8 @@ export interface AvaToolsServices {
   agentService: AgentService;
   /** Optional event emitter used for board-write change notifications */
   events?: EventEmitter;
+  /** Optional sensor registry — required for get_presence_state tool */
+  sensorRegistryService?: SensorRegistryService;
 }
 
 export interface AvaToolsConfig {
@@ -63,6 +66,11 @@ export interface AvaToolsConfig {
   projectMgmt?: boolean;
   /** Enable orchestration tools (get_execution_order, set_feature_dependencies) */
   orchestration?: boolean;
+  /**
+   * When true, register the get_presence_state tool in the boardRead group.
+   * Only meaningful when the userPresenceDetection feature flag is enabled.
+   */
+  userPresenceDetection?: boolean;
   /**
    * Pre-approved destructive tool calls (HITL flow).
    * Each entry contains the tool name and a stable JSON hash of the input args.
@@ -253,6 +261,45 @@ export function buildAvaTools(
         return { title, ...planData };
       },
     });
+
+    // get_presence_state — only registered when userPresenceDetection flag is enabled
+    if (config.userPresenceDetection && services.sensorRegistryService) {
+      const sensorRegistry = services.sensorRegistryService;
+      tools['get_presence_state'] = makeTool({
+        description:
+          'Return the current user presence state and the list of active sensors. ' +
+          'Presence state is derived from the builtin:user-activity sensor and indicates ' +
+          'whether the user is active, idle, afk, or headless (no browser connected).',
+        inputSchema: z.object({}),
+        execute: async () => {
+          const userActivityEntry = sensorRegistry.get('builtin:user-activity');
+
+          let presenceStatus: string;
+          if (!userActivityEntry || userActivityEntry.state === 'offline') {
+            presenceStatus = 'headless';
+          } else {
+            const status = userActivityEntry.reading?.data?.status as string | undefined;
+            if (status === 'afk' || status === 'idle' || status === 'active') {
+              presenceStatus = status;
+            } else {
+              presenceStatus = 'headless';
+            }
+          }
+
+          const activeSensors = sensorRegistry
+            .getAll()
+            .filter((entry) => entry.state === 'active')
+            .map((entry) => ({
+              id: entry.sensor.id,
+              name: entry.sensor.name,
+              state: entry.state,
+              lastSeenAt: entry.sensor.lastSeenAt,
+            }));
+
+          return { presenceStatus, activeSensors };
+        },
+      });
+    }
   }
 
   // -----------------------------------------------------------------------

--- a/apps/server/src/routes/chat/index.ts
+++ b/apps/server/src/routes/chat/index.ts
@@ -264,6 +264,14 @@ export function createChatRoutes(services: ServiceContainer): Router {
       // Build tool set for this request — gated by per-project toolGroups config.
       // approvedActions carries pre-approved destructive-tool call identifiers for
       // the HITL confirmation flow.
+      // Read the userPresenceDetection flag from global settings (non-blocking fallback to false).
+      let userPresenceDetection = false;
+      try {
+        const globalSettings = await services.settingsService.getGlobalSettings();
+        userPresenceDetection = globalSettings.featureFlags?.userPresenceDetection ?? false;
+      } catch {
+        // Settings unavailable — safe default (flag disabled)
+      }
       const tools = projectPath
         ? buildAvaTools(
             projectPath,
@@ -271,9 +279,13 @@ export function createChatRoutes(services: ServiceContainer): Router {
               featureLoader: services.featureLoader,
               autoModeService: services.autoModeService,
               agentService: services.agentService,
+              sensorRegistryService: userPresenceDetection
+                ? services.sensorRegistryService
+                : undefined,
             },
             {
               ...avaConfig.toolGroups,
+              userPresenceDetection,
               approvedActions: approvedActions ?? [],
             }
           )

--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -86,6 +86,7 @@ import { FactStoreService } from '../services/fact-store-service.js';
 import { TrajectoryStoreService } from '../services/trajectory-store-service.js';
 import { LeadHandoffService } from '../services/lead-handoff-service.js';
 import { ChannelRouter } from '../services/channel-router.js';
+import { NotificationRouter } from '../services/notification-router.js';
 
 // Services originally loaded via top-level dynamic imports — now static for proper typing
 import { ProjectLifecycleService } from '../services/project-lifecycle-service.js';
@@ -180,6 +181,7 @@ export interface ServiceContainer {
   // Dev server & notifications
   devServerService: ReturnType<typeof getDevServerService>;
   notificationService: ReturnType<typeof getNotificationService>;
+  notificationRouter: NotificationRouter;
   actionableItemService: ReturnType<typeof getActionableItemService>;
   actionableItemBridge: ActionableItemBridgeService;
   integrityWatchdogService: DataIntegrityWatchdogService;
@@ -582,6 +584,32 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
     { pm: pmAgent, projm: projmAgent, em: emAgent }
   );
 
+  // Notification Router — presence-aware routing for completion/failure/HITL events.
+  // Reads userPresenceDetection flag from settings; discord DM recipients from
+  // DISCORD_DM_RECIPIENTS env var (comma-separated usernames).
+  // Subscribes to feature:completed, feature:error, and hitl:form-requested in its constructor.
+  let presenceEnabled = false;
+  try {
+    const globalSettings = await settingsService.getGlobalSettings();
+    presenceEnabled = globalSettings.featureFlags?.userPresenceDetection ?? false;
+  } catch {
+    // Settings unavailable — safe default
+  }
+  const discordDmRecipientsEnv = process.env.DISCORD_DM_RECIPIENTS ?? '';
+  const discordDmRecipients = discordDmRecipientsEnv
+    ? discordDmRecipientsEnv
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
+  const notificationRouter = new NotificationRouter(
+    sensorRegistryService,
+    notificationService,
+    events,
+    discordBotService,
+    { enabled: presenceEnabled, discordRecipients: discordDmRecipients }
+  );
+
   // Issue Management Pipeline (failure → triage → GitHub issue → Discord)
   const triageService = new TriageService(events);
   const issueCreationService = new IssueCreationService(
@@ -717,6 +745,7 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
     antagonisticReviewService,
     devServerService,
     notificationService,
+    notificationRouter,
     actionableItemService,
     actionableItemBridge,
     integrityWatchdogService,

--- a/apps/server/src/services/notification-router.ts
+++ b/apps/server/src/services/notification-router.ts
@@ -1,0 +1,335 @@
+/**
+ * NotificationRouter - Routes feature completion/failure/HITL events
+ * based on the current user presence state.
+ *
+ * Presence states are derived from SensorRegistryService readings:
+ *   active   → in-app toast only
+ *   idle     → in-app toast + browser push
+ *   afk      → Discord DM (falls back to toast if Discord unavailable)
+ *   headless → Discord DM only (no browser connected)
+ *
+ * Falls back to in-app toast only when the router is disabled
+ * (userPresenceDetection flag is off).
+ *
+ * The router subscribes to:
+ *   - feature:completed  → routes a success notification
+ *   - feature:error      → routes a failure notification
+ *   - hitl:form-requested → routes a human-input-required notification
+ */
+
+import { createLogger } from '@protolabs-ai/utils';
+import type { EventType, NotificationType } from '@protolabs-ai/types';
+import type { SensorRegistryService } from './sensor-registry-service.js';
+import type { NotificationService } from './notification-service.js';
+import type { DiscordBotService } from './discord-bot-service.js';
+import type { EventEmitter } from '../lib/events.js';
+
+const logger = createLogger('NotificationRouter');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Computed presence state derived from sensor readings.
+ *
+ * - active:   browser is visible and user is interacting
+ * - idle:     browser is open but user has not interacted for >1 min
+ * - afk:      browser is open but user has been gone >5 min
+ * - headless: no browser sensors are connected (server-only / CI)
+ */
+export type NotificationPresenceState = 'active' | 'idle' | 'afk' | 'headless';
+
+/** A notification event that should be routed to the user. */
+export interface NotificationEvent {
+  /** Category of the event driving the notification. */
+  type: 'completion' | 'failure' | 'hitl';
+  /** Short title shown in the notification. */
+  title: string;
+  /** Descriptive message body. */
+  message: string;
+  /** Optional feature ID for cross-linking. */
+  featureId?: string;
+  /** Project path required to persist via NotificationService. */
+  projectPath?: string;
+}
+
+/** Configuration for the NotificationRouter. */
+export interface NotificationRouterConfig {
+  /**
+   * Discord usernames to send DMs to when presence is 'afk' or 'headless'.
+   * Ignored if no DiscordBotService is provided.
+   */
+  discordRecipients?: string[];
+  /**
+   * When false, all events fall back to in-app toast regardless of presence.
+   * Set to false when the userPresenceDetection feature flag is disabled.
+   * @default true
+   */
+  enabled?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// NotificationRouter
+// ---------------------------------------------------------------------------
+
+export class NotificationRouter {
+  private readonly sensorRegistry: SensorRegistryService;
+  private readonly notificationService: NotificationService;
+  private readonly events: EventEmitter;
+  private readonly discordBot?: DiscordBotService;
+  private readonly discordRecipients: string[];
+  private readonly enabled: boolean;
+
+  constructor(
+    sensorRegistry: SensorRegistryService,
+    notificationService: NotificationService,
+    events: EventEmitter,
+    discordBot?: DiscordBotService,
+    config?: NotificationRouterConfig
+  ) {
+    this.sensorRegistry = sensorRegistry;
+    this.notificationService = notificationService;
+    this.events = events;
+    this.discordBot = discordBot;
+    this.discordRecipients = config?.discordRecipients ?? [];
+    this.enabled = config?.enabled ?? true;
+
+    this.subscribeToEvents();
+    logger.info(
+      `NotificationRouter initialized (enabled=${this.enabled}, ` +
+        `discordRecipients=[${this.discordRecipients.join(', ')}])`
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Presence detection
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Compute the current user presence state from SensorRegistryService.
+   *
+   * Uses the 'builtin:user-activity' sensor (reported by the usePresence hook)
+   * to determine activity level.  Returns 'headless' when the sensor is absent
+   * or offline — indicating no browser client is connected.
+   */
+  computePresenceState(): NotificationPresenceState {
+    const entry = this.sensorRegistry.get('builtin:user-activity');
+
+    if (!entry || entry.state === 'offline') {
+      return 'headless';
+    }
+
+    const status = entry.reading?.data?.status as string | undefined;
+
+    if (status === 'afk') return 'afk';
+    if (status === 'idle') return 'idle';
+    if (status === 'active') return 'active';
+
+    // Sensor is registered but hasn't reported a known status yet
+    return 'headless';
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public routing API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Route a notification event to the appropriate channel based on the
+   * current user presence state.
+   *
+   * When the router is disabled (userPresenceDetection off), the event is
+   * always sent as an in-app toast — preserving backward-compatible behaviour.
+   */
+  async route(event: NotificationEvent): Promise<void> {
+    if (!this.enabled) {
+      await this.sendInAppToast(event);
+      return;
+    }
+
+    const presence = this.computePresenceState();
+    logger.info(`Routing ${event.type} notification [presence=${presence}]: "${event.title}"`);
+
+    switch (presence) {
+      case 'active':
+        await this.sendInAppToast(event);
+        break;
+
+      case 'idle':
+        await this.sendInAppToast(event);
+        await this.sendBrowserPush(event);
+        break;
+
+      case 'afk':
+        await this.sendDiscordDM(event);
+        break;
+
+      case 'headless':
+        await this.sendDiscordDM(event);
+        break;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private delivery helpers
+  // ---------------------------------------------------------------------------
+
+  /** Persist to NotificationService (and emit notification:created via events). */
+  private async sendInAppToast(event: NotificationEvent): Promise<void> {
+    if (event.projectPath) {
+      try {
+        await this.notificationService.createNotification({
+          type: this.toNotificationType(event.type),
+          title: event.title,
+          message: event.message,
+          featureId: event.featureId,
+          projectPath: event.projectPath,
+        });
+      } catch (error) {
+        logger.error('Failed to create in-app notification:', error);
+      }
+    } else {
+      // No projectPath: emit a lightweight event so connected WebSocket clients
+      // still receive the toast without persisting to disk.
+      this.events.emit('notification:created', {
+        type: this.toNotificationType(event.type),
+        title: event.title,
+        message: event.message,
+        featureId: event.featureId,
+      });
+    }
+  }
+
+  /** Emit a push notification request for the browser push API handler. */
+  private sendBrowserPush(event: NotificationEvent): void {
+    // notification:push-requested is handled by the WebSocket layer to trigger
+    // the browser's Push API on connected clients.
+    this.events.emit('notification:push-requested' as EventType, {
+      title: event.title,
+      message: event.message,
+      type: event.type,
+      featureId: event.featureId,
+      projectPath: event.projectPath,
+    });
+  }
+
+  /** Send a Discord DM to all configured recipients. */
+  private async sendDiscordDM(event: NotificationEvent): Promise<void> {
+    const bot = this.discordBot;
+    if (!bot || !bot.isConnected() || this.discordRecipients.length === 0) {
+      logger.warn(
+        'Discord DM unavailable (bot not connected or no recipients configured), ' +
+          'falling back to in-app toast'
+      );
+      await this.sendInAppToast(event);
+      return;
+    }
+
+    const message = this.formatDiscordMessage(event);
+
+    await Promise.all(
+      this.discordRecipients.map(async (username) => {
+        try {
+          const sent = await bot.sendDM(username, message);
+          if (sent) {
+            logger.info(`Discord DM sent to @${username}: "${event.title}"`);
+          } else {
+            logger.error(`Discord DM failed (bot returned false) for @${username}`);
+          }
+        } catch (error) {
+          logger.error(`Discord DM error for @${username}:`, error);
+        }
+      })
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Event subscriptions
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Subscribe to relevant system events and route them as notifications.
+   *
+   * Subscriptions:
+   *   feature:completed     → completion notification
+   *   feature:error         → failure notification
+   *   hitl:form-requested   → HITL / human-input-required notification
+   */
+  private subscribeToEvents(): void {
+    this.events.subscribe((type, payload) => {
+      if (type === 'feature:completed') {
+        const data = payload as {
+          featureId?: string;
+          featureTitle?: string;
+          projectPath?: string;
+        };
+        void this.route({
+          type: 'completion',
+          title: 'Feature Completed',
+          message: data.featureTitle
+            ? `"${data.featureTitle}" completed successfully.`
+            : 'A feature completed successfully.',
+          featureId: data.featureId,
+          projectPath: data.projectPath,
+        });
+      } else if (type === 'feature:error') {
+        const data = payload as {
+          featureId?: string;
+          featureTitle?: string;
+          projectPath?: string;
+          error?: string;
+        };
+        void this.route({
+          type: 'failure',
+          title: 'Feature Failed',
+          message: data.featureTitle
+            ? `"${data.featureTitle}" encountered an error.`
+            : `Feature failed: ${data.error ?? 'unknown error'}`,
+          featureId: data.featureId,
+          projectPath: data.projectPath,
+        });
+      } else if (type === 'hitl:form-requested') {
+        const data = payload as {
+          featureId?: string;
+          projectPath?: string;
+          title?: string;
+        };
+        void this.route({
+          type: 'hitl',
+          title: 'Human Input Required',
+          message: data.title ?? 'An agent is waiting for your input.',
+          featureId: data.featureId,
+          projectPath: data.projectPath,
+        });
+      }
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Utilities
+  // ---------------------------------------------------------------------------
+
+  /** Format a Discord DM message for the given notification event. */
+  private formatDiscordMessage(event: NotificationEvent): string {
+    const emoji = event.type === 'completion' ? '✅' : event.type === 'failure' ? '❌' : '⚠️';
+    let message = `${emoji} **${event.title}**\n${event.message}`;
+    if (event.featureId) {
+      message += `\n_Feature: \`${event.featureId}\`_`;
+    }
+    return message;
+  }
+
+  /** Map a NotificationEvent type to the closest NotificationType. */
+  private toNotificationType(type: NotificationEvent['type']): NotificationType {
+    switch (type) {
+      case 'completion':
+        return 'agent_complete';
+      case 'failure':
+        return 'agent_complete';
+      case 'hitl':
+        return 'feature_waiting_approval';
+      default:
+        return 'agent_complete';
+    }
+  }
+}


### PR DESCRIPTION
## Summary

**Milestone:** Ava Integration + Notification Routing

Create apps/server/src/services/notification-router.ts: reads UserPresenceState from ContextAggregator and routes feature completion/failure/HITL events: active -> in-app toast only, idle -> toast + browser push, afk -> Discord DM, headless -> Discord DM only. Wire into agent completion events in AgentService. Also add get_presence_state tool to apps/server/src/routes/chat/ava-tools.ts in the boardRead tool group — returns current UserPresen...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic user presence detection to monitor activity status (active, idle, away, offline).
  * Implemented presence-aware notification routing: delivers in-app notifications to active users, browser push to idle users, and Discord messages to away/offline users.
  * Added Discord DM integration for notifications with automatic fallback to in-app delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->