### PR TITLE
Update feature selection to be project-scoped

### DIFF
--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { createLogger } from '@protolabsai/utils';
+import { loadProtoConfig } from '@protolabsai/platform';
 import { createEventEmitter, type EventEmitter } from '../lib/events.js';
 
 import { AgentService } from '../services/agent-service.js';
@@ -745,6 +746,32 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   leadEngineerService.setKnowledgeStoreService(knowledgeStoreService);
   leadEngineerService.setHITLFormService(hitlFormService);
   await leadEngineerService.initialize();
+
+  // Wire project-affinity filtering into auto-mode when projectPreferences are configured.
+  // This enables multi-instance deployments to scope feature pickup to assigned projects.
+  // Single-instance setups (no proto.config.yaml projectPreferences) are unaffected.
+  try {
+    const protoConfig = await loadProtoConfig(repoRoot);
+    const projectPreferences = protoConfig?.['projectPreferences'] as
+      | { preferredProjects?: string[]; overflowEnabled?: boolean }
+      | undefined;
+    const hasPreferredProjects =
+      Array.isArray(projectPreferences?.preferredProjects) &&
+      projectPreferences.preferredProjects.length > 0;
+    if (hasPreferredProjects) {
+      const overflowEnabled = projectPreferences?.overflowEnabled ?? true;
+      autoModeService.setProjectAssignmentService(
+        crdtSyncService.getInstanceId(),
+        projectAssignmentService,
+        overflowEnabled
+      );
+      logger.info(
+        `[Affinity] Project-affinity filtering enabled (instanceId=${crdtSyncService.getInstanceId()}, preferredProjects=${projectPreferences?.preferredProjects?.join(',') ?? ''}, overflow=${overflowEnabled})`
+      );
+    }
+  } catch (err) {
+    logger.warn('[Affinity] Failed to load project preferences — affinity filtering skipped:', err);
+  }
 
   // Wire pipelineOrchestrator processors
   pipelineOrchestrator.setProcessors({ ops: pmAgent, gtm: gtmAgent, projm: projmAgent });

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -392,6 +392,36 @@ export class AutoModeService {
     this.workIntakeService = service;
   }
 
