### PR TITLE
ask_user Inline Form Tool — Server Side

### DIFF
--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -13,6 +13,7 @@
 
 import type { Tool } from 'ai';
 import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
 import fs from 'fs/promises';
 import path from 'path';
 import type { EventEmitter, EventType } from '../../lib/events.js';
@@ -1948,6 +1949,78 @@ export function buildAvaTools(
       execute: async ({ updates }) => {
         const settings = await settingsSvc.updateProjectSettings(projectPath, updates);
         return { success: true, settings };
+      },
+    });
+  }
+
+  // -----------------------------------------------------------------------
+  // HITL – request structured input from the user via an inline form
+  // -----------------------------------------------------------------------
+  if (services.events) {
+    const eventsEmitter = services.events;
+
+    tools['request_user_input'] = makeTool({
+      description:
+        'Request structured input from the user via an inline form rendered in the chat UI. ' +
+        'Provide a title and one or more form steps, each with a JSON Schema (draft-07) defining the fields. ' +
+        'The tool pauses execution and waits until the user submits the form. ' +
+        'Use this to collect config values, choices, credentials, or any structured data from the user.',
+      inputSchema: z.object({
+        title: z.string().describe('Form dialog title shown to the user'),
+        description: z.string().optional().describe('Optional description shown below the title'),
+        steps: z
+          .array(
+            z.object({
+              schema: z
+                .record(z.string(), z.unknown())
+                .describe('JSON Schema (draft-07) defining the form fields'),
+              uiSchema: z
+                .record(z.string(), z.unknown())
+                .optional()
+                .describe('@rjsf layout hints (field ordering, widgets)'),
+              title: z.string().optional().describe('Step title shown in wizard header'),
+              description: z
+                .string()
+                .optional()
+                .describe('Step description shown below step title'),
+            })
+          )
+          .min(1)
+          .describe('One or more form steps. Multiple steps render as a wizard.'),
+      }),
+      execute: async ({ title, description, steps }) => {
+        const formId = `chat-form-${randomUUID().slice(0, 8)}`;
+        const timestamp = new Date().toISOString();
+
+        // Emit the user_input_request event so the UI renders an inline form
+        eventsEmitter.emit('chat:user-input-request' as EventType, {
+          formId,
+          title,
+          description,
+          steps,
+          timestamp,
+        });
+
+        // Pause and await the user's form submission
+        return new Promise<unknown>((resolve) => {
+          const unsub = eventsEmitter.on(
+            'hitl:form-responded' as EventType,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (payload: any) => {
+              if (payload?.formId !== formId) return;
+              unsub();
+              if (payload.cancelled) {
+                resolve({ cancelled: true, message: 'The user cancelled the form.' });
+              } else {
+                resolve({
+                  cancelled: false,
+                  formId,
+                  response: payload.response ?? [],
+                });
+              }
+            }
+          );
+        });
       },
     });
   }

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -318,6 +318,8 @@ export type EventType =
   | 'job:failed'
   // Chat tool progress events (real-time sideband for Ava tool execution)
   | 'chat:tool-progress'
+  // Chat user input request events (inline form rendered in the chat UI)
+  | 'chat:user-input-request'
   // Subagent tool approval events (gated trust model)
   | 'subagent:tool-approval-request'
   | 'subagent:tool-approval-response'
@@ -734,6 +736,25 @@ export interface EventPayloadMap {
     toolCallId: string;
     label: string;
     toolName?: string;
+    timestamp: string;
+  };
+
+  // Chat user input request events (inline form rendered in the chat UI)
+  'chat:user-input-request': {
+    /** Unique form ID used to correlate the response */
+    formId: string;
+    /** Form dialog title */
+    title: string;
+    /** Optional description shown below the title */
+    description?: string;
+    /** One or more form steps (multi-step renders as a wizard) */
+    steps: Array<{
+      schema: Record<string, unknown>;
+      uiSchema?: Record<string, unknown>;
+      title?: string;
+      description?: string;
+    }>;
+    /** ISO timestamp */
     timestamp: string;
   };
 


### PR DESCRIPTION
## Summary

**Milestone:** Interactive Tools

Register the request_user_input tool in ava-tools.ts so Ava can call it during chat sessions. The tool already exists in libs/tools/ and the MCP server but is not wired into Ava's tool list. When called, it should emit a structured event (type: user_input_request) with a JSON Schema form definition over the WebSocket stream so the UI can render an inline form. The tool should pause and await the user's form submission response before returning.

**Files to Modif...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added form-based input functionality to chat, enabling users to respond to structured input requests with custom fields and multi-step workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->