### PR TITLE
Shared Settings Sync

### DIFF
--- a/apps/server/src/services/crdt-sync-service.ts
+++ b/apps/server/src/services/crdt-sync-service.ts
@@ -37,7 +37,18 @@ interface PeerMessage {
   priority?: number;
 }
 
-type SyncMessage = PeerMessage | CrdtFeatureEvent;
+/**
+ * Wire message carrying shared settings from one instance to all peers.
+ * Credentials and API keys MUST NOT be included in the settings payload.
+ */
+interface CrdtSettingsEvent {
+  type: 'settings_event';
+  instanceId: string;
+  settings: Record<string, unknown>;
+  timestamp: string;
+}
+
+type SyncMessage = PeerMessage | CrdtFeatureEvent | CrdtSettingsEvent;
 
 interface TrackedPeer extends HivemindPeer {
   ws?: WebSocket;
@@ -62,9 +73,45 @@ export class CrdtSyncService {
   private selfPriority = -1;
   private promotionPending = false;
   private _eventBus: EventEmitter | null = null;
+  private _settingsCallback: ((settings: Record<string, unknown>) => void) | null = null;
 
   constructor() {
     this.instanceId = os.hostname();
+  }
+
+  /**
+   * Register a callback invoked when shared settings arrive from a remote peer.
+   * The callback receives a plain settings record (never contains credentials).
+   * Call this before `start()`.
+   */
+  onSettingsReceived(callback: (settings: Record<string, unknown>) => void): void {
+    this._settingsCallback = callback;
+  }
+
+  /**
+   * Broadcast shared settings to all connected peers.
+   * Credentials and API keys MUST NOT be included in the settings object.
+   */
+  publishSettings(settings: Record<string, unknown>): void {
+    if (!this.started) return;
+
+    const msg: CrdtSettingsEvent = {
+      type: 'settings_event',
+      instanceId: this.instanceId,
+      settings,
+      timestamp: new Date().toISOString(),
+    };
+    const raw = JSON.stringify(msg);
+
+    if (this.role === 'primary') {
+      this._broadcastToServer(raw);
+    } else if (this.wsClient?.readyState === WebSocket.OPEN) {
+      try {
+        this.wsClient.send(raw);
+      } catch {
+        // Best effort
+      }
+    }
   }
 
   /**
@@ -643,6 +690,22 @@ export class CrdtSyncService {
         this._eventBus.emit(msg.eventType, msg.payload);
 
         // Primary relays feature events to all other connected workers.
+        if (this.role === 'primary') {
+          this._broadcastToServerExcept(JSON.stringify(msg), ws);
+        }
+        break;
+      }
+      case 'settings_event': {
+        // Ignore settings from this instance to prevent feedback loops.
+        if (msg.instanceId === this.instanceId) break;
+
+        logger.debug(`[CRDT] Received remote settings update from ${msg.instanceId}`);
+
+        if (this._settingsCallback) {
+          this._settingsCallback(msg.settings);
+        }
+
+        // Primary relays settings events to all other connected workers.
         if (this.role === 'primary') {
           this._broadcastToServerExcept(JSON.stringify(msg), ws);
         }

--- a/apps/server/src/services/settings-service.ts
+++ b/apps/server/src/services/settings-service.ts
@@ -53,6 +53,7 @@ import {
   migrateCursorModelIds,
   migrateOpencodeModelIds,
 } from '@protolabsai/types';
+import type { SharedSettings } from '@protolabsai/types';
 
 const logger = createLogger('SettingsService');
 
@@ -90,6 +91,29 @@ async function fileExists(filePath: string): Promise<boolean> {
  */
 async function writeSettingsJson(filePath: string, data: unknown): Promise<void> {
   await atomicWriteJson(filePath, data, { backupCount: DEFAULT_BACKUP_COUNT });
+}
+
+/**
+ * Apply shared settings fields onto a ProjectSettings base.
+ *
+ * Only the fields defined in SharedSettings are applied — credentials and
+ * UI-only preferences are never touched by this function.
+ */
+function applySharedSettings(base: ProjectSettings, shared: SharedSettings): ProjectSettings {
+  const result = { ...base };
+
+  if (shared.maxConcurrentAgents !== undefined) {
+    result.maxConcurrentAgents = shared.maxConcurrentAgents;
+  }
+
+  if (shared.workflow !== undefined) {
+    result.workflow = {
+      ...base.workflow,
+      ...shared.workflow,
+    } as ProjectSettings['workflow'];
+  }
+
+  return result;
 }
 
 /**
@@ -844,6 +868,49 @@ export class SettingsService {
       ...DEFAULT_PROJECT_SETTINGS,
       ...settings,
     };
+  }
+
+  /**
+   * Get the effective project settings by merging three layers in order:
+   *
+   *   proto.config defaults < shared CRDT settings < local .automaker/settings.json overrides
+   *
+   * The local file always wins. Shared CRDT settings override proto.config defaults.
+   * Credentials and API keys are never accepted in the shared settings layers.
+   *
+   * @param projectPath - Absolute path to project directory
+   * @param protoConfigDefaults - Optional shared settings from proto.config.yaml (lowest priority)
+   * @param sharedSettings - Optional shared settings from CRDT store (middle priority)
+   * @returns Promise resolving to merged ProjectSettings with local overrides applied last
+   */
+  async getEffectiveProjectSettings(
+    projectPath: string,
+    protoConfigDefaults?: SharedSettings,
+    sharedSettings?: SharedSettings
+  ): Promise<ProjectSettings> {
+    const localSettings = await this.getProjectSettings(projectPath);
+
+    // Start from defaults then apply each layer in priority order
+    let effective: ProjectSettings = { ...DEFAULT_PROJECT_SETTINGS };
+
+    // Layer 1: proto.config.yaml sharedSettings (lowest priority)
+    if (protoConfigDefaults) {
+      effective = applySharedSettings(effective, protoConfigDefaults);
+    }
+
+    // Layer 2: shared CRDT settings (middle priority)
+    if (sharedSettings) {
+      effective = applySharedSettings(effective, sharedSettings);
+    }
+
+    // Layer 3: local .automaker/settings.json (highest priority — always wins)
+    effective = {
+      ...effective,
+      ...localSettings,
+      version: PROJECT_SETTINGS_VERSION,
+    };
+
+    return effective;
   }
 
   /**

--- a/libs/crdt/src/documents.ts
+++ b/libs/crdt/src/documents.ts
@@ -133,15 +133,57 @@ export const normalizeConfigDocument: SchemaNormalizer<ConfigDocument> = (raw) =
 };
 
 // ---------------------------------------------------------------------------
+// SharedSettings domain
+// ---------------------------------------------------------------------------
+
+/**
+ * SharedSettingsDocument stores settings that should propagate across
+ * all instances in a hive. Credentials and API keys MUST NOT be included.
+ *
+ * Resolution order (lowest → highest priority):
+ *   proto.config defaults < shared CRDT settings < local .automaker/settings.json
+ *
+ * Use document id="shared" within the 'settings' domain.
+ */
+export interface SharedSettingsDocument extends CRDTDocumentRoot {
+  schemaVersion: 1;
+  /**
+   * Shared settings payload. Keys map to project settings fields that are
+   * safe to propagate: phaseModelOverrides, maxConcurrency, workflow tuning.
+   * Credentials, API keys, and UI-only preferences are excluded.
+   */
+  settings: Record<string, unknown>;
+  updatedAt: string;
+}
+
+export const normalizeSharedSettingsDocument: SchemaNormalizer<SharedSettingsDocument> = (raw) => {
+  const doc = raw as Partial<SharedSettingsDocument>;
+
+  const _meta = doc._meta ?? {
+    instanceId: 'unknown',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  return {
+    schemaVersion: 1,
+    _meta,
+    settings: doc.settings ?? {},
+    updatedAt: doc.updatedAt ?? _meta.updatedAt,
+  };
+};
+
+// ---------------------------------------------------------------------------
 // Normalizer registry
 // ---------------------------------------------------------------------------
 
-type AnyDocument = FeatureDocument | ProjectDocument | ConfigDocument;
+type AnyDocument = FeatureDocument | ProjectDocument | ConfigDocument | SharedSettingsDocument;
 
 const NORMALIZERS: Record<string, SchemaNormalizer<AnyDocument>> = {
   features: normalizeFeatureDocument as SchemaNormalizer<AnyDocument>,
   projects: normalizeProjectDocument as SchemaNormalizer<AnyDocument>,
   config: normalizeConfigDocument as SchemaNormalizer<AnyDocument>,
+  settings: normalizeSharedSettingsDocument as SchemaNormalizer<AnyDocument>,
 };
 
 /**

--- a/libs/crdt/src/index.ts
+++ b/libs/crdt/src/index.ts
@@ -15,9 +15,15 @@ export {
   normalizeFeatureDocument,
   normalizeProjectDocument,
   normalizeConfigDocument,
+  normalizeSharedSettingsDocument,
 } from './documents.js';
 
-export type { FeatureDocument, ProjectDocument, ConfigDocument } from './documents.js';
+export type {
+  FeatureDocument,
+  ProjectDocument,
+  ConfigDocument,
+  SharedSettingsDocument,
+} from './documents.js';
 
 export type {
   CRDTDocumentRoot,

--- a/libs/crdt/src/types.ts
+++ b/libs/crdt/src/types.ts
@@ -30,7 +30,7 @@ export interface CRDTDocumentRoot {
 /**
  * Supported domain namespaces for grouping CRDT documents.
  */
-export type DomainName = 'features' | 'projects' | 'config';
+export type DomainName = 'features' | 'projects' | 'config' | 'settings';
 
 /**
  * Configuration for a WebSocket sync peer (typically a Tailscale peer).

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -890,6 +890,7 @@ export {
   ProtoHiveSchema,
   ProtoInstanceSchema,
   ProtoAssignmentSchema,
+  SharedSettingsSchema,
 } from './proto-config.js';
 export type {
   ProtoConfig,
@@ -901,6 +902,7 @@ export type {
   ProtoHive,
   ProtoInstance,
   ProtoAssignment,
+  SharedSettings,
 } from './proto-config.js';
 
 // PenFile types (vector graphics format v2.8)

--- a/libs/types/src/proto-config.ts
+++ b/libs/types/src/proto-config.ts
@@ -136,6 +136,39 @@ export const ProtoAssignmentSchema = z.object({
 export type ProtoAssignment = z.infer<typeof ProtoAssignmentSchema>;
 
 // ---------------------------------------------------------------------------
+// Shared Settings — settings that propagate across instances via CRDT sync
+// ---------------------------------------------------------------------------
+
+/**
+ * SharedSettings defines which settings are eligible for cross-instance
+ * propagation. Credentials and API keys are NEVER included here.
+ *
+ * Resolution order: proto.config defaults < shared CRDT settings < local overrides
+ */
+export const SharedSettingsSchema = z.object({
+  /**
+   * Maximum concurrent agents across all projects on this hive.
+   * Maps to ProjectSettings.maxConcurrentAgents.
+   */
+  maxConcurrentAgents: z.number().int().min(1).optional(),
+  /** Shared workflow tuning parameters */
+  workflow: z
+    .object({
+      /** Maximum retries before escalation (default varies by implementation) */
+      maxRetries: z.number().int().min(0).optional(),
+      /** Whether to automatically commit after each agent step */
+      enableAutoCommit: z.boolean().optional(),
+      /** Whether to automatically open PRs after feature completion */
+      enableAutoPR: z.boolean().optional(),
+      /** Whether to skip validation phase in the pipeline */
+      skipValidation: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+export type SharedSettings = z.infer<typeof SharedSettingsSchema>;
+
+// ---------------------------------------------------------------------------
 // Root ProtoConfig
 // ---------------------------------------------------------------------------
 
@@ -160,6 +193,12 @@ export const ProtoConfigSchema = z.object({
   instances: z.array(ProtoInstanceSchema).optional(),
   /** Work assignment strategy across instances */
   assignment: ProtoAssignmentSchema.optional(),
+  /**
+   * Shared settings defaults — lowest-priority layer in config resolution.
+   * These values are overridden by shared CRDT settings and local overrides.
+   * Credentials and API keys MUST NOT be placed here.
+   */
+  sharedSettings: SharedSettingsSchema.optional(),
 });
 
 export type ProtoConfig = z.infer<typeof ProtoConfigSchema>;


### PR DESCRIPTION
## Summary

**Milestone:** Projects and Settings Sync

Create a shared-settings Automerge document for configuration that should propagate across instances (shared model preferences, workflow tuning, etc). Instance-local settings remain in .automaker/settings.json. Effective config = proto.config defaults MERGED with shared CRDT settings MERGED with local overrides.

**Files to Modify:**
- apps/server/src/services/settings-service.ts
- apps/server/src/services/crdt-sync-service.ts
- libs/crdt/src/documents....

---
*Recovered automatically by Automaker post-agent hook*