### PR TITLE
Simplify escalation to project-level

### DIFF
--- a/apps/server/src/routes/hivemind/escalation.ts
+++ b/apps/server/src/routes/hivemind/escalation.ts
@@ -1,12 +1,8 @@
 /**
- * Escalation routes — exposes escalation protocol controls for the hivemind dashboard.
+ * Escalation routes — exposes reactor health and degraded-peer status for the hivemind dashboard.
  *
- * These routes allow operators to:
- * - Trigger an escalation_request for a blocked feature (POST /api/hivemind/escalation/request)
- * - Query current degraded peer state (GET /api/hivemind/escalation/degraded-peers)
- *
- * The escalation protocol itself is driven by the AvaChannelReactorService via
- * the Ava Channel CRDT. HTTP routes serve as an operator interface and status endpoint.
+ * Feature-level escalation negotiation has been removed. Ava now handles blocked projects
+ * directly via the assign_project MCP tool when a project_blocked broadcast is received.
  */
 
 import { Router } from 'express';
@@ -14,65 +10,6 @@ import type { AvaChannelReactorService } from '../../services/ava-channel-reacto
 
 export function createEscalationRoutes(reactorService: AvaChannelReactorService): Router {
   const router = Router();
-
-  /**
-   * POST /request
-   *
-   * Manually trigger an escalation_request for a blocked feature.
-   * Body: { featureId, failureCount, lastError, worktreeState, featureData }
-   *
-   * Returns 400 if failureCount < 2 (escalation threshold not met).
-   * Returns 503 if reactor is not active.
-   */
-  router.post('/request', async (req, res) => {
-    const { featureId, failureCount, lastError, worktreeState, featureData } = req.body as {
-      featureId?: string;
-      failureCount?: number;
-      lastError?: string;
-      worktreeState?: string;
-      featureData?: Record<string, unknown>;
-    };
-
-    if (!featureId || typeof featureId !== 'string') {
-      res.status(400).json({ error: 'featureId is required' });
-      return;
-    }
-
-    if (typeof failureCount !== 'number' || failureCount < 2) {
-      res.status(400).json({
-        error: 'failureCount must be a number >= 2 to trigger escalation',
-      });
-      return;
-    }
-
-    const status = reactorService.getStatus();
-    if (!status.active) {
-      res.status(503).json({ error: 'Reactor is not active on this instance' });
-      return;
-    }
-
-    try {
-      await reactorService.postEscalationRequest({
-        featureId,
-        failureCount,
-        lastError: lastError ?? 'Unknown error',
-        worktreeState: worktreeState ?? 'unknown',
-        featureData: featureData ?? {},
-      });
-
-      res.json({
-        ok: true,
-        featureId,
-        failureCount,
-        message: 'escalation_request posted to Ava Channel',
-      });
-    } catch (err) {
-      res.status(500).json({
-        error: 'Failed to post escalation_request',
-        detail: err instanceof Error ? err.message : String(err),
-      });
-    }
-  });
 
   /**
    * GET /degraded-peers
@@ -91,14 +28,13 @@ export function createEscalationRoutes(reactorService: AvaChannelReactorService)
   /**
    * GET /status
    *
-   * Returns escalation-relevant reactor status fields.
+   * Returns reactor status fields relevant to health and capacity.
    */
   router.get('/status', (_req, res) => {
     const status = reactorService.getStatus();
     res.json({
       active: status.active,
       enabled: status.enabled,
-      pendingEscalations: status.pendingEscalationCount,
       degradedPeerCount: status.degradedPeerCount,
       errorCount: status.errorCount,
     });

--- a/apps/server/src/services/ava-channel-reactor-service.ts
+++ b/apps/server/src/services/ava-channel-reactor-service.ts
@@ -20,9 +20,6 @@ import type {
   CapacityHeartbeat,
   WorkRequest,
   WorkOffer,
-  EscalationRequest,
-  EscalationOffer,
-  EscalationAccept,
   HealthAlert,
   FrictionReport,
   DoraReport,
@@ -61,6 +58,8 @@ const HEALTH_ALERT_MEMORY_THRESHOLD = 85;
 const HEALTH_ALERT_CPU_THRESHOLD = 90;
 /** Duration (ms) to pause work-stealing from a degraded peer */
 const HEALTH_ALERT_PAUSE_MS = 5 * 60 * 1000;
+/** Number of blocked features in a project that triggers a project_blocked broadcast */
+const PROJECT_BLOCKED_THRESHOLD = 3;
 
 // ---------------------------------------------------------------------------
 // Dependencies
@@ -122,8 +121,6 @@ export interface ReactorStatus {
   degradedPeerCount: number;
   /** Instance IDs of peers currently in health-alert pause */
   degradedPeers: string[];
-  /** Number of escalations originated by this instance awaiting resolution */
-  pendingEscalationCount: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -175,10 +172,6 @@ export class AvaChannelReactorService {
 
   // Health alert pause — set of instanceIds we should not steal work from
   private readonly degradedPeers = new Map<string, ReturnType<typeof setTimeout>>();
-
-  // Escalation tracking — tracks pending escalation_requests we originated
-  // keyed by featureId → first-responder instanceId (set after sending accept)
-  private readonly pendingEscalations = new Map<string, string>();
 
   constructor(deps: ReactorDependencies) {
     this.deps = deps;
@@ -245,7 +238,6 @@ export class AvaChannelReactorService {
       clearTimeout(timer);
     }
     this.degradedPeers.clear();
-    this.pendingEscalations.clear();
 
     this.knownMessageIds.clear();
     this.pendingQueue.length = 0;
@@ -273,7 +265,6 @@ export class AvaChannelReactorService {
       pendingQueueSize: this.pendingQueue.length,
       degradedPeerCount: this.degradedPeers.size,
       degradedPeers: [...this.degradedPeers.keys()],
-      pendingEscalationCount: this.pendingEscalations.size,
     };
   }
 
@@ -699,24 +690,6 @@ export class AvaChannelReactorService {
       return;
     }
 
-    // escalation_request handler
-    if (message.content.startsWith('[escalation_request]')) {
-      await this.onEscalationRequest(message);
-      return;
-    }
-
-    // escalation_offer handler
-    if (message.content.startsWith('[escalation_offer]')) {
-      await this.onEscalationOffer(message);
-      return;
-    }
-
-    // escalation_accept handler
-    if (message.content.startsWith('[escalation_accept]')) {
-      await this.onEscalationAccept(message);
-      return;
-    }
-
     // health_alert handler
     if (message.content.startsWith('[health_alert]')) {
       await this.onHealthAlert(message);
@@ -927,216 +900,6 @@ export class AvaChannelReactorService {
   }
 
   // ---------------------------------------------------------------------------
-  // Escalation protocol handlers
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Post an escalation_request when a feature hits blocked status with failureCount >= 2.
-   * Called by external code (e.g., feature status watcher) when these conditions are met.
-   */
-  async postEscalationRequest(opts: {
-    featureId: string;
-    failureCount: number;
-    lastError: string;
-    worktreeState: string;
-    featureData: Record<string, unknown>;
-  }): Promise<void> {
-    if (opts.failureCount < 2) return;
-
-    const payload: EscalationRequest = {
-      featureId: opts.featureId,
-      failureCount: opts.failureCount,
-      lastError: opts.lastError,
-      worktreeState: opts.worktreeState,
-      originatingInstanceId: this.deps.instanceId,
-    };
-
-    await this.deps.avaChannelService.postMessage(
-      `[escalation_request] ${JSON.stringify({ ...payload, featureData: opts.featureData })}`,
-      'system',
-      {
-        intent: 'escalation',
-        expectsResponse: true,
-        context: { featureId: opts.featureId },
-      }
-    );
-
-    logger.info(
-      `Posted escalation_request for feature ${opts.featureId} (failureCount=${opts.failureCount})`
-    );
-  }
-
-  /**
-   * Handle an incoming escalation_request from a peer.
-   * If this instance has idle capacity, respond with an escalation_offer.
-   */
-  private async onEscalationRequest(message: AvaChatMessage): Promise<void> {
-    // Ignore self
-    if (message.instanceId === this.deps.instanceId) return;
-
-    let payload: EscalationRequest & { featureData?: Record<string, unknown> };
-    try {
-      const json = message.content.replace('[escalation_request]', '').trim();
-      payload = JSON.parse(json) as EscalationRequest & { featureData?: Record<string, unknown> };
-    } catch {
-      logger.warn('Received malformed escalation_request, ignoring');
-      return;
-    }
-
-    // Only respond if we have idle capacity
-    const localMetrics = this.deps.autoModeService?.getCapacityMetrics();
-    const localActive = localMetrics?.runningAgents ?? 0;
-    const localMax = localMetrics?.maxAgents ?? 5;
-
-    if (localActive >= localMax) {
-      logger.debug(
-        `Received escalation_request for ${payload.featureId} but we are at capacity — skipping offer`
-      );
-      return;
-    }
-
-    const offerPayload: EscalationOffer = {
-      offeringInstanceId: this.deps.instanceId,
-      originatingInstanceId: payload.originatingInstanceId,
-      featureId: payload.featureId,
-    };
-
-    await this.deps.avaChannelService.postMessage(
-      `[escalation_offer] ${JSON.stringify(offerPayload)}`,
-      'system',
-      {
-        intent: 'response',
-        expectsResponse: false,
-        context: { featureId: payload.featureId },
-      }
-    );
-
-    logger.info(
-      `Sent escalation_offer for feature ${payload.featureId} to ${payload.originatingInstanceId}`
-    );
-  }
-
-  /**
-   * Handle an incoming escalation_offer from a peer.
-   * Accept the first offer by posting an escalation_accept with full feature data.
-   */
-  private async onEscalationOffer(message: AvaChatMessage): Promise<void> {
-    // Ignore self
-    if (message.instanceId === this.deps.instanceId) return;
-
-    let offer: EscalationOffer;
-    try {
-      const json = message.content.replace('[escalation_offer]', '').trim();
-      offer = JSON.parse(json) as EscalationOffer;
-    } catch {
-      logger.warn('Received malformed escalation_offer, ignoring');
-      return;
-    }
-
-    // Only process if we are the originating instance
-    if (offer.originatingInstanceId !== this.deps.instanceId) return;
-
-    // Ignore if already accepted an offer for this feature
-    if (this.pendingEscalations.has(offer.featureId)) {
-      logger.debug(
-        `Received escalation_offer for ${offer.featureId} from ${offer.offeringInstanceId} but already accepted another offer — ignoring`
-      );
-      return;
-    }
-
-    // Mark this feature as delegated
-    this.pendingEscalations.set(offer.featureId, offer.offeringInstanceId);
-
-    // Retrieve full feature data to send
-    let featureData: Record<string, unknown> = {};
-    if (this.deps.featureLoader && this.deps.projectPath) {
-      try {
-        const allFeatures = await this.deps.featureLoader.getAll(this.deps.projectPath);
-        const feature = allFeatures.find((f) => f.id === offer.featureId);
-        if (feature) {
-          featureData = feature as Record<string, unknown>;
-        }
-      } catch (err) {
-        logger.warn(`Failed to load feature data for escalation_accept: ${err}`);
-      }
-    }
-
-    const acceptPayload: EscalationAccept = {
-      acceptingInstanceId: offer.offeringInstanceId,
-      originatingInstanceId: this.deps.instanceId,
-      featureId: offer.featureId,
-      featureData,
-    };
-
-    await this.deps.avaChannelService.postMessage(
-      `[escalation_accept] ${JSON.stringify(acceptPayload)}`,
-      'system',
-      {
-        intent: 'coordination',
-        expectsResponse: false,
-        context: { featureId: offer.featureId },
-      }
-    );
-
-    logger.info(
-      `Sent escalation_accept for feature ${offer.featureId} to ${offer.offeringInstanceId}`
-    );
-  }
-
-  /**
-   * Handle an incoming escalation_accept from the originating instance.
-   * Clone the feature onto this instance's board with escalated complexity.
-   */
-  private async onEscalationAccept(message: AvaChatMessage): Promise<void> {
-    // Ignore self
-    if (message.instanceId === this.deps.instanceId) return;
-
-    let accept: EscalationAccept;
-    try {
-      const json = message.content.replace('[escalation_accept]', '').trim();
-      accept = JSON.parse(json) as EscalationAccept;
-    } catch {
-      logger.warn('Received malformed escalation_accept, ignoring');
-      return;
-    }
-
-    // Only process if we are the accepting instance
-    if (accept.acceptingInstanceId !== this.deps.instanceId) return;
-
-    if (!this.deps.featureLoader || !this.deps.projectPath) {
-      logger.warn('escalation_accept received but featureLoader/projectPath not configured');
-      return;
-    }
-
-    // Determine escalated complexity
-    const originalComplexity = (accept.featureData.complexity as string) ?? 'medium';
-    const escalatedComplexity =
-      originalComplexity === 'large' || originalComplexity === 'architectural'
-        ? 'architectural'
-        : 'large';
-
-    try {
-      const { id: _originalId, ...rest } = accept.featureData as {
-        id: string;
-        [key: string]: unknown;
-      };
-      const created = await this.deps.featureLoader.create(this.deps.projectPath, {
-        ...rest,
-        status: 'backlog',
-        complexity: escalatedComplexity,
-        escalatedFromInstanceId: accept.originatingInstanceId,
-        escalatedFromFeatureId: _originalId ?? accept.featureId,
-      });
-      logger.info(
-        `Escalated feature created locally: ${created.id} (original: ${accept.featureId}, complexity: ${escalatedComplexity})`
-      );
-    } catch (err) {
-      this.errorCount++;
-      logger.error(`Failed to create escalated feature:`, err);
-    }
-  }
-
-  // ---------------------------------------------------------------------------
   // Health alert handlers
   // ---------------------------------------------------------------------------
 
@@ -1303,6 +1066,14 @@ export class AvaChannelReactorService {
         };
       };
 
+      // Check for project_blocked when a feature becomes blocked
+      if (newStatus === 'blocked') {
+        this.checkAndBroadcastProjectBlocked().catch((err) => {
+          this.errorCount++;
+          logger.error('Failed to check project blocked status:', err);
+        });
+      }
+
       if (newStatus !== 'done') return;
       if (!feature?.systemImprovement) return;
 
@@ -1327,6 +1098,39 @@ export class AvaChannelReactorService {
     });
 
     logger.debug('Subscribed to feature:status-changed for System Improvement resolution');
+  }
+
+  /**
+   * Check if the project has >= PROJECT_BLOCKED_THRESHOLD blocked features.
+   * If so, broadcast a project_blocked message so Ava can reassign via assign_project.
+   */
+  private async checkAndBroadcastProjectBlocked(): Promise<void> {
+    if (!this.deps.featureLoader || !this.deps.projectPath) return;
+
+    const allFeatures = await this.deps.featureLoader.getAll(this.deps.projectPath);
+    const blockedCount = allFeatures.filter((f) => f.status === 'blocked').length;
+
+    if (blockedCount < PROJECT_BLOCKED_THRESHOLD) return;
+
+    const payload = {
+      projectPath: this.deps.projectPath,
+      blockedCount,
+      instanceId: this.deps.instanceId,
+      timestamp: new Date().toISOString(),
+    };
+
+    await this.deps.avaChannelService.postMessage(
+      `[project_blocked] ${JSON.stringify(payload)}`,
+      'system',
+      {
+        intent: 'escalation',
+        expectsResponse: false,
+      }
+    );
+
+    logger.warn(
+      `Broadcast project_blocked: ${blockedCount} blocked features in project (threshold=${PROJECT_BLOCKED_THRESHOLD})`
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/apps/server/tests/unit/routes/escalation-route.test.ts
+++ b/apps/server/tests/unit/routes/escalation-route.test.ts
@@ -1,13 +1,10 @@
 /**
- * Temporary verification test for the escalation route handler logic.
+ * Unit tests for the escalation route handler logic.
  * Tests the route factory directly without spinning up a full HTTP server.
  *
  * This file verifies:
- * - POST /request validates failureCount >= 2
- * - POST /request validates featureId presence
- * - POST /request returns 503 when reactor is inactive
  * - GET /degraded-peers returns degraded peer state
- * - GET /status returns escalation-relevant fields
+ * - GET /status returns reactor health fields (no pendingEscalations)
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -33,13 +30,11 @@ function makeMockReactor(overrides: Record<string, unknown> = {}) {
     getStatus: vi.fn().mockReturnValue({
       active: true,
       enabled: true,
-      pendingEscalationCount: 0,
       degradedPeerCount: 0,
       degradedPeers: [],
       errorCount: 0,
       ...overrides,
     }),
-    postEscalationRequest: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -98,71 +93,6 @@ describe('createEscalationRoutes', () => {
     router = createEscalationRoutes(reactor as Parameters<typeof createEscalationRoutes>[0]);
   });
 
-  describe('POST /request', () => {
-    it('returns 400 when featureId is missing', async () => {
-      const handler = getHandler(router, 'post', '/request');
-      expect(handler).toBeDefined();
-
-      const req = makeReq({ failureCount: 3 });
-      const res = makeRes();
-      await handler!(req, res as unknown as Response);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({ error: expect.stringContaining('featureId') })
-      );
-    });
-
-    it('returns 400 when failureCount < 2', async () => {
-      const handler = getHandler(router, 'post', '/request');
-      const req = makeReq({ featureId: 'feat-1', failureCount: 1 });
-      const res = makeRes();
-      await handler!(req, res as unknown as Response);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({ error: expect.stringContaining('failureCount') })
-      );
-    });
-
-    it('returns 503 when reactor is not active', async () => {
-      reactor.getStatus.mockReturnValue({
-        active: false,
-        enabled: false,
-        degradedPeerCount: 0,
-        degradedPeers: [],
-        pendingEscalationCount: 0,
-        errorCount: 0,
-      });
-      const handler = getHandler(router, 'post', '/request');
-      const req = makeReq({ featureId: 'feat-1', failureCount: 2 });
-      const res = makeRes();
-      await handler!(req, res as unknown as Response);
-
-      expect(res.status).toHaveBeenCalledWith(503);
-    });
-
-    it('returns 200 and calls postEscalationRequest on valid input', async () => {
-      const handler = getHandler(router, 'post', '/request');
-      const req = makeReq({
-        featureId: 'feat-1',
-        failureCount: 3,
-        lastError: 'Agent crashed',
-        worktreeState: 'dirty',
-        featureData: { title: 'Feature 1' },
-      });
-      const res = makeRes();
-      await handler!(req, res as unknown as Response);
-
-      expect(reactor.postEscalationRequest).toHaveBeenCalledWith(
-        expect.objectContaining({ featureId: 'feat-1', failureCount: 3 })
-      );
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({ ok: true, featureId: 'feat-1' })
-      );
-    });
-  });
-
   describe('GET /degraded-peers', () => {
     it('returns degraded peer state', () => {
       reactor.getStatus.mockReturnValue({
@@ -170,7 +100,6 @@ describe('createEscalationRoutes', () => {
         enabled: true,
         degradedPeerCount: 2,
         degradedPeers: ['peer-1', 'peer-2'],
-        pendingEscalationCount: 1,
         errorCount: 0,
       });
       const handler = getHandler(router, 'get', '/degraded-peers');
@@ -188,13 +117,12 @@ describe('createEscalationRoutes', () => {
   });
 
   describe('GET /status', () => {
-    it('returns escalation status fields', () => {
+    it('returns reactor status fields without pendingEscalations', () => {
       reactor.getStatus.mockReturnValue({
         active: true,
         enabled: true,
         degradedPeerCount: 0,
         degradedPeers: [],
-        pendingEscalationCount: 3,
         errorCount: 1,
       });
 
@@ -208,10 +136,14 @@ describe('createEscalationRoutes', () => {
       expect(res.json).toHaveBeenCalledWith({
         active: true,
         enabled: true,
-        pendingEscalations: 3,
         degradedPeerCount: 0,
         errorCount: 1,
       });
+    });
+
+    it('does not expose POST /request route', () => {
+      const handler = getHandler(router, 'post', '/request');
+      expect(handler).toBeUndefined();
     });
   });
 });

--- a/apps/server/tests/unit/services/ava-channel-reactor-escalation.test.ts
+++ b/apps/server/tests/unit/services/ava-channel-reactor-escalation.test.ts
@@ -1,14 +1,10 @@
 /**
- * Unit tests for the AvaChannelReactorService escalation handshake and health alert protocol.
+ * Unit tests for the AvaChannelReactorService health alert protocol and
+ * project_blocked broadcast.
  *
  * Covers:
- * - escalation_request is posted when failureCount >= 2
- * - escalation_request is NOT posted when failureCount < 2
- * - Peer responds with escalation_offer within one tick when it has idle capacity
- * - Peer does NOT respond with escalation_offer when at capacity
- * - Originator accepts the first escalation_offer with escalation_accept
- * - Originator ignores duplicate escalation_offers for the same feature
- * - Accepting instance creates feature with escalated complexity on escalation_accept
+ * - project_blocked is broadcast when a project reaches 3+ blocked features
+ * - project_blocked is NOT broadcast when fewer than 3 features are blocked
  * - health_alert is broadcast when memory > 85% or cpu > 90%
  * - health_alert is NOT broadcast when both are below thresholds
  * - Work-stealing is paused from a peer that sent a health_alert
@@ -81,408 +77,97 @@ function makeDeps(overrides: Partial<ReactorDependencies> = {}): ReactorDependen
 }
 
 // ---------------------------------------------------------------------------
-// Escalation request posting
+// project_blocked broadcast
 // ---------------------------------------------------------------------------
 
-describe('postEscalationRequest()', () => {
-  it('posts escalation_request when failureCount >= 2', async () => {
-    const deps = makeDeps();
+describe('project_blocked — broadcast when 3+ blocked features', () => {
+  it('broadcasts project_blocked when project has 3 blocked features', async () => {
+    const deps = makeDeps({
+      featureLoader: {
+        getAll: vi.fn().mockResolvedValue([
+          { id: 'feat-1', status: 'blocked' },
+          { id: 'feat-2', status: 'blocked' },
+          { id: 'feat-3', status: 'blocked' },
+          { id: 'feat-4', status: 'in-progress' },
+        ]),
+        create: vi.fn().mockResolvedValue({ id: 'new' }),
+      },
+    });
     const reactor = new AvaChannelReactorService(deps);
 
-    await reactor.postEscalationRequest({
-      featureId: 'feat-1',
-      failureCount: 2,
-      lastError: 'Agent timed out',
-      worktreeState: 'dirty',
-      featureData: { title: 'Feature 1' },
-    });
+    await (
+      reactor as unknown as { checkAndBroadcastProjectBlocked: () => Promise<void> }
+    ).checkAndBroadcastProjectBlocked();
 
     expect(deps.avaChannelService.postMessage).toHaveBeenCalledWith(
-      expect.stringContaining('[escalation_request]'),
+      expect.stringContaining('[project_blocked]'),
       'system',
-      expect.objectContaining({ intent: 'escalation', expectsResponse: true })
+      expect.objectContaining({ intent: 'escalation' })
     );
+
+    const call = (deps.avaChannelService.postMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+    const payload = JSON.parse((call[0] as string).replace('[project_blocked]', '').trim());
+    expect(payload.blockedCount).toBe(3);
+    expect(payload.projectPath).toBe('/test/project');
+    expect(payload.instanceId).toBe('local-instance');
   });
 
-  it('posts escalation_request when failureCount > 2', async () => {
-    const deps = makeDeps();
+  it('broadcasts project_blocked when project has more than 3 blocked features', async () => {
+    const deps = makeDeps({
+      featureLoader: {
+        getAll: vi.fn().mockResolvedValue([
+          { id: 'feat-1', status: 'blocked' },
+          { id: 'feat-2', status: 'blocked' },
+          { id: 'feat-3', status: 'blocked' },
+          { id: 'feat-4', status: 'blocked' },
+          { id: 'feat-5', status: 'done' },
+        ]),
+        create: vi.fn().mockResolvedValue({ id: 'new' }),
+      },
+    });
     const reactor = new AvaChannelReactorService(deps);
 
-    await reactor.postEscalationRequest({
-      featureId: 'feat-1',
-      failureCount: 5,
-      lastError: 'Repeated failure',
-      worktreeState: 'clean',
-      featureData: {},
-    });
+    await (
+      reactor as unknown as { checkAndBroadcastProjectBlocked: () => Promise<void> }
+    ).checkAndBroadcastProjectBlocked();
 
     expect(deps.avaChannelService.postMessage).toHaveBeenCalledTimes(1);
-  });
-
-  it('does NOT post escalation_request when failureCount < 2', async () => {
-    const deps = makeDeps();
-    const reactor = new AvaChannelReactorService(deps);
-
-    await reactor.postEscalationRequest({
-      featureId: 'feat-1',
-      failureCount: 1,
-      lastError: 'Single failure',
-      worktreeState: 'clean',
-      featureData: {},
-    });
-
-    expect(deps.avaChannelService.postMessage).not.toHaveBeenCalled();
-  });
-
-  it('includes featureId in context', async () => {
-    const deps = makeDeps();
-    const reactor = new AvaChannelReactorService(deps);
-
-    await reactor.postEscalationRequest({
-      featureId: 'feat-xyz',
-      failureCount: 3,
-      lastError: 'Crash',
-      worktreeState: 'dirty',
-      featureData: { id: 'feat-xyz', title: 'XYZ' },
-    });
-
     expect(deps.avaChannelService.postMessage).toHaveBeenCalledWith(
-      expect.any(String),
+      expect.stringContaining('[project_blocked]'),
       'system',
-      expect.objectContaining({ context: { featureId: 'feat-xyz' } })
+      expect.any(Object)
     );
   });
-});
 
-// ---------------------------------------------------------------------------
-// Escalation offer — peer responds within one reactor tick
-// ---------------------------------------------------------------------------
-
-describe('escalation_offer — peer responds to escalation_request', () => {
-  it('sends escalation_offer when peer has idle capacity', async () => {
+  it('does NOT broadcast project_blocked when fewer than 3 features are blocked', async () => {
     const deps = makeDeps({
-      instanceId: 'peer-instance',
-      autoModeService: {
-        getCapacityMetrics: vi.fn().mockReturnValue({
-          runningAgents: 2,
-          maxAgents: 5,
-          backlogCount: 0,
-          cpuPercent: 10,
-          ramUsagePercent: 30,
-        }),
+      featureLoader: {
+        getAll: vi.fn().mockResolvedValue([
+          { id: 'feat-1', status: 'blocked' },
+          { id: 'feat-2', status: 'blocked' },
+          { id: 'feat-3', status: 'in-progress' },
+        ]),
+        create: vi.fn().mockResolvedValue({ id: 'new' }),
       },
     });
     const reactor = new AvaChannelReactorService(deps);
 
-    // Simulate receiving an escalation_request from a remote instance
-    const escalationMsg = {
-      id: 'msg-esc-1',
-      instanceId: 'remote-instance',
-      instanceName: 'remote',
-      content: `[escalation_request] ${JSON.stringify({
-        featureId: 'feat-1',
-        failureCount: 2,
-        lastError: 'Agent timed out',
-        worktreeState: 'dirty',
-        originatingInstanceId: 'remote-instance',
-        featureData: { title: 'Feature 1' },
-      })}`,
-      source: 'system' as const,
-      timestamp: new Date().toISOString(),
-    };
-
-    // Directly invoke the internal handler via handleWorkStealProtocol-like path
-    // by feeding a CRDT shard change that includes the message
-    const mockDoc = {
-      messages: [escalationMsg],
-    };
-    // Access private method via casting
     await (
-      reactor as unknown as {
-        handleWorkStealProtocol: (msg: typeof escalationMsg) => Promise<void>;
-      }
-    ).handleWorkStealProtocol(escalationMsg);
-
-    expect(deps.avaChannelService.postMessage).toHaveBeenCalledWith(
-      expect.stringContaining('[escalation_offer]'),
-      'system',
-      expect.objectContaining({ intent: 'response' })
-    );
-
-    const callArg = (deps.avaChannelService.postMessage as ReturnType<typeof vi.fn>).mock
-      .calls[0][0] as string;
-    const payload = JSON.parse(callArg.replace('[escalation_offer]', '').trim());
-    expect(payload.featureId).toBe('feat-1');
-    expect(payload.originatingInstanceId).toBe('remote-instance');
-    expect(payload.offeringInstanceId).toBe('peer-instance');
-  });
-
-  it('does NOT send escalation_offer when peer is at capacity', async () => {
-    const deps = makeDeps({
-      instanceId: 'peer-instance',
-      autoModeService: {
-        getCapacityMetrics: vi.fn().mockReturnValue({
-          runningAgents: 5,
-          maxAgents: 5,
-          backlogCount: 2,
-          cpuPercent: 80,
-          ramUsagePercent: 70,
-        }),
-      },
-    });
-    const reactor = new AvaChannelReactorService(deps);
-
-    const escalationMsg = {
-      id: 'msg-esc-2',
-      instanceId: 'remote-instance',
-      instanceName: 'remote',
-      content: `[escalation_request] ${JSON.stringify({
-        featureId: 'feat-2',
-        failureCount: 3,
-        lastError: 'Crash',
-        worktreeState: 'clean',
-        originatingInstanceId: 'remote-instance',
-        featureData: {},
-      })}`,
-      source: 'system' as const,
-      timestamp: new Date().toISOString(),
-    };
-
-    await (
-      reactor as unknown as {
-        handleWorkStealProtocol: (msg: typeof escalationMsg) => Promise<void>;
-      }
-    ).handleWorkStealProtocol(escalationMsg);
+      reactor as unknown as { checkAndBroadcastProjectBlocked: () => Promise<void> }
+    ).checkAndBroadcastProjectBlocked();
 
     expect(deps.avaChannelService.postMessage).not.toHaveBeenCalled();
   });
 
-  it('ignores escalation_request from self', async () => {
-    const deps = makeDeps({ instanceId: 'local-instance' });
+  it('does NOT broadcast project_blocked when no featureLoader configured', async () => {
+    const deps = makeDeps({ featureLoader: undefined });
     const reactor = new AvaChannelReactorService(deps);
 
-    const selfMsg = {
-      id: 'msg-self',
-      instanceId: 'local-instance',
-      instanceName: 'local',
-      content: `[escalation_request] ${JSON.stringify({
-        featureId: 'feat-3',
-        failureCount: 2,
-        lastError: 'err',
-        worktreeState: 'clean',
-        originatingInstanceId: 'local-instance',
-        featureData: {},
-      })}`,
-      source: 'system' as const,
-      timestamp: new Date().toISOString(),
-    };
-
     await (
-      reactor as unknown as { handleWorkStealProtocol: (msg: typeof selfMsg) => Promise<void> }
-    ).handleWorkStealProtocol(selfMsg);
+      reactor as unknown as { checkAndBroadcastProjectBlocked: () => Promise<void> }
+    ).checkAndBroadcastProjectBlocked();
 
     expect(deps.avaChannelService.postMessage).not.toHaveBeenCalled();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Escalation accept — originator accepts first offer
-// ---------------------------------------------------------------------------
-
-describe('escalation_accept — originator accepts first escalation_offer', () => {
-  it('sends escalation_accept with feature data for the first offer', async () => {
-    const deps = makeDeps({ instanceId: 'originator-instance' });
-    const reactor = new AvaChannelReactorService(deps);
-
-    const offerMsg = {
-      id: 'msg-offer-1',
-      instanceId: 'peer-instance',
-      instanceName: 'peer',
-      content: `[escalation_offer] ${JSON.stringify({
-        offeringInstanceId: 'peer-instance',
-        originatingInstanceId: 'originator-instance',
-        featureId: 'feat-1',
-      })}`,
-      source: 'system' as const,
-      timestamp: new Date().toISOString(),
-    };
-
-    await (
-      reactor as unknown as { handleWorkStealProtocol: (msg: typeof offerMsg) => Promise<void> }
-    ).handleWorkStealProtocol(offerMsg);
-
-    expect(deps.avaChannelService.postMessage).toHaveBeenCalledWith(
-      expect.stringContaining('[escalation_accept]'),
-      'system',
-      expect.objectContaining({ intent: 'coordination' })
-    );
-
-    const callArg = (deps.avaChannelService.postMessage as ReturnType<typeof vi.fn>).mock
-      .calls[0][0] as string;
-    const payload = JSON.parse(callArg.replace('[escalation_accept]', '').trim());
-    expect(payload.acceptingInstanceId).toBe('peer-instance');
-    expect(payload.featureId).toBe('feat-1');
-  });
-
-  it('ignores a second escalation_offer for the same feature', async () => {
-    const deps = makeDeps({ instanceId: 'originator-instance' });
-    const reactor = new AvaChannelReactorService(deps);
-
-    const makeOfferMsg = (offeringInstanceId: string) => ({
-      id: `msg-offer-${offeringInstanceId}`,
-      instanceId: offeringInstanceId,
-      instanceName: offeringInstanceId,
-      content: `[escalation_offer] ${JSON.stringify({
-        offeringInstanceId,
-        originatingInstanceId: 'originator-instance',
-        featureId: 'feat-1',
-      })}`,
-      source: 'system' as const,
-      timestamp: new Date().toISOString(),
-    });
-
-    await (
-      reactor as unknown as {
-        handleWorkStealProtocol: (msg: ReturnType<typeof makeOfferMsg>) => Promise<void>;
-      }
-    ).handleWorkStealProtocol(makeOfferMsg('peer-1'));
-    await (
-      reactor as unknown as {
-        handleWorkStealProtocol: (msg: ReturnType<typeof makeOfferMsg>) => Promise<void>;
-      }
-    ).handleWorkStealProtocol(makeOfferMsg('peer-2'));
-
-    // Only one accept should have been sent
-    const acceptCalls = (
-      deps.avaChannelService.postMessage as ReturnType<typeof vi.fn>
-    ).mock.calls.filter((c: unknown[]) => (c[0] as string).includes('[escalation_accept]'));
-    expect(acceptCalls).toHaveLength(1);
-  });
-
-  it('ignores escalation_offer not targeting this instance', async () => {
-    const deps = makeDeps({ instanceId: 'some-other-instance' });
-    const reactor = new AvaChannelReactorService(deps);
-
-    const offerMsg = {
-      id: 'msg-offer-other',
-      instanceId: 'peer-instance',
-      instanceName: 'peer',
-      content: `[escalation_offer] ${JSON.stringify({
-        offeringInstanceId: 'peer-instance',
-        originatingInstanceId: 'originator-instance', // not this instance
-        featureId: 'feat-1',
-      })}`,
-      source: 'system' as const,
-      timestamp: new Date().toISOString(),
-    };
-
-    await (
-      reactor as unknown as { handleWorkStealProtocol: (msg: typeof offerMsg) => Promise<void> }
-    ).handleWorkStealProtocol(offerMsg);
-
-    expect(deps.avaChannelService.postMessage).not.toHaveBeenCalled();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Escalation accept handling — accepting instance clones feature
-// ---------------------------------------------------------------------------
-
-describe('escalation_accept — accepting instance creates escalated feature', () => {
-  it('creates feature with complexity escalated to large when original is medium', async () => {
-    const deps = makeDeps({ instanceId: 'accepting-instance' });
-    const reactor = new AvaChannelReactorService(deps);
-
-    const acceptMsg = {
-      id: 'msg-accept-1',
-      instanceId: 'originator-instance',
-      instanceName: 'originator',
-      content: `[escalation_accept] ${JSON.stringify({
-        acceptingInstanceId: 'accepting-instance',
-        originatingInstanceId: 'originator-instance',
-        featureId: 'feat-1',
-        featureData: {
-          id: 'feat-1',
-          title: 'Test Feature',
-          status: 'blocked',
-          complexity: 'medium',
-        },
-      })}`,
-      source: 'system' as const,
-      timestamp: new Date().toISOString(),
-    };
-
-    await (
-      reactor as unknown as { handleWorkStealProtocol: (msg: typeof acceptMsg) => Promise<void> }
-    ).handleWorkStealProtocol(acceptMsg);
-
-    expect(deps.featureLoader!.create).toHaveBeenCalledWith(
-      '/test/project',
-      expect.objectContaining({
-        complexity: 'large',
-        status: 'backlog',
-        escalatedFromInstanceId: 'originator-instance',
-        escalatedFromFeatureId: 'feat-1',
-      })
-    );
-  });
-
-  it('creates feature with complexity escalated to architectural when original is large', async () => {
-    const deps = makeDeps({ instanceId: 'accepting-instance' });
-    const reactor = new AvaChannelReactorService(deps);
-
-    const acceptMsg = {
-      id: 'msg-accept-2',
-      instanceId: 'originator-instance',
-      instanceName: 'originator',
-      content: `[escalation_accept] ${JSON.stringify({
-        acceptingInstanceId: 'accepting-instance',
-        originatingInstanceId: 'originator-instance',
-        featureId: 'feat-large',
-        featureData: {
-          id: 'feat-large',
-          title: 'Large Feature',
-          status: 'blocked',
-          complexity: 'large',
-        },
-      })}`,
-      source: 'system' as const,
-      timestamp: new Date().toISOString(),
-    };
-
-    await (
-      reactor as unknown as { handleWorkStealProtocol: (msg: typeof acceptMsg) => Promise<void> }
-    ).handleWorkStealProtocol(acceptMsg);
-
-    expect(deps.featureLoader!.create).toHaveBeenCalledWith(
-      '/test/project',
-      expect.objectContaining({ complexity: 'architectural' })
-    );
-  });
-
-  it('ignores escalation_accept not targeting this instance', async () => {
-    const deps = makeDeps({ instanceId: 'some-other-instance' });
-    const reactor = new AvaChannelReactorService(deps);
-
-    const acceptMsg = {
-      id: 'msg-accept-3',
-      instanceId: 'originator-instance',
-      instanceName: 'originator',
-      content: `[escalation_accept] ${JSON.stringify({
-        acceptingInstanceId: 'different-instance',
-        originatingInstanceId: 'originator-instance',
-        featureId: 'feat-1',
-        featureData: { id: 'feat-1', complexity: 'medium' },
-      })}`,
-      source: 'system' as const,
-      timestamp: new Date().toISOString(),
-    };
-
-    await (
-      reactor as unknown as { handleWorkStealProtocol: (msg: typeof acceptMsg) => Promise<void> }
-    ).handleWorkStealProtocol(acceptMsg);
-
-    expect(deps.featureLoader!.create).not.toHaveBeenCalled();
   });
 });
 
@@ -724,17 +409,24 @@ describe('health_alert — broadcast and peer pause', () => {
 });
 
 // ---------------------------------------------------------------------------
-// getStatus() — escalation fields
+// getStatus() — health fields
 // ---------------------------------------------------------------------------
 
-describe('getStatus() — escalation and health fields', () => {
-  it('reports degradedPeerCount and degradedPeers', async () => {
+describe('getStatus() — health fields', () => {
+  it('reports degradedPeerCount and degradedPeers', () => {
     const deps = makeDeps();
     const reactor = new AvaChannelReactorService(deps);
 
     const status = reactor.getStatus();
     expect(status.degradedPeerCount).toBe(0);
     expect(status.degradedPeers).toEqual([]);
-    expect(status.pendingEscalationCount).toBe(0);
+  });
+
+  it('does not include pendingEscalationCount', () => {
+    const deps = makeDeps();
+    const reactor = new AvaChannelReactorService(deps);
+
+    const status = reactor.getStatus();
+    expect('pendingEscalationCount' in status).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

**Milestone:** Integration

Remove feature-level escalation handlers (escalation_request, escalation_offer, escalation_accept) from ava-channel-reactor-service.ts. Replace with a simple project_blocked broadcast when a project has 3+ blocked features. No automated negotiation — Ava reassigns the project via assign_project MCP tool. Remove pendingEscalations tracking.

**Files to Modify:**
- apps/server/src/services/ava-channel-reactor-service.ts

**Acceptance Criteria:**
- [ ] Feature-level esca...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced project blocked notifications triggered when three or more features are blocked.

* **Removed Features**
  * Removed the escalation request endpoint.
  * Removed escalation tracking from status responses.

* **Changes**
  * Escalation handling now uses project assignment tools instead of a separate escalation protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->