### PR TITLE
docs: Ava architecture pipeline, delegation flow, and SDK integration

### DIFF
--- a/docs/agents/ava-delegation.md
+++ b/docs/agents/ava-delegation.md
@@ -1,0 +1,172 @@
+# Ava Delegation Flow
+
+When Ava's orchestration loop determines it needs to run a task autonomously — writing code, running tests, researching an issue — it delegates to a specialized inner agent via the `execute_dynamic_agent` tool. This page documents the delegation path from Ava's tool call through role resolution, agent execution, progress streaming, and back to the chat UI.
+
+## Overview
+
+```
+Ava (outer loop, streamText)
+  │  calls execute_dynamic_agent tool
+  ▼
+ava-tools.ts: execute_dynamic_agent handler
+  ├── RoleRegistryService.get(role)          → AgentTemplate
+  ├── AgentFactoryService.createFromTemplate() → AgentConfig
+  └── DynamicAgentExecutor.execute()
+        ├── ClaudeProvider.executeQuery()    → SDK query()
+        └── WebSocket progress events        → AgentOutputCard (chat UI)
+```
+
+The outer Ava session continues streaming SSE to the browser while the inner agent runs asynchronously, emitting progress over WebSocket.
+
+## Step-by-Step Delegation
+
+### 1. Ava Decides to Delegate
+
+During a `streamText` step, Ava emits a tool call to `execute_dynamic_agent`:
+
+```json
+{
+  "toolName": "execute_dynamic_agent",
+  "input": {
+    "role": "implementer",
+    "feature_id": "feature-1234",
+    "prompt": "Implement the login form component described in the feature spec.",
+    "trust": "standard"
+  }
+}
+```
+
+The `role` field identifies which registered agent template to use. `feature_id` is optional — it provides context about which board item the agent is working on. `trust` can override the project-level `subagentTrust` downward (it cannot grant more trust than the project allows).
+
+### 2. Role Registry Lookup
+
+`RoleRegistryService.get(role)` retrieves the named template from the in-memory registry. Templates are registered at server startup from:
+
+- Built-in templates (e.g., `implementer`, `reviewer`, `researcher`) registered in `apps/server/src/services/role-registry-service.ts`
+- Project-local templates loaded from `.automaker/roles/` at project open time
+
+If the role is not found, `execute_dynamic_agent` returns an error result and Ava reports the failure to the user.
+
+See [Dynamic Role Registry](./dynamic-role-registry.md) for the full template schema.
+
+### 3. Agent Config Resolution
+
+`AgentFactoryService.createFromTemplate(role, projectPath, overrides?)` resolves the template into a concrete `AgentConfig`:
+
+- Applies project-specific overrides (from `.automaker/roles/{role}.override.json` if present)
+- Resolves the system prompt (template's `systemPrompt` field, rendered with feature context)
+- Determines the tool set: template `capabilities` → allowed tool names
+- Caps trust at `min(template.maxTrust, subagentTrust)` from AvaConfig
+
+The returned `AgentConfig` is a fully resolved, immutable snapshot — no further registry lookups occur during execution.
+
+### 4. DynamicAgentExecutor
+
+`DynamicAgentExecutor.execute(config, options)` runs the inner agent:
+
+```
+DynamicAgentExecutor.execute(config, options)
+  ├── Validate canUseTool for every tool in config.allowedTools
+  │     → Tools exceeding trust level are removed from the set
+  ├── ClaudeProvider.executeQuery({
+  │     systemPrompt: config.systemPrompt,
+  │     tools: config.allowedTools,
+  │     mcpServers: AvaConfig.mcpServers,
+  │     hooks: { PostToolUse, Notification, SubagentStop }
+  │   })
+  └── Returns: AgentResult { output, cost, stepCount, error? }
+```
+
+The executor is stateless — it does not maintain agent sessions between Ava calls. Each `execute_dynamic_agent` invocation starts a fresh SDK session.
+
+### 5. canUseTool Gate
+
+Before running, `DynamicAgentExecutor` validates each tool against the effective trust level:
+
+```
+for each tool in config.allowedTools:
+  if tool.requiredTrust > effectiveTrust:
+    remove from allowed set
+    log("tool_blocked: {toolName}")
+```
+
+This is enforced at the executor level — not in the SDK's `canUseTool` callback — so blocked tools are simply removed before the agent starts rather than causing mid-run refusals.
+
+If the approved tool set becomes empty (all tools blocked), `DynamicAgentExecutor` returns an error result immediately rather than running an agent with no tools.
+
+### 6. Progress Streaming Back to Chat UI
+
+During execution, `DynamicAgentExecutor` emits progress events via the server's WebSocket channel, keyed by `agentRunId` (generated per `execute_dynamic_agent` call and passed through the tool result for the UI to subscribe with):
+
+| Event               | When emitted                              | UI component                      |
+| ------------------- | ----------------------------------------- | --------------------------------- |
+| `agent:text`        | Inner agent emits a text chunk            | `AgentOutputCard` — streamed text |
+| `agent:tool-use`    | Inner agent calls a tool                  | Tool invocation row               |
+| `agent:tool-result` | Inner tool returns (via PostToolUse hook) | Collapsible result                |
+| `agent:complete`    | `SubagentStop` hook fires                 | Cost + step count chip            |
+| `agent:error`       | Agent throws or SDK errors                | Error callout                     |
+
+The chat bubble for `execute_dynamic_agent` renders as `AgentOutputCard` (registered in `toolResultRegistry`). It subscribes to the WebSocket channel by `agentRunId` extracted from the tool's input-streaming output.
+
+### 7. Result Returned to Ava
+
+After the inner agent completes, `execute_dynamic_agent` returns a structured result to the outer Ava `streamText` loop:
+
+```json
+{
+  "success": true,
+  "output": "Implemented LoginForm component at apps/ui/src/components/auth/login-form.tsx. Added form validation and error states. Tests added at apps/ui/src/components/auth/__tests__/login-form.test.tsx.",
+  "cost": { "inputTokens": 14200, "outputTokens": 3100 },
+  "stepCount": 8
+}
+```
+
+Ava receives this as a tool result and continues its response — typically summarizing what the agent accomplished and updating the board state.
+
+If the inner agent failed, `success: false` is returned with an `error` field. Ava will surface the error to the user and can decide to retry, escalate, or report the failure.
+
+## Role Registry and Template Resolution
+
+Templates are the source of truth for what an agent is allowed to do. Key fields relevant to delegation:
+
+| Field          | Purpose                                                                 |
+| -------------- | ----------------------------------------------------------------------- |
+| `name`         | Role identifier — matches the `role` field in `execute_dynamic_agent`   |
+| `systemPrompt` | Agent identity and instructions (rendered with `{{ feature }}` context) |
+| `capabilities` | List of allowed tool group names                                        |
+| `maxTrust`     | Maximum trust level this role may operate at                            |
+| `tier`         | `0` = protected (cannot be unregistered), `1` = managed                 |
+
+Built-in roles (`implementer`, `reviewer`, `researcher`) are tier 0 and cannot be overridden by project-local files. Project roles in `.automaker/roles/` are tier 1 and can be registered, updated, or removed at runtime.
+
+See [Dynamic Role Registry](./dynamic-role-registry.md) for the complete template schema and registration API.
+
+## Approval Flow for Delegated Agents
+
+When `subagentTrust` is `standard` and the inner agent calls a destructive tool, the `canUseTool` gate allows it but the tool itself checks `needsApproval()`. In this case:
+
+1. The inner agent's tool execution is paused
+2. An `agent:approval-requested` WebSocket event is emitted with `{ toolName, input, inputHash }`
+3. `AgentOutputCard` renders an inline `ConfirmationCard` within the agent bubble
+4. User approves → WebSocket message sent back → execution resumes
+5. User rejects → tool result = `"denied"` → agent receives denial and adapts
+
+This mirrors the outer HITL flow but is scoped to the inner agent session. The outer Ava session remains blocked on the `execute_dynamic_agent` tool result until the inner agent completes (including any mid-agent approvals).
+
+## Key Files
+
+| File                                                                   | Role                                                         |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `apps/server/src/routes/chat/ava-tools.ts`                             | `execute_dynamic_agent` tool definition and handler          |
+| `apps/server/src/services/role-registry-service.ts`                    | `RoleRegistryService` — template store and lookup            |
+| `apps/server/src/services/agent-factory-service.ts`                    | `AgentFactoryService.createFromTemplate()` — config resolver |
+| `apps/server/src/services/dynamic-agent-executor.ts`                   | `DynamicAgentExecutor.execute()` — runs the inner agent      |
+| `apps/server/src/providers/claude-provider.ts`                         | `ClaudeProvider.executeQuery()` — SDK wrapper                |
+| `apps/ui/src/components/views/chat/tool-results/agent-output-card.tsx` | Chat UI card — renders agent progress stream                 |
+
+## See Also
+
+- [Ava Chat System — Architecture Pipeline](../dev/ava-chat-system.md#architecture-pipeline) — full request flow from chat input to response
+- [Ava Chat Server API](../server/ava-chat.md) — SDK hooks, trust model, MCP server config
+- [Dynamic Role Registry](./dynamic-role-registry.md) — template schema, registration, and tier enforcement
+- [SDK Integration](./sdk-integration.md) — Claude Agent SDK query options and session management

--- a/docs/dev/ava-chat-system.md
+++ b/docs/dev/ava-chat-system.md
@@ -30,6 +30,150 @@ ChatMessageList                          POST /api/chat
 6. Server extracts `[[feature:id]]` / `[[doc:path]]` citations, writes as `data-citations` chunk
 7. Client renders each step as its own bubble with custom tool result cards
 
+## Architecture Pipeline
+
+The full end-to-end pipeline from a user's chat input through tool execution, agent delegation, and response streaming:
+
+### Full Request Flow
+
+```
+Chat UI (ChatInput)
+  │  { messages, projectPath, model? }
+  ▼
+POST /api/chat
+  ├── loadAvaConfig(projectPath)
+  │     → AvaConfig { model, toolGroups, mcpServers, subagentTrust,
+  │                   sitrepInjection, contextInjection, systemPromptExtension }
+  ├── getSitrep(projectPath)           [if sitrepInjection: true]
+  ├── loadContextFiles(projectPath)    [if contextInjection: true]
+  ├── buildAvaSystemPrompt()
+  │     → AVA_BASE_PROMPT (personas.ts)
+  │     + ava-prompt.md               (UI chat surface)
+  │     + CLAUDE.md                   (project root)
+  │     + sitrep                      (live board state)
+  │     + systemPromptExtension       (user custom text)
+  ├── buildAvaTools(projectPath, services, config)
+  │     → tool set gated by config.toolGroups flags
+  │     → execute_dynamic_agent tool  [if agentDelegation enabled]
+  └── streamText({ tools, maxSteps: 10 })
+        │
+        ├── [text chunk]  → SSE text delta → ChatMessageMarkdown
+        ├── [reasoning]   → SSE reasoning delta → ChainOfThought
+        ├── [tool-call]   → SSE tool-call → ToolInvocationPart (input-streaming)
+        │     ├── needsApproval?  → approval-requested → ConfirmationCard
+        │     │     User approves → re-request with approvedActions
+        │     │     User rejects  → result = "denied"
+        │     └── tool executes  → SSE tool-result → ToolInvocationPart (output-available)
+        ├── [step-start]  → groupByStep() splits into separate bubbles
+        └── [done]        → extractCitations() → data-citations chunk
+```
+
+### Ava Tool Delegation
+
+When Ava invokes `execute_dynamic_agent`, the call passes through the full agent stack:
+
+```
+streamText tool call: execute_dynamic_agent
+  │  { role, feature_id?, prompt, trust? }
+  ▼
+ava-tools.ts: execute_dynamic_agent handler
+  ├── RoleRegistryService.get(role)        → AgentTemplate
+  ├── AgentFactoryService.createFromTemplate(role, projectPath)
+  │     → AgentConfig (resolved capabilities, tools, system prompt)
+  └── DynamicAgentExecutor.execute(config, options)
+        ├── Builds system prompt with capability constraints
+        ├── Filters disallowed tools per template
+        ├── ClaudeProvider.executeQuery()
+        │     → @anthropic-ai/claude-agent-sdk query()
+        │           Cost tracking, session resume, context compaction
+        └── Streams progress events via WebSocket → AgentOutputCard
+              { type: 'agent:text' | 'agent:tool-use' | 'agent:complete' }
+```
+
+The inner agent runs in a worktree-isolated environment with its own tool set (defined by the role template) and cannot exceed the capabilities granted by `subagentTrust`.
+
+### SDK Integration Points
+
+The Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`) exposes three hook types that protoLabs wires into `DynamicAgentExecutor`:
+
+| Hook           | Trigger                                 | protoLabs Use                                      |
+| -------------- | --------------------------------------- | -------------------------------------------------- |
+| `PostToolUse`  | After every tool execution              | Log cost accumulation, emit `agent:tool-result` WS |
+| `Notification` | SDK informational events (context, etc) | Surface warnings in agent output log               |
+| `SubagentStop` | Inner agent session ends                | Mark sub-run complete, aggregate cost into parent  |
+
+**`canUseTool` gate:** When `subagentTrust` is set below the tool's required trust level, the SDK's `canUseTool` callback returns `false`, preventing the inner agent from calling that tool. This is how Ava enforces that delegated agents cannot exceed their granted permissions.
+
+**Custom MCP servers:** If `AvaConfig.mcpServers` lists server entries, they are passed to the SDK via `createChatOptions({ mcpServers })` before the inner agent runs. This lets Ava-delegated agents access project-specific MCP tools (e.g., GitHub, filesystem) without exposing them to the outer Ava loop.
+
+### Prompt Chain
+
+The Ava system prompt is assembled in layers by `buildAvaSystemPrompt()` in `personas.ts`:
+
+```
+Layer 1: AVA_BASE_PROMPT          — Fixed persona header (always injected)
+Layer 2: ava-prompt.md            — UI chat body: tool guidance, HITL awareness, citations
+Layer 3: CLAUDE.md                — Project-level instructions (if file exists at root)
+Layer 4: sitrep                   — Live board state: feature counts, running agents
+Layer 5: systemPromptExtension    — User-supplied custom text from AvaConfig
+```
+
+Each layer is optional except Layer 1 (base prompt) and Layer 2 (chat prompt body). If `sitrepInjection: false` in AvaConfig, Layer 4 is omitted. If `contextInjection: false`, CLAUDE.md and `.automaker/context/` files are omitted.
+
+### HITL Detailed Flow
+
+```
+1. streamText emits tool-call for a destructive tool (delete_feature, stop_agent, etc.)
+2. ava-tools.ts: needsApproval(toolName, approvedActions) → true
+3. Server returns partial result: { __hitl: true, action, summary, inputHash }
+4. SSE tool-result → ToolInvocationPart state = 'approval-requested'
+5. Client renders ConfirmationCard inline (no modal, inline in message bubble)
+6. User clicks Approve:
+     → useChat re-sends messages with approvedActions: [{ toolName, inputHash }]
+     → Server finds matching hash → executes tool → returns real result
+     → ToolInvocationPart state = 'output-available'
+7. User clicks Reject:
+     → Client marks tool result = "denied"
+     → ToolInvocationPart state = 'output-denied'
+     → Ava receives "denied" in next step, acknowledges to user
+```
+
+The `inputHash` is a stable JSON hash of the tool arguments. This ensures approvals are scoped to the exact invocation — re-approving a different set of arguments requires a new approval.
+
+### AvaConfig Reference
+
+Full set of supported fields, including newer delegation and trust fields:
+
+```typescript
+interface AvaConfig {
+  // Model
+  model: 'haiku' | 'sonnet' | 'opus';
+
+  // Tool access gates
+  toolGroups: {
+    boardRead: boolean; // get_board_summary, list_features, get_feature
+    boardWrite: boolean; // create_feature, update_feature, move_feature, delete_feature
+    agentControl: boolean; // list_running_agents, start_agent, stop_agent, get_agent_output
+    autoMode: boolean; // get_auto_mode_status, start_auto_mode, stop_auto_mode
+    projectMgmt: boolean; // get_project_spec, update_project_spec
+    orchestration: boolean; // get_execution_order, set_feature_dependencies
+  };
+
+  // Context injection
+  sitrepInjection: boolean; // Inject live board state into system prompt
+  contextInjection: boolean; // Inject .automaker/context/ files into prompt
+
+  // Custom prompt
+  systemPromptExtension: string; // Appended after all other prompt layers
+
+  // Agent delegation
+  mcpServers?: Record<string, MCPServerConfig>; // Custom MCP servers for inner agents
+  subagentTrust?: 'high' | 'standard' | 'restricted'; // Max trust granted to delegated agents
+}
+```
+
+All fields default to enabled. `mcpServers` and `subagentTrust` are optional — omitting them uses the system defaults (standard trust, no extra MCP servers). See `apps/server/src/routes/chat/ava-config.ts`.
+
 ## Server API
 
 ### `POST /api/chat`
@@ -361,3 +505,10 @@ apps/ui/src/components/views/chat-overlay/
   conversation-list.tsx             # Session history sidebar
   ava-settings-panel.tsx            # Config popover
 ```
+
+## See Also
+
+- [Ava Chat Server API](../server/ava-chat.md) — SDK hooks, MCP server config, trust model, tool progress WebSocket events
+- [Ava Delegation Flow](../agents/ava-delegation.md) — how `execute_dynamic_agent` routes through role registry and `DynamicAgentExecutor`
+- [Dynamic Role Registry](../agents/dynamic-role-registry.md) — agent template schema and registration
+- [SDK Integration](../agents/sdk-integration.md) — Claude Agent SDK query options and session management

--- a/docs/server/ava-chat.md
+++ b/docs/server/ava-chat.md
@@ -89,3 +89,67 @@ Sessions are stored in Zustand (`chat-store.ts`) keyed by `projectId`. Switching
 ## Settings UI
 
 The gear icon in the chat header opens `AvaSettingsPanel`, which loads config via `GET /api/ava/config/get` and saves via `POST /api/ava/config/update`. Changes take effect on the next chat request — no server restart required.
+
+## SDK Hooks
+
+When Ava delegates to an inner agent via `execute_dynamic_agent`, the Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`) is invoked through `DynamicAgentExecutor`. Three hook types are wired in:
+
+| Hook           | Trigger                                          | Effect                                                      |
+| -------------- | ------------------------------------------------ | ----------------------------------------------------------- |
+| `PostToolUse`  | After every tool execution in inner agent        | Accumulates cost, emits `agent:tool-result` WebSocket event |
+| `Notification` | SDK informational events (context compact, etc.) | Surfaces warnings in the agent output log                   |
+| `SubagentStop` | Inner agent session ends                         | Marks sub-run complete, aggregates cost to parent           |
+
+Hooks are configured in `DynamicAgentExecutor` before calling `query()`. They are not exposed to the outer Ava loop — Ava only sees the final tool result from `execute_dynamic_agent`.
+
+## Custom MCP Servers
+
+`AvaConfig.mcpServers` lets projects supply additional MCP server definitions that are forwarded to delegated agents:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "${GITHUB_TOKEN}" }
+    }
+  }
+}
+```
+
+These servers are passed to `createChatOptions({ mcpServers })` before the inner agent runs. The outer Ava session does **not** receive MCP tools — they are scoped to delegated agents only. This prevents Ava from directly calling high-privilege tools while still allowing inner agents to use them under the trust gate.
+
+## Trust Model
+
+`AvaConfig.subagentTrust` controls the maximum trust level granted to agents Ava delegates to:
+
+| Level        | Effect                                                                      |
+| ------------ | --------------------------------------------------------------------------- |
+| `high`       | Inner agents may call all tools including destructive ones without approval |
+| `standard`   | Inner agents call most tools; destructive tools still require approval      |
+| `restricted` | Inner agents are limited to read-only and low-risk tools                    |
+
+Trust is enforced via the SDK's `canUseTool` callback in `DynamicAgentExecutor`. If the requested tool's required trust level exceeds `subagentTrust`, `canUseTool` returns `false` and the SDK does not execute the tool. Ava receives `"tool_blocked"` as the tool result.
+
+Omitting `subagentTrust` from `ava-config.json` defaults to `standard`.
+
+## Tool Progress WebSocket Events
+
+During agent delegation, `DynamicAgentExecutor` emits progress events over the WebSocket connection (keyed by `agentRunId`). The chat UI subscribes to these via `AgentOutputCard`:
+
+| Event type          | Payload                                     | Rendered by                   |
+| ------------------- | ------------------------------------------- | ----------------------------- |
+| `agent:text`        | `{ text }` — streamed text from inner agent | `AgentOutputCard` text stream |
+| `agent:tool-use`    | `{ toolName, input }` — inner tool call     | Tool invocation row           |
+| `agent:tool-result` | `{ toolName, result }` — inner tool result  | Collapsible result            |
+| `agent:complete`    | `{ cost, stepCount }` — final summary       | Completion chip               |
+| `agent:error`       | `{ message }` — agent error                 | Error callout                 |
+
+These events are only emitted for delegated agents — Ava's own tool calls stream through the SSE channel, not WebSocket.
+
+## See Also
+
+- [Ava Chat System — Architecture Pipeline](../dev/ava-chat-system.md#architecture-pipeline) — full end-to-end request flow diagram
+- [Ava Delegation Flow](../agents/ava-delegation.md) — how `execute_dynamic_agent` routes to `DynamicAgentExecutor`
+- [SDK Integration](../agents/sdk-integration.md) — Claude Agent SDK query options and session management


### PR DESCRIPTION
## Summary
- Adds comprehensive Architecture Pipeline section to `docs/dev/ava-chat-system.md` covering full request flow, tool delegation, SDK hooks, prompt chain, HITL flow, and AvaConfig reference
- Updates `docs/server/ava-chat.md` with SDK integration points (hooks, MCP servers, trust model)
- Creates new `docs/agents/ava-delegation.md` documenting the delegation flow from Ava to inner agents

## Test plan
- [ ] Verify all three doc files render correctly
- [ ] Verify cross-references between docs are valid
- [ ] Verify docs follow docs-standard.md conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed documentation covering Ava agent delegation workflows, including role resolution and dynamic agent execution
  * Expanded Ava Chat System documentation with architecture pipeline, SDK integration points, and prompt chain details
  * Enhanced server documentation with SDK hooks, custom MCP server configuration, trust model clarification, and delegated agent WebSocket events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->