### PR TITLE
Aggregate milestone-level facts on milestone completion

### DIFF
--- a/apps/server/src/services/ceremony-service.ts
+++ b/apps/server/src/services/ceremony-service.ts
@@ -13,7 +13,7 @@ import path from 'path';
 import fs from 'fs';
 import readline from 'readline';
 import { createLogger } from '@protolabsai/utils';
-import { secureFs, getProjectDir, getDataDirectory } from '@protolabsai/platform';
+import { secureFs, getProjectDir, getDataDirectory, getAutomakerDir } from '@protolabsai/platform';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { createStandupFlow, createRetroFlow, createProjectRetroFlow } from '@protolabsai/flows';
 import type { CeremonyState } from '@protolabsai/types';
@@ -556,6 +556,19 @@ export class CeremonyService {
     // State transition: milestone_active → milestone_retro
     await this.applyTransition(projectPath, projectSlug, 'milestone:completed', payload);
 
+    // Aggregate milestone facts for project-level knowledge accumulation
+    const milestoneSlugForFacts = milestoneTitle.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    void this.aggregateMilestoneFacts(
+      projectPath,
+      projectSlug,
+      milestoneSlugForFacts,
+      payload.featureSummaries?.map((f) => f.id) ?? []
+    ).catch((err) => {
+      logger.warn(
+        `Milestone fact aggregation failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+    });
+
     const projectSettings = await this.settingsService.getProjectSettings(projectPath);
     const ceremonySettings = projectSettings.ceremonySettings;
     if (!ceremonySettings?.enabled || !ceremonySettings?.enableMilestoneUpdates) {
@@ -643,6 +656,95 @@ export class CeremonyService {
         payload: { title: `Retro: ${milestoneTitle}` },
       });
     }
+  }
+
+  /**
+   * Aggregate facts from all features in a completed milestone.
+   * Deduplicates by exact content match, filters to confidence >= 0.8,
+   * and writes to .automaker/projects/{projectSlug}/milestone-facts/{milestoneSlug}.json
+   */
+  private async aggregateMilestoneFacts(
+    projectPath: string,
+    projectSlug: string,
+    milestoneSlug: string,
+    featureIds: string[]
+  ): Promise<void> {
+    const fsPromises = await import('node:fs/promises');
+    const automakerDir = getAutomakerDir(projectPath);
+
+    // If no featureIds from payload, load from featureLoader by milestoneSlug
+    let ids = featureIds;
+    if (ids.length === 0 && this.featureLoader) {
+      const all = await this.featureLoader.getAll(projectPath);
+      ids = all
+        .filter((f) => (f as { milestoneSlug?: string }).milestoneSlug === milestoneSlug)
+        .map((f) => f.id);
+    }
+
+    if (ids.length === 0) {
+      logger.debug(`No features found for milestone ${milestoneSlug}, skipping fact aggregation`);
+      return;
+    }
+
+    // Gather facts from each feature's trajectory
+    const seen = new Set<string>();
+    const aggregated: Array<{
+      content: string;
+      category: string;
+      confidence: number;
+      featureId: string;
+    }> = [];
+
+    for (const featureId of ids) {
+      try {
+        const factsPath = path.join(automakerDir, 'trajectory', featureId, 'facts.json');
+        const content = await fsPromises.readFile(factsPath, 'utf-8');
+        const parsed = JSON.parse(content) as {
+          facts: Array<{ content: string; category: string; confidence: number }>;
+        };
+        for (const fact of parsed.facts ?? []) {
+          if (
+            typeof fact.confidence === 'number' &&
+            fact.confidence >= 0.8 &&
+            !seen.has(fact.content)
+          ) {
+            seen.add(fact.content);
+            aggregated.push({
+              content: fact.content,
+              category: fact.category ?? 'general',
+              confidence: fact.confidence,
+              featureId,
+            });
+          }
+        }
+      } catch {
+        // No facts.json for this feature — skip
+      }
+    }
+
+    // Write aggregated facts to project milestone-facts directory
+    const milestoneFactsDir = path.join(automakerDir, 'projects', projectSlug, 'milestone-facts');
+    await fsPromises.mkdir(milestoneFactsDir, { recursive: true });
+    const outputPath = path.join(milestoneFactsDir, `${milestoneSlug}.json`);
+    await fsPromises.writeFile(
+      outputPath,
+      JSON.stringify(
+        {
+          milestoneSlug,
+          projectSlug,
+          aggregatedAt: new Date().toISOString(),
+          featureCount: ids.length,
+          facts: aggregated,
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+
+    logger.info(
+      `Aggregated ${aggregated.length} milestone facts for ${projectSlug}/${milestoneSlug} (from ${ids.length} features)`
+    );
   }
 
   private async handleCeremonyFired(payload: CeremonyFiredPayload): Promise<void> {

--- a/apps/server/src/services/lead-engineer-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-execute-processor.ts
@@ -322,6 +322,73 @@ export class ExecuteProcessor implements StateProcessor {
       logger.warn('[EXECUTE] Failed to load sibling reflections:', err);
     }
 
+    // Load milestone facts (project-level knowledge accumulation)
+    try {
+      if (ctx.feature.projectSlug) {
+        const fsPromises = await import('node:fs/promises');
+        const milestoneFactsDir = path.join(
+          getAutomakerDir(ctx.projectPath),
+          'projects',
+          ctx.feature.projectSlug,
+          'milestone-facts'
+        );
+        let entries: string[] = [];
+        try {
+          const dirEntries = await fsPromises.readdir(milestoneFactsDir);
+          entries = dirEntries.filter((e) => e.endsWith('.json'));
+        } catch {
+          // No milestone-facts directory yet — skip
+        }
+        if (entries.length > 0) {
+          const allFacts: Array<{ content: string; category: string; confidence: number }> = [];
+          for (const entry of entries) {
+            try {
+              const raw = await fsPromises.readFile(path.join(milestoneFactsDir, entry), 'utf-8');
+              const parsed = JSON.parse(raw) as {
+                facts: Array<{ content: string; category: string; confidence: number }>;
+              };
+              allFacts.push(...(parsed.facts ?? []));
+            } catch {
+              // Skip malformed files
+            }
+          }
+          if (allFacts.length > 0) {
+            // Group by category and format as Project Knowledge section
+            const byCategory = new Map<string, Array<{ content: string; confidence: number }>>();
+            for (const fact of allFacts) {
+              const cat = fact.category || 'general';
+              if (!byCategory.has(cat)) byCategory.set(cat, []);
+              byCategory.get(cat)!.push({
+                content: fact.content,
+                confidence: fact.confidence,
+              });
+            }
+            const lines: string[] = [
+              '## Project Knowledge\n\nPatterns established in completed milestones:\n',
+            ];
+            for (const [cat, catFacts] of byCategory) {
+              lines.push(`### ${cat}`);
+              for (const { confidence, content } of catFacts) {
+                lines.push(`- [${Math.round(confidence * 100)}%] ${content}`);
+              }
+            }
+            let projectKnowledge = lines.join('\n');
+            // Cap at ~2000 tokens (approx 8000 chars at 4 chars/token)
+            const TOKEN_CHAR_CAP = 8000;
+            if (projectKnowledge.length > TOKEN_CHAR_CAP) {
+              projectKnowledge = projectKnowledge.slice(0, TOKEN_CHAR_CAP) + '\n...(truncated)';
+            }
+            ctx.projectKnowledge = projectKnowledge;
+            logger.info(
+              `[EXECUTE] Loaded project knowledge from ${entries.length} milestone fact files (${allFacts.length} facts)`
+            );
+          }
+        }
+      }
+    } catch (err) {
+      logger.warn('[EXECUTE] Failed to load milestone facts:', err);
+    }
+
     // Run pre-flight checks (worktree currency, package builds, dep merge verification)
     const preFlightEnabled = await this.isPreFlightEnabled(ctx.projectPath);
     if (preFlightEnabled) {
@@ -876,6 +943,9 @@ export class ExecuteProcessor implements StateProcessor {
         contextParts.push(
           `## Review Feedback (Changes Requested)\n\nAddress these issues:\n\n${ctx.reviewFeedback}`
         );
+      }
+      if (ctx.projectKnowledge) {
+        contextParts.push(ctx.projectKnowledge);
       }
       if (ctx.siblingReflections && ctx.siblingReflections.length > 0) {
         contextParts.push(

--- a/apps/server/src/services/lead-engineer-types.ts
+++ b/apps/server/src/services/lead-engineer-types.ts
@@ -147,6 +147,8 @@ export interface StateContext {
   reviewFeedback?: string;
   /** Learnings from sibling features: structured facts (markdown, grouped by category) from facts.json, or raw reflection.md content as fallback */
   siblingReflections?: string[];
+  /** Aggregated facts from completed milestones in this project, formatted as "Project Knowledge" markdown section */
+  projectKnowledge?: string;
   /** ISO 8601 timestamp when processing started */
   startedAt?: string;
 }


### PR DESCRIPTION
## Summary

## Problem
Facts are extracted per-feature via FTS5. No project-level knowledge accumulation. Feature 8 doesn't know patterns established by features 1-7 unless search happens to match.

## Requirements

### 1. Milestone completion aggregation
On `milestone:completed` event in ceremony-service.ts:
- Gather facts from `.automaker/trajectory/{featureId}/facts.json` for all features in that milestone
- Deduplicate by content similarity (exact match)
- Filter to confidence >= 0.8
- Write to `.automa...

---
*Recovered automatically by Automaker post-agent hook*