### PR TITLE
Worktree locking: prevent cleanup while agents are active

### DIFF
--- a/.automaker/skills/headsdown.md
+++ b/.automaker/skills/headsdown.md
@@ -1,0 +1,72 @@
+---
+name: headsdown
+emoji: 🛡️
+description: Worktree safety guardrails for headsdown mode. NEVER remove worktrees from running agents.
+metadata:
+  author: agent
+  created: 2026-03-05T00:00:00.000Z
+  usageCount: 0
+  successRate: 0
+  tags: [headsdown, worktree, safety, critical]
+  source: feature
+---
+
+# Headsdown Mode Worktree Safety
+
+These rules prevent data loss and session-breaking failures when cleaning up worktrees during or after headsdown mode.
+
+## NEVER Remove Worktrees With Active Agents
+
+Before removing ANY worktree, you MUST verify no agent is running in it. Removing a worktree from under a running agent:
+- Breaks the agent's Bash tool permanently for the session
+- Destroys uncommitted work
+- Corrupts the agent's working state
+
+### Pre-Removal Checklist (ALL must pass)
+
+1. **Check running agents**: `list_running_agents` - if any agent's `worktreePath` matches, DO NOT remove
+2. **Check the lock file**: look for `.automaker-lock` in the worktree directory. If it exists and the PID is alive, DO NOT remove
+3. **Check for uncommitted changes**: run `git -C <worktreePath> status --short` - if output is non-empty (`changedFilesCount > 0`), DO NOT remove
+4. **Check for unpushed commits**: run `git -C <worktreePath> log --oneline origin/HEAD..HEAD` - if output is non-empty, DO NOT remove
+
+```bash
+# Full pre-removal safety check (use -C, NEVER cd into worktrees)
+WORKTREE="/path/to/.worktrees/feature-branch"
+
+# 1. Check lock file
+cat "$WORKTREE/.automaker-lock" 2>/dev/null && echo "LOCKED - check PID before removing"
+
+# 2. Check uncommitted changes
+git -C "$WORKTREE" status --short
+
+# 3. Check unpushed commits
+git -C "$WORKTREE" log --oneline origin/HEAD..HEAD 2>/dev/null
+```
+
+## Safe Removal Order
+
+Only proceed if ALL of the following are true:
+- `list_running_agents` shows no agent with this worktree path
+- No `.automaker-lock` file exists (or PID in lock file is dead)
+- `git status --short` output is empty (no uncommitted changes)
+- `git log origin/HEAD..HEAD` output is empty (no unpushed commits)
+
+```bash
+# Safe removal (from project root, NOT from inside the worktree)
+git worktree remove --force ".worktrees/feature-branch-name"
+```
+
+## Preserving Uncommitted Work Before Removal
+
+If uncommitted changes exist and the worktree needs to be removed:
+
+```bash
+# Commit before removing
+git -C "$WORKTREE" add -A -- ':!.automaker/'
+git -C "$WORKTREE" commit --no-verify -m "wip: preserve work before cleanup"
+git -C "$WORKTREE" push -u origin HEAD
+```
+
+## NEVER `cd` Into Worktrees
+
+Always use `git -C <path>` to run commands in a worktree. See `worktree-safety` skill for full explanation.

