### PR TITLE
Fix shell injection in run-command job actions

### DIFF
--- a/apps/server/src/services/job-executor-service.ts
+++ b/apps/server/src/services/job-executor-service.ts
@@ -20,6 +20,53 @@ const logger = createLogger('JobExecutorService');
 /** Maximum command execution time: 5 minutes */
 const COMMAND_TIMEOUT_MS = 300_000;
 
+/** Maximum allowed command length in characters */
+const MAX_COMMAND_LENGTH = 1024;
+
+/**
+ * Regex that detects unescaped shell metacharacters.
+ * Matched characters: ; | > < $ ` and the two-character sequences && and ||
+ * A preceding backslash (e.g. \; or \$) exempts the character from rejection.
+ */
+const SHELL_METACHAR_RE = /(?<!\\)[;|><$`]|(?<!\\)&&/;
+
+/**
+ * Validate and sanitize a shell command before execution.
+ *
+ * Rules enforced:
+ * - Must not exceed MAX_COMMAND_LENGTH (1024) characters
+ * - Must not contain unescaped shell metacharacters: ; && || | > < $ `
+ *
+ * Exported as a pure function so it can be unit-tested in isolation.
+ *
+ * @param command Raw command string supplied by the job action
+ * @returns The same command string if it passes all checks
+ * @throws Error with a descriptive message when the command is invalid
+ *
+ * @example
+ *   sanitizeCommand('npm run build')          // OK — returns the command
+ *   sanitizeCommand('npm run build; rm -rf /') // throws — unescaped ;
+ *   sanitizeCommand('echo $HOME')              // throws — unescaped $
+ */
+export function sanitizeCommand(command: string): string {
+  if (command.length > MAX_COMMAND_LENGTH) {
+    throw new Error(
+      `Command exceeds maximum length of ${MAX_COMMAND_LENGTH} characters (got ${command.length})`
+    );
+  }
+
+  if (SHELL_METACHAR_RE.test(command)) {
+    throw new Error(
+      `Command contains unescaped shell metacharacters. ` +
+        `Only simple single commands are allowed (e.g. "npm run build"). ` +
+        `Disallowed characters: ; && || | > < $ \`. ` +
+        `Escape special characters with a backslash if they are required literally.`
+    );
+  }
+
+  return command;
+}
+
 export class JobExecutorService {
   constructor(
     private calendarService: CalendarService,
@@ -150,10 +197,16 @@ export class JobExecutorService {
 
   /**
    * Execute a shell command with a timeout.
+   * The command is validated and sanitized via {@link sanitizeCommand} before
+   * being passed to exec — unescaped shell metacharacters and commands exceeding
+   * the length limit are rejected with an error.
    */
   private executeCommand(command: string, cwd?: string): Promise<void> {
+    const sanitized = sanitizeCommand(command);
+    logger.info(`Executing sanitized command: ${sanitized}`);
+
     return new Promise((resolve, reject) => {
-      exec(command, { cwd, timeout: COMMAND_TIMEOUT_MS }, (error, stdout, stderr) => {
+      exec(sanitized, { cwd, timeout: COMMAND_TIMEOUT_MS }, (error, stdout, stderr) => {
         if (error) {
           const msg = stderr?.trim() || error.message;
           reject(new Error(`Command failed: ${msg}`));

--- a/libs/types/src/calendar.ts
+++ b/libs/types/src/calendar.ts
@@ -17,11 +17,48 @@ export type JobStatus = 'pending' | 'running' | 'completed' | 'failed';
 
 /**
  * Job action types
+ *
+ * ### `run-command` format
+ *
+ * The `command` field must be a **single, simple shell command** with no shell
+ * metacharacters. The executor enforces the following constraints at runtime:
+ *
+ * - Maximum length: 1024 characters
+ * - Disallowed (unescaped): `;`  `&&`  `||`  `|`  `>`  `<`  `$`  `` ` ``
+ *
+ * If a special character is required literally, prefix it with a backslash
+ * (e.g. `\$`). Shell features such as piping, redirection, variable expansion,
+ * and command chaining are **not** supported and will cause the job to fail.
+ *
+ * **Valid examples:**
+ * ```
+ * npm run build
+ * python3 scripts/migrate.py
+ * ./bin/run-task.sh --env production
+ * ```
+ *
+ * **Invalid examples (will be rejected):**
+ * ```
+ * npm run build && npm test   // && not allowed
+ * echo $HOME                  // $ not allowed
+ * cat file.txt | grep error   // | not allowed
+ * ```
  */
 export type JobAction =
   | { type: 'start-agent'; featureId: string }
   | { type: 'run-automation'; automationId: string }
-  | { type: 'run-command'; command: string; cwd?: string };
+  | {
+      type: 'run-command';
+      /**
+       * The shell command to execute.
+       * Must be a single command with no shell metacharacters.
+       * Maximum length: 1024 characters.
+       * @see {JobAction} for full format rules and examples.
+       */
+      command: string;
+      /** Optional working directory for the command */
+      cwd?: string;
+    };
 
 /**
  * Result of a job execution


### PR DESCRIPTION
## Summary

**Milestone:** Critical Bug Fixes & Security

In JobExecutorService.executeCommand(), replace the raw exec() call with a safe execution strategy. Validate and sanitize the command before execution: reject commands containing shell metacharacters (;, &&, ||, |, >, <, $, `, backtick) unless explicitly escaped. Add a maximum command length limit. Log the sanitized command before execution. Update the CalendarEvent type docs to clarify the allowed command format.

**Files to Modify:**
- apps/server/...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command validation with length limits and character restrictions for command execution.

* **Documentation**
  * Improved documentation for command parameters and working directory configuration with detailed constraints and usage guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->