### PR TITLE
PipelineResult type and LE return value

### DIFF
--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -10,7 +10,13 @@
  */
 
 import { createLogger } from '@protolabsai/utils';
-import type { EventType, LeadEngineerSession, ExecuteOptions } from '@protolabsai/types';
+import type {
+  EventType,
+  LeadEngineerSession,
+  ExecuteOptions,
+  PipelineResult,
+} from '@protolabsai/types';
+import { FeatureState } from '@protolabsai/types';
 import type { EventEmitter } from '../lib/events.js';
 import type { FeatureLoader } from './feature-loader.js';
 import type { AutoModeService } from './auto-mode-service.js';
@@ -294,7 +300,11 @@ export class LeadEngineerService {
     return this.activeFeatures.has(featureId);
   }
 
-  async process(projectPath: string, featureId: string, options: ExecuteOptions): Promise<void> {
+  async process(
+    projectPath: string,
+    featureId: string,
+    options: ExecuteOptions
+  ): Promise<PipelineResult> {
     logger.info(`[LeadEngineer] Processing feature ${featureId}`, {
       projectPath,
       model: options.model,
@@ -392,17 +402,33 @@ export class LeadEngineerService {
         unsubPipelineSync();
       }
 
+      const outcome: PipelineResult['outcome'] =
+        result.finalState === 'DONE'
+          ? 'completed'
+          : result.finalState === 'ESCALATE'
+            ? 'escalated'
+            : 'blocked';
+
+      const pipelineResult: PipelineResult = {
+        outcome,
+        finalState: result.finalState as unknown as FeatureState,
+        failureCount: result.context.retryCount,
+      };
+
       logger.info(`[LeadEngineer] Feature processing completed`, {
         featureId,
         finalState: result.finalState,
+        outcome,
         escalated: result.finalState === 'ESCALATE',
       });
       this.events.emit('lead-engineer:feature-processed' as EventType, {
         projectPath,
         featureId,
         finalState: result.finalState,
+        outcome,
         success: result.finalState !== 'ESCALATE',
       });
+      return pipelineResult;
     } catch (error: unknown) {
       logger.error(`[LeadEngineer] Feature processing failed`, {
         featureId,

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -767,6 +767,7 @@ export type {
   PersonaAssignment,
   LeadEngineerService,
   PhaseHandoff,
+  PipelineResult,
 } from './lead-engineer.js';
 
 // Twitch integration types (chat suggestions)

--- a/libs/types/src/lead-engineer.ts
+++ b/libs/types/src/lead-engineer.ts
@@ -276,6 +276,25 @@ export interface PersonaAssignment {
   maxConcurrency?: number;
 }
 
+// ────────────────────────── Pipeline Result ──────────────────────────
+
+/**
+ * Structured result returned by LeadEngineerService.process()
+ * Captures the outcome, final state, and optional retry/failure metadata.
+ */
+export interface PipelineResult {
+  /** High-level outcome of the pipeline run */
+  outcome: 'completed' | 'escalated' | 'blocked' | 'needs_retry';
+  /** The final state the feature was in when processing ended */
+  finalState: FeatureState;
+  /** Human-readable reason for this outcome */
+  reason?: string;
+  /** Cumulative failure count at the time processing ended */
+  failureCount?: number;
+  /** Suggested delay before retrying, in milliseconds */
+  retryAfterMs?: number;
+}
+
 // ────────────────────────── Phase Handoffs ──────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

**Milestone:** Structured Pipeline Results

Define PipelineResult in libs/types/src/lead-engineer.ts: { outcome: 'completed' | 'escalated' | 'blocked' | 'needs_retry'; finalState: LeadEngineerState; reason?: string; failureCount?: number; retryAfterMs?: number }. Update LeadEngineerService.process() to return PipelineResult instead of void. Surface the finalState already tracked at lead-engineer-service.ts:397. Update lead-engineer:feature-processed event payload to include outcome.

**Files to ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Lead Engineer Service now provides structured processing results when executing features. The response includes detailed outcome information (completed, escalated, blocked, or needs retry), final state information, and optional metadata such as failure counts and retry timing guidance for enhanced visibility into feature processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->