### PR TITLE
we have many references to `npm run dev:web` throughout our docs and internal references, but its no

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,8 +108,10 @@ See `docs/protolabs/brand.md` for the full brand bible including voice, team, na
 ```bash
 # Development
 npm run dev                 # Interactive launcher (choose web or electron)
-npm run dev:web             # Web browser mode (localhost:3007)
-npm run dev:electron        # Desktop app mode
+npm run dev:full            # Web mode — starts UI (:3007) AND server (:3008) together
+npm run dev:web             # UI only (localhost:3007) — requires server running separately on :3008
+npm run dev:server          # Backend server only (localhost:3008)
+npm run dev:electron        # Desktop app mode (bundles server automatically)
 npm run dev:electron:debug  # Desktop with DevTools open
 
 # Building

--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ git clone https://github.com/proto-labs-ai/protolabs-studio.git
 cd protolabs-studio
 npm install
 npm run dev                 # Interactive launcher (choose web or electron)
-npm run dev:web             # Web browser mode (localhost:3007)
-npm run dev:electron        # Desktop app mode
+npm run dev:full            # Web mode — starts UI (localhost:3007) AND server (localhost:3008)
+npm run dev:electron        # Desktop app mode (bundles server automatically)
 ```
+
+> **Note:** `npm run dev:web` starts only the UI frontend on port 3007. It requires a separate server instance running on port 3008. Use `npm run dev:full` (recommended) to start both together, or `npm run dev:server` in a second terminal.
 
 Requires **Node.js 22+** and an authenticated [Claude Code CLI](https://code.claude.com/docs/en/quickstart).
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -18,11 +18,23 @@ You create a feature → Agent claims it → Works in isolated branch → Create
 
 Walk through the core workflow: create a feature, let an agent implement it, and merge the PR.
 
-### Step 1: Start the Server
+### Step 1: Start the Application
+
+`npm run dev:web` starts only the UI frontend (port 3007). The backend server (port 3008) must also be running. Use `dev:full` to start both in one command:
 
 ```bash
 cd /path/to/your-project
-npm run dev:web   # Starts UI on :3007, server on :3008
+npm run dev:full   # Starts UI on :3007 and server on :3008 concurrently
+```
+
+Or start them separately in two terminals:
+
+```bash
+# Terminal 1 — backend server
+npm run dev:server
+
+# Terminal 2 — web UI
+npm run dev:web
 ```
 
 Open `http://localhost:3007` in your browser. You'll see the Kanban board.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -31,11 +31,13 @@ This opens an interactive launcher. Choose between:
 Or specify directly:
 
 ```bash
-npm run dev:web              # Web browser mode
-npm run dev:electron         # Desktop app
+npm run dev:full             # Web mode — starts UI (:3007) AND server (:3008) together (recommended)
+npm run dev:electron         # Desktop app (bundles server automatically)
 npm run dev:electron:debug   # Desktop with DevTools
 npm run dev:electron:wsl     # WSL (Windows Subsystem for Linux)
 ```
+
+> **Important:** `npm run dev:web` starts only the UI frontend on port 3007. It requires the backend server to be running separately on port 3008. Use `npm run dev:full` to start both in one command, or run `npm run dev:server` in a second terminal alongside `npm run dev:web`.
 
 ## TUI Launcher
 


### PR DESCRIPTION
## Summary

we have many references to `npm run dev:web` throughout our docs and internal references, but its not clear that it needs to have a server instance to connect to. Audit as needed and create a project for updating quick start guides and getting user facing docs finished

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development command workflows with clearer instructions for starting the application
  * Added `dev:full` command to start UI and server together
  * Clarified individual commands: `dev:web` (UI only), `dev:server` (backend only), and `dev:electron` (desktop mode with bundled server)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->