### PR TITLE
promote: dev to staging (brand icons)

### DIFF
--- a/apps/ui/public/protolabs-logo.svg
+++ b/apps/ui/public/protolabs-logo.svg
@@ -1,13 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 80" role="img" aria-label="protoLabs Logo">
-  <defs>
-    <linearGradient id="diamond-gradient" x1="0" y1="0" x2="56" y2="56" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#c4b5fd" />
-      <stop offset="100%" stop-color="#7c3aed" />
-    </linearGradient>
-  </defs>
   <!-- Bot icon on rounded-square background -->
-  <rect x="4" y="12" width="56" height="56" rx="14" fill="url(#diamond-gradient)" />
-  <g transform="translate(8, 16) scale(2)" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="12" width="56" height="56" rx="14" fill="#7c3aed" />
+  <g transform="translate(56, 16) scale(-2, 2)" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <path d="M12 8V4H8" />
     <rect width="16" height="12" x="4" y="8" rx="2" />
     <path d="M2 14h2" />

--- a/apps/ui/public/readme_logo.svg
+++ b/apps/ui/public/readme_logo.svg
@@ -1,27 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1456" height="330" viewBox="0 0 1456 330" role="img" aria-label="protoLabs Studio Logo">
-  <defs>
-    <!-- Brand Gradient (violet) -->
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#c4b5fd" />
-      <stop offset="100%" stop-color="#7c3aed" />
-    </linearGradient>
-
-    <!-- Shadow filter -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#000000" flood-opacity="0.3" />
-    </filter>
-  </defs>
-
   <!-- Dark background for contrast on all GitHub themes -->
   <rect width="1456" height="330" rx="20" fill="#09090b" />
 
-  <!-- Logo Icon (Diamond on rounded square) -->
+  <!-- Logo Icon (Bot on rounded square) -->
   <g transform="translate(80, 65)">
     <!-- Rounded square background -->
-    <rect width="200" height="200" rx="50" fill="url(#bg)" />
+    <rect width="200" height="200" rx="50" fill="#7c3aed" />
 
