### PR TITLE
Project page: fix getProject response type (remove `as unknown as Project` cast)

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
-  "pid": 13093,
-  "featureId": "feature-1772730612438-oy02y59ih",
-  "startedAt": "2026-03-05T17:11:56.057Z"
+  "pid": 7,
+  "featureId": "feature-1772706888361-wu8p3s5ml",
+  "startedAt": "2026-03-05T20:40:03.044Z"
 }

--- a/apps/ui/src/components/views/projects-view/hooks/use-project.ts
+++ b/apps/ui/src/components/views/projects-view/hooks/use-project.ts
@@ -1,7 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAppStore } from '@/store/app-store';
 import { getHttpApiClient } from '@/lib/http-api-client';
-import type { Project } from '@protolabsai/types';
 
 export function useProject(projectSlug: string | null) {
   const projectPath = useAppStore((s) => s.currentProject?.path) ?? '';
@@ -11,7 +10,7 @@ export function useProject(projectSlug: string | null) {
     queryFn: async () => {
       const api = getHttpApiClient();
       const res = await api.lifecycle.getProject(projectPath, projectSlug!);
-      if (res.success && res.project) return res.project as unknown as Project;
+      if (res.success && res.project) return res.project;
       return null;
     },
     enabled: !!projectPath && !!projectSlug,

--- a/apps/ui/src/lib/clients/system-client.ts
+++ b/apps/ui/src/lib/clients/system-client.ts
@@ -21,7 +21,7 @@ import type {
   IntegrationStatusResponse,
   SystemHealthResponse,
 } from './api-types';
-import type { DiscordChannelSignalConfig, ProjectHealth } from '@protolabsai/types';
+import type { DiscordChannelSignalConfig, Project, ProjectHealth } from '@protolabsai/types';
 import { BaseHttpClient, type Constructor } from './base-http-client';
 
 export const withSystemClient = <TBase extends Constructor<BaseHttpClient>>(Base: TBase) =>
@@ -228,13 +228,7 @@ export const withSystemClient = <TBase extends Constructor<BaseHttpClient>>(Base
         projectSlug: string
       ): Promise<{
         success: boolean;
-        project?: {
-          slug: string;
-          title: string;
-          status: string;
-          prd?: { situation: string; problem: string; approach: string; results: string };
-          milestones?: Array<{ title: string; phases: Array<{ title: string; status?: string }> }>;
-        };
+        project?: Project;
         error?: string;
       }> => this.post('/api/projects/get', { projectPath, projectSlug }),
       approvePrd: (


### PR DESCRIPTION
## Summary

The `getProject` API call in `system-client.ts` only types a partial subset of fields (slug, title, status, prd, milestones). The UI works around this with `as unknown as Project` in `use-project.ts` — a type lie that masks missing fields (health, priority, lead, members, startDate, targetDate, links, updates, color, ongoing, description, researchSummary, reviewComments).

**What to do:**
- Update the `getProject` response type in `apps/ui/src/lib/clients/system-client.ts` to return the full `Pr...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type definitions and removed unnecessary type casting to enhance code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->