### PR TITLE
Wire providerOptions for context management

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1772735068513-6w511kkim",
-  "startedAt": "2026-03-05T22:38:29.210Z"
+  "featureId": "feature-1772735068516-e9ufgm36p",
+  "startedAt": "2026-03-05T23:22:41.610Z"
 }

--- a/apps/server/src/routes/chat/index.ts
+++ b/apps/server/src/routes/chat/index.ts
@@ -453,13 +453,24 @@ export function createChatRoutes(services: ServiceContainer): Router {
         system: systemPrompt,
         tools,
         stopWhen: stepCountIs(10),
-        ...(extendedThinking && {
-          providerOptions: {
-            anthropic: {
+        providerOptions: {
+          anthropic: {
+            ...(extendedThinking && {
               thinking: { type: 'enabled', budgetTokens: THINKING_BUDGET_TOKENS },
+            }),
+            contextManagement: {
+              edits: [
+                {
+                  type: 'clear_tool_uses_20250919',
+                  trigger: { type: 'input_tokens', value: 80000 },
+                  keep: { type: 'tool_uses', value: 5 },
+                  clearAtLeast: { type: 'input_tokens', value: 10000 },
+                  clearToolInputs: true,
+                },
+              ],
             },
           },
-        }),
+        },
         experimental_telemetry: {
           isEnabled: true,
           metadata: {


### PR DESCRIPTION
## Summary

**Milestone:** Claude API Context Editing

Add `contextManagement` to `providerOptions.anthropic` in the `streamText()` call in the chat route. Enable the `clear_tool_uses_20250919` strategy to automatically clear old tool results server-side when the conversation grows. The AI SDK (`@ai-sdk/anthropic`) automatically adds the required `context-management-2025-06-27` beta header when `contextManagement` is set — no manual header management needed.

The schema (from `@ai-sdk/anthropic/src/anthropi...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved chat request handling with enhanced context management for better processing of tool interactions.
  * Optimized Anthropic provider configuration to conditionally support advanced thinking capabilities.

* **Chores**
  * Updated internal configuration identifiers and timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->