--- a/apps/server/src/lib/worktree-lock.ts
+++ b/apps/server/src/lib/worktree-lock.ts
@@ -1,0 +1,113 @@
+/**
+ * Worktree lock file utilities.
+ *
+ * When an agent starts executing in a worktree, a `.automaker-lock` file is
+ * written containing the server process PID, feature ID, and start timestamp.
+ * Before any worktree removal operation, callers check the lock file: if the
+ * recorded PID is still alive, the removal is refused to prevent deleting a
+ * worktree from under a running agent.
+ */
+
+import path from 'path';
+import * as fs from 'fs/promises';
+import { createLogger } from '@protolabsai/utils';
+
+const logger = createLogger('WorktreeLock');
+
+const LOCK_FILENAME = '.automaker-lock';
+
+export interface WorktreeLock {
+  /** PID of the process that owns this lock (server process) */
+  pid: number;
+  /** Feature ID being executed in this worktree */
+  featureId: string;
+  /** ISO timestamp when the lock was written */
+  startedAt: string;
+}
+
+/**
+ * Returns true if the given PID is alive on the current system.
+ * Uses signal 0 (no-op probe) which succeeds without actually sending a signal.
+ */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Absolute path to the lock file inside a worktree */
+export function getLockPath(worktreePath: string): string {
+  return path.join(worktreePath, LOCK_FILENAME);
+}
+
+/**
+ * Write a lock file to the worktree directory.
+ * Called immediately before the agent starts executing in the worktree.
+ */
+export async function writeLock(worktreePath: string, featureId: string): Promise<void> {
+  const lock: WorktreeLock = {
+    pid: process.pid,
+    featureId,
+    startedAt: new Date().toISOString(),
+  };
+
+  try {
+    await fs.writeFile(getLockPath(worktreePath), JSON.stringify(lock, null, 2), 'utf-8');
+    logger.debug(`Lock written for feature ${featureId} in ${worktreePath}`);
+  } catch (error) {
+    // Non-fatal: log but do not block agent startup
+    logger.warn(`Failed to write lock file for feature ${featureId}: ${error}`);
+  }
+}
+
+/**
+ * Remove the lock file from the worktree directory.
+ * Called when agent execution completes (success or failure).
+ */
+export async function removeLock(worktreePath: string): Promise<void> {
+  try {
+    await fs.unlink(getLockPath(worktreePath));
+    logger.debug(`Lock removed from ${worktreePath}`);
+  } catch {
+    // Lock file may not exist (e.g. was never written) — ignore
+  }
+}
+
+/**
+ * Read and parse the lock file from the worktree directory.
+ * Returns null if no lock file exists or it cannot be parsed.
+ */
+export async function readLock(worktreePath: string): Promise<WorktreeLock | null> {
+  try {
+    const data = await fs.readFile(getLockPath(worktreePath), 'utf-8');
+    return JSON.parse(data) as WorktreeLock;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns true if the worktree has a valid lock file whose process is still alive.
+ *
+ * A lock is considered active when:
+ * 1. The `.automaker-lock` file exists and is parseable
+ * 2. The recorded PID is still alive (`process.kill(pid, 0)` succeeds)
+ *
+ * A stale lock (PID no longer running) is treated as not locked so cleanup
+ * can proceed after a server restart.
+ */
+export async function isWorktreeLocked(worktreePath: string): Promise<boolean> {
+  const lock = await readLock(worktreePath);
+  if (!lock) return false;
+
+  const alive = isProcessAlive(lock.pid);
+  if (!alive) {
+    logger.debug(
+      `Stale lock found in ${worktreePath} (PID ${lock.pid} no longer running, feature ${lock.featureId})`
+    );
+  }
+  return alive;
+}

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -92,6 +92,7 @@ import type { EventEmitter } from '../lib/events.js';
 import { TypedEventBus } from './auto-mode/typed-event-bus.js';
 import { ConcurrencyManager } from './auto-mode/concurrency-manager.js';
 import { ensureCleanWorktree } from '../lib/worktree-guard.js';
+import { isWorktreeLocked } from '../lib/worktree-lock.js';
 import {
   agentCostTotal,
   agentExecutionDuration,
@@ -1155,16 +1156,59 @@ export class AutoModeService {
           // Reset idle event flag since we're doing work again
           projectState.hasEmittedIdleEvent = false;
 
-          // Safety timeout: Remove from starting set after 30 seconds if still there
-          // This prevents features from getting permanently stuck in "starting" state
-          const startingTimeout = setTimeout(() => {
-            if (projectState.startingFeatures.has(nextFeature.id)) {
-              logger.warn(
-                `[AutoLoop] Feature ${nextFeature.id} stuck in starting state for 30s, cleaning up`
-              );
-              projectState.startingFeatures.delete(nextFeature.id);
-            }
-          }, 30000);
+          // Safety timeout: Remove from starting set after 30 seconds if still there.
+          // Before declaring a feature stuck, check whether a lock file exists in its
+          // worktree — if it does, the agent process is alive and startup succeeded;
+          // extend the timeout rather than cleaning up prematurely.
+          const featureForTimeout = nextFeature;
+          const scheduleStartingTimeout = (delayMs: number): NodeJS.Timeout => {
+            return setTimeout(() => {
+              if (!projectState.startingFeatures.has(featureForTimeout.id)) return;
+
+              // If the feature is already in runningFeatures, startup succeeded — clear silently
+              if (this.runningFeatures.has(featureForTimeout.id)) {
+                projectState.startingFeatures.delete(featureForTimeout.id);
+                return;
+              }
+
+              // Check worktree lock file: if a live process holds the lock, extend the timeout
+              const branchForLock = featureForTimeout.branchName;
+              if (branchForLock) {
+                const worktreePathForLock = path.join(
+                  projectPath,
+                  '.worktrees',
+                  branchForLock.replace(/\//g, '-')
+                );
+                isWorktreeLocked(worktreePathForLock)
+                  .then((locked) => {
+                    if (locked) {
+                      logger.info(
+                        `[AutoLoop] Feature ${featureForTimeout.id} still starting after ${delayMs}ms but lock file shows live process — extending timeout`
+                      );
+                      scheduleStartingTimeout(30000);
+                    } else {
+                      logger.warn(
+                        `[AutoLoop] Feature ${featureForTimeout.id} stuck in starting state for ${delayMs}ms, cleaning up`
+                      );
+                      projectState.startingFeatures.delete(featureForTimeout.id);
+                    }
+                  })
+                  .catch(() => {
+                    // Cannot read lock file — treat as not locked and clean up
+                    logger.warn(
+                      `[AutoLoop] Feature ${featureForTimeout.id} stuck in starting state for ${delayMs}ms, cleaning up`
+                    );
+                    projectState.startingFeatures.delete(featureForTimeout.id);
+                  });
+              } else {
+                logger.warn(
+                  `[AutoLoop] Feature ${featureForTimeout.id} stuck in starting state for ${delayMs}ms, cleaning up`
+                );
+                projectState.startingFeatures.delete(featureForTimeout.id);
+              }
+            }, delayMs);
+          };
+          const startingTimeout = scheduleStartingTimeout(30000);
 
           // Start feature execution in background.
           // Content features (featureType === 'content') always route through leadEngineerService

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -75,6 +75,7 @@ import { RecoveryService } from '../recovery-service.js';
 import { checkAndRecoverUncommittedWork } from '../worktree-recovery-service.js';
 import { gitWorkflowService } from '../git-workflow-service.js';
 import type { KnowledgeStoreService } from '../knowledge-store-service.js';
+import { writeLock, removeLock } from '../../lib/worktree-lock.js';
 
 import type {
   RunningFeature,
@@ -469,6 +470,11 @@ export class ExecutionService {
 
       // Update running feature with actual worktree info
       tempRunningFeature.worktreePath = worktreePath;
+
+      // Write worktree lock file so cleanup operations can detect a live agent
+      if (worktreePath) {
+        await writeLock(worktreePath, featureId);
+      }
 
       // Authority system policy check: verify permission before starting this feature
       if (this.authorityService && this.settingsService) {
@@ -1278,6 +1284,12 @@ export class ExecutionService {
     } finally {
       logger.info(`Feature ${featureId} execution ended, cleaning up runningFeatures`);
       abortController?.abort();
+
+      // Remove worktree lock file now that the agent has exited
+      const worktreeForCleanup = tempRunningFeature.worktreePath;
+      if (worktreeForCleanup) {
+        await removeLock(worktreeForCleanup);
+      }
 
       // Only delete if the current entry is still the one we created
       // (delegated executions may have created a new entry)

--- a/apps/server/src/services/worktree-lifecycle-service.ts
+++ b/apps/server/src/services/worktree-lifecycle-service.ts
@@ -19,6 +19,7 @@ import { createLogger } from '@protolabsai/utils';
 import * as secureFs from '../lib/secure-fs.js';
 import type { EventEmitter } from '../lib/events.js';
 import type { FeatureLoader } from './feature-loader.js';
+import { isWorktreeLocked } from '../lib/worktree-lock.js';
 
 const logger = createLogger('WorktreeLifecycle');
 
@@ -219,6 +220,15 @@ export class WorktreeLifecycleService {
           );
           return; // Skip cleanup - worktree is in use
         }
+      }
+
+      // Check worktree lock file: refuse removal if a live agent process holds the lock
+      const locked = await isWorktreeLocked(worktreePath);
+      if (locked) {
+        logger.warn(
+          `[SAFETY] Cannot clean up worktree ${worktreeName} - lock file indicates a live agent process is active`
+        );
+        return; // Skip cleanup - worktree lock is held by a running process
       }
 
       // Check if worktree exists


### PR DESCRIPTION
## Summary

**Problem:** No mechanism prevents worktree deletion while a Claude agent subprocess is actively using it. The "stuck in starting state" cleanup, manual cleanup, and headsdown mode can all remove worktrees from under running agents.

**Two-part fix needed:**

**Part 1: Worktree lock file**
When an agent starts in a worktree, write a `.automaker-lock` file (or similar) containing `{ pid, featureId, startedAt }`. Before any worktree removal operation (git worktree remove, rm -rf), check for the lo...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-05T06:45:40.570Z -->