### PR TITLE
feat: per-project Discord webhook settings UI

### DIFF
--- a/apps/ui/src/components/views/projects/project-settings-panel.tsx
+++ b/apps/ui/src/components/views/projects/project-settings-panel.tsx
@@ -150,21 +150,11 @@ export function ProjectSettingsPanel({ project }: ProjectSettingsPanelProps) {
             disabled={testStatus === 'loading' || !webhookUrl}
             data-testid="test-webhook-button"
           >
-            {testStatus === 'loading' && (
-              <Send className="w-4 h-4 animate-pulse" />
-            )}
-            {testStatus === 'success' && (
-              <CheckCircle2 className="w-4 h-4 text-green-500" />
-            )}
-            {testStatus === 'error' && (
-              <XCircle className="w-4 h-4 text-destructive" />
-            )}
-            {testStatus === 'idle' && (
-              <Send className="w-4 h-4" />
-            )}
-            <span className="ml-2">
-              {testStatus === 'loading' ? 'Sending...' : 'Test webhook'}
-            </span>
+            {testStatus === 'loading' && <Send className="w-4 h-4 animate-pulse" />}
+            {testStatus === 'success' && <CheckCircle2 className="w-4 h-4 text-green-500" />}
+            {testStatus === 'error' && <XCircle className="w-4 h-4 text-destructive" />}
+            {testStatus === 'idle' && <Send className="w-4 h-4" />}
+            <span className="ml-2">{testStatus === 'loading' ? 'Sending...' : 'Test webhook'}</span>
           </Button>
         </div>
         {urlError && (

--- a/apps/ui/tests/unit/webhook-settings.test.tsx
+++ b/apps/ui/tests/unit/webhook-settings.test.tsx
@@ -22,25 +22,19 @@ describe('validateDiscordWebhookUrl', () => {
 
     it('accepts a webhook URL with a token containing hyphens and underscores', () => {
       expect(
-        validateDiscordWebhookUrl(
-          'https://discord.com/api/webhooks/9876543210/abc-def_ghi-123'
-        )
+        validateDiscordWebhookUrl('https://discord.com/api/webhooks/9876543210/abc-def_ghi-123')
       ).toBe(true);
     });
 
     it('accepts a canary.discord.com webhook URL', () => {
       expect(
-        validateDiscordWebhookUrl(
-          'https://canary.discord.com/api/webhooks/1234567890/sometoken123'
-        )
+        validateDiscordWebhookUrl('https://canary.discord.com/api/webhooks/1234567890/sometoken123')
       ).toBe(true);
     });
 
     it('accepts a ptb.discord.com webhook URL', () => {
       expect(
-        validateDiscordWebhookUrl(
-          'https://ptb.discord.com/api/webhooks/1234567890/sometoken123'
-        )
+        validateDiscordWebhookUrl('https://ptb.discord.com/api/webhooks/1234567890/sometoken123')
       ).toBe(true);
     });
 
@@ -78,9 +72,7 @@ describe('validateDiscordWebhookUrl', () => {
 
     it('rejects a Discord URL with http instead of https', () => {
       expect(
-        validateDiscordWebhookUrl(
-          'http://discord.com/api/webhooks/1234567890/sometoken123'
-        )
+        validateDiscordWebhookUrl('http://discord.com/api/webhooks/1234567890/sometoken123')
       ).toBe(false);
     });
 
@@ -91,9 +83,9 @@ describe('validateDiscordWebhookUrl', () => {
     });
 
     it('rejects a non-numeric webhook ID', () => {
-      expect(
-        validateDiscordWebhookUrl('https://discord.com/api/webhooks/abc/sometoken123')
-      ).toBe(false);
+      expect(validateDiscordWebhookUrl('https://discord.com/api/webhooks/abc/sometoken123')).toBe(
+        false
+      );
     });
 
     it('rejects a random string', () => {


### PR DESCRIPTION
## Summary
- Add per-project Discord webhook settings to the project settings panel
- Remove duplicate `discordWebhookUrl` from CeremonySettings type
- Format project-settings-panel and webhook test files

## Test plan
- [ ] Verify project settings panel renders Discord webhook fields
- [ ] Verify ceremony settings no longer have duplicate webhook URL field
- [ ] CI passes (lint, typecheck, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure and initialization flow for completion detection service to improve maintainability and reliability of test execution patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->