### PR TITLE
feat: add PR merge poller to Lead Engineer service

### DIFF
--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -550,9 +550,7 @@ export class LeadEngineerService {
 
     for (const feature of reviewFeaturesWithPR) {
       try {
-        const { stdout } = await execAsync(
-          `gh pr view ${feature.prNumber} --json state,mergedAt`
-        );
+        const { stdout } = await execAsync(`gh pr view ${feature.prNumber} --json state,mergedAt`);
         const prData = JSON.parse(stdout.trim()) as { state: string; mergedAt?: string | null };
 
         if (prData.state !== 'MERGED') continue;

--- a/apps/server/tests/unit/services/lead-engineer-service.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-service.test.ts
@@ -555,11 +555,9 @@ describe('LeadEngineerService', () => {
       await service.start('/test/project', 'my-project');
 
       const mergedAt = '2026-03-10T15:00:00Z';
-      mockExec
-        .mockRejectedValueOnce(new Error('gh: PR not found'))
-        .mockResolvedValueOnce({
-          stdout: JSON.stringify({ state: 'MERGED', mergedAt }),
-        });
+      mockExec.mockRejectedValueOnce(new Error('gh: PR not found')).mockResolvedValueOnce({
+        stdout: JSON.stringify({ state: 'MERGED', mergedAt }),
+      });
 
       await (service as any).checkMergedPRs('/test/project');
 
@@ -637,9 +635,7 @@ describe('LeadEngineerService', () => {
       await vi.advanceTimersByTimeAsync(2.5 * 60 * 1000 + 100);
       await vi.advanceTimersByTimeAsync(100);
 
-      expect(mockExec).toHaveBeenCalledWith(
-        expect.stringContaining('gh pr view 42')
-      );
+      expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('gh pr view 42'));
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `checkMergedPRs()` method to `LeadEngineerService` that polls features in `review` status every 2.5 minutes via `gh pr view`
- When a PR is detected as merged externally, auto-transitions the feature to `done` with `prMergedAt` timestamp and emits `feature:pr-merged` event
- Each feature is independently try/catch'd — gh CLI failures are logged as warnings and don't block other features

## Files Changed
- `apps/server/src/services/lead-engineer-service.ts` — poller logic, interval setup/teardown
- `apps/server/tests/unit/services/lead-engineer-service.test.ts` — 8 new tests

## Test plan
- [x] Merged PR auto-transitions feature to done
- [x] Open PR leaves feature unchanged
- [x] Features without prNumber are skipped
- [x] Features not in review status are skipped
- [x] gh CLI failure is handled gracefully (continues to next feature)
- [x] Stopped session does not run poller
- [x] Null mergedAt falls back to current timestamp
- [x] Interval fires every 2.5 minutes

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic PR merge detection: features in review now auto-transition to "done" when their PR is merged
  * Periodic polling (every 2.5 minutes) to detect merged PRs and attach merge timestamps
  * Emits notifications/events when PRs are detected as merged; polling stops when the session stops

* **Tests**
  * Comprehensive tests covering merge detection, timing/interval behavior, error handling, and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->