### PR TITLE
feat: add lazy feature lookup to world state event handler

### DIFF
--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -581,7 +581,7 @@ export class LeadEngineerService {
     }
   }
 
-  private onEvent(type: EventType, payload: unknown): void {
+  private async onEvent(type: EventType, payload: unknown): Promise<void> {
     const p = payload as Record<string, unknown> | null;
     const nested = p?.payload as Record<string, unknown> | null;
     const projectPath = (p?.projectPath ?? nested?.projectPath) as string | undefined;
@@ -604,7 +604,20 @@ export class LeadEngineerService {
     const featureId = (p?.featureId ?? nested?.featureId) as string | undefined;
     if (featureId) {
       for (const session of this.sessions.values()) {
-        if (session.flowState !== 'running' || !session.worldState.features[featureId]) continue;
+        if (session.flowState !== 'running') continue;
+        if (!session.worldState.features[featureId]) {
+          try {
+            const feature = await this.featureLoader.get(session.projectPath, featureId);
+            if (feature) {
+              session.worldState.features[featureId] =
+                this.worldStateBuilder.featureToSnapshot(feature);
+            } else {
+              continue;
+            }
+          } catch {
+            continue;
+          }
+        }
         this.worldStateBuilder.updateFromEvent(session.worldState, type, payload);
         this.getActionExecutor(undefined, session.projectPath).evaluateAndExecute(
           session,

--- a/apps/server/tests/unit/services/lead-engineer-service.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-service.test.ts
@@ -359,6 +359,81 @@ describe('LeadEngineerService', () => {
     });
   });
 
+  // ──── Lazy feature lookup ────
+
+  describe('lazy feature lookup in onEvent', () => {
+    it('loads unknown features from disk when event arrives with featureId', async () => {
+      // Start with empty features so worldState has none
+      featureLoader = createMockFeatureLoader([]);
+      const lazyFeature = createMockFeature({
+        id: 'lazy-1',
+        status: 'in_progress',
+        branchName: 'feature/lazy-1',
+      });
+      // featureLoader.get returns the feature on lazy lookup
+      featureLoader.get.mockResolvedValue(lazyFeature);
+
+      service = new LeadEngineerService(
+        events as any,
+        featureLoader as any,
+        autoModeService as any,
+        projectService as any,
+        projectLifecycleService as any,
+        settingsService as any,
+        metricsService as any
+      );
+      await service.initialize();
+      await service.start('/test/project', 'my-project');
+
+      // Confirm feature not in worldState initially
+      const sessionBefore = service.getSession('/test/project');
+      expect(sessionBefore?.worldState.features['lazy-1']).toBeUndefined();
+
+      // Fire event for unknown feature
+      events._fire('feature:status-changed' as EventType, {
+        featureId: 'lazy-1',
+        oldStatus: 'in_progress',
+        newStatus: 'review',
+      });
+
+      // Allow async onEvent to resolve
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Feature should now be in worldState via lazy load
+      const sessionAfter = service.getSession('/test/project');
+      expect(sessionAfter?.worldState.features['lazy-1']).toBeDefined();
+      expect(featureLoader.get).toHaveBeenCalledWith('/test/project', 'lazy-1');
+    });
+
+    it('skips gracefully when lazy lookup returns null', async () => {
+      featureLoader = createMockFeatureLoader([]);
+      featureLoader.get.mockResolvedValue(null);
+
+      service = new LeadEngineerService(
+        events as any,
+        featureLoader as any,
+        autoModeService as any,
+        projectService as any,
+        projectLifecycleService as any,
+        settingsService as any,
+        metricsService as any
+      );
+      await service.initialize();
+      await service.start('/test/project', 'my-project');
+
+      events._fire('feature:status-changed' as EventType, {
+        featureId: 'missing-1',
+        oldStatus: 'in_progress',
+        newStatus: 'review',
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      const session = service.getSession('/test/project');
+      expect(session?.worldState.features['missing-1']).toBeUndefined();
+    });
+  });
+
   // ──── Flow state transitions ────
 
   describe('flow state transitions', () => {


### PR DESCRIPTION
## Summary
- When Lead Engineer receives an event for a featureId not in worldState, lazily loads it from disk via `featureLoader.get()` and converts to snapshot
- Makes `onEvent` async to support the disk lookup
- Adds 2 unit tests: successful lazy load and graceful null handling

## Test plan
- [ ] `npm run test:server` passes (22 existing + 2 new tests)
- [ ] Events for features created after LE session start are now handled
- [ ] Null/missing features don't crash the event handler

Epic: World State Lazy Population
Project: lead-engineer-lifecycle-gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented on-demand loading of feature data when event handling references unavailable features, ensuring improved data availability and resilience.

* **Tests**
  * Added test coverage for lazy feature loading behavior during event processing, including successful loads and null-return scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->