### PR TITLE
cant adjust concurrent agents

### DIFF
--- a/apps/server/src/routes/auto-mode/index.ts
+++ b/apps/server/src/routes/auto-mode/index.ts
@@ -39,7 +39,11 @@ export function createAutoModeRoutes(
   router.post('/stop', validatePathParams('projectPath'), createStopHandler(autoModeService));
 
   router.post('/stop-feature', createStopFeatureHandler(autoModeService));
-  router.post('/status', validatePathParams('projectPath?'), createStatusHandler(autoModeService));
+  router.post(
+    '/status',
+    validatePathParams('projectPath?'),
+    createStatusHandler(autoModeService, settingsService)
+  );
   router.post(
     '/run-feature',
     validatePathParams('projectPath'),

--- a/apps/server/src/routes/auto-mode/routes/status.ts
+++ b/apps/server/src/routes/auto-mode/routes/status.ts
@@ -7,16 +7,28 @@
 
 import type { Request, Response } from 'express';
 import type { AutoModeService } from '../../../services/auto-mode-service.js';
+import type { SettingsService } from '../../../services/settings-service.js';
 import { MAX_SYSTEM_CONCURRENCY } from '@protolabs-ai/types';
 import { getErrorMessage, logError } from '../common.js';
 
-export function createStatusHandler(autoModeService: AutoModeService) {
+export function createStatusHandler(
+  autoModeService: AutoModeService,
+  settingsService?: SettingsService
+) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
       const { projectPath, branchName } = req.body as {
         projectPath?: string;
         branchName?: string | null;
       };
+
+      // Resolve effective system max concurrency: prefer UI-set value from settings,
+      // fall back to env var value (MAX_SYSTEM_CONCURRENCY)
+      let effectiveSystemMax = MAX_SYSTEM_CONCURRENCY;
+      if (settingsService) {
+        const settings = await settingsService.getGlobalSettings();
+        effectiveSystemMax = settings.systemMaxConcurrency ?? MAX_SYSTEM_CONCURRENCY;
+      }
 
       // If projectPath is provided, return per-project/worktree status
       if (projectPath) {
@@ -33,7 +45,7 @@ export function createStatusHandler(autoModeService: AutoModeService) {
           runningFeatures: projectStatus.runningFeatures,
           runningCount: projectStatus.runningCount,
           maxConcurrency: projectStatus.maxConcurrency,
-          systemMaxConcurrency: MAX_SYSTEM_CONCURRENCY,
+          systemMaxConcurrency: effectiveSystemMax,
           projectPath,
           branchName: normalizedBranchName,
         });
@@ -49,7 +61,7 @@ export function createStatusHandler(autoModeService: AutoModeService) {
         ...status,
         activeAutoLoopProjects: activeProjects,
         activeAutoLoopWorktrees: activeWorktrees,
-        systemMaxConcurrency: MAX_SYSTEM_CONCURRENCY,
+        systemMaxConcurrency: effectiveSystemMax,
       });
     } catch (error) {
       logError(error, 'Get status failed');

--- a/apps/ui/src/components/views/analytics-view.tsx
+++ b/apps/ui/src/components/views/analytics-view.tsx
@@ -3,23 +3,95 @@
  *
  * React Flow system architecture with floating panels.
  * Feature node clicks navigate to the board for editing.
+ * Includes auto-mode controls for starting/stopping concurrent agent execution.
  */
 
 import { useCallback } from 'react';
 import { useNavigate } from '@tanstack/react-router';
+import { useShallow } from 'zustand/react/shallow';
+import { Label } from '@protolabs-ai/ui/atoms';
+import { Switch } from '@protolabs-ai/ui/atoms';
+import { createLogger } from '@protolabs-ai/utils/logger';
+import { DEFAULT_MAX_CONCURRENCY } from '@protolabs-ai/types';
 import { useAppStore } from '@/store/app-store';
+import { useWorktreeStore } from '@/store/worktree-store';
+import { useAutoMode } from '@/hooks/use-auto-mode';
+import { useUpdateGlobalSettings } from '@/hooks/mutations/use-settings-mutations';
 import { FlowGraphView } from './flow-graph';
+import { AutoModeSettingsPopover } from './board-view/dialogs/auto-mode-settings-popover';
+
+const logger = createLogger('AnalyticsView');
 
 export function AnalyticsView() {
-  const currentProject = useAppStore((s) => s.currentProject);
+  const { currentProject, skipVerificationInAutoMode, setSkipVerificationInAutoMode } = useAppStore(
+    useShallow((s) => ({
+      currentProject: s.currentProject,
+      skipVerificationInAutoMode: s.skipVerificationInAutoMode,
+      setSkipVerificationInAutoMode: s.setSkipVerificationInAutoMode,
+    }))
+  );
   const projectPath = currentProject?.path;
   const navigate = useNavigate();
+
+  // Use main worktree auto-mode (no worktree arg = null branchName = main)
+  const autoMode = useAutoMode(undefined);
+  const runningAutoTasks = autoMode.runningTasks;
+  const maxConcurrency = autoMode.maxConcurrency;
+
+  const setMaxConcurrencyForWorktree = useWorktreeStore(
+    (state) => state.setMaxConcurrencyForWorktree
+  );
+  const updateGlobalSettings = useUpdateGlobalSettings({ showSuccessToast: false });
 
   const handleFeatureClick = useCallback(
     (featureId: string) => {
       navigate({ to: '/board', search: { featureId } });
     },
     [navigate]
+  );
+
+  const handleConcurrencyChange = useCallback(
+    (newMaxConcurrency: number) => {
+      if (!currentProject) return;
+      setMaxConcurrencyForWorktree(currentProject.id, null, newMaxConcurrency);
+      const worktreeKey = `${currentProject.id}::__main__`;
+      const currentAutoMode = useWorktreeStore.getState().autoModeByWorktree;
+      const persistedAutoMode: Record<
+        string,
+        { maxConcurrency: number; branchName: string | null }
+      > = {};
+      for (const [key, value] of Object.entries(currentAutoMode)) {
+        persistedAutoMode[key] = {
+          maxConcurrency: value.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
+          branchName: value.branchName,
+        };
+      }
+      persistedAutoMode[worktreeKey] = { maxConcurrency: newMaxConcurrency, branchName: null };
+      updateGlobalSettings.mutate({ autoModeByWorktree: persistedAutoMode });
+      if (autoMode.isRunning) {
+        autoMode.stop().then(() => {
+          autoMode.start().catch((error) => {
+            logger.error('[AutoMode] Failed to restart with new concurrency:', error);
+          });
+        });
+      }
+    },
+    [currentProject, setMaxConcurrencyForWorktree, updateGlobalSettings, autoMode]
+  );
+
+  const handleAutoModeToggle = useCallback(
+    (enabled: boolean) => {
+      if (enabled) {
+        autoMode.start().catch((error) => {
+          logger.error('[AutoMode] Failed to start:', error);
+        });
+      } else {
+        autoMode.stop().catch((error) => {
+          logger.error('[AutoMode] Failed to stop:', error);
+        });
+      }
+    },
+    [autoMode]
   );
 
   if (!currentProject) {
@@ -30,5 +102,43 @@ export function AnalyticsView() {
     );
   }
 
-  return <FlowGraphView projectPath={projectPath} onFeatureClick={handleFeatureClick} />;
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Auto-mode controls toolbar */}
+      <div className="flex items-center gap-3 px-4 py-2 border-b border-border/50 bg-card/50 shrink-0">
+        <div className="flex items-center gap-2">
+          <Label
+            htmlFor="analytics-auto-mode-toggle"
+            className="text-xs font-medium cursor-pointer whitespace-nowrap"
+          >
+            Auto Mode
+          </Label>
+          <span
+            className="text-[10px] font-medium text-muted-foreground bg-muted/60 px-1.5 py-0.5 rounded"
+            title="Max concurrent agents"
+          >
+            {maxConcurrency}
+          </span>
+          <Switch
+            id="analytics-auto-mode-toggle"
+            checked={autoMode.isRunning}
+            onCheckedChange={handleAutoModeToggle}
+            data-testid="analytics-auto-mode-toggle"
+          />
+          <AutoModeSettingsPopover
+            skipVerificationInAutoMode={skipVerificationInAutoMode}
+            onSkipVerificationChange={setSkipVerificationInAutoMode}
+            maxConcurrency={maxConcurrency}
+            runningAgentsCount={runningAutoTasks.length}
+            onConcurrencyChange={handleConcurrencyChange}
+          />
+        </div>
+      </div>
+
+      {/* Flow graph */}
+      <div className="flex-1 overflow-hidden">
+        <FlowGraphView projectPath={projectPath} onFeatureClick={handleFeatureClick} />
+      </div>
+    </div>
+  );
 }

