### PR TITLE
Migrate dashboard, welcome, calendar, settings, and remaining views

### DIFF
--- a/apps/ui/src/components/layout/bottom-panel/events-tab.tsx
+++ b/apps/ui/src/components/layout/bottom-panel/events-tab.tsx
@@ -34,18 +34,18 @@ function classifyService(eventType: string): string {
 }
 
 const SERVICE_COLORS: Record<string, string> = {
-  features: 'text-amber-400',
-  agents: 'text-violet-400',
-  'auto-mode': 'text-blue-400',
-  'pr-feedback': 'text-emerald-400',
-  github: 'text-zinc-300',
-  linear: 'text-indigo-400',
-  discord: 'text-purple-400',
-  'signal-intake': 'text-orange-400',
-  projects: 'text-pink-400',
-  'lead-engineer': 'text-rose-400',
-  content: 'text-teal-400',
-  system: 'text-zinc-400',
+  features: 'text-status-warning',
+  agents: 'text-brand-400',
+  'auto-mode': 'text-primary',
+  'pr-feedback': 'text-status-success',
+  github: 'text-foreground-secondary',
+  linear: 'text-chart-5',
+  discord: 'text-brand-400',
+  'signal-intake': 'text-chart-1',
+  projects: 'text-chart-4',
+  'lead-engineer': 'text-destructive',
+  content: 'text-chart-3',
+  system: 'text-muted-foreground',
 };
 
 const MAX_EVENTS = 200;
