### PR TITLE
Three-Layer World State Types

### DIFF
--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -791,12 +791,15 @@ export type {
 } from './metrics.js';
 
 // Lead Engineer types (production-phase nerve center)
-export { FeatureState } from './lead-engineer.js';
+export { FeatureState, WorldStateDomain } from './lead-engineer.js';
 export type {
   LeadFeatureSnapshot,
   LeadAgentSnapshot,
   LeadPRSnapshot,
   LeadMilestoneSnapshot,
+  AvaWorldState,
+  PMWorldState,
+  LEWorldState,
   LeadWorldState,
   LeadRuleAction,
   LeadFastPathRule,

--- a/libs/types/src/knowledge.ts
+++ b/libs/types/src/knowledge.ts
@@ -5,6 +5,8 @@
  * code, and context for semantic search and retrieval.
  */
 
+import type { WorldStateDomain } from './lead-engineer.js';
+
 /**
  * Source type for a knowledge chunk
  */
@@ -43,6 +45,9 @@ export interface KnowledgeChunk {
 
   /** Optional tags for categorization */
   tags?: string[];
+
+  /** Optional domain classification for cross-agent retrieval scoping */
+  domain?: WorldStateDomain;
 
   /** Importance score (0-1) for ranking results */
   importance: number;

--- a/libs/types/src/lead-engineer.ts
+++ b/libs/types/src/lead-engineer.ts
@@ -60,12 +60,111 @@ export interface LeadMilestoneSnapshot {
   completedPhases: number;
 }
 
-// ────────────────────────── World State ──────────────────────────
+// ────────────────────────── World State Domains ──────────────────────────
 
-/** Comprehensive state of a managed project */
-export interface LeadWorldState {
+/**
+ * Domain classification for world state types.
+ * Each domain owns a distinct slice of operational knowledge.
+ */
+export enum WorldStateDomain {
+  /** Ava's domain: strategic context, cross-project rollups, team health */
+  Strategic = 'strategic',
+  /** Project Manager's domain: projects, milestones, ceremonies, timelines */
+  Project = 'project',
+  /** Lead Engineer's domain: features, agents, PR status, build state */
+  Engineering = 'engineering',
+}
+
+/**
+ * Ava's world state — strategic context, cross-project rollups, team health.
+ */
+export interface AvaWorldState {
+  /** Domain tag */
+  domain: WorldStateDomain.Strategic;
+
+  /** ISO timestamp of last update */
+  updatedAt: string;
+
+  /** High-level project health rollup (projectSlug → health summary) */
+  projectRollups: Record<
+    string,
+    {
+      status: string;
+      openFeatures: number;
+      blockers: number;
+      lastActivityAt?: string;
+    }
+  >;
+
+  /** Team health signals */
+  teamHealth: {
+    activeAgents: number;
+    escalations: number;
+    errorBudgetExhausted: boolean;
+  };
+
+  /** Strategic notes or directives from the CoS layer */
+  strategicContext?: string;
+}
+
+/**
+ * Project Manager's world state — projects, milestones, ceremonies, timelines.
+ */
+export interface PMWorldState {
+  /** Domain tag */
+  domain: WorldStateDomain.Project;
+
+  /** ISO timestamp of last update */
+  updatedAt: string;
+
+  /** Active projects (projectSlug → summary) */
+  projects: Record<
+    string,
+    {
+      status: string;
+      phase: string;
+      milestoneCount: number;
+      completedMilestones: number;
+    }
+  >;
+
+  /** Milestone progress (milestoneSlug → snapshot) */
+  milestones: Record<
+    string,
+    {
+      title: string;
+      totalPhases: number;
+      completedPhases: number;
+      dueAt?: string;
+    }
+  >;
+
+  /** Upcoming ceremony dates (ceremonyType → ISO datetime) */
+  ceremonies: Record<string, string>;
+
+  /** Timeline entries for active projects */
+  upcomingDeadlines: Array<{
+    projectSlug: string;
+    label: string;
+    dueAt: string;
+  }>;
+}
+
+/**
+ * Lead Engineer's world state — features, agents, PR status, build state.
+ * LeadWorldState extends this for backward compatibility during migration.
+ */
+export interface LEWorldState {
+  /** Domain tag */
+  domain: WorldStateDomain.Engineering;
+
+  /** Project path on disk */
   projectPath: string;
+
+  /** Short project identifier */
   projectSlug: string;
+
+  /** ISO timestamp of last update */
   updatedAt: string;
 
   /** Board counts by status */
@@ -100,10 +199,17 @@ export interface LeadWorldState {
   /**
    * Whether the error budget is currently exhausted.
    * When true, auto-mode should only pick up features tagged as bug-fix.
-   * Populated from ErrorBudgetService.isExhausted() at world state refresh time.
    */
   errorBudgetExhausted?: boolean;
 }
+
+// ────────────────────────── World State ──────────────────────────
+
+/**
+ * Comprehensive state of a managed project.
+ * Extends LEWorldState for backward compatibility during migration to domain-typed world states.
+ */
+export interface LeadWorldState extends Omit<LEWorldState, 'domain'> {}
 
 // ────────────────────────── Rule Actions ──────────────────────────
 


### PR DESCRIPTION
## Summary

**Milestone:** Types & Knowledge Store Activation

Define AvaWorldState, PMWorldState, and LEWorldState types in libs/types/. AvaWorldState owns strategic context, cross-project rollups, team health. PMWorldState owns projects, milestones, ceremonies, timelines. LEWorldState owns features, agents, PR status, build state. Add a WorldStateDomain enum and domain-tagged interfaces. Update LeadWorldState to extend LEWorldState for backward compat during migration.

**Files to Modify:**
- libs/types/s...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added domain classification to knowledge management, enabling knowledge retrieval scoped to specific agent domains.
  * Introduced domain-aware world state structures partitioning system data and perspectives by domain type: Strategic, Project, and Engineering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->