### PR TITLE
feat: gated approval WebSocket flow and inline SubagentApprovalCard

### DIFF
--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -16,7 +16,7 @@ import { z } from 'zod';
 import fs from 'fs/promises';
 import path from 'path';
 import type { EventEmitter } from 'events';
-import type { NotesWorkspace } from '@protolabs-ai/types';
+import type { NotesWorkspace, CanUseTool } from '@protolabs-ai/types';
 import {
   getNotesWorkspacePath,
   ensureNotesDir,
@@ -83,6 +83,12 @@ export interface AvaToolsServices {
   projectService?: ProjectService;
   /** Tool progress emitter — optional, enables real-time progress labels in chat */
   toolProgressEmitter?: ToolProgressEmitter;
+  /**
+   * Permission callback for subagent tool execution (gated trust model).
+   * When set, each tool call made by inner agents must be explicitly approved.
+   * Undefined means full trust (bypassPermissions).
+   */
+  canUseTool?: CanUseTool;
 }
 
 export interface AvaToolsConfig {
@@ -678,6 +684,8 @@ export function buildAvaTools(
                 emitter.emitProgress(toolCallId, `${agentLabel} -- Composing response`);
               },
             }),
+          // Gated trust: pass canUseTool callback so inner agent tool calls require approval
+          ...(services.canUseTool && { canUseTool: services.canUseTool }),
         });
 
         // Cleanup rate-limit tracking

--- a/apps/server/src/routes/chat/index.ts
+++ b/apps/server/src/routes/chat/index.ts
@@ -42,8 +42,11 @@ import { getSitrep } from './sitrep.js';
 import { buildAvaTools } from './ava-tools.js';
 import type { PlanData } from './ava-tools.js';
 import { ToolProgressEmitter } from './tool-progress.js';
+import { buildCanUseToolCallback } from '../../lib/agent-trust.js';
+import type { ToolApprovalResponse } from '../../lib/agent-trust.js';
 import type { ServiceContainer } from '../../server/services.js';
 import type { FeatureLoader } from '../../services/feature-loader.js';
+import type { EventType } from '@protolabs-ai/types';
 
 export type { AvaConfig };
 
@@ -263,6 +266,13 @@ export function createChatRoutes(services: ServiceContainer): Router {
         ? await loadAvaConfig(projectPath)
         : { ...DEFAULT_AVA_CONFIG, toolGroups: { ...DEFAULT_AVA_CONFIG.toolGroups } };
 
+      // Build canUseTool callback for gated subagent trust.
+      // Full trust (default) returns undefined — subagents run with bypassPermissions.
+      const canUseTool =
+        avaConfig.subagentTrust === 'gated'
+          ? buildCanUseToolCallback('gated', services.events)
+          : undefined;
+
       // Model selection: session picker (header/body) > AvaConfig.model > default (sonnet)
       // The inline ChatModelSelect sends x-model-alias; config model is the fallback for new chats.
       const modelAlias =
@@ -350,6 +360,7 @@ export function createChatRoutes(services: ServiceContainer): Router {
               sensorRegistryService: userPresenceDetection
                 ? services.sensorRegistryService
                 : undefined,
+              canUseTool,
             },
             {
               ...avaConfig.toolGroups,
@@ -471,6 +482,43 @@ export function createChatRoutes(services: ServiceContainer): Router {
 
       res.status(500).json({ error: message });
     }
+  });
+
+  /**
+   * POST /api/chat/tool-approval
+   *
+   * Resolves a pending subagent tool-approval request for the gated trust model.
+   * Accepts { approvalId, approved, message? } and emits
+   * `subagent:tool-approval-response` on the shared event bus so the waiting
+   * `canUseTool` promise in agent-trust.ts resolves immediately.
+   *
+   * Body: { approvalId: string, approved: boolean, message?: string }
+   */
+  router.post('/tool-approval', (req: Request, res: Response) => {
+    const { approvalId, approved, message } = req.body as {
+      approvalId: string;
+      approved: boolean;
+      message?: string;
+    };
+
+    if (!approvalId || typeof approved !== 'boolean') {
+      res.status(400).json({ error: 'approvalId and approved (boolean) are required' });
+      return;
+    }
+
+    const response: ToolApprovalResponse = {
+      approvalId,
+      approved,
+      ...(message !== undefined && { message }),
+    };
+
+    // Use EventType cast — subagent approval event types are defined in
+    // libs/types/src/event.ts but the shared dist may be ahead of the published package.
+    services.events.emit('subagent:tool-approval-response' as EventType, response);
+
+    logger.info(`Tool approval response emitted: approvalId=${approvalId}, approved=${approved}`);
+
+    res.json({ ok: true });
   });
 
   return router;

