### PR TITLE
fix: broadcast chat:user-input-request event to reach WebSocket clients

### DIFF
--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -2004,8 +2004,8 @@ export function buildAvaTools(
         const formId = `chat-form-${randomUUID().slice(0, 8)}`;
         const timestamp = new Date().toISOString();
 
-        // Emit the user_input_request event so the UI renders an inline form
-        eventsEmitter.emit('chat:user-input-request' as EventType, {
+        // Broadcast the user_input_request event so the UI renders an inline form
+        eventsEmitter.broadcast('chat:user-input-request' as EventType, {
           formId,
           title,
           description,


### PR DESCRIPTION
## Summary
- Replaces `eventsEmitter.emit()` with `eventsEmitter.broadcast()` for the `chat:user-input-request` event in `ava-tools.ts`
- `emit()` only fires server-side listeners; `broadcast()` is required to deliver events to WebSocket clients in the UI
- This ensures the HITL inline form renders correctly in the frontend when Ava triggers a user input request

## Root Cause
CodeRabbit review on PR #2094 (GH Issue #2099) identified that the HITL tool was using `emit()` instead of `broadcast()`, meaning the `chat:user-input-request` event never reached frontend WebSocket clients — the inline form would never render.

## Test plan
- [ ] Trigger a HITL user input request via Ava in the chat UI
- [ ] Verify the inline form renders in the frontend (previously would silently fail)
- [ ] Confirm the form response flow (`hitl:form-responded`) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat input form notification to ensure UI updates are properly received during user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->