### PR TITLE
Wire emitReminder() into JobExecutorService

### DIFF
--- a/apps/server/src/services/job-executor-service.ts
+++ b/apps/server/src/services/job-executor-service.ts
@@ -125,6 +125,12 @@ export class JobExecutorService {
       jobStatus: 'running',
     });
 
+    this.calendarService.emitReminder({
+      title: job.title,
+      description: job.description ?? `Job started: ${job.title}`,
+      event: job,
+    });
+
     this.events.emit('job:started', {
       jobId: job.id,
       projectPath,
@@ -140,6 +146,12 @@ export class JobExecutorService {
       await this.calendarService.updateEvent(projectPath, job.id, {
         jobStatus: 'completed',
         jobResult: { startedAt, completedAt, durationMs },
+      });
+
+      this.calendarService.emitReminder({
+        title: job.title,
+        description: `Job completed: ${job.title}`,
+        event: job,
       });
 
       this.events.emit('job:completed', {
@@ -158,6 +170,12 @@ export class JobExecutorService {
       await this.calendarService.updateEvent(projectPath, job.id, {
         jobStatus: 'failed',
         jobResult: { startedAt, completedAt, durationMs, error: errorMessage },
+      });
+
+      this.calendarService.emitReminder({
+        title: job.title,
+        description: `Job failed: ${job.title} — ${errorMessage}`,
+        event: job,
       });
 
       this.events.emit('job:failed', {


### PR DESCRIPTION
## Summary

**Milestone:** Critical Bug Fixes & Security

JobExecutorService.executeJob() currently updates job status but never calls calendarService.emitReminder(). Add CalendarService as a constructor dependency (it's already available in services.ts). After marking a job as 'running', emit a reminder with the job title and description. Also emit on completion and failure with appropriate descriptions. This activates the reminder→ReactiveSpawner pipeline that is already wired in services.ts:729.

**Files...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job execution now automatically emits calendar reminders at key lifecycle events: when a job starts, completes successfully, or fails. Each reminder includes the job title and status-specific details for better tracking and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->