### PR TITLE
Promote dev to staging

### DIFF
--- a/apps/ui/src/components/layout/bottom-panel/bottom-panel.tsx
+++ b/apps/ui/src/components/layout/bottom-panel/bottom-panel.tsx
@@ -1,6 +1,8 @@
 import { useAppStore, type Feature } from '@/store/app-store';
+import { useChatStore } from '@/store/chat-store';
 import { useIsMobile } from '@/hooks/use-media-query';
 import { useRunningAgentsCount } from '@/hooks/queries/use-running-agents';
+import { isElectron, getOverlayAPI } from '@/lib/electron';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@protolabs-ai/ui/atoms';
 import {
   Bot,
@@ -13,6 +15,7 @@ import {
   LineChart,
   Radio,
   PanelBottomOpen,
+  MessageCircle,
   X,
 } from 'lucide-react';
 import { ActivityTab } from './activity-tab';
@@ -30,6 +33,9 @@ export function BottomPanel() {
   const toggleBottomPanel = useAppStore((s) => s.toggleBottomPanel);
   const setBottomPanelActiveTab = useAppStore((s) => s.setBottomPanelActiveTab);
   const features = useAppStore((s) => s.features);
+  const avaChat = useAppStore((s) => s.featureFlags.avaChat);
+  const chatModalOpen = useChatStore((s) => s.chatModalOpen);
+  const setChatModalOpen = useChatStore((s) => s.setChatModalOpen);
   const { data: agentCount } = useRunningAgentsCount();
 
   if (isMobile) return null;
@@ -141,6 +147,24 @@ export function BottomPanel() {
 
         {/* Spacer */}
         <div className="flex-1" />
+
+        {/* Ava Chat toggle */}
+        {avaChat && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              if (isElectron()) {
+                getOverlayAPI()?.toggleOverlay?.();
+              } else {
+                setChatModalOpen(!chatModalOpen);
+              }
+            }}
+            className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+            title="Open Ava Chat"
+          >
+            <MessageCircle className="h-3.5 w-3.5" />
+          </button>
+        )}
 
         {/* Panel toggle */}
         <PanelBottomOpen

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -255,7 +255,6 @@ export function Sidebar() {
     hideSpecEditor,
     hideContext,
     hideTerminal,
-    hideChat: !featureFlags.avaChat,
     hideCalendar: !featureFlags.calendar,
     hideDesigns: !featureFlags.designs,
     hideDocs: !featureFlags.docs,

--- a/apps/ui/src/components/layout/sidebar/hooks/use-navigation.ts
+++ b/apps/ui/src/components/layout/sidebar/hooks/use-navigation.ts
@@ -17,7 +17,6 @@ import {
   CalendarDays,
   FolderOpen,
   FolderKanban,
-  MessageCircle,
 } from 'lucide-react';
 import type { NavSection, NavItem } from '../types';
 import type { KeyboardShortcut } from '@/hooks/use-keyboard-shortcuts';
@@ -56,7 +55,6 @@ interface UseNavigationProps {
   hideSpecEditor: boolean;
   hideContext: boolean;
   hideTerminal: boolean;
-  hideChat: boolean;
   hideCalendar: boolean;
   hideDesigns: boolean;
   hideDocs: boolean;
@@ -86,7 +84,6 @@ export function useNavigation({
   hideSpecEditor,
   hideContext,
   hideTerminal,
-  hideChat,
   hideCalendar,
   hideDesigns,
   hideDocs,
@@ -183,14 +180,6 @@ export function useNavigation({
         shortcut: shortcuts.board,
       },
     ];
-
-    if (!hideChat) {
-      projectItems.push({
-        id: 'chat',
-        label: 'Ava Chat',
-        icon: MessageCircle,
-      });
-    }
 
     projectItems.push({
       id: 'notes',
@@ -313,7 +302,6 @@ export function useNavigation({
     shortcuts,
     hideSpecEditor,
     hideContext,
-    hideChat,
     hideTerminal,
     hideCalendar,
     hideDesigns,


### PR DESCRIPTION
## Summary
- Move Ava Chat from sidebar nav to bottom ticker bar (MessageCircle icon, feature-flag gated)

## Test plan
- [ ] Verify Ava Chat no longer appears in sidebar
- [ ] Verify chat icon appears in bottom ticker bar when `avaChat` flag is enabled
- [ ] Verify clicking chat icon opens ChatModal on web / overlay on Electron
- [ ] Verify clicking chat icon does not toggle the bottom panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ava Chat toggle now available in the bottom panel with support for Electron overlay and modal implementations.

* **Refactor**
  * Chat navigation has been restructured and relocated from the sidebar to the bottom panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->