### PR TITLE
Scheduler Status Endpoint

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,0 +1,5 @@
+{
+  "pid": 7,
+  "featureId": "feature-1772700291782-d7qohhuux",
+  "startedAt": "2026-03-05T09:03:26.017Z"
+}

--- a/apps/server/src/routes/automations/index.ts
+++ b/apps/server/src/routes/automations/index.ts
@@ -19,11 +19,13 @@ import { createUpdateHandler } from './routes/update.js';
 import { createDeleteHandler } from './routes/delete.js';
 import { createHistoryHandler } from './routes/history.js';
 import { createRunHandler } from './routes/run.js';
+import { createSchedulerStatusHandler } from './routes/scheduler-status.js';
 
 export function createAutomationsRoutes(automationService: AutomationService): Router {
   const router = Router();
 
   router.get('/list', createListHandler(automationService));
+  router.get('/scheduler/status', createSchedulerStatusHandler(automationService));
   router.post('/create', createCreateHandler(automationService));
   router.get('/:id/history', createHistoryHandler(automationService));
   router.post('/:id/run', createRunHandler(automationService));

--- a/apps/server/src/routes/automations/routes/list.ts
+++ b/apps/server/src/routes/automations/routes/list.ts
@@ -9,7 +9,12 @@ export function createListHandler(automationService: AutomationService) {
   return async (_req: Request, res: Response): Promise<void> => {
     try {
       const automations = await automationService.list();
-      res.json({ automations });
+      const schedulerMap = automationService.getSchedulerStatusMap();
+      const result = automations.map((automation) => ({
+        ...automation,
+        schedulerStats: schedulerMap.get(automation.id) ?? null,
+      }));
+      res.json({ automations: result });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       res.status(500).json({ error: message });

--- a/apps/server/src/routes/automations/routes/scheduler-status.ts
+++ b/apps/server/src/routes/automations/routes/scheduler-status.ts
@@ -1,0 +1,13 @@
+/**
+ * GET /api/automations/scheduler/status - Return all scheduler task states
+ */
+
+import type { Request, Response } from 'express';
+import type { AutomationService } from '../../../services/automation-service.js';
+
+export function createSchedulerStatusHandler(automationService: AutomationService) {
+  return (_req: Request, res: Response): void => {
+    const tasks = automationService.getSchedulerStatus();
+    res.json({ tasks });
+  };
+}

--- a/apps/server/src/services/automation-service.ts
+++ b/apps/server/src/services/automation-service.ts
@@ -694,4 +694,71 @@ export class AutomationService {
   async loadAll(): Promise<StoredAutomation[]> {
     return this.readAutomations();
   }
+
+  // ---------------------------------------------------------------------------
+  // Scheduler status
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Task status entry returned by getSchedulerStatus() and getSchedulerStatusMap().
+   */
+  getSchedulerStatus(): Array<{
+    id: string;
+    name: string;
+    enabled: boolean;
+    cronExpression: string;
+    nextRun: string | null;
+    lastRun: string | null;
+    executionCount: number;
+    lastError: string | null;
+    averageDurationMs: number | null;
+  }> {
+    return this.schedulerService.getAllTasks().map((task) => ({
+      id: task.id,
+      name: task.name,
+      enabled: task.enabled,
+      cronExpression: task.cronExpression,
+      nextRun: task.nextRun ?? null,
+      lastRun: task.lastRun ?? null,
+      executionCount: task.executionCount,
+      lastError: task.lastError ?? null,
+      averageDurationMs: null,
+    }));
+  }
+
+  /**
+   * Returns a Map of automation ID -> scheduler task status, for easy join in list routes.
+   * Task IDs are stored as `automation:{automationId}` — this method strips the prefix.
+   */
+  getSchedulerStatusMap(): Map<
+    string,
+    {
+      nextRun: string | null;
+      lastRun: string | null;
+      executionCount: number;
+      lastError: string | null;
+    }
+  > {
+    const map = new Map<
+      string,
+      {
+        nextRun: string | null;
+        lastRun: string | null;
+        executionCount: number;
+        lastError: string | null;
+      }
+    >();
+    for (const task of this.schedulerService.getAllTasks()) {
+      const automationId = task.id.startsWith(AUTOMATION_TASK_PREFIX)
+        ? task.id.slice(AUTOMATION_TASK_PREFIX.length)
+        : task.id;
+      map.set(automationId, {
+        nextRun: task.nextRun ?? null,
+        lastRun: task.lastRun ?? null,
+        executionCount: task.executionCount,
+        lastError: task.lastError ?? null,
+      });
+    }
+    return map;
+  }
 }


### PR DESCRIPTION
## Summary

**Milestone:** Scheduler REST API

Add GET /api/automations/scheduler/status route that calls SchedulerService.getStatus() and returns all task states (id, name, enabled, cronExpression, nextRun, lastRun, executionCount, lastError, averageDurationMs). Also extend the existing GET /api/automations/list response to include a schedulerStats object per automation entry (nextRun, lastRun, executionCount, lastError) by joining with scheduler task state on taskId. Wire the new route into apps/server/sr...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new scheduler status endpoint to retrieve current task states and execution details.
  * Enhanced automation list response to include scheduler statistics for each automation, such as next run time, last run time, and execution metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->