### PR TITLE
Add error budget auto-freeze to AutoModeService

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -130,6 +130,7 @@ import {
   type LoopState,
   type AutoModeLoopConfig,
 } from './auto-mode/auto-loop-coordinator.js';
+import { AutoModeCoordinator } from './auto-mode/auto-mode-coordinator.js';
 import { FeatureStateManager } from './auto-mode/feature-state-manager.js';
 import { ExecutionService } from './auto-mode/execution-service.js';
 import type {
@@ -198,6 +199,7 @@ export class AutoModeService {
   private concurrencyManager: ConcurrencyManager;
   private runningFeatures = new Map<string, RunningFeature>();
   private readonly coordinator = new AutoLoopCoordinator();
+  private autoModeCoordinator!: AutoModeCoordinator;
   /** Guards against TOCTOU race in startAutoLoopForProject: keys claimed synchronously before any await */
   private readonly pendingLoopStarts = new Set<string>();
   private featureLoader = new FeatureLoader();
@@ -248,6 +250,7 @@ export class AutoModeService {
     this.settingsService = settingsService ?? null;
     this.recoveryService = getRecoveryService(events);
     this.featureStateManager = new FeatureStateManager(this.events, this.featureLoader);
+    this.autoModeCoordinator = new AutoModeCoordinator(events, this.settingsService);
 
     // Initialize ExecutionService with all dependencies and callbacks
     const callbacks: IAutoModeCallbacks = {
@@ -313,6 +316,7 @@ export class AutoModeService {
       sleep: this.sleep.bind(this),
       HEAP_USAGE_STOP_NEW_AGENTS_THRESHOLD: this.HEAP_USAGE_STOP_NEW_AGENTS_THRESHOLD,
       HEAP_USAGE_ABORT_AGENTS_THRESHOLD: this.HEAP_USAGE_ABORT_AGENTS_THRESHOLD,
+      isPickupFrozen: () => this.autoModeCoordinator.isPickupFrozen(),
     };
     this.scheduler = new FeatureScheduler({
       featureLoader: this.featureLoader,

--- a/apps/server/src/services/auto-mode/auto-mode-coordinator.ts
+++ b/apps/server/src/services/auto-mode/auto-mode-coordinator.ts
@@ -1,0 +1,101 @@
+/**
+ * AutoModeCoordinator — error budget freeze gate for auto-mode.
+ *
+ * Listens to `error_budget:exhausted` and `error_budget:recovered` events
+ * emitted by ErrorBudgetService and maintains a pickup-freeze flag that
+ * FeatureScheduler checks before starting new feature agents.
+ *
+ * Running agents are NOT affected — only new feature pickup is blocked.
+ *
+ * The freeze gate is controlled by the `errorBudgetAutoFreeze` WorkflowSettings
+ * field (default: true).  When the setting is false the coordinator ignores
+ * budget events entirely.
+ */
+
+import type { EventEmitter } from '../../lib/events.js';
+import type { EventType } from '@protolabsai/types';
+import { createLogger } from '@protolabsai/utils';
+import type { SettingsService } from '../settings-service.js';
+
+const logger = createLogger('AutoModeCoordinator');
+
+export class AutoModeCoordinator {
+  /** Whether new feature pickup is currently frozen by an error budget exhaustion. */
+  private _pickupFrozen = false;
+
+  private readonly events: EventEmitter;
+  private readonly settingsService: SettingsService | null;
+
+  constructor(events: EventEmitter, settingsService?: SettingsService | null) {
+    this.events = events;
+    this.settingsService = settingsService ?? null;
+
+    this.events.on('error_budget:exhausted' as EventType, (data: unknown) => {
+      void this._handleExhausted(data as { projectPath: string; failRate: number });
+    });
+
+    this.events.on('error_budget:recovered' as EventType, (data: unknown) => {
+      void this._handleRecovered(data as { projectPath: string; failRate: number });
+    });
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  /**
+   * Returns true when new feature pickup should be paused due to an error
+   * budget freeze.  Returns false when the setting is disabled or the budget
+   * is healthy.
+   */
+  isPickupFrozen(): boolean {
+    return this._pickupFrozen;
+  }
+
+  // ── Private handlers ───────────────────────────────────────────────────────
+
+  private async _handleExhausted(data: { projectPath: string; failRate: number }): Promise<void> {
+    if (!(await this._isAutoFreezeEnabled())) {
+      logger.debug(
+        '[AutoModeCoordinator] error_budget:exhausted received but errorBudgetAutoFreeze is disabled — skipping freeze'
+      );
+      return;
+    }
+
+    if (!this._pickupFrozen) {
+      this._pickupFrozen = true;
+      logger.warn(
+        `[AutoModeCoordinator] Error budget exhausted (failRate=${data.failRate.toFixed(3)}) — new feature pickup frozen`
+      );
+    }
+  }
+
+  private async _handleRecovered(data: { projectPath: string; failRate: number }): Promise<void> {
+    if (this._pickupFrozen) {
+      this._pickupFrozen = false;
+      logger.info(
+        `[AutoModeCoordinator] Error budget recovered (failRate=${data.failRate.toFixed(3)}) — new feature pickup resumed`
+      );
+    }
+  }
+
+  private async _isAutoFreezeEnabled(): Promise<boolean> {
+    if (!this.settingsService) return true; // default: enabled
+
+    try {
+      // errorBudgetAutoFreeze is stored on the first active project's workflow settings.
+      // We read global settings to find the first project path, then check workflow settings.
+      const globalSettings = await this.settingsService.getGlobalSettings();
+      const projectPath = globalSettings.projects?.[0]?.path;
+      if (!projectPath) return true;
+
+      const projectSettings = await this.settingsService.getProjectSettings(projectPath);
+      const workflow = projectSettings.workflow as
+        | (typeof projectSettings.workflow & { errorBudgetAutoFreeze?: boolean })
+        | undefined;
+
+      // Default is true (enabled)
+      return workflow?.errorBudgetAutoFreeze !== false;
+    } catch {
+      return true; // fail-safe: default to enabled
+    }
+  }
+}

--- a/apps/server/src/services/error-budget-service.ts
+++ b/apps/server/src/services/error-budget-service.ts
@@ -14,9 +14,16 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { EventEmitter } from 'node:events';
 import { createLogger } from '@protolabsai/utils';
 
 const logger = createLogger('ErrorBudgetService');
+
+/** Burn rate above which the budget is considered fully exhausted (100% consumed). */
+const EXHAUSTION_BURN_RATE = 1.0;
+
+/** Burn rate below which the budget is considered recovered. */
+const RECOVERY_BURN_RATE = 0.8;
 
 // ---------------------------------------------------------------------------
 // Disk document shape
@@ -49,7 +56,7 @@ function ensureDir(dir: string): void {
 // Service
 // ---------------------------------------------------------------------------
 
-export class ErrorBudgetService {
+export class ErrorBudgetService extends EventEmitter {
   /** Path to the project root — used to resolve `.automaker/metrics/error-budget.json`. */
   private readonly projectPath: string;
 
@@ -58,6 +65,12 @@ export class ErrorBudgetService {
 
   /** Fail rate threshold above which the budget is exhausted (default: 0.2 = 20%). */
   private readonly threshold: number;
+
+  /**
+   * Whether the budget is currently in the exhausted state.
+   * Used to avoid emitting duplicate exhausted/recovered events.
+   */
+  private _isExhaustedState = false;
 
   constructor(
     projectPath: string,
@@ -68,6 +81,7 @@ export class ErrorBudgetService {
       threshold?: number;
     } = {}
   ) {
+    super();
     this.projectPath = projectPath;
     this.windowMs = (options.windowDays ?? 7) * 24 * 60 * 60 * 1000;
     this.threshold = options.threshold ?? 0.2;
@@ -96,10 +110,15 @@ export class ErrorBudgetService {
 
     this.writeDocument(doc);
 
+    const failRate = this.getFailRate();
+    const exhausted = this.isExhausted();
+
     logger.info(
       `[ErrorBudget] Recorded merge featureId=${featureId} failedCi=${failedCi} ` +
-        `failRate=${this.getFailRate().toFixed(3)} exhausted=${this.isExhausted()}`
+        `failRate=${failRate.toFixed(3)} exhausted=${exhausted}`
     );
+
+    this._checkAndEmitBudgetEvents(failRate);
   }
 
   /**
@@ -121,6 +140,7 @@ export class ErrorBudgetService {
         doc.updatedAt = new Date().toISOString();
         this.writeDocument(doc);
         logger.info(`[ErrorBudget] Marked CI failure for featureId=${featureId}`);
+        this._checkAndEmitBudgetEvents(this.getFailRate());
       }
     } else {
       // No prior merge record in the window — create one representing a CI failure
@@ -171,6 +191,46 @@ export class ErrorBudgetService {
   // ---------------------------------------------------------------------------
   // Internal helpers
   // ---------------------------------------------------------------------------
+
+  /**
+   * Check current burn rate and emit `error_budget:exhausted` or
+   * `error_budget:recovered` events when the state crosses a threshold.
+   *
+   * Exhausted fires when burn rate >= EXHAUSTION_BURN_RATE (1.0) and the
+   * service was not already in the exhausted state.
+   *
+   * Recovered fires when burn rate drops below RECOVERY_BURN_RATE (0.8) and
+   * the service was in the exhausted state.
+   */
+  private _checkAndEmitBudgetEvents(failRate: number): void {
+    const { total, failed } = this.getWindowCounts();
+
+    if (!this._isExhaustedState && failRate >= EXHAUSTION_BURN_RATE) {
+      this._isExhaustedState = true;
+      logger.warn(
+        `[ErrorBudget] Budget exhausted: failRate=${failRate.toFixed(3)} >= ${EXHAUSTION_BURN_RATE} — emitting error_budget:exhausted`
+      );
+      this.emit('error_budget:exhausted', {
+        projectPath: this.projectPath,
+        failRate,
+        threshold: EXHAUSTION_BURN_RATE,
+        totalMerges: total,
+        failedMerges: failed,
+      });
+    } else if (this._isExhaustedState && failRate < RECOVERY_BURN_RATE) {
+      this._isExhaustedState = false;
+      logger.info(
+        `[ErrorBudget] Budget recovered: failRate=${failRate.toFixed(3)} < ${RECOVERY_BURN_RATE} — emitting error_budget:recovered`
+      );
+      this.emit('error_budget:recovered', {
+        projectPath: this.projectPath,
+        failRate,
+        threshold: EXHAUSTION_BURN_RATE,
+        totalMerges: total,
+        failedMerges: failed,
+      });
+    }
+  }
 
   private getWindowCounts(): { total: number; failed: number } {
     const doc = this.readDocument();

--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -96,6 +96,11 @@ export interface SchedulerCallbacks {
   /** Memory thresholds */
   HEAP_USAGE_STOP_NEW_AGENTS_THRESHOLD: number;
   HEAP_USAGE_ABORT_AGENTS_THRESHOLD: number;
+  /**
+   * Optional hook: returns true when new feature pickup should be paused
+   * due to an error budget freeze. Running agents are NOT affected.
+   */
+  isPickupFrozen?(): boolean;
 }
 
 /** Interface for the feature health auditor (optional). */
@@ -312,6 +317,18 @@ export class FeatureScheduler {
               `[AutoLoop] High heap usage (${Math.round(heapUsage * 100)}%), deferring new agent start`
             );
             await this.callbacks.sleep(5000);
+            continue;
+          }
+
+          // Error budget freeze: pause pickup when budget is exhausted
+          if (this.callbacks.isPickupFrozen?.()) {
+            logger.warn(
+              `[AutoLoop] Error budget frozen — pausing new feature pickup for ${worktreeDesc}`
+            );
+            await this.callbacks.sleep(
+              SLEEP_INTERVAL_CAPACITY_MS,
+              projectState.abortController.signal
+            );
             continue;
           }
 

--- a/apps/server/tests/unit/services/error-budget-service.test.ts
+++ b/apps/server/tests/unit/services/error-budget-service.test.ts
@@ -9,12 +9,16 @@
  * - getState() returns a complete snapshot
  * - Rolling window excludes old records
  * - Persistence round-trip (write => read)
+ * - error_budget:exhausted event emitted when burn rate >= 1.0
+ * - error_budget:recovered event emitted when burn rate drops below 0.8
+ * - AutoModeCoordinator respects errorBudgetAutoFreeze setting
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { EventEmitter } from 'node:events';
 
 // Mock logger before imports
 vi.mock('@protolabsai/utils', () => ({
@@ -27,6 +31,7 @@ vi.mock('@protolabsai/utils', () => ({
 }));
 
 import { ErrorBudgetService } from '@/services/error-budget-service.js';
+import { AutoModeCoordinator } from '@/services/auto-mode/auto-mode-coordinator.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -271,5 +276,146 @@ describe('ErrorBudgetService', () => {
     const svc = new ErrorBudgetService(tmpDir, { windowDays: 14 });
     const state = svc.getState();
     expect(state.windowDays).toBe(14);
+  });
+
+  // ──────────────────────────── Error budget events ────────────────────────────
+
+  it('emits error_budget:exhausted when burn rate reaches 1.0 (all merges failed)', () => {
+    // Use threshold=0.2 for isExhausted() but the NEW exhausted event fires at 1.0 burn rate
+    const svc = new ErrorBudgetService(tmpDir);
+    const exhaustedListener = vi.fn();
+    svc.on('error_budget:exhausted', exhaustedListener);
+
+    // Drive all merges to failed → failRate = 1.0
+    svc.recordMerge('f1', true);
+    svc.recordMerge('f2', true);
+
+    expect(exhaustedListener).toHaveBeenCalledTimes(1);
+    const payload = exhaustedListener.mock.calls[0][0] as {
+      projectPath: string;
+      failRate: number;
+      threshold: number;
+    };
+    expect(payload.projectPath).toBe(tmpDir);
+    expect(payload.failRate).toBe(1);
+    expect(payload.threshold).toBe(1.0);
+  });
+
+  it('does not emit error_budget:exhausted twice without recovery in between', () => {
+    const svc = new ErrorBudgetService(tmpDir);
+    const exhaustedListener = vi.fn();
+    svc.on('error_budget:exhausted', exhaustedListener);
+
+    // First exhaustion: all merges fail
+    svc.recordMerge('f1', true);
+    svc.recordMerge('f2', true);
+    // Still at 100% — second call should NOT fire again
+    svc.recordMerge('f3', true);
+
+    expect(exhaustedListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits error_budget:recovered when burn rate drops below 0.8 after exhaustion', () => {
+    const svc = new ErrorBudgetService(tmpDir);
+    const exhaustedListener = vi.fn();
+    const recoveredListener = vi.fn();
+    svc.on('error_budget:exhausted', exhaustedListener);
+    svc.on('error_budget:recovered', recoveredListener);
+
+    // Drive to 100% failure → exhausted
+    svc.recordMerge('f1', true);
+    svc.recordMerge('f2', true);
+    expect(exhaustedListener).toHaveBeenCalledTimes(1);
+    expect(recoveredListener).not.toHaveBeenCalled();
+
+    // Add many successful merges to bring failRate below 0.8
+    // 2 failed / 12 total = 16.7% < 80%
+    for (let i = 3; i <= 12; i++) {
+      svc.recordMerge(`f${i}`, false);
+    }
+
+    expect(recoveredListener).toHaveBeenCalledTimes(1);
+    const payload = recoveredListener.mock.calls[0][0] as {
+      projectPath: string;
+      failRate: number;
+    };
+    expect(payload.projectPath).toBe(tmpDir);
+    expect(payload.failRate).toBeLessThan(0.8);
+  });
+
+  it('does not emit error_budget:recovered if never exhausted', () => {
+    const svc = new ErrorBudgetService(tmpDir);
+    const exhaustedListener = vi.fn();
+    const recoveredListener = vi.fn();
+    svc.on('error_budget:exhausted', exhaustedListener);
+    svc.on('error_budget:recovered', recoveredListener);
+
+    // Start with successful merges so failRate never reaches 1.0
+    // 1 failed / 4 total = 25% — below 100% exhaustion threshold
+    svc.recordMerge('f1', false);
+    svc.recordMerge('f2', false);
+    svc.recordMerge('f3', false);
+    svc.recordMerge('f4', true);
+
+    // Budget was never fully exhausted (failRate stayed below 1.0)
+    expect(exhaustedListener).not.toHaveBeenCalled();
+    expect(recoveredListener).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AutoModeCoordinator — errorBudgetAutoFreeze behavior
+// ---------------------------------------------------------------------------
+
+describe('AutoModeCoordinator', () => {
+  it('sets pickup frozen when error_budget:exhausted is received (autoFreeze default=true)', async () => {
+    const emitter = new EventEmitter() as unknown as import('@/lib/events.js').EventEmitter;
+    const coordinator = new AutoModeCoordinator(emitter, null);
+
+    expect(coordinator.isPickupFrozen()).toBe(false);
+
+    emitter.emit('error_budget:exhausted', { projectPath: '/tmp/test', failRate: 1.0 });
+
+    // Allow promise microtasks to settle
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(coordinator.isPickupFrozen()).toBe(true);
+  });
+
+  it('clears pickup frozen when error_budget:recovered is received', async () => {
+    const emitter = new EventEmitter() as unknown as import('@/lib/events.js').EventEmitter;
+    const coordinator = new AutoModeCoordinator(emitter, null);
+
+    emitter.emit('error_budget:exhausted', { projectPath: '/tmp/test', failRate: 1.0 });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(coordinator.isPickupFrozen()).toBe(true);
+
+    emitter.emit('error_budget:recovered', { projectPath: '/tmp/test', failRate: 0.3 });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(coordinator.isPickupFrozen()).toBe(false);
+  });
+
+  it('skips freeze when errorBudgetAutoFreeze=false in settings', async () => {
+    const emitter = new EventEmitter() as unknown as import('@/lib/events.js').EventEmitter;
+
+    // Mock settings service with errorBudgetAutoFreeze=false
+    const mockSettingsService = {
+      getGlobalSettings: vi.fn().mockResolvedValue({
+        projects: [{ path: '/tmp/project', id: 'proj-1' }],
+      }),
+      getProjectSettings: vi.fn().mockResolvedValue({
+        workflow: { errorBudgetAutoFreeze: false },
+      }),
+    } as unknown as import('@/services/settings-service.js').SettingsService;
+
+    const coordinator = new AutoModeCoordinator(emitter, mockSettingsService);
+
+    emitter.emit('error_budget:exhausted', { projectPath: '/tmp/test', failRate: 1.0 });
+
+    // Allow async settings read to complete
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Should NOT be frozen because setting is disabled
+    expect(coordinator.isPickupFrozen()).toBe(false);
   });
 });

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -340,7 +340,10 @@ export type EventType =
   | 'agent:completed'
   | 'pr:merged'
   | 'pr:review-requested'
-  | 'ava-channel:message';
+  | 'ava-channel:message'
+  // Error budget events (burn rate threshold enforcement)
+  | 'error_budget:exhausted'
+  | 'error_budget:recovered';
 
 export type EventCallback = (type: EventType, payload: unknown) => void;
 
@@ -547,6 +550,20 @@ export interface EventPayloadMap {
     projectPath: string;
     elapsedMinutes: number;
     capMinutes: number;
+  };
+  'error_budget:exhausted': {
+    projectPath: string;
+    failRate: number;
+    threshold: number;
+    totalMerges: number;
+    failedMerges: number;
+  };
+  'error_budget:recovered': {
+    projectPath: string;
+    failRate: number;
+    threshold: number;
+    totalMerges: number;
+    failedMerges: number;
   };
   'feature:status-changed': {
     featureId: string;

--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -256,6 +256,14 @@ export interface WorkflowSettings {
    * @default 10
    */
   maxInReview?: number;
+  /**
+   * When true, auto-mode pauses new feature pickup when the error budget is exhausted
+   * (burn rate >= exhaustion threshold, default 1.0 = 100% consumed). Pickup resumes
+   * automatically when the budget recovers (burn rate drops below 0.8). Running agents
+   * are NOT affected — only new feature starts are blocked.
+   * @default true
+   */
+  errorBudgetAutoFreeze?: boolean;
 }
 
 /** Default workflow settings */


### PR DESCRIPTION
## Summary

**Milestone:** Error Budget Enforcement

ErrorBudgetService already tracks budget burn. Add error_budget:exhausted event emitted when burn rate exceeds threshold (default 1.0 = 100% consumed). AutoModeService listens and pauses new feature pickup (keeps running agents alive but does not start new ones). When ErrorBudgetService emits error_budget:recovered (burn drops below 0.8), AutoModeService resumes. Add errorBudgetAutoFreeze to WorkflowSettings (default: true). Add unit tests for: budget exh...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-freezes new feature pickup when an error budget is exhausted and automatically resumes when it recovers.
  * Scheduling now pauses pickup during freezes to reduce failed rollouts.
  * New workflow setting errorBudgetAutoFreeze (default: enabled) lets teams opt out of automatic freeze per project/workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->