### PR TITLE
feat: cross-instance assignment - board instance badges and peers panel

### DIFF
--- a/apps/server/src/routes/hivemind/index.ts
+++ b/apps/server/src/routes/hivemind/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Hivemind routes — exposes peer/instance status for the unified dashboard.
+ *
+ * GET /api/hivemind/peers  — returns all known peers with identity, status,
+ *                            and capacity metrics.
+ */
+
+import { Router } from 'express';
+import type { CrdtSyncService } from '../../services/crdt-sync-service.js';
+
+export function createHivemindRoutes(crdtSyncService: CrdtSyncService): Router {
+  const router = Router();
+
+  /**
+   * GET /peers
+   *
+   * Returns all peers known to this instance (online and offline).
+   * Each peer includes status (online/offline/draining) and capacity metrics.
+   */
+  router.get('/peers', (_req, res) => {
+    const peers = crdtSyncService.getPeers();
+    res.json({ peers });
+  });
+
+  /**
+   * GET /status
+   *
+   * Returns the full sync status for this instance, including peer count,
+   * role, and capacity summary. Convenience alias for /api/health/detailed
+   * that only surfaces hivemind-relevant fields.
+   */
+  router.get('/status', (_req, res) => {
+    const status = crdtSyncService.getSyncStatus();
+    res.json(status);
+  });
+
+  /**
+   * GET /self
+   *
+   * Returns the instanceId of this Automaker instance. Used by the UI to
+   * know which instance it is talking to, for the cross-instance dashboard.
+   */
+  router.get('/self', (_req, res) => {
+    res.json({ instanceId: crdtSyncService.getInstanceId() });
+  });
+
+  return router;
+}

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -88,6 +88,7 @@ import { createAutomationsRoutes } from '../routes/automations/index.js';
 import { createSensorRoutes } from '../routes/sensors/index.js';
 import { createProjectPmRoutes } from '../routes/project-pm/index.js';
 import { createLedgerRoutes } from '../routes/ledger/index.js';
+import { createHivemindRoutes } from '../routes/hivemind/index.js';
 
 const logger = createLogger('Server:Routes');
 
@@ -422,6 +423,10 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   // Ledger REST endpoints (event persistence layer)
   app.use('/api/ledger', createLedgerRoutes(ledgerService, featureLoader));
   logger.info('Ledger routes mounted at /api/ledger');
+
+  // Hivemind routes (peer/instance status for unified dashboard)
+  app.use('/api/hivemind', createHivemindRoutes(crdtSyncService));
+  logger.info('Hivemind routes mounted at /api/hivemind');
 
   // Note: Sentry v8 automatically captures Express errors - no manual error handler needed
 }

