### PR TITLE
feat: Rollback and Circuit Breaker

### DIFF
--- a/apps/server/src/routes/features/index.ts
+++ b/apps/server/src/routes/features/index.ts
@@ -20,6 +20,7 @@ import { createGenerateTitleHandler } from './routes/generate-title.js';
 import { createHealthHandler } from './routes/health.js';
 import { createAssignAgentHandler } from './routes/assign-agent.js';
 import { createSummaryHandler } from './routes/summary.js';
+import { createRollbackHandler } from './routes/rollback.js';
 import type { FeatureHealthService } from '../../services/feature-health-service.js';
 import type { RoleRegistryService } from '../../services/role-registry-service.js';
 import type { TrustTierService } from '../../services/trust-tier-service.js';
@@ -75,6 +76,8 @@ export function createFeaturesRoutes(
   if (healthService) {
     router.post('/health', validatePathParams('projectPath'), createHealthHandler(healthService));
   }
+
+  router.post('/rollback', validatePathParams('projectPath'), createRollbackHandler(featureLoader));
 
   return router;
 }

--- a/apps/server/src/routes/features/routes/rollback.ts
+++ b/apps/server/src/routes/features/routes/rollback.ts
@@ -1,0 +1,108 @@
+/**
+ * POST /rollback endpoint - Rollback a deployed feature
+ *
+ * Body: { featureId: string, projectPath: string }
+ * Finds the feature's merge commit, reverts it, and moves the feature back to review.
+ */
+
+import { execSync } from 'child_process';
+import type { Request, Response } from 'express';
+import { FeatureLoader } from '../../../services/feature-loader.js';
+import { createLogger } from '@protolabsai/utils';
+
+const logger = createLogger('features/rollback');
+
+export function createRollbackHandler(featureLoader: FeatureLoader) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { featureId, projectPath } = req.body as {
+        featureId: unknown;
+        projectPath: unknown;
+      };
+
+      if (typeof featureId !== 'string' || featureId.trim().length === 0) {
+        res.status(400).json({ success: false, error: 'featureId must be a non-empty string' });
+        return;
+      }
+
+      if (typeof projectPath !== 'string' || projectPath.trim().length === 0) {
+        res.status(400).json({ success: false, error: 'projectPath must be a non-empty string' });
+        return;
+      }
+
+      const feature = await featureLoader.get(projectPath, featureId);
+      if (!feature) {
+        res.status(404).json({ success: false, error: `Feature not found: ${featureId}` });
+        return;
+      }
+
+      const { prNumber, prMergedAt } = feature;
+      if (!prNumber || !prMergedAt) {
+        res.status(400).json({
+          success: false,
+          error: 'Feature has no merged PR — cannot determine merge commit to revert',
+        });
+        return;
+      }
+
+      // Find the merge commit for this PR by searching the git log
+      let mergeCommit: string;
+      try {
+        const logOutput = execSync(
+          `git log --oneline --merges --grep="Merge pull request #${prNumber} " HEAD`,
+          { cwd: projectPath, encoding: 'utf-8', timeout: 30_000 }
+        ).trim();
+
+        if (!logOutput) {
+          res.status(404).json({
+            success: false,
+            error: `Merge commit for PR #${prNumber} not found in git log`,
+          });
+          return;
+        }
+
+        // First token on the first line is the abbreviated commit SHA
+        mergeCommit = logOutput.split('\n')[0].split(' ')[0];
+      } catch (gitError) {
+        const msg = gitError instanceof Error ? gitError.message : String(gitError);
+        logger.error(`Failed to find merge commit for PR #${prNumber}:`, gitError);
+        res.status(500).json({ success: false, error: `Git log failed: ${msg}` });
+        return;
+      }
+
+      // Execute git revert of the merge commit (preserving mainline parent)
+      try {
+        execSync(`git revert -m 1 --no-edit ${mergeCommit}`, {
+          cwd: projectPath,
+          encoding: 'utf-8',
+          timeout: 60_000,
+        });
+        logger.info(
+          `Reverted merge commit ${mergeCommit} for feature ${featureId} (PR #${prNumber})`
+        );
+      } catch (revertError) {
+        const msg = revertError instanceof Error ? revertError.message : String(revertError);
+        logger.error(`git revert failed for commit ${mergeCommit}:`, revertError);
+        res.status(500).json({ success: false, error: `Git revert failed: ${msg}` });
+        return;
+      }
+
+      // Move feature back to review with rollback reason
+      const updated = await featureLoader.update(projectPath, featureId, {
+        status: 'review',
+        statusChangeReason: 'Rolled back due to health degradation',
+      });
+
+      res.json({
+        success: true,
+        feature: updated,
+        mergeCommit,
+        message: `Reverted merge commit ${mergeCommit} for PR #${prNumber}. Feature moved back to review.`,
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      logger.error('Rollback feature failed:', error);
+      res.status(500).json({ success: false, error: msg });
+    }
+  };
+}

