### PR TITLE
Add auto-failover timer to ProjectAssignmentService

### DIFF
--- a/apps/server/src/services/project-assignment-service.ts
+++ b/apps/server/src/services/project-assignment-service.ts
@@ -2,12 +2,14 @@
  * ProjectAssignmentService — manages project-to-instance assignment.
  *
  * Methods:
- *   assignProject         — write assignedTo/assignedAt/assignedBy to project
- *   unassignProject       — clear assignment fields
- *   getAssignments        — list all project assignments for a projectPath
- *   getMyAssignedProjects — list projects assigned to this instance
- *   claimPreferredProjects — boot-time: claim unassigned preferred projects from proto.config.yaml
- *   reassignOrphanedProjects — detect stale heartbeats (>120s) and auto-claim orphans
+ *   assignProject               — write assignedTo/assignedAt/assignedBy to project
+ *   unassignProject             — clear assignment fields
+ *   getAssignments              — list all project assignments for a projectPath
+ *   getMyAssignedProjects       — list projects assigned to this instance
+ *   claimPreferredProjects      — boot-time: claim unassigned preferred projects from proto.config.yaml
+ *   reassignOrphanedProjects    — detect stale heartbeats (>120s) and auto-claim orphans
+ *   startPeriodicFailoverCheck  — start a 60s interval that auto-claims orphaned projects
+ *   stopPeriodicFailoverCheck   — stop the periodic failover check
  */
 
 import { createLogger } from '@protolabsai/utils';
@@ -15,11 +17,15 @@ import { loadProtoConfig } from '@protolabsai/platform';
 import type { Project, UpdateProjectInput } from '@protolabsai/types';
 import type { ProjectService } from './project-service.js';
 import type { CrdtSyncService } from './crdt-sync-service.js';
+import type { EventEmitter } from '../lib/events.js';
 
 const logger = createLogger('ProjectAssignmentService');
 
 /** TTL threshold in milliseconds for considering a peer's heartbeat stale */
 const ORPHAN_TTL_MS = 120_000;
