### PR TITLE
Bug: Project creation pipeline missing milestone persistence step

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 95410,
-  "featureId": "feature-1772773978727-bjkih9du1",
-  "startedAt": "2026-03-06T21:20:04.513Z"
+  "featureId": "feature-1772745104661-py3thfpj1",
+  "startedAt": "2026-03-06T21:17:52.115Z"
 }

--- a/apps/server/src/routes/projects/lifecycle/index.ts
+++ b/apps/server/src/routes/projects/lifecycle/index.ts
@@ -15,6 +15,7 @@ import { createApprovePrdHandler } from './approve-prd.js';
 import { createLaunchHandler } from './launch.js';
 import { createStatusHandler } from './status.js';
 import { createRequestChangesHandler } from './request-changes.js';
+import { createSaveMilestonesHandler } from './save-milestones.js';
 import type { EventEmitter } from '../../../lib/events.js';
 
 export function createLifecycleRoutes(
@@ -63,6 +64,13 @@ export function createLifecycleRoutes(
     validatePathParams('projectPath'),
     validateSlugs('projectSlug'),
     createRequestChangesHandler(projectService, events)
+  );
+
+  router.post(
+    '/save-milestones',
+    validatePathParams('projectPath'),
+    validateSlugs('projectSlug'),
+    createSaveMilestonesHandler(lifecycleService)
   );
 
   return router;

--- a/apps/server/src/routes/projects/lifecycle/save-milestones.ts
+++ b/apps/server/src/routes/projects/lifecycle/save-milestones.ts
@@ -1,0 +1,50 @@
+/**
+ * POST /lifecycle/save-milestones - Save structured milestone data to a project
+ *
+ * This is the missing seam between PM agent PRD output and approve_project.
+ * After the PM agent generates a PRD, call this to persist structured milestones
+ * so that approve_project_prd can find them.
+ */
+
+import type { Request, Response } from 'express';
+import type { ProjectLifecycleService } from '../../../services/project-lifecycle-service.js';
+import { getErrorMessage, logError } from '../common.js';
+
+export function createSaveMilestonesHandler(lifecycleService: ProjectLifecycleService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, projectSlug, milestones } = req.body as {
+        projectPath: string;
+        projectSlug: string;
+        milestones: unknown[];
+      };
+
+      if (!projectPath || !projectSlug) {
+        res.status(400).json({ success: false, error: 'projectPath and projectSlug are required' });
+        return;
+      }
+
+      if (!Array.isArray(milestones) || milestones.length === 0) {
+        res.status(400).json({ success: false, error: 'milestones must be a non-empty array' });
+        return;
+      }
+
+      const project = await lifecycleService.saveMilestones(
+        projectPath,
+        projectSlug,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        milestones as any
+      );
+
+      res.json({
+        success: true,
+        projectSlug: project.slug,
+        milestonesCount: project.milestones.length,
+        status: project.status,
+      });
+    } catch (error) {
+      logError(error, 'Save milestones failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/apps/server/src/services/project-lifecycle-service.ts
+++ b/apps/server/src/services/project-lifecycle-service.ts
@@ -10,6 +10,8 @@ import type {
   LifecycleApproveResult,
   LifecycleLaunchResult,
   LifecycleStatus,
+  Milestone,
+  Project,
   ProjectLifecyclePhase,
 } from '@protolabsai/types';
 import { createLogger, slugify } from '@protolabsai/utils';
@@ -62,6 +64,21 @@ export class ProjectLifecycleService {
       localSlug,
       hasDuplicates: false,
     };
+  }
+
+  /**
+   * Save structured milestone data parsed from PM agent PRD output.
+   *
+   * This bridges the gap between PM agent PRD generation and approve_project.
+   * Call this after the PM agent drafts the PRD to persist milestones so
+   * approve_project_prd can find them.
+   */
+  async saveMilestones(
+    projectPath: string,
+    projectSlug: string,
+    milestones: Milestone[]
+  ): Promise<Project> {
+    return this.projectService.saveProjectMilestones(projectPath, projectSlug, milestones);
   }
 
   /**

--- a/apps/server/src/services/project-service.ts
+++ b/apps/server/src/services/project-service.ts
@@ -9,6 +9,7 @@ import path from 'path';
 import type {
   Project,
   Feature,
+  Milestone,
   CreateProjectInput,
   UpdateProjectInput,
   CreateFeaturesFromProjectOptions,
@@ -168,6 +169,81 @@ export class ProjectService {
       priority: 'high',
       color: '#ef4444',
     });
+  }
+
+  /**
+   * Save structured milestone data to a project.
+   *
+   * This is the missing seam between the PM agent's PRD output and approve_project.
+   * After the PM agent drafts a PRD, call this to persist the structured milestones
+   * so that approve_project can find them.
+   */
+  async saveProjectMilestones(
+    projectPath: string,
+    projectSlug: string,
+    milestones: Milestone[]
+  ): Promise<Project> {
+    const project = await this.getProject(projectPath, projectSlug);
+    if (!project) {
+      throw new Error(`Project "${projectSlug}" not found`);
+    }
+
+    // Update project with new milestones and advance status to 'reviewing'
+    const updated: Project = {
+      ...project,
+      milestones,
+      status:
+        project.status === 'active' || project.status === 'scaffolded'
+          ? project.status
+          : 'reviewing',
+      updatedAt: new Date().toISOString(),
+    };
+
+    // Write updated project.json
+    const jsonPath = getProjectJsonPath(projectPath, projectSlug);
+    await secureFs.writeFile(jsonPath, JSON.stringify(updated, null, 2));
+
+    // Write project.md
+    const mdPath = getProjectFilePath(projectPath, projectSlug);
+    await secureFs.writeFile(mdPath, generateProjectMarkdown(updated));
+
+    // Write milestone directories and files
+    for (const milestone of milestones) {
+      await ensureMilestoneDir(projectPath, projectSlug, milestone.slug);
+
+      // Write milestone.md
+      const milestoneMdPath = getMilestoneFilePath(projectPath, projectSlug, milestone.slug);
+      await secureFs.writeFile(milestoneMdPath, generateMilestoneMarkdown(milestone, updated));
+
+      // Write phase files
+      for (let i = 0; i < milestone.phases.length; i++) {
+        const phase = milestone.phases[i];
+        const phaseFilename = `phase-${String(i + 1).padStart(2, '0')}-${slugify(phase.title, 30)}.md`;
+        const phasePath = path.join(
+          getMilestoneDir(projectPath, projectSlug, milestone.slug),
+          phaseFilename
+        );
+        await secureFs.writeFile(phasePath, generatePhaseMarkdown(phase, milestone, updated));
+      }
+    }
+
+    // Sync milestone target dates to calendar events
+    if (this.calendarService && milestones) {
+      for (const milestone of milestones) {
+        if (milestone.targetDate) {
+          const sourceId = `project:${projectSlug}/milestone:${slugify(milestone.title)}`;
+          await this.calendarService.upsertBySourceId(projectPath, sourceId, {
+            title: `${milestone.title} (${updated.title})`,
+            date: milestone.targetDate,
+            type: 'milestone',
+            description: milestone.description,
+          });
+        }
+      }
+    }
+
+    logger.info(`Saved ${milestones.length} milestones for project: ${projectSlug}`);
+    return updated;
   }
 
   /**

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1159,6 +1159,13 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         additionalContext: args.additionalContext,
       });
 
+    case 'save_project_milestones':
+      return apiCall('/projects/lifecycle/save-milestones', {
+        projectPath: args.projectPath,
+        projectSlug: args.projectSlug,
+        milestones: args.milestones,
+      });
+
     case 'approve_project_prd':
       return apiCall('/projects/lifecycle/approve-prd', {
         projectPath: args.projectPath,

--- a/packages/mcp-server/src/tools/project-tools.ts
+++ b/packages/mcp-server/src/tools/project-tools.ts
@@ -292,6 +292,73 @@ export const projectTools: Tool[] = [
     },
   },
   {
+    name: 'save_project_milestones',
+    description:
+      'Save structured milestone/phase data to a project. This bridges the gap between PM agent PRD output and approve_project_prd. ' +
+      'Call this after the PM agent generates a PRD to persist the structured milestones. ' +
+      'Pipeline: initiate_project → PM agent drafts PRD → save_project_milestones → approve_project_prd → launch_project',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        projectSlug: {
+          type: 'string',
+          description: 'Project slug',
+        },
+        milestones: {
+          type: 'array',
+          description: 'Structured milestone and phase data parsed from PM agent PRD output',
+          items: {
+            type: 'object',
+            properties: {
+              number: { type: 'number', description: 'Milestone number (1-based)' },
+              slug: { type: 'string', description: 'Milestone slug' },
+              title: { type: 'string', description: 'Milestone title' },
+              description: { type: 'string', description: 'Milestone description' },
+              status: {
+                type: 'string',
+                enum: ['stub', 'planning', 'planned', 'pending', 'in-progress', 'completed'],
+                description: 'Milestone status (default: planned)',
+              },
+              targetDate: { type: 'string', description: 'Target date (YYYY-MM-DD)' },
+              dependencies: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'Dependent milestone slugs',
+              },
+              phases: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    number: { type: 'number', description: 'Phase number (1-based)' },
+                    name: { type: 'string', description: 'Phase slug/name' },
+                    title: { type: 'string', description: 'Phase title' },
+                    description: { type: 'string', description: 'Phase description' },
+                    complexity: {
+                      type: 'string',
+                      enum: ['small', 'medium', 'large'],
+                      description: 'Complexity estimate',
+                    },
+                    filesToModify: { type: 'array', items: { type: 'string' } },
+                    acceptanceCriteria: { type: 'array', items: { type: 'string' } },
+                    dependencies: { type: 'array', items: { type: 'string' } },
+                  },
+                  required: ['number', 'name', 'title', 'description'],
+                },
+              },
+            },
+            required: ['number', 'slug', 'title', 'description', 'phases'],
+          },
+        },
+      },
+      required: ['projectPath', 'projectSlug', 'milestones'],
+    },
+  },
+  {
     name: 'approve_project_prd',
     description:
       'Approve the PRD and create board features from project milestones. Call after the project has a PRD and milestones defined.',


### PR DESCRIPTION
## Summary

## Root Cause

`approve_project` reads structured milestone data from `.automaker/projects/{slug}/milestones/` (JSON files). The PM agent generates a PRD as markdown text which gets written to `spec.md`. There is no tool or step that parses the PM agent's PRD output and persists it as structured milestone/phase records into the project data files.

The pipeline has a broken seam:

```
create_project_plan → pm agent drafts PRD (markdown) → ❌ missing step → approve_project
```

`approve_project` f...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save and manage project milestones with structured phases.
  * Milestones include numbers, slugs, titles, descriptions, status, target dates, dependencies, and phase details.
  * New API endpoint and tool action to submit milestone data programmatically.
  * Automatic sync of milestone target dates to configured calendar services.
  * Automatic creation/update of milestone documentation and project status when milestones are saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->