### PR TITLE
Update docs after: Reactive Nervous System

### DIFF
--- a/docs/dev/distributed-sync.md
+++ b/docs/dev/distributed-sync.md
@@ -1,18 +1,25 @@
 # Distributed Sync
 
-How protoLabs synchronizes state across multiple instances using Automerge CRDTs, partition detection, and reconnection resilience.
+How protoLabs synchronizes state across multiple instances using Automerge CRDTs, partition detection, reconnection resilience, and fleet-wide feature scheduling.
 
 ## Architecture Overview
 
-protoLabs uses a WebSocket-based sync mesh where one instance acts as **primary** and others connect as **workers**. All instances exchange CRDT changes (feature events, project events, settings) in real time.
+protoLabs uses two parallel WebSocket layers for distributed sync:
+
+1. **Peer mesh** (`CrdtSyncService`, port 4444) — heartbeats, peer TTL, leader election, feature/project/settings event broadcast, and registry sync.
+2. **Automerge binary sync** (`CRDTStore`, port 4445) — low-level Automerge document replication for the Ava Channel, calendar events, and todos.
+
+One instance acts as **primary** and others connect as **workers** on both ports. The ports are derived from `protolab.syncPort` in `proto.config.yaml`; the CRDT store always uses `syncPort + 1`.
 
 ```
 Worker A ──────┐
                ▼
-Worker B ────▶ Primary (WebSocket server :4444)
+Worker B ────▶ Primary (peer mesh :4444, CRDT store :4445)
                ▲
 Worker C ──────┘
 ```
+
+Fleet coordination (work assignment, capacity advertising, escalations, scheduling) is layered on top via the Ava Channel — a daily-sharded CRDT document that all instances write to and the `AvaChannelReactorService` subscribes to.
 
 Instance roles are set in `proto.config.yaml`:
 
