### PR TITLE
Message Branch Navigation (response variants)

### DIFF
--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
@@ -11,7 +11,8 @@
  * require value/onChange props to be threaded through the tree.
  */
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import type { UIMessage } from 'ai';
 import { History, X, Settings, ChevronUp, ChevronDown, SquarePen, ListOrdered } from 'lucide-react';
 import {
   ChatMessageList,
@@ -20,6 +21,7 @@ import {
   PromptInputProvider,
   QueueView,
   type QueueItem,
+  type BranchInfo,
 } from '@protolabs-ai/ui/ai';
 import { Button } from '@protolabs-ai/ui/atoms';
 import { Popover, PopoverContent, PopoverTrigger } from '@protolabs-ai/ui/atoms';
@@ -73,6 +75,15 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
   const [queueOpen, setQueueOpen] = useState(false);
   const [queuePaused, setQueuePaused] = useState(false);
 
+  // Branch state — tracks multiple response variants per assistant message.
+  // branchMap key: the ID of the first (original) assistant message variant.
+  // branchMap value: all variants in order (original first, newest last).
+  const [branchMap, setBranchMap] = useState<Map<string, UIMessage[]>>(new Map());
+  const [currentBranchIndex, setCurrentBranchIndex] = useState<Map<string, number>>(new Map());
+  // Set to the origId when a regeneration is in-flight, cleared when the new
+  // assistant message arrives and is added to the branch list.
+  const pendingBranchFor = useRef<string | null>(null);
+
   const suggestions = useContextualSuggestions(features ?? []);
 
   // onSubmit receives the trimmed text from ChatInput (via PromptInputProvider).
@@ -98,17 +109,130 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
     getOverlayAPI()?.resizeOverlay?.(next ? OVERLAY_HEIGHT_EXPANDED : OVERLAY_HEIGHT_DEFAULT);
   }, [expanded]);
 
-  // Regenerate: re-send the last user message text
+  // Regenerate: push the current last assistant response as a branch variant,
+  // then re-send the last user message to generate a new response.
   const handleRegenerate = useCallback(() => {
+    const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant');
     const lastUserMsg = [...messages].reverse().find((m) => m.role === 'user');
-    if (lastUserMsg) {
-      const text = (lastUserMsg.parts ?? [])
-        .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
-        .map((p) => p.text)
-        .join('');
-      if (text) sendMessage({ text });
-    }
+    if (!lastAssistant || !lastUserMsg) return;
+
+    const origId = lastAssistant.id;
+
+    // Register the current response as the first branch (if not already tracked)
+    setBranchMap((prev) => {
+      if (prev.has(origId)) return prev;
+      const next = new Map(prev);
+      next.set(origId, [lastAssistant]);
+      return next;
+    });
+    setCurrentBranchIndex((prev) => {
+      if (prev.has(origId)) return prev;
+      const next = new Map(prev);
+      next.set(origId, 0);
+      return next;
+    });
+
+    // Mark that the next completed assistant message should be added to this branch
+    pendingBranchFor.current = origId;
+
+    // Re-send the last user message
+    const text = (lastUserMsg.parts ?? [])
+      .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+      .map((p) => p.text)
+      .join('');
+    if (text) sendMessage({ text });
   }, [messages, sendMessage]);
