### PR TITLE
Add review queue depth tracking and auto-pause rule

### DIFF
--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -315,6 +315,20 @@ export class FeatureScheduler {
             continue;
           }
 
+          // Review queue WIP limit: pause pickup when too many PRs are in review
+          const reviewDepth = await this.getReviewQueueDepth(projectPath);
+          const maxPendingReviews = await this.getMaxPendingReviews(projectPath);
+          if (reviewDepth >= maxPendingReviews) {
+            logger.warn(
+              `[AutoLoop] Review queue saturated (${reviewDepth}/${maxPendingReviews} PRs in review) — pausing feature pickup for ${worktreeDesc}`
+            );
+            await this.callbacks.sleep(
+              SLEEP_INTERVAL_CAPACITY_MS,
+              projectState.abortController.signal
+            );
+            continue;
+          }
+
           // Double-check we're not at capacity (defensive check before starting)
           const currentRunningCount = await this.callbacks.getRunningCountForWorktree(
             projectPath,
@@ -1123,6 +1137,51 @@ export class FeatureScheduler {
       return settings?.autoModePickupCooldownMs ?? DEFAULT_COOLDOWN_MS;
     } catch {
       return DEFAULT_COOLDOWN_MS;
+    }
+  }
+
+  /**
+   * Read the maxPendingReviews threshold from project workflow settings.
+   * Default: 5. When the review queue depth meets or exceeds this value,
+   * auto-mode feature pickup is paused.
+   */
+  private async getMaxPendingReviews(projectPath: string): Promise<number> {
+    const DEFAULT_MAX = 5;
+    try {
+      if (!this.settingsService) return DEFAULT_MAX;
+      const projectSettings = await this.settingsService.getProjectSettings(projectPath);
+      const workflow = projectSettings.workflow as typeof projectSettings.workflow & {
+        maxPendingReviews?: number;
+      };
+      return workflow?.maxPendingReviews ?? DEFAULT_MAX;
+    } catch {
+      return DEFAULT_MAX;
+    }
+  }
+
+  /**
+   * Count the number of features currently in 'review' state for a project.
+   * Used to enforce the review queue WIP limit.
+   */
+  private async getReviewQueueDepth(projectPath: string): Promise<number> {
+    const featuresDir = getFeaturesDir(projectPath);
+    try {
+      const entries = await secureFs.readdir(featuresDir, { withFileTypes: true });
+      let reviewCount = 0;
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const featurePath = path.join(featuresDir, entry.name, 'feature.json');
+        const result = await readJsonWithRecovery<{ status?: string } | null>(featurePath, null, {
+          maxBackups: DEFAULT_BACKUP_COUNT,
+          autoRestore: false,
+        });
+        if (result.data?.status === 'review') {
+          reviewCount++;
+        }
+      }
+      return reviewCount;
+    } catch {
+      return 0;
     }
   }
 

--- a/apps/server/src/services/lead-engineer-rules.ts
+++ b/apps/server/src/services/lead-engineer-rules.ts
@@ -630,6 +630,91 @@ export const missingCIChecks: LeadFastPathRule = {
   },
 };
 
+// ────────────────────────── Review Queue Monitor ──────────────────────────
+
+/** Default maximum PRs allowed in review state before pausing pickup */
+const DEFAULT_MAX_PENDING_REVIEWS = 5;
+
+/**
+ * ReviewQueueMonitor — tracks review queue depth over time.
+ *
+ * Records a timestamped sample each time the queue depth is checked.
+ * Exposes helpers for determining whether the queue is saturated.
+ */
+export class ReviewQueueMonitor {
+  /** Chronological history of review queue depth samples */
+  readonly history: Array<{ timestamp: number; depth: number }> = [];
+
+  /** Maximum number of historical samples to keep */
+  private readonly maxHistory: number;
+
+  constructor(maxHistory = 100) {
+    this.maxHistory = maxHistory;
+  }
+
+  /**
+   * Record the current review queue depth.
+   * @param depth Number of features currently in review state
+   */
+  record(depth: number): void {
+    this.history.push({ timestamp: Date.now(), depth });
+    if (this.history.length > this.maxHistory) {
+      this.history.shift();
+    }
+  }
+
+  /**
+   * Return the most recently recorded depth, or 0 if no samples.
+   */
+  currentDepth(): number {
+    return this.history.length > 0 ? this.history[this.history.length - 1].depth : 0;
+  }
+
+  /**
+   * Return true if the current depth meets or exceeds the threshold.
+   */
+  isSaturated(threshold: number): boolean {
+    return this.currentDepth() >= threshold;
+  }
+}
+
+/**
+ * reviewQueueSaturated — Pause auto-mode feature pickup when the review queue is full.
+ *
+ * Fires when the number of features in 'review' state meets or exceeds
+ * `maxPendingReviews` (from WorkflowSettings, default 5). Emits a log action
+ * to surface the condition. The actual pickup pause is enforced in FeatureScheduler
+ * by checking the review queue depth before starting new features.
+ */
+export const reviewQueueSaturated: LeadFastPathRule = {
+  name: 'reviewQueueSaturated',
+  description:
+    'Review queue depth >= maxPendingReviews → log saturation (pickup paused by scheduler)',
+  triggers: ['feature:status-changed', 'feature:pr-merged', 'lead-engineer:rule-evaluated'],
+
+  evaluate(worldState, _eventType, _payload): LeadRuleAction[] {
+    const reviewCount = Object.values(worldState.features).filter(
+      (f) => f.status === 'review'
+    ).length;
+
+    const threshold =
+      (worldState as LeadWorldState & { maxPendingReviews?: number }).maxPendingReviews ??
+      DEFAULT_MAX_PENDING_REVIEWS;
+
+    if (reviewCount >= threshold) {
+      return [
+        {
+          type: 'log',
+          level: 'warn',
+          message: `reviewQueueSaturated: ${reviewCount}/${threshold} PRs in review — auto-mode feature pickup paused until queue drains`,
+        },
+      ];
+    }
+
+    return [];
+  },
+};
+
 // ────────────────────────── Exports ──────────────────────────
 
 /** Default set of fast-path rules */
@@ -649,6 +734,7 @@ export const DEFAULT_RULES: LeadFastPathRule[] = [
   hitlFormResponse,
   missingCIChecks,
   rollbackTriggered,
+  reviewQueueSaturated,
 ];
 
 /**

--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -184,6 +184,14 @@ export interface WorkflowSettings {
    * @default true
    */
   preFlightChecks?: boolean;
+  /**
+   * Maximum number of PRs allowed in the review state before auto-mode pauses
+   * new feature pickup. Prevents flooding the review queue.
+   * When review count >= this threshold, the reviewQueueSaturated rule fires and
+   * the scheduler pauses pickup until the queue drains below the threshold.
+   * @default 5
+   */
+  maxPendingReviews?: number;
 }
 
 /** Default workflow settings */


### PR DESCRIPTION
## Summary

**Milestone:** Review Queue WIP Limits

Add a ReviewQueueMonitor that tracks PRs in review state. Add `maxPendingReviews` to WorkflowSettings (default: 5). Add a new LeadEngineerRule `reviewQueueSaturated` that fires when review count >= threshold — pauses auto-mode feature pickup (not running agents). Resume when review count drops below threshold. Track metric: review queue depth over time.

**Files to Modify:**
- apps/server/src/services/lead-engineer-rules.ts
- apps/server/src/services/lead-...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added review queue capacity management that monitors and limits concurrent pull requests in review state. The system now pauses new feature pickup when pending reviews reach a configurable threshold (default: 5), with warning logs when capacity is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->