### PR TITLE
Project page: wire PRD lifecycle actions (Approve, Request Changes, Launch)

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1772733699146-8uegry6tb",
-  "startedAt": "2026-03-05T21:30:56.132Z"
+  "featureId": "feature-1772706882969-z2skuiyw0",
+  "startedAt": "2026-03-05T21:34:57.198Z"
 }

--- a/apps/ui/src/components/views/projects-view/hooks/use-project.ts
+++ b/apps/ui/src/components/views/projects-view/hooks/use-project.ts
@@ -46,3 +46,51 @@ export function useProjectDelete() {
     },
   });
 }
+
+export function useApprovePrd(projectSlug: string) {
+  const projectPath = useAppStore((s) => s.currentProject?.path) ?? '';
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      const api = getHttpApiClient();
+      return api.lifecycle.approvePrd(projectPath, projectSlug, {
+        createEpics: true,
+        setupDependencies: true,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['project-detail', projectPath, projectSlug] });
+    },
+  });
+}
+
+export function useRequestChanges(projectSlug: string) {
+  const projectPath = useAppStore((s) => s.currentProject?.path) ?? '';
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (feedback: string) => {
+      const api = getHttpApiClient();
+      return api.lifecycle.requestChanges(projectPath, projectSlug, feedback);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['project-detail', projectPath, projectSlug] });
+    },
+  });
+}
+
+export function useLaunchProject(projectSlug: string) {
+  const projectPath = useAppStore((s) => s.currentProject?.path) ?? '';
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (maxConcurrency?: number) => {
+      const api = getHttpApiClient();
+      return api.lifecycle.launch(projectPath, projectSlug, maxConcurrency);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['project-detail', projectPath, projectSlug] });
+    },
+  });
+}

