### PR TITLE
Remove legacy executeFeature fallback

### DIFF
--- a/apps/server/src/routes/auto-mode/index.ts
+++ b/apps/server/src/routes/auto-mode/index.ts
@@ -7,6 +7,7 @@
 import { Router } from 'express';
 import type { AutoModeService } from '../../services/auto-mode-service.js';
 import type { FeatureLoader } from '../../services/feature-loader.js';
+import type { LeadEngineerService } from '../../services/lead-engineer-service.js';
 import type { SettingsService } from '../../services/settings-service.js';
 import type { EventEmitter } from '../../lib/events.js';
 import { validatePathParams } from '../../middleware/validate-paths.js';
@@ -29,6 +30,7 @@ import { createReconcileHandler } from './routes/reconcile.js';
 export function createAutoModeRoutes(
   autoModeService: AutoModeService,
   featureLoader: FeatureLoader,
+  leadEngineerService: LeadEngineerService,
   settingsService: SettingsService,
   events?: EventEmitter
 ): Router {
@@ -47,7 +49,7 @@ export function createAutoModeRoutes(
   router.post(
     '/run-feature',
     validatePathParams('projectPath'),
-    createRunFeatureHandler(autoModeService, featureLoader)
+    createRunFeatureHandler(autoModeService, featureLoader, leadEngineerService)
   );
   router.post(
     '/verify-feature',

--- a/apps/server/src/routes/auto-mode/routes/run-feature.ts
+++ b/apps/server/src/routes/auto-mode/routes/run-feature.ts
@@ -5,6 +5,7 @@
 import type { Request, Response } from 'express';
 import type { AutoModeService } from '../../../services/auto-mode-service.js';
 import type { FeatureLoader } from '../../../services/feature-loader.js';
+import type { LeadEngineerService } from '../../../services/lead-engineer-service.js';
 import {
   areDependenciesSatisfied,
   getBlockingDependencies,
@@ -16,7 +17,8 @@ const logger = createLogger('AutoMode');
 
 export function createRunFeatureHandler(
   autoModeService: AutoModeService,
-  featureLoader: FeatureLoader
+  featureLoader: FeatureLoader,
+  leadEngineerService: LeadEngineerService
 ) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
@@ -74,17 +76,10 @@ export function createRunFeatureHandler(
         return;
       }
 
-      // Start execution in background
-      // executeFeature derives workDir from feature.branchName
-      autoModeService
-        .executeFeature(projectPath, featureId, useWorktrees ?? false, false)
-        .catch((error) => {
-          logger.error(`Feature ${featureId} error:`, error);
-        })
-        .finally(() => {
-          // Release the starting slot when execution completes (success or error)
-          // Note: The feature should be in runningFeatures by this point
-        });
+      // Start execution in background via LeadEngineerService state machine
+      leadEngineerService.process(projectPath, featureId).catch((error) => {
+        logger.error(`Feature ${featureId} error:`, error);
+      });
 
       res.json({ success: true });
     } catch (error) {

--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -25,6 +25,7 @@ import {
 } from '@protolabsai/platform';
 import type { FeatureLoader } from '../../services/feature-loader.js';
 import type { AutoModeService } from '../../services/auto-mode-service.js';
+import type { LeadEngineerService } from '../../services/lead-engineer-service.js';
 import type { AgentService } from '../../services/agent-service.js';
 import type { SensorRegistryService } from '../../services/sensor-registry-service.js';
 import type { RoleRegistryService } from '../../services/role-registry-service.js';
@@ -64,6 +65,7 @@ export interface PlanData {
 export interface AvaToolsServices {
   featureLoader: FeatureLoader;
   autoModeService: AutoModeService;
+  leadEngineerService: LeadEngineerService;
   agentService: AgentService;
   /** Optional event emitter used for board-write change notifications */
   events?: EventEmitter;
@@ -450,7 +452,7 @@ export function buildAvaTools(
       }),
       needsApproval: destructiveNeedsApproval,
       execute: async ({ featureId }) => {
-        await services.autoModeService.executeFeature(projectPath, featureId, true);
+        await services.leadEngineerService.process(projectPath, featureId);
         return { success: true, featureId };
       },
     });

--- a/apps/server/src/routes/chat/index.ts
+++ b/apps/server/src/routes/chat/index.ts
@@ -349,6 +349,7 @@ export function createChatRoutes(services: ServiceContainer): Router {
             {
               featureLoader: services.featureLoader,
               autoModeService: services.autoModeService,
+              leadEngineerService: services.leadEngineerService,
               agentService: services.agentService,
               roleRegistryService: services.roleRegistryService,
               agentFactoryService: services.agentFactoryService,

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -250,7 +250,13 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   );
   app.use(
     '/api/auto-mode',
-    createAutoModeRoutes(autoModeService, featureLoader, settingsService, events)
+    createAutoModeRoutes(
+      autoModeService,
+      featureLoader,
+      leadEngineerService,
+      settingsService,
+      events
+    )
   );
   app.use('/api/enhance-prompt', createEnhancePromptRoutes(settingsService));
   app.use(

--- a/apps/server/src/server/wiring.ts
+++ b/apps/server/src/server/wiring.ts
@@ -18,6 +18,12 @@ import { register as registerInfrastructure } from '../services/infrastructure.m
  * Ordering matters — some modules depend on others having run first (e.g. Discord before DiscordDM).
  */
 export async function wireServices(services: ServiceContainer): Promise<void> {
+  // Guard: leadEngineerService is required — auto-mode no longer has a fallback execution path.
+  // If this throws at startup, services.ts failed to initialize LeadEngineerService.
+  if (!services.leadEngineerService) {
+    throw new Error('LeadEngineerService failed to initialize — cannot start server');
+  }
+
   await registerCore(services);
   await registerEscalationChannels(services);
   await registerEventSubscriptions(services);

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -279,8 +279,8 @@ export class AutoModeService {
   private authorityService: AuthorityService | null = null;
   // Data integrity watchdog service for monitoring feature count (optional)
   private integrityWatchdogService: DataIntegrityWatchdogService | null = null;
-  // Lead Engineer service for delegated feature execution (optional)
-  private leadEngineerService: LeadEngineerService | null = null;
+  // Lead Engineer service for feature execution (required)
+  private leadEngineerService!: LeadEngineerService;
   // Knowledge Store service for learning deduplication (optional)
   private knowledgeStoreService: KnowledgeStoreService | null = null;
   // Pipeline Checkpoint service for crash recovery checkpoint cleanup (optional)
@@ -379,10 +379,11 @@ export class AutoModeService {
   }
 
   /**
-   * Wire up the Lead Engineer service for delegated feature execution.
-   * When set, auto-mode will delegate feature processing to the state machine.
+   * Wire up the Lead Engineer service for feature execution.
+   * Required — auto-mode routes all features through the state machine.
    */
   setLeadEngineerService(service: LeadEngineerService): void {
+    if (!service) throw new Error('LeadEngineerService is required');
     this.leadEngineerService = service;
   }
 
@@ -1143,18 +1144,7 @@ export class AutoModeService {
             continue;
           }
 
-          // Guard: content features (featureType === 'content') must route through
-          // leadEngineerService to the GTM execution path. They must NOT be launched
-          // with the standard code agent. If leadEngineerService is not available, skip them.
-          if (nextFeature.featureType === 'content' && !this.leadEngineerService) {
-            logger.warn(
-              `[AutoLoop] Skipping content feature ${nextFeature.id} ("${nextFeature.title}") — LeadEngineerService required for GTM execution path`
-            );
-            await this.sleep(2000);
-            continue;
-          }
-
-          // Mark feature as starting BEFORE calling executeFeature to prevent race conditions
+          // Mark feature as starting BEFORE calling process() to prevent race conditions
           projectState.startingFeatures.add(nextFeature.id);
 
           logger.info(`[AutoLoop] Starting feature ${nextFeature.id}: ${nextFeature.title}`);
@@ -1216,18 +1206,10 @@ export class AutoModeService {
           const startingTimeout = scheduleStartingTimeout(30000);
 
           // Start feature execution in background.
-          // Content features (featureType === 'content') always route through leadEngineerService
-          // to the GTM execution path (guarded above — leadEngineerService is non-null here).
-          // Code features use leadEngineerService if available, otherwise fall back to executeFeature.
-          // Model selection for the LE path is handled inside IntakeProcessor.
-          const executionPromise = this.leadEngineerService
-            ? this.leadEngineerService.process(projectPath, nextFeature.id)
-            : this.executeFeature(
-                projectPath,
-                nextFeature.id,
-                projectState.config.useWorktrees,
-                true
-              );
+          // All features route through leadEngineerService.process() — the state machine
+          // handles both code and content (GTM) features.
+          // Model selection is handled inside IntakeProcessor.
+          const executionPromise = this.leadEngineerService.process(projectPath, nextFeature.id);
 
           // Convert the raw execution promise into a structured PipelineResult so all
           // outcomes — success, escalation, and retryable failures — are handled


### PR DESCRIPTION
## Summary

**Milestone:** Thin Scheduler Extraction

Remove the ternary fallback in auto-mode dispatch (auto-mode-service.ts:1173-1183). Update run-feature.ts and ava-tools.ts to route through leadEngineerService.process() directly. Update setLeadEngineerService setter to throw if called with null — required now, not optional. Add startup guard in wiring.ts.

**Files to Modify:**
- apps/server/src/services/auto-mode-service.ts
- apps/server/src/routes/auto-mode/routes/run-feature.ts
- apps/server/src/route...

---
*Recovered automatically by Automaker post-agent hook*