### PR TITLE
feat: detect permanently missing CI status checks in PR Maintainer

### DIFF
--- a/apps/server/src/services/pr-feedback-service.ts
+++ b/apps/server/src/services/pr-feedback-service.ts
@@ -51,6 +51,16 @@ const CI_POLL_INTERVAL_MS = 60_000;
 /** Max time to wait for CI checks to complete (10 minutes) */
 const CI_MAX_WAIT_MS = 10 * 60 * 1000;
 
+/**
+ * How long a PR can wait before we alert on required CI checks that never registered.
+ * A check is considered "permanently missing" when it has been absent this long.
+ * Configurable via MISSING_CI_CHECK_THRESHOLD_MINUTES env variable (default: 30).
+ */
+const MISSING_CI_CHECK_THRESHOLD_MS = (() => {
+  const minutes = parseInt(process.env.MISSING_CI_CHECK_THRESHOLD_MINUTES ?? '30', 10);
+  return (isNaN(minutes) || minutes <= 0 ? 30 : minutes) * 60 * 1000;
+})();
+
 export class PRFeedbackService {
   private readonly events: EventEmitter;
   private readonly featureLoader: FeatureLoader;
@@ -67,6 +77,9 @@ export class PRFeedbackService {
 
   /** Collected evaluation decisions during remediation, keyed by featureId */
   private collectedDecisions = new Map<string, FeedbackThreadDecision[]>();
+
+  /** Features already alerted for missing CI status checks (prevents repeat alerts) */
+  private alertedMissingChecks = new Set<string>();
 
   private readonly feedbackAggregator: FeedbackAggregator;
   private readonly threadResolver: ThreadResolver;
@@ -174,6 +187,7 @@ export class PRFeedbackService {
     this.trackedPRs.clear();
     this.remediatingFeatures.clear();
     this.collectedDecisions.clear();
+    this.alertedMissingChecks.clear();
     this.initialized = false;
   }
 
@@ -188,6 +202,7 @@ export class PRFeedbackService {
     }
     this.remediatingFeatures.delete(featureId);
     this.collectedDecisions.delete(featureId);
+    this.alertedMissingChecks.delete(featureId);
   }
 
   /**
@@ -221,6 +236,11 @@ export class PRFeedbackService {
               ? new Date(feature.prLastPolledAt).getTime()
               : 0;
 
+          const trackedSince =
+            feature.prTrackedSince && typeof feature.prTrackedSince === 'string'
+              ? new Date(feature.prTrackedSince).getTime()
+              : (lastPolledAt || Date.now());
+
           this.trackedPRs.set(feature.id, {
             featureId: feature.id,
             projectPath,
@@ -230,6 +250,7 @@ export class PRFeedbackService {
             lastCheckedAt: lastPolledAt,
             reviewState: 'pending',
             iterationCount: feature.prIterationCount || 0,
+            trackedSince,
           });
 
           logger.info(
@@ -267,6 +288,7 @@ export class PRFeedbackService {
       lastCheckedAt: 0,
       reviewState: 'pending',
       iterationCount: existing?.iterationCount || 0,
+      trackedSince: existing?.trackedSince ?? Date.now(),
     });
 
     void this.featureLoader.update(projectPath, featureId, {
@@ -301,6 +323,7 @@ export class PRFeedbackService {
         lastCheckedAt: 0,
         reviewState: 'pending',
         iterationCount: feature.prIterationCount || 0,
+        trackedSince: Date.now(),
       });
 
       logger.info(
@@ -358,6 +381,7 @@ export class PRFeedbackService {
 
   private async pollAllPRs(): Promise<void> {
     await this.pollCIStatus();
+    await this.detectMissingCIChecks();
 
     for (const [featureId, pr] of this.trackedPRs) {
       if (Date.now() - pr.lastCheckedAt < POLL_INTERVAL_MS * 0.8) continue;
@@ -998,6 +1022,80 @@ export class PRFeedbackService {
       logger.error(`Failed to process pending feedback for ${featureId}:`, error);
       this.remediatingFeatures.delete(featureId);
       this.collectedDecisions.delete(featureId);
+    }
+  }
+
+  /**
+   * Detect PRs that have been waiting longer than MISSING_CI_CHECK_THRESHOLD_MS
+   * for required status checks that have never registered on the commit.
+   *
+   * This catches misconfigured CI workflows (e.g. a workflow that only triggers
+   * on PRs targeting `main` while branch protection is configured on `dev`).
+   */
+  private async detectMissingCIChecks(): Promise<void> {
+    const now = Date.now();
+
+    for (const [featureId, pr] of this.trackedPRs) {
+      // Only surface once per PR tracking session
+      if (this.alertedMissingChecks.has(featureId)) continue;
+
+      // Only flag PRs still in the initial pending state — changes_requested / approved
+      // mean the pipeline is already moving
+      if (pr.reviewState !== 'pending') continue;
+
+      // Must have been tracked long enough for checks to reasonably appear
+      const trackedSince = pr.trackedSince ?? now;
+      const waitingMs = now - trackedSince;
+      if (waitingMs < MISSING_CI_CHECK_THRESHOLD_MS) continue;
+
+      try {
+        // Resolve base branch and HEAD SHA from GitHub
+        const prDetails = await prStatusChecker.fetchPRDetails(pr);
+        if (!prDetails) continue;
+
+        const { baseBranch, headSha } = prDetails;
+
+        // Fetch what checks are required on the target branch
+        const requiredChecks = await prStatusChecker.fetchRequiredStatusChecks(pr, baseBranch);
+        if (requiredChecks.length === 0) continue;
+
+        // Fetch check runs that have actually been registered for the HEAD commit
+        const checkRuns = await prStatusChecker.fetchCICheckRuns(pr, headSha);
+        const registeredCheckNames = new Set(checkRuns.map((c) => c.name));
+
+        // A check is "permanently missing" when it has never appeared at all
+        const missingChecks = requiredChecks.filter((name) => !registeredCheckNames.has(name));
+        if (missingChecks.length === 0) continue;
+
+        const waitingMinutes = Math.round(waitingMs / 60_000);
+
+        logger.warn(
+          `PR #${pr.prNumber} (feature ${featureId}) has been waiting ${waitingMinutes}m for required CI checks that never registered: ${missingChecks.join(', ')}. ` +
+            `Base branch: '${baseBranch}'. Possible cause: CI workflow not configured to trigger on PRs targeting '${baseBranch}'.`
+        );
+
+        // Mark as alerted so we don't repeat on every poll cycle
+        this.alertedMissingChecks.add(featureId);
+
+        this.events.emit('pr:missing-ci-checks', {
+          projectPath: pr.projectPath,
+          featureId,
+          prNumber: pr.prNumber,
+          prUrl: pr.prUrl,
+          branchName: pr.branchName,
+          baseBranch,
+          headSha,
+          missingChecks,
+          waitingMinutes,
+          possibleCauses: [
+            `CI workflow may not be configured to trigger on PRs targeting '${baseBranch}'`,
+            `Check that the workflow trigger includes 'branches: [${baseBranch}]' or uses a wildcard`,
+            `Verify the workflow file is valid YAML and has not been accidentally excluded`,
+          ],
+        });
+      } catch (error) {
+        logger.debug(`Failed to check for missing CI checks on PR #${pr.prNumber}: ${error}`);
+      }
     }
   }
 

--- a/apps/server/src/services/pr-status-checker.ts
+++ b/apps/server/src/services/pr-status-checker.ts
@@ -25,6 +25,8 @@ export interface TrackedPR {
   reviewState: 'pending' | 'changes_requested' | 'approved' | 'commented';
   iterationCount: number;
   lastProcessedReviewAt?: number;
+  /** When this PR was first added to tracking (epoch ms) */
+  trackedSince?: number;
   ciMonitoring?: {
     headSha: string;
     startedAt: number;
@@ -224,6 +226,66 @@ export class PRStatusChecker {
         }
       )
       .filter(Boolean) as ThreadFeedbackItem[];
+  }
+
+  /**
+   * Fetch the PR's base branch and HEAD commit SHA.
+   * Used to detect required status checks that never registered.
+   */
+  async fetchPRDetails(pr: TrackedPR): Promise<{ baseBranch: string; headSha: string } | null> {
+    try {
+      const { stdout } = await execFileAsync(
+        'gh',
+        ['pr', 'view', String(pr.prNumber), '--json', 'baseRefName,headRefOid'],
+        {
+          cwd: pr.projectPath,
+          timeout: 15_000,
+          encoding: 'utf-8',
+        }
+      );
+
+      const data = JSON.parse(stdout) as { baseRefName: string; headRefOid: string };
+      return { baseBranch: data.baseRefName, headSha: data.headRefOid };
+    } catch (error) {
+      logger.debug(`Failed to fetch PR details for PR #${pr.prNumber}: ${error}`);
+      return null;
+    }
+  }
+
+  /**
+   * Fetch the names of required status checks configured on a branch's protection rules.
+   * Returns an empty array if the branch has no protection or no required checks.
+   */
+  async fetchRequiredStatusChecks(pr: TrackedPR, baseBranch: string): Promise<string[]> {
+    try {
+      const { stdout } = await execFileAsync(
+        'gh',
+        [
+          'api',
+          `repos/{owner}/{repo}/branches/${baseBranch}/protection/required_status_checks`,
+        ],
+        {
+          cwd: pr.projectPath,
+          timeout: 15_000,
+          encoding: 'utf-8',
+        }
+      );
+
+      const data = JSON.parse(stdout) as {
+        contexts?: string[];
+        checks?: Array<{ context: string; app_id: number | null }>;
+      };
+
+      // Prefer `checks` (newer GitHub API) over `contexts` (deprecated)
+      if (data.checks && data.checks.length > 0) {
+        return data.checks.map((c) => c.context);
+      }
+      return data.contexts ?? [];
+    } catch (error) {
+      // Branch may have no protection configured — this is normal
+      logger.debug(`No required status checks found for branch '${baseBranch}': ${error}`);
+      return [];
+    }
   }
 
   /**

--- a/libs/prompts/src/agents/pr-maintainer.ts
+++ b/libs/prompts/src/agents/pr-maintainer.ts
@@ -25,6 +25,7 @@ You are the PR Maintainer — a lightweight specialist that keeps the PR pipelin
 - Rebase branches that are behind main
 - Create PRs from orphaned worktrees with uncommitted or unpushed work
 - Trigger CodeRabbit review when missing on a PR
+- Diagnose PRs that are stuck waiting for required CI checks that never registered
 
 ## Operating Rules
 
@@ -35,5 +36,15 @@ You are the PR Maintainer — a lightweight specialist that keeps the PR pipelin
 - Use \`gh pr merge <number> --auto --squash\` for auto-merge
 - Use resolve_review_threads MCP tool for batch CodeRabbit resolution
 - Never force-push to main or delete branches with running agents
-- If a build failure is a TypeScript error (not format), report it — don't attempt complex fixes${config?.additionalContext ? `\n\n${config.additionalContext}` : ''}`;
+- If a build failure is a TypeScript error (not format), report it — don't attempt complex fixes
+
+## Missing CI Status Checks
+
+When a \`pr:missing-ci-checks\` alert fires, a required status check has never registered on the PR after the configured waiting threshold. This is not a CI failure — the check never ran at all.
+
+Diagnostic steps:
+1. Note which checks are listed as \`missingChecks\` and what the PR's \`baseBranch\` is
+2. Inspect the CI workflow trigger conditions: does the \`on.pull_request.branches\` filter include the base branch?
+3. Common root cause: workflow only triggers on PRs targeting \`main\` but branch protection requires the check on \`dev\` (or another branch)
+4. Report the findings — do NOT attempt to modify CI workflow files unless explicitly instructed${config?.additionalContext ? `\n\n${config.additionalContext}` : ''}`;
 }


### PR DESCRIPTION
## Summary

- Adds missing CI status check detection to PR Maintainer crew
- When a PR waits for a required check longer than 30 minutes without the check ever registering, surfaces a diagnostic message
- Identifies which checks are missing and suggests possible causes (CI trigger mismatch with base branch)

## Files Changed

- `apps/server/src/services/pr-feedback-service.ts` — New missing-check detection logic
- `apps/server/src/services/pr-status-checker.ts` — Threshold-based check staleness detection  
- `libs/prompts/src/agents/pr-maintainer.ts` — Updated prompt with missing check awareness

## Test plan

- [ ] PR Maintainer crew detects PRs waiting for checks that never register
- [ ] Diagnostic message identifies missing check names
- [ ] No false positives on PRs where checks are simply slow

*Recovered automatically by Ava from interrupted agent work*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and alerting for PRs stuck waiting for required CI checks that never register.
  * Introduced configurable threshold (default 30 minutes) to identify and report missing CI checks with diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->