--- a/apps/ui/src/components/views/projects-view/project-detail.tsx
+++ b/apps/ui/src/components/views/projects-view/project-detail.tsx
@@ -96,7 +96,7 @@ export function ProjectDetail({
             </TabsList>
 
             <TabsContent value="prd">
-              <PrdTab project={project as Project} />
+              <PrdTab project={project as Project} projectSlug={projectSlug} />
             </TabsContent>
 
             <TabsContent value="features">

--- a/apps/ui/src/components/views/projects-view/tabs/prd-tab.tsx
+++ b/apps/ui/src/components/views/projects-view/tabs/prd-tab.tsx
@@ -1,7 +1,17 @@
 import { useState } from 'react';
-import { ChevronDown, ChevronRight } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronRight,
+  CheckCircle,
+  MessageSquare,
+  Rocket,
+  Loader2,
+} from 'lucide-react';
 import Markdown from 'react-markdown';
+import { Button } from '@protolabsai/ui/atoms';
+import { toast } from 'sonner';
 import type { Project } from '@protolabsai/types';
+import { useApprovePrd, useRequestChanges, useLaunchProject } from '../hooks/use-project';
 
 const SPARC_SECTIONS = [
   { key: 'situation', label: 'Situation', color: 'text-[var(--status-info)]' },
@@ -46,7 +56,170 @@ function CollapsibleSection({
   );
 }
 
-export function PrdTab({ project }: { project: Project }) {
+function ReviewingActions({ projectSlug }: { projectSlug: string }) {
+  const [showFeedback, setShowFeedback] = useState(false);
+  const [feedback, setFeedback] = useState('');
+  const approveMutation = useApprovePrd(projectSlug);
+  const requestChangesMutation = useRequestChanges(projectSlug);
+
+  const handleApprove = () => {
+    approveMutation.mutate(undefined, {
+      onSuccess: (res) => {
+        if (res.success) {
+          toast.success('PRD approved — creating features');
+        } else {
+          toast.error(res.error ?? 'Failed to approve PRD');
+        }
+      },
+      onError: () => toast.error('Failed to approve PRD'),
+    });
+  };
+
+  const handleRequestChanges = () => {
+    if (!feedback.trim()) {
+      toast.error('Please provide feedback before submitting');
+      return;
+    }
+    requestChangesMutation.mutate(feedback, {
+      onSuccess: (res) => {
+        if (res.success) {
+          toast.success('Changes requested — feedback stored for PRD regeneration');
+          setShowFeedback(false);
+          setFeedback('');
+        } else {
+          toast.error(res.error ?? 'Failed to request changes');
+        }
+      },
+      onError: () => toast.error('Failed to request changes'),
+    });
+  };
+
+  const isPending = approveMutation.isPending || requestChangesMutation.isPending;
+
+  return (
+    <div className="border-t border-border/30 pt-3 mt-3 space-y-3">
+      {showFeedback && (
+        <div className="space-y-2">
+          <textarea
+            className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none"
+            rows={4}
+            placeholder="Describe the changes needed..."
+            value={feedback}
+            onChange={(e) => setFeedback(e.target.value)}
+            disabled={requestChangesMutation.isPending}
+          />
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setShowFeedback(false);
+                setFeedback('');
+              }}
+              disabled={requestChangesMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleRequestChanges}
+              disabled={requestChangesMutation.isPending}
+            >
+              {requestChangesMutation.isPending ? (
+                <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" />
+              ) : (
+                <MessageSquare className="w-3.5 h-3.5 mr-1.5" />
+              )}
+              Submit Feedback
+            </Button>
+          </div>
+        </div>
+      )}
+      {!showFeedback && (
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowFeedback(true)}
+            disabled={isPending}
+            data-testid="request-changes-button"
+          >
+            <MessageSquare className="w-3.5 h-3.5 mr-1.5" />
+            Request Changes
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleApprove}
+            disabled={isPending}
+            data-testid="approve-prd-button"
+          >
+            {approveMutation.isPending ? (
+              <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" />
+            ) : (
+              <CheckCircle className="w-3.5 h-3.5 mr-1.5" />
+            )}
+            Approve PRD
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ApprovedActions({ projectSlug }: { projectSlug: string }) {
+  const launchMutation = useLaunchProject(projectSlug);
+  const [maxConcurrency, setMaxConcurrency] = useState<string>('');
+
+  const handleLaunch = () => {
+    const concurrency = maxConcurrency.trim() ? parseInt(maxConcurrency, 10) : undefined;
+    launchMutation.mutate(concurrency, {
+      onSuccess: (res) => {
+        if (res.success) {
+          toast.success(
+            res.autoModeStarted
+              ? `Project launched — auto-mode started with ${res.featuresInBacklog ?? 0} features`
+              : 'Project launched'
+          );
+        } else {
+          toast.error(res.error ?? 'Failed to launch project');
+        }
+      },
+      onError: () => toast.error('Failed to launch project'),
+    });
+  };
+
+  return (
+    <div className="border-t border-border/30 pt-3 mt-3">
+      <div className="flex items-center justify-end gap-2">
+        <input
+          type="number"
+          min={1}
+          max={10}
+          placeholder="Max concurrency (optional)"
+          value={maxConcurrency}
+          onChange={(e) => setMaxConcurrency(e.target.value)}
+          disabled={launchMutation.isPending}
+          className="w-48 rounded-lg border border-border bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <Button
+          size="sm"
+          onClick={handleLaunch}
+          disabled={launchMutation.isPending}
+          data-testid="launch-project-button"
+        >
+          {launchMutation.isPending ? (
+            <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" />
+          ) : (
+            <Rocket className="w-3.5 h-3.5 mr-1.5" />
+          )}
+          Launch
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function PrdTab({ project, projectSlug }: { project: Project; projectSlug: string }) {
   if (!project.prd) {
     return (
       <div className="text-center py-12">
@@ -72,6 +245,9 @@ export function PrdTab({ project }: { project: Project }) {
           />
         );
       })}
+
+      {project.status === 'reviewing' && <ReviewingActions projectSlug={projectSlug} />}
+      {project.status === 'approved' && <ApprovedActions projectSlug={projectSlug} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The PRD tab is read-only. Six lifecycle client methods exist but are never called from any component: `approvePrd`, `requestChanges`, `getStatus`, `launch`. The project detail has no way to move a project through its lifecycle from the UI.

**What to do:**
- Add action buttons to `ProjectHeader` or `PrdTab` based on current project status:
  - Status `reviewing` → show 'Approve PRD' and 'Request Changes' buttons
  - Status `approved` → show 'Launch' button (with optional maxConcurrency input)
  ...

---
*Recovered automatically by Automaker post-agent hook*