### PR TITLE
docs: plan completion verification + reactive-spawner test fix

### DIFF
--- a/.automaker/context/plan-completion-verification.md
+++ b/.automaker/context/plan-completion-verification.md
@@ -1,0 +1,57 @@
+# Plan Completion Verification
+
+When implementing a multi-step plan (project phases, architecture redesigns, multi-file features), run this verification checklist BEFORE committing. Half-finished work that passes CI is worse than a build failure --- it ships silently broken code.
+
+## The Problem
+
+CI tests verify "what exists works correctly" but NOT "what should exist actually does." A service can have 32 passing unit tests and still be completely disconnected from the runtime. This is a commission/omission asymmetry --- breaking existing code gets caught, failing to wire new code passes silently.
+
+## Verification Checklist
+
+### 1. Import Check (No Dead Code)
+
+Every new file created in the plan MUST be imported by at least one non-test file. Run:
+
+```bash
+# For each new file, verify it has at least one importer
+grep -r "from.*<new-file>" apps/ libs/ --include="*.ts" | grep -v ".test." | grep -v "__tests__"
+```
+
+If a new service/module file has zero non-test importers, the wiring is incomplete.
+
+### 2. Interface Check (No Orphan Methods)
+
+Every new public method or service added to a shared interface (like `ServiceContainer`) MUST have at least one caller outside its own file and test file. A method that exists only in definition and tests is dead code.
+
+### 3. Integration Test Requirement
+
+Every new service that integrates with the runtime (receives dependencies, runs on a lifecycle hook, responds to events) MUST have at least one test that verifies the integration point --- not just the service logic in isolation.
+
+Examples:
+- Service wired into auto-mode start/stop -> test that start() is called when auto-mode starts
+- Service registered in ServiceContainer -> test that the container type includes it
+- Event handler registered -> test that the handler fires on the expected event
+
+### 4. Plan Step Audit
+
+Before the final commit, review each step in the plan and check:
+- [ ] All files listed in the step's file table were modified/created
+- [ ] All "wire X into Y" instructions were executed (not just "remove old X")
+- [ ] Removal steps (delete old code) AND addition steps (wire new code) are both complete
+
+## Common Failure Patterns
+
+| Pattern | Why CI Misses It | How to Catch |
+|---------|-----------------|--------------|
+| Service created but never instantiated | No test asserts instantiation | Import check |
+| Service instantiated but deps never injected | Service guards on null deps, no-ops silently | Integration test |
+| Old code removed, new code not wired | Removing imports makes things compile | Plan step audit |
+| Module file created but not registered in wiring.ts | Module never runs | Import check |
+
+## When to Apply
+
+- Any PR implementing 3+ files from a plan
+- Any PR that creates new services or modules
+- Any PR that replaces one system with another (old removed + new added)
+
+Single-file changes and bug fixes do not need this checklist.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ This is a greenfield codebase. We are building the future, not maintaining the p
 
 - When creating plans, start with the minimal viable scope. Do NOT propose multi-phase plans unless explicitly asked. Default to the smallest, lowest-risk approach first.
 - Do not exit plan mode or transition away from planning until the user explicitly confirms the plan is complete and approved. Wait for user signal before proceeding to implementation.
+- **Plan completion verification**: Before committing a multi-step plan implementation, run the verification checklist in `.automaker/context/plan-completion-verification.md`. CI catches broken code but NOT unwired code — a service with passing tests can be completely disconnected from the runtime. Every new file must have a non-test importer. Every new service must have an integration test covering its wiring point.
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary

- **Plan completion verification checklist**: New context file (`.automaker/context/plan-completion-verification.md`) loaded into all agent prompts. Addresses the commission/omission asymmetry where CI catches broken code but not unwired code.
- **CLAUDE.md updated**: References the verification checklist for multi-step plan implementations.
- Includes the wiring commit and test fix from PR #2086 that already merged.

## Test plan

- [ ] CI passes
- [ ] Context file present in `.automaker/context/`


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added plan completion verification documentation with checklists and best practices to validate proper implementation integration.
  * Updated planning guidance to reference the new verification checklist for multi-step work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->