### PR TITLE
proto.config Loader

### DIFF
--- a/libs/platform/src/index.ts
+++ b/libs/platform/src/index.ts
@@ -269,4 +269,5 @@ export {
   type ProtoConfigBrand,
   type ProtoConfigDiscord,
   type ProtoConfigServer,
+  type ProtoConfigHive,
 } from './proto-config.js';

--- a/libs/platform/src/proto-config.ts
+++ b/libs/platform/src/proto-config.ts
@@ -15,6 +15,7 @@
 
 import path from 'path';
 import fs from 'node:fs';
+import os from 'node:os';
 
 // yaml is loaded lazily to avoid CJS/ESM compatibility issues
 // ("Dynamic require of process is not supported") when platform
@@ -50,6 +51,17 @@ export interface ProtoConfigServer {
   port?: number;
 }
 
+export interface ProtoConfigHive {
+  /** Shared identifier for the hive cluster */
+  hiveId?: string;
+  /** WebSocket port for CRDT sync between instances */
+  syncPort?: number;
+  /** Whether multi-instance mesh sync is enabled */
+  meshEnabled?: boolean;
+  /** Resolved identity for the current instance */
+  instanceId?: string;
+}
+
 /**
  * Top-level shape of proto.config.yaml.
  * Open-ended (`[key: string]: unknown`) so callers can store additional fields.
@@ -60,6 +72,7 @@ export interface ProtoConfig {
   brand?: ProtoConfigBrand;
   discord?: ProtoConfigDiscord;
   server?: ProtoConfigServer;
+  hive?: ProtoConfigHive;
   [key: string]: unknown;
 }
 
@@ -110,6 +123,7 @@ function deepMerge(
  *   PROTO_DISCORD_SERVER_ID   — config.discord.serverId
  *   PROTO_DISCORD_CHANNEL_ID  — config.discord.channelId
  *   PROTO_SERVER_PORT         — config.server.port (integer)
+ *   PROTO_HIVE_INSTANCE_ID    — config.hive.instanceId (overrides auto-detection)
  */
 function applyEnvOverrides(config: ProtoConfig): ProtoConfig {
   const result: ProtoConfig = { ...config };
@@ -138,7 +152,41 @@ function applyEnvOverrides(config: ProtoConfig): ProtoConfig {
     }
   }
 
+  if (process.env.PROTO_HIVE_INSTANCE_ID) {
+    result.hive = { ...result.hive, instanceId: process.env.PROTO_HIVE_INSTANCE_ID };
+  }
+
   return result;
+}
+
+/**
+ * Resolves the instanceId for this process.
+ *
+ * Priority:
+ *   1. Explicit instanceId already set in config (from YAML or settings.json)
+ *   2. Match by hostname against the `instances` registry in config
+ *   3. Fall back to os.hostname() directly
+ */
+function resolveInstanceIdentity(config: ProtoConfig): ProtoConfig {
+  if (config.hive?.instanceId) {
+    // Already explicitly set — nothing to do
+    return config;
+  }
+
+  const hostname = os.hostname();
+  const instances = config['instances'] as
+    | Array<{ instanceId: string; hostname?: string }>
+    | undefined;
+
+  // Find matching entry in instance registry by hostname
+  const match = instances?.find((inst) => inst.hostname && inst.hostname === hostname);
+
+  const instanceId = match?.instanceId ?? hostname;
+
+  return {
+    ...config,
+    hive: { ...config.hive, instanceId },
+  };
 }
 
 // ─── Public API ───────────────────────────────────────────────────────────────
@@ -190,7 +238,10 @@ export async function loadProtoConfig(projectPath: string): Promise<ProtoConfig 
   }
 
   // Layer 3: env var overrides