-    <!-- Bot icon -->
-    <g transform="translate(28, 28) scale(6)" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" filter="url(#shadow)">
+    <!-- Bot icon (mirrored) -->
+    <g transform="translate(172, 28) scale(-6, 6)" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M12 8V4H8" />
       <rect width="16" height="12" x="4" y="8" rx="2" />
       <path d="M2 14h2" />

--- a/apps/ui/src/components/layout/project-switcher/project-switcher.tsx
+++ b/apps/ui/src/components/layout/project-switcher/project-switcher.tsx
@@ -310,22 +310,9 @@ export function ProjectSwitcher() {
               aria-label="protoLabs Logo"
               className="size-10 group-hover:rotate-12 transition-transform duration-300 ease-out"
             >
-              <defs>
-                <linearGradient
-                  id="bg-switcher"
-                  x1="0"
-                  y1="0"
-                  x2="256"
-                  y2="256"
-                  gradientUnits="userSpaceOnUse"
-                >
-                  <stop offset="0%" style={{ stopColor: 'var(--brand-400)' }} />
-                  <stop offset="100%" style={{ stopColor: 'var(--brand-600)' }} />
-                </linearGradient>
-              </defs>
-              <rect x="16" y="16" width="224" height="224" rx="56" fill="url(#bg-switcher)" />
+              <rect x="16" y="16" width="224" height="224" rx="56" fill="#7c3aed" />
               <g
-                transform="translate(32, 32) scale(8)"
+                transform="translate(224, 32) scale(-8, 8)"
                 fill="none"
                 stroke="#FFFFFF"
                 strokeWidth="2"

--- a/apps/ui/src/components/layout/sidebar/components/automaker-logo.tsx
+++ b/apps/ui/src/components/layout/sidebar/components/automaker-logo.tsx
@@ -51,37 +51,14 @@ export function AutomakerLogo({ sidebarOpen, navigate }: AutomakerLogoProps) {
           aria-label="protoLabs Logo"
           className="size-8 group-hover:rotate-12 transition-transform duration-300 ease-out"
         >
-          <defs>
-            <linearGradient
-              id="bg-collapsed"
-              x1="0"
-              y1="0"
-              x2="256"
-              y2="256"
-              gradientUnits="userSpaceOnUse"
-            >
-              <stop offset="0%" style={{ stopColor: 'var(--brand-400)' }} />
-              <stop offset="100%" style={{ stopColor: 'var(--brand-600)' }} />
-            </linearGradient>
-            <filter id="iconShadow-collapsed" x="-20%" y="-20%" width="140%" height="140%">
-              <feDropShadow
-                dx="0"
-                dy="4"
-                stdDeviation="4"
-                floodColor="#000000"
-                floodOpacity="0.25"
-              />
-            </filter>
-          </defs>
-          <rect x="16" y="16" width="224" height="224" rx="56" fill="url(#bg-collapsed)" />
+          <rect x="16" y="16" width="224" height="224" rx="56" fill="#7c3aed" />
           <g
-            transform="translate(32, 32) scale(8)"
+            transform="translate(224, 32) scale(-8, 8)"
             fill="none"
             stroke="#FFFFFF"
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
-            filter="url(#iconShadow-collapsed)"
           >
             <path d="M12 8V4H8" />
             <rect width="16" height="12" x="4" y="8" rx="2" />
@@ -104,37 +81,14 @@ export function AutomakerLogo({ sidebarOpen, navigate }: AutomakerLogoProps) {
               aria-label="protoLabs"
               className="h-8 w-8 lg:h-[36.8px] lg:w-[36.8px] shrink-0 group-hover:rotate-12 transition-transform duration-300 ease-out"
             >
-              <defs>
-                <linearGradient
-                  id="bg-expanded"
-                  x1="0"
-                  y1="0"
-                  x2="256"
-                  y2="256"
-                  gradientUnits="userSpaceOnUse"
-                >
-                  <stop offset="0%" style={{ stopColor: 'var(--brand-400)' }} />
-                  <stop offset="100%" style={{ stopColor: 'var(--brand-600)' }} />
-                </linearGradient>
-                <filter id="iconShadow-expanded" x="-20%" y="-20%" width="140%" height="140%">
-                  <feDropShadow
-                    dx="0"
-                    dy="4"
-                    stdDeviation="4"
-                    floodColor="#000000"
-                    floodOpacity="0.25"
-                  />
-                </filter>
-              </defs>
-              <rect x="16" y="16" width="224" height="224" rx="56" fill="url(#bg-expanded)" />
+              <rect x="16" y="16" width="224" height="224" rx="56" fill="#7c3aed" />
               <g
-                transform="translate(32, 32) scale(8)"
+                transform="translate(224, 32) scale(-8, 8)"
                 fill="none"
                 stroke="#FFFFFF"
                 strokeWidth="2"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                filter="url(#iconShadow-expanded)"
               >
                 <path d="M12 8V4H8" />
                 <rect width="16" height="12" x="4" y="8" rx="2" />

--- a/apps/ui/src/components/splash-screen.tsx
+++ b/apps/ui/src/components/splash-screen.tsx
@@ -215,37 +215,14 @@ export function SplashScreen({ onComplete }: { onComplete: () => void }) {
             filter: 'drop-shadow(0 0 30px var(--brand-500))',
           }}
         >
-          <defs>
-            <linearGradient
-              id="splash-bg"
-              x1="0"
-              y1="0"
-              x2="256"
-              y2="256"
-              gradientUnits="userSpaceOnUse"
-            >
-              <stop offset="0%" style={{ stopColor: 'var(--brand-400)' }} />
-              <stop offset="100%" style={{ stopColor: 'var(--brand-600)' }} />
-            </linearGradient>
-            <filter id="splash-shadow" x="-20%" y="-20%" width="140%" height="140%">
-              <feDropShadow
-                dx="0"
-                dy="4"
-                stdDeviation="4"
-                floodColor="#000000"
-                floodOpacity="0.25"
-              />
-            </filter>
-          </defs>
-          <rect x="16" y="16" width="224" height="224" rx="56" fill="url(#splash-bg)" />
+          <rect x="16" y="16" width="224" height="224" rx="56" fill="#7c3aed" />
           <g
-            transform="translate(32, 32) scale(8)"
+            transform="translate(224, 32) scale(-8, 8)"
             fill="none"
             stroke="#FFFFFF"
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
-            filter="url(#splash-shadow)"
           >
             <path d="M12 8V4H8" />
             <rect width="16" height="12" x="4" y="8" rx="2" />

--- a/apps/ui/src/components/views/dashboard-view.tsx
+++ b/apps/ui/src/components/views/dashboard-view.tsx
@@ -516,37 +516,14 @@ export function DashboardView() {
               aria-label="protoLabs Logo"
               className="size-8 sm:size-10 group-hover:rotate-12 transition-transform duration-300 ease-out"
             >
-              <defs>
-                <linearGradient
-                  id="bg-dashboard"
-                  x1="0"
-                  y1="0"
-                  x2="256"
-                  y2="256"
-                  gradientUnits="userSpaceOnUse"
-                >
-                  <stop offset="0%" style={{ stopColor: 'var(--brand-400)' }} />
-                  <stop offset="100%" style={{ stopColor: 'var(--brand-600)' }} />
-                </linearGradient>
-                <filter id="iconShadow-dashboard" x="-20%" y="-20%" width="140%" height="140%">
-                  <feDropShadow
-                    dx="0"
-                    dy="4"
-                    stdDeviation="4"
-                    floodColor="#000000"
-                    floodOpacity="0.25"
-                  />
-                </filter>
-              </defs>
-              <rect x="16" y="16" width="224" height="224" rx="56" fill="url(#bg-dashboard)" />
+              <rect x="16" y="16" width="224" height="224" rx="56" fill="#7c3aed" />
               <g
-                transform="translate(32, 32) scale(8)"
+                transform="translate(224, 32) scale(-8, 8)"
                 fill="none"
                 stroke="#FFFFFF"
                 strokeWidth="2"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                filter="url(#iconShadow-dashboard)"
               >
                 <path d="M12 8V4H8" />
                 <rect width="16" height="12" x="4" y="8" rx="2" />

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,15 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="protoLabs Icon">
-  <defs>
-    <linearGradient id="brand-gradient" x1="0" y1="0" x2="256" y2="256" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#c4b5fd" />
-      <stop offset="100%" stop-color="#7c3aed" />
-    </linearGradient>
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="4" stdDeviation="4" flood-color="#000000" flood-opacity="0.25" />
-    </filter>
-  </defs>
-  <rect x="16" y="16" width="224" height="224" rx="56" fill="url(#brand-gradient)" />
-  <g transform="translate(32, 32) scale(8)" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" filter="url(#shadow)">
+  <rect x="16" y="16" width="224" height="224" rx="56" fill="#7c3aed" />
+  <g transform="translate(224, 32) scale(-8, 8)" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <path d="M12 8V4H8" />
     <rect width="16" height="12" x="4" y="8" rx="2" />
     <path d="M2 14h2" />

--- a/site/changelog/index.html
+++ b/site/changelog/index.html
@@ -29,7 +29,7 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237c3aed' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M12 8V4H8'/><rect width='16' height='12' x='4' y='8' rx='2'/><path d='M2 14h2'/><path d='M20 14h2'/><path d='M15 13v2'/><path d='M9 13v2'/></svg>"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237c3aed' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><g transform='translate(24,0) scale(-1,1)'><path d='M12 8V4H8'/><rect width='16' height='12' x='4' y='8' rx='2'/><path d='M2 14h2'/><path d='M20 14h2'/><path d='M15 13v2'/><path d='M9 13v2'/></g></svg>"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -154,12 +154,14 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           >
-            <path d="M12 8V4H8" />
-            <rect width="16" height="12" x="4" y="8" rx="2" />
-            <path d="M2 14h2" />
-            <path d="M20 14h2" />
-            <path d="M15 13v2" />
-            <path d="M9 13v2" />
+            <g transform="translate(24, 0) scale(-1, 1)">
+              <path d="M12 8V4H8" />
+              <rect width="16" height="12" x="4" y="8" rx="2" />
+              <path d="M2 14h2" />
+              <path d="M20 14h2" />
+              <path d="M15 13v2" />
+              <path d="M9 13v2" />
+            </g>
           </svg>
           <span>proto<span class="text-accent">Labs</span></span>
         </a>
@@ -22167,12 +22169,14 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           >
-            <path d="M12 8V4H8" />
-            <rect width="16" height="12" x="4" y="8" rx="2" />
-            <path d="M2 14h2" />
-            <path d="M20 14h2" />
-            <path d="M15 13v2" />
-            <path d="M9 13v2" />
+            <g transform="translate(24, 0) scale(-1, 1)">
+              <path d="M12 8V4H8" />
+              <rect width="16" height="12" x="4" y="8" rx="2" />
+              <path d="M2 14h2" />
+              <path d="M20 14h2" />
+              <path d="M15 13v2" />
+              <path d="M9 13v2" />
+            </g>
           </svg>
           <span>proto<span class="text-zinc-400">Labs</span></span>
           <span class="text-zinc-700">&middot;</span>

--- a/site/consulting/index.html
+++ b/site/consulting/index.html
@@ -29,7 +29,7 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237c3aed' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M12 8V4H8'/><rect width='16' height='12' x='4' y='8' rx='2'/><path d='M2 14h2'/><path d='M20 14h2'/><path d='M15 13v2'/><path d='M9 13v2'/></svg>"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237c3aed' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><g transform='translate(24,0) scale(-1,1)'><path d='M12 8V4H8'/><rect width='16' height='12' x='4' y='8' rx='2'/><path d='M2 14h2'/><path d='M20 14h2'/><path d='M15 13v2'/><path d='M9 13v2'/></g></svg>"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -192,12 +192,14 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           >
-            <path d="M12 8V4H8" />
-            <rect width="16" height="12" x="4" y="8" rx="2" />
-            <path d="M2 14h2" />
-            <path d="M20 14h2" />
-            <path d="M15 13v2" />
-            <path d="M9 13v2" />
+            <g transform="translate(24, 0) scale(-1, 1)">
+              <path d="M12 8V4H8" />
+              <rect width="16" height="12" x="4" y="8" rx="2" />
+              <path d="M2 14h2" />
+              <path d="M20 14h2" />
+              <path d="M15 13v2" />
+              <path d="M9 13v2" />
+            </g>
           </svg>
           <span>proto<span class="text-accent">Labs</span></span>
           <span class="text-zinc-600 text-sm font-normal ml-1">consulting</span>
@@ -558,12 +560,14 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           >
-            <path d="M12 8V4H8" />
-            <rect width="16" height="12" x="4" y="8" rx="2" />
-            <path d="M2 14h2" />
-            <path d="M20 14h2" />
-            <path d="M15 13v2" />
-            <path d="M9 13v2" />
+            <g transform="translate(24, 0) scale(-1, 1)">
+              <path d="M12 8V4H8" />
+              <rect width="16" height="12" x="4" y="8" rx="2" />
+              <path d="M2 14h2" />
+              <path d="M20 14h2" />
+              <path d="M15 13v2" />
+              <path d="M9 13v2" />
+            </g>
           </svg>
           <span>proto<span class="text-zinc-400">Labs</span></span>
           <span class="text-zinc-700">&middot;</span>

--- a/site/index.html
+++ b/site/index.html
@@ -29,7 +29,7 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237c3aed' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M12 8V4H8'/><rect width='16' height='12' x='4' y='8' rx='2'/><path d='M2 14h2'/><path d='M20 14h2'/><path d='M15 13v2'/><path d='M9 13v2'/></svg>"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237c3aed' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><g transform='translate(24,0) scale(-1,1)'><path d='M12 8V4H8'/><rect width='16' height='12' x='4' y='8' rx='2'/><path d='M2 14h2'/><path d='M20 14h2'/><path d='M15 13v2'/><path d='M9 13v2'/></g></svg>"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -321,12 +321,14 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           >
-            <path d="M12 8V4H8" />
-            <rect width="16" height="12" x="4" y="8" rx="2" />
-            <path d="M2 14h2" />
-            <path d="M20 14h2" />
-            <path d="M15 13v2" />
-            <path d="M9 13v2" />
+            <g transform="translate(24, 0) scale(-1, 1)">
+              <path d="M12 8V4H8" />
+              <rect width="16" height="12" x="4" y="8" rx="2" />
+              <path d="M2 14h2" />
+              <path d="M20 14h2" />
+              <path d="M15 13v2" />
+              <path d="M9 13v2" />
+            </g>
           </svg>
           <span>proto<span class="text-accent">Labs</span></span>
         </a>
@@ -1011,12 +1013,14 @@
                   stroke-linecap="round"
                   stroke-linejoin="round"
                 >
-                  <path d="M12 8V4H8" />
-                  <rect width="16" height="12" x="4" y="8" rx="2" />
-                  <path d="M2 14h2" />
-                  <path d="M20 14h2" />
-                  <path d="M15 13v2" />
-                  <path d="M9 13v2" />
+                  <g transform="translate(24, 0) scale(-1, 1)">
+                    <path d="M12 8V4H8" />
+                    <rect width="16" height="12" x="4" y="8" rx="2" />
+                    <path d="M2 14h2" />
+                    <path d="M20 14h2" />
+                    <path d="M15 13v2" />
+                    <path d="M9 13v2" />
+                  </g>
                 </svg>
                 Lessons written to agent memory &middot; patterns indexed for reuse
               </div>
@@ -1285,12 +1289,14 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           >
-            <path d="M12 8V4H8" />
-            <rect width="16" height="12" x="4" y="8" rx="2" />
-            <path d="M2 14h2" />
-            <path d="M20 14h2" />
-            <path d="M15 13v2" />
-            <path d="M9 13v2" />
+            <g transform="translate(24, 0) scale(-1, 1)">
+              <path d="M12 8V4H8" />
+              <rect width="16" height="12" x="4" y="8" rx="2" />
+              <path d="M2 14h2" />
+              <path d="M20 14h2" />
+              <path d="M15 13v2" />
+              <path d="M9 13v2" />
+            </g>
           </svg>
           <span>proto<span class="text-zinc-400">Labs</span></span>
           <span class="text-zinc-700">&middot;</span>

--- a/site/report/index.html
+++ b/site/report/index.html
@@ -30,7 +30,7 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237c3aed' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M12 8V4H8'/><rect width='16' height='12' x='4' y='8' rx='2'/><path d='M2 14h2'/><path d='M20 14h2'/><path d='M15 13v2'/><path d='M9 13v2'/></svg>"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237c3aed' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><g transform='translate(24,0) scale(-1,1)'><path d='M12 8V4H8'/><rect width='16' height='12' x='4' y='8' rx='2'/><path d='M2 14h2'/><path d='M20 14h2'/><path d='M15 13v2'/><path d='M9 13v2'/></g></svg>"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -268,12 +268,14 @@
                 stroke-linecap="round"
                 stroke-linejoin="round"
               >
-                <path d="M12 8V4H8" />
-                <rect width="16" height="12" x="4" y="8" rx="2" />
-                <path d="M2 14h2" />
-                <path d="M20 14h2" />
-                <path d="M15 13v2" />
-                <path d="M9 13v2" />
+                <g transform="translate(24, 0) scale(-1, 1)">
+                  <path d="M12 8V4H8" />
+                  <rect width="16" height="12" x="4" y="8" rx="2" />
+                  <path d="M2 14h2" />
+                  <path d="M20 14h2" />
+                  <path d="M15 13v2" />
+                  <path d="M9 13v2" />
+                </g>
               </svg>
               <span>proto<span class="text-zinc-300">Labs</span></span>
               <span class="text-zinc-700">&middot;</span>
@@ -1079,12 +1081,14 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           >
-            <path d="M12 8V4H8" />
-            <rect width="16" height="12" x="4" y="8" rx="2" />
-            <path d="M2 14h2" />
-            <path d="M20 14h2" />
-            <path d="M15 13v2" />
-            <path d="M9 13v2" />
+            <g transform="translate(24, 0) scale(-1, 1)">
+              <path d="M12 8V4H8" />
+              <rect width="16" height="12" x="4" y="8" rx="2" />
+              <path d="M2 14h2" />
+              <path d="M20 14h2" />
+              <path d="M15 13v2" />
+              <path d="M9 13v2" />
+            </g>
           </svg>
           <span>proto<span class="text-zinc-400">Labs</span></span>
           <span class="text-zinc-700">&middot;</span>

--- a/site/roadmap/index.html
+++ b/site/roadmap/index.html
@@ -29,7 +29,7 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237c3aed' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M12 8V4H8'/><rect width='16' height='12' x='4' y='8' rx='2'/><path d='M2 14h2'/><path d='M20 14h2'/><path d='M15 13v2'/><path d='M9 13v2'/></svg>"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237c3aed' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><g transform='translate(24,0) scale(-1,1)'><path d='M12 8V4H8'/><rect width='16' height='12' x='4' y='8' rx='2'/><path d='M2 14h2'/><path d='M20 14h2'/><path d='M15 13v2'/><path d='M9 13v2'/></g></svg>"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -166,12 +166,14 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           >
-            <path d="M12 8V4H8" />
-            <rect width="16" height="12" x="4" y="8" rx="2" />
-            <path d="M2 14h2" />
-            <path d="M20 14h2" />
-            <path d="M15 13v2" />
-            <path d="M9 13v2" />
+            <g transform="translate(24, 0) scale(-1, 1)">
+              <path d="M12 8V4H8" />
+              <rect width="16" height="12" x="4" y="8" rx="2" />
+              <path d="M2 14h2" />
+              <path d="M20 14h2" />
+              <path d="M15 13v2" />
+              <path d="M9 13v2" />
+            </g>
           </svg>
           <span>proto<span class="text-accent">Labs</span></span>
         </a>
@@ -999,12 +1001,14 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           >
-            <path d="M12 8V4H8" />
-            <rect width="16" height="12" x="4" y="8" rx="2" />
-            <path d="M2 14h2" />
-            <path d="M20 14h2" />
-            <path d="M15 13v2" />
-            <path d="M9 13v2" />
+            <g transform="translate(24, 0) scale(-1, 1)">
+              <path d="M12 8V4H8" />
+              <rect width="16" height="12" x="4" y="8" rx="2" />
+              <path d="M2 14h2" />
+              <path d="M20 14h2" />
+              <path d="M15 13v2" />
+              <path d="M9 13v2" />
+            </g>
           </svg>
           <span>proto<span class="text-zinc-400">Labs</span></span>
           <span class="text-zinc-700">&middot;</span>

--- a/site/scripts/generate-og-images.mjs
+++ b/site/scripts/generate-og-images.mjs
@@ -79,10 +79,10 @@ async function generateOGImages() {
           <!-- Background gradient accent -->
           <rect width="1200" height="630" fill="url(#accent-gradient)" />
 
-          <!-- Bot logo (centered top) -->
+          <!-- Bot logo (centered top, mirrored) -->
           <g transform="translate(550, 120)">
-            <rect width="100" height="100" rx="25" fill="url(#text-gradient)" />
-            <g transform="translate(12, 12) scale(3.2)" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect width="100" height="100" rx="25" fill="#7c3aed" />
+            <g transform="translate(88, 12) scale(-3.2, 3.2)" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M12 8V4H8" />
               <rect width="16" height="12" x="4" y="8" rx="2" />
               <path d="M2 14h2" />


### PR DESCRIPTION
## Summary
- Solid #7c3aed + mirrored bot across all site HTML, docs, OG images, splash screen, sidebar, dashboard, project switcher, README logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated logo styling across the application and website with horizontal mirroring transformations.
  * Simplified logo rendering by replacing gradient fills and decorative effects with solid color styling.
  * Applied consistent visual updates to logos throughout the dashboard, sidebar, splash screen, and website sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->