### PR TITLE
Server URL override in auth layer + app store

### DIFF
--- a/apps/ui/src/store/app-store.ts
+++ b/apps/ui/src/store/app-store.ts
@@ -338,6 +338,7 @@ export interface AppActions {
 
   // Server URL runtime override actions
   setServerUrlOverride: (url: string | null) => void;
+  addRecentServerUrl: (url: string) => void; // Adds to recentServerUrls (max 10, deduplicated)
 
   // Server connection actions
   connectToServer: (url: string) => Promise<void>;
@@ -1368,6 +1369,16 @@ export const useAppStore = create<AppState & AppActions>()((set, get) => ({
 
     // Invalidate cached HTTP client and trigger WebSocket reconnection
     invalidateHttpClient();
+  },
+
+  addRecentServerUrl: (url) => {
+    const recentServerUrls = [url, ...get().recentServerUrls.filter((u) => u !== url)].slice(0, 10);
+    try {
+      localStorage.setItem('automaker:recentServerUrls', JSON.stringify(recentServerUrls));
+    } catch {
+      // localStorage might be disabled
+    }
+    set({ recentServerUrls });
   },
 
   // Server connection actions


### PR DESCRIPTION
## Summary

Modify getServerUrl() in apps/ui/src/lib/clients/auth.ts to check a runtime override stored in app-store before falling back to env vars. Add serverUrlOverride state + setServerUrlOverride action to app-store. Add recentServerUrls array (max 10) persisted via localStorage. When override changes, invalidate cached HTTP client and WebSocket connection, trigger reconnection. Add CORS middleware on server to accept requests from any origin when hivemind is enabled.

**Project:** Headless Server + Re...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functionality to track and display recently used server URLs for quick access to previous connections. The system maintains up to 10 unique URLs and persists them locally, with graceful handling of any storage issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->