### PR TITLE
Fix bug report button URL in quick actions

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,0 +1,5 @@
+{
+  "pid": 13093,
+  "featureId": "feature-1772730612438-oy02y59ih",
+  "startedAt": "2026-03-05T17:11:56.057Z"
+}

--- a/apps/ui/src/components/layout/project-switcher/project-switcher.tsx
+++ b/apps/ui/src/components/layout/project-switcher/project-switcher.tsx
@@ -133,7 +133,7 @@ export function ProjectSwitcher() {
 
   const handleBugReportClick = useCallback(() => {
     const api = getElectronAPI();
-    api.openExternalLink('https://github.com/AutoMaker-Org/automaker/issues');
+    api.openExternalLink('https://github.com/protolabsai/protomaker/issues');
   }, []);
 
   const handleWikiClick = useCallback(() => {

--- a/apps/ui/src/components/layout/sidebar/components/bug-report-button.tsx
+++ b/apps/ui/src/components/layout/sidebar/components/bug-report-button.tsx
@@ -10,7 +10,7 @@ interface BugReportButtonProps {
 export function BugReportButton({ sidebarExpanded }: BugReportButtonProps) {
   const handleBugReportClick = useCallback(() => {
     const api = getElectronAPI();
-    api.openExternalLink('https://github.com/AutoMaker-Org/automaker/issues');
+    api.openExternalLink('https://github.com/protolabsai/protomaker/issues');
   }, []);
 
   return (


### PR DESCRIPTION
## Summary

The 'Bug Report' button in the quick actions panel links to the wrong GitHub repository.

**Current behavior:** Links to `https://github.com/protolabsai/automaker`
**Expected behavior:** Links to `https://github.com/protolabsai/protomaker`

## Fix
Find the quick actions component (likely in `apps/ui/src/`) and update the hardcoded GitHub URL from `protolabsai/automaker` to `protolabsai/protomaker`.

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bug report links throughout the application to direct to the correct repository for submitting issues.
  * Added internal process tracking configuration to support system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->