### PR TITLE
Artifact storage service + ceremony report persistence

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
-  "pid": 78565,
-  "featureId": "feature-1772867039241-zwrbo1c8k",
-  "startedAt": "2026-03-07T08:00:43.171Z"
+  "pid": 2020,
+  "featureId": "feature-1772863574155-y1w3b6382",
+  "startedAt": "2026-03-07T08:22:26.725Z"
 }

--- a/apps/server/src/services/ceremony-service.ts
+++ b/apps/server/src/services/ceremony-service.ts
@@ -25,6 +25,7 @@ import type { MetricsService } from './metrics-service.js';
 import type { CeremonyAuditLogService } from './ceremony-audit-service.js';
 import type { SchedulerService } from './scheduler-service.js';
 import { transition } from './ceremony-state-machine.js';
+import { projectArtifactService } from './project-artifact-service.js';
 
 const logger = createLogger('CeremonyService');
 
@@ -552,6 +553,23 @@ export class CeremonyService {
         discordChannelId,
       });
       await flow.invoke({});
+
+      // Persist ceremony report artifact
+      void projectArtifactService
+        .saveArtifact(projectPath, projectSlug, 'ceremony-report', {
+          ceremonyType: 'milestone_retro',
+          milestoneSlug,
+          milestoneTitle,
+          milestoneNumber,
+          projectTitle,
+          completedAt: new Date().toISOString(),
+        })
+        .catch((err) => {
+          logger.warn(
+            `Failed to save milestone retro artifact for ${projectSlug}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        });
+
       this.auditLog?.record({
         id: correlationId,
         timestamp: new Date().toISOString(),
@@ -664,6 +682,24 @@ export class CeremonyService {
         discordChannelId,
       });
       await flow.invoke({});
+
+      // Persist ceremony report artifact
+      void projectArtifactService
+        .saveArtifact(projectPath, projectSlug, 'ceremony-report', {
+          ceremonyType: 'project_retro',
+          projectTitle,
+          totalMilestones: payload.totalMilestones,
+          totalFeatures: payload.totalFeatures,
+          totalCostUsd: payload.totalCostUsd,
+          failureCount: payload.failureCount,
+          milestoneSummaries: payload.milestoneSummaries,
+          completedAt: new Date().toISOString(),
+        })
+        .catch((err) => {
+          logger.warn(
+            `Failed to save project retro artifact for ${projectSlug}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        });
 
       this.reflectionCount++;
       this.lastReflection = {

--- a/apps/server/src/services/project-artifact-service.ts
+++ b/apps/server/src/services/project-artifact-service.ts
@@ -1,0 +1,123 @@
+/**
+ * ProjectArtifactService — persist and retrieve project artifacts.
+ *
+ * Artifacts are stored at:
+ *   {projectPath}/.automaker/projects/{slug}/artifacts/{type}/{id}.json
+ *
+ * Each file stores a ProjectArtifact (id, type, timestamp, content).
+ *
+ * An index file is maintained at:
+ *   {projectPath}/.automaker/projects/{slug}/artifacts/index.json
+ */
+
+import path from 'path';
+import fs from 'fs';
+import { createLogger } from '@protolabsai/utils';
+import { getProjectDir } from '@protolabsai/platform';
+import type {
+  ArtifactType,
+  ArtifactIndexEntry,
+  ArtifactIndex,
+  ProjectArtifact,
+} from '@protolabsai/types';
+
+const logger = createLogger('ProjectArtifactService');
+
+const ARTIFACTS_DIR = 'artifacts';
+const INDEX_FILE = 'index.json';
+
+function getArtifactsDir(projectPath: string, slug: string): string {
+  return path.join(getProjectDir(projectPath, slug), ARTIFACTS_DIR);
+}
+
+function getIndexPath(projectPath: string, slug: string): string {
+  return path.join(getArtifactsDir(projectPath, slug), INDEX_FILE);
+}
+
+export class ProjectArtifactService {
+  /**
+   * Save an artifact to disk and update the index.
+   *
+   * @returns The artifact ID (used for retrieval via getArtifact)
+   */
+  async saveArtifact(
+    projectPath: string,
+    slug: string,
+    type: ArtifactType,
+    content: unknown
+  ): Promise<string> {
+    const timestamp = new Date().toISOString();
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const filename = `${id}.json`;
+
+    const artifactsDir = getArtifactsDir(projectPath, slug);
+    const typeDir = path.join(artifactsDir, type);
+    const artifactFile = path.join(typeDir, filename);
+
+    // Ensure type directory exists (also creates artifacts dir)
+    await fs.promises.mkdir(typeDir, { recursive: true });
+
+    // Write artifact record
+    const artifact: ProjectArtifact = { id, type, timestamp, content };
+    await fs.promises.writeFile(artifactFile, JSON.stringify(artifact, null, 2), 'utf-8');
+
+    // Update index
+    const indexPath = getIndexPath(projectPath, slug);
+    const index = await this._readIndex(indexPath);
+    const entry: ArtifactIndexEntry = { id, type, timestamp, filename };
+    index.entries.push(entry);
+    await fs.promises.writeFile(indexPath, JSON.stringify(index, null, 2), 'utf-8');
+
+    logger.debug(`Saved artifact ${id} (type=${type}) for project ${slug}`);
+    return id;
+  }
+
+  /**
+   * List artifact index entries for a project, optionally filtered by type.
+   */
+  async listArtifacts(
+    projectPath: string,
+    slug: string,
+    type?: ArtifactType
+  ): Promise<ArtifactIndexEntry[]> {
+    const indexPath = getIndexPath(projectPath, slug);
+    const index = await this._readIndex(indexPath);
+    if (type) {
+      return index.entries.filter((e: ArtifactIndexEntry) => e.type === type);
+    }
+    return index.entries;
+  }
+
+  /**
+   * Retrieve the full content of an artifact by ID.
+   *
+   * @throws if the artifact is not found in the index or file is missing
+   */
+  async getArtifact(projectPath: string, slug: string, artifactId: string): Promise<unknown> {
+    const indexPath = getIndexPath(projectPath, slug);
+    const index = await this._readIndex(indexPath);
+    const entry = index.entries.find((e: ArtifactIndexEntry) => e.id === artifactId);
+    if (!entry) {
+      throw new Error(`Artifact not found: ${artifactId} (project=${slug})`);
+    }
+    const artifactFile = path.join(getArtifactsDir(projectPath, slug), entry.type, entry.filename);
+    const raw = await fs.promises.readFile(artifactFile, 'utf-8');
+    const artifact = JSON.parse(raw) as ProjectArtifact;
+    return artifact.content;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private async _readIndex(indexPath: string): Promise<ArtifactIndex> {
+    try {
+      const raw = await fs.promises.readFile(indexPath, 'utf-8');
+      return JSON.parse(raw) as ArtifactIndex;
+    } catch {
+      return { version: 1, entries: [] };
+    }
+  }
+}
+
+export const projectArtifactService = new ProjectArtifactService();

--- a/apps/server/tests/unit/services/project-artifact-service.test.ts
+++ b/apps/server/tests/unit/services/project-artifact-service.test.ts
@@ -1,0 +1,207 @@
+/**
+ * ProjectArtifactService Unit Tests
+ *
+ * Tests:
+ * 1. saveArtifact writes to .automaker/projects/{slug}/artifacts/{type}/{id}.json
+ * 2. saveArtifact updates the index file
+ * 3. listArtifacts returns all index entries
+ * 4. listArtifacts filtered by type returns correct entries
+ * 5. getArtifact returns full content
+ * 6. getArtifact throws for unknown artifact ID
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@protolabsai/utils', async () => {
+  const actual = await vi.importActual('@protolabsai/utils');
+  return {
+    ...actual,
+    createLogger: vi.fn(() => ({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
+  };
+});
+
+vi.mock('@protolabsai/platform', () => ({
+  getProjectDir: vi.fn((projectPath: string, slug: string) =>
+    path.join(projectPath, '.automaker', 'projects', slug)
+  ),
+}));
+
+import { ProjectArtifactService } from '../../../src/services/project-artifact-service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+describe('ProjectArtifactService', () => {
+  let service: ProjectArtifactService;
+  let tmpDir: string;
+  const slug = 'test-project';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-svc-'));
+    service = new ProjectArtifactService();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // saveArtifact
+  // -------------------------------------------------------------------------
+
+  describe('saveArtifact()', () => {
+    it('writes artifact file to artifacts/{type}/{id}.json', async () => {
+      const content = { summary: 'All done', score: 100 };
+      const id = await service.saveArtifact(tmpDir, slug, 'ceremony-report', content);
+
+      const artifactsBase = path.join(tmpDir, '.automaker', 'projects', slug, 'artifacts');
+      const typeDir = path.join(artifactsBase, 'ceremony-report');
+      const files = fs.readdirSync(typeDir);
+      expect(files).toHaveLength(1);
+      expect(files[0]).toBe(`${id}.json`);
+
+      const written = JSON.parse(
+        fs.readFileSync(path.join(typeDir, `${id}.json`), 'utf-8')
+      ) as typeof content;
+      expect(written).toEqual(content);
+    });
+
+    it('creates the index file on first save', async () => {
+      await service.saveArtifact(tmpDir, slug, 'standup', { message: 'hello' });
+
+      const indexPath = path.join(
+        tmpDir,
+        '.automaker',
+        'projects',
+        slug,
+        'artifacts',
+        'index.json'
+      );
+      expect(fs.existsSync(indexPath)).toBe(true);
+
+      const index = JSON.parse(fs.readFileSync(indexPath, 'utf-8')) as {
+        version: number;
+        entries: unknown[];
+      };
+      expect(index.version).toBe(1);
+      expect(index.entries).toHaveLength(1);
+    });
+
+    it('appends to the index on subsequent saves', async () => {
+      await service.saveArtifact(tmpDir, slug, 'ceremony-report', { a: 1 });
+      await service.saveArtifact(tmpDir, slug, 'standup', { b: 2 });
+      await service.saveArtifact(tmpDir, slug, 'escalation', { c: 3 });
+
+      const indexPath = path.join(
+        tmpDir,
+        '.automaker',
+        'projects',
+        slug,
+        'artifacts',
+        'index.json'
+      );
+      const index = JSON.parse(fs.readFileSync(indexPath, 'utf-8')) as {
+        version: number;
+        entries: Array<{ type: string }>;
+      };
+      expect(index.entries).toHaveLength(3);
+      expect(index.entries.map((e) => e.type)).toEqual([
+        'ceremony-report',
+        'standup',
+        'escalation',
+      ]);
+    });
+
+    it('returns the artifact ID', async () => {
+      const id = await service.saveArtifact(tmpDir, slug, 'changelog', { log: [] });
+      expect(typeof id).toBe('string');
+      expect(id.length).toBeGreaterThan(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // listArtifacts
+  // -------------------------------------------------------------------------
+
+  describe('listArtifacts()', () => {
+    it('returns empty array when no artifacts exist', async () => {
+      const entries = await service.listArtifacts(tmpDir, slug);
+      expect(entries).toEqual([]);
+    });
+
+    it('returns all entries when no type filter', async () => {
+      await service.saveArtifact(tmpDir, slug, 'ceremony-report', { a: 1 });
+      await service.saveArtifact(tmpDir, slug, 'standup', { b: 2 });
+
+      const entries = await service.listArtifacts(tmpDir, slug);
+      expect(entries).toHaveLength(2);
+    });
+
+    it('filters by type when type is provided', async () => {
+      await service.saveArtifact(tmpDir, slug, 'ceremony-report', { a: 1 });
+      await service.saveArtifact(tmpDir, slug, 'standup', { b: 2 });
+      await service.saveArtifact(tmpDir, slug, 'ceremony-report', { c: 3 });
+
+      const entries = await service.listArtifacts(tmpDir, slug, 'ceremony-report');
+      expect(entries).toHaveLength(2);
+      expect(entries.every((e) => e.type === 'ceremony-report')).toBe(true);
+    });
+
+    it('index entries have correct shape', async () => {
+      await service.saveArtifact(tmpDir, slug, 'escalation', { urgent: true });
+
+      const entries = await service.listArtifacts(tmpDir, slug, 'escalation');
+      expect(entries).toHaveLength(1);
+      const [entry] = entries;
+      expect(entry).toMatchObject({
+        type: 'escalation',
+        filePath: expect.stringContaining('escalation'),
+        createdAt: expect.any(String),
+        id: expect.any(String),
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getArtifact
+  // -------------------------------------------------------------------------
+
+  describe('getArtifact()', () => {
+    it('returns the full content of a saved artifact', async () => {
+      const content = { summary: 'Retro done', lessons: ['Ship faster'] };
+      const id = await service.saveArtifact(tmpDir, slug, 'ceremony-report', content);
+
+      const retrieved = await service.getArtifact(tmpDir, slug, id);
+      expect(retrieved).toEqual(content);
+    });
+
+    it('throws when artifact ID is not in the index', async () => {
+      await expect(service.getArtifact(tmpDir, slug, 'nonexistent-id')).rejects.toThrow(
+        'Artifact not found'
+      );
+    });
+
+    it('can retrieve multiple artifacts independently', async () => {
+      const c1 = { step: 1 };
+      const c2 = { step: 2 };
+      const id1 = await service.saveArtifact(tmpDir, slug, 'standup', c1);
+      const id2 = await service.saveArtifact(tmpDir, slug, 'standup', c2);
+
+      expect(await service.getArtifact(tmpDir, slug, id1)).toEqual(c1);
+      expect(await service.getArtifact(tmpDir, slug, id2)).toEqual(c2);
+    });
+  });
+});

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -149,6 +149,10 @@ export type {
   LifecycleStatus,
   LifecycleCollectResult,
   ProjectStats,
+  ArtifactType,
+  ArtifactIndexEntry,
+  ArtifactIndex,
+  ProjectArtifact,
 } from './project.js';
 
 // Calendar types

--- a/libs/types/src/project.ts
+++ b/libs/types/src/project.ts
@@ -620,6 +620,53 @@ export interface ProjectStats {
 }
 
 /**
+ * Artifact type — categories of persisted project artifacts
+ */
+export type ArtifactType = 'ceremony-report' | 'changelog' | 'escalation' | 'standup';
+
+/**
+ * A single entry in the artifact index
+ */
+export interface ArtifactIndexEntry {
+  /** Unique artifact ID */
+  id: string;
+
+  /** Artifact type */
+  type: ArtifactType;
+
+  /** ISO 8601 creation timestamp */
+  timestamp: string;
+
+  /** Filename within the type directory (e.g. "1700000000000.json") */
+  filename: string;
+}
+
+/**
+ * Artifact index file (.automaker/projects/{slug}/artifacts/index.json)
+ */
+export interface ArtifactIndex {
+  version: 1;
+  entries: ArtifactIndexEntry[];
+}
+
+/**
+ * Full artifact record as stored on disk
+ */
+export interface ProjectArtifact {
+  /** Unique artifact ID */
+  id: string;
+
+  /** Artifact type */
+  type: ArtifactType;
+
+  /** ISO 8601 creation timestamp */
+  timestamp: string;
+
+  /** Artifact content payload */
+  content: unknown;
+}
+
+/**
  * Discord channel mapping for a project
  * Stores the association between a project and its Discord channels
  */


### PR DESCRIPTION
## Summary

**Milestone:** Project Artifact Persistence

TDD phase. Create apps/server/src/services/project-artifact-service.ts. Write unit tests first: (1) saveArtifact(projectPath, slug, type, content) writes to .automaker/projects/{slug}/artifacts/{type}/{timestamp}.json and updates the index. (2) listArtifacts(projectPath, slug, type?) returns index entries. (3) getArtifact(projectPath, slug, artifactId) returns full content. Types: 'ceremony-report', 'changelog', 'escalation', 'standup'. Then implement...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ceremony reports are now automatically saved and persisted following milestone and project retrospectives without blocking ceremony workflows.
  * Introduced a new artifact management system supporting multiple artifact types—ceremony reports, changelogs, escalations, and standups—with capabilities to save, retrieve, filter, and organize project artifacts for improved documentation and historical tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->