### PR TITLE
feat: slim Ava default tool groups for delegation model

### DIFF
--- a/apps/server/src/routes/chat/ava-config.ts
+++ b/apps/server/src/routes/chat/ava-config.ts
@@ -61,30 +61,41 @@ export interface AvaConfig {
 
 /**
  * Default configuration used when no per-project config file exists.
- * All tools are enabled; model defaults to sonnet.
+ *
+ * Enabled by default (~20 tools): briefing, health, notes, calendar, discord,
+ * avaChannel, metrics, settings, delegation, boardRead.
+ *
+ * Disabled by default (project-tactical): boardWrite, agentControl, autoMode,
+ * prWorkflow, promotion, contextFiles, orchestration, projectMgmt,
+ * agentDelegation, projects.
+ *
+ * Any group can be re-enabled via .automaker/ava-config.json.
  */
 export const DEFAULT_AVA_CONFIG: AvaConfig = {
   model: 'sonnet',
   toolGroups: {
+    // ── Always-on: oversight & communication ──────────────────────────────
     boardRead: true,
-    boardWrite: true,
-    agentControl: true,
-    autoMode: true,
-    projectMgmt: true,
-    orchestration: true,
-    agentDelegation: true,
-    notes: true,
-    metrics: true,
-    prWorkflow: true,
-    promotion: true,
-    contextFiles: true,
-    projects: true,
     briefing: true,
-    avaChannel: true,
-    discord: true,
-    calendar: true,
     health: true,
+    notes: true,
+    calendar: true,
+    discord: true,
+    avaChannel: true,
+    metrics: true,
     settings: true,
+    delegation: true,
+    // ── Off by default: project-tactical (re-enable via ava-config.json) ──
+    boardWrite: false,
+    agentControl: false,
+    autoMode: false,
+    prWorkflow: false,
+    promotion: false,
+    contextFiles: false,
+    orchestration: false,
+    projectMgmt: false,
+    agentDelegation: false,
+    projects: false,
   },
   sitrepInjection: true,
   contextInjection: true,

--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -173,6 +173,8 @@ export interface AvaToolsConfig {
   settings?: boolean;
   /** Enable PM delegation tool (delegate_to_pm) */
   delegateToPm?: boolean;
+  /** Enable delegation tool group (delegate_to_pm) — preferred alias for delegateToPm */
+  delegation?: boolean;
 }
 
 // Re-use the same status literals that the Feature type exposes
@@ -2038,7 +2040,7 @@ export function buildAvaTools(
   // -----------------------------------------------------------------------
   // delegateToPm – delegate a question to the Project Manager
   // -----------------------------------------------------------------------
-  if (config.delegateToPm) {
+  if (config.delegateToPm || config.delegation) {
     tools['delegate_to_pm'] = makeTool({
       description:
         'Delegate a question about a project to the Project Manager (PM). ' +


### PR DESCRIPTION
## Summary
- Disable project-tactical tool groups by default (boardWrite, agentControl, autoMode, prWorkflow, promotion, contextFiles, orchestration, projectMgmt, agentDelegation, projects)
- Keep oversight/communication tools enabled (boardRead, briefing, health, notes, calendar, discord, avaChannel, metrics, settings, delegation)
- Add `delegation` tool group alias for `delegate_to_pm`

## Test plan
- [ ] Build passes (server typecheck)
- [ ] Ava loads with reduced default tool set
- [ ] Users can re-enable disabled groups via ava-config.json

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an alternative configuration parameter for enabling delegation functionality alongside existing options.

* **Changes**
  * Reorganized default tool set to include commonly-used features while providing options to enable additional capabilities as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->