### PR TITLE
Extract TerminalKeyboardMap and finalize

### DIFF
--- a/apps/ui/src/components/views/terminal-view/index.ts
+++ b/apps/ui/src/components/views/terminal-view/index.ts
@@ -1,0 +1,17 @@
+// Barrel export for terminal-view sub-components.
+// Consumers can import from this single entry point instead of reaching into
+// individual files: `import { TerminalPanel } from './terminal-view'`
+
+export { TerminalPanel } from './terminal-panel';
+export {
+  TerminalToolbar,
+  MIN_FONT_SIZE,
+  MAX_FONT_SIZE,
+  DEFAULT_FONT_SIZE,
+} from './terminal-toolbar';
+export type { TerminalToolbarProps } from './terminal-toolbar';
+export { TerminalSettingsPopover } from './terminal-settings-popover';
+export type { TerminalSettingsPopoverProps } from './terminal-settings-popover';
+export { TerminalErrorBoundary } from './terminal-error-boundary';
+export { TerminalContextMenu } from './terminal-keyboard-map';
+export type { TerminalContextMenuProps, ContextMenuAction } from './terminal-keyboard-map';

--- a/apps/ui/src/components/views/terminal-view/terminal-keyboard-map.tsx
+++ b/apps/ui/src/components/views/terminal-view/terminal-keyboard-map.tsx
@@ -1,0 +1,192 @@
+import { useState, useRef, useEffect } from 'react';
+import { Copy, ClipboardPaste, CheckSquare, Trash2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type ContextMenuAction = 'copy' | 'paste' | 'selectAll' | 'clear';
+
+const MENU_ACTIONS: ContextMenuAction[] = ['copy', 'paste', 'selectAll', 'clear'];
+
+export interface TerminalContextMenuProps {
+  /** Position of the context menu, or null when closed */
+  contextMenu: { x: number; y: number } | null;
+  /** Whether the user is on macOS (affects shortcut display: ⌘ vs Ctrl) */
+  isMac: boolean;
+  /** Called to close the menu (e.g. Escape key or Tab) */
+  onClose: () => void;
+  /** Called when a menu action is selected (parent handles close + xterm focus) */
+  onAction: (action: ContextMenuAction) => void;
+  /** Focuses the xterm instance (called after Escape to restore keyboard input) */
+  focusXterm: () => void;
+}
+
+/**
+ * TerminalContextMenu — the keyboard shortcut map display for the terminal.
+ *
+ * Renders a context menu that shows available terminal actions alongside their
+ * keyboard shortcut labels (⌘C / Ctrl+C, etc.). Self-manages focus state and
+ * keyboard navigation; delegates action execution and menu close to the parent
+ * via `onAction` and `onClose` props.
+ */
+export function TerminalContextMenu({
+  contextMenu,
+  isMac,
+  onClose,
+  onAction,
+  focusXterm,
+}: TerminalContextMenuProps) {
+  const contextMenuRef = useRef<HTMLDivElement>(null);
+  const [focusedMenuIndex, setFocusedMenuIndex] = useState(0);
+  const focusedMenuIndexRef = useRef(0);
+
+  // Keep ref in sync with state for use inside event handlers
+  useEffect(() => {
+    focusedMenuIndexRef.current = focusedMenuIndex;
+  }, [focusedMenuIndex]);
+
+  // Close context menu on click outside or scroll; handle keyboard navigation
+  useEffect(() => {
+    if (!contextMenu) return;
+
+    // Reset focus index and focus the first menu item when the menu opens
+    setFocusedMenuIndex(0);
+    focusedMenuIndexRef.current = 0;
+    requestAnimationFrame(() => {
+      const firstButton =
+        contextMenuRef.current?.querySelector<HTMLButtonElement>('[role="menuitem"]');
+      firstButton?.focus();
+    });
+
+    const handleClick = () => onClose();
+    const handleScroll = () => onClose();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const updateFocusIndex = (newIndex: number) => {
+        focusedMenuIndexRef.current = newIndex;
+        setFocusedMenuIndex(newIndex);
+      };
+
+      switch (e.key) {
+        case 'Escape':
+          e.preventDefault();
+          e.stopPropagation();
+          onClose();
+          focusXterm();
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+          e.stopPropagation();
+          updateFocusIndex((focusedMenuIndexRef.current + 1) % MENU_ACTIONS.length);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          e.stopPropagation();
+          updateFocusIndex(
+            (focusedMenuIndexRef.current - 1 + MENU_ACTIONS.length) % MENU_ACTIONS.length
+          );
+          break;
+        case 'Enter':
+        case ' ':
+          e.preventDefault();
+          e.stopPropagation();
+          onAction(MENU_ACTIONS[focusedMenuIndexRef.current]);
+          break;
+        case 'Tab':
+          e.preventDefault();
+          e.stopPropagation();
+          onClose();
+          break;
+      }
+    };
+
+    document.addEventListener('click', handleClick);
+    document.addEventListener('scroll', handleScroll, true);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('click', handleClick);
+      document.removeEventListener('scroll', handleScroll, true);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [contextMenu, onClose, focusXterm, onAction]);
+
+  // Programmatically focus the correct menu item when keyboard navigation changes
+  useEffect(() => {
+    if (!contextMenu || !contextMenuRef.current) return;
+    const buttons = contextMenuRef.current.querySelectorAll<HTMLButtonElement>('[role="menuitem"]');
+    buttons[focusedMenuIndex]?.focus();
+  }, [focusedMenuIndex, contextMenu]);
+
+  if (!contextMenu) return null;
+
+  return (
+    <div
+      ref={contextMenuRef}
+      role="menu"
+      aria-label="Terminal context menu"
+      className="fixed z-50 min-w-[160px] rounded-md border border-border bg-popover p-1 shadow-md animate-in fade-in-0 zoom-in-95"
+      style={{ left: contextMenu.x, top: contextMenu.y }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <button
+        role="menuitem"
+        tabIndex={focusedMenuIndex === 0 ? 0 : -1}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-popover-foreground cursor-default outline-none',
+          focusedMenuIndex === 0
+            ? 'bg-accent text-accent-foreground'
+            : 'hover:bg-accent hover:text-accent-foreground'
+        )}
+        onClick={() => onAction('copy')}
+      >
+        <Copy className="h-4 w-4" />
+        <span className="flex-1 text-left">Copy</span>
+        <span className="text-xs text-muted-foreground">{isMac ? '⌘C' : 'Ctrl+C'}</span>
+      </button>
+      <button
+        role="menuitem"
+        tabIndex={focusedMenuIndex === 1 ? 0 : -1}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-popover-foreground cursor-default outline-none',
+          focusedMenuIndex === 1
+            ? 'bg-accent text-accent-foreground'
+            : 'hover:bg-accent hover:text-accent-foreground'
+        )}
+        onClick={() => onAction('paste')}
+      >
+        <ClipboardPaste className="h-4 w-4" />
+        <span className="flex-1 text-left">Paste</span>
+        <span className="text-xs text-muted-foreground">{isMac ? '⌘V' : 'Ctrl+V'}</span>
+      </button>
+      <div role="separator" className="my-1 h-px bg-border" />
+      <button
+        role="menuitem"
+        tabIndex={focusedMenuIndex === 2 ? 0 : -1}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-popover-foreground cursor-default outline-none',
+          focusedMenuIndex === 2
+            ? 'bg-accent text-accent-foreground'
+            : 'hover:bg-accent hover:text-accent-foreground'
+        )}
+        onClick={() => onAction('selectAll')}
+      >
+        <CheckSquare className="h-4 w-4" />
+        <span className="flex-1 text-left">Select All</span>
+        <span className="text-xs text-muted-foreground">{isMac ? '⌘A' : 'Ctrl+A'}</span>
+      </button>
+      <button
+        role="menuitem"
+        tabIndex={focusedMenuIndex === 3 ? 0 : -1}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-popover-foreground cursor-default outline-none',
+          focusedMenuIndex === 3
+            ? 'bg-accent text-accent-foreground'
+            : 'hover:bg-accent hover:text-accent-foreground'
+        )}
+        onClick={() => onAction('clear')}
+      >
+        <Trash2 className="h-4 w-4" />
+        <span className="flex-1 text-left">Clear</span>
+      </button>
+    </div>
+  );
+}

