### PR TITLE
Test infrastructure: lint coverage + typed mock factories

### DIFF
--- a/apps/server/eslint.config.mjs
+++ b/apps/server/eslint.config.mjs
@@ -85,7 +85,24 @@ const eslintConfig = defineConfig([
       },
     },
   },
-  globalIgnores(['dist/**', 'node_modules/**', 'tests/**']),
+  // Test-specific overrides: relax rules that are impractical to enforce in test files.
+  {
+    files: ['tests/**/*.ts'],
+    rules: {
+      // Allow `as any` in tests as a warning; typed factories are preferred but
+      // tests need escape hatches for complex mocks that can't be fully typed.
+      '@typescript-eslint/no-explicit-any': 'warn',
+      // Tests legitimately use the generic `Function` type for mock callbacks.
+      '@typescript-eslint/no-unsafe-function-type': 'warn',
+      // Generator functions used as mock async iterators often lack yield.
+      'require-yield': 'warn',
+      // Regex literals with spaces are sometimes intentional in test fixtures.
+      'no-regex-spaces': 'warn',
+      // Tests use @/ path aliases which the n plugin cannot resolve to node_modules.
+      'n/no-extraneous-import': 'off',
+    },
+  },
+  globalIgnores(['dist/**', 'node_modules/**']),
 ]);
 
 export default eslintConfig;

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -15,7 +15,7 @@
     "dev:test": "tsx src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "lint": "eslint src/",
+    "lint": "eslint src/ tests/",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",

