### PR TITLE
Add agentic metrics to collection service

### DIFF
--- a/apps/server/src/services/metrics-collection-service.ts
+++ b/apps/server/src/services/metrics-collection-service.ts
@@ -18,7 +18,15 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { createLogger } from '@protolabsai/utils';
-import type { DoraTimeSeriesEntry, DoraTimeSeriesDocument } from '@protolabsai/types';
+import type {
+  DoraTimeSeriesEntry,
+  DoraTimeSeriesDocument,
+  AgenticMetricsEntry,
+  AgenticMetricsDocument,
+  AgenticAutonomyRate,
+  AgenticRemediationRecord,
+  AgenticWipSaturation,
+} from '@protolabsai/types';
 import type { EventEmitter } from '../lib/events.js';
 import type { FeatureLoader } from './feature-loader.js';
 
@@ -288,5 +296,316 @@ export class MetricsCollectionService {
       this.weekMergeCount = 0;
       this.weekBucketStart = today;
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AgenticMetricsService
+// ---------------------------------------------------------------------------
+
+/**
+ * WIP limit configuration per pipeline stage.
+ * Set to null to indicate no cap is configured for a stage.
+ */
+interface WipLimits {
+  execution: number | null;
+  review: number | null;
+  approval: number | null;
+}
+
+/**
+ * AgenticMetricsService — event-driven agentic metrics collector.
+ *
+ * Subscribes to the event bus and tracks four agentic health metrics:
+ *
+ *   1. Autonomy rate — % of features reaching done without human intervention
+ *      beyond approval gates.
+ *   2. Remediation loop count — PR review iterations per feature before merge.
+ *   3. Cost per shipped feature — LLM cost from Langfuse per feature.
+ *      TODO: integrate Langfuse cost API — currently recorded as null.
+ *   4. WIP saturation index — current WIP / WIP limit per pipeline stage
+ *      (execution, review, approval).
+ *
+ * Each observable event appends a snapshot entry to the time-series document
+ * persisted at `.automaker/metrics/agentic.json`.  All state is derived from
+ * events — no polling.
+ *
+ * Events consumed:
+ *   - feature:status-changed  — WIP saturation + autonomy rate
+ *   - agent:completed         — autonomy tracking (agent drove the transition)
+ *   - pr:merged               — remediation loop finalisation + cost snapshot
+ *   - pr:review-requested     — remediation loop count increment
+ */
+export class AgenticMetricsService {
+  private readonly events: EventEmitter;
+  /** Path to the project root — used to locate `.automaker/metrics/agentic.json`. */
+  private readonly projectPath: string;
+  /** Configurable WIP limits per stage (null = uncapped). */
+  private readonly wipLimits: WipLimits;
+
+  // ---- autonomy rate state ----
+  private totalDone = 0;
+  private autonomousDone = 0;
+  /** featureIds where an agent:completed event was received before the feature reached done. */
+  private readonly agentDrivenFeatures = new Set<string>();
+  /** featureIds that received a human-triggered status change. */
+  private readonly humanIntervenedFeatures = new Set<string>();
+
+  // ---- WIP counters ----
+  private readonly wipCounters: Record<'execution' | 'review' | 'approval', number> = {
+    execution: 0,
+    review: 0,
+    approval: 0,
+  };
+
+  // ---- remediation loops ----
+  private readonly remediationLoops = new Map<string, AgenticRemediationRecord>();
+
+  /** Cleanup function returned by `events.subscribe`. */
+  private unsubscribe?: () => void;
+
+  constructor(
+    events: EventEmitter,
+    projectPath: string,
+    wipLimits: WipLimits = { execution: null, review: null, approval: null }
+  ) {
+    this.events = events;
+    this.projectPath = projectPath;
+    this.wipLimits = wipLimits;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  /** Subscribe to events and start collecting.  Call once on server startup. */
+  initialize(): void {
+    this.unsubscribe = this.events.subscribe((type, payload) => {
+      const p = payload as Record<string, unknown>;
+
+      switch (type) {
+        case 'feature:status-changed':
+          this.onFeatureStatusChanged(p);
+          break;
+
+        case 'agent:completed':
+          this.onAgentCompleted(p);
+          break;
+
+        case 'pr:merged':
+          this.onPrMerged(p);
+          break;
+
+        case 'pr:review-requested':
+          this.onPrReviewRequested(p);
+          break;
+
+        default:
+          break;
+      }
+    });
+
+    logger.info('AgenticMetricsService initialized — subscribing to events');
+  }
+
+  /** Unsubscribe from events.  Call on server shutdown. */
+  dispose(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Event handlers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * feature:status-changed — update WIP counters and autonomy rate.
+   *
+   * Canonical payload: { featureId, oldStatus?, newStatus?, projectPath? }
+   * Also accepts legacy fromStatus/toStatus field names.
+   * Also checks triggeredBy for human intervention detection.
+   */
+  private onFeatureStatusChanged(payload: Record<string, unknown>): void {
+    const featureId = payload['featureId'] as string | undefined;
+    const fromStatus =
+      (payload['oldStatus'] as string | undefined) ??
+      (payload['fromStatus'] as string | undefined) ??
+      '';
+    const toStatus =
+      (payload['newStatus'] as string | undefined) ??
+      (payload['toStatus'] as string | undefined) ??
+      '';
+    const triggeredBy = payload['triggeredBy'] as string | undefined;
+
+    if (featureId && triggeredBy === 'human') {
+      this.humanIntervenedFeatures.add(featureId);
+    }
+
+    const fromStage = this.statusToStage(fromStatus);
+    const toStage = this.statusToStage(toStatus);
+
+    if (fromStage && this.wipCounters[fromStage] > 0) {
+      this.wipCounters[fromStage] -= 1;
+    }
+    if (toStage) {
+      this.wipCounters[toStage] += 1;
+    }
+
+    if (featureId && this.isDoneStatus(toStatus)) {
+      this.totalDone += 1;
+      const wasAgentDriven = this.agentDrivenFeatures.has(featureId);
+      const hadHumanIntervention = this.humanIntervenedFeatures.has(featureId);
+      if (wasAgentDriven && !hadHumanIntervention) {
+        this.autonomousDone += 1;
+      }
+      this.agentDrivenFeatures.delete(featureId);
+      this.humanIntervenedFeatures.delete(featureId);
+    }
+
+    this.persistSnapshot();
+  }
+
+  /**
+   * agent:completed — mark this feature as agent-driven for autonomy tracking.
+   */
+  private onAgentCompleted(payload: Record<string, unknown>): void {
+    const featureId = payload['featureId'] as string | undefined;
+    if (featureId) {
+      this.agentDrivenFeatures.add(featureId);
+    }
+  }
+
+  /**
+   * pr:merged — finalise remediation loop for the feature and snapshot.
+   */
+  private onPrMerged(payload: Record<string, unknown>): void {
+    const featureId = payload['featureId'] as string | undefined;
+    if (!featureId) {
+      this.persistSnapshot();
+      return;
+    }
+
+    const existing = this.remediationLoops.get(featureId);
+    if (existing) {
+      existing.merged = true;
+    } else {
+      this.remediationLoops.set(featureId, { featureId, reviewIterations: 0, merged: true });
+    }
+
+    this.persistSnapshot();
+    logger.info(
+      `[Agentic] PR merged featureId=${featureId} reviewIterations=${existing?.reviewIterations ?? 0}`
+    );
+  }
+
+  /**
+   * pr:review-requested — increment the PR iteration counter for this feature.
+   */
+  private onPrReviewRequested(payload: Record<string, unknown>): void {
+    const featureId = payload['featureId'] as string | undefined;
+    if (!featureId) return;
+
+    const existing = this.remediationLoops.get(featureId);
+    if (existing) {
+      existing.reviewIterations += 1;
+    } else {
+      this.remediationLoops.set(featureId, { featureId, reviewIterations: 1, merged: false });
+    }
+
+    logger.info(
+      `[Agentic] Review requested featureId=${featureId} iterations=${this.remediationLoops.get(featureId)!.reviewIterations}`
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Snapshot helpers
+  // ---------------------------------------------------------------------------
+
+  private buildAutonomyRate(): AgenticAutonomyRate {
+    return {
+      totalDone: this.totalDone,
+      autonomousDone: this.autonomousDone,
+      rate: this.totalDone > 0 ? this.autonomousDone / this.totalDone : 0,
+    };
+  }
+
+  private buildWipSaturation(): AgenticWipSaturation[] {
+    const stages: Array<'execution' | 'review' | 'approval'> = ['execution', 'review', 'approval'];
+    return stages.map((stage) => {
+      const currentWip = this.wipCounters[stage];
+      const wipLimit = this.wipLimits[stage];
+      const saturation = wipLimit !== null && wipLimit > 0 ? currentWip / wipLimit : null;
+      return { stage, currentWip, wipLimit, saturation };
+    });
+  }
+
+  private persistSnapshot(): void {
+    const entry: AgenticMetricsEntry = {
+      timestamp: new Date().toISOString(),
+      autonomyRate: this.buildAutonomyRate(),
+      remediationLoops: Array.from(this.remediationLoops.values()),
+      // TODO: integrate Langfuse cost API to derive actual cost per shipped feature
+      costPerFeatureUsd: null,
+      wipSaturation: this.buildWipSaturation(),
+    };
+    this.appendAgenticEntry(entry);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Disk persistence
+  // ---------------------------------------------------------------------------
+
+  private getAgenticPath(): string {
+    return path.join(this.projectPath, '.automaker', 'metrics', 'agentic.json');
+  }
+
+  private readAgenticDocument(): AgenticMetricsDocument {
+    const filePath = this.getAgenticPath();
+    try {
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      return JSON.parse(raw) as AgenticMetricsDocument;
+    } catch {
+      return { version: 1, updatedAt: new Date().toISOString(), entries: [] };
+    }
+  }
+
+  private appendAgenticEntry(entry: AgenticMetricsEntry): void {
+    const filePath = this.getAgenticPath();
+    ensureDir(path.dirname(filePath));
+
+    const doc = this.readAgenticDocument();
+    doc.entries.push(entry);
+    doc.updatedAt = new Date().toISOString();
+
+    try {
+      fs.writeFileSync(filePath, JSON.stringify(doc, null, 2), 'utf-8');
+    } catch (err) {
+      logger.error('Failed to persist agentic metrics entry:', err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /** Map a feature status string to one of the three tracked pipeline stages. */
+  private statusToStage(status: string): 'execution' | 'review' | 'approval' | null {
+    const s = status.toLowerCase();
+    if (s === 'in_progress' || s === 'in-progress' || s === 'executing') return 'execution';
+    if (s === 'in_review' || s === 'in-review' || s === 'reviewing') return 'review';
+    if (
+      s === 'pending_approval' ||
+      s === 'pending-approval' ||
+      s === 'awaiting-approval' ||
+      s === 'awaiting_approval'
+    )
+      return 'approval';
+    return null;
+  }
+
+  /** Return true when a status string represents a terminal done state. */
+  private isDoneStatus(status: string): boolean {
+    const s = status.toLowerCase();
+    return s === 'done' || s === 'completed' || s === 'verified' || s === 'merged';
   }
 }

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -335,6 +335,9 @@ export type EventType =
   | 'work_stealing:request'
   | 'work_stealing:offer'
   | 'work_stealing:accept'
+  | 'agent:completed'
+  | 'pr:merged'
+  | 'pr:review-requested'
   | 'ava-channel:message';
 
 export type EventCallback = (type: EventType, payload: unknown) => void;

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -787,6 +787,11 @@ export type {
   TimeGroupBy,
   DoraTimeSeriesEntry,
   DoraTimeSeriesDocument,
+  AgenticAutonomyRate,
+  AgenticRemediationRecord,
+  AgenticWipSaturation,
+  AgenticMetricsEntry,
+  AgenticMetricsDocument,
 } from './metrics.js';
 
 // Lead Engineer types (production-phase nerve center)

--- a/libs/types/src/metrics.ts
+++ b/libs/types/src/metrics.ts
@@ -261,3 +261,58 @@ export interface DoraTimeSeriesDocument {
   /** Ordered list of snapshot entries (newest last) */
   entries: DoraTimeSeriesEntry[];
 }
+
+// ---------------------------------------------------------------------------
+// Agentic Metrics Persistence
+// ---------------------------------------------------------------------------
+
+/**
+ * Autonomy rate snapshot — percentage of features that reached "done" without
+ * human intervention beyond approval gates.
+ */
+export interface AgenticAutonomyRate {
+  totalDone: number;
+  autonomousDone: number;
+  rate: number;
+}
+
+/**
+ * Remediation loop counts per feature — number of PR iterations before merge.
+ */
+export interface AgenticRemediationRecord {
+  featureId: string;
+  reviewIterations: number;
+  merged: boolean;
+}
+
+/**
+ * WIP saturation for a single pipeline stage.
+ */
+export interface AgenticWipSaturation {
+  stage: 'execution' | 'review' | 'approval';
+  currentWip: number;
+  wipLimit: number | null;
+  saturation: number | null;
+}
+
+/**
+ * A single agentic-metrics snapshot — one entry per collection event.
+ * Persisted to `.automaker/metrics/agentic.json` as an array of entries.
+ */
+export interface AgenticMetricsEntry {
+  timestamp: string;
+  autonomyRate: AgenticAutonomyRate;
+  remediationLoops: AgenticRemediationRecord[];
+  /** TODO: integrate Langfuse cost API — currently null until available */
+  costPerFeatureUsd: number | null;
+  wipSaturation: AgenticWipSaturation[];
+}
+
+/**
+ * The full agentic metrics document persisted to disk.
+ */
+export interface AgenticMetricsDocument {
+  version: 1;
+  updatedAt: string;
+  entries: AgenticMetricsEntry[];
+}


### PR DESCRIPTION
## Summary

**Milestone:** Agentic Metrics

Extend MetricsCollectionService to track: (1) Autonomy rate — % of features reaching done without human intervention beyond approval gates, (2) Remediation loop count — PR iterations per feature, (3) Cost per shipped feature — LLM cost from Langfuse per feature, (4) WIP saturation index — current WIP / WIP limit per pipeline stage (execution, review, approval). Derive from existing events: feature:status-changed, agent:completed, pr:merged, pr:review-requested. Pe...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced agentic health metrics tracking autonomy rate, remediation loop counts, and work-in-progress saturation across execution, review, and approval stages.
  * New observable system events: agent-completed, pull request merged, and review requested.
  * Agentic metrics are automatically persisted for historical tracking and analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->