--- a/apps/server/src/services/auto-mode/lead-engineer-rules.ts
+++ b/apps/server/src/services/auto-mode/lead-engineer-rules.ts
@@ -1,0 +1,91 @@
+/**
+ * Lead Engineer Fast-Path Rules
+ *
+ * Pure-function rules that fire synchronously in response to events.
+ * No LLM calls, no service imports — just world-state + event → actions.
+ */
+
+import type { LeadFastPathRule, LeadRuleAction, LeadWorldState } from '@protolabsai/types';
+
+// ────────────────────────── Helpers ──────────────────────────
+
+/** Returns true if the feature was recently deployed (prMergedAt within last 24 hours). */
+function isRecentlyDeployed(prMergedAt: string | undefined): boolean {
+  if (!prMergedAt) return false;
+  const mergedTime = new Date(prMergedAt).getTime();
+  if (isNaN(mergedTime)) return false;
+  const twentyFourHoursMs = 24 * 60 * 60 * 1000;
+  return Date.now() - mergedTime < twentyFourHoursMs;
+}
+
+// ────────────────────────── Rules ──────────────────────────
+
+/**
+ * rollbackTriggered — fast-path rule
+ *
+ * Fires when a health degradation signal is received and there are
+ * recently-deployed features in DONE status. For each qualifying feature,
+ * emits a rollback_feature action and a move_feature action to ESCALATE.
+ *
+ * Trigger events:
+ * - health:issue-detected  (from HealthMonitorService)
+ * - feature:health-degraded  (from FeatureHealthService or DORA metrics)
+ */
+export const rollbackTriggeredRule: LeadFastPathRule = {
+  name: 'rollbackTriggered',
+  description:
+    'Rolls back recently-deployed features when a health degradation signal is detected. ' +
+    'Moves the feature back to review and transitions Lead Engineer state to ESCALATE.',
+  triggers: ['health:issue-detected', 'feature:health-degraded'],
+  evaluate(
+    worldState: LeadWorldState,
+    _eventType: string,
+    _eventPayload: unknown
+  ): LeadRuleAction[] {
+    const actions: LeadRuleAction[] = [];
+
+    for (const [featureId, snapshot] of Object.entries(worldState.features)) {
+      // Only target features that are DONE (deployed) with a recent merge
+      if (snapshot.status !== 'done') continue;
+      if (!isRecentlyDeployed(snapshot.prMergedAt)) continue;
+
+      // Emit rollback action for this feature
+      actions.push({
+        type: 'rollback_feature',
+        featureId,
+        projectPath: worldState.projectPath,
+        reason: 'Health degradation signal received after deploy',
+      });
+
+      // Update status reason before escalating
+      actions.push({
+        type: 'update_feature',
+        featureId,
+        updates: {
+          statusChangeReason: 'Rollback triggered by health degradation signal',
+        },
+      });
+
+      // Transition feature to ESCALATE so a human can review
+      actions.push({
+        type: 'move_feature',
+        featureId,
+        toStatus: 'blocked',
+      });
+
+      actions.push({
+        type: 'log',
+        level: 'warn',
+        message: `rollbackTriggered: queued rollback for feature ${featureId} (recently deployed, health degraded)`,
+      });
+    }
+
+    return actions;
+  },
+};
+
+/**
+ * All registered fast-path rules for the Lead Engineer.
+ * Rules are evaluated in order; all matching rules fire.
+ */
+export const LEAD_ENGINEER_RULES: LeadFastPathRule[] = [rollbackTriggeredRule];