+
+/** Interval in milliseconds for the periodic failover check */
+const FAILOVER_CHECK_INTERVAL_MS = 60_000;
 
 export interface ProjectAssignment {
   projectSlug: string;
@@ -29,9 +35,13 @@ export interface ProjectAssignment {
 }
 
 export class ProjectAssignmentService {
+  private failoverCheckInterval: ReturnType<typeof setInterval> | null = null;
+  private failoverProjectPath: string | null = null;
+
   constructor(
     private readonly projectService: ProjectService,
-    private readonly crdtSyncService: CrdtSyncService
+    private readonly crdtSyncService: CrdtSyncService,
+    private readonly eventEmitter?: EventEmitter
   ) {}
 
   // ─── Core Assignment Operations ─────────────────────────────────────────
@@ -174,26 +184,31 @@ export class ProjectAssignmentService {
 
   /**
    * Detect projects assigned to peers with stale heartbeats (>120s) and claim
-   * them for this instance.
+   * them for this instance. Uses 'auto-failover' as the assignedBy value so
+   * the source of the claim is distinguishable from manual assignments.
+   *
+   * NOTE: When the original instance recovers, it will NOT auto-reclaim its
+   * old projects — a human operator or Ava must explicitly reassign.
    */
   async reassignOrphanedProjects(projectPath: string): Promise<string[]> {
     const instanceId = this.crdtSyncService.getInstanceId();
     const peers = this.crdtSyncService.getPeers();
     const now = Date.now();
 
-    // Collect instance IDs with stale heartbeats
-    const stalePeerIds = new Set<string>();
+    // Collect instance IDs with stale heartbeats, along with their staleness
+    const stalePeers = new Map<string, number>(); // instanceId → stalenessMs
     for (const peer of peers) {
       const lastSeen = new Date(peer.lastSeen).getTime();
-      if (now - lastSeen > ORPHAN_TTL_MS) {
-        stalePeerIds.add(peer.identity.instanceId);
+      const stalenessMs = now - lastSeen;
+      if (stalenessMs > ORPHAN_TTL_MS) {
+        stalePeers.set(peer.identity.instanceId, stalenessMs);
         logger.warn(
-          `[ASSIGN] Peer "${peer.identity.instanceId}" heartbeat stale (${now - lastSeen}ms ago) — marking as orphan candidate`
+          `[ASSIGN] Peer "${peer.identity.instanceId}" heartbeat stale (${stalenessMs}ms ago) — marking as orphan candidate`
         );
       }
     }
 
-    if (stalePeerIds.size === 0) {
+    if (stalePeers.size === 0) {
       return [];
     }
 
@@ -205,18 +220,68 @@ export class ProjectAssignmentService {
         const project = await this.projectService.getProject(projectPath, slug);
         if (!project?.assignedTo) continue;
         if (project.assignedTo === instanceId) continue;
-        if (!stalePeerIds.has(project.assignedTo)) continue;
+        if (!stalePeers.has(project.assignedTo)) continue;
 
-        await this.assignProject(projectPath, slug, instanceId, instanceId);
+        const previousOwner = project.assignedTo;
+        const stalenessMs = stalePeers.get(previousOwner)!;
+
+        await this.assignProject(projectPath, slug, instanceId, 'auto-failover');
         reassigned.push(slug);
+
         logger.info(
-          `[ASSIGN] Reassigned orphaned project "${slug}" from "${project.assignedTo}" to "${instanceId}"`
+          `[ASSIGN] Failover: claimed orphaned project "${slug}" from "${previousOwner}" (stale ${stalenessMs}ms) to "${instanceId}"`
         );
+
+        // Emit observability event
+        this.eventEmitter?.emit('project:failover', {
+          projectSlug: slug,
+          projectPath,
+          previousOwner,
+          newOwner: instanceId,
+          stalenessMs,
+          timestamp: new Date().toISOString(),
+        });
       } catch (err) {
         logger.warn(`[ASSIGN] Failed to reassign orphaned project "${slug}":`, err);
       }
     }
 
     return reassigned;
+  }
+
+  // ─── Periodic failover check ─────────────────────────────────────────────
+
+  /**
+   * Start a periodic check (every 60s) that detects and auto-claims orphaned
+   * projects. Safe to call multiple times — clears any existing interval first.
+   *
+   * @param projectPath The project root path to scan for orphaned assignments.
+   */
+  startPeriodicFailoverCheck(projectPath: string): void {
+    this.stopPeriodicFailoverCheck();
+
+    this.failoverProjectPath = projectPath;
+    this.failoverCheckInterval = setInterval(() => {
+      this.reassignOrphanedProjects(projectPath).catch((err) => {
+        logger.error('[ASSIGN] Periodic failover check failed:', err);
+      });
+    }, FAILOVER_CHECK_INTERVAL_MS);
+
+    logger.info(
+      `[ASSIGN] Periodic failover check started (interval=${FAILOVER_CHECK_INTERVAL_MS}ms, projectPath="${projectPath}")`
+    );
+  }
+
+  /**
+   * Stop the periodic failover check started by startPeriodicFailoverCheck().
+   * Safe to call even if the check was never started.
+   */
+  stopPeriodicFailoverCheck(): void {
+    if (this.failoverCheckInterval !== null) {
+      clearInterval(this.failoverCheckInterval);
+      this.failoverCheckInterval = null;
+      logger.info('[ASSIGN] Periodic failover check stopped');
+    }
+    this.failoverProjectPath = null;
   }
 }

--- a/apps/server/tests/unit/services/project-assignment-service.test.ts
+++ b/apps/server/tests/unit/services/project-assignment-service.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for ProjectAssignmentService
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ProjectAssignmentService } from '@/services/project-assignment-service.js';
 
 // Mock loadProtoConfig from @protolabsai/platform
@@ -46,6 +46,14 @@ const makeCrdtSyncService = (instanceId = 'instance-alpha') => ({
   getPeers: vi.fn().mockReturnValue([]),
 });
 
+const makeEventEmitter = () => ({
+  emit: vi.fn(),
+  broadcast: vi.fn(),
+  subscribe: vi.fn(),
+  on: vi.fn(),
+  setRemoteBroadcaster: vi.fn(),
+});
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('ProjectAssignmentService', () => {
@@ -55,16 +63,24 @@ describe('ProjectAssignmentService', () => {
 
   let projectService: ReturnType<typeof makeProjectService>;
   let crdtSyncService: ReturnType<typeof makeCrdtSyncService>;
+  let eventEmitter: ReturnType<typeof makeEventEmitter>;
   let service: ProjectAssignmentService;
 
   beforeEach(() => {
     vi.clearAllMocks();
     projectService = makeProjectService();
     crdtSyncService = makeCrdtSyncService(INSTANCE_ID);
+    eventEmitter = makeEventEmitter();
     service = new ProjectAssignmentService(
       projectService as unknown as import('@/services/project-service.js').ProjectService,
-      crdtSyncService as unknown as import('@/services/crdt-sync-service.js').CrdtSyncService
+      crdtSyncService as unknown as import('@/services/crdt-sync-service.js').CrdtSyncService,
+      eventEmitter as unknown as import('@/lib/events.js').EventEmitter
     );
+  });
+
+  afterEach(() => {
+    // Ensure any running intervals are cleaned up between tests
+    service.stopPeriodicFailoverCheck();
   });
 
   // ─── assignProject ─────────────────────────────────────────────────────────
@@ -253,6 +269,48 @@ describe('ProjectAssignmentService', () => {
       expect((updates as Record<string, string>).assignedTo).toBe(INSTANCE_ID);
     });
 
+    it('uses "auto-failover" as assignedBy when claiming orphans', async () => {
+      const staleTimestamp = new Date(Date.now() - 200_000).toISOString();
+      crdtSyncService.getPeers.mockReturnValue([
+        { identity: { instanceId: 'stale-peer' }, lastSeen: staleTimestamp },
+      ]);
+      projectService.listProjects.mockResolvedValue(['orphan-proj']);
+      projectService.getProject.mockResolvedValue(
+        makeProject({ slug: 'orphan-proj', assignedTo: 'stale-peer' })
+      );
+
+      await service.reassignOrphanedProjects(PROJECT_PATH);
+
+      const [, , updates] = projectService.updateProject.mock.calls[0];
+      expect((updates as Record<string, string>).assignedBy).toBe('auto-failover');
+    });
+
+    it('emits "project:failover" event for each orphan claimed', async () => {
+      const staleTimestamp = new Date(Date.now() - 200_000).toISOString();
+      crdtSyncService.getPeers.mockReturnValue([
+        { identity: { instanceId: 'stale-peer' }, lastSeen: staleTimestamp },
+      ]);
+      projectService.listProjects.mockResolvedValue(['orphan-proj']);
+      projectService.getProject.mockResolvedValue(
+        makeProject({ slug: 'orphan-proj', assignedTo: 'stale-peer' })
+      );
+
+      await service.reassignOrphanedProjects(PROJECT_PATH);
+
+      expect(eventEmitter.emit).toHaveBeenCalledOnce();
+      const [eventType, payload] = eventEmitter.emit.mock.calls[0];
+      expect(eventType).toBe('project:failover');
+      expect(payload).toMatchObject({
+        projectSlug: 'orphan-proj',
+        projectPath: PROJECT_PATH,
+        previousOwner: 'stale-peer',
+        newOwner: INSTANCE_ID,
+      });
+      expect(typeof (payload as Record<string, unknown>).stalenessMs).toBe('number');
+      expect((payload as Record<string, unknown>).stalenessMs).toBeGreaterThan(120_000);
+      expect(typeof (payload as Record<string, unknown>).timestamp).toBe('string');
+    });
+
     it('does not claim projects from peers with fresh heartbeats', async () => {
       const freshTimestamp = new Date(Date.now() - 30_000).toISOString(); // 30s ago < 120s TTL
       crdtSyncService.getPeers.mockReturnValue([
@@ -296,6 +354,93 @@ describe('ProjectAssignmentService', () => {
 
       const reassigned = await service.reassignOrphanedProjects(PROJECT_PATH);
       expect(reassigned).toHaveLength(0);
+    });
+
+    it('does not emit events when no orphans are claimed', async () => {
+      crdtSyncService.getPeers.mockReturnValue([]);
+      await service.reassignOrphanedProjects(PROJECT_PATH);
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── startPeriodicFailoverCheck / stopPeriodicFailoverCheck ───────────────
+
+  describe('startPeriodicFailoverCheck()', () => {
+    it('calls reassignOrphanedProjects on each tick', async () => {
+      vi.useFakeTimers();
+
+      crdtSyncService.getPeers.mockReturnValue([]);
+
+      service.startPeriodicFailoverCheck(PROJECT_PATH);
+
+      // Advance timer by 60s — should trigger one check
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(projectService.listProjects).not.toHaveBeenCalled(); // no stale peers, exits early
+
+      vi.useRealTimers();
+    });
+
+    it('triggers failover when an orphaned project is detected on tick', async () => {
+      vi.useFakeTimers();
+
+      const staleTimestamp = new Date(Date.now() - 200_000).toISOString();
+      crdtSyncService.getPeers.mockReturnValue([
+        { identity: { instanceId: 'stale-peer' }, lastSeen: staleTimestamp },
+      ]);
+      projectService.listProjects.mockResolvedValue(['orphan-proj']);
+      projectService.getProject.mockResolvedValue(
+        makeProject({ slug: 'orphan-proj', assignedTo: 'stale-peer' })
+      );
+
+      service.startPeriodicFailoverCheck(PROJECT_PATH);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(projectService.updateProject).toHaveBeenCalledOnce();
+      const [, slug, updates] = projectService.updateProject.mock.calls[0];
+      expect(slug).toBe('orphan-proj');
+      expect((updates as Record<string, string>).assignedBy).toBe('auto-failover');
+      expect(eventEmitter.emit).toHaveBeenCalledWith('project:failover', expect.any(Object));
+
+      vi.useRealTimers();
+    });
+
+    it('replaces any existing interval when called twice', async () => {
+      vi.useFakeTimers();
+
+      crdtSyncService.getPeers.mockReturnValue([]);
+
+      service.startPeriodicFailoverCheck(PROJECT_PATH);
+      service.startPeriodicFailoverCheck(PROJECT_PATH); // second call should clear the first
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      // Should still work — only one interval active
+      expect(crdtSyncService.getPeers).toHaveBeenCalledOnce();
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('stopPeriodicFailoverCheck()', () => {
+    it('stops the periodic check', async () => {
+      vi.useFakeTimers();
+
+      crdtSyncService.getPeers.mockReturnValue([]);
+
+      service.startPeriodicFailoverCheck(PROJECT_PATH);
+      service.stopPeriodicFailoverCheck();
+
+      await vi.advanceTimersByTimeAsync(120_000); // advance 2 ticks
+
+      expect(crdtSyncService.getPeers).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('is safe to call before start', () => {
+      expect(() => service.stopPeriodicFailoverCheck()).not.toThrow();
     });
   });
 });

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -343,7 +343,9 @@ export type EventType =
   | 'ava-channel:message'
   // Error budget events (burn rate threshold enforcement)
   | 'error_budget:exhausted'
-  | 'error_budget:recovered';
+  | 'error_budget:recovered'
+  // Project failover events (auto-claim of orphaned projects)
+  | 'project:failover';
 
 export type EventCallback = (type: EventType, payload: unknown) => void;
 
@@ -602,6 +604,18 @@ export interface EventPayloadMap {
     projectSlug: string;
     projectPath: string;
     feedback: string;
+  };
+  // Project failover event (auto-claim of orphaned project)
+  'project:failover': {
+    projectSlug: string;
+    projectPath: string;
+    /** Instance ID that previously owned the project (now stale) */
+    previousOwner: string;
+    /** Instance ID that claimed the project */
+    newOwner: string;
+    /** Milliseconds since the previous owner's last heartbeat */
+    stalenessMs: number;
+    timestamp: string;
   };
 
   // Lead Engineer events


### PR DESCRIPTION
## Summary

**Milestone:** Integration

Add a periodic check (every 60s) in ProjectAssignmentService that reads peer heartbeats, detects orphaned projects (assignedTo instance stale >120s), and auto-claims them. When original instance comes back, it does NOT auto-reclaim — Ava or operator must explicitly reassign. Emit event when failover occurs for observability.

**Files to Modify:**
- apps/server/src/services/project-assignment-service.ts

**Acceptance Criteria:**
- [ ] Periodic check runs every 60 secon...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic periodic failover mechanism to recover orphaned projects every 60 seconds.
  * Added project failover observability events with details on assignment changes, including previous owner, new owner, and staleness duration.
  * Enhanced project assignment tracking with new metadata fields for assignment timestamp and assignment origin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->