### PR TITLE
Segment memoization for long messages (5k+ tokens)

### DIFF
--- a/.automaker/features/feature-1772733730532-lzqnrerdr/agent-output.md.stale
+++ b/.automaker/features/feature-1772733730532-lzqnrerdr/agent-output.md.stale
@@ -1,0 +1,5 @@
+
+🔧 Tool: ToolSearch
+Input: {
+  "query": "select:Read,Bash,Write,TodoWrite"
+}

--- a/.automaker/features/feature-1772733730532-lzqnrerdr/feature.json
+++ b/.automaker/features/feature-1772733730532-lzqnrerdr/feature.json
@@ -3,7 +3,7 @@
   "description": "## Context\nFor long AI responses (5k+ tokens), react-markdown re-parsing the full string on every token update causes frame drops. Implement segment memoization: split completed content into settled segments at paragraph boundaries, memoize them, and only re-render the active tail.\n\n## Implementation\n\n**Location:** `apps/ui/src/components/` — new component `StreamedMessage` or modification of existing message component.\n\n```tsx\nimport { memo, useMemo } from 'react';\nimport ReactMarkdown from 'react-markdown';\nimport remarkGfm from 'remark-gfm';\n\nconst SEGMENT_SIZE = 500; // characters — tune based on profiling\nconst REMARK_PLUGINS = [remarkGfm];\n\nfunction splitIntoSegments(content: string): { settled: string[]; tail: string } {\n  const settled: string[] = [];\n  let remaining = content;\n\n  while (remaining.length > SEGMENT_SIZE + 200) {\n    // Find paragraph boundary near SEGMENT_SIZE\n    const breakAt = remaining.indexOf('\\n\\n', SEGMENT_SIZE);\n    if (breakAt === -1 || breakAt > SEGMENT_SIZE + 200) {\n      settled.push(remaining.slice(0, SEGMENT_SIZE));\n      remaining = remaining.slice(SEGMENT_SIZE);\n    } else {\n      settled.push(remaining.slice(0, breakAt));\n      remaining = remaining.slice(breakAt + 2);\n    }\n  }\n\n  return { settled, tail: remaining };\n}\n\nconst SettledSegment = memo(({ content }: { content: string }) => (\n  <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{content}</ReactMarkdown>\n));\nSettledSegment.displayName = 'SettledSegment';\n\nexport function StreamedMessage({ content, isComplete }: { content: string; isComplete: boolean }) {\n  const { settled, tail } = useMemo(() => splitIntoSegments(content), [content]);\n\n  return (\n    <>\n      {settled.map((seg, i) => (\n        <SettledSegment key={i} content={seg} />\n      ))}\n      {/* Active tail — re-renders on each token */}\n      <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>\n        {isComplete ? tail : sanitizeStreamingMarkdown(tail)}\n      </ReactMarkdown>\n    </>\n  );\n}\n```\n\nOnly activate segmentation when `content.length > 5000` — for short messages the overhead isn't worth it.\n\nImport `sanitizeStreamingMarkdown` from the helper created in the first feature.\n\n## Acceptance Criteria\n- Messages under 5000 characters render without segmentation (no regression)\n- Messages over 5000 characters split at paragraph boundaries, settled segments are memoized\n- `SettledSegment` has `displayName` set for React DevTools\n- No TypeScript errors\n- Verify with React DevTools Profiler that settled segments don't re-render during streaming of the tail",
   "title": "Segment memoization for long messages (5k+ tokens)",
   "priority": 1,
-  "status": "backlog",
+  "status": "review",
   "id": "feature-1772733730532-lzqnrerdr",
   "branchName": "feature/segment-memoization-for-long-messages",
   "descriptionHistory": [
@@ -20,10 +20,24 @@
       "to": "backlog",
       "timestamp": "2026-03-05T18:02:10.536Z",
       "reason": "Feature created"
+    },
+    {
+      "from": "backlog",
+      "to": "review",
+      "timestamp": "2026-03-05T21:00:23.977Z"
     }
   ],
   "featureType": "code",
   "dependencies": [
     "feature-1772733692445-4to4sjr3r"
-  ]
+  ],
+  "costUsd": 0.5629214999999999,
+  "lastSessionId": "be9bbfff-8f3d-4453-89dc-7609b320e2e4",
+  "lastTraceId": "a0690694-eb49-4df0-9256-8e9a8caf6645",
+  "prUrl": "https://github.com/protoLabsAI/protoMaker/pull/1840",
+  "prNumber": 1840,
+  "prCreatedAt": "2026-03-05T21:00:23.977Z",
+  "reviewStartedAt": "2026-03-05T21:00:23.977Z",
+  "prTrackedSince": "2026-03-05T21:00:24.314Z",
+  "prLastPolledAt": "2026-03-05T21:00:54.158Z"
 }

