### PR TITLE
Bug: Multiple agents writing to main repo despite worktree isolation (P1)

### DIFF
--- a/apps/server/src/lib/sdk-options.ts
+++ b/apps/server/src/lib/sdk-options.ts
@@ -654,6 +654,9 @@ export function createChatOptions(config: CreateSdkOptionsConfig): Options {
   // Build thinking options
   const thinkingOptions = buildThinkingOptions(config.thinkingLevel);
 
+  // Build worktree write guard hook (blocks writes outside the worktree)
+  const worktreeHooks = buildWorktreeGuardHooks(config);
+
   return {
     ...getBaseOptions(),
     model: getModelForUseCase('chat', effectiveModel),
@@ -662,6 +665,7 @@ export function createChatOptions(config: CreateSdkOptionsConfig): Options {
     allowedTools: [...TOOL_PRESETS.chat],
     ...claudeMdOptions,
     ...thinkingOptions,
+    ...worktreeHooks,
     ...(config.abortController && { abortController: config.abortController }),
     ...mcpOptions.mcpServerOptions,
   };
@@ -738,6 +742,9 @@ export function createCustomOptions(
     ? [...config.allowedTools]
     : [...TOOL_PRESETS.readOnly];
 
+  // Build worktree write guard hook (blocks writes outside the worktree)
+  const worktreeHooks = buildWorktreeGuardHooks(config);
+
   return {
     ...getBaseOptions(),
     model: getModelForUseCase('default', config.model),
@@ -746,6 +753,7 @@ export function createCustomOptions(
     allowedTools: effectiveAllowedTools,
     ...claudeMdOptions,
     ...thinkingOptions,
+    ...worktreeHooks,
     ...(config.abortController && { abortController: config.abortController }),
     ...mcpOptions.mcpServerOptions,
   };


### PR DESCRIPTION
## Summary

**Bug Report — P1 Systemic**

Multiple agents are writing their changes to the main repo working directory instead of their isolated worktrees. The worktree write guard (PreToolUse hook from commit `4e29408f4`) was merged to dev but does NOT appear to be active for agents that started before or shortly after the merge.

**Evidence:**
`git diff --stat HEAD` in the main repo shows uncommitted changes from at least 3 agents:
1. **Simplify escalation agent** — `ava-channel-reactor-service.ts` (253 l...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added write operation safeguards for worktree-based configurations to prevent modifications outside the configured project directory when a project path is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->