### PR TITLE
promote: staging -> main

### DIFF
--- a/apps/server/src/providers/simple-query-service.ts
+++ b/apps/server/src/providers/simple-query-service.ts
@@ -133,6 +133,7 @@ export async function simpleQuery(options: SimpleQueryOptions): Promise<SimpleQu
   }
 
   let responseText = '';
+  let thinkingText = '';
   let structuredOutput: Record<string, unknown> | undefined;
 
   // Build provider options
@@ -162,11 +163,13 @@ export async function simpleQuery(options: SimpleQueryOptions): Promise<SimpleQu
       throw new Error(errorMessage);
     }
 
-    // Extract text from assistant messages
+    // Extract text and thinking from assistant messages
     if (msg.type === 'assistant' && msg.message?.content) {
       for (const block of msg.message.content) {
         if (block.type === 'text' && block.text) {
           responseText += block.text;
+        } else if (block.type === 'thinking' && block.thinking) {
+          thinkingText += block.thinking;
         }
       }
     }
@@ -189,6 +192,14 @@ export async function simpleQuery(options: SimpleQueryOptions): Promise<SimpleQu
         throw new Error('Could not produce valid structured output after retries');
       }
     }
+  }
+
+  // When extended thinking is active (e.g. Opus), the model may put
+  // substantive content in thinking blocks and return only a brief
+  // summary in text. Use thinking content as fallback when text is
+  // too short to pass downstream validation gates.
+  if (responseText.length < 100 && thinkingText.length > responseText.length) {
+    responseText = thinkingText;
   }
 
   return { text: responseText, structured_output: structuredOutput };


### PR DESCRIPTION
## Summary
- fix: capture thinking blocks in simpleQuery for Opus plan generation

Opus 4.6 extended thinking puts plans in thinking blocks, simpleQuery only captured text blocks causing "plan too short" validation failures.

## Merge strategy
Use **merge commit** (not squash) per branch-strategy.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced response processing to ensure more comprehensive results are delivered when initial responses are incomplete or truncated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->