### PR TITLE
Project page: add members edit UI and project color picker to sidebar

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
-  "pid": 46739,
-  "featureId": "feature-1772706904273-c0nss1nw7",
-  "startedAt": "2026-03-05T21:23:51.695Z"
+  "pid": 7,
+  "featureId": "feature-1772706893670-zawxa8dgf",
+  "startedAt": "2026-03-05T22:03:11.338Z"
 }


### PR DESCRIPTION
## Summary

Two Project fields are missing edit capability in ProjectSidebar:
1. `members` — rendered as `project.members?.join(', ')` with no add/remove UI
2. `color` — field exists on the Project type but is never displayed or editable anywhere

**What to do:**
- Members: replace the read-only display with a tag-input component — add member (text input + enter), remove member (×). Call `useProjectUpdate` on change.
- Color: add a color swatch/picker control to the sidebar. Use a simple color input or a sm...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration metadata.

**Note:** This release contains no user-facing changes or feature updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->