### PR TITLE
Bug: Lead Engineer REVIEW loop on done features

### DIFF
--- a/apps/server/src/services/lead-engineer-world-state.ts
+++ b/apps/server/src/services/lead-engineer-world-state.ts
@@ -47,17 +47,26 @@ export class WorldStateBuilder {
   ): Promise<LeadWorldState> {
     const features = await this.deps.featureLoader.getAll(projectPath);
 
-    // Board counts
+    // Terminal statuses — features in these states need no further processing
+    const TERMINAL_STATUSES = new Set(['done', 'completed', 'verified']);
+
+    // Board counts (all features, including terminal)
     const boardCounts: Record<string, number> = {};
     for (const f of features) {
       const status = f.status || 'backlog';
       boardCounts[status] = (boardCounts[status] || 0) + 1;
     }
 
-    // Feature snapshots
+    // Feature snapshots — only non-terminal features enter world state
+    // so the state machine and rules never process features that are already done
     const featureMap: Record<string, LeadFeatureSnapshot> = {};
+    // All-features lookup used for milestone completion checks (done features must be visible there)
+    const allFeaturesById: Record<string, Feature> = {};
     for (const f of features) {
-      featureMap[f.id] = this.featureToSnapshot(f);
+      allFeaturesById[f.id] = f;
+      if (!TERMINAL_STATUSES.has(f.status as string)) {
+        featureMap[f.id] = this.featureToSnapshot(f);
+      }
     }
 
     // Running agents
@@ -112,7 +121,7 @@ export class WorldStateBuilder {
           const completedPhases =
             ms.phases?.filter((p) => {
               if (!p.featureId) return false;
-              const f = featureMap[p.featureId];
+              const f = allFeaturesById[p.featureId];
               return f && (f.status === 'done' || f.status === 'verified');
             }).length || 0;
           milestones.push({


### PR DESCRIPTION
## Summary

**P1 Bug — Lead Engineer supervisor loops 100x on done features then escalates**

The Lead Engineer's world state includes ALL features (128 total, 116 done). The supervisor/state machine re-processes `done` features that have merged PRs, gets stuck in REVIEW state trying to transition them, hits the max same-state transition limit (100), and fires escalation signals.

**Root cause:** WorldStateBuilder loads all features without filtering out terminal states (`done`). The state machine then trie...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed world state population to exclude features with terminal completion statuses (done, completed, verified), improving accuracy of active feature tracking.
  * Enhanced milestone completion calculations to properly account for all terminal status features when determining milestone phase completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->