--- a/apps/ui/src/components/views/board-view/dialogs/auto-mode-settings-popover.tsx
+++ b/apps/ui/src/components/views/board-view/dialogs/auto-mode-settings-popover.tsx
@@ -146,8 +146,8 @@ export function AutoModeSettingsPopover({
               <div className="flex items-start gap-1.5 text-[10px] text-amber-500">
                 <AlertTriangle className="w-3 h-3 shrink-0 mt-0.5" />
                 <span>
-                  System limit: {systemMaxConcurrency} concurrent agents. Set{' '}
-                  AUTOMAKER_MAX_CONCURRENCY to increase.
+                  System limit: {systemMaxConcurrency} concurrent agents. Increase in Settings
+                  &rsaquo; Defaults.
                 </span>
               </div>
             )}

--- a/apps/ui/src/components/views/settings-view.tsx
+++ b/apps/ui/src/components/views/settings-view.tsx
@@ -68,6 +68,8 @@ export function SettingsView() {
     setDefaultFeatureModel,
     promptCustomization,
     setPromptCustomization,
+    systemMaxConcurrency,
+    setSystemMaxConcurrency,
   } = useAppStore();
   const { skipSandboxWarning, setSkipSandboxWarning } = useAIModelsStore();
   const { theme, setTheme } = useThemeStore();