+
+  // Detect when a regenerated response has finished streaming and add it to
+  // the appropriate branch list.
+  useEffect(() => {
+    if (!pendingBranchFor.current || isStreaming) return;
+
+    const origId = pendingBranchFor.current;
+    const currentBranches = branchMap.get(origId) ?? [];
+    const knownIds = new Set(currentBranches.map((b) => b.id));
+
+    const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant');
+    if (!lastAssistant || knownIds.has(lastAssistant.id)) return;
+
+    // New finished assistant message — add as latest branch and focus it
+    const newBranches = [...currentBranches, lastAssistant];
+    setBranchMap((prev) => {
+      const next = new Map(prev);
+      next.set(origId, newBranches);
+      return next;
+    });
+    setCurrentBranchIndex((prev) => {
+      const next = new Map(prev);
+      next.set(origId, newBranches.length - 1);
+      return next;
+    });
+    pendingBranchFor.current = null;
+  }, [messages, isStreaming, branchMap]);
+
+  // Clear branch state when starting a new chat session
+  useEffect(() => {
+    setBranchMap(new Map());
+    setCurrentBranchIndex(new Map());
+    pendingBranchFor.current = null;
+  }, [currentSessionId]);
+
+  // Navigate to the previous branch variant for a given message
+  const handlePreviousBranch = useCallback((origId: string) => {
+    setCurrentBranchIndex((prev) => {
+      const idx = prev.get(origId) ?? 0;
+      if (idx <= 0) return prev;
+      const next = new Map(prev);
+      next.set(origId, idx - 1);
+      return next;
+    });
+  }, []);
+
+  // Navigate to the next branch variant for a given message
+  const handleNextBranch = useCallback(
+    (origId: string) => {
+      setCurrentBranchIndex((prev) => {
+        const variants = branchMap.get(origId);
+        const idx = prev.get(origId) ?? 0;
+        if (!variants || idx >= variants.length - 1) return prev;
+        const next = new Map(prev);
+        next.set(origId, idx + 1);
+        return next;
+      });
+    },
+    [branchMap]
+  );
+
+  // Compute displayed messages — substitute branch variants at branch positions
+  // and trim the re-sent user+assistant pairs that accumulate after regenerations.
+  const displayedMessages = useMemo<UIMessage[]>(() => {
+    if (branchMap.size === 0) return messages;
+
+    let result = [...messages];
+    // Process each branch point (typically just one at a time in practice)
+    for (const [origId, variants] of branchMap) {
+      const idx = currentBranchIndex.get(origId) ?? variants.length - 1;
+      const origPos = result.findIndex((m) => m.id === origId);
+      if (origPos === -1) continue;
+      // Replace from the original position onwards with the selected variant
+      result = [...result.slice(0, origPos), variants[idx]];
+    }
+    return result;
+  }, [messages, branchMap, currentBranchIndex]);
+
+  // Build branchInfoMap for ChatMessageList — maps each displayed variant's ID
+  // to its branch navigation context so ChatMessage can show the nav bar.
+  const branchInfoMap = useMemo<Map<string, BranchInfo>>(() => {
+    const map = new Map<string, BranchInfo>();
+    for (const [origId, variants] of branchMap) {
+      const idx = currentBranchIndex.get(origId) ?? variants.length - 1;
+      // Tag all variants so the currently displayed one gets nav props
+      for (let i = 0; i < variants.length; i++) {
+        map.set(variants[i].id, { branchIndex: idx, branchCount: variants.length, origId });
+      }
+    }
+    return map;
+  }, [branchMap, currentBranchIndex]);
 
   // Thumbs up/down — no-op placeholders; wire to telemetry or feedback API as needed
   const handleThumbsUp = useCallback(() => {
@@ -264,16 +388,19 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
         {/* Chat area */}
         <div className="flex min-w-0 flex-1 flex-col">
           <ChatMessageList
-            messages={messages}
+            messages={displayedMessages}
             emptyMessage="Ask Ava anything..."
             isStreaming={isStreaming}
             onRegenerate={handleRegenerate}
             onThumbsUp={handleThumbsUp}
             onThumbsDown={handleThumbsDown}
+            branchInfoMap={branchInfoMap}
+            onPreviousBranch={handlePreviousBranch}
+            onNextBranch={handleNextBranch}
           />
 
           {/* Contextual suggestions — shown only when no messages in current session */}
-          {messages.length === 0 && (
+          {displayedMessages.length === 0 && (
             <SuggestionList suggestions={suggestions} onSelect={handleSuggestionSelect} />
           )}
 

--- a/libs/ui/src/ai/chat-message-list.tsx
+++ b/libs/ui/src/ai/chat-message-list.tsx
@@ -20,6 +20,13 @@ import { Button } from '../atoms/button.js';
 import { ChatMessage } from './chat-message.js';
 import { ShimmerLoader } from './shimmer.js';
 
+/** Per-message branch info keyed by message ID. */
+export interface BranchInfo {
+  branchIndex: number;
+  branchCount: number;
+  origId: string;
+}
+
 export function ChatMessageList({
   messages,
   emptyMessage = 'Start a conversation...',
@@ -28,6 +35,9 @@ export function ChatMessageList({
   onRegenerate,
   onThumbsUp,
   onThumbsDown,
+  branchInfoMap,
+  onPreviousBranch,
+  onNextBranch,
 }: {
   messages: UIMessage[];
   emptyMessage?: string;
@@ -40,6 +50,12 @@ export function ChatMessageList({
   onThumbsUp?: () => void;
   /** Called when the user clicks Thumbs Down on an assistant message. */
   onThumbsDown?: () => void;
+  /** Branch info keyed by message ID — provided by the parent managing branch state. */
+  branchInfoMap?: Map<string, BranchInfo>;
+  /** Called with the origId when the user navigates to the previous branch. */
+  onPreviousBranch?: (origId: string) => void;
+  /** Called with the origId when the user navigates to the next branch. */
+  onNextBranch?: (origId: string) => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -152,15 +168,24 @@ export function ChatMessageList({
               <p className="text-sm text-muted-foreground">{emptyMessage}</p>
             </div>
           ) : (
-            messages.map((message) => (
-              <ChatMessage
-                key={message.id}
-                message={message}
-                onRegenerate={onRegenerate}
-                onThumbsUp={onThumbsUp}
-                onThumbsDown={onThumbsDown}
-              />
-            ))
+            messages.map((message) => {
+              const branchInfo = branchInfoMap?.get(message.id);
+              return (
+                <ChatMessage
+                  key={message.id}
+                  message={message}
+                  onRegenerate={onRegenerate}
+                  onThumbsUp={onThumbsUp}
+                  onThumbsDown={onThumbsDown}
+                  branchIndex={branchInfo?.branchIndex}
+                  branchCount={branchInfo?.branchCount}
+                  onPreviousBranch={
+                    branchInfo ? () => onPreviousBranch?.(branchInfo.origId) : undefined
+                  }
+                  onNextBranch={branchInfo ? () => onNextBranch?.(branchInfo.origId) : undefined}
+                />
+              );
+            })
           )}
           {showShimmer && <ShimmerLoader />}
         </div>

--- a/libs/ui/src/ai/chat-message.tsx
+++ b/libs/ui/src/ai/chat-message.tsx
@@ -29,6 +29,7 @@ import { MessageSources } from './message-sources.js';
 import type { Citation } from './inline-citation.js';
 import { AILoader } from './loader.js';
 import { MessageActions } from './message-actions.js';
+import { MessageBranches } from './message-branches.js';
 import { PlanPart, extractPlanData, type PlanData } from './plan-part.js';
 
 const messageVariants = cva('flex gap-3 px-4 py-2', {
@@ -340,6 +341,10 @@ export function ChatMessage({
   onRegenerate,
   onThumbsUp,
   onThumbsDown,
+  branchIndex,
+  branchCount,
+  onPreviousBranch,
+  onNextBranch,
 }: {
   message: UIMessage;
   className?: string;
@@ -353,6 +358,14 @@ export function ChatMessage({
   onThumbsUp?: () => void;
   /** Called when the user clicks Thumbs Down on an assistant message. */
   onThumbsDown?: () => void;
+  /** Zero-based index of the currently shown branch variant (for assistant messages). */
+  branchIndex?: number;
+  /** Total number of branch variants. When > 1, MessageBranches nav renders. */
+  branchCount?: number;
+  /** Called when the user clicks the Previous branch chevron. */
+  onPreviousBranch?: () => void;
+  /** Called when the user clicks the Next branch chevron. */
+  onNextBranch?: () => void;
 } & Partial<VariantProps<typeof messageVariants>>) {
   const role = message.role as MessageRole;
   const parts = message.parts ?? [];
@@ -464,14 +477,26 @@ export function ChatMessage({
                 {groupIdx === stepGroups.length - 1 && <MessageSources citations={citations} />}
               </ChatMessageBubble>
 
-              {/* MessageActions toolbar — assistant bubbles only */}
+              {/* MessageActions + branch navigation — assistant bubbles only */}
               {role === 'assistant' && (
-                <MessageActions
-                  text={bubbleText}
-                  onRegenerate={onRegenerate}
-                  onFeedback={onFeedback}
-                  className="mt-0.5 ml-1"
-                />
+                <div className="mt-0.5 ml-1 flex items-center gap-1">
+                  <MessageActions
+                    text={bubbleText}
+                    onRegenerate={onRegenerate}
+                    onFeedback={onFeedback}
+                  />
+                  {branchCount !== undefined &&
+                    branchCount > 1 &&
+                    onPreviousBranch &&
+                    onNextBranch && (
+                      <MessageBranches
+                        branchIndex={branchIndex ?? 0}
+                        branchCount={branchCount}
+                        onPrevious={onPreviousBranch}
+                        onNext={onNextBranch}
+                      />
+                    )}
+                </div>
               )}
             </div>
           </div>

--- a/libs/ui/src/ai/index.ts
+++ b/libs/ui/src/ai/index.ts
@@ -25,7 +25,7 @@ export { ChatMessageMarkdown, type ChatMessageMarkdownProps } from './chat-messa
 
 export { CodeBlock, type CodeBlockProps } from './code-block.js';
 
-export { ChatMessageList } from './chat-message-list.js';
+export { ChatMessageList, type BranchInfo } from './chat-message-list.js';
 
 export { ChatInput } from './chat-input.js';
 
@@ -58,6 +58,8 @@ export {
   type MessageActionsProps,
   type FeedbackRating,
 } from './message-actions.js';
+
+export { MessageBranches, type MessageBranchesProps } from './message-branches.js';
 
 export { AILoader, type AILoaderProps } from './loader.js';
 

--- a/libs/ui/src/ai/message-branches.tsx
+++ b/libs/ui/src/ai/message-branches.tsx
@@ -1,0 +1,64 @@
+/**
+ * MessageBranches — Compact branch navigation bar for assistant messages.
+ *
+ * Renders a "< 2/3 >" nav bar when an assistant message has multiple branch
+ * variants (e.g., from repeated regenerations). Renders nothing when
+ * branchCount <= 1, so callers can always mount this component safely.
+ */
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { cn } from '../lib/utils.js';
+import { Button } from '../atoms/button.js';
+
+export interface MessageBranchesProps {
+  /** Zero-based index of the currently displayed branch. */
+  branchIndex: number;
+  /** Total number of branch variants. Component renders null when <= 1. */
+  branchCount: number;
+  /** Called when the user clicks the Previous (left) chevron. */
+  onPrevious: () => void;
+  /** Called when the user clicks the Next (right) chevron. */
+  onNext: () => void;
+  className?: string;
+}
+
+export function MessageBranches({
+  branchIndex,
+  branchCount,
+  onPrevious,
+  onNext,
+  className,
+}: MessageBranchesProps) {
+  if (branchCount <= 1) return null;
+
+  return (
+    <div
+      data-slot="message-branches"
+      className={cn('flex items-center gap-0.5 text-xs text-muted-foreground', className)}
+    >
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={onPrevious}
+        disabled={branchIndex === 0}
+        aria-label="Previous branch"
+        className="size-5"
+      >
+        <ChevronLeft className="size-3" />
+      </Button>
+      <span className="select-none tabular-nums">
+        {branchIndex + 1}/{branchCount}
+      </span>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={onNext}
+        disabled={branchIndex === branchCount - 1}
+        aria-label="Next branch"
+        className="size-5"
+      >
+        <ChevronRight className="size-3" />
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

**Note: Enhanced Model Selector is DONE** (chat-model-select.tsx — Popover+Command combobox with tier badges). Only branch navigation remains.

Create MessageBranches component (libs/ui/src/ai/message-branches.tsx): compact nav bar showing current/total branches with Previous/Next chevron buttons. Only renders when branchCount > 1.

Branch state management in chat-overlay-content.tsx:
- branchMap: Map tracking multiple response variants per messageId
- currentBranchIndex: Map tracking which vari...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branch-based regeneration for assistant messages, allowing generation of multiple response variants.
  * Navigate between variants using Previous and Next controls with position indicators (e.g., "2/3").
  * Branch state automatically resets on new chat sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->