### PR TITLE
Promote dev to staging — fix Docker DTS build

### DIFF
--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -70,6 +70,7 @@
     "node": ">=22.0.0 <23.0.0"
   },
   "dependencies": {
+    "@protolabsai/types": "*",
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-collapsible": "1.1.12",
     "@radix-ui/react-dialog": "^1.1.4",

--- a/libs/ui/tsup.config.ts
+++ b/libs/ui/tsup.config.ts
@@ -11,9 +11,7 @@ export default defineConfig({
   ],
   format: ['esm'],
   external: [/^@rjsf\//],
-  dts: {
-    resolve: true,
-  },
+  dts: true,
   clean: true,
   sourcemap: true,
   treeshake: true,


### PR DESCRIPTION
## Summary
- fix: add @protolabsai/types dep to libs/ui and stop inlining external DTS
- Fixes staging deploy failure: `TS7016: Could not find a declaration file for module '@protolabsai/types'`

## Root cause
`libs/ui` imported `@protolabsai/types` but didn't declare it as a dependency. `tsup dts: { resolve: true }` tried to inline the types during Docker build, but the package wasn't in the dependency graph. Changed to `dts: true` (standard mode) and added the missing dep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies with new type support library
  * Modified TypeScript declaration generation configuration for streamlined build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->