### PR TITLE
ask ava chat window doesn't focus on open

### DIFF
--- a/apps/ui/src/components/layout/chat-modal.tsx
+++ b/apps/ui/src/components/layout/chat-modal.tsx
@@ -30,6 +30,10 @@ export function ChatModal() {
       <DialogContent
         showCloseButton={false}
         className="max-w-2xl h-[70vh] p-0 gap-0 overflow-hidden"
+        onOpenAutoFocus={(e: Event) => {
+          e.preventDefault();
+          document.querySelector<HTMLTextAreaElement>('[data-slot="chat-input"] textarea')?.focus();
+        }}
       >
         <DialogTitle className="sr-only">Ava Chat</DialogTitle>
         <ChatOverlayContent {...chatSession} onHide={handleClose} isModal />

--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-view.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-view.tsx
@@ -42,6 +42,9 @@ export function ChatOverlayView() {
     const cleanup = bridge.onOverlayDidShow(() => {
       isHidingRef.current = false;
       setAnimClass('animate-in slide-in-from-top-2 fade-in duration-200');
+      requestAnimationFrame(() => {
+        document.querySelector<HTMLTextAreaElement>('[data-slot="chat-input"] textarea')?.focus();
+      });
     });
     return cleanup;
   }, []);


### PR DESCRIPTION
## Summary

it should focus input on open and after chatting to keep the conversation flowing and user in the chat
**Source:** Linear issue 64b1a4f6-0710-4c88-933f-69bfda6b2645
**Team:** ProtoLabsAI

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced chat input focus handling—the chat input field now automatically receives focus when the chat modal or overlay opens, enabling users to start typing immediately without an additional click.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->