@@ -31,6 +38,34 @@ hivemind:
     - ws://100.64.0.2:4444 # worker-1
     - ws://100.64.0.3:4444 # worker-2
 ```
+
+## CRDT Store and Service Injection
+
+`crdt-store.module.ts` initializes the `CRDTStore` (Automerge document persistence) when hivemind mode is enabled, then injects the store into three services via their `setCrdtStore()` hook:
+
+- `AvaChannelService` — daily-sharded coordination messages
+- `CalendarService` — shared calendar events synced under `doc:calendar/shared`
+- `TodoService` — shared todo workspace synced under `doc:todos/workspace`
+
+Features and projects do **not** use the CRDT store directly; they rely on EventBus-based sync handled by `crdt-sync.module.ts`.
+
+## Registry Sync (Split-Brain Prevention)
+
+The CRDT store uses a **registry** to track which document IDs are known to the fleet. Without this, instances that miss document creation events can end up with orphaned or diverged documents.
+
+`CrdtSyncService` exposes two hooks:
+
+```typescript
+// Primary: provide a snapshot of all known documents (key → URL map)
+crdtSyncService.setRegistryProvider(() => store.getKnownDocumentIds());
+
+// All instances: receive and reconcile incoming registry snapshots
+crdtSyncService.onRegistryReceived((registry) => {
+  store.reconcileRegistry(registry);
+});
+```
+
+When a worker connects (or reconnects after a partition), the primary sends its full registry snapshot. The worker reconciles any missing documents by requesting them from the primary before replaying buffered changes. This prevents split-brain where two instances believe they hold the authoritative version of the same logical document.
 
 ## Sync Health Metrics
 
@@ -173,6 +208,179 @@ Each entry includes:
 - `snapshot` — the full document state after this change was applied
 
 This is useful for diagnosing merge conflicts, identifying the source of unexpected state, and reconstructing the sequence of events during a network partition.
+
+## Fleet Coordination via Ava Channel
+
+While the CRDT sync mesh handles state replication, **fleet coordination** (which instance works on which features) is handled through the **Ava Channel** — a daily-sharded CRDT document (`doc:ava-channel/YYYY-MM-DD`) that all instances read and write. The `AvaChannelReactorService` subscribes to this document and dispatches coordination messages.
+
+The reactor is activated by `ava-channel-reactor.module.ts`, which requires **all three** conditions to be met:
+
+1. The `reactorEnabled` feature flag is `true` in global settings.
+2. `proto.config.yaml` exists with `hivemind.enabled: true`.
+3. The `CRDTStore` has been registered by `crdt-store.module` (i.e. `crdt-store.module` must run first).
+
+The `FleetSchedulerService` is instantiated and started inside the same module registration and shares the same lifecycle.
+
+### Ava Channel Document
+
+Each message in the Ava Channel has:
+
+```typescript
+interface AvaChatMessage {
+  id: string;
+  instanceId: string;
+  instanceName: string;
+  content: string;
+  context?: AvaChannelContext; // optional machine-readable metadata
+  source: 'ava' | 'operator' | 'system';
+  timestamp: string; // ISO 8601
+  intent?: MessageIntent; // request | inform | response | coordination | escalation | system_alert
+  inReplyTo?: string; // ID of the parent message in a thread
+  expectsResponse?: boolean;
+  conversationDepth?: number;
+}
+```
+
+`AvaChannelContext` carries optional structured metadata alongside the free-form `content`:
+
+```typescript
+interface AvaChannelContext {
+  featureId?: string;
+  boardSummary?: string;
+  capacity?: { runningAgents: number; maxAgents: number; backlogCount: number };
+}
+```
+
+The reactor classifies incoming messages via a rule chain of `MessageClassifierRule` patterns and dispatches appropriate responses. Loop prevention is enforced at three layers: (1) classifier chain (`shouldRespond` result), (2) per-thread cooldown timer, and (3) a busy gate that queues one pending message while a response is in-flight.
+
+**Protocol message filtering**: Messages with `source='system'` that start with a `[bracket_prefix]` (e.g. `[capacity_heartbeat]`, `[work_request]`, `[schedule_assignment]`, `[dora_report]`) are intercepted by `handleWorkStealProtocol()` before reaching the classifier chain. These machine-to-machine protocol messages are dispatched directly to their typed handlers and never generate a classifier response.
+
+### Work-Stealing Protocol
+
+When a fleet instance finishes its assigned features and has spare capacity, it advertises itself and requests more work:
+
+1. Every 60s, each reactor broadcasts a `CapacityHeartbeat` with its current load.
+2. An idle instance posts a `WorkRequest` (requesting up to 2 features).
+3. The primary (or any instance with spare inventory) responds with a `WorkOffer`.
+4. The requesting instance accepts the offer and begins work.
+
+This allows the fleet to self-balance without any centralized coordinator — any instance can fulfill a `WorkRequest`. Epics are excluded from work-stealing; only leaf features are eligible.
+
+### Escalation Protocol (Blocked Feature Handoff)
+
+When an instance is blocked on a feature (e.g., waiting for a human decision) and cannot make progress:
+
+1. The blocked instance posts an `EscalationRequest` to the Ava Channel.
+2. Any instance with capacity responds with an `EscalationOffer`.
+3. The blocked instance replies with `EscalationAccept`, transferring ownership.
+4. The accepting instance takes over the feature from its current state.
+
+This prevents features from stalling when an individual instance is stuck.
+
+### Health Alerts
+
+Each instance monitors its own resource usage and posts `HealthAlert` messages when thresholds are exceeded (memory > 85%, CPU > 90%):
+
+```typescript
+interface HealthAlert {
+  instanceId: string;
+  memoryUsed: number; // percentage 0–100
+  cpuLoad: number; // percentage 0–100
+  alertTimestamp: string; // ISO 8601
+}
+```
+
+Peers that receive a `HealthAlert` pause work-stealing from the degraded instance for 5 minutes.
+
+### Self-Healing Subscription
+
+`AvaChannelReactorService` uses exponential backoff on subscription failure: 5-second base delay, capped at 60 seconds. If the daily-sharded document is unavailable at startup, the reactor retries automatically without manual intervention.
+
+## Fleet Scheduler
+
+`FleetSchedulerService` is a higher-level scheduler that distributes **project phases** across fleet instances. It runs on top of the Ava Channel and handles parallel execution of independent work. Epics are excluded from fleet scheduling; only concrete features are assigned.
+
+### How It Works
+
+1. **Inventory Broadcast**: Every instance periodically posts a `[work_inventory]` message describing its current backlog and active features (in dependency order).
+2. **Schedule Assignment**: The active scheduler runs `runScheduleCycle()` every 5 minutes, computing an optimal assignment of features to instances. It posts a `[schedule_assignment]` message mapping `instanceId → featureIds[]`.
+3. **Failover**: If no `[scheduler_heartbeat]` is received within 10 minutes, the longest-running worker instance takes over as active scheduler (last-writer-wins on uptime, with lower `instanceId` as tiebreaker).
+4. **Conflict Resolution**: If two instances both claim the same feature, a `[schedule_conflict]` is broadcast. The instance with the **higher** `instanceId` (lexicographic) releases the claim and moves the feature back to backlog.
+
+### Phase Parallelization
+
+When a new project is created, the fleet scheduler decomposes it into phases using a topological sort (Kahn's BFS). Independent phases are grouped and dispatched to separate instances simultaneously:
+
+```
+Phase 1 (setup)
+    ├── Phase 2a (feature-A)  → Instance prod-01
+    ├── Phase 2b (feature-B)  → Instance prod-02
+    └── Phase 2c (feature-C)  → Instance prod-03
+Phase 3 (integration) — starts after all Phase 2 complete
+```
+
+Progress is tracked via `ProjectProgressMsg`, which each instance posts when it completes a phase. The scheduler waits for all parallel phases to complete before unblocking dependent phases.
+
+### Fleet Status API
+
+```
+GET /api/projects/:slug/fleet-status
+```
+
+Returns the aggregated execution status of a project across all fleet instances:
+
+```json
+{
+  "projectSlug": "my-project",
+  "phases": [
+    {
+      "milestoneSlug": "milestone-1",
+      "phaseName": "feature-A",
+      "status": "done",
+      "instanceId": "prod-01",
+      "timestamp": "2026-03-09T10:00:00.000Z"
+    },
+    {
+      "milestoneSlug": "milestone-1",
+      "phaseName": "feature-B",
+      "status": "in_progress",
+      "instanceId": "prod-02",
+      "timestamp": "2026-03-09T10:05:00.000Z"
+    }
+  ]
+}
+```
+
+This endpoint is backed by `FleetSchedulerService.getProjectFleetStatus()`, which aggregates `ProjectProgress` (a.k.a. `ProjectProgressMsg`) entries received via the Ava Channel and stored in the in-memory `projectProgressByPhase` map.
+
+### Fleet Scheduler Message Types
+
+| Message Type            | Frequency    | Purpose                                        |
+| ----------------------- | ------------ | ---------------------------------------------- |
+| `WorkInventoryMsg`      | Per instance | Broadcast backlog + active features            |
+| `ScheduleAssignmentMsg` | Every 5 min  | Primary assigns features to instances          |
+| `SchedulerHeartbeatMsg` | Every 1 min  | Failover detection (absent >10 min = takeover) |
+| `ScheduleConflictMsg`   | On conflict  | Resolve double-claims (lower instanceId wins)  |
+| `ProjectProgressMsg`    | Per phase    | Track phase completion across instances        |
+
+### Key Timing Constants
+
+| Constant                 | Value      | Purpose                                       |
+| ------------------------ | ---------- | --------------------------------------------- |
+| Peer inventory TTL       | 6 minutes  | Stale inventory is ignored in schedule cycles |
+| Primary absent threshold | 10 minutes | No heartbeat for 10 min triggers failover     |
+| Schedule cycle interval  | 5 minutes  | How often the primary recomputes assignments  |
+| Scheduler heartbeat      | 1 minute   | Proves primary is still running the scheduler |
+
+## Observability: DORA Metrics and Friction Tracking
+
+`AvaChannelReactorService` also posts higher-level operational signals:
+
+- **`DoraReport`**: Deployment frequency, lead time, and blocked feature count. Broadcast as a `[dora_report]` system message **every hour**. Peers merge incoming reports into the aggregate CRDT entry under `domain='metrics', id='dora'`.
+- **`PatternResolved`**: Broadcast as a `[pattern_resolved]` system message when a System Improvement feature completes. Peers clear their local friction counters for the resolved pattern on receipt.
+- **Friction Tracker**: Monitors repeated failures via `FrictionTrackerService`. When the same failure pattern recurs, a System Improvement feature is automatically filed. Incoming `[friction_report]` messages from peers are used for de-duplication.
+
+These signals are visible in the Ava Channel for fleet-wide visibility and can be consumed by the metrics dashboard.
 
 ## Sync Events
 

--- a/docs/server/ava-channel-reactor.md
+++ b/docs/server/ava-channel-reactor.md
@@ -66,18 +66,20 @@ All responses set `expectsResponse: false` enforcing the **one-shot response pol
 Every 60 seconds (default), the reactor broadcasts a `capacity_heartbeat` message:
 
 ```typescript