+  /**
+   * Wire up project-affinity filtering for multi-instance deployments.
+   *
+   * When set, the scheduler will filter pending features by project ownership and sort them
+   * (assigned projects first, then own unassigned, then overflow). The featureLoader will
+   * also stamp createdByInstance on newly created features.
+   *
+   * Not required for single-instance setups — omitting this call preserves the existing
+   * behavior (all eligible features are candidates, sorted only by priority).
+   *
+   * @param instanceId - This instance's identity string (from CrdtSyncService.getInstanceId())
+   * @param projectAssignmentService - Service that tracks project-to-instance assignments
+   * @param overflowEnabled - Whether this instance accepts features from non-assigned projects
+   */
+  setProjectAssignmentService(
+    instanceId: string,
+    projectAssignmentService: import('./project-assignment-service.js').ProjectAssignmentService,
+    overflowEnabled = true
+  ): void {
+    // Stamp instance ID on newly created features
+    this.featureLoader.setInstanceId(instanceId);
+
+    // Wire project affinity into the scheduler
+    const getAssignedProjectSlugs = async (projectPath: string): Promise<Set<string>> => {
+      const projects = await projectAssignmentService.getMyAssignedProjects(projectPath);
+      return new Set(projects.map((p) => p.slug));
+    };
+    this.scheduler.setProjectAffinity(instanceId, getAssignedProjectSlugs, overflowEnabled);
+  }
+
   /** Total number of currently running agent features across all projects. */
   getRunningAgentCount(): number {
     return this.runningFeatures.size;

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -48,6 +48,8 @@ export type { Feature };
 export class FeatureLoader implements FeatureStore {
   private integrityWatchdog: DataIntegrityWatchdogService | null = null;
   private events: EventEmitter | null = null;
+  /** Instance ID stamped onto newly created features as createdByInstance */
+  private instanceId: string | null = null;
 
   setIntegrityWatchdog(watchdog: DataIntegrityWatchdogService): void {
     this.integrityWatchdog = watchdog;
@@ -55,6 +57,14 @@ export class FeatureLoader implements FeatureStore {
 
   setEventEmitter(events: EventEmitter): void {
     this.events = events;
+  }
+
+  /**
+   * Set the instance ID used to stamp createdByInstance on new features.
+   * Call this once at startup when multi-instance identity is configured.
+   */
+  setInstanceId(instanceId: string): void {
+    this.instanceId = instanceId;
   }
   /**
    * Normalize feature status to canonical values
@@ -559,6 +569,11 @@ export class FeatureLoader implements FeatureStore {
           reason: 'Feature created',
         },
       ],
+      // Stamp the creating instance ID when multi-instance identity is configured.
+      // Caller-supplied createdByInstance takes precedence (e.g. CRDT sync from peer).
+      ...(featureData.createdByInstance == null && this.instanceId != null
+        ? { createdByInstance: this.instanceId }
+        : {}),
     };
 
     // Write feature.json atomically with backup support

--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -117,6 +117,22 @@ export class FeatureScheduler {
   private runner: PipelineRunner;
   private callbacks: SchedulerCallbacks;
   private featureHealthAuditor: FeatureHealthAuditor | null = null;
+  /**
+   * Instance identity for project-affinity filtering.
+   * When null, no affinity filtering is applied (single-instance backward compat).
+   */
+  private instanceId: string | null = null;
+  /**
+   * Async callback that returns the set of project slugs currently assigned to this instance.
+   * Injected from AutoModeService to avoid a hard dependency on ProjectAssignmentService.
+   * When null, affinity filtering is bypassed.
+   */
+  private getAssignedProjectSlugs: ((projectPath: string) => Promise<Set<string>>) | null = null;
+  /**
+   * Whether this instance accepts overflow work from projects not explicitly assigned to it.
+   * Read from proto.config.yaml projectPreferences.overflowEnabled (default: true).
+   */
+  private overflowEnabled = true;
 
   constructor(deps: {
     featureLoader: FeatureLoader;
@@ -134,6 +150,25 @@ export class FeatureScheduler {
 
   setFeatureHealthAuditor(auditor: FeatureHealthAuditor): void {
     this.featureHealthAuditor = auditor;
+  }
+
+  /**
+   * Configure project-affinity filtering for multi-instance deployments.
+   * When set, loadPendingFeatures() will filter and sort features by project ownership.
+   * Leave unset for single-instance deployments (backward compatible).
+   *
+   * @param instanceId - This instance's identity string
+   * @param getAssignedProjectSlugs - Async fn returning slugs of projects assigned to this instance
+   * @param overflowEnabled - Whether to accept features from non-assigned projects (default: true)
+   */
+  setProjectAffinity(
+    instanceId: string,
+    getAssignedProjectSlugs: (projectPath: string) => Promise<Set<string>>,
+    overflowEnabled = true
+  ): void {
+    this.instanceId = instanceId;
+    this.getAssignedProjectSlugs = getAssignedProjectSlugs;
+    this.overflowEnabled = overflowEnabled;
   }
 
   // ── Loop ─────────────────────────────────────────────────────────────────
@@ -1130,11 +1165,63 @@ export class FeatureScheduler {
       const priorityOrder = (p?: number | null): number => (p === 0 || p == null ? 3 : p);
       readyFeatures.sort((a, b) => priorityOrder(a.priority) - priorityOrder(b.priority));
 
+      // ── Project affinity filtering and sorting ──
+      // Only applied when instance identity is configured (multi-instance deployments).
+      // Single-instance setups with no proto.config.yaml identity pass through unmodified.
+      let affinityFilteredFeatures = readyFeatures;
+      if (this.instanceId && this.getAssignedProjectSlugs) {
+        try {
+          const assignedSlugs = await this.getAssignedProjectSlugs(projectPath);
+
+          // Categorise each feature by affinity tier:
+          //   0 = assigned project    (projectSlug explicitly assigned to this instance)
+          //   1 = own unassigned      (no projectSlug but createdByInstance matches this instance)
+          //   2 = overflow            (all other features — eligible only when overflowEnabled)
+          const affinityTier = (f: Feature): 0 | 1 | 2 => {
+            if (f.projectSlug && assignedSlugs.has(f.projectSlug)) return 0;
+            if (!f.projectSlug && f.createdByInstance === this.instanceId) return 1;
+            return 2;
+          };
+
+          const beforeCount = readyFeatures.length;
+          affinityFilteredFeatures = readyFeatures.filter((f) => {
+            const tier = affinityTier(f);
+            if (tier === 2 && !this.overflowEnabled) {
+              logger.debug(
+                `[loadPendingFeatures] Affinity: skipping overflow feature ${f.id} (overflowEnabled=false)`
+              );
+              return false;
+            }
+            return true;
+          });
+
+          // Sort: assigned (0) > own unassigned (1) > overflow (2)
+          // Within the same tier, preserve the existing priority order.
+          affinityFilteredFeatures.sort((a, b) => {
+            const tierDiff = affinityTier(a) - affinityTier(b);
+            if (tierDiff !== 0) return tierDiff;
+            return priorityOrder(a.priority) - priorityOrder(b.priority);
+          });
+
+          logger.info(
+            `[loadPendingFeatures] Affinity filter (instanceId=${this.instanceId}): ${beforeCount} → ${affinityFilteredFeatures.length} features ` +
+              `(assigned=${assignedSlugs.size} projects, overflow=${this.overflowEnabled})`
+          );
+        } catch (err) {
+          // On error, fall back to the unfiltered list (safe degradation)
+          logger.warn(
+            '[loadPendingFeatures] Affinity filtering failed, using unfiltered list:',
+            err
+          );
+          affinityFilteredFeatures = readyFeatures;
+        }
+      }
+
       logger.info(
-        `[loadPendingFeatures] After dependency filtering: ${readyFeatures.length} ready features (skipVerification=${skipVerification})`
+        `[loadPendingFeatures] After dependency filtering: ${affinityFilteredFeatures.length} ready features (skipVerification=${skipVerification})`
       );
 
-      return readyFeatures;
+      return affinityFilteredFeatures;
     } catch (error) {
       logger.error(`[loadPendingFeatures] Error loading features:`, error);
       return [];

--- a/apps/server/tests/unit/services/feature-loader.test.ts
+++ b/apps/server/tests/unit/services/feature-loader.test.ts
@@ -319,6 +319,40 @@ describe('feature-loader.ts', () => {
 
       expect(result.category).toBe('Uncategorized');
     });
+
+    it('stamps createdByInstance when instanceId is set via setInstanceId()', async () => {
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+      loader.setInstanceId('instance-alpha');
+      const result = await loader.create(testProjectPath, { description: 'Test' });
+
+      expect(result.createdByInstance).toBe('instance-alpha');
+    });
+
+    it('does NOT stamp createdByInstance when no instanceId is configured (single-instance)', async () => {
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+      // No setInstanceId call → single-instance mode
+      const result = await loader.create(testProjectPath, { description: 'Test' });
+
+      expect(result.createdByInstance).toBeUndefined();
+    });
+
+    it('caller-supplied createdByInstance takes precedence over instanceId', async () => {
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+      loader.setInstanceId('instance-alpha');
+      const result = await loader.create(testProjectPath, {
+        description: 'Synced from peer',
+        createdByInstance: 'instance-beta',
+      });
+
+      // The caller (e.g. CRDT sync) explicitly set createdByInstance — must not be overwritten
+      expect(result.createdByInstance).toBe('instance-beta');
+    });
   });
 
   describe('update', () => {

--- a/apps/server/tests/unit/services/scheduler-loop.test.ts
+++ b/apps/server/tests/unit/services/scheduler-loop.test.ts
@@ -622,3 +622,153 @@ describe('AutoModeService - concurrency and race prevention', () => {
     expect(count >= maxConcurrency).toBe(true);
   });
 });
+
+// ─── FeatureScheduler - project affinity filtering ───────────────────────────
+
+describe('FeatureScheduler - project affinity filtering', () => {
+  let scheduler: FeatureScheduler;
+  const mockFeatureLoader = {
+    update: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn(),
+    getAll: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+  };
+  const mockEvents = {
+    subscribe: vi.fn(),
+    emit: vi.fn(),
+    on: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+    broadcast: vi.fn(),
+  };
+  const mockRunner: PipelineRunner = { run: vi.fn() };
+  const mockCallbacks: SchedulerCallbacks = {
+    getRunningCountForWorktree: vi.fn().mockResolvedValue(0),
+    hasInProgressFeatures: vi.fn().mockResolvedValue(false),
+    isFeatureRunning: vi.fn().mockReturnValue(false),
+    isFeatureFinished: vi.fn().mockReturnValue(false),
+    emitAutoModeEvent: vi.fn(),
+    getHeapUsagePercent: vi.fn().mockReturnValue(0),
+    getMostRecentRunningFeature: vi.fn().mockReturnValue(null),
+    recordSuccessForProject: vi.fn(),
+    trackFailureAndCheckPauseForProject: vi.fn().mockReturnValue(false),
+    signalShouldPauseForProject: vi.fn(),
+    sleep: vi.fn().mockResolvedValue(undefined),
+    HEAP_USAGE_STOP_NEW_AGENTS_THRESHOLD: 85,
+    HEAP_USAGE_ABORT_AGENTS_THRESHOLD: 92,
+  };
+
+  const INSTANCE_ID = 'instance-alpha';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetFeaturesDir.mockReturnValue('/fake/project/.automaker/features');
+    mockEvents.on.mockReturnValue({ unsubscribe: vi.fn() });
+    mockFeatureLoader.update.mockResolvedValue(undefined);
+    scheduler = new FeatureScheduler({
+      featureLoader: mockFeatureLoader as never,
+      settingsService: null,
+      events: mockEvents as never,
+      runner: mockRunner,
+      callbacks: mockCallbacks,
+    });
+  });
+
+  const setupSchedulerWithAffinity = (assignedSlugs: string[], overflowEnabled = true) => {
+    const getAssignedProjectSlugs = vi.fn().mockResolvedValue(new Set(assignedSlugs));
+    scheduler.setProjectAffinity(INSTANCE_ID, getAssignedProjectSlugs, overflowEnabled);
+    return getAssignedProjectSlugs;
+  };
+
+  it('single-instance: no affinity set → all eligible features returned', async () => {
+    // No setProjectAffinity call = single-instance mode
+    const f1 = makeFeature({ id: 'feat-001', projectSlug: 'project-a' });
+    const f2 = makeFeature({ id: 'feat-002', projectSlug: 'project-b' });
+    const f3 = makeFeature({ id: 'feat-003' }); // no projectSlug
+
+    setupDefaultExecMocks();
+    setupFeaturesOnDisk([f1, f2, f3]);
+
+    const result = await scheduler.loadPendingFeatures('/fake/project');
+    const ids = result.map((f) => f.id);
+
+    expect(ids).toContain('feat-001');
+    expect(ids).toContain('feat-002');
+    expect(ids).toContain('feat-003');
+  });
+
+  it('assigned project filter: feature with matching projectSlug is included', async () => {
+    setupSchedulerWithAffinity(['project-a']);
+    const f1 = makeFeature({ id: 'feat-001', projectSlug: 'project-a' });
+    const f2 = makeFeature({ id: 'feat-002', projectSlug: 'project-b' });
+
+    setupDefaultExecMocks();
+    setupFeaturesOnDisk([f1, f2]);
+
+    const result = await scheduler.loadPendingFeatures('/fake/project');
+    const ids = result.map((f) => f.id);
+
+    expect(ids).toContain('feat-001');
+    // project-b is overflow — included by default (overflowEnabled=true)
+    expect(ids).toContain('feat-002');
+  });
+
+  it('own unassigned filter: feature with no projectSlug and createdByInstance matches is included', async () => {
+    setupSchedulerWithAffinity([]);
+    const f1 = makeFeature({ id: 'feat-own', createdByInstance: INSTANCE_ID }); // own unassigned
+    const f2 = makeFeature({ id: 'feat-other', createdByInstance: 'instance-beta' }); // another instance's
+
+    setupDefaultExecMocks();
+    setupFeaturesOnDisk([f1, f2]);
+
+    const result = await scheduler.loadPendingFeatures('/fake/project');
+    const ids = result.map((f) => f.id);
+
+    expect(ids).toContain('feat-own');
+    // feat-other is overflow — included by default (overflowEnabled=true)
+    expect(ids).toContain('feat-other');
+  });
+
+  it('overflow disabled: only assigned + own unassigned features are returned', async () => {
+    setupSchedulerWithAffinity(['project-a'], false); // overflow disabled
+    const assigned = makeFeature({ id: 'feat-assigned', projectSlug: 'project-a' });
+    const ownUnassigned = makeFeature({ id: 'feat-own', createdByInstance: INSTANCE_ID });
+    const overflow = makeFeature({ id: 'feat-overflow', projectSlug: 'project-other' });
+    const overflow2 = makeFeature({ id: 'feat-overflow2', createdByInstance: 'instance-beta' });
+
+    setupDefaultExecMocks();
+    setupFeaturesOnDisk([assigned, ownUnassigned, overflow, overflow2]);
+
+    const result = await scheduler.loadPendingFeatures('/fake/project');
+    const ids = result.map((f) => f.id);
+
+    expect(ids).toContain('feat-assigned');
+    expect(ids).toContain('feat-own');
+    expect(ids).not.toContain('feat-overflow');
+    expect(ids).not.toContain('feat-overflow2');
+  });
+
+  it('sort order: assigned (tier 0) before own unassigned (tier 1) before overflow (tier 2)', async () => {
+    setupSchedulerWithAffinity(['project-a'], true);
+    const overflow = makeFeature({ id: 'feat-overflow', projectSlug: 'project-other' });
+    const ownUnassigned = makeFeature({ id: 'feat-own', createdByInstance: INSTANCE_ID });
+    const assigned = makeFeature({ id: 'feat-assigned', projectSlug: 'project-a' });
+
+    setupDefaultExecMocks();
+    // Push in reverse order to confirm sorting changes their position
+    setupFeaturesOnDisk([overflow, ownUnassigned, assigned]);
+
+    const result = await scheduler.loadPendingFeatures('/fake/project');
+    const ids = result.map((f) => f.id);
+
+    const assignedIdx = ids.indexOf('feat-assigned');
+    const ownIdx = ids.indexOf('feat-own');
+    const overflowIdx = ids.indexOf('feat-overflow');
+
+    expect(assignedIdx).toBeGreaterThanOrEqual(0);
+    expect(ownIdx).toBeGreaterThanOrEqual(0);
+    expect(overflowIdx).toBeGreaterThanOrEqual(0);
+
+    expect(assignedIdx).toBeLessThan(ownIdx);
+    expect(ownIdx).toBeLessThan(overflowIdx);
+  });
+});


### PR DESCRIPTION
## Summary

**Milestone:** Core Services

Modify FeatureScheduler.loadPendingFeatures() to filter by project ownership. Features eligible if: projectSlug in assigned projects, OR projectSlug null and createdByInstance matches, OR projectSlug unassigned and overflow enabled. Sort: assigned > own unassigned > overflow. Stamp createdByInstance in FeatureLoader.create(). When no instance identity configured, bypass affinity filtering (backward compat for single-instance).

**Files to Modify:**
- apps/server/src...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced project-affinity filtering for multi-instance deployments, enabling features to be scoped to assigned projects with improved feature assignment efficiency and overflow handling.

* **Tests**
  * Added test coverage for project-affinity filtering and instance identity management in multi-instance configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->