### PR TITLE
feat: wire PRWatcherService — webhook, Ava tool, UI push notifications

### DIFF
--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -38,6 +38,7 @@ import type { SettingsService } from '../../services/settings-service.js';
 import type { ToolProgressEmitter } from './tool-progress.js';
 import { buildProgressHooks } from '../../lib/agent-hooks.js';
 import { githubMergeService } from '../../services/github-merge-service.js';
+import { getPRWatcherService } from '../../services/pr-watcher-service.js';
 import { getEventHistoryService } from '../../services/event-history-service.js';
 import { getBriefingCursorService } from '../../services/briefing-cursor-service.js';
 
@@ -879,6 +880,22 @@ export function buildAvaTools(
       }),
       execute: async ({ prNumber }) => {
         return githubMergeService.checkPRStatus(projectPath, prNumber);
+      },
+    });
+
+    tools['watch_pr'] = makeTool({
+      description:
+        'Register a PR for background CI monitoring. Returns immediately. When all checks pass or any check fails, a push notification is injected into this chat session — no polling needed.',
+      inputSchema: z.object({
+        prNumber: z.number().int().describe('PR number to watch'),
+      }),
+      execute: async ({ prNumber }) => {
+        const watcher = getPRWatcherService();
+        if (!watcher) {
+          return { error: 'PR watcher service unavailable' };
+        }
+        watcher.addWatch(prNumber, projectPath);
+        return { watching: true, prNumber };
       },
     });
 

--- a/apps/server/src/routes/github/index.ts
+++ b/apps/server/src/routes/github/index.ts
@@ -102,5 +102,8 @@ export function createGitHubRoutes(
     createResolvePRCommentHandler()
   );
 
+  // Background PR CI watcher (Ava push notifications)
+  router.post('/watch-pr', validatePathParams('projectPath'), createWatchPRHandler(events));
+
   return router;
 }

--- a/apps/server/src/routes/github/routes/webhook.ts
+++ b/apps/server/src/routes/github/routes/webhook.ts
@@ -17,9 +17,11 @@ import type {
   GitHubPingWebhookPayload,
   WebhookVerificationResult,
   GitHubCheckSuiteWebhookPayload,
+  GitHubCheckRunWebhookPayload,
 } from '@protolabsai/types';
 import type { SettingsService } from '../../../services/settings-service.js';
 import type { EventEmitter } from '../../../lib/events.js';
+import { getPRWatcherService } from '../../../services/pr-watcher-service.js';
 
 const logger = createLogger('GitHubWebhook');
 
@@ -264,6 +266,38 @@ async function handleCheckSuiteEvent(
 }
 
 /**
+ * Handle GitHub check run completed event — fast-path trigger for PRWatcherService
+ */
+async function handleCheckRunEvent(
+  payload: GitHubCheckRunWebhookPayload,
+  projectPath: string
+): Promise<void> {
+  const { action, check_run } = payload;
+
+  // Only react to completed check runs
+  if (action !== 'completed') return;
+
+  const prs = check_run.pull_requests ?? [];
+  if (prs.length === 0) return;
+
+  const watcher = getPRWatcherService();
+  if (!watcher) return;
+
+  for (const pr of prs) {
+    if (watcher.isWatching(pr.number)) {
+      logger.info(
+        `check_run completed for PR #${pr.number} (${check_run.name}) — triggering watcher check`
+      );
+      await watcher.triggerCheck(pr.number);
+    }
+  }
+
+  logger.debug(
+    `Processed check_run ${check_run.id} (${check_run.name}) for project: ${projectPath}`
+  );
+}
+
+/**
  * Create webhook handler
  *
  * Receives GitHub webhook events, verifies signatures, and processes the payload.
@@ -385,6 +419,10 @@ export function createWebhookHandler(
             projectPath,
             events
           );
+          break;
+
+        case 'check_run':
+          await handleCheckRunEvent(payload as GitHubCheckRunWebhookPayload, projectPath);
           break;
 
         case 'push':

--- a/apps/server/src/services/core.module.ts
+++ b/apps/server/src/services/core.module.ts
@@ -1,4 +1,5 @@
 import type { ServiceContainer } from '../server/services.js';
+import { getPRWatcherService } from './pr-watcher-service.js';
 
 /**
  * Wires core service dependencies: calendar, headsdown, dev server, notifications,
@@ -61,4 +62,8 @@ export function register(container: ServiceContainer): void {
 
   // Audit service initialization
   auditService.initialize(authorityService);
+
+  // PRWatcherService — initialize singleton with the app event bus so the watch_pr
+  // Ava tool can call getPRWatcherService() without arguments and always get an instance.
+  getPRWatcherService(events);
 }

--- a/apps/ui/src/hooks/use-chat-session.ts
+++ b/apps/ui/src/hooks/use-chat-session.ts
@@ -130,6 +130,28 @@ export function useChatSession({
     return () => unsubscribe();
   }, []);
 
+  // Subscribe to pr:watch-resolved events and inject as a user message so Ava can respond
+  useEffect(() => {
+    const api = getHttpApiClient();
+    const unsubscribe = api.subscribeToEvents((type: string, payload: unknown) => {
+      if (type === 'pr:watch-resolved') {
+        const event = payload as {
+          prNumber: number;
+          status: 'passed' | 'failed';
+          checks: Array<{ name: string; conclusion: string }>;
+          timestamp: string;
+        };
+        const failedChecks = event.checks.filter((c) => c.conclusion === 'failure');
+        const messageText =
+          event.status === 'passed'
+            ? `[Background notification] PR #${event.prNumber}: all CI checks passed.`
+            : `[Background notification] PR #${event.prNumber}: CI failed. Failed checks: ${failedChecks.map((c) => c.name).join(', ')}.`;
+        void sendMessage({ text: messageText });
+      }
+    });
+    return () => unsubscribe();
+  }, [sendMessage]);
+
   /** Remove a pending approval from the list (after approve or deny). */
   const removePendingApproval = useCallback((approvalId: string) => {
     setPendingSubagentApprovals((prev) => prev.filter((a) => a.approvalId !== approvalId));

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -546,6 +546,7 @@ export type {
   GitHubPushWebhookPayload,
   GitHubPingWebhookPayload,
   GitHubCheckSuiteWebhookPayload,
+  GitHubCheckRunWebhookPayload,
   GitHubWebhookPayload,
   WebhookVerificationResult,
   WebhookSettings,


### PR DESCRIPTION
## Summary

- Wire the existing `PRWatcherService` end-to-end — it existed but was disconnected from the system
- Register `watch-pr` route in the GitHub router
- Add `check_run` webhook handler for fast-path CI status notifications
- Add `watch_pr` tool to Ava chat tools (returns immediately, pushes notification on resolution)
- Initialize `PRWatcherService` singleton in `core.module.ts`
- Wire `pr:watch-resolved` WebSocket events to inject chat messages in `use-chat-session.ts`
- Export `GitHubCheckRunWebhookPayload` from `@protolabsai/types`

## Test plan

- [ ] `watch_pr(N)` returns `{ watching: true, prNumber: N }` immediately
- [ ] When a watched PR's checks complete, a push notification appears in the Ava chat session
- [ ] `check_run` webhook events trigger fast-path resolution for watched PRs
- [ ] Polling fallback works when webhooks are unavailable
- [ ] Watches auto-expire after 30 minutes

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to watch pull requests for background CI monitoring.
  * Automatic chat notifications when CI checks complete, indicating pass or fail status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->