### PR TITLE
fix: restore sync status in detailed health endpoint

### DIFF
--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -157,6 +157,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
     repoRoot,
     sensorRegistryService,
     projectPmService,
+    crdtSyncService,
   } = services;
 
   // Run stale validation cleanup every hour to prevent memory leaks from crashed validations
@@ -221,7 +222,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api', authMiddleware);
 
   // --- PROTECTED HEALTH ENDPOINTS (detailed info requires auth) ---
-  app.get('/api/health/detailed', createDetailedHandler());
+  app.get('/api/health/detailed', createDetailedHandler(crdtSyncService));
   app.get('/api/health/quick', createQuickHandler());
   app.get(
     '/api/health/standard',


### PR DESCRIPTION
## Summary
- Passes `crdtSyncService` to `createDetailedHandler()` in routes.ts
- Previous PRs (#1988) dropped the argument, causing `/api/health/detailed` to return `sync: null` even though CRDT sync is running

## Test plan
- [x] `npm run build:server` passes
- [ ] `/api/health/detailed` returns `sync.role`, `sync.connected`, etc. after deploy

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Updated health check endpoint handler to integrate additional service monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->