-  return applyEnvOverrides(merged as ProtoConfig);
+  const withEnv = applyEnvOverrides(merged as ProtoConfig);
+
+  // Layer 4: resolve instance identity from hostname or instance registry
+  return resolveInstanceIdentity(withEnv);
 }
 
 /**

--- a/libs/platform/tests/proto-config.test.ts
+++ b/libs/platform/tests/proto-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import path from 'path';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -171,6 +171,72 @@ describe('loadProtoConfig', () => {
       const result = await loadProtoConfig(tmpDir);
       expect(result?.name).toBe('env');
     });
+  });
+});
+
+describe('instance identity resolution', () => {
+  let tmpDir: string;
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    savedEnv = { ...process.env };
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('PROTO_')) delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('sets hive.instanceId to os.hostname() when no explicit config', async () => {
+    writeFile(tmpDir, 'proto.config.yaml', 'name: test\n');
+    const result = await loadProtoConfig(tmpDir);
+    expect(result?.hive?.instanceId).toBe(os.hostname());
+  });
+
+  it('uses explicit instanceId from hive config in YAML', async () => {
+    writeFile(tmpDir, 'proto.config.yaml', 'name: test\nhive:\n  instanceId: explicit-id\n');
+    const result = await loadProtoConfig(tmpDir);
+    expect(result?.hive?.instanceId).toBe('explicit-id');
+  });
+
+  it('resolves instanceId by matching hostname in instances registry', async () => {
+    const hostname = os.hostname();
+    writeFile(
+      tmpDir,
+      'proto.config.yaml',
+      `name: test\ninstances:\n  - instanceId: matched-instance\n    hostname: ${hostname}\n  - instanceId: other-instance\n    hostname: other-host\n`
+    );
+    const result = await loadProtoConfig(tmpDir);
+    expect(result?.hive?.instanceId).toBe('matched-instance');
+  });
+
+  it('falls back to hostname when no instance registry match', async () => {
+    writeFile(
+      tmpDir,
+      'proto.config.yaml',
+      'name: test\ninstances:\n  - instanceId: unrelated\n    hostname: some-other-host\n'
+    );
+    const result = await loadProtoConfig(tmpDir);
+    expect(result?.hive?.instanceId).toBe(os.hostname());
+  });
+
+  it('PROTO_HIVE_INSTANCE_ID env var overrides resolved identity', async () => {
+    writeFile(tmpDir, 'proto.config.yaml', 'name: test\n');
+    process.env.PROTO_HIVE_INSTANCE_ID = 'env-override-id';
+    const result = await loadProtoConfig(tmpDir);
+    expect(result?.hive?.instanceId).toBe('env-override-id');
+  });
+
+  it('PROTO_HIVE_INSTANCE_ID wins over YAML hive.instanceId', async () => {
+    writeFile(tmpDir, 'proto.config.yaml', 'name: test\nhive:\n  instanceId: yaml-id\n');
+    process.env.PROTO_HIVE_INSTANCE_ID = 'env-id';
+    const result = await loadProtoConfig(tmpDir);
+    expect(result?.hive?.instanceId).toBe('env-id');
   });
 });
 

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -881,6 +881,9 @@ export {
   ProtoGitSchema,
   ProtoLabSchema,
   ProtoDefaultsSchema,
+  ProtoHiveSchema,
+  ProtoInstanceSchema,
+  ProtoAssignmentSchema,
 } from './proto-config.js';
 export type {
   ProtoConfig,
@@ -889,6 +892,9 @@ export type {
   ProtoGit,
   ProtoLab,
   ProtoDefaults,
+  ProtoHive,
+  ProtoInstance,
+  ProtoAssignment,
 } from './proto-config.js';
 
 // PenFile types (vector graphics format v2.8)

--- a/libs/types/src/proto-config.ts
+++ b/libs/types/src/proto-config.ts
@@ -93,6 +93,49 @@ export const ProtoDefaultsSchema = z.object({
 export type ProtoDefaults = z.infer<typeof ProtoDefaultsSchema>;
 
 // ---------------------------------------------------------------------------
+// Hive identity — multi-instance mesh coordination
+// ---------------------------------------------------------------------------
+
+export const ProtoHiveSchema = z.object({
+  /** Shared identifier for the hive cluster (all instances share this) */
+  hiveId: z.string().optional(),
+  /** WebSocket port used for CRDT sync between instances */
+  syncPort: z.number().int().min(1024).max(65535).default(9800),
+  /** Whether multi-instance mesh sync is enabled */
+  meshEnabled: z.boolean().default(false),
+});
+
+export type ProtoHive = z.infer<typeof ProtoHiveSchema>;
+
+// ---------------------------------------------------------------------------
+// Instance registry — per-instance identity entries
+// ---------------------------------------------------------------------------
+
+export const ProtoInstanceSchema = z.object({
+  /** Stable unique ID for this instance (e.g. "dev-mac", "ci-runner-1") */
+  instanceId: z.string(),
+  /** Hostname this entry applies to (used for auto-detection) */
+  hostname: z.string().optional(),
+  /** Maximum number of concurrent features this instance can handle */
+  capacity: z.number().int().min(1).default(1),
+});
+
+export type ProtoInstance = z.infer<typeof ProtoInstanceSchema>;
+
+// ---------------------------------------------------------------------------
+// Assignment strategy — how work is distributed across instances
+// ---------------------------------------------------------------------------
+
+export const ProtoAssignmentSchema = z.object({
+  /** Work distribution algorithm */
+  strategy: z.enum(['round-robin', 'capacity-weighted', 'random']).default('round-robin'),
+  /** Whether features stay pinned to the instance that started them */
+  stickyFeatures: z.boolean().default(false),
+});
+
+export type ProtoAssignment = z.infer<typeof ProtoAssignmentSchema>;
+
+// ---------------------------------------------------------------------------
 // Root ProtoConfig
 // ---------------------------------------------------------------------------
 
@@ -111,6 +154,12 @@ export const ProtoConfigSchema = z.object({
   protolab: ProtoLabSchema.optional(),
   /** Project-level defaults for features and automation */
   defaults: ProtoDefaultsSchema.optional(),
+  /** Hive mesh identity and sync configuration */
+  hive: ProtoHiveSchema.optional(),
+  /** Registry of known instances in this hive */
+  instances: z.array(ProtoInstanceSchema).optional(),
+  /** Work assignment strategy across instances */
+  assignment: ProtoAssignmentSchema.optional(),
 });
 
 export type ProtoConfig = z.infer<typeof ProtoConfigSchema>;


### PR DESCRIPTION
## Summary

**Milestone:** Foundation

Create proto.config.yaml schema and loader in libs/platform. Implements layered config resolution: proto.config.yaml (git-tracked shared defaults) -> .automaker/settings.json (instance-local overrides) -> environment variables. Defines hive identity, instance registry, sync port, assignment strategy, and shared defaults. Loader returns effective config for the current instance.

**Files to Modify:**
- libs/platform/src/proto-config.ts
- libs/types/src/proto-config.ts
-...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-instance mesh coordination configuration with hive, instances, and assignment settings
  * Added environment variable support for instance identity configuration
  * Introduced automatic instance identity resolution with hostname detection fallback

* **Tests**
  * Expanded test coverage for instance identity resolution scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->