### PR TITLE
Per-project Discord webhook config + ceremony routing

### DIFF
--- a/apps/server/src/services/ceremony-service.ts
+++ b/apps/server/src/services/ceremony-service.ts
@@ -107,6 +107,27 @@ function createDiscordAdapter(emitter: EventEmitter) {
 }
 
 // ---------------------------------------------------------------------------
+// HTTP webhook adapter
+// Posts ceremony output directly to a Discord webhook URL.
+// ---------------------------------------------------------------------------
+
+function createWebhookAdapter(webhookUrl: string) {
+  return {
+    sendMessage: async (_channelId: string, content: string): Promise<{ id: string }> => {
+      const response = await fetch(webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content }),
+      });
+      if (!response.ok) {
+        throw new Error(`Webhook POST failed: ${response.status} ${response.statusText}`);
+      }
+      return { id: '' };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // CeremonyService
 // ---------------------------------------------------------------------------
 

--- a/libs/types/src/agent-settings.ts
+++ b/libs/types/src/agent-settings.ts
@@ -280,6 +280,12 @@ export interface CeremonySettings {
   enabled: boolean;
   /** Discord channel ID for ceremony announcements (overrides project default) */
   discordChannelId?: string;
+  /**
+   * Discord webhook URL for ceremony announcements.
+   * When set, ceremony output is POSTed directly to this webhook URL instead of
+   * routing through the Discord bot channel. Takes precedence over discordChannelId.
+   */
+  discordWebhookUrl?: string;
   /** Enable epic kickoff announcements when created (default: true) */
   enableEpicKickoff?: boolean;
   /** Enable milestone standup announcements at start (default: true) */


### PR DESCRIPTION
## Summary
- Add discordWebhookUrl to CeremonySettings type
- Add HTTP webhook adapter for direct webhook posting
- Webhook URL takes precedence over discordChannelId when set

Recovered from agent turn-limit exit — work was uncommitted in worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Archive query API with filtering and retention management
  * Event ledger for audit trails and feature lifecycle events
  * Per-project Discord webhook configuration
  * Project timeline API for feature tracking
  * Staging branch protection workflow

* **Bug Fixes**
  * Auto-mode cooldown resume race condition handling
  * Persistent PR tracking state across server restarts
  * Feature status auto-emission and event ordering

* **Improvements**
  * Feature completion cascade verification via ledger-based dedup
  * Enhanced project milestone and ceremony state persistence
  * Bidirectional traceability tracking with Langfuse integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->