--- a/apps/ui/src/components/views/terminal-view/terminal-panel.tsx
+++ b/apps/ui/src/components/views/terminal-view/terminal-panel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { createLogger } from '@protolabs-ai/utils/logger';
-import { Copy, ClipboardPaste, CheckSquare, Trash2, ImageIcon, ArrowDown } from 'lucide-react';
+import { ImageIcon, ArrowDown } from 'lucide-react';
 import { Button } from '@protolabs-ai/ui/atoms';
 import { Spinner } from '@protolabs-ai/ui/atoms';
 import { cn } from '@/lib/utils';
@@ -20,6 +20,7 @@ import {
   MAX_FONT_SIZE,
   DEFAULT_FONT_SIZE,
 } from './terminal-toolbar';
+import { TerminalContextMenu } from './terminal-keyboard-map';
 
 const logger = createLogger('Terminal');
 const NO_STORE_CACHE_MODE: RequestCache = 'no-store';
@@ -105,9 +106,6 @@ export function TerminalPanel({
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const [isMac, setIsMac] = useState(false);
   const isMacRef = useRef(false);
-  const contextMenuRef = useRef<HTMLDivElement>(null);
-  const [focusedMenuIndex, setFocusedMenuIndex] = useState(0);
-  const focusedMenuIndexRef = useRef(0);
   const [isImageDragOver, setIsImageDragOver] = useState(false);
   const [isProcessingImage, setIsProcessingImage] = useState(false);
   const hasRunInitialCommandRef = useRef(false);
@@ -441,6 +439,11 @@ export function TerminalPanel({
   // Close context menu
   const closeContextMenu = useCallback(() => {
     setContextMenu(null);
+  }, []);
+
+  // Focus the xterm instance (passed to TerminalContextMenu for Escape-key restore)
+  const focusXterm = useCallback(() => {
+    xtermRef.current?.focus();
   }, []);
 
   // Handle context menu action
@@ -1397,86 +1400,6 @@ export function TerminalPanel({
     return () => container.removeEventListener('wheel', handleWheel);
   }, [zoomIn, zoomOut]);
 
-  // Context menu actions for keyboard navigation
-  const menuActions = ['copy', 'paste', 'selectAll', 'clear'] as const;
-
-  // Keep ref in sync with state for use in event handlers
-  useEffect(() => {
-    focusedMenuIndexRef.current = focusedMenuIndex;
-  }, [focusedMenuIndex]);
-
-  // Close context menu on click outside or scroll, handle keyboard navigation
-  useEffect(() => {
-    if (!contextMenu) return;
-
-    // Reset focus index and focus menu when opened
-    setFocusedMenuIndex(0);
-    focusedMenuIndexRef.current = 0;
-    requestAnimationFrame(() => {
-      const firstButton =
-        contextMenuRef.current?.querySelector<HTMLButtonElement>('[role="menuitem"]');
-      firstButton?.focus();
-    });
-
-    const handleClick = () => closeContextMenu();
-    const handleScroll = () => closeContextMenu();
-    const handleKeyDown = (e: KeyboardEvent) => {
-      const updateFocusIndex = (newIndex: number) => {
-        focusedMenuIndexRef.current = newIndex;
-        setFocusedMenuIndex(newIndex);
-      };
-
-      switch (e.key) {
-        case 'Escape':
-          e.preventDefault();
-          e.stopPropagation();
-          closeContextMenu();
-          xtermRef.current?.focus();
-          break;
-        case 'ArrowDown':
-          e.preventDefault();
-          e.stopPropagation();
-          updateFocusIndex((focusedMenuIndexRef.current + 1) % menuActions.length);
-          break;
-        case 'ArrowUp':
-          e.preventDefault();
-          e.stopPropagation();
-          updateFocusIndex(
-            (focusedMenuIndexRef.current - 1 + menuActions.length) % menuActions.length
-          );
-          break;
-        case 'Enter':
-        case ' ':
-          e.preventDefault();
-          e.stopPropagation();
-          handleContextMenuAction(menuActions[focusedMenuIndexRef.current]);
-          break;
-        case 'Tab':
-          e.preventDefault();
-          e.stopPropagation();
-          closeContextMenu();
-          break;
-      }
-    };
-
-    document.addEventListener('click', handleClick);
-    document.addEventListener('scroll', handleScroll, true);
-    document.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      document.removeEventListener('click', handleClick);
-      document.removeEventListener('scroll', handleScroll, true);
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [contextMenu, closeContextMenu, handleContextMenuAction]);
-
-  // Focus the correct menu item when navigation changes
-  useEffect(() => {
-    if (!contextMenu || !contextMenuRef.current) return;
-    const buttons = contextMenuRef.current.querySelectorAll<HTMLButtonElement>('[role="menuitem"]');
-    buttons[focusedMenuIndex]?.focus();
-  }, [focusedMenuIndex, contextMenu]);
-
   // Handle right-click context menu with boundary checking
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -1782,78 +1705,14 @@ export function TerminalPanel({
         </Button>
       )}
 
-      {/* Context menu */}
-      {contextMenu && (
-        <div
-          ref={contextMenuRef}
-          role="menu"
-          aria-label="Terminal context menu"
-          className="fixed z-50 min-w-[160px] rounded-md border border-border bg-popover p-1 shadow-md animate-in fade-in-0 zoom-in-95"
-          style={{ left: contextMenu.x, top: contextMenu.y }}
-          onClick={(e) => e.stopPropagation()}
-        >
-          <button
-            role="menuitem"
-            tabIndex={focusedMenuIndex === 0 ? 0 : -1}
-            className={cn(
-              'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-popover-foreground cursor-default outline-none',
-              focusedMenuIndex === 0
-                ? 'bg-accent text-accent-foreground'
-                : 'hover:bg-accent hover:text-accent-foreground'
-            )}
-            onClick={() => handleContextMenuAction('copy')}
-          >
-            <Copy className="h-4 w-4" />
-            <span className="flex-1 text-left">Copy</span>
-            <span className="text-xs text-muted-foreground">{isMac ? '⌘C' : 'Ctrl+C'}</span>
-          </button>
-          <button
-            role="menuitem"
-            tabIndex={focusedMenuIndex === 1 ? 0 : -1}
-            className={cn(
-              'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-popover-foreground cursor-default outline-none',
-              focusedMenuIndex === 1
-                ? 'bg-accent text-accent-foreground'
-                : 'hover:bg-accent hover:text-accent-foreground'
-            )}
-            onClick={() => handleContextMenuAction('paste')}
-          >
-            <ClipboardPaste className="h-4 w-4" />
-            <span className="flex-1 text-left">Paste</span>
-            <span className="text-xs text-muted-foreground">{isMac ? '⌘V' : 'Ctrl+V'}</span>
-          </button>
-          <div role="separator" className="my-1 h-px bg-border" />
-          <button
-            role="menuitem"
-            tabIndex={focusedMenuIndex === 2 ? 0 : -1}
-            className={cn(
-              'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-popover-foreground cursor-default outline-none',
-              focusedMenuIndex === 2
-                ? 'bg-accent text-accent-foreground'
-                : 'hover:bg-accent hover:text-accent-foreground'
-            )}
-            onClick={() => handleContextMenuAction('selectAll')}
-          >
-            <CheckSquare className="h-4 w-4" />
-            <span className="flex-1 text-left">Select All</span>
-            <span className="text-xs text-muted-foreground">{isMac ? '⌘A' : 'Ctrl+A'}</span>
-          </button>
-          <button
-            role="menuitem"
-            tabIndex={focusedMenuIndex === 3 ? 0 : -1}
-            className={cn(
-              'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-popover-foreground cursor-default outline-none',
-              focusedMenuIndex === 3
-                ? 'bg-accent text-accent-foreground'
-                : 'hover:bg-accent hover:text-accent-foreground'
-            )}
-            onClick={() => handleContextMenuAction('clear')}
-          >
-            <Trash2 className="h-4 w-4" />
-            <span className="flex-1 text-left">Clear</span>
-          </button>
-        </div>
-      )}
+      {/* Context menu — keyboard shortcut map display */}
+      <TerminalContextMenu
+        contextMenu={contextMenu}
+        isMac={isMac}
+        onClose={closeContextMenu}
+        onAction={handleContextMenuAction}
+        focusXterm={focusXterm}
+      />
     </div>
   );
 }

--- a/docs/dev/frontend-philosophy.md
+++ b/docs/dev/frontend-philosophy.md
@@ -444,16 +444,16 @@ npm run build:electron   →  Vite build + electron-builder for desktop
 
 Current gaps between philosophy and implementation. These are tracked as future work — don't fix opportunistically, fix deliberately.
 
-| Debt                 | Current                                                                    | Target                                                                 | Priority |
-| -------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------- | -------- |
-| Monolithic terminal  | `terminal-panel.tsx` (2,251 lines)                                         | Decompose into sub-components like board-view already has              | High     |
-| Storybook coverage   | 27 stories in `libs/ui/` (25 atoms + 2 ai); 5 legacy stories in `apps/ui/` | Stories for all UI primitives, interaction tests, Chromatic CI         | High     |
-| UI package gaps      | 25 atoms extracted to `@protolabs-ai/ui`; molecules/organisms pending      | Full extraction of all primitives to `libs/ui/`                        | Medium   |
-| Static theme files   | 8 hand-written CSS files in `libs/ui/src/themes/`                          | Generate from TypeScript config                                        | Medium   |
-| Minimal a11y         | Relies on Radix defaults, no linting or testing                            | `eslint-plugin-jsx-a11y`, Storybook `addon-a11y`, skip-to-content link | Medium   |
-| Loose files          | 5 components at `src/components/` root level                               | Move to `shared/` or `layout/`                                         | Low      |
-| No typography tokens | Font sizes, line heights are ad-hoc Tailwind classes                       | Formalize as semantic tokens                                           | Low      |
-| No spacing tokens    | Spacing uses Tailwind defaults only                                        | Define semantic spacing scale if needed                                | Low      |
+| Debt                 | Current                                                                                                                                                                                                | Target                                                                                 | Priority |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | -------- |
+| Monolithic terminal  | `terminal-panel.tsx` decomposed: `TerminalToolbar`, `TerminalSettingsPopover`, and `TerminalContextMenu` (keyboard shortcut map) extracted; barrel at `terminal-view/index.ts`; panel now ~1,718 lines | Further decomposition toward sub-800-line target remains (WebSocket, xterm init hooks) | Low      |
+| Storybook coverage   | 27 stories in `libs/ui/` (25 atoms + 2 ai); 5 legacy stories in `apps/ui/`                                                                                                                             | Stories for all UI primitives, interaction tests, Chromatic CI                         | High     |
+| UI package gaps      | 25 atoms extracted to `@protolabs-ai/ui`; molecules/organisms pending                                                                                                                                  | Full extraction of all primitives to `libs/ui/`                                        | Medium   |
+| Static theme files   | 8 hand-written CSS files in `libs/ui/src/themes/`                                                                                                                                                      | Generate from TypeScript config                                                        | Medium   |
+| Minimal a11y         | Relies on Radix defaults, no linting or testing                                                                                                                                                        | `eslint-plugin-jsx-a11y`, Storybook `addon-a11y`, skip-to-content link                 | Medium   |
+| Loose files          | 5 components at `src/components/` root level                                                                                                                                                           | Move to `shared/` or `layout/`                                                         | Low      |
+| No typography tokens | Font sizes, line heights are ad-hoc Tailwind classes                                                                                                                                                   | Formalize as semantic tokens                                                           | Low      |
+| No spacing tokens    | Spacing uses Tailwind defaults only                                                                                                                                                                    | Define semantic spacing scale if needed                                                | Low      |
 
 ## What we do NOT adopt
 


### PR DESCRIPTION
## Summary

**Milestone:** Terminal Panel Decomposition

Extract the keyboard shortcut map display (if present in terminal-panel.tsx) into terminal-keyboard-map.tsx. After all extractions, terminal-panel.tsx should be under 800 lines. Update the technical debt table in docs/dev/frontend-philosophy.md to reflect completion.

**Files to Modify:**
- apps/ui/src/components/views/terminal-view/terminal-panel.tsx
- apps/ui/src/components/views/terminal-view/terminal-keyboard-map.tsx
- docs/dev/frontend-philosophy...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved terminal component organization through modular decomposition and optimized code structure.
  * Enhanced context menu functionality with better keyboard navigation and accessibility handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->