### PR TITLE
Server Connection section in Developer Settings

### DIFF
--- a/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
+++ b/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
@@ -1,10 +1,11 @@
 import { Label } from '@protolabsai/ui/atoms';
 import { Switch } from '@protolabsai/ui/atoms';
-import { Code2, Flag } from 'lucide-react';
+import { Code2, Flag, Server, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAppStore, type ServerLogLevel } from '@/store/app-store';
 import { toast } from 'sonner';
 import type { FeatureFlags } from '@protolabsai/types';
+import { useState } from 'react';
 
 const LOG_LEVEL_OPTIONS: { value: ServerLogLevel; label: string; description: string }[] = [
   { value: 'error', label: 'Error', description: 'Only show error messages' },
@@ -55,7 +56,15 @@ export function DeveloperSection() {
     setEnableRequestLogging,
     featureFlags,
     setFeatureFlags,
+    serverUrlOverride,
+    serverStatus,
+    serverInfo,
+    recentConnections,
+    connectToServer,
+    removeRecentConnection,
   } = useAppStore();
+
+  const [urlInput, setUrlInput] = useState(serverUrlOverride ?? '');
 
   return (
     <div
@@ -125,6 +134,159 @@ export function DeveloperSection() {
               });
             }}
           />
+        </div>
+
+        {/* Server Connection */}
+        <div className="pt-4 border-t border-border/30 space-y-3">
+          <div className="flex items-center gap-2">
+            <Server className="w-4 h-4 text-muted-foreground" />
+            <Label className="text-foreground font-medium">Server Connection</Label>
+            {/* Status badge */}
+            <span
+              className={cn(
+                'ml-auto inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium',
+                serverStatus === 'connected' &&
+                  'bg-green-500/15 text-green-600 dark:text-green-400',
+                serverStatus === 'disconnected' && 'bg-red-500/15 text-red-600 dark:text-red-400',
+                serverStatus === 'connecting' &&
+                  'bg-yellow-500/15 text-yellow-600 dark:text-yellow-400'
+              )}
+            >
+              <span
+                className={cn(
+                  'w-1.5 h-1.5 rounded-full',
+                  serverStatus === 'connected' && 'bg-green-500',
+                  serverStatus === 'disconnected' && 'bg-red-500',
+                  serverStatus === 'connecting' && 'bg-yellow-500 animate-pulse'
+                )}
+              />
+              {serverStatus === 'connected'
+                ? 'Connected'
+                : serverStatus === 'connecting'
+                  ? 'Connecting…'
+                  : 'Disconnected'}
+            </span>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Connect to a different Automaker server at runtime. Leave blank to use the default
+            server.
+          </p>
+
+          {/* URL input + Connect button */}
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={urlInput}
+              onChange={(e) => setUrlInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && urlInput.trim()) {
+                  void connectToServer(urlInput.trim()).then(() => {
+                    toast.success('Server connection updated', {
+                      description: urlInput.trim(),
+                    });
+                  });
+                }
+              }}
+              placeholder="http://localhost:3008"
+              className={cn(
+                'flex-1 px-3 py-2 rounded-lg',
+                'bg-accent/30 border border-border/50',
+                'text-foreground text-sm placeholder:text-muted-foreground/50',
+                'focus:outline-none focus:ring-2 focus:ring-purple-500/30'
+              )}
+            />
+            <button
+              onClick={() => {
+                const url = urlInput.trim();
+                if (!url) return;
+                void connectToServer(url).then(() => {
+                  toast.success('Server connection updated', {
+                    description: url,
+                  });
+                });
+              }}
+              disabled={serverStatus === 'connecting' || !urlInput.trim()}
+              className={cn(
+                'px-3 py-2 rounded-lg text-sm font-medium',
+                'bg-purple-500/20 text-purple-600 dark:text-purple-400',
+                'border border-purple-500/30',
+                'hover:bg-purple-500/30 transition-colors',
+                'disabled:opacity-50 disabled:cursor-not-allowed'
+              )}
+            >
+              {serverStatus === 'connecting' ? 'Connecting…' : 'Connect'}
+            </button>
+          </div>
+
+          {/* Connected server info */}
+          {serverStatus === 'connected' && serverInfo && (
+            <div
+              className={cn(
+                'rounded-lg px-3 py-2 space-y-1',
+                'bg-green-500/5 border border-green-500/20'
+              )}
+            >
+              <p className="text-xs font-medium text-green-600 dark:text-green-400">
+                Connected server
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Version: <span className="text-foreground">{serverInfo.version}</span>
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Status: <span className="text-foreground">{serverInfo.status}</span>
+              </p>
+            </div>
+          )}
+
+          {/* Recent connections */}
+          {recentConnections.length > 0 && (
+            <div className="space-y-1">
+              <p className="text-xs text-muted-foreground font-medium">Recent connections</p>
+              <div className="space-y-1">
+                {recentConnections.map((conn) => (
+                  <div
+                    key={conn.url}
+                    className={cn(
+                      'flex items-center gap-2 px-2 py-1.5 rounded-lg',
+                      'bg-accent/20 border border-border/30',
+                      'group'
+                    )}
+                  >
+                    <button
+                      onClick={() => {
+                        setUrlInput(conn.url);
+                        void connectToServer(conn.url).then(() => {
+                          toast.success('Server connection updated', {
+                            description: conn.url,
+                          });
+                        });
+                      }}
+                      className="flex-1 text-left min-w-0"
+                    >
+                      <p className="text-xs text-foreground truncate">{conn.url}</p>
+                      <p className="text-xs text-muted-foreground/70">
+                        {new Date(conn.lastConnected).toLocaleString()}
+                      </p>
+                    </button>
+                    <button
+                      onClick={() => {
+                        removeRecentConnection(conn.url);
+                        toast.success('Removed from history');
+                      }}
+                      className={cn(
+                        'flex-shrink-0 p-1 rounded',
+                        'text-muted-foreground/50 hover:text-muted-foreground',
+                        'opacity-0 group-hover:opacity-100 transition-opacity'
+                      )}
+                      aria-label={`Remove ${conn.url} from history`}
+                    >
+                      <X className="w-3 h-3" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Feature Flags */}

--- a/apps/ui/src/store/app-store.ts
+++ b/apps/ui/src/store/app-store.ts
@@ -163,6 +163,11 @@ export interface AppState {
   // Server URL runtime override
   serverUrlOverride: string | null; // Runtime server URL override (null = use env var / default)
   recentServerUrls: string[]; // Recently used server URLs, max 10, persisted in localStorage
+
+  // Server connection state
+  serverStatus: 'connected' | 'disconnected' | 'connecting'; // Current connection status
+  serverInfo: { version: string; status: string; timestamp: string } | null; // Info from /api/health
+  recentConnections: Array<{ url: string; lastConnected: string }>; // Recent connections with timestamps
 }
 
 export interface AppActions {
@@ -330,6 +335,10 @@ export interface AppActions {
   // Server URL runtime override actions
   setServerUrlOverride: (url: string | null) => void;
 
+  // Server connection actions
+  connectToServer: (url: string) => Promise<void>;
+  removeRecentConnection: (url: string) => void;
+
   // Reset
   reset: () => void;
 }
@@ -420,6 +429,17 @@ const initialState: AppState = {
     try {
       const stored = localStorage.getItem('automaker:recentServerUrls');
       return stored ? (JSON.parse(stored) as string[]) : [];
+    } catch {
+      return [];
+    }
+  })(),
+  // Server connection state
+  serverStatus: 'disconnected' as 'connected' | 'disconnected' | 'connecting',
+  serverInfo: null,
+  recentConnections: (() => {
+    try {
+      const stored = localStorage.getItem('automaker:recentConnections');
+      return stored ? (JSON.parse(stored) as Array<{ url: string; lastConnected: string }>) : [];
     } catch {
       return [];
     }
@@ -1329,6 +1349,66 @@ export const useAppStore = create<AppState & AppActions>()((set, get) => ({
 
     // Invalidate cached HTTP client and trigger WebSocket reconnection
     invalidateHttpClient();
+  },
+
+  // Server connection actions
+  connectToServer: async (url) => {
+    set({ serverStatus: 'connecting', serverInfo: null });
+    try {
+      const response = await fetch(`${url}/api/health`, {
+        method: 'GET',
+        cache: 'no-store',
+        signal: AbortSignal.timeout(5000),
+      });
+      if (!response.ok) {
+        set({ serverStatus: 'disconnected' });
+        return;
+      }
+      const data = (await response.json()) as {
+        version?: string;
+        status?: string;
+        timestamp?: string;
+      };
+      const serverInfo = {
+        version: data.version ?? 'unknown',
+        status: data.status ?? 'ok',
+        timestamp: data.timestamp ?? new Date().toISOString(),
+      };
+
+      // Update recent connections (deduplicated, max 10)
+      const lastConnected = new Date().toISOString();
+      const existing = get().recentConnections.filter((c) => c.url !== url);
+      const recentConnections = [{ url, lastConnected }, ...existing].slice(0, 10);
+      try {
+        localStorage.setItem('automaker:recentConnections', JSON.stringify(recentConnections));
+      } catch {
+        // localStorage might be disabled
+      }
+
+      set({ serverStatus: 'connected', serverInfo, recentConnections });
+
+      // Apply the URL override so all subsequent API calls use the new server
+      get().setServerUrlOverride(url);
+    } catch {
+      set({ serverStatus: 'disconnected' });
+    }
+  },
+
+  removeRecentConnection: (url) => {
+    const recentConnections = get().recentConnections.filter((c) => c.url !== url);
+    try {
+      localStorage.setItem('automaker:recentConnections', JSON.stringify(recentConnections));
+    } catch {
+      // localStorage might be disabled
+    }
+    // Also remove from legacy recentServerUrls list for consistency
+    const recentServerUrls = get().recentServerUrls.filter((u) => u !== url);
+    try {
+      localStorage.setItem('automaker:recentServerUrls', JSON.stringify(recentServerUrls));
+    } catch {
+      // localStorage might be disabled
+    }
+    set({ recentConnections, recentServerUrls });
   },
 
   // Reset


### PR DESCRIPTION
## Summary

**Milestone:** Server URL Runtime Switching

Add a Server Connection section to developer-section.tsx with: (1) text input for server URL with a Connect button, (2) dropdown/list of recent connections showing URL + last-connected timestamp, (3) connection status indicator (connected/disconnected/connecting), (4) current server info display (instance name, role, version from /api/health). Clicking a recent connection auto-fills and connects. Clear button to remove from history.

**Files to Modify...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server connection management to developer settings with ability to input and connect to custom server URLs
  * Displays connected server information including version and status
  * Tracks recent server connections with quick-connect and remove-from-history options
  * Includes real-time connection status indicator and success/error notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->