### PR TITLE
Ava World State Builder

### DIFF
--- a/apps/server/src/services/ava-world-state-builder.ts
+++ b/apps/server/src/services/ava-world-state-builder.ts
@@ -1,0 +1,208 @@
+/**
+ * Ava World State Builder
+ *
+ * Aggregates distilled summaries from the PM (PMWorldStateBuilder) and
+ * Lead Engineer (LeadEngineerWorldStateProvider) layers. Adds strategic
+ * context: team health, cross-project dependencies, brand/content status.
+ * Exposes getFullBriefing() returning comprehensive briefing markdown.
+ */
+
+import { createLogger } from '@protolabsai/utils';
+import type { AvaWorldState } from '@protolabsai/types';
+import { WorldStateDomain } from '@protolabsai/types';
+import type { PMWorldStateBuilder } from './pm-world-state-builder.js';
+
+const logger = createLogger('AvaWorldStateBuilder');
+
+// ────────────────────────── Interfaces ──────────────────────────
+
+/**
+ * Minimal interface for Lead Engineer service to provide a world state
+ * summary. The concrete implementation is added to LeadEngineerService
+ * by a separate feature.
+ */
+export interface LeadEngineerWorldStateProvider {
+  getWorldStateSummary(): string;
+}
+
+export interface AvaWorldStateBuilderConfig {
+  /** Optional strategic directives or brand context to surface in briefing */
+  strategicContext?: string;
+}
+
+// ────────────────────────── Class ──────────────────────────
+
+export class AvaWorldStateBuilder {
+  private readonly log = logger;
+
+  constructor(
+    private readonly pmBuilder: PMWorldStateBuilder,
+    private readonly leProvider: LeadEngineerWorldStateProvider,
+    private readonly config: AvaWorldStateBuilderConfig = {}
+  ) {}
+
+  // ────────────────────────── Public API ──────────────────────────
+
+  /**
+   * Returns a comprehensive briefing markdown string aggregating:
+   * - PM world state (projects, milestones, upcoming items)
+   * - LE world state (features, agents, PR status)
+   * - Strategic context (team health, cross-project deps, brand/content)
+   */
+  getFullBriefing(): string {
+    const lines: string[] = [];
+    const now = new Date().toISOString();
+
+    lines.push('# Ava Full Briefing');
+    lines.push(`_Generated: ${now}_`);
+    lines.push('');
+
+    // ── PM Layer ────────────────────────────────────────────────────
+    lines.push('## Project Management Layer');
+    lines.push('');
+    try {
+      const pmSummary = this.pmBuilder.getDistilledSummary();
+      lines.push(pmSummary);
+    } catch (err) {
+      this.log.warn('Failed to get PM distilled summary:', err);
+      lines.push('_PM summary unavailable_');
+    }
+    lines.push('');
+
+    // ── LE Layer ────────────────────────────────────────────────────
+    lines.push('## Engineering Layer');
+    lines.push('');
+    try {
+      const leSummary = this.leProvider.getWorldStateSummary();
+      lines.push(leSummary);
+    } catch (err) {
+      this.log.warn('Failed to get LE world state summary:', err);
+      lines.push('_Engineering summary unavailable_');
+    }
+    lines.push('');
+
+    // ── Strategic Context ───────────────────────────────────────────
+    lines.push('## Strategic Context');
+    lines.push('');
+
+    // Team health
+    const teamHealth = this.getTeamHealthSummary();
+    lines.push('### Team Health');
+    lines.push(teamHealth);
+    lines.push('');
+
+    // Cross-project dependencies
+    const crossProjectDeps = this.getCrossProjectDependencies();
+    lines.push('### Cross-Project Dependencies');
+    if (crossProjectDeps.length === 0) {
+      lines.push('_No cross-project dependencies detected_');
+    } else {
+      for (const dep of crossProjectDeps) {
+        lines.push(`- ${dep}`);
+      }
+    }
+    lines.push('');
+
+    // Brand / content status
+    lines.push('### Brand & Content');
+    const brandStatus = this.getBrandContentStatus();
+    lines.push(brandStatus);
+    lines.push('');
+
+    // Strategic directives (optional)
+    if (this.config.strategicContext) {
+      lines.push('### Strategic Directives');
+      lines.push(this.config.strategicContext);
+      lines.push('');
+    }
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Build a structured AvaWorldState snapshot from current PM and LE data.
+   */
+  buildState(): AvaWorldState {
+    return {
+      domain: WorldStateDomain.Strategic,
+      updatedAt: new Date().toISOString(),
+      projectRollups: this.buildProjectRollups(),
+      teamHealth: this.deriveTeamHealth(),
+      strategicContext: this.config.strategicContext,
+    };
+  }
+
+  // ────────────────────────── Private Helpers ──────────────────────────
+
+  /** Format team health as a markdown bullet list */
+  private getTeamHealthSummary(): string {
+    const health = this.deriveTeamHealth();
+    const lines: string[] = [
+      `- Active Agents: ${health.activeAgents}`,
+      `- Escalations: ${health.escalations}`,
+      `- Error Budget Exhausted: ${health.errorBudgetExhausted ? 'Yes ⚠️' : 'No ✅'}`,
+    ];
+    return lines.join('\n');
+  }
+
+  /** Derive team health metrics from available PM state */
+  private deriveTeamHealth(): AvaWorldState['teamHealth'] {
+    const pmState = this.pmBuilder.getState();
+    const projectCount = Object.keys(pmState.projects).length;
+
+    return {
+      activeAgents: 0, // populated when LE provides active agent data
+      escalations: 0,
+      errorBudgetExhausted: projectCount === 0,
+    };
+  }
+
+  /** Identify cross-project dependency signals from PM state */
+  private getCrossProjectDependencies(): string[] {
+    const pmState = this.pmBuilder.getState();
+    const projectSlugs = Object.keys(pmState.projects);
+    const deps: string[] = [];
+
+    if (projectSlugs.length > 1) {
+      deps.push(`${projectSlugs.length} active projects — review for shared dependencies`);
+    }
+
+    return deps;
+  }
+
+  /** Summarise brand/content status from upcoming PM deadlines */
+  private getBrandContentStatus(): string {
+    const pmState = this.pmBuilder.getState();
+    const now = new Date().toISOString();
+
+    const upcoming = pmState.upcomingDeadlines
+      .filter((d) => d.dueAt >= now)
+      .sort((a, b) => a.dueAt.localeCompare(b.dueAt))
+      .slice(0, 3);
+
+    if (upcoming.length === 0) {
+      return '_No brand/content deadlines on the horizon_';
+    }
+
+    return upcoming
+      .map((d) => `- ${d.dueAt.slice(0, 10)} — ${d.label} _(${d.projectSlug})_`)
+      .join('\n');
+  }
+
+  /** Build per-project rollups from PM state */
+  private buildProjectRollups(): AvaWorldState['projectRollups'] {
+    const pmState = this.pmBuilder.getState();
+    const rollups: AvaWorldState['projectRollups'] = {};
+
+    for (const [slug, project] of Object.entries(pmState.projects)) {
+      const openFeatures = project.milestoneCount - project.completedMilestones;
+      rollups[slug] = {
+        status: project.status,
+        openFeatures: Math.max(0, openFeatures),
+        blockers: 0, // detailed blocker data comes from LE layer
+      };
+    }
+
+    return rollups;
+  }
+}

--- a/apps/server/tests/unit/services/ava-world-state-builder.test.ts
+++ b/apps/server/tests/unit/services/ava-world-state-builder.test.ts
@@ -1,0 +1,384 @@
+/**
+ * AvaWorldStateBuilder — unit tests
+ *
+ * Covers:
+ * - getFullBriefing() aggregates PM + LE summaries
+ * - getFullBriefing() includes all required section headers
+ * - Team health metrics are included
+ * - Cross-project dependency detection
+ * - Brand/content status from PM upcoming deadlines
+ * - buildState() returns structured AvaWorldState
+ * - Graceful handling of PM / LE errors
+ * - Strategic context is included when configured
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AvaWorldStateBuilder } from '@/services/ava-world-state-builder.js';
+import type { LeadEngineerWorldStateProvider } from '@/services/ava-world-state-builder.js';
+import type { PMWorldStateBuilder } from '@/services/pm-world-state-builder.js';
+import { WorldStateDomain } from '@protolabsai/types';
+
+// ────────────────────────── Module Mocks ──────────────────────────
+
+vi.mock('@protolabsai/utils', async () => {
+  const actual = await vi.importActual<typeof import('@protolabsai/utils')>('@protolabsai/utils');
+  return {
+    ...actual,
+    createLogger: vi.fn(() => ({
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    })),
+  };
+});
+
+// ────────────────────────── Helpers ──────────────────────────
+
+function makePmState(
+  overrides: Partial<{
+    projects: Record<
+      string,
+      { status: string; phase: string; milestoneCount: number; completedMilestones: number }
+    >;
+    milestones: Record<
+      string,
+      { title: string; totalPhases: number; completedPhases: number; dueAt?: string }
+    >;
+    ceremonies: Record<string, string>;
+    upcomingDeadlines: Array<{ projectSlug: string; label: string; dueAt: string }>;
+    updatedAt: string;
+  }> = {}
+) {
+  return {
+    domain: WorldStateDomain.Project,
+    updatedAt: overrides.updatedAt ?? '2026-03-10T00:00:00.000Z',
+    projects: overrides.projects ?? {},
+    milestones: overrides.milestones ?? {},
+    ceremonies: overrides.ceremonies ?? {},
+    upcomingDeadlines: overrides.upcomingDeadlines ?? [],
+  };
+}
+
+function makeMockPmBuilder(pmStateOverrides: Parameters<typeof makePmState>[0] = {}) {
+  const state = makePmState(pmStateOverrides);
+  return {
+    getState: vi.fn(() => state),
+    getDistilledSummary: vi.fn(
+      () => `## Project Status\n- **test-project**: active / development (0/1 milestones)`
+    ),
+  } as unknown as PMWorldStateBuilder;
+}
+
+function makeMockLeProvider(summary = '## Engineering\n- 3 features in progress') {
+  return {
+    getWorldStateSummary: vi.fn(() => summary),
+  } as LeadEngineerWorldStateProvider;
+}
+
+// ────────────────────────── Tests ──────────────────────────
+
+describe('AvaWorldStateBuilder', () => {
+  let pmBuilder: PMWorldStateBuilder;
+  let leProvider: LeadEngineerWorldStateProvider;
+  let builder: AvaWorldStateBuilder;
+
+  beforeEach(() => {
+    pmBuilder = makeMockPmBuilder();
+    leProvider = makeMockLeProvider();
+    builder = new AvaWorldStateBuilder(pmBuilder, leProvider);
+  });
+
+  // ── getFullBriefing() — structure ──────────────────────────────────
+
+  describe('getFullBriefing() — structure', () => {
+    it('should include top-level heading', () => {
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('# Ava Full Briefing');
+    });
+
+    it('should include PM layer section', () => {
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('## Project Management Layer');
+    });
+
+    it('should include Engineering layer section', () => {
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('## Engineering Layer');
+    });
+
+    it('should include Strategic Context section', () => {
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('## Strategic Context');
+    });
+
+    it('should include Team Health subsection', () => {
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('### Team Health');
+    });
+
+    it('should include Cross-Project Dependencies subsection', () => {
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('### Cross-Project Dependencies');
+    });
+
+    it('should include Brand & Content subsection', () => {
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('### Brand & Content');
+    });
+
+    it('should include a generation timestamp', () => {
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toMatch(/_Generated: \d{4}-\d{2}-\d{2}/);
+    });
+  });
+
+  // ── getFullBriefing() — aggregation ──────────────────────────────────
+
+  describe('getFullBriefing() — aggregation', () => {
+    it('should include PM distilled summary content', () => {
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('## Project Status');
+      expect(briefing).toContain('test-project');
+    });
+
+    it('should call pmBuilder.getDistilledSummary()', () => {
+      builder.getFullBriefing();
+      expect(vi.mocked(pmBuilder.getDistilledSummary)).toHaveBeenCalledOnce();
+    });
+
+    it('should include LE world state summary content', () => {
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('## Engineering');
+      expect(briefing).toContain('3 features in progress');
+    });
+
+    it('should call leProvider.getWorldStateSummary()', () => {
+      builder.getFullBriefing();
+      expect(vi.mocked(leProvider.getWorldStateSummary)).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ── Team health ──────────────────────────────────────────────────────
+
+  describe('team health metrics', () => {
+    it('should show active agents count', () => {
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('Active Agents: 0');
+    });
+
+    it('should show escalations count', () => {
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('Escalations: 0');
+    });
+
+    it('should flag errorBudgetExhausted=true when no projects exist', () => {
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('Error Budget Exhausted: Yes');
+    });
+
+    it('should flag errorBudgetExhausted=false when projects exist', () => {
+      pmBuilder = makeMockPmBuilder({
+        projects: {
+          'my-project': {
+            status: 'active',
+            phase: 'dev',
+            milestoneCount: 1,
+            completedMilestones: 0,
+          },
+        },
+      });
+      builder = new AvaWorldStateBuilder(pmBuilder, leProvider);
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('Error Budget Exhausted: No');
+    });
+  });
+
+  // ── Cross-project dependencies ───────────────────────────────────────
+
+  describe('cross-project dependencies', () => {
+    it('should show no-dependency placeholder with single project', () => {
+      pmBuilder = makeMockPmBuilder({
+        projects: {
+          solo: { status: 'active', phase: 'dev', milestoneCount: 0, completedMilestones: 0 },
+        },
+      });
+      builder = new AvaWorldStateBuilder(pmBuilder, leProvider);
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('_No cross-project dependencies detected_');
+    });
+
+    it('should flag multiple active projects', () => {
+      pmBuilder = makeMockPmBuilder({
+        projects: {
+          'proj-a': { status: 'active', phase: 'dev', milestoneCount: 1, completedMilestones: 0 },
+          'proj-b': { status: 'active', phase: 'dev', milestoneCount: 1, completedMilestones: 0 },
+        },
+      });
+      builder = new AvaWorldStateBuilder(pmBuilder, leProvider);
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('2 active projects');
+      expect(briefing).toContain('shared dependencies');
+    });
+  });
+
+  // ── Brand & content status ───────────────────────────────────────────
+
+  describe('brand & content status', () => {
+    it('should show no-deadlines placeholder when none exist', () => {
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('_No brand/content deadlines on the horizon_');
+    });
+
+    it('should show upcoming deadlines from PM state', () => {
+      pmBuilder = makeMockPmBuilder({
+        upcomingDeadlines: [
+          { projectSlug: 'content', label: 'Blog Post Launch', dueAt: '2099-06-01T00:00:00.000Z' },
+        ],
+      });
+      builder = new AvaWorldStateBuilder(pmBuilder, leProvider);
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('Blog Post Launch');
+      expect(briefing).toContain('2099-06-01');
+      expect(briefing).toContain('content');
+    });
+
+    it('should not show past deadlines in brand section', () => {
+      pmBuilder = makeMockPmBuilder({
+        upcomingDeadlines: [
+          { projectSlug: 'old', label: 'Past Launch', dueAt: '2020-01-01T00:00:00.000Z' },
+        ],
+      });
+      builder = new AvaWorldStateBuilder(pmBuilder, leProvider);
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('_No brand/content deadlines on the horizon_');
+    });
+
+    it('should limit brand deadlines to 3 entries', () => {
+      const deadlines = Array.from({ length: 5 }, (_, i) => ({
+        projectSlug: 'proj',
+        label: `Deadline ${i + 1}`,
+        dueAt: `2099-0${i + 1}-01T00:00:00.000Z`,
+      }));
+      pmBuilder = makeMockPmBuilder({ upcomingDeadlines: deadlines });
+      builder = new AvaWorldStateBuilder(pmBuilder, leProvider);
+      const briefing = builder.getFullBriefing();
+      const matches = briefing.match(/^- 2099-\d{2}-\d{2}/gm) ?? [];
+      expect(matches.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  // ── Strategic context ────────────────────────────────────────────────
+
+  describe('strategic context', () => {
+    it('should not include Strategic Directives section when not configured', () => {
+      const briefing = builder.getFullBriefing();
+      expect(briefing).not.toContain('### Strategic Directives');
+    });
+
+    it('should include Strategic Directives when configured', () => {
+      builder = new AvaWorldStateBuilder(pmBuilder, leProvider, {
+        strategicContext: 'Focus on revenue-generating features this sprint.',
+      });
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('### Strategic Directives');
+      expect(briefing).toContain('Focus on revenue-generating features');
+    });
+  });
+
+  // ── Error resilience ─────────────────────────────────────────────────
+
+  describe('error resilience', () => {
+    it('should show PM unavailable message when getDistilledSummary throws', () => {
+      vi.mocked(pmBuilder.getDistilledSummary).mockImplementation(() => {
+        throw new Error('PM disk failure');
+      });
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('_PM summary unavailable_');
+    });
+
+    it('should show LE unavailable message when getWorldStateSummary throws', () => {
+      vi.mocked(leProvider.getWorldStateSummary).mockImplementation(() => {
+        throw new Error('LE service unavailable');
+      });
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('_Engineering summary unavailable_');
+    });
+
+    it('should still produce a complete briefing despite PM failure', () => {
+      vi.mocked(pmBuilder.getDistilledSummary).mockImplementation(() => {
+        throw new Error('oops');
+      });
+      const briefing = builder.getFullBriefing();
+      expect(briefing).toContain('## Strategic Context');
+      expect(briefing).toContain('### Team Health');
+    });
+  });
+
+  // ── buildState() ─────────────────────────────────────────────────────
+
+  describe('buildState()', () => {
+    it('should return AvaWorldState with domain = Strategic', () => {
+      const state = builder.buildState();
+      expect(state.domain).toBe(WorldStateDomain.Strategic);
+    });
+
+    it('should include an updatedAt timestamp', () => {
+      const state = builder.buildState();
+      expect(state.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('should include teamHealth', () => {
+      const state = builder.buildState();
+      expect(state.teamHealth).toBeDefined();
+      expect(typeof state.teamHealth.activeAgents).toBe('number');
+      expect(typeof state.teamHealth.escalations).toBe('number');
+      expect(typeof state.teamHealth.errorBudgetExhausted).toBe('boolean');
+    });
+
+    it('should include projectRollups from PM state', () => {
+      pmBuilder = makeMockPmBuilder({
+        projects: {
+          'my-app': {
+            status: 'on-track',
+            phase: 'execution',
+            milestoneCount: 5,
+            completedMilestones: 2,
+          },
+        },
+      });
+      builder = new AvaWorldStateBuilder(pmBuilder, leProvider);
+      const state = builder.buildState();
+
+      expect(state.projectRollups['my-app']).toMatchObject({
+        status: 'on-track',
+        openFeatures: 3,
+        blockers: 0,
+      });
+    });
+
+    it('should include strategicContext when configured', () => {
+      builder = new AvaWorldStateBuilder(pmBuilder, leProvider, {
+        strategicContext: 'Q2 launch preparation.',
+      });
+      const state = builder.buildState();
+      expect(state.strategicContext).toBe('Q2 launch preparation.');
+    });
+
+    it('should not include strategicContext when not configured', () => {
+      const state = builder.buildState();
+      expect(state.strategicContext).toBeUndefined();
+    });
+
+    it('should clamp openFeatures to 0 when completedMilestones exceeds milestoneCount', () => {
+      pmBuilder = makeMockPmBuilder({
+        projects: {
+          proj: { status: 'active', phase: 'dev', milestoneCount: 2, completedMilestones: 5 },
+        },
+      });
+      builder = new AvaWorldStateBuilder(pmBuilder, leProvider);
+      const state = builder.buildState();
+      expect(state.projectRollups['proj'].openFeatures).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

**Milestone:** Layered World State

Create AvaWorldStateBuilder that aggregates distilled summaries from PM and LE layers. Queries PMWorldStateBuilder.getDistilledSummary() and LeadEngineerService.getWorldStateSummary(). Adds strategic context: team health, cross-project deps, brand/content status. Exposes getFullBriefing().

**Files to Modify:**
- apps/server/src/services/ava-world-state-builder.ts
- apps/server/tests/unit/services/ava-world-state-builder.test.ts

**Acceptance Criteria:**
- [ ]...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Backend infrastructure improvements to enhance state management and data aggregation capabilities across system layers
  * Internal systems now better coordinate to provide comprehensive insights and context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->