### PR TITLE
Google Calendar cancelled event cleanup and periodic sync

### DIFF
--- a/apps/server/src/services/google-calendar-sync-service.ts
+++ b/apps/server/src/services/google-calendar-sync-service.ts
@@ -191,21 +191,71 @@ export class GoogleCalendarSyncService {
    * Fetches events for a 90-day window (30 days back, 60 days forward) and
    * upserts them as 'google' type CalendarEvent records keyed by sourceId.
    *
-   * Returns the count of events synced (created + updated).
+   * Also deletes local Google events that have been cancelled upstream or are
+   * no longer present in the sync window (stale events deleted from Google).
+   *
+   * Returns the count of events synced (created + updated) and deleted.
    */
-  async syncFromGoogle(projectPath: string): Promise<{ synced: number; created: number }> {
+  async syncFromGoogle(
+    projectPath: string
+  ): Promise<{ synced: number; created: number; deleted: number }> {
     const now = new Date();
-    const timeMin = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
-    const timeMax = new Date(now.getTime() + 60 * 24 * 60 * 60 * 1000).toISOString();
+    const timeMinDate = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+    const timeMaxDate = new Date(now.getTime() + 60 * 24 * 60 * 60 * 1000);
+    const timeMin = timeMinDate.toISOString();
+    const timeMax = timeMaxDate.toISOString();
+    const windowStart = timeMin.substring(0, 10);
+    const windowEnd = timeMax.substring(0, 10);
 
     logger.info('Starting Google Calendar sync', { projectPath, timeMin, timeMax });
 
     const googleEvents = await this.listGoogleEvents(projectPath, timeMin, timeMax);
+
+    // Build sets of all Google sourceIds and cancelled sourceIds from this sync response
+    const allGoogleSourceIds = new Set<string>(googleEvents.map((e) => e.id));
+    const cancelledSourceIds = new Set<string>(
+      googleEvents.filter((e) => e.status === 'cancelled').map((e) => e.id)
+    );
+
+    // Read all existing local Google events to detect stale / cancelled ones
+    const localGoogleEvents = await this.calendarService.listEvents(projectPath, {
+      types: ['google'],
+    });
+
     let synced = 0;
     let created = 0;
+    let deleted = 0;
 
+    // Delete local events that have been cancelled or are absent from the sync window
+    for (const localEvent of localGoogleEvents) {
+      if (!localEvent.sourceId) continue;
+
+      const isCancelled = cancelledSourceIds.has(localEvent.sourceId);
+      const isWithinWindow = localEvent.date >= windowStart && localEvent.date <= windowEnd;
+      const isAbsent = !allGoogleSourceIds.has(localEvent.sourceId);
+
+      if (isCancelled || (isWithinWindow && isAbsent)) {
+        try {
+          await this.calendarService.deleteEvent(projectPath, localEvent.id);
+          deleted++;
+          logger.info('Deleted stale/cancelled Google Calendar event', {
+            id: localEvent.id,
+            sourceId: localEvent.sourceId,
+            reason: isCancelled ? 'cancelled' : 'absent-from-sync',
+          });
+        } catch (err) {
+          logger.warn('Failed to delete stale Google Calendar event', {
+            id: localEvent.id,
+            sourceId: localEvent.sourceId,
+            err,
+          });
+        }
+      }
+    }
+
+    // Upsert active (non-cancelled) events
     for (const gEvent of googleEvents) {
-      // Skip cancelled events
+      // Skip cancelled events — already handled above
       if (gEvent.status === 'cancelled') {
         continue;
       }
@@ -251,8 +301,9 @@ export class GoogleCalendarSyncService {
       synced,
       created,
       updated: synced - created,
+      deleted,
     });
 
-    return { synced, created };
+    return { synced, created, deleted };
   }
 }

--- a/apps/server/src/services/scheduler.module.ts
+++ b/apps/server/src/services/scheduler.module.ts
@@ -48,6 +48,40 @@ export function register(container: ServiceContainer): void {
         true
       );
 
+      // Register periodic Google Calendar sync — runs every 6 hours for all connected projects
+      await schedulerService.registerTask(
+        'google-calendar:sync',
+        'Google Calendar Sync',
+        '0 */6 * * *',
+        async () => {
+          const globalSettings = await settingsService.getGlobalSettings();
+          const projects = globalSettings.projects ?? [];
+
+          for (const project of projects) {
+            const projectSettings = await settingsService.getProjectSettings(project.path);
+            const google = projectSettings.integrations?.google;
+
+            if (!google?.accessToken || !google?.refreshToken) {
+              continue; // Google Calendar not connected for this project
+            }
+
+            try {
+              const result = await container.googleCalendarSyncService.syncFromGoogle(project.path);
+              logger.info('Scheduled Google Calendar sync complete', {
+                projectPath: project.path,
+                ...result,
+              });
+            } catch (err) {
+              logger.error('Scheduled Google Calendar sync failed', {
+                projectPath: project.path,
+                err,
+              });
+            }
+          }
+        },
+        true
+      );
+
       // Apply taskOverrides from global settings after all tasks are registered
       await schedulerService.applySettingsOverrides();
     })


### PR DESCRIPTION
## Summary

**Milestone:** Runtime Integrations & Google Sync Completion

Two gaps in Google Calendar sync: (1) Cancelled events are skipped in syncFromGoogle() but previously synced events that get cancelled upstream persist locally forever. Fix by tracking which sourceIds were returned in the latest sync response and deleting local events whose sourceId is no longer present (within the sync window). (2) Sync is manual-only. Register a periodic scheduler task (e.g. every 6 hours) in scheduler.module.ts tha...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic Google Calendar synchronization now runs every 6 hours for all projects with active Google integration.
  * Cancelled Google Calendar events and events outside the current sync window are now automatically removed from local storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->