### PR TITLE
Migrate auto-mode and LE to typed subscriptions

### DIFF
--- a/apps/server/src/lib/events.ts
+++ b/apps/server/src/lib/events.ts
@@ -6,7 +6,13 @@
  * (NATS, Redis) can be swapped in for hivemind distribution.
  */
 
-import type { EventType, EventCallback, EventBus, EventSubscription } from '@protolabsai/types';
+import type {
+  EventType,
+  EventCallback,
+  EventBus,
+  EventSubscription,
+  TypedEventCallback,
+} from '@protolabsai/types';
 import { createLogger } from '@protolabsai/utils';
 
 const logger = createLogger('Events');
@@ -21,6 +27,7 @@ export type UnsubscribeFn = (() => void) & EventSubscription;
 export interface EventEmitter extends EventBus {
   emit: (type: EventType, payload: unknown) => void;
   subscribe: (callback: EventCallback) => UnsubscribeFn;
+  on: <T extends EventType>(type: T, callback: TypedEventCallback<T>) => EventSubscription;
 }
 
 export function createEventEmitter(): EventEmitter {
@@ -47,6 +54,20 @@ export function createEventEmitter(): EventEmitter {
       const unsubWithMethod = unsub as UnsubscribeFn;
       unsubWithMethod.unsubscribe = unsub;
       return unsubWithMethod;
+    },
+
+    on<T extends EventType>(type: T, callback: TypedEventCallback<T>) {
+      const wrapper: EventCallback = (eventType, payload) => {
+        if (eventType === type) {
+          callback(payload as Parameters<TypedEventCallback<T>>[0]);
+        }
+      };
+      subscribers.add(wrapper);
+      return {
+        unsubscribe: () => {
+          subscribers.delete(wrapper);
+        },
+      };
     },
 
     broadcast(type: EventType, payload?: unknown) {

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -341,24 +341,17 @@ export class AutoModeService {
     // Stop running agents when their feature reaches a terminal state.
     // This prevents zombie agents from continuing to run (and consume API budget)
     // after a feature is marked done/verified externally (MCP, manual update, epic merge).
-    this.events.subscribe((type, payload) => {
-      if (type === 'feature:status-changed') {
-        const data = payload as {
-          featureId?: string;
-          newStatus?: string;
-          projectPath?: string;
-        };
-        if (data.featureId && (data.newStatus === 'done' || data.newStatus === 'verified')) {
-          if (this.runningFeatures.has(data.featureId)) {
-            logger.info(
-              `Stopping agent for completed feature ${data.featureId} (→ ${data.newStatus})`
-            );
-            void this.stopFeature(data.featureId);
-          }
-
-          // Auto-unblock: Check if any features were waiting on this as a human-blocked dependency
-          void this.handleFeatureCompletion(data.featureId, data.projectPath);
+    this.events.on('feature:status-changed', (data) => {
+      if (data.featureId && (data.newStatus === 'done' || data.newStatus === 'verified')) {
+        if (this.runningFeatures.has(data.featureId)) {
+          logger.info(
+            `Stopping agent for completed feature ${data.featureId} (→ ${data.newStatus})`
+          );
+          void this.stopFeature(data.featureId);
         }
+
+        // Auto-unblock: Check if any features were waiting on this as a human-blocked dependency
+        void this.handleFeatureCompletion(data.featureId, data.projectPath);
       }
     });
   }

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -10,7 +10,12 @@
  */
 
 import { createLogger } from '@protolabsai/utils';
-import type { EventType, LeadEngineerSession, PipelineResult } from '@protolabsai/types';
+import type {
+  EventType,
+  EventSubscription,
+  LeadEngineerSession,
+  PipelineResult,
+} from '@protolabsai/types';
 import { FeatureState } from '@protolabsai/types';
 import type { EventEmitter } from '../lib/events.js';
 import type { FeatureLoader } from './feature-loader.js';
@@ -55,7 +60,7 @@ const SUPERVISOR_CHECK_MS = 30 * 1000;
 
 export class LeadEngineerService {
   private sessions = new Map<string, LeadEngineerSession>();
-  private unsubscribe: (() => void) | null = null;
+  private subscriptions: EventSubscription[] = [];
   private refreshIntervals = new Map<string, ReturnType<typeof setInterval>>();
   private supervisorIntervals = new Map<string, ReturnType<typeof setInterval>>();
   private activeFeatures = new Set<string>();
@@ -144,26 +149,30 @@ export class LeadEngineerService {
   }
 
   async initialize(): Promise<void> {
-    this.unsubscribe = this.events.subscribe((type: EventType, payload: unknown) => {
-      if (type === 'project:lifecycle:launched') {
-        const p = payload as { projectPath?: string; projectSlug?: string } | null;
+    this.subscriptions.push(
+      this.events.on('project:lifecycle:launched', (data) => {
+        const p = data as { projectPath?: string; projectSlug?: string } | null;
         if (p?.projectPath && p?.projectSlug) {
           this.start(p.projectPath, p.projectSlug).catch((err) =>
             logger.error(`Auto-start failed for ${p.projectSlug}:`, err)
           );
         }
-        return;
-      }
-      if (type === ('lead-engineer:project-completing-requested' as EventType)) {
-        const p = payload as { projectPath?: string } | null;
-        if (p?.projectPath) {
-          const session = this.sessions.get(p.projectPath);
+      }),
+      this.events.on('lead-engineer:project-completing-requested', (data) => {
+        if (data?.projectPath) {
+          const session = this.sessions.get(data.projectPath);
           if (session) void this.handleProjectCompleting(session);
         }
-        return;
-      }
-      this.onEvent(type, payload);
-    });
+      }),
+      this.events.subscribe((type: EventType, payload: unknown) => {
+        if (
+          type !== 'project:lifecycle:launched' &&
+          type !== 'lead-engineer:project-completing-requested'
+        ) {
+          this.onEvent(type, payload);
+        }
+      })
+    );
     await this.sessionStore.restore(async (projectPath, projectSlug, maxConcurrency) => {
       await this.start(projectPath, projectSlug, { maxConcurrency });
     });
@@ -176,10 +185,8 @@ export class LeadEngineerService {
   }
 
   destroy(): void {
-    if (this.unsubscribe) {
-      this.unsubscribe();
-      this.unsubscribe = null;
-    }
+    for (const sub of this.subscriptions) sub.unsubscribe();
+    this.subscriptions = [];
     for (const [projectPath] of this.sessions) this.clearIntervals(projectPath);
     this.sessions.clear();
     logger.info('LeadEngineerService destroyed');

--- a/apps/server/tests/integration/services/auto-mode-service.integration.test.ts
+++ b/apps/server/tests/integration/services/auto-mode-service.integration.test.ts
@@ -27,10 +27,12 @@ describe('auto-mode-service.ts (integration)', () => {
   const mockEvents = {
     subscribe: vi.fn(),
     emit: vi.fn(),
+    on: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
   };
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockEvents.on.mockReturnValue({ unsubscribe: vi.fn() });
     service = new AutoModeService(mockEvents as any);
     featureLoader = new FeatureLoader();
     testRepo = await createTestGitRepo();

--- a/apps/server/tests/unit/services/auto-mode-service-planning.test.ts
+++ b/apps/server/tests/unit/services/auto-mode-service-planning.test.ts
@@ -6,10 +6,12 @@ describe('auto-mode-service.ts - Planning Mode', () => {
   const mockEvents = {
     subscribe: vi.fn(),
     emit: vi.fn(),
+    on: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockEvents.on.mockReturnValue({ unsubscribe: vi.fn() });
     service = new AutoModeService(mockEvents as any);
   });
 

--- a/apps/server/tests/unit/services/auto-mode-service.test.ts
+++ b/apps/server/tests/unit/services/auto-mode-service.test.ts
@@ -7,10 +7,12 @@ describe('auto-mode-service.ts', () => {
   const mockEvents = {
     subscribe: vi.fn(),
     emit: vi.fn(),
+    on: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockEvents.on.mockReturnValue({ unsubscribe: vi.fn() });
     service = new AutoModeService(mockEvents as any);
   });
 

--- a/apps/server/tests/unit/services/lead-engineer-service.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-service.test.ts
@@ -30,6 +30,7 @@ const mockGetWorkflowSettings = getWorkflowSettings as unknown as ReturnType<typ
 
 function createMockEvents() {
   const subscribers: Array<(type: EventType, payload: unknown) => void> = [];
+  const typedSubscribers: Array<{ type: EventType; cb: (payload: unknown) => void }> = [];
   return {
     emit: vi.fn(),
     subscribe: vi.fn((cb: (type: EventType, payload: unknown) => void) => {
@@ -41,8 +42,20 @@ function createMockEvents() {
       (unsub as any).unsubscribe = unsub;
       return unsub;
     }),
+    on: vi.fn((type: EventType, cb: (payload: unknown) => void) => {
+      typedSubscribers.push({ type, cb });
+      return {
+        unsubscribe: () => {
+          const idx = typedSubscribers.findIndex((s) => s.type === type && s.cb === cb);
+          if (idx >= 0) typedSubscribers.splice(idx, 1);
+        },
+      };
+    }),
     _fire(type: EventType, payload: unknown) {
       for (const cb of subscribers) cb(type, payload);
+      for (const s of typedSubscribers) {
+        if (s.type === type) s.cb(payload);
+      }
     },
     _subscribers: subscribers,
   };

--- a/apps/server/tests/unit/services/scheduler-loop.test.ts
+++ b/apps/server/tests/unit/services/scheduler-loop.test.ts
@@ -377,12 +377,14 @@ describe('AutoModeService - loadPendingFeatures', () => {
   const mockEvents = {
     subscribe: vi.fn(),
     emit: vi.fn(),
+    on: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
     // Re-establish platform mocks cleared by vitest's mockReset: true
     mockGetFeaturesDir.mockReturnValue('/fake/project/.automaker/features');
+    mockEvents.on.mockReturnValue({ unsubscribe: vi.fn() });
     service = new AutoModeService(mockEvents as any);
   });
 
@@ -532,10 +534,12 @@ describe('AutoModeService - concurrency and race prevention', () => {
   const mockEvents = {
     subscribe: vi.fn(),
     emit: vi.fn(),
+    on: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockEvents.on.mockReturnValue({ unsubscribe: vi.fn() });
     service = new AutoModeService(mockEvents as any);
   });
 

--- a/libs/types/src/event-bus.ts
+++ b/libs/types/src/event-bus.ts
@@ -6,7 +6,7 @@
  * (NATS, Redis pub/sub) can be swapped in for hivemind distribution.
  */
 
-import type { EventType, EventCallback } from './event.js';
+import type { EventType, EventCallback, TypedEventCallback } from './event.js';
 
 /** Handle returned by subscribe() for cleanup */
 export interface EventSubscription {
@@ -22,6 +22,12 @@ export interface EventBus {
    * The callback receives (type, payload) for every emitted event.
    */
   subscribe(callback: EventCallback): EventSubscription;
+
+  /**
+   * Subscribe to a single event type with a typed payload callback.
+   * Returns an EventSubscription for cleanup.
+   */
+  on<T extends EventType>(type: T, callback: TypedEventCallback<T>): EventSubscription;
 
   /**
    * Broadcast an event to all subscribers, including remote peers.

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -316,6 +316,7 @@ export type EventType =
   | 'lead-engineer:rule-evaluated'
   | 'lead-engineer:project-completing'
   | 'lead-engineer:project-completed'
+  | 'lead-engineer:project-completing-requested'
   | 'lead-engineer:hitl-response'
   // Notes workspace events (agent-initiated tab mutations)
   | 'notes:tab-created'
@@ -612,6 +613,7 @@ export interface EventPayloadMap {
   };
   'lead-engineer:project-completing': { projectPath: string; projectSlug: string };
   'lead-engineer:project-completed': { projectPath: string; projectSlug: string };
+  'lead-engineer:project-completing-requested': { projectPath: string };
   'lead-engineer:hitl-response': {
     formId: string;
     featureId?: string;


### PR DESCRIPTION
## Summary

**Milestone:** Typed Event Bus

Replace generic subscribe() calls in auto-mode-service.ts (line 337, feature:status-changed) and lead-engineer-service.ts (project:lifecycle:launched, lead-engineer:project-completing-requested) with typed on() subscriptions. These two services previously woke on all 263 event types.

**Files to Modify:**
- apps/server/src/services/auto-mode-service.ts
- apps/server/src/services/lead-engineer-service.ts

**Acceptance Criteria:**
- [ ] auto-mode-service uses bus.on...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-05T06:45:33.086Z -->