### PR TITLE
Gate rehype-highlight behind isComplete + wire sanitizeStreamingMarkdown into message renderer

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1772733720136-qpstecjfm",
-  "startedAt": "2026-03-05T21:20:11.256Z"
+  "featureId": "feature-1772733699146-8uegry6tb",
+  "startedAt": "2026-03-05T21:30:56.132Z"
 }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -133,6 +133,7 @@
     "react-markdown": "10.1.0",
     "react-resizable-panels": "3.0.6",
     "recharts": "^3.7.0",
+    "rehype-highlight": "^7.0.2",
     "rehype-raw": "7.0.0",
     "sonner": "2.0.7",
     "tailwind-merge": "3.4.0",

--- a/apps/ui/src/components/streamed-message.tsx
+++ b/apps/ui/src/components/streamed-message.tsx
@@ -1,10 +1,13 @@
 import { memo, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
 import { sanitizeStreamingMarkdown } from '@/lib/sanitize-streaming-markdown';
 
 const SEGMENT_SIZE = 500;
 const REMARK_PLUGINS = [remarkGfm];
+const REHYPE_PLUGINS_STREAMING: [] = [];
+const REHYPE_PLUGINS_COMPLETE = [rehypeHighlight];
 
 function splitIntoSegments(content: string): { settled: string[]; tail: string } {
   const settled: string[] = [];
@@ -25,7 +28,9 @@ function splitIntoSegments(content: string): { settled: string[]; tail: string }
 }
 
 const SettledSegment = memo(({ content }: { content: string }) => (
-  <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{content}</ReactMarkdown>
+  <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS_COMPLETE}>
+    {content}
+  </ReactMarkdown>
 ));
 SettledSegment.displayName = 'SettledSegment';
 
@@ -38,7 +43,10 @@ export function StreamedMessage({ content, isComplete }: StreamedMessageProps) {
   // For short messages skip segmentation entirely — no overhead
   if (content.length <= 5000) {
     return (
-      <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>
+      <ReactMarkdown
+        remarkPlugins={REMARK_PLUGINS}
+        rehypePlugins={isComplete ? REHYPE_PLUGINS_COMPLETE : REHYPE_PLUGINS_STREAMING}
+      >
         {isComplete ? content : sanitizeStreamingMarkdown(content)}
       </ReactMarkdown>
     );
@@ -55,7 +63,10 @@ function SegmentedMessage({ content, isComplete }: StreamedMessageProps) {
       {settled.map((seg, i) => (
         <SettledSegment key={i} content={seg} />
       ))}
-      <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>
+      <ReactMarkdown
+        remarkPlugins={REMARK_PLUGINS}
+        rehypePlugins={isComplete ? REHYPE_PLUGINS_COMPLETE : REHYPE_PLUGINS_STREAMING}
+      >
         {isComplete ? tail : sanitizeStreamingMarkdown(tail)}
       </ReactMarkdown>
     </>


### PR DESCRIPTION
## Summary

## Context
Depends on: sanitizeStreamingMarkdown helper and plugin memoization fix (ship that first).

Two render-layer changes to the message component:

## Part 1: Gate syntax highlighting
During streaming, rehype-highlight re-tokenizes the entire code block on every token. This is expensive and looks noisy. Disable it while streaming, apply on completion.

```tsx
const REMARK_PLUGINS = [remarkGfm]; // already fixed by dependency feature
const REHYPE_PLUGINS_STREAMING: [] = [];
const REHYPE_PL...

---
*Recovered automatically by Automaker post-agent hook*