### PR TITLE
Changelog persistence + escalation artifact recording

### DIFF
--- a/apps/server/src/services/changelog-service.ts
+++ b/apps/server/src/services/changelog-service.ts
@@ -17,6 +17,7 @@ import type { EventEmitter } from '../lib/events.js';
 import type { SettingsService } from './settings-service.js';
 import type { FeatureLoader } from './feature-loader.js';
 import type { ProjectService } from './project-service.js';
+import type { ProjectArtifactService } from './project-artifact-service.js';
 import type { Feature } from '@protolabsai/types';
 
 const logger = createLogger('ChangelogService');
@@ -74,6 +75,7 @@ export class ChangelogService {
   private settingsService: SettingsService | null = null;
   private featureLoader: FeatureLoader | null = null;
   private projectService: ProjectService | null = null;
+  private projectArtifactService: ProjectArtifactService | null = null;
   private unsubscribe: (() => void) | null = null;
 
   /**
@@ -83,12 +85,14 @@ export class ChangelogService {
     emitter: EventEmitter,
     settingsService: SettingsService,
     featureLoader: FeatureLoader,
-    projectService: ProjectService
+    projectService: ProjectService,
+    projectArtifactService?: ProjectArtifactService
   ): void {
     this.emitter = emitter;
     this.settingsService = settingsService;
     this.featureLoader = featureLoader;
     this.projectService = projectService;
+    this.projectArtifactService = projectArtifactService ?? null;
 
     // Subscribe to milestone and project completion events
     this.unsubscribe = emitter.subscribe((type, payload) => {
@@ -114,6 +118,7 @@ export class ChangelogService {
     this.settingsService = null;
     this.featureLoader = null;
     this.projectService = null;
+    this.projectArtifactService = null;
   }
 
   /**
@@ -164,6 +169,17 @@ export class ChangelogService {
       // Store changelog in the project directory
       await this.storeChangelog(projectPath, projectSlug, changelogContent, milestone.slug);
 
+      // Persist changelog as a project artifact
+      if (this.projectArtifactService) {
+        await this.projectArtifactService.saveArtifact(
+          projectPath,
+          projectSlug,
+          'changelog',
+          changelogContent
+        );
+        logger.debug(`Changelog artifact saved for milestone ${milestoneTitle}`);
+      }
+
       // Post to Discord
       await this.postToDiscord(
         projectPath,
@@ -206,6 +222,17 @@ export class ChangelogService {
 
       // Store changelog in the project directory
       await this.storeChangelog(projectPath, projectSlug, changelogContent);
+
+      // Persist changelog as a project artifact
+      if (this.projectArtifactService) {
+        await this.projectArtifactService.saveArtifact(
+          projectPath,
+          projectSlug,
+          'changelog',
+          changelogContent
+        );
+        logger.debug(`Changelog artifact saved for project ${projectTitle}`);
+      }
 
       // Post to Discord
       await this.postToDiscord(

--- a/apps/server/src/services/event-ledger-service.ts
+++ b/apps/server/src/services/event-ledger-service.ts
@@ -20,6 +20,7 @@ import { randomUUID } from 'node:crypto';
 import { createLogger } from '@protolabsai/utils';
 import type { EventLedgerEntry, EventLedgerCorrelationIds } from '@protolabsai/types';
 import type { EventEmitter } from '../lib/events.js';
+import type { ProjectArtifactService } from './project-artifact-service.js';
 
 const logger = createLogger('EventLedgerService');
 
@@ -71,9 +72,11 @@ export class EventLedgerService {
   /** In-memory set of known IDs for fast idempotency checks */
   private seenIds: Set<string> | null = null;
   private initPromise: Promise<void> | null = null;
+  private projectArtifactService: ProjectArtifactService | null = null;
 
-  constructor(dataDir: string) {
+  constructor(dataDir: string, projectArtifactService?: ProjectArtifactService) {
     this.dataDir = dataDir;
+    this.projectArtifactService = projectArtifactService ?? null;
   }
 
   /**
@@ -421,6 +424,26 @@ export class EventLedgerService {
             payload,
             source: 'EventLedgerService',
           });
+
+          // Persist escalation as a project artifact when project context is available
+          const context = payload.context as
+            | { projectPath?: string; projectSlug?: string; featureId?: string; reason?: string }
+            | undefined;
+          if (this.projectArtifactService && context?.projectPath && context?.projectSlug) {
+            void this.projectArtifactService
+              .saveArtifact(context.projectPath, context.projectSlug, 'escalation', {
+                signal: payload.type as string | undefined,
+                reason: context.reason,
+                featureId: context.featureId ?? featureId,
+                source: payload.source,
+                severity: payload.severity,
+                context,
+                timestamp: payload.timestamp ?? new Date().toISOString(),
+              })
+              .catch((err) => {
+                logger.error('EventLedger: failed to save escalation artifact:', err);
+              });
+          }
           break;
         }
 


### PR DESCRIPTION
## Summary
- Add artifact types (ArtifactType, ArtifactIndexEntry, ArtifactIndex, ProjectArtifact)
- Persist changelog as project artifact on milestone/project completion
- Record escalation artifacts on escalation:signal-received events
- Wire ProjectArtifactService into changelog-service and event-ledger-service

Recovered from agent turn-limit exit — work was uncommitted in worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.40.5

* **New Features**
  * Archive system for completed features with automatic retention policies
  * Event ledger for tracking system events and lifecycle history
  * Bidirectional traceability for features, projects, and milestones
  * Failure classification and escalation tracking
  * Project artifact persistence for changelogs and reports
  * Milestone and phase management persistence
  * Project timeline API with unified event feed
  * Updated project editor tool in chat

* **Bug Fixes**
  * Auto-mode cooldown resume race condition prevention
  * Archival completeness improvements for feature metadata
  * Staging branch promotion workflow enhancements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->