### PR TITLE
feat: unify CRDT sync — wire CRDTStore into all domains

### DIFF
--- a/apps/server/src/routes/todo/index.ts
+++ b/apps/server/src/routes/todo/index.ts
@@ -8,13 +8,11 @@
 import { Router, type Request, type Response } from 'express';
 import { createLogger } from '@protolabsai/utils';
 import { validatePath } from '@protolabsai/platform';
-import { TodoService } from '../../services/todo-service.js';
-import type { EventEmitter } from '../../lib/events.js';
+import type { TodoService } from '../../services/todo-service.js';
 
 const logger = createLogger('TodoRoutes');
-const todoService = new TodoService();
 
-export function createTodoRoutes(_events?: EventEmitter): Router {
+export function createTodoRoutes(todoService: TodoService): Router {
   const router = Router();
 
   /**

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -160,6 +160,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
     sensorRegistryService,
     projectPmService,
     crdtSyncService,
+    todoService,
     avaChannelService,
   } = services;
 
@@ -396,7 +397,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api/chat', createChatRoutes(services));
   app.use('/api/ai', createAIRoutes());
   app.use('/api/notes', createNotesRoutes(events));
-  app.use('/api/todos', createTodoRoutes(events));
+  app.use('/api/todos', createTodoRoutes(todoService));
   app.use('/api/sitrep', createSitrepRoutes({ featureLoader, autoModeService, repoRoot }));
   // Knowledge store routes (chunked retrieval)
   if (knowledgeStoreService) {

--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -101,6 +101,7 @@ import { ProjectPMService } from '../services/project-pm-service.js';
 import * as projectPmModule from '../services/project-pm.module.js';
 import { CrdtSyncService } from '../services/crdt-sync-service.js';
 import { AvaChannelService } from '../services/ava-channel-service.js';
+import { TodoService } from '../services/todo-service.js';
 import type { WorkStealingService } from '../services/work-stealing-service.js';
 
 const logger = createLogger('Server:Services');
@@ -262,8 +263,14 @@ export interface ServiceContainer {
   // Work-stealing (cross-instance feature redistribution)
   workStealingService?: WorkStealingService;
 
+  // Todo workspace (per-project todo lists synced via CRDT)
+  todoService: TodoService;
+
   // DORA metrics (lead time, deployment frequency, change failure rate, recovery time, rework rate)
   doraMetricsService: DoraMetricsService;
+
+  // CRDT document store cleanup (set by crdt-store.module, called on shutdown)
+  _crdtStoreCleanup?: () => Promise<void>;
 
   // Drift detection interval (set by wireServices, cleared by shutdown)
   driftCheckInterval: ReturnType<typeof setInterval> | null;
@@ -646,6 +653,9 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   // Project PM Service — session store for PM Agent chat
   const projectPmService = new ProjectPMService();
 
+  // Todo Service — per-project workspace, CRDT-synced when hivemind active
+  const todoService = new TodoService();
+
   // CRDT Sync Service — multi-instance coordination via WebSocket sync server
   const crdtSyncService = new CrdtSyncService();
 
@@ -779,6 +789,7 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
     projectPlanningService,
     projectPmService,
     crdtSyncService,
+    todoService,
     avaChannelService,
     doraMetricsService,
     driftCheckInterval: null,

--- a/apps/server/src/server/shutdown.ts
+++ b/apps/server/src/server/shutdown.ts
@@ -68,6 +68,14 @@ async function gracefulShutdown(server: http.Server, services: ServiceContainer)
   hitlFormService.shutdown();
   actionableItemBridge.shutdown();
   agentDiscordRouter.stop();
+  // Shut down CRDT document store (closes Automerge sync server + flushes)
+  if (services._crdtStoreCleanup) {
+    try {
+      await services._crdtStoreCleanup();
+    } catch (err) {
+      logger.warn('[SHUTDOWN] CRDT store cleanup failed:', err);
+    }
+  }
   await crdtSyncService.shutdown();
   await shutdownLangfuse();
   await shutdownOtel();

--- a/apps/server/src/server/startup.ts
+++ b/apps/server/src/server/startup.ts
@@ -83,6 +83,19 @@ export async function runStartup(
     logger.warn('[CRDT] Sync service failed to start (single-instance mode):', err);
   }
 
+  // Initialize CRDT document store and inject into services
+  // Must run after CrdtSyncService.start() so proto.config.yaml is loaded
+  try {
+    const { register: registerCrdtStore } = await import('../services/crdt-store.module.js');
+    const result = await registerCrdtStore(services);
+    if (result) {
+      services._crdtStoreCleanup = result.close;
+      logger.info('[CRDT] Document store initialized and injected into services');
+    }
+  } catch (err) {
+    logger.warn('[CRDT] Document store failed to initialize (filesystem fallback):', err);
+  }
+
   // Initialize Knowledge Store Service for all known projects
   if (knowledgeStoreService) {
     try {

--- a/apps/server/src/services/ava-channel-service.ts
+++ b/apps/server/src/services/ava-channel-service.ts
@@ -34,7 +34,7 @@ const ARCHIVE_AFTER_DAYS = 30;
 const ARCHIVE_CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 
 export class AvaChannelService {
-  private readonly store: CRDTStore | null;
+  private store: CRDTStore | null;
   private readonly instanceId: string;
   private readonly instanceName: string;
   /** Directory where archived shards are written as JSON files */
@@ -56,6 +56,15 @@ export class AvaChannelService {
 
   setEventEmitter(emit: (type: string, payload: unknown) => void): void {
     this._emitEvent = emit;
+  }
+
+  /**
+   * Register a CRDTStore for syncing channel messages across instances.
+   * When set, messages are stored in CRDT documents instead of in-memory.
+   */
+  setCrdtStore(store: CRDTStore): void {
+    this.store = store;
+    logger.info('[AvaChannel] CRDT store registered — messages will sync across instances');
   }
 
   /**

--- a/apps/server/src/services/crdt-store.module.ts
+++ b/apps/server/src/services/crdt-store.module.ts
@@ -1,0 +1,142 @@
+/**
+ * CRDT Store Module — instantiates the shared CRDTStore and injects it into all
+ * services that support document-level CRDT sync.
+ *
+ * This module bridges the gap between:
+ *   - CrdtSyncService (peer mesh, heartbeat, event broadcast)
+ *   - CRDTStore (Automerge document persistence + replication)
+ *
+ * CrdtSyncService owns the peer mesh on port N (default 4444).
+ * CRDTStore runs a separate Automerge sync server on port N+1 (default 4445)
+ * for binary document replication. Both ports are only active when
+ * proto.config.yaml enables hivemind mode.
+ *
+ * Services injected:
+ *   - AvaChannelService.setCrdtStore()
+ *   - CalendarService.setCrdtStore()
+ *   - TodoService.setCrdtStore()
+ *
+ * Features and Projects use EventBus-based sync (handled by crdt-sync.module.ts)
+ * because their storage is filesystem-primary with event notifications.
+ */
+
+import { join } from 'node:path';
+import { WebSocketServer } from 'ws';
+import { CRDTStore, WebSocketServerAdapter } from '@protolabsai/crdt';
+import { loadProtoConfig } from '@protolabsai/platform';
+import { createLogger } from '@protolabsai/utils';
+import type { ServiceContainer } from '../server/services.js';
+
+const logger = createLogger('CrdtStoreModule');
+
+/** Default port offset from the CrdtSyncService sync port */
+const CRDT_STORE_PORT_OFFSET = 1;
+
+export interface CrdtStoreModuleResult {
+  store: CRDTStore;
+  close: () => Promise<void>;
+}
+
+/**
+ * Initialize the CRDTStore and inject it into all services that need it.
+ * Returns the store instance and a cleanup function.
+ *
+ * Safe to call in single-instance mode — returns null when proto.config.yaml
+ * is absent (no hivemind configured).
+ */
+export async function register(container: ServiceContainer): Promise<CrdtStoreModuleResult | null> {
+  const { repoRoot } = container;
+
+  const protoConfig = await loadProtoConfig(repoRoot);
+  if (!protoConfig) {
+    logger.info('No proto.config.yaml — CRDT store disabled (single-instance mode)');
+    return null;
+  }
+
+  const hivemind = protoConfig['hivemind'] as { enabled?: boolean; peers?: string[] } | undefined;
+  if (!hivemind?.enabled) {
+    logger.info('Hivemind not enabled in proto.config.yaml — CRDT store disabled');
+    return null;
+  }
+
+  const protolab = protoConfig['protolab'] as
+    | { instanceId?: string; syncPort?: number; role?: string }
+    | undefined;
+
+  const instanceId = protolab?.instanceId ?? container.crdtSyncService.getInstanceId();
+  const baseSyncPort = protolab?.syncPort ?? 4444;
+  const crdtStorePort = baseSyncPort + CRDT_STORE_PORT_OFFSET;
+  const role = protolab?.role ?? 'worker';
+  const storageDir = join(repoRoot, '.automaker', 'crdt');
+
+  // Build peer URLs — remap from sync port to CRDT store port
+  const peers = (hivemind.peers ?? [])
+    .map((peerUrl) => {
+      try {
+        const url = new URL(peerUrl);
+        const peerSyncPort = parseInt(url.port, 10) || baseSyncPort;
+        url.port = String(peerSyncPort + CRDT_STORE_PORT_OFFSET);
+        return { url: url.toString() };
+      } catch {
+        logger.warn(`Invalid peer URL: ${peerUrl}, skipping`);
+        return null;
+      }
+    })
+    .filter((p): p is { url: string } => p !== null);
+
+  logger.info(
+    `Initializing CRDTStore: instanceId=${instanceId}, role=${role}, ` +
+      `port=${crdtStorePort}, peers=${peers.length}, storageDir=${storageDir}`
+  );
+
+  const store = new CRDTStore({
+    storageDir,
+    instanceId,
+    peers,
+    compactIntervalMs: 5 * 60 * 1000,
+  });
+
+  await store.init();
+  logger.info('CRDTStore initialized');
+
+  // If primary, start WebSocket server for Automerge binary sync
+  let syncServer: WebSocketServer | null = null;
+  if (role === 'primary') {
+    syncServer = new WebSocketServer({ port: crdtStorePort });
+    await new Promise<void>((resolve, reject) => {
+      syncServer!.on('listening', () => {
+        logger.info(`CRDTStore sync server listening on port ${crdtStorePort}`);
+        resolve();
+      });
+      syncServer!.on('error', (err) => {
+        logger.error(`CRDTStore sync server error on port ${crdtStorePort}:`, err);
+        reject(err);
+      });
+    });
+    // Cast through unknown to satisfy differing ws type versions
+    store.attachServerAdapter(
+      new WebSocketServerAdapter(
+        syncServer as unknown as ConstructorParameters<typeof WebSocketServerAdapter>[0]
+      )
+    );
+  }
+
+  // Inject into services that have setCrdtStore() hooks
+  container.avaChannelService.setCrdtStore(store);
+  container.calendarService.setCrdtStore(store);
+  container.todoService.setCrdtStore(store);
+
+  logger.info('CRDTStore injected into AvaChannelService, CalendarService, TodoService');
+
+  const close = async () => {
+    await store.close();
+    if (syncServer) {
+      await new Promise<void>((resolve) => {
+        syncServer!.close(() => resolve());
+      });
+    }
+    logger.info('CRDTStore shut down');
+  };
+
+  return { store, close };
+}

--- a/apps/server/src/services/crdt-sync.module.ts
+++ b/apps/server/src/services/crdt-sync.module.ts
@@ -1,7 +1,7 @@
 // CRDT sync module — wires EventBus to CrdtSyncService for cross-instance event propagation.
 // Startup handles the actual start() call after repoRoot is resolved.
 
-import type { Feature } from '@protolabsai/types';
+import type { Feature, Project } from '@protolabsai/types';
 import { createLogger } from '@protolabsai/utils';
 import type { ServiceContainer } from '../server/services.js';
 
@@ -20,7 +20,7 @@ export async function register(container: ServiceContainer): Promise<void> {
     container.autoModeService.getCapacityMetrics()
   );
 
-  // Persist remote feature events locally so the board stays in sync across instances.
+  // Persist remote events locally so the board + projects stay in sync across instances.
   // This handler runs BEFORE the event is re-emitted on the local bus, so downstream
   // subscribers (UI WebSocket, IntegrationService, etc.) see already-persisted data.
   container.crdtSyncService.onRemoteFeatureEvent((eventType, payload) => {
@@ -32,6 +32,7 @@ export async function register(container: ServiceContainer): Promise<void> {
     const featureLoader = container.featureLoader;
 
     switch (eventType) {
+      // ── Feature events ──────────────────────────────────────────────────
       case 'feature:created': {
         const feature = payload.feature as Feature | undefined;
         if (!feature?.id) {
@@ -84,6 +85,34 @@ export async function register(container: ServiceContainer): Promise<void> {
         logger.info(`[CRDT] Persisting remote feature:deleted ${featureId}`);
         featureLoader.delete(projectPath, featureId).catch((err) => {
           logger.error(`[CRDT] Failed to persist remote feature:deleted ${featureId}: ${err}`);
+        });
+        break;
+      }
+
+      // ── Project events ──────────────────────────────────────────────────
+      case 'project:created':
+      case 'project:updated': {
+        const project = payload.project as Project | undefined;
+        const slug = (payload.projectSlug as string) || project?.slug;
+        if (!slug || !project) {
+          logger.warn(`[CRDT] Received ${eventType} without project data, skipping`);
+          break;
+        }
+        logger.info(`[CRDT] Persisting remote ${eventType} ${slug}`);
+        container.projectService.persistRemoteProject(projectPath, project).catch((err) => {
+          logger.error(`[CRDT] Failed to persist remote ${eventType} ${slug}: ${err}`);
+        });
+        break;
+      }
+      case 'project:deleted': {
+        const projectSlug = payload.projectSlug as string | undefined;
+        if (!projectSlug) {
+          logger.warn('[CRDT] Received project:deleted without projectSlug, skipping');
+          break;
+        }
+        logger.info(`[CRDT] Persisting remote project:deleted ${projectSlug}`);
+        container.projectService.persistRemoteDelete(projectPath, projectSlug).catch((err) => {
+          logger.error(`[CRDT] Failed to persist remote project:deleted ${projectSlug}: ${err}`);
         });
         break;
       }

--- a/apps/server/src/services/project-service.ts
+++ b/apps/server/src/services/project-service.ts
@@ -182,6 +182,63 @@ export class ProjectService {
     logger.debug(`[CRDT] Applied ${changes.length} remote change(s) for ${projectPath}`);
   }
 
+  // ─── Remote sync (called by crdt-sync.module.ts) ─────────────────────────
+
+  /**
+   * Persist a project received from a remote instance.
+   * Writes to disk + updates local Automerge doc WITHOUT emitting events
+   * (the caller re-emits via the local EventBus to prevent loops).
+   */
+  async persistRemoteProject(projectPath: string, project: Project): Promise<void> {
+    const slug = project.slug;
+    if (!slug) {
+      logger.warn('[CRDT] Received remote project without slug, skipping');
+      return;
+    }
+
+    // Ensure directory exists
+    await ensureProjectDir(projectPath, slug);
+
+    // Write project.json
+    const jsonPath = getProjectJsonPath(projectPath, slug);
+    await secureFs.writeFile(jsonPath, JSON.stringify(project, null, 2));
+
+    // Update local Automerge doc (no event emission)
+    if (this._isCrdtEnabled(projectPath)) {
+      const doc = await this._ensureDoc(projectPath);
+      const newDoc = Automerge.change(doc, (d) => {
+        (d.projects as Record<string, unknown>)[slug] = this._toAutomergeValue(project);
+      });
+      this._docs.set(projectPath, newDoc);
+    }
+
+    logger.info(`[CRDT] Persisted remote project: ${slug}`);
+  }
+
+  /**
+   * Delete a project received from a remote instance.
+   * Removes from disk + local Automerge doc WITHOUT emitting events.
+   */
+  async persistRemoteDelete(projectPath: string, projectSlug: string): Promise<void> {
+    const projectDir = getProjectDir(projectPath, projectSlug);
+    try {
+      await secureFs.rm(projectDir, { recursive: true, force: true });
+    } catch {
+      // Directory may not exist locally — that's fine
+    }
+
+    // Update local Automerge doc (no event emission)
+    if (this._isCrdtEnabled(projectPath)) {
+      const doc = await this._ensureDoc(projectPath);
+      const newDoc = Automerge.change(doc, (d) => {
+        delete (d.projects as Record<string, Project | undefined>)[projectSlug];
+      });
+      this._docs.set(projectPath, newDoc);
+    }
+
+    logger.info(`[CRDT] Persisted remote project delete: ${projectSlug}`);
+  }
+
   // ─── Public API ────────────────────────────────────────────────────────────
 
   /**

--- a/apps/server/tests/unit/services/crdt-store-module.test.ts
+++ b/apps/server/tests/unit/services/crdt-store-module.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock all external dependencies before any imports
+vi.mock('@protolabsai/platform', () => ({
+  loadProtoConfig: vi.fn(),
+}));
+
+vi.mock('@protolabsai/crdt', () => {
+  const mockStore = {
+    init: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    attachServerAdapter: vi.fn(),
+  };
+  // Must use function (not arrow) so it can be called with `new`
+  const CRDTStore = vi.fn(function () {
+    return mockStore;
+  });
+  return {
+    CRDTStore,
+    WebSocketServerAdapter: vi.fn(function () {
+      return {};
+    }),
+  };
+});
+
+vi.mock('ws', () => {
+  const mockWss = {
+    on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+      if (event === 'listening') setTimeout(() => cb(), 0);
+    }),
+    close: vi.fn((cb: () => void) => cb()),
+    clients: new Set(),
+  };
+  return {
+    WebSocketServer: vi.fn(function () {
+      return mockWss;
+    }),
+  };
+});
+
+import { loadProtoConfig } from '@protolabsai/platform';
+import { CRDTStore } from '@protolabsai/crdt';
+import { register } from '@/services/crdt-store.module.js';
+
+const mockLoadProtoConfig = vi.mocked(loadProtoConfig);
+
+function createMockContainer() {
+  return {
+    repoRoot: '/test/project',
+    crdtSyncService: {
+      getInstanceId: vi.fn(() => 'test-instance'),
+    },
+    avaChannelService: {
+      setCrdtStore: vi.fn(),
+    },
+    calendarService: {
+      setCrdtStore: vi.fn(),
+    },
+    todoService: {
+      setCrdtStore: vi.fn(),
+    },
+  } as unknown as Parameters<typeof register>[0];
+}
+
+describe('crdt-store.module', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('register()', () => {
+    it('should return null when no proto.config.yaml exists', async () => {
+      mockLoadProtoConfig.mockResolvedValue(null);
+      const container = createMockContainer();
+
+      const result = await register(container);
+
+      expect(result).toBeNull();
+      expect(CRDTStore).not.toHaveBeenCalled();
+    });
+
+    it('should return null when hivemind is not enabled', async () => {
+      mockLoadProtoConfig.mockResolvedValue({
+        hivemind: { enabled: false },
+      } as ReturnType<typeof loadProtoConfig> extends Promise<infer T> ? NonNullable<T> : never);
+      const container = createMockContainer();
+
+      const result = await register(container);
+
+      expect(result).toBeNull();
+      expect(CRDTStore).not.toHaveBeenCalled();
+    });
+
+    it('should return null when hivemind key is missing', async () => {
+      mockLoadProtoConfig.mockResolvedValue(
+        {} as ReturnType<typeof loadProtoConfig> extends Promise<infer T> ? NonNullable<T> : never
+      );
+      const container = createMockContainer();
+
+      const result = await register(container);
+
+      expect(result).toBeNull();
+    });
+
+    it('should initialize CRDTStore when hivemind is enabled', async () => {
+      mockLoadProtoConfig.mockResolvedValue({
+        hivemind: { enabled: true, peers: [] },
+        protolab: { instanceId: 'node-a', syncPort: 4444, role: 'worker' },
+      } as ReturnType<typeof loadProtoConfig> extends Promise<infer T> ? NonNullable<T> : never);
+      const container = createMockContainer();
+
+      const result = await register(container);
+
+      expect(result).not.toBeNull();
+      expect(CRDTStore).toHaveBeenCalledWith({
+        storageDir: '/test/project/.automaker/crdt',
+        instanceId: 'node-a',
+        peers: [],
+        compactIntervalMs: 300000,
+      });
+    });
+
+    it('should inject CRDTStore into all services', async () => {
+      mockLoadProtoConfig.mockResolvedValue({
+        hivemind: { enabled: true, peers: [] },
+        protolab: { instanceId: 'node-a', syncPort: 4444, role: 'worker' },
+      } as ReturnType<typeof loadProtoConfig> extends Promise<infer T> ? NonNullable<T> : never);
+      const container = createMockContainer();
+
+      await register(container);
+
+      const mockStoreInstance = vi.mocked(CRDTStore).mock.results[0].value;
+      expect(container.avaChannelService.setCrdtStore).toHaveBeenCalledWith(mockStoreInstance);
+      expect(container.calendarService.setCrdtStore).toHaveBeenCalledWith(mockStoreInstance);
+      expect(container.todoService.setCrdtStore).toHaveBeenCalledWith(mockStoreInstance);
+    });
+
+    it('should call store.init()', async () => {
+      mockLoadProtoConfig.mockResolvedValue({
+        hivemind: { enabled: true, peers: [] },
+        protolab: { instanceId: 'node-a', role: 'worker' },
+      } as ReturnType<typeof loadProtoConfig> extends Promise<infer T> ? NonNullable<T> : never);
+      const container = createMockContainer();
+
+      await register(container);
+
+      const mockStoreInstance = vi.mocked(CRDTStore).mock.results[0].value;
+      expect(mockStoreInstance.init).toHaveBeenCalled();
+    });
+
+    it('should start WebSocket server for primary role', async () => {
+      const { WebSocketServer } = await import('ws');
+      mockLoadProtoConfig.mockResolvedValue({
+        hivemind: { enabled: true, peers: [] },
+        protolab: { instanceId: 'node-a', syncPort: 4444, role: 'primary' },
+      } as ReturnType<typeof loadProtoConfig> extends Promise<infer T> ? NonNullable<T> : never);
+      const container = createMockContainer();
+
+      await register(container);
+
+      // WebSocketServer should be created with port 4445 (4444 + 1)
+      expect(WebSocketServer).toHaveBeenCalledWith({ port: 4445 });
+    });
+
+    it('should NOT start WebSocket server for worker role', async () => {
+      const { WebSocketServer } = await import('ws');
+      vi.mocked(WebSocketServer).mockClear();
+      mockLoadProtoConfig.mockResolvedValue({
+        hivemind: { enabled: true, peers: [] },
+        protolab: { instanceId: 'node-a', role: 'worker' },
+      } as ReturnType<typeof loadProtoConfig> extends Promise<infer T> ? NonNullable<T> : never);
+      const container = createMockContainer();
+
+      await register(container);
+
+      expect(WebSocketServer).not.toHaveBeenCalled();
+    });
+
+    it('should remap peer URLs to CRDT store port', async () => {
+      mockLoadProtoConfig.mockResolvedValue({
+        hivemind: {
+          enabled: true,
+          peers: ['ws://100.101.189.45:4444', 'ws://192.168.1.10:5000'],
+        },
+        protolab: { instanceId: 'node-a', syncPort: 4444, role: 'worker' },
+      } as ReturnType<typeof loadProtoConfig> extends Promise<infer T> ? NonNullable<T> : never);
+      const container = createMockContainer();
+
+      await register(container);
+
+      expect(CRDTStore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          peers: [{ url: 'ws://100.101.189.45:4445/' }, { url: 'ws://192.168.1.10:5001/' }],
+        })
+      );
+    });
+
+    it('should skip invalid peer URLs', async () => {
+      mockLoadProtoConfig.mockResolvedValue({
+        hivemind: {
+          enabled: true,
+          peers: ['ws://valid:4444', 'not-a-url', 'ws://also-valid:4444'],
+        },
+        protolab: { instanceId: 'node-a', role: 'worker' },
+      } as ReturnType<typeof loadProtoConfig> extends Promise<infer T> ? NonNullable<T> : never);
+      const container = createMockContainer();
+
+      await register(container);
+
+      // Only valid URLs should be passed
+      const config = vi.mocked(CRDTStore).mock.calls[0][0];
+      expect(config.peers).toHaveLength(2);
+    });
+
+    it('should fall back to crdtSyncService instanceId when protolab is absent', async () => {
+      mockLoadProtoConfig.mockResolvedValue({
+        hivemind: { enabled: true, peers: [] },
+      } as ReturnType<typeof loadProtoConfig> extends Promise<infer T> ? NonNullable<T> : never);
+      const container = createMockContainer();
+
+      await register(container);
+
+      expect(CRDTStore).toHaveBeenCalledWith(
+        expect.objectContaining({ instanceId: 'test-instance' })
+      );
+    });
+
+    it('should return a close function that shuts down store', async () => {
+      mockLoadProtoConfig.mockResolvedValue({
+        hivemind: { enabled: true, peers: [] },
+        protolab: { instanceId: 'node-a', role: 'worker' },
+      } as ReturnType<typeof loadProtoConfig> extends Promise<infer T> ? NonNullable<T> : never);
+      const container = createMockContainer();
+
+      const result = await register(container);
+      expect(result).not.toBeNull();
+
+      await result!.close();
+
+      const mockStoreInstance = vi.mocked(CRDTStore).mock.results[0].value;
+      expect(mockStoreInstance.close).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **P1 fix**: Projects, calendar, todos, and ava-channel were missing CRDTStore injection, causing divergent state across hivemind instances
- Adds `crdt-store.module.ts` — central wiring module that reads `proto.config.yaml`, instantiates CRDTStore, starts WebSocket sync server (port N+1) for primary role, and injects into AvaChannelService, CalendarService, TodoService
- Adds project event handlers (`project:created/updated/deleted`) to `crdt-sync.module.ts` with loop-free persistence via `persistRemoteProject`/`persistRemoteDelete`
- Promotes TodoService to ServiceContainer for proper DI
- Wires CRDTStore init into startup and cleanup into shutdown

## Sync Architecture (after this PR)

| Domain | Sync Mechanism | Status |
|--------|---------------|--------|
| Features | EventBus → crdt-sync.module | Working (existing) |
| Projects | EventBus → crdt-sync.module | **Fixed** |
| Calendar | CRDTStore (store.change) | **Fixed** |
| Todos | CRDTStore (store.change) | **Fixed** |
| Ava Channel | CRDTStore (daily shards) | **Fixed** |
| Settings | Custom wire protocol | Working (existing) |
| Capacity | Heartbeat | Working (existing) |

## Test plan

- [x] 12 unit tests for crdt-store.module (all passing)
- [x] Full server test suite: 2,374 passed, 0 failed
- [x] Full package test suite: 1,069 passed, 0 failed
- [ ] Manual: deploy to staging with 2+ instances and verify project/calendar/todo sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced CRDT Store Module enabling cross-instance data handling with WebSocket server support
  * Added remote project persistence capabilities

* **Refactor**
  * Improved TodoService through dependency injection
  * Enhanced service container integration with better service wiring

* **Tests**
  * Added comprehensive unit test suite for CRDT Store Module covering initialization scenarios and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->