### PR TITLE
Clean up dead events and EventType gaps

### DIFF
--- a/apps/server/src/routes/project-pm/index.ts
+++ b/apps/server/src/routes/project-pm/index.ts
@@ -35,7 +35,6 @@ import type { CeremonyService } from '../../services/ceremony-service.js';
 import type { FeatureLoader } from '../../services/feature-loader.js';
 import type { LeadEngineerService } from '../../services/lead-engineer-service.js';
 import type { EventEmitter } from '../../lib/events.js';
-import type { EventType } from '@protolabsai/types';
 import { buildCeremonyTools } from './pm-tools.js';
 
 const logger = createLogger('ProjectPMRoutes');
@@ -451,7 +450,7 @@ export function createProjectPmRoutes(
               .describe('Milestone slug (required for retro and project-retro)'),
           }),
           execute: async ({ ceremonyType, milestoneSlug }) => {
-            events.emit('ceremony:trigger-requested' as EventType, {
+            events.emit('ceremony:trigger-requested', {
               projectPath,
               projectSlug,
               ceremonyType,
@@ -564,7 +563,7 @@ export function createProjectPmRoutes(
               .describe('Severity level'),
           }),
           execute: async ({ message, severity }) => {
-            events.emit('notification:created' as EventType, {
+            events.emit('notification:created', {
               source: `PM Agent (${projectSlug})`,
               message,
               severity,

--- a/apps/server/src/routes/project-pm/pm-agent.ts
+++ b/apps/server/src/routes/project-pm/pm-agent.ts
@@ -15,7 +15,6 @@ import type { ProjectService } from '../../services/project-service.js';
 import type { CeremonyService } from '../../services/ceremony-service.js';
 import type { FeatureLoader } from '../../services/feature-loader.js';
 import type { EventEmitter } from '../../lib/events.js';
-import type { EventType } from '@protolabsai/types';
 import { buildCeremonyTools } from './pm-tools.js';
 
 const logger = createLogger('PMAgent');
@@ -280,7 +279,7 @@ export async function queryPm(
           .describe('Milestone slug (required for retro and project-retro)'),
       }),
       execute: async ({ ceremonyType, milestoneSlug }) => {
-        events.emit('ceremony:trigger-requested' as EventType, {
+        events.emit('ceremony:trigger-requested', {
           projectPath,
           projectSlug,
           ceremonyType,
@@ -350,7 +349,7 @@ export async function queryPm(
           .describe('Severity level'),
       }),
       execute: async ({ message, severity }) => {
-        events.emit('notification:created' as EventType, {
+        events.emit('notification:created', {
           source: `PM Agent (${projectSlug})`,
           message,
           severity,

--- a/apps/server/src/services/authority-agents/projm-agent.ts
+++ b/apps/server/src/services/authority-agents/projm-agent.ts
@@ -100,30 +100,6 @@ export class ProjMAuthorityAgent {
           void this.handleApprovedIdea(data);
         }
       }
-
-      // Also listen for legacy pm-epic-created and pm-research-completed for backward compat
-      if (type === 'authority:pm-epic-created') {
-        const data = payload as { projectPath: string; featureId?: string; epicId?: string };
-
-        if (!this.state.isInitialized(data.projectPath)) {
-          logger.warn(
-            `[ProjMAgent] Received pm-epic-created event for uninitialized project: ${data.projectPath}`
-          );
-          void (async () => {
-            try {
-              await this.initialize(data.projectPath);
-              await this.scanForPlannedFeatures(data.projectPath);
-            } catch (error) {
-              logger.error(
-                `[ProjMAgent] Auto-initialization failed for ${data.projectPath}:`,
-                error
-              );
-            }
-          })();
-        } else {
-          void this.scanForPlannedFeatures(data.projectPath);
-        }
-      }
     });
   }
 

--- a/apps/server/src/services/ceremony-action-executor.ts
+++ b/apps/server/src/services/ceremony-action-executor.ts
@@ -304,33 +304,12 @@ export class CeremonyActionExecutor {
           retroSource,
           result.item
         );
-      } else if (result.actionType === 'gate-tuning' && result.signalDescription) {
-        this.emitter.emit('gate:tuning-signal', {
-          projectPath,
-          projectSlug,
-          milestoneSlug,
-          retroSource,
-          signal: result.signalDescription,
-          originalItem: result.item,
-          timestamp: new Date().toISOString(),
-        });
-        logger.info(
-          `CeremonyActionExecutor: emitted gate:tuning-signal for ${retroSource}: ${result.signalDescription}`
-        );
       }
     }
 
     logger.info(
       `CeremonyActionExecutor: processed ${classified.length} retro items for ${retroSource}`
     );
-
-    this.emitter.emit('retro:improvements:created', {
-      projectPath,
-      projectSlug,
-      milestoneSlug,
-      retroSource,
-      itemsProcessed: classified.length,
-    });
   }
 }
 

--- a/apps/server/src/services/ceremony-service.ts
+++ b/apps/server/src/services/ceremony-service.ts
@@ -278,7 +278,7 @@ export class CeremonyService {
         this.handleProjectLifecycleLaunched(payload as ProjectLifecycleLaunchedPayload).catch(
           (err) => logger.warn('Project lifecycle launched error:', err)
         );
-      } else if (type === ('ceremony:trigger-requested' as string)) {
+      } else if (type === 'ceremony:trigger-requested') {
         this.handleCeremonyTriggerRequested(
           payload as {
             projectPath: string;
@@ -287,17 +287,6 @@ export class CeremonyService {
             milestoneSlug?: string;
           }
         ).catch((err) => logger.warn('Ceremony trigger-requested error:', err));
-      } else if (type === ('retro:improvements:created' as string)) {
-        const p = payload as {
-          projectPath: string;
-          projectSlug: string;
-          milestoneSlug?: string;
-          retroSource: string;
-          itemsProcessed: number;
-        };
-        logger.info(
-          `CeremonyService: retro improvements created for ${p.retroSource} — ${p.itemsProcessed} items processed`
-        );
       }
     });
 

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -205,6 +205,7 @@ export type EventType =
   | 'ceremony:project-retro'
   | 'ceremony:triggered'
   | 'ceremony:fired'
+  | 'ceremony:trigger-requested'
   | 'ceremony:post-project-docs'
   | 'ceremony:post-project-docs:complete'
   | 'ceremony:post-project-docs:failed'


### PR DESCRIPTION
## Summary

**Milestone:** Dead Events and Stub Cleanup

Remove dead emissions: gate:tuning-signal and retro:improvements:created from CeremonyActionExecutor. Add ceremony:trigger-requested to EventType union. Remove unsafe casts in 3 files. Remove legacy pm-epic-created listener from projm-agent.ts.

**Files to Modify:**
- apps/server/src/services/ceremony-action-executor.ts
- libs/types/src/events.ts
- apps/server/src/services/ceremony-service.ts
- apps/server/src/routes/project-pm/index.ts
- apps/server/...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed legacy event handling for automatic project initialization.
  * Removed gate-tuning action support and related signal emissions.
  * Removed retro improvements creation notifications.

* **Refactoring**
  * Simplified event type handling by removing unnecessary type casting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->