-{
-  type: 'capacity_heartbeat';
+interface CapacityHeartbeat {
   instanceId: string;
-  runningAgents: number;
-  maxAgents: number;
-  backlogSize: number;
-  memoryUsagePct: number; // 0–100
-  cpuUsagePct: number; // 0–100
+  role: string;
+  backlogCount: number; // features in backlog
+  activeCount: number; // features currently in-progress
+  maxConcurrency: number; // max concurrent agents
+  cpuLoad: number; // 0–100
+  memoryUsed: number; // 0–100
 }
 ```
 
-Peer instances receive these and update their local `PeerCapacityMap`. The capacity map drives work-stealing and health alert decisions.
+Peer instances receive these and update their local `peerCapacities` map. The capacity map drives work-stealing and health alert decisions.
+
+**Note:** `[capacity_heartbeat]` messages have `source: 'system'` and are intercepted by `handleWorkStealProtocol()` before the classifier chain runs — they never trigger a classifier response.
 
 ### Work-Stealing
 
@@ -114,27 +116,25 @@ The `EscalationCoordinator` tracks pending escalations and enforces timeouts (30
 
 ### Health Alerts
 
-When a peer's heartbeat shows degraded resources, the reactor emits a `health_alert`:
+Each instance broadcasts a `[health_alert]` when its own resource usage exceeds fixed thresholds (checked during the capacity heartbeat cycle):
 
 ```typescript
-{
-  type: 'health_alert';
-  instanceId: string;       // degraded peer
-  severity: 'warning' | 'critical';
-  memoryUsagePct?: number;
-  cpuUsagePct?: number;
-  reason: string;
+interface HealthAlert {
+  instanceId: string;
+  memoryUsed: number; // percentage 0–100
+  cpuLoad: number; // percentage 0–100
+  alertTimestamp: string; // ISO 8601
 }
 ```
 
 **Thresholds:**
 
-| Resource | Warning | Critical |
-| -------- | ------- | -------- |
-| Memory   | > 85%   | > 95%    |
-| CPU      | > 90%   | > 98%    |
+| Resource | Threshold |
+| -------- | --------- |
+| Memory   | > 85%     |
+| CPU      | > 90%     |
 
-While a peer is marked degraded, work-stealing from that peer is paused. Degraded status clears automatically when the next heartbeat shows recovery.
+While a peer is marked degraded (has sent a recent `health_alert`), work-stealing from that peer is paused for 5 minutes. There is a single threshold level (no warning/critical distinction).
 
 ### DORA Reports
 

--- a/docs/server/ava-channel.md
+++ b/docs/server/ava-channel.md
@@ -255,17 +255,19 @@ CRDT shard change (new message arrives)
 
 The classifier chain determines whether a message warrants a response. Rules are pure functions evaluated highest-to-lowest priority. The first non-null result wins.
 
-| Priority | Rule                | Blocks When                                                |
-| -------- | ------------------- | ---------------------------------------------------------- |
-| 100      | LoopBreakerRule     | `conversationDepth >= maxConversationDepth`                |
-| 90       | TerminalMessageRule | `expectsResponse === false`                                |
-| 80       | SelfMessageRule     | `instanceId === localInstanceId`                           |
-| 75       | StaleMessageRule    | Message older than `staleThresholdMs`                      |
-| 70       | SystemSourceRule    | `source: 'system'` (unless `[BugReport]`/`[SystemAlert]`)  |
-| 50       | RequestRule         | `intent: 'request'` + `expectsResponse: true` --> respond  |
-| 40       | CoordinationRule    | `intent: 'coordination'` --> respond if capacity available |
-| 30       | EscalationRule      | `intent: 'escalation'` --> respond if depth < 3            |
-| 0        | DefaultRule         | Everything else --> informational, no response             |
+**Protocol message pre-filter:** Before the classifier chain runs, `handleWorkStealProtocol()` intercepts any `source: 'system'` message whose content starts with a `[bracket_prefix]` (e.g. `[capacity_heartbeat]`, `[work_request]`, `[schedule_assignment]`). These machine-to-machine messages are dispatched to typed handlers and never enter the classifier chain.
+
+| Priority | Rule                | Blocks When                                                              |
+| -------- | ------------------- | ------------------------------------------------------------------------ |
+| 100      | LoopBreakerRule     | `conversationDepth >= maxConversationDepth`                              |
+| 90       | TerminalMessageRule | `expectsResponse === false`                                              |
+| 80       | SelfMessageRule     | `instanceId === localInstanceId`                                         |
+| 75       | StaleMessageRule    | Message older than `staleThresholdMs`                                    |
+| 70       | SystemSourceRule    | `source: 'system'` (residual — protocol messages already filtered above) |
+| 50       | RequestRule         | `intent: 'request'` + `expectsResponse: true` --> respond                |
+| 40       | CoordinationRule    | `intent: 'coordination'` --> respond if capacity available               |
+| 30       | EscalationRule      | `intent: 'escalation'` --> respond if depth < 3                          |
+| 0        | DefaultRule         | Everything else --> informational, no response                           |
 
 **Usage:**
 

--- a/docs/server/calendar-api.md
+++ b/docs/server/calendar-api.md
@@ -183,11 +183,24 @@ The calendar assistant agent (`/calendar-assistant`) has exclusive write access 
 
 ## Storage
 
-Custom events are persisted in `.automaker/calendar.json`:
+### CRDT mode (multi-instance)
+
+When a `CRDTStore` is registered (hivemind active), all custom event writes route through the CRDT layer so events sync across all instances automatically. The shared document is:
+
+```
+domain: 'calendar'
+id: 'shared'
+shape: { events: Record<string, CalendarEvent>, updatedAt: string }
+```
+
+`crdt-store.module.ts` calls `calendarService.setCrdtStore(store)` during startup to enable CRDT mode.
+
+### Filesystem mode (single-instance)
+
+When no CRDT store is registered, custom events are persisted in `.automaker/calendar.json`:
 
 ```json
 {
-  "version": 1,
   "events": [
     {
       "id": "uuid",
@@ -201,13 +214,20 @@ Custom events are persisted in `.automaker/calendar.json`:
 }
 ```
 
-Writes use `atomicWriteJson` with automatic recovery from corrupted files.
+Writes use `atomicWriteJson` with 3-backup rotation and automatic recovery from corrupted files.
+
+### Storage routing summary
+
+| Mode       | When                     | Read                      | Write                            |
+| ---------- | ------------------------ | ------------------------- | -------------------------------- |
+| CRDT       | `setCrdtStore()` called  | `CRDTStore.getOrCreate()` | `CRDTStore.change()`             |
+| Filesystem | No CRDT store registered | `readJsonWithRecovery()`  | `atomicWriteJson` with 3 backups |
 
 ## Architecture
 
 ```
 CalendarService (singleton)
-  ├── Custom events     ← .automaker/calendar.json
+  ├── Custom events     ← CRDTStore ('calendar','shared') or .automaker/calendar.json
   ├── Feature due dates ← FeatureLoader
   └── Google events     ← GoogleCalendarSyncService
 ```


### PR DESCRIPTION
## Summary

18 doc-relevant files changed recently.

Changed files requiring docs review:
- apps/server/src/routes/chat/ava-config.ts
- apps/server/src/routes/chat/ava-tools.ts
- apps/server/src/routes/chat/index.ts
- apps/server/src/routes/projects/fleet-status.ts
- apps/server/src/routes/projects/index.ts
- apps/server/src/services/ava-channel-reactor-service.ts
- apps/server/src/services/ava-channel-reactor.module.ts
- apps/server/src/services/ava-channel-service.ts
- apps/server/src/services/calendar-se...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated distributed sync architecture documentation with fleet coordination protocols, work-stealing and escalation flows, health alerts, and system observability metrics.
* Calendar service now supports dual storage modes: CRDT-based storage for multi-instance deployments and filesystem-based storage for single-instance setups.
* Enhanced health monitoring with updated alerting thresholds and system degradation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->