@@ -190,8 +190,8 @@ export function EventsTab() {
           </span>
           {!paused && (
             <span className="relative flex h-1.5 w-1.5">
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
-              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-400" />
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-status-success opacity-75" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-status-success" />
             </span>
           )}
         </div>
@@ -201,7 +201,7 @@ export function EventsTab() {
             title={showHistory ? 'Hide server history' : 'Load server history'}
             className={cn(
               'p-1 rounded-md hover:bg-muted/50 text-muted-foreground hover:text-foreground',
-              showHistory && 'text-violet-400'
+              showHistory && 'text-brand-400'
             )}
           >
             <History className="w-3 h-3" />
@@ -224,7 +224,7 @@ export function EventsTab() {
           className={cn(
             'text-[10px] px-1.5 py-0.5 rounded-md shrink-0',
             filter === null
-              ? 'bg-violet-500/15 text-violet-400'
+              ? 'bg-brand-500/15 text-brand-400'
               : 'text-muted-foreground hover:text-foreground'
           )}
         >
@@ -237,7 +237,7 @@ export function EventsTab() {
             className={cn(
               'text-[10px] px-1.5 py-0.5 rounded-md shrink-0',
               filter === svc
-                ? 'bg-violet-500/15 text-violet-400'
+                ? 'bg-brand-500/15 text-brand-400'
                 : 'text-muted-foreground hover:text-foreground'
             )}
           >
@@ -256,7 +256,7 @@ export function EventsTab() {
             className={cn(
               'text-[10px] px-1.5 py-0.5 rounded-md shrink-0',
               timeRange === tr.ms
-                ? 'bg-blue-500/15 text-blue-400'
+                ? 'bg-primary/15 text-primary'
                 : 'text-muted-foreground hover:text-foreground'
             )}
           >
@@ -299,7 +299,7 @@ export function EventsTab() {
               <span
                 className={cn(
                   'text-[10px] font-medium shrink-0 w-20 truncate',
-                  SERVICE_COLORS[event.service] || 'text-zinc-400'
+                  SERVICE_COLORS[event.service] || 'text-muted-foreground'
                 )}
               >
                 {event.service}

--- a/apps/ui/src/components/views/calendar-view/calendar-view.tsx
+++ b/apps/ui/src/components/views/calendar-view/calendar-view.tsx
@@ -31,11 +31,11 @@ const MAX_DOTS_PER_DAY = 3;
 
 /** Color mapping for event types (used when event has no custom color) */
 const EVENT_TYPE_COLORS: Record<CalendarEventType, string> = {
-  feature: 'bg-blue-500',
-  milestone: 'bg-violet-500',
-  custom: 'bg-emerald-500',
-  google: 'bg-red-500',
-  linear: 'bg-indigo-500',
+  feature: 'bg-chart-1',
+  milestone: 'bg-chart-2',
+  custom: 'bg-chart-3',
+  google: 'bg-chart-4',
+  linear: 'bg-chart-5',
 };
 
 /** Human-readable labels for event types */

--- a/apps/ui/src/components/views/dashboard-view.tsx
+++ b/apps/ui/src/components/views/dashboard-view.tsx
@@ -656,15 +656,15 @@ export function DashboardView() {
 
                 {/* Open Project Card */}
                 <div
-                  className="group relative rounded-xl border border-border bg-card/80 backdrop-blur-sm hover:bg-card hover:border-blue-500/30 hover:shadow-xl hover:shadow-blue-500/5 transition-all duration-300 cursor-pointer hover:-translate-y-1"
+                  className="group relative rounded-xl border border-border bg-card/80 backdrop-blur-sm hover:bg-card hover:border-primary/30 hover:shadow-xl hover:shadow-primary/5 transition-all duration-300 cursor-pointer hover:-translate-y-1"
                   onClick={handleOpenProject}
                   data-testid="open-project-card"
                 >
-                  <div className="absolute inset-0 rounded-xl bg-linear-to-br from-blue-500/5 via-transparent to-cyan-600/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+                  <div className="absolute inset-0 rounded-xl bg-linear-to-br from-primary/5 via-transparent to-primary/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                   <div className="relative p-4 sm:p-6 h-full flex flex-col">
                     <div className="flex items-start gap-3 sm:gap-4 flex-1">
-                      <div className="w-10 h-10 sm:w-12 sm:h-12 rounded-xl bg-muted border border-border flex items-center justify-center group-hover:bg-blue-500/10 group-hover:border-blue-500/30 group-hover:scale-105 transition-all duration-300 shrink-0">
-                        <FolderOpen className="w-5 h-5 sm:w-6 sm:h-6 text-muted-foreground group-hover:text-blue-500 transition-colors duration-300" />
+                      <div className="w-10 h-10 sm:w-12 sm:h-12 rounded-xl bg-muted border border-border flex items-center justify-center group-hover:bg-primary/10 group-hover:border-primary/30 group-hover:scale-105 transition-all duration-300 shrink-0">
+                        <FolderOpen className="w-5 h-5 sm:w-6 sm:h-6 text-muted-foreground group-hover:text-primary transition-colors duration-300" />
                       </div>
                       <div className="flex-1 min-w-0">
                         <h3 className="text-lg font-semibold text-foreground mb-1.5">
@@ -677,7 +677,7 @@ export function DashboardView() {
                     </div>
                     <Button
                       variant="secondary"
-                      className="w-full mt-4 sm:mt-5 bg-secondary/80 hover:bg-secondary text-foreground border border-border hover:border-blue-500/30 transition-all"
+                      className="w-full mt-4 sm:mt-5 bg-secondary/80 hover:bg-secondary text-foreground border border-border hover:border-primary/30 transition-all"
                       data-testid="open-existing-project"
                     >
                       <FolderOpen className="w-4 h-4 mr-2" />
@@ -748,8 +748,8 @@ export function DashboardView() {
               {favoriteProjects.length > 0 && (
                 <div>
                   <div className="flex items-center gap-2 sm:gap-2.5 mb-3 sm:mb-4">
-                    <div className="w-7 h-7 sm:w-8 sm:h-8 rounded-lg bg-yellow-500/10 flex items-center justify-center">
-                      <Star className="w-3.5 h-3.5 sm:w-4 sm:h-4 text-yellow-500 fill-yellow-500" />
+                    <div className="w-7 h-7 sm:w-8 sm:h-8 rounded-lg bg-status-warning/10 flex items-center justify-center">
+                      <Star className="w-3.5 h-3.5 sm:w-4 sm:h-4 text-status-warning fill-status-warning" />
                     </div>
                     <h3 className="text-base sm:text-lg font-semibold text-foreground">
                       Favorites
@@ -759,14 +759,14 @@ export function DashboardView() {
                     {favoriteProjects.map((project) => (
                       <div
                         key={project.id}
-                        className="group relative rounded-xl border border-yellow-500/30 bg-card/60 backdrop-blur-sm hover:bg-card hover:border-yellow-500/50 hover:shadow-lg hover:shadow-yellow-500/5 transition-all duration-300 cursor-pointer hover:-translate-y-0.5"
+                        className="group relative rounded-xl border border-status-warning/30 bg-card/60 backdrop-blur-sm hover:bg-card hover:border-status-warning/50 hover:shadow-lg hover:shadow-status-warning/5 transition-all duration-300 cursor-pointer hover:-translate-y-0.5"
                         onClick={() => handleProjectClick(project)}
                         data-testid={`project-card-${project.id}`}
                       >
-                        <div className="absolute inset-0 rounded-xl bg-linear-to-br from-yellow-500/5 to-amber-600/5 opacity-0 group-hover:opacity-100 transition-all duration-300" />
+                        <div className="absolute inset-0 rounded-xl bg-linear-to-br from-status-warning/5 to-status-warning/5 opacity-0 group-hover:opacity-100 transition-all duration-300" />
                         <div className="relative p-3 sm:p-4">
                           <div className="flex items-start gap-2.5 sm:gap-3">
-                            <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-lg bg-yellow-500/10 border border-yellow-500/30 flex items-center justify-center group-hover:bg-yellow-500/20 transition-all duration-300 shrink-0 overflow-hidden">
+                            <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-lg bg-status-warning/10 border border-status-warning/30 flex items-center justify-center group-hover:bg-status-warning/20 transition-all duration-300 shrink-0 overflow-hidden">
                               {project.customIconPath ? (
                                 <img
                                   src={getAuthenticatedImageUrl(
@@ -780,13 +780,13 @@ export function DashboardView() {
                                 (() => {
                                   const IconComponent = getIconComponent(project.icon);
                                   return (
-                                    <IconComponent className="w-4 h-4 sm:w-5 sm:h-5 text-yellow-500" />
+                                    <IconComponent className="w-4 h-4 sm:w-5 sm:h-5 text-status-warning" />
                                   );
                                 })()
                               )}
                             </div>
                             <div className="flex-1 min-w-0">
-                              <p className="text-sm sm:text-base font-medium text-foreground truncate group-hover:text-yellow-500 transition-colors duration-300">
+                              <p className="text-sm sm:text-base font-medium text-foreground truncate group-hover:text-status-warning transition-colors duration-300">
                                 {project.name}
                               </p>
                               <p className="text-xs text-muted-foreground/70 truncate mt-0.5 sm:mt-1">
@@ -801,10 +801,10 @@ export function DashboardView() {
                             <div className="flex items-center gap-0.5 sm:gap-1">
                               <button
                                 onClick={(e) => handleToggleFavorite(e, project.id)}
-                                className="p-1 sm:p-1.5 rounded-lg hover:bg-yellow-500/20 transition-colors"
+                                className="p-1 sm:p-1.5 rounded-lg hover:bg-status-warning/20 transition-colors"
                                 title="Remove from favorites"
                               >
-                                <Star className="w-3.5 h-3.5 sm:w-4 sm:h-4 text-yellow-500 fill-yellow-500" />
+                                <Star className="w-3.5 h-3.5 sm:w-4 sm:h-4 text-status-warning fill-status-warning" />
                               </button>
                               <DropdownMenu>
                                 <DropdownMenuTrigger asChild>
@@ -895,7 +895,7 @@ export function DashboardView() {
                                 className="p-1 sm:p-1.5 rounded-lg hover:bg-muted transition-colors"
                                 title="Add to favorites"
                               >
-                                <Star className="w-3.5 h-3.5 sm:w-4 sm:h-4 text-muted-foreground/50 hover:text-yellow-500 transition-colors" />
+                                <Star className="w-3.5 h-3.5 sm:w-4 sm:h-4 text-muted-foreground/50 hover:text-status-warning transition-colors" />
                               </button>
                               <DropdownMenu>
                                 <DropdownMenuTrigger asChild>

--- a/apps/ui/src/components/views/file-editor-view/file-tree.tsx
+++ b/apps/ui/src/components/views/file-editor-view/file-tree.tsx
@@ -37,15 +37,15 @@ function getGitStatusColor(status: FileStatus | undefined): string {
   switch (code) {
     case 'A':
     case '?':
-      return 'text-green-500';
+      return 'text-status-success';
     case 'D':
-      return 'text-red-500';
+      return 'text-destructive';
     case 'M':
     case 'U':
-      return 'text-amber-500';
+      return 'text-status-warning';
     case 'R':
     case 'C':
-      return 'text-blue-400';
+      return 'text-primary';
     default:
       return '';
   }
@@ -127,9 +127,9 @@ function TreeNode({ entry, projectPath, gitStatusMap, depth }: TreeNodeProps) {
             <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
           )}
           {isExpanded ? (
-            <FolderOpen className="size-3.5 shrink-0 text-sky-400" />
+            <FolderOpen className="size-3.5 shrink-0 text-primary" />
           ) : (
-            <Folder className="size-3.5 shrink-0 text-sky-500" />
+            <Folder className="size-3.5 shrink-0 text-primary" />
           )}
           <span className="truncate">{entry.name}</span>
         </button>

--- a/apps/ui/src/components/views/settings-view/integrations/integration-config-dialog.tsx
+++ b/apps/ui/src/components/views/settings-view/integrations/integration-config-dialog.tsx
@@ -194,7 +194,7 @@ export function IntegrationConfigDialog({
           <div className="space-y-6 py-2">
             {Object.entries(groupedFields).map(([group, fields]) => (
               <div key={group} className="space-y-3">
-                <h4 className="text-xs font-medium text-zinc-500 uppercase tracking-wider">
+                <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
                   {group}
                 </h4>
                 <div className="space-y-3">
@@ -224,7 +224,7 @@ export function IntegrationConfigDialog({
           </div>
         )}
 
-        {saveError && <p className="text-sm text-red-600 dark:text-red-400">{saveError}</p>}
+        {saveError && <p className="text-sm text-destructive">{saveError}</p>}
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
@@ -304,32 +304,33 @@ function SignalSourcesSection({
 
   return (
     <div className="space-y-3">
-      <h4 className="text-xs font-medium text-zinc-500 uppercase tracking-wider">Signal Sources</h4>
+      <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+        Signal Sources
+      </h4>
 
       {loading ? (
         <div className="flex items-center justify-center py-4">
           <Spinner />
         </div>
       ) : channels.length === 0 && !showAddForm ? (
-        <p className="text-xs text-zinc-400 dark:text-zinc-500">
+        <p className="text-xs text-muted-foreground">
           No channels monitored. Add a Discord channel to start receiving signals.
         </p>
       ) : (
         <div className="space-y-2">
           {channels.map((channel, index) => (
-            <div
-              key={channel.channelId}
-              className="rounded-md border border-zinc-200 dark:border-zinc-700 p-3 space-y-2"
-            >
+            <div key={channel.channelId} className="rounded-md border border-border p-3 space-y-2">
               <div className="flex items-center justify-between gap-2">
                 <div className="min-w-0">
                   <p className="text-sm font-medium truncate">{channel.channelName}</p>
-                  <p className="text-xs text-zinc-400 truncate font-mono">{channel.channelId}</p>
+                  <p className="text-xs text-muted-foreground truncate font-mono">
+                    {channel.channelId}
+                  </p>
                 </div>
                 <button
                   type="button"
                   onClick={() => removeChannel(index)}
-                  className="shrink-0 text-zinc-400 hover:text-red-500 transition-colors"
+                  className="shrink-0 text-muted-foreground hover:text-destructive transition-colors"
                   aria-label="Remove channel"
                 >
                   <Trash2 className="w-4 h-4" />
@@ -338,7 +339,7 @@ function SignalSourcesSection({
 
               <div className="grid grid-cols-2 gap-2">
                 <div className="space-y-1">
-                  <Label className="text-xs text-zinc-500">Intent override</Label>
+                  <Label className="text-xs text-muted-foreground">Intent override</Label>
                   <Select
                     value={channel.intentOverride ?? 'auto'}
                     onValueChange={(v) =>
@@ -361,7 +362,7 @@ function SignalSourcesSection({
                 </div>
 
                 <div className="space-y-1">
-                  <Label className="text-xs text-zinc-500">Auto-feature</Label>
+                  <Label className="text-xs text-muted-foreground">Auto-feature</Label>
                   <div className="flex items-center h-8">
                     <Switch
                       checked={channel.autoFeature}
@@ -372,7 +373,7 @@ function SignalSourcesSection({
               </div>
 
               <div className="flex items-center justify-between">
-                <Label className="text-xs text-zinc-500">Enabled</Label>
+                <Label className="text-xs text-muted-foreground">Enabled</Label>
                 <Switch
                   checked={channel.enabled}
                   onCheckedChange={(v) => updateChannel(index, { enabled: v })}
@@ -384,7 +385,7 @@ function SignalSourcesSection({
       )}
 
       {showAddForm ? (
-        <div className="rounded-md border border-zinc-200 dark:border-zinc-700 p-3 space-y-2">
+        <div className="rounded-md border border-border p-3 space-y-2">
           <div className="space-y-1.5">
             <Label className="text-xs">Channel ID</Label>
             <Input
@@ -469,7 +470,9 @@ function DiscordProfileSection() {
   return (
     <>
       <div className="space-y-3">
-        <h4 className="text-xs font-medium text-zinc-500 uppercase tracking-wider">Bot Identity</h4>
+        <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          Bot Identity
+        </h4>
         <div className="space-y-1.5">
           <Label className="text-sm">Discord username</Label>
           <Input
@@ -487,7 +490,7 @@ function DiscordProfileSection() {
       </div>
 
       <div className="space-y-3">
-        <h4 className="text-xs font-medium text-zinc-500 uppercase tracking-wider">
+        <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
           Notification Channels
         </h4>
         <div className="space-y-3">
@@ -585,7 +588,7 @@ function DiscordProfileSection() {
       </div>
 
       <div className="space-y-3">
-        <h4 className="text-xs font-medium text-zinc-500 uppercase tracking-wider">
+        <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
           Trusted Users
         </h4>
         <div className="space-y-1.5">
@@ -596,7 +599,7 @@ function DiscordProfileSection() {
             onBlur={() => saveAllowedUsers()}
             placeholder="username1, username2"
           />
-          <p className="text-xs text-zinc-500">
+          <p className="text-xs text-muted-foreground">
             These users can interact with agents and trigger reaction abilities.
           </p>
         </div>
@@ -629,7 +632,7 @@ function FieldRenderer({
           <div>
             <Label className="text-sm">{field.label}</Label>
             {field.description && (
-              <p className="text-xs text-zinc-500 mt-0.5">{field.description}</p>
+              <p className="text-xs text-muted-foreground mt-0.5">{field.description}</p>
             )}
           </div>
           <Switch checked={!!value} onCheckedChange={(v) => onChange(v)} />
@@ -640,7 +643,9 @@ function FieldRenderer({
       return (
         <div className="space-y-1.5">
           <Label className="text-sm">{field.label}</Label>
-          {field.description && <p className="text-xs text-zinc-500">{field.description}</p>}
+          {field.description && (
+            <p className="text-xs text-muted-foreground">{field.description}</p>
+          )}
           <div className="relative">
             <Input
               type={revealed ? 'text' : 'password'}
@@ -652,7 +657,7 @@ function FieldRenderer({
             <button
               type="button"
               onClick={onToggleReveal}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
             >
               {revealed ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
             </button>
@@ -664,7 +669,9 @@ function FieldRenderer({
       return (
         <div className="space-y-1.5">
           <Label className="text-sm">{field.label}</Label>
-          {field.description && <p className="text-xs text-zinc-500">{field.description}</p>}
+          {field.description && (
+            <p className="text-xs text-muted-foreground">{field.description}</p>
+          )}
           <Input
             type="number"
             value={value !== undefined ? String(value) : ''}
@@ -681,7 +688,9 @@ function FieldRenderer({
       return (
         <div className="space-y-1.5">
           <Label className="text-sm">{field.label}</Label>
-          {field.description && <p className="text-xs text-zinc-500">{field.description}</p>}
+          {field.description && (
+            <p className="text-xs text-muted-foreground">{field.description}</p>
+          )}
           <Select value={(value as string) ?? ''} onValueChange={(v) => onChange(v)}>
             <SelectTrigger>
               <SelectValue placeholder={field.placeholder ?? 'Select...'} />
@@ -703,7 +712,9 @@ function FieldRenderer({
       return (
         <div className="space-y-1.5">
           <Label className="text-sm">{field.label}</Label>
-          {field.description && <p className="text-xs text-zinc-500">{field.description}</p>}
+          {field.description && (
+            <p className="text-xs text-muted-foreground">{field.description}</p>
+          )}
           <Input
             type={field.type === 'url' ? 'url' : 'text'}
             value={(value as string) ?? ''}

--- a/apps/ui/src/components/views/welcome-view.tsx
+++ b/apps/ui/src/components/views/welcome-view.tsx
@@ -598,15 +598,15 @@ export function WelcomeView() {
 
             {/* Open Project Card */}
             <div
-              className="group relative rounded-xl border border-border bg-card/80 backdrop-blur-sm hover:bg-card hover:border-blue-500/30 hover:shadow-xl hover:shadow-blue-500/5 transition-all duration-300 cursor-pointer hover:-translate-y-1"
+              className="group relative rounded-xl border border-border bg-card/80 backdrop-blur-sm hover:bg-card hover:border-primary/30 hover:shadow-xl hover:shadow-primary/5 transition-all duration-300 cursor-pointer hover:-translate-y-1"
               onClick={handleOpenProject}
               data-testid="open-project-card"
             >
-              <div className="absolute inset-0 rounded-xl bg-linear-to-br from-blue-500/5 via-transparent to-cyan-600/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+              <div className="absolute inset-0 rounded-xl bg-linear-to-br from-primary/5 via-transparent to-primary/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
               <div className="relative p-6 h-full flex flex-col">
                 <div className="flex items-start gap-4 flex-1">
-                  <div className="w-12 h-12 rounded-xl bg-muted border border-border flex items-center justify-center group-hover:bg-blue-500/10 group-hover:border-blue-500/30 group-hover:scale-105 transition-all duration-300 shrink-0">
-                    <FolderOpen className="w-6 h-6 text-muted-foreground group-hover:text-blue-500 transition-colors duration-300" />
+                  <div className="w-12 h-12 rounded-xl bg-muted border border-border flex items-center justify-center group-hover:bg-primary/10 group-hover:border-primary/30 group-hover:scale-105 transition-all duration-300 shrink-0">
+                    <FolderOpen className="w-6 h-6 text-muted-foreground group-hover:text-primary transition-colors duration-300" />
                   </div>
                   <div className="flex-1 min-w-0">
                     <h3 className="text-lg font-semibold text-foreground mb-1.5">Open Project</h3>
@@ -617,7 +617,7 @@ export function WelcomeView() {
                 </div>
                 <Button
                   variant="secondary"
-                  className="w-full mt-5 bg-secondary/80 hover:bg-secondary text-foreground border border-border hover:border-blue-500/30 transition-all"
+                  className="w-full mt-5 bg-secondary/80 hover:bg-secondary text-foreground border border-border hover:border-primary/30 transition-all"
                   data-testid="open-existing-project"
                 >
                   <FolderOpen className="w-4 h-4 mr-2" />
@@ -725,7 +725,7 @@ export function WelcomeView() {
                     key={file}
                     className="flex items-center gap-2.5 text-sm text-muted-foreground"
                   >
-                    <div className="w-2 h-2 rounded-full bg-green-500" />
+                    <div className="w-2 h-2 rounded-full bg-status-success" />
                     <code className="text-xs bg-muted px-2.5 py-1 rounded-md font-mono">
                       {file}
                     </code>


### PR DESCRIPTION
## Summary

**Milestone:** Semantic Color Migration

Replace raw palette colors in view-level components:

**Files:**
- `apps/ui/src/components/views/dashboard-view.tsx` — hover:border-blue-500/30, bg-blue-500/10, border-yellow-500/30, bg-yellow-500/10
- `apps/ui/src/components/views/welcome-view.tsx` — hover:border-blue-500/30, bg-blue-500/10
- `apps/ui/src/components/views/calendar-view/calendar-view.tsx` — bg-blue-500, bg-violet-500, bg-emerald-500, bg-red-500, bg-indigo-500 category colors
- `apps/ui/sr...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refreshed color tokens and styling across the app: dashboard cards, event indicators, calendar dots, file tree icons, welcome/open-project cards, and settings dialogs.
  * Standardized status and interactive states (success, warning, destructive, primary/brand) for service labels, filters, time-range buttons, status dots, favorites, and hover/active effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->