### PR TITLE
feat: Project Sync — CRDT-backed ProjectService

### DIFF
--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -465,7 +465,7 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
     hitlFormService
   );
 
-  const projectService = new ProjectService(featureLoader);
+  const projectService = new ProjectService(featureLoader, events);
   projectService.setCalendarService(calendarService);
 
   // Project Lifecycle Service

--- a/apps/server/src/services/crdt-sync-service.ts
+++ b/apps/server/src/services/crdt-sync-service.ts
@@ -72,6 +72,9 @@ export class CrdtSyncService {
    *
    * - Registers a remote broadcaster: when `broadcast()` is called locally for
    *   a synced event type, the event is published to all connected peers.
+   *   Synced event types include both feature events (feature:created, feature:updated,
+   *   feature:deleted, feature:status-changed) and project events (project:created,
+   *   project:updated, project:deleted).
    * - Incoming `feature_event` CRDT messages trigger a local `emit()` (NOT
    *   `broadcast()`) to prevent feedback loops.
    *

--- a/apps/server/src/services/project-service.ts
+++ b/apps/server/src/services/project-service.ts
@@ -6,6 +6,8 @@
  */
 
 import path from 'path';
+import { existsSync } from 'node:fs';
+import * as Automerge from '@automerge/automerge';
 import type {
   Project,
   Feature,
@@ -46,24 +48,87 @@ import {
 } from '@protolabsai/platform';
 import type { FeatureLoader } from './feature-loader.js';
 import type { CalendarService } from './calendar-service.js';
+import type { EventEmitter } from '../lib/events.js';
 
 const logger = createLogger('ProjectService');
 
+/** Automerge document shape — one per projectPath, keyed by project slug */
+type ProjectsDoc = { projects: Record<string, Project> };
+
 export class ProjectService {
   private calendarService?: CalendarService;
+  private readonly _docs = new Map<string, Automerge.Doc<ProjectsDoc>>();
+  private readonly _initPromises = new Map<string, Promise<void>>();
+  private readonly _crdtEnabled = new Map<string, boolean>();
+  private readonly _crdtEvents: EventEmitter | null;
 
-  constructor(private featureLoader: FeatureLoader) {}
+  constructor(
+    private featureLoader: FeatureLoader,
+    events?: EventEmitter
+  ) {
+    this._crdtEvents = events ?? null;
+  }
 
   setCalendarService(calendarService: CalendarService): void {
     this.calendarService = calendarService;
   }
 
-  /**
-   * List all projects in a project path
-   */
-  async listProjects(projectPath: string): Promise<string[]> {
-    const projectsDir = getProjectsDir(projectPath);
+  // ─── CRDT helpers ──────────────────────────────────────────────────────────
 
+  private _isCrdtEnabled(projectPath: string): boolean {
+    const cached = this._crdtEnabled.get(projectPath);
+    if (cached !== undefined) return cached;
+    const enabled = existsSync(path.join(projectPath, 'proto.config.yaml'));
+    this._crdtEnabled.set(projectPath, enabled);
+    return enabled;
+  }
+
+  private _toAutomergeValue(project: Project): Record<string, unknown> {
+    return JSON.parse(JSON.stringify(project)) as Record<string, unknown>;
+  }
+
+  private async _ensureDoc(projectPath: string): Promise<Automerge.Doc<ProjectsDoc>> {
+    if (this._docs.has(projectPath)) return this._docs.get(projectPath)!;
+    if (!this._initPromises.has(projectPath)) {
+      this._initPromises.set(projectPath, this._initDoc(projectPath));
+    }
+    await this._initPromises.get(projectPath);
+    return this._docs.get(projectPath)!;
+  }
+
+  private async _initDoc(projectPath: string): Promise<void> {
+    const slugs = await this._listSlugsFromDisk(projectPath);
+    let doc = Automerge.from<ProjectsDoc>({ projects: {} });
+    const projects: Project[] = [];
+    for (const slug of slugs) {
+      const p = await this._readFromDisk(projectPath, slug);
+      if (p) projects.push(p);
+    }
+    doc = Automerge.change(doc, (d) => {
+      for (const p of projects) {
+        (d.projects as Record<string, unknown>)[p.slug] = this._toAutomergeValue(p);
+      }
+    });
+    this._docs.set(projectPath, doc);
+    logger.info(
+      `[CRDT] Initialized projects doc for ${projectPath} with ${projects.length} projects`
+    );
+  }
+
+  private async _readFromDisk(projectPath: string, projectSlug: string): Promise<Project | null> {
+    const jsonPath = getProjectJsonPath(projectPath, projectSlug);
+    try {
+      const rawContent = await secureFs.readFile(jsonPath, 'utf-8');
+      const content = typeof rawContent === 'string' ? rawContent : rawContent.toString('utf-8');
+      return JSON.parse(content) as Project;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw error;
+    }
+  }
+
+  private async _listSlugsFromDisk(projectPath: string): Promise<string[]> {
+    const projectsDir = getProjectsDir(projectPath);
     try {
       const entries = await secureFs.readdir(projectsDir, { withFileTypes: true });
       return entries
@@ -71,31 +136,75 @@ export class ProjectService {
         .map((entry) => entry.name)
         .sort();
     } catch (error) {
-      // Directory doesn't exist yet
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        return [];
-      }
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
       throw error;
     }
+  }
+
+  /**
+   * Apply Automerge binary changes received from a remote peer.
+   * Merges the changes into the local doc and emits project events for any
+   * projects that changed. Called by the wiring layer on 'crdt:remote-changes'.
+   */
+  applyRemoteChanges(projectPath: string, changes: Uint8Array[]): void {
+    let doc = this._docs.get(projectPath);
+    const isNew = !doc;
+    if (!doc) {
+      doc = Automerge.init<ProjectsDoc>();
+      this._initPromises.set(projectPath, Promise.resolve());
+    }
+    const oldProjects = doc.projects || {};
+    const [newDoc] = Automerge.applyChanges<ProjectsDoc>(doc, changes);
+    this._docs.set(projectPath, newDoc);
+    const newProjects = newDoc.projects || {};
+    const allSlugs = new Set([...Object.keys(oldProjects), ...Object.keys(newProjects)]);
+    for (const slug of allSlugs) {
+      const oldProject = isNew ? undefined : oldProjects[slug];
+      const newProject = newProjects[slug];
+      const unchanged =
+        !isNew &&
+        oldProject !== undefined &&
+        newProject !== undefined &&
+        JSON.stringify(oldProject) === JSON.stringify(newProject);
+      if (!unchanged) {
+        if (newProject) {
+          const eventType = oldProject ? 'project:updated' : 'project:created';
+          this._crdtEvents?.emit(eventType, {
+            projectSlug: slug,
+            projectPath,
+            project: newProject,
+          });
+        } else {
+          this._crdtEvents?.emit('project:deleted', { projectSlug: slug, projectPath });
+        }
+      }
+    }
+    logger.debug(`[CRDT] Applied ${changes.length} remote change(s) for ${projectPath}`);
+  }
+
+  // ─── Public API ────────────────────────────────────────────────────────────
+
+  /**
+   * List all projects in a project path
+   */
+  async listProjects(projectPath: string): Promise<string[]> {
+    if (this._isCrdtEnabled(projectPath)) {
+      const doc = await this._ensureDoc(projectPath);
+      return Object.keys(doc.projects || {}).sort();
+    }
+    return this._listSlugsFromDisk(projectPath);
   }
 
   /**
    * Get a project by slug
    */
   async getProject(projectPath: string, projectSlug: string): Promise<Project | null> {
-    const jsonPath = getProjectJsonPath(projectPath, projectSlug);
-
-    try {
-      const rawContent = await secureFs.readFile(jsonPath, 'utf-8');
-      // Ensure we have a string for JSON.parse (handle Buffer case)
-      const content = typeof rawContent === 'string' ? rawContent : rawContent.toString('utf-8');
-      return JSON.parse(content) as Project;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        return null;
-      }
-      throw error;
+    if (this._isCrdtEnabled(projectPath)) {
+      const doc = await this._ensureDoc(projectPath);
+      const raw = (doc.projects || {})[projectSlug];
+      return raw ? (raw as Project) : null;
     }
+    return this._readFromDisk(projectPath, projectSlug);
   }
 
   /**
@@ -148,6 +257,20 @@ export class ProjectService {
           });
         }
       }
+    }
+
+    // Update CRDT doc and emit event
+    if (this._isCrdtEnabled(projectPath)) {
+      const doc = await this._ensureDoc(projectPath);
+      const newDoc = Automerge.change(doc, (d) => {
+        (d.projects as Record<string, unknown>)[project.slug] = this._toAutomergeValue(project);
+      });
+      this._docs.set(projectPath, newDoc);
+      this._crdtEvents?.emit('project:created', {
+        projectSlug: project.slug,
+        projectPath,
+        project,
+      });
     }
 
     logger.info(`Created project: ${project.slug}`);
@@ -292,6 +415,20 @@ export class ProjectService {
       }
     }
 
+    // Update CRDT doc and emit event
+    if (this._isCrdtEnabled(projectPath)) {
+      const doc = await this._ensureDoc(projectPath);
+      const newDoc = Automerge.change(doc, (d) => {
+        (d.projects as Record<string, unknown>)[projectSlug] = this._toAutomergeValue(updated);
+      });
+      this._docs.set(projectPath, newDoc);
+      this._crdtEvents?.emit('project:updated', {
+        projectSlug,
+        projectPath,
+        project: updated,
+      });
+    }
+
     logger.info(`Updated project: ${projectSlug}`);
     return updated;
   }
@@ -360,6 +497,17 @@ export class ProjectService {
     try {
       await secureFs.rm(projectDir, { recursive: true, force: true });
       logger.info(`Deleted project: ${projectSlug} (stats preserved)`);
+
+      // Update CRDT doc and emit event
+      if (this._isCrdtEnabled(projectPath)) {
+        const doc = await this._ensureDoc(projectPath);
+        const newDoc = Automerge.change(doc, (d) => {
+          delete (d.projects as Record<string, Project | undefined>)[projectSlug];
+        });
+        this._docs.set(projectPath, newDoc);
+        this._crdtEvents?.emit('project:deleted', { projectSlug, projectPath });
+      }
+
       return true;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {

--- a/libs/crdt/src/documents.ts
+++ b/libs/crdt/src/documents.ts
@@ -66,6 +66,10 @@ export interface ProjectDocument extends CRDTDocumentRoot {
   title: string;
   goal: string;
   status: string;
+  /** PRD markdown content — stored as a plain string for Automerge sync */
+  prd: string;
+  /** Number of milestones — denormalized for quick reads */
+  milestoneCount: number;
   createdAt: string;
 }
 
@@ -93,6 +97,8 @@ export const normalizeProjectDocument: SchemaNormalizer<ProjectDocument> = (raw)
     title: doc.title ?? '',
     goal: doc.goal ?? '',
     status,
+    prd: doc.prd ?? '',
+    milestoneCount: doc.milestoneCount ?? 0,
     createdAt: doc.createdAt ?? _meta.createdAt,
   };
 };

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -108,6 +108,8 @@ export type EventType =
   | 'integration:unregistered'
   | 'integration:toggled'
   // Project orchestration events
+  | 'project:created'
+  | 'project:updated'
   | 'project:scaffolded'
   | 'project:deleted'
   | 'project:status-changed'
@@ -544,6 +546,9 @@ export interface EventPayloadMap {
 
   // Milestone/project lifecycle
   'milestone:completed': { milestone?: string; projectPath?: string };
+  'project:created': { projectSlug: string; projectPath: string; project?: unknown };
+  'project:updated': { projectSlug: string; projectPath: string; project?: unknown };
+  'project:deleted': { projectSlug: string; projectPath: string };
   'project:completed': { project?: string; projectPath?: string };
   'project:prd:changes-requested': {
     projectSlug: string;

--- a/libs/types/src/events.ts
+++ b/libs/types/src/events.ts
@@ -16,6 +16,9 @@ export const CRDT_SYNCED_EVENT_TYPES: ReadonlySet<EventType> = new Set<EventType
   'feature:updated',
   'feature:created',
   'feature:deleted',
+  'project:created',
+  'project:updated',
+  'project:deleted',
 ]);
 
 /**


### PR DESCRIPTION
## Summary\n- Add Automerge CRDT integration to ProjectService following AutomergeFeatureStore pattern\n- CRDT-gated reads for listProjects/getProject (in-memory when proto.config.yaml present)\n- CRDT writes on createProject/updateProject/deleteProject with event emission\n- applyRemoteChanges for incoming peer project changes\n- Wire EventEmitter to ProjectService constructor in services.ts\n- Add project:created/updated/deleted to EventType union and CRDT_SYNCED_EVENT_TYPES\n- Extend ProjectDocument with prd and milestoneCount fields\n\n## Test plan\n- [ ] Verify ProjectService works without proto.config.yaml (filesystem fallback)\n- [ ] Verify CRDT reads serve from Automerge doc when enabled\n- [ ] Verify project events are emitted on CRUD operations\n- [ ] TypeScript compiles cleanly\n- [ ] ESLint and Prettier pass

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-07T18:12:08.399Z -->