### PR TITLE
Change dev server default port to avoid collision with Docker container

### DIFF
--- a/apps/ui/vite.config.mts
+++ b/apps/ui/vite.config.mts
@@ -179,7 +179,7 @@ export default defineConfig(({ command }) => {
       allowedHosts: true,
       proxy: {
         '/api': {
-          target: process.env.VITE_SERVER_URL || 'http://localhost:3008',
+          target: process.env.VITE_SERVER_URL || 'http://localhost:3009',
           changeOrigin: true,
           ws: true,
         },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "_dev:electron:debug": "npm run dev:electron:debug --workspace=apps/ui",
     "_dev:electron:wsl": "npm run dev:electron:wsl --workspace=apps/ui",
     "_dev:electron:wsl:gpu": "npm run dev:electron:wsl:gpu --workspace=apps/ui",
-    "_dev:server": "npm run dev --workspace=apps/server",
+    "_dev:server": "PORT=3009 npm run dev --workspace=apps/server",
     "dev:web": "npm run build:packages && npm run _dev:web",
     "dev:electron": "npm run build:packages && npm run _dev:electron",
     "dev:electron:debug": "npm run build:packages && npm run _dev:electron:debug",


### PR DESCRIPTION
## Summary

**Feature Request — P2 Developer Experience**

With the new Docker-based dev-branch server running permanently on :3008, `npm run dev` needs a different default port so both can run side-by-side.

**Current state:**
- Server default port: 3008 (hardcoded fallback in `apps/server/src/index.ts`)
- UI default: connects to localhost:3008
- UI already has a server URL override in developer settings (`serverUrl` in app store)
- Port is already configurable via `PORT` env var

**Change:**
- `npm run de...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development environment configuration to align API proxy and development server settings for improved local development consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->