--- a/apps/ui/src/hooks/use-chat-session.ts
+++ b/apps/ui/src/hooks/use-chat-session.ts
@@ -5,10 +5,21 @@
  * and syncing between useChat's live state and the Zustand store.
  */
 
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
 import { useChatStore } from '@/store/chat-store';
+import { getHttpApiClient, getServerUrlSync } from '@/lib/http-api-client';
+
+/** A pending subagent tool approval surfaced from the subagent:tool-approval-request event */
+export interface PendingSubagentApproval {
+  approvalId: string;
+  toolCallId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  /** ISO timestamp when the approval was received (for 5-minute timeout UI) */
+  receivedAt: string;
+}
 
 interface UseChatSessionOptions {
   /** Default model for new sessions */
@@ -85,6 +96,83 @@ export function useChatSession({
     });
 
   const isStreaming = status === 'streaming' || status === 'submitted';
+
+  // ── Subagent approval state (gated trust model) ────────────────────────────
+
+  const [pendingSubagentApprovals, setPendingSubagentApprovals] = useState<
+    PendingSubagentApproval[]
+  >([]);
+
+  // Subscribe to subagent:tool-approval-request events from the server
+  useEffect(() => {
+    const api = getHttpApiClient();
+    const unsubscribe = api.subscribeToEvents((type: string, payload: unknown) => {
+      if (type === 'subagent:tool-approval-request') {
+        const req = payload as {
+          approvalId: string;
+          toolCallId: string;
+          toolName: string;
+          toolInput: Record<string, unknown>;
+        };
+        setPendingSubagentApprovals((prev) => [
+          ...prev,
+          {
+            approvalId: req.approvalId,
+            toolCallId: req.toolCallId,
+            toolName: req.toolName,
+            toolInput: req.toolInput,
+            receivedAt: new Date().toISOString(),
+          },
+        ]);
+      }
+    });
+    return () => unsubscribe();
+  }, []);
+
+  /** Remove a pending approval from the list (after approve or deny). */
+  const removePendingApproval = useCallback((approvalId: string) => {
+    setPendingSubagentApprovals((prev) => prev.filter((a) => a.approvalId !== approvalId));
+  }, []);
+
+  /** Approve a subagent tool call — posts to /api/chat/tool-approval. */
+  const approveSubagentTool = useCallback(
+    async (approvalId: string) => {
+      removePendingApproval(approvalId);
+      try {
+        await fetch(`${getServerUrlSync()}/api/chat/tool-approval`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ approvalId, approved: true }),
+        });
+      } catch (err) {
+        console.error('Failed to approve subagent tool:', err);
+      }
+    },
+    [removePendingApproval]
+  );
+
+  /** Deny a subagent tool call — posts to /api/chat/tool-approval. */
+  const denySubagentTool = useCallback(
+    async (approvalId: string, message?: string) => {
+      removePendingApproval(approvalId);
+      try {
+        await fetch(`${getServerUrlSync()}/api/chat/tool-approval`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            approvalId,
+            approved: false,
+            message: message ?? 'Denied by user',
+          }),
+        });
+      } catch (err) {
+        console.error('Failed to deny subagent tool:', err);
+      }
+    },
+    [removePendingApproval]
+  );
 
   // When messages change, persist to store
   useEffect(() => {
@@ -173,9 +261,14 @@ export function useChatSession({
     error,
     setMessages,
 
-    // HITL
+    // HITL (native AI SDK approval for Ava tools)
     approveToolAction,
     rejectToolAction,
+
+    // Subagent approval (gated trust model)
+    pendingSubagentApprovals,
+    approveSubagentTool,
+    denySubagentTool,
 
     // Session management
     sessions: visibleSessions,

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -357,6 +357,9 @@ export type EventType =
   | 'job:failed'
   // Chat tool progress events (real-time sideband for Ava tool execution)
   | 'chat:tool-progress'
+  // Subagent tool approval events (gated trust model)
+  | 'subagent:tool-approval-request'
+  | 'subagent:tool-approval-response'
   // Server lifecycle events
   | 'server:shutdown';
 
@@ -761,6 +764,19 @@ export interface EventPayloadMap {
     sensorId: string;
     data: Record<string, unknown>;
     receivedAt: string;
+  };
+
+  // Subagent tool approval events (gated trust model)
+  'subagent:tool-approval-request': {
+    approvalId: string;
+    toolCallId: string;
+    toolName: string;
+    toolInput: Record<string, unknown>;
+  };
+  'subagent:tool-approval-response': {
+    approvalId: string;
+    approved: boolean;
+    message?: string;
   };
 }
 

--- a/libs/ui/src/ai/chat-message-list.tsx
+++ b/libs/ui/src/ai/chat-message-list.tsx
@@ -19,6 +19,8 @@ import { cn } from '../lib/utils.js';
 import { Button } from '../atoms/button.js';
 import { ChatMessage } from './chat-message.js';
 import { ShimmerLoader } from './shimmer.js';
+import { SubagentApprovalCard } from './subagent-approval-card.js';
+import type { PendingSubagentApproval } from './subagent-approval-card.js';
 
 /** Per-message branch info keyed by message ID. */
 export interface BranchInfo {
@@ -26,6 +28,9 @@ export interface BranchInfo {
   branchCount: number;
   origId: string;
 }
+
+// Re-export so consumers can import from this module
+export type { PendingSubagentApproval };
 
 export function ChatMessageList({
   messages,
@@ -41,6 +46,9 @@ export function ChatMessageList({
   onPreviousBranch,
   onNextBranch,
   getToolProgressLabel,
+  pendingSubagentApprovals,
+  onSubagentApprove,
+  onSubagentDeny,
 }: {
   messages: UIMessage[];
   emptyMessage?: string;
@@ -65,6 +73,12 @@ export function ChatMessageList({
   onNextBranch?: (origId: string) => void;
   /** Returns a live progress label for a running tool, keyed by toolCallId. */
   getToolProgressLabel?: (toolCallId: string) => string | undefined;
+  /** Pending subagent tool approvals from the gated trust model. */
+  pendingSubagentApprovals?: PendingSubagentApproval[];
+  /** Called when the user approves a subagent tool call. Receives the approvalId. */
+  onSubagentApprove?: (approvalId: string) => void;
+  /** Called when the user denies a subagent tool call. Receives the approvalId. */
+  onSubagentDeny?: (approvalId: string) => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -216,6 +230,23 @@ export function ChatMessageList({
             })
           )}
           {showShimmer && <ShimmerLoader />}
+
+          {/* Subagent tool approval cards (gated trust model) */}
+          {pendingSubagentApprovals && pendingSubagentApprovals.length > 0 && (
+            <div className="px-4">
+              {pendingSubagentApprovals.map((approval) => (
+                <SubagentApprovalCard
+                  key={approval.approvalId}
+                  approvalId={approval.approvalId}
+                  toolName={approval.toolName}
+                  toolInput={approval.toolInput}
+                  receivedAt={approval.receivedAt}
+                  onApprove={onSubagentApprove}
+                  onDeny={onSubagentDeny}
+                />
+              ))}
+            </div>
+          )}
         </div>
       </div>
 

--- a/libs/ui/src/ai/subagent-approval-card.tsx
+++ b/libs/ui/src/ai/subagent-approval-card.tsx
@@ -1,0 +1,234 @@
+/**
+ * SubagentApprovalCard — Inline approval UI for subagent tool calls (gated trust model).
+ *
+ * Shown in the chat message list when a subagent tool call is waiting for
+ * human approval in gated trust mode. The card displays the tool name,
+ * abbreviated input arguments, and Approve/Deny buttons.
+ *
+ * Visual states:
+ *   - pending:  Blue/amber accent, tool details, Approve/Deny buttons
+ *   - approved: Spinner while the inner agent continues with the tool
+ *   - denied:   Muted "denied" summary
+ *   - expired:  Muted "expired" summary (5-minute auto-deny timeout)
+ */
+
+import { useState, useEffect } from 'react';
+import { ShieldAlert, ShieldCheck, ShieldX, Loader2, Clock } from 'lucide-react';
+import { cn } from '../lib/utils.js';
+
+/** 5-minute approval timeout in milliseconds */
+const APPROVAL_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * A pending subagent tool approval received from the server via WebSocket.
+ * Consumed by the chat message list to render approval cards inline.
+ */
+export interface PendingSubagentApproval {
+  approvalId: string;
+  toolCallId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  /** ISO timestamp when the approval was received (for 5-minute timeout tracking) */
+  receivedAt: string;
+}
+
+export interface SubagentApprovalCardProps {
+  /** Unique ID for this approval request */
+  approvalId: string;
+  /** Name of the tool requesting execution */
+  toolName: string;
+  /** Input arguments passed to the tool */
+  toolInput: Record<string, unknown>;
+  /** ISO timestamp when the request was received (for timeout tracking) */
+  receivedAt: string;
+  /** Called when the user clicks Approve */
+  onApprove?: (approvalId: string) => void;
+  /** Called when the user clicks Deny */
+  onDeny?: (approvalId: string) => void;
+  className?: string;
+}
+
+type CardState = 'pending' | 'approving' | 'denied' | 'expired';
+
+/**
+ * Format the tool name for display — converts snake_case to Title Case with spaces.
+ */
+function formatToolName(name: string): string {
+  return name
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+/**
+ * Abbreviate tool input to a concise one-line summary.
+ * Shows up to 3 key-value pairs, truncating long strings.
+ */
+function abbreviateInput(input: Record<string, unknown>): string {
+  const entries = Object.entries(input).slice(0, 3);
+  if (entries.length === 0) return '(no arguments)';
+
+  const parts = entries.map(([key, value]) => {
+    const strVal =
+      typeof value === 'string'
+        ? value.length > 50
+          ? `"${value.slice(0, 50)}…"`
+          : `"${value}"`
+        : JSON.stringify(value);
+    return `${key}: ${strVal}`;
+  });
+
+  const hasMore = Object.keys(input).length > 3;
+  return parts.join(', ') + (hasMore ? ', …' : '');
+}
+
+export function SubagentApprovalCard({
+  approvalId,
+  toolName,
+  toolInput,
+  receivedAt,
+  onApprove,
+  onDeny,
+  className,
+}: SubagentApprovalCardProps) {
+  const [state, setState] = useState<CardState>('pending');
+
+  // Auto-expire after 5 minutes (matches server-side timeout)
+  useEffect(() => {
+    const receivedTime = new Date(receivedAt).getTime();
+    const remaining = APPROVAL_TIMEOUT_MS - (Date.now() - receivedTime);
+
+    if (remaining <= 0) {
+      setState('expired');
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setState((prev) => (prev === 'pending' ? 'expired' : prev));
+    }, remaining);
+
+    return () => clearTimeout(timer);
+  }, [receivedAt]);
+
+  function handleApprove() {
+    if (state !== 'pending') return;
+    setState('approving');
+    onApprove?.(approvalId);
+  }
+
+  function handleDeny() {
+    if (state !== 'pending') return;
+    setState('denied');
+    onDeny?.(approvalId);
+  }
+
+  const displayName = formatToolName(toolName);
+  const inputSummary = abbreviateInput(toolInput);
+
+  // ── Expired state ──────────────────────────────────────────────────────────
+  if (state === 'expired') {
+    return (
+      <div
+        data-slot="subagent-approval-card"
+        data-state="expired"
+        className={cn(
+          'my-1 flex max-w-full items-center gap-2 overflow-hidden rounded-md border border-border/50 bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground',
+          className
+        )}
+      >
+        <Clock className="size-3.5 shrink-0" />
+        <span className="shrink-0 font-medium">Approval expired</span>
+        <span className="text-muted-foreground/40">—</span>
+        <span className="truncate text-muted-foreground/70">{displayName}</span>
+      </div>
+    );
+  }
+
+  // ── Denied state ───────────────────────────────────────────────────────────
+  if (state === 'denied') {
+    return (
+      <div
+        data-slot="subagent-approval-card"
+        data-state="denied"
+        className={cn(
+          'my-1 flex max-w-full items-center gap-2 overflow-hidden rounded-md border border-border/50 bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground',
+          className
+        )}
+      >
+        <ShieldX className="size-3.5 shrink-0" />
+        <span className="shrink-0 font-medium">Tool denied</span>
+        <span className="text-muted-foreground/40">—</span>
+        <span className="truncate text-muted-foreground/70">{displayName}</span>
+      </div>
+    );
+  }
+
+  // ── Approving state (spinner while inner agent continues) ──────────────────
+  if (state === 'approving') {
+    return (
+      <div
+        data-slot="subagent-approval-card"
+        data-state="approving"
+        className={cn(
+          'my-1 flex max-w-full items-center gap-2 overflow-hidden rounded-md border border-blue-500/30 bg-blue-500/5 px-3 py-2.5 text-xs',
+          className
+        )}
+      >
+        <Loader2 className="size-3.5 shrink-0 animate-spin text-blue-500" />
+        <span className="font-medium text-blue-700 dark:text-blue-300">Approving…</span>
+        <span className="text-muted-foreground/40">—</span>
+        <span className="truncate text-foreground/60">{displayName}</span>
+      </div>
+    );
+  }
+
+  // ── Pending state (default) ────────────────────────────────────────────────
+  return (
+    <div
+      data-slot="subagent-approval-card"
+      data-state="pending"
+      className={cn(
+        'my-1 max-w-full overflow-hidden rounded-md border border-blue-500/40 bg-blue-500/5 text-xs',
+        className
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-start gap-2 px-3 py-2.5">
+        <ShieldAlert className="mt-0.5 size-3.5 shrink-0 text-blue-500" />
+        <div className="min-w-0 flex-1">
+          <p className="font-semibold text-foreground/90">Subagent tool approval required</p>
+          <p className="mt-0.5 font-medium text-foreground/80">{displayName}</p>
+          <p
+            className="mt-0.5 truncate text-muted-foreground"
+            title={JSON.stringify(toolInput, null, 2)}
+          >
+            {inputSummary}
+          </p>
+        </div>
+        <span className="shrink-0 rounded bg-blue-500/15 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wider text-blue-600 dark:text-blue-400">
+          Subagent
+        </span>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex items-center gap-2 border-t border-blue-500/20 px-3 py-2">
+        <button
+          type="button"
+          onClick={handleApprove}
+          className="flex items-center gap-1.5 rounded-md bg-blue-500/15 px-2.5 py-1 font-medium text-blue-700 transition-colors hover:bg-blue-500/25 dark:text-blue-300"
+        >
+          <ShieldCheck className="size-3" />
+          Approve
+        </button>
+        <button
+          type="button"
+          onClick={handleDeny}
+          className="flex items-center gap-1.5 rounded-md bg-muted/60 px-2.5 py-1 font-medium text-muted-foreground transition-colors hover:bg-muted"
+        >
+          <ShieldX className="size-3" />
+          Deny
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `subagent:tool-approval-request` and `subagent:tool-approval-response` WebSocket event types
- Wires `canUseTool` through Ava chat route and `execute_dynamic_agent`
- Adds `POST /api/chat/tool-approval` endpoint for approve/deny responses
- Creates `SubagentApprovalCard` component for inline tool approval UI in chat
- Subscribes to approval requests in `useChatSession` hook

## Test plan
- [ ] Verify TypeScript builds cleanly
- [ ] Verify gated trust mode surfaces tool approval requests in chat
- [ ] Verify approve/deny buttons send correct response via WebSocket
- [ ] Verify 5min timeout shows expired state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subagent tool approval workflow: when gated trust mode is enabled, users can review and approve or deny subagent tool execution requests.
  * Introduced approval interface displaying pending tool requests with tool details and action buttons; requests auto-expire after 5 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->