### PR TITLE
Promote dev to staging: kanban spacing

### DIFF
--- a/apps/ui/src/components/views/board-view/components/kanban-column.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-column.tsx
@@ -88,7 +88,7 @@ export const KanbanColumn = memo(function KanbanColumn({
       {/* Column Content */}
       <div
         className={cn(
-          'relative z-10 flex-1 overflow-y-auto p-2',
+          'relative z-10 flex-1 overflow-y-auto p-1.5',
           !disableItemSpacing && 'space-y-2.5',
           hideScrollbar &&
             '[&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]',

--- a/apps/ui/src/components/views/board-view/kanban-board.tsx
+++ b/apps/ui/src/components/views/board-view/kanban-board.tsx
@@ -314,7 +314,7 @@ export function KanbanBoard({
   return (
     <div
       className={cn(
-        'flex-1 overflow-x-auto px-5 pt-4 pb-4 relative',
+        'flex-1 overflow-x-auto px-3 pt-4 pb-4 relative',
         'transition-opacity duration-200',
         className
       )}

--- a/apps/ui/src/hooks/use-responsive-kanban.ts
+++ b/apps/ui/src/hooks/use-responsive-kanban.ts
@@ -15,10 +15,10 @@ export interface ResponsiveKanbanConfig {
  */
 const DEFAULT_CONFIG: ResponsiveKanbanConfig = {
   columnWidth: 288, // 18rem = 288px (w-72)
-  columnMinWidth: 280, // Minimum column width - ensures usability
+  columnMinWidth: 260, // Minimum column width - tighter fit
   columnMaxWidth: Infinity, // No max width - columns scale evenly to fill viewport
-  gap: 20, // gap-5 = 20px
-  padding: 40, // px-5 on both sides = 40px (matches gap between columns)
+  gap: 12, // gap-3 = 12px
+  padding: 24, // px-3 on both sides = 24px
 };
 
 // Sidebar transition duration (matches sidebar.tsx)


### PR DESCRIPTION
## Summary
- Tightened kanban column spacing: gap 20px → 12px, board padding 20px → 12px/side, column content padding 8px → 6px, min column width 280 → 260px
- All values on the standard Tailwind spacing scale (gap-3, px-3, p-1.5)

## Test plan
- [ ] Columns appear tighter with less wasted space between them
- [ ] Cards still render properly with reduced content padding
- [ ] Horizontal scrolling still works when columns hit min width (260px)
- [ ] Responsive behavior correct when sidebar opens/closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the Kanban board layout with refined spacing throughout. Adjusted column widths and minimum dimensions, reduced gaps between columns, and optimized board margins to create a more compact and visually efficient presentation. These improvements provide better space utilization while maintaining optimal usability and readability of your tasks and workflow organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->