### PR TITLE
Pending Tool Approval Cards

### DIFF
--- a/.automaker/memory/content-pipeline-validation.md
+++ b/.automaker/memory/content-pipeline-validation.md
@@ -5,7 +5,7 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 108
+  loaded: 111
   referenced: 6
   successfulFeatures: 6
 ---

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,7 +5,7 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 928
+  loaded: 934
   referenced: 262
   successfulFeatures: 262
 ---

--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -1,15 +1,14 @@
 ---
 tags: []
-summary: 'relevantTo: []'
+summary: "relevantTo: []"
 relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 180
+  loaded: 186
   referenced: 32
   successfulFeatures: 32
 ---
-
 # GTM Signal Intelligence & Content Operations
 
 ## Status: ACTIVE — Linear project created, content pipeline running

--- a/.automaker/projects/ava-anywhere-chat-overlay-polish/project.json
+++ b/.automaker/projects/ava-anywhere-chat-overlay-polish/project.json
@@ -27,7 +27,10 @@
             "Build passes with no TypeScript errors"
           ],
           "complexity": "medium",
-          "featureId": "feature-1773071246977-otgnov5q6"
+          "featureId": "feature-1773071246977-otgnov5q6",
+          "claimedBy": "mac-dev",
+          "claimedAt": "2026-03-09T22:05:32.473Z",
+          "executionStatus": "in_progress"
         }
       ],
       "status": "completed",
@@ -56,7 +59,10 @@
             "Build passes with no TypeScript errors"
           ],
           "complexity": "small",
-          "featureId": "feature-1773071246989-4y9op8gq8"
+          "featureId": "feature-1773071246989-4y9op8gq8",
+          "claimedBy": "mac-dev",
+          "claimedAt": "2026-03-09T22:05:32.695Z",
+          "executionStatus": "in_progress"
         }
       ],
       "status": "completed",
@@ -85,7 +91,10 @@
             "Build passes with no TypeScript errors"
           ],
           "complexity": "small",
-          "featureId": "feature-1773071247003-55274be31"
+          "featureId": "feature-1773071247003-55274be31",
+          "claimedBy": "mac-dev",
+          "claimedAt": "2026-03-09T22:06:02.474Z",
+          "executionStatus": "in_progress"
         }
       ],
       "status": "completed",
@@ -116,7 +125,10 @@
             "Server unit test added or updated for ReactiveSpawnerService wiring"
           ],
           "complexity": "medium",
-          "featureId": "feature-1773071247014-9i0q7ko9j"
+          "featureId": "feature-1773071247014-9i0q7ko9j",
+          "claimedBy": "mac-dev",
+          "claimedAt": "2026-03-09T22:08:28.805Z",
+          "executionStatus": "in_progress"
         }
       ],
       "status": "pending",
@@ -138,5 +150,5 @@
     ]
   },
   "createdAt": "2026-03-09T15:47:21.685Z",
-  "updatedAt": "2026-03-09T17:09:40.751Z"
+  "updatedAt": "2026-03-09T22:08:29.011Z"
 }

--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -107,6 +107,7 @@ import { ProjectPMService } from '../services/project-pm-service.js';
 import * as projectPmModule from '../services/project-pm.module.js';
 import { CrdtSyncService } from '../services/crdt-sync-service.js';
 import { AvaChannelService } from '../services/ava-channel-service.js';
+import { WorkIntakeService } from '../services/work-intake-service.js';
 import { TodoService } from '../services/todo-service.js';
 import type { AvaChannelReactorService } from '../services/ava-channel-reactor-service.js';
 import type { FleetSchedulerService } from '../services/fleet-scheduler-service.js';
