### PR TITLE
PM model upgrade to Sonnet

### DIFF
--- a/apps/server/src/routes/project-pm/index.ts
+++ b/apps/server/src/routes/project-pm/index.ts
@@ -3,8 +3,9 @@
  *
  * POST /api/project-pm/chat — streaming chat with the Project PM agent.
  *   Body: { projectPath, projectSlug, messages }
+ *   Headers: x-model-alias (optional) — override model (haiku|sonnet|opus)
  *   Uses Vercel AI SDK streamText with PM system prompt and inline tools.
- *   PM agent is haiku model, no bash, no file write.
+ *   PM agent defaults to sonnet model; supports extended thinking on sonnet/opus.
  *
  * GET /api/project-pm/sessions — returns all active PM sessions.
  * GET /api/project-pm/session/:slug — returns session history + ceremony state.
@@ -331,7 +332,12 @@ export function createProjectPmRoutes(
         }),
       };
 
-      const resolvedModelId = resolveModelString('haiku', 'haiku');
+      // Model selection: x-model-alias header > default (sonnet)
+      const modelAlias = (req.headers['x-model-alias'] as string) || 'sonnet';
+      const resolvedModelId = resolveModelString(modelAlias, 'sonnet');
+      const extendedThinking =
+        resolvedModelId.includes('opus') || resolvedModelId.includes('sonnet');
+
       const messages: ModelMessage[] = await convertToModelMessages(rawMessages, { tools });
 
       // Prepend session history (system event messages from feature completions, etc.)
@@ -341,7 +347,7 @@ export function createProjectPmRoutes(
       const allMessages: ModelMessage[] = [...sessionHistory, ...messages];
 
       logger.info(
-        `PM chat request: ${messages.length} user messages + ${sessionHistory.length} session events, project=${projectSlug}, model=haiku`
+        `PM chat request: ${messages.length} user messages + ${sessionHistory.length} session events, project=${projectSlug}, model=${modelAlias}, extendedThinking=${extendedThinking}`
       );
 
       const result = streamText({
@@ -350,6 +356,13 @@ export function createProjectPmRoutes(
         messages: allMessages,
         tools,
         stopWhen: stepCountIs(5),
+        ...(extendedThinking && {
+          providerOptions: {
+            anthropic: {
+              thinking: { type: 'enabled', budgetTokens: 10_000 },
+            },
+          },
+        }),
         experimental_telemetry: {
           isEnabled: true,
           metadata: { route: '/api/project-pm/chat', projectSlug },


### PR DESCRIPTION
## Summary

**Milestone:** Expand PM Tool Surface

Change PM chat route to use Sonnet by default instead of Haiku. Update transport config, system prompt to leverage Sonnet capabilities. Add extended thinking support for PM. Ensure model alias flows through from client header.

**Files to Modify:**
- apps/server/src/routes/project-pm/index.ts
- apps/ui/src/hooks/use-pm-chat-session.ts

**Acceptance Criteria:**
- [ ] PM uses Sonnet by default
- [ ] x-model-alias header respected for PM chat
- [ ] Extended th...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to select the AI model for chat requests via header, defaulting to Sonnet when unspecified
  * Enabled advanced reasoning capabilities for Opus and Sonnet models to improve response quality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->