### PR TITLE
chore: promote staging to main

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -87,6 +87,7 @@ import {
   FeatureScheduler,
   type SchedulerCallbacks,
   type PipelineRunner,
+  type DispatchResult,
 } from './feature-scheduler.js';
 import { ConcurrencyManager } from './auto-mode/concurrency-manager.js';
 import { ensureCleanWorktree } from '../lib/worktree-guard.js';
@@ -310,11 +311,21 @@ export class AutoModeService {
 
     // Initialize FeatureScheduler with callbacks back into this service
     const schedulerRunner: PipelineRunner = {
-      run: async (projectPath: string, featureId: string) => {
+      run: async (projectPath: string, featureId: string): Promise<DispatchResult> => {
         if (!this.leadEngineerService) {
           throw new Error('LeadEngineerService not wired yet — cannot dispatch feature');
         }
-        await this.leadEngineerService.process(projectPath, featureId);
+        const result = await this.leadEngineerService.process(projectPath, featureId);
+        switch (result.outcome) {
+          case 'completed':
+            return { outcome: 'completed' };
+          case 'escalated':
+            return { outcome: 'escalated', errorInfo: classifyError(new Error(result.reason)) };
+          case 'blocked':
+            return { outcome: 'blocked' };
+          case 'needs_retry':
+            return { outcome: 'needs_retry', retryAfterMs: result.retryAfterMs };
+        }
       },
     };
     const schedulerCallbacks: SchedulerCallbacks = {

--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -55,7 +55,7 @@ const SLEEP_INTERVAL_ERROR_MS = 5000;
 
 /** Structured outcome from an auto-loop feature dispatch attempt. */
 export interface DispatchResult {
-  outcome: 'completed' | 'escalated' | 'needs_retry';
+  outcome: 'completed' | 'escalated' | 'blocked' | 'needs_retry';
   retryAfterMs?: number;
   errorInfo?: ReturnType<typeof classifyError>;
 }
@@ -65,7 +65,7 @@ export interface DispatchResult {
  * FeatureScheduler calls run() when it decides a feature should be executed.
  */
 export interface PipelineRunner {
-  run(projectPath: string, featureId: string): Promise<void>;
+  run(projectPath: string, featureId: string): Promise<DispatchResult>;
 }
 
 /**
@@ -394,12 +394,10 @@ export class FeatureScheduler {
           // Start feature execution in background.
           // All features route through the PipelineRunner.
           // Model selection is handled inside IntakeProcessor.
-          const executionPromise = this.runner.run(projectPath, nextFeature.id);
-
-          // Convert the raw execution promise into a structured DispatchResult so all
-          // outcomes — success, escalation, and retryable failures — are handled uniformly.
-          const dispatchResultPromise: Promise<DispatchResult> = executionPromise
-            .then((): DispatchResult => ({ outcome: 'completed' }))
+          // The runner returns a structured DispatchResult so all outcomes —
+          // success, escalation, blocked, and retryable failures — are handled uniformly.
+          const dispatchResultPromise: Promise<DispatchResult> = this.runner
+            .run(projectPath, nextFeature.id)
             .catch((error: unknown): DispatchResult => {
               const errorInfo = classifyError(error);
               if (errorInfo.isRateLimit) {
@@ -434,6 +432,10 @@ export class FeatureScheduler {
                 }
                 break;
               }
+              case 'blocked':
+                projectState.startingFeatures.delete(nextFeature.id);
+                logger.warn(`[AutoLoop] Feature ${nextFeature.id} blocked by pipeline`);
+                break;
               case 'needs_retry': {
                 const delay = result.retryAfterMs ?? SLEEP_INTERVAL_ERROR_MS;
                 logger.info(


### PR DESCRIPTION
## Summary
- fix: propagate PipelineResult outcome through FeatureScheduler (#1881)
  - Adds `blocked` to `DispatchResult.outcome` union type
  - Changes `PipelineRunner.run()` from `Promise<void>` to `Promise<DispatchResult>`
  - Updates auto-mode-service runner to map `PipelineResult` → `DispatchResult`
  - Adds `blocked` case handler in FeatureScheduler switch

## Test plan
- [x] Build passes
- [x] Tests pass
- [x] Merged to staging and verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved execution flow management with explicit outcome reporting. The system now supports a new blocked state alongside completion, escalation, and retry scenarios. Enhanced error classification and improved flow control provide better handling of different execution outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->