### PR TITLE
feat: implement authority enforcement with audit trail

### DIFF
--- a/apps/server/src/services/authority-service.ts
+++ b/apps/server/src/services/authority-service.ts
@@ -42,6 +42,18 @@ const logger = createLogger('AuthorityService');
 // ============================================================================
 
 /**
+ * ExecuteActionResult — the outcome of an executeAction() call.
+ * 'allowed'  → the action passed enforcement (or enforcement is disabled).
+ * 'blocked'  → the action was blocked because risk exceeded the agent's trust tier.
+ */
+export interface ExecuteActionResult {
+  verdict: 'allowed' | 'blocked';
+  reason: string;
+  /** Approval request ID created when the action is blocked */
+  requestId?: string;
+}
+
+/**
  * RegisteredAgent - Runtime extension of AuthorityAgent with project context.
  * The base AuthorityAgent type lacks projectPath and createdAt, which we need
  * for multi-project agent tracking and audit trails.
@@ -133,6 +145,14 @@ const MAX_RISK_BY_TRUST: Record<TrustLevel, RiskLevel> = {
   1: 'low',
   2: 'medium',
   3: 'high',
+};
+
+/** Numeric order for risk levels — used to compare risk severity */
+const RISK_LEVEL_ORDER: Record<RiskLevel, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3,
 };
 
 /**
@@ -472,17 +492,128 @@ export class AuthorityService {
   }
 
   // --------------------------------------------------------------------------
-  // Action Execution (Placeholder)
+  // Action Execution
   // --------------------------------------------------------------------------
 
   /**
-   * Placeholder for delegating approved actions to FeatureLoader/AutoMode.
-   * In a full implementation, this would route to the appropriate service
-   * based on the action type.
+   * Execute an action proposed by an agent, with optional enforcement.
+   *
+   * When authorityEnforcement is false (default): logs and returns — existing behavior unchanged.
+   *
+   * When authorityEnforcement is true, performs real enforcement:
+   *   1. Looks up the agent's trust tier and its max-risk allowance.
+   *   2. If the proposal's risk exceeds the agent's max-risk level → BLOCK:
+   *      - Creates an approval request in the actionable items queue.
+   *      - Logs the denial with full context (agent, action, risk, trust tier).
+   *      - Returns an ExecuteActionResult with verdict 'blocked'.
+   *   3. If the proposal is pre-approved → AUTO-APPROVE immediately with no queue.
+   *   4. Otherwise the action is within trust → ALLOW.
+   *
+   * @param proposal    The action the agent wants to execute.
+   * @param projectPath The project this action belongs to.
+   * @param options     Enforcement options.
+   * @returns An ExecuteActionResult describing the enforcement outcome.
    */
