### PR TITLE
Bug: Project creation pipeline missing milestone persistence step

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,0 @@
-{
-  "pid": 42731,
-  "featureId": "feature-1772745104661-py3thfpj1",
-  "startedAt": "2026-03-07T02:31:01.883Z"
-}


### PR DESCRIPTION
## Summary

## Root Cause

`approve_project` reads structured milestone data from `.automaker/projects/{slug}/milestones/` (JSON files). The PM agent generates a PRD as markdown text which gets written to `spec.md`. There is no tool or step that parses the PM agent's PRD output and persists it as structured milestone/phase records into the project data files.

The pipeline has a broken seam:

```
create_project_plan → pm agent drafts PRD (markdown) → ❌ missing step → approve_project
```

`approve_project` f...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed lock file metadata to reset internal state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->