### PR TITLE
Hivemind instance auto-discovery in server picker

### DIFF
--- a/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
+++ b/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
@@ -1,10 +1,10 @@
 import { Label } from '@protolabsai/ui/atoms';
 import { Switch } from '@protolabsai/ui/atoms';
-import { Code2, Flag, Server, X } from 'lucide-react';
+import { Code2, Flag, Network, RefreshCw, Server, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAppStore, type ServerLogLevel } from '@/store/app-store';
 import { toast } from 'sonner';
-import type { FeatureFlags } from '@protolabsai/types';
+import type { FeatureFlags, HivemindPeer } from '@protolabsai/types';
 import { useState } from 'react';
 
 const LOG_LEVEL_OPTIONS: { value: ServerLogLevel; label: string; description: string }[] = [
@@ -48,6 +48,104 @@ const FEATURE_FLAG_LABELS: Record<keyof FeatureFlags, { label: string; descripti
   },
 };
 
+// Role badge colour mapping
+const ROLE_BADGE_CLASSES: Record<string, string> = {
+  fullstack: 'bg-purple-500/15 text-purple-600 dark:text-purple-400',
+  frontend: 'bg-blue-500/15 text-blue-600 dark:text-blue-400',
+  backend: 'bg-orange-500/15 text-orange-600 dark:text-orange-400',
+  infra: 'bg-slate-500/15 text-slate-600 dark:text-slate-400',
+  docs: 'bg-teal-500/15 text-teal-600 dark:text-teal-400',
+  qa: 'bg-rose-500/15 text-rose-600 dark:text-rose-400',
+  primary: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
+  worker: 'bg-zinc-500/15 text-zinc-500 dark:text-zinc-400',
+};
+
+function PeerCard({ peer, onConnect }: { peer: HivemindPeer; onConnect: (url: string) => void }) {
+  const { identity } = peer;
+  const hasUrl = Boolean(identity.url);
+  const isOnline = identity.status !== 'offline';
+  const runningAgents = identity.capacity?.runningAgents ?? 0;
+  const maxAgents = identity.capacity?.maxAgents ?? 0;
+  const capacityPercent = maxAgents > 0 ? Math.round((runningAgents / maxAgents) * 100) : 0;
+  const roleKey = identity.role ?? '';
+  const roleBadgeClass = ROLE_BADGE_CLASSES[roleKey] ?? 'bg-zinc-500/15 text-zinc-500';
+
+  return (
+    <button
+      onClick={() => {
+        if (hasUrl && identity.url) onConnect(identity.url);
+      }}
+      disabled={!hasUrl || !isOnline}
+      className={cn(
+        'w-full text-left rounded-lg px-3 py-2.5 space-y-2',
+        'border transition-colors',
+        isOnline && hasUrl
+          ? 'bg-accent/20 border-border/40 hover:bg-accent/40 hover:border-border/60 cursor-pointer'
+          : 'bg-accent/10 border-border/20 opacity-60 cursor-not-allowed'
+      )}
+      aria-label={
+        !hasUrl
+          ? `${identity.name ?? identity.instanceId} — no direct access`
+          : `Connect to ${identity.name ?? identity.instanceId}`
+      }
+    >
+      <div className="flex items-center gap-2">
+        {/* Online/offline dot */}
+        <span
+          className={cn(
+            'flex-shrink-0 w-2 h-2 rounded-full',
+            identity.status === 'online' && 'bg-green-500',
+            identity.status === 'draining' && 'bg-yellow-500',
+            identity.status === 'offline' && 'bg-zinc-400',
+            !identity.status && 'bg-green-500' // default online if status not set
+          )}
+        />
+        {/* Name */}
+        <span className="flex-1 text-sm font-medium text-foreground truncate">
+          {identity.name ?? identity.instanceId}
+        </span>
+        {/* Role badge */}
+        {roleKey && (
+          <span
+            className={cn(
+              'flex-shrink-0 text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded',
+              roleBadgeClass
+            )}
+          >
+            {roleKey}
+          </span>
+        )}
+      </div>
+
+      {/* Capacity bar + agent count */}
+      {maxAgents > 0 && (
+        <div className="space-y-1">
+          <div className="flex justify-between text-[10px] text-muted-foreground">
+            <span>{runningAgents} running</span>
+            <span>{capacityPercent}% capacity</span>
+          </div>
+          <div className="h-1 w-full rounded-full bg-border/40 overflow-hidden">
+            <div
+              className={cn(
+                'h-full rounded-full transition-all',
+                capacityPercent >= 90
+                  ? 'bg-red-500'
+                  : capacityPercent >= 60
+                    ? 'bg-yellow-500'
+                    : 'bg-green-500'
+              )}
+              style={{ width: `${capacityPercent}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* No direct access label */}
+      {!hasUrl && <p className="text-[10px] text-muted-foreground/70 italic">no direct access</p>}
+    </button>
+  );
+}
+
 export function DeveloperSection() {
   const {
     serverLogLevel,
@@ -62,9 +160,24 @@ export function DeveloperSection() {
     recentConnections,
     connectToServer,
     removeRecentConnection,
+    peers,
+    fetchPeers,
   } = useAppStore();
 
   const [urlInput, setUrlInput] = useState(serverUrlOverride ?? '');
+  const [isRefreshingPeers, setIsRefreshingPeers] = useState(false);
+
+  const handleRefreshPeers = () => {
+    setIsRefreshingPeers(true);
+    void fetchPeers().finally(() => setIsRefreshingPeers(false));
+  };
+
+  const handleConnectToPeer = (url: string) => {
+    setUrlInput(url);
+    void connectToServer(url).then(() => {
+      toast.success('Connected to peer', { description: url });
+    });
+  };
 
   return (
     <div
@@ -285,6 +398,46 @@ export function DeveloperSection() {
                   </div>
                 ))}
               </div>
+            </div>
+          )}
+        </div>
+
+        {/* Hivemind Peers */}
+        <div className="pt-4 border-t border-border/30 space-y-3">
+          <div className="flex items-center gap-2">
+            <Network className="w-4 h-4 text-muted-foreground" />
+            <Label className="text-foreground font-medium">Hivemind Peers</Label>
+            <button
+              onClick={handleRefreshPeers}
+              disabled={isRefreshingPeers}
+              className={cn(
+                'ml-auto p-1 rounded text-muted-foreground/60 hover:text-muted-foreground',
+                'transition-colors disabled:opacity-40'
+              )}
+              aria-label="Refresh peer list"
+            >
+              <RefreshCw className={cn('w-3.5 h-3.5', isRefreshingPeers && 'animate-spin')} />
+            </button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Online instances in the hivemind mesh. Click a peer to connect to its server.
+          </p>
+
+          {peers.length === 0 ? (
+            <div className="rounded-lg px-3 py-4 text-center bg-accent/10 border border-border/20">
+              <p className="text-xs text-muted-foreground">
+                No peers detected. Hivemind may be disabled or no other instances are online.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {peers.map((peer) => (
+                <PeerCard
+                  key={peer.identity.instanceId}
+                  peer={peer}
+                  onConnect={handleConnectToPeer}
+                />
+              ))}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

**Milestone:** Hivemind Instance Picker + Build Targets

When connected to any server, fetch the peer list from /api/health (which already includes onlinePeers with full InstanceIdentity). Display peers in the Server Connection section as clickable cards showing: instance name, role badge, running agents count, capacity bar, online/offline status. Clicking a peer sets its identity.url as the server URL override and connects. Add a refresh button to re-fetch peers. Handle the case where peers don...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Hivemind Peers section to developer settings, displaying peer nodes with status, capacity, and role information
  * Added peer list refresh capability
  * Added direct peer connection functionality from the developer settings panel with confirmation notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->