### PR TITLE
Regenerate Button and Branch Navigator

### DIFF
--- a/apps/ui/src/components/views/chat-overlay/ask-ava-tab.tsx
+++ b/apps/ui/src/components/views/chat-overlay/ask-ava-tab.tsx
@@ -35,6 +35,8 @@ export interface AskAvaTabProps {
     estimated: boolean;
   };
   branchInfoMap: Map<string, BranchInfo>;
+  /** The origId of the message currently being regenerated, or null if none. */
+  pendingBranchOrigId?: string | null;
   settingsOpen: boolean;
   historyOpen: boolean;
   queueOpen: boolean;
@@ -70,6 +72,7 @@ export function AskAvaTab({
   modelAlias,
   tokenUsage,
   branchInfoMap,
+  pendingBranchOrigId,
   settingsOpen,
   historyOpen,
   queueOpen,
@@ -141,6 +144,7 @@ export function AskAvaTab({
           onToolApprove={onToolApprove}
           onToolReject={onToolReject}
           branchInfoMap={branchInfoMap}
+          pendingBranchOrigId={pendingBranchOrigId}
           onPreviousBranch={onPreviousBranch}
           onNextBranch={onNextBranch}
           getToolProgressLabel={getToolProgressLabel}

--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
@@ -96,7 +96,10 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
   const [currentBranchIndex, setCurrentBranchIndex] = useState<Map<string, number>>(new Map());
   // Set to the origId when a regeneration is in-flight, cleared when the new
   // assistant message arrives and is added to the branch list.
+  // pendingBranchFor ref is used for non-reactive logic in effects.
+  // pendingBranchOrigId state mirrors it so the UI can show a Regenerating shimmer.
   const pendingBranchFor = useRef<string | null>(null);
+  const [pendingBranchOrigId, setPendingBranchOrigId] = useState<string | null>(null);
 
   const suggestions = useContextualSuggestions(features ?? []);
   const { getProgressLabel, activeLabel: activeToolLabel } = useToolProgress();
@@ -183,8 +186,10 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
       return next;
     });
 
-    // Mark that the next completed assistant message should be added to this branch
+    // Mark that the next completed assistant message should be added to this branch.
+    // Both the ref (for effect logic) and state (for UI shimmer) are updated.
     pendingBranchFor.current = origId;
+    setPendingBranchOrigId(origId);
 
     // Re-send the last user message
     const text = (lastUserMsg.parts ?? [])
@@ -219,6 +224,7 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
       return next;
     });
     pendingBranchFor.current = null;
+    setPendingBranchOrigId(null);
   }, [messages, isStreaming, branchMap]);
 
   // Clear branch state when starting a new chat session
@@ -226,6 +232,7 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
     setBranchMap(new Map());
     setCurrentBranchIndex(new Map());
     pendingBranchFor.current = null;
+    setPendingBranchOrigId(null);
   }, [currentSessionId]);
 
   // Navigate to the previous branch variant for a given message
@@ -454,6 +461,7 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
           modelAlias={modelAlias}
           tokenUsage={tokenUsage}
           branchInfoMap={branchInfoMap}
+          pendingBranchOrigId={pendingBranchOrigId}
           settingsOpen={settingsOpen}
           historyOpen={historyOpen}
           queueOpen={queueOpen}

--- a/libs/ui/src/ai/chat-message-list.tsx
+++ b/libs/ui/src/ai/chat-message-list.tsx
@@ -43,6 +43,7 @@ export function ChatMessageList({
   onToolApprove,
   onToolReject,
   branchInfoMap,
+  pendingBranchOrigId,
   onPreviousBranch,
   onNextBranch,
   getToolProgressLabel,
@@ -67,6 +68,9 @@ export function ChatMessageList({
   onToolReject?: (approvalId: string) => void;
   /** Branch info keyed by message ID — provided by the parent managing branch state. */
   branchInfoMap?: Map<string, BranchInfo>;
+  /** The origId of the message currently being regenerated. When set, a shimmer
+   *  is rendered below that message to indicate a new variant is being generated. */
+  pendingBranchOrigId?: string | null;
   /** Called with the origId when the user navigates to the previous branch. */
   onPreviousBranch?: (origId: string) => void;
   /** Called with the origId when the user navigates to the next branch. */
@@ -220,24 +224,36 @@ export function ChatMessageList({
             messages.map((message, idx) => {
               const branchInfo = branchInfoMap?.get(message.id);
               const isLastMessage = idx === messages.length - 1;
+              // Show a 'Regenerating...' shimmer below this message when a new
+              // variant is being generated for it.
+              const isRegenerating =
+                !!pendingBranchOrigId &&
+                (branchInfo?.origId === pendingBranchOrigId || message.id === pendingBranchOrigId);
               return (
-                <ChatMessage
-                  key={message.id}
-                  message={message}
-                  isStreaming={isStreaming && isLastMessage}
-                  onRegenerate={onRegenerate}
-                  onThumbsUp={onThumbsUp}
-                  onThumbsDown={onThumbsDown}
-                  onToolApprove={onToolApprove}
-                  onToolReject={onToolReject}
-                  branchIndex={branchInfo?.branchIndex}
-                  branchCount={branchInfo?.branchCount}
-                  onPreviousBranch={
-                    branchInfo ? () => onPreviousBranch?.(branchInfo.origId) : undefined
-                  }
-                  onNextBranch={branchInfo ? () => onNextBranch?.(branchInfo.origId) : undefined}
-                  getToolProgressLabel={getToolProgressLabel}
-                />
+                <div key={message.id}>
+                  <ChatMessage
+                    message={message}
+                    isStreaming={isStreaming && isLastMessage}
+                    onRegenerate={onRegenerate}
+                    onThumbsUp={onThumbsUp}
+                    onThumbsDown={onThumbsDown}
+                    onToolApprove={onToolApprove}
+                    onToolReject={onToolReject}
+                    branchIndex={branchInfo?.branchIndex}
+                    branchCount={branchInfo?.branchCount}
+                    onPreviousBranch={
+                      branchInfo ? () => onPreviousBranch?.(branchInfo.origId) : undefined
+                    }
+                    onNextBranch={branchInfo ? () => onNextBranch?.(branchInfo.origId) : undefined}
+                    getToolProgressLabel={getToolProgressLabel}
+                  />
+                  {isRegenerating && (
+                    <div>
+                      <p className="px-4 pb-1 text-xs text-muted-foreground">Regenerating...</p>
+                      <ShimmerLoader />
+                    </div>
+                  )}
+                </div>
               );
             })
           )}


### PR DESCRIPTION
## Summary

**Milestone:** Message Regeneration UI

Add a regenerate icon button below each assistant message in the Ask Ava tab. When multiple variants exist (branchMap has >1 entry for a message), show prev/next arrows and a '1 of N' counter. Wire the regenerate button to the existing onRegenerate handler in chat-overlay-content.tsx. Wire prev/next to update currentBranchIndex. The branchInfoMap computed state already provides { branchIndex, branchCount, origId } — use it to drive the UI. Add a subtle 'Re...

---
*Recovered automatically by Automaker post-agent hook*