### PR TITLE
fix: filter stub directories in listProjectPlans

### DIFF
--- a/libs/platform/src/projects.ts
+++ b/libs/platform/src/projects.ts
@@ -352,10 +352,18 @@ export async function listProjectPlans(projectPath: string): Promise<string[]> {
   }
 
   const entries = (await secureFs.readdir(projectsDir, { withFileTypes: true })) as any[];
-  return entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .sort((a, b) => a.localeCompare(b)); // Sort for deterministic output
+  const dirs = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+
+  // Only return projects that have a valid project.json — stub directories
+  // (from failed creation or deleted projects) are filtered out
+  const valid: string[] = [];
+  for (const slug of dirs) {
+    if (await projectPlanExists(projectPath, slug)) {
+      valid.push(slug);
+    }
+  }
+
+  return valid.sort((a, b) => a.localeCompare(b));
 }
 
 /**


### PR DESCRIPTION
## Summary
- Filter out stub directories without valid `project.json` in `listProjectPlans()`
- Stub directories (from failed creation or deleted projects) caused 404 errors that crashed the Projects tab UI

## Test plan
- [x] Projects tab loads correctly when stub directories exist
- [x] Valid projects still listed normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed project listing to exclude invalid or deleted projects from appearing in project directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->