--- a/apps/server/tests/helpers/mock-factories.ts
+++ b/apps/server/tests/helpers/mock-factories.ts
@@ -1,0 +1,183 @@
+/**
+ * Typed Mock Factories
+ *
+ * Provides reusable, properly-typed mock objects for unit tests.
+ * Factories return typed Partials with vi.fn() stubs — no `as any` casts required.
+ *
+ * Usage:
+ *   const featureLoader = createMockFeatureLoader();
+ *   featureLoader.getAll.mockResolvedValue([...]);
+ *
+ * All factories accept an optional `overrides` object to customize specific methods.
+ */
+
+import { vi } from 'vitest';
+import type { Feature, EventType, EventCallback, TypedEventCallback } from '@protolabsai/types';
+import type { FeatureLoader } from '../../src/services/feature-loader.js';
+import type { SettingsService } from '../../src/services/settings-service.js';
+import type { ProjectService } from '../../src/services/project-service.js';
+import type { MetricsService } from '../../src/services/metrics-service.js';
+import type { EventEmitter, UnsubscribeFn } from '../../src/lib/events.js';
+
+// ---------------------------------------------------------------------------
+// FeatureLoader
+// ---------------------------------------------------------------------------
+
+export type MockFeatureLoader = {
+  getAll: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+  findByTitle: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  claim: ReturnType<typeof vi.fn>;
+  release: ReturnType<typeof vi.fn>;
+  setEventEmitter: ReturnType<typeof vi.fn>;
+  setIntegrityWatchdog: ReturnType<typeof vi.fn>;
+} & Partial<FeatureLoader>;
+
+export function createMockFeatureLoader(
+  features: Feature[] = [],
+  overrides: Partial<MockFeatureLoader> = {}
+): MockFeatureLoader {
+  return {
+    getAll: vi.fn().mockResolvedValue(features),
+    get: vi.fn().mockImplementation(async (_path: string, id: string) => {
+      return features.find((f) => f.id === id) ?? null;
+    }),
+    findByTitle: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(null),
+    update: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(false),
+    claim: vi.fn().mockResolvedValue(true),
+    release: vi.fn().mockResolvedValue(undefined),
+    setEventEmitter: vi.fn(),
+    setIntegrityWatchdog: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SettingsService
+// ---------------------------------------------------------------------------
+
+export type MockSettingsService = {
+  getProjectSettings: ReturnType<typeof vi.fn>;
+  updateProjectSettings: ReturnType<typeof vi.fn>;
+  getGlobalSettings: ReturnType<typeof vi.fn>;
+  updateGlobalSettings: ReturnType<typeof vi.fn>;
+  hasProjectSettings: ReturnType<typeof vi.fn>;
+} & Partial<SettingsService>;
+
+export function createMockSettingsService(
+  overrides: Partial<MockSettingsService> = {}
+): MockSettingsService {
+  return {
+    getProjectSettings: vi.fn().mockResolvedValue({}),
+    updateProjectSettings: vi.fn().mockResolvedValue({}),
+    getGlobalSettings: vi.fn().mockResolvedValue({}),
+    updateGlobalSettings: vi.fn().mockResolvedValue({}),
+    hasProjectSettings: vi.fn().mockResolvedValue(false),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ProjectService
+// ---------------------------------------------------------------------------
+
+export type MockProjectService = {
+  getProject: ReturnType<typeof vi.fn>;
+  updateProject: ReturnType<typeof vi.fn>;
+  listProjects: ReturnType<typeof vi.fn>;
+  createProject: ReturnType<typeof vi.fn>;
+  deleteProject: ReturnType<typeof vi.fn>;
+} & Partial<ProjectService>;
+
+export function createMockProjectService(
+  overrides: Partial<MockProjectService> = {}
+): MockProjectService {
+  return {
+    getProject: vi.fn().mockResolvedValue(null),
+    updateProject: vi.fn().mockResolvedValue(undefined),
+    listProjects: vi.fn().mockResolvedValue([]),
+    createProject: vi.fn().mockResolvedValue(null),
+    deleteProject: vi.fn().mockResolvedValue(false),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MetricsService
+// ---------------------------------------------------------------------------
+
+export type MockMetricsService = {
+  getProjectMetrics: ReturnType<typeof vi.fn>;
+  getCapacityMetrics: ReturnType<typeof vi.fn>;
+  generateImpactReport: ReturnType<typeof vi.fn>;
+} & Partial<MetricsService>;
+
+export function createMockMetricsService(
+  overrides: Partial<MockMetricsService> = {}
+): MockMetricsService {
+  return {
+    getProjectMetrics: vi.fn().mockResolvedValue({}),
+    getCapacityMetrics: vi.fn().mockResolvedValue({}),
+    generateImpactReport: vi.fn().mockResolvedValue(''),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// EventEmitter
+// ---------------------------------------------------------------------------
+
+export type MockEventEmitter = EventEmitter & {
+  emit: ReturnType<typeof vi.fn>;
+  subscribe: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+  /** Fire a raw event to all subscribers (test helper) */
+  _fire(type: EventType, payload: unknown): void;
+};
+
+export function createMockEventEmitter(
+  overrides: Partial<MockEventEmitter> = {}
+): MockEventEmitter {
+  const subscribers: Array<EventCallback> = [];
+
+  function makeUnsub(fn: () => void): UnsubscribeFn {
+    const unsub = fn as UnsubscribeFn;
+    unsub.unsubscribe = fn;
+    return unsub;
+  }
+
+  function dispatch(type: EventType, payload: unknown): void {
+    for (const cb of subscribers) cb(type, payload);
+  }
+
+  const emitter: MockEventEmitter = {
+    // emit is both a spy AND actually dispatches to subscribers,
+    // so tests can trigger service handlers via emit() and also assert on calls.
+    emit: vi.fn((type: EventType, payload: unknown) => {
+      dispatch(type, payload);
+    }),
+    subscribe: vi.fn((cb: EventCallback) => {
+      subscribers.push(cb);
+      return makeUnsub(() => {
+        const idx = subscribers.indexOf(cb);
+        if (idx >= 0) subscribers.splice(idx, 1);
+      });
+    }),
+    on: vi.fn((_type: EventType, _cb: TypedEventCallback<EventType>) => {
+      return makeUnsub(() => {});
+    }),
+    // _fire is an alias for dispatch — useful when you want to inject events
+    // without adding a spy call to emit's history.
+    _fire(type: EventType, payload: unknown) {
+      dispatch(type, payload);
+    },
+    ...overrides,
+  };
+
+  return emitter;
+}

--- a/apps/server/tests/unit/services/archival-service.test.ts
+++ b/apps/server/tests/unit/services/archival-service.test.ts
@@ -11,7 +11,12 @@ import { ArchivalService } from '@/services/archival-service.js';
 import type { FeatureLoader } from '@/services/feature-loader.js';
 import type { LedgerService } from '@/services/ledger-service.js';
 import type { SettingsService } from '@/services/settings-service.js';
-import type { EventEmitter } from '@/lib/events.js';
+import {
+  createMockEventEmitter,
+  createMockSettingsService,
+  type MockEventEmitter,
+  type MockSettingsService,
+} from '../../helpers/mock-factories.js';
 
 describe('ArchivalService', () => {
   let archivalService: ArchivalService;
@@ -20,12 +25,8 @@ describe('ArchivalService', () => {
     archiveFeature: ReturnType<typeof vi.fn>;
   };
   let mockLedgerService: { recordFeatureCompletion: ReturnType<typeof vi.fn> };
-  let mockSettingsService: { getGlobalSettings: ReturnType<typeof vi.fn> };
-  let mockEvents: {
-    emit: ReturnType<typeof vi.fn>;
-    subscribe: ReturnType<typeof vi.fn>;
-    on: ReturnType<typeof vi.fn>;
-  };
+  let mockSettingsService: MockSettingsService;
+  let mockEvents: MockEventEmitter;
 
   const projectPath = '/test/project';
   const retentionHours = 2;
@@ -49,24 +50,20 @@ describe('ArchivalService', () => {
       recordFeatureCompletion: vi.fn().mockResolvedValue(undefined),
     };
 
-    mockSettingsService = {
+    mockSettingsService = createMockSettingsService({
       getGlobalSettings: vi.fn().mockResolvedValue({
         archival: { enabled: true, retentionHours },
         projects: [{ path: projectPath }],
       }),
-    };
+    });
 
-    mockEvents = {
-      emit: vi.fn(),
-      subscribe: vi.fn(),
-      on: vi.fn(),
-    };
+    mockEvents = createMockEventEmitter();
 
     archivalService = new ArchivalService(
       mockFeatureLoader as unknown as FeatureLoader,
       mockLedgerService as unknown as LedgerService,
       mockSettingsService as unknown as SettingsService,
-      mockEvents as unknown as EventEmitter
+      mockEvents
     );
   });
 

--- a/apps/server/tests/unit/services/calendar-service.test.ts
+++ b/apps/server/tests/unit/services/calendar-service.test.ts
@@ -4,6 +4,7 @@ import type { FeatureLoader } from '@/services/feature-loader.js';
 import * as secureFs from '@/lib/secure-fs.js';
 import { atomicWriteJson, readJsonWithRecovery } from '@protolabsai/utils';
 import type { Feature, CalendarEvent } from '@protolabsai/types';
+import { createMockFeatureLoader } from '../../helpers/mock-factories.js';
 
 // Mock modules
 vi.mock('@/lib/secure-fs.js');
@@ -34,9 +35,7 @@ describe('calendar-service.ts', () => {
     service = CalendarService.getInstance();
 
     // Mock FeatureLoader
-    mockFeatureLoader = {
-      getAll: vi.fn().mockResolvedValue([]),
-    } as unknown as FeatureLoader;
+    mockFeatureLoader = createMockFeatureLoader() as unknown as FeatureLoader;
 
     service.setFeatureLoader(mockFeatureLoader);
 

--- a/apps/server/tests/unit/services/ceremony-service.test.ts
+++ b/apps/server/tests/unit/services/ceremony-service.test.ts
@@ -21,6 +21,12 @@ import type { FeatureLoader } from '../../../src/services/feature-loader.js';
 import type { ProjectService } from '../../../src/services/project-service.js';
 import type { MetricsService } from '../../../src/services/metrics-service.js';
 import type { ProjectSettings } from '@protolabsai/types';
+import {
+  createMockSettingsService,
+  createMockFeatureLoader,
+  createMockProjectService,
+  createMockMetricsService,
+} from '../../helpers/mock-factories.js';
 
 // ---------------------------------------------------------------------------
 // Module mocks — prevent real LLM calls
@@ -37,21 +43,6 @@ vi.mock('@protolabsai/flows', () => ({
 }));
 
 import { createStandupFlow, createRetroFlow, createProjectRetroFlow } from '@protolabsai/flows';
-
-// ---------------------------------------------------------------------------
-// Mock factories
-// ---------------------------------------------------------------------------
-
-const createMockSettingsService = (): SettingsService =>
-  ({ getProjectSettings: vi.fn() }) as unknown as SettingsService;
-
-const createMockFeatureLoader = (): FeatureLoader =>
-  ({ getAll: vi.fn() }) as unknown as FeatureLoader;
-
-const createMockProjectService = (): ProjectService =>
-  ({ getProject: vi.fn() }) as unknown as ProjectService;
-
-const createMockMetricsService = (): MetricsService => ({}) as unknown as MetricsService;
 
 /** Settings with ceremonies enabled and a Discord channel configured. */
 const enabledSettings = (
@@ -93,10 +84,10 @@ describe('CeremonyService', () => {
   beforeEach(() => {
     ceremonyService = new CeremonyService();
     emitter = createEventEmitter();
-    mockSettingsService = createMockSettingsService();
-    mockFeatureLoader = createMockFeatureLoader();
-    mockProjectService = createMockProjectService();
-    mockMetricsService = createMockMetricsService();
+    mockSettingsService = createMockSettingsService() as unknown as SettingsService;
+    mockFeatureLoader = createMockFeatureLoader() as unknown as FeatureLoader;
+    mockProjectService = createMockProjectService() as unknown as ProjectService;
+    mockMetricsService = createMockMetricsService() as unknown as MetricsService;
     vi.clearAllMocks();
   });
 

--- a/apps/server/tests/unit/services/completion-detector-service.test.ts
+++ b/apps/server/tests/unit/services/completion-detector-service.test.ts
@@ -7,29 +7,22 @@
  * Also tests deduplication and the areMilestonePhasesDone guard.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { CompletionDetectorService } from '@/services/completion-detector-service.js';
+import type { FeatureLoader } from '@/services/feature-loader.js';
+import type { ProjectService } from '@/services/project-service.js';
 import type { Feature, Milestone, Project } from '@protolabsai/types';
-import type { EventType } from '@protolabsai/types';
-
-// ────────────────────────── Mocks ──────────────────────────
-
-function createMockEvents() {
-  const subscribers: Array<(type: EventType, payload: unknown) => void> = [];
-  return {
-    emit: vi.fn(),
-    subscribe: vi.fn((cb: (type: EventType, payload: unknown) => void) => {
-      subscribers.push(cb);
-      return () => {
-        const idx = subscribers.indexOf(cb);
-        if (idx >= 0) subscribers.splice(idx, 1);
-      };
-    }),
-    _fire(type: EventType, payload: unknown) {
-      for (const cb of subscribers) cb(type, payload);
-    },
-  };
-}
+import {
+  createMockEventEmitter,
+  createMockFeatureLoader,
+  createMockProjectService,
+  type MockEventEmitter,
+  type MockFeatureLoader,
+  type MockProjectService,
+} from '../../helpers/mock-factories.js';
 
 function createTestFeature(overrides: Partial<Feature> = {}): Feature {
   return {
@@ -54,64 +47,37 @@ function createTestMilestone(overrides: Partial<Milestone> = {}): Milestone {
   };
 }
 
-function createMockFeatureLoader(features: Feature[] = []) {
-  return {
-    getAll: vi.fn().mockResolvedValue(features),
-    get: vi.fn().mockImplementation(async (_path: string, id: string) => {
-      return features.find((f) => f.id === id) || null;
-    }),
-    update: vi.fn().mockResolvedValue(undefined),
-  };
-}
-
-function createMockProjectService(project: Partial<Project> | null = null) {
-  return {
-    getProject: vi.fn().mockResolvedValue(project),
-    updateProject: vi.fn().mockResolvedValue(undefined),
-  };
-}
-
-function createMockSettingsService() {
-  return {
-    getProjectSettings: vi.fn().mockResolvedValue({}),
-  };
-}
-
 // ────────────────────────── Tests ──────────────────────────
 
 describe('CompletionDetectorService', () => {
   let service: CompletionDetectorService;
-  let events: ReturnType<typeof createMockEvents>;
-  let featureLoader: ReturnType<typeof createMockFeatureLoader>;
-  let projectService: ReturnType<typeof createMockProjectService>;
-  let settingsService: ReturnType<typeof createMockSettingsService>;
+  let events: MockEventEmitter;
+  let featureLoader: MockFeatureLoader;
+  let projectService: MockProjectService;
 
   beforeEach(() => {
     service = new CompletionDetectorService();
-    events = createMockEvents();
+    events = createMockEventEmitter();
     featureLoader = createMockFeatureLoader();
     projectService = createMockProjectService();
-    settingsService = createMockSettingsService();
     vi.clearAllMocks();
   });
 
   describe('initialization', () => {
     it('should initialize and subscribe to events', () => {
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
       expect(events.subscribe).toHaveBeenCalledOnce();
     });
 
     it('should cleanup on destroy', () => {
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
       expect(() => service.destroy()).not.toThrow();
     });
@@ -130,10 +96,9 @@ describe('CompletionDetectorService', () => {
 
       featureLoader = createMockFeatureLoader([epic, child1, child2]);
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
 
       // Simulate feature:status-changed for child-2 moving to done
@@ -168,10 +133,9 @@ describe('CompletionDetectorService', () => {
 
       featureLoader = createMockFeatureLoader([epic, child1, child2]);
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
 
       events._fire('feature:status-changed', {
@@ -192,10 +156,9 @@ describe('CompletionDetectorService', () => {
 
       featureLoader = createMockFeatureLoader([epic, child1]);
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
 
       events._fire('feature:status-changed', {
@@ -258,12 +221,11 @@ describe('CompletionDetectorService', () => {
       };
 
       featureLoader = createMockFeatureLoader([feature1, feature2]);
-      projectService = createMockProjectService(project as Project);
+      projectService = createMockProjectService({ getProject: vi.fn().mockResolvedValue(project) });
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
 
       events._fire('feature:status-changed', {
@@ -323,12 +285,11 @@ describe('CompletionDetectorService', () => {
       };
 
       featureLoader = createMockFeatureLoader([feature1]);
-      projectService = createMockProjectService(project as Project);
+      projectService = createMockProjectService({ getProject: vi.fn().mockResolvedValue(project) });
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
 
       events._fire('feature:status-changed', {
@@ -387,12 +348,11 @@ describe('CompletionDetectorService', () => {
       };
 
       featureLoader = createMockFeatureLoader([feature1, feature2]);
-      projectService = createMockProjectService(project as Project);
+      projectService = createMockProjectService({ getProject: vi.fn().mockResolvedValue(project) });
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
 
       events._fire('feature:status-changed', {
@@ -460,12 +420,11 @@ describe('CompletionDetectorService', () => {
       };
 
       featureLoader = createMockFeatureLoader([epic, child]);
-      projectService = createMockProjectService(project as Project);
+      projectService = createMockProjectService({ getProject: vi.fn().mockResolvedValue(project) });
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
 
       events._fire('feature:status-changed', {
@@ -524,12 +483,11 @@ describe('CompletionDetectorService', () => {
       };
 
       featureLoader = createMockFeatureLoader([feature]);
-      projectService = createMockProjectService(project as Project);
+      projectService = createMockProjectService({ getProject: vi.fn().mockResolvedValue(project) });
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
 
       events._fire('feature:status-changed', {
@@ -582,12 +540,11 @@ describe('CompletionDetectorService', () => {
       };
 
       featureLoader = createMockFeatureLoader([feature1]);
-      projectService = createMockProjectService(project as Project);
+      projectService = createMockProjectService({ getProject: vi.fn().mockResolvedValue(project) });
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
 
       // Fire twice
@@ -650,12 +607,11 @@ describe('CompletionDetectorService', () => {
       };
 
       featureLoader = createMockFeatureLoader([feature1]);
-      projectService = createMockProjectService(project as Project);
+      projectService = createMockProjectService({ getProject: vi.fn().mockResolvedValue(project) });
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
 
       events._fire('feature:status-changed', {
@@ -707,12 +663,11 @@ describe('CompletionDetectorService', () => {
       };
 
       featureLoader = createMockFeatureLoader([feature1]);
-      projectService = createMockProjectService(project as Project);
+      projectService = createMockProjectService({ getProject: vi.fn().mockResolvedValue(project) });
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
 
       events._fire('feature:status-changed', {
@@ -745,10 +700,9 @@ describe('CompletionDetectorService', () => {
       const feature1 = createTestFeature({ id: 'f1', status: 'done' });
       featureLoader = createMockFeatureLoader([feature1]);
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
 
       events._fire('auto-mode:event', {
@@ -766,10 +720,9 @@ describe('CompletionDetectorService', () => {
 
     it('should NOT trigger on auto_mode_feature_complete with passes=false', async () => {
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
 
       events._fire('auto-mode:event', {
@@ -807,12 +760,11 @@ describe('CompletionDetectorService', () => {
       };
 
       featureLoader = createMockFeatureLoader([feature1]);
-      projectService = createMockProjectService(project as Project);
+      projectService = createMockProjectService({ getProject: vi.fn().mockResolvedValue(project) });
       service.initialize(
-        events as any,
-        featureLoader as any,
-        projectService as any,
-        settingsService as any
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService
       );
 
       events._fire('feature:status-changed', {
@@ -825,6 +777,158 @@ describe('CompletionDetectorService', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(events.emit).not.toHaveBeenCalledWith('milestone:completed', expect.anything());
+    });
+  });
+
+  // ────────────────────────── Ledger durability ──────────────────────────
+
+  describe('JSONL ledger durability', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'completion-detector-test-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('cold start: creates completion-emitted.jsonl and records entries on completion', async () => {
+      const feature1 = createTestFeature({
+        id: 'f1',
+        status: 'done',
+        projectSlug: 'proj',
+        milestoneSlug: 'ms-1',
+        costUsd: 1.0,
+      });
+
+      const milestone = createTestMilestone({
+        slug: 'ms-1',
+        phases: [
+          {
+            number: 1,
+            name: 'p1',
+            title: 'Phase 1',
+            description: '',
+            featureId: 'f1',
+            complexity: 'small',
+          },
+        ],
+      });
+
+      const project: Partial<Project> = {
+        title: 'Cold Start Project',
+        slug: 'proj',
+        status: 'active',
+        milestones: [milestone],
+      };
+
+      featureLoader = createMockFeatureLoader([feature1]);
+      projectService = createMockProjectService({ getProject: vi.fn().mockResolvedValue(project) });
+      service.initialize(
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService,
+        tmpDir
+      );
+
+      events._fire('feature:status-changed', {
+        projectPath: '/test/path',
+        featureId: 'f1',
+        previousStatus: 'review',
+        newStatus: 'done',
+      });
+
+      // Wait for async cascade + file writes
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      const ledgerPath = path.join(tmpDir, 'ledger', 'completion-emitted.jsonl');
+      expect(fs.existsSync(ledgerPath)).toBe(true);
+
+      const lines = fs
+        .readFileSync(ledgerPath, 'utf-8')
+        .split('\n')
+        .filter((l) => l.trim());
+      expect(lines.length).toBeGreaterThanOrEqual(1);
+
+      const entries = lines.map((l) => JSON.parse(l) as { type: string; key: string });
+      const types = entries.map((e) => e.type);
+      expect(types).toContain('milestone');
+      expect(types).toContain('project');
+    });
+
+    it('warm restart: pre-populates Sets from ledger and suppresses duplicate events', async () => {
+      const feature1 = createTestFeature({
+        id: 'f1',
+        status: 'done',
+        projectSlug: 'proj',
+        milestoneSlug: 'ms-1',
+      });
+
+      const milestone = createTestMilestone({
+        slug: 'ms-1',
+        phases: [
+          {
+            number: 1,
+            name: 'p1',
+            title: 'Phase 1',
+            description: '',
+            featureId: 'f1',
+            complexity: 'small',
+          },
+        ],
+      });
+
+      const project: Partial<Project> = {
+        title: 'Warm Restart Project',
+        slug: 'proj',
+        status: 'active',
+        milestones: [milestone],
+      };
+
+      // Pre-write a ledger that records milestone + project as already emitted
+      const ledgerDir = path.join(tmpDir, 'ledger');
+      fs.mkdirSync(ledgerDir, { recursive: true });
+      const ledgerPath = path.join(ledgerDir, 'completion-emitted.jsonl');
+      const milestoneKey = '/test/path:proj:ms-1';
+      const projectKey = '/test/path:proj';
+      fs.writeFileSync(
+        ledgerPath,
+        [
+          JSON.stringify({
+            type: 'milestone',
+            key: milestoneKey,
+            timestamp: '2026-01-01T00:00:00Z',
+          }),
+          JSON.stringify({ type: 'project', key: projectKey, timestamp: '2026-01-01T00:00:00Z' }),
+        ].join('\n') + '\n',
+        'utf-8'
+      );
+
+      featureLoader = createMockFeatureLoader([feature1]);
+      projectService = createMockProjectService({ getProject: vi.fn().mockResolvedValue(project) });
+      service.initialize(
+        events,
+        featureLoader as unknown as FeatureLoader,
+        projectService as unknown as ProjectService,
+        tmpDir
+      );
+
+      // Wait for ledger load to complete before firing events
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      events._fire('feature:status-changed', {
+        projectPath: '/test/path',
+        featureId: 'f1',
+        previousStatus: 'review',
+        newStatus: 'done',
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // milestone and project completions should be suppressed (already in ledger)
+      expect(events.emit).not.toHaveBeenCalledWith('milestone:completed', expect.anything());
+      expect(events.emit).not.toHaveBeenCalledWith('project:completed', expect.anything());
     });
   });
 });

--- a/apps/server/tests/unit/services/lead-engineer-service.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-service.test.ts
@@ -9,6 +9,16 @@ import type {
   StateTransitionResult,
   FeatureProcessingState,
 } from '@/services/lead-engineer-types.js';
+import {
+  createMockFeatureLoader,
+  createMockSettingsService,
+  createMockProjectService,
+  createMockMetricsService,
+  type MockFeatureLoader,
+  type MockSettingsService,
+  type MockProjectService,
+  type MockMetricsService,
+} from '../../helpers/mock-factories.js';
 
 // ────────────────────────── Mocks ──────────────────────────
 
@@ -71,16 +81,6 @@ function createMockFeature(overrides: Partial<Feature> = {}): Feature {
   };
 }
 
-function createMockFeatureLoader(features: Feature[] = []) {
-  return {
-    getAll: vi.fn().mockResolvedValue(features),
-    update: vi.fn().mockResolvedValue(undefined),
-    get: vi.fn().mockImplementation(async (_path: string, id: string) => {
-      return features.find((f) => f.id === id) || null;
-    }),
-  };
-}
-
 function createMockAutoModeService() {
   return {
     getRunningAgents: vi.fn().mockResolvedValue([]),
@@ -91,36 +91,9 @@ function createMockAutoModeService() {
   };
 }
 
-function createMockProjectService() {
-  return {
-    getProject: vi.fn().mockResolvedValue({
-      title: 'Test Project',
-      slug: 'test-project',
-      milestones: [],
-    }),
-  };
-}
-
 function createMockProjectLifecycleService() {
   return {
     launch: vi.fn().mockResolvedValue({ autoModeStarted: true }),
-  };
-}
-
-function createMockSettingsService() {
-  return {
-    getGlobalSettings: vi.fn().mockResolvedValue({ maxConcurrency: 3 }),
-    getProjectSettings: vi.fn().mockResolvedValue({ workflow: {} }),
-  };
-}
-
-function createMockMetricsService() {
-  return {
-    getProjectMetrics: vi.fn().mockResolvedValue({
-      avgCycleTimeMs: 60000,
-      totalCostUsd: 5.0,
-      completedFeatures: 3,
-    }),
   };
 }
 
@@ -146,12 +119,12 @@ function createMockProcessor(
 describe('LeadEngineerService', () => {
   let service: LeadEngineerService;
   let events: ReturnType<typeof createMockEvents>;
-  let featureLoader: ReturnType<typeof createMockFeatureLoader>;
+  let featureLoader: MockFeatureLoader;
   let autoModeService: ReturnType<typeof createMockAutoModeService>;
-  let projectService: ReturnType<typeof createMockProjectService>;
+  let projectService: MockProjectService;
   let projectLifecycleService: ReturnType<typeof createMockProjectLifecycleService>;
-  let settingsService: ReturnType<typeof createMockSettingsService>;
-  let metricsService: ReturnType<typeof createMockMetricsService>;
+  let settingsService: MockSettingsService;
+  let metricsService: MockMetricsService;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -167,10 +140,25 @@ describe('LeadEngineerService', () => {
     events = createMockEvents();
     featureLoader = createMockFeatureLoader([]);
     autoModeService = createMockAutoModeService();
-    projectService = createMockProjectService();
+    projectService = createMockProjectService({
+      getProject: vi.fn().mockResolvedValue({
+        title: 'Test Project',
+        slug: 'test-project',
+        milestones: [],
+      }),
+    });
     projectLifecycleService = createMockProjectLifecycleService();
-    settingsService = createMockSettingsService();
-    metricsService = createMockMetricsService();
+    settingsService = createMockSettingsService({
+      getGlobalSettings: vi.fn().mockResolvedValue({ maxConcurrency: 3 }),
+      getProjectSettings: vi.fn().mockResolvedValue({ workflow: {} }),
+    });
+    metricsService = createMockMetricsService({
+      getProjectMetrics: vi.fn().mockResolvedValue({
+        avgCycleTimeMs: 60000,
+        totalCostUsd: 5.0,
+        completedFeatures: 3,
+      }),
+    });
 
     service = new LeadEngineerService(
       events as any,

--- a/apps/server/tests/unit/services/signal-intake-service.test.ts
+++ b/apps/server/tests/unit/services/signal-intake-service.test.ts
@@ -13,43 +13,15 @@ import type { EventEmitter } from '../../../src/lib/events.js';
 import type { FeatureLoader } from '../../../src/services/feature-loader.js';
 import type { SettingsService } from '../../../src/services/settings-service.js';
 import type { Feature, ProjectSettings } from '@protolabsai/types';
-
-// Mock factories
-const createMockEventEmitter = (): EventEmitter => {
-  const listeners: Array<(type: string, payload: any) => void> = [];
-
-  return {
-    emit: vi.fn((type: string, payload: any) => {
-      // Call all subscribed handlers with the event type and payload
-      listeners.forEach((handler) => handler(type, payload));
-    }),
-    subscribe: vi.fn((handler: (type: string, payload: any) => void) => {
-      listeners.push(handler);
-      return () => {
-        const index = listeners.indexOf(handler);
-        if (index > -1) listeners.splice(index, 1);
-      };
-    }),
-  } as unknown as EventEmitter;
-};
-
-const createMockFeatureLoader = (): FeatureLoader => {
-  return {
-    create: vi.fn().mockResolvedValue({
-      id: 'feature-123',
-      title: 'Test Feature',
-      status: 'backlog',
-    }),
-  } as unknown as FeatureLoader;
-};
-
-const createMockSettingsService = (): SettingsService => {
-  return {
-    getGlobalSettings: vi.fn().mockResolvedValue({
-      gtmEnabled: true,
-    }),
-  } as unknown as SettingsService;
-};
+import {
+  createMockFeatureLoader,
+  createMockSettingsService,
+} from '../../helpers/mock-factories.js';
+import {
+  createMockEventEmitter,
+  createMockFeatureLoader,
+  createMockSettingsService,
+} from '../../helpers/mock-factories.js';
 
 // Test data factories
 const createTestSignal = (overrides: any = {}) => ({
@@ -71,9 +43,9 @@ describe('SignalIntakeService', () => {
   let mockSettingsService: SettingsService;
 
   beforeEach(() => {
-    mockEmitter = createMockEventEmitter();
-    mockFeatureLoader = createMockFeatureLoader();
-    mockSettingsService = createMockSettingsService();
+    mockEmitter = createMockEventEmitter() as unknown as EventEmitter;
+    mockFeatureLoader = createMockFeatureLoader() as unknown as FeatureLoader;
+    mockSettingsService = createMockSettingsService() as unknown as SettingsService;
 
     signalIntakeService = new SignalIntakeService(
       mockEmitter,


### PR DESCRIPTION
## Summary

## Problem

Server tests are completely excluded from ESLint via `globalIgnores(['tests/**'])` in `apps/server/eslint.config.mjs`. This means `as any` casts, unused imports, and other quality issues go undetected. Agents write sloppy test code because there's no lint gate.

Additionally, tests use `as unknown as ServiceType` or `as any` for mock objects instead of proper typed mock factories, making tests fragile and hard to maintain.

## Scope

### Phase 1: Enable test linting
- Remove `tests/*...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Created centralized mock factory helpers to reduce duplication across test files and improve mock consistency.
  * Refactored multiple test files to use the new mock factories instead of inline implementations.

* **Chores**
  * Updated linting configuration to include test files with relaxed rules for test-specific patterns.
  * Expanded lint script to validate both source and test code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->