### PR TITLE
Deduplicate antagonistic review interfaces and inline logic

### DIFF
--- a/apps/server/src/routes/ceremonies/index.ts
+++ b/apps/server/src/routes/ceremonies/index.ts
@@ -18,8 +18,51 @@ import type { CeremonyService } from '../../services/ceremony-service.js';
 import type { CeremonyAuditLogService } from '../../services/ceremony-audit-service.js';
 import { validatePathParams } from '../../middleware/validate-paths.js';
 import { createLogger } from '@protolabsai/utils';
+import type { Feature } from '@protolabsai/types';
+import type { Project } from '@protolabsai/types';
 
 const logger = createLogger('ceremonies');
+
+interface MilestoneSummary {
+  milestoneTitle: string;
+  featureCount: number;
+  costUsd: number;
+}
+
+interface ProjectStats {
+  totalFeatures: number;
+  totalCostUsd: number;
+  failureCount: number;
+  milestoneSummaries: MilestoneSummary[];
+}
+
+/**
+ * Aggregate ceremony stats across all milestones for a project.
+ */
+function aggregateCeremonyStats(project: Project, allFeatures: Feature[]): ProjectStats {
+  let totalFeatures = 0;
+  let totalCostUsd = 0;
+  let failureCount = 0;
+  const milestoneSummaries: MilestoneSummary[] = [];
+
+  for (const milestone of project.milestones) {
+    const milestoneFeatures = allFeatures.filter((f) =>
+      milestone.phases.some((p) => p.featureId === f.id)
+    );
+    const costUsd = milestoneFeatures.reduce((sum, f) => sum + (f.costUsd || 0), 0);
+    totalFeatures += milestoneFeatures.length;
+    totalCostUsd += costUsd;
+    failureCount += milestoneFeatures.filter((f) => (f.failureCount || 0) > 0).length;
+
+    milestoneSummaries.push({
+      milestoneTitle: milestone.title,
+      featureCount: milestoneFeatures.length,
+      costUsd,
+    });
+  }
+
+  return { totalFeatures, totalCostUsd, failureCount, milestoneSummaries };
+}
 
 type CeremonyType = 'standup' | 'retro' | 'project-retro';
 
