### PR TITLE
WebSocket broadcast for calendar mutations and job lifecycle

### DIFF
--- a/apps/server/src/routes/calendar/index.ts
+++ b/apps/server/src/routes/calendar/index.ts
@@ -5,15 +5,17 @@
 import { Router, type Request, type Response } from 'express';
 import { validatePathParams } from '../../middleware/validate-paths.js';
 import type { CalendarService, CalendarQueryOptions } from '../../services/calendar-service.js';
-import type { JobAction } from '@protolabsai/types';
+import type { JobAction, EventType } from '@protolabsai/types';
 import type { JobExecutorService } from '../../services/job-executor-service.js';
+import type { EventEmitter } from '../../lib/events.js';
 
 /**
  * Create calendar routes
  */
 export function createCalendarRoutes(
   calendarService: CalendarService,
-  jobExecutorService: JobExecutorService
+  jobExecutorService: JobExecutorService,
+  eventBus?: EventEmitter
 ): Router {
   const router = Router();
 
@@ -109,6 +111,14 @@ export function createCalendarRoutes(
         }),
       });
 
+      // Cast required: EventType in node_modules resolves to the main-repo's compiled dist
+      // via npm hoisting; the worktree's updated types/dist is correct but not yet picked up.
+      eventBus?.emit('calendar:event:created' as EventType, {
+        eventId: event.id,
+        projectPath,
+        event,
+      });
+
       res.json({ success: true, event });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -199,6 +209,12 @@ export function createCalendarRoutes(
 
       const event = await calendarService.updateEvent(projectPath, id, updates);
 
+      eventBus?.emit('calendar:event:updated' as EventType, {
+        eventId: id,
+        projectPath,
+        event,
+      });
+
       res.json({
         success: true,
         event,
@@ -238,6 +254,11 @@ export function createCalendarRoutes(
       }
 
       await calendarService.deleteEvent(projectPath, id);
+
+      eventBus?.emit('calendar:event:deleted' as EventType, {
+        eventId: id,
+        projectPath,
+      });
 
       res.json({
         success: true,

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -294,7 +294,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api/context', createContextRoutes(settingsService));
   app.use('/api/content', createContentRoutes(settingsService));
   app.use('/api/backlog-plan', createBacklogPlanRoutes(events, settingsService));
-  app.use('/api/calendar', createCalendarRoutes(calendarService, jobExecutorService));
+  app.use('/api/calendar', createCalendarRoutes(calendarService, jobExecutorService, events));
   app.use('/api/mcp', createMCPRoutes(mcpTestService));
   app.use(
     '/api/integrations',

--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -716,6 +716,39 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
       .catch((err) => logger.warn('[CalendarReminder] spawnForCron failed:', err));
   });
 
+  // Relay job lifecycle events to remote peers in hivemind mode.
+  // JobExecutorService calls events.emit() (local only); the subscriptions below
+  // ensure job state changes are also forwarded via the remote broadcaster when one
+  // is registered (e.g. CRDT sync). A broadcasting flag prevents re-entrancy.
+  let broadcastingJob = false;
+  events.on('job:started', (payload) => {
+    if (broadcastingJob) return;
+    broadcastingJob = true;
+    try {
+      events.broadcast('job:started', payload);
+    } finally {
+      broadcastingJob = false;
+    }
+  });
+  events.on('job:completed', (payload) => {
+    if (broadcastingJob) return;
+    broadcastingJob = true;
+    try {
+      events.broadcast('job:completed', payload);
+    } finally {
+      broadcastingJob = false;
+    }
+  });
+  events.on('job:failed', (payload) => {
+    if (broadcastingJob) return;
+    broadcastingJob = true;
+    try {
+      events.broadcast('job:failed', payload);
+    } finally {
+      broadcastingJob = false;
+    }
+  });
+
   // Wire integrations health checks (requires integrationService + integrationRegistryService)
   integrationService.initialize(events, settingsService, featureLoader);
   wireHealthChecks(integrationRegistryService);

--- a/apps/ui/src/components/views/calendar-view/use-calendar-events.ts
+++ b/apps/ui/src/components/views/calendar-view/use-calendar-events.ts
@@ -4,11 +4,17 @@
  * Fetches calendar events for a given month/year from the backend API.
  * Provides mutation functions for creating, updating, and deleting events.
  * Uses the apiFetch pattern consistent with the rest of the codebase.
+ *
+ * Also subscribes to WebSocket events (calendar:event:created/updated/deleted,
+ * job:started/job:completed/job:failed) and triggers a refetch when events
+ * arrive for the currently-active project path.
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { apiPost } from '@/lib/api-fetch';
+import { getHttpApiClient } from '@/lib/http-api-client';
 import type { CalendarEvent, CalendarEventType, JobAction } from '@protolabsai/types';
+import type { EventType } from '@protolabsai/types';
 
 interface CalendarListResponse {
   success: boolean;
@@ -92,9 +98,21 @@ function getMonthDateRange(month: number, year: number): { startDate: string; en
   return { startDate, endDate };
 }
 
+/** WebSocket event types that should trigger a calendar refetch */
+const CALENDAR_WS_EVENT_TYPES: EventType[] = [
+  'calendar:event:created',
+  'calendar:event:updated',
+  'calendar:event:deleted',
+  'job:started',
+  'job:completed',
+  'job:failed',
+];
+
 /**
  * Fetch calendar events for a given month from the backend.
  * Provides CRUD mutation functions that automatically refetch after success.
+ * Subscribes to WebSocket calendar/job events to keep the view in sync
+ * when changes originate from other clients or server-side processes.
  */
 export function useCalendarEvents({
   projectPath,
@@ -152,6 +170,28 @@ export function useCalendarEvents({
   useEffect(() => {
     fetchEvents();
   }, [fetchEvents]);
+
+  // Subscribe to WebSocket calendar and job events to refetch when the server
+  // signals a state change for the currently-active project.
+  useEffect(() => {
+    if (!projectPath) return;
+
+    const api = getHttpApiClient();
+
+    const unsubscribe = api.subscribeToEvents((type: EventType, payload: unknown) => {
+      if (!CALENDAR_WS_EVENT_TYPES.includes(type)) return;
+
+      // Only refetch if the event belongs to the current project
+      const p = payload as Record<string, unknown> | null;
+      if (p && p['projectPath'] && p['projectPath'] !== projectPath) return;
+
+      void fetchEvents();
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [projectPath, fetchEvents]);
 
   const createEvent = useCallback(
     async (input: CreateEventInput): Promise<CalendarEvent | null> => {

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -315,6 +315,10 @@ export type EventType =
   // Sensor registry events (core sensor framework)
   | 'sensor:registered'
   | 'sensor:data-received'
+  // Calendar CRUD events (emitted by calendar routes after successful create/update/delete)
+  | 'calendar:event:created'
+  | 'calendar:event:updated'
+  | 'calendar:event:deleted'
   // Calendar job events (one-time scheduled actions)
   | 'job:started'
   | 'job:completed'


### PR DESCRIPTION
## Summary

**Milestone:** Runtime Integrations & Google Sync Completion

Calendar CRUD operations and job state changes currently emit no WebSocket events. In the calendar routes (routes/calendar/index.ts), inject the EventEmitter and emit events after successful create/update/delete operations (e.g. 'calendar:event:created', 'calendar:event:updated', 'calendar:event:deleted'). In services.ts, subscribe to job:started/job:completed/job:failed and broadcast them to WebSocket clients. Define the event payloa...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar events now sync in real-time across the application when created, updated, or deleted.
  * Job lifecycle events are broadcast in distributed environments for synchronized state management.

* **Chores**
  * Implemented event-driven architecture to enable live synchronization of calendar operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->