### PR TITLE
promote: staging → main (dep check fix)

### DIFF
--- a/apps/server/src/services/discord-bot-service.ts
+++ b/apps/server/src/services/discord-bot-service.ts
@@ -1679,7 +1679,8 @@ export class DiscordBotService {
   ): Promise<void> {
     switch (workflow.workflow) {
       case 'bug_triage':
-        await this.handleBugWorkflow(message, workflow);
+        // Disabled: bug triage now only fires via reaction ability (bug emoji).
+        // Channel workflow auto-trigger on every message was too noisy.
         break;
       case 'agent_conversation':
         await this.handleAgentConversationWorkflow(message, workflow);
@@ -1857,8 +1858,15 @@ export class DiscordBotService {
 
     const channelId = data.channelId as string;
     const messageId = data.messageId as string;
+    const username = data.username as string;
 
     if (!channelId || !messageId) return;
+
+    // Only chukz can trigger bug triage via reaction
+    if (username !== 'chukz') {
+      logger.debug(`Bug reaction from ${username} ignored — only chukz can trigger bug triage`);
+      return;
+    }
 
     try {
       const channel = (await this.client.channels.fetch(channelId)) as TextChannel;

--- a/apps/server/src/services/lead-engineer-escalation.ts
+++ b/apps/server/src/services/lead-engineer-escalation.ts
@@ -35,9 +35,11 @@ export class EscalateProcessor implements StateProcessor {
   }
 
   async process(ctx: StateContext): Promise<StateTransitionResult> {
-    // Move feature to blocked
+    // Move feature to blocked with reason and failure tracking
     await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
       status: 'blocked',
+      statusChangeReason: ctx.escalationReason || 'Escalated by lead engineer',
+      failureCount: (ctx.feature.failureCount ?? 0) + 1,
     });
 
     // Classify the failure for structured analysis

--- a/apps/server/src/services/lead-engineer-processors.ts
+++ b/apps/server/src/services/lead-engineer-processors.ts
@@ -7,6 +7,7 @@
 
 import { createLogger } from '@protolabsai/utils';
 import { resolveModelString } from '@protolabsai/model-resolver';
+import { areDependenciesSatisfied } from '@protolabsai/dependency-resolver';
 import type { AgentRole, Feature } from '@protolabsai/types';
 import { getWorkflowSettings } from '../lib/settings-helpers.js';
 import { simpleQuery } from '../providers/simple-query-service.js';
@@ -37,19 +38,20 @@ export class IntakeProcessor implements StateProcessor {
   async process(ctx: StateContext): Promise<StateTransitionResult> {
     const { feature } = ctx;
 
-    // Validate dependencies against real feature state
+    // Validate dependencies using the shared resolver (same logic as loadPendingFeatures)
     if (feature.dependencies && feature.dependencies.length > 0) {
       const allFeatures = await this.serviceContext.featureLoader.getAll(ctx.projectPath);
-      const unmetDeps: string[] = [];
 
-      for (const depId of feature.dependencies) {
-        const dep = allFeatures.find((f) => f.id === depId);
-        if (!dep || (dep.status !== 'done' && dep.status !== 'verified')) {
-          unmetDeps.push(depId);
-        }
-      }
+      if (!areDependenciesSatisfied(feature, allFeatures)) {
+        const unmetDeps = feature.dependencies.filter((depId) => {
+          const dep = allFeatures.find((f) => f.id === depId);
+          if (!dep) return true;
+          if (dep.isFoundation) {
+            return dep.status !== 'done' && dep.status !== 'completed' && dep.status !== 'verified';
+          }
+          return !dep.status || !['completed', 'verified', 'done', 'review'].includes(dep.status);
+        });
 
-      if (unmetDeps.length > 0) {
         ctx.escalationReason = `Unmet dependencies: ${unmetDeps.join(', ')}`;
         logger.warn(`[INTAKE] Feature has ${unmetDeps.length} unmet dependencies`, {
           featureId: feature.id,


### PR DESCRIPTION
## Summary
- Fix auto-mode dependency check inconsistency that causes infinite thrash loop
- IntakeProcessor now uses shared `areDependenciesSatisfied()` resolver (same as `loadPendingFeatures`)
- EscalateProcessor sets `statusChangeReason` and increments `failureCount` for defense-in-depth

## Bug
IntakeProcessor only accepted `done`/`verified` for deps while the eligibility filter accepted `review` for non-foundation deps. Features cycled `backlog → blocked` every 3 seconds indefinitely with no escalation or circuit breaker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bug triage workflow now uses reaction-based triggering instead of automatic message activation.

* **Bug Fixes**
  * Enhanced escalation tracking with detailed status change reasons and failure counts for blocked features.
  * Improved dependency validation with clearer escalation context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->