### PR TITLE
fix: AvaChannelService test constructor signature

### DIFF
--- a/apps/server/tests/unit/services/ava-channel-service.test.ts
+++ b/apps/server/tests/unit/services/ava-channel-service.test.ts
@@ -91,12 +91,11 @@ describe('AvaChannelService', () => {
   beforeEach(() => {
     store = makeMockStore();
     archiveDir = makeTempDir();
-    service = new AvaChannelService(
-      store as unknown as import('@protolabsai/crdt').CRDTStore,
-      archiveDir,
-      'test-instance',
-      'Test Instance'
-    );
+    service = new AvaChannelService(archiveDir, {
+      store: store as unknown as import('@protolabsai/crdt').CRDTStore,
+      instanceId: 'test-instance',
+      instanceName: 'Test Instance',
+    });
   });
 
   afterEach(() => {
@@ -284,12 +283,11 @@ describe('AvaChannelService', () => {
   describe('runArchiveCycle()', () => {
     it('creates archive directory if missing', async () => {
       const newArchiveDir = path.join(archiveDir, 'subdir');
-      const archiveService = new AvaChannelService(
-        store as unknown as import('@protolabsai/crdt').CRDTStore,
-        newArchiveDir,
-        'test-instance',
-        'Test Instance'
-      );
+      const archiveService = new AvaChannelService(newArchiveDir, {
+        store: store as unknown as import('@protolabsai/crdt').CRDTStore,
+        instanceId: 'test-instance',
+        instanceName: 'Test Instance',
+      });
 
       await archiveService.runArchiveCycle();
 


### PR DESCRIPTION
## Summary
- Updates test constructor calls to match the new `AvaChannelService(archiveDir, options?)` signature introduced in #1986
- The squash merge of #1986 changed the constructor but the tests from #1988 still used the old `(store, archiveDir, instanceId, instanceName)` positional args

## Test plan
- [ ] CI passes (tests no longer throw `ERR_INVALID_ARG_TYPE`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated service initialization pattern to use consolidated configuration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->