### PR TITLE
Server-side compaction safety net

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1772735068516-e9ufgm36p",
-  "startedAt": "2026-03-05T23:22:41.610Z"
+  "featureId": "feature-1772735068518-9yzihk5vz",
+  "startedAt": "2026-03-05T23:32:09.138Z"
 }

--- a/apps/server/src/routes/chat/index.ts
+++ b/apps/server/src/routes/chat/index.ts
@@ -467,6 +467,10 @@ export function createChatRoutes(services: ServiceContainer): Router {
                   clearAtLeast: { type: 'input_tokens', value: 10000 },
                   clearToolInputs: true,
                 },
+                {
+                  type: 'compact_20260112',
+                  trigger: { type: 'input_tokens', value: 150000 },
+                },
               ],
             },
           },
@@ -522,6 +526,22 @@ export function createChatRoutes(services: ServiceContainer): Router {
                 outputTokens: usage.outputTokens ?? 0,
               },
             } as UIMessageChunk);
+
+            // Detect server-side compaction activation (compact_20260112).
+            // When compaction fires, the Anthropic API includes a compaction block
+            // in the response. The AI SDK surfaces provider-specific data via
+            // providerMetadata — log when this occurs so we can monitor its frequency.
+            try {
+              const meta = await result.providerMetadata;
+              const anthropicMeta = meta?.['anthropic'] as Record<string, unknown> | undefined;
+              if (anthropicMeta && 'compaction' in anthropicMeta) {
+                logger.info(
+                  `Server-side compaction activated (compact_20260112): ${JSON.stringify(anthropicMeta['compaction'])}`
+                );
+              }
+            } catch {
+              // providerMetadata unavailable — not critical, skip
+            }
           } catch {
             logger.warn(`Chat complete: ${Date.now() - requestStartTime}ms (usage unavailable)`);
           }


### PR DESCRIPTION
## Summary

**Milestone:** Claude API Context Editing

Add the `compact_20260112` beta as a final safety net. When the conversation is very long, enable server-side compaction which auto-summarizes older context. The AI SDK (`@ai-sdk/anthropic`) automatically adds the `compact-2026-01-12` beta header.

The schema (from `@ai-sdk/anthropic/src/anthropic-messages-options.ts`):

```ts
providerOptions: {
  anthropic: {
    contextManagement: {
      edits: [
        { type: 'clear_tool_uses_20250919', ... }, // ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal lockfile entries with new identifiers and timestamps.
  * Added server-side detection and logging for compaction events in chat operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->