### PR TITLE
Unit tests for CalendarService and JobExecutorService

### DIFF
--- a/apps/server/tests/unit/services/calendar-service.test.ts
+++ b/apps/server/tests/unit/services/calendar-service.test.ts
@@ -470,4 +470,261 @@ describe('calendar-service.ts', () => {
       );
     });
   });
+
+  describe('getDueJobs', () => {
+    function makeJobEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+      return {
+        id: 'job-1',
+        title: 'Test Job',
+        date: '2026-03-10',
+        time: '09:00',
+        type: 'job',
+        jobStatus: 'pending',
+        jobAction: { type: 'start-agent', featureId: 'feature-123' },
+        projectPath,
+        createdAt: '2026-03-01T00:00:00Z',
+        updatedAt: '2026-03-01T00:00:00Z',
+        ...overrides,
+      };
+    }
+
+    it('should return pending job events that are due', async () => {
+      // Create a "now" that is definitely after the job's scheduled time
+      // Parse date+time the same way as the service: new Date(`${date}T${time}:00`)
+      // Then set now to be 1 hour after that
+      const jobDt = new Date('2026-03-10T09:00:00');
+      const now = new Date(jobDt.getTime() + 60 * 60 * 1000); // 1hr later
+      const dueJob = makeJobEvent({ date: '2026-03-10', time: '09:00' });
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: [dueJob],
+        recovered: false,
+        source: 'main',
+      });
+
+      const jobs = await service.getDueJobs(projectPath, now);
+
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].id).toBe('job-1');
+    });
+
+    it('should exclude job events with time in the future', async () => {
+      // now is before the job's scheduled time
+      const jobDt = new Date('2026-03-10T09:00:00');
+      const now = new Date(jobDt.getTime() - 60 * 60 * 1000); // 1hr before
+      const futureJob = makeJobEvent({ date: '2026-03-10', time: '09:00' });
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: [futureJob],
+        recovered: false,
+        source: 'main',
+      });
+
+      const jobs = await service.getDueJobs(projectPath, now);
+
+      expect(jobs).toHaveLength(0);
+    });
+
+    it('should exclude non-job type events', async () => {
+      const jobDt = new Date('2026-03-10T09:00:00');
+      const now = new Date(jobDt.getTime() + 60 * 60 * 1000);
+      const customEvent = makeJobEvent({ type: 'custom' });
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: [customEvent],
+        recovered: false,
+        source: 'main',
+      });
+
+      const jobs = await service.getDueJobs(projectPath, now);
+
+      expect(jobs).toHaveLength(0);
+    });
+
+    it('should exclude job events with non-pending status', async () => {
+      const jobDt = new Date('2026-03-10T09:00:00');
+      const now = new Date(jobDt.getTime() + 60 * 60 * 1000);
+      const runningJob = makeJobEvent({ id: 'job-running', jobStatus: 'running' });
+      const completedJob = makeJobEvent({ id: 'job-completed', jobStatus: 'completed' });
+      const failedJob = makeJobEvent({ id: 'job-failed', jobStatus: 'failed' });
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: [runningJob, completedJob, failedJob],
+        recovered: false,
+        source: 'main',
+      });
+
+      const jobs = await service.getDueJobs(projectPath, now);
+
+      expect(jobs).toHaveLength(0);
+    });
+
+    it('should exclude job events without a time field', async () => {
+      const now = new Date('2026-03-10T10:00:00');
+      const noTimeJob = makeJobEvent({ time: undefined });
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: [noTimeJob],
+        recovered: false,
+        source: 'main',
+      });
+
+      const jobs = await service.getDueJobs(projectPath, now);
+
+      expect(jobs).toHaveLength(0);
+    });
+
+    it('should return only due jobs when mixed events are present', async () => {
+      const jobDt = new Date('2026-03-10T09:00:00');
+      const now = new Date(jobDt.getTime() + 30 * 60 * 1000); // 09:30 — after 09:00, before 11:00
+      const dueJob = makeJobEvent({ id: 'job-due', date: '2026-03-10', time: '09:00' });
+      const futureJob = makeJobEvent({ id: 'job-future', date: '2026-03-10', time: '11:00' });
+      const customEvent = makeJobEvent({ id: 'custom-1', type: 'custom' });
+      const completedJob = makeJobEvent({ id: 'job-done', jobStatus: 'completed' });
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: [dueJob, futureJob, customEvent, completedJob],
+        recovered: false,
+        source: 'main',
+      });
+
+      const jobs = await service.getDueJobs(projectPath, now);
+
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].id).toBe('job-due');
+    });
+  });
+
+  describe('isDateInRange (via listEvents)', () => {
+    it('should include all events when no date range is specified', async () => {
+      const events: CalendarEvent[] = [
+        {
+          id: 'event-past',
+          title: 'Past',
+          date: '2020-01-01',
+          type: 'custom',
+          projectPath,
+          createdAt: '2020-01-01T00:00:00Z',
+          updatedAt: '2020-01-01T00:00:00Z',
+        },
+        {
+          id: 'event-future',
+          title: 'Future',
+          date: '2030-01-01',
+          type: 'custom',
+          projectPath,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ];
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: events,
+        recovered: false,
+        source: 'main',
+      });
+
+      const result = await service.listEvents(projectPath, {});
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('should include event exactly on startDate boundary', async () => {
+      const events: CalendarEvent[] = [
+        {
+          id: 'event-boundary',
+          title: 'Boundary',
+          date: '2026-03-01',
+          type: 'custom',
+          projectPath,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ];
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: events,
+        recovered: false,
+        source: 'main',
+      });
+
+      const result = await service.listEvents(projectPath, { startDate: '2026-03-01' });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('event-boundary');
+    });
+
+    it('should include event exactly on endDate boundary', async () => {
+      const events: CalendarEvent[] = [
+        {
+          id: 'event-end',
+          title: 'End',
+          date: '2026-03-31',
+          type: 'custom',
+          projectPath,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ];
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: events,
+        recovered: false,
+        source: 'main',
+      });
+
+      const result = await service.listEvents(projectPath, { endDate: '2026-03-31' });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('event-end');
+    });
+
+    it('should exclude event strictly before startDate', async () => {
+      const events: CalendarEvent[] = [
+        {
+          id: 'event-before',
+          title: 'Before',
+          date: '2026-02-28',
+          type: 'custom',
+          projectPath,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ];
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: events,
+        recovered: false,
+        source: 'main',
+      });
+
+      const result = await service.listEvents(projectPath, { startDate: '2026-03-01' });
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should exclude event strictly after endDate', async () => {
+      const events: CalendarEvent[] = [
+        {
+          id: 'event-after',
+          title: 'After',
+          date: '2026-04-01',
+          type: 'custom',
+          projectPath,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ];
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: events,
+        recovered: false,
+        source: 'main',
+      });
+
+      const result = await service.listEvents(projectPath, { endDate: '2026-03-31' });
+
+      expect(result).toHaveLength(0);
+    });
+  });
 });

