### PR TITLE
Migrate protolabs-report to organisms

### DIFF
--- a/apps/ui/src/components/shared/protolabs-report/index.ts
+++ b/apps/ui/src/components/shared/protolabs-report/index.ts
@@ -1,2 +1,1 @@
 export { ProtoLabsReportDialog } from './protolabs-report-dialog';
-export { ProtoLabsReportResults } from './protolabs-report-results';

--- a/apps/ui/src/components/shared/protolabs-report/protolabs-report-dialog.tsx
+++ b/apps/ui/src/components/shared/protolabs-report/protolabs-report-dialog.tsx
@@ -12,7 +12,7 @@ import { Button } from '@protolabs-ai/ui/atoms';
 import { cn } from '@/lib/utils';
 import { getElectronAPI } from '@/lib/electron';
 import { toast } from 'sonner';
-import { ProtoLabsReportResults } from './protolabs-report-results';
+import { ProtoLabsReportResults } from '@protolabs-ai/ui/organisms';
 import type { RepoResearchResult, GapAnalysisReport, AlignmentProposal } from '@protolabs-ai/types';
 
 type PipelineStep = 'idle' | 'researching' | 'analyzing' | 'generating' | 'complete' | 'error';

--- a/libs/ui/src/organisms/index.ts
+++ b/libs/ui/src/organisms/index.ts
@@ -1,1 +1,2 @@
 export * from './hitl-form/index.js';
+export { ProtoLabsReportResults } from './protolabs-report/index.js';

--- a/libs/ui/src/organisms/protolabs-report/index.ts
+++ b/libs/ui/src/organisms/protolabs-report/index.ts
@@ -1,0 +1,1 @@
+export { ProtoLabsReportResults } from './protolabs-report-results.js';

--- a/libs/ui/src/organisms/protolabs-report/protolabs-report-results.tsx
+++ b/libs/ui/src/organisms/protolabs-report/protolabs-report-results.tsx
@@ -1,0 +1,136 @@
+import { ExternalLink, Plus, AlertTriangle, Info, CheckCircle2 } from 'lucide-react';
+import { Button } from '../../atoms/button.js';
+import { Badge } from '../../atoms/badge.js';
+import { cn } from '../../lib/utils.js';
+import type { GapAnalysisReport, AlignmentProposal } from '@protolabs-ai/types';
+
+interface ProtoLabsReportResultsProps {
+  report: GapAnalysisReport;
+  reportPath: string;
+  onOpenReport: () => void;
+  onCreateFeatures: () => void;
+  isCreatingFeatures: boolean;
+  proposal?: AlignmentProposal;
+}
+
+function getScoreColor(score: number): string {
+  if (score >= 80) return 'text-green-500';
+  if (score >= 50) return 'text-yellow-500';
+  return 'text-red-500';
+}
+
+function getScoreRingColor(score: number): string {
+  if (score >= 80) return 'stroke-green-500';
+  if (score >= 50) return 'stroke-yellow-500';
+  return 'stroke-red-500';
+}
+
+function ScoreRing({ score }: { score: number }) {
+  const radius = 40;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (score / 100) * circumference;
+
+  return (
+    <div className="relative inline-flex items-center justify-center">
+      <svg width="100" height="100" className="-rotate-90">
+        <circle
+          cx="50"
+          cy="50"
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="6"
+          className="text-muted/20"
+        />
+        <circle
+          cx="50"
+          cy="50"
+          r={radius}
+          fill="none"
+          strokeWidth="6"
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          className={cn('transition-all duration-1000 ease-out', getScoreRingColor(score))}
+        />
+      </svg>
+      <span className={cn('absolute text-2xl font-bold', getScoreColor(score))}>{score}</span>
+    </div>
+  );
+}
+
+export function ProtoLabsReportResults({
+  report,
+  reportPath,
+  onOpenReport,
+  onCreateFeatures,
+  isCreatingFeatures,
+  proposal,
+}: ProtoLabsReportResultsProps) {
+  return (
+    <div className="space-y-6">
+      {/* Score + Summary */}
+      <div className="flex items-center gap-6">
+        <ScoreRing score={report.overallScore} />
+        <div className="flex-1 space-y-2">
+          <h3 className="text-lg font-semibold">Alignment Score</h3>
+          <div className="flex flex-wrap gap-2">
+            {report.summary.critical > 0 && (
+              <Badge variant="destructive" className="gap-1">
+                <AlertTriangle className="size-3" />
+                {report.summary.critical} critical
+              </Badge>
+            )}
+            {report.summary.recommended > 0 && (
+              <Badge variant="secondary" className="gap-1 bg-yellow-500/10 text-yellow-600">
+                <Info className="size-3" />
+                {report.summary.recommended} recommended
+              </Badge>
+            )}
+            {report.summary.optional > 0 && (
+              <Badge variant="outline" className="gap-1">
+                <Info className="size-3" />
+                {report.summary.optional} optional
+              </Badge>
+            )}
+            {report.summary.compliant > 0 && (
+              <Badge variant="secondary" className="gap-1 bg-green-500/10 text-green-600">
+                <CheckCircle2 className="size-3" />
+                {report.summary.compliant} compliant
+              </Badge>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex gap-3">
+        <Button onClick={onOpenReport} variant="outline" className="gap-2">
+          <ExternalLink className="size-4" />
+          Open HTML Report
+        </Button>
+        <Button
+          onClick={onCreateFeatures}
+          disabled={isCreatingFeatures || report.gaps.length === 0}
+          className="gap-2"
+        >
+          <Plus className="size-4" />
+          {isCreatingFeatures ? 'Creating...' : `Create Alignment Features (${report.gaps.length})`}
+        </Button>
+      </div>
+
+      {/* Proposal summary */}
+      {proposal && (
+        <p className="text-sm text-muted-foreground">
+          {proposal.totalFeatures} features across {proposal.milestones.length} milestones created
+          on the board.
+        </p>
+      )}
+
+      {/* Report path */}
+      <p className="text-xs text-muted-foreground truncate" title={reportPath}>
+        Report saved to: {reportPath}
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

**Milestone:** Organisms Extraction

Move the protolabs-report results component from `apps/ui/src/components/shared/protolabs-report/` to `libs/ui/src/organisms/protolabs-report/`. The dialog component stays in apps/ui because it has app-level dependencies.

## CRITICAL: Lessons from hitl-form Migration

The previous migration (hitl-form) failed CI because the agent:
1. Used `@protolabs-ai/ui/atoms` imports inside `libs/ui/` — **self-reference breaks tsup**. Use relative imports: `../../atoms/b...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced alignment score visualization with dynamic color-coded progress ring and summary badges displaying critical, recommended, optional, and compliant status.
  * Added action buttons for opening reports and creating alignment features.
  * Implemented report path display within the score visualization interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->