--- a/apps/server/src/services/crdt-sync-service.ts
+++ b/apps/server/src/services/crdt-sync-service.ts
@@ -368,6 +368,13 @@ export class CrdtSyncService {
   }
 
   /**
+   * Returns the instanceId of this instance.
+   */
+  getInstanceId(): string {
+    return this.instanceId;
+  }
+
+  /**
    * Returns all known peers (including offline).
    */
   getPeers(): HivemindPeer[] {

--- a/apps/ui/src/components/views/board-view.tsx
+++ b/apps/ui/src/components/views/board-view.tsx
@@ -71,6 +71,7 @@ import { CreateBranchDialog } from './board-view/dialogs/create-branch-dialog';
 import { PRDReviewModal } from './prd-review-modal';
 import { WorktreePanel } from './board-view/worktree-panel';
 import type { PRInfo, WorktreeInfo, MergeConflictInfo } from './board-view/worktree-panel/types';
+import { PeersPanel } from './peers-panel';
 import { COLUMNS, getColumnsWithPipeline, type ColumnId } from './board-view/constants';
 import {
   useBoardFeatures,
@@ -124,6 +125,8 @@ export function BoardView() {
     updateFeature,
     planUseSelectedWorktreeBranch,
     addFeatureUseSelectedWorktreeBranch,
+    instanceFilter,
+    selfInstanceId,
   } = useAppStore(
     useShallow((state) => ({
       currentProject: state.currentProject,
@@ -135,6 +138,8 @@ export function BoardView() {
       updateFeature: state.updateFeature,
       planUseSelectedWorktreeBranch: state.planUseSelectedWorktreeBranch,
       addFeatureUseSelectedWorktreeBranch: state.addFeatureUseSelectedWorktreeBranch,
+      instanceFilter: state.instanceFilter,
+      selfInstanceId: state.selfInstanceId,
     }))
   );
 
@@ -1162,9 +1167,16 @@ export function BoardView() {
     ]
   );
 
+  // Apply cross-instance filter: 'mine' shows only features assigned to this instance
+  // (or unassigned), 'all' shows features from every instance.
+  const instanceFilteredFeatures = useMemo(() => {
+    if (instanceFilter === 'all' || !selfInstanceId) return hookFeatures;
+    return hookFeatures.filter((f) => !f.assignedInstance || f.assignedInstance === selfInstanceId);
+  }, [hookFeatures, instanceFilter, selfInstanceId]);
+
   // Use column features hook
   const { getColumnFeatures, completedFeatures } = useBoardColumnFeatures({
-    features: hookFeatures,
+    features: instanceFilteredFeatures,
     runningAutoTasks,
     searchQuery,
     currentWorktreePath,
@@ -1465,6 +1477,9 @@ export function BoardView() {
             }))}
           />
         )}
+
+        {/* Peers Panel — cross-instance mesh status and instance filter */}
+        <PeersPanel className="border-b border-border/30 px-3 py-2" />
 
         {/* Main Content Area */}
         <div className="flex-1 flex flex-col overflow-hidden">

--- a/apps/ui/src/components/views/board-view/components/kanban-card/card-badges.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/card-badges.tsx
@@ -22,6 +22,7 @@ import {
   Loader2,
   FileText,
   XCircle,
+  Server,
 } from 'lucide-react';
 import { getBlockingDependencies } from '@protolabsai/dependency-resolver';
 import { useShallow } from 'zustand/react/shallow';
