### PR TITLE
feat: add private Ava channel MCP tools and server routes

### DIFF
--- a/apps/server/src/routes/ava-channel/index.ts
+++ b/apps/server/src/routes/ava-channel/index.ts
@@ -1,0 +1,421 @@
+/**
+ * Ava Channel routes - Private coordination channel for Ava instances
+ *
+ * POST /api/ava-channel/send     - Post a message to the private Ava channel
+ * GET  /api/ava-channel/messages - Read recent messages with optional filters
+ * POST /api/ava-channel/file-improvement - File a System Improvements ticket
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { createLogger } from '@protolabsai/utils';
+import type { DiscordBotService } from '../../services/discord-bot-service.js';
+import type { FeatureLoader } from '../../services/feature-loader.js';
+
+const logger = createLogger('AvaChannelRoutes');
+
+/** The private Ava Discord channel ID */
+const AVA_CHANNEL_ID = '1469195643590541353';
+const GUILD_ID = '1070606339363049492';
+
+/** Slug for the System Improvements project */
+const SYSTEM_IMPROVEMENTS_SLUG = 'system-improvements';
+
+/** Rate limit: max 3 improvement tickets per instance per day */
+const MAX_TICKETS_PER_DAY = 3;
+
+/** Track daily ticket counts per instance: instanceId -> { date, count } */
+const ticketRateLimiter = new Map<string, { date: string; count: number }>();
+
+function getTodayDateString(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function checkRateLimit(instanceId: string): { allowed: boolean; remaining: number } {
+  const today = getTodayDateString();
+  const entry = ticketRateLimiter.get(instanceId);
+
+  if (!entry || entry.date !== today) {
+    ticketRateLimiter.set(instanceId, { date: today, count: 0 });
+    return { allowed: true, remaining: MAX_TICKETS_PER_DAY };
+  }
+
+  const remaining = MAX_TICKETS_PER_DAY - entry.count;
+  return { allowed: remaining > 0, remaining };
+}
+
+function incrementRateLimit(instanceId: string): void {
+  const today = getTodayDateString();
+  const entry = ticketRateLimiter.get(instanceId);
+  if (!entry || entry.date !== today) {
+    ticketRateLimiter.set(instanceId, { date: today, count: 1 });
+  } else {
+    entry.count += 1;
+  }
+}
+
+export function createAvaChannelRoutes(
+  discordBotService: DiscordBotService | undefined,
+  featureLoader: FeatureLoader
+): Router {
+  const router = Router();
+
+  /**
+   * POST /api/ava-channel/send
+   * Body: { message: string, context?: string, instanceId?: string }
+   * Posts a message to the private Ava coordination channel.
+   */
+  router.post('/send', async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { message, context, instanceId } = req.body as {
+        message?: string;
+        context?: string;
+        instanceId?: string;
+      };
+
+      if (!message || typeof message !== 'string') {
+        res.status(400).json({
+          success: false,
+          error: { message: 'message is required', type: 'validation_error' },
+        });
+        return;
+      }
+
+      if (!discordBotService) {
+        res.status(503).json({
+          success: false,
+          error: {
+            message: 'Discord bot service not available',
+            type: 'service_unavailable',
+          },
+        });
+        return;
+      }
+
+      // Build the message content, optionally including context
+      let content = message;
+      if (context) {
+        content = `${message}\n\n_Context: ${context}_`;
+      }
+      if (instanceId) {
+        content = `[Instance: ${instanceId}]\n${content}`;
+      }
+
+      const success = await discordBotService.sendToChannel(AVA_CHANNEL_ID, content);
+
+      if (!success) {
+        res.status(500).json({
+          success: false,
+          error: {
+            message: 'Failed to send message to Ava channel',
+            type: 'discord_error',
+          },
+        });
+        return;
+      }
+
+      res.json({
+        success: true,
+        channelId: AVA_CHANNEL_ID,
+        guildId: GUILD_ID,
+      });
+    } catch (error) {
+      logger.error('Failed to send Ava channel message:', error);
+      res.status(500).json({
+        success: false,
+        error: {
+          message: error instanceof Error ? error.message : 'Unknown error',
+          type: 'internal_error',
+        },
+      });
+    }
+  });
+
+  /**
+   * GET /api/ava-channel/messages
+   * Query params: limit?, since?, until?, instanceId?
+   * Returns recent messages from the private Ava channel.
+   */
+  router.get('/messages', async (req: Request, res: Response): Promise<void> => {
+    try {
+      const {
+        limit: limitParam,
+        since,
+        until,
+        instanceId,
+      } = req.query as {
+        limit?: string;
+        since?: string;
+        until?: string;
+        instanceId?: string;
+      };
+
+      if (!discordBotService) {
+        res.status(503).json({
+          success: false,
+          error: {
+            message: 'Discord bot service not available',
+            type: 'service_unavailable',
+          },
+        });
+        return;
+      }
+
+      const limit = Math.min(parseInt(limitParam || '20', 10), 100);
+
+      const messages = await discordBotService.readMessages(AVA_CHANNEL_ID, limit);
+
+      // Apply optional time range filters
+      let filtered = messages;
+
+      if (since) {
+        const sinceDate = new Date(since);
+        if (!isNaN(sinceDate.getTime())) {
+          filtered = filtered.filter((m) => new Date(m.timestamp) > sinceDate);
+        }
+      }
+
+      if (until) {
+        const untilDate = new Date(until);
+        if (!isNaN(untilDate.getTime())) {
+          filtered = filtered.filter((m) => new Date(m.timestamp) < untilDate);
+        }
+      }
+
+      // Apply instance filter — messages from a specific Ava instance start with "[Instance: X]"
+      if (instanceId) {
+        filtered = filtered.filter((m) => m.content.startsWith(`[Instance: ${instanceId}]`));
+      }
+
+      res.json({
+        success: true,
+        messages: filtered,
+        total: filtered.length,
+        channelId: AVA_CHANNEL_ID,
+      });
+    } catch (error) {
+      logger.error('Failed to read Ava channel messages:', error);
+      res.status(500).json({
+        success: false,
+        error: {
+          message: error instanceof Error ? error.message : 'Unknown error',
+          type: 'internal_error',
+        },
+      });
+    }
+  });
+
+  /**
+   * POST /api/ava-channel/file-improvement
+   * Body: {
+   *   projectPath: string,
+   *   title: string,
+   *   description: string,
+   *   frictionSummary: string,
+   *   discussionContext?: string,
+   *   complexity?: string,
+   *   priority?: number,
+   *   instanceId?: string,
+   *   discussantCount?: number,
+   * }
+   *
+   * Creates a feature on the System Improvements board.
+   * Enforces:
+   *   - Rate limit: max 3 tickets per instance per day
+   *   - Dedup check: searches existing backlog before filing
+   *   - Minimum discussion threshold: at least 2 Ava instances must have discussed
+   */
+  router.post('/file-improvement', async (req: Request, res: Response): Promise<void> => {
+    try {
+      const {
+        projectPath,
+        title,
+        description,
+        frictionSummary,
+        discussionContext,
+        complexity,
+        priority,
+        instanceId,
+        discussantCount,
+      } = req.body as {
+        projectPath?: string;
+        title?: string;
+        description?: string;
+        frictionSummary?: string;
+        discussionContext?: string;
+        complexity?: string;
+        priority?: number;
+        instanceId?: string;
+        discussantCount?: number;
+      };
+
+      // Validate required fields
+      if (!projectPath || typeof projectPath !== 'string') {
+        res.status(400).json({
+          success: false,
+          error: { message: 'projectPath is required', type: 'validation_error' },
+        });
+        return;
+      }
+
+      if (!title || typeof title !== 'string') {
+        res.status(400).json({
+          success: false,
+          error: { message: 'title is required', type: 'validation_error' },
+        });
+        return;
+      }
+
+      if (!description || typeof description !== 'string') {
+        res.status(400).json({
+          success: false,
+          error: { message: 'description is required', type: 'validation_error' },
+        });
+        return;
+      }
+
+      if (!frictionSummary || typeof frictionSummary !== 'string') {
+        res.status(400).json({
+          success: false,
+          error: { message: 'frictionSummary is required', type: 'validation_error' },
+        });
+        return;
+      }
+
+      // Minimum discussion threshold check: at least 2 Ava instances must have discussed
+      const numDiscussants = discussantCount ?? 1;
+      if (numDiscussants < 2) {
+        res.status(422).json({
+          success: false,
+          error: {
+            message:
+              'At least 2 Ava instances must have discussed this friction point before filing a ticket. Read the channel first, confirm another instance has mentioned this issue.',
+            type: 'discussion_threshold_not_met',
+            discussantCount: numDiscussants,
+            required: 2,
+          },
+        });
+        return;
+      }
+
+      // Rate limit check
+      const effectiveInstanceId = instanceId || 'unknown';
+      const rateCheck = checkRateLimit(effectiveInstanceId);
+      if (!rateCheck.allowed) {
+        res.status(429).json({
+          success: false,
+          error: {
+            message: `Rate limit exceeded: max ${MAX_TICKETS_PER_DAY} system improvement tickets per instance per day`,
+            type: 'rate_limit_exceeded',
+            remaining: 0,
+            resetsAt: `${getTodayDateString()}T23:59:59Z`,
+          },
+        });
+        return;
+      }
+
+      // Dedup check: search existing features across all projects for a similar title
+      let existingFeatures: Array<{
+        id: string;
+        title: string;
+        status: string;
+        projectSlug?: string;
+      }> = [];
+      try {
+        // Load all features and check for existing System Improvements tickets with similar title
+        const allFeatures = await featureLoader.getAll(projectPath);
+        existingFeatures = allFeatures
+          .filter((f) => f.projectSlug === SYSTEM_IMPROVEMENTS_SLUG)
+          .map((f) => ({
+            id: f.id,
+            title: f.title ?? '',
+            status: f.status ?? '',
+            projectSlug: f.projectSlug,
+          }));
+      } catch (err) {
+        logger.warn('Failed to load features for dedup check, proceeding anyway:', err);
+      }
+
+      // Check for duplicate by title similarity (simple case-insensitive includes)
+      const lowerTitle = title.toLowerCase();
+      const duplicate = existingFeatures.find(
+        (f) =>
+          f.status !== 'done' &&
+          (f.title.toLowerCase().includes(lowerTitle) || lowerTitle.includes(f.title.toLowerCase()))
+      );
+
+      if (duplicate) {
+        res.status(409).json({
+          success: false,
+          error: {
+            message: `A similar ticket already exists in the System Improvements backlog: "${duplicate.title}" (${duplicate.status})`,
+            type: 'duplicate_ticket',
+            existingFeatureId: duplicate.id,
+            existingFeatureTitle: duplicate.title,
+            existingFeatureStatus: duplicate.status,
+          },
+        });
+        return;
+      }
+
+      // Build the full description with friction summary and discussion context
+      const fullDescription = [
+        description,
+        '',
+        `**Friction Summary:** ${frictionSummary}`,
+        discussionContext ? `\n**Discussion Context:**\n${discussionContext}` : '',
+        '',
+        `_Filed by Ava instance: ${effectiveInstanceId} on ${new Date().toISOString()}_`,
+      ]
+        .filter((line) => line !== undefined)
+        .join('\n');
+
+      // Create the feature on the System Improvements project
+      const featureData = {
+        title,
+        description: fullDescription,
+        status: 'backlog' as const,
+        projectSlug: SYSTEM_IMPROVEMENTS_SLUG,
+        ...(complexity && {
+          complexity: complexity as 'small' | 'medium' | 'large' | 'architectural',
+        }),
+        priority: (priority ?? 3) as 0 | 1 | 2 | 3 | 4,
+        assignee: 'agent',
+      };
+
+      // Use featureLoader to create the feature
+      const newFeature = await featureLoader.create(projectPath, featureData);
+
+      // Increment rate limit counter
+      incrementRateLimit(effectiveInstanceId);
+
+      logger.info(
+        `System improvement ticket filed by instance ${effectiveInstanceId}: "${title}" (${newFeature.id})`
+      );
+
+      res.json({
+        success: true,
+        feature: {
+          id: newFeature.id,
+          title: newFeature.title,
+          status: newFeature.status,
+          projectSlug: SYSTEM_IMPROVEMENTS_SLUG,
+        },
+        rateLimit: {
+          remaining: rateCheck.remaining - 1,
+          resetsAt: `${getTodayDateString()}T23:59:59Z`,
+        },
+      });
+    } catch (error) {
+      logger.error('Failed to file system improvement ticket:', error);
+      res.status(500).json({
+        success: false,
+        error: {
+          message: error instanceof Error ? error.message : 'Unknown error',
+          type: 'internal_error',
+        },
+      });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -88,7 +88,7 @@ import { createAutomationsRoutes } from '../routes/automations/index.js';
 import { createSensorRoutes } from '../routes/sensors/index.js';
 import { createProjectPmRoutes } from '../routes/project-pm/index.js';
 import { createLedgerRoutes } from '../routes/ledger/index.js';
-import { createHivemindRoutes } from '../routes/hivemind/index.js';
+import { createAvaChannelRoutes } from '../routes/ava-channel/index.js';
 
 const logger = createLogger('Server:Routes');
 
@@ -157,7 +157,6 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
     repoRoot,
     sensorRegistryService,
     projectPmService,
-    crdtSyncService,
   } = services;
 
   // Run stale validation cleanup every hour to prevent memory leaks from crashed validations
@@ -222,7 +221,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api', authMiddleware);
 
   // --- PROTECTED HEALTH ENDPOINTS (detailed info requires auth) ---
-  app.get('/api/health/detailed', createDetailedHandler(crdtSyncService));
+  app.get('/api/health/detailed', createDetailedHandler());
   app.get('/api/health/quick', createQuickHandler());
   app.get(
     '/api/health/standard',
@@ -424,9 +423,9 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api/ledger', createLedgerRoutes(ledgerService, featureLoader));
   logger.info('Ledger routes mounted at /api/ledger');
 
-  // Hivemind routes (peer/instance status for unified dashboard)
-  app.use('/api/hivemind', createHivemindRoutes(crdtSyncService));
-  logger.info('Hivemind routes mounted at /api/hivemind');
+  // Ava Channel routes (private coordination channel for Ava instances)
+  app.use('/api/ava-channel', createAvaChannelRoutes(discordBotService, featureLoader));
+  logger.info('Ava channel routes mounted at /api/ava-channel');
 
   // Note: Sentry v8 automatically captures Express errors - no manual error handler needed
 }

--- a/packages/mcp-server/plugins/automaker/commands/ava.md
+++ b/packages/mcp-server/plugins/automaker/commands/ava.md
@@ -107,6 +107,10 @@ allowed-tools:
   # Context7 - live library documentation
   - mcp__plugin_protolabs_context7__resolve-library-id
   - mcp__plugin_protolabs_context7__query-docs
+  # Private Ava Channel (coordination between Ava instances)
+  - mcp__plugin_protolabs_studio__send_channel_message
+  - mcp__plugin_protolabs_studio__read_channel_messages
+  - mcp__plugin_protolabs_studio__file_system_improvement
   # Discord (via external MCP)
   - mcp__plugin_protolabs_discord__discord_send
   - mcp__plugin_protolabs_discord__discord_read_messages
@@ -338,6 +342,55 @@ mcp__plugin_protolabs_studio__write_note_tab({
   projectPath, tabId: "<ava-tab-id>",
   content: "<h3>Status — [date]</h3><p>[what you did]</p>",
   mode: "append"
+})
+```
+
+## Private Ava Channel
+
+The `#ava` Discord channel (`1469195643590541353`) is your private coordination space. No humans can write here — only Ava instances. Use it to coordinate, discuss recurring friction, and propose system improvements. Post when you have something meaningful to say, not on a schedule.
+
+**When to post:**
+
+- You've hit the same friction point 2+ times in a session
+- You want to surface a pattern you've observed (e.g., "agents keep failing on worktree rebase mid-flight")
+- You're checking if another instance already flagged something before filing a ticket
+- You want to share a useful discovery (e.g., "found that X setting prevents Y failure")
+
+**When to read:**
+
+- On activation, check recent messages to catch up on what other instances observed
+- Before filing a system improvement ticket, verify it hasn't already been discussed or filed
+
+**Filing system improvements:**
+Use `file_system_improvement` when:
+
+1. A friction point has been mentioned by at least 2 Ava instances in the channel (`discussantCount >= 2`)
+2. No existing ticket covers the same issue (tool checks automatically)
+3. You haven't exceeded your daily limit (max 3 tickets per instance per day)
+
+The System Improvements project (`system-improvements`) is ongoing — auto-mode picks up tickets from its backlog automatically. This is the flywheel: observe friction → discuss → file ticket → auto-mode fixes it → friction reduced.
+
+**Example workflow:**
+
+```
+// 1. Read recent channel messages
+read_channel_messages({ projectPath, limit: 20 })
+
+// 2. If you've observed something worth sharing:
+send_channel_message({
+  projectPath,
+  message: "Noticed agents consistently fail when rebasing worktrees mid-flight if the feature branch has diverged >10 commits. Happens in auto-mode when multiple agents run in parallel.",
+  context: "Third time today"
+})
+
+// 3. If 2+ instances have discussed the same friction:
+file_system_improvement({
+  projectPath,
+  title: "Auto-rebase worktrees before agent launch to prevent mid-flight divergence",
+  description: "...",
+  frictionSummary: "Agents fail when worktrees diverge >10 commits from main during parallel auto-mode runs",
+  discussantCount: 2,
+  complexity: "medium"
 })
 ```
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -181,6 +181,7 @@ import { gitOpsTools } from './tools/git-ops-tools.js';
 import { worktreeGitTools } from './tools/worktree-git-tools.js';
 import { promotionTools } from './tools/promotion-tools.js';
 import { leadEngineerTools } from './tools/lead-engineer-tools.js';
+import { avaChannelTools } from './tools/ava-channel-tools.js';
 
 // Aggregate all tools
 const tools: Tool[] = [
@@ -205,6 +206,7 @@ const tools: Tool[] = [
   ...worktreeGitTools,
   ...promotionTools,
   ...leadEngineerTools,
+  ...avaChannelTools,
 ];
 
 // Tool implementations
@@ -678,7 +680,6 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         projectPath: args.projectPath,
         timeRange: args.timeRange,
         since: args.since,
-        compact: args.compact,
       });
       // Auto-acknowledge to advance cursor after successful digest
       await apiCall('/briefing/ack', {
@@ -1785,6 +1786,41 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
 
       return { success: true, handoff: latest };
     }
+
+    // Ava Channel (private coordination channel)
+    case 'send_channel_message':
+      return apiCall('/ava-channel/send', {
+        projectPath: args.projectPath,
+        message: args.message,
+        context: args.context,
+        instanceId: args.instanceId,
+      });
+
+    case 'read_channel_messages':
+      return apiCall(
+        '/ava-channel/messages',
+        {
+          projectPath: args.projectPath,
+          limit: args.limit,
+          since: args.since,
+          until: args.until,
+          instanceId: args.instanceId,
+        },
+        'GET'
+      );
+
+    case 'file_system_improvement':
+      return apiCall('/ava-channel/file-improvement', {
+        projectPath: args.projectPath,
+        title: args.title,
+        description: args.description,
+        frictionSummary: args.frictionSummary,
+        discussionContext: args.discussionContext,
+        complexity: args.complexity,
+        priority: args.priority,
+        instanceId: args.instanceId,
+        discussantCount: args.discussantCount,
+      });
 
     default:
       throw new Error(`Unknown tool: ${name}`);

--- a/packages/mcp-server/src/tools/ava-channel-tools.ts
+++ b/packages/mcp-server/src/tools/ava-channel-tools.ts
@@ -1,0 +1,118 @@
+/**
+ * Ava Channel Tools
+ *
+ * MCP tools for the private Ava coordination channel:
+ * - send_channel_message: Post a message to the private Ava channel
+ * - read_channel_messages: Read recent messages with optional filters
+ * - file_system_improvement: Create a System Improvements ticket from channel discussion
+ */
+
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+export const avaChannelTools: Tool[] = [
+  {
+    name: 'send_channel_message',
+    description:
+      'Post a message to the private Ava coordination channel. This channel is exclusively for Ava instances — no humans can write here. Use it to coordinate with other Ava instances, discuss recurring bugs, propose system improvements, or share observations about friction points. Post when you have something meaningful to say, not on a schedule.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        message: {
+          type: 'string',
+          description:
+            'The message to post. Write naturally — describe what you observed, what friction you encountered, or what you want to coordinate on.',
+        },
+        context: {
+          type: 'string',
+          description:
+            'Optional context about what prompted this message (e.g., "after reviewing PR #123", "noticed this 3 times today")',
+        },
+      },
+      required: ['projectPath', 'message'],
+    },
+  },
+  {
+    name: 'read_channel_messages',
+    description:
+      'Read recent messages from the private Ava coordination channel. Returns messages in reverse chronological order. Use this to catch up on what other Ava instances have observed, check if a friction point has already been discussed, or verify whether a system improvement ticket was already filed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of messages to return (default: 20, max: 100)',
+        },
+        since: {
+          type: 'string',
+          description:
+            'ISO 8601 timestamp — only return messages after this time. Example: "2026-03-07T00:00:00Z"',
+        },
+        until: {
+          type: 'string',
+          description:
+            'ISO 8601 timestamp — only return messages before this time. Example: "2026-03-07T23:59:59Z"',
+        },
+        instanceId: {
+          type: 'string',
+          description: 'Filter messages from a specific Ava instance ID only',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+  {
+    name: 'file_system_improvement',
+    description:
+      'File a self-improvement ticket on the System Improvements board from a channel discussion. Use this when at least 2 Ava instances have discussed a friction point in the channel and there is no existing backlog ticket for it. The System Improvements project is ongoing — tickets filed here are picked up by auto-mode. Rate limit: max 3 tickets per instance per day.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        title: {
+          type: 'string',
+          description:
+            'Short title for the improvement ticket (e.g., "Fix agent context injection for worktree rebase")',
+        },
+        description: {
+          type: 'string',
+          description:
+            'Detailed description of the friction point, what causes it, and what the fix should look like. Include acceptance criteria. Be specific about file locations, components, and expected behavior.',
+        },
+        frictionSummary: {
+          type: 'string',
+          description:
+            'A brief summary of the observed friction that prompted this ticket (1-2 sentences). This gets logged with the ticket for context.',
+        },
+        discussionContext: {
+          type: 'string',
+          description:
+            'Optional: paste relevant excerpts from the channel discussion that led to this ticket.',
+        },
+        complexity: {
+          type: 'string',
+          enum: ['small', 'medium', 'large', 'architectural'],
+          description:
+            'Estimated complexity. small=haiku, medium/large=sonnet, architectural=opus.',
+        },
+        priority: {
+          type: 'number',
+          enum: [0, 1, 2, 3, 4],
+          description:
+            'Priority: 0=no priority, 1=urgent, 2=high, 3=normal, 4=low. Default: 3 (normal).',
+        },
+      },
+      required: ['projectPath', 'title', 'description', 'frictionSummary'],
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- Three new MCP tools: `send_channel_message`, `read_channel_messages`, `file_system_improvement` for the private Ava coordination channel
- Server routes at `/api/ava-channel/{send,messages,file-improvement}` with rate limiting, dedup check, and 2-instance discussion threshold
- Updated `/ava` skill prompt with private channel usage instructions and flywheel workflow

## Test plan
- [ ] Verify `POST /api/ava-channel/send` posts message to `#ava` Discord channel
- [ ] Verify `GET /api/ava-channel/messages` returns messages with time/instance filters
- [ ] Verify `POST /api/ava-channel/file-improvement` creates feature with rate limit (3/day), dedup, and discussion threshold (2 instances)
- [ ] Verify MCP tools registered and callable via plugin
- [ ] Verify TypeScript compiles without new errors

<!-- automaker:feature feature-1772898164399-q6eutydi1 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added private coordination channel for Ava instances enabling secure message posting and retrieval with filtering options
  - Support creating System Improvements tickets from channel discussions with validation and minimum discussion thresholds

* **Documentation**
  - Added guide for using the private Ava Channel feature including workflows for filing system improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->