### PR TITLE
Migrate escalation-router and notification-router

### DIFF
--- a/apps/server/src/services/agent-discord-router.ts
+++ b/apps/server/src/services/agent-discord-router.ts
@@ -68,6 +68,7 @@ export class AgentDiscordRouter {
   start(): void {
     logger.info('Starting AgentDiscordRouter');
 
+    // TODO: migrate to bus.on()
     this.unsubscribe = this.events.subscribe((type, payload) => {
       if (type === 'discord:user-message:routed') {
         this.handleRoutedMessage(payload as DiscordUserMessageRoutedPayload).catch((error) => {

--- a/apps/server/src/services/audit-service.ts
+++ b/apps/server/src/services/audit-service.ts
@@ -90,6 +90,7 @@ export class AuditService {
     this.initialized = true;
     this.authorityService = authorityService;
 
+    // TODO: migrate to bus.on()
     this.events.subscribe((type, payload) => {
       const data = payload as Record<string, unknown>;
       const projectPath = data.projectPath as string | undefined;

--- a/apps/server/src/services/ava-gateway-service.ts
+++ b/apps/server/src/services/ava-gateway-service.ts
@@ -182,6 +182,7 @@ export class AvaGatewayService {
       throw new Error('EventEmitter not initialized. Call initialize() first.');
     }
 
+    // TODO: migrate to bus.on()
     this.unsubscribe = this.events.subscribe((type, payload) => {
       this.handleCriticalEvent(type, payload);
     });

--- a/apps/server/src/services/escalation-router.ts
+++ b/apps/server/src/services/escalation-router.ts
@@ -15,7 +15,7 @@ import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 
 import type { EscalationSignal, EscalationChannel } from '@protolabsai/types';
-import { EscalationSeverity } from '@protolabsai/types';
+import { EscalationSeverity, EscalationSource } from '@protolabsai/types';
 import { createLogger } from '@protolabsai/utils';
 import type { EventEmitter } from '../lib/events.js';
 
@@ -141,13 +141,27 @@ export class EscalationRouter {
   setEventEmitter(events: EventEmitter): void {
     this.events = events;
 
-    events.subscribe((type, payload) => {
-      if (type === 'escalation:signal-received') {
-        void this.routeSignal(payload as EscalationSignal);
-      }
+    events.on('escalation:signal-received', (payload) => {
+      void this.routeSignal(payload as unknown as EscalationSignal);
     });
 
-    logger.info('EscalationRouter listening for escalation:signal-received events');
+    events.on('feature:blocked', (payload) => {
+      const featureId = payload['featureId'] as string | undefined;
+      const featureTitle = payload['featureTitle'] as string | undefined;
+      const reason = payload['reason'] as string | undefined;
+      void this.routeSignal({
+        type: 'feature-blocked',
+        source: EscalationSource.lead_engineer_escalation,
+        severity: EscalationSeverity.medium,
+        deduplicationKey: `feature-blocked:${featureId ?? 'unknown'}`,
+        timestamp: new Date().toISOString(),
+        context: { featureId, featureTitle, reason },
+      });
+    });
+
+    logger.info(
+      'EscalationRouter listening for escalation:signal-received and feature:blocked events'
+    );
   }
 
   /**

--- a/apps/server/src/services/event-subscriptions.module.ts
+++ b/apps/server/src/services/event-subscriptions.module.ts
@@ -11,6 +11,7 @@ const logger = createLogger('Server:Wiring');
 export function register(container: ServiceContainer): void {
   const { events, featureLoader, autoModeService, escalationRouter } = container;
 
+  // TODO: migrate to bus.on() — feature:stopped, feature:deleted, escalation:acknowledged
   // feature:stopped → reset stale in_progress features to backlog immediately
   events.subscribe((type, payload) => {
     if (type !== 'feature:stopped') return;

--- a/apps/server/src/services/notification-router.ts
+++ b/apps/server/src/services/notification-router.ts
@@ -256,52 +256,38 @@ export class NotificationRouter {
    *   hitl:form-requested   → HITL / human-input-required notification
    */
   private subscribeToEvents(): void {
-    this.events.subscribe((type, payload) => {
-      if (type === 'feature:completed') {
-        const data = payload as {
-          featureId?: string;
-          featureTitle?: string;
-          projectPath?: string;
-        };
-        void this.route({
-          type: 'completion',
-          title: 'Feature Completed',
-          message: data.featureTitle
-            ? `"${data.featureTitle}" completed successfully.`
-            : 'A feature completed successfully.',
-          featureId: data.featureId,
-          projectPath: data.projectPath,
-        });
-      } else if (type === 'feature:error') {
-        const data = payload as {
-          featureId?: string;
-          featureTitle?: string;
-          projectPath?: string;
-          error?: string;
-        };
-        void this.route({
-          type: 'failure',
-          title: 'Feature Failed',
-          message: data.featureTitle
-            ? `"${data.featureTitle}" encountered an error.`
-            : `Feature failed: ${data.error ?? 'unknown error'}`,
-          featureId: data.featureId,
-          projectPath: data.projectPath,
-        });
-      } else if (type === 'hitl:form-requested') {
-        const data = payload as {
-          featureId?: string;
-          projectPath?: string;
-          title?: string;
-        };
-        void this.route({
-          type: 'hitl',
-          title: 'Human Input Required',
-          message: data.title ?? 'An agent is waiting for your input.',
-          featureId: data.featureId,
-          projectPath: data.projectPath,
-        });
-      }
+    this.events.on('feature:completed', (data) => {
+      void this.route({
+        type: 'completion',
+        title: 'Feature Completed',
+        message: data.featureTitle
+          ? `"${data.featureTitle}" completed successfully.`
+          : 'A feature completed successfully.',
+        featureId: data.featureId,
+        projectPath: data.projectPath,
+      });
+    });
+
+    this.events.on('feature:error', (data) => {
+      void this.route({
+        type: 'failure',
+        title: 'Feature Failed',
+        message: data.featureTitle
+          ? `"${data.featureTitle}" encountered an error.`
+          : `Feature failed: ${data.error ?? 'unknown error'}`,
+        featureId: data.featureId,
+        projectPath: data.projectPath,
+      });
+    });
+
+    this.events.on('hitl:form-requested', (data) => {
+      void this.route({
+        type: 'hitl',
+        title: 'Human Input Required',
+        message: data.title ?? 'An agent is waiting for your input.',
+        featureId: data.featureId,
+        projectPath: data.projectPath,
+      });
     });
   }
 

--- a/apps/server/src/services/pr-feedback-service.ts
+++ b/apps/server/src/services/pr-feedback-service.ts
@@ -103,6 +103,7 @@ export class PRFeedbackService {
     if (this.initialized) return;
     this.initialized = true;
 
+    // TODO: migrate to bus.on()
     this.events.subscribe((type, payload) => {
       if (type === 'auto-mode:event') {
         const data = payload as Record<string, unknown>;

--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -105,6 +105,7 @@ export class SignalIntakeService {
   }
 
   private registerListener(): void {
+    // TODO: migrate to bus.on()
     this.events.subscribe((type, payload) => {
       if (type === 'signal:received') {
         void this.handleSignal(payload as SignalPayload);

--- a/apps/server/src/services/worktree-lifecycle-service.ts
+++ b/apps/server/src/services/worktree-lifecycle-service.ts
@@ -74,6 +74,7 @@ export class WorktreeLifecycleService {
     if (this.initialized) return;
     this.initialized = true;
 
+    // TODO: migrate to bus.on()
     this.events.subscribe((type, payload) => {
       // Clean up worktree after PR is merged
       if (type === 'feature:pr-merged') {


### PR DESCRIPTION
## Summary

**Milestone:** Typed Event Bus

Migrate escalation-router.ts and notification-router.ts from broadcast-all subscribe() to typed on() subscriptions — the highest-volume handlers outside auto-mode/LE. Document remaining broadcast-all services with a TODO comment.

**Files to Modify:**
- apps/server/src/services/escalation-router.ts
- apps/server/src/routes/notification/notification-router.ts

**Acceptance Criteria:**
- [ ] escalation-router uses typed on() for escalation:* and feature:blocked even...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced escalation routing to handle blocked features, automatically generating escalation signals with appropriate metadata for better incident management.

* **Bug Fixes & Improvements**
  * Refactored event handling in notification service for improved reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->