### PR TITLE
Ava Channel Tab in Ava Anywhere

### DIFF
--- a/apps/ui/src/components/layout/chat-modal.tsx
+++ b/apps/ui/src/components/layout/chat-modal.tsx
@@ -8,14 +8,12 @@
 
 import { useCallback, useEffect } from 'react';
 import { Dialog, DialogContent, DialogTitle } from '@protolabsai/ui/atoms';
-import { useChatSession } from '@/hooks/use-chat-session';
 import { useChatStore } from '@/store/chat-store';
 import { ChatOverlayContent } from '@/components/views/chat-overlay/chat-overlay-content';
 
 export function ChatModal() {
   const chatModalOpen = useChatStore((s) => s.chatModalOpen);
   const setChatModalOpen = useChatStore((s) => s.setChatModalOpen);
-  const chatSession = useChatSession({ defaultModel: 'sonnet' });
 
   const handleClose = useCallback(() => {
     setChatModalOpen(false);
@@ -32,7 +30,7 @@ export function ChatModal() {
         }}
       >
         <DialogTitle className="sr-only">Ava Chat</DialogTitle>
-        <ChatOverlayContent {...chatSession} onHide={handleClose} isModal />
+        <ChatOverlayContent onHide={handleClose} isModal />
       </DialogContent>
     </Dialog>
   );

--- a/apps/ui/src/components/views/chat-overlay/ask-ava-tab.tsx
+++ b/apps/ui/src/components/views/chat-overlay/ask-ava-tab.tsx
@@ -1,0 +1,202 @@
+/**
+ * AskAvaTab — the human<>Ava chat tab for the overlay and modal.
+ *
+ * Extracted from ChatOverlayContent to support a two-tab layout.
+ * Contains: queue panel, conversation history panel, settings panel, chat area.
+ */
+
+import type { UIMessage } from 'ai';
+import {
+  ChatMessageList,
+  ChatInput,
+  SuggestionList,
+  PromptInputProvider,
+  QueueView,
+  type BranchInfo,
+} from '@protolabsai/ui/ai';
+import { cn } from '@/lib/utils';
+import { ChatModelSelect } from '@/components/views/chat/components/chat-model-select';
+import { ConversationList } from './conversation-list';
+import { AvaSettingsPanel } from './ava-settings-panel';
+import type { ChatSession } from '@/store/chat-store';
+import type { SuggestionItem } from '@protolabsai/ui/ai';
+
+export interface AskAvaTabProps {
+  displayedMessages: UIMessage[];
+  isStreaming: boolean;
+  suggestions: SuggestionItem[];
+  sessions: ChatSession[];
+  currentSessionId: string | null;
+  modelAlias: string;
+  tokenUsage: {
+    total: number;
+    input: number;
+    output: number;
+    estimated: boolean;
+  };
+  branchInfoMap: Map<string, BranchInfo>;
+  settingsOpen: boolean;
+  historyOpen: boolean;
+  queueOpen: boolean;
+  queuePaused: boolean;
+  projectPath?: string;
+  shortcutHint: string;
+
+  onSubmit: (text: string) => void;
+  onStop: () => void;
+  onSuggestionSelect: (value: string) => void;
+  onRegenerate: () => void;
+  onThumbsUp: () => void;
+  onThumbsDown: () => void;
+  onToolApprove: (toolCallId: string) => void;
+  onToolReject: (toolCallId: string) => void;
+  onPreviousBranch: (origId: string) => void;
+  onNextBranch: (origId: string) => void;
+  onSelectSession: (id: string) => void;
+  onNewChat: () => void;
+  onDeleteSession: (id: string) => void;
+  onCloseHistory: () => void;
+  onToggleQueuePause: () => void;
+  onModelChange: (alias: string) => void;
+  getToolProgressLabel: (toolCallId: string) => string | undefined;
+}
+
+export function AskAvaTab({
+  displayedMessages,
+  isStreaming,
+  suggestions,
+  sessions,
+  currentSessionId,
+  modelAlias,
+  tokenUsage,
+  branchInfoMap,
+  settingsOpen,
+  historyOpen,
+  queueOpen,
+  queuePaused,
+  projectPath,
+  shortcutHint,
+  onSubmit,
+  onStop,
+  onSuggestionSelect,
+  onRegenerate,
+  onThumbsUp,
+  onThumbsDown,
+  onToolApprove,
+  onToolReject,
+  onPreviousBranch,
+  onNextBranch,
+  onSelectSession,
+  onNewChat,
+  onDeleteSession,
+  onCloseHistory,
+  onToggleQueuePause,
+  onModelChange,
+  getToolProgressLabel,
+}: AskAvaTabProps) {
+  return (
+    <div className="flex min-h-0 flex-1">
+      {/* Queue panel — slide in from left */}
+      {queueOpen && (
+        <div className="w-56 shrink-0 border-r border-border overflow-y-auto p-2 animate-in slide-in-from-left duration-200">
+          <QueueView
+            items={[]}
+            paused={queuePaused}
+            onTogglePause={onToggleQueuePause}
+          />
+        </div>
+      )}
+
+      {/* Conversation list panel — slide in from left */}
+      {historyOpen && (
+        <ConversationList
+          sessions={sessions}
+          currentSessionId={currentSessionId}
+          onSelect={(id) => {
+            onSelectSession(id);
+            onCloseHistory();
+          }}
+          onNew={() => {
+            onNewChat();
+            onCloseHistory();
+          }}
+          onDelete={onDeleteSession}
+          onClose={onCloseHistory}
+          className="animate-in slide-in-from-left duration-200"
+        />
+      )}
+
+      {/* Settings panel — slides in from right, replaces chat area */}
+      {settingsOpen && (
+        <div className="flex min-w-0 flex-1 flex-col overflow-y-auto animate-in slide-in-from-right duration-200">
+          <AvaSettingsPanel projectPath={projectPath} />
+        </div>
+      )}
+
+      {/* Chat area — hidden when settings is open */}
+      <div className={cn('flex min-w-0 flex-1 flex-col', settingsOpen && 'hidden')}>
+        <ChatMessageList
+          messages={displayedMessages}
+          emptyMessage="Ask Ava anything..."
+          isStreaming={isStreaming}
+          onRegenerate={onRegenerate}
+          onThumbsUp={onThumbsUp}
+          onThumbsDown={onThumbsDown}
+          onToolApprove={onToolApprove}
+          onToolReject={onToolReject}
+          branchInfoMap={branchInfoMap}
+          onPreviousBranch={onPreviousBranch}
+          onNextBranch={onNextBranch}
+          getToolProgressLabel={getToolProgressLabel}
+        />
+
+        {/* Contextual suggestions — shown only when no messages in current session */}
+        {displayedMessages.length === 0 && (
+          <SuggestionList suggestions={suggestions} onSelect={onSuggestionSelect} />
+        )}
+
+        {/* PromptInputProvider scopes input state to this chat area */}
+        <PromptInputProvider>
+          <ChatInput
+            onSubmit={onSubmit}
+            onStop={onStop}
+            isStreaming={isStreaming}
+            placeholder="Ask Ava..."
+            autoFocus
+            actions={
+              <>
+                <ChatModelSelect value={modelAlias} onValueChange={onModelChange} />
+                {tokenUsage.total > 0 && (
+                  <span
+                    className={cn(
+                      'text-xs tabular-nums',
+                      tokenUsage.total > 100_000
+                        ? 'text-destructive font-medium'
+                        : tokenUsage.total > 50_000
+                          ? 'text-yellow-500'
+                          : 'text-muted-foreground'
+                    )}
+                    title={
+                      tokenUsage.estimated
+                        ? `~${tokenUsage.total.toLocaleString()} estimated context size`
+                        : `Context: ${tokenUsage.input.toLocaleString()} tokens (last response: ${tokenUsage.output.toLocaleString()} output)`
+                    }
+                  >
+                    {tokenUsage.estimated && '~'}
+                    {tokenUsage.total >= 1000
+                      ? `${(tokenUsage.total / 1000).toFixed(1)}k`
+                      : tokenUsage.total}{' '}
+                    tokens
+                  </span>
+                )}
+                <span className="text-xs text-muted-foreground">
+                  {isStreaming ? 'Streaming...' : `Enter to send \u00B7 ${shortcutHint}`}
+                </span>
+              </>
+            }
+          />
+        </PromptInputProvider>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/views/chat-overlay/ava-channel-tab.tsx
+++ b/apps/ui/src/components/views/chat-overlay/ava-channel-tab.tsx
@@ -1,0 +1,237 @@
+/**
+ * AvaChannelTab — read-only stream of private Ava-to-Ava coordination messages.
+ *
+ * Shows chronological messages with instance badges. Real-time updates are
+ * appended via useAvaChannelStore. Empty state shown when hivemind is inactive.
+ * Operator override input (amber-toned, collapsed by default) allows injecting
+ * messages into the channel.
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Search, ChevronDown, ChevronUp, Send, RefreshCw } from 'lucide-react';
+import { Button } from '@protolabsai/ui/atoms';
+import { cn } from '@/lib/utils';
+import { useAvaChannelStore } from '@/store/ava-channel-store';
+import type { AvaChatMessage } from '@protolabsai/types';
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+function formatRelativeTime(timestamp: string): string {
+  const now = Date.now();
+  const then = new Date(timestamp).getTime();
+  const diffMs = now - then;
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHr = Math.floor(diffMin / 60);
+
+  if (diffSec < 60) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHr < 24) return `${diffHr}h ago`;
+  return new Date(timestamp).toLocaleDateString();
+}
+
+function InstanceBadge({ instanceName, source }: { instanceName: string; source: AvaChatMessage['source'] }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium',
+        source === 'operator'
+          ? 'bg-amber-500/20 text-amber-600 dark:text-amber-400'
+          : source === 'system'
+            ? 'bg-muted text-muted-foreground'
+            : 'bg-primary/10 text-primary'
+      )}
+    >
+      {source === 'operator' ? 'operator' : instanceName}
+    </span>
+  );
+}
+
+function ChannelMessage({ message }: { message: AvaChatMessage }) {
+  return (
+    <div className="flex flex-col gap-0.5 py-2 border-b border-border/50 last:border-0">
+      <div className="flex items-center gap-2">
+        <InstanceBadge instanceName={message.instanceName} source={message.source} />
+        <span className="text-[10px] text-muted-foreground">{formatRelativeTime(message.timestamp)}</span>
+      </div>
+      <p className="text-sm text-foreground leading-relaxed whitespace-pre-wrap">{message.content}</p>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+      <div className="size-8 rounded-full bg-muted flex items-center justify-center">
+        <div className="size-3 rounded-full bg-muted-foreground/40" />
+      </div>
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-foreground">Hivemind not active</p>
+        <p className="text-xs text-muted-foreground max-w-[240px]">
+          Enable multi-instance coordination in{' '}
+          <code className="text-[11px] bg-muted px-1 py-0.5 rounded">proto.config.yaml</code>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Main component
+// ============================================================================
+
+export function AvaChannelTab() {
+  const messages = useAvaChannelStore((s) => s.messages);
+  const loading = useAvaChannelStore((s) => s.loading);
+  const error = useAvaChannelStore((s) => s.error);
+  const hivemindActive = useAvaChannelStore((s) => s.hivemindActive);
+  const filterQuery = useAvaChannelStore((s) => s.filterQuery);
+  const fetchMessages = useAvaChannelStore((s) => s.fetchMessages);
+  const sendOperatorMessage = useAvaChannelStore((s) => s.sendOperatorMessage);
+  const setFilterQuery = useAvaChannelStore((s) => s.setFilterQuery);
+
+  const [operatorOpen, setOperatorOpen] = useState(false);
+  const [operatorInput, setOperatorInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Fetch messages on mount
+  useEffect(() => {
+    fetchMessages({ limit: 50 });
+  }, [fetchMessages]);
+
+  // Auto-scroll to bottom when new messages arrive
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  const handleSendOperator = useCallback(async () => {
+    const text = operatorInput.trim();
+    if (!text || sending) return;
+    setSending(true);
+    await sendOperatorMessage(text);
+    setOperatorInput('');
+    setSending(false);
+  }, [operatorInput, sending, sendOperatorMessage]);
+
+  const handleOperatorKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        void handleSendOperator();
+      }
+    },
+    [handleSendOperator]
+  );
+
+  // Filter messages by query
+  const filteredMessages =
+    filterQuery.trim()
+      ? messages.filter(
+          (m) =>
+            m.content.toLowerCase().includes(filterQuery.toLowerCase()) ||
+            m.instanceName.toLowerCase().includes(filterQuery.toLowerCase())
+        )
+      : messages;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Filter bar */}
+      <div className="flex items-center gap-1.5 border-b border-border px-2 py-1.5">
+        <Search className="size-3 text-muted-foreground shrink-0" />
+        <input
+          type="text"
+          value={filterQuery}
+          onChange={(e) => setFilterQuery(e.target.value)}
+          placeholder="Filter messages..."
+          className="flex-1 bg-transparent text-xs text-foreground placeholder:text-muted-foreground outline-none"
+        />
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6"
+          onClick={() => fetchMessages({ limit: 50 })}
+          title="Refresh"
+          aria-label="Refresh channel messages"
+          disabled={loading}
+        >
+          <RefreshCw className={cn('size-3', loading && 'animate-spin')} />
+        </Button>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="border-b border-destructive/20 bg-destructive/10 px-3 py-1.5 text-xs text-destructive">
+          {error}
+        </div>
+      )}
+
+      {/* Message stream */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-3">
+        {loading && messages.length === 0 ? (
+          <div className="flex items-center justify-center py-8">
+            <div className="text-xs text-muted-foreground">Loading messages...</div>
+          </div>
+        ) : !hivemindActive && messages.length === 0 ? (
+          <EmptyState />
+        ) : filteredMessages.length === 0 ? (
+          <div className="flex items-center justify-center py-8">
+            <div className="text-xs text-muted-foreground">No messages match your filter</div>
+          </div>
+        ) : (
+          <div className="py-2">
+            {filteredMessages.map((message) => (
+              <ChannelMessage key={message.id} message={message} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Operator override — collapsed by default, amber-toned */}
+      <div className="border-t border-border">
+        <button
+          type="button"
+          className="flex w-full items-center justify-between px-3 py-1.5 text-xs text-amber-600 dark:text-amber-400 hover:bg-amber-50/50 dark:hover:bg-amber-950/20 transition-colors"
+          onClick={() => setOperatorOpen((v) => !v)}
+          aria-expanded={operatorOpen}
+        >
+          <span className="font-medium">Send as Operator</span>
+          {operatorOpen ? <ChevronDown className="size-3" /> : <ChevronUp className="size-3" />}
+        </button>
+
+        {operatorOpen && (
+          <div className="border-t border-amber-200/60 dark:border-amber-800/40 bg-amber-50/30 dark:bg-amber-950/10 px-2 py-2">
+            <div className="flex gap-2">
+              <textarea
+                value={operatorInput}
+                onChange={(e) => setOperatorInput(e.target.value)}
+                onKeyDown={handleOperatorKeyDown}
+                placeholder="Inject an operator message into the Ava channel..."
+                rows={2}
+                className="flex-1 resize-none rounded border border-amber-300/60 dark:border-amber-700/40 bg-background px-2 py-1.5 text-xs text-foreground placeholder:text-muted-foreground outline-none focus:ring-1 focus:ring-amber-400/60"
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-8 self-end text-amber-600 dark:text-amber-400 hover:bg-amber-100/50 dark:hover:bg-amber-900/20"
+                onClick={handleSendOperator}
+                disabled={!operatorInput.trim() || sending}
+                title="Send operator message"
+                aria-label="Send operator message"
+              >
+                <Send className="size-3" />
+              </Button>
+            </div>
+            <p className="mt-1 text-[10px] text-muted-foreground">
+              Enter to send, Shift+Enter for new line
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
@@ -1,7 +1,10 @@
 /**
  * ChatOverlayContent — Shared chat content for overlay and modal.
  *
- * Contains the header, message list, input, and conversation history.
+ * Contains the header, tab bar, and tab content areas.
+ * Tab 1: Ask Ava — human<>Ava chat (unchanged behavior)
+ * Tab 2: Ava Channel — private Ava-to-Ava coordination message stream
+ *
  * Used by both the Electron overlay view and the web fallback modal.
  *
  * Reads currentProject from useAppStore and passes projectId/projectPath
@@ -14,26 +17,21 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import type { UIMessage } from 'ai';
 import { History, X, Settings, ChevronUp, ChevronDown, SquarePen, ListOrdered } from 'lucide-react';
-import {
-  ChatMessageList,
-  ChatInput,
-  SuggestionList,
-  PromptInputProvider,
-  QueueView,
-  type QueueItem,
-  type BranchInfo,
-} from '@protolabsai/ui/ai';
+import { type BranchInfo } from '@protolabsai/ui/ai';
 import { Button } from '@protolabsai/ui/atoms';
 import { cn } from '@/lib/utils';
-import { ChatModelSelect } from '@/components/views/chat/components/chat-model-select';
-import { ConversationList } from './conversation-list';
-import { AvaSettingsPanel } from './ava-settings-panel';
 import { useChatSession } from '@/hooks/use-chat-session';
 import { useAppStore } from '@/store/app-store';
 import { useContextualSuggestions } from '@/hooks/use-contextual-suggestions';
 import { useToolProgress } from '@/hooks/use-tool-progress';
 import { ChatStatusBar } from './chat-status-bar';
 import { getOverlayAPI } from '@/lib/electron';
+import { AskAvaTab } from './ask-ava-tab';
+import { AvaChannelTab } from './ava-channel-tab';
+import {
+  useAvaChannelStore,
+  type AvaChannelTab as AvaChannelTabType,
+} from '@/store/ava-channel-store';
 
 const OVERLAY_HEIGHT_DEFAULT = 600;
 const OVERLAY_HEIGHT_EXPANDED = 900;
@@ -77,6 +75,19 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
   const [expanded, setExpanded] = useState(false);
   const [queueOpen, setQueueOpen] = useState(false);
   const [queuePaused, setQueuePaused] = useState(false);
+
+  // Tab state — persisted in ava-channel-store so keyboard shortcut restores last active tab
+  const lastActiveTab = useAvaChannelStore((s) => s.lastActiveTab);
+  const setLastActiveTab = useAvaChannelStore((s) => s.setLastActiveTab);
+  const [activeTab, setActiveTab] = useState<AvaChannelTabType>(lastActiveTab);
+
+  const handleTabChange = useCallback(
+    (tab: AvaChannelTabType) => {
+      setActiveTab(tab);
+      setLastActiveTab(tab);
+    },
+    [setLastActiveTab]
+  );
 
   // Branch state — tracks multiple response variants per assistant message.
   // branchMap key: the ID of the first (original) assistant message variant.
@@ -314,37 +325,41 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
           <span className="text-sm font-medium text-foreground">Ava</span>
         </div>
         <div className={cn('flex items-center gap-1', !isModal && 'pointer-events-auto')}>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-7"
-            onClick={toggleHistory}
-            title="Conversation history"
-            aria-label="Toggle conversation history"
-          >
-            <History className="size-3.5" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-7"
-            onClick={() => setQueueOpen((v) => !v)}
-            title="Feature queue"
-            aria-label="Toggle feature queue"
-            data-testid="queue-panel-toggle"
-          >
-            <ListOrdered className="size-3.5" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-7"
-            onClick={handleNewChat}
-            title="New chat"
-            aria-label="New chat"
-          >
-            <SquarePen className="size-3.5" />
-          </Button>
+          {activeTab === 'ask-ava' && (
+            <>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                onClick={toggleHistory}
+                title="Conversation history"
+                aria-label="Toggle conversation history"
+              >
+                <History className="size-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                onClick={() => setQueueOpen((v) => !v)}
+                title="Feature queue"
+                aria-label="Toggle feature queue"
+                data-testid="queue-panel-toggle"
+              >
+                <ListOrdered className="size-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                onClick={handleNewChat}
+                title="New chat"
+                aria-label="New chat"
+              >
+                <SquarePen className="size-3.5" />
+              </Button>
+            </>
+          )}
           {!isModal && (
             <Button
               variant="ghost"
@@ -380,124 +395,90 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
         </div>
       </div>
 
-      {/* Error banner */}
-      {error && (
+      {/* Error banner — shown for Ask Ava tab errors */}
+      {activeTab === 'ask-ava' && error && (
         <div className="border-b border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">
           {error.message || 'An error occurred'}
         </div>
       )}
 
       {/* Status bar — tool progress + project event tickers */}
-      <ChatStatusBar
-        toolProgressLabel={activeToolLabel}
-        isStreaming={isStreaming}
-        stepCount={stepCount}
-      />
+      {activeTab === 'ask-ava' && (
+        <ChatStatusBar
+          toolProgressLabel={activeToolLabel}
+          isStreaming={isStreaming}
+          stepCount={stepCount}
+        />
+      )}
 
-      {/* Main content area */}
-      <div className="flex min-h-0 flex-1">
-        {/* Queue panel — slide in from left */}
-        {queueOpen && (
-          <div className="w-56 shrink-0 border-r border-border overflow-y-auto p-2 animate-in slide-in-from-left duration-200">
-            <QueueView
-              items={[]}
-              paused={queuePaused}
-              onTogglePause={() => setQueuePaused((v) => !v)}
-            />
-          </div>
-        )}
-
-        {/* Conversation list panel — slide in from left */}
-        {historyOpen && (
-          <ConversationList
-            sessions={sessions}
-            currentSessionId={currentSessionId}
-            onSelect={(id) => {
-              handleSwitchSession(id);
-              setHistoryOpen(false);
-            }}
-            onNew={() => {
-              handleNewChat();
-              setHistoryOpen(false);
-            }}
-            onDelete={handleDeleteSession}
-            onClose={() => setHistoryOpen(false)}
-            className="animate-in slide-in-from-left duration-200"
-          />
-        )}
-
-        {/* Settings panel — slides in from right, replaces chat area */}
-        {settingsOpen && (
-          <div className="flex min-w-0 flex-1 flex-col overflow-y-auto animate-in slide-in-from-right duration-200">
-            <AvaSettingsPanel projectPath={currentProject?.path} />
-          </div>
-        )}
-
-        {/* Chat area — hidden when settings is open */}
-        <div className={cn('flex min-w-0 flex-1 flex-col', settingsOpen && 'hidden')}>
-          <ChatMessageList
-            messages={displayedMessages}
-            emptyMessage="Ask Ava anything..."
-            isStreaming={isStreaming}
-            onRegenerate={handleRegenerate}
-            onThumbsUp={handleThumbsUp}
-            onThumbsDown={handleThumbsDown}
-            onToolApprove={approveToolAction}
-            onToolReject={rejectToolAction}
-            branchInfoMap={branchInfoMap}
-            onPreviousBranch={handlePreviousBranch}
-            onNextBranch={handleNextBranch}
-            getToolProgressLabel={getProgressLabel}
-          />
-
-          {/* Contextual suggestions — shown only when no messages in current session */}
-          {displayedMessages.length === 0 && (
-            <SuggestionList suggestions={suggestions} onSelect={handleSuggestionSelect} />
+      {/* Tab bar */}
+      <div className="flex items-center border-b border-border px-2">
+        <button
+          type="button"
+          className={cn(
+            'px-3 py-1.5 text-xs font-medium transition-colors border-b-2 -mb-px',
+            activeTab === 'ask-ava'
+              ? 'border-primary text-foreground'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
           )}
-
-          {/* PromptInputProvider scopes input state to this chat area */}
-          <PromptInputProvider>
-            <ChatInput
-              onSubmit={handleSubmit}
-              onStop={stop}
-              isStreaming={isStreaming}
-              placeholder="Ask Ava..."
-              autoFocus
-              actions={
-                <>
-                  <ChatModelSelect value={modelAlias} onValueChange={handleModelChange} />
-                  {tokenUsage.total > 0 && (
-                    <span
-                      className={cn(
-                        'text-xs tabular-nums',
-                        tokenUsage.total > 100_000
-                          ? 'text-destructive font-medium'
-                          : tokenUsage.total > 50_000
-                            ? 'text-yellow-500'
-                            : 'text-muted-foreground'
-                      )}
-                      title={
-                        tokenUsage.estimated
-                          ? `~${tokenUsage.total.toLocaleString()} estimated context size`
-                          : `Context: ${tokenUsage.input.toLocaleString()} tokens (last response: ${tokenUsage.output.toLocaleString()} output)`
-                      }
-                    >
-                      {tokenUsage.estimated && '~'}
-                      {tokenUsage.total >= 1000
-                        ? `${(tokenUsage.total / 1000).toFixed(1)}k`
-                        : tokenUsage.total}{' '}
-                      tokens
-                    </span>
-                  )}
-                  <span className="text-xs text-muted-foreground">
-                    {isStreaming ? 'Streaming...' : `Enter to send \u00B7 ${shortcutHint}`}
-                  </span>
-                </>
-              }
-            />
-          </PromptInputProvider>
-        </div>
+          onClick={() => handleTabChange('ask-ava')}
+          aria-selected={activeTab === 'ask-ava'}
+        >
+          Ask Ava
+        </button>
+        <button
+          type="button"
+          className={cn(
+            'px-3 py-1.5 text-xs font-medium transition-colors border-b-2 -mb-px',
+            activeTab === 'ava-channel'
+              ? 'border-primary text-foreground'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
+          )}
+          onClick={() => handleTabChange('ava-channel')}
+          aria-selected={activeTab === 'ava-channel'}
+        >
+          Ava Channel
+        </button>
       </div>
+
+      {/* Tab content */}
+      {activeTab === 'ask-ava' ? (
+        <AskAvaTab
+          displayedMessages={displayedMessages}
+          isStreaming={isStreaming}
+          suggestions={suggestions}
+          sessions={sessions}
+          currentSessionId={currentSessionId}
+          modelAlias={modelAlias}
+          tokenUsage={tokenUsage}
+          branchInfoMap={branchInfoMap}
+          settingsOpen={settingsOpen}
+          historyOpen={historyOpen}
+          queueOpen={queueOpen}
+          queuePaused={queuePaused}
+          projectPath={currentProject?.path}
+          shortcutHint={shortcutHint}
+          onSubmit={handleSubmit}
+          onStop={stop}
+          onSuggestionSelect={handleSuggestionSelect}
+          onRegenerate={handleRegenerate}
+          onThumbsUp={handleThumbsUp}
+          onThumbsDown={handleThumbsDown}
+          onToolApprove={approveToolAction}
+          onToolReject={rejectToolAction}
+          onPreviousBranch={handlePreviousBranch}
+          onNextBranch={handleNextBranch}
+          onSelectSession={handleSwitchSession}
+          onNewChat={handleNewChat}
+          onDeleteSession={handleDeleteSession}
+          onCloseHistory={() => setHistoryOpen(false)}
+          onToggleQueuePause={() => setQueuePaused((v) => !v)}
+          onModelChange={handleModelChange}
+          getToolProgressLabel={getProgressLabel}
+        />
+      ) : (
+        <AvaChannelTab />
+      )}
     </div>
   );
 }

--- a/apps/ui/src/store/ava-channel-store.ts
+++ b/apps/ui/src/store/ava-channel-store.ts
@@ -1,0 +1,115 @@
+/**
+ * Ava Channel Store — append-only message stream for private Ava-to-Ava coordination.
+ *
+ * This is a separate Zustand store — NOT an extension of chat-store.
+ * Different data model: append-only stream vs bidirectional chat sessions.
+ * Different source: CRDT/API vs AI SDK.
+ *
+ * Messages are fetched from /api/ava-channel/messages and can be appended
+ * in real-time via the appendMessage action (called by WebSocket event handlers).
+ */
+
+import { create } from 'zustand';
+import type { AvaChatMessage } from '@protolabsai/types';
+import { apiFetch } from '@/lib/api-fetch';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type AvaChannelTab = 'ask-ava' | 'ava-channel';
+
+interface AvaChannelState {
+  messages: AvaChatMessage[];
+  loading: boolean;
+  error: string | null;
+  /** Whether hivemind (multi-instance) mode is detected as active */
+  hivemindActive: boolean;
+  /** Last active tab — persisted so keyboard shortcut restores it */
+  lastActiveTab: AvaChannelTab;
+  /** Filter string for searching within the channel */
+  filterQuery: string;
+}
+
+interface AvaChannelActions {
+  fetchMessages: (options?: { limit?: number; since?: string }) => Promise<void>;
+  appendMessage: (message: AvaChatMessage) => void;
+  sendOperatorMessage: (content: string) => Promise<void>;
+  setHivemindActive: (active: boolean) => void;
+  setLastActiveTab: (tab: AvaChannelTab) => void;
+  setFilterQuery: (query: string) => void;
+  clearMessages: () => void;
+}
+
+// ============================================================================
+// Store
+// ============================================================================
+
+export const useAvaChannelStore = create<AvaChannelState & AvaChannelActions>()((set) => ({
+  messages: [],
+  loading: false,
+  error: null,
+  hivemindActive: false,
+  lastActiveTab: 'ask-ava',
+  filterQuery: '',
+
+  fetchMessages: async (options = {}) => {
+    set({ loading: true, error: null });
+    try {
+      const params = new URLSearchParams();
+      if (options.limit) params.set('limit', String(options.limit));
+      if (options.since) params.set('since', options.since);
+
+      const response = await apiFetch(`/api/ava-channel/messages?${params.toString()}`, 'GET');
+
+      if (!response.ok) {
+        const data = (await response.json()) as { error?: { message?: string } };
+        set({
+          loading: false,
+          error: data.error?.message ?? `HTTP ${response.status}`,
+        });
+        return;
+      }
+
+      const data = (await response.json()) as {
+        success: boolean;
+        messages?: AvaChatMessage[];
+      };
+
+      if (data.success && data.messages) {
+        set({ messages: data.messages, loading: false, hivemindActive: true });
+      } else {
+        set({ loading: false, hivemindActive: false });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load messages';
+      set({ loading: false, error: message });
+    }
+  },
+
+  appendMessage: (message) => {
+    set((state) => ({
+      messages: [...state.messages, message],
+    }));
+  },
+
+  sendOperatorMessage: async (content: string) => {
+    try {
+      const response = await apiFetch('/api/ava-channel/send', 'POST', {
+        body: { message: content, instanceId: 'operator' },
+      });
+      if (!response.ok) {
+        const data = (await response.json()) as { error?: { message?: string } };
+        set({ error: data.error?.message ?? 'Failed to send message' });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to send message';
+      set({ error: message });
+    }
+  },
+
+  setHivemindActive: (active) => set({ hivemindActive: active }),
+  setLastActiveTab: (tab) => set({ lastActiveTab: tab }),
+  setFilterQuery: (query) => set({ filterQuery: query }),
+  clearMessages: () => set({ messages: [], error: null }),
+}));


### PR DESCRIPTION
## Summary

**Milestone:** Private Ava Channel

Add a second tab to the Ava Anywhere overlay (ChatOverlayView / ChatOverlayContent) and web ChatModal: 'Ava Channel' shows the private Ava-to-Ava conversation as a read-only message stream. Tab 1 remains 'Ask Ava' (human<>Ava chat, unchanged). Tab 2 'Ava Channel' shows chronological messages with instance badges, real-time CRDT updates, and an operator override input (amber-toned, collapsed by default, labeled 'Send as Operator'). Empty state when hivemind not...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat overlay now features a two-tab interface: "Ask Ava" and "Ava Channel."
  * Added Ava Channel tab displaying a read-only private Ava-to-Ava message stream with real-time updates.
  * Operator override panel enables multi-line messaging in Ava Channel.
  * Message filtering capability in Ava Channel.
  * Tab selection persists between sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->