--- a/apps/server/src/services/lead-engineer-rules.ts
+++ b/apps/server/src/services/lead-engineer-rules.ts
@@ -539,6 +539,60 @@ export const hitlFormResponse: LeadFastPathRule = {
 };
 
 /**
+ * rollbackTriggered — Feature in DONE/DEPLOY with health degradation signal → escalate.
+ * Fires when the health monitor or DORA metrics emits a degradation signal for a
+ * recently-deployed feature. Calls rollback logic and transitions feature to ESCALATE.
+ */
+export const rollbackTriggered: LeadFastPathRule = {
+  name: 'rollbackTriggered',
+  description:
+    'Feature in done/deploy with health degradation signal → move to escalate for rollback',
+  triggers: ['feature:health-degraded', 'health:signal'],
+
+  evaluate(worldState, _eventType, payload): LeadRuleAction[] {
+    const event = payload as Record<string, unknown> | null;
+    if (!event) return [];
+
+    const featureId = event.featureId as string | undefined;
+    if (!featureId) return [];
+
+    const feature = worldState.features[featureId];
+    if (!feature) return [];
+
+    // Only trigger for features that have been deployed (done or deploy status)
+    if (feature.status !== 'done' && feature.status !== 'deploy') return [];
+
+    // Feature must have a merged PR to be rollbackable
+    if (!feature.prMergedAt || !feature.prNumber) return [];
+
+    return [
+      {
+        type: 'update_feature',
+        featureId,
+        updates: {
+          statusChangeReason: `Health degradation detected after deploy — rollback triggered for PR #${feature.prNumber}`,
+        },
+      },
+      {
+        type: 'move_feature',
+        featureId,
+        toStatus: 'blocked',
+      },
+      {
+        type: 'log',
+        level: 'warn',
+        message: `rollbackTriggered: feature ${featureId} (PR #${feature.prNumber}) escalated due to health degradation signal`,
+      },
+      {
+        type: 'escalate_llm',
+        reason: `Health degradation detected for deployed feature ${featureId} (PR #${feature.prNumber}). Rollback required.`,
+        context: { featureId, prNumber: feature.prNumber, prMergedAt: feature.prMergedAt },
+      },
+    ];
+  },
+};
+
+/**
  * missingCIChecks — PR waiting >30min for required CI checks that have never registered.
  * Surfaces a diagnostic warning with the missing check names and a suggested cause
  * (e.g., a CI workflow configured to only trigger on PRs targeting a different base branch).
@@ -594,6 +648,7 @@ export const DEFAULT_RULES: LeadFastPathRule[] = [
   classifiedRecovery,
   hitlFormResponse,
   missingCIChecks,
+  rollbackTriggered,
 ];
 
 /**

--- a/libs/types/src/lead-engineer.ts
+++ b/libs/types/src/lead-engineer.ts
@@ -125,7 +125,8 @@ export type LeadRuleAction =
         failureCount?: number;
         awaitingGatePhase?: null;
       };
-    };
+    }
+  | { type: 'rollback_feature'; featureId: string; projectPath: string; reason: string };
 
 // ────────────────────────── Fast-Path Rules ──────────────────────────
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -297,6 +297,12 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         updates: { status: args.status },
       });
 
+    case 'rollback_feature':
+      return apiCall('/features/rollback', {
+        projectPath: args.projectPath,
+        featureId: args.featureId,
+      });
+
     case 'update_feature_git_settings': {
       const gitWorkflow: Record<string, unknown> = {};
       if (args.autoCommit !== undefined) gitWorkflow.autoCommit = args.autoCommit;

--- a/packages/mcp-server/src/tools/feature-tools.ts
+++ b/packages/mcp-server/src/tools/feature-tools.ts
@@ -293,4 +293,23 @@ export const featureTools: Tool[] = [
       required: ['projectPath', 'featureId'],
     },
   },
+  {
+    name: 'rollback_feature',
+    description:
+      "Rollback a deployed feature by reverting its merge commit. Finds the merge commit from the feature's prNumber, runs git revert -m 1, and moves the feature back to review status.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory (git repo root)',
+        },
+        featureId: {
+          type: 'string',
+          description: 'The feature ID (UUID) to roll back',
+        },
+      },
+      required: ['projectPath', 'featureId'],
+    },
+  },
 ];


### PR DESCRIPTION
## Summary
- Adds `POST /api/features/rollback` route that finds a feature's merge commit via `git log --grep`, executes `git revert -m 1 --no-edit`, and moves the feature back to `review` with a rollback `statusChangeReason`
- Adds `rollbackTriggered` fast-path rule in `lead-engineer-rules.ts` that fires on `feature:health-degraded` / `health:signal` for features in `done`/`deploy` with a merged PR — escalates and moves to `blocked`
- Adds `apps/server/src/services/auto-mode/lead-engineer-rules.ts` with the standalone `rollbackTriggeredRule` for recently-deployed (24h) features responding to health signals
- Adds `rollback_feature` action variant to `LeadRuleAction` discriminated union in `libs/types`
- Registers `rollback_feature` MCP tool in `packages/mcp-server` wired to the new route

## Test plan
- [ ] `npm run typecheck` passes (verified clean in worktree)
- [ ] `npm run build:server` passes (verified exit 0 in worktree)
- [ ] POST /api/features/rollback returns 400 for missing featureId/projectPath
- [ ] POST /api/features/rollback returns 400 for feature with no merged PR
- [ ] POST /api/features/rollback finds merge commit and reverts it
- [ ] rollbackTriggered rule fires only for done/deploy features with prMergedAt + prNumber
- [ ] MCP tool `rollback_feature` routes correctly to `/features/rollback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added feature rollback capability enabling users to revert deployed features by reverting merge commits.
  * Introduced automatic rollback triggering when system health degradation is detected after recent deployments.
  * Extended feature management API with new rollback endpoints and tools.
  * Rolled-back features are returned to review status with detailed reason tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->