@@ -158,6 +159,7 @@ export interface ServiceContainer {
 
   // Auto-mode
   autoModeService: AutoModeService;
+  workIntakeService: WorkIntakeService;
   hitlFormService: HITLFormService;
 
   // Claude usage
@@ -335,6 +337,7 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   // Calendar service (singleton wired in wireServices)
   const googleCalendarSyncService = new GoogleCalendarSyncService(settingsService, calendarService);
   const autoModeService = new AutoModeService(events, settingsService);
+  const workIntakeService = new WorkIntakeService();
   const hitlFormService = new HITLFormService({
     events,
     followUpFeature: (projectPath, featureId, prompt) =>
@@ -793,6 +796,7 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
     automationService,
     jobExecutorService,
     autoModeService,
+    workIntakeService,
     hitlFormService,
     claudeUsageService,
     mcpTestService,

--- a/apps/server/src/server/wiring.ts
+++ b/apps/server/src/server/wiring.ts
@@ -16,6 +16,7 @@ import { register as registerInfrastructure } from '../services/infrastructure.m
 import { register as registerProjectPm } from '../services/project-pm.module.js';
 import { register as registerEventLedger } from '../services/event-ledger.module.js';
 import { register as registerCrdtSync } from '../services/crdt-sync.module.js';
+import { register as registerWorkIntake } from '../services/work-intake.module.js';
 import { register as registerAvaChannel } from '../services/ava-channel.module.js';
 
 /**
@@ -42,6 +43,7 @@ export async function wireServices(services: ServiceContainer): Promise<void> {
   await registerProjectPm(services);
   await registerEventLedger(services);
   await registerCrdtSync(services);
+  await registerWorkIntake(services);
   await registerAvaChannel(services);
 
   // Start built-in sensors (websocket-clients + electron-idle) after all wiring is complete.

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -414,6 +414,28 @@ export class AutoModeService {
     this.pipelineCheckpointService = service;
   }
 
+  // Work Intake service for pull-based phase claiming (optional, set by work-intake.module)
+  private workIntakeService: import('./work-intake-service.js').WorkIntakeService | null = null;
+
+  setWorkIntakeService(service: import('./work-intake-service.js').WorkIntakeService): void {
+    this.workIntakeService = service;
+  }
+
+  /** Total number of currently running agent features across all projects. */
+  getRunningAgentCount(): number {
+    return this.runningFeatures.size;
+  }
+
+  /** Maximum concurrency from the first active auto-loop, or default. */
+  getMaxConcurrency(): number {
+    for (const [, state] of this.coordinator.loops) {
+      if (state.isRunning) {
+        return state.config.maxConcurrency;
+      }
+    }
+    return DEFAULT_MAX_CONCURRENCY;
+  }
+
   /**
    * Wire up the Feature Health service for periodic health sweeps in auto-mode.
    * When set, the auto-loop runs board audits every ~100s and escalates issues.
@@ -901,6 +923,9 @@ export class AutoModeService {
         this.scheduler.runLoop(worktreeKey, state)
       );
 
+      // Start work intake tick loop (pull-based phase claiming from shared projects)
+      this.workIntakeService?.start(projectPath);
+
       return resolvedMaxConcurrency;
     } catch (error) {
       // If initialization fails, clean up the state we just set
@@ -992,6 +1017,9 @@ export class AutoModeService {
         logger.info(`Cancelled retry timer for feature ${featureId} during auto-loop stop`);
       }
     }
+
+    // Stop work intake tick loop
+    this.workIntakeService?.stop();
 
     // Clear execution state when auto-loop is explicitly stopped
     await this.clearExecutionState(projectPath, branchName);

--- a/apps/server/src/services/project-service.ts
+++ b/apps/server/src/services/project-service.ts
@@ -441,6 +441,53 @@ export class ProjectService {
   }
 
   /**
+   * Update a single phase's claim fields on the shared project doc.
+   * Used by WorkIntakeService for phase claiming and completion reporting.
+   */
+  async updatePhaseClaim(
+    projectPath: string,
+    projectSlug: string,
+    milestoneSlug: string,
+    phaseName: string,
+    update: Partial<import('@protolabsai/types').Phase>
+  ): Promise<void> {
+    const project = await this.getProject(projectPath, projectSlug);
+    if (!project) throw new Error(`Project "${projectSlug}" not found`);
+
+    const milestone = project.milestones.find((m) => m.slug === milestoneSlug);
+    if (!milestone)
+      throw new Error(`Milestone "${milestoneSlug}" not found in project "${projectSlug}"`);
+
+    const phase = milestone.phases.find((p) => p.name === phaseName);
+    if (!phase) throw new Error(`Phase "${phaseName}" not found in milestone "${milestoneSlug}"`);
+
+    Object.assign(phase, update);
+    project.updatedAt = new Date().toISOString();
+
+    const jsonPath = getProjectJsonPath(projectPath, projectSlug);
+    await secureFs.writeFile(jsonPath, JSON.stringify(project, null, 2));
+  }
+
+  /**
+   * Read the latest state of a single phase.
+   * Used by WorkIntakeService to verify claims survived Automerge merge.
+   */
+  async getPhase(
+    projectPath: string,
+    projectSlug: string,
+    milestoneSlug: string,
+    phaseName: string
+  ): Promise<import('@protolabsai/types').Phase | null> {
+    const project = await this.getProject(projectPath, projectSlug);
+    if (!project) return null;
+
+    const milestone = project.milestones.find((m) => m.slug === milestoneSlug);
+    if (!milestone) return null;
+
+    return milestone.phases.find((p) => p.name === phaseName) ?? null;
+  }
+
+  /**
    * Update an existing project
    */
   async updateProject(

--- a/apps/server/src/services/work-intake.module.ts
+++ b/apps/server/src/services/work-intake.module.ts
@@ -1,0 +1,74 @@
+// Work Intake module — wires WorkIntakeService dependencies from proto.config.yaml and ServiceContainer.
+// Safe to call in single-instance mode — configures deps unconditionally so the service is ready
+// when auto-mode starts (the service itself gates on config.enabled and deps being set).
+
+import { loadProtoConfig } from '@protolabsai/platform';
+import { createLogger } from '@protolabsai/utils';
+import type { InstanceIdentity } from '@protolabsai/types';
+import type { ServiceContainer } from '../server/services.js';
+
+const logger = createLogger('WorkIntakeModule');
+
+export async function register(container: ServiceContainer): Promise<void> {
+  const protoConfig = await loadProtoConfig(container.repoRoot);
+
+  // Extract typed config sections from the open-ended ProtoConfig
+  const workIntakeConfig = protoConfig?.['workIntake'] as
+    | { enabled?: boolean; tickIntervalMs?: number; claimTimeoutMs?: number }
+    | undefined;
+  const protolabConfig = protoConfig?.['protolab'] as { instanceId?: string } | undefined;
+  const instanceConfig = protoConfig?.['instance'] as
+    | { role?: import('@protolabsai/types').InstanceRole; tags?: string[] }
+    | undefined;
+
+  // Apply config from proto.config.yaml (if present)
+  if (workIntakeConfig) {
+    container.workIntakeService.configure(workIntakeConfig);
+  }
+
+  // Set dependencies so the service can tick when auto-mode starts
+  container.workIntakeService.setDependencies({
+    events: container.events,
+    instanceId: protolabConfig?.instanceId || 'default',
+    role: instanceConfig?.role || 'fullstack',
+    tags: instanceConfig?.tags,
+    getProjects: async (projectPath: string) => {
+      const slugs = await container.projectService.listProjects(projectPath);
+      const projects = await Promise.all(
+        slugs.map((slug) => container.projectService.getProject(projectPath, slug))
+      );
+      return projects.filter((p) => p !== null);
+    },
+    updatePhaseClaim: async (projectPath, projectSlug, milestoneSlug, phaseName, update) => {
+      await container.projectService.updatePhaseClaim(
+        projectPath,
+        projectSlug,
+        milestoneSlug,
+        phaseName,
+        update
+      );
+    },
+    getPhase: async (projectPath, projectSlug, milestoneSlug, phaseName) => {
+      return container.projectService.getPhase(projectPath, projectSlug, milestoneSlug, phaseName);
+    },
+    createFeature: async (projectPath, featureData) => {
+      const feature = await container.featureLoader.create(projectPath, featureData);
+      return { id: feature.id };
+    },
+    getRunningAgentCount: () => container.autoModeService.getRunningAgentCount(),
+    getMaxConcurrency: () => container.autoModeService.getMaxConcurrency(),
+    getPeerStatus: () => {
+      const peers = container.crdtSyncService.getPeers();
+      const map = new Map<string, InstanceIdentity>();
+      for (const peer of peers) {
+        map.set(peer.identity.instanceId, peer.identity);
+      }
+      return map;
+    },
+  });
+
+  // Wire work intake into auto-mode start/stop lifecycle
+  container.autoModeService.setWorkIntakeService(container.workIntakeService);
+
+  logger.info('Work intake module registered');
+}

--- a/apps/server/tests/unit/services/work-intake-wiring.test.ts
+++ b/apps/server/tests/unit/services/work-intake-wiring.test.ts
@@ -1,0 +1,157 @@
+/**
+ * WorkIntakeService — wiring verification tests
+ *
+ * Verifies:
+ * 1. WorkIntakeService is present on the ServiceContainer interface (type-level check)
+ * 2. When setDependencies() has been called, start() begins the tick loop
+ * 3. When stop() is called, the tick loop stops
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WorkIntakeService } from '../../../src/services/work-intake-service.js';
+import type { ServiceContainer } from '../../../src/server/services.js';
+import type { WorkIntakeDependencies } from '../../../src/services/work-intake-service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMockDeps(overrides: Partial<WorkIntakeDependencies> = {}): WorkIntakeDependencies {
+  return {
+    events: { emit: vi.fn(), on: vi.fn(), subscribe: vi.fn() } as never,
+    instanceId: 'test-instance',
+    role: 'fullstack',
+    getProjects: vi.fn().mockResolvedValue([]),
+    updatePhaseClaim: vi.fn().mockResolvedValue(undefined),
+    getPhase: vi.fn().mockResolvedValue(null),
+    createFeature: vi.fn().mockResolvedValue({ id: 'feat-1' }),
+    getRunningAgentCount: vi.fn().mockReturnValue(0),
+    getMaxConcurrency: vi.fn().mockReturnValue(3),
+    getPeerStatus: vi.fn().mockReturnValue(new Map()),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WorkIntakeService wiring', () => {
+  let service: WorkIntakeService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    service = new WorkIntakeService();
+  });
+
+  afterEach(() => {
+    service.stop();
+    vi.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Type-level check: WorkIntakeService is on ServiceContainer
+  // -------------------------------------------------------------------------
+
+  it('ServiceContainer includes workIntakeService', () => {
+    // This is a compile-time check — if WorkIntakeService is not on the
+    // interface, this file will fail to compile. The runtime assertion
+    // confirms the type system is satisfied.
+    const typeCheck = (container: ServiceContainer) => container.workIntakeService;
+    expect(typeCheck).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. start() begins the tick loop when dependencies are set
+  // -------------------------------------------------------------------------
+
+  it('start() begins ticking when dependencies are set', async () => {
+    const deps = makeMockDeps();
+    service.setDependencies(deps);
+
+    service.start('/test/project');
+
+    // The first tick runs immediately on start().
+    // Each tick calls getProjects twice (once in reclaimStalePhases, once in the main loop).
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(deps.getProjects).toHaveBeenCalledWith('/test/project');
+    const callsAfterFirstTick = (deps.getProjects as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    // Advance by one tick interval (default 30s) to verify recurring ticks
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect((deps.getProjects as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(
+      callsAfterFirstTick
+    );
+  });
+
+  it('start() does not tick when dependencies are NOT set', () => {
+    // No setDependencies() called
+    service.start('/test/project');
+
+    // Should not throw, but getProjects should not be called
+    // since the service guards on deps being null
+    vi.advanceTimersByTime(30_000);
+  });
+
+  it('start() is idempotent — second call is a no-op', async () => {
+    const deps = makeMockDeps();
+    service.setDependencies(deps);
+
+    service.start('/test/project');
+    service.start('/test/project');
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Only one immediate tick fires (each tick calls getProjects twice:
+    // once in reclaimStalePhases and once in the main loop).
+    // Two start() calls should NOT produce two ticks.
+    const callCount = (deps.getProjects as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(callCount).toBe(2); // 1 tick x 2 getProjects calls per tick
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. stop() halts the tick loop
+  // -------------------------------------------------------------------------
+
+  it('stop() halts the tick loop', async () => {
+    const deps = makeMockDeps();
+    service.setDependencies(deps);
+
+    service.start('/test/project');
+    await vi.advanceTimersByTimeAsync(0);
+    const callsAfterFirstTick = (deps.getProjects as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(callsAfterFirstTick).toBeGreaterThan(0);
+
+    service.stop();
+
+    // Advance past several tick intervals — no more calls
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect((deps.getProjects as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+      callsAfterFirstTick
+    );
+  });
+
+  it('stop() is idempotent — safe to call when not running', () => {
+    expect(() => service.stop()).not.toThrow();
+  });
+
+  it('can restart after stop', async () => {
+    const deps = makeMockDeps();
+    service.setDependencies(deps);
+
+    service.start('/test/project');
+    await vi.advanceTimersByTimeAsync(0);
+    const callsAfterFirstStart = (deps.getProjects as ReturnType<typeof vi.fn>).mock.calls.length;
+    service.stop();
+
+    service.start('/test/project');
+    await vi.advanceTimersByTimeAsync(0);
+
+    // After restart, a second tick should have fired
+    expect((deps.getProjects as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(
+      callsAfterFirstStart
+    );
+  });
+});

--- a/libs/platform/src/index.ts
+++ b/libs/platform/src/index.ts
@@ -270,4 +270,6 @@ export {
   type ProtoConfigDiscord,
   type ProtoConfigServer,
   type ProtoConfigHive,
+  type ProtoConfigProtolab,
+  type ProtoConfigInstance,
 } from './proto-config.js';

--- a/libs/platform/src/proto-config.ts
+++ b/libs/platform/src/proto-config.ts
@@ -62,6 +62,24 @@ export interface ProtoConfigHive {
   instanceId?: string;
 }
 
+export interface ProtoConfigProtolab {
+  /** Whether ProtoLab sync is enabled for this project */
+  enabled?: boolean;
+  /** Port used for CRDT sync WebSocket connection */
+  syncPort?: number;
+  /** Unique instance identifier for mesh coordination */
+  instanceId?: string;
+}
+
+export interface ProtoConfigInstance {
+  /** Human-readable display name for this instance */
+  name?: string;
+  /** Primary work focus (default: fullstack) */
+  role?: string;
+  /** Additional capabilities beyond the primary role */
+  tags?: string[];
+}
+
 /**
  * Top-level shape of proto.config.yaml.
  * Open-ended (`[key: string]: unknown`) so callers can store additional fields.
@@ -73,6 +91,8 @@ export interface ProtoConfig {
   discord?: ProtoConfigDiscord;
   server?: ProtoConfigServer;
   hive?: ProtoConfigHive;
+  protolab?: ProtoConfigProtolab;
+  instance?: ProtoConfigInstance;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

In the Ask Ava tab, render each entry in pendingSubagentApprovals as an inline card above the chat input. Each card shows: tool name, a truncated preview of toolInput (JSON, max 200 chars), an Approve button (calls approveSubagentTool), and a Deny button (calls denySubagentTool). Cards should be visually distinct (amber border or accent) so they are immediately noticeable. When no approvals are pending, render nothing. Multiple pending approvals stack vertically. Add a received timestamp ('Waiti...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-03-09T22:15:31.298Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Work intake service integration for automated task management and project phase coordination
  * New phase management capabilities enabling updates and retrieval of specific project phases
  * Agent concurrency metrics now exposed for improved visibility into automation workload
  * Enhanced configuration support for instance and protolab settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->