### PR TITLE
Fix MCP enum mismatch and ID prefix inconsistency

### DIFF
--- a/apps/server/src/services/calendar-service.ts
+++ b/apps/server/src/services/calendar-service.ts
@@ -468,7 +468,7 @@ export class CalendarService {
     }
 
     // Create new event
-    const id = `google-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+    const id = `event-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
     const newEvent: CalendarEvent = {
       ...data,
       id,

--- a/packages/mcp-server/src/tools/calendar-tools.ts
+++ b/packages/mcp-server/src/tools/calendar-tools.ts
@@ -34,7 +34,7 @@ export const calendarTools: Tool[] = [
           type: 'array',
           items: {
             type: 'string',
-            enum: ['custom', 'feature_due_date', 'milestone', 'job'],
+            enum: ['custom', 'feature', 'google', 'ceremony', 'milestone', 'job'],
           },
           description: 'Optional array of event types to filter by. If omitted, returns all types.',
         },


### PR DESCRIPTION
## Summary

**Milestone:** Critical Bug Fixes & Security

In calendar-tools.ts, replace 'feature_due_date' with 'feature' and add 'google' and 'ceremony' to the types enum. In calendar-service.ts, unify the ID prefix in upsertBySourceId() to use 'event-' consistently on both CRDT and filesystem paths (remove the 'google-' prefix on the filesystem fallback branch).

**Files to Modify:**
- packages/mcp-server/src/tools/calendar-tools.ts
- apps/server/src/services/calendar-service.ts

**Acceptance Criteria:**
...

---
*Recovered automatically by Automaker post-agent hook*