### PR TITLE
useScrollLock hook — auto-scroll with user override

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1772706877097-ukzhf656v",
-  "startedAt": "2026-03-05T21:02:33.881Z"
+  "featureId": "feature-1772733708297-mu9jb54f2",
+  "startedAt": "2026-03-05T21:12:47.144Z"
 }

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useAutoMode } from './use-auto-mode';
+export { useScrollLock } from './use-scroll-lock';
 export { useBoardBackgroundSettings } from './use-board-background-settings';
 export { useKeyboardShortcuts } from './use-keyboard-shortcuts';
 export { useOSDetection, type OperatingSystem, type OSDetectionResult } from './use-os-detection';

--- a/apps/ui/src/hooks/use-scroll-lock.ts
+++ b/apps/ui/src/hooks/use-scroll-lock.ts
@@ -1,0 +1,29 @@
+import { useRef, useEffect, useCallback } from 'react';
+
+export function useScrollLock() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const lockedRef = useRef(true);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const onScroll = () => {
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+      lockedRef.current = distanceFromBottom < 100;
+    };
+
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const scrollToBottom = useCallback((force = false) => {
+    const el = containerRef.current;
+    if (!el) return;
+    if (force || lockedRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, []);
+
+  return { containerRef, scrollToBottom };
+}

--- a/libs/ui/src/ai/chat-message-list.tsx
+++ b/libs/ui/src/ai/chat-message-list.tsx
@@ -12,7 +12,7 @@
  *    bottom, so a manually-scrolled-up view is never hijacked.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { ArrowDown } from 'lucide-react';
 import type { UIMessage } from 'ai';
 import { cn } from '../lib/utils.js';
@@ -88,7 +88,7 @@ export function ChatMessageList({
   const checkIfAtBottom = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return true;
-    return el.scrollHeight - el.scrollTop - el.clientHeight < 20;
+    return el.scrollHeight - el.scrollTop - el.clientHeight < 100;
   }, []);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
@@ -180,12 +180,22 @@ export function ChatMessageList({
   // When a new message is appended, scroll to bottom only if the user
   // has not manually scrolled away. This prevents hijacking reading position
   // during long conversations / streaming.
-  useEffect(() => {
+  // useLayoutEffect fires before paint, preventing a one-frame lag vs useEffect.
+  useLayoutEffect(() => {
     if (!userScrolledRef.current) {
       scrollToBottom('instant');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messages.length]);
+
+  // Force-scroll to bottom on stream completion regardless of lock state.
+  const prevIsStreamingRef = useRef(isStreaming);
+  useLayoutEffect(() => {
+    if (prevIsStreamingRef.current && !isStreaming) {
+      scrollToBottom('instant');
+    }
+    prevIsStreamingRef.current = isStreaming;
+  }, [isStreaming, scrollToBottom]);
 
   // Determine if ShimmerLoader should be shown:
   // Show when streaming and the last message has no text content yet (pending response).


### PR DESCRIPTION
## Summary

## Context
Implement a reusable scroll lock hook for the chat message list. Requirements:
1. Auto-scroll to bottom while AI is streaming
2. Stop auto-scrolling if user scrolls up (reading earlier content)
3. Resume auto-scrolling when user scrolls back near the bottom (within 100px)
4. Force-scroll to bottom on stream completion regardless of lock state

## Implementation
**Location:** `apps/ui/src/hooks/use-scroll-lock.ts`

```tsx
import { useRef, useEffect, useCallback, useLayoutEffect } from ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamed message rendering now automatically segments long content for improved performance
  * Added scroll management functionality for message containers
  * Improved markdown formatting during streaming with automatic sanitization

* **Bug Fixes**
  * Enhanced scroll detection to more accurately identify when user is at the bottom of messages
  * Fixed auto-scroll behavior when streaming completes

* **Tests**
  * Added tests for markdown sanitization functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->