### PR TITLE
Consolidate formatDuration, formatTimestamp, and formatElapsed

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -79,6 +79,7 @@
     "@protolabsai/dependency-resolver": "^0.41.0",
     "@protolabsai/spec-parser": "^0.41.0",
     "@protolabsai/types": "^0.41.0",
+    "@protolabsai/utils": "^0.41.0",
     "@radix-ui/react-checkbox": "1.3.3",
     "@radix-ui/react-collapsible": "1.1.12",
     "@radix-ui/react-dialog": "1.1.15",

--- a/apps/ui/src/components/views/analytics-view/velocity-panel.tsx
+++ b/apps/ui/src/components/views/analytics-view/velocity-panel.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@protolabsai/ui/atoms';
 import { Clock } from 'lucide-react';
+import { formatDuration } from '@protolabsai/utils';
 
 interface VelocityPanelProps {
   avgCycleTimeMs: number;
@@ -7,16 +8,6 @@ interface VelocityPanelProps {
   avgPrReviewTimeMs: number;
   estimatedBacklogTimeMs: number;
   isLoading: boolean;
-}
-
-function formatDuration(ms: number): string {
-  if (ms === 0) return '0m';
-  const minutes = Math.round(ms / 60_000);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
-  if (remainingMinutes === 0) return `${hours}h`;
-  return `${hours}h ${remainingMinutes}m`;
 }
 
 function MetricRow({ label, value }: { label: string; value: string }) {

--- a/apps/ui/src/components/views/dashboard-view/event-feed.tsx
+++ b/apps/ui/src/components/views/dashboard-view/event-feed.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@prot
 import * as LucideIcons from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatTimestamp } from '@protolabsai/utils';
 
 interface EventFeedProps {
   projectPath: string | null;
@@ -22,25 +23,6 @@ function getIconComponent(iconName: string): LucideIcon {
     return (LucideIcons as unknown as Record<string, LucideIcon>)[iconName];
   }
   return LucideIcons.Circle;
-}
-
-/**
- * Format a timestamp for display
- */
-function formatTimestamp(timestamp: string): string {
-  const date = new Date(timestamp);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMs / 3600000);
-  const diffDays = Math.floor(diffMs / 86400000);
-
-  if (diffMins < 1) return 'Just now';
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays < 7) return `${diffDays}d ago`;
-
-  return date.toLocaleDateString();
 }
 
 /**

--- a/apps/ui/src/components/views/dashboard-view/metrics/blocked-timeline.tsx
+++ b/apps/ui/src/components/views/dashboard-view/metrics/blocked-timeline.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@protolabsai/ui/atoms'
 import { useChartColors } from '@/hooks/use-chart-colors';
 import { useBlockedTimeline } from '@/hooks/queries/use-metrics';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
+import { formatDuration } from '@protolabsai/utils';
 
 interface BlockedTimelineProps {
   projectPath: string;
@@ -25,15 +26,6 @@ const CATEGORY_LABELS: Record<string, string> = {
   unclear: 'Unclear',
   other: 'Other',
 };
-
-/** Format milliseconds into a human-readable duration string. */
-function formatDuration(ms: number): string {
-  const hours = Math.floor(ms / (1000 * 60 * 60));
-  if (hours < 24) return `${hours}h`;
-  const days = Math.floor(hours / 24);
-  const remainingHours = hours % 24;
-  return remainingHours > 0 ? `${days}d ${remainingHours}h` : `${days}d`;
-}
 
 interface ChartDatum {
   featureTitle: string;

--- a/apps/ui/src/components/views/dashboard-view/metrics/integrations-tab.tsx
+++ b/apps/ui/src/components/views/dashboard-view/metrics/integrations-tab.tsx
@@ -21,6 +21,7 @@ import {
   Activity,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatDuration, formatTimestamp } from '@protolabsai/utils';
 
 interface IntegrationsTabProps {
   projectPath: string | undefined;
@@ -224,38 +225,6 @@ function AgentSessionCard() {
       </CardContent>
     </Card>
   );
-}
-
-/**
- * Format a timestamp for display
- */
-function formatTimestamp(timestamp: string | Date): string {
-  const date = new Date(timestamp);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-
-  if (diffMins < 1) return 'Just now';
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffMins < 1440) return `${Math.floor(diffMins / 60)}h ago`;
-  return `${Math.floor(diffMins / 1440)}d ago`;
-}
-
-/**
- * Format duration in milliseconds to human-readable string
- */
-function formatDuration(ms: number): string {
-  const seconds = Math.floor(ms / 1000);
-  const minutes = Math.floor(seconds / 60);
-  const hours = Math.floor(minutes / 60);
-
-  if (hours > 0) {
-    return `${hours}h ${minutes % 60}m`;
-  }
-  if (minutes > 0) {
-    return `${minutes}m ${seconds % 60}s`;
-  }
-  return `${seconds}s`;
 }
 
 /**

--- a/apps/ui/src/components/views/dashboard-view/metrics/kpi-cards.tsx
+++ b/apps/ui/src/components/views/dashboard-view/metrics/kpi-cards.tsx
@@ -4,6 +4,7 @@
 
 import { Card, CardContent } from '@protolabsai/ui/atoms';
 import { DollarSign, Hash, Zap, Clock, GitPullRequest, GitCommit } from 'lucide-react';
+import { formatDuration } from '@protolabsai/utils';
 
 interface KpiCardsProps {
   data?: {
@@ -16,17 +17,6 @@ interface KpiCardsProps {
     commitsPerDay: number;
   };
   isLoading: boolean;
-}
-
-function formatDuration(ms: number): string {
-  if (ms === 0) return '0m';
-  const minutes = Math.floor(ms / 60000);
-  const hours = Math.floor(minutes / 60);
-  if (hours > 0) {
-    const rem = minutes % 60;
-    return rem > 0 ? `${hours}h ${rem}m` : `${hours}h`;
-  }
-  return `${minutes}m`;
 }
 
 function formatCost(usd: number): string {

--- a/apps/ui/src/components/views/flow-graph/dialogs/node-detail-sections.tsx
+++ b/apps/ui/src/components/views/flow-graph/dialogs/node-detail-sections.tsx
@@ -24,6 +24,7 @@ import { Badge } from '@protolabsai/ui/atoms';
 import { Button } from '@protolabsai/ui/atoms';
 import { scrubPii } from '@/lib/scrub-pii';
 import { formatCostUsd } from '@/lib/format';
+import { formatDuration } from '@protolabsai/utils';
 import { getLangfuseTraceUrl, getLangfuseSpanUrl } from '@/lib/langfuse-url';
 import { getHttpApiClient } from '@/lib/http-api-client';
 import { queryKeys } from '@/lib/query-keys';
@@ -67,12 +68,6 @@ function TraceLink({ traceId }: { traceId: string }) {
       View Trace
     </a>
   );
-}
-
-function formatDuration(ms: number): string {
-  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
-  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`;
-  return `${(ms / 3_600_000).toFixed(1)}h`;
 }
 
 function formatTimeAgo(dateStr: string): string {

--- a/apps/ui/src/components/views/flow-graph/dialogs/pipeline-monitor.tsx
+++ b/apps/ui/src/components/views/flow-graph/dialogs/pipeline-monitor.tsx
@@ -14,6 +14,7 @@ import { CheckCircle, XCircle, Clock, Shield, AlertTriangle } from 'lucide-react
 import { getHttpApiClient } from '@/lib/http-api-client';
 import { queryKeys } from '@/lib/query-keys';
 import { useAppStore } from '@/store/app-store';
+import { formatTimestamp } from '@protolabsai/utils';
 
 const PIPELINE_STATES = ['INTAKE', 'PLAN', 'EXECUTE', 'REVIEW', 'MERGE', 'DEPLOY', 'DONE'] as const;
 
@@ -23,15 +24,6 @@ const STATE_COLORS: Record<string, string> = {
   upcoming: 'bg-muted-foreground/20',
   escalated: 'bg-red-500',
 };
-
-function formatTimestamp(ts: string): string {
-  const date = new Date(ts);
-  const now = Date.now();
-  const age = now - date.getTime();
-  if (age < 60_000) return 'just now';
-  if (age < 3_600_000) return `${Math.round(age / 60_000)}m ago`;
-  return `${(age / 3_600_000).toFixed(1)}h ago`;
-}
 
 interface PipelineCheckpoint {
   featureId: string;

--- a/apps/ui/src/components/views/flow-graph/dialogs/timeline-visualization.tsx
+++ b/apps/ui/src/components/views/flow-graph/dialogs/timeline-visualization.tsx
@@ -11,6 +11,7 @@
 import { ExternalLink, Clock, AlertCircle } from 'lucide-react';
 import type { PipelinePhase, PhaseTransition } from '@protolabsai/types';
 import { getLangfuseSpanUrl } from '@/lib/langfuse-url';
+import { formatDuration, formatTimestamp } from '@protolabsai/utils';
 
 interface ToolExecution {
   name: string;
@@ -53,27 +54,6 @@ const PHASE_COLORS: Record<PipelinePhase, string> = {
   VERIFY: 'bg-orange-500/30',
   PUBLISH: 'bg-green-500/30',
 };
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  const seconds = Math.floor(ms / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = seconds % 60;
-  if (minutes < 60) return `${minutes}m ${remainingSeconds}s`;
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
-  return `${hours}h ${remainingMinutes}m`;
-}
-
-function formatTimestamp(isoString: string): string {
-  const date = new Date(isoString);
-  return date.toLocaleTimeString('en-US', {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  });
-}
 
 export function TimelineVisualization({
   phaseDurations = {},

--- a/apps/ui/src/components/views/flow-graph/nodes/agent-node.tsx
+++ b/apps/ui/src/components/views/flow-graph/nodes/agent-node.tsx
@@ -10,6 +10,7 @@ import { motion } from 'motion/react';
 import { Bot } from 'lucide-react';
 import type { AgentNodeData, ActiveTool } from '../types';
 import { cn } from '@/lib/utils';
+import { formatDuration } from '@protolabsai/utils';
 
 function getModelBadge(model?: string): { label: string; color: string } {
   if (!model) return { label: 'Agent', color: 'zinc' };
@@ -19,19 +20,9 @@ function getModelBadge(model?: string): { label: string; color: string } {
   return { label: 'Agent', color: 'zinc' };
 }
 
-function formatDuration(startTime: number): string {
-  const seconds = Math.floor((Date.now() - startTime) / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const mins = Math.floor(seconds / 60);
-  const secs = seconds % 60;
-  if (mins < 60) return `${mins}m ${secs}s`;
-  const hours = Math.floor(mins / 60);
-  return `${hours}h ${mins % 60}m`;
-}
-
 function AgentNodeComponent({ data }: NodeProps & { data: AgentNodeData }) {
   const badge = getModelBadge(data.model);
-  const [duration, setDuration] = useState(formatDuration(data.startTime));
+  const [duration, setDuration] = useState(formatDuration(Date.now() - data.startTime));
   const [shouldFadeToolBadge, setShouldFadeToolBadge] = useState(false);
   const [lastActiveTool, setLastActiveTool] = useState<ActiveTool | null | undefined>(
     data.activeTool
@@ -39,7 +30,7 @@ function AgentNodeComponent({ data }: NodeProps & { data: AgentNodeData }) {
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setDuration(formatDuration(data.startTime));
+      setDuration(formatDuration(Date.now() - data.startTime));
     }, 1000);
     return () => clearInterval(interval);
   }, [data.startTime]);

--- a/apps/ui/src/components/views/flow-graph/pipeline-analytics.tsx
+++ b/apps/ui/src/components/views/flow-graph/pipeline-analytics.tsx
@@ -20,6 +20,7 @@ import {
 import { getHttpApiClient } from '@/lib/http-api-client';
 import { useAppStore } from '@/store/app-store';
 import { cn } from '@/lib/utils';
+import { formatDuration } from '@protolabsai/utils';
 
 interface PipelineAnalyticsData {
   activePipelines: number;
@@ -32,14 +33,6 @@ interface PipelineAnalyticsData {
     successRate: number;
     gateHoldCount: number;
   }>;
-}
-
-function formatDuration(minutes: number): string {
-  if (minutes < 1) return '<1m';
-  if (minutes < 60) return `${Math.round(minutes)}m`;
-  const hours = Math.floor(minutes / 60);
-  const mins = Math.round(minutes % 60);
-  return `${hours}h ${mins}m`;
 }
 
 function StatCard({
@@ -130,7 +123,7 @@ function PipelineAnalyticsComponent() {
                 <StatCard
                   icon={Clock}
                   label="Avg Duration"
-                  value={formatDuration(analytics.avgDurationMinutes)}
+                  value={formatDuration(analytics.avgDurationMinutes * 60_000)}
                 />
                 <StatCard
                   icon={Hand}

--- a/apps/ui/src/components/views/settings-view/automations/automation-history-panel.tsx
+++ b/apps/ui/src/components/views/settings-view/automations/automation-history-panel.tsx
@@ -5,33 +5,11 @@ import { CheckCircle2, XCircle, Loader2, ExternalLink } from 'lucide-react';
 import type { AutomationRunRecord, AutomationRunStatus } from '@protolabsai/types';
 import { getAutomationHistory } from '@/lib/api';
 import { getLangfuseTraceUrl } from '@/lib/langfuse-url';
+import { formatDuration, formatTimestamp } from '@protolabsai/utils';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatTimestamp(isoString: string): string {
-  const d = new Date(isoString);
-  return d.toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  });
-}
-
-function formatDuration(startedAt: string, completedAt?: string): string {
-  if (!completedAt) return '—';
-  const ms = new Date(completedAt).getTime() - new Date(startedAt).getTime();
-  if (ms < 0) return '—';
-  if (ms < 1000) return `${ms}ms`;
-  const sec = Math.floor(ms / 1000);
-  if (sec < 60) return `${sec}s`;
-  const min = Math.floor(sec / 60);
-  const remSec = sec % 60;
-  return remSec > 0 ? `${min}m ${remSec}s` : `${min}m`;
-}
 
 function RunStatusBadge({ status }: { status: AutomationRunStatus }) {
   const configs: Record<
@@ -144,7 +122,11 @@ export function AutomationHistoryPanel({ automationId, colSpan }: AutomationHist
                       {formatTimestamp(run.startedAt)}
                     </td>
                     <td className="px-3 py-2 text-muted-foreground tabular-nums whitespace-nowrap">
-                      {formatDuration(run.startedAt, run.completedAt)}
+                      {run.completedAt
+                        ? formatDuration(
+                            new Date(run.completedAt).getTime() - new Date(run.startedAt).getTime()
+                          )
+                        : '—'}
                     </td>
                     <td className="px-3 py-2">
                       <RunStatusBadge status={run.status} />

--- a/apps/ui/src/lib/dashboard-transforms.ts
+++ b/apps/ui/src/lib/dashboard-transforms.ts
@@ -1,4 +1,5 @@
 import type { LucideIcon } from 'lucide-react';
+import { formatDuration, formatTimestamp } from '@protolabsai/utils';
 
 // ============================================================================
 // Type Definitions
@@ -275,30 +276,6 @@ export function eventsToActivity(events: EventEntry[] | null | undefined): Activ
 // ============================================================================
 
 /**
- * Formats a timestamp into a short display string
- */
-function formatTimestamp(timestamp: string | number): string {
-  if (!timestamp) return 'N/A';
-
-  try {
-    const date = new Date(timestamp);
-    if (isNaN(date.getTime())) return 'Invalid';
-
-    // Format as HH:MM or MM/DD depending on context
-    const now = new Date();
-    const isToday = date.toDateString() === now.toDateString();
-
-    if (isToday) {
-      return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
-    } else {
-      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-    }
-  } catch {
-    return 'Invalid';
-  }
-}
-
-/**
  * Formats model names for display
  */
 function formatModelName(name: string): string {
@@ -342,15 +319,7 @@ export function formatPercentage(value: number): string {
   return `${Math.round(value)}%`;
 }
 
-/**
- * Formats durations in milliseconds
- */
-export function formatDuration(ms: number): string {
-  if (ms < 1000) return `${Math.round(ms)}ms`;
-  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
-  if (ms < 3600000) return `${Math.floor(ms / 60000)}m ${Math.floor((ms % 60000) / 1000)}s`;
-  return `${Math.floor(ms / 3600000)}h ${Math.floor((ms % 3600000) / 60000)}m`;
-}
+export { formatDuration } from '@protolabsai/utils';
 
 /**
  * Formats relative time from timestamp

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -71,6 +71,7 @@
   },
   "dependencies": {
     "@protolabsai/types": "*",
+    "@protolabsai/utils": "*",
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-collapsible": "1.1.12",
     "@radix-ui/react-dialog": "^1.1.4",

--- a/libs/ui/src/ai/chain-of-thought.tsx
+++ b/libs/ui/src/ai/chain-of-thought.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { Brain, ChevronDown, Loader2, Check } from 'lucide-react';
+import { formatDuration } from '@protolabsai/utils';
 import { cn } from '../lib/utils.js';
 
 export interface ChainOfThoughtProps {
@@ -51,12 +52,6 @@ function parseSteps(text: string): string[] {
     .split(/\n/)
     .map((s) => s.replace(/^\d+\.\s+/, '').trim())
     .filter(Boolean);
-}
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${Math.round(ms)}ms`;
-  const seconds = Math.round(ms / 1000);
-  return `${seconds}s`;
 }
 
 export function ChainOfThought({ text, state, className }: ChainOfThoughtProps) {

--- a/libs/ui/src/ai/tool-results/agent-status-card.tsx
+++ b/libs/ui/src/ai/tool-results/agent-status-card.tsx
@@ -8,6 +8,7 @@
  */
 
 import { Loader2, Bot, CheckCircle2, XCircle, Clock } from 'lucide-react';
+import { formatElapsed } from '@protolabsai/utils';
 import { cn } from '../../lib/utils.js';
 import type { ToolResultRendererProps } from '../tool-result-registry.js';
 
@@ -42,16 +43,6 @@ function extractData(output: unknown): AgentStatusData | null {
   }
   if ('agent' in o || 'agents' in o || 'featureId' in o) return o as AgentStatusData;
   return o as AgentStatusData;
-}
-
-/** Format elapsed milliseconds into a human-readable string */
-function formatElapsed(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  const rem = s % 60;
-  return rem > 0 ? `${m}m ${rem}s` : `${m}m`;
 }
 
 type AgentDisplayStatus = 'running' | 'stopped' | 'done' | 'error' | 'unknown';

