### PR TITLE
Add typed on() method to EventEmitter

### DIFF
--- a/apps/server/src/lib/events.ts
+++ b/apps/server/src/lib/events.ts
@@ -6,7 +6,13 @@
  * (NATS, Redis) can be swapped in for hivemind distribution.
  */
 
-import type { EventType, EventCallback, EventBus, EventSubscription } from '@protolabsai/types';
+import type {
+  EventType,
+  EventCallback,
+  EventBus,
+  EventSubscription,
+  EventPayload,
+} from '@protolabsai/types';
 import { createLogger } from '@protolabsai/utils';
 
 const logger = createLogger('Events');
@@ -21,10 +27,18 @@ export type UnsubscribeFn = (() => void) & EventSubscription;
 export interface EventEmitter extends EventBus {
   emit: (type: EventType, payload: unknown) => void;
   subscribe: (callback: EventCallback) => UnsubscribeFn;
+  on: <T extends EventType>(type: T, handler: (payload: EventPayload<T>) => void) => UnsubscribeFn;
 }
 
 export function createEventEmitter(): EventEmitter {
   const subscribers = new Set<EventCallback>();
+  const typedHandlers = new Map<EventType, Set<(payload: unknown) => void>>();
+
+  function makeUnsub(fn: () => void): UnsubscribeFn {
+    const unsub = fn as UnsubscribeFn;
+    unsub.unsubscribe = fn;
+    return unsub;
+  }
 
   const bus: EventEmitter = {
     emit(type: EventType, payload: unknown) {
@@ -35,18 +49,34 @@ export function createEventEmitter(): EventEmitter {
           logger.error('Error in event subscriber:', error);
         }
       }
+      const handlers = typedHandlers.get(type);
+      if (handlers) {
+        for (const handler of handlers) {
+          try {
+            handler(payload);
+          } catch (error) {
+            logger.error('Error in typed event handler:', error);
+          }
+        }
+      }
     },
 
     subscribe(callback: EventCallback) {
       subscribers.add(callback);
-      // Return cleanup function (legacy pattern, still works)
-      const unsub = () => {
+      return makeUnsub(() => {
         subscribers.delete(callback);
-      };
-      // Attach EventSubscription interface for new consumers
-      const unsubWithMethod = unsub as UnsubscribeFn;
-      unsubWithMethod.unsubscribe = unsub;
-      return unsubWithMethod;
+      });
+    },
+
+    on<T extends EventType>(type: T, handler: (payload: EventPayload<T>) => void): UnsubscribeFn {
+      if (!typedHandlers.has(type)) {
+        typedHandlers.set(type, new Set());
+      }
+      const typed = handler as (payload: unknown) => void;
+      typedHandlers.get(type)!.add(typed);
+      return makeUnsub(() => {
+        typedHandlers.get(type)?.delete(typed);
+      });
     },
 
     broadcast(type: EventType, payload?: unknown) {

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -573,6 +573,7 @@ export interface EventPayloadMap {
   };
 
   // Auto-mode events
+  'auto-mode:event': { type: string; projectPath?: string; data?: Record<string, unknown> };
   'auto-mode:started': { projectPath?: string };
   'auto-mode:stopped': { projectPath?: string; reason?: string };
   'auto-mode:idle': { projectPath?: string };


### PR DESCRIPTION
## Summary

**Milestone:** Typed Event Bus

Add on<T extends EventType>(type: T, handler: (payload: EventPayloadMap[T]) => void): UnsubscribeFn to EventEmitter interface and implementation in apps/server/src/lib/events.ts. Internally maintain a Map<EventType, Set<handler>> alongside the existing subscribers Set. Add EventPayloadMap type to libs/types/src/event.ts for core types: feature:completed, feature:status-changed, feature:error, auto-mode:event, lead-engineer:feature-processed.

**Files to Modify:**
...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Type-safe event subscriptions with automatic payload validation
  * Support for auto-mode event payloads with structured data

* **Improvements**
  * Streamlined event unsubscription mechanism for cleaner code
  * Enhanced error handling for event handlers with improved logging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->