### PR TITLE
Reactor Module + ServiceContainer Integration

### DIFF
--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -103,6 +103,7 @@ import { CrdtSyncService } from '../services/crdt-sync-service.js';
 import { AvaChannelService } from '../services/ava-channel-service.js';
 import { TodoService } from '../services/todo-service.js';
 import type { WorkStealingService } from '../services/work-stealing-service.js';
+import type { AvaChannelReactorService } from '../services/ava-channel-reactor-service.js';
 
 const logger = createLogger('Server:Services');
 
@@ -269,8 +270,17 @@ export interface ServiceContainer {
   // DORA metrics (lead time, deployment frequency, change failure rate, recovery time, rework rate)
   doraMetricsService: DoraMetricsService;
 
+  // CRDT document store (set by crdt-store.module, used by dependent modules)
+  _crdtStore?: import('@protolabsai/crdt').CRDTStore;
+
   // CRDT document store cleanup (set by crdt-store.module, called on shutdown)
   _crdtStoreCleanup?: () => Promise<void>;
+
+  // Ava Channel Reactor (set by ava-channel-reactor.module, called on shutdown)
+  avaChannelReactorService?: AvaChannelReactorService;
+
+  // Ava Channel Reactor stop function (set by ava-channel-reactor.module, called on shutdown)
+  _avaChannelReactorStop?: () => void;
 
   // Drift detection interval (set by wireServices, cleared by shutdown)
   driftCheckInterval: ReturnType<typeof setInterval> | null;

--- a/apps/server/src/server/shutdown.ts
+++ b/apps/server/src/server/shutdown.ts
@@ -68,6 +68,14 @@ async function gracefulShutdown(server: http.Server, services: ServiceContainer)
   hitlFormService.shutdown();
   actionableItemBridge.shutdown();
   agentDiscordRouter.stop();
+  // Shut down Ava Channel Reactor
+  if (services._avaChannelReactorStop) {
+    try {
+      services._avaChannelReactorStop();
+    } catch (err) {
+      logger.warn('[SHUTDOWN] Ava Channel Reactor stop failed:', err);
+    }
+  }
   // Shut down CRDT document store (closes Automerge sync server + flushes)
   if (services._crdtStoreCleanup) {
     try {

--- a/apps/server/src/server/startup.ts
+++ b/apps/server/src/server/startup.ts
@@ -89,11 +89,26 @@ export async function runStartup(
     const { register: registerCrdtStore } = await import('../services/crdt-store.module.js');
     const result = await registerCrdtStore(services);
     if (result) {
+      services._crdtStore = result.store;
       services._crdtStoreCleanup = result.close;
       logger.info('[CRDT] Document store initialized and injected into services');
     }
   } catch (err) {
     logger.warn('[CRDT] Document store failed to initialize (filesystem fallback):', err);
+  }
+
+  // Initialize Ava Channel Reactor (depends on crdt-store.module having run first)
+  try {
+    const { register: registerAvaChannelReactor } =
+      await import('../services/ava-channel-reactor.module.js');
+    const result = await registerAvaChannelReactor(services);
+    if (result) {
+      services.avaChannelReactorService = result.service;
+      services._avaChannelReactorStop = result.stop;
+      logger.info('[REACTOR] Ava Channel Reactor started');
+    }
+  } catch (err) {
+    logger.warn('[REACTOR] Ava Channel Reactor failed to start:', err);
   }
 
   // Initialize Knowledge Store Service for all known projects

--- a/apps/server/src/services/ava-channel-reactor.module.ts
+++ b/apps/server/src/services/ava-channel-reactor.module.ts
@@ -1,0 +1,99 @@
+/**
+ * Ava Channel Reactor Module — instantiates AvaChannelReactorService and wires it
+ * into the server lifecycle.
+ *
+ * Reads hivemind config from proto.config.yaml and checks for the `reactorEnabled`
+ * feature flag in global settings. When both conditions are met, starts the reactor
+ * and returns a {service, stop} handle for the server shutdown sequence.
+ *
+ * Must run after crdt-store.module so that container._crdtStore is populated.
+ *
+ * Safe to call in single-instance mode — returns null when proto.config.yaml is
+ * absent, hivemind is not enabled, or the reactorEnabled flag is off.
+ */
+
+import { loadProtoConfig } from '@protolabsai/platform';
+import { createLogger } from '@protolabsai/utils';
+import { AvaChannelReactorService } from './ava-channel-reactor-service.js';
+import type { ServiceContainer } from '../server/services.js';
+
+const logger = createLogger('AvaChannelReactorModule');
+
+export interface AvaChannelReactorModuleResult {
+  service: AvaChannelReactorService;
+  stop: () => void;
+}
+
+/**
+ * Initialize AvaChannelReactorService and attach it to the server lifecycle.
+ * Returns the service instance and a stop function, or null when the reactor
+ * should not run (single-instance mode, hivemind disabled, or flag off).
+ */
+export async function register(
+  container: ServiceContainer
+): Promise<AvaChannelReactorModuleResult | null> {
+  const { repoRoot, settingsService, avaChannelService, crdtSyncService, autoModeService } =
+    container;
+
+  // Check reactorEnabled feature flag (fast path before filesystem I/O)
+  let reactorEnabled = false;
+  try {
+    const globalSettings = await settingsService.getGlobalSettings();
+    reactorEnabled = globalSettings.featureFlags?.reactorEnabled ?? false;
+  } catch (err) {
+    logger.warn('Failed to read global settings — reactor disabled:', err);
+    return null;
+  }
+
+  if (!reactorEnabled) {
+    logger.info('reactorEnabled feature flag is off — Ava Channel Reactor disabled');
+    return null;
+  }
+
+  // Check hivemind config
+  const protoConfig = await loadProtoConfig(repoRoot);
+  if (!protoConfig) {
+    logger.info('No proto.config.yaml — Ava Channel Reactor disabled (single-instance mode)');
+    return null;
+  }
+
+  const hivemind = protoConfig['hivemind'] as { enabled?: boolean } | undefined;
+  if (!hivemind?.enabled) {
+    logger.info('Hivemind not enabled in proto.config.yaml — Ava Channel Reactor disabled');
+    return null;
+  }
+
+  // Require the CRDTStore registered by crdt-store.module
+  const crdtStore = container._crdtStore;
+  if (!crdtStore) {
+    logger.warn(
+      'CRDTStore not available on container — ' +
+        'ensure crdt-store.module registers before ava-channel-reactor.module'
+    );
+    return null;
+  }
+
+  const instanceId = crdtSyncService.getInstanceId();
+  const instanceName = instanceId;
+
+  logger.info(`Initializing AvaChannelReactorService: instanceId=${instanceId}`);
+
+  const service = new AvaChannelReactorService({
+    avaChannelService,
+    crdtStore,
+    instanceId,
+    instanceName,
+    settingsService,
+    autoModeService,
+  });
+
+  await service.start();
+  logger.info('AvaChannelReactorService started');
+
+  const stop = () => {
+    service.stop();
+    logger.info('AvaChannelReactorService stopped');
+  };
+
+  return { service, stop };
+}

--- a/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
+++ b/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
@@ -40,6 +40,11 @@ const FEATURE_FLAG_LABELS: Record<keyof FeatureFlags, { label: string; descripti
     description:
       'Enable sensor-driven user presence awareness. Requires compatible sensor hardware or agent.',
   },
+  reactorEnabled: {
+    label: 'Ava Channel Reactor',
+    description:
+      'Enable the reactive orchestrator that monitors the Ava Channel and auto-responds to incoming messages. Requires hivemind mode.',
+  },
 };
 
 export function DeveloperSection() {

--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -209,6 +209,12 @@ export interface FeatureFlags {
    * Reports readings to POST /api/sensors/report. Off by default.
    */
   userPresenceDetection: boolean;
+  /**
+   * Ava Channel Reactor — enables the reactive orchestrator that monitors the
+   * CRDT-backed Ava Channel and auto-responds to incoming messages.
+   * Requires hivemind to be enabled in proto.config.yaml. Off by default.
+   */
+  reactorEnabled: boolean;
 }
 
 /** Default feature flags — all off by default, opt-in per environment */
@@ -219,6 +225,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   specEditor: false,
   systemView: false,
   userPresenceDetection: false,
+  reactorEnabled: false,
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary

**Milestone:** Reactor Wiring

Create apps/server/src/services/ava-channel-reactor.module.ts following the pattern of crdt-store.module.ts. The module reads the hivemind config, checks for a reactorEnabled flag, instantiates AvaChannelReactorService with the CRDTStore, and returns a {start, stop} handle. Register the module in apps/server/src/server/services.ts alongside the existing crdt-store.module registration. Add the avaChannelReactorService to ServiceContainer type. Wire startup/shutdown ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Ava Channel Reactor, a reactive service for monitoring and orchestrating messages with auto-response capabilities
  * Added feature flag in developer settings to enable/disable the Ava Channel Reactor
  * Implemented proper initialization and lifecycle management for the new service

<!-- end of auto-generated comment: release notes by coderabbit.ai -->