--- a/libs/ui/src/ai/tool-results/dynamic-agent-card.tsx
+++ b/libs/ui/src/ai/tool-results/dynamic-agent-card.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Loader2, Bot, CheckCircle2, XCircle, Clock } from 'lucide-react';
+import { formatDuration } from '@protolabsai/utils';
 import { cn } from '../../lib/utils.js';
 import type { ToolResultRendererProps } from '../tool-result-registry.js';
 
@@ -24,15 +25,6 @@ function extractData(output: unknown): DynamicAgentData | null {
     return o.data as DynamicAgentData;
   }
   return o as DynamicAgentData;
-}
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  const rem = s % 60;
-  return rem > 0 ? `${m}m ${rem}s` : `${m}m`;
 }
 
 export function DynamicAgentCard({ output, state }: ToolResultRendererProps) {

--- a/libs/ui/src/ai/tool-results/running-agents-card.tsx
+++ b/libs/ui/src/ai/tool-results/running-agents-card.tsx
@@ -12,6 +12,7 @@
  */
 
 import { Loader2, Bot, Clock, Hash } from 'lucide-react';
+import { formatElapsed } from '@protolabsai/utils';
 import { cn } from '../../lib/utils.js';
 import type { ToolResultRendererProps } from '../tool-result-registry.js';
 
@@ -41,16 +42,6 @@ function extractData(output: unknown): ListRunningAgentsData | null {
   }
   if ('agents' in o) return o as ListRunningAgentsData;
   return null;
-}
-
-/** Format elapsed milliseconds into a human-readable string */
-function formatElapsed(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  const rem = s % 60;
-  return rem > 0 ? `${m}m ${rem}s` : `${m}m`;
 }
 
 function resolveIsIdle(status: string | undefined, state: string | undefined): boolean {

--- a/libs/utils/src/format-time.ts
+++ b/libs/utils/src/format-time.ts
@@ -1,0 +1,71 @@
+/**
+ * format-time.ts — Shared time formatting utilities
+ *
+ * Canonical implementations for duration, timestamp, and elapsed time
+ * formatting used across UI and libs.
+ */
+
+/**
+ * Formats a duration given in milliseconds into a human-readable string.
+ *
+ * Examples:
+ *   500     → "500ms"
+ *   1500    → "1s"
+ *   90000   → "1m 30s"
+ *   3700000 → "1h 1m"
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes < 60) return `${minutes}m ${remainingSeconds}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+/**
+ * Formats a Date (or ISO string / timestamp number) into a short display string.
+ *
+ * - If the date is today, returns a time string like "02:30 PM".
+ * - Otherwise, returns a short date like "Jan 5".
+ */
+export function formatTimestamp(date: Date | string | number): string {
+  if (!date) return 'N/A';
+
+  try {
+    const d = new Date(date as string | number);
+    if (isNaN(d.getTime())) return 'Invalid';
+
+    const now = new Date();
+    const isToday = d.toDateString() === now.toDateString();
+
+    if (isToday) {
+      return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+    } else {
+      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    }
+  } catch {
+    return 'Invalid';
+  }
+}
+
+/**
+ * Formats an elapsed duration given in milliseconds into a compact string.
+ *
+ * Examples:
+ *   500   → "500ms"
+ *   5000  → "5s"
+ *   90000 → "1m 30s"
+ *   3700000 → "1h 1m"
+ */
+export function formatElapsed(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return rem > 0 ? `${m}m ${rem}s` : `${m}m`;
+}

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -197,3 +197,6 @@ export {
   type SanitizationResult,
   type SanitizationSeverity,
 } from './sanitize.js';
+
+// Time formatting utilities
+export { formatDuration, formatTimestamp, formatElapsed } from './format-time.js';


### PR DESCRIPTION
## Summary

**Milestone:** Utility Consolidation

Create libs/utils/src/format-time.ts with formatDuration(ms), formatTimestamp(date), formatElapsed(ms). Replace all 12 formatDuration copies, 7 formatTimestamp copies, 3 formatElapsed copies across UI and libs with imports from @protolabsai/utils.

**Files to Modify:**
- libs/utils/src/format-time.ts
- libs/utils/src/index.ts
- apps/ui/src/lib/dashboard-transforms.ts
- libs/ui/src/ai/tool-results/dynamic-agent-card.tsx
- libs/ui/src/ai/chain-of-thought.tsx
-...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated time and duration formatting utilities into a centralized shared module. All time/duration displays across the application now leverage consistent formatting logic, improving maintainability and code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->