### PR TITLE
fix(deploy): make Tailscale HTTPS setup non-fatal

### DIFF
--- a/scripts/setup-staging.sh
+++ b/scripts/setup-staging.sh
@@ -366,10 +366,15 @@ setup_tailscale_https() {
   tailscale serve reset 2>/dev/null || true
 
   # Serve UI on HTTPS :443 (enables PWA install prompt)
-  tailscale serve --https=443 "http://localhost:${ui_port}"
+  # Requires `sudo tailscale set --operator=$USER` to have been run once.
+  # Non-fatal: HTTPS is a convenience for PWA install, not a deploy requirement.
+  if ! tailscale serve --https=443 "http://localhost:${ui_port}" 2>/dev/null; then
+    warn "Tailscale HTTPS setup failed (needs operator permission). Run: sudo tailscale set --operator=\$USER"
+    return 0
+  fi
 
   # Serve API on HTTPS :8443 so the UI can proxy to it
-  tailscale serve --https=8443 "http://localhost:${api_port}"
+  tailscale serve --https=8443 "http://localhost:${api_port}" 2>/dev/null || true
 
   local ts_hostname
   ts_hostname=$(tailscale status --self --json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['Self']['DNSName'].rstrip('.'))" 2>/dev/null || echo "unknown")


### PR DESCRIPTION
## Summary
- Make `tailscale serve` non-fatal in `setup-staging.sh`
- CI runner doesn't have operator permission, causing deploy failure
- HTTPS is a convenience for PWA install, not a deploy requirement

## Test plan
- [x] Deploy should no longer fail at Tailscale step
- [ ] Staging deploy verifies healthy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup process resilience by implementing graceful error handling. The setup flow now continues even when optional HTTPS configuration fails, preventing unnecessary setup interruptions and allowing the system to proceed with core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->