### PR TITLE
Wire ReactiveSpawnerService into Service Container

### DIFF
--- a/apps/server/src/services/ava-channel-reactor-service.ts
+++ b/apps/server/src/services/ava-channel-reactor-service.ts
@@ -478,8 +478,9 @@ export class AvaChannelReactorService {
           return this.deps.reactiveSpawnerService!.spawnForMessage(message);
         })
         .then(() => {
-          logger.debug(
-            `Spawned agent for message ${message.id} (type=${classification.type}, depth=${conversationDepth})`
+          logger.info(
+            `dispatchResponse: spawned session for request message ${message.id} ` +
+              `(depth=${conversationDepth})`
           );
           this.responsesSent++;
           this.setCooldown(message.inReplyTo ?? message.id);

--- a/apps/server/tests/unit/services/reactive-spawner.test.ts
+++ b/apps/server/tests/unit/services/reactive-spawner.test.ts
@@ -7,10 +7,15 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// Use vi.hoisted so the mock variable is available inside the vi.mock factory
+const { mockLoggerInfo } = vi.hoisted(() => ({
+  mockLoggerInfo: vi.fn(),
+}));
+
 // Mock logger before any imports that create module-level loggers
 vi.mock('@protolabsai/utils', () => ({
   createLogger: vi.fn(() => ({
-    info: vi.fn(),
+    info: mockLoggerInfo,
     debug: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
@@ -93,6 +98,7 @@ describe('AvaChannelReactorService — reactiveSpawnerService wiring', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockLoggerInfo.mockClear();
     deps = makeDeps();
     reactor = new AvaChannelReactorService(deps);
     await reactor.start();
@@ -144,6 +150,27 @@ describe('AvaChannelReactorService — reactiveSpawnerService wiring', () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(deps.reactiveSpawnerService!.spawnForMessage).not.toHaveBeenCalled();
+  });
+
+  it('logs an info message after successfully spawning a session for a request-type message', async () => {
+    const message = makeMessage({ intent: 'request', expectsResponse: true });
+
+    (deps.crdtStore as unknown as { _trigger: (doc: unknown) => void })._trigger({
+      messages: [message],
+    });
+
+    // Allow async operations to settle
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // At least one logger.info call should mention the message id and "spawned"
+    const infoMessages: string[] = mockLoggerInfo.mock.calls
+      .filter((args) => typeof args[0] === 'string')
+      .map((args) => args[0] as string);
+    const spawnLog = infoMessages.find(
+      (msg) => msg.includes('dispatchResponse') && msg.includes(message.id)
+    );
+    expect(spawnLog).toBeDefined();
+    expect(spawnLog).toContain('spawned session for request message');
   });
 
   it('falls back to text-only response when reactiveSpawnerService is not provided', async () => {


### PR DESCRIPTION
## Summary

**Milestone:** dispatchResponse Wiring Audit

Audit apps/server/src/server/services.ts: check if ReactiveSpawnerService is instantiated and if it is passed to AvaChannelReactorService. Audit ava-channel-reactor-service.ts: confirm dispatchResponse calls reactiveSpawnerService.spawnForMessage() for request-type messages. Audit reactive-spawner-service.ts: confirm it is initialized with DynamicAgentExecutor and the 'ava' template. Fix any missing wiring. If ReactiveSpawnerService is not instantiat...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased logging visibility for session spawning operations with an updated message format that includes request ID and conversation depth information.

* **Tests**
  * Added verification test to ensure session spawning operations emit appropriate log messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->