### PR TITLE
Provider types and ClaudeProvider wiring

### DIFF
--- a/apps/server/src/providers/claude-provider.ts
+++ b/apps/server/src/providers/claude-provider.ts
@@ -5,7 +5,14 @@
  * with the provider architecture.
  */
 
-import { query, type Options, type SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import {
+  query,
+  type Options,
+  type SDKUserMessage,
+  type HookCallback,
+  type HookCallbackMatcher,
+  type CanUseTool,
+} from '@anthropic-ai/claude-agent-sdk';
 import {
   getThinkingTokenBudget,
   validateBareModelId,
@@ -264,6 +271,12 @@ export class ClaudeProvider extends BaseProvider {
       ...(maxThinkingTokens && { maxThinkingTokens }),
       // Subagents configuration for specialized task delegation
       ...(options.agents && { agents: options.agents }),
+      // Lifecycle hooks for the Claude Agent SDK
+      ...(options.hooks && { hooks: options.hooks as Options['hooks'] }),
+      // Tool permission callback
+      ...(options.canUseTool && { canUseTool: options.canUseTool as CanUseTool }),
+      // Explicitly disallowed tools
+      ...(options.disallowedTools && { disallowedTools: options.disallowedTools }),
       // Pass through outputFormat for structured JSON outputs
       ...(options.outputFormat && { outputFormat: options.outputFormat }),
     };

--- a/apps/server/src/providers/simple-query-service.ts
+++ b/apps/server/src/providers/simple-query-service.ts
@@ -22,6 +22,8 @@ import type {
   ClaudeApiProfile,
   ClaudeCompatibleProvider,
   Credentials,
+  HookCallbackMatcher,
+  CanUseTool,
 } from '@protolabs-ai/types';
 import { stripProviderPrefix } from '@protolabs-ai/types';
 
@@ -68,6 +70,20 @@ export interface SimpleQueryOptions {
   claudeCompatibleProvider?: ClaudeCompatibleProvider;
   /** Credentials for resolving 'credentials' apiKeySource in Claude API profiles/providers */
   credentials?: Credentials;
+  /**
+   * Lifecycle hooks for the Claude Agent SDK.
+   * Maps hook event names (e.g. 'PreToolUse', 'PostToolUse') to arrays of callback matchers.
+   */
+  hooks?: Partial<Record<string, HookCallbackMatcher[]>>;
+  /**
+   * Permission callback invoked before each tool execution.
+   * Return value controls whether the tool is allowed to run.
+   */
+  canUseTool?: CanUseTool;
+  /**
+   * Tools that are explicitly disallowed for this execution.
+   */
+  disallowedTools?: string[];
   /** Trace context for Langfuse enrichment (feature ID, role, tags) */
   traceContext?: {
     featureId?: string;
@@ -154,6 +170,9 @@ export async function simpleQuery(options: SimpleQueryOptions): Promise<SimpleQu
     claudeApiProfile: options.claudeApiProfile, // Legacy: Pass active Claude API profile for alternative endpoint configuration
     claudeCompatibleProvider: options.claudeCompatibleProvider, // New: Pass Claude-compatible provider (takes precedence)
     credentials: options.credentials, // Pass credentials for resolving 'credentials' apiKeySource
+    hooks: options.hooks,
+    canUseTool: options.canUseTool,
+    disallowedTools: options.disallowedTools,
   };
 
   for await (const msg of provider.executeQuery(providerOptions)) {
@@ -254,6 +273,9 @@ export async function streamingQuery(options: StreamingQueryOptions): Promise<Si
     claudeApiProfile: options.claudeApiProfile, // Legacy: Pass active Claude API profile for alternative endpoint configuration
     claudeCompatibleProvider: options.claudeCompatibleProvider, // New: Pass Claude-compatible provider (takes precedence)
     credentials: options.credentials, // Pass credentials for resolving 'credentials' apiKeySource
+    hooks: options.hooks,
+    canUseTool: options.canUseTool,
+    disallowedTools: options.disallowedTools,
   };
 
   for await (const msg of provider.executeQuery(providerOptions)) {

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -30,6 +30,9 @@ export type {
   McpHttpServerConfig,
   AgentDefinition,
   ReasoningEffort,
+  HookCallback,
+  HookCallbackMatcher,
+  CanUseTool,
 } from './provider.js';
 
 // Provider constants and utilities

--- a/libs/types/src/provider.ts
+++ b/libs/types/src/provider.ts
@@ -137,6 +137,40 @@ export interface McpHttpServerConfig {
 }
 
 /**
+ * Lifecycle hook callback function.
+ * Structurally compatible with @anthropic-ai/claude-agent-sdk HookCallback.
+ * Uses `any` for input/output to avoid a hard dependency on the SDK from this package.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type HookCallback = (
+  input: any,
+  toolUseID: string | undefined,
+  options: { signal: AbortSignal }
+) => Promise<any>;
+
+/**
+ * Matcher configuration for lifecycle hooks.
+ * Structurally compatible with @anthropic-ai/claude-agent-sdk HookCallbackMatcher.
+ */
+export interface HookCallbackMatcher {
+  matcher?: string;
+  hooks: HookCallback[];
+  timeout?: number;
+}
+
+/**
+ * Tool permission callback invoked before each tool execution.
+ * Structurally compatible with @anthropic-ai/claude-agent-sdk CanUseTool.
+ * Uses `any` return type to avoid a hard dependency on the SDK from this package.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type CanUseTool = (
+  toolName: string,
+  input: Record<string, unknown>,
+  options: { signal: AbortSignal }
+) => Promise<any>;
+
+/**
  * Subagent definition for specialized task delegation
  */
 export interface AgentDefinition {
@@ -189,6 +223,21 @@ export interface ExecuteOptions {
    * Key: agent name, Value: agent definition
    */
   agents?: Record<string, AgentDefinition>;
+  /**
+   * Lifecycle hooks for the Claude Agent SDK.
+   * Maps hook event names (e.g. 'PreToolUse', 'PostToolUse') to arrays of callback matchers.
+   */
+  hooks?: Partial<Record<string, HookCallbackMatcher[]>>;
+  /**
+   * Permission callback invoked before each tool execution.
+   * Return value controls whether the tool is allowed to run.
+   */
+  canUseTool?: CanUseTool;
+  /**
+   * Tools that are explicitly disallowed for this execution.
+   * The SDK will refuse to invoke any tool whose name appears in this list.
+   */
+  disallowedTools?: string[];
   /**
    * Reasoning effort for Codex/OpenAI models with reasoning capabilities.
    * Controls how many reasoning tokens the model generates before responding.


### PR DESCRIPTION
## Summary

**Milestone:** Stack Plumbing

Add hooks, canUseTool, and disallowedTools to ExecuteOptions in libs/types/src/provider.ts. Add the same fields to SimpleQueryOptions and StreamingQueryOptions in apps/server/src/providers/simple-query-service.ts and wire them into the providerOptions object passed to ClaudeProvider. In apps/server/src/providers/claude-provider.ts, spread hooks, canUseTool, and disallowedTools into sdkOptions (following the existing pattern for agents at line 266). Import SDK types...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle hooks support for query execution monitoring and control.
  * Introduced tool permission controls, enabling granular access management for tool usage.
  * Added ability to restrict specific tools on a per-execution basis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->