### PR TITLE
Promote dev to staging — fix disk space auto-cleanup

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -78,10 +78,21 @@ jobs:
 
           MIN_GB=10
           if [ "$AVAIL_GB" -lt "$MIN_GB" ]; then
-            echo "ERROR: Only ${AVAIL_GB}GB free — need at least ${MIN_GB}GB for Docker build"
-            echo "Run: docker system prune -a --volumes"
-            df -h "$DEPLOY_DIR"
-            exit 1
+            echo "WARN: Only ${AVAIL_GB}GB free — running aggressive Docker cleanup"
+            # Remove all unused images (not just dangling), build cache, and unused volumes
+            docker system prune -af --volumes 2>/dev/null || true
+            docker builder prune -af 2>/dev/null || true
+
+            # Re-check after cleanup
+            AVAIL_KB=$(df -k "$DEPLOY_DIR" | awk 'NR==2 {print $4}')
+            AVAIL_GB=$((AVAIL_KB / 1024 / 1024))
+            echo "After cleanup: ${AVAIL_GB}GB free"
+
+            if [ "$AVAIL_GB" -lt "$MIN_GB" ]; then
+              echo "ERROR: Still only ${AVAIL_GB}GB free after cleanup — need at least ${MIN_GB}GB"
+              df -h "$DEPLOY_DIR"
+              exit 1
+            fi
           fi
           echo "Disk space OK: ${AVAIL_GB}GB free (minimum ${MIN_GB}GB)"
 


### PR DESCRIPTION
## Summary
- fix(ci): auto-cleanup Docker when staging disk is low
- Deploy workflow now runs `docker system prune -af --volumes` + `docker builder prune -af` when disk is below 10GB, instead of failing immediately

## Context
Staging deploy failed with "Only 8GB free — need at least 10GB". Server is at 100% disk from accumulated Docker build cache and old images. This fix makes the deploy self-healing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced deployment reliability: The staging deployment pre-check now intelligently handles low disk space by automatically attempting cleanup and re-evaluation before failing. Deployments proceed if sufficient space is recovered, significantly improving success rates and reducing manual intervention needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->