### PR TITLE
feat: implement PMWorldStateBuilder with layered world state

### DIFF
--- a/apps/server/src/services/pm-world-state-builder.ts
+++ b/apps/server/src/services/pm-world-state-builder.ts
@@ -1,0 +1,299 @@
+/**
+ * PM World State Builder
+ *
+ * Constructs and maintains PMWorldState from project files, milestone status,
+ * ceremony schedules, and timeline data. Exposes getDistilledSummary() returning
+ * concise markdown. Runs on a 60s refresh interval.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createLogger } from '@protolabsai/utils';
+import type { PMWorldState } from '@protolabsai/types';
+import { WorldStateDomain } from '@protolabsai/types';
+
+const logger = createLogger('PMWorldStateBuilder');
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+export interface PMWorldStateBuilderConfig {
+  /** Root directory to scan for project files (.automaker/projects/) */
+  projectRoot?: string;
+}
+
+/**
+ * Builds and incrementally refreshes PMWorldState from disk.
+ */
+export class PMWorldStateBuilder {
+  private state: PMWorldState;
+  private refreshTimer: NodeJS.Timeout | null = null;
+  private readonly projectRoot: string;
+
+  constructor(config: PMWorldStateBuilderConfig = {}) {
+    this.projectRoot = config.projectRoot ?? process.cwd();
+    this.state = this.emptyState();
+  }
+
+  // ────────────────────────── Public API ──────────────────────────
+
+  /** Start the 60s auto-refresh loop. */
+  start(): void {
+    if (this.refreshTimer) return;
+    // Fire immediately, then on interval
+    void this.buildState();
+    this.refreshTimer = setInterval(() => {
+      void this.buildState();
+    }, REFRESH_INTERVAL_MS);
+  }
+
+  /** Stop the auto-refresh loop. */
+  stop(): void {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  /** Return the current in-memory world state snapshot. */
+  getState(): PMWorldState {
+    return this.state;
+  }
+
+  /**
+   * Return a concise markdown summary suitable for injection into agent context.
+   *
+   * Format:
+   * ## Project Status
+   * - slug: status / phase (M completedMilestones/milestoneCount)
+   *
+   * ## Milestone Progress
+   * - title: X/Y phases
+   *
+   * ## Upcoming Items
+   * - dueAt label (projectSlug)
+   */
+  getDistilledSummary(): string {
+    const { projects, milestones, upcomingDeadlines, ceremonies, updatedAt } = this.state;
+
+    const lines: string[] = [`_Last refreshed: ${updatedAt}_`, ''];
+
+    // ── Project Status ────────────────────────────────────────────
+    lines.push('## Project Status');
+    const projectEntries = Object.entries(projects);
+    if (projectEntries.length === 0) {
+      lines.push('_No active projects_');
+    } else {
+      for (const [slug, p] of projectEntries) {
+        lines.push(
+          `- **${slug}**: ${p.status} / ${p.phase} (${p.completedMilestones}/${p.milestoneCount} milestones)`
+        );
+      }
+    }
+    lines.push('');
+
+    // ── Milestone Progress ────────────────────────────────────────
+    lines.push('## Milestone Progress');
+    const milestoneEntries = Object.entries(milestones);
+    if (milestoneEntries.length === 0) {
+      lines.push('_No milestones_');
+    } else {
+      for (const [slug, ms] of milestoneEntries) {
+        const pct =
+          ms.totalPhases > 0 ? Math.round((ms.completedPhases / ms.totalPhases) * 100) : 0;
+        const due = ms.dueAt ? ` (due ${ms.dueAt.slice(0, 10)})` : '';
+        lines.push(
+          `- **${ms.title}** \`${slug}\`: ${ms.completedPhases}/${ms.totalPhases} phases (${pct}%)${due}`
+        );
+      }
+    }
+    lines.push('');
+
+    // ── Upcoming Items ────────────────────────────────────────────
+    lines.push('## Upcoming Items');
+
+    // Merge upcomingDeadlines and ceremonies into a single sorted list
+    const upcoming: Array<{ dueAt: string; label: string; source: string }> = [];
+
+    for (const d of upcomingDeadlines) {
+      upcoming.push({ dueAt: d.dueAt, label: d.label, source: d.projectSlug });
+    }
+    for (const [type, iso] of Object.entries(ceremonies)) {
+      upcoming.push({ dueAt: iso, label: type, source: 'ceremony' });
+    }
+
+    upcoming.sort((a, b) => a.dueAt.localeCompare(b.dueAt));
+
+    const now = new Date().toISOString();
+    const future = upcoming.filter((u) => u.dueAt >= now);
+
+    if (future.length === 0) {
+      lines.push('_No upcoming items_');
+    } else {
+      for (const item of future.slice(0, 10)) {
+        const dateStr = item.dueAt.slice(0, 10);
+        lines.push(`- ${dateStr} — ${item.label} _(${item.source})_`);
+      }
+    }
+
+    return lines.join('\n');
+  }
+
+  // ────────────────────────── State Building ──────────────────────────
+
+  /**
+   * Read project data from disk and rebuild the PMWorldState.
+   * Gracefully handles missing directories or malformed files.
+   */
+  async buildState(): Promise<void> {
+    try {
+      const next = this.emptyState();
+
+      await this.loadProjects(next);
+      await this.loadCeremonies(next);
+      await this.loadTimelines(next);
+
+      next.updatedAt = new Date().toISOString();
+      this.state = next;
+
+      logger.debug(`PMWorldState refreshed — ${Object.keys(next.projects).length} projects`);
+    } catch (err) {
+      logger.warn('PMWorldStateBuilder.buildState() failed, retaining previous state:', err);
+    }
+  }
+
+  // ────────────────────────── Private Helpers ──────────────────────────
+
+  private emptyState(): PMWorldState {
+    return {
+      domain: WorldStateDomain.Project,
+      updatedAt: new Date().toISOString(),
+      projects: {},
+      milestones: {},
+      ceremonies: {},
+      upcomingDeadlines: [],
+    };
+  }
+
+  /**
+   * Scan .automaker/projects/ for project.json files and populate
+   * state.projects and state.milestones.
+   */
+  private async loadProjects(state: PMWorldState): Promise<void> {
+    const projectsDir = path.join(this.projectRoot, '.automaker', 'projects');
+
+    let slugs: string[];
+    try {
+      const entries = await fs.readdir(projectsDir, { withFileTypes: true });
+      slugs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+    } catch {
+      // .automaker/projects/ may not exist — that's fine
+      return;
+    }
+
+    for (const slug of slugs) {
+      const projectJsonPath = path.join(projectsDir, slug, 'project.json');
+      try {
+        const raw = await fs.readFile(projectJsonPath, 'utf-8');
+        const project = JSON.parse(raw) as {
+          status?: string;
+          phase?: string;
+          milestones?: Array<{
+            slug?: string;
+            title: string;
+            phases?: Array<{ featureId?: string; status?: string }>;
+            dueAt?: string;
+          }>;
+        };
+
+        const milestones = project.milestones ?? [];
+        const completedMilestones = milestones.filter((ms) => {
+          const phases = ms.phases ?? [];
+          if (phases.length === 0) return false;
+          return phases.every((p) => p.status === 'done' || p.status === 'verified');
+        }).length;
+
+        state.projects[slug] = {
+          status: project.status ?? 'active',
+          phase: project.phase ?? 'development',
+          milestoneCount: milestones.length,
+          completedMilestones,
+        };
+
+        for (const ms of milestones) {
+          const msSlug =
+            ms.slug ??
+            ms.title
+              .toLowerCase()
+              .replace(/\s+/g, '-')
+              .replace(/[^a-z0-9-]/g, '');
+          const phases = ms.phases ?? [];
+          const completedPhases = phases.filter(
+            (p) => p.status === 'done' || p.status === 'verified'
+          ).length;
+
+          state.milestones[msSlug] = {
+            title: ms.title,
+            totalPhases: phases.length,
+            completedPhases,
+            dueAt: ms.dueAt,
+          };
+        }
+      } catch {
+        // Skip malformed or missing project.json
+        logger.debug(`Skipping project ${slug}: could not read project.json`);
+      }
+    }
+  }
+
+  /**
+   * Load upcoming ceremony dates from .automaker/ceremony-state.json.
+   */
+  private async loadCeremonies(state: PMWorldState): Promise<void> {
+    const ceremonyStatePath = path.join(this.projectRoot, '.automaker', 'ceremony-state.json');
+    try {
+      const raw = await fs.readFile(ceremonyStatePath, 'utf-8');
+      const data = JSON.parse(raw) as Record<
+        string,
+        { nextRunAt?: string; nextAt?: string; type?: string }
+      >;
+
+      for (const [key, entry] of Object.entries(data)) {
+        const nextAt = entry.nextRunAt ?? entry.nextAt;
+        if (nextAt) {
+          state.ceremonies[entry.type ?? key] = nextAt;
+        }
+      }
+    } catch {
+      // ceremony-state.json may not exist — that's fine
+    }
+  }
+
+  /**
+   * Load upcoming deadline entries from .automaker/timeline.json.
+   */
+  private async loadTimelines(state: PMWorldState): Promise<void> {
+    const timelinePath = path.join(this.projectRoot, '.automaker', 'timeline.json');
+    try {
+      const raw = await fs.readFile(timelinePath, 'utf-8');
+      const data = JSON.parse(raw) as Array<{
+        projectSlug: string;
+        label: string;
+        dueAt: string;
+      }>;
+
+      if (Array.isArray(data)) {
+        for (const entry of data) {
+          if (entry.projectSlug && entry.label && entry.dueAt) {
+            state.upcomingDeadlines.push({
+              projectSlug: entry.projectSlug,
+              label: entry.label,
+              dueAt: entry.dueAt,
+            });
+          }
+        }
+      }
+    } catch {
+      // timeline.json may not exist — that's fine
+    }
+  }
+}

--- a/apps/server/tests/unit/services/pm-world-state-builder.test.ts
+++ b/apps/server/tests/unit/services/pm-world-state-builder.test.ts
@@ -1,0 +1,442 @@
+/**
+ * PMWorldStateBuilder — unit tests
+ *
+ * Covers:
+ * - State building from disk (projects, milestones, ceremonies, timelines)
+ * - Graceful handling of missing directories/files
+ * - getDistilledSummary() markdown output
+ * - 60s refresh interval (start / stop)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import { PMWorldStateBuilder } from '@/services/pm-world-state-builder.js';
+import { WorldStateDomain } from '@protolabsai/types';
+
+// ────────────────────────── Module Mocks ──────────────────────────
+
+vi.mock('node:fs/promises');
+vi.mock('@protolabsai/utils', async () => {
+  const actual = await vi.importActual<typeof import('@protolabsai/utils')>('@protolabsai/utils');
+  return {
+    ...actual,
+    createLogger: vi.fn(() => ({
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    })),
+  };
+});
+
+// ────────────────────────── Helpers ──────────────────────────
+
+function makeProjectJson(overrides: object = {}): string {
+  return JSON.stringify({
+    status: 'active',
+    phase: 'development',
+    milestones: [
+      {
+        slug: 'milestone-1',
+        title: 'Milestone One',
+        phases: [
+          { featureId: 'f1', status: 'done' },
+          { featureId: 'f2', status: 'in_progress' },
+        ],
+        dueAt: '2026-04-01T00:00:00.000Z',
+      },
+    ],
+    ...overrides,
+  });
+}
+
+function setupMockFs(
+  opts: {
+    projects?: Array<{ slug: string; projectJson?: string }>;
+    ceremonyState?: object;
+    timeline?: object;
+  } = {}
+) {
+  const mReaddir = vi.mocked(fs.readdir);
+  const mReadFile = vi.mocked(fs.readFile);
+
+  mReaddir.mockImplementation(async (dirPath, _opts) => {
+    const p = String(dirPath);
+    if (p.endsWith('projects')) {
+      return (opts.projects ?? []).map(
+        (proj) =>
+          ({ name: proj.slug, isDirectory: () => true }) as unknown as import('node:fs').Dirent
+      );
+    }
+    return [];
+  });
+
+  mReadFile.mockImplementation(async (filePath) => {
+    const p = String(filePath);
+
+    // project.json files
+    for (const proj of opts.projects ?? []) {
+      if (p.endsWith(`${proj.slug}/project.json`)) {
+        return proj.projectJson ?? makeProjectJson();
+      }
+    }
+
+    // ceremony-state.json
+    if (p.endsWith('ceremony-state.json')) {
+      if (opts.ceremonyState) return JSON.stringify(opts.ceremonyState);
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    }
+
+    // timeline.json
+    if (p.endsWith('timeline.json')) {
+      if (opts.timeline) return JSON.stringify(opts.timeline);
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    }
+
+    throw Object.assign(new Error('ENOENT: ' + p), { code: 'ENOENT' });
+  });
+}
+
+// ────────────────────────── Tests ──────────────────────────
+
+describe('PMWorldStateBuilder', () => {
+  let builder: PMWorldStateBuilder;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    builder = new PMWorldStateBuilder({ projectRoot: '/workspace' });
+  });
+
+  afterEach(() => {
+    builder.stop();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  // ── Initial State ──────────────────────────────────────────────────
+
+  describe('initial state', () => {
+    it('should have domain = WorldStateDomain.Project', () => {
+      const state = builder.getState();
+      expect(state.domain).toBe(WorldStateDomain.Project);
+    });
+
+    it('should start with empty collections', () => {
+      const state = builder.getState();
+      expect(state.projects).toEqual({});
+      expect(state.milestones).toEqual({});
+      expect(state.ceremonies).toEqual({});
+      expect(state.upcomingDeadlines).toEqual([]);
+    });
+  });
+
+  // ── buildState() ──────────────────────────────────────────────────
+
+  describe('buildState()', () => {
+    it('should populate projects and milestones from project.json', async () => {
+      setupMockFs({
+        projects: [{ slug: 'my-project', projectJson: makeProjectJson() }],
+      });
+
+      await builder.buildState();
+      const state = builder.getState();
+
+      expect(state.projects['my-project']).toEqual({
+        status: 'active',
+        phase: 'development',
+        milestoneCount: 1,
+        completedMilestones: 0, // only 1 of 2 phases done
+      });
+
+      expect(state.milestones['milestone-1']).toEqual({
+        title: 'Milestone One',
+        totalPhases: 2,
+        completedPhases: 1,
+        dueAt: '2026-04-01T00:00:00.000Z',
+      });
+    });
+
+    it('should mark milestone as completed when all phases are done', async () => {
+      const projectJson = JSON.stringify({
+        status: 'active',
+        phase: 'development',
+        milestones: [
+          {
+            slug: 'ms-complete',
+            title: 'Complete MS',
+            phases: [
+              { featureId: 'f1', status: 'done' },
+              { featureId: 'f2', status: 'verified' },
+            ],
+          },
+        ],
+      });
+
+      setupMockFs({ projects: [{ slug: 'proj', projectJson }] });
+      await builder.buildState();
+      const state = builder.getState();
+
+      expect(state.projects['proj'].completedMilestones).toBe(1);
+      expect(state.milestones['ms-complete'].completedPhases).toBe(2);
+    });
+
+    it('should derive milestone slug from title when slug field is absent', async () => {
+      const projectJson = JSON.stringify({
+        milestones: [{ title: 'My Feature Set', phases: [] }],
+      });
+
+      setupMockFs({ projects: [{ slug: 'proj', projectJson }] });
+      await builder.buildState();
+      const state = builder.getState();
+
+      expect(state.milestones['my-feature-set']).toBeDefined();
+    });
+
+    it('should load ceremony schedules from ceremony-state.json', async () => {
+      setupMockFs({
+        ceremonyState: {
+          standup: { type: 'standup', nextRunAt: '2026-03-11T09:00:00.000Z' },
+          retro: { type: 'retro', nextRunAt: '2026-03-15T14:00:00.000Z' },
+        },
+      });
+
+      await builder.buildState();
+      const state = builder.getState();
+
+      expect(state.ceremonies['standup']).toBe('2026-03-11T09:00:00.000Z');
+      expect(state.ceremonies['retro']).toBe('2026-03-15T14:00:00.000Z');
+    });
+
+    it('should load timeline deadlines from timeline.json', async () => {
+      setupMockFs({
+        timeline: [
+          { projectSlug: 'proj-a', label: 'Launch', dueAt: '2026-05-01T00:00:00.000Z' },
+          { projectSlug: 'proj-b', label: 'Beta', dueAt: '2026-04-15T00:00:00.000Z' },
+        ],
+      });
+
+      await builder.buildState();
+      const state = builder.getState();
+
+      expect(state.upcomingDeadlines).toHaveLength(2);
+      expect(state.upcomingDeadlines[0]).toEqual({
+        projectSlug: 'proj-a',
+        label: 'Launch',
+        dueAt: '2026-05-01T00:00:00.000Z',
+      });
+    });
+
+    it('should handle missing .automaker/projects directory gracefully', async () => {
+      vi.mocked(fs.readdir).mockRejectedValue(
+        Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      );
+      vi.mocked(fs.readFile).mockRejectedValue(
+        Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      );
+
+      await expect(builder.buildState()).resolves.toBeUndefined();
+
+      const state = builder.getState();
+      expect(state.projects).toEqual({});
+      expect(state.milestones).toEqual({});
+    });
+
+    it('should skip a project when project.json is malformed JSON', async () => {
+      vi.mocked(fs.readdir).mockResolvedValue([
+        { name: 'bad-proj', isDirectory: () => true } as unknown as import('node:fs').Dirent,
+      ]);
+      vi.mocked(fs.readFile).mockImplementation(async (p) => {
+        const ps = String(p);
+        if (ps.endsWith('project.json')) return '{ not valid json';
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      });
+
+      await builder.buildState();
+      const state = builder.getState();
+      expect(state.projects['bad-proj']).toBeUndefined();
+    });
+
+    it('should handle missing ceremony-state.json gracefully', async () => {
+      setupMockFs({ projects: [] }); // no ceremony file set → mock throws ENOENT
+
+      await builder.buildState();
+      expect(builder.getState().ceremonies).toEqual({});
+    });
+
+    it('should handle missing timeline.json gracefully', async () => {
+      setupMockFs({ projects: [] }); // no timeline file set → mock throws ENOENT
+
+      await builder.buildState();
+      expect(builder.getState().upcomingDeadlines).toEqual([]);
+    });
+
+    it('should update lastRefreshed (updatedAt) after each build', async () => {
+      setupMockFs({});
+      const before = new Date('2026-03-10T00:00:00.000Z');
+      vi.setSystemTime(before);
+
+      await builder.buildState();
+      const firstUpdated = builder.getState().updatedAt;
+
+      vi.setSystemTime(new Date('2026-03-10T00:01:00.000Z'));
+      await builder.buildState();
+      const secondUpdated = builder.getState().updatedAt;
+
+      expect(secondUpdated > firstUpdated).toBe(true);
+    });
+  });
+
+  // ── getDistilledSummary() ──────────────────────────────────────────
+
+  describe('getDistilledSummary()', () => {
+    it('should return markdown with expected section headers', () => {
+      const summary = builder.getDistilledSummary();
+      expect(summary).toContain('## Project Status');
+      expect(summary).toContain('## Milestone Progress');
+      expect(summary).toContain('## Upcoming Items');
+    });
+
+    it('should show empty state placeholders when no data', () => {
+      const summary = builder.getDistilledSummary();
+      expect(summary).toContain('_No active projects_');
+      expect(summary).toContain('_No milestones_');
+      expect(summary).toContain('_No upcoming items_');
+    });
+
+    it('should include project status after buildState()', async () => {
+      setupMockFs({
+        projects: [
+          {
+            slug: 'alpha',
+            projectJson: makeProjectJson({ status: 'on-track', phase: 'execution' }),
+          },
+        ],
+      });
+      await builder.buildState();
+
+      const summary = builder.getDistilledSummary();
+      expect(summary).toContain('**alpha**');
+      expect(summary).toContain('on-track');
+      expect(summary).toContain('execution');
+    });
+
+    it('should include milestone progress after buildState()', async () => {
+      setupMockFs({
+        projects: [{ slug: 'proj', projectJson: makeProjectJson() }],
+      });
+      await builder.buildState();
+
+      const summary = builder.getDistilledSummary();
+      expect(summary).toContain('Milestone One');
+      expect(summary).toContain('1/2');
+    });
+
+    it('should include upcoming deadlines from timeline', async () => {
+      setupMockFs({
+        timeline: [{ projectSlug: 'proj', label: 'Launch v1', dueAt: '2099-05-01T00:00:00.000Z' }],
+      });
+      await builder.buildState();
+
+      const summary = builder.getDistilledSummary();
+      expect(summary).toContain('Launch v1');
+      expect(summary).toContain('2099-05-01');
+    });
+
+    it('should include ceremony dates in upcoming items', async () => {
+      setupMockFs({
+        ceremonyState: {
+          standup: { type: 'standup', nextRunAt: '2099-06-01T09:00:00.000Z' },
+        },
+      });
+      await builder.buildState();
+
+      const summary = builder.getDistilledSummary();
+      expect(summary).toContain('standup');
+      expect(summary).toContain('2099-06-01');
+    });
+
+    it('should not show past items in upcoming items', async () => {
+      setupMockFs({
+        timeline: [
+          { projectSlug: 'proj', label: 'Past Deadline', dueAt: '2020-01-01T00:00:00.000Z' },
+        ],
+      });
+      await builder.buildState();
+
+      const summary = builder.getDistilledSummary();
+      expect(summary).toContain('_No upcoming items_');
+    });
+
+    it('should limit upcoming items to 10 entries', async () => {
+      const deadlines = Array.from({ length: 15 }, (_, i) => ({
+        projectSlug: 'proj',
+        label: `Deadline ${i + 1}`,
+        dueAt: `2099-0${Math.floor(i / 10) + 1}-${String((i % 28) + 1).padStart(2, '0')}T00:00:00.000Z`,
+      }));
+
+      setupMockFs({ timeline: deadlines });
+      await builder.buildState();
+
+      const summary = builder.getDistilledSummary();
+      const matches = summary.match(/^- \d{4}-\d{2}-\d{2}/gm) ?? [];
+      expect(matches.length).toBeLessThanOrEqual(10);
+    });
+  });
+
+  // ── start() / stop() ──────────────────────────────────────────────
+
+  describe('start() / stop()', () => {
+    it('should call buildState immediately on start()', async () => {
+      setupMockFs({});
+      const spy = vi.spyOn(builder, 'buildState').mockResolvedValue();
+
+      builder.start();
+      // Flush the initial async call
+      await Promise.resolve();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call buildState again after 60s', async () => {
+      setupMockFs({});
+      const spy = vi.spyOn(builder, 'buildState').mockResolvedValue();
+
+      builder.start();
+      await Promise.resolve();
+
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not call buildState after stop()', async () => {
+      setupMockFs({});
+      const spy = vi.spyOn(builder, 'buildState').mockResolvedValue();
+
+      builder.start();
+      await Promise.resolve();
+
+      builder.stop();
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not create duplicate timers on multiple start() calls', async () => {
+      setupMockFs({});
+      const spy = vi.spyOn(builder, 'buildState').mockResolvedValue();
+
+      builder.start();
+      builder.start(); // second call should be a no-op
+      await Promise.resolve();
+
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+
+      // Only 1 timer running → 2 calls total (initial + one interval tick)
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- PMWorldStateBuilder reads project files, milestones, ceremonies, and timeline data from disk
- Exposes `getDistilledSummary()` returning concise markdown for agent context injection
- Refreshes on 60s interval via `start()`/`stop()` lifecycle
- 24 unit tests covering all paths

## Test plan
- [x] `npm run build:server` passes
- [x] 24/24 unit tests pass
- [ ] Integration with Ava world state builder (separate feature)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a world state builder that automatically scans and maintains project management data with 60-second refresh intervals, providing real-time state snapshots and markdown summaries of projects, milestones, and upcoming deadlines.

* **Tests**
  * Added comprehensive unit test coverage for state construction, lifecycle management, and edge-case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->