--- a/apps/ui/src/components/streamed-message.tsx
+++ b/apps/ui/src/components/streamed-message.tsx
@@ -1,0 +1,63 @@
+import { memo, useMemo } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { sanitizeStreamingMarkdown } from '@/lib/sanitize-streaming-markdown';
+
+const SEGMENT_SIZE = 500;
+const REMARK_PLUGINS = [remarkGfm];
+
+function splitIntoSegments(content: string): { settled: string[]; tail: string } {
+  const settled: string[] = [];
+  let remaining = content;
+
+  while (remaining.length > SEGMENT_SIZE + 200) {
+    const breakAt = remaining.indexOf('\n\n', SEGMENT_SIZE);
+    if (breakAt === -1 || breakAt > SEGMENT_SIZE + 200) {
+      settled.push(remaining.slice(0, SEGMENT_SIZE));
+      remaining = remaining.slice(SEGMENT_SIZE);
+    } else {
+      settled.push(remaining.slice(0, breakAt));
+      remaining = remaining.slice(breakAt + 2);
+    }
+  }
+
+  return { settled, tail: remaining };
+}
+
+const SettledSegment = memo(({ content }: { content: string }) => (
+  <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{content}</ReactMarkdown>
+));
+SettledSegment.displayName = 'SettledSegment';
+
+interface StreamedMessageProps {
+  content: string;
+  isComplete: boolean;
+}
+
+export function StreamedMessage({ content, isComplete }: StreamedMessageProps) {
+  // For short messages skip segmentation entirely — no overhead
+  if (content.length <= 5000) {
+    return (
+      <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>
+        {isComplete ? content : sanitizeStreamingMarkdown(content)}
+      </ReactMarkdown>
+    );
+  }
+
+  return <SegmentedMessage content={content} isComplete={isComplete} />;
+}
+
+function SegmentedMessage({ content, isComplete }: StreamedMessageProps) {
+  const { settled, tail } = useMemo(() => splitIntoSegments(content), [content]);
+
+  return (
+    <>
+      {settled.map((seg, i) => (
+        <SettledSegment key={i} content={seg} />
+      ))}
+      <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>
+        {isComplete ? tail : sanitizeStreamingMarkdown(tail)}
+      </ReactMarkdown>
+    </>
+  );
+}

--- a/apps/ui/src/lib/sanitize-streaming-markdown.ts
+++ b/apps/ui/src/lib/sanitize-streaming-markdown.ts
@@ -1,0 +1,26 @@
+/**
+ * sanitizeStreamingMarkdown — fix incomplete markdown syntax during streaming.
+ *
+ * When an LLM streams tokens, the partially-received content may contain
+ * unclosed syntax that confuses react-markdown (e.g. an unclosed code fence
+ * turns all subsequent text into a code block). This function closes any
+ * dangling structures so the renderer always sees syntactically valid input.
+ *
+ * Only called on the active streaming tail — settled segments are left untouched.
+ */
+export function sanitizeStreamingMarkdown(content: string): string {
+  let result = content;
+
+  // Close unclosed fenced code blocks (``` or ~~~)
+  const backtickFences = (result.match(/^```/gm) ?? []).length;
+  const tildeFences = (result.match(/^~~~/gm) ?? []).length;
+
+  if (backtickFences % 2 !== 0) {
+    result += '\n```';
+  }
+  if (tildeFences % 2 !== 0) {
+    result += '\n~~~';
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

## Context
For long AI responses (5k+ tokens), react-markdown re-parsing the full string on every token update causes frame drops. Implement segment memoization: split completed content into settled segments at paragraph boundaries, memoize them, and only re-render the active tail.

## Implementation

**Location:** `apps/ui/src/components/` — new component `StreamedMessage` or modification of existing message component.

```tsx
import { memo, useMemo } from 'react';
import ReactMarkdown from 're...

---
*Recovered automatically by Automaker post-agent hook*