-  async executeAction(proposal: ActionProposal): Promise<void> {
+  async executeAction(
+    proposal: ActionProposal,
+    projectPath?: string,
+    options?: { authorityEnforcement?: boolean }
+  ): Promise<ExecuteActionResult> {
+    const enforcement = options?.authorityEnforcement ?? false;
+
     logger.info(`Executing action: ${proposal.what} on ${proposal.target} by ${proposal.who}`);
-    // Future: delegate to FeatureLoader, AutoModeService, etc.
+
+    if (!enforcement || !projectPath) {
+      // Passthrough — original placeholder behaviour
+      return { verdict: 'allowed', reason: 'Authority enforcement is disabled' };
+    }
+
+    await this.initialize(projectPath);
+
+    const agent = this.findAgentById(proposal.who, projectPath);
+    if (!agent) {
+      const reason = `Agent ${proposal.who} is not registered`;
+      logger.warn(`executeAction blocked: ${reason}`);
+      await this.persistDecisionRecord({
+        proposal,
+        decision: { verdict: 'deny', reason },
+        projectPath,
+      });
+      return { verdict: 'blocked', reason };
+    }
+
+    // Pre-approved actions bypass the risk threshold check
+    if (proposal.preApproved) {
+      const reason = 'Action is pre-approved';
+      logger.info(`executeAction auto-approved: ${proposal.what} (pre-approved)`);
+      await this.persistDecisionRecord({
+        proposal,
+        decision: { verdict: 'allow', reason },
+        projectPath,
+      });
+      this.updateProfileStats(agent.role, 'allow', projectPath);
+      return { verdict: 'allowed', reason };
+    }
+
+    const maxRisk = MAX_RISK_BY_TRUST[agent.trust];
+    const proposalRiskOrder = RISK_LEVEL_ORDER[proposal.risk];
+    const maxRiskOrder = RISK_LEVEL_ORDER[maxRisk];
+
+    if (proposalRiskOrder > maxRiskOrder) {
+      // Block — risk exceeds the agent's trust tier threshold
+      const reason =
+        `Action '${proposal.what}' has risk '${proposal.risk}' which exceeds ` +
+        `agent trust tier ${agent.trust} max risk '${maxRisk}'`;
+
+      logger.warn(
+        `executeAction BLOCKED: agent=${proposal.who} action=${proposal.what} ` +
+          `risk=${proposal.risk} trustTier=${agent.trust} maxRisk=${maxRisk}`
+      );
+
+      // Create an approval request in the queue
+      const request = await this.queueApprovalRequest(proposal, projectPath);
+
+      // Persist the denial decision record
+      await this.persistDecisionRecord({
+        proposal,
+        decision: { verdict: 'deny', reason, approver: request.id },
+        projectPath,
+        requestId: request.id,
+      });
+
+      // Update stats
+      this.updateProfileStats(agent.role, 'deny', projectPath);
+
+      this.events.emit('authority:rejected', {
+        projectPath,
+        proposal,
+        decision: { verdict: 'deny', reason },
+      });
+
+      return { verdict: 'blocked', reason, requestId: request.id };
+    }
+
+    // Action is within the agent's trust tier — allow
+    const reason = `Action '${proposal.what}' (risk: ${proposal.risk}) is within agent trust tier ${agent.trust} (max risk: ${maxRisk})`;
+    logger.info(
+      `executeAction ALLOWED: agent=${proposal.who} action=${proposal.what} risk=${proposal.risk}`
+    );
+
+    await this.persistDecisionRecord({
+      proposal,
+      decision: { verdict: 'allow', reason },
+      projectPath,
+    });
+
+    this.updateProfileStats(agent.role, 'allow', projectPath);
+
+    this.events.emit('authority:approved', {
+      projectPath,
+      proposal,
+      decision: { verdict: 'allow', reason },
+    });
+
+    return { verdict: 'allowed', reason };
   }
 
   // --------------------------------------------------------------------------

--- a/apps/server/tests/unit/services/authority-service.test.ts
+++ b/apps/server/tests/unit/services/authority-service.test.ts
@@ -1,0 +1,293 @@
+/**
+ * AuthorityService Unit Tests
+ *
+ * Tests for executeAction() enforcement:
+ * - Action within trust tier → allowed
+ * - Action above trust tier → blocked + approval request created
+ * - Pre-approved action → auto-approved (bypasses risk threshold)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { AuthorityService } from '@/services/authority-service.js';
+import type { ActionProposal } from '@protolabsai/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEventEmitter() {
+  const emitted: Array<{ event: string; payload: unknown }> = [];
+  return {
+    emit(event: string, payload: unknown) {
+      emitted.push({ event, payload });
+    },
+    emitted,
+  };
+}
+
+function makeActionableItemService() {
+  const created: unknown[] = [];
+  return {
+    async createActionableItem(input: unknown) {
+      created.push(input);
+      return { id: 'mock-actionable-id', ...input };
+    },
+    created,
+  };
+}
+
+function makeProposal(overrides: Partial<ActionProposal> = {}): ActionProposal {
+  return {
+    who: 'AGENT_PLACEHOLDER', // replaced in tests
+    what: 'create_work',
+    target: 'Test Feature',
+    justification: 'Testing enforcement',
+    risk: 'low',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AuthorityService.executeAction()', () => {
+  let testDir: string;
+  let events: ReturnType<typeof makeEventEmitter>;
+  let service: AuthorityService;
+
+  beforeEach(async () => {
+    testDir = path.join(os.tmpdir(), `authority-service-test-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+
+    events = makeEventEmitter();
+    service = new AuthorityService(events as any);
+
+    const actionableItems = makeActionableItemService();
+    service.setActionableItemService(actionableItems as any);
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Enforcement disabled (default)
+  // -------------------------------------------------------------------------
+
+  describe('when authorityEnforcement is false (default)', () => {
+    it('returns allowed without any enforcement checks', async () => {
+      const result = await service.executeAction(makeProposal(), testDir, {
+        authorityEnforcement: false,
+      });
+
+      expect(result.verdict).toBe('allowed');
+      expect(result.reason).toMatch(/disabled/i);
+    });
+
+    it('returns allowed when no options are passed (backward compat)', async () => {
+      // Old signature: executeAction(proposal) — no projectPath, no options
+      const result = await service.executeAction(makeProposal());
+      expect(result.verdict).toBe('allowed');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Enforcement enabled
+  // -------------------------------------------------------------------------
+
+  describe('when authorityEnforcement is true', () => {
+    // Register an agent with trust level 1 (max risk: 'low') before each test
+    let agentId: string;
+
+    beforeEach(async () => {
+      // Register a product-manager agent (trust level 1, max risk: low)
+      const agent = await service.registerAgent('product-manager', testDir);
+      agentId = agent.id;
+    });
+
+    // -----------------------------------------------------------------------
+    // Path 1: action within trust → approved
+    // -----------------------------------------------------------------------
+
+    describe('action within trust tier', () => {
+      it('allows a low-risk action for a trust-1 agent', async () => {
+        const proposal = makeProposal({ who: agentId, risk: 'low' });
+
+        const result = await service.executeAction(proposal, testDir, {
+          authorityEnforcement: true,
+        });
+
+        expect(result.verdict).toBe('allowed');
+        expect(result.requestId).toBeUndefined();
+      });
+
+      it('does not create an approval request for an allowed action', async () => {
+        const actionableItems = makeActionableItemService();
+        service.setActionableItemService(actionableItems as any);
+
+        const proposal = makeProposal({ who: agentId, risk: 'low' });
+        await service.executeAction(proposal, testDir, { authorityEnforcement: true });
+
+        expect(actionableItems.created).toHaveLength(0);
+      });
+
+      it('emits authority:approved event', async () => {
+        const proposal = makeProposal({ who: agentId, risk: 'low' });
+        await service.executeAction(proposal, testDir, { authorityEnforcement: true });
+
+        const approvedEvents = events.emitted.filter((e) => e.event === 'authority:approved');
+        expect(approvedEvents).toHaveLength(1);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Path 2: action above trust → blocked + approval created
+    // -----------------------------------------------------------------------
+
+    describe('action above trust tier', () => {
+      it('blocks a high-risk action for a trust-1 agent (max risk: low)', async () => {
+        const proposal = makeProposal({ who: agentId, risk: 'high' });
+
+        const result = await service.executeAction(proposal, testDir, {
+          authorityEnforcement: true,
+        });
+
+        expect(result.verdict).toBe('blocked');
+        expect(result.reason).toMatch(/high/);
+        expect(result.reason).toMatch(/low/);
+      });
+
+      it('creates an approval request when blocked', async () => {
+        const actionableItems = makeActionableItemService();
+        service.setActionableItemService(actionableItems as any);
+
+        const proposal = makeProposal({ who: agentId, risk: 'high' });
+        const result = await service.executeAction(proposal, testDir, {
+          authorityEnforcement: true,
+        });
+
+        expect(result.requestId).toBeDefined();
+        expect(actionableItems.created).toHaveLength(1);
+      });
+
+      it('includes the approval request ID in the result', async () => {
+        const proposal = makeProposal({ who: agentId, risk: 'medium' });
+
+        const result = await service.executeAction(proposal, testDir, {
+          authorityEnforcement: true,
+        });
+
+        // trust-1 max risk is 'low', so 'medium' should be blocked
+        expect(result.verdict).toBe('blocked');
+        expect(typeof result.requestId).toBe('string');
+      });
+
+      it('emits authority:rejected event when blocked', async () => {
+        const proposal = makeProposal({ who: agentId, risk: 'critical' });
+        await service.executeAction(proposal, testDir, { authorityEnforcement: true });
+
+        const rejectedEvents = events.emitted.filter((e) => e.event === 'authority:rejected');
+        expect(rejectedEvents).toHaveLength(1);
+      });
+
+      it('adds the blocked action to the pending approvals queue', async () => {
+        const proposal = makeProposal({ who: agentId, risk: 'high' });
+        await service.executeAction(proposal, testDir, { authorityEnforcement: true });
+
+        const pending = await service.getPendingApprovals(testDir);
+        expect(pending).toHaveLength(1);
+        expect(pending[0].proposal.what).toBe(proposal.what);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Path 3: pre-approved action → auto-approved
+    // -----------------------------------------------------------------------
+
+    describe('pre-approved action', () => {
+      it('auto-approves an action marked as preApproved even when risk exceeds trust tier', async () => {
+        // trust-1 max risk is 'low', but preApproved skips threshold check
+        const proposal = makeProposal({ who: agentId, risk: 'critical', preApproved: true });
+
+        const result = await service.executeAction(proposal, testDir, {
+          authorityEnforcement: true,
+        });
+
+        expect(result.verdict).toBe('allowed');
+        expect(result.reason).toMatch(/pre-approved/i);
+        expect(result.requestId).toBeUndefined();
+      });
+
+      it('does not create an approval request for pre-approved actions', async () => {
+        const actionableItems = makeActionableItemService();
+        service.setActionableItemService(actionableItems as any);
+
+        const proposal = makeProposal({ who: agentId, risk: 'high', preApproved: true });
+        await service.executeAction(proposal, testDir, { authorityEnforcement: true });
+
+        expect(actionableItems.created).toHaveLength(0);
+      });
+
+      it('does not add pre-approved actions to the pending approvals queue', async () => {
+        const proposal = makeProposal({ who: agentId, risk: 'high', preApproved: true });
+        await service.executeAction(proposal, testDir, { authorityEnforcement: true });
+
+        const pending = await service.getPendingApprovals(testDir);
+        expect(pending).toHaveLength(0);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Unregistered agent
+    // -----------------------------------------------------------------------
+
+    describe('unregistered agent', () => {
+      it('blocks the action when agent is not registered', async () => {
+        const proposal = makeProposal({ who: 'unknown-agent-id', risk: 'low' });
+
+        const result = await service.executeAction(proposal, testDir, {
+          authorityEnforcement: true,
+        });
+
+        expect(result.verdict).toBe('blocked');
+        expect(result.reason).toMatch(/not registered/i);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Higher trust tiers
+    // -----------------------------------------------------------------------
+
+    describe('higher trust tier agents', () => {
+      it('allows a high-risk action for a CTO agent (trust level 3, max risk: high)', async () => {
+        const ctoAgent = await service.registerAgent('cto', testDir);
+        const proposal = makeProposal({ who: ctoAgent.id, risk: 'high' });
+
+        const result = await service.executeAction(proposal, testDir, {
+          authorityEnforcement: true,
+        });
+
+        expect(result.verdict).toBe('allowed');
+      });
+
+      it('blocks a critical-risk action even for a CTO agent (max risk: high)', async () => {
+        const ctoAgent = await service.registerAgent('cto', testDir);
+        const proposal = makeProposal({ who: ctoAgent.id, risk: 'critical' });
+
+        const result = await service.executeAction(proposal, testDir, {
+          authorityEnforcement: true,
+        });
+
+        expect(result.verdict).toBe('blocked');
+      });
+    });
+  });
+});

--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -219,6 +219,15 @@ export interface WorkflowSettings {
    * @default 10
    */
   maxPendingCiRuns?: number;
+  /**
+   * Enable real authority enforcement in executeAction().
+   * When true, actions above the agent's trust tier risk threshold are blocked,
+   * an approval request is created in the actionable items queue, and the denial
+   * is logged with full context (agent, action, risk level, trust tier).
+   * When false (default), executeAction() is a no-op placeholder — existing behavior unchanged.
+   * @default false
+   */
+  authorityEnforcement?: boolean;
 }
 
 /** Default workflow settings */


### PR DESCRIPTION
## Summary
- Implements real enforcement logic in `AuthorityService.executeAction()`
- Adds `ExecuteActionResult` with `verdict: 'allowed' | 'blocked'` discriminated union
- Enforcement paths: disabled (passthrough), within-trust (allow), above-trust (block + approval request), pre-approved (auto-approve)
- Emits `authority:approved` and `authority:rejected` events with full audit context
- Adds `authorityEnforcement` workflow setting (default: false, opt-in)
- 16 unit tests covering all enforcement paths

## Test plan
- [ ] `npm run test:server -- tests/unit/services/authority-service.test.ts` passes
- [ ] Build succeeds with `npm run build:packages`
- [ ] Prettier check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added action execution enforcement that evaluates proposals against agent trust levels and blocks actions exceeding authorized risk thresholds.
  * Implemented automatic approval request creation for high-risk actions.
  * Introduced configurable enforcement toggle; disabled by default to maintain backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->