### PR TITLE
Add update_project tool to Ava UI chat surface

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 95410,
-  "featureId": "feature-1772830526455-nw8zjiefj",
-  "startedAt": "2026-03-06T21:24:58.353Z"
+  "featureId": "feature-1772773978727-bjkih9du1",
+  "startedAt": "2026-03-06T21:20:04.513Z"
 }

--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -113,7 +113,7 @@ export interface AvaToolsConfig {
   agentControl?: boolean;
   /** Enable auto-mode tools (get_auto_mode_status, start_auto_mode, stop_auto_mode) */
   autoMode?: boolean;
-  /** Enable project management tools (get_project_spec, update_project_spec) */
+  /** Enable project management tools (get_project_spec, update_project_spec, update_project) */
   projectMgmt?: boolean;
   /** Enable orchestration tools (get_execution_order, set_feature_dependencies) */
   orchestration?: boolean;
@@ -588,6 +588,48 @@ export function buildAvaTools(
         await fs.mkdir(specDir, { recursive: true });
         await fs.writeFile(specPath, content, 'utf-8');
         return { success: true, path: specPath };
+      },
+    });
+
+    tools['update_project'] = makeTool({
+      description:
+        'Update a project plan. Can update title, goal, or status (e.g. mark as completed).',
+      inputSchema: z.object({
+        projectSlug: z.string().describe('The project slug to update'),
+        title: z.string().optional().describe('New title (optional)'),
+        goal: z.string().optional().describe('New goal (optional)'),
+        status: z
+          .enum([
+            'ongoing',
+            'researching',
+            'drafting',
+            'reviewing',
+            'approved',
+            'scaffolded',
+            'active',
+            'completed',
+          ])
+          .optional()
+          .describe('New status (optional)'),
+      }),
+      execute: async ({ projectSlug, title, goal, status }) => {
+        if (!services.projectService) {
+          return { error: 'Project service not available' };
+        }
+        const updated = await services.projectService.updateProject(projectPath, projectSlug, {
+          ...(title !== undefined && { title }),
+          ...(goal !== undefined && { goal }),
+          ...(status !== undefined && { status }),
+        });
+        if (!updated) {
+          return { error: `Project "${projectSlug}" not found` };
+        }
+        return {
+          slug: updated.slug,
+          title: updated.title,
+          goal: updated.goal,
+          status: updated.status,
+        };
       },
     });
   }

--- a/apps/server/src/routes/chat/tool-compaction.ts
+++ b/apps/server/src/routes/chat/tool-compaction.ts
@@ -222,6 +222,8 @@ export function compactToolResult(toolName: string, result: unknown): unknown {
       return truncateTextField(result, 'content');
     case 'update_project_spec':
       return result;
+    case 'update_project':
+      return result;
 
     // orchestration
     case 'get_execution_order':


### PR DESCRIPTION
## Summary

The `update_project` tool is missing from the Ava UI chat surface tool registry. It's available in the MCP server but not exposed via the UI chat route.

**Problem:** Ava cannot update project status (e.g. mark as `completed`) from the UI chat surface. Attempting to call `update_project` returns: 'Model tried to call unavailable tool.'

**Required:** Add `update_project` to the UI surface tool group — likely under `projectMgmt` alongside `get_project_spec` and `update_project_spec`. Wire it thro...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `update_project` tool to manage project information, including title, goal, and status options (ongoing, researching, drafting, reviewing, approved, scaffolded, active, or completed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->