### PR TITLE
fix: CRDT sync path remapping for cross-instance persistence

### DIFF
--- a/apps/server/src/services/crdt-sync.module.ts
+++ b/apps/server/src/services/crdt-sync.module.ts
@@ -24,8 +24,10 @@ export async function register(container: ServiceContainer): Promise<void> {
   // This handler runs BEFORE the event is re-emitted on the local bus, so downstream
   // subscribers (UI WebSocket, IntegrationService, etc.) see already-persisted data.
   container.crdtSyncService.onRemoteFeatureEvent((eventType, payload) => {
-    const projectPath = payload.projectPath as string | undefined;
-    if (!projectPath) return;
+    // Remap remote projectPath to local — each instance has its own filesystem path
+    // (e.g. Mac sends /Users/kj/dev/automaker, staging expects /home/josh/dev/ava)
+    const projectPath = container.repoRoot;
+    if (!payload.projectPath) return;
 
     const featureLoader = container.featureLoader;
 
@@ -52,11 +54,16 @@ export async function register(container: ServiceContainer): Promise<void> {
         }
         logger.info(`[CRDT] Persisting remote ${eventType} ${featureId}`);
         // Write the full feature state to disk, skipping event emission to prevent loops.
+        // Fall back to create if the feature doesn't exist locally yet.
         featureLoader
           .update(projectPath, featureId, feature, undefined, undefined, undefined, {
             skipEventEmission: true,
           })
           .catch((err) => {
+            if (String(err).includes('not found')) {
+              logger.info(`[CRDT] Feature ${featureId} not found locally, creating from remote`);
+              return featureLoader.create(projectPath, { ...feature, id: featureId });
+            }
             logger.error(`[CRDT] Failed to persist remote ${eventType} ${featureId}: ${err}`);
           });
         break;


### PR DESCRIPTION
## Summary
- Remap remote `projectPath` to local `repoRoot` in CRDT sync receiver
- Fall back to `create` when `update` fails with "Feature not found" (remote features that don't exist locally yet)

## Root cause
Remote peers broadcast their local filesystem path (e.g. `/Users/kj/dev/automaker`) in event payloads. The receiving instance's `ALLOWED_ROOT_DIRECTORY` sandbox correctly rejects this foreign path. Fix: always use the local `container.repoRoot`.

## Merge strategy
Use **merge commit** (not squash) per branch strategy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote feature synchronization reliability by implementing automatic creation of missing features instead of failing silently.
  * Enhanced project path resolution in feature event handling for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->