### PR TITLE
LE Knowledge Indexing

### DIFF
--- a/apps/server/src/services/knowledge-ingestion-service.ts
+++ b/apps/server/src/services/knowledge-ingestion-service.ts
@@ -172,7 +172,7 @@ Output the compressed memory file:`;
             0,
             `Reflection: ${featureId}`,
             content.trim(),
-            JSON.stringify(['reflection', featureId]),
+            JSON.stringify(['reflection', 'engineering', featureId]),
             0.8, // Higher importance for reflections
             timestamp,
             timestamp
@@ -254,7 +254,7 @@ Output the compressed memory file:`;
             0,
             `Agent Output: ${featureId}`,
             content.trim(),
-            JSON.stringify(['agent_output', featureId]),
+            JSON.stringify(['agent_output', 'engineering', featureId]),
             0.6, // Medium importance for agent outputs
             timestamp,
             timestamp
@@ -269,5 +269,206 @@ Output the compressed memory file:`;
 
     logger.info(`Indexed ${indexedCount} agent outputs from ${projectPath}`);
     return indexedCount;
+  }
+
+  /**
+   * Ingest engineering learnings when a feature reaches DONE state.
+   * Extracts and indexes agent-output.md, reflection.md, and failure classification
+   * data from feature.json. All chunks are tagged with domain='engineering'.
+   *
+   * @param db - Database instance
+   * @param projectPath - Project path
+   * @param featureId - Feature ID that just completed
+   * @returns Number of chunks indexed
+   */
+  async ingestFeatureCompletionLearnings(
+    db: BetterSqlite3.Database,
+    projectPath: string,
+    featureId: string
+  ): Promise<number> {
+    const featureDir = path.join(projectPath, '.automaker', 'features', featureId);
+    if (!fs.existsSync(featureDir)) {
+      logger.debug(`Feature directory not found for ${featureId}, skipping ingestion`);
+      return 0;
+    }
+
+    let indexedCount = 0;
+    const timestamp = new Date().toISOString();
+
+    // 1. Ingest agent-output.md (last 2000 chars — the summary section)
+    const agentOutputPath = path.join(featureDir, 'agent-output.md');
+    if (fs.existsSync(agentOutputPath)) {
+      try {
+        const fullContent = await fs.promises.readFile(agentOutputPath, 'utf-8');
+        if (fullContent.trim()) {
+          const content = fullContent.length > 2000 ? fullContent.slice(-2000) : fullContent;
+          this.upsertChunk(db, {
+            chunkId: `completion-agent-output-${featureId}`,
+            sourceType: 'agent_output',
+            sourceFile: `.automaker/features/${featureId}/agent-output.md`,
+            projectPath,
+            heading: `Agent Output: ${featureId}`,
+            content: content.trim(),
+            tags: JSON.stringify(['agent_output', 'engineering', featureId]),
+            importance: 0.7,
+            timestamp,
+          });
+          indexedCount++;
+        }
+      } catch (err) {
+        logger.warn(`Failed to ingest agent-output for ${featureId}:`, err);
+      }
+    }
+
+    // 2. Ingest reflection.md (generated during DEPLOY phase)
+    const reflectionPath = path.join(featureDir, 'reflection.md');
+    if (fs.existsSync(reflectionPath)) {
+      try {
+        const content = await fs.promises.readFile(reflectionPath, 'utf-8');
+        if (content.trim()) {
+          this.upsertChunk(db, {
+            chunkId: `completion-reflection-${featureId}`,
+            sourceType: 'reflection',
+            sourceFile: `.automaker/features/${featureId}/reflection.md`,
+            projectPath,
+            heading: `Reflection: ${featureId}`,
+            content: content.trim(),
+            tags: JSON.stringify(['reflection', 'engineering', featureId]),
+            importance: 0.85,
+            timestamp,
+          });
+          indexedCount++;
+        }
+      } catch (err) {
+        logger.warn(`Failed to ingest reflection for ${featureId}:`, err);
+      }
+    }
+
+    // 3. Extract failure patterns and PR feedback from feature.json
+    const featureJsonPath = path.join(featureDir, 'feature.json');
+    if (fs.existsSync(featureJsonPath)) {
+      try {
+        const raw = await fs.promises.readFile(featureJsonPath, 'utf-8');
+        const feature = JSON.parse(raw) as Record<string, unknown>;
+        const failureLines: string[] = [];
+        const featureTitle = (feature.title as string | undefined) ?? featureId;
+
+        // Extract structured failure classification (set by EscalateProcessor)
+        if (feature.failureClassification) {
+          const fc = feature.failureClassification as {
+            category: string;
+            confidence: number;
+            recoveryStrategy: { type: string; [key: string]: unknown };
+            retryable: boolean;
+            timestamp: string;
+          };
+          failureLines.push(
+            `## Failure Classification`,
+            `- Category: ${fc.category}`,
+            `- Confidence: ${fc.confidence}`,
+            `- Recovery strategy: ${fc.recoveryStrategy.type}`,
+            `- Retryable: ${fc.retryable}`,
+            `- Classified at: ${fc.timestamp}`
+          );
+        }
+
+        // Extract retry/failure counts
+        if (feature.retryCount != null || feature.failureCount != null) {
+          failureLines.push(
+            `## Failure Counts`,
+            `- Retry count: ${feature.retryCount ?? 0}`,
+            `- Failure count: ${feature.failureCount ?? 0}`
+          );
+        }
+
+        // Extract PR feedback from status history (transitions to/from review)
+        if (Array.isArray(feature.statusHistory)) {
+          const reviewTransitions = (
+            feature.statusHistory as Array<{ from: string | null; to: string; reason?: string }>
+          ).filter((h) => h.from === 'review' || h.to === 'review');
+
+          if (reviewTransitions.length > 0) {
+            failureLines.push(`## PR Review History`);
+            for (const t of reviewTransitions) {
+              const reason = t.reason ? ` — ${t.reason}` : '';
+              failureLines.push(`- ${t.from ?? 'null'} → ${t.to}${reason}`);
+            }
+          }
+        }
+
+        if (failureLines.length > 0) {
+          const content = `# Engineering Learnings: ${featureTitle}\n\n${failureLines.join('\n')}`;
+          this.upsertChunk(db, {
+            chunkId: `completion-failure-${featureId}`,
+            sourceType: 'reflection',
+            sourceFile: `.automaker/features/${featureId}/feature.json`,
+            projectPath,
+            heading: `Failure Patterns: ${featureTitle}`,
+            content,
+            tags: JSON.stringify(['failure_pattern', 'engineering', featureId]),
+            importance: 0.9,
+            timestamp,
+          });
+          indexedCount++;
+        }
+      } catch (err) {
+        logger.warn(`Failed to extract failure patterns for ${featureId}:`, err);
+      }
+    }
+
+    if (indexedCount > 0) {
+      this.rebuildIndex(db, projectPath);
+      logger.info(`Indexed ${indexedCount} completion learnings for feature ${featureId}`);
+    }
+
+    return indexedCount;
+  }
+
+  /**
+   * Upsert a chunk into the database (insert if new, update if existing).
+   *
+   * @param db - Database instance
+   * @param opts - Chunk fields
+   */
+  private upsertChunk(
+    db: BetterSqlite3.Database,
+    opts: {
+      chunkId: string;
+      sourceType: string;
+      sourceFile: string;
+      projectPath: string;
+      heading: string;
+      content: string;
+      tags: string;
+      importance: number;
+      timestamp: string;
+    }
+  ): void {
+    const existing = db.prepare('SELECT id FROM chunks WHERE id = ?').get(opts.chunkId);
+    if (existing) {
+      db.prepare('UPDATE chunks SET content = ?, tags = ?, updated_at = ? WHERE id = ?').run(
+        opts.content,
+        opts.tags,
+        opts.timestamp,
+        opts.chunkId
+      );
+    } else {
+      db.prepare(
+        `INSERT INTO chunks (id, source_type, source_file, project_path, chunk_index, heading, content, tags, importance, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        opts.chunkId,
+        opts.sourceType,
+        opts.sourceFile,
+        opts.projectPath,
+        0,
+        opts.heading,
+        opts.content,
+        opts.tags,
+        opts.importance,
+        opts.timestamp,
+        opts.timestamp
+      );
+    }
   }
 }

--- a/apps/server/src/services/knowledge-search-service.ts
+++ b/apps/server/src/services/knowledge-search-service.ts
@@ -465,7 +465,8 @@ export class KnowledgeSearchService {
   async searchReflections(
     projectPath: string,
     query: string,
-    maxResults: number = 5
+    maxResults: number = 5,
+    domain?: string
   ): Promise<KnowledgeSearchResult[]> {
     // Sanitize for FTS5 — strip operators that break MATCH syntax, then quote
     // each token individually so FTS5 never treats a word as a column filter.
@@ -487,6 +488,7 @@ export class KnowledgeSearchService {
       sourceTypes: ['reflection', 'agent_output'],
       maxResults,
       maxTokens: 3000,
+      domain,
     });
 
     return results;

--- a/apps/server/src/services/knowledge-store-service.ts
+++ b/apps/server/src/services/knowledge-store-service.ts
@@ -586,7 +586,7 @@ export class KnowledgeStoreService {
 
   /**
    * Search for reflections and agent outputs using FTS5.
-   * Convenience method that filters to reflection and agent_output source types.
+   * Filters to reflection and agent_output source types with domain='engineering'.
    *
    * @param projectPath - Project path
    * @param query - Search query (feature title + description works well)
@@ -606,7 +606,28 @@ export class KnowledgeStoreService {
       this.initialize(projectPath);
     }
 
-    return this.searchService.searchReflections(projectPath, query, maxResults);
+    return this.searchService.searchReflections(projectPath, query, maxResults, 'engineering');
+  }
+
+  /**
+   * Ingest engineering learnings when a feature reaches DONE state.
+   * Indexes agent-output.md, reflection.md, and failure classification data
+   * from feature.json. All chunks are tagged with domain='engineering'.
+   *
+   * @param projectPath - Project path
+   * @param featureId - Feature ID that just completed
+   * @returns Number of chunks indexed
+   */
+  async ingestFeatureCompletionLearnings(projectPath: string, featureId: string): Promise<number> {
+    if (!this.db || !this.projectPath) {
+      throw new Error('Knowledge store not initialized');
+    }
+
+    if (this.projectPath !== projectPath) {
+      this.initialize(projectPath);
+    }
+
+    return this.ingestionService.ingestFeatureCompletionLearnings(this.db, projectPath, featureId);
   }
 
   /**

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -469,6 +469,19 @@ export class LeadEngineerService {
         outcome,
         success: result.finalState !== 'ESCALATE',
       });
+
+      // Index engineering learnings when feature completes via state machine (DONE)
+      if (result.finalState === 'DONE' && this.knowledgeStoreService) {
+        this.knowledgeStoreService
+          .ingestFeatureCompletionLearnings(projectPath, featureId)
+          .catch((err) =>
+            logger.warn(
+              `[LeadEngineer] Failed to ingest completion learnings for ${featureId} (non-fatal):`,
+              err
+            )
+          );
+      }
+
       return pipelineResult;
     } catch (error: unknown) {
       logger.error(`[LeadEngineer] Feature processing failed`, {
@@ -565,6 +578,18 @@ export class LeadEngineerService {
           prNumber: feature.prNumber,
           projectPath,
         });
+
+        // Index engineering learnings when feature reaches DONE via PR merge
+        if (this.knowledgeStoreService) {
+          this.knowledgeStoreService
+            .ingestFeatureCompletionLearnings(projectPath, feature.id)
+            .catch((err) =>
+              logger.warn(
+                `[PRMergePoller] Failed to ingest learnings for ${feature.id} (non-fatal):`,
+                err
+              )
+            );
+        }
       } catch (err) {
         logger.warn(
           `[PRMergePoller] Failed to check PR #${feature.prNumber} for feature "${feature.id}" (non-fatal):`,


### PR DESCRIPTION
## Summary

**Milestone:** Knowledge Flow Pipeline

When Lead Engineer completes a feature (state -> DONE), automatically index engineering reflections, failure patterns, and architecture decisions into KnowledgeStoreService with domain='engineering'. Extract learnings from agent-output.md, PR feedback, and failure classifications.

**Files to Modify:**
- apps/server/src/services/lead-engineer-service.ts
- apps/server/src/services/knowledge-ingestion-service.ts

**Acceptance Criteria:**
- [ ] Feature comple...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic capture of engineering learnings when features are marked as complete, including completion notes, reflections, and failure patterns.
  * Domain-filtered search results to focus on engineering-related knowledge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->