### PR TITLE
fix: pr maintainer robustness — CodeRabbit transient handling, review timeout, watermark injection

### DIFF
--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -8,6 +8,7 @@
 import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import path from 'path';
+import { randomUUID } from 'crypto';
 import { createLogger } from '@protolabs-ai/utils';
 import { buildGitAddCommand } from '../lib/git-staging-utils.js';
 import type {
@@ -22,6 +23,7 @@ import { validatePRState } from '@protolabs-ai/types';
 import { githubMergeService } from './github-merge-service.js';
 import { codeRabbitResolverService } from './coderabbit-resolver-service.js';
 import type { EventEmitter } from '../lib/events.js';
+import { buildPROwnershipWatermark } from '../routes/github/utils/pr-ownership.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -551,7 +553,9 @@ export class GitWorkflowService {
               projectPath,
               feature,
               branchName,
-              prBaseBranch
+              prBaseBranch,
+              settings.instanceId,
+              settings.teamId
             );
             result.prUrl = prResult.prUrl;
             result.prNumber = prResult.prNumber;
@@ -804,6 +808,78 @@ export class GitWorkflowService {
     if (body.includes('💡')) return 'suggestion';
 
     return 'info';
+  }
+
+  /**
+   * Validate that GitHub Actions workflows are configured to trigger on the PR base branch.
+   *
+   * This is a purely advisory check that logs a warning when CI workflows exist but their
+   * `branches:` filter does not mention `prBaseBranch`. If CI never triggers on that branch,
+   * checks will remain "pending" indefinitely and features will time out in REVIEW state.
+   *
+   * Does NOT block PR creation — failures here are logged and swallowed.
+   */
+  private async validateCIWorkflowTriggers(
+    projectPath: string,
+    prBaseBranch: string
+  ): Promise<void> {
+    try {
+      const workflowDir = path.join(projectPath, '.github', 'workflows');
+
+      // List workflow files (non-fatal if the directory doesn't exist)
+      let workflowFiles: string[] = [];
+      try {
+        const { stdout } = await execAsync(`ls "${workflowDir}"`, { env: execEnv });
+        workflowFiles = stdout
+          .trim()
+          .split('\n')
+          .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
+      } catch {
+        // No .github/workflows/ directory — nothing to validate
+        return;
+      }
+
+      if (workflowFiles.length === 0) return;
+
+      let anyWorkflowTriggersBranch = false;
+      const misconfiguredFiles: string[] = [];
+
+      for (const file of workflowFiles) {
+        try {
+          const filePath = path.join(workflowDir, file);
+          const { stdout: content } = await execAsync(`cat "${filePath}"`, { env: execEnv });
+
+          // Text-based check: does the file mention the base branch in a branches list?
+          // Handles common YAML patterns: `- dev`, `"dev"`, `'dev'`
+          const branchMentioned =
+            content.includes(`- ${prBaseBranch}`) ||
+            content.includes(`"${prBaseBranch}"`) ||
+            content.includes(`'${prBaseBranch}'`);
+
+          if (branchMentioned) {
+            anyWorkflowTriggersBranch = true;
+          } else if (content.includes('branches:')) {
+            // Workflow has an explicit branches filter but doesn't mention prBaseBranch
+            misconfiguredFiles.push(file);
+          }
+        } catch {
+          // Ignore individual file read errors
+        }
+      }
+
+      if (!anyWorkflowTriggersBranch && misconfiguredFiles.length > 0) {
+        logger.warn(
+          `[CI Validation] ⚠️  CI workflows may not trigger on branch '${prBaseBranch}'.\n` +
+            `  Affected workflow files: ${misconfiguredFiles.join(', ')}\n` +
+            `  This means CI checks will stay "pending" indefinitely on PRs targeting '${prBaseBranch}',\n` +
+            `  causing features to time out in REVIEW state.\n` +
+            `  Fix: add '- ${prBaseBranch}' to the 'branches:' list in each workflow's push/pull_request trigger.`
+        );
+      }
+    } catch (err) {
+      // Validation is advisory — never let it crash the workflow
+      logger.debug(`[CI Validation] Skipped: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
 
   /**
@@ -1208,7 +1284,9 @@ export class GitWorkflowService {
     projectPath: string,
     feature: Feature,
     branchName: string,
-    baseBranch: string
+    baseBranch: string,
+    instanceId?: string,
+    teamId?: string
   ): Promise<{
     prUrl: string | null;
     prNumber?: number;
@@ -1223,7 +1301,21 @@ export class GitWorkflowService {
     }
 
     const title = feature.title || extractTitleFromDescription(feature.description);
-    const body = buildPRBody(feature);
+    let body = buildPRBody(feature);
+
+    // Always append ownership watermark so the PR Maintainer crew never silently skips managed PRs.
+    // If instanceId was not configured, generate a transient fallback and warn.
+    const effectiveInstanceId = instanceId || `transient-${randomUUID().slice(0, 8)}`;
+    if (!instanceId) {
+      logger.warn(
+        `[GitWorkflow] No instanceId in settings — using transient ID "${effectiveInstanceId}" for PR watermark. ` +
+          'Configure instanceId in global settings to ensure consistent PR ownership tracking.'
+      );
+    }
+    body = `${body}\n\n${buildPROwnershipWatermark(effectiveInstanceId, teamId ?? '')}`;
+    logger.debug(
+      `[GitWorkflow] Appended ownership watermark to PR body (instance=${effectiveInstanceId})`
+    );
 
     // Detect repository info by checking remotes
     // We need to explicitly set --repo to avoid gh defaulting to wrong upstream
@@ -1265,6 +1357,11 @@ export class GitWorkflowService {
     const targetRepo = originRepo || upstreamRepo;
     const headRef = branchName; // No cross-fork PR - target our own repo
     const repoArg = targetRepo ? ` --repo "${targetRepo}"` : '';
+
+    // Validate CI workflow triggers before creating/returning PR.
+    // Logs a warning (non-blocking) if CI workflows don't include the base branch —
+    // which would cause checks to stay "pending" indefinitely on the new PR.
+    await this.validateCIWorkflowTriggers(projectPath, baseBranch);
 
     try {
       const listCmd = `gh pr list${repoArg} --head "${headRef}" --json number,title,url,state --limit 1`;

--- a/apps/server/src/services/github-merge-service.ts
+++ b/apps/server/src/services/github-merge-service.ts
@@ -119,6 +119,19 @@ export class GitHubMergeService {
         const conclusion = check.conclusion?.toLowerCase();
 
         if (status === 'completed') {
+          // Detect CodeRabbit FAILURE — treat as transient pending rather than a hard failure.
+          // CodeRabbit commonly sets commit status to FAILURE when rate-limited by simultaneous
+          // batch PRs. Counting it as a real failure would block merge unnecessarily.
+          const checkIdentifier = (check.name ?? check.context ?? '').toLowerCase();
+          if (checkIdentifier.includes('coderabbit') && conclusion === 'failure') {
+            logger.warn(
+              `[CodeRabbit] FAILURE status on '${check.name ?? check.context}' — ` +
+                `treating as transient pending (possible rate-limit). Will not count as hard failure.`
+            );
+            pendingCount++;
+            continue;
+          }
+
           if (conclusion === 'success' || conclusion === 'neutral' || conclusion === 'skipped') {
             passedCount++;
           } else {

--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -18,6 +18,7 @@ import type {
 import {
   MERGE_RETRY_DELAY_MS,
   REVIEW_POLL_DELAY_MS,
+  REVIEW_PENDING_TIMEOUT_MS,
   MAX_TOTAL_REMEDIATION_CYCLES,
   MAX_PR_ITERATIONS,
 } from './lead-engineer-types.js';
@@ -47,10 +48,21 @@ function sanitizePrNumber(prNumber: unknown): number {
 export class ReviewProcessor implements StateProcessor {
   constructor(private serviceContext: ProcessorServiceContext) {}
 
+  /**
+   * Tracks when each feature first entered REVIEW state (epoch ms).
+   * Used to enforce REVIEW_PENDING_TIMEOUT_MS — features cannot stay in REVIEW
+   * indefinitely waiting for CI that may never trigger (e.g., workflows misconfigured).
+   */
+  private readonly reviewStartedAt = new Map<string, number>();
+
   async enter(ctx: StateContext): Promise<void> {
     logger.info(`[REVIEW] PR review started for feature: ${ctx.feature.id}`, {
       prNumber: ctx.prNumber,
     });
+    // Stamp entry time only once — prevent reset if REVIEW re-enters due to re-checks
+    if (!this.reviewStartedAt.has(ctx.feature.id)) {
+      this.reviewStartedAt.set(ctx.feature.id, Date.now());
+    }
   }
 
   async process(ctx: StateContext): Promise<StateTransitionResult> {
@@ -185,9 +197,33 @@ export class ReviewProcessor implements StateProcessor {
       };
     }
 
-    // Status is 'pending' or 'commented' — wait and re-check
+    // Status is 'pending' or 'commented' — enforce timeout before waiting
+    const reviewStartMs = this.reviewStartedAt.get(ctx.feature.id) ?? Date.now();
+    const reviewElapsedMs = Date.now() - reviewStartMs;
+
+    if (reviewElapsedMs > REVIEW_PENDING_TIMEOUT_MS) {
+      const elapsedMin = Math.round(reviewElapsedMs / 60000);
+      const limitMin = Math.round(REVIEW_PENDING_TIMEOUT_MS / 60000);
+      ctx.escalationReason =
+        `PR #${ctx.prNumber} has been pending CI/review for ${elapsedMin} minute(s) ` +
+        `(configured timeout: ${limitMin} min). Possible causes: ` +
+        `(1) CI workflow triggers do not include the PR base branch — check .github/workflows/ ` +
+        `and ensure the 'branches:' list includes your configured prBaseBranch; ` +
+        `(2) CodeRabbit was rate-limited — check the PR for a CodeRabbit FAILURE commit status; ` +
+        `(3) Required reviewers have not been assigned. ` +
+        `Adjust the timeout via the REVIEW_PENDING_TIMEOUT_MINUTES environment variable.`;
+      this.reviewStartedAt.delete(ctx.feature.id);
+      return {
+        nextState: 'ESCALATE',
+        shouldContinue: true,
+        reason: ctx.escalationReason,
+      };
+    }
+
     logger.info(`[REVIEW] PR pending review, waiting ${REVIEW_POLL_DELAY_MS / 1000}s`, {
       prNumber: ctx.prNumber,
+      elapsedMinutes: Math.round(reviewElapsedMs / 60000),
+      timeoutMinutes: Math.round(REVIEW_PENDING_TIMEOUT_MS / 60000),
     });
     await new Promise((r) => setTimeout(r, REVIEW_POLL_DELAY_MS));
 
@@ -198,8 +234,10 @@ export class ReviewProcessor implements StateProcessor {
     };
   }
 
-  async exit(_ctx: StateContext): Promise<void> {
+  async exit(ctx: StateContext): Promise<void> {
     logger.info('[REVIEW] Review phase completed');
+    // Clean up review start timestamp when leaving REVIEW state
+    this.reviewStartedAt.delete(ctx.feature.id);
   }
 
   private async getPRReviewState(ctx: StateContext): Promise<string> {
@@ -211,7 +249,7 @@ export class ReviewProcessor implements StateProcessor {
 
     try {
       const { stdout } = await execAsync(
-        `gh pr view ${ctx.prNumber} --json reviewDecision,statusCheckRollup,reviews --jq '{decision: .reviewDecision, checks: [(.statusCheckRollup // [])[] | .conclusion], approvedCount: ([(.reviews // [])[] | select(.state == "APPROVED")] | length)}'`,
+        `gh pr view ${ctx.prNumber} --json reviewDecision,statusCheckRollup,reviews --jq '{decision: .reviewDecision, checks: [(.statusCheckRollup // [])[] | {name: .context, conclusion: .conclusion}], approvedCount: ([(.reviews // [])[] | select(.state == "APPROVED")] | length)}'`,
         { cwd: ctx.projectPath, timeout: 15000 }
       );
 
@@ -220,12 +258,41 @@ export class ReviewProcessor implements StateProcessor {
       if (data.decision === 'APPROVED') return 'approved';
       if (data.decision === 'CHANGES_REQUESTED') return 'changes_requested';
 
-      // Require at least one human APPROVED review — CI passing alone is not sufficient
-      const checks = (data.checks || []) as string[];
+      // Separate CodeRabbit checks from real CI checks.
+      // CodeRabbit rate-limit sets commit status to FAILURE, but this is transient
+      // and should not block the approval flow.
+      const checks = (data.checks || []) as Array<{ name: string; conclusion: string }>;
+      const codeRabbitChecks = checks.filter(
+        (c) =>
+          c.name?.toLowerCase().includes('coderabbit') ||
+          c.name?.toLowerCase().includes('code-rabbit')
+      );
+      const ciChecks = checks.filter(
+        (c) =>
+          !c.name?.toLowerCase().includes('coderabbit') &&
+          !c.name?.toLowerCase().includes('code-rabbit')
+      );
+
+      // Log transient CodeRabbit failures so operators can diagnose
+      const codeRabbitFailures = codeRabbitChecks.filter(
+        (c) => c.conclusion && c.conclusion !== 'SUCCESS'
+      );
+      if (codeRabbitFailures.length > 0) {
+        logger.info(
+          `[REVIEW] CodeRabbit check(s) not passing (likely rate-limited), treating as transient`,
+          {
+            prNumber: ctx.prNumber,
+            codeRabbitChecks: codeRabbitFailures.map((c) => `${c.name}=${c.conclusion}`),
+          }
+        );
+      }
+
+      // Require at least one human APPROVED review — CI passing alone is not sufficient.
+      // Only real CI checks (non-CodeRabbit) block approval.
       const approvedCount = (data.approvedCount as number) ?? 0;
       if (
         approvedCount > 0 &&
-        (checks.length === 0 || checks.every((c: string) => c === 'SUCCESS'))
+        (ciChecks.length === 0 || ciChecks.every((c) => c.conclusion === 'SUCCESS'))
       ) {
         return 'approved';
       }

--- a/apps/server/src/services/lead-engineer-types.ts
+++ b/apps/server/src/services/lead-engineer-types.ts
@@ -26,6 +26,19 @@ export const MAX_TOTAL_REMEDIATION_CYCLES = 4;
 export const MERGE_RETRY_DELAY_MS = 60 * 1000; // 60 seconds
 export const REVIEW_POLL_DELAY_MS = 30 * 1000; // 30 seconds
 
+/**
+ * Maximum time a feature can remain in the REVIEW state (waiting for CI/approval)
+ * before auto-escalating to ESCALATE with an actionable error message.
+ *
+ * Configurable via REVIEW_PENDING_TIMEOUT_MINUTES env variable (default: 45 minutes).
+ * The previous implicit timeout was ~9 minutes due to polling interaction with
+ * external timing constraints; this raises it to a safe configurable value.
+ */
+export const REVIEW_PENDING_TIMEOUT_MS = (() => {
+  const minutes = parseInt(process.env.REVIEW_PENDING_TIMEOUT_MINUTES ?? '45', 10);
+  return (isNaN(minutes) || minutes <= 0 ? 45 : minutes) * 60 * 1000;
+})();
+
 // ────────────────────────── Retry limits ──────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Fixes 3 of 4 issues from the PR maintainer bug report (P1) where 10 PRs silently stuck for 5+ hours:

- **CodeRabbit rate-limit treated as transient**: ReviewProcessor and GitHubMergeService now filter CodeRabbit checks from real CI checks. CodeRabbit FAILURE status (rate-limit) no longer blocks approval flow.
- **Review timeout configurable**: `REVIEW_PENDING_TIMEOUT_MS` now defaults to 45 minutes (was ~9 min implicit). Configurable via `REVIEW_PENDING_TIMEOUT_MINUTES` env var. Escalation message includes actionable diagnostics.
- **PR ownership watermark always injected**: `createPullRequest()` generates a transient fallback `instanceId` when settings lack one, ensuring PR Maintainer crew never silently skips managed PRs.

## Files Changed

| File | Change |
|------|--------|
| `lead-engineer-review-merge-processors.ts` | Filter CodeRabbit checks, enforce configurable review timeout |
| `lead-engineer-types.ts` | Add `REVIEW_PENDING_TIMEOUT_MS` constant with env var override |
| `github-merge-service.ts` | Treat CodeRabbit FAILURE as transient pending in merge checks |
| `git-workflow-service.ts` | Always inject PR watermark with transient fallback instanceId |

## Test plan

- [ ] `npm run typecheck` passes (verified locally)
- [ ] PR with CodeRabbit rate-limit FAILURE still moves to approved when human review + real CI pass
- [ ] PR stuck in REVIEW for >45min auto-escalates with actionable diagnostics
- [ ] PRs created without instanceId in settings still get ownership watermark

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CI workflow validation for PR base-branch configuration scanning
  * Implemented review pending timeout enforcement (45-minute default)
  * Added PR ownership watermarking functionality

* **Bug Fixes**
  * CodeRabbit check failures now treated as transient instead of blocking PR merges
  * Improved distinction between CodeRabbit checks and real CI checks in approval logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->