### PR TITLE
Tab Consolidation + Responsive Layout

### DIFF
--- a/apps/ui/src/components/views/projects-view/components/project-header.tsx
+++ b/apps/ui/src/components/views/projects-view/components/project-header.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ArrowLeft, ExternalLink, Trash2 } from 'lucide-react';
+import { ArrowLeft, ExternalLink, Trash2, PanelLeft } from 'lucide-react';
 import { Badge } from '@protolabsai/ui/atoms';
 import { Button } from '@protolabsai/ui/atoms';
 import { HealthIndicator } from './health-indicator';
@@ -11,9 +11,17 @@ interface ProjectHeaderProps {
   project: Project;
   onBack: () => void;
   onDelete?: () => void;
+  onToggleSidebar?: () => void;
+  sidebarOpen?: boolean;
 }
 
-export function ProjectHeader({ project, onBack, onDelete }: ProjectHeaderProps) {
+export function ProjectHeader({
+  project,
+  onBack,
+  onDelete,
+  onToggleSidebar,
+  sidebarOpen,
+}: ProjectHeaderProps) {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   return (
@@ -22,6 +30,17 @@ export function ProjectHeader({ project, onBack, onDelete }: ProjectHeaderProps)
         <Button size="sm" variant="ghost" onClick={onBack}>
           <ArrowLeft className="w-4 h-4" />
         </Button>
+        {onToggleSidebar && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onToggleSidebar}
+            className={`md:hidden ${sidebarOpen ? 'text-foreground' : 'text-muted-foreground'}`}
+            aria-label="Toggle sidebar"
+          >
+            <PanelLeft className="w-4 h-4" />
+          </Button>
+        )}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <h1 className="text-lg font-semibold text-foreground tracking-tight truncate">

--- a/apps/ui/src/components/views/projects-view/components/project-sidebar.tsx
+++ b/apps/ui/src/components/views/projects-view/components/project-sidebar.tsx
@@ -32,7 +32,7 @@ function PropertyRow({ label, children }: { label: string; children: React.React
   );
 }
 
-export function ProjectSidebar({ project }: { project: Project }) {
+export function ProjectSidebar({ project, isOpen }: { project: Project; isOpen?: boolean }) {
   const updateMutation = useProjectUpdate(project.slug);
   const [editingField, setEditingField] = useState<string | null>(null);
   const [editValue, setEditValue] = useState('');
@@ -63,7 +63,9 @@ export function ProjectSidebar({ project }: { project: Project }) {
   };
 
   return (
-    <div className="w-72 shrink-0 border-r border-border/40 overflow-y-auto px-4 py-4 space-y-4">
+    <div
+      className={`w-72 shrink-0 border-r border-border/40 overflow-y-auto px-4 py-4 space-y-4 ${isOpen ? 'block' : 'hidden'} md:block`}
+    >
       {/* Goal */}
       {project.goal && (
         <div>

--- a/apps/ui/src/components/views/projects-view/project-detail.tsx
+++ b/apps/ui/src/components/views/projects-view/project-detail.tsx
@@ -1,4 +1,5 @@
-import { FileText, Milestone, Layers, FolderOpen, MessageSquare } from 'lucide-react';
+import { useState } from 'react';
+import { FileText, Layers, BookOpen, MessageSquare } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@protolabsai/ui/atoms';
 import { Spinner } from '@protolabsai/ui/atoms';
 import { toast } from 'sonner';
@@ -6,7 +7,6 @@ import { ProjectHeader } from './components/project-header';
 import { ProjectSidebar } from './components/project-sidebar';
 import { useProject, useProjectDelete } from './hooks/use-project';
 import { PrdTab } from './tabs/prd-tab';
-import { MilestonesTab } from './tabs/milestones-tab';
 import { FeaturesTab } from './tabs/features-tab';
 import { ResourcesTab } from './tabs/resources-tab';
 import { UpdatesTab } from './tabs/updates-tab';
@@ -21,6 +21,7 @@ export function ProjectDetail({
 }) {
   const { data: project, isLoading } = useProject(projectSlug);
   const deleteMutation = useProjectDelete();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const handleDelete = () => {
     deleteMutation.mutate(projectSlug, {
@@ -54,35 +55,41 @@ export function ProjectDetail({
     );
   }
 
+  const hasResources = (project.links?.length ?? 0) > 0;
+
   return (
     <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
-      <ProjectHeader project={project as Project} onBack={onBack} onDelete={handleDelete} />
+      <ProjectHeader
+        project={project as Project}
+        onBack={onBack}
+        onDelete={handleDelete}
+        onToggleSidebar={() => setSidebarOpen((prev) => !prev)}
+        sidebarOpen={sidebarOpen}
+      />
 
       <div className="flex-1 flex min-h-0">
-        <ProjectSidebar project={project as Project} />
+        <ProjectSidebar project={project as Project} isOpen={sidebarOpen} />
 
-        <div className="flex-1 overflow-y-auto px-6">
-          <Tabs defaultValue="prd" className="flex flex-col h-full">
+        <div className="flex-1 overflow-y-auto px-3 sm:px-6">
+          <Tabs defaultValue="features" className="flex flex-col h-full">
             <TabsList className="mt-3 mb-1">
               <TabsTrigger value="prd">
                 <FileText />
-                PRD
-              </TabsTrigger>
-              <TabsTrigger value="milestones">
-                <Milestone />
-                Milestones
+                <span className="hidden sm:inline">PRD</span>
               </TabsTrigger>
               <TabsTrigger value="features">
                 <Layers />
-                Features
+                <span className="hidden sm:inline">Features</span>
               </TabsTrigger>
-              <TabsTrigger value="resources">
-                <FolderOpen />
-                Resources
-              </TabsTrigger>
+              {hasResources && (
+                <TabsTrigger value="resources">
+                  <BookOpen />
+                  <span className="hidden sm:inline">Resources</span>
+                </TabsTrigger>
+              )}
               <TabsTrigger value="updates">
                 <MessageSquare />
-                Updates
+                <span className="hidden sm:inline">Updates</span>
               </TabsTrigger>
             </TabsList>
 
@@ -90,17 +97,15 @@ export function ProjectDetail({
               <PrdTab project={project as Project} />
             </TabsContent>
 
-            <TabsContent value="milestones">
-              <MilestonesTab project={project as Project} />
-            </TabsContent>
-
             <TabsContent value="features">
               <FeaturesTab projectSlug={projectSlug} />
             </TabsContent>
 
-            <TabsContent value="resources">
-              <ResourcesTab projectSlug={projectSlug} project={project as Project} />
-            </TabsContent>
+            {hasResources && (
+              <TabsContent value="resources">
+                <ResourcesTab projectSlug={projectSlug} project={project as Project} />
+              </TabsContent>
+            )}
 
             <TabsContent value="updates">
               <UpdatesTab project={project as Project} />


### PR DESCRIPTION
## Summary

**Milestone:** Mobile Project View Overhaul

Update project-detail.tsx to use 4 tabs: PRD, Features, Resources (conditional — only shown when project has docs or links), Updates. Remove Milestones tab entirely. Set default tab to 'features'. Update ProjectSidebar to be collapsible on mobile using hidden md:block with a toggle button in the project header for small screens. Apply responsive padding: px-3 sm:px-6 on content area. Make tab labels icon-only on mobile: wrap label text in span with hi...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sidebar toggle button for mobile and smaller screens
  * Added Resources tab to display project links when available

* **Style**
  * Enhanced responsive design with improved tab labels and layout spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->