### PR TITLE
fix: show project details inline instead of broken PrdReviewDialog

### DIFF
--- a/apps/ui/src/components/views/projects-view/projects-view.tsx
+++ b/apps/ui/src/components/views/projects-view/projects-view.tsx
@@ -1,12 +1,22 @@
 import { useState, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { FolderKanban, Plus, Loader2, Milestone, Layers } from 'lucide-react';
+import {
+  FolderKanban,
+  Plus,
+  Loader2,
+  Milestone,
+  Layers,
+  ArrowLeft,
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+} from 'lucide-react';
 import { Badge } from '@protolabs-ai/ui/atoms';
 import { Button } from '@protolabs-ai/ui/atoms';
 import { Spinner } from '@protolabs-ai/ui/atoms';
+import Markdown from 'react-markdown';
 import { useAppStore } from '@/store/app-store';
 import { getHttpApiClient } from '@/lib/http-api-client';
-import { PrdReviewDialog } from '@/components/views/flow-graph/dialogs/prd-review-dialog';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 
@@ -23,9 +33,65 @@ const STATUS_COLORS: Record<string, string> = {
 interface ProjectSummary {
   slug: string;
   title: string;
+  goal: string;
   status: string;
-  milestones?: Array<{ title: string; phases: Array<{ title: string; status?: string }> }>;
-  prd?: { situation: string; problem: string; approach: string; results: string };
+  linearProjectUrl?: string;
+  milestones?: Array<{
+    title: string;
+    description: string;
+    status: string;
+    phases: Array<{ title: string; description: string; complexity?: string; status?: string }>;
+  }>;
+  prd?: {
+    situation: string;
+    problem: string;
+    approach: string;
+    results: string;
+    constraints: string;
+  };
+}
+
+const SPARC_SECTIONS = [
+  { key: 'situation', label: 'Situation', color: 'text-blue-400' },
+  { key: 'problem', label: 'Problem', color: 'text-rose-400' },
+  { key: 'approach', label: 'Approach', color: 'text-emerald-400' },
+  { key: 'results', label: 'Results', color: 'text-amber-400' },
+  { key: 'constraints', label: 'Constraints', color: 'text-violet-400' },
+] as const;
+
+function CollapsibleSection({
+  label,
+  color,
+  content,
+  defaultOpen = false,
+}: {
+  label: string;
+  color: string;
+  content: string;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border border-border/20 rounded-lg overflow-hidden">
+      <button
+        type="button"
+        className="flex items-center gap-2 w-full px-3 py-2 text-left hover:bg-muted/30 transition-colors"
+        onClick={() => setOpen(!open)}
+      >
+        {open ? (
+          <ChevronDown className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+        ) : (
+          <ChevronRight className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+        )}
+        <h4 className={`text-xs font-semibold uppercase tracking-wider ${color}`}>{label}</h4>
+      </button>
+      {open && (
+        <div className="px-3 pb-3 prose prose-sm prose-invert max-w-none prose-p:text-foreground/90 prose-headings:text-foreground prose-li:text-foreground/90 prose-strong:text-foreground">
+          <Markdown>{content}</Markdown>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function ProjectsView() {
@@ -104,6 +170,7 @@ export function ProjectsView() {
   }, [newTitle, newDescription, initiateMutation]);
 
   const projects = projectDetails || [];
+  const selectedProject = selectedSlug ? projects.find((p) => p.slug === selectedSlug) : null;
   const isLoading = isLoadingList || isLoadingDetails;
 
   if (!projectPath) {
@@ -114,6 +181,133 @@ export function ProjectsView() {
     );
   }
 
+  // Detail view for selected project
+  if (selectedProject) {
+    const statusClass = STATUS_COLORS[selectedProject.status] || 'bg-muted text-muted-foreground';
+    return (
+      <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+        {/* Detail Header */}
+        <div className="shrink-0 px-6 py-4 border-b border-border/40">
+          <div className="flex items-center gap-3">
+            <Button size="sm" variant="ghost" onClick={() => setSelectedSlug(null)}>
+              <ArrowLeft className="w-4 h-4" />
+            </Button>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <h1 className="text-lg font-semibold text-foreground tracking-tight truncate">
+                  {selectedProject.title}
+                </h1>
+                <Badge
+                  variant="outline"
+                  className={cn('text-[10px] uppercase tracking-wider shrink-0', statusClass)}
+                >
+                  {selectedProject.status}
+                </Badge>
+              </div>
+              <p className="text-xs text-muted-foreground mt-0.5">{selectedProject.slug}</p>
+            </div>
+            {selectedProject.linearProjectUrl && (
+              <a
+                href={selectedProject.linearProjectUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ExternalLink className="w-4 h-4" />
+              </a>
+            )}
+          </div>
+        </div>
+
+        {/* Detail Content */}
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+          {/* Goal */}
+          {selectedProject.goal && (
+            <div>
+              <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1.5">
+                Goal
+              </h3>
+              <p className="text-sm text-foreground/90">{selectedProject.goal}</p>
+            </div>
+          )}
+
+          {/* PRD (SPARC sections) */}
+          {selectedProject.prd && (
+            <div className="space-y-2">
+              <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                PRD
+              </h3>
+              {SPARC_SECTIONS.map(({ key, label, color }) => {
+                const content = selectedProject.prd?.[key as keyof typeof selectedProject.prd];
+                if (!content) return null;
+                return (
+                  <CollapsibleSection
+                    key={key}
+                    label={label}
+                    color={color}
+                    content={content}
+                    defaultOpen={key === 'situation'}
+                  />
+                );
+              })}
+            </div>
+          )}
+
+          {/* Milestones */}
+          {selectedProject.milestones && selectedProject.milestones.length > 0 && (
+            <div className="space-y-2">
+              <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                Milestones
+              </h3>
+              {selectedProject.milestones.map((ms, i) => (
+                <div key={i} className="border border-border/30 rounded-lg overflow-hidden">
+                  <div className="px-3 py-2 bg-muted/20">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium text-foreground">{ms.title}</span>
+                      {ms.status && (
+                        <Badge variant="outline" className="text-[10px]">
+                          {ms.status}
+                        </Badge>
+                      )}
+                    </div>
+                    {ms.description && (
+                      <p className="text-xs text-muted-foreground mt-0.5">{ms.description}</p>
+                    )}
+                  </div>
+                  {ms.phases && ms.phases.length > 0 && (
+                    <div className="divide-y divide-border/20">
+                      {ms.phases.map((phase, j) => (
+                        <div key={j} className="px-3 py-1.5 flex items-center gap-2">
+                          <span className="text-xs text-foreground/80 flex-1">{phase.title}</span>
+                          {phase.complexity && (
+                            <span className="text-[10px] text-muted-foreground">
+                              {phase.complexity}
+                            </span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Empty state — no PRD and no milestones */}
+          {!selectedProject.prd &&
+            (!selectedProject.milestones || selectedProject.milestones.length === 0) && (
+              <div className="text-center py-8">
+                <p className="text-sm text-muted-foreground">
+                  No PRD or milestones yet. Generate a PRD to start planning.
+                </p>
+              </div>
+            )}
+        </div>
+      </div>
+    );
+  }
+
+  // List view
   return (
     <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
       {/* Header */}
@@ -259,17 +453,6 @@ export function ProjectsView() {
           </div>
         )}
       </div>
-
-      {/* PRD Review Dialog */}
-      {selectedSlug && (
-        <PrdReviewDialog
-          open={!!selectedSlug}
-          onOpenChange={(open) => {
-            if (!open) setSelectedSlug(null);
-          }}
-          projectSlug={selectedSlug}
-        />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces `PrdReviewDialog` (which requires structured SPARC PRD data) with an inline detail view
- Shows goal, SPARC sections (when available), and milestones with phases for all projects
- Fixes "No PRD found" error that appeared for most projects (only 7 of 21 have PRD data)

## Test plan
- [ ] Enable Projects feature flag in Settings > Developer
- [ ] Navigate to /projects
- [ ] Click on any project — should show details inline instead of "No PRD found"
- [ ] Projects with PRD data show collapsible SPARC sections
- [ ] Projects without PRD data still show goal and milestones

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced project detail view with expandable content sections, goals, and milestones
  * Added status-based visual styling for better project organization
  * External project link navigation support

* **Improvements**
  * Better handling of empty states and loading conditions
  * Improved text formatting and readability across project details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->