### PR TITLE
Bug: Auto-loop 'stuck in starting state' cleanup races with LE pipeline startup

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -1155,16 +1155,23 @@ export class AutoModeService {
           // Reset idle event flag since we're doing work again
           projectState.hasEmittedIdleEvent = false;
 
-          // Safety timeout: Remove from starting set after 30 seconds if still there
-          // This prevents features from getting permanently stuck in "starting" state
+          // Safety timeout: Remove from starting set after 120 seconds if still there.
+          // The LE pipeline's INTAKE→worktree creation→rebase→agent launch sequence can take
+          // >30s under concurrency (3+ agents starting simultaneously). Using 120s gives the
+          // pipeline enough time to complete before cleanup fires and creates ghost agents.
+          const STARTING_TIMEOUT_MS = 120000;
           const startingTimeout = setTimeout(() => {
             if (projectState.startingFeatures.has(nextFeature.id)) {
-              logger.warn(
-                `[AutoLoop] Feature ${nextFeature.id} stuck in starting state for 30s, cleaning up`
-              );
-              projectState.startingFeatures.delete(nextFeature.id);
+              // Only clean up if not already tracked in runningFeatures — if it's running,
+              // the executionPromise .then() handler will clean up startingFeatures normally.
+              if (!this.runningFeatures.has(nextFeature.id)) {
+                logger.warn(
+                  `[AutoLoop] Feature ${nextFeature.id} stuck in starting state for ${STARTING_TIMEOUT_MS / 1000}s, cleaning up`
+                );
+                projectState.startingFeatures.delete(nextFeature.id);
+              }
             }
-          }, 30000);
+          }, STARTING_TIMEOUT_MS);
 
           // Start feature execution in background.
           // Content features (featureType === 'content') always route through leadEngineerService


### PR DESCRIPTION
## Summary

**Problem:** The auto-loop's 30-second 'stuck in starting state' cleanup fires before the Lead Engineer pipeline completes its INTAKE→EXECUTE transition when multiple agents start simultaneously. The LE pipeline creates the worktree, rebases, and launches the agent — this takes >30s when doing 3+ concurrently. The cleanup removes features from `runningFeatures` but doesn't kill the subprocess, creating orphaned 'ghost agents' that work fine but aren't tracked.

**Symptoms:**
- `list_running_agen...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended auto-mode feature startup timeout from 30 to 120 seconds for improved initialization reliability.
  * Improved cleanup logic to prevent premature termination of active features during concurrent operations.
  * Enhanced logging to better reflect timeout behavior and system state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->