@@ -112,30 +155,8 @@ export function createCeremoniesRoutes(
 
         // Aggregate stats and re-emit project:completed
         const allFeatures = await featureLoader.getAll(projectPath);
-        let totalFeatures = 0;
-        let totalCostUsd = 0;
-        let failureCount = 0;
-        const milestoneSummaries: Array<{
-          milestoneTitle: string;
-          featureCount: number;
-          costUsd: number;
-        }> = [];
-
-        for (const milestone of project.milestones) {
-          const milestoneFeatures = allFeatures.filter((f) =>
-            milestone.phases.some((p) => p.featureId === f.id)
-          );
-          const costUsd = milestoneFeatures.reduce((sum, f) => sum + (f.costUsd || 0), 0);
-          totalFeatures += milestoneFeatures.length;
-          totalCostUsd += costUsd;
-          failureCount += milestoneFeatures.filter((f) => (f.failureCount || 0) > 0).length;
-
-          milestoneSummaries.push({
-            milestoneTitle: milestone.title,
-            featureCount: milestoneFeatures.length,
-            costUsd,
-          });
-        }
+        const { totalFeatures, totalCostUsd, failureCount, milestoneSummaries } =
+          aggregateCeremonyStats(project, allFeatures);
 
         events.emit('project:completed', {
           projectPath,
@@ -185,30 +206,8 @@ export function createCeremoniesRoutes(
 
         if (ceremonyType === 'project-retro') {
           // Aggregate project-wide stats and emit project:completed
-          let totalFeatures = 0;
-          let totalCostUsd = 0;
-          let failureCount = 0;
-          const milestoneSummaries: Array<{
-            milestoneTitle: string;
-            featureCount: number;
-            costUsd: number;
-          }> = [];
-
-          for (const milestone of project.milestones) {
-            const milestoneFeatures = allFeatures.filter((f) =>
-              milestone.phases.some((p) => p.featureId === f.id)
-            );
-            const costUsd = milestoneFeatures.reduce((sum, f) => sum + (f.costUsd || 0), 0);
-            totalFeatures += milestoneFeatures.length;
-            totalCostUsd += costUsd;
-            failureCount += milestoneFeatures.filter((f) => (f.failureCount || 0) > 0).length;
-
-            milestoneSummaries.push({
-              milestoneTitle: milestone.title,
-              featureCount: milestoneFeatures.length,
-              costUsd,
-            });
-          }
+          const { totalFeatures, totalCostUsd, failureCount, milestoneSummaries } =
+            aggregateCeremonyStats(project, allFeatures);
 
           events.emit('project:completed', {
             projectPath,

--- a/apps/server/src/services/antagonistic-review-adapter.ts
+++ b/apps/server/src/services/antagonistic-review-adapter.ts
@@ -9,6 +9,8 @@
 import { createLogger } from '@protolabsai/utils';
 import { createAntagonisticReviewGraph } from '@protolabsai/flows';
 import type { SPARCPrd } from '@protolabsai/types';
+import type { ReviewResult, ConsolidatedReview, ReviewRequest } from '@protolabsai/types';
+import { extractPRDFromText } from '@protolabsai/types';
 import { LangfuseClient, calculateCost } from '@protolabsai/observability';
 import { v4 as uuidv4 } from 'uuid';
 import { createFlowModel } from '../lib/flow-model-factory.js';
@@ -31,45 +33,6 @@ interface FlowReviewPerspective {
   }>;
   generalComments?: string[];
   comments?: string[];
-}
-
-/**
- * Review result from a single agent
- */
-export interface ReviewResult {
-  success: boolean;
-  reviewer: string;
-  verdict: string;
-  concerns?: string[];
-  recommendations?: string[];
-  durationMs: number;
-  error?: string;
-}
-
-/**
- * Consolidated review output
- */
-export interface ConsolidatedReview {
-  success: boolean;
-  avaReview: ReviewResult;
-  jonReview: ReviewResult;
-  resolution: string;
-  finalPRD?: SPARCPrd;
-  totalDurationMs: number;
-  totalCost?: number;
-  traceId?: string;
-  threadId?: string;
-  hitlPending?: boolean;
-  error?: string;
-}
-
-/**
- * Review request parameters
- */
-export interface ReviewRequest {
-  prd: SPARCPrd;
-  prdId: string;
-  projectPath: string;
 }
 
 /**
@@ -191,7 +154,7 @@ export class AntagonisticReviewAdapter {
           const jonReview = this.extractJonReview(result);
           const resolution =
             result.finalVerdict || result.consolidatedReview?.synthesizedReview || '';
-          const finalPRD = result.consolidatedPrd || this.extractFinalPRD(resolution, prd);
+          const finalPRD = result.consolidatedPrd || extractPRDFromText(resolution, prd);
 
           logger.info(
             `Review paused for HITL at node(s): ${snapshot.next.join(', ')} (thread: ${threadId})`
@@ -229,7 +192,7 @@ export class AntagonisticReviewAdapter {
       const avaReview = this.extractAvaReview(result);
       const jonReview = this.extractJonReview(result);
       const resolution = result.finalVerdict || result.consolidatedReview?.synthesizedReview || '';
-      const finalPRD = result.consolidatedPrd || this.extractFinalPRD(resolution, prd);
+      const finalPRD = result.consolidatedPrd || extractPRDFromText(resolution, prd);
 
       // Create spans for individual review nodes (retroactive tracking)
       if (result.avaReview) {
@@ -391,7 +354,7 @@ export class AntagonisticReviewAdapter {
       const avaReview = this.extractAvaReview(result);
       const jonReview = this.extractJonReview(result);
       const resolution = result.finalVerdict || result.consolidatedReview?.synthesizedReview || '';
-      const finalPRD = result.consolidatedPrd || this.extractFinalPRD(resolution, prd);
+      const finalPRD = result.consolidatedPrd || extractPRDFromText(resolution, prd);
 
       // Flush Langfuse events
       await this.langfuse?.flush();
@@ -516,37 +479,6 @@ export class AntagonisticReviewAdapter {
       recommendations,
       durationMs: 0,
     };
-  }
-
-  /**
-   * Extract final PRD from resolution text
-   */
-  private extractFinalPRD(resolution: string, originalPrd: SPARCPrd): SPARCPrd | undefined {
-    try {
-      // Try to parse SPARC sections from the resolution
-      const situationMatch = resolution.match(/### Situation\s+([\s\S]*?)(?=###|$)/);
-      const problemMatch = resolution.match(/### Problem\s+([\s\S]*?)(?=###|$)/);
-      const approachMatch = resolution.match(/### Approach\s+([\s\S]*?)(?=###|$)/);
-      const resultsMatch = resolution.match(/### Results\s+([\s\S]*?)(?=###|$)/);
-      const constraintsMatch = resolution.match(/### Constraints\s+([\s\S]*?)(?=###|$)/);
-
-      if (situationMatch || problemMatch || approachMatch || resultsMatch) {
-        return {
-          situation: situationMatch?.[1]?.trim() || originalPrd.situation,
-          problem: problemMatch?.[1]?.trim() || originalPrd.problem,
-          approach: approachMatch?.[1]?.trim() || originalPrd.approach,
-          results: resultsMatch?.[1]?.trim() || originalPrd.results,
-          constraints: constraintsMatch?.[1]?.trim() || originalPrd.constraints,
-          generatedAt: new Date().toISOString(),
-        };
-      }
-
-      // If no SPARC sections found, return original PRD
-      return originalPrd;
-    } catch (error) {
-      logger.error('Failed to extract PRD from resolution:', error);
-      return originalPrd;
-    }
   }
 }
 

--- a/apps/server/src/services/antagonistic-review-service.ts
+++ b/apps/server/src/services/antagonistic-review-service.ts
@@ -14,6 +14,8 @@ import type { EventEmitter } from '../lib/events.js';
 import type { AgentFactoryService } from './agent-factory-service.js';
 import { DynamicAgentExecutor } from './dynamic-agent-executor.js';
 import type { SPARCPrd } from '@protolabsai/types';
+import type { ReviewResult, ConsolidatedReview, ReviewRequest } from '@protolabsai/types';
+import { extractPRDFromText } from '@protolabsai/types';
 import { AntagonisticReviewAdapter } from './antagonistic-review-adapter.js';
 import { getLangfuseInstance } from '../lib/langfuse-singleton.js';
 import type { SettingsService } from './settings-service.js';
@@ -23,45 +25,6 @@ import { simpleQuery } from '../providers/simple-query-service.js';
 const logger = createLogger('AntagonisticReview');
 
 const REVIEW_TIMEOUT_MS = 180_000; // 3 minutes
-
-/**
- * Review result from a single agent
- */
-export interface ReviewResult {
-  success: boolean;
-  reviewer: string;
-  verdict: string;
-  concerns?: string[];
-  recommendations?: string[];
-  durationMs: number;
-  error?: string;
-}
-
-/**
- * Consolidated review output
- */
-export interface ConsolidatedReview {
-  success: boolean;
-  avaReview: ReviewResult;
-  jonReview: ReviewResult;
-  resolution: string;
-  finalPRD?: SPARCPrd;
-  totalDurationMs: number;
-  totalCost?: number;
-  traceId?: string;
-  threadId?: string;
-  hitlPending?: boolean;
-  error?: string;
-}
-
-/**
- * Review request parameters
- */
-export interface ReviewRequest {
-  prd: SPARCPrd;
-  prdId: string;
-  projectPath: string;
-}
 
 export class AntagonisticReviewService {
   private static instance: AntagonisticReviewService;
@@ -237,7 +200,7 @@ export class AntagonisticReviewService {
           avaReview,
           jonReview,
           resolution: resolution.output,
-          finalPRD: this.extractPRDFromResolution(resolution.output),
+          finalPRD: extractPRDFromText(resolution.output, prd),
           totalDurationMs,
         };
       } finally {
@@ -753,37 +716,6 @@ Minor suggestions don't warrant rejection — only reject for issues that would 
     } catch (err) {
       logger.warn('[verifyPlan] Review failed, approving by default', err);
       return null;
-    }
-  }
-
-  /**
-   * Extract PRD from resolution output
-   */
-  private extractPRDFromResolution(resolution: string): SPARCPrd | undefined {
-    try {
-      // Parse SPARC sections from the resolution
-      const situationMatch = resolution.match(/### Situation\s+([\s\S]*?)(?=###|$)/);
-      const problemMatch = resolution.match(/### Problem\s+([\s\S]*?)(?=###|$)/);
-      const approachMatch = resolution.match(/### Approach\s+([\s\S]*?)(?=###|$)/);
-      const resultsMatch = resolution.match(/### Results\s+([\s\S]*?)(?=###|$)/);
-      const constraintsMatch = resolution.match(/### Constraints\s+([\s\S]*?)(?=###|$)/);
-
-      if (!situationMatch || !problemMatch || !approachMatch || !resultsMatch) {
-        logger.warn('Could not extract complete PRD from resolution');
-        return undefined;
-      }
-
-      return {
-        situation: situationMatch[1].trim(),
-        problem: problemMatch[1].trim(),
-        approach: approachMatch[1].trim(),
-        results: resultsMatch[1].trim(),
-        constraints: constraintsMatch ? constraintsMatch[1].trim() : '',
-        generatedAt: new Date().toISOString(),
-      };
-    } catch (error) {
-      logger.error('Failed to extract PRD from resolution:', error);
-      return undefined;
     }
   }
 }

--- a/apps/server/src/services/lead-engineer-processors.ts
+++ b/apps/server/src/services/lead-engineer-processors.ts
@@ -7,7 +7,7 @@
 
 import { createLogger } from '@protolabsai/utils';
 import { resolveModelString, DEFAULT_MODELS } from '@protolabsai/model-resolver';
-import { areDependenciesSatisfied } from '@protolabsai/dependency-resolver';
+import { getBlockingDependencies } from '@protolabsai/dependency-resolver';
 import type { AgentRole, Feature } from '@protolabsai/types';
 import { getWorkflowSettings, getPhaseModelWithOverrides } from '../lib/settings-helpers.js';
 import { simpleQuery } from '../providers/simple-query-service.js';
@@ -41,17 +41,9 @@ export class IntakeProcessor implements StateProcessor {
     // Validate dependencies using the shared resolver (same logic as loadPendingFeatures)
     if (feature.dependencies && feature.dependencies.length > 0) {
       const allFeatures = await this.serviceContext.featureLoader.getAll(ctx.projectPath);
+      const unmetDeps = getBlockingDependencies(feature, allFeatures);
 
-      if (!areDependenciesSatisfied(feature, allFeatures)) {
-        const unmetDeps = feature.dependencies.filter((depId) => {
-          const dep = allFeatures.find((f) => f.id === depId);
-          if (!dep) return true;
-          if (dep.isFoundation) {
-            return dep.status !== 'done' && dep.status !== 'completed' && dep.status !== 'verified';
-          }
-          return !dep.status || !['completed', 'verified', 'done', 'review'].includes(dep.status);
-        });
-
+      if (unmetDeps.length > 0) {
         ctx.escalationReason = `Unmet dependencies: ${unmetDeps.join(', ')}`;
         logger.warn(`[INTAKE] Feature has ${unmetDeps.length} unmet dependencies`, {
           featureId: feature.id,

--- a/libs/types/src/antagonistic-review.ts
+++ b/libs/types/src/antagonistic-review.ts
@@ -1,0 +1,79 @@
+/**
+ * Antagonistic Review shared types
+ *
+ * Shared interfaces used by AntagonisticReviewService and AntagonisticReviewAdapter.
+ */
+
+import type { SPARCPrd } from './project.js';
+
+/**
+ * Review result from a single agent
+ */
+export interface ReviewResult {
+  success: boolean;
+  reviewer: string;
+  verdict: string;
+  concerns?: string[];
+  recommendations?: string[];
+  durationMs: number;
+  error?: string;
+}
+
+/**
+ * Consolidated review output
+ */
+export interface ConsolidatedReview {
+  success: boolean;
+  avaReview: ReviewResult;
+  jonReview: ReviewResult;
+  resolution: string;
+  finalPRD?: SPARCPrd;
+  totalDurationMs: number;
+  totalCost?: number;
+  traceId?: string;
+  threadId?: string;
+  hitlPending?: boolean;
+  error?: string;
+}
+
+/**
+ * Review request parameters
+ */
+export interface ReviewRequest {
+  prd: SPARCPrd;
+  prdId: string;
+  projectPath: string;
+}
+
+/**
+ * Extract a SPARCPrd from a resolution text string.
+ * Parses ### Situation / Problem / Approach / Results / Constraints sections.
+ * Returns the original PRD if sections cannot be found.
+ */
+export function extractPRDFromText(
+  resolution: string,
+  originalPrd: SPARCPrd
+): SPARCPrd | undefined {
+  try {
+    const situationMatch = resolution.match(/### Situation\s+([\s\S]*?)(?=###|$)/);
+    const problemMatch = resolution.match(/### Problem\s+([\s\S]*?)(?=###|$)/);
+    const approachMatch = resolution.match(/### Approach\s+([\s\S]*?)(?=###|$)/);
+    const resultsMatch = resolution.match(/### Results\s+([\s\S]*?)(?=###|$)/);
+    const constraintsMatch = resolution.match(/### Constraints\s+([\s\S]*?)(?=###|$)/);
+
+    if (situationMatch || problemMatch || approachMatch || resultsMatch) {
+      return {
+        situation: situationMatch?.[1]?.trim() || originalPrd.situation,
+        problem: problemMatch?.[1]?.trim() || originalPrd.problem,
+        approach: approachMatch?.[1]?.trim() || originalPrd.approach,
+        results: resultsMatch?.[1]?.trim() || originalPrd.results,
+        constraints: constraintsMatch?.[1]?.trim() || originalPrd.constraints,
+        generatedAt: new Date().toISOString(),
+      };
+    }
+
+    return originalPrd;
+  } catch {
+    return originalPrd;
+  }
+}

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -766,6 +766,10 @@ export type {
 } from './review.js';
 export { DistillationDepth } from './review.js';
 
+// Antagonistic Review service types (ReviewResult, ConsolidatedReview, ReviewRequest)
+export type { ReviewResult, ConsolidatedReview, ReviewRequest } from './antagonistic-review.js';
+export { extractPRDFromText } from './antagonistic-review.js';
+
 // Content generation types
 export { SectionSchema, OutlineSchema } from './content.js';
 export type { ContentType, ContentConfig, Section, Outline, ResearchSummary } from './content.js';


### PR DESCRIPTION
## Summary

**Milestone:** Utility Consolidation

Move ReviewResult, ConsolidatedReview, ReviewRequest to libs/types/. Consolidate duplicate PRD extraction logic into single function. Extract ceremony stat aggregation helper. Replace IntakeProcessor inline dep check with getBlockingDependencies().

**Files to Modify:**
- libs/types/src/antagonistic-review.ts
- libs/types/src/index.ts
- apps/server/src/services/antagonistic-review-service.ts
- apps/server/src/services/antagonistic-review-adapter.ts
- apps/se...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal statistics aggregation logic to reduce duplication across ceremony processing routes.
  * Reorganized review-related types into a shared library for better code organization across services.
  * Streamlined PRD extraction and dependency validation logic with improved error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->