### PR TITLE
Instance Capacity Advertising

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -10,6 +10,7 @@
  */
 
 import * as v8 from 'node:v8';
+import { freemem, totalmem, cpus, loadavg } from 'node:os';
 import { ProviderFactory } from '../providers/provider-factory.js';
 import { simpleQuery } from '../providers/simple-query-service.js';
 import { StreamObserver } from './stream-observer-service.js';
@@ -262,6 +263,8 @@ export class AutoModeService {
   // Track which projects have already been checked for interrupted features this server lifecycle.
   // Prevents the UI from re-triggering resumeInterruptedFeatures on every board mount.
   private resumeCheckedProjects = new Set<string>();
+  // Cached backlog count refreshed asynchronously on each capacity read.
+  private _backlogCountCache = 0;
   // Memory management thresholds (configurable via env vars)
   private readonly HEAP_USAGE_STOP_NEW_AGENTS_THRESHOLD = parseFloat(
     process.env.HEAP_STOP_THRESHOLD || '0.8'
@@ -2891,6 +2894,77 @@ Format your response as a structured markdown document.`;
       runningFeatures: Array.from(this.runningFeatures.keys()),
       runningCount: this.runningFeatures.size,
     };
+  }
+
+  /**
+   * Returns a synchronous snapshot of this instance's capacity metrics for
+   * publication via CRDT heartbeat. OS metrics (CPU, RAM) are computed fresh
+   * on each call. Backlog count is served from a cache that is refreshed
+   * asynchronously on each call (non-blocking — first call returns 0).
+   */
+  getCapacityMetrics(): import('@protolabsai/types').InstanceCapacity {
+    const totalMem = totalmem();
+    const usedMem = totalMem - freemem();
+    const ramUsagePercent = Math.round((usedMem / totalMem) * 100);
+
+    const coreCount = cpus().length || 1;
+    const cpuPercent = Math.min(Math.round((loadavg()[0] / coreCount) * 100), 100);
+
+    // Resolve global max concurrency across all active loops (use first active or default).
+    let maxAgents = DEFAULT_MAX_CONCURRENCY;
+    for (const [, state] of this.coordinator.loops) {
+      if (state.isRunning) {
+        maxAgents = state.config.maxConcurrency;
+        break;
+      }
+    }
+
+    // Refresh backlog cache async (fire-and-forget, non-blocking).
+    void this._refreshBacklogCount();
+
+    return {
+      cores: coreCount,
+      ramMb: Math.round(totalMem / (1024 * 1024)),
+      runningAgents: this.runningFeatures.size,
+      maxAgents,
+      backlogCount: this._backlogCountCache,
+      ramUsagePercent,
+      cpuPercent,
+    };
+  }
+
+  /** Async refresh of the backlog count cache from all active project paths. */
+  private async _refreshBacklogCount(): Promise<void> {
+    try {
+      // Collect unique project paths from running features and active loops.
+      const projectPaths = new Set<string>();
+      for (const rf of this.runningFeatures.values()) {
+        projectPaths.add(rf.projectPath);
+      }
+      for (const [, state] of this.coordinator.loops) {
+        projectPaths.add(state.config.projectPath);
+      }
+
+      if (projectPaths.size === 0) {
+        this._backlogCountCache = 0;
+        return;
+      }
+
+      let total = 0;
+      await Promise.all(
+        [...projectPaths].map(async (projectPath) => {
+          try {
+            const features = await this.featureLoader.getAll(projectPath);
+            total += features.filter((f) => f.status === 'backlog').length;
+          } catch {
+            // Best effort — skip project paths that fail to load.
+          }
+        })
+      );
+      this._backlogCountCache = total;
+    } catch {
+      // Best effort — keep last cached value on error.
+    }
   }
 
   /**

--- a/apps/server/src/services/crdt-sync-service.ts
+++ b/apps/server/src/services/crdt-sync-service.ts
@@ -14,6 +14,7 @@ import { loadProtoConfig } from '@protolabsai/platform';
 import type {
   HivemindPeer,
   HivemindConfig,
+  InstanceCapacity,
   SyncRole,
   SyncServerStatus,
   CrdtFeatureEvent,
@@ -35,6 +36,8 @@ interface PeerMessage {
   url?: string;
   timestamp: string;
   priority?: number;
+  /** Capacity metrics published by the sender on every heartbeat */
+  capacity?: InstanceCapacity;
 }
 
 /**
@@ -74,6 +77,7 @@ export class CrdtSyncService {
   private promotionPending = false;
   private _eventBus: EventEmitter | null = null;
   private _settingsCallback: ((settings: Record<string, unknown>) => void) | null = null;
+  private _capacityProvider: (() => InstanceCapacity) | null = null;
 
   constructor() {
     this.instanceId = os.hostname();
@@ -86,6 +90,15 @@ export class CrdtSyncService {
    */
   onSettingsReceived(callback: (settings: Record<string, unknown>) => void): void {
     this._settingsCallback = callback;
+  }
+
+  /**
+   * Register a callback that returns this instance's current capacity metrics.
+   * Called on every heartbeat to include fresh metrics in the outgoing message.
+   * Must be called before `start()`.
+   */
+  setCapacityProvider(provider: () => InstanceCapacity): void {
+    this._capacityProvider = provider;
   }
 
   /**
@@ -280,11 +293,23 @@ export class CrdtSyncService {
 
   /**
    * Returns the current sync status for the /health endpoint.
+   * Includes peer capacity summaries so operators can see load across instances.
    */
   getSyncStatus(): SyncServerStatus {
     const onlinePeers = [...this.peers.values()]
       .filter((p) => p.identity.status === 'online')
       .map(({ ws: _ws, priority: _priority, ...peer }) => peer as HivemindPeer);
+
+    const peerCapacitySummary = [...this.peers.values()]
+      .filter((p) => p.identity.status === 'online')
+      .map((p) => ({
+        instanceId: p.identity.instanceId,
+        runningAgents: p.identity.capacity.runningAgents,
+        maxAgents: p.identity.capacity.maxAgents,
+        backlogCount: p.identity.capacity.backlogCount,
+        ramUsagePercent: p.identity.capacity.ramUsagePercent,
+        cpuPercent: p.identity.capacity.cpuPercent,
+      }));
 
     return {
       role: this.role,
@@ -296,6 +321,7 @@ export class CrdtSyncService {
       peerCount: this.peers.size,
       onlinePeers,
       isLeader: this.role === 'primary',
+      peerCapacitySummary,
     };
   }
 
@@ -584,6 +610,7 @@ export class CrdtSyncService {
         instanceId: this.instanceId,
         url: this.instanceUrl ?? undefined,
         timestamp: new Date().toISOString(),
+        capacity: this._capacityProvider ? this._capacityProvider() : undefined,
       };
       const msg = JSON.stringify(beat);
 
@@ -721,12 +748,21 @@ export class CrdtSyncService {
       existing.identity.lastHeartbeat = msg.timestamp;
       existing.identity.status = 'online';
       if (msg.url) existing.identity.url = msg.url;
+      if (msg.capacity) existing.identity.capacity = msg.capacity;
     } else {
       this.peers.set(msg.instanceId, {
         identity: {
           instanceId: msg.instanceId,
           url: msg.url,
-          capacity: { cores: 0, ramMb: 0, maxAgents: 0, runningAgents: 0 },
+          capacity: msg.capacity ?? {
+            cores: 0,
+            ramMb: 0,
+            maxAgents: 0,
+            runningAgents: 0,
+            backlogCount: 0,
+            ramUsagePercent: 0,
+            cpuPercent: 0,
+          },
           domains: [],
           lastHeartbeat: msg.timestamp,
           status: 'online',

--- a/apps/server/src/services/crdt-sync.module.ts
+++ b/apps/server/src/services/crdt-sync.module.ts
@@ -8,4 +8,11 @@ export async function register(container: ServiceContainer): Promise<void> {
   // After this call, broadcast() publishes feature events to remote peers and
   // incoming remote feature events are re-emitted locally.
   container.crdtSyncService.attachEventBus(container.events);
+
+  // Register capacity provider so each heartbeat includes fresh instance metrics.
+  // The provider is synchronous and non-blocking; backlog count is refreshed
+  // async in the background on each call.
+  container.crdtSyncService.setCapacityProvider(() =>
+    container.autoModeService.getCapacityMetrics()
+  );
 }

--- a/libs/crdt/src/documents.ts
+++ b/libs/crdt/src/documents.ts
@@ -174,16 +174,74 @@ export const normalizeSharedSettingsDocument: SchemaNormalizer<SharedSettingsDoc
 };
 
 // ---------------------------------------------------------------------------
+// Capacity domain
+// ---------------------------------------------------------------------------
+
+/**
+ * CapacityDocument stores per-instance capacity metrics in the shared CRDT
+ * assignments document. Each instance publishes its own capacity snapshot
+ * keyed by instanceId. Used by the work-stealing protocol to identify idle
+ * and busy peers.
+ *
+ * Use domain='capacity', document id=instanceId.
+ */
+export interface CapacityDocument extends CRDTDocumentRoot {
+  schemaVersion: 1;
+  /** Instance that owns this capacity record */
+  instanceId: string;
+  /** Number of agents currently running on this instance */
+  runningAgents: number;
+  /** Maximum agents this instance is configured to run concurrently */
+  maxAgents: number;
+  /** Number of features in backlog status across all active projects */
+  backlogCount: number;
+  /** System RAM usage as a percentage (0-100) */
+  ramUsagePercent: number;
+  /** CPU load as a percentage (0-100) */
+  cpuPercent: number;
+  /** ISO timestamp of last update */
+  updatedAt: string;
+}
+
+export const normalizeCapacityDocument: SchemaNormalizer<CapacityDocument> = (raw) => {
+  const doc = raw as Partial<CapacityDocument>;
+
+  const _meta = doc._meta ?? {
+    instanceId: 'unknown',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  return {
+    schemaVersion: 1,
+    _meta,
+    instanceId: doc.instanceId ?? _meta.instanceId,
+    runningAgents: doc.runningAgents ?? 0,
+    maxAgents: doc.maxAgents ?? 0,
+    backlogCount: doc.backlogCount ?? 0,
+    ramUsagePercent: doc.ramUsagePercent ?? 0,
+    cpuPercent: doc.cpuPercent ?? 0,
+    updatedAt: doc.updatedAt ?? _meta.updatedAt,
+  };
+};
+
+// ---------------------------------------------------------------------------
 // Normalizer registry
 // ---------------------------------------------------------------------------
 
-type AnyDocument = FeatureDocument | ProjectDocument | ConfigDocument | SharedSettingsDocument;
+type AnyDocument =
+  | FeatureDocument
+  | ProjectDocument
+  | ConfigDocument
+  | SharedSettingsDocument
+  | CapacityDocument;
 
 const NORMALIZERS: Record<string, SchemaNormalizer<AnyDocument>> = {
   features: normalizeFeatureDocument as SchemaNormalizer<AnyDocument>,
   projects: normalizeProjectDocument as SchemaNormalizer<AnyDocument>,
   config: normalizeConfigDocument as SchemaNormalizer<AnyDocument>,
   settings: normalizeSharedSettingsDocument as SchemaNormalizer<AnyDocument>,
+  capacity: normalizeCapacityDocument as SchemaNormalizer<AnyDocument>,
 };
 
 /**

--- a/libs/types/src/hivemind.ts
+++ b/libs/types/src/hivemind.ts
@@ -8,6 +8,16 @@
 /** Role of an instance in the sync mesh */
 export type SyncRole = 'primary' | 'worker';
 
+/** Compact capacity summary for a single peer — used in /health responses */
+export interface PeerCapacitySummary {
+  instanceId: string;
+  runningAgents: number;
+  maxAgents: number;
+  backlogCount: number;
+  ramUsagePercent: number;
+  cpuPercent: number;
+}
+
 /** Health status of the CRDT sync service for the /health endpoint */
 export interface SyncServerStatus {
   /** This instance's current role */
@@ -22,6 +32,8 @@ export interface SyncServerStatus {
   onlinePeers: HivemindPeer[];
   /** Whether this instance is currently acting as the leader/primary */
   isLeader: boolean;
+  /** Compact capacity snapshot for each online peer */
+  peerCapacitySummary?: PeerCapacitySummary[];
 }
 
 /** Capacity metrics for an instance */
@@ -30,6 +42,12 @@ export interface InstanceCapacity {
   ramMb: number;
   maxAgents: number;
   runningAgents: number;
+  /** Number of features in backlog status across all active projects */
+  backlogCount: number;
+  /** System RAM usage as a percentage (0-100) */
+  ramUsagePercent: number;
+  /** CPU load as a percentage (0-100), derived from 1-minute load average */
+  cpuPercent: number;
 }
 
 /** A domain is a set of codebase paths owned by an instance */


### PR DESCRIPTION
## Summary

**Milestone:** Cross-Instance Assignment

Each instance periodically updates its InstanceCapacity in the CRDT assignments document: running agents, max agents, RAM usage, CPU load, backlog depth. This data is used by the work-stealing protocol to identify idle instances and busy peers.

**Files to Modify:**
- apps/server/src/services/crdt-sync-service.ts
- libs/crdt/src/documents.ts
- libs/types/src/hivemind.ts
- apps/server/src/services/auto-mode-service.ts

**Acceptance Criteria:**
- [ ] Each ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * System now monitors and reports capacity metrics including CPU usage percentage, RAM usage percentage, running agents, maximum agents, and backlog count.
  * Capacity metrics are automatically shared across distributed peers, providing enhanced visibility into system resource allocation and load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->