### PR TITLE
fix: Lead Engineer onEvent infinite recursion stack overflow (P1)

### DIFF
--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -181,7 +181,8 @@ export class LeadEngineerService {
       this.events.subscribe((type: EventType, payload: unknown) => {
         if (
           type !== 'project:lifecycle:launched' &&
-          type !== 'lead-engineer:project-completing-requested'
+          type !== 'lead-engineer:project-completing-requested' &&
+          type !== 'lead-engineer:rule-evaluated'
         ) {
           this.onEvent(type, payload);
         }


### PR DESCRIPTION
## Summary
- Excludes `lead-engineer:rule-evaluated` from the global event subscriber in `LeadEngineerService`
- This event was emitted by `evaluateAndExecute()` and caught by the same subscriber, creating infinite recursion when multiple rules triggered on it
- Server crashed with `RangeError: Maximum call stack size exceeded` on startup when auto-mode was active with features in review

## Test plan
- [ ] Server starts without stack overflow when features are in review
- [ ] Lead engineer rules still evaluate correctly via periodic refresh
- [ ] `npm run test:server` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)