### PR TITLE
Server URL override in auth layer + app store

### DIFF
--- a/apps/ui/src/store/app-store.ts
+++ b/apps/ui/src/store/app-store.ts
@@ -338,7 +338,9 @@ export interface AppActions {
 
   // Server URL runtime override actions
   setServerUrlOverride: (url: string | null) => void;
+  clearServerUrlOverride: () => void; // Clears the server URL override (alias for setServerUrlOverride(null))
   addRecentServerUrl: (url: string) => void; // Adds to recentServerUrls (max 10, deduplicated)
+  removeRecentServerUrl: (url: string) => void; // Removes a URL from recentServerUrls
 
   // Server connection actions
   connectToServer: (url: string) => Promise<void>;
@@ -1360,8 +1362,22 @@ export const useAppStore = create<AppState & AppActions>()((set, get) => ({
     invalidateHttpClient();
   },
 
+  clearServerUrlOverride: () => {
+    get().setServerUrlOverride(null);
+  },
+
   addRecentServerUrl: (url) => {
     const recentServerUrls = [url, ...get().recentServerUrls.filter((u) => u !== url)].slice(0, 10);
+    try {
+      localStorage.setItem('automaker:recentServerUrls', JSON.stringify(recentServerUrls));
+    } catch {
+      // localStorage might be disabled
+    }
+    set({ recentServerUrls });
+  },
+
+  removeRecentServerUrl: (url) => {
+    const recentServerUrls = get().recentServerUrls.filter((u) => u !== url);
     try {
       localStorage.setItem('automaker:recentServerUrls', JSON.stringify(recentServerUrls));
     } catch {


### PR DESCRIPTION
## Summary

Modify getServerUrl() in apps/ui/src/lib/clients/auth.ts to check a runtime override stored in app-store before falling back to env vars. Add serverUrlOverride state + setServerUrlOverride action to app-store. Add recentServerUrls array (max 10) persisted via localStorage. When override changes, invalidate cached HTTP client and WebSocket connection, trigger reconnection. Add CORS middleware on server to accept requests from any origin when hivemind is enabled.

**Project:** Headless Server + Re...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clear server URL overrides - reset server URL configurations to defaults.
  * Remove recent server URLs - delete specific URLs from your recent servers history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->