### PR TITLE
Ava settings MCP servers UI

### DIFF
--- a/apps/ui/src/components/views/chat-overlay/ava-settings-panel.tsx
+++ b/apps/ui/src/components/views/chat-overlay/ava-settings-panel.tsx
@@ -147,6 +147,17 @@ export function AvaSettingsPanel({ projectPath }: AvaSettingsPanelProps) {
     [saveMutation]
   );
 
+  const handleMcpServerToggle = useCallback(
+    (serverId: string, enabled: boolean) => {
+      if (!data) return;
+      const updated = (data.mcpServers ?? []).map((s) =>
+        s.id === serverId ? { ...s, enabled } : s
+      );
+      saveMutation.mutate({ mcpServers: updated });
+    },
+    [saveMutation, data]
+  );
+
   const handlePromptChange = useCallback(
     (value: string) => {
       setLocalPrompt(value);
@@ -304,6 +315,49 @@ export function AvaSettingsPanel({ projectPath }: AvaSettingsPanelProps) {
           onChange={(checked) => saveMutation.mutate({ autoApproveTools: checked })}
         />
       </div>
+
+      {/* MCP Servers — only shown when servers are configured */}
+      {(data.mcpServers ?? []).length > 0 && (
+        <>
+          <hr className="border-border" />
+          <Collapsible>
+            <CollapsibleTrigger className="flex w-full items-center gap-1.5 text-xs font-medium text-foreground group">
+              <ChevronRight className="size-3 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+              MCP Servers
+              <span className="ml-auto text-[10px] font-normal text-muted-foreground">
+                {(data.mcpServers ?? []).filter((s) => s.enabled !== false).length}/
+                {(data.mcpServers ?? []).length}
+              </span>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="grid grid-cols-2 gap-1.5 pt-2">
+                {(data.mcpServers ?? []).map((server) => (
+                  <button
+                    key={server.id}
+                    type="button"
+                    onClick={() => handleMcpServerToggle(server.id, server.enabled === false)}
+                    title={server.description ?? server.name}
+                    className={cn(
+                      'flex items-center gap-1.5 rounded-md border px-2 py-1.5 text-[11px] transition-colors',
+                      server.enabled !== false
+                        ? 'border-primary/30 bg-primary/10 text-foreground'
+                        : 'border-border bg-muted/30 text-muted-foreground'
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        'size-1.5 shrink-0 rounded-full',
+                        server.enabled !== false ? 'bg-green-500' : 'bg-muted-foreground/30'
+                      )}
+                    />
+                    {server.name}
+                  </button>
+                ))}
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        </>
+      )}
 
       <hr className="border-border" />
 

--- a/apps/ui/src/lib/clients/ava-client.ts
+++ b/apps/ui/src/lib/clients/ava-client.ts
@@ -4,6 +4,9 @@
  * Provides: ava (getConfig, updateConfig)
  */
 import { BaseHttpClient, type Constructor } from './base-http-client';
+import type { MCPServerConfig } from '@protolabs-ai/types';
+
+export type { MCPServerConfig };
 
 export interface AvaToolGroups {
   boardRead: boolean;
@@ -29,6 +32,8 @@ export interface AvaConfig {
   contextInjection: boolean;
   systemPromptExtension: string;
   autoApproveTools: boolean;
+  /** MCP servers available to Ava and delegated inner agents */
+  mcpServers?: MCPServerConfig[];
 }
 
 export const withAvaClient = <TBase extends Constructor<BaseHttpClient>>(Base: TBase) =>


### PR DESCRIPTION
## Summary

**Milestone:** Ava Custom MCP Servers

Add an MCP servers section to the Ava settings panel (apps/ui/src/components/views/chat-overlay/ava-settings-panel.tsx). Show the list of configured Ava MCP servers with name, description, tool count, and enabled/disabled toggle. Use the same compact chip style established for tool groups. The settings panel already has a save/update flow — wire MCP server enable/disable through the same avaConfig mutation. Read server list from avaConfig.mcpServers. This i...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP Server configuration panel to Ava Settings with toggles to enable or disable individual servers
  * Server status displayed with visual indicators and collapsible interface for easier management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->