### PR TITLE
sanitizeStreamingMarkdown() helper + react-markdown plugin memoization fix

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1772706888361-wu8p3s5ml",
-  "startedAt": "2026-03-05T20:40:03.044Z"
+  "featureId": "feature-1772733692445-4to4sjr3r",
+  "startedAt": "2026-03-05T20:40:14.300Z"
 }

--- a/apps/ui/src/lib/__tests__/streaming-markdown.test.ts
+++ b/apps/ui/src/lib/__tests__/streaming-markdown.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeStreamingMarkdown } from '../streaming-markdown';
+
+describe('sanitizeStreamingMarkdown', () => {
+  it('closes unclosed fenced code block', () => {
+    const input = 'Some text\n```typescript\nconst x = 1;';
+    const result = sanitizeStreamingMarkdown(input);
+    expect(result).toBe(input + '\n```');
+  });
+
+  it('closes unclosed inline code', () => {
+    const input = 'Use `foo to do something';
+    const result = sanitizeStreamingMarkdown(input);
+    expect(result).toBe(input + '`');
+  });
+
+  it('closes unclosed bold', () => {
+    const input = 'This is **bold text';
+    const result = sanitizeStreamingMarkdown(input);
+    expect(result).toBe(input + '**');
+  });
+
+  it('returns clean input unchanged', () => {
+    const input = 'This is **bold** and `inline` and\n```\ncode\n```';
+    const result = sanitizeStreamingMarkdown(input);
+    expect(result).toBe(input);
+  });
+});

--- a/apps/ui/src/lib/streaming-markdown.ts
+++ b/apps/ui/src/lib/streaming-markdown.ts
@@ -1,0 +1,15 @@
+export function sanitizeStreamingMarkdown(text: string): string {
+  // Close unclosed fenced code blocks
+  const fences = (text.match(/```/g) || []).length;
+  if (fences % 2 !== 0) return text + '\n```';
+
+  // Close unclosed inline code
+  const backticks = (text.match(/(?<!`)`(?!`)/g) || []).length;
+  if (backticks % 2 !== 0) return text + '`';
+
+  // Close unclosed bold
+  const boldMarkers = (text.match(/\*\*/g) || []).length;
+  if (boldMarkers % 2 !== 0) return text + '**';
+
+  return text;
+}

--- a/apps/ui/vitest.config.ts
+++ b/apps/ui/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'ui',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/__tests__/**/*.test.ts'],
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,10 @@ export default defineConfig({
   test: {
     // Use projects instead of deprecated workspace
     // Glob patterns auto-discover projects with vitest.config.ts
-    projects: ['libs/*/vitest.config.ts', 'apps/server/vitest.config.ts'],
+    projects: [
+      'libs/*/vitest.config.ts',
+      'apps/server/vitest.config.ts',
+      'apps/ui/vitest.config.ts',
+    ],
   },
 });


### PR DESCRIPTION
## Summary

## Context
Two quick wins that should ship together. Both live in the message render component.

## Part 1: sanitizeStreamingMarkdown()
Create a utility function that makes partial markdown safe to render mid-stream by closing unclosed syntax constructs.

**Location:** `apps/ui/src/lib/streaming-markdown.ts`

```ts
export function sanitizeStreamingMarkdown(text: string): string {
  // Close unclosed fenced code blocks
  const fences = (text.match(/```/g) || []).length;
  if (fences % 2 !== 0) re...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added markdown sanitization utility that auto-closes unclosed fenced code blocks, inline code, and bold formatting.

* **Tests**
  * Added comprehensive tests covering markdown sanitization edge cases.
  * Added test configuration to include the UI package in the test runner discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->