### PR TITLE
ci: add workflow_dispatch to auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -15,6 +15,7 @@ on:
     types: [closed]
     branches:
       - main
+  workflow_dispatch:
 
 permissions: read-all
 
@@ -22,9 +23,10 @@ jobs:
   release:
     runs-on: self-hosted
     if: >-
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.head.ref == 'staging' &&
-      github.repository == 'protoLabsAI/protoMaker'
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.head.ref == 'staging' &&
+       github.repository == 'protoLabsAI/protoMaker')
     timeout-minutes: 15
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to auto-release workflow
- Allows manual triggering when auto-merge doesn't fire the `pull_request:closed` event
- Cherry-picked to main to unblock the v0.35.2 release that didn't fire

## Test plan
- [ ] Merge this PR, then trigger the workflow manually from Actions tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow automation to support manual triggering in addition to existing automatic triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->