### PR TITLE
Replace inline hardcoded colors in flow-graph, analytics, and renderers

### DIFF
--- a/apps/ui/src/components/shared/json-syntax-editor.tsx
+++ b/apps/ui/src/components/shared/json-syntax-editor.tsx
@@ -64,7 +64,7 @@ const editorTheme = EditorView.theme({
     borderLeftColor: 'var(--primary)',
   },
   '&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection': {
-    backgroundColor: 'oklch(0.55 0.25 265 / 0.3)',
+    backgroundColor: 'var(--editor-selection-bg)',
   },
   '.cm-activeLine': {
     backgroundColor: 'var(--accent)',

--- a/apps/ui/src/components/shared/shell-syntax-editor.tsx
+++ b/apps/ui/src/components/shared/shell-syntax-editor.tsx
@@ -67,7 +67,7 @@ const editorTheme = EditorView.theme({
     borderLeftColor: 'var(--primary)',
   },
   '&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection': {
-    backgroundColor: 'oklch(0.55 0.25 265 / 0.3)',
+    backgroundColor: 'var(--editor-selection-bg)',
   },
   '.cm-activeLine': {
     backgroundColor: 'transparent',

--- a/apps/ui/src/components/views/analytics-view/cost-panel.tsx
+++ b/apps/ui/src/components/views/analytics-view/cost-panel.tsx
@@ -9,12 +9,18 @@ interface CostPanelProps {
 }
 
 const MODEL_COLORS: Record<string, string> = {
-  sonnet: '#8b5cf6',
-  opus: '#f59e0b',
-  haiku: '#10b981',
+  sonnet: 'var(--chart-4)',
+  opus: 'var(--chart-1)',
+  haiku: 'var(--chart-2)',
 };
 
-const FALLBACK_COLORS = ['#6366f1', '#ec4899', '#06b6d4', '#f97316', '#84cc16'];
+const FALLBACK_COLORS = [
+  'var(--chart-1)',
+  'var(--chart-5)',
+  'var(--chart-2)',
+  'var(--chart-3)',
+  'var(--chart-4)',
+];
 
 function getModelColor(model: string, index: number): string {
   const key = model.toLowerCase();

--- a/apps/ui/src/components/views/designs-view/renderer/pen-node-renderer.tsx
+++ b/apps/ui/src/components/views/designs-view/renderer/pen-node-renderer.tsx
@@ -36,7 +36,7 @@ export function PenNodeRenderer({ node }: PenNodeRendererProps) {
   // Wrapper style for selection outline
   const wrapperStyle = isSelected
     ? {
-        outline: '2px solid #3b82f6',
+        outline: '2px solid var(--pen-node-selection-outline)',
         outlineOffset: '2px',
       }
     : undefined;
@@ -68,8 +68,8 @@ export function PenNodeRenderer({ node }: PenNodeRendererProps) {
           onClick={handleClick}
           style={{
             padding: '8px',
-            background: '#f0f0f0',
-            border: '1px dashed #ccc',
+            background: 'var(--pen-node-placeholder-bg)',
+            border: '1px dashed var(--pen-node-placeholder-border)',
             borderRadius: '4px',
             ...wrapperStyle,
           }}

--- a/apps/ui/src/components/views/designs-view/renderer/pen-ref-renderer.tsx
+++ b/apps/ui/src/components/views/designs-view/renderer/pen-ref-renderer.tsx
@@ -50,10 +50,10 @@ export function PenRefRenderer({ node, onClick, style: externalStyle }: PenRefRe
       <div
         style={{
           padding: '8px',
-          background: '#fff3cd',
-          border: '1px dashed #ffc107',
+          background: 'var(--pen-ref-missing-bg)',
+          border: '1px dashed var(--pen-ref-missing-border)',
           borderRadius: '4px',
-          color: '#856404',
+          color: 'var(--pen-ref-missing-text)',
           ...externalStyle,
         }}
         data-node-id={node.id}

--- a/apps/ui/src/components/views/flow-graph/edges/flow-edge.tsx
+++ b/apps/ui/src/components/views/flow-graph/edges/flow-edge.tsx
@@ -36,7 +36,9 @@ function FlowEdgeComponent({
 
   const edgeData = data as FlowEdgeData | undefined;
   const isConditional = edgeData?.isConditional ?? false;
-  const strokeColor = isConditional ? 'oklch(0.65 0.18 40)' : 'oklch(0.65 0.2 290)';
+  const strokeColor = isConditional
+    ? 'var(--flow-edge-conditional-color)'
+    : 'var(--flow-edge-standard-color)';
 
   return (
     <>

--- a/apps/ui/src/components/views/flow-graph/flow-graph-canvas.tsx
+++ b/apps/ui/src/components/views/flow-graph/flow-graph-canvas.tsx
@@ -91,7 +91,7 @@ export function FlowGraphCanvas({
           variant={BackgroundVariant.Dots}
           gap={24}
           size={1}
-          color="oklch(0.4 0 0 / 0.15)"
+          color="var(--flow-canvas-dot-color)"
         />
         <Controls
           showInteractive={false}

--- a/apps/ui/src/components/views/flow-graph/flow-graph-legend.tsx
+++ b/apps/ui/src/components/views/flow-graph/flow-graph-legend.tsx
@@ -23,7 +23,7 @@ const EDGE_LEGEND = [
           y1="4"
           x2="28"
           y2="4"
-          stroke="oklch(0.65 0.2 290 / 0.5)"
+          stroke="var(--flow-edge-delegation-color)"
           strokeWidth="1.5"
           strokeDasharray="4 3"
         />
@@ -34,8 +34,15 @@ const EDGE_LEGEND = [
     label: 'Workflow',
     render: () => (
       <svg width="28" height="8" className="shrink-0">
-        <line x1="0" y1="4" x2="28" y2="4" stroke="oklch(0.6 0.18 275 / 0.5)" strokeWidth="1.5" />
-        <circle r="2.5" fill="oklch(0.7 0.2 275)" opacity={0.8}>
+        <line
+          x1="0"
+          y1="4"
+          x2="28"
+          y2="4"
+          stroke="var(--flow-edge-workflow-color)"
+          strokeWidth="1.5"
+        />
+        <circle r="2.5" fill="var(--flow-edge-workflow-dot)" opacity={0.8}>
           <animateMotion dur="1.5s" repeatCount="indefinite" path="M0,4 L28,4" />
         </circle>
       </svg>
@@ -45,7 +52,14 @@ const EDGE_LEGEND = [
     label: 'Integration',
     render: () => (
       <svg width="28" height="8" className="shrink-0">
-        <line x1="0" y1="4" x2="28" y2="4" stroke="oklch(0.7 0.17 155 / 0.5)" strokeWidth="1" />
+        <line
+          x1="0"
+          y1="4"
+          x2="28"
+          y2="4"
+          stroke="var(--flow-edge-integration-color)"
+          strokeWidth="1"
+        />
       </svg>
     ),
   },
@@ -58,7 +72,7 @@ const EDGE_LEGEND = [
           y1="4"
           x2="28"
           y2="4"
-          stroke="oklch(0.65 0.15 250 / 0.4)"
+          stroke="var(--flow-edge-pipeline-color)"
           strokeWidth="1"
           strokeDasharray="2 2"
         />

--- a/apps/ui/src/components/views/flow-graph/panels/flow-detail-panel.tsx
+++ b/apps/ui/src/components/views/flow-graph/panels/flow-detail-panel.tsx
@@ -106,11 +106,17 @@ export function FlowDetailPanel({ graphId, featureId, onClose }: FlowDetailPanel
         style: {
           ...node.style,
           opacity: isCompleted ? 0.5 : 1,
-          backgroundColor: isActive ? '#8b5cf6' : isCompleted ? '#22c55e' : '#3f3f46',
+          backgroundColor: isActive
+            ? 'var(--flow-node-active-bg)'
+            : isCompleted
+              ? 'var(--flow-node-completed-bg)'
+              : 'var(--flow-node-pending-bg)',
           color: 'white',
-          borderColor: isActive ? '#a78bfa' : '#52525b',
+          borderColor: isActive
+            ? 'var(--flow-node-active-border)'
+            : 'var(--flow-node-pending-border)',
           borderWidth: isActive ? 2 : 1,
-          boxShadow: isActive ? '0 0 20px rgba(139, 92, 246, 0.5)' : undefined,
+          boxShadow: isActive ? '0 0 20px var(--flow-node-active-shadow)' : undefined,
         },
       };
     });
@@ -233,7 +239,7 @@ export function FlowDetailPanel({ graphId, featureId, onClose }: FlowDetailPanel
               >
                 <div className="flex flex-col gap-2">
                   <div className="flex items-center gap-2">
-                    <div className="w-3 h-3 rounded-full bg-violet-600 border-2 border-violet-400 shadow-[0_0_10px_rgba(139,92,246,0.5)]" />
+                    <div className="w-3 h-3 rounded-full bg-violet-600 border-2 border-violet-400 shadow-[0_0_10px_var(--flow-node-active-shadow)]" />
                     <span className="text-muted-foreground">Active</span>
                   </div>
                   <div className="flex items-center gap-2">

--- a/apps/ui/src/styles/global.css
+++ b/apps/ui/src/styles/global.css
@@ -35,6 +35,37 @@
   :root {
     /* Fallback to 100vh when not set by JS (desktop or unsupported browsers) */
     --visual-viewport-height: 100vh;
+
+    /* Flow graph node state tokens */
+    --flow-node-active-bg: oklch(0.55 0.25 290);
+    --flow-node-completed-bg: oklch(0.62 0.2 145);
+    --flow-node-pending-bg: oklch(0.37 0 0);
+    --flow-node-active-border: oklch(0.67 0.21 290);
+    --flow-node-pending-border: oklch(0.45 0 0);
+    --flow-node-active-shadow: oklch(0.55 0.2 290 / 0.5);
+
+    /* Flow graph edge color tokens */
+    --flow-edge-delegation-color: oklch(0.65 0.2 290 / 0.5);
+    --flow-edge-workflow-color: oklch(0.6 0.18 275 / 0.5);
+    --flow-edge-workflow-dot: oklch(0.7 0.2 275);
+    --flow-edge-integration-color: oklch(0.7 0.17 155 / 0.5);
+    --flow-edge-pipeline-color: oklch(0.65 0.15 250 / 0.4);
+    --flow-edge-conditional-color: oklch(0.65 0.18 40);
+    --flow-edge-standard-color: oklch(0.65 0.2 290);
+
+    /* Flow canvas background token */
+    --flow-canvas-dot-color: oklch(0.4 0 0 / 0.15);
+
+    /* Code editor selection token */
+    --editor-selection-bg: oklch(0.55 0.25 265 / 0.3);
+
+    /* Pen renderer placeholder/state tokens */
+    --pen-ref-missing-bg: oklch(0.97 0.05 85);
+    --pen-ref-missing-border: oklch(0.78 0.15 80);
+    --pen-ref-missing-text: oklch(0.5 0.12 75);
+    --pen-node-placeholder-bg: oklch(0.95 0 0);
+    --pen-node-placeholder-border: oklch(0.8 0 0);
+    --pen-node-selection-outline: oklch(0.6 0.2 245);
   }
 
   /* Apply monospace font to code elements */


### PR DESCRIPTION
## Summary

**Milestone:** Hardcoded Color Values

Replace hardcoded color values with CSS custom properties:

**Flow graph files (highest density):**
- `flow-detail-panel.tsx` — inline backgroundColor/borderColor/boxShadow with hex/rgba -> CSS vars
- `flow-edge.tsx` — inline oklch() stroke colors -> CSS vars
- `flow-graph-legend.tsx` — SVG stroke/fill oklch() literals -> CSS vars
- `flow-graph-canvas.tsx` — inline oklch() grid color -> CSS var
- `pipeline-progress-bar.tsx` — raw violet/amber/zinc palette -...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Unified color styling across editors, flow visualization components, and design renderers to use centralized theme tokens
  * Enhanced theming infrastructure to support improved visual consistency across the interface and enable easier customization of colors throughout the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->