### PR TITLE
fix: remove duplicate estimatedTokens declaration

### DIFF
--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
@@ -105,13 +105,6 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
     return (lastMsg.parts ?? []).filter((p) => p.type === 'step-start').length;
   }, [messages, isStreaming]);
 
-  // Estimate token count from conversation messages (chars / 4 approximation)
-  const estimatedTokens = useMemo(() => {
-    if (messages.length === 0) return 0;
-    const chars = JSON.stringify(messages).length;
-    return Math.ceil(chars / 4);
-  }, [messages]);
-
   // onSubmit receives the trimmed text from ChatInput (via PromptInputProvider).
   // ChatInput clears the input immediately after calling this.
   const handleSubmit = useCallback(


### PR DESCRIPTION
## Summary
- Removes duplicate `estimatedTokens` useMemo declaration in `chat-overlay-content.tsx`
- Two parallel features both added the same variable — merged sequentially, git couldn't detect the duplicate
- Fixes TS2451 and build failure on staging->main promotion (PR #1826)

## Test plan
- [x] `tsc --noEmit` passes locally
- [ ] CI checks + build pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>