### PR TITLE
EventBus CRDT Bridge

### DIFF
--- a/apps/server/src/lib/events.ts
+++ b/apps/server/src/lib/events.ts
@@ -25,15 +25,24 @@ export type { EventType, EventCallback };
 // subscribe() returns a function (legacy cleanup pattern) that also has .unsubscribe()
 export type UnsubscribeFn = (() => void) & EventSubscription;
 
+/** Callback invoked by broadcast() to publish an event to remote peers. */
+export type RemoteBroadcastFn = (type: EventType, payload: unknown) => void;
+
 export interface EventEmitter extends EventBus {
   emit: (type: EventType, payload: unknown) => void;
   subscribe: (callback: EventCallback) => UnsubscribeFn;
   on: <T extends EventType>(type: T, callback: TypedEventCallback<T>) => UnsubscribeFn;
+  /**
+   * Register a function that publishes events to remote peers (e.g. via CRDT sync).
+   * Called once during service wiring. Replaces any previously registered broadcaster.
+   */
+  setRemoteBroadcaster(fn: RemoteBroadcastFn): void;
 }
 
 export function createEventEmitter(): EventEmitter {
   const subscribers = new Set<EventCallback>();
   const typedHandlers = new Map<EventType, Set<(payload: unknown) => void>>();
+  let remoteBroadcaster: RemoteBroadcastFn | null = null;
 
   function makeUnsub(fn: () => void): UnsubscribeFn {
     const unsub = fn as UnsubscribeFn;
@@ -81,9 +90,20 @@ export function createEventEmitter(): EventEmitter {
     },
 
     broadcast(type: EventType, payload?: unknown) {
-      // In single-instance mode, broadcast === emit.
-      // In hivemind mode, this will also publish to the mesh.
+      // Always emit locally first.
       bus.emit(type, payload);
+      // In hivemind mode, also publish to remote peers via the registered broadcaster.
+      if (remoteBroadcaster) {
+        try {
+          remoteBroadcaster(type, payload ?? null);
+        } catch (error) {
+          logger.error('Error in remote broadcaster:', error);
+        }
+      }
+    },
+
+    setRemoteBroadcaster(fn: RemoteBroadcastFn) {
+      remoteBroadcaster = fn;
     },
   };
 

--- a/apps/server/src/services/crdt-sync-service.ts
+++ b/apps/server/src/services/crdt-sync-service.ts
@@ -11,7 +11,15 @@ import os from 'node:os';
 import { WebSocket, WebSocketServer } from 'ws';
 import { createLogger } from '@protolabsai/utils';
 import { loadProtoConfig } from '@protolabsai/platform';
-import type { HivemindPeer, HivemindConfig, SyncRole, SyncServerStatus } from '@protolabsai/types';
+import type {
+  HivemindPeer,
+  HivemindConfig,
+  SyncRole,
+  SyncServerStatus,
+  CrdtFeatureEvent,
+} from '@protolabsai/types';
+import { CRDT_SYNCED_EVENT_TYPES } from '@protolabsai/types';
+import type { EventEmitter } from '../lib/events.js';
 
 const logger = createLogger('CrdtSyncService');
 
@@ -21,13 +29,15 @@ const DEFAULT_SYNC_PORT = 4444;
 const RECONNECT_INTERVAL_MS = 5_000;
 const TTL_CHECK_INTERVAL_MS = 10_000;
 
-interface SyncMessage {
+interface PeerMessage {
   type: 'heartbeat' | 'goodbye' | 'identity' | 'promote';
   instanceId: string;
   url?: string;
   timestamp: string;
   priority?: number;
 }
+
+type SyncMessage = PeerMessage | CrdtFeatureEvent;
 
 interface TrackedPeer extends HivemindPeer {
   ws?: WebSocket;
@@ -51,9 +61,49 @@ export class CrdtSyncService {
   private lastPrimaryContact: number | null = null;
   private selfPriority = -1;
   private promotionPending = false;
+  private _eventBus: EventEmitter | null = null;
 
   constructor() {
     this.instanceId = os.hostname();
+  }
+
+  /**
+   * Attach an EventBus to bridge CRDT sync with the local event system.
+   *
+   * - Registers a remote broadcaster: when `broadcast()` is called locally for
+   *   a synced event type, the event is published to all connected peers.
+   * - Incoming `feature_event` CRDT messages trigger a local `emit()` (NOT
+   *   `broadcast()`) to prevent feedback loops.
+   *
+   * Must be called before `start()` or immediately after; safe to call multiple
+   * times (replaces previous registration).
+   */
+  attachEventBus(bus: EventEmitter): void {
+    this._eventBus = bus;
+
+    bus.setRemoteBroadcaster((type, payload) => {
+      if (!CRDT_SYNCED_EVENT_TYPES.has(type)) return;
+      if (!this.started) return;
+
+      const msg: CrdtFeatureEvent = {
+        type: 'feature_event',
+        instanceId: this.instanceId,
+        eventType: type,
+        payload,
+        timestamp: new Date().toISOString(),
+      };
+      const raw = JSON.stringify(msg);
+
+      if (this.role === 'primary') {
+        this._broadcastToServer(raw);
+      } else if (this.wsClient?.readyState === WebSocket.OPEN) {
+        try {
+          this.wsClient.send(raw);
+        } catch {
+          // Best effort
+        }
+      }
+    });
   }
 
   /**
@@ -512,6 +562,20 @@ export class CrdtSyncService {
     }
   }
 
+  /** Broadcast to all connected peers except the given sender socket. */
+  private _broadcastToServerExcept(msg: string, except: WebSocket): void {
+    if (!this.wsServer) return;
+    for (const client of this.wsServer.clients) {
+      if (client !== except && client.readyState === WebSocket.OPEN) {
+        try {
+          client.send(msg);
+        } catch {
+          // Ignore send errors
+        }
+      }
+    }
+  }
+
   // ─── Private: TTL Check ───────────────────────────────────────────────────
 
   private _startTtlCheck(): void {
@@ -563,10 +627,28 @@ export class CrdtSyncService {
         }
         break;
       }
+      case 'feature_event': {
+        // Ignore events originating from this instance (shouldn't happen in normal flow
+        // since we only send to peers, but guard against misconfigured loops).
+        if (msg.instanceId === this.instanceId) break;
+        if (!this._eventBus) break;
+
+        logger.debug(
+          `[CRDT] Received remote feature event: ${msg.eventType} from ${msg.instanceId}`
+        );
+        // Use emit() NOT broadcast() to avoid re-publishing to peers.
+        this._eventBus.emit(msg.eventType, msg.payload);
+
+        // Primary relays feature events to all other connected workers.
+        if (this.role === 'primary') {
+          this._broadcastToServerExcept(JSON.stringify(msg), ws);
+        }
+        break;
+      }
     }
   }
 
-  private _upsertPeer(msg: SyncMessage, ws: WebSocket, now: string): void {
+  private _upsertPeer(msg: PeerMessage, ws: WebSocket, now: string): void {
     const existing = this.peers.get(msg.instanceId);
     if (existing) {
       existing.lastSeen = now;

--- a/apps/server/src/services/crdt-sync.module.ts
+++ b/apps/server/src/services/crdt-sync.module.ts
@@ -1,9 +1,11 @@
-// CRDT sync module — no cross-service wiring needed at this stage.
+// CRDT sync module — wires EventBus to CrdtSyncService for cross-instance event propagation.
 // Startup handles the actual start() call after repoRoot is resolved.
 
 import type { ServiceContainer } from '../server/services.js';
 
-export async function register(_container: ServiceContainer): Promise<void> {
-  // No cross-service wiring required for crdt-sync at startup.
-  // CrdtSyncService.start() is called from startup.ts with repoRoot.
+export async function register(container: ServiceContainer): Promise<void> {
+  // Bridge the local EventBus to the CRDT sync channel.
+  // After this call, broadcast() publishes feature events to remote peers and
+  // incoming remote feature events are re-emitted locally.
+  container.crdtSyncService.attachEventBus(container.events);
 }

--- a/libs/types/src/events.ts
+++ b/libs/types/src/events.ts
@@ -1,0 +1,32 @@
+/**
+ * Types for the EventBus-CRDT bridge.
+ *
+ * Defines the protocol for broadcasting EventBus events to remote peers
+ * via the CRDT sync channel, and which event types are eligible for sync.
+ */
+
+import type { EventType } from './event.js';
+
+/**
+ * Feature-related event types that propagate across CRDT sync instances.
+ * Only these events are published to remote peers via the sync channel.
+ */
+export const CRDT_SYNCED_EVENT_TYPES: ReadonlySet<EventType> = new Set<EventType>([
+  'feature:status-changed',
+  'feature:updated',
+  'feature:created',
+  'feature:deleted',
+]);
+
+/**
+ * CRDT wire message carrying a local EventBus event to remote instances.
+ * Transported as JSON over the sync WebSocket channel.
+ */
+export interface CrdtFeatureEvent {
+  type: 'feature_event';
+  /** Originating instance ID — receivers skip re-emit if it matches self */
+  instanceId: string;
+  eventType: EventType;
+  payload: unknown;
+  timestamp: string;
+}

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -6,6 +6,10 @@
 // Event Ledger types — append-only JSONL event persistence layer
 export type { EventLedgerCorrelationIds, EventLedgerEntry } from './event-ledger.js';
 
+// EventBus-CRDT bridge types
+export { CRDT_SYNCED_EVENT_TYPES } from './events.js';
+export type { CrdtFeatureEvent } from './events.js';
+
 // Automation registry supplementary types (CreateAutomationInput, UpdateAutomationInput, FlowFactory)
 // Core types (Automation, AutomationRunRecord, etc.) are already exported from the base workspace types
 export type {


### PR DESCRIPTION
## Summary

**Milestone:** Feature Sync

Wire EventBus.broadcast() to emit events across instances via CRDT change subscriptions. When a remote peer changes a feature, the local EventBus emits the corresponding event (feature:updated, feature:status-changed, etc.) so the UI and auto-mode react as if the change were local. This is the glue between CRDT sync and the existing event-driven architecture.

**Files to Modify:**
- apps/server/src/lib/events.ts
- apps/server/src/server/wiring.ts
- libs/types/src/eve...

---
*Recovered automatically by Automaker post-agent hook*