### PR TITLE
Move model selection into INTAKE

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -305,7 +305,6 @@ export class AutoModeService {
       resumeFeature: this.resumeFeature.bind(this),
       findExistingWorktreeForBranch: this.findExistingWorktreeForBranch.bind(this),
       createWorktreeForBranch: this.createWorktreeForBranch.bind(this),
-      getModelForFeature: this.getModelForFeature.bind(this),
       saveExecutionState: this.saveExecutionState.bind(this),
       getAutoLoopRunning: () => this.autoLoopRunning,
       updateFeatureStatus: this.updateFeatureStatus.bind(this),
@@ -1177,11 +1176,9 @@ export class AutoModeService {
           // Content features (featureType === 'content') always route through leadEngineerService
           // to the GTM execution path (guarded above — leadEngineerService is non-null here).
           // Code features use leadEngineerService if available, otherwise fall back to executeFeature.
-          const featureModelResult = await this.getModelForFeature(nextFeature, projectPath);
+          // Model selection for the LE path is handled inside IntakeProcessor.
           const executionPromise = this.leadEngineerService
-            ? this.leadEngineerService.process(projectPath, nextFeature.id, {
-                model: featureModelResult.model,
-              } as unknown as ExecuteOptions) // State machine builds full ExecuteOptions internally
+            ? this.leadEngineerService.process(projectPath, nextFeature.id)
             : this.executeFeature(
                 projectPath,
                 nextFeature.id,

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -70,6 +70,7 @@ import {
   getMCPServersFromSettings,
   getPromptCustomization,
   getProviderByModelId,
+  getPhaseModelWithOverrides,
 } from '../../lib/settings-helpers.js';
 import { RecoveryService } from '../recovery-service.js';
 import { checkAndRecoverUncommittedWork } from '../worktree-recovery-service.js';
@@ -584,7 +585,7 @@ export class ExecutionService {
       );
 
       // Get model based on feature complexity and failure count
-      const modelResult = await this.callbacks.getModelForFeature(feature, projectPath);
+      const modelResult = await this.getModelForFeature(feature, projectPath);
       const maxTurns = getTurnsForFeature(feature);
       const provider = ProviderFactory.getProviderNameForModel(modelResult.model);
       logger.info(
@@ -1511,7 +1512,7 @@ export class ExecutionService {
     );
 
     // Get model based on feature complexity and failure count
-    const modelResult = await this.callbacks.getModelForFeature(feature, projectPath);
+    const modelResult = await this.getModelForFeature(feature, projectPath);
 
     // Run the agent for this pipeline step
     await this.runAgent(
@@ -3101,6 +3102,47 @@ You can use the Read tool to view these images at any time during implementation
     } catch (error) {
       logger.warn(`Failed to extract learnings from feature ${feature.id}:`, error);
     }
+  }
+
+  /**
+   * Select model based on feature complexity, failure count, and settings.
+   * Priority: explicit feature.model > failure escalation > architectural > settings > complexity
+   */
+  private async getModelForFeature(
+    feature: { model?: string; complexity?: string; failureCount?: number },
+    projectPath?: string
+  ): Promise<{ model: string; providerId?: string }> {
+    if (feature.model) {
+      return { model: resolveModelString(feature.model, DEFAULT_MODELS.autoMode) };
+    }
+    if (feature.failureCount && feature.failureCount >= 2) {
+      logger.info(`Escalating to opus after ${feature.failureCount} failures`);
+      return { model: DEFAULT_MODELS.claude };
+    }
+    if (feature.complexity === 'architectural') {
+      logger.info('Using opus for architectural feature');
+      return { model: DEFAULT_MODELS.claude };
+    }
+    try {
+      const { phaseModel } = await getPhaseModelWithOverrides(
+        'agentExecutionModel',
+        this.settingsService,
+        projectPath
+      );
+      if (phaseModel?.model) {
+        return {
+          model: resolveModelString(phaseModel.model, DEFAULT_MODELS.autoMode),
+          providerId: phaseModel.providerId,
+        };
+      }
+    } catch (err) {
+      logger.warn(`Failed to read agentExecutionModel setting, using fallback: ${err}`);
+    }
+    if (feature.complexity === 'small') {
+      logger.info('Using haiku for small feature');
+      return { model: DEFAULT_MODELS.trivial };
+    }
+    return { model: DEFAULT_MODELS.autoMode };
   }
 
   /**

--- a/apps/server/src/services/auto-mode/execution-types.ts
+++ b/apps/server/src/services/auto-mode/execution-types.ts
@@ -84,12 +84,6 @@ export interface IAutoModeCallbacks {
     feature: Feature
   ): Promise<string | null>;
 
-  // Model selection
-  getModelForFeature(
-    feature: Feature,
-    projectPath?: string
-  ): Promise<{ model: string; providerId?: string }>;
-
   // State persistence
   saveExecutionState(projectPath: string): Promise<void>;
 

--- a/apps/server/src/services/lead-engineer-processors.ts
+++ b/apps/server/src/services/lead-engineer-processors.ts
@@ -6,10 +6,10 @@
  */
 
 import { createLogger } from '@protolabsai/utils';
-import { resolveModelString } from '@protolabsai/model-resolver';
+import { resolveModelString, DEFAULT_MODELS } from '@protolabsai/model-resolver';
 import { areDependenciesSatisfied } from '@protolabsai/dependency-resolver';
 import type { AgentRole, Feature } from '@protolabsai/types';
-import { getWorkflowSettings } from '../lib/settings-helpers.js';
+import { getWorkflowSettings, getPhaseModelWithOverrides } from '../lib/settings-helpers.js';
 import { simpleQuery } from '../providers/simple-query-service.js';
 import type {
   ProcessorServiceContext,
@@ -80,10 +80,15 @@ export class IntakeProcessor implements StateProcessor {
     // Determine if PLAN phase is needed
     ctx.planRequired = this.requiresPlan(feature);
 
-    // Mark feature as in_progress on the board and persist complexity
+    // Select model based on complexity and feature type, store in StateContext
+    ctx.selectedModel = await this.selectModel(feature, ctx.projectPath);
+    logger.info(`[INTAKE] Selected model: ${ctx.selectedModel}`);
+
+    // Mark feature as in_progress on the board and persist complexity + selected model
     await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
       status: 'in_progress',
       complexity: ctx.feature.complexity,
+      model: ctx.selectedModel,
     });
     logger.info('[INTAKE] Feature status updated to in_progress');
 
@@ -105,6 +110,50 @@ export class IntakeProcessor implements StateProcessor {
 
   async exit(_ctx: StateContext): Promise<void> {
     logger.info('[INTAKE] Completed intake processing');
+  }
+
+  private async selectModel(
+    feature: { model?: string; complexity?: string; failureCount?: number },
+    projectPath: string
+  ): Promise<string> {
+    // 1. Feature explicitly specifies a model → use it (highest priority)
+    if (feature.model) {
+      return resolveModelString(feature.model, DEFAULT_MODELS.autoMode);
+    }
+
+    // 2. Escalate to opus after multiple failures (safety net)
+    if (feature.failureCount && feature.failureCount >= 2) {
+      logger.info(`[INTAKE] Escalating to opus after ${feature.failureCount} failures`);
+      return DEFAULT_MODELS.claude; // opus
+    }
+
+    // 3. Architectural complexity always gets opus
+    if (feature.complexity === 'architectural') {
+      logger.info('[INTAKE] Using opus for architectural feature');
+      return DEFAULT_MODELS.claude; // opus
+    }
+
+    // 4. Read user's configured agent execution model from settings
+    try {
+      const { phaseModel } = await getPhaseModelWithOverrides(
+        'agentExecutionModel',
+        this.serviceContext.settingsService,
+        projectPath
+      );
+      if (phaseModel?.model) {
+        return resolveModelString(phaseModel.model, DEFAULT_MODELS.autoMode);
+      }
+    } catch (err) {
+      logger.warn(`[INTAKE] Failed to read agentExecutionModel setting, using fallback: ${err}`);
+    }
+
+    // 5. Fallback: complexity-based (only if no setting configured)
+    if (feature.complexity === 'small') {
+      logger.info('[INTAKE] Using haiku for small feature');
+      return DEFAULT_MODELS.trivial; // haiku
+    }
+
+    return DEFAULT_MODELS.autoMode; // sonnet
   }
 
   private assignPersona(feature: Feature): AgentRole {

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -10,7 +10,7 @@
  */
 
 import { createLogger } from '@protolabsai/utils';
-import type { EventType, LeadEngineerSession, ExecuteOptions } from '@protolabsai/types';
+import type { EventType, LeadEngineerSession } from '@protolabsai/types';
 import type { EventEmitter } from '../lib/events.js';
 import type { FeatureLoader } from './feature-loader.js';
 import type { AutoModeService } from './auto-mode-service.js';
@@ -294,10 +294,9 @@ export class LeadEngineerService {
     return this.activeFeatures.has(featureId);
   }
 
-  async process(projectPath: string, featureId: string, options: ExecuteOptions): Promise<void> {
+  async process(projectPath: string, featureId: string): Promise<void> {
     logger.info(`[LeadEngineer] Processing feature ${featureId}`, {
       projectPath,
-      model: options.model,
     });
     this.activeFeatures.add(featureId);
     try {
@@ -382,12 +381,7 @@ export class LeadEngineerService {
 
       let result: Awaited<ReturnType<typeof stateMachine.processFeature>>;
       try {
-        result = await stateMachine.processFeature(
-          feature,
-          projectPath,
-          options,
-          resumeFromCheckpoint
-        );
+        result = await stateMachine.processFeature(feature, projectPath, resumeFromCheckpoint);
       } finally {
         unsubPipelineSync();
       }

--- a/apps/server/src/services/lead-engineer-state-machine.ts
+++ b/apps/server/src/services/lead-engineer-state-machine.ts
@@ -6,7 +6,7 @@
  */
 
 import { createLogger } from '@protolabsai/utils';
-import type { Feature, ExecuteOptions, GoalGateResult, EventType } from '@protolabsai/types';
+import type { Feature, GoalGateResult, EventType } from '@protolabsai/types';
 import type { EventEmitter } from '../lib/events.js';
 import type { PipelineCheckpointService } from './pipeline-checkpoint-service.js';
 import { IntakeProcessor, PlanProcessor } from './lead-engineer-processors.js';
@@ -128,7 +128,6 @@ export class FeatureStateMachine {
   async processFeature(
     feature: Feature,
     projectPath: string,
-    options: ExecuteOptions,
     resumeFromCheckpoint?: {
       state: FeatureProcessingState;
       restoredContext?: Partial<StateContext>;
@@ -137,7 +136,6 @@ export class FeatureStateMachine {
     const ctx: StateContext = {
       feature,
       projectPath,
-      options,
       retryCount: 0,
       infraRetryCount: 0,
       planRequired: false,

--- a/apps/server/src/services/lead-engineer-types.ts
+++ b/apps/server/src/services/lead-engineer-types.ts
@@ -4,7 +4,7 @@
  * All types shared across the lead-engineer subsystem files.
  */
 
-import type { Feature, ExecuteOptions, AgentRole } from '@protolabsai/types';
+import type { Feature, AgentRole } from '@protolabsai/types';
 import type { EventEmitter } from '../lib/events.js';
 import type { FeatureLoader } from './feature-loader.js';
 import type { AutoModeService } from './auto-mode-service.js';
@@ -126,7 +126,8 @@ export interface StateTransitionResult {
 export interface StateContext {
   feature: Feature;
   projectPath: string;
-  options: ExecuteOptions;
+  /** Model selected during INTAKE phase. Used by ExecuteProcessor to run the agent. */
+  selectedModel?: string;
   /** Number of full agent re-runs triggered by agent-level failures (bad code, logic errors). */
   retryCount: number;
   /**


### PR DESCRIPTION
## Summary

**Milestone:** Pipeline Owns Its State

Move auto-mode-service.getModelForFeature() (lines 426-471) into IntakeProcessor.process(). INTAKE selects the model and stores it in StateContext. Remove the getModelForFeature call from the auto-mode dispatch block (line 1160). Remove getModelForFeature from IAutoModeCallbacks. The as unknown as ExecuteOptions cast disappears.

**Files to Modify:**
- apps/server/src/services/lead-engineer-processors.ts
- apps/server/src/services/lead-engineer-types.ts
- ...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-05T06:45:24.762Z -->