### PR TITLE
Server URL override in auth layer + app store

### DIFF
--- a/apps/ui/src/lib/hooks/useRecentServerUrls.ts
+++ b/apps/ui/src/lib/hooks/useRecentServerUrls.ts
@@ -1,0 +1,33 @@
+/**
+ * Custom hook for managing recent server URLs.
+ *
+ * Provides access to the recentServerUrls list from app-store, which is
+ * persisted via localStorage (max 10, deduplicated). Also exposes helpers
+ * to add a URL to the list and to set the active server URL override.
+ */
+import { useAppStore } from '@/store/app-store';
+
+export interface UseRecentServerUrlsReturn {
+  /** Recently used server URLs, max 10, deduplicated. Persisted in localStorage. */
+  recentServerUrls: string[];
+  /** Current server URL override (null = use env var / default). */
+  serverUrlOverride: string | null;
+  /** Add a URL to recentServerUrls (deduplicated, max 10). */
+  addRecentServerUrl: (url: string) => void;
+  /** Set the active server URL override, persist to localStorage, and trigger WebSocket reconnection. */
+  setServerUrlOverride: (url: string | null) => void;
+}
+
+export function useRecentServerUrls(): UseRecentServerUrlsReturn {
+  const recentServerUrls = useAppStore((s) => s.recentServerUrls);
+  const serverUrlOverride = useAppStore((s) => s.serverUrlOverride);
+  const addRecentServerUrl = useAppStore((s) => s.addRecentServerUrl);
+  const setServerUrlOverride = useAppStore((s) => s.setServerUrlOverride);
+
+  return {
+    recentServerUrls,
+    serverUrlOverride,
+    addRecentServerUrl,
+    setServerUrlOverride,
+  };
+}


### PR DESCRIPTION
## Summary

Modify getServerUrl() in apps/ui/src/lib/clients/auth.ts to check a runtime override stored in app-store before falling back to env vars. Add serverUrlOverride state + setServerUrlOverride action to app-store. Add recentServerUrls array (max 10) persisted via localStorage. When override changes, invalidate cached HTTP client and WebSocket connection, trigger reconnection. Add CORS middleware on server to accept requests from any origin when hivemind is enabled.

**Project:** Headless Server + Re...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server URL history management. Users can now access and reuse up to 10 recently used server URLs with automatic persistence and support for temporary overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->