### PR TITLE
Remove @ts-nocheck from board view files

### DIFF
--- a/apps/ui/src/components/views/board-view.tsx
+++ b/apps/ui/src/components/views/board-view.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- DnD kit type conflicts with Feature index signature
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { createLogger } from '@protolabsai/utils/logger';
 import {
@@ -10,7 +9,6 @@ import {
   useSensors,
   rectIntersection,
   pointerWithin,
-  type PointerEvent as DndPointerEvent,
   type CollisionDetection,
   type Collision,
 } from '@dnd-kit/core';
@@ -20,7 +18,7 @@ class DialogAwarePointerSensor extends PointerSensor {
   static activators = [
     {
       eventName: 'onPointerDown' as const,
-      handler: ({ nativeEvent: event }: { nativeEvent: DndPointerEvent }) => {
+      handler: ({ nativeEvent: event }: { nativeEvent: PointerEvent }) => {
         // Don't start drag if the event originated from inside a dialog
         if ((event.target as Element)?.closest?.('[role="dialog"]')) {
           return false;
@@ -320,7 +318,8 @@ export function BoardView() {
 
     const unsubscribers = [
       // PRD generated - show notification with action to review
-      api['subscribeToEvent']('ideation:prd-generated', (payload: unknown) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ideation events not in EventType union yet
+      (api as any).subscribeToEvent('ideation:prd-generated', (payload: unknown) => {
         const p = payload as Record<string, unknown>;
         if (p.projectPath !== currentProject.path) return;
 
@@ -344,7 +343,8 @@ export function BoardView() {
       }),
 
       // PRD approved - show success notification
-      api['subscribeToEvent']('ideation:prd-approved', (payload: unknown) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ideation events not in EventType union yet
+      (api as any).subscribeToEvent('ideation:prd-approved', (payload: unknown) => {
         const p = payload as Record<string, unknown>;
         if (p.projectPath !== currentProject.path) return;
         toast.success('PRD approved - breaking down into epics...');
@@ -352,7 +352,8 @@ export function BoardView() {
       }),
 
       // PRD rejected - show info notification
-      api['subscribeToEvent']('ideation:prd-rejected', (payload: unknown) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ideation events not in EventType union yet
+      (api as any).subscribeToEvent('ideation:prd-rejected', (payload: unknown) => {
         const p = payload as Record<string, unknown>;
         if (p.projectPath !== currentProject.path) return;
         toast.info('PRD rejected');
@@ -523,7 +524,10 @@ export function BoardView() {
 
   // Auto mode hook - pass current worktree to get worktree-specific state
   // Must be after selectedWorktree is defined
-  const autoMode = useAutoMode(selectedWorktree ?? undefined);
+  const autoModeWorktree = selectedWorktree
+    ? { ...selectedWorktree, isCurrent: false, hasWorktree: true }
+    : undefined;
+  const autoMode = useAutoMode(autoModeWorktree);
   // Get runningTasks from the hook (scoped to current project/worktree)
   const runningAutoTasks = autoMode.runningTasks;
   // Get worktree-specific maxConcurrency from the hook
@@ -933,7 +937,7 @@ export function BoardView() {
 
   // Handler called when user confirms the pull & resolve conflicts dialog
   const handleConfirmResolveConflicts = useCallback(
-    async (worktree: WorktreeInfo, remoteBranch: string) => {
+    async (worktree: { branch: string; path: string; isMain: boolean }, remoteBranch: string) => {
       const description = `Pull latest from ${remoteBranch} and resolve conflicts. Merge ${remoteBranch} into the current branch (${worktree.branch}), resolving any merge conflicts that arise. After resolving conflicts, ensure the code compiles and tests pass.`;
 
       // Create the feature
@@ -1047,28 +1051,27 @@ export function BoardView() {
     const api = getElectronAPI();
     if (!api?.backlogPlan) return;
 
-    const unsubscribe = api.backlogPlan.onEvent(
-      (event: { type: string; result?: BacklogPlanResult; error?: string }) => {
-        if (event.type === 'backlog_plan_complete') {
-          setIsGeneratingPlan(false);
-          if (event.result && event.result.changes?.length > 0) {
-            setPendingBacklogPlan(event.result);
-            toast.success('Plan ready! Click to review.', {
-              duration: 10000,
-              action: {
-                label: 'Review',
-                onClick: () => setShowPlanDialog(true),
-              },
-            });
-          } else {
-            toast.info('No changes generated. Try again with a different prompt.');
-          }
-        } else if (event.type === 'backlog_plan_error') {
-          setIsGeneratingPlan(false);
-          toast.error(`Plan generation failed: ${event.error}`);
+    const unsubscribe = api.backlogPlan.onEvent((data: unknown) => {
+      const event = data as { type: string; result?: BacklogPlanResult; error?: string };
+      if (event.type === 'backlog_plan_complete') {
+        setIsGeneratingPlan(false);
+        if (event.result && event.result.changes?.length > 0) {
+          setPendingBacklogPlan(event.result);
+          toast.success('Plan ready! Click to review.', {
+            duration: 10000,
+            action: {
+              label: 'Review',
+              onClick: () => setShowPlanDialog(true),
+            },
+          });
+        } else {
+          toast.info('No changes generated. Try again with a different prompt.');
         }
+      } else if (event.type === 'backlog_plan_error') {
+        setIsGeneratingPlan(false);
+        toast.error(`Plan generation failed: ${event.error}`);
       }
-    );
+    });
 
     return unsubscribe;
   }, []);
@@ -1187,7 +1190,7 @@ export function BoardView() {
   // Build columnFeaturesMap for ListView
   // pipelineConfig is now from usePipelineConfig React Query hook at the top
   const columnFeaturesMap = useMemo(() => {
-    const columns = getColumnsWithPipeline(pipelineConfig);
+    const columns = getColumnsWithPipeline(pipelineConfig ?? null);
     const map: Record<string, typeof hookFeatures> = {};
     for (const column of columns) {
       map[column.id] = getColumnFeatures(column.id as ColumnId);
@@ -1539,7 +1542,7 @@ export function BoardView() {
                 },
               }}
               runningAutoTasks={runningAutoTasks}
-              pipelineConfig={pipelineConfig}
+              pipelineConfig={pipelineConfig ?? null}
               onAddFeature={() => setShowAddDialog(true)}
               isSelectionMode={isSelectionMode}
               selectedFeatureIds={selectedFeatureIds}
@@ -1586,14 +1589,13 @@ export function BoardView() {
               onAddFeature={() => setShowAddDialog(true)}
               onShowCompletedModal={() => setShowCompletedModal(true)}
               completedCount={completedFeatures.length}
-              pipelineConfig={pipelineConfig}
+              pipelineConfig={pipelineConfig ?? null}
               onOpenPipelineSettings={() => setShowPipelineSettings(true)}
               isSelectionMode={isSelectionMode}
               selectionTarget={selectionTarget}
               selectedFeatureIds={selectedFeatureIds}
               onToggleFeatureSelection={toggleFeatureSelection}
               onToggleSelectionMode={toggleSelectionMode}
-              viewMode={viewMode}
               isDragging={activeFeature !== null}
               onAiSuggest={() => setShowPlanDialog(true)}
               className="transition-opacity duration-200"
@@ -1744,7 +1746,7 @@ export function BoardView() {
         open={showPipelineSettings}
         onClose={() => setShowPipelineSettings(false)}
         projectPath={currentProject.path}
-        pipelineConfig={pipelineConfig}
+        pipelineConfig={pipelineConfig ?? null}
         onSave={async (config) => {
           const api = getHttpApiClient();
           const result = await api.pipeline.saveConfig(currentProject.path, config);

--- a/apps/ui/src/components/views/board-view/components/kanban-card/agent-suggestion.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/agent-suggestion.tsx
@@ -1,9 +1,10 @@
-// @ts-nocheck -- Feature index signature causes property access type errors
 import { memo, useState, useCallback } from 'react';
 import { Bot, ChevronDown, ChevronUp, Check, RefreshCw } from 'lucide-react';
-import { Feature, useAppStore } from '@/store/app-store';
+import { Feature } from '@/store/app-store';
 import { apiPost } from '@/lib/api-fetch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@protolabsai/ui/atoms';
+import { useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/query-keys';
 
 const ROLE_LABELS: Record<string, string> = {
   'frontend-engineer': 'Frontend',
@@ -40,7 +41,7 @@ export const AgentSuggestion = memo(function AgentSuggestion({
 }: AgentSuggestionProps) {
   const [expanded, setExpanded] = useState(false);
   const [assigning, setAssigning] = useState(false);
-  const refreshFeatures = useAppStore((state) => state.refreshFeatures);
+  const queryClient = useQueryClient();
 
   const suggestion = feature.routingSuggestion;
   if (!suggestion) return null;
@@ -57,14 +58,14 @@ export const AgentSuggestion = memo(function AgentSuggestion({
           featureId: feature.id,
           role: newRole,
         });
-        refreshFeatures?.();
+        queryClient.invalidateQueries({ queryKey: queryKeys.features.all(projectPath) });
       } catch {
         // Silently handle - feature may have been updated
       } finally {
         setAssigning(false);
       }
     },
-    [projectPath, feature.id, refreshFeatures]
+    [projectPath, feature.id, queryClient]
   );
 
   return (

--- a/apps/ui/src/components/views/board-view/components/kanban-card/card-actions.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/card-actions.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- Feature index signature causes property access type errors
 import { memo } from 'react';
 import { Feature } from '@/store/types';
 import { Button } from '@protolabsai/ui/atoms';

--- a/apps/ui/src/components/views/board-view/components/kanban-card/card-badges.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/card-badges.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- Feature index signature causes property access type errors
 import { memo, useEffect, useMemo, useState } from 'react';
 import { Feature, useAppStore } from '@/store/app-store';
 import { cn } from '@/lib/utils';

--- a/apps/ui/src/components/views/board-view/components/kanban-card/card-content-sections.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/card-content-sections.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- Feature index signature causes property access type errors
 import { memo } from 'react';
 import { Feature } from '@/store/types';
 import { GitBranch, GitPullRequest, ExternalLink } from 'lucide-react';

--- a/apps/ui/src/components/views/board-view/components/kanban-card/card-header.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/card-header.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- Feature index signature causes property access type errors
 import { memo, useState } from 'react';
 import { Feature } from '@/store/types';
 import { cn } from '@/lib/utils';

--- a/apps/ui/src/components/views/board-view/components/kanban-card/kanban-card.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/kanban-card.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- DnD kit type conflicts with Feature index signature
 import React, { memo, useLayoutEffect, useState, useCallback } from 'react';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 import { cn } from '@/lib/utils';

--- a/apps/ui/src/components/views/board-view/components/kanban-card/summary-dialog.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/summary-dialog.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- Feature index signature causes property access type errors
 import { useState } from 'react';
 import { Feature } from '@/store/types';
 import { AgentTaskInfo } from '@/lib/agent-context-parser';

--- a/apps/ui/src/components/views/board-view/components/list-view/list-row.tsx
+++ b/apps/ui/src/components/views/board-view/components/list-view/list-row.tsx
@@ -1,6 +1,4 @@
-// TODO: Remove @ts-nocheck after fixing BaseFeature's index signature issue
 // The `[key: string]: unknown` in BaseFeature causes property access type errors
-// @ts-nocheck -- BaseFeature index signature causes property access type errors
 import { memo, useCallback, useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@protolabsai/ui/atoms';

--- a/apps/ui/src/components/views/board-view/dialogs/add-feature-dialog.tsx
+++ b/apps/ui/src/components/views/board-view/dialogs/add-feature-dialog.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- Feature index signature causes property access type errors
 import { useState, useEffect, useRef } from 'react';
 import { createLogger } from '@protolabsai/utils/logger';
 import {

--- a/apps/ui/src/components/views/board-view/dialogs/completed-features-modal.tsx
+++ b/apps/ui/src/components/views/board-view/dialogs/completed-features-modal.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- Feature index signature causes property access type errors
 import {
   Dialog,
   DialogContent,

--- a/apps/ui/src/components/views/board-view/dialogs/dependency-tree-dialog.tsx
+++ b/apps/ui/src/components/views/board-view/dialogs/dependency-tree-dialog.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- Feature index signature causes property access type errors
 import { useState, useEffect } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@protolabsai/ui/atoms';
 import { Feature } from '@/store/types';

--- a/apps/ui/src/components/views/board-view/dialogs/edit-feature-dialog.tsx
+++ b/apps/ui/src/components/views/board-view/dialogs/edit-feature-dialog.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- Feature index signature causes property access type errors
 import { useState, useEffect } from 'react';
 import {
   Dialog,
@@ -58,7 +57,7 @@ interface EditFeatureDialogProps {
       imagePaths: DescriptionImagePath[];
       textFilePaths: DescriptionTextFilePath[];
       branchName: string; // Can be empty string to use current branch
-      priority: number;
+      priority: 0 | 1 | 2 | 3 | 4;
       planningMode: PlanningMode;
       requirePlanApproval: boolean;
       dependencies?: string[];
@@ -233,7 +232,7 @@ export function EditFeatureDialog({
     // Determine if description changed and what source to use
     const descriptionChanged = editingFeature.description !== originalDescription;
     let historySource: 'enhance' | 'edit' | undefined;
-    let historyEnhancementMode: 'improve' | 'technical' | 'simplify' | 'acceptance' | undefined;
+    let historyEnhancementMode: EnhancementMode | undefined;
 
     if (descriptionChanged && descriptionChangeSource) {
       if (descriptionChangeSource === 'edit') {
@@ -553,7 +552,7 @@ export function EditFeatureDialog({
                   onPrioritySelect={(priority) =>
                     setEditingFeature({
                       ...editingFeature,
-                      priority,
+                      priority: priority as 0 | 1 | 2 | 3 | 4,
                     })
                   }
                   testIdPrefix="edit-priority"

--- a/apps/ui/src/components/views/board-view/hooks/use-board-actions.ts
+++ b/apps/ui/src/components/views/board-view/hooks/use-board-actions.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck -- Feature index signature causes property access type errors
 import { useCallback } from 'react';
 import {
   Feature,
@@ -10,7 +9,11 @@ import {
 } from '@/store/app-store';
 import { useWorktreeStore } from '@/store/worktree-store';
 import type { ReasoningEffort } from '@protolabsai/types';
-import { FeatureImagePath as DescriptionImagePath } from '@/components/views/board-view/components/description-image-dropzone';
+import {
+  FeatureImagePath as DescriptionImagePath,
+  FeatureTextFilePath as DescriptionTextFilePath,
+} from '@/components/views/board-view/components/description-image-dropzone';
+import type { EnhancementMode } from '@protolabsai/types';
 import { getElectronAPI } from '@/lib/electron';
 import { isConnectionError, handleServerOffline } from '@/lib/http-api-client';
 import { toast } from 'sonner';
@@ -26,7 +29,7 @@ interface UseBoardActionsProps {
   currentProject: { path: string; id: string } | null;
   features: Feature[];
   runningAutoTasks: string[];
-  loadFeatures: () => Promise<void>;
+  loadFeatures: () => Promise<void> | void;
   persistFeatureCreate: (feature: Feature) => Promise<void>;
   persistFeatureUpdate: (
     featureId: string,
@@ -91,8 +94,13 @@ export function useBoardActions({
     enableDependencyBlocking,
     skipVerificationInAutoMode,
   } = useAppStore();
-  const { useWorktrees, isPrimaryWorktreeBranch, getPrimaryWorktreeBranch, getAutoModeState } =
-    useWorktreeStore();
+  const {
+    useWorktrees,
+    isPrimaryWorktreeBranch,
+    getPrimaryWorktreeBranch,
+    getAutoModeState,
+    getWorktrees,
+  } = useWorktreeStore();
   const autoMode = useAutoMode();
 
   // React Query mutations for feature operations
@@ -183,7 +191,7 @@ export function useBoardActions({
       }
 
       // Check if we need to generate a title
-      const needsTitleGeneration = !featureData.title.trim() && featureData.description.trim();
+      const needsTitleGeneration = !!(!featureData.title.trim() && featureData.description.trim());
 
       const newFeatureData = {
         ...featureData,
@@ -192,6 +200,8 @@ export function useBoardActions({
         status: 'backlog' as const,
         branchName: finalBranchName,
         dependencies: featureData.dependencies || [],
+        steps: [] as string[],
+        priority: featureData.priority as 0 | 1 | 2 | 3 | 4,
       };
       const createdFeature = addFeature(newFeatureData);
       // Must await to ensure feature exists on server before user can drag it
@@ -272,8 +282,9 @@ export function useBoardActions({
         thinkingLevel: ThinkingLevel;
         reasoningEffort: ReasoningEffort;
         imagePaths: DescriptionImagePath[];
+        textFilePaths?: DescriptionTextFilePath[];
         branchName: string;
-        priority: number;
+        priority: 0 | 1 | 2 | 3 | 4;
         planningMode?: PlanningMode;
         requirePlanApproval?: boolean;
         workMode?: 'current' | 'auto' | 'custom';
@@ -281,7 +292,7 @@ export function useBoardActions({
         childDependencies?: string[]; // Feature IDs that should depend on this feature
       },
       descriptionHistorySource?: 'enhance' | 'edit',
-      enhancementMode?: 'improve' | 'technical' | 'simplify' | 'acceptance' | 'ux-reviewer',
+      enhancementMode?: EnhancementMode,
       preEnhancementDescription?: string
     ) => {
       const workMode = updates.workMode || 'current';
@@ -783,7 +794,15 @@ export function useBoardActions({
           return;
         }
 
-        const result = await api.worktree.mergeFeature(currentProject.path, feature.id);
+        const branchName = feature.branchName ?? '';
+        const worktrees = getWorktrees(currentProject.path);
+        const worktreePath =
+          worktrees.find((w) => w.branch === branchName)?.path ?? currentProject.path;
+        const result = await api.worktree.mergeFeature(
+          currentProject.path,
+          branchName,
+          worktreePath
+        );
 
         if (result.success) {
           await loadFeatures();
@@ -805,7 +824,7 @@ export function useBoardActions({
         });
       }
     },
-    [currentProject, loadFeatures]
+    [currentProject, loadFeatures, getWorktrees]
   );
 
   const handleCompleteFeature = useCallback(

--- a/apps/ui/src/components/views/board-view/hooks/use-board-column-features.ts
+++ b/apps/ui/src/components/views/board-view/hooks/use-board-column-features.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck -- Feature index signature causes property access type errors
 import { useMemo, useCallback } from 'react';
 import { Feature, useAppStore } from '@/store/app-store';
 import { useWorktreeStore } from '@/store/worktree-store';
@@ -202,7 +201,9 @@ export function useBoardColumnFeatures({
     // This ensures features appear in dependency order (dependencies before dependents)
     // Within the same dependency level, features are sorted by priority
     if (map.backlog.length > 0) {
-      const { orderedFeatures } = resolveDependencies(map.backlog);
+      const { orderedFeatures: _orderedFeatures } = resolveDependencies(map.backlog);
+      // Cast from base Feature type (libs/types) to UI Feature type (store/types)
+      const orderedFeatures = _orderedFeatures as Feature[];
 
       // Get all features to check blocking dependencies against
       const enableDependencyBlocking = useAppStore.getState().enableDependencyBlocking;

--- a/apps/ui/src/components/views/board-view/shared/model-selector.tsx
+++ b/apps/ui/src/components/views/board-view/shared/model-selector.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck -- model alias union types need refactoring for strict checks
 import { Label } from '@protolabsai/ui/atoms';
 import { Badge } from '@protolabsai/ui/atoms';
 import { Brain, AlertTriangle } from 'lucide-react';
@@ -33,15 +32,15 @@ export function ModelSelector({
     fetchCodexModels,
     disabledProviders,
   } = useAIModelsStore();
-  const { cursorCliStatus, codexCliStatus } = useSetupStore();
+  const { cursorCliStatus, codexCliStatus, codexAuthStatus } = useSetupStore();
 
   const selectedProvider = getModelProvider(selectedModel);
 
   // Check if Cursor CLI is available
   const isCursorAvailable = cursorCliStatus?.installed && cursorCliStatus?.auth?.authenticated;
 
-  // Check if Codex CLI is available
-  const isCodexAvailable = codexCliStatus?.installed && codexCliStatus?.auth?.authenticated;
+  // Check if Codex CLI is available (codexCliStatus is CliStatus without .auth; use codexAuthStatus)
+  const isCodexAvailable = codexCliStatus?.installed && codexAuthStatus?.authenticated;
 
   // Fetch Codex models on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary

**Milestone:** Type Safety Restoration

Remove // @ts-nocheck from 16 board-view files. Fix resulting TypeScript errors with proper type annotations/guards. The Feature type no longer has [key: string]: unknown so most should compile cleanly.

**Files to Modify:**
- apps/ui/src/components/views/board-view.tsx
- apps/ui/src/components/views/board-view/hooks/use-board-actions.ts
- apps/ui/src/components/views/board-view/hooks/use-board-column-features.ts
- apps/ui/src/components/views/board-view/d...

---
*Recovered automatically by Automaker post-agent hook*