@@ -157,6 +159,7 @@ export function SettingsView() {
             defaultRequirePlanApproval={defaultRequirePlanApproval}
             enableAiCommitMessages={enableAiCommitMessages}
             defaultFeatureModel={defaultFeatureModel}
+            systemMaxConcurrency={systemMaxConcurrency}
             onDefaultSkipTestsChange={setDefaultSkipTests}
             onEnableDependencyBlockingChange={setEnableDependencyBlocking}
             onSkipVerificationInAutoModeChange={setSkipVerificationInAutoMode}
@@ -164,6 +167,7 @@ export function SettingsView() {
             onDefaultRequirePlanApprovalChange={setDefaultRequirePlanApproval}
             onEnableAiCommitMessagesChange={setEnableAiCommitMessages}
             onDefaultFeatureModelChange={setDefaultFeatureModel}
+            onSystemMaxConcurrencyChange={setSystemMaxConcurrency}
           />
         );
       case 'worktrees':

--- a/apps/ui/src/components/views/settings-view/feature-defaults/feature-defaults-section.tsx
+++ b/apps/ui/src/components/views/settings-view/feature-defaults/feature-defaults-section.tsx
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
 import { Label } from '@protolabs-ai/ui/atoms';
 import { Checkbox } from '@protolabs-ai/ui/atoms';
+import { Slider } from '@protolabs-ai/ui/atoms';
 import {
   FlaskConical,
   TestTube,
@@ -16,8 +16,6 @@ import {
   Gauge,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { getElectronAPI } from '@/lib/electron';
-import { queryKeys } from '@/lib/query-keys';
 import {
   Select,
   SelectContent,
@@ -38,6 +36,7 @@ interface FeatureDefaultsSectionProps {
   defaultRequirePlanApproval: boolean;
   enableAiCommitMessages: boolean;
   defaultFeatureModel: PhaseModelEntry;
+  systemMaxConcurrency: number;
   onDefaultSkipTestsChange: (value: boolean) => void;
   onEnableDependencyBlockingChange: (value: boolean) => void;
   onSkipVerificationInAutoModeChange: (value: boolean) => void;
@@ -45,6 +44,7 @@ interface FeatureDefaultsSectionProps {
   onDefaultRequirePlanApprovalChange: (value: boolean) => void;
   onEnableAiCommitMessagesChange: (value: boolean) => void;
   onDefaultFeatureModelChange: (value: PhaseModelEntry) => void;
+  onSystemMaxConcurrencyChange: (value: number) => void;
 }
 
 export function FeatureDefaultsSection({
@@ -55,6 +55,7 @@ export function FeatureDefaultsSection({
   defaultRequirePlanApproval,
   enableAiCommitMessages,
   defaultFeatureModel,
+  systemMaxConcurrency,
   onDefaultSkipTestsChange,
   onEnableDependencyBlockingChange,
   onSkipVerificationInAutoModeChange,
@@ -62,22 +63,8 @@ export function FeatureDefaultsSection({
   onDefaultRequirePlanApprovalChange,
   onEnableAiCommitMessagesChange,
   onDefaultFeatureModelChange,
+  onSystemMaxConcurrencyChange,
 }: FeatureDefaultsSectionProps) {
-  // Fetch global auto-mode status to display the server-side concurrency cap
-  const { data: autoModeStatusData } = useQuery({
-    queryKey: ['autoMode', 'status', undefined],
-    queryFn: async () => {
-      const api = getElectronAPI();
-      return api.autoMode?.status(undefined, null);
-    },
-    staleTime: 60_000,
-    refetchOnWindowFocus: false,
-  });
-
-  const systemMaxConcurrency: number =
-    ((autoModeStatusData as Record<string, unknown> | undefined)?.systemMaxConcurrency as number) ??
-    null;
-
   return (
     <div
       className={cn(
@@ -337,27 +324,35 @@ export function FeatureDefaultsSection({
         {/* Separator */}
         <div className="border-t border-border/30" />
 
-        {/* System Concurrency Limit (read-only) */}
-        <div className="group flex items-start space-x-3 p-3 rounded-lg -mx-3">
-          <div className="w-10 h-10 mt-0.5 rounded-lg flex items-center justify-center shrink-0 bg-muted/40">
-            <Gauge className="w-5 h-5 text-muted-foreground" />
+        {/* System Concurrency Limit (editable) */}
+        <div className="group flex items-start space-x-3 p-3 rounded-xl hover:bg-accent/30 transition-colors duration-200 -mx-3">
+          <div className="w-10 h-10 mt-0.5 rounded-xl flex items-center justify-center shrink-0 bg-brand-500/10">
+            <Gauge className="w-5 h-5 text-brand-500" />
           </div>
-          <div className="flex-1 space-y-1.5">
+          <div className="flex-1 space-y-2">
             <div className="flex items-center justify-between">
               <Label className="text-foreground font-medium">System Concurrency Limit</Label>
               <span
-                className="text-xs font-semibold tabular-nums px-2 py-0.5 rounded bg-muted/50 text-muted-foreground"
+                className="text-xs font-semibold tabular-nums px-2 py-0.5 rounded bg-muted/50 text-foreground"
                 data-testid="system-max-concurrency-value"
               >
-                {systemMaxConcurrency !== null ? systemMaxConcurrency : '--'}
+                {systemMaxConcurrency}
               </span>
             </div>
+            <div className="flex items-center gap-3">
+              <Slider
+                value={[systemMaxConcurrency]}
+                onValueChange={(value) => onSystemMaxConcurrencyChange(value[0])}
+                min={1}
+                max={20}
+                step={1}
+                className="flex-1"
+                data-testid="system-max-concurrency-slider"
+              />
+            </div>
             <p className="text-xs text-muted-foreground/80 leading-relaxed">
-              Maximum concurrent agents allowed system-wide. Set by the{' '}
-              <code className="font-mono text-[11px] bg-muted/60 px-1 py-0.5 rounded">
-                AUTOMAKER_MAX_CONCURRENCY
-              </code>{' '}
-              environment variable. Read-only — restart the server to apply changes.
+              Maximum concurrent agents allowed system-wide. This caps the per-project concurrency
+              slider. Higher values allow more parallel work but use more API resources.
             </p>
           </div>
         </div>

--- a/apps/ui/src/hooks/use-settings-sync.ts
+++ b/apps/ui/src/hooks/use-settings-sync.ts
@@ -49,6 +49,7 @@ const SETTINGS_FIELDS_TO_SYNC = [
   'openTerminalMode', // Maps to terminalState.openTerminalMode
   'sidebarOpen',
   'maxConcurrency',
+  'systemMaxConcurrency',
   'autoModeByWorktree', // Per-worktree auto mode settings (only maxConcurrency is persisted)
   'defaultSkipTests',
   'enableDependencyBlocking',
@@ -800,6 +801,7 @@ export async function refreshSettingsFromServer(): Promise<boolean> {
       defaultSkipTests: serverSettings.defaultSkipTests,
       enableDependencyBlocking: serverSettings.enableDependencyBlocking,
       skipVerificationInAutoMode: serverSettings.skipVerificationInAutoMode,
+      systemMaxConcurrency: serverSettings.systemMaxConcurrency ?? 10,
       defaultPlanningMode: serverSettings.defaultPlanningMode,
       defaultRequirePlanApproval: serverSettings.defaultRequirePlanApproval,
       defaultFeatureModel: serverSettings.defaultFeatureModel

--- a/apps/ui/src/store/app-store.ts
+++ b/apps/ui/src/store/app-store.ts
@@ -78,6 +78,7 @@ export interface AppState {
   enableDependencyBlocking: boolean; // When true, show blocked badges and warnings for features with incomplete dependencies (default: true)
   skipVerificationInAutoMode: boolean; // When true, auto-mode grabs features even if dependencies are not verified (only checks they're not running)
   enableAiCommitMessages: boolean; // When true, auto-generate commit messages using AI when opening commit dialog
+  systemMaxConcurrency: number; // User-configurable system-wide maximum concurrent agents (default: 10)
   planUseSelectedWorktreeBranch: boolean; // When true, Plan dialog creates features on the currently selected worktree branch
   addFeatureUseSelectedWorktreeBranch: boolean; // When true, Add Feature dialog defaults to custom mode with selected worktree branch
 
@@ -227,6 +228,7 @@ export interface AppActions {
   setEnableDependencyBlocking: (enabled: boolean) => void;
   setSkipVerificationInAutoMode: (enabled: boolean) => Promise<void>;
   setEnableAiCommitMessages: (enabled: boolean) => Promise<void>;
+  setSystemMaxConcurrency: (max: number) => void;
   setPlanUseSelectedWorktreeBranch: (enabled: boolean) => Promise<void>;
   setAddFeatureUseSelectedWorktreeBranch: (enabled: boolean) => Promise<void>;
 
@@ -334,6 +336,7 @@ const initialState: AppState = {
   enableDependencyBlocking: true, // Default to enabled (show dependency blocking UI)
   skipVerificationInAutoMode: false, // Default to disabled (require dependencies to be verified)
   enableAiCommitMessages: true, // Default to enabled (auto-generate commit messages)
+  systemMaxConcurrency: 10, // Default to 10 concurrent agents (user-configurable)
   planUseSelectedWorktreeBranch: true, // Default to enabled (Plan creates features on selected worktree branch)
   addFeatureUseSelectedWorktreeBranch: false, // Default to disabled (Add Feature uses normal defaults)
   keyboardShortcuts: DEFAULT_KEYBOARD_SHORTCUTS, // Default keyboard shortcuts
@@ -988,6 +991,7 @@ export const useAppStore = create<AppState & AppActions>()((set, get) => ({
   // Feature Default Settings actions
   setDefaultSkipTests: (skip) => set({ defaultSkipTests: skip }),
   setEnableDependencyBlocking: (enabled) => set({ enableDependencyBlocking: enabled }),
+  setSystemMaxConcurrency: (max) => set({ systemMaxConcurrency: max }),
   setSkipVerificationInAutoMode: async (enabled) => {
     set({ skipVerificationInAutoMode: enabled });
     // Sync to server settings file

--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -274,6 +274,8 @@ export interface GlobalSettings {
   // Feature Generation Defaults
   /** Max features to generate concurrently */
   maxConcurrency: number;
+  /** User-configurable system-wide maximum concurrent agents (overrides env var default) */
+  systemMaxConcurrency?: number;
   /** Default: skip tests during feature generation */
   defaultSkipTests: boolean;
   /** Default: enable dependency blocking */
@@ -661,6 +663,7 @@ export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
   theme: 'dark',
   sidebarOpen: true,
   maxConcurrency: DEFAULT_MAX_CONCURRENCY,
+  systemMaxConcurrency: 10,
   defaultSkipTests: true,
   enableDependencyBlocking: true,
   skipVerificationInAutoMode: false,


### PR DESCRIPTION
## Summary

count is stuck and im not sure if the api works, need to remove from envvar reliance and into ui. also need to add the automode and trigger to the analytics page
**Source:** Linear issue 94ba7471-3e64-4a52-bab1-0e866a703b3c
**Team:** ProtoLabsAI

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-mode controls added to Analytics view (toggle, toolbar, start/stop).
  * Per-project and global max-concurrency can be adjusted and persisted.

* **Improvements**
  * System concurrency limit is configurable via an editable slider in Settings (default 10).
  * Concurrency changes persist, sync with the server, and restart auto-mode when active.
  * Updated wording when system limit is reached to point to Settings » Defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->