### PR TITLE
Project page: add research summary tab and project-level progress indicator

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 46739,
-  "featureId": "feature-1772706897841-3mogrgs2b",
-  "startedAt": "2026-03-05T21:23:18.597Z"
+  "featureId": "feature-1772706904273-c0nss1nw7",
+  "startedAt": "2026-03-05T21:23:51.695Z"
 }

--- a/.automaker/features/feature-1772706882969-z2skuiyw0/feature.json
+++ b/.automaker/features/feature-1772706882969-z2skuiyw0/feature.json
@@ -21,5 +21,7 @@
       "timestamp": "2026-03-05T10:34:42.976Z",
       "reason": "Feature created"
     }
-  ]
+  ],
+  "featureType": "code",
+  "prLastPolledAt": "2026-03-05T21:55:23.081Z"
 }

--- a/apps/ui/src/components/views/projects-view/components/project-header.tsx
+++ b/apps/ui/src/components/views/projects-view/components/project-header.tsx
@@ -5,6 +5,7 @@ import { Button } from '@protolabsai/ui/atoms';
 import { HealthIndicator } from './health-indicator';
 import { getProjectStatusVariant } from '../lib/status-variants';
 import { DeleteConfirmDialog } from '@/components/shared/delete-confirm-dialog';
+import { useProjectFeatures } from '../hooks/use-project-features';
 import type { Project, ProjectHealth } from '@protolabsai/types';
 
 interface ProjectHeaderProps {
@@ -27,6 +28,11 @@ export function ProjectHeader({
   pmChatOpen,
 }: ProjectHeaderProps) {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const { data: featuresData } = useProjectFeatures(project.slug);
+
+  const features = (featuresData?.data?.features ?? []) as Array<{ status?: string }>;
+  const totalFeatures = features.length;
+  const doneFeatures = features.filter((f) => f.status === 'done').length;
 
   return (
     <div className="shrink-0 px-6 py-4 border-b border-border/40">
@@ -57,6 +63,11 @@ export function ProjectHeader({
             >
               {project.status}
             </Badge>
+            {totalFeatures > 0 && (
+              <span className="text-xs text-muted-foreground shrink-0">
+                {doneFeatures} / {totalFeatures} done
+              </span>
+            )}
             {project.health && <HealthIndicator health={project.health as ProjectHealth} />}
           </div>
           <p className="text-xs text-muted-foreground mt-0.5">{project.slug}</p>

--- a/apps/ui/src/components/views/projects-view/project-detail.tsx
+++ b/apps/ui/src/components/views/projects-view/project-detail.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { FileText, Layers, BookOpen, MessageSquare } from 'lucide-react';
+import { FileText, Layers, BookOpen, MessageSquare, FlaskConical } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@protolabsai/ui/atoms';
 import { Spinner } from '@protolabsai/ui/atoms';
 import { toast } from 'sonner';
@@ -12,6 +12,7 @@ import { PrdTab } from './tabs/prd-tab';
 import { FeaturesTab } from './tabs/features-tab';
 import { ResourcesTab } from './tabs/resources-tab';
 import { UpdatesTab } from './tabs/updates-tab';
+import { ResearchTab } from './tabs/research-tab';
 import type { Project } from '@protolabsai/types';
 
 export function ProjectDetail({
@@ -93,6 +94,12 @@ export function ProjectDetail({
                 <MessageSquare />
                 <span className="hidden sm:inline">Updates</span>
               </TabsTrigger>
+              {project.researchSummary && (
+                <TabsTrigger value="research">
+                  <FlaskConical />
+                  <span className="hidden sm:inline">Research</span>
+                </TabsTrigger>
+              )}
             </TabsList>
 
             <TabsContent value="prd">
@@ -110,6 +117,12 @@ export function ProjectDetail({
             <TabsContent value="updates">
               <UpdatesTab project={project as Project} />
             </TabsContent>
+
+            {project.researchSummary && (
+              <TabsContent value="research">
+                <ResearchTab project={project as Project} />
+              </TabsContent>
+            )}
           </Tabs>
         </div>
       </div>

--- a/apps/ui/src/components/views/projects-view/projects-list.tsx
+++ b/apps/ui/src/components/views/projects-view/projects-list.tsx
@@ -10,6 +10,7 @@ import { useAppStore } from '@/store/app-store';
 import { getHttpApiClient } from '@/lib/http-api-client';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
+import { useProjectFeatures } from './hooks/use-project-features';
 
 interface ProjectSummary {
   slug: string;
@@ -56,6 +57,31 @@ const PROJECT_STATUS_LABELS: Record<string, string> = {
   active: 'Active',
   completed: 'Completed',
 };
+
+function ProjectProgress({ projectSlug }: { projectSlug: string }) {
+  const { data: featuresData } = useProjectFeatures(projectSlug);
+  const features = (featuresData?.data?.features ?? []) as Array<{ status?: string }>;
+  const total = features.length;
+  const done = features.filter((f) => f.status === 'done').length;
+
+  if (total === 0) return null;
+
+  const pct = Math.round((done / total) * 100);
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="w-16 h-1.5 rounded-full bg-muted overflow-hidden">
+        <div
+          className="h-full rounded-full bg-[var(--status-success)]"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-xs text-muted-foreground whitespace-nowrap">
+        {done}/{total}
+      </span>
+    </div>
+  );
+}
 
 export function ProjectsList() {
   const projectPath = useAppStore((s) => s.currentProject?.path);
@@ -322,10 +348,11 @@ export function ProjectsList() {
                             )}
                           </div>
 
-                          {/* Milestone / phase counts */}
-                          <div className="w-32 shrink-0 flex items-center gap-3 text-xs text-muted-foreground pr-3">
+                          {/* Milestone / phase counts + progress */}
+                          <div className="w-36 shrink-0 flex items-center gap-3 text-xs text-muted-foreground pr-3">
                             {milestoneCount > 0 && <span>{milestoneCount} ms</span>}
                             {phaseCount > 0 && <span>{phaseCount} ph</span>}
+                            <ProjectProgress projectSlug={project.slug} />
                           </div>
 
                           {/* Navigate chevron */}

--- a/apps/ui/src/components/views/projects-view/tabs/research-tab.tsx
+++ b/apps/ui/src/components/views/projects-view/tabs/research-tab.tsx
@@ -1,0 +1,20 @@
+import Markdown from 'react-markdown';
+import type { Project } from '@protolabsai/types';
+
+export function ResearchTab({ project }: { project: Project }) {
+  if (!project.researchSummary) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-sm text-muted-foreground">No research summary available yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="py-4">
+      <div className="prose prose-sm prose-invert max-w-none prose-p:text-foreground/90 prose-headings:text-foreground prose-li:text-foreground/90 prose-strong:text-foreground">
+        <Markdown>{project.researchSummary}</Markdown>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Two gaps in project visibility:

1. **Research Summary tab** — `Project.researchSummary` is populated during the deep research pipeline but never surfaced in the UI. Add a 'Research' tab to ProjectDetail that renders `project.researchSummary` as Markdown (similar to PrdTab). Only show the tab if `researchSummary` is non-empty.

2. **Project-level progress** — The project list and header show no overall completion percentage. Add a progress indicator (e.g. '12 / 34 features done') to:
   - `Proje...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Projects now display feature progress tracking with done/total count summaries, visible in both the project header and project list views
  * Added a new optional "Research" tab on project detail pages that displays project research summaries formatted in markdown, appearing only when research data is available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->