### PR TITLE
SchedulerSettings Type and Persistence Wiring

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,0 @@
-{
-  "pid": 7,
-  "featureId": "feature-1772700291782-d7qohhuux",
-  "startedAt": "2026-03-05T09:03:26.017Z"
-}

--- a/apps/server/src/services/scheduler-service.ts
+++ b/apps/server/src/services/scheduler-service.ts
@@ -25,6 +25,7 @@ import { createLogger } from '@protolabsai/utils';
 import { secureFs } from '@protolabsai/platform';
 import path from 'path';
 import type { EventEmitter } from '../lib/events.js';
+import type { SettingsService } from './settings-service.js';
 
 const logger = createLogger('Scheduler');
 
@@ -336,6 +337,7 @@ export class SchedulerService {
   private running = false;
   private events: EventEmitter | null = null;
   private dataDir: string | null = null;
+  private settingsService: SettingsService | null = null;
 
   /** Check interval in milliseconds (default: 60 seconds) */
   private checkInterval = 60000;
@@ -350,6 +352,13 @@ export class SchedulerService {
     this.events = events;
     this.dataDir = dataDir;
     logger.info('Scheduler service initialized');
+  }
+
+  /**
+   * Set the settings service for persisting task overrides to global settings
+   */
+  setSettingsService(settingsService: SettingsService): void {
+    this.settingsService = settingsService;
   }
 
   /**
@@ -576,6 +585,9 @@ export class SchedulerService {
     // Save tasks after enabling
     await this.saveTasks();
 
+    // Persist enabled override to global settings
+    await this.persistTaskOverride(id, { enabled: true });
+
     return true;
   }
 
@@ -596,6 +608,9 @@ export class SchedulerService {
 
     // Save tasks after disabling
     await this.saveTasks();
+
+    // Persist disabled override to global settings
+    await this.persistTaskOverride(id, { enabled: false });
 
     return true;
   }
@@ -636,6 +651,9 @@ export class SchedulerService {
 
     await this.saveTasks();
 
+    // Persist cron expression override to global settings
+    await this.persistTaskOverride(id, { cronExpression });
+
     return true;
   }
 
@@ -673,6 +691,82 @@ export class SchedulerService {
         executionCount: t.executionCount,
       })),
     };
+  }
+
+  /**
+   * Persist a task override (enabled/cronExpression) to global settings
+   */
+  private async persistTaskOverride(
+    taskId: string,
+    override: { enabled?: boolean; cronExpression?: string }
+  ): Promise<void> {
+    if (!this.settingsService) return;
+
+    try {
+      const settings = await this.settingsService.getGlobalSettings();
+      const existing = settings.schedulerSettings?.taskOverrides ?? {};
+      await this.settingsService.updateGlobalSettings({
+        schedulerSettings: {
+          taskOverrides: {
+            ...existing,
+            [taskId]: {
+              ...existing[taskId],
+              ...override,
+            },
+          },
+        },
+      });
+    } catch (error) {
+      logger.error(`Failed to persist task override for "${taskId}":`, error);
+    }
+  }
+
+  /**
+   * Apply taskOverrides from global settings to registered tasks.
+   * Must be called after all tasks are registered.
+   */
+  async applySettingsOverrides(): Promise<void> {
+    if (!this.settingsService) return;
+
+    try {
+      const settings = await this.settingsService.getGlobalSettings();
+      const overrides = settings.schedulerSettings?.taskOverrides ?? {};
+
+      for (const [taskId, override] of Object.entries(overrides)) {
+        const task = this.tasks.get(taskId);
+        if (!task) continue;
+
+        if (override.enabled !== undefined && task.enabled !== override.enabled) {
+          task.enabled = override.enabled;
+          task.nextRun = task.enabled
+            ? getNextRunTime(task.cronExpression).toISOString()
+            : undefined;
+          logger.info(
+            `Applied settings override for task "${task.name}" (${taskId}): enabled=${override.enabled}`
+          );
+        }
+
+        if (override.cronExpression && task.cronExpression !== override.cronExpression) {
+          const validation = validateCronExpression(override.cronExpression);
+          if (validation.valid) {
+            task.cronExpression = override.cronExpression;
+            this.parsedCrons.set(taskId, parseCronExpression(override.cronExpression));
+            if (task.enabled) {
+              task.nextRun = getNextRunTime(override.cronExpression).toISOString();
+            }
+            logger.info(
+              `Applied settings override for task "${task.name}" (${taskId}): cronExpression=${override.cronExpression}`
+            );
+          } else {
+            logger.warn(
+              `Ignoring invalid cronExpression override for task "${task.name}" (${taskId}): ${validation.error}`
+            );
+          }
+        }
+      }
+    } catch (error) {
+      logger.error('Failed to apply settings overrides:', error);
+    }
   }
 
   /**

--- a/apps/server/src/services/scheduler.module.ts
+++ b/apps/server/src/services/scheduler.module.ts
@@ -26,6 +26,7 @@ export function register(container: ServiceContainer): void {
 
   // Scheduler Service initialization and task registration via AutomationService
   schedulerService.initialize(events, dataDir);
+  schedulerService.setSettingsService(settingsService);
   void schedulerService
     .start()
     .then(async () => {
@@ -39,13 +40,16 @@ export function register(container: ServiceContainer): void {
       });
 
       // Register calendar job executor — scans for due jobs every minute
-      schedulerService.registerTask(
+      await schedulerService.registerTask(
         'job-executor:tick',
         'Calendar Job Executor',
         '* * * * *',
         () => container.jobExecutorService.tick(),
         true
       );
+
+      // Apply taskOverrides from global settings after all tasks are registered
+      await schedulerService.applySettingsOverrides();
     })
     .catch((err) => {
       logger.error('Scheduler startup or automation sync failed:', err);

--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -230,6 +230,27 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   userPresenceDetection: false,
 };
 
+// ============================================================================
+// Scheduler Settings
+// ============================================================================
+
+/**
+ * Scheduler settings for persisting task state across server restarts.
+ */
+export interface SchedulerSettings {
+  /**
+   * Per-task overrides for built-in scheduled tasks.
+   * Key: task ID (e.g., "archival", "health-check")
+   * Value: overrides for enabled state and/or cron expression
+   */
+  taskOverrides: Record<string, { enabled?: boolean; cronExpression?: string }>;
+}
+
+/** Default scheduler settings — no overrides */
+export const DEFAULT_SCHEDULER_SETTINGS: SchedulerSettings = {
+  taskOverrides: {},
+};
+
 export interface GlobalSettings {
   /** Version number for schema migration */
   version: number;
@@ -648,6 +669,12 @@ export interface GlobalSettings {
    * Toggled per-installation via Settings > Developer > Feature Flags.
    */
   featureFlags?: FeatureFlags;
+
+  /**
+   * Scheduler settings for persisting task enable/disable state and cron overrides.
+   * @see SchedulerSettings
+   */
+  schedulerSettings?: SchedulerSettings;
 }
 
 /** Default global settings used when no settings file exists */
@@ -723,4 +750,6 @@ export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
   },
   // Feature flags — all on in development by default
   featureFlags: DEFAULT_FEATURE_FLAGS,
+  // Scheduler settings — no task overrides by default
+  schedulerSettings: DEFAULT_SCHEDULER_SETTINGS,
 };


### PR DESCRIPTION
## Summary

**Milestone:** Settings Persistence

Add SchedulerSettings interface to libs/types/src/global-settings.ts with taskOverrides: Record<string, { enabled?: boolean; cronExpression?: string }> and add DEFAULT_SCHEDULER_SETTINGS constant included in DEFAULT_GLOBAL_SETTINGS. Update SchedulerService.start() to read taskOverrides from settingsService and apply them after registering tasks. Update enableTask(), disableTask(), and updateTaskSchedule() to write back to GlobalSettings via settingsService wh...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduler tasks can now have their enabled/disabled state and execution schedule persisted as overrides in global settings.
  * Persisted scheduler task overrides are automatically applied on startup, allowing configuration to be maintained across restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->