### PR TITLE
Bug 4: Max Retries Is Hardcoded and Doesn't Distinguish Failure Types
File: lead-engineer-execute-pr

### DIFF
--- a/apps/server/src/services/lead-engineer-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-execute-processor.ts
@@ -17,7 +17,7 @@ import type {
   StateProcessor,
   StateTransitionResult,
 } from './lead-engineer-types.js';
-import { EXECUTE_TIMEOUT_MS } from './lead-engineer-types.js';
+import { EXECUTE_TIMEOUT_MS, MAX_AGENT_RETRIES, MAX_INFRA_RETRIES } from './lead-engineer-types.js';
 import type { VerifiedTrajectory } from '@protolabs-ai/types';
 
 const execAsync = promisify(exec);
@@ -31,10 +31,51 @@ const logger = createLogger('LeadEngineerService');
  * Waits for completion via event listener with a 30-minute timeout.
  */
 export class ExecuteProcessor implements StateProcessor {
-  private readonly MAX_RETRIES = 3;
   private readonly MAX_BUDGET_USD = 10.0;
 
   constructor(private serviceContext: ProcessorServiceContext) {}
+
+  /**
+   * Resolve the effective max agent retries for this project.
+   * Reads from project workflow settings when the settings service is available,
+   * falling back to the module-level constant so behaviour is unchanged for
+   * projects that haven't customised this value.
+   */
+  private async resolveMaxAgentRetries(projectPath: string): Promise<number> {
+    try {
+      if (this.serviceContext.settingsService) {
+        const settings = await this.serviceContext.settingsService.getProjectSettings(projectPath);
+        const configured = settings.workflow?.pipeline?.maxAgentRetries;
+        if (typeof configured === 'number' && configured > 0) {
+          return configured;
+        }
+      }
+    } catch {
+      /* non-fatal — fall back to constant */
+    }
+    return MAX_AGENT_RETRIES;
+  }
+
+  /**
+   * Resolve the effective max infra retries for this project.
+   * Reads from project workflow settings when the settings service is available,
+   * falling back to the module-level constant so behaviour is unchanged for
+   * projects that haven't customised this value.
+   */
+  private async resolveMaxInfraRetries(projectPath: string): Promise<number> {
+    try {
+      if (this.serviceContext.settingsService) {
+        const settings = await this.serviceContext.settingsService.getProjectSettings(projectPath);
+        const configured = settings.workflow?.pipeline?.maxInfraRetries;
+        if (typeof configured === 'number' && configured > 0) {
+          return configured;
+        }
+      }
+    } catch {
+      /* non-fatal — fall back to constant */
+    }
+    return MAX_INFRA_RETRIES;
+  }
 
   async enter(ctx: StateContext): Promise<void> {
     logger.info(`[EXECUTE] Starting execution for feature: ${ctx.feature.id}`, {
@@ -55,9 +96,10 @@ export class ExecuteProcessor implements StateProcessor {
       };
     }
 
-    // Check retry limit
-    if (ctx.retryCount >= this.MAX_RETRIES) {
-      ctx.escalationReason = `Max retries exceeded (${this.MAX_RETRIES})`;
+    // Check agent retry limit (configurable via workflow settings, falls back to module constant)
+    const maxAgentRetries = await this.resolveMaxAgentRetries(ctx.projectPath);
+    if (ctx.retryCount >= maxAgentRetries) {
+      ctx.escalationReason = `Max agent retries exceeded (${maxAgentRetries})`;
       return {
         nextState: 'ESCALATE',
         shouldContinue: true,
@@ -270,24 +312,34 @@ export class ExecuteProcessor implements StateProcessor {
         };
       }
 
-      // Classify failure: infrastructure errors should escalate immediately
-      // rather than burning agent retries on unrecoverable issues
+      // ── Classify the failure into one of three categories ──────────────────
+      //
+      //  1. FATAL infrastructure failures  → escalate immediately (human required)
+      //  2. TRANSIENT infrastructure failures → retry the specific step without
+      //     re-running the agent (does not consume an agent retry slot)
+      //  3. Agent failures (bad code, logic errors) → retry the full agent
+      //     with accumulated context
+      //
+      // This ensures compute budget is not wasted re-running agents when only
+      // a post-flight step (git push, PR creation) failed transiently.
+      // ───────────────────────────────────────────────────────────────────────
+
       const errorMsg = (result.error || '').toLowerCase();
-      const isInfraFailure =
+
+      // Fatal: unrecoverable without human intervention
+      const isFatalInfraFailure =
         errorMsg.includes('permission denied') ||
-        errorMsg.includes('lock file') ||
         errorMsg.includes('enospc') ||
         errorMsg.includes('no space left') ||
-        errorMsg.includes('worktree') ||
-        errorMsg.includes('git push failed') ||
         errorMsg.includes('authentication failed') ||
         errorMsg.includes('could not resolve host') ||
         errorMsg.includes('connection refused') ||
+        errorMsg.includes('worktree') ||
         errorMsg.includes('timed out');
 
-      if (isInfraFailure) {
+      if (isFatalInfraFailure) {
         ctx.escalationReason = `Infrastructure failure (not retryable): ${result.error}`;
-        logger.warn('[EXECUTE] Infrastructure failure detected, escalating immediately', {
+        logger.warn('[EXECUTE] Fatal infrastructure failure detected, escalating immediately', {
           featureId: ctx.feature.id,
           error: result.error,
         });
@@ -298,16 +350,63 @@ export class ExecuteProcessor implements StateProcessor {
         };
       }
 
+      // Transient: lightweight step failures (git push lock, gh CLI error, etc.)
+      // Retry without re-running the agent; uses a separate counter so agent
+      // retries are preserved for actual code-quality failures.
+      const isTransientInfraFailure =
+        errorMsg.includes('lock file') ||
+        errorMsg.includes('git push failed') ||
+        errorMsg.includes('failed to create pull request') ||
+        errorMsg.includes('pr creation failed') ||
+        errorMsg.includes('gh: ');
+
+      if (isTransientInfraFailure) {
+        // Resolve configurable infra retry limit (falls back to module constant)
+        const maxInfraRetries = await this.resolveMaxInfraRetries(ctx.projectPath);
+        ctx.infraRetryCount++;
+        if (ctx.infraRetryCount <= maxInfraRetries) {
+          logger.warn(
+            '[EXECUTE] Transient infrastructure failure, retrying step (no agent re-run)',
+            {
+              featureId: ctx.feature.id,
+              infraRetryCount: ctx.infraRetryCount,
+              maxInfraRetries,
+              error: result.error,
+            }
+          );
+          return {
+            nextState: 'EXECUTE',
+            shouldContinue: true,
+            reason: `Transient infra failure (attempt ${ctx.infraRetryCount}/${maxInfraRetries}): ${result.error || 'unknown'}`,
+          };
+        }
+
+        // Infrastructure retries exhausted — escalate
+        ctx.escalationReason = `Infrastructure step failed after ${maxInfraRetries} retries: ${result.error}`;
+        logger.warn('[EXECUTE] Infrastructure retries exhausted, escalating', {
+          featureId: ctx.feature.id,
+          infraRetryCount: ctx.infraRetryCount,
+          error: result.error,
+        });
+        return {
+          nextState: 'ESCALATE',
+          shouldContinue: false,
+          reason: ctx.escalationReason,
+        };
+      }
+
+      // Agent failure: re-run the agent with accumulated context
       ctx.retryCount++;
-      logger.warn('[EXECUTE] Agent execution failed, will retry', {
+      logger.warn('[EXECUTE] Agent execution failed, will retry with context', {
         retryCount: ctx.retryCount,
+        maxAgentRetries,
         error: result.error,
       });
 
       return {
         nextState: 'EXECUTE',
         shouldContinue: true,
-        reason: `Execution failed: ${result.error || 'unknown'}`,
+        reason: `Agent failed: ${result.error || 'unknown'}`,
       };
     }
 

--- a/apps/server/src/services/lead-engineer-state-machine.ts
+++ b/apps/server/src/services/lead-engineer-state-machine.ts
@@ -139,6 +139,7 @@ export class FeatureStateMachine {
       projectPath,
       options,
       retryCount: 0,
+      infraRetryCount: 0,
       planRequired: false,
       remediationAttempts: 0,
       mergeRetryCount: 0,

--- a/apps/server/src/services/lead-engineer-types.ts
+++ b/apps/server/src/services/lead-engineer-types.ts
@@ -26,6 +26,22 @@ export const MAX_TOTAL_REMEDIATION_CYCLES = 4;
 export const MERGE_RETRY_DELAY_MS = 60 * 1000; // 60 seconds
 export const REVIEW_POLL_DELAY_MS = 30 * 1000; // 30 seconds
 
+// ────────────────────────── Retry limits ──────────────────────────
+
+/**
+ * Maximum number of full agent re-runs (burns compute budget).
+ * Triggered when the agent produces bad code or logic errors.
+ * Centralised here so it can be adjusted without touching processor logic.
+ */
+export const MAX_AGENT_RETRIES = 3;
+
+/**
+ * Maximum number of retries for lightweight infrastructure steps
+ * (e.g. git push blocked by a lock file, gh CLI transient error).
+ * These retries do NOT re-run the agent, so they are cheap.
+ */
+export const MAX_INFRA_RETRIES = 3;
+
 // ────────────────────────── Service Context ──────────────────────────
 
 /**
@@ -98,7 +114,13 @@ export interface StateContext {
   feature: Feature;
   projectPath: string;
   options: ExecuteOptions;
+  /** Number of full agent re-runs triggered by agent-level failures (bad code, logic errors). */
   retryCount: number;
+  /**
+   * Number of lightweight infrastructure step retries (git push lock, gh CLI error, etc.).
+   * These do NOT re-run the agent, so they do not consume compute budget.
+   */
+  infraRetryCount: number;
   planRequired: boolean;
   assignedPersona?: AgentRole;
   planOutput?: string;

--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -123,6 +123,19 @@ export interface WorkflowSettings {
     maxAgentCostUsd: number;
     /** Enable antagonistic plan review for large/architectural features (default: true) */
     antagonisticPlanReview?: boolean;
+    /**
+     * Maximum number of full agent re-runs triggered by agent-level failures
+     * (e.g. bad code, logic errors). Each retry burns compute budget.
+     * (default: 3)
+     */
+    maxAgentRetries?: number;
+    /**
+     * Maximum number of retries for lightweight infrastructure steps
+     * (e.g. git push blocked by a lock file, gh CLI transient error).
+     * These retries do NOT re-run the agent, so they are cheap.
+     * (default: 3)
+     */
+    maxInfraRetries?: number;
   };
   retro: {
     /** Enable automatic retrospective generation on project completion (default: true) */
@@ -171,6 +184,8 @@ export const DEFAULT_WORKFLOW_SETTINGS: WorkflowSettings = {
     maxAgentRuntimeMinutes: 45,
     maxAgentCostUsd: 15,
     antagonisticPlanReview: true,
+    maxAgentRetries: 3,
+    maxInfraRetries: 3,
   },
   retro: {
     enabled: true,


### PR DESCRIPTION
## Summary

Bug 4: Max Retries Is Hardcoded and Doesn't Distinguish Failure Types
File: lead-engineer-execute-processor.ts

private readonly MAX_RETRIES = 3;
Not configurable. The system doesn't distinguish between:

'Agent wrote bad code' (should retry with better context)
'Git push failed because of a lock file' (should just retry the push)
'PR creation failed because gh CLI error' (should just retry the PR)
All three burn a retry. Infrastructure failures eat agent retries.

Severity: Medium — wastes comp...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects can now configure retry limits for agent and infrastructure steps within workflow settings.
  * Improved failure handling with three distinct categories: fatal infrastructure, transient infrastructure, and agent failures—each with appropriate retry strategies.

* **Improvements**
  * Enhanced logging with clearer error messages and retry behavior tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->