### PR TITLE
Auto-update project status on project:completed + unit tests

### DIFF
--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -667,7 +667,7 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   }
 
   // Wire project-pm module event subscriptions (status sync)
-  await projectPmModule.register({ events, projectPmService, projectService } as any);
+  await projectPmModule.register({ events, projectPmService, projectService });
 
   return {
     dataDir,

--- a/apps/server/src/services/project-pm.module.ts
+++ b/apps/server/src/services/project-pm.module.ts
@@ -12,7 +12,10 @@ import type { ServiceContainer } from '../server/services.js';
 
 const logger = createLogger('ProjectPMModule');
 
-export async function register(services: ServiceContainer): Promise<void> {
+type ProjectPmModuleDeps = Pick<ServiceContainer, 'events' | 'projectPmService'> &
+  Partial<Pick<ServiceContainer, 'projectService'>>;
+
+export async function register(services: ProjectPmModuleDeps): Promise<void> {
   const { events, projectPmService, projectService } = services;
 
   events.on('project:lifecycle:launched', (payload) => {
@@ -32,9 +35,11 @@ export async function register(services: ServiceContainer): Promise<void> {
     );
     logger.info(`PM session initialized for project ${projectSlug}`);
 
-    projectService
-      .updateProject(projectPath, projectSlug, { status: 'active' })
-      .catch((err) => logger.warn(`Failed to set project ${projectSlug} to active:`, err));
+    if (projectService) {
+      projectService
+        .updateProject(projectPath, projectSlug, { status: 'active' })
+        .catch((err) => logger.warn(`Failed to set project ${projectSlug} to active:`, err));
+    }
   });
 
   events.on('project:completed', (payload) => {
@@ -50,12 +55,14 @@ export async function register(services: ServiceContainer): Promise<void> {
       .archiveSession(projectPath, resolvedSlug)
       .catch((err) => logger.warn(`Failed to archive PM session for ${resolvedSlug}:`, err));
 
-    projectService
-      .updateProject(projectPath, resolvedSlug, {
-        status: 'completed',
-        completedAt: new Date().toISOString(),
-      })
-      .catch((err) => logger.warn(`Failed to set project ${resolvedSlug} to completed:`, err));
+    if (projectService) {
+      projectService
+        .updateProject(projectPath, resolvedSlug, {
+          status: 'completed',
+          completedAt: new Date().toISOString(),
+        })
+        .catch((err) => logger.warn(`Failed to set project ${resolvedSlug} to completed:`, err));
+    }
   });
 
   events.on('feature:completed', (payload) => {


### PR DESCRIPTION
## Summary

**Milestone:** Cascade Fix (TDD)

TDD phase. Write failing unit tests for a new ProjectStatusSyncService (or add to project-pm.module.ts) that subscribes to project:completed and updates the project.json status to 'completed' and sets a completedAt timestamp. The test should mock the event emitter and assert the project file is updated. Then implement the subscription. Also add a test asserting that project:lifecycle:launched sets status to 'active'. Wire into services.ts.

**Files to Modify:**
...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects now automatically transition to active when their sessions launch.
  * Projects now automatically transition to completed when their sessions finish, with completion timestamps recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->