### PR TITLE
promote: staging -> main

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -15,6 +15,7 @@ on:
     types: [closed]
     branches:
       - main
+  workflow_dispatch:
 
 permissions: read-all
 
@@ -22,9 +23,10 @@ jobs:
   release:
     runs-on: self-hosted
     if: >-
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.head.ref == 'staging' &&
-      github.repository == 'protoLabsAI/protoMaker'
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.head.ref == 'staging' &&
+       github.repository == 'protoLabsAI/protoMaker')
     timeout-minutes: 15
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- ci: add workflow_dispatch trigger to auto-release
- Fixes missed auto-release when PR #1812 auto-merge didn't fire the pull_request:closed event
- All prior UI/docs changes from dev already on main via #1812

## Notes
This merge will trigger auto-release, cutting a new version tag and GitHub Release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to enable manual triggering of releases, in addition to the existing automatic release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->