### PR TITLE
Set up Chromatic CI integration

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,47 @@
+name: Chromatic
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
+    paths:
+      - 'libs/ui/**'
+      - 'apps/ui/**'
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chromatic:
+    name: Run Chromatic Visual Tests
+    runs-on: ubuntu-latest
+    # Non-blocking: errors here do not block PR merges
+    continue-on-error: true
+    # Only run for PRs from the same repository (not forks)
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Full history is required by Chromatic to determine the baseline build
+          fetch-depth: 0
+
+      - name: Setup project
+        uses: ./.github/actions/setup-project
+        with:
+          skip-native-rebuild: 'true'
+
+      - name: Build Storybook
+        run: npm run build-storybook --workspace=apps/ui
+        env:
+          NODE_OPTIONS: '--max-old-space-size=4096'
+
+      - name: Publish to Chromatic
+        run: npx chromatic --storybook-build-dir=apps/ui/storybook-static --exit-zero-on-changes
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "@changesets/cli": "^2.29.8",
     "@commitlint/cli": "^20.4.2",
     "@commitlint/config-conventional": "^20.4.2",
+    "chromatic": "^11.0.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "husky": "9.1.7",
     "lint-staged": "16.2.7",


### PR DESCRIPTION
## Summary

**Milestone:** Storybook Coverage

Add Chromatic to the CI pipeline. Install chromatic package. Add a chromatic.yml GitHub Actions workflow that runs on PRs targeting dev/staging: build Storybook, publish to Chromatic for visual diffing. Use CHROMATIC_PROJECT_TOKEN secret. Configure to run only when libs/ui or apps/ui files change (path filter). Do not block PRs on Chromatic — set as informational check only initially.

**Files to Modify:**
- package.json
- .github/workflows/chromatic.yml

**Acc...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated visual regression testing for UI changes on pull requests targeting development and staging branches. Tests run non-blocking to validate UI consistency without affecting merge processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->