### PR TITLE
Auto-Expand Tool Result Cards on Completion

### DIFF
--- a/libs/ui/src/ai/tool-invocation-part.tsx
+++ b/libs/ui/src/ai/tool-invocation-part.tsx
@@ -9,7 +9,7 @@
  * output-available, and output-error.
  */
 
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { ChevronDown, Wrench, Loader2, Check, AlertTriangle } from 'lucide-react';
 import { cn } from '../lib/utils.js';
 import { ConfirmationCard } from './confirmation-card.js';
@@ -181,6 +181,17 @@ export function ToolInvocationPart({
   onReject,
 }: ToolInvocationPartProps) {
   const [isOpen, setIsOpen] = useState(false);
+  // Track whether we've already auto-expanded so manual collapse is preserved
+  const hasAutoExpanded = useRef(false);
+
+  // Auto-expand when tool transitions to output-available (once only)
+  useEffect(() => {
+    if ((state === 'output-available' || state === 'output-error') && !hasAutoExpanded.current) {
+      hasAutoExpanded.current = true;
+      setIsOpen(true);
+    }
+  }, [state]);
+
   const config = stateConfig[state] ?? stateConfig['input-available'];
   const StateIcon = config.icon;
   const isRunning =


### PR DESCRIPTION
## Summary

**Milestone:** Chat Render Pipeline

Tool result cards (ToolCallBlock / tool-result-registry components) currently stay collapsed after streaming ends. When a tool transitions to output-available state, auto-expand the result card. The collapsed state should only be the default for cards that haven't finished yet. Add a prop or state that tracks whether the card has been auto-expanded so manual collapse is preserved on re-renders.

**Files to Modify:**
- libs/ui/src/ai/tool-call-block.tsx
- libs...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool invocation panels now automatically expand when outputs become available or errors occur during invocation processing. This enhancement ensures users can immediately see critical results and error messages without requiring manual expansion of the panels. Auto-expansion occurs once per invocation, optimizing the user experience while preventing unnecessary repeated expansions of already-viewed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->