--- a/apps/server/tests/unit/services/job-executor-service.test.ts
+++ b/apps/server/tests/unit/services/job-executor-service.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { JobExecutorService, sanitizeCommand } from '@/services/job-executor-service.js';
+import type { CalendarService } from '@/services/calendar-service.js';
+import type { AutoModeService } from '@/services/auto-mode-service.js';
+import type { AutomationService } from '@/services/automation-service.js';
+import type { SettingsService } from '@/services/settings-service.js';
+import type { CalendarEvent } from '@protolabsai/types';
+import { createMockEventEmitter } from '../../helpers/mock-factories.js';
+
+// Mock node:child_process so run-command tests don't spawn real processes
+// Use importOriginal to preserve other exports (execFile, spawn, etc.)
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    exec: vi.fn(),
+  };
+});
+
+// Import after mock so vi.mocked() works
+import { exec } from 'node:child_process';
+
+// Silence logger output during tests
+vi.mock('@protolabsai/utils', async () => {
+  const actual = await vi.importActual<typeof import('@protolabsai/utils')>('@protolabsai/utils');
+  return {
+    ...actual,
+    createLogger: vi.fn(() => ({
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    })),
+  };
+});
+
+describe('JobExecutorService', () => {
+  let service: JobExecutorService;
+  let mockCalendarService: Partial<CalendarService>;
+  let mockAutoModeService: Partial<AutoModeService>;
+  let mockAutomationService: Partial<AutomationService>;
+  let mockSettingsService: Partial<SettingsService>;
+  let mockEvents: ReturnType<typeof createMockEventEmitter>;
+
+  const projectPath = '/test/project';
+
+  function makeJob(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+    return {
+      id: 'job-1',
+      title: 'Test Job',
+      date: '2026-03-10',
+      time: '09:00',
+      type: 'job',
+      jobStatus: 'pending',
+      jobAction: { type: 'start-agent', featureId: 'feature-123' },
+      projectPath,
+      createdAt: '2026-03-01T00:00:00Z',
+      updatedAt: '2026-03-01T00:00:00Z',
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockCalendarService = {
+      updateEvent: vi.fn().mockResolvedValue({}),
+      emitReminder: vi.fn(),
+      getDueJobs: vi.fn().mockResolvedValue([]),
+    };
+
+    mockAutoModeService = {
+      executeFeature: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockAutomationService = {
+      executeAutomation: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockSettingsService = {
+      getGlobalSettings: vi.fn().mockResolvedValue({ projects: [] }),
+    };
+
+    mockEvents = createMockEventEmitter();
+
+    service = new JobExecutorService(
+      mockCalendarService as CalendarService,
+      mockAutoModeService as AutoModeService,
+      mockAutomationService as AutomationService,
+      mockSettingsService as SettingsService,
+      mockEvents
+    );
+  });
+
+  describe('executeJob', () => {
+    describe('action dispatch', () => {
+      it('dispatches start-agent action to autoModeService.executeFeature', async () => {
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feature-abc' } });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockAutoModeService.executeFeature).toHaveBeenCalledWith(
+          projectPath,
+          'feature-abc',
+          true
+        );
+      });
+
+      it('dispatches run-automation action to automationService.executeAutomation', async () => {
+        const job = makeJob({
+          jobAction: { type: 'run-automation', automationId: 'automation-xyz' },
+        });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockAutomationService.executeAutomation).toHaveBeenCalledWith(
+          'automation-xyz',
+          'scheduler'
+        );
+      });
+
+      it('dispatches run-command action via exec', async () => {
+        const mockExec = vi.mocked(exec);
+        mockExec.mockImplementation((_cmd: string, _opts: unknown, callback: unknown) => {
+          (callback as (err: null, stdout: string, stderr: string) => void)(null, 'ok', '');
+          return {} as ReturnType<typeof exec>;
+        });
+
+        const job = makeJob({
+          jobAction: { type: 'run-command', command: 'npm run build' },
+        });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockExec).toHaveBeenCalledWith(
+          'npm run build',
+          expect.objectContaining({ timeout: expect.any(Number) }),
+          expect.any(Function)
+        );
+      });
+    });
+
+    describe('status transitions', () => {
+      it('marks job as running before dispatch', async () => {
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feat-1' } });
+
+        await service.executeJob(projectPath, job);
+
+        // First updateEvent call should set status to 'running'
+        expect(mockCalendarService.updateEvent).toHaveBeenNthCalledWith(
+          1,
+          projectPath,
+          job.id,
+          expect.objectContaining({ jobStatus: 'running' })
+        );
+      });
+
+      it('marks job as completed after successful dispatch', async () => {
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feat-1' } });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockCalendarService.updateEvent).toHaveBeenCalledWith(
+          projectPath,
+          job.id,
+          expect.objectContaining({ jobStatus: 'completed' })
+        );
+      });
+
+      it('marks job as failed when dispatch throws', async () => {
+        mockAutoModeService.executeFeature = vi.fn().mockRejectedValue(new Error('Agent failed'));
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feat-fail' } });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockCalendarService.updateEvent).toHaveBeenCalledWith(
+          projectPath,
+          job.id,
+          expect.objectContaining({ jobStatus: 'failed' })
+        );
+      });
+
+      it('includes error message in jobResult when job fails', async () => {
+        const errorMsg = 'Something broke';
+        mockAutoModeService.executeFeature = vi.fn().mockRejectedValue(new Error(errorMsg));
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feat-fail' } });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockCalendarService.updateEvent).toHaveBeenCalledWith(
+          projectPath,
+          job.id,
+          expect.objectContaining({
+            jobStatus: 'failed',
+            jobResult: expect.objectContaining({ error: errorMsg }),
+          })
+        );
+      });
+
+      it('includes timing info in jobResult on success', async () => {
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feat-1' } });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockCalendarService.updateEvent).toHaveBeenCalledWith(
+          projectPath,
+          job.id,
+          expect.objectContaining({
+            jobStatus: 'completed',
+            jobResult: expect.objectContaining({
+              startedAt: expect.any(String),
+              completedAt: expect.any(String),
+              durationMs: expect.any(Number),
+            }),
+          })
+        );
+      });
+    });
+
+    describe('event emission', () => {
+      it('emits job:started and job:completed events on success', async () => {
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feat-1' } });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockEvents.emit).toHaveBeenCalledWith(
+          'job:started',
+          expect.objectContaining({ jobId: job.id, projectPath })
+        );
+        expect(mockEvents.emit).toHaveBeenCalledWith(
+          'job:completed',
+          expect.objectContaining({ jobId: job.id, projectPath })
+        );
+      });
+
+      it('emits job:started and job:failed events on failure', async () => {
+        mockAutoModeService.executeFeature = vi.fn().mockRejectedValue(new Error('fail'));
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feat-1' } });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockEvents.emit).toHaveBeenCalledWith(
+          'job:started',
+          expect.objectContaining({ jobId: job.id })
+        );
+        expect(mockEvents.emit).toHaveBeenCalledWith(
+          'job:failed',
+          expect.objectContaining({ jobId: job.id, error: 'fail' })
+        );
+      });
+    });
+
+    it('skips execution if job has no jobAction', async () => {
+      const job = makeJob({ jobAction: undefined });
+
+      await service.executeJob(projectPath, job);
+
+      expect(mockAutoModeService.executeFeature).not.toHaveBeenCalled();
+      expect(mockAutomationService.executeAutomation).not.toHaveBeenCalled();
+      expect(mockCalendarService.updateEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sanitizeCommand', () => {
+    describe('allows valid commands', () => {
+      it('allows a simple npm command', () => {
+        expect(() => sanitizeCommand('npm run build')).not.toThrow();
+      });
+
+      it('allows git commands', () => {
+        expect(() => sanitizeCommand('git status')).not.toThrow();
+      });
+
+      it('allows commands with flags', () => {
+        expect(() => sanitizeCommand('ls -la')).not.toThrow();
+      });
+
+      it('allows python scripts', () => {
+        expect(() => sanitizeCommand('python3 scripts/migrate.py')).not.toThrow();
+      });
+
+      it('returns the command unchanged when valid', () => {
+        const cmd = 'npm run build';
+        expect(sanitizeCommand(cmd)).toBe(cmd);
+      });
+
+      it('accepts a command at exactly the max length (1024 chars)', () => {
+        const exactCommand = 'a'.repeat(1024);
+        expect(() => sanitizeCommand(exactCommand)).not.toThrow();
+      });
+    });
+
+    describe('rejects shell metacharacters', () => {
+      it('rejects commands with semicolons', () => {
+        expect(() => sanitizeCommand('npm run build; rm -rf /')).toThrow(
+          /unescaped shell metacharacters/
+        );
+      });
+
+      it('rejects commands with pipe operator', () => {
+        expect(() => sanitizeCommand('cat /etc/passwd | grep root')).toThrow(
+          /unescaped shell metacharacters/
+        );
+      });
+
+      it('rejects commands with output redirect', () => {
+        expect(() => sanitizeCommand('echo hello > /tmp/file')).toThrow(
+          /unescaped shell metacharacters/
+        );
+      });
+
+      it('rejects commands with input redirect', () => {
+        expect(() => sanitizeCommand('cat < /etc/passwd')).toThrow(
+          /unescaped shell metacharacters/
+        );
+      });
+
+      it('rejects commands with $ variable expansion', () => {
+        expect(() => sanitizeCommand('echo $HOME')).toThrow(/unescaped shell metacharacters/);
+      });
+
+      it('rejects commands with backtick substitution', () => {
+        expect(() => sanitizeCommand('echo `whoami`')).toThrow(/unescaped shell metacharacters/);
+      });
+
+      it('rejects commands with && chaining', () => {
+        expect(() => sanitizeCommand('npm run build && npm run test')).toThrow(
+          /unescaped shell metacharacters/
+        );
+      });
+    });
+
+    describe('rejects oversized commands', () => {
+      it('rejects a command exceeding the 1024-character limit', () => {
+        const longCommand = 'a'.repeat(1025);
+        expect(() => sanitizeCommand(longCommand)).toThrow(/exceeds maximum length/);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

**Milestone:** Skill Rewrite & Test Coverage

Add Vitest unit tests covering the core calendar business logic. CalendarService tests: listEvents() aggregation (custom + feature events), createEvent() filesystem path, updateEvent() not-found error, deleteEvent() removes correct event, upsertBySourceId() create and update paths, getDueJobs() filters correctly by date+time+status, isDateInRange() edge cases. JobExecutorService tests: executeJob() dispatches start-agent/run-automation/run-command co...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for calendar event filtering and retrieval operations.
  * Added extensive test suite for job execution service, covering action dispatch workflows, status transitions, event emissions, and command validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->