### PR TITLE
fix: exclude epics from work-stealing and fleet scheduling

### DIFF
--- a/apps/server/src/services/ava-channel-reactor-service.ts
+++ b/apps/server/src/services/ava-channel-reactor-service.ts
@@ -800,10 +800,15 @@ export class AvaChannelReactorService {
       return;
     }
 
-    // Find unblocked backlog features
+    // Find unblocked backlog features — exclude epics (container-only, not implementable)
     const allFeatures = await this.deps.featureLoader.getAll(this.deps.projectPath);
     const backlogFeatures = allFeatures
-      .filter((f) => f.status === 'backlog' && !(f as Record<string, unknown>).claimedBy)
+      .filter(
+        (f) =>
+          f.status === 'backlog' &&
+          !(f as Record<string, unknown>).claimedBy &&
+          !(f as Record<string, unknown>).isEpic
+      )
       .slice(0, Math.min(request.maxFeatures, MAX_STEAL_PER_CYCLE));
 
     if (backlogFeatures.length === 0) {
@@ -858,11 +863,37 @@ export class AvaChannelReactorService {
     // Cap at MAX_STEAL_PER_CYCLE to prevent thundering herd
     const featuresToCreate = offer.features.slice(0, MAX_STEAL_PER_CYCLE);
 
-    logger.info(
-      `Received work_offer from ${offer.offeringInstanceId} — creating ${featuresToCreate.length} features locally`
+    // Dedup: check which features already exist locally (by branchName or stolenFromFeatureId)
+    const existingFeatures = await this.deps.featureLoader.getAll(this.deps.projectPath);
+    const existingBranches = new Set(
+      existingFeatures.map((f) => (f as Record<string, unknown>).branchName).filter(Boolean)
+    );
+    const existingStolenIds = new Set(
+      existingFeatures
+        .map((f) => (f as Record<string, unknown>).stolenFromFeatureId)
+        .filter(Boolean)
     );
 
-    for (const featureData of featuresToCreate) {
+    const newFeatures = featuresToCreate.filter((fd) => {
+      const data = fd as Record<string, unknown>;
+      if (data.branchName && existingBranches.has(data.branchName)) return false;
+      if (data.id && existingStolenIds.has(data.id)) return false;
+      if (data.isEpic) return false;
+      return true;
+    });
+
+    if (newFeatures.length === 0) {
+      logger.debug(
+        `work_offer from ${offer.offeringInstanceId}: all ${featuresToCreate.length} features already exist locally — skipping`
+      );
+      return;
+    }
+
+    logger.info(
+      `Received work_offer from ${offer.offeringInstanceId} — creating ${newFeatures.length} features locally (${featuresToCreate.length - newFeatures.length} skipped as duplicates)`
+    );
+
+    for (const featureData of newFeatures) {
       try {
         // Strip the original ID so create() generates a new one for this instance
         const { id: _originalId, ...rest } = featureData as { id: string; [key: string]: unknown };

--- a/apps/server/src/services/fleet-scheduler-service.ts
+++ b/apps/server/src/services/fleet-scheduler-service.ts
@@ -528,7 +528,10 @@ export class FleetSchedulerService {
 
     try {
       const allFeatures = await this.deps.featureLoader.getAll(this.deps.projectPath);
-      const backlogFeatures = allFeatures.filter((f) => f.status === 'backlog');
+      // Exclude epics — they are container features, not schedulable work
+      const backlogFeatures = allFeatures.filter(
+        (f) => f.status === 'backlog' && !(f as Record<string, unknown>).isEpic
+      );
       const activeFeatures = allFeatures.filter((f) => f.status === 'in_progress');
 
       // Sort backlog by dependency order (features with no unmet deps first)
@@ -1000,7 +1003,10 @@ export class FleetSchedulerService {
 
     try {
       const allFeatures = await this.deps.featureLoader.getAll(this.deps.projectPath);
-      const backlogFeatures = allFeatures.filter((f) => f.status === 'backlog');
+      // Exclude epics — they are container features, not schedulable work
+      const backlogFeatures = allFeatures.filter(
+        (f) => f.status === 'backlog' && !(f as Record<string, unknown>).isEpic
+      );
       const activeFeatures = allFeatures.filter((f) => f.status === 'in_progress');
       const orderedBacklog = this.sortByDependencyOrder(backlogFeatures, allFeatures);
       const metrics = this.deps.autoModeService?.getCapacityMetrics();


### PR DESCRIPTION
## Summary
- Epics (container features) were being scheduled by the fleet scheduler and stolen via the reactor work-stealing protocol
- This caused 100+ duplicate features and blocked the auto-mode concurrency slot
- Adds `isEpic` filter to reactor work_offer, fleet scheduler broadcast, and fleet scheduler local inventory
- Adds dedup logic to reactor work_offer handler (by branchName and stolenFromFeatureId)

## Test plan
- [ ] Verify epics stay in backlog and are never moved to in_progress by auto-mode
- [ ] Verify work-stealing does not create duplicate features
- [ ] Verify normal features still schedule and execute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Epic items are now properly excluded from backlog processing and scheduling.
  * Duplicate features are no longer created during work offer processing; the system detects and skips features already present locally.
  * Improved logging accuracy to reflect the number of newly created versus skipped features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->