@@ -167,8 +168,17 @@ export const CardBadges = memo(function CardBadges({ feature, onPRDClick }: Card
   const hasCost = costUsd != null && costUsd > 0;
   const isNeedsAction =
     feature.status === 'blocked' && isHumanInterventionRequired(feature.statusChangeReason ?? '');
+  const hasAssignedInstance = !!feature.assignedInstance;
 
-  if (!hasError && !hasEpic && !hasDueDate && !hasCost && !hasWorkItemState && !isNeedsAction) {
+  if (
+    !hasError &&
+    !hasEpic &&
+    !hasDueDate &&
+    !hasCost &&
+    !hasWorkItemState &&
+    !isNeedsAction &&
+    !hasAssignedInstance
+  ) {
     return null;
   }
 
@@ -184,6 +194,26 @@ export const CardBadges = memo(function CardBadges({ feature, onPRDClick }: Card
     <div className="flex flex-wrap items-center gap-1.5 px-3 pt-1.5 min-h-[24px]">
       {/* Epic badge - shows parent epic for child features */}
       {hasEpic && <EpicBadge feature={feature} />}
+
+      {/* Instance badge - shows which instance owns this feature (cross-instance dashboard) */}
+      {hasAssignedInstance && (
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className="inline-flex items-center gap-1 px-1.5 h-5 rounded text-[10px] font-medium bg-violet-500/15 text-violet-400 border border-violet-500/30"
+                data-testid={`instance-badge-${feature.id}`}
+              >
+                <Server className="w-2.5 h-2.5" />
+                {feature.assignedInstance}
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              <p>Assigned to instance: {feature.assignedInstance}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
 
       {/* Work Item State badge - authority system lifecycle */}
       {hasWorkItemState && workItemStateBadge && (

--- a/apps/ui/src/components/views/board-view/dialogs/edit-feature-dialog.tsx
+++ b/apps/ui/src/components/views/board-view/dialogs/edit-feature-dialog.tsx
@@ -614,6 +614,27 @@ export function EditFeatureDialog({
                 </div>
               </div>
             )}
+
+            {/* Cross-instance assignment info (read-only) */}
+            {(editingFeature.assignedInstance || editingFeature.claimedBy) && (
+              <div className="pt-2 space-y-1.5">
+                <Label className="text-xs text-muted-foreground">Instance Assignment</Label>
+                <div className="flex flex-col gap-1 rounded-md border border-border/40 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+                  {editingFeature.assignedInstance && (
+                    <div className="flex items-center gap-2">
+                      <span className="text-foreground font-medium">Assigned to:</span>
+                      <span className="font-mono">{editingFeature.assignedInstance}</span>
+                    </div>
+                  )}
+                  {editingFeature.claimedBy && (
+                    <div className="flex items-center gap-2">
+                      <span className="text-foreground font-medium">Claimed by:</span>
+                      <span className="font-mono">{editingFeature.claimedBy}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
           </div>
         </div>
 

--- a/apps/ui/src/components/views/feature-detail.tsx
+++ b/apps/ui/src/components/views/feature-detail.tsx
@@ -11,6 +11,7 @@ import {
   XCircle,
   AlertTriangle,
   RefreshCw,
+  Server,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { Feature } from '@/store/types';
@@ -227,6 +228,17 @@ export const FeatureDetail = memo(function FeatureDetail({ feature }: FeatureDet
               <div>
                 <span className="text-sm font-medium text-muted-foreground">Assignee: </span>
                 <span className="text-sm">{feature.assignee}</span>
+              </div>
+            )}
+            {feature.assignedInstance && (
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Assigned Instance:{' '}
+                </span>
+                <span className="inline-flex items-center gap-1 text-sm text-violet-400">
+                  <Server className="w-3.5 h-3.5" />
+                  {feature.assignedInstance}
+                </span>
               </div>
             )}
           </div>

--- a/apps/ui/src/components/views/peers-panel.tsx
+++ b/apps/ui/src/components/views/peers-panel.tsx
@@ -1,0 +1,276 @@
+/**
+ * PeersPanel — shows all connected instances with status and capacity metrics.
+ *
+ * Used in the unified board dashboard. Fetches peer data from /api/hivemind/peers
+ * on mount and every 30 seconds. Reads instanceFilter from the app store to
+ * control cross-instance feature visibility.
+ */
+
+import React, { useEffect, useCallback } from 'react';
+import { useAppStore } from '@/store/app-store';
+import { useShallow } from 'zustand/react/shallow';
+import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@protolabsai/ui/atoms';
+import { RefreshCw, Cpu, Database, Users, Wifi, WifiOff, Activity } from 'lucide-react';
+import type { HivemindPeer } from '@protolabsai/types';
+
+const PEERS_POLL_INTERVAL_MS = 30_000;
+
+// ─── Status badge ────────────────────────────────────────────────────────────
+
+function getStatusColor(status: string | undefined): string {
+  switch (status) {
+    case 'online':
+      return 'bg-green-500';
+    case 'draining':
+      return 'bg-yellow-500';
+    default:
+      return 'bg-zinc-500';
+  }
+}
+
+// ─── Single peer row ─────────────────────────────────────────────────────────
+
+function PeerRow({ peer, isSelf }: { peer: HivemindPeer; isSelf?: boolean }) {
+  const { identity, lastSeen } = peer;
+  const status = identity.status ?? 'offline';
+  const capacity = identity.capacity;
+
+  const agentLoad =
+    capacity && capacity.maxAgents > 0
+      ? Math.round((capacity.runningAgents / capacity.maxAgents) * 100)
+      : 0;
+
+  const lastSeenLabel = (() => {
+    try {
+      const diff = Date.now() - new Date(lastSeen).getTime();
+      if (diff < 60_000) return 'just now';
+      if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+      return `${Math.floor(diff / 3_600_000)}h ago`;
+    } catch {
+      return lastSeen;
+    }
+  })();
+
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-2 rounded-md border bg-card/60 p-2.5',
+        isSelf ? 'border-primary/40 bg-primary/5' : 'border-border/40'
+      )}
+      data-testid={`peer-row-${identity.instanceId}`}
+    >
+      {/* Status dot */}
+      <div className="mt-1 flex-shrink-0">
+        <span
+          className={cn('inline-block h-2 w-2 rounded-full', getStatusColor(status))}
+          aria-label={status}
+        />
+      </div>
+
+      {/* Identity */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-1">
+          <div className="flex items-center gap-1 min-w-0">
+            <span className="truncate text-xs font-medium text-foreground">
+              {identity.instanceId}
+            </span>
+            {isSelf && (
+              <span className="shrink-0 text-[9px] font-bold px-1 py-px rounded bg-primary/20 text-primary border border-primary/30">
+                this
+              </span>
+            )}
+          </div>
+          <span className="shrink-0 text-[10px] text-muted-foreground">{lastSeenLabel}</span>
+        </div>
+
+        {/* Capacity metrics row */}
+        {capacity && status !== 'offline' && (
+          <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground">
+                    <Activity className="h-2.5 w-2.5" />
+                    {capacity.runningAgents}/{capacity.maxAgents}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  <p>
+                    Running agents: {capacity.runningAgents} / {capacity.maxAgents} ({agentLoad}%
+                    load)
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground">
+                    <Database className="h-2.5 w-2.5" />
+                    {capacity.ramUsagePercent.toFixed(0)}%
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  <p>RAM usage: {capacity.ramUsagePercent.toFixed(1)}%</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground">
+                    <Cpu className="h-2.5 w-2.5" />
+                    {capacity.cpuPercent.toFixed(0)}%
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  <p>CPU: {capacity.cpuPercent.toFixed(1)}%</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+
+            {typeof capacity.backlogCount === 'number' && capacity.backlogCount > 0 && (
+              <span className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground">
+                <Users className="h-2.5 w-2.5" />
+                {capacity.backlogCount} backlog
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── PeersPanel ──────────────────────────────────────────────────────────────
+
+export interface PeersPanelProps {
+  className?: string;
+}
+
+export function PeersPanel({ className }: PeersPanelProps) {
+  const {
+    peers,
+    selfInstanceId,
+    instanceFilter,
+    setInstanceFilter,
+    fetchPeers,
+    fetchSelfInstanceId,
+  } = useAppStore(
+    useShallow((s) => ({
+      peers: s.peers,
+      selfInstanceId: s.selfInstanceId,
+      instanceFilter: s.instanceFilter,
+      setInstanceFilter: s.setInstanceFilter,
+      fetchPeers: s.fetchPeers,
+      fetchSelfInstanceId: s.fetchSelfInstanceId,
+    }))
+  );
+
+  const refresh = useCallback(() => {
+    fetchPeers();
+  }, [fetchPeers]);
+
+  // Fetch self identity once on mount
+  useEffect(() => {
+    fetchSelfInstanceId();
+  }, [fetchSelfInstanceId]);
+
+  // Poll peers on mount and every 30 seconds
+  useEffect(() => {
+    refresh();
+    const timer = setInterval(refresh, PEERS_POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [refresh]);
+
+  const onlinePeers = peers.filter((p) => p.identity.status === 'online');
+  const offlinePeers = peers.filter((p) => p.identity.status !== 'online');
+
+  return (
+    <div className={cn('flex flex-col gap-2', className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          {onlinePeers.length > 0 ? (
+            <Wifi className="h-3.5 w-3.5 text-green-500" />
+          ) : (
+            <WifiOff className="h-3.5 w-3.5 text-muted-foreground" />
+          )}
+          <span className="text-xs font-semibold text-foreground">
+            Instances
+            {peers.length > 0 && (
+              <span className="ml-1 text-muted-foreground">({onlinePeers.length} online)</span>
+            )}
+          </span>
+        </div>
+
+        <button
+          onClick={refresh}
+          className="rounded p-0.5 text-muted-foreground hover:text-foreground"
+          aria-label="Refresh peers"
+          title="Refresh"
+        >
+          <RefreshCw className="h-3 w-3" />
+        </button>
+      </div>
+
+      {/* Instance filter toggle */}
+      <div className="flex rounded-md border border-border/40 p-0.5 text-xs">
+        <button
+          onClick={() => setInstanceFilter('all')}
+          className={cn(
+            'flex-1 rounded px-2 py-0.5 transition-colors',
+            instanceFilter === 'all'
+              ? 'bg-primary text-primary-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          All
+        </button>
+        <button
+          onClick={() => setInstanceFilter('mine')}
+          className={cn(
+            'flex-1 rounded px-2 py-0.5 transition-colors',
+            instanceFilter === 'mine'
+              ? 'bg-primary text-primary-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          Mine
+        </button>
+      </div>
+
+      {/* Peer list */}
+      {peers.length === 0 ? (
+        <p className="text-[11px] text-muted-foreground">
+          No peers detected. Running in single-instance mode.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {onlinePeers.map((peer) => (
+            <PeerRow
+              key={peer.identity.instanceId}
+              peer={peer}
+              isSelf={peer.identity.instanceId === selfInstanceId}
+            />
+          ))}
+          {offlinePeers.length > 0 && (
+            <>
+              {onlinePeers.length > 0 && <div className="my-0.5 border-t border-border/20" />}
+              {offlinePeers.map((peer) => (
+                <PeerRow
+                  key={peer.identity.instanceId}
+                  peer={peer}
+                  isSelf={peer.identity.instanceId === selfInstanceId}
+                />
+              ))}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/lib/clients/system-client.ts
+++ b/apps/ui/src/lib/clients/system-client.ts
@@ -21,7 +21,13 @@ import type {
   IntegrationStatusResponse,
   SystemHealthResponse,
 } from './api-types';
-import type { DiscordChannelSignalConfig, Project, ProjectHealth } from '@protolabsai/types';
+import type {
+  DiscordChannelSignalConfig,
+  Project,
+  ProjectHealth,
+  HivemindPeer,
+  SyncServerStatus,
+} from '@protolabsai/types';
 import { BaseHttpClient, type Constructor } from './base-http-client';
 
 export const withSystemClient = <TBase extends Constructor<BaseHttpClient>>(Base: TBase) =>
@@ -357,5 +363,17 @@ export const withSystemClient = <TBase extends Constructor<BaseHttpClient>>(Base
         this.post('/api/projects/tools/project_delete_doc', { projectPath, projectSlug, docId }),
       getProjectFeatures: (projectPath: string, projectSlug: string) =>
         this.post('/api/projects/tools/project_list_features', { projectPath, projectSlug }),
+    };
+
+    // Hivemind API — cross-instance mesh peer status
+    hivemind = {
+      /** Returns all known peers (online and offline) with identity, status, and capacity. */
+      getPeers: (): Promise<{ peers: HivemindPeer[] }> => this.get('/api/hivemind/peers'),
+
+      /** Returns the full sync status for this instance (role, connected, peer count, etc.). */
+      getStatus: (): Promise<SyncServerStatus> => this.get('/api/hivemind/status'),
+
+      /** Returns the instanceId of this Automaker instance. */
+      getSelf: (): Promise<{ instanceId: string }> => this.get('/api/hivemind/self'),
     };
   };

--- a/apps/ui/src/store/app-store.ts
+++ b/apps/ui/src/store/app-store.ts
@@ -12,6 +12,7 @@ import type {
   ServerLogLevel,
   EventHook,
   FeatureFlags,
+  HivemindPeer,
 } from '@protolabsai/types';
 import { DEFAULT_FEATURE_FLAGS } from '@protolabsai/types';
 import { DEFAULT_KEYBOARD_SHORTCUTS } from './types';
@@ -153,6 +154,11 @@ export interface AppState {
 
   // User Identity (for board assignment)
   userIdentity: string | null;
+
+  // Hivemind / Cross-instance dashboard
+  peers: HivemindPeer[];
+  instanceFilter: 'all' | 'mine'; // 'all' = show features from all instances, 'mine' = local only
+  selfInstanceId: string | null; // The instanceId of this Automaker instance
 }
 
 export interface AppActions {
@@ -310,6 +316,13 @@ export interface AppActions {
   // User Identity actions
   setUserIdentity: (identity: string | null) => void;
 
+  // Hivemind / Cross-instance dashboard actions
+  setPeers: (peers: HivemindPeer[]) => void;
+  setInstanceFilter: (filter: 'all' | 'mine') => void;
+  fetchPeers: () => Promise<void>;
+  setSelfInstanceId: (id: string | null) => void;
+  fetchSelfInstanceId: () => Promise<void>;
+
   // Reset
   reset: () => void;
 }
@@ -384,6 +397,10 @@ const initialState: AppState = {
   lastProjectDir: '',
   recentFolders: [],
   userIdentity: null,
+  // Hivemind / Cross-instance dashboard
+  peers: [],
+  instanceFilter: 'all',
+  selfInstanceId: null,
 };
 
 export const useAppStore = create<AppState & AppActions>()((set, get) => ({
@@ -1237,6 +1254,29 @@ export const useAppStore = create<AppState & AppActions>()((set, get) => ({
 
   // User Identity actions
   setUserIdentity: (identity) => set({ userIdentity: identity }),
+
+  // Hivemind / Cross-instance dashboard actions
+  setPeers: (peers) => set({ peers }),
+  setInstanceFilter: (instanceFilter) => set({ instanceFilter }),
+  fetchPeers: async () => {
+    try {
+      const api = getHttpApiClient();
+      const data = await api.hivemind.getPeers();
+      set({ peers: data.peers });
+    } catch (err) {
+      logger.warn('[AppStore] Failed to fetch hivemind peers:', err);
+    }
+  },
+  setSelfInstanceId: (selfInstanceId) => set({ selfInstanceId }),
+  fetchSelfInstanceId: async () => {
+    try {
+      const api = getHttpApiClient();
+      const data = await api.hivemind.getSelf();
+      set({ selfInstanceId: data.instanceId });
+    } catch (err) {
+      logger.warn('[AppStore] Failed to fetch self instanceId:', err);
+    }
+  },
 
   // Reset
   reset: () => set(initialState),


### PR DESCRIPTION
## Summary
- Add `GET /api/hivemind/peers|status|self` endpoints backed by `CrdtSyncService`
- Create `PeersPanel` component showing connected instances with status (online/draining/offline), capacity metrics (agents, RAM%, CPU%), and All/Mine filter toggle
- Add violet instance badge on kanban feature cards when `feature.assignedInstance` is set
- Add instance filter (All/Mine) to board view with filtered features memo
- Show `assignedInstance` and `claimedBy` in feature detail view and edit dialog
- Add hivemind HTTP client methods to `system-client`

## Acceptance Criteria
- [x] Board view shows instance badge on each feature card
- [x] Peers panel shows all connected instances with status and capacity
- [x] Features from all instances visible in unified board
- [x] Filter by instance (show only my features, show all)
- [x] Cross-instance assignment visible in feature detail view

## Test plan
- [ ] Open board view — feature cards with `assignedInstance` show a violet "Server" badge
- [ ] Peers panel renders above board showing connected instances with status dots and capacity metrics
- [ ] Toggle "Mine" filter — board shows only features owned by this instance
- [ ] Toggle "All" — board shows all features again
- [ ] Open a feature detail — "Assigned Instance" field visible when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Multi-instance Peer Visibility**: Added a Peers Panel displaying connected instances with real-time status and capacity metrics (agents, RAM, CPU usage).
* **Instance Filtering**: Toggle board view between showing all features or only features from your instance.
* **Instance Assignment Display**: Feature cards, dialogs, and detail views now show which instance a feature is assigned to.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->