### PR TITLE
test(scheduler): add unit tests for auto-mode scheduling loop

### DIFF
--- a/apps/server/tests/unit/services/scheduler-loop.test.ts
+++ b/apps/server/tests/unit/services/scheduler-loop.test.ts
@@ -64,6 +64,7 @@ vi.mock('@protolabsai/platform', async () => {
 import { exec } from 'child_process';
 import { readdir } from '@/lib/secure-fs.js';
 import { readJsonWithRecovery, logRecoveryWarning } from '@protolabsai/utils';
+import { getFeaturesDir } from '@protolabsai/platform';
 import { AutoLoopCoordinator } from '@/services/auto-mode/auto-loop-coordinator.js';
 import { ConcurrencyManager } from '@/services/auto-mode/concurrency-manager.js';
 import { AutoModeService } from '@/services/auto-mode-service.js';
@@ -72,6 +73,7 @@ import type { Feature } from '@protolabsai/types';
 const mockExec = exec as unknown as ReturnType<typeof vi.fn>;
 const mockReaddir = readdir as unknown as ReturnType<typeof vi.fn>;
 const mockReadJsonWithRecovery = readJsonWithRecovery as unknown as ReturnType<typeof vi.fn>;
+const mockGetFeaturesDir = getFeaturesDir as unknown as ReturnType<typeof vi.fn>;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -101,9 +103,7 @@ function setupDefaultExecMocks() {
 
 function setupFeaturesOnDisk(features: Feature[]) {
   // readdir returns one entry per feature
-  mockReaddir.mockResolvedValue(
-    features.map((f) => ({ name: f.id, isDirectory: () => true }))
-  );
+  mockReaddir.mockResolvedValue(features.map((f) => ({ name: f.id, isDirectory: () => true })));
   // readJsonWithRecovery returns each feature in order
   for (const f of features) {
     mockReadJsonWithRecovery.mockResolvedValueOnce({
@@ -381,6 +381,8 @@ describe('AutoModeService - loadPendingFeatures', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Re-establish platform mocks cleared by vitest's mockReset: true
+    mockGetFeaturesDir.mockReturnValue('/fake/project/.automaker/features');
     service = new AutoModeService(mockEvents as any);
   });
 
@@ -565,9 +567,7 @@ describe('AutoModeService - concurrency and race prevention', () => {
   });
 
   it('different project+branch combinations can run concurrently', async () => {
-    await expect(
-      service.startAutoLoopForProject('/test/project', null, 2)
-    ).resolves.not.toThrow();
+    await expect(service.startAutoLoopForProject('/test/project', null, 2)).resolves.not.toThrow();
 
     await expect(
       service.startAutoLoopForProject('/test/project', 'feature/branch', 2)


### PR DESCRIPTION
## Summary
- Unit tests for auto-mode scheduling loop: AutoLoopCoordinator, ConcurrencyManager, loadPendingFeatures
- Tests circuit breaker (pause after 3 failures, cooldown, resume), concurrency lease management, dependency resolution
- Foundation vs non-foundation dep handling, git-workflow block guard
- Part of M1: Test Foundation milestone for Server Pipeline Refactor project

## Test plan
- [x] Tests written by agent (594 lines)
- [ ] CI passes (checks + test suite)
- [ ] Tests pass with `npm run test:server`

Generated by auto-mode agent (Sonnet)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for the auto-mode scheduler loop covering circuit-breaker behavior, pause/resume/reset flows, concurrency/lease semantics, dependency resolution (including foundation vs non-foundation), git/workflow blocking scenarios, lifecycle/race conditions for start/stop, and extensive mocks to validate normal and edge-case behaviors (high coverage, ~594 new test lines).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->