### PR TITLE
feat: live UI updates for CRDT mesh feature sync

### DIFF
--- a/apps/ui/src/hooks/use-query-invalidation.ts
+++ b/apps/ui/src/hooks/use-query-invalidation.ts
@@ -229,11 +229,45 @@ export function useSessionQueryInvalidation(sessionId: string | undefined) {
  * }
  * ```
  */
+/**
+ * Invalidate feature queries when remote CRDT sync events arrive.
+ *
+ * The CRDT mesh emits feature:created, feature:updated, feature:deleted,
+ * and feature:status-changed when a remote instance changes a feature.
+ * Without this hook the board only updates on manual refresh.
+ */
+export function useFeatureEventQueryInvalidation(projectPath: string | undefined) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!projectPath) return;
+
+    const api = getElectronAPI();
+    if (!api?.features?.onFeatureEvent) return;
+
+    const unsubscribe = api.features.onFeatureEvent((event) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.features.all(projectPath),
+      });
+
+      // Also invalidate running agents — status changes may affect agent state
+      if (event.type === 'feature:status-changed') {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.runningAgents.all(),
+        });
+      }
+    });
+
+    return unsubscribe;
+  }, [projectPath, queryClient]);
+}
+
 export function useQueryInvalidation(
   projectPath: string | undefined,
   sessionId?: string | undefined
 ) {
   useAutoModeQueryInvalidation(projectPath);
+  useFeatureEventQueryInvalidation(projectPath);
   useSpecRegenerationQueryInvalidation(projectPath);
   useGitHubValidationQueryInvalidation(projectPath);
   useSessionQueryInvalidation(sessionId);

--- a/apps/ui/src/lib/clients/base-http-client.ts
+++ b/apps/ui/src/lib/clients/base-http-client.ts
@@ -40,7 +40,11 @@ export type EventType =
   | 'actionable-item:created'
   | 'actionable-item:status-changed'
   | 'chat:tool-progress'
-  | 'scheduler:task-failed';
+  | 'scheduler:task-failed'
+  | 'feature:created'
+  | 'feature:updated'
+  | 'feature:deleted'
+  | 'feature:status-changed';
 
 export type EventCallback = (payload: unknown) => void;
 

--- a/apps/ui/src/lib/clients/features-client.ts
+++ b/apps/ui/src/lib/clients/features-client.ts
@@ -80,6 +80,20 @@ export const withFeaturesClient = <TBase extends Constructor<BaseHttpClient>>(Ba
         this.post('/api/features/bulk-update', { projectPath, featureIds, updates }),
       bulkDelete: (projectPath: string, featureIds: string[]) =>
         this.post('/api/features/bulk-delete', { projectPath, featureIds }),
+      onFeatureEvent: (callback: (event: { type: string; payload: unknown }) => void) => {
+        const featureEvents = [
+          'feature:created',
+          'feature:updated',
+          'feature:deleted',
+          'feature:status-changed',
+        ] as const;
+        const unsubs = featureEvents.map((eventType) =>
+          this.subscribeToEvent(eventType, ((payload: unknown) => {
+            callback({ type: eventType, payload });
+          }) as EventCallback)
+        );
+        return () => unsubs.forEach((unsub) => unsub());
+      },
     };
 
     // Auto Mode API

--- a/apps/ui/src/lib/electron.ts
+++ b/apps/ui/src/lib/electron.ts
@@ -383,6 +383,7 @@ export interface FeaturesAPI {
     description: string,
     projectPath?: string
   ) => Promise<{ success: boolean; title?: string; error?: string }>;
+  onFeatureEvent: (callback: (event: { type: string; payload: unknown }) => void) => () => void;
 }
 
 export interface AutoModeAPI {


### PR DESCRIPTION
## Summary
- Subscribes to `feature:created`, `feature:updated`, `feature:deleted`, and `feature:status-changed` WebSocket events in the UI
- Invalidates React Query feature cache when remote CRDT sync events arrive
- Board now auto-refreshes when features change on other instances — no manual reload needed

## Test plan
- [x] TypeScript compiles cleanly
- [ ] Create a feature on staging, verify it appears on local board without refresh
- [ ] Update a feature on one instance, verify the other instance reflects the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time feature event notifications for creation, updates, deletion, and status changes
  * Automatic cache invalidation to keep feature information current when remote events occur

<!-- end of auto-generated comment: release notes by coderabbit.ai -->