### PR TITLE
Trust config types and canUseTool factory

### DIFF
--- a/apps/server/src/lib/agent-trust.ts
+++ b/apps/server/src/lib/agent-trust.ts
@@ -1,0 +1,142 @@
+/**
+ * Agent Trust — canUseTool callback factory for subagent permission control.
+ *
+ * Provides `buildCanUseToolCallback` which returns the appropriate tool
+ * permission callback based on the configured trust level:
+ *
+ * - 'full':  Returns undefined. The caller preserves bypassPermissions mode,
+ *            allowing subagents to run fully autonomously.
+ * - 'gated': Returns an async canUseTool function. Each tool invocation emits
+ *            a `subagent:tool-approval-request` event and awaits a matching
+ *            `subagent:tool-approval-response` event before proceeding.
+ *            Automatically denies after a 5-minute timeout.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { CanUseTool, EventType } from '@protolabs-ai/types';
+import type { EventEmitter } from './events.js';
+
+/** Timeout duration before an unresponded approval request is auto-denied. */
+const APPROVAL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Payload emitted with a `subagent:tool-approval-request` event.
+ */
+export interface ToolApprovalRequest {
+  /** Unique identifier for this specific tool call instance */
+  toolCallId: string;
+  /** Name of the tool requesting permission */
+  toolName: string;
+  /** Input arguments passed to the tool */
+  toolInput: Record<string, unknown>;
+  /** Unique identifier linking the request to its response */
+  approvalId: string;
+}
+
+/**
+ * Payload expected in a `subagent:tool-approval-response` event.
+ */
+export interface ToolApprovalResponse {
+  /** Must match the `approvalId` from the corresponding request */
+  approvalId: string;
+  /** Whether the tool call is approved */
+  approved: boolean;
+  /** Optional message explaining the decision */
+  message?: string;
+}
+
+/**
+ * Build a `canUseTool` callback appropriate for the given trust level.
+ *
+ * @param trust           - 'full' | 'gated'. Full trust returns undefined so the
+ *                          caller can keep bypassPermissions. Gated trust returns
+ *                          an async callback that gates every tool invocation.
+ * @param approvalEmitter - EventEmitter used to emit approval requests and
+ *                          receive approval responses. Required when trust is
+ *                          'gated'; ignored when trust is 'full'.
+ * @returns A CanUseTool callback for 'gated' trust, or undefined for 'full'.
+ */
+export function buildCanUseToolCallback(
+  trust: 'full' | 'gated',
+  approvalEmitter?: EventEmitter
+): CanUseTool | undefined {
+  if (trust === 'full') {
+    return undefined;
+  }
+
+  // Gated trust: every tool call must be explicitly approved via events.
+  return async (
+    toolName: string,
+    toolInput: Record<string, unknown>,
+    { signal }: { signal: AbortSignal }
+  ): Promise<{ behavior: 'allow' | 'deny'; message?: string }> => {
+    if (!approvalEmitter) {
+      return {
+        behavior: 'deny',
+        message: 'No approval emitter configured for gated subagent trust',
+      };
+    }
+
+    const approvalId = randomUUID();
+    const toolCallId = randomUUID();
+
+    return new Promise<{ behavior: 'allow' | 'deny'; message?: string }>((resolve) => {
+      let settled = false;
+      // Declare onAbort as undefined initially so settle can safely reference it
+      // before the event listener is registered (handles the already-aborted case).
+      let onAbort: (() => void) | undefined;
+
+      /** Settle the promise once, cleaning up subscriptions and timer. */
+      const settle = (result: { behavior: 'allow' | 'deny'; message?: string }) => {
+        if (settled) return;
+        settled = true;
+        unsubscribe();
+        clearTimeout(timeoutHandle);
+        if (onAbort) {
+          signal.removeEventListener('abort', onAbort);
+        }
+        resolve(result);
+      };
+
+      // Subscribe to all events; filter for matching approval responses.
+      const unsubscribe = approvalEmitter.subscribe((eventType, payload) => {
+        if (eventType === ('subagent:tool-approval-response' as EventType)) {
+          const response = payload as ToolApprovalResponse;
+          if (response.approvalId === approvalId) {
+            settle(
+              response.approved
+                ? { behavior: 'allow' }
+                : { behavior: 'deny', message: response.message ?? 'Denied by approver' }
+            );
+          }
+        }
+      });
+
+      // Auto-deny after 5 minutes if no response arrives.
+      const timeoutHandle = setTimeout(() => {
+        settle({
+          behavior: 'deny',
+          message: 'Approval request timed out after 5 minutes',
+        });
+      }, APPROVAL_TIMEOUT_MS);
+
+      // Deny immediately if the signal is already aborted.
+      if (signal.aborted) {
+        settle({ behavior: 'deny', message: 'Request was aborted' });
+        return;
+      }
+
+      // Deny if the abort signal fires while we're waiting.
+      onAbort = () => settle({ behavior: 'deny', message: 'Request was aborted' });
+      signal.addEventListener('abort', onAbort, { once: true });
+
+      // Emit the approval request for external handlers to process.
+      approvalEmitter.emit('subagent:tool-approval-request' as EventType, {
+        toolCallId,
+        toolName,
+        toolInput,
+        approvalId,
+      } satisfies ToolApprovalRequest);
+    });
+  };
+}

--- a/apps/server/src/providers/claude-provider.ts
+++ b/apps/server/src/providers/claude-provider.ts
@@ -255,9 +255,11 @@ export class ClaudeProvider extends BaseProvider {
       env: buildEnv(providerConfig, credentials),
       // Pass through allowedTools if provided by caller (decided by sdk-options.ts)
       ...(allowedTools && { allowedTools }),
-      // AUTONOMOUS MODE: Always bypass permissions for fully autonomous operation
-      permissionMode: 'bypassPermissions',
-      allowDangerouslySkipPermissions: true,
+      // Permission mode: use 'default' when a canUseTool gating callback is active
+      // so the SDK respects the callback's decisions. Fall back to 'bypassPermissions'
+      // for fully autonomous (full-trust) operation when no callback is provided.
+      permissionMode: options.canUseTool ? 'default' : 'bypassPermissions',
+      allowDangerouslySkipPermissions: !options.canUseTool,
       abortController,
       // Resume existing SDK session if we have a session ID
       ...(sdkSessionId && conversationHistory && conversationHistory.length > 0

--- a/apps/server/src/routes/chat/ava-config.ts
+++ b/apps/server/src/routes/chat/ava-config.ts
@@ -46,6 +46,13 @@ export interface AvaConfig {
   autoApproveTools: boolean;
   /** MCP servers available to Ava and delegated inner agents */
   mcpServers?: MCPServerConfig[];
+  /**
+   * Trust level for subagent tool execution.
+   * - 'full': Subagents run with bypassPermissions (fully autonomous).
+   * - 'gated': Each tool call requires approval via the event-based approval flow.
+   * Defaults to 'full'.
+   */
+  subagentTrust: 'full' | 'gated';
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -79,6 +86,7 @@ export const DEFAULT_AVA_CONFIG: AvaConfig = {
   systemPromptExtension: '',
   autoApproveTools: false,
   mcpServers: [],
+  subagentTrust: 'full',
 };
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/apps/server/tests/unit/lib/agent-trust.test.ts
+++ b/apps/server/tests/unit/lib/agent-trust.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for agent-trust.ts
+ * Verifies buildCanUseToolCallback behavior for both 'full' and 'gated' trust levels.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildCanUseToolCallback } from '../../../src/lib/agent-trust.js';
+import type { EventEmitter } from '../../../src/lib/events.js';
+import type { EventType } from '@protolabs-ai/types';
+
+// ─── Minimal EventEmitter mock ────────────────────────────────────────────────
+
+function createMockEmitter(): EventEmitter & {
+  _subscribers: Set<(type: string, payload: unknown) => void>;
+  _emitToSubscribers: (type: string, payload: unknown) => void;
+} {
+  const subscribers = new Set<(type: string, payload: unknown) => void>();
+
+  return {
+    _subscribers: subscribers,
+    _emitToSubscribers(type: string, payload: unknown) {
+      for (const sub of subscribers) {
+        sub(type, payload);
+      }
+    },
+    emit(type: EventType, payload: unknown) {
+      // record emitted events for assertions
+    },
+    subscribe(callback: (type: string, payload: unknown) => void) {
+      subscribers.add(callback);
+      const unsub = () => subscribers.delete(callback);
+      const unsubWithMethod = unsub as ReturnType<EventEmitter['subscribe']>;
+      unsubWithMethod.unsubscribe = unsub;
+      return unsubWithMethod;
+    },
+    broadcast(type: EventType, payload?: unknown) {
+      // no-op in tests
+    },
+  };
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('buildCanUseToolCallback', () => {
+  const signal = new AbortController().signal;
+
+  describe('full trust', () => {
+    it('returns undefined for full trust', () => {
+      const cb = buildCanUseToolCallback('full');
+      expect(cb).toBeUndefined();
+    });
+
+    it('returns undefined for full trust even with emitter provided', () => {
+      const emitter = createMockEmitter();
+      const cb = buildCanUseToolCallback('full', emitter as unknown as EventEmitter);
+      expect(cb).toBeUndefined();
+    });
+  });
+
+  describe('gated trust', () => {
+    it('returns a function for gated trust', () => {
+      const emitter = createMockEmitter();
+      const cb = buildCanUseToolCallback('gated', emitter as unknown as EventEmitter);
+      expect(typeof cb).toBe('function');
+    });
+
+    it('denies immediately when no emitter is provided', async () => {
+      const cb = buildCanUseToolCallback('gated');
+      expect(cb).toBeDefined();
+      const result = await cb!('Bash', { command: 'ls' }, { signal });
+      expect(result.behavior).toBe('deny');
+      expect(result.message).toContain('No approval emitter');
+    });
+
+    it('emits a tool-approval-request event with correct fields', async () => {
+      const emitter = createMockEmitter();
+      const emitSpy = vi.spyOn(emitter, 'emit');
+
+      const cb = buildCanUseToolCallback('gated', emitter as unknown as EventEmitter);
+
+      // Start the call but don't await — we'll resolve it manually
+      const callPromise = cb!('Read', { file: '/etc/hosts' }, { signal });
+
+      // Give the microtask queue a tick for the emit to fire
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(emitSpy).toHaveBeenCalledTimes(1);
+      const [eventType, payload] = emitSpy.mock.calls[0];
+      expect(eventType).toBe('subagent:tool-approval-request');
+      const req = payload as { toolName: string; approvalId: string; toolInput: unknown };
+      expect(req.toolName).toBe('Read');
+      expect(req.toolInput).toEqual({ file: '/etc/hosts' });
+      expect(typeof req.approvalId).toBe('string');
+
+      // Resolve by sending the response event
+      emitter._emitToSubscribers('subagent:tool-approval-response', {
+        approvalId: req.approvalId,
+        approved: true,
+      });
+
+      const result = await callPromise;
+      expect(result.behavior).toBe('allow');
+    });
+
+    it('allows the tool when approver responds with approved: true', async () => {
+      const emitter = createMockEmitter();
+      let capturedApprovalId: string | undefined;
+
+      vi.spyOn(emitter, 'emit').mockImplementation((_type, payload) => {
+        capturedApprovalId = (payload as { approvalId: string }).approvalId;
+      });
+
+      const cb = buildCanUseToolCallback('gated', emitter as unknown as EventEmitter);
+      const callPromise = cb!('Bash', { command: 'echo hi' }, { signal });
+
+      await new Promise((r) => setTimeout(r, 0));
+
+      emitter._emitToSubscribers('subagent:tool-approval-response', {
+        approvalId: capturedApprovalId,
+        approved: true,
+      });
+
+      const result = await callPromise;
+      expect(result.behavior).toBe('allow');
+    });
+
+    it('denies the tool when approver responds with approved: false', async () => {
+      const emitter = createMockEmitter();
+      let capturedApprovalId: string | undefined;
+
+      vi.spyOn(emitter, 'emit').mockImplementation((_type, payload) => {
+        capturedApprovalId = (payload as { approvalId: string }).approvalId;
+      });
+
+      const cb = buildCanUseToolCallback('gated', emitter as unknown as EventEmitter);
+      const callPromise = cb!('Write', { path: '/etc/hosts', content: 'x' }, { signal });
+
+      await new Promise((r) => setTimeout(r, 0));
+
+      emitter._emitToSubscribers('subagent:tool-approval-response', {
+        approvalId: capturedApprovalId,
+        approved: false,
+        message: 'Too dangerous',
+      });
+
+      const result = await callPromise;
+      expect(result.behavior).toBe('deny');
+      expect(result.message).toBe('Too dangerous');
+    });
+
+    it('ignores responses with a non-matching approvalId', async () => {
+      const emitter = createMockEmitter();
+      let capturedApprovalId: string | undefined;
+
+      vi.spyOn(emitter, 'emit').mockImplementation((_type, payload) => {
+        capturedApprovalId = (payload as { approvalId: string }).approvalId;
+      });
+
+      const cb = buildCanUseToolCallback('gated', emitter as unknown as EventEmitter);
+      const callPromise = cb!('Glob', { pattern: '*.ts' }, { signal });
+
+      await new Promise((r) => setTimeout(r, 0));
+
+      // Send a response for a different approvalId — should be ignored
+      emitter._emitToSubscribers('subagent:tool-approval-response', {
+        approvalId: 'wrong-id',
+        approved: true,
+      });
+
+      // Now send the correct response
+      emitter._emitToSubscribers('subagent:tool-approval-response', {
+        approvalId: capturedApprovalId,
+        approved: false,
+        message: 'Denied',
+      });
+
+      const result = await callPromise;
+      expect(result.behavior).toBe('deny');
+    });
+
+    it('denies immediately when the abort signal is already aborted', async () => {
+      const emitter = createMockEmitter();
+      const abortController = new AbortController();
+      abortController.abort();
+
+      const cb = buildCanUseToolCallback('gated', emitter as unknown as EventEmitter);
+      const result = await cb!('Bash', { command: 'rm -rf /' }, { signal: abortController.signal });
+
+      expect(result.behavior).toBe('deny');
+      expect(result.message).toContain('aborted');
+    });
+
+    it('denies when the abort signal fires while waiting', async () => {
+      const emitter = createMockEmitter();
+      const abortController = new AbortController();
+
+      vi.spyOn(emitter, 'emit');
+
+      const cb = buildCanUseToolCallback('gated', emitter as unknown as EventEmitter);
+      const callPromise = cb!('Bash', { command: 'sleep 10' }, { signal: abortController.signal });
+
+      await new Promise((r) => setTimeout(r, 0));
+
+      abortController.abort();
+
+      const result = await callPromise;
+      expect(result.behavior).toBe('deny');
+      expect(result.message).toContain('aborted');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

**Milestone:** canUseTool Trust Model

Add subagentTrust: 'full' | 'gated' to AvaConfig in apps/server/src/routes/chat/ava-config.ts (default: 'full'). Create apps/server/src/lib/agent-trust.ts: export buildCanUseToolCallback(trust, approvalEmitter?) that returns undefined when trust is 'full' (preserving bypassPermissions), and a canUseTool async function when trust is 'gated'. The gated canUseTool: emits a subagent:tool-approval-request event via EventEmitter with { toolCallId, toolName, toolI...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable subagent tool access control with two trust levels: full (unrestricted) and gated (approval-required)
  * Gated mode enables external approval workflow for tool execution with 5-minute timeout and abort signal handling
  * New configuration option for trust level selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->