### PR TITLE
feat: reactive message protocol types and service extensions

### DIFF
--- a/apps/server/src/services/ava-channel-service.ts
+++ b/apps/server/src/services/ava-channel-service.ts
@@ -109,6 +109,10 @@ export class AvaChannelService {
       source,
       timestamp: new Date().toISOString(),
       ...(options?.context ? { context: options.context } : {}),
+      ...(options?.intent !== undefined ? { intent: options.intent } : {}),
+      ...(options?.expectsResponse !== undefined
+        ? { expectsResponse: options.expectsResponse }
+        : {}),
     };
 
     if (this.store) {

--- a/libs/types/src/ava-channel.ts
+++ b/libs/types/src/ava-channel.ts
@@ -6,6 +6,52 @@
  */
 
 /**
+ * Intent of a message in the Ava Channel.
+ * Used by the reactor classifier chain to route and prioritize messages.
+ *
+ * - 'request'      — Asking another instance to do something
+ * - 'inform'       — Status broadcast; no response expected (auto-posts use this)
+ * - 'response'     — Reply to a prior request
+ * - 'coordination' — Multi-instance coordination (locking, voting, handoffs)
+ * - 'escalation'   — Requesting human or supervisor intervention
+ * - 'system_alert' — Automated alert from infrastructure (errors, thresholds)
+ */
+export type MessageIntent =
+  | 'request'
+  | 'inform'
+  | 'response'
+  | 'coordination'
+  | 'escalation'
+  | 'system_alert';
+
+/**
+ * A single rule in the message classifier chain.
+ * Rules are evaluated in order; the first match determines the intent.
+ */
+export interface MessageClassifierRule {
+  /** Regex pattern matched against the message content (case-insensitive) */
+  pattern?: string;
+  /** Intent assigned when this rule matches */
+  intent: MessageIntent;
+  /** Optional human-readable description of the rule's purpose */
+  description?: string;
+  /** Source filter — only applies if the message source matches */
+  source?: 'ava' | 'operator' | 'system';
+}
+
+/**
+ * Context provided to the message classifier chain when classifying a message.
+ */
+export type ClassificationContext = {
+  /** The message being classified */
+  message: AvaChatMessage;
+  /** Recent messages in the same conversation thread (for context-aware classification) */
+  recentMessages?: AvaChatMessage[];
+  /** ID of the instance running the classification */
+  instanceId?: string;
+};
+
+/**
  * Optional structured context attached to an Ava Channel message.
  * Used for machine-readable context alongside free-form content.
  */
@@ -43,6 +89,14 @@ export interface AvaChatMessage {
   source: 'ava' | 'operator' | 'system';
   /** ISO 8601 timestamp */
   timestamp: string;
+  /** Intent classification — what kind of message this is */
+  intent?: MessageIntent;
+  /** ID of the message this is replying to (for threaded conversations) */
+  inReplyTo?: string;
+  /** Whether the sender expects a response to this message */
+  expectsResponse?: boolean;
+  /** Depth in a conversation thread (0 = root message) */
+  conversationDepth?: number;
 }
 
 /**
@@ -70,6 +124,10 @@ export interface PostMessageOptions {
   instanceName?: string;
   /** Optional structured context */
   context?: AvaChannelContext;
+  /** Intent of this message — for classifier chain routing */
+  intent?: MessageIntent;
+  /** Whether this message expects a response from other instances */
+  expectsResponse?: boolean;
 }
 
 /**

--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -225,6 +225,51 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
 // Scheduler Settings
 // ============================================================================
 
+// ============================================================================
+// Ava Channel Reactor Settings
+// ============================================================================
+
+/**
+ * AvaChannelReactorSettings — Configuration for the Ava Channel reactor.
+ *
+ * The reactor listens for incoming messages on the Ava Channel and decides
+ * whether/how to respond. These settings live in WorkflowSettings so they
+ * can be toggled per-instance alongside other workflow automation flags.
+ */
+export interface AvaChannelReactorSettings {
+  /** Whether the Ava Channel reactor is enabled (default: false) */
+  enabled: boolean;
+  /**
+   * Maximum conversation depth before the reactor stops auto-responding.
+   * Prevents runaway conversation loops. (default: 5)
+   */
+  maxConversationDepth: number;
+  /**
+   * Minimum milliseconds between reactor responses to the same conversation.
+   * Prevents flooding the channel with rapid-fire replies. (default: 30000)
+   */
+  cooldownMs: number;
+  /**
+   * Model alias or ID to use for reactor response generation.
+   * Defaults to 'haiku' for cost efficiency on broadcast monitoring.
+   */
+  reactorModel: string;
+  /**
+   * Messages older than this many milliseconds are considered stale and
+   * will not trigger a reactor response. (default: 300000 = 5 minutes)
+   */
+  staleMessageThresholdMs: number;
+}
+
+/** Default Ava Channel reactor settings — disabled by default */
+export const DEFAULT_AVA_CHANNEL_REACTOR_SETTINGS: AvaChannelReactorSettings = {
+  enabled: false,
+  maxConversationDepth: 5,
+  cooldownMs: 30_000,
+  reactorModel: 'haiku',
+  staleMessageThresholdMs: 300_000,
+};
+
 /**
  * Scheduler settings for persisting task state across server restarts.
  */
@@ -660,6 +705,14 @@ export interface GlobalSettings {
    * @see SchedulerSettings
    */
   schedulerSettings?: SchedulerSettings;
+
+  /**
+   * Ava Channel reactor settings.
+   * Controls whether this instance auto-responds to incoming Ava Channel messages
+   * and at what depth/cadence.
+   * @see AvaChannelReactorSettings
+   */
+  avaChannelReactor?: AvaChannelReactorSettings;
 }
 
 /** Default global settings used when no settings file exists */

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -10,6 +10,9 @@ export type {
   AvaChannelDocument,
   PostMessageOptions,
   GetMessagesOptions,
+  MessageIntent,
+  MessageClassifierRule,
+  ClassificationContext,
 } from './ava-channel.js';
 
 // Event Ledger types — append-only JSONL event persistence layer
@@ -357,6 +360,9 @@ export type {
   ClaudeApiProfileTemplate,
   // Workflow settings types
   WorkflowSettings,
+  // Ava Channel reactor settings
+  AvaChannelReactorSettings,
+  SchedulerSettings,
 } from './settings.js';
 export {
   DEFAULT_KEYBOARD_SHORTCUTS,
@@ -386,6 +392,9 @@ export {
   DEFAULT_TRUST_BOUNDARY_CONFIG,
   // Workflow settings defaults
   DEFAULT_WORKFLOW_SETTINGS,
+  // Ava Channel reactor settings defaults
+  DEFAULT_AVA_CHANNEL_REACTOR_SETTINGS,
+  DEFAULT_SCHEDULER_SETTINGS,
   // Integration config defaults
   DEFAULT_DISCORD_INTEGRATION,
   // Claude-compatible provider templates (new)


### PR DESCRIPTION
## Summary
- Add `MessageIntent` type for classifier chain routing
- Extend `AvaChatMessage` with `intent`, `expectsResponse`, `conversationDepth`, `inReplyTo` fields
- Add `MessageClassifierRule` and `ClassificationContext` types
- Add `AvaChannelReactorSettings` to `WorkflowSettings`
- Update `AvaChannelService.postMessage()` to persist new fields

## Context
These types are required by the Classifier Chain and Reactor Service epics. They were implemented locally but never committed to a remote branch, causing CI failures on epic PRs #2009 and #2010.

## Test plan
- [x] Types compile cleanly
- [x] Backward compatible (all new fields optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages now support intent classification (request, inform, response, coordination, escalation, system alert) for semantic routing
  * Added conversation threading with reply tracking and depth awareness
  * Messages can indicate response expectations
  * Introduced configurable Ava Channel reactor with customizable depth limits, cooldown periods, and model selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->