### PR TITLE
Server URL override in auth layer + app store

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -27,7 +27,7 @@ setupSentry();
 import { execSync } from 'node:child_process';
 import express from 'express';
 import { createServer } from 'http';
-import { initAllowedPaths } from '@protolabsai/platform';
+import { initAllowedPaths, loadProtoConfig } from '@protolabsai/platform';
 import { createLogger, registerLogTransport } from '@protolabsai/utils';
 import { MAX_SYSTEM_CONCURRENCY } from '@protolabsai/types';
 import { createFileLogTransport } from './lib/server-log.js';
@@ -107,9 +107,17 @@ if (process.env.ANTHROPIC_API_KEY) {
 // Initialize security
 initAllowedPaths();
 
+// Detect hivemind mode to decide whether to allow all CORS origins
+const _protoConfig = await loadProtoConfig(REPO_ROOT).catch(() => null);
+const _hivemindConfig = _protoConfig?.['hivemind'] as { enabled?: boolean } | undefined;
+const hivemindEnabled = _hivemindConfig?.enabled === true;
+if (hivemindEnabled) {
+  logger.info('[SERVER_STARTUP] Hivemind enabled — CORS will accept requests from any origin');
+}
+
 // Create Express app and wire all server modules
 const app = express();
-setupMiddleware(app);
+setupMiddleware(app, { allowAllOrigins: hivemindEnabled });
 
 const services = await createServices(DATA_DIR, REPO_ROOT);
 await wireServices(services);

--- a/apps/server/src/server/middleware.ts
+++ b/apps/server/src/server/middleware.ts
@@ -34,7 +34,7 @@ export function isRequestLoggingEnabled(): boolean {
 /**
  * Register all Express middleware: logging, CORS, Prometheus, body parsing
  */
-export function setupMiddleware(app: Express): void {
+export function setupMiddleware(app: Express, options?: { allowAllOrigins?: boolean }): void {
   // Custom colored logger showing only endpoint and status code (dynamically configurable)
   morgan.token('status-colored', (_req, res) => {
     const status = res.statusCode;
@@ -57,12 +57,19 @@ export function setupMiddleware(app: Express): void {
   // CORS configuration
   // When using credentials (cookies), origin cannot be '*'
   // We dynamically allow the requesting origin for local development
+  const allowAllOrigins = options?.allowAllOrigins === true;
   app.use(
     cors({
       origin: (origin, callback) => {
         // Allow requests with no origin (like mobile apps, curl, Electron)
         if (!origin) {
           callback(null, true);
+          return;
+        }
+
+        // When hivemind is enabled, accept requests from any origin
+        if (allowAllOrigins) {
+          callback(null, origin);
           return;
         }
 

--- a/apps/ui/src/lib/clients/auth.ts
+++ b/apps/ui/src/lib/clients/auth.ts
@@ -90,7 +90,18 @@ export const initServerUrl = async (): Promise<void> => {
   }
 };
 
+const SERVER_URL_OVERRIDE_KEY = 'automaker:serverUrlOverride';
+
 export const getServerUrl = (): string => {
+  // Check runtime override stored in localStorage (set via app-store.setServerUrlOverride)
+  if (typeof window !== 'undefined') {
+    try {
+      const runtimeOverride = window.localStorage.getItem(SERVER_URL_OVERRIDE_KEY);
+      if (runtimeOverride) return runtimeOverride;
+    } catch {
+      // localStorage might be disabled; fall through to other sources
+    }
+  }
   if (cachedServerUrl) return cachedServerUrl;
   if (typeof window !== 'undefined') {
     const envUrl = import.meta.env.VITE_SERVER_URL;

--- a/apps/ui/src/lib/clients/base-http-client.ts
+++ b/apps/ui/src/lib/clients/base-http-client.ts
@@ -74,6 +74,26 @@ export class BaseHttpClient {
     }
   }
 
+  /**
+   * Force-close the current WebSocket connection and reconnect using the current server URL.
+   * Called when the server URL override changes at runtime.
+   */
+  public reconnect(): void {
+    this.serverUrl = getServerUrl();
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      this.ws.onclose = null; // suppress auto-reconnect from the old socket's onclose
+      this.ws.close();
+      this.ws = null;
+    }
+    this.isConnecting = false;
+    this.reconnectAttempt = 0;
+    this.connectWebSocket();
+  }
+
   // -- WebSocket infrastructure -----------------------------------------------
 
   private async fetchWsToken(): Promise<string | null> {

--- a/apps/ui/src/lib/http-api-client.ts
+++ b/apps/ui/src/lib/http-api-client.ts
@@ -120,6 +120,19 @@ export function getHttpApiClient(): HttpApiClient {
   return httpApiClientInstance;
 }
 
+/**
+ * Invalidate the cached HTTP client singleton and trigger WebSocket reconnection.
+ * Called when the server URL override changes so the new URL is picked up immediately.
+ */
+export function invalidateHttpClient(): void {
+  if (httpApiClientInstance) {
+    httpApiClientInstance.reconnect();
+  }
+  httpApiClientInstance = null;
+  // Re-create immediately so callers get a fresh instance pointing at the new URL
+  httpApiClientInstance = new HttpApiClient();
+}
+
 // Start API key initialization immediately when this module is imported
 // This ensures the init promise is created early, even before React components mount
 // The actual async work happens in the background and won't block module loading

--- a/apps/ui/src/store/app-store.ts
+++ b/apps/ui/src/store/app-store.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 // Note: persist middleware removed - settings now sync via API (use-settings-sync.ts)
 import type { Project, TrashedProject } from '@/lib/electron';
-import { getHttpApiClient } from '@/lib/http-api-client';
+import { getHttpApiClient, invalidateHttpClient } from '@/lib/http-api-client';
 import { createLogger } from '@protolabsai/utils/logger';
 import { UI_SANS_FONT_OPTIONS, UI_MONO_FONT_OPTIONS } from '@/config/ui-font-options';
 import type {
@@ -159,6 +159,10 @@ export interface AppState {
   peers: HivemindPeer[];
   instanceFilter: 'all' | 'mine'; // 'all' = show features from all instances, 'mine' = local only
   selfInstanceId: string | null; // The instanceId of this Automaker instance
+
+  // Server URL runtime override
+  serverUrlOverride: string | null; // Runtime server URL override (null = use env var / default)
+  recentServerUrls: string[]; // Recently used server URLs, max 10, persisted in localStorage
 }
 
 export interface AppActions {
@@ -323,6 +327,9 @@ export interface AppActions {
   setSelfInstanceId: (id: string | null) => void;
   fetchSelfInstanceId: () => Promise<void>;
 
+  // Server URL runtime override actions
+  setServerUrlOverride: (url: string | null) => void;
+
   // Reset
   reset: () => void;
 }
@@ -401,6 +408,22 @@ const initialState: AppState = {
   peers: [],
   instanceFilter: 'all',
   selfInstanceId: null,
+  // Server URL runtime override
+  serverUrlOverride: (() => {
+    try {
+      return localStorage.getItem('automaker:serverUrlOverride') ?? null;
+    } catch {
+      return null;
+    }
+  })(),
+  recentServerUrls: (() => {
+    try {
+      const stored = localStorage.getItem('automaker:recentServerUrls');
+      return stored ? (JSON.parse(stored) as string[]) : [];
+    } catch {
+      return [];
+    }
+  })(),
 };
 
 export const useAppStore = create<AppState & AppActions>()((set, get) => ({
@@ -1276,6 +1299,36 @@ export const useAppStore = create<AppState & AppActions>()((set, get) => ({
     } catch (err) {
       logger.warn('[AppStore] Failed to fetch self instanceId:', err);
     }
+  },
+
+  // Server URL runtime override actions
+  setServerUrlOverride: (url) => {
+    // Persist override to localStorage
+    try {
+      if (url) {
+        localStorage.setItem('automaker:serverUrlOverride', url);
+      } else {
+        localStorage.removeItem('automaker:serverUrlOverride');
+      }
+    } catch {
+      // localStorage might be disabled
+    }
+
+    // Update recent URLs (deduplicated, max 10)
+    let recentServerUrls = get().recentServerUrls;
+    if (url) {
+      recentServerUrls = [url, ...recentServerUrls.filter((u) => u !== url)].slice(0, 10);
+      try {
+        localStorage.setItem('automaker:recentServerUrls', JSON.stringify(recentServerUrls));
+      } catch {
+        // localStorage might be disabled
+      }
+    }
+
+    set({ serverUrlOverride: url, recentServerUrls });
+
+    // Invalidate cached HTTP client and trigger WebSocket reconnection
+    invalidateHttpClient();
   },
 
   // Reset


### PR DESCRIPTION
## Summary

**Milestone:** Server URL Runtime Switching

Modify getServerUrl() in apps/ui/src/lib/clients/auth.ts to check a runtime override stored in app-store before falling back to env vars. Add serverUrlOverride state + setServerUrlOverride action to app-store. Add recentServerUrls array (max 10) persisted via localStorage. When override changes, invalidate cached HTTP client and WebSocket connection, trigger reconnection. Add CORS middleware on server to accept requests from any origin when hivemind i...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime server URL override capability—users can now switch the server connection at runtime with persistence.
  * Added recent server URL tracking (max 10 entries) for quick access.
  * Added HTTP client reconnection functionality to seamlessly switch between servers.
  * Introduced hivemind mode support for cross-origin request handling on the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->