### PR TITLE
Promote staging to main

### DIFF
--- a/.automaker/context/prettier-before-commit.md
+++ b/.automaker/context/prettier-before-commit.md
@@ -1,0 +1,50 @@
+# Prettier Before Commit
+
+**CRITICAL: Always run prettier on modified files before committing.**
+
+## Why This Matters
+
+CI runs `npm run format:check` (prettier) on every PR. Agent commits that skip prettier
+formatting will fail CI with a `format:check` error. This has caused failures on multiple
+PRs (#2210, #2211, and others).
+
+## Required Step Before Every `git commit`
+
+Before running `git commit` (or any equivalent commit command), you MUST run prettier on
+all files you have modified or created:
+
+```bash
+# Format all modified/staged files before committing
+npx prettier --write <file1> <file2> ...
+
+# Or format all staged files at once
+git diff --name-only --cached | xargs npx prettier --write --ignore-unknown
+```
+
+## Workflow
+
+1. Make your code changes
+2. Stage files: `git add <files>`
+3. **Run prettier on staged files:**
+   ```bash
+   git diff --name-only --cached | xargs npx prettier --write --ignore-unknown
+   ```
+4. Re-stage any files prettier modified: `git add <files>`
+5. Commit: `git commit -m "..."`
+
+## Alternative: Format Then Stage
+
+```bash
+# Format first, then stage
+npx prettier --write <file1> <file2> ...
+git add <file1> <file2> ...
+git commit -m "..."
+```
+
+## Notes
+
+- `--ignore-unknown` prevents prettier from failing on binary or unsupported file types
+- prettier is already installed — use `npx prettier` to run it
+- The CI check uses `prettier --ignore-path .prettierignore --check .` — the `--write`
+  flag applied to your changed files achieves the same result for those files
+- This applies to ALL commits, whether in a worktree or the main repo

--- a/.automaker/lead-engineer-sessions.json
+++ b/.automaker/lead-engineer-sessions.json
@@ -2,5 +2,5 @@
   "projectPath": "/Users/kj/dev/automaker",
   "projectSlug": "flow-intelligence-kill-criteria",
   "maxConcurrency": 1,
-  "startedAt": "2026-03-10T23:06:10.075Z"
+  "startedAt": "2026-03-11T01:58:52.459Z"
 }

--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,9 +5,9 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 454
-  referenced: 107
-  successfulFeatures: 107
+  loaded: 474
+  referenced: 108
+  successfulFeatures: 108
 ---
 <!-- domain: API Design & Integration | GitHub GraphQL, REST endpoints, HTTP client patterns -->
 
@@ -104,3 +104,9 @@ usageStats:
 - **Situation:** GraphQL query fetches review threads with `first: 100`. PRs with >100 threads lose threads beyond the page limit.
 - **Root cause:** GitHub GraphQL requires explicit cursor-based pagination. There's no way to fetch all items without implementing pagination loop.
 - **How to avoid:** For most PRs, 100 threads is sufficient. Add `pageInfo { hasNextPage, endCursor }` to query and implement pagination loop if thread count regularly exceeds 100.
+
+
+#### [Pattern] getServerUrl() implements strict precedence: localStorage override > cached value > environment variable. The precedence order is non-configurable and critical. (2026-03-11)
+- **Problem solved:** Resolving multiple server URL sources with different specificity levels
+- **Why this works:** Precedence chain implements proper specificity: user intent (override) > transient state (cache) > static config (env). Prevents static config from shadowing user choice.
+- **Trade-offs:** Gained: Clean override semantics without code changes. Lost: Hidden state machine - source of truth is precedence-dependent, complicates debugging

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,9 +5,9 @@ relevantTo: [architecture]
 importance: 0.9
 relatedFiles: []
 usageStats:
-  loaded: 116
-  referenced: 50
-  successfulFeatures: 50
+  loaded: 144
+  referenced: 53
+  successfulFeatures: 53
 ---
 <!-- domain: Architecture Decisions | System-wide structural decisions that have breaking consequences if changed -->
 
@@ -120,3 +120,55 @@ usageStats:
 - **Context:** Providing audit trail and UI feedback for autonomous cleanup operations.
 - **Why:** Dual-event approach enables (1) real-time UI updates via individual events and (2) health monitoring via completion event with aggregate counts.
 - **Breaking if changed:** Removing individual events loses real-time UI feedback. Removing completion event loses health/monitoring signal. Both matter for different consumers.
+
+
+#### [Pattern] localStorage used as neutral bridge between auth.ts and app-store.ts. getServerUrl() reads from 'automaker:serverUrlOverride', setServerUrlOverride() writes to same key. No direct import between layers. (2026-03-11)
+- **Problem solved:** Multiple layers (auth, state management) need access to same server URL override without creating circular dependency or tight coupling.
+- **Why this works:** Avoids circular imports and direct service coupling. Creates implicit contract on localStorage key as decoupling mechanism.
+- **Trade-offs:** One indirection (localStorage lookup) vs. zero import coupling; implicit key contract harder to refactor than explicit exports
+
+#### [Pattern] HTTP client fully invalidated (recreated) on setServerUrlOverride(), not just base URL patched. Calls invalidateHttpClient() which triggers WebSocket reconnection. (2026-03-11)
+- **Problem solved:** User switches server URL at runtime. Old connections/interceptors/middleware were initialized with original origin and need reset.
+- **Why this works:** HTTP clients cache connections, configure TLS/auth per-origin, bind request middleware to specific base URL. Can't patch URL property; full recreation required.
+- **Trade-offs:** Immediate fresh connection (good UX, correct state) vs. more expensive (full recreation vs. shallow update)
+
+#### [Gotcha] Recent URLs deduplication removes old occurrence and appends new one. Array persisted to localStorage with max 10 entries. Deduplication via array filter + push, not Set or Map. (2026-03-11)
+- **Situation:** User may switch to same server URL multiple times. Need clean dropdown UI without duplicates and bounded storage usage.
+- **Root cause:** Array approach preserves insertion order (most recent at end) for UX. Set would lose order. 10-entry cap prevents localStorage quota creep. Filter+push is simpler than index tracking.
+- **How to avoid:** Simple ordered dedup vs. unbounded storage; old entries lost when max reached
+
+### When serverUrlOverride changes, setServerUrlOverride() explicitly calls invalidateHttpClient() to force recreation of both HTTP and WebSocket clients, rather than having clients auto-detect and reconnect. (2026-03-11)
+- **Context:** Ensuring both HTTP and WebSocket stay synchronized when switching servers at runtime
+- **Why:** Clients cache server URL internally at instantiation; explicit invalidation guarantees both client types get fresh instances pointing to new URL. Prevents subtle bugs where HTTP migrates but WebSocket stays on old server.
+- **Rejected:** Reactive auto-reconnect pattern (clients watch serverUrlOverride store change) - too implicit, risk of partial state divergence; URL property mutation (clients don't know to reconnect); separate invalidation per client (easy to forget one)
+- **Trade-offs:** Gained: Explicit guarantee of sync, atomic client refresh. Lost: Manual trigger coupling; tight lifecycle bond between URL changes and client creation
+- **Breaking if changed:** If invalidateHttpClient() call is removed, clients remain connected to original server despite URL change, silently failing requests
+
+#### [Gotcha] invalidateHttpClient() must be called AFTER serverUrlOverride state is set in store, not before. Calling before means new clients read stale URL from store. (2026-03-11)
+- **Situation:** Ordering of state mutation vs client recreation
+- **Root cause:** New HTTP/WebSocket clients read serverUrlOverride from store during instantiation. If invalidate is called before state update, new clients get old URL.
+- **How to avoid:** Gained: Clients always read fresh state. Lost: Implicit ordering dependency that's not obvious in code
+
+### SDK single-level constraint enforced via synchronous interface design: LeadEngineerWorldStateProvider.getWorldStateSummary() is deliberately synchronous (not async/async-generator) to structurally prevent it from being implemented as a subagent. (2026-03-11)
+- **Context:** Anthropic SDK enforces single-level of subagents. Need to allow LE queries within Ava's PM delegated flow without violating this constraint.
+- **Why:** Synchronous interface makes subagent implementation impossible at the type level. This uses the type system as constraint enforcement rather than relying on documentation or runtime checks.
+- **Rejected:** Could implement LE as async subagent (SDK violation) or document the constraint. Type-level enforcement prevents accidental misuse.
+- **Trade-offs:** LE implementation cannot be async/parallel, but constraint violation becomes impossible. Adds clarity at cost of implementation flexibility.
+- **Breaking if changed:** Converting to async interface would require SDK restructuring to separate Ava's PM context from LE query evaluation, violating single-level constraint.
+
+#### [Pattern] Three-layer briefing with independent failure degradation: PM layer, LE layer, and strategic context layer each fail independently with graceful markdown fallback ('_World state unavailable: provider error_') rather than cascade failure. (2026-03-11)
+- **Problem solved:** Ava entry point aggregates heterogeneous world state (project management + engineering execution + brand context). Any layer could be unavailable or slow.
+- **Why this works:** Each layer has different SLA and failure modes. PM might be stale, LE might be slow. Degrading independently ensures Ava can operate with partial information rather than blocking.
+- **Trade-offs:** Adds error handling complexity in each layer but preserves Ava operability. Briefing output clarity slightly reduced when layer unavailable.
+
+#### [Pattern] Adapter pattern via BriefingWorldStateProvider interface: briefing.ts remains framework-agnostic (no imports from apps/server, no direct service dependencies) by delegating to provided interface implementation rather than instantiating services directly. (2026-03-11)
+- **Problem solved:** Briefing framework must live in packages/mcp-server (MCP tool registration) but world state assembly lives in apps/server (PM/LE services). Module boundary violation if direct coupling.
+- **Why this works:** Adapter pattern inverts dependency: framework depends on interface contract, not concrete implementation. Allows apps/server to provide implementation without cyclic imports.
+- **Trade-offs:** Extra abstraction layer adds indirection (BriefingWorldStateProvider interface) but enables clean module separation. Interface contract becomes documentation.
+
+### PMProjectQueryService uses synchronous service boundary (queries LeadEngineerWorldStateProvider via sync call) rather than spawning LE as child subagent, even though PM is itself delegated by Ava. (2026-03-11)
+- **Context:** Ava delegates to PM, PM needs LE status. Could structure as: Ava→PM(subagent)→LE(subagent), but SDK limits to single subagent level.
+- **Why:** SDK single-level constraint means LE cannot be a child subagent of PM subagent. Synchronous service call stays within single level: Ava delegates to PM (one level), PM queries LE as service (not subagent).
+- **Rejected:** Async subagent model (Ava→PM→LE hierarchy) violates SDK. Sequential async/await in PM would require LE to be subagent.
+- **Trade-offs:** PM is synchronous query service (not async subagent), which means PM cannot parallelize LE queries or benefit from subagent infrastructure (tool use, reasoning). But stays within SDK constraints.
+- **Breaking if changed:** Removing SDK single-level constraint would allow LE to become child subagent, enabling async parallelism and tool use within LE context.

--- a/.automaker/memory/auth.md
+++ b/.automaker/memory/auth.md
@@ -5,9 +5,9 @@ relevantTo: [auth]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 53
-  referenced: 22
-  successfulFeatures: 22
+  loaded: 57
+  referenced: 24
+  successfulFeatures: 24
 ---
 <!-- domain: Authentication & Authorization | OAuth, token management, access control -->
 
@@ -82,3 +82,13 @@ usageStats:
 - **Rejected:** Backend persistence would require bootstrapping with a default server URL, creating initialization ordering issues
 - **Trade-offs:** Simpler, faster, works offline, but configuration doesn't sync across devices or persist after localStorage clear
 - **Breaking if changed:** Moving to backend storage requires solving initialization sequence (how to know server URL before connecting); removing localStorage loses offline capability
+
+#### [Pattern] Server URL discovery layered: localStorage override → Electron cached URL → environment var → default hardcoded URL. Fallback chain with increasing specificity. (2026-03-11)
+- **Problem solved:** Need to support: user runtime override, Electron preload injection, deployment env config, and fallback default.
+- **Why this works:** Each layer represents a different source of truth with different scope (user session > app launch > deployment > code). Layering respects precedence.
+- **Trade-offs:** Flexible layering vs. multiple places to debug; explicit fallback chain vs. implicit magic
+
+#### [Pattern] Server URL override is persisted to localStorage ('automaker:serverUrlOverride') in parallel with React state, making persistence explicit but requiring manual sync between storage and state. (2026-03-11)
+- **Problem solved:** Runtime server URL switching for development/hivemind testing
+- **Why this works:** localStorage persistence survives page reloads without server round-trip; React state provides immediate reactivity; dual sync avoids redundant reads on every render
+- **Trade-offs:** Gained: Survival across restarts without server cost. Lost: Must manage sync between two sources of truth; synchronous localStorage blocks if data is large

--- a/.automaker/memory/content-pipeline-validation.md
+++ b/.automaker/memory/content-pipeline-validation.md
@@ -5,7 +5,7 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 136
+  loaded: 138
   referenced: 11
   successfulFeatures: 11
 ---

--- a/.automaker/memory/documentation.md
+++ b/.automaker/memory/documentation.md
@@ -5,9 +5,9 @@ relevantTo: [documentation]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 303
-  referenced: 66
-  successfulFeatures: 66
+  loaded: 323
+  referenced: 67
+  successfulFeatures: 67
 ---
 <!-- domain: Documentation | Docs standards, structure, maintenance patterns -->
 

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 1079
-  referenced: 308
-  successfulFeatures: 308
+  loaded: 1107
+  referenced: 311
+  successfulFeatures: 311
 ---
 <!-- domain: Gotchas & Pitfalls | Known traps, anti-patterns, and hard-won lessons across all domains -->
 

--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -5,9 +5,9 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 257
-  referenced: 59
-  successfulFeatures: 59
+  loaded: 269
+  referenced: 62
+  successfulFeatures: 62
 ---
 <!-- domain: GTM Signal Intelligence | Go-to-market signal processing and routing -->
 

--- a/.automaker/memory/patterns.md
+++ b/.automaker/memory/patterns.md
@@ -5,7 +5,7 @@ relevantTo: [patterns]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 64
+  loaded: 65
   referenced: 22
   successfulFeatures: 22
 ---

--- a/.automaker/memory/performance.md
+++ b/.automaker/memory/performance.md
@@ -305,3 +305,8 @@ usageStats:
 - **Rejected:** Always running merge detection regardless of current status — wastes gh CLI calls on features that are already done
 - **Trade-offs:** Extra feature reload on every REVIEW.process() call, but saves many gh CLI calls. Reload is cached/fast; gh calls are not.
 - **Breaking if changed:** If early status check is removed, forces unnecessary gh CLI calls on every loop iteration, increasing latency and GitHub API quota usage
+
+#### [Gotcha] Recent server URLs are deduplicated and trimmed to 10 on every add operation via .filter() + .slice(), making each add O(n) in array size. (2026-03-11)
+- **Situation:** Preventing duplicate URLs from bloating recent history
+- **Root cause:** Write-time deduplication keeps localStorage small and getRecentUrls() reads fast; alternative (read-time dedup) would add latency to every access; unbounded lists eventually degrade
+- **How to avoid:** Gained: Fast reads, clean state. Lost: O(n) cost per add (acceptable since adds are infrequent, but non-obvious)

--- a/.automaker/memory/security.md
+++ b/.automaker/memory/security.md
@@ -5,7 +5,7 @@ relevantTo: [security]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 73
+  loaded: 77
   referenced: 21
   successfulFeatures: 21
 ---
@@ -104,3 +104,14 @@ usageStats:
 - **Problem solved:** CSRF attacks on OAuth redirect can trick users into authorizing attacker's client. State parameter prevents this.
 - **Why this works:** State parameter is OAuth 2.0 standard (RFC 6749). In-memory Map is simplest implementation for single instance. 10-minute window is long enough for OAuth flow but short enough to prevent state reuse.
 - **Trade-offs:** In-memory state is fast and simple but loses state across process restarts and doesn't scale to multiple servers.
+
+
+#### [Pattern] CORS policy controlled by runtime config flag 'hivemindEnabled'. When true, middleware sets Access-Control-Allow-Origin: *. When false, restrictive CORS (same-origin only). (2026-03-11)
+- **Problem solved:** Default: app runs single-origin. Hivemind mode: same app instance accessed from multiple origins (multi-client scenario).
+- **Why this works:** Standard single-origin CORS sufficient for normal use. Hivemind requires cross-origin access; feature gate prevents accidental exposure.
+- **Trade-offs:** Runtime flexibility + explicit feature gate vs. security gap risk if flag accidentally enabled without understanding implications
+
+#### [Pattern] CORS allowAllOrigins flag is conditional on hivemind.enabled, creating a dev-only CORS policy. Production never enables permissive CORS unless hivemind feature is active. (2026-03-11)
+- **Problem solved:** Balancing developer convenience in local testing with production security lockdown
+- **Why this works:** hivemind is explicit development feature; tying CORS to it ensures CORS exposure is never accidental in production. Fail-secure default.
+- **Trade-offs:** Gained: Impossible to accidentally expose permissive CORS in production. Lost: CORS availability is implicit in feature flag, adds discovery burden

--- a/.automaker/memory/storage.md
+++ b/.automaker/memory/storage.md
@@ -5,7 +5,7 @@ relevantTo: [storage]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 17
+  loaded: 18
   referenced: 5
   successfulFeatures: 5
 ---

--- a/.automaker/memory/testing.md
+++ b/.automaker/memory/testing.md
@@ -102,3 +102,9 @@ usageStats:
 - **Situation:** After adding @/ path alias to tsconfig, tests importing @/lib/foo failed at runtime despite TypeScript compiling cleanly.
 - **Root cause:** Vitest uses its own module resolver that doesn't read tsconfig.paths by default. Both must be configured independently.
 - **How to avoid:** When adding path aliases to tsconfig, immediately add matching entry to vitest.config.ts resolve.alias.
+
+
+#### [Pattern] Inline object stubs (not vi.mock) for interface-driven test coverage: Tests create inline implementations of BriefingWorldStateProvider, PMWorldStateBuilder, LeadEngineerWorldStateProvider to avoid mock complexity and preserve interface contract visibility. (2026-03-11)
+- **Problem solved:** Integration tests verify data flow through three layers with failure scenarios. Code is heavily interface-driven with multiple collaboration points.
+- **Why this works:** Inline stubs make interface contracts explicit in test code and provide fine-grained control over each layer's behavior independently. Mock libraries abstract away the contract.
+- **Trade-offs:** More test setup boilerplate but better visibility. Easier to debug stub behavior. Less 'magic' in test infrastructure.

--- a/.automaker/memory/ui.md
+++ b/.automaker/memory/ui.md
@@ -1,0 +1,17 @@
+---
+tags: [ui]
+summary: ui implementation decisions and patterns
+relevantTo: [ui]
+importance: 0.7
+relatedFiles: []
+usageStats:
+  loaded: 0
+  referenced: 0
+  successfulFeatures: 0
+---
+# ui
+
+#### [Pattern] Recent server URLs stored as deduplicated, capped-at-10 list in localStorage (automaker:recentServerUrls). Each setServerUrlOverride() call filters duplicates before capping. (2026-03-11)
+- **Problem solved:** Users need history dropdown of visited servers; storage is limited; UX should not show same URL twice
+- **Why this works:** Deduplication improves UX (no confusing duplicate entries). Cap at 10 provides useful history depth while preventing unbounded localStorage growth (~500 bytes per URL × 10 = manageable).
+- **Trade-offs:** Slight complexity in dedup+cap logic vs cleaner UX and bounded storage

--- a/.automaker/metrics/dora.json
+++ b/.automaker/metrics/dora.json
@@ -1,0 +1,195 @@
+{
+  "version": 1,
+  "updatedAt": "2026-03-11T01:32:07.882Z",
+  "entries": [
+    {
+      "timestamp": "2026-03-10T23:27:16.307Z",
+      "deploymentFrequency": {
+        "mergesPerDay": 1,
+        "mergesPerWeek": 1,
+        "dayBucket": "2026-03-10"
+      },
+      "changeLeadTime": {
+        "featureId": "feature-1773184531845-k1iqe3fc8",
+        "featureTitle": "Fix: preFlightChecks missing from settings merge logic",
+        "featureCreatedAt": "2026-03-10T23:15:31.845Z",
+        "prMergedAt": "2026-03-10T23:27:16.307Z",
+        "leadTimeMs": 704462
+      },
+      "changeFailRate": {
+        "totalMerges": 1,
+        "totalFailures": 0,
+        "ratio": 0
+      },
+      "recoveryTime": null
+    },
+    {
+      "timestamp": "2026-03-10T23:45:59.607Z",
+      "deploymentFrequency": {
+        "mergesPerDay": 1,
+        "mergesPerWeek": 1,
+        "dayBucket": "2026-03-10"
+      },
+      "changeLeadTime": {
+        "featureId": "feature-1773182889372-f7cuqoda4",
+        "featureTitle": "Fix MCP enum mismatch and ID prefix inconsistency",
+        "featureCreatedAt": "2026-03-10T22:48:09.372Z",
+        "prMergedAt": "2026-03-10T23:45:59.607Z",
+        "leadTimeMs": 3470235
+      },
+      "changeFailRate": {
+        "totalMerges": 1,
+        "totalFailures": 0,
+        "ratio": 0
+      },
+      "recoveryTime": null
+    },
+    {
+      "timestamp": "2026-03-10T23:48:39.192Z",
+      "deploymentFrequency": {
+        "mergesPerDay": 1,
+        "mergesPerWeek": 1,
+        "dayBucket": "2026-03-10"
+      },
+      "changeLeadTime": {
+        "featureId": "feature-1773170748190-au64ffsgq",
+        "featureTitle": "PM Knowledge Indexing & Cross-Layer Queries",
+        "featureCreatedAt": "2026-03-10T19:25:48.192Z",
+        "prMergedAt": "2026-03-10T23:48:39.192Z",
+        "leadTimeMs": 15771000
+      },
+      "changeFailRate": {
+        "totalMerges": 1,
+        "totalFailures": 0,
+        "ratio": 0
+      },
+      "recoveryTime": null
+    },
+    {
+      "timestamp": "2026-03-10T23:48:40.156Z",
+      "deploymentFrequency": {
+        "mergesPerDay": 2,
+        "mergesPerWeek": 2,
+        "dayBucket": "2026-03-10"
+      },
+      "changeLeadTime": {
+        "featureId": "feature-1773184528261-6azg6wzgp",
+        "featureTitle": "Improve: chunk ID uniqueness and input validation in knowledge store",
+        "featureCreatedAt": "2026-03-10T23:15:28.261Z",
+        "prMergedAt": "2026-03-10T23:48:40.156Z",
+        "leadTimeMs": 1991895
+      },
+      "changeFailRate": {
+        "totalMerges": 2,
+        "totalFailures": 0,
+        "ratio": 0
+      },
+      "recoveryTime": null
+    },
+    {
+      "timestamp": "2026-03-11T00:18:03.039Z",
+      "deploymentFrequency": {
+        "mergesPerDay": 1,
+        "mergesPerWeek": 1,
+        "dayBucket": "2026-03-11"
+      },
+      "changeLeadTime": {
+        "featureId": "feature-1773182889373-tk032c59v",
+        "featureTitle": "Fix shell injection in run-command job actions",
+        "featureCreatedAt": "2026-03-10T22:48:09.373Z",
+        "prMergedAt": "2026-03-11T00:18:03.039Z",
+        "leadTimeMs": 5393666
+      },
+      "changeFailRate": {
+        "totalMerges": 1,
+        "totalFailures": 0,
+        "ratio": 0
+      },
+      "recoveryTime": null
+    },
+    {
+      "timestamp": "2026-03-11T00:18:03.478Z",
+      "deploymentFrequency": {
+        "mergesPerDay": 2,
+        "mergesPerWeek": 2,
+        "dayBucket": "2026-03-11"
+      },
+      "changeLeadTime": {
+        "featureId": "feature-1773184807748-9zxaqipbf",
+        "featureTitle": "Server URL override in auth layer + app store",
+        "featureCreatedAt": "2026-03-10T23:20:07.748Z",
+        "prMergedAt": "2026-03-11T00:18:03.478Z",
+        "leadTimeMs": 3475730
+      },
+      "changeFailRate": {
+        "totalMerges": 2,
+        "totalFailures": 0,
+        "ratio": 0
+      },
+      "recoveryTime": null
+    },
+    {
+      "timestamp": "2026-03-11T00:57:32.850Z",
+      "deploymentFrequency": {
+        "mergesPerDay": 1,
+        "mergesPerWeek": 1,
+        "dayBucket": "2026-03-11"
+      },
+      "changeLeadTime": {
+        "featureId": "feature-1773182889376-gbnwhlidl",
+        "featureTitle": "Wire emitReminder() into JobExecutorService",
+        "featureCreatedAt": "2026-03-10T22:48:09.376Z",
+        "prMergedAt": "2026-03-11T00:57:32.850Z",
+        "leadTimeMs": 7763474
+      },
+      "changeFailRate": {
+        "totalMerges": 1,
+        "totalFailures": 0,
+        "ratio": 0
+      },
+      "recoveryTime": null
+    },
+    {
+      "timestamp": "2026-03-11T01:16:11.783Z",
+      "deploymentFrequency": {
+        "mergesPerDay": 1,
+        "mergesPerWeek": 1,
+        "dayBucket": "2026-03-11"
+      },
+      "changeLeadTime": {
+        "featureId": "feature-1773182889379-bgtpd0n85",
+        "featureTitle": "Ceremony-to-calendar integration",
+        "featureCreatedAt": "2026-03-10T22:48:09.380Z",
+        "prMergedAt": "2026-03-11T01:16:11.783Z",
+        "leadTimeMs": 8882403
+      },
+      "changeFailRate": {
+        "totalMerges": 1,
+        "totalFailures": 0,
+        "ratio": 0
+      },
+      "recoveryTime": null
+    },
+    {
+      "timestamp": "2026-03-11T01:32:07.868Z",
+      "deploymentFrequency": {
+        "mergesPerDay": 1,
+        "mergesPerWeek": 1,
+        "dayBucket": "2026-03-11"
+      },
+      "changeLeadTime": {
+        "featureId": "feature-1773182889383-jrsoc1uc3",
+        "featureTitle": "Rewrite calendar-assistant skill for SDK-native patterns",
+        "featureCreatedAt": "2026-03-10T22:48:09.383Z",
+        "prMergedAt": "2026-03-11T01:32:07.868Z",
+        "leadTimeMs": 9838485
+      },
+      "changeFailRate": {
+        "totalMerges": 1,
+        "totalFailures": 0,
+        "ratio": 0
+      },
+      "recoveryTime": null
+    }
+  ]
+}

--- a/.automaker/metrics/error-budget.json
+++ b/.automaker/metrics/error-budget.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "updatedAt": "2026-03-11T01:32:07.868Z",
+  "records": [
+    {
+      "featureId": "feature-1773184531845-k1iqe3fc8",
+      "mergedAt": "2026-03-10T23:27:16.308Z",
+      "failedCi": false
+    },
+    {
+      "featureId": "feature-1773182889372-f7cuqoda4",
+      "mergedAt": "2026-03-10T23:45:59.607Z",
+      "failedCi": false
+    },
+    {
+      "featureId": "feature-1773170748190-au64ffsgq",
+      "mergedAt": "2026-03-10T23:48:39.192Z",
+      "failedCi": false
+    },
+    {
+      "featureId": "feature-1773184528261-6azg6wzgp",
+      "mergedAt": "2026-03-10T23:48:40.157Z",
+      "failedCi": false
+    },
+    {
+      "featureId": "feature-1773182889373-tk032c59v",
+      "mergedAt": "2026-03-11T00:18:03.039Z",
+      "failedCi": false
+    },
+    {
+      "featureId": "feature-1773184807748-9zxaqipbf",
+      "mergedAt": "2026-03-11T00:18:03.478Z",
+      "failedCi": false
+    },
+    {
+      "featureId": "feature-1773182889376-gbnwhlidl",
+      "mergedAt": "2026-03-11T00:57:32.851Z",
+      "failedCi": false
+    },
+    {
+      "featureId": "feature-1773182889379-bgtpd0n85",
+      "mergedAt": "2026-03-11T01:16:11.783Z",
+      "failedCi": false
+    },
+    {
+      "featureId": "feature-1773182889383-jrsoc1uc3",
+      "mergedAt": "2026-03-11T01:32:07.868Z",
+      "failedCi": false
+    }
+  ]
+}

--- a/.automaker/projects/headless-server-remote-client-architecture/project.json
+++ b/.automaker/projects/headless-server-remote-client-architecture/project.json
@@ -31,7 +31,7 @@
           ],
           "complexity": "medium",
           "claimedBy": "mac-dev",
-          "claimedAt": "2026-03-10T17:07:12.469Z",
+          "claimedAt": "2026-03-11T01:57:42.379Z",
           "executionStatus": "in_progress",
           "lastError": "Reclaimed from offline instance mac-dev"
         },
@@ -136,5 +136,5 @@
     }
   ],
   "createdAt": "2026-03-10T01:41:48.204Z",
-  "updatedAt": "2026-03-10T17:07:12.671Z"
+  "updatedAt": "2026-03-11T01:57:42.585Z"
 }

--- a/apps/server/.automaker/pr-tracking.json
+++ b/apps/server/.automaker/pr-tracking.json
@@ -1,4 +1,16 @@
 {
-  "trackedPRs": [],
-  "savedAt": "2026-03-10T23:02:24.295Z"
+  "trackedPRs": [
+    {
+      "featureId": "feature-1773182889384-scnnedrgi",
+      "projectPath": "/Users/kj/dev/automaker",
+      "prNumber": 2226,
+      "prUrl": "https://github.com/protoLabsAI/protoMaker/pull/2226",
+      "branchName": "",
+      "lastCheckedAt": 0,
+      "reviewStatus": "pending",
+      "remediationCount": 0,
+      "trackedSince": 1773194320275
+    }
+  ],
+  "savedAt": "2026-03-11T01:58:40.278Z"
 }

--- a/apps/server/src/lib/settings-helpers.ts
+++ b/apps/server/src/lib/settings-helpers.ts
@@ -785,6 +785,8 @@ export async function getWorkflowSettings(
         postMergeVerificationCommands:
           projectSettings.workflow.postMergeVerificationCommands ??
           DEFAULT_WORKFLOW_SETTINGS.postMergeVerificationCommands,
+        preFlightChecks:
+          projectSettings.workflow.preFlightChecks ?? DEFAULT_WORKFLOW_SETTINGS.preFlightChecks,
       };
     }
     return DEFAULT_WORKFLOW_SETTINGS;

--- a/apps/server/src/routes/calendar/index.ts
+++ b/apps/server/src/routes/calendar/index.ts
@@ -5,15 +5,17 @@
 import { Router, type Request, type Response } from 'express';
 import { validatePathParams } from '../../middleware/validate-paths.js';
 import type { CalendarService, CalendarQueryOptions } from '../../services/calendar-service.js';
-import type { JobAction } from '@protolabsai/types';
+import type { JobAction, EventType } from '@protolabsai/types';
 import type { JobExecutorService } from '../../services/job-executor-service.js';
+import type { EventEmitter } from '../../lib/events.js';
 
 /**
  * Create calendar routes
  */
 export function createCalendarRoutes(
   calendarService: CalendarService,
-  jobExecutorService: JobExecutorService
+  jobExecutorService: JobExecutorService,
+  eventBus?: EventEmitter
 ): Router {
   const router = Router();
 
@@ -109,6 +111,14 @@ export function createCalendarRoutes(
         }),
       });
 
+      // Cast required: EventType in node_modules resolves to the main-repo's compiled dist
+      // via npm hoisting; the worktree's updated types/dist is correct but not yet picked up.
+      eventBus?.emit('calendar:event:created' as EventType, {
+        eventId: event.id,
+        projectPath,
+        event,
+      });
+
       res.json({ success: true, event });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -199,6 +209,12 @@ export function createCalendarRoutes(
 
       const event = await calendarService.updateEvent(projectPath, id, updates);
 
+      eventBus?.emit('calendar:event:updated' as EventType, {
+        eventId: id,
+        projectPath,
+        event,
+      });
+
       res.json({
         success: true,
         event,
@@ -238,6 +254,11 @@ export function createCalendarRoutes(
       }
 
       await calendarService.deleteEvent(projectPath, id);
+
+      eventBus?.emit('calendar:event:deleted' as EventType, {
+        eventId: id,
+        projectPath,
+      });
 
       res.json({
         success: true,

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -294,7 +294,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api/context', createContextRoutes(settingsService));
   app.use('/api/content', createContentRoutes(settingsService));
   app.use('/api/backlog-plan', createBacklogPlanRoutes(events, settingsService));
-  app.use('/api/calendar', createCalendarRoutes(calendarService, jobExecutorService));
+  app.use('/api/calendar', createCalendarRoutes(calendarService, jobExecutorService, events));
   app.use('/api/mcp', createMCPRoutes(mcpTestService));
   app.use(
     '/api/integrations',

--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -716,6 +716,39 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
       .catch((err) => logger.warn('[CalendarReminder] spawnForCron failed:', err));
   });
 
+  // Relay job lifecycle events to remote peers in hivemind mode.
+  // JobExecutorService calls events.emit() (local only); the subscriptions below
+  // ensure job state changes are also forwarded via the remote broadcaster when one
+  // is registered (e.g. CRDT sync). A broadcasting flag prevents re-entrancy.
+  let broadcastingJob = false;
+  events.on('job:started', (payload) => {
+    if (broadcastingJob) return;
+    broadcastingJob = true;
+    try {
+      events.broadcast('job:started', payload);
+    } finally {
+      broadcastingJob = false;
+    }
+  });
+  events.on('job:completed', (payload) => {
+    if (broadcastingJob) return;
+    broadcastingJob = true;
+    try {
+      events.broadcast('job:completed', payload);
+    } finally {
+      broadcastingJob = false;
+    }
+  });
+  events.on('job:failed', (payload) => {
+    if (broadcastingJob) return;
+    broadcastingJob = true;
+    try {
+      events.broadcast('job:failed', payload);
+    } finally {
+      broadcastingJob = false;
+    }
+  });
+
   // Wire integrations health checks (requires integrationService + integrationRegistryService)
   integrationService.initialize(events, settingsService, featureLoader);
   wireHealthChecks(integrationRegistryService);

--- a/apps/server/src/services/ava-tools.ts
+++ b/apps/server/src/services/ava-tools.ts
@@ -1,0 +1,121 @@
+/**
+ * Ava Tools — PM Project Query Service
+ *
+ * Provides the PM-backed project status query capability for Ava's chat context.
+ *
+ * Flow:
+ *   user asks Ava
+ *     → Ava invokes PMProjectQueryService (PM subagent role)
+ *       → PM assembles world state from PMWorldStateBuilder
+ *       → PM queries LE execution state via service call
+ *             (NOT a subagent — Claude Agent SDK single-level limit)
+ *     → distilled answer returned to Ava for relay to user
+ *
+ * The PM subagent queries LE via direct service call to work within the
+ * SDK's single-level subagent constraint.
+ */
+
+import { createLogger } from '@protolabsai/utils';
+import type { PMWorldStateBuilder } from './pm-world-state-builder.js';
+import type { LeadEngineerWorldStateProvider } from './ava-world-state-builder.js';
+
+const logger = createLogger('AvaTools');
+
+// ────────────────────────── Result Types ──────────────────────────
+
+/**
+ * Distilled project status result produced by the PM subagent.
+ * Aggregates PM world state + LE execution state for Ava to relay.
+ */
+export interface AvaProjectStatusResult {
+  /** Distilled summary of current project status (markdown) */
+  summary: string;
+  /** PM layer distilled summary (projects, milestones, upcoming deadlines) */
+  pmSummary: string;
+  /** LE layer world state summary (execution status, active features) */
+  leSummary: string;
+  /** ISO timestamp of when this status was generated */
+  generatedAt: string;
+}
+
+// ────────────────────────── Service ──────────────────────────
+
+/**
+ * PM Project Query Service
+ *
+ * Implements the Ava → PM → LE query chain for project status queries.
+ *
+ * When Ava receives a project-status question, she delegates to this service
+ * which plays the "PM subagent" role: it assembles PM world state and queries
+ * the LE layer via service call (not a nested subagent).
+ *
+ * Example usage:
+ * ```typescript
+ * const pmQueryService = new PMProjectQueryService(pmBuilder, leProvider);
+ * const result = await pmQueryService.queryProjectStatus();
+ * // relay result.summary back to user via Ava
+ * ```
+ */
+export class PMProjectQueryService {
+  private readonly log = logger;
+
+  constructor(
+    private readonly pmBuilder: PMWorldStateBuilder,
+    private readonly leProvider: LeadEngineerWorldStateProvider
+  ) {}
+
+  /**
+   * Query current project status by aggregating PM world state and LE execution state.
+   *
+   * PM layer provides: project status, milestone progress, upcoming deadlines.
+   * LE layer provides: active feature execution state, flow status.
+   *
+   * LE is queried via service call — NOT a subagent (SDK single-level limit).
+   *
+   * @returns AvaProjectStatusResult with distilled summary for Ava to relay
+   */
+  async queryProjectStatus(): Promise<AvaProjectStatusResult> {
+    const generatedAt = new Date().toISOString();
+
+    // ── PM Layer ─────────────────────────────────────────────────────────────
+    let pmSummary: string;
+    try {
+      pmSummary = this.pmBuilder.getDistilledSummary();
+    } catch (err) {
+      this.log.warn('PMProjectQueryService: failed to get PM distilled summary', err);
+      pmSummary = '_PM summary unavailable_';
+    }
+
+    // ── LE Layer (service call, not subagent) ────────────────────────────────
+    let leSummary: string;
+    try {
+      leSummary = this.leProvider.getWorldStateSummary();
+    } catch (err) {
+      this.log.warn('PMProjectQueryService: failed to get LE world state summary', err);
+      leSummary = '_Engineering status unavailable_';
+    }
+
+    const summary = this.buildDistilledAnswer(pmSummary, leSummary);
+
+    return { summary, pmSummary, leSummary, generatedAt };
+  }
+
+  /**
+   * Build a distilled markdown answer from PM + LE summaries.
+   * Formats both layers into a unified project status report.
+   */
+  private buildDistilledAnswer(pmSummary: string, leSummary: string): string {
+    const lines: string[] = [
+      '## Project Status',
+      '',
+      '### PM Layer (Project Management)',
+      '',
+      pmSummary,
+      '',
+      '### LE Layer (Engineering Execution)',
+      '',
+      leSummary,
+    ];
+    return lines.join('\n');
+  }
+}

--- a/apps/server/src/services/ava-world-state-builder.ts
+++ b/apps/server/src/services/ava-world-state-builder.ts
@@ -25,9 +25,31 @@ export interface LeadEngineerWorldStateProvider {
   getWorldStateSummary(): string;
 }
 
+/**
+ * Minimal search interface for knowledge store queries.
+ * Compatible with KnowledgeStoreService.search() and KnowledgeSearchService.search().
+ */
+export interface KnowledgeSearchProvider {
+  search(
+    projectPath: string,
+    query: string,
+    opts?: { domain?: string; maxResults?: number; maxTokens?: number }
+  ): Promise<{ results: Array<{ chunk: { content: string; heading?: string } }> }>;
+}
+
 export interface AvaWorldStateBuilderConfig {
   /** Optional strategic directives or brand context to surface in briefing */
   strategicContext?: string;
+  /**
+   * Optional knowledge store search provider for querying both 'project' and
+   * 'engineering' domains to enrich the Ava briefing with distilled insights.
+   */
+  knowledgeSearch?: KnowledgeSearchProvider;
+  /**
+   * Project path to use when querying the knowledge store.
+   * Required when knowledgeSearch is provided.
+   */
+  knowledgeProjectPath?: string;
 }
 
 // ────────────────────────── Class ──────────────────────────
@@ -48,8 +70,9 @@ export class AvaWorldStateBuilder {
    * - PM world state (projects, milestones, upcoming items)
    * - LE world state (features, agents, PR status)
    * - Strategic context (team health, cross-project deps, brand/content)
+   * - Knowledge store insights (cross-domain query results from 'project' + 'engineering')
    */
-  getFullBriefing(): string {
+  async getFullBriefing(): Promise<string> {
     const lines: string[] = [];
     const now = new Date().toISOString();
 
@@ -80,6 +103,18 @@ export class AvaWorldStateBuilder {
       lines.push('_Engineering summary unavailable_');
     }
     lines.push('');
+
+    // ── Knowledge Insights ───────────────────────────────────────────
+    if (this.config.knowledgeSearch && this.config.knowledgeProjectPath) {
+      lines.push('## Knowledge Insights');
+      lines.push('');
+      const insights = await this.getKnowledgeInsights(
+        this.config.knowledgeSearch,
+        this.config.knowledgeProjectPath
+      );
+      lines.push(insights);
+      lines.push('');
+    }
 
     // ── Strategic Context ───────────────────────────────────────────
     lines.push('## Strategic Context');
@@ -133,6 +168,87 @@ export class AvaWorldStateBuilder {
   }
 
   // ────────────────────────── Private Helpers ──────────────────────────
+
+  /**
+   * Query the knowledge store across both 'project' and 'engineering' domains
+   * and return a distilled markdown summary of the top results.
+   *
+   * Uses a broad status query that surfaces milestone completions, ceremony outcomes,
+   * and recent engineering learnings.
+   */
+  private async getKnowledgeInsights(
+    search: KnowledgeSearchProvider,
+    projectPath: string
+  ): Promise<string> {
+    const sections: string[] = [];
+
+    // Query project domain — milestone completions, ceremonies, timeline
+    try {
+      const { results: projectResults } = await search.search(
+        projectPath,
+        'milestone progress ceremony timeline deadline',
+        { domain: 'project', maxResults: 5, maxTokens: 2000 }
+      );
+
+      if (projectResults.length > 0) {
+        sections.push('### Project Knowledge');
+        for (const r of projectResults) {
+          const heading = r.chunk.heading ? `**${r.chunk.heading}**` : '_chunk_';
+          // Trim content to first 300 chars for briefing
+          const preview =
+            r.chunk.content.length > 300
+              ? r.chunk.content.slice(0, 300).trimEnd() + '…'
+              : r.chunk.content;
+          sections.push(`#### ${heading}`);
+          sections.push(preview);
+          sections.push('');
+        }
+      } else {
+        sections.push('### Project Knowledge');
+        sections.push('_No project knowledge chunks indexed yet_');
+        sections.push('');
+      }
+    } catch (err) {
+      this.log.warn('Knowledge search (domain=project) failed:', err);
+      sections.push('### Project Knowledge');
+      sections.push('_Project knowledge unavailable_');
+      sections.push('');
+    }
+
+    // Query engineering domain — reflections, agent outputs, failure patterns
+    try {
+      const { results: engResults } = await search.search(
+        projectPath,
+        'engineering reflection learning failure pattern',
+        { domain: 'engineering', maxResults: 5, maxTokens: 2000 }
+      );
+
+      if (engResults.length > 0) {
+        sections.push('### Engineering Knowledge');
+        for (const r of engResults) {
+          const heading = r.chunk.heading ? `**${r.chunk.heading}**` : '_chunk_';
+          const preview =
+            r.chunk.content.length > 300
+              ? r.chunk.content.slice(0, 300).trimEnd() + '…'
+              : r.chunk.content;
+          sections.push(`#### ${heading}`);
+          sections.push(preview);
+          sections.push('');
+        }
+      } else {
+        sections.push('### Engineering Knowledge');
+        sections.push('_No engineering knowledge chunks indexed yet_');
+        sections.push('');
+      }
+    } catch (err) {
+      this.log.warn('Knowledge search (domain=engineering) failed:', err);
+      sections.push('### Engineering Knowledge');
+      sections.push('_Engineering knowledge unavailable_');
+      sections.push('');
+    }
+
+    return sections.join('\n');
+  }
 
   /** Format team health as a markdown bullet list */
   private getTeamHealthSummary(): string {

--- a/apps/server/src/services/calendar-service.ts
+++ b/apps/server/src/services/calendar-service.ts
@@ -36,8 +36,17 @@ export interface CalendarReminderPayload {
   event: CalendarEvent;
 }
 
-/** Document id used for the shared global calendar in the CRDT store */
-const CALENDAR_DOC_ID = 'shared';
+/**
+ * Derive a stable, project-scoped CRDT document ID from a projectPath.
+ * Replaces path separators with dashes and strips leading/trailing dashes.
+ * e.g. "/Users/kj/dev/automaker" → "Users-kj-dev-automaker"
+ */
+function calendarDocId(projectPath: string): string {
+  return projectPath
+    .replace(/\//g, '-')
+    .replace(/\\/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
 
 /**
  * Singleton service for managing calendar events
@@ -103,7 +112,7 @@ export class CalendarService {
       try {
         const handle = await this.crdtStore.getOrCreate<CalendarDocument>(
           'calendar',
-          CALENDAR_DOC_ID,
+          calendarDocId(projectPath),
           { events: {}, updatedAt: new Date().toISOString() }
         );
         const doc = handle.doc();
@@ -121,9 +130,9 @@ export class CalendarService {
   /**
    * Write a single event — to CRDT if available, otherwise rebuild filesystem.
    */
-  private async upsertEventToCrdt(event: CalendarEvent): Promise<void> {
+  private async upsertEventToCrdt(projectPath: string, event: CalendarEvent): Promise<void> {
     if (!this.crdtStore) return;
-    await this.crdtStore.change<CalendarDocument>('calendar', CALENDAR_DOC_ID, (doc) => {
+    await this.crdtStore.change<CalendarDocument>('calendar', calendarDocId(projectPath), (doc) => {
       if (!doc.events) {
         (doc as CalendarDocument).events = {};
       }
@@ -135,9 +144,9 @@ export class CalendarService {
   /**
    * Delete a single event from CRDT by id.
    */
-  private async deleteEventFromCrdt(id: string): Promise<void> {
+  private async deleteEventFromCrdt(projectPath: string, id: string): Promise<void> {
     if (!this.crdtStore) return;
-    await this.crdtStore.change<CalendarDocument>('calendar', CALENDAR_DOC_ID, (doc) => {
+    await this.crdtStore.change<CalendarDocument>('calendar', calendarDocId(projectPath), (doc) => {
       if (doc.events) {
         delete doc.events[id];
       }
@@ -301,7 +310,7 @@ export class CalendarService {
 
     if (this.crdtStore) {
       // Write through CRDT layer — syncs to all peers
-      await this.upsertEventToCrdt(event);
+      await this.upsertEventToCrdt(projectPath, event);
     } else {
       // Filesystem fallback
       const events = await this.readCalendarFile(projectPath);
@@ -337,7 +346,7 @@ export class CalendarService {
         updatedAt: new Date().toISOString(),
       };
 
-      await this.upsertEventToCrdt(updatedEvent);
+      await this.upsertEventToCrdt(projectPath, updatedEvent);
       logger.info(`Updated calendar event ${id}`);
       return updatedEvent;
     }
@@ -381,7 +390,7 @@ export class CalendarService {
         throw new Error(`Calendar event ${id} not found`);
       }
 
-      await this.deleteEventFromCrdt(id);
+      await this.deleteEventFromCrdt(projectPath, id);
       logger.info(`Deleted calendar event ${id}`);
       return;
     }
@@ -429,7 +438,7 @@ export class CalendarService {
           createdAt: existingEvent.createdAt,
           updatedAt: now,
         };
-        await this.upsertEventToCrdt(updated);
+        await this.upsertEventToCrdt(projectPath, updated);
         return { event: updated, created: false };
       }
 
@@ -442,7 +451,7 @@ export class CalendarService {
         createdAt: now,
         updatedAt: now,
       };
-      await this.upsertEventToCrdt(newEvent);
+      await this.upsertEventToCrdt(projectPath, newEvent);
       logger.info(`Created synced calendar event ${id} (sourceId: ${sourceId})`);
       return { event: newEvent, created: true };
     }
@@ -468,7 +477,7 @@ export class CalendarService {
     }
 
     // Create new event
-    const id = `google-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+    const id = `event-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
     const newEvent: CalendarEvent = {
       ...data,
       id,

--- a/apps/server/src/services/ceremony-service.ts
+++ b/apps/server/src/services/ceremony-service.ts
@@ -27,6 +27,7 @@ import type { CeremonyAuditLogService } from './ceremony-audit-service.js';
 import type { SchedulerService } from './scheduler-service.js';
 import { transition } from './ceremony-state-machine.js';
 import { projectArtifactService } from './project-artifact-service.js';
+import type { CalendarService } from './calendar-service.js';
 
 const logger = createLogger('CeremonyService');
 
@@ -138,6 +139,7 @@ export class CeremonyService {
   private projectService: ProjectService | null = null;
   private auditLog: CeremonyAuditLogService | null = null;
   private schedulerService: SchedulerService | null = null;
+  private calendarService: CalendarService | null = null;
   private unsubscribe: (() => void) | null = null;
 
   // Observability counters (same shape as old CeremonyBase.ceremonyCounts)
@@ -301,6 +303,10 @@ export class CeremonyService {
     this.schedulerService = schedulerService;
   }
 
+  setCalendarService(calendarService: CalendarService): void {
+    this.calendarService = calendarService;
+  }
+
   destroy(): void {
     if (this.unsubscribe) {
       this.unsubscribe();
@@ -405,6 +411,60 @@ export class CeremonyService {
   }
 
   // ---------------------------------------------------------------------------
+  // Calendar integration helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Upsert a 'ceremony' type CalendarEvent for a given project.
+   * Uses projectSlug as the stable sourceId for deduplication.
+   */
+  private async upsertCeremonyCalendarEvent(
+    projectPath: string,
+    projectSlug: string,
+    projectTitle: string
+  ): Promise<void> {
+    if (!this.calendarService) return;
+    const sourceId = `ceremony:${projectSlug}`;
+    try {
+      await this.calendarService.upsertBySourceId(projectPath, sourceId, {
+        title: `Ceremonies: ${projectTitle}`,
+        date: new Date().toISOString().slice(0, 10),
+        type: 'ceremony',
+        description: `Recurring standup and retro ceremonies for project ${projectTitle}`,
+      });
+      logger.debug(`Upserted ceremony calendar event for ${projectSlug}`);
+    } catch (err) {
+      logger.warn(
+        `Failed to upsert ceremony calendar event for ${projectSlug}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  /**
+   * Delete the 'ceremony' type CalendarEvent for a given project.
+   * Looks up the event by sourceId and deletes it.
+   */
+  private async deleteCeremonyCalendarEvent(
+    projectPath: string,
+    projectSlug: string
+  ): Promise<void> {
+    if (!this.calendarService) return;
+    const sourceId = `ceremony:${projectSlug}`;
+    try {
+      const events = await this.calendarService.listEvents(projectPath, { types: ['ceremony'] });
+      const event = events.find((e) => e.sourceId === sourceId);
+      if (event) {
+        await this.calendarService.deleteEvent(projectPath, event.id);
+        logger.debug(`Deleted ceremony calendar event for ${projectSlug}`);
+      }
+    } catch (err) {
+      logger.warn(
+        `Failed to delete ceremony calendar event for ${projectSlug}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // Private event handlers — delegate to LangGraph flows
   // ---------------------------------------------------------------------------
 
@@ -427,6 +487,9 @@ export class CeremonyService {
 
     // Transition state machine: awaiting_kickoff → milestone_active
     await this.applyTransition(projectPath, projectSlug, 'project:lifecycle:launched', payload);
+
+    // Upsert a ceremony calendar event so ceremonies appear in the calendar UI
+    await this.upsertCeremonyCalendarEvent(projectPath, projectSlug, projectSlug);
 
     // Register standup scheduler task
     if (this.schedulerService) {
@@ -779,6 +842,9 @@ export class CeremonyService {
         logger.info(`Unregistered standup task ${taskId} on project completion`);
       }
     }
+
+    // Remove the ceremony calendar event now that the project is complete
+    await this.deleteCeremonyCalendarEvent(projectPath, projectSlug);
 
     const dedupeKey = `${projectPath}:${projectSlug}`;
     if (this.processedProjects.has(dedupeKey)) {

--- a/apps/server/src/services/ceremony.module.ts
+++ b/apps/server/src/services/ceremony.module.ts
@@ -4,10 +4,12 @@ import { ceremonyActionExecutor } from './ceremony-action-executor.js';
 /**
  * Wires CeremonyService cross-service dependencies.
  * Passes schedulerService so CeremonyService can register/unregister standup tasks.
+ * Passes calendarService so CeremonyService can upsert/delete ceremony calendar events.
  * Initializes CeremonyActionExecutor to process retro completion events.
  */
 export function register(container: ServiceContainer): void {
-  const { ceremonyService, schedulerService, events, featureLoader } = container;
+  const { ceremonyService, schedulerService, calendarService, events, featureLoader } = container;
   ceremonyService.setSchedulerService(schedulerService);
+  ceremonyService.setCalendarService(calendarService);
   ceremonyActionExecutor.initialize(events, featureLoader);
 }

--- a/apps/server/src/services/google-calendar-sync-service.ts
+++ b/apps/server/src/services/google-calendar-sync-service.ts
@@ -191,21 +191,71 @@ export class GoogleCalendarSyncService {
    * Fetches events for a 90-day window (30 days back, 60 days forward) and
    * upserts them as 'google' type CalendarEvent records keyed by sourceId.
    *
-   * Returns the count of events synced (created + updated).
+   * Also deletes local Google events that have been cancelled upstream or are
+   * no longer present in the sync window (stale events deleted from Google).
+   *
+   * Returns the count of events synced (created + updated) and deleted.
    */
-  async syncFromGoogle(projectPath: string): Promise<{ synced: number; created: number }> {
+  async syncFromGoogle(
+    projectPath: string
+  ): Promise<{ synced: number; created: number; deleted: number }> {
     const now = new Date();
-    const timeMin = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
-    const timeMax = new Date(now.getTime() + 60 * 24 * 60 * 60 * 1000).toISOString();
+    const timeMinDate = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+    const timeMaxDate = new Date(now.getTime() + 60 * 24 * 60 * 60 * 1000);
+    const timeMin = timeMinDate.toISOString();
+    const timeMax = timeMaxDate.toISOString();
+    const windowStart = timeMin.substring(0, 10);
+    const windowEnd = timeMax.substring(0, 10);
 
     logger.info('Starting Google Calendar sync', { projectPath, timeMin, timeMax });
 
     const googleEvents = await this.listGoogleEvents(projectPath, timeMin, timeMax);
+
+    // Build sets of all Google sourceIds and cancelled sourceIds from this sync response
+    const allGoogleSourceIds = new Set<string>(googleEvents.map((e) => e.id));
+    const cancelledSourceIds = new Set<string>(
+      googleEvents.filter((e) => e.status === 'cancelled').map((e) => e.id)
+    );
+
+    // Read all existing local Google events to detect stale / cancelled ones
+    const localGoogleEvents = await this.calendarService.listEvents(projectPath, {
+      types: ['google'],
+    });
+
     let synced = 0;
     let created = 0;
+    let deleted = 0;
 
+    // Delete local events that have been cancelled or are absent from the sync window
+    for (const localEvent of localGoogleEvents) {
+      if (!localEvent.sourceId) continue;
+
+      const isCancelled = cancelledSourceIds.has(localEvent.sourceId);
+      const isWithinWindow = localEvent.date >= windowStart && localEvent.date <= windowEnd;
+      const isAbsent = !allGoogleSourceIds.has(localEvent.sourceId);
+
+      if (isCancelled || (isWithinWindow && isAbsent)) {
+        try {
+          await this.calendarService.deleteEvent(projectPath, localEvent.id);
+          deleted++;
+          logger.info('Deleted stale/cancelled Google Calendar event', {
+            id: localEvent.id,
+            sourceId: localEvent.sourceId,
+            reason: isCancelled ? 'cancelled' : 'absent-from-sync',
+          });
+        } catch (err) {
+          logger.warn('Failed to delete stale Google Calendar event', {
+            id: localEvent.id,
+            sourceId: localEvent.sourceId,
+            err,
+          });
+        }
+      }
+    }
+
+    // Upsert active (non-cancelled) events
     for (const gEvent of googleEvents) {
-      // Skip cancelled events
+      // Skip cancelled events — already handled above
       if (gEvent.status === 'cancelled') {
         continue;
       }
@@ -251,8 +301,9 @@ export class GoogleCalendarSyncService {
       synced,
       created,
       updated: synced - created,
+      deleted,
     });
 
-    return { synced, created };
+    return { synced, created, deleted };
   }
 }

--- a/apps/server/src/services/job-executor-service.ts
+++ b/apps/server/src/services/job-executor-service.ts
@@ -20,6 +20,53 @@ const logger = createLogger('JobExecutorService');
 /** Maximum command execution time: 5 minutes */
 const COMMAND_TIMEOUT_MS = 300_000;
 
+/** Maximum allowed command length in characters */
+const MAX_COMMAND_LENGTH = 1024;
+
+/**
+ * Regex that detects unescaped shell metacharacters.
+ * Matched characters: ; | > < $ ` and the two-character sequences && and ||
+ * A preceding backslash (e.g. \; or \$) exempts the character from rejection.
+ */
+const SHELL_METACHAR_RE = /(?<!\\)[;|><$`]|(?<!\\)&&/;
+
+/**
+ * Validate and sanitize a shell command before execution.
+ *
+ * Rules enforced:
+ * - Must not exceed MAX_COMMAND_LENGTH (1024) characters
+ * - Must not contain unescaped shell metacharacters: ; && || | > < $ `
+ *
+ * Exported as a pure function so it can be unit-tested in isolation.
+ *
+ * @param command Raw command string supplied by the job action
+ * @returns The same command string if it passes all checks
+ * @throws Error with a descriptive message when the command is invalid
+ *
+ * @example
+ *   sanitizeCommand('npm run build')          // OK — returns the command
+ *   sanitizeCommand('npm run build; rm -rf /') // throws — unescaped ;
+ *   sanitizeCommand('echo $HOME')              // throws — unescaped $
+ */
+export function sanitizeCommand(command: string): string {
+  if (command.length > MAX_COMMAND_LENGTH) {
+    throw new Error(
+      `Command exceeds maximum length of ${MAX_COMMAND_LENGTH} characters (got ${command.length})`
+    );
+  }
+
+  if (SHELL_METACHAR_RE.test(command)) {
+    throw new Error(
+      `Command contains unescaped shell metacharacters. ` +
+        `Only simple single commands are allowed (e.g. "npm run build"). ` +
+        `Disallowed characters: ; && || | > < $ \`. ` +
+        `Escape special characters with a backslash if they are required literally.`
+    );
+  }
+
+  return command;
+}
+
 export class JobExecutorService {
   constructor(
     private calendarService: CalendarService,
@@ -78,6 +125,12 @@ export class JobExecutorService {
       jobStatus: 'running',
     });
 
+    this.calendarService.emitReminder({
+      title: job.title,
+      description: job.description ?? `Job started: ${job.title}`,
+      event: job,
+    });
+
     this.events.emit('job:started', {
       jobId: job.id,
       projectPath,
@@ -93,6 +146,12 @@ export class JobExecutorService {
       await this.calendarService.updateEvent(projectPath, job.id, {
         jobStatus: 'completed',
         jobResult: { startedAt, completedAt, durationMs },
+      });
+
+      this.calendarService.emitReminder({
+        title: job.title,
+        description: `Job completed: ${job.title}`,
+        event: job,
       });
 
       this.events.emit('job:completed', {
@@ -111,6 +170,12 @@ export class JobExecutorService {
       await this.calendarService.updateEvent(projectPath, job.id, {
         jobStatus: 'failed',
         jobResult: { startedAt, completedAt, durationMs, error: errorMessage },
+      });
+
+      this.calendarService.emitReminder({
+        title: job.title,
+        description: `Job failed: ${job.title} — ${errorMessage}`,
+        event: job,
       });
 
       this.events.emit('job:failed', {
@@ -150,10 +215,16 @@ export class JobExecutorService {
 
   /**
    * Execute a shell command with a timeout.
+   * The command is validated and sanitized via {@link sanitizeCommand} before
+   * being passed to exec — unescaped shell metacharacters and commands exceeding
+   * the length limit are rejected with an error.
    */
   private executeCommand(command: string, cwd?: string): Promise<void> {
+    const sanitized = sanitizeCommand(command);
+    logger.info(`Executing sanitized command: ${sanitized}`);
+
     return new Promise((resolve, reject) => {
-      exec(command, { cwd, timeout: COMMAND_TIMEOUT_MS }, (error, stdout, stderr) => {
+      exec(sanitized, { cwd, timeout: COMMAND_TIMEOUT_MS }, (error, stdout, stderr) => {
         if (error) {
           const msg = stderr?.trim() || error.message;
           reject(new Error(`Command failed: ${msg}`));

--- a/apps/server/src/services/knowledge-ingestion-service.ts
+++ b/apps/server/src/services/knowledge-ingestion-service.ts
@@ -3,6 +3,7 @@
  *
  * Handles file ingestion operations for the knowledge store:
  * - File ingestion (reflections, agent outputs)
+ * - Project state change indexing (milestones, ceremonies, timelines)
  * - Category compaction
  */
 
@@ -11,6 +12,7 @@ import * as fs from 'node:fs';
 import * as BetterSqlite3 from 'better-sqlite3';
 import Anthropic from '@anthropic-ai/sdk';
 import { createLogger } from '@protolabsai/utils';
+import type { PMWorldState } from '@protolabsai/types';
 import { KnowledgeEmbeddingOrchestrator } from './knowledge-embedding-orchestrator.js';
 
 const logger = createLogger('KnowledgeIngestionService');
@@ -419,6 +421,145 @@ Output the compressed memory file:`;
     if (indexedCount > 0) {
       this.rebuildIndex(db, projectPath);
       logger.info(`Indexed ${indexedCount} completion learnings for feature ${featureId}`);
+    }
+
+    return indexedCount;
+  }
+
+  /**
+   * Ingest PM project state changes into the knowledge store with domain='project'.
+   *
+   * Creates or updates four snapshot chunks:
+   * - project-overview-snapshot: high-level project status
+   * - project-milestones-snapshot: milestone completion progress
+   * - project-ceremonies-snapshot: upcoming ceremony dates
+   * - project-timeline-snapshot: upcoming deadline entries
+   *
+   * All chunks are tagged with ['project', ...] so they are retrievable
+   * via domain='project' queries.
+   *
+   * @param db - Database instance
+   * @param projectPath - Project path (used as source_file prefix)
+   * @param state - Current PMWorldState snapshot
+   * @returns Number of chunks indexed (0–4)
+   */
+  async ingestProjectStateChanges(
+    db: BetterSqlite3.Database,
+    projectPath: string,
+    state: PMWorldState
+  ): Promise<number> {
+    const timestamp = new Date().toISOString();
+    let indexedCount = 0;
+
+    // ── 1. Project Overview ──────────────────────────────────────────
+    const projectEntries = Object.entries(state.projects);
+    if (projectEntries.length > 0) {
+      const lines: string[] = [`# Project Overview`, `_Updated: ${state.updatedAt}_`, ''];
+      for (const [slug, p] of projectEntries) {
+        lines.push(
+          `- **${slug}**: ${p.status} / ${p.phase} (${p.completedMilestones}/${p.milestoneCount} milestones)`
+        );
+      }
+      this.upsertChunk(db, {
+        chunkId: 'project-overview-snapshot',
+        sourceType: 'reflection',
+        sourceFile: '.automaker/projects/overview',
+        projectPath,
+        heading: 'Project Overview',
+        content: lines.join('\n'),
+        tags: JSON.stringify(['project', 'overview']),
+        importance: 0.8,
+        timestamp,
+      });
+      indexedCount++;
+    }
+
+    // ── 2. Milestone Progress ─────────────────────────────────────────
+    const milestoneEntries = Object.entries(state.milestones);
+    if (milestoneEntries.length > 0) {
+      const lines: string[] = [`# Milestone Progress`, `_Updated: ${state.updatedAt}_`, ''];
+      for (const [slug, ms] of milestoneEntries) {
+        const pct =
+          ms.totalPhases > 0 ? Math.round((ms.completedPhases / ms.totalPhases) * 100) : 0;
+        const due = ms.dueAt ? ` (due ${ms.dueAt.slice(0, 10)})` : '';
+        const status = ms.completedPhases === ms.totalPhases && ms.totalPhases > 0 ? ' ✅' : '';
+        lines.push(
+          `- **${ms.title}** \`${slug}\`: ${ms.completedPhases}/${ms.totalPhases} phases (${pct}%)${due}${status}`
+        );
+      }
+      this.upsertChunk(db, {
+        chunkId: 'project-milestones-snapshot',
+        sourceType: 'reflection',
+        sourceFile: '.automaker/projects/milestones',
+        projectPath,
+        heading: 'Milestone Progress',
+        content: lines.join('\n'),
+        tags: JSON.stringify(['project', 'milestone']),
+        importance: 0.85,
+        timestamp,
+      });
+      indexedCount++;
+    }
+
+    // ── 3. Upcoming Ceremonies ────────────────────────────────────────
+    const ceremonyEntries = Object.entries(state.ceremonies);
+    if (ceremonyEntries.length > 0) {
+      const lines: string[] = [`# Upcoming Ceremonies`, `_Updated: ${state.updatedAt}_`, ''];
+      const now = new Date().toISOString();
+      const upcoming = ceremonyEntries
+        .filter(([, iso]) => iso >= now)
+        .sort(([, a], [, b]) => a.localeCompare(b));
+      if (upcoming.length === 0) {
+        lines.push('_No upcoming ceremonies_');
+      } else {
+        for (const [type, iso] of upcoming) {
+          lines.push(`- **${type}**: ${iso.slice(0, 10)}`);
+        }
+      }
+      this.upsertChunk(db, {
+        chunkId: 'project-ceremonies-snapshot',
+        sourceType: 'reflection',
+        sourceFile: '.automaker/ceremony-state.json',
+        projectPath,
+        heading: 'Upcoming Ceremonies',
+        content: lines.join('\n'),
+        tags: JSON.stringify(['project', 'ceremony']),
+        importance: 0.7,
+        timestamp,
+      });
+      indexedCount++;
+    }
+
+    // ── 4. Timeline Deadlines ─────────────────────────────────────────
+    if (state.upcomingDeadlines.length > 0) {
+      const now = new Date().toISOString();
+      const future = state.upcomingDeadlines
+        .filter((d) => d.dueAt >= now)
+        .sort((a, b) => a.dueAt.localeCompare(b.dueAt));
+
+      if (future.length > 0) {
+        const lines: string[] = [`# Timeline Deadlines`, `_Updated: ${state.updatedAt}_`, ''];
+        for (const d of future.slice(0, 20)) {
+          lines.push(`- ${d.dueAt.slice(0, 10)} — **${d.label}** _(${d.projectSlug})_`);
+        }
+        this.upsertChunk(db, {
+          chunkId: 'project-timeline-snapshot',
+          sourceType: 'reflection',
+          sourceFile: '.automaker/timeline.json',
+          projectPath,
+          heading: 'Timeline Deadlines',
+          content: lines.join('\n'),
+          tags: JSON.stringify(['project', 'timeline']),
+          importance: 0.75,
+          timestamp,
+        });
+        indexedCount++;
+      }
+    }
+
+    if (indexedCount > 0) {
+      this.rebuildIndex(db, projectPath);
+      logger.info(`Indexed ${indexedCount} project state chunks for ${projectPath}`);
     }
 
     return indexedCount;

--- a/apps/server/src/services/knowledge-store-service.ts
+++ b/apps/server/src/services/knowledge-store-service.ts
@@ -7,6 +7,7 @@
 
 import * as path from 'node:path';
 import * as fs from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import * as BetterSqlite3 from 'better-sqlite3';
 import { createLogger } from '@protolabsai/utils';
 import type {
@@ -504,8 +505,35 @@ export class KnowledgeStoreService {
       this.initialize(projectPath);
     }
 
+    // Input validation
+    if (!domain || typeof domain !== 'string' || domain.trim().length === 0) {
+      throw new Error('Invalid domain: must be a non-empty string');
+    }
+    if (domain.length > 256) {
+      throw new Error('Invalid domain: must not exceed 256 characters');
+    }
+
+    if (!content || typeof content !== 'string' || content.trim().length === 0) {
+      throw new Error('Invalid content: must be a non-empty string');
+    }
+    const MAX_CONTENT_LENGTH = 100_000;
+    if (content.length > MAX_CONTENT_LENGTH) {
+      throw new Error(
+        `Invalid content: exceeds maximum length of ${MAX_CONTENT_LENGTH} characters`
+      );
+    }
+
+    if (heading !== undefined && heading !== null) {
+      if (typeof heading !== 'string' || heading.trim().length === 0) {
+        throw new Error('Invalid heading: must be a non-empty string if provided');
+      }
+      if (heading.length > 512) {
+        throw new Error('Invalid heading: must not exceed 512 characters');
+      }
+    }
+
     const timestamp = new Date().toISOString();
-    const chunkId = `manual-${domain}-${Date.now()}`;
+    const chunkId = `manual-${domain}-${randomUUID()}`;
     const tags = JSON.stringify([domain]);
 
     this.db

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -57,6 +57,41 @@ export type { FeatureProcessingState, StateContext };
 export type { ProcessorServiceContext } from './lead-engineer-types.js';
 export { FeatureStateMachine } from './lead-engineer-state-machine.js';
 
+// ────────────────────────── Bidirectional Integration Types ──────────────────────────
+
+/**
+ * Execution status summary that LE exposes to the PM layer.
+ * Defined here so LeadEngineerService can produce it without importing from PM.
+ */
+export interface LEExecutionStatusSummary {
+  activeProjectCount: number;
+  activeFeaturesCount: number;
+  projectStatuses: Array<{
+    projectPath: string;
+    projectSlug: string;
+    flowState: string;
+  }>;
+}
+
+/**
+ * Next assignable phase as returned by the PM layer.
+ * Defined here so LeadEngineerService can consume it without importing from PM.
+ */
+export interface PMNextAssignablePhase {
+  milestoneSlug: string;
+  milestoneTitle: string;
+  remainingPhases: number;
+  dueAt?: string;
+}
+
+/**
+ * Interface the PM layer must implement to provide next-phase data to LE.
+ * Injected via setPMWorldStateProvider() to avoid circular dependencies.
+ */
+export interface IPMWorldStateProvider {
+  getNextAssignablePhase(): PMNextAssignablePhase | null;
+}
+
 const execAsync = promisify(exec);
 const logger = createLogger('LeadEngineerService');
 const WORLD_STATE_REFRESH_MS = 5 * 60 * 1000;
@@ -91,6 +126,7 @@ export class LeadEngineerService {
 
   private worldStateBuilder: WorldStateBuilder;
   private sessionStore: LeadEngineerSessionStore;
+  private pmWorldStateProvider?: IPMWorldStateProvider;
 
   constructor(
     private events: EventEmitter,
@@ -146,6 +182,41 @@ export class LeadEngineerService {
   }
   setAuthorityService(s: AuthorityService): void {
     this.authorityService = s;
+  }
+
+  // ────────────────────────── Bidirectional Integration ──────────────────────────
+
+  /**
+   * Inject a PM world-state provider so LE can query PM for next-phase assignments.
+   * Use this pattern (vs. direct import) to avoid circular module dependencies.
+   */
+  setPMWorldStateProvider(provider: IPMWorldStateProvider): void {
+    this.pmWorldStateProvider = provider;
+  }
+
+  /**
+   * Query the PM layer for the next phase LE should work on.
+   * Returns null when no provider has been injected or PM has no pending phases.
+   */
+  queryPMNextAssignment(): PMNextAssignablePhase | null {
+    return this.pmWorldStateProvider?.getNextAssignablePhase() ?? null;
+  }
+
+  /**
+   * Return a concise snapshot of LE's current execution state.
+   * Called by the PM layer via ILeadEngineerStatusProvider.
+   */
+  getExecutionStatusSummary(): LEExecutionStatusSummary {
+    const sessions = this.getAllSessions();
+    return {
+      activeProjectCount: sessions.filter((s) => s.flowState === 'running').length,
+      activeFeaturesCount: this.activeFeatures.size,
+      projectStatuses: sessions.map((s) => ({
+        projectPath: s.projectPath,
+        projectSlug: s.projectSlug,
+        flowState: s.flowState,
+      })),
+    };
   }
 
   /**

--- a/apps/server/src/services/pm-world-state-builder.ts
+++ b/apps/server/src/services/pm-world-state-builder.ts
@@ -16,9 +16,62 @@ const logger = createLogger('PMWorldStateBuilder');
 
 const REFRESH_INTERVAL_MS = 60_000;
 
+/**
+ * Minimal interface for knowledge ingestion of PM project state.
+ * Implemented by any service that can persist PM state changes to the knowledge store.
+ */
+export interface PMKnowledgeIngestor {
+  ingestProjectStateChanges(projectPath: string, state: PMWorldState): Promise<number>;
+}
+
 export interface PMWorldStateBuilderConfig {
   /** Root directory to scan for project files (.automaker/projects/) */
   projectRoot?: string;
+  /**
+   * Optional knowledge ingestor for indexing PM state changes with domain='project'.
+   * When provided, state changes are written to the knowledge store on every refresh.
+   */
+  knowledgeIngestor?: PMKnowledgeIngestor;
+  /**
+   * Project path passed to the knowledge ingestor.
+   * Defaults to projectRoot if not set.
+   */
+  knowledgeProjectPath?: string;
+}
+
+// ────────────────────────── Bidirectional Integration Types ──────────────────────────
+
+/**
+ * Execution status summary returned by the Lead Engineer layer.
+ * Defined here so PMWorldStateBuilder can consume it without importing from LE.
+ */
+export interface LEExecutionStatusSummary {
+  activeProjectCount: number;
+  activeFeaturesCount: number;
+  projectStatuses: Array<{
+    projectPath: string;
+    projectSlug: string;
+    flowState: string;
+  }>;
+}
+
+/**
+ * Interface the Lead Engineer layer must implement to provide execution status to PM.
+ * Injected via setLeadEngineerStatusProvider() to avoid circular dependencies.
+ */
+export interface ILeadEngineerStatusProvider {
+  getExecutionStatusSummary(): LEExecutionStatusSummary;
+}
+
+/**
+ * Next assignable phase as determined by the PM layer.
+ * Returned by getNextAssignablePhase() for LE to consume.
+ */
+export interface PMNextAssignablePhase {
+  milestoneSlug: string;
+  milestoneTitle: string;
+  remainingPhases: number;
+  dueAt?: string;
 }
 
 /**
@@ -28,9 +81,14 @@ export class PMWorldStateBuilder {
   private state: PMWorldState;
   private refreshTimer: NodeJS.Timeout | null = null;
   private readonly projectRoot: string;
+  private readonly knowledgeIngestor: PMKnowledgeIngestor | undefined;
+  private readonly knowledgeProjectPath: string;
+  private leStatusProvider?: ILeadEngineerStatusProvider;
 
   constructor(config: PMWorldStateBuilderConfig = {}) {
     this.projectRoot = config.projectRoot ?? process.cwd();
+    this.knowledgeIngestor = config.knowledgeIngestor;
+    this.knowledgeProjectPath = config.knowledgeProjectPath ?? this.projectRoot;
     this.state = this.emptyState();
   }
 
@@ -138,11 +196,52 @@ export class PMWorldStateBuilder {
     return lines.join('\n');
   }
 
+  // ────────────────────────── Bidirectional Integration ──────────────────────────
+
+  /**
+   * Inject a Lead Engineer status provider so PM can query LE execution state.
+   * Use this pattern (vs. direct import) to avoid circular module dependencies.
+   */
+  setLeadEngineerStatusProvider(provider: ILeadEngineerStatusProvider): void {
+    this.leStatusProvider = provider;
+  }
+
+  /**
+   * Query the Lead Engineer layer for current execution status.
+   * Returns null when no provider has been injected.
+   */
+  queryLEExecutionStatus(): LEExecutionStatusSummary | null {
+    return this.leStatusProvider?.getExecutionStatusSummary() ?? null;
+  }
+
+  /**
+   * Return the first milestone with remaining (incomplete) phases.
+   * Called by the Lead Engineer layer to discover what PM considers next-up.
+   * Returns null when all milestones are complete or no milestones exist.
+   */
+  getNextAssignablePhase(): PMNextAssignablePhase | null {
+    for (const [slug, ms] of Object.entries(this.state.milestones)) {
+      const remaining = ms.totalPhases - ms.completedPhases;
+      if (remaining > 0) {
+        return {
+          milestoneSlug: slug,
+          milestoneTitle: ms.title,
+          remainingPhases: remaining,
+          dueAt: ms.dueAt,
+        };
+      }
+    }
+    return null;
+  }
+
   // ────────────────────────── State Building ──────────────────────────
 
   /**
    * Read project data from disk and rebuild the PMWorldState.
    * Gracefully handles missing directories or malformed files.
+   *
+   * After a successful refresh, indexes the new state into the knowledge store
+   * (if a knowledgeIngestor was provided) with domain='project'.
    */
   async buildState(): Promise<void> {
     try {
@@ -156,6 +255,19 @@ export class PMWorldStateBuilder {
       this.state = next;
 
       logger.debug(`PMWorldState refreshed — ${Object.keys(next.projects).length} projects`);
+
+      // Index PM state changes into the knowledge store (domain='project')
+      if (this.knowledgeIngestor) {
+        try {
+          const count = await this.knowledgeIngestor.ingestProjectStateChanges(
+            this.knowledgeProjectPath,
+            next
+          );
+          logger.debug(`PM knowledge ingestion complete: ${count} chunks indexed`);
+        } catch (err) {
+          logger.warn('PM knowledge ingestion failed (non-fatal):', err);
+        }
+      }
     } catch (err) {
       logger.warn('PMWorldStateBuilder.buildState() failed, retaining previous state:', err);
     }

--- a/apps/server/src/services/scheduler.module.ts
+++ b/apps/server/src/services/scheduler.module.ts
@@ -48,6 +48,40 @@ export function register(container: ServiceContainer): void {
         true
       );
 
+      // Register periodic Google Calendar sync — runs every 6 hours for all connected projects
+      await schedulerService.registerTask(
+        'google-calendar:sync',
+        'Google Calendar Sync',
+        '0 */6 * * *',
+        async () => {
+          const globalSettings = await settingsService.getGlobalSettings();
+          const projects = globalSettings.projects ?? [];
+
+          for (const project of projects) {
+            const projectSettings = await settingsService.getProjectSettings(project.path);
+            const google = projectSettings.integrations?.google;
+
+            if (!google?.accessToken || !google?.refreshToken) {
+              continue; // Google Calendar not connected for this project
+            }
+
+            try {
+              const result = await container.googleCalendarSyncService.syncFromGoogle(project.path);
+              logger.info('Scheduled Google Calendar sync complete', {
+                projectPath: project.path,
+                ...result,
+              });
+            } catch (err) {
+              logger.error('Scheduled Google Calendar sync failed', {
+                projectPath: project.path,
+                err,
+              });
+            }
+          }
+        },
+        true
+      );
+
       // Apply taskOverrides from global settings after all tasks are registered
       await schedulerService.applySettingsOverrides();
     })

--- a/apps/server/tests/integration/ava-pm-le-flow.test.ts
+++ b/apps/server/tests/integration/ava-pm-le-flow.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Ava → PM → LE Integration Flow Test
+ *
+ * Verifies the full wiring: user asks Ava → PM subagent assembles project status
+ * → PM queries LE execution state via service call → distilled answer returned.
+ *
+ * Uses inline mocks for PM and LE services — no disk I/O, no LLM calls.
+ *
+ * Scenarios covered:
+ *   1. Happy path: both PM and LE return data → distilled summary contains both layers
+ *   2. PM unavailable: PM throws → answer uses fallback text, LE still surfaces
+ *   3. LE unavailable: LE throws → answer uses fallback text, PM still surfaces
+ *   4. AvaWorldStateBuilder.getFullBriefing() aggregates PM + LE layers
+ *   5. buildLayeredBriefing() wraps AvaWorldStateBuilder result
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PMProjectQueryService } from '@/services/ava-tools.js';
+import { AvaWorldStateBuilder } from '@/services/ava-world-state-builder.js';
+import { buildLayeredBriefing } from '../../../../packages/mcp-server/plugins/automaker/tools/briefing.js';
+import type { PMWorldStateBuilder } from '@/services/pm-world-state-builder.js';
+import type { LeadEngineerWorldStateProvider } from '@/services/ava-world-state-builder.js';
+import type { BriefingWorldStateProvider } from '../../../../packages/mcp-server/plugins/automaker/tools/briefing.js';
+import type { PMWorldState } from '@protolabsai/types';
+import { WorldStateDomain } from '@protolabsai/types';
+
+// ─── Shared test fixtures ─────────────────────────────────────────────────────
+
+const PM_SUMMARY =
+  '_Last refreshed: 2026-01-01T00:00:00.000Z_\n\n## Project Status\n- **automaker**: active / production (3/5 milestones)\n\n## Milestone Progress\n- **Integration Wiring** `integration-wiring`: 2/4 phases (50%)\n\n## Upcoming Items\n- 2026-03-15 — Demo _(automaker)_';
+
+const LE_SUMMARY =
+  '**Engineering Execution**\n- Active projects: 1\n- Active features: 2\n- automaker: production / features in progress';
+
+function makePMBuilder(override?: Partial<PMWorldStateBuilder>): PMWorldStateBuilder {
+  const pmState: PMWorldState = {
+    domain: WorldStateDomain.ProjectManagement,
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    projects: {
+      automaker: {
+        slug: 'automaker',
+        title: 'Automaker',
+        status: 'active',
+        phase: 'production',
+        milestoneCount: 5,
+        completedMilestones: 3,
+      },
+    },
+    milestones: {
+      'integration-wiring': {
+        slug: 'integration-wiring',
+        title: 'Integration Wiring',
+        projectSlug: 'automaker',
+        totalPhases: 4,
+        completedPhases: 2,
+      },
+    },
+    upcomingDeadlines: [
+      { dueAt: '2026-03-15T00:00:00.000Z', label: 'Demo', projectSlug: 'automaker' },
+    ],
+    ceremonies: {},
+  };
+
+  return {
+    getDistilledSummary: () => PM_SUMMARY,
+    getState: () => pmState,
+    ...override,
+  } as unknown as PMWorldStateBuilder;
+}
+
+function makeLEProvider(
+  override?: Partial<LeadEngineerWorldStateProvider>
+): LeadEngineerWorldStateProvider {
+  return {
+    getWorldStateSummary: () => LE_SUMMARY,
+    ...override,
+  };
+}
+
+// ─── 1. PMProjectQueryService ─────────────────────────────────────────────────
+
+describe('PMProjectQueryService (Ava → PM → LE chain)', () => {
+  it('happy path: returns distilled summary with PM and LE layers', async () => {
+    const pm = makePMBuilder();
+    const le = makeLEProvider();
+    const svc = new PMProjectQueryService(pm, le);
+
+    const result = await svc.queryProjectStatus();
+
+    expect(result.pmSummary).toBe(PM_SUMMARY);
+    expect(result.leSummary).toBe(LE_SUMMARY);
+    expect(result.summary).toContain('## Project Status');
+    expect(result.summary).toContain('### PM Layer');
+    expect(result.summary).toContain('### LE Layer');
+    expect(result.summary).toContain(PM_SUMMARY);
+    expect(result.summary).toContain(LE_SUMMARY);
+    expect(result.generatedAt).toBeTruthy();
+  });
+
+  it('PM unavailable: returns fallback text for PM, still surfaces LE', async () => {
+    const pm = makePMBuilder({
+      getDistilledSummary: () => {
+        throw new Error('PM service down');
+      },
+    });
+    const le = makeLEProvider();
+    const svc = new PMProjectQueryService(pm, le);
+
+    const result = await svc.queryProjectStatus();
+
+    expect(result.pmSummary).toContain('unavailable');
+    expect(result.leSummary).toBe(LE_SUMMARY);
+    expect(result.summary).toContain('### LE Layer');
+    expect(result.summary).toContain(LE_SUMMARY);
+  });
+
+  it('LE unavailable: returns fallback text for LE, still surfaces PM', async () => {
+    const pm = makePMBuilder();
+    const le = makeLEProvider({
+      getWorldStateSummary: () => {
+        throw new Error('LE service down');
+      },
+    });
+    const svc = new PMProjectQueryService(pm, le);
+
+    const result = await svc.queryProjectStatus();
+
+    expect(result.pmSummary).toBe(PM_SUMMARY);
+    expect(result.leSummary).toContain('unavailable');
+    expect(result.summary).toContain('### PM Layer');
+    expect(result.summary).toContain(PM_SUMMARY);
+  });
+
+  it('generates a generatedAt ISO timestamp', async () => {
+    const svc = new PMProjectQueryService(makePMBuilder(), makeLEProvider());
+    const result = await svc.queryProjectStatus();
+
+    expect(() => new Date(result.generatedAt)).not.toThrow();
+    expect(new Date(result.generatedAt).toISOString()).toBe(result.generatedAt);
+  });
+});
+
+// ─── 2. AvaWorldStateBuilder ──────────────────────────────────────────────────
+
+describe('AvaWorldStateBuilder.getFullBriefing() (three-layer aggregation)', () => {
+  it('aggregates PM and LE summaries into a full briefing', async () => {
+    const pm = makePMBuilder();
+    const le = makeLEProvider();
+    const builder = new AvaWorldStateBuilder(pm, le);
+
+    const briefing = await builder.getFullBriefing();
+
+    expect(briefing).toContain('# Ava Full Briefing');
+    expect(briefing).toContain('## Project Management Layer');
+    expect(briefing).toContain(PM_SUMMARY);
+    expect(briefing).toContain('## Engineering Layer');
+    expect(briefing).toContain(LE_SUMMARY);
+    expect(briefing).toContain('## Strategic Context');
+  });
+
+  it('handles PM failure gracefully in full briefing', async () => {
+    const pm = makePMBuilder({
+      getDistilledSummary: () => {
+        throw new Error('PM down');
+      },
+    });
+    const le = makeLEProvider();
+    const builder = new AvaWorldStateBuilder(pm, le);
+
+    const briefing = await builder.getFullBriefing();
+
+    expect(briefing).toContain('PM summary unavailable');
+    expect(briefing).toContain(LE_SUMMARY);
+  });
+
+  it('handles LE failure gracefully in full briefing', async () => {
+    const pm = makePMBuilder();
+    const le = makeLEProvider({
+      getWorldStateSummary: () => {
+        throw new Error('LE down');
+      },
+    });
+    const builder = new AvaWorldStateBuilder(pm, le);
+
+    const briefing = await builder.getFullBriefing();
+
+    expect(briefing).toContain(PM_SUMMARY);
+    expect(briefing).toContain('Engineering summary unavailable');
+  });
+});
+
+// ─── 3. buildLayeredBriefing (MCP briefing tool integration) ─────────────────
+
+describe('buildLayeredBriefing() (/briefing returns layered world state)', () => {
+  it('returns layered briefing markdown from world state provider', async () => {
+    const pm = makePMBuilder();
+    const le = makeLEProvider();
+    const avaBuilder = new AvaWorldStateBuilder(pm, le);
+
+    const provider: BriefingWorldStateProvider = {
+      getFullBriefing: () => avaBuilder.getFullBriefing(),
+    };
+
+    const result = await buildLayeredBriefing(provider);
+
+    expect(result.markdown).toContain('# Ava Full Briefing');
+    expect(result.markdown).toContain(PM_SUMMARY);
+    expect(result.markdown).toContain(LE_SUMMARY);
+    expect(result.layers).toHaveLength(1);
+    expect(result.layers[0].name).toBe('ava');
+    expect(result.generatedAt).toBeTruthy();
+  });
+
+  it('returns fallback markdown when world state provider throws', async () => {
+    const provider: BriefingWorldStateProvider = {
+      getFullBriefing: async () => {
+        throw new Error('provider failed');
+      },
+    };
+
+    const result = await buildLayeredBriefing(provider);
+
+    expect(result.markdown).toContain('World state unavailable');
+    expect(result.layers).toHaveLength(1);
+  });
+});
+
+// ─── 4. Full end-to-end chain ─────────────────────────────────────────────────
+
+describe('Full chain: Ava → PM query → LE status → distilled briefing', () => {
+  it('verifies complete data flow from LE service call through to briefing output', async () => {
+    // Step 1: Set up PM and LE service stubs
+    const pm = makePMBuilder();
+    const le = makeLEProvider();
+
+    // Step 2: Ava uses PMProjectQueryService (PM subagent role)
+    const pmQueryService = new PMProjectQueryService(pm, le);
+
+    // Step 3: PM queries LE via service call (not subagent — SDK single-level limit)
+    const projectStatus = await pmQueryService.queryProjectStatus();
+    expect(projectStatus.pmSummary).toBe(PM_SUMMARY);
+    expect(projectStatus.leSummary).toBe(LE_SUMMARY);
+
+    // Step 4: Answer distills back through AvaWorldStateBuilder
+    const avaBuilder = new AvaWorldStateBuilder(pm, le);
+    const fullBriefing = await avaBuilder.getFullBriefing();
+    expect(fullBriefing).toContain(PM_SUMMARY);
+    expect(fullBriefing).toContain(LE_SUMMARY);
+
+    // Step 5: /briefing MCP tool returns layered world state
+    const provider: BriefingWorldStateProvider = {
+      getFullBriefing: () => avaBuilder.getFullBriefing(),
+    };
+    const layeredBriefing = await buildLayeredBriefing(provider);
+    expect(layeredBriefing.markdown).toContain(PM_SUMMARY);
+    expect(layeredBriefing.markdown).toContain(LE_SUMMARY);
+    expect(layeredBriefing.layers[0].name).toBe('ava');
+  });
+});

--- a/apps/server/tests/knowledge-flow-pipeline.test.ts
+++ b/apps/server/tests/knowledge-flow-pipeline.test.ts
@@ -1,0 +1,575 @@
+/**
+ * Knowledge Flow Pipeline – End-to-End Tests
+ *
+ * Verifies the distillation pipeline:
+ *   raw PM state → knowledge chunks (domain='project') →
+ *   Ava knowledge search → Ava briefing
+ *
+ * Uses an in-memory SQLite database (better-sqlite3 :memory:) to avoid disk I/O.
+ * Skipped in CI when better-sqlite3 native bindings are not available.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type BetterSqlite3 from 'better-sqlite3';
+
+let Database: typeof BetterSqlite3;
+let hasSqlite = false;
+try {
+  Database = (await import('better-sqlite3')).default;
+  hasSqlite = true;
+} catch {
+  // Native bindings not available (e.g. CI without rebuild)
+}
+import type { PMWorldState } from '@protolabsai/types';
+import { WorldStateDomain } from '@protolabsai/types';
+import { KnowledgeIngestionService } from '../src/services/knowledge-ingestion-service.js';
+import { PMWorldStateBuilder } from '../src/services/pm-world-state-builder.js';
+import { AvaWorldStateBuilder } from '../src/services/ava-world-state-builder.js';
+import type {
+  PMKnowledgeIngestor,
+  PMWorldStateBuilderConfig,
+} from '../src/services/pm-world-state-builder.js';
+import type { KnowledgeSearchProvider } from '../src/services/ava-world-state-builder.js';
+
+// ────────────────────────── Helpers ──────────────────────────────────────────
+
+/** Create and initialise an in-memory knowledge store DB with the same schema as production */
+function createTestDb(): BetterSqlite3.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS chunks (
+      id TEXT PRIMARY KEY,
+      source_type TEXT NOT NULL,
+      source_file TEXT NOT NULL,
+      project_path TEXT NOT NULL,
+      chunk_index INTEGER NOT NULL,
+      heading TEXT,
+      content TEXT NOT NULL,
+      tags TEXT,
+      importance REAL NOT NULL DEFAULT 0.5,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      last_retrieved_at TEXT,
+      retrieval_count INTEGER NOT NULL DEFAULT 0
+    )
+  `);
+
+  db.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+      heading,
+      content,
+      content=chunks,
+      content_rowid=rowid
+    )
+  `);
+
+  // Keep FTS5 in sync
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS chunks_ai AFTER INSERT ON chunks BEGIN
+      INSERT INTO chunks_fts(rowid, heading, content)
+      VALUES (new.rowid, new.heading, new.content);
+    END
+  `);
+
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS chunks_au AFTER UPDATE ON chunks BEGIN
+      INSERT INTO chunks_fts(chunks_fts, rowid, heading, content)
+      VALUES ('delete', old.rowid, old.heading, old.content);
+      INSERT INTO chunks_fts(rowid, heading, content)
+      VALUES (new.rowid, new.heading, new.content);
+    END
+  `);
+
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS chunks_ad AFTER DELETE ON chunks BEGIN
+      INSERT INTO chunks_fts(chunks_fts, rowid, heading, content)
+      VALUES ('delete', old.rowid, old.heading, old.content);
+    END
+  `);
+
+  return db;
+}
+
+/** Build a sample PMWorldState for testing */
+function buildSampleState(): PMWorldState {
+  return {
+    domain: WorldStateDomain.Project,
+    updatedAt: '2026-03-10T12:00:00.000Z',
+    projects: {
+      'automaker-core': {
+        status: 'active',
+        phase: 'development',
+        milestoneCount: 3,
+        completedMilestones: 1,
+      },
+    },
+    milestones: {
+      'auth-foundation': {
+        title: 'Auth Foundation',
+        totalPhases: 4,
+        completedPhases: 4,
+        dueAt: '2026-03-15T00:00:00.000Z',
+      },
+      'knowledge-flow': {
+        title: 'Knowledge Flow Pipeline',
+        totalPhases: 3,
+        completedPhases: 1,
+        dueAt: '2026-04-01T00:00:00.000Z',
+      },
+    },
+    ceremonies: {
+      retro: '2026-03-20T14:00:00.000Z',
+      planning: '2026-03-25T10:00:00.000Z',
+    },
+    upcomingDeadlines: [
+      {
+        projectSlug: 'automaker-core',
+        label: 'MVP launch',
+        dueAt: '2026-05-01T00:00:00.000Z',
+      },
+    ],
+  };
+}
+
+// ────────────────────────── Tests ─────────────────────────────────────────────
+
+// Skip all tests when better-sqlite3 native bindings are unavailable (CI)
+describe.skipIf(!hasSqlite)('Knowledge Flow Pipeline (requires better-sqlite3)', () => {
+  describe('KnowledgeIngestionService.ingestProjectStateChanges', () => {
+    let db: BetterSqlite3.Database;
+    let ingestion: KnowledgeIngestionService;
+
+    beforeEach(() => {
+      db = createTestDb();
+      // Mock the embedding orchestrator to be a no-op
+      ingestion = new KnowledgeIngestionService({
+        runBackgroundEmbedding: vi.fn().mockResolvedValue(undefined),
+        getEmbeddingService: vi.fn().mockReturnValue({ isReady: () => false }),
+      } as unknown as ConstructorParameters<typeof KnowledgeIngestionService>[0]);
+    });
+
+    it('indexes project overview chunk with domain=project tag', async () => {
+      const state = buildSampleState();
+      const count = await ingestion.ingestProjectStateChanges(db, '/test/project', state);
+
+      expect(count).toBeGreaterThan(0);
+
+      const row = db
+        .prepare('SELECT * FROM chunks WHERE id = ?')
+        .get('project-overview-snapshot') as
+        | { tags: string; content: string; heading: string }
+        | undefined;
+      expect(row).toBeDefined();
+      const tags = JSON.parse(row!.tags) as string[];
+      expect(tags).toContain('project');
+      expect(row!.content).toContain('automaker-core');
+    });
+
+    it('indexes milestone progress chunk with domain=project tag', async () => {
+      const state = buildSampleState();
+      await ingestion.ingestProjectStateChanges(db, '/test/project', state);
+
+      const row = db
+        .prepare('SELECT * FROM chunks WHERE id = ?')
+        .get('project-milestones-snapshot') as { tags: string; content: string } | undefined;
+      expect(row).toBeDefined();
+      const tags = JSON.parse(row!.tags) as string[];
+      expect(tags).toContain('project');
+      expect(tags).toContain('milestone');
+      expect(row!.content).toContain('Auth Foundation');
+      expect(row!.content).toContain('Knowledge Flow Pipeline');
+      // Completed milestone should be marked
+      expect(row!.content).toContain('✅');
+    });
+
+    it('indexes ceremonies chunk with domain=project tag', async () => {
+      const state = buildSampleState();
+      await ingestion.ingestProjectStateChanges(db, '/test/project', state);
+
+      const row = db
+        .prepare('SELECT * FROM chunks WHERE id = ?')
+        .get('project-ceremonies-snapshot') as { tags: string; content: string } | undefined;
+      expect(row).toBeDefined();
+      const tags = JSON.parse(row!.tags) as string[];
+      expect(tags).toContain('project');
+      expect(tags).toContain('ceremony');
+    });
+
+    it('indexes timeline deadlines chunk with domain=project tag', async () => {
+      const state = buildSampleState();
+      await ingestion.ingestProjectStateChanges(db, '/test/project', state);
+
+      const row = db
+        .prepare('SELECT * FROM chunks WHERE id = ?')
+        .get('project-timeline-snapshot') as { tags: string; content: string } | undefined;
+      expect(row).toBeDefined();
+      const tags = JSON.parse(row!.tags) as string[];
+      expect(tags).toContain('project');
+      expect(tags).toContain('timeline');
+      expect(row!.content).toContain('MVP launch');
+    });
+
+    it('upserts chunks on repeated calls (idempotent)', async () => {
+      const state = buildSampleState();
+      await ingestion.ingestProjectStateChanges(db, '/test/project', state);
+      await ingestion.ingestProjectStateChanges(db, '/test/project', state);
+
+      // Should still be exactly one overview chunk, not two
+      const rows = db
+        .prepare("SELECT COUNT(*) as cnt FROM chunks WHERE id = 'project-overview-snapshot'")
+        .get() as { cnt: number };
+      expect(rows.cnt).toBe(1);
+    });
+
+    it('returns 0 when state has no projects, milestones, ceremonies, or deadlines', async () => {
+      const empty: PMWorldState = {
+        domain: WorldStateDomain.Project,
+        updatedAt: new Date().toISOString(),
+        projects: {},
+        milestones: {},
+        ceremonies: {},
+        upcomingDeadlines: [],
+      };
+      const count = await ingestion.ingestProjectStateChanges(db, '/test/project', empty);
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('PMWorldStateBuilder – knowledge ingestion on buildState()', () => {
+    it('calls knowledgeIngestor.ingestProjectStateChanges after state refresh', async () => {
+      const ingestFn = vi.fn().mockResolvedValue(3);
+      const ingestor: PMKnowledgeIngestor = {
+        ingestProjectStateChanges: ingestFn,
+      };
+
+      const config: PMWorldStateBuilderConfig = {
+        // Use a temp dir — projects directory won't exist, so state will be empty
+        projectRoot: '/tmp/pm-test-nonexistent',
+        knowledgeIngestor: ingestor,
+        knowledgeProjectPath: '/tmp/knowledge-test',
+      };
+
+      const builder = new PMWorldStateBuilder(config);
+      await builder.buildState();
+
+      expect(ingestFn).toHaveBeenCalledOnce();
+      const [projectPath, state] = ingestFn.mock.calls[0] as [string, PMWorldState];
+      expect(projectPath).toBe('/tmp/knowledge-test');
+      expect(state.domain).toBe(WorldStateDomain.Project);
+    });
+
+    it('does not call ingestor when knowledgeIngestor is not configured', async () => {
+      const builder = new PMWorldStateBuilder({ projectRoot: '/tmp/pm-test-no-ingestor' });
+      // Should not throw
+      await expect(builder.buildState()).resolves.not.toThrow();
+    });
+
+    it('does not fail if knowledgeIngestor throws', async () => {
+      const ingestor: PMKnowledgeIngestor = {
+        ingestProjectStateChanges: vi.fn().mockRejectedValue(new Error('DB connection failed')),
+      };
+
+      const builder = new PMWorldStateBuilder({
+        projectRoot: '/tmp/pm-test-error',
+        knowledgeIngestor: ingestor,
+      });
+
+      // buildState() should still succeed even if ingestion fails
+      await expect(builder.buildState()).resolves.not.toThrow();
+    });
+  });
+
+  describe('Cross-domain queries', () => {
+    let db: BetterSqlite3.Database;
+    let ingestion: KnowledgeIngestionService;
+
+    beforeEach(() => {
+      db = createTestDb();
+      ingestion = new KnowledgeIngestionService({
+        runBackgroundEmbedding: vi.fn().mockResolvedValue(undefined),
+        getEmbeddingService: vi.fn().mockReturnValue({ isReady: () => false }),
+      } as unknown as ConstructorParameters<typeof KnowledgeIngestionService>[0]);
+    });
+
+    it('domain=project filter returns only project-tagged chunks', async () => {
+      const state = buildSampleState();
+      await ingestion.ingestProjectStateChanges(db, '/test/project', state);
+
+      // Insert an engineering chunk (simulating feature completion ingestion)
+      const ts = new Date().toISOString();
+      db.prepare(
+        `INSERT INTO chunks (id, source_type, source_file, project_path, chunk_index, heading, content, tags, importance, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'eng-test-chunk',
+        'reflection',
+        '.automaker/features/test/reflection.md',
+        '/test/project',
+        0,
+        'Engineering Reflection',
+        'A technical reflection on implementation choices.',
+        JSON.stringify(['engineering', 'reflection', 'test-feature']),
+        0.8,
+        ts,
+        ts
+      );
+
+      // Query for domain=project
+      const projectRows = db
+        .prepare(
+          `SELECT id FROM chunks
+         WHERE tags IS NOT NULL
+           AND EXISTS (SELECT 1 FROM json_each(tags) WHERE json_each.value = ?)`
+        )
+        .all('project') as Array<{ id: string }>;
+
+      const projectIds = projectRows.map((r) => r.id);
+      expect(projectIds).toContain('project-overview-snapshot');
+      expect(projectIds).toContain('project-milestones-snapshot');
+      expect(projectIds).not.toContain('eng-test-chunk');
+
+      // Query for domain=engineering
+      const engRows = db
+        .prepare(
+          `SELECT id FROM chunks
+         WHERE tags IS NOT NULL
+           AND EXISTS (SELECT 1 FROM json_each(tags) WHERE json_each.value = ?)`
+        )
+        .all('engineering') as Array<{ id: string }>;
+
+      const engIds = engRows.map((r) => r.id);
+      expect(engIds).toContain('eng-test-chunk');
+      expect(engIds).not.toContain('project-overview-snapshot');
+    });
+  });
+
+  describe('AvaWorldStateBuilder.getFullBriefing() – knowledge insights', () => {
+    it('includes Knowledge Insights section when knowledgeSearch is provided', async () => {
+      // Mock PM builder
+      const mockPmBuilder = {
+        getDistilledSummary: vi.fn().mockReturnValue('## Project Status\n- test: active'),
+        getState: vi.fn().mockReturnValue({
+          domain: WorldStateDomain.Project,
+          updatedAt: new Date().toISOString(),
+          projects: {},
+          milestones: {},
+          ceremonies: {},
+          upcomingDeadlines: [],
+        }),
+      };
+
+      // Mock LE provider
+      const mockLeProvider = {
+        getWorldStateSummary: vi.fn().mockReturnValue('## Features\n- test feature'),
+      };
+
+      // Mock knowledge search provider returning project results
+      const mockSearch: KnowledgeSearchProvider = {
+        search: vi.fn().mockImplementation(async (_path, _query, opts) => {
+          if (opts?.domain === 'project') {
+            return {
+              results: [
+                {
+                  chunk: {
+                    content: '# Project Overview\n- automaker-core: active / development',
+                    heading: 'Project Overview',
+                  },
+                },
+              ],
+            };
+          }
+          return { results: [] };
+        }),
+      };
+
+      const builder = new AvaWorldStateBuilder(
+        mockPmBuilder as unknown as ConstructorParameters<typeof AvaWorldStateBuilder>[0],
+        mockLeProvider,
+        {
+          knowledgeSearch: mockSearch,
+          knowledgeProjectPath: '/test/project',
+        }
+      );
+
+      const briefing = await builder.getFullBriefing();
+
+      expect(briefing).toContain('## Knowledge Insights');
+      expect(briefing).toContain('### Project Knowledge');
+      expect(briefing).toContain('Project Overview');
+      expect(briefing).toContain('### Engineering Knowledge');
+    });
+
+    it('omits Knowledge Insights section when no knowledgeSearch configured', async () => {
+      const mockPmBuilder = {
+        getDistilledSummary: vi.fn().mockReturnValue('## Project Status'),
+        getState: vi.fn().mockReturnValue({
+          domain: WorldStateDomain.Project,
+          updatedAt: new Date().toISOString(),
+          projects: {},
+          milestones: {},
+          ceremonies: {},
+          upcomingDeadlines: [],
+        }),
+      };
+      const mockLeProvider = {
+        getWorldStateSummary: vi.fn().mockReturnValue('## Features'),
+      };
+
+      const builder = new AvaWorldStateBuilder(
+        mockPmBuilder as unknown as ConstructorParameters<typeof AvaWorldStateBuilder>[0],
+        mockLeProvider,
+        {}
+      );
+
+      const briefing = await builder.getFullBriefing();
+      expect(briefing).not.toContain('## Knowledge Insights');
+    });
+
+    it('shows fallback message when knowledge store has no indexed chunks', async () => {
+      const mockPmBuilder = {
+        getDistilledSummary: vi.fn().mockReturnValue(''),
+        getState: vi.fn().mockReturnValue({
+          domain: WorldStateDomain.Project,
+          updatedAt: new Date().toISOString(),
+          projects: {},
+          milestones: {},
+          ceremonies: {},
+          upcomingDeadlines: [],
+        }),
+      };
+      const mockLeProvider = {
+        getWorldStateSummary: vi.fn().mockReturnValue(''),
+      };
+
+      // Empty search results
+      const mockSearch: KnowledgeSearchProvider = {
+        search: vi.fn().mockResolvedValue({ results: [] }),
+      };
+
+      const builder = new AvaWorldStateBuilder(
+        mockPmBuilder as unknown as ConstructorParameters<typeof AvaWorldStateBuilder>[0],
+        mockLeProvider,
+        {
+          knowledgeSearch: mockSearch,
+          knowledgeProjectPath: '/test/empty',
+        }
+      );
+
+      const briefing = await builder.getFullBriefing();
+      expect(briefing).toContain('No project knowledge chunks indexed yet');
+      expect(briefing).toContain('No engineering knowledge chunks indexed yet');
+    });
+
+    it('includes both project and engineering domain queries', async () => {
+      const mockPmBuilder = {
+        getDistilledSummary: vi.fn().mockReturnValue(''),
+        getState: vi.fn().mockReturnValue({
+          domain: WorldStateDomain.Project,
+          updatedAt: new Date().toISOString(),
+          projects: {},
+          milestones: {},
+          ceremonies: {},
+          upcomingDeadlines: [],
+        }),
+      };
+      const mockLeProvider = { getWorldStateSummary: vi.fn().mockReturnValue('') };
+
+      const mockSearch: KnowledgeSearchProvider = {
+        search: vi.fn().mockResolvedValue({ results: [] }),
+      };
+
+      const builder = new AvaWorldStateBuilder(
+        mockPmBuilder as unknown as ConstructorParameters<typeof AvaWorldStateBuilder>[0],
+        mockLeProvider,
+        { knowledgeSearch: mockSearch, knowledgeProjectPath: '/test/project' }
+      );
+
+      await builder.getFullBriefing();
+
+      const calls = (mockSearch.search as ReturnType<typeof vi.fn>).mock.calls as [
+        string,
+        string,
+        { domain?: string },
+      ][];
+      const domains = calls.map((c) => c[2]?.domain);
+      expect(domains).toContain('project');
+      expect(domains).toContain('engineering');
+    });
+  });
+
+  describe('Distillation pipeline – end-to-end', () => {
+    it('flows raw state → knowledge chunks → briefing with real in-memory DB', async () => {
+      // 1. Set up in-memory DB
+      const db = createTestDb();
+
+      const ingestion = new KnowledgeIngestionService({
+        runBackgroundEmbedding: vi.fn().mockResolvedValue(undefined),
+        getEmbeddingService: vi.fn().mockReturnValue({ isReady: () => false }),
+      } as unknown as ConstructorParameters<typeof KnowledgeIngestionService>[0]);
+
+      // 2. Ingest raw PM state
+      const state = buildSampleState();
+      const ingestedCount = await ingestion.ingestProjectStateChanges(db, '/test/e2e', state);
+      expect(ingestedCount).toBeGreaterThan(0);
+
+      // 3. Build knowledge search provider using the in-memory DB directly
+      const knowledgeSearch: KnowledgeSearchProvider = {
+        search: async (_projectPath, _query, opts) => {
+          const domain = opts?.domain;
+          let sql = `
+          SELECT c.content, c.heading
+          FROM chunks c
+          WHERE 1=1
+        `;
+          const params: unknown[] = [];
+          if (domain) {
+            sql += ` AND c.tags IS NOT NULL AND EXISTS (
+            SELECT 1 FROM json_each(c.tags) WHERE json_each.value = ?
+          )`;
+            params.push(domain);
+          }
+          sql += ' LIMIT 10';
+          const rows = db.prepare(sql).all(...params) as Array<{
+            content: string;
+            heading: string | null;
+          }>;
+          return {
+            results: rows.map((r) => ({
+              chunk: { content: r.content, heading: r.heading ?? undefined },
+            })),
+          };
+        },
+      };
+
+      // 4. Build Ava briefing
+      const mockPmBuilder = {
+        getDistilledSummary: vi.fn().mockReturnValue('## Project Status\n- automaker-core: active'),
+        getState: vi.fn().mockReturnValue(state),
+      };
+      const mockLeProvider = {
+        getWorldStateSummary: vi.fn().mockReturnValue('## Engineering\n- All good'),
+      };
+
+      const avaBuilder = new AvaWorldStateBuilder(
+        mockPmBuilder as unknown as ConstructorParameters<typeof AvaWorldStateBuilder>[0],
+        mockLeProvider,
+        { knowledgeSearch, knowledgeProjectPath: '/test/e2e' }
+      );
+
+      const briefing = await avaBuilder.getFullBriefing();
+
+      // 5. Verify the full pipeline
+      expect(briefing).toContain('# Ava Full Briefing');
+      expect(briefing).toContain('## Project Management Layer');
+      expect(briefing).toContain('## Engineering Layer');
+      expect(briefing).toContain('## Knowledge Insights');
+      expect(briefing).toContain('### Project Knowledge');
+      // The project chunk content should appear (overview mentions 'automaker-core')
+      expect(briefing).toContain('automaker-core');
+
+      db.close();
+    });
+  });
+}); // end skipIf wrapper

--- a/apps/server/tests/unit/calendar-routes.test.ts
+++ b/apps/server/tests/unit/calendar-routes.test.ts
@@ -1,0 +1,773 @@
+/**
+ * Integration tests for calendar HTTP routes
+ *
+ * Tests the createCalendarRoutes factory directly — no HTTP server required.
+ * Each test invokes route handlers through the Express router stack.
+ *
+ * Coverage:
+ * - POST /list — date range and type filters
+ * - POST /create — required field validation, job-specific field validation
+ * - POST /update — returns updated event
+ * - POST /delete — removes the event
+ * - POST /run-job — rejects non-pending jobs, starts execution for pending jobs
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response } from 'express';
+
+// Mock @protolabsai/platform so validatePath always allows paths in tests
+vi.mock('@protolabsai/platform', () => ({
+  validatePath: vi.fn(),
+  PathNotAllowedError: class PathNotAllowedError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'PathNotAllowedError';
+    }
+  },
+  getAutomakerDir: vi.fn((p: string) => `${p}/.automaker`),
+}));
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+  atomicWriteJson: vi.fn(),
+  readJsonWithRecovery: vi.fn(),
+}));
+
+import { createCalendarRoutes } from '@/routes/calendar/index.js';
+import type { CalendarService } from '@/services/calendar-service.js';
+import type { JobExecutorService } from '@/services/job-executor-service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReq(body: Record<string, unknown> = {}): Request {
+  return { body, headers: {}, params: {}, query: {} } as unknown as Request;
+}
+
+function makeRes() {
+  const res = {
+    _status: 200,
+    json: vi.fn(),
+    status: vi.fn(),
+  };
+  res.status.mockReturnValue(res);
+  return res as unknown as Response & {
+    json: ReturnType<typeof vi.fn>;
+    status: ReturnType<typeof vi.fn>;
+  };
+}
+
+/**
+ * Extract the last (actual route) handler from a router stack entry.
+ * Express route stacks include middleware first; the last handle is the route handler.
+ */
+function getHandler(
+  router: ReturnType<typeof createCalendarRoutes>,
+  method: string,
+  routePath: string
+) {
+  const stack = (
+    router as unknown as {
+      stack: Array<{
+        route?: {
+          path: string;
+          stack: Array<{ method: string; handle: (req: Request, res: Response) => unknown }>;
+        };
+      }>;
+    }
+  ).stack;
+
+  const layer = stack.find((l) => l.route?.path === routePath);
+  if (!layer?.route) return undefined;
+
+  // Return the last handle in the stack (the actual route handler, after middleware)
+  const handles = layer.route.stack.filter((s) => s.method === method);
+  return handles[handles.length - 1]?.handle;
+}
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+function makeMockCalendarService(overrides: Partial<CalendarService> = {}): CalendarService {
+  return {
+    listEvents: vi.fn().mockResolvedValue([]),
+    createEvent: vi.fn().mockResolvedValue({
+      id: 'event-123',
+      projectPath: '/test/project',
+      title: 'Test Event',
+      date: '2026-03-10',
+      type: 'milestone',
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    }),
+    updateEvent: vi.fn().mockResolvedValue({
+      id: 'event-123',
+      projectPath: '/test/project',
+      title: 'Updated Event',
+      date: '2026-03-15',
+      type: 'milestone',
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-15T00:00:00.000Z',
+    }),
+    deleteEvent: vi.fn().mockResolvedValue(undefined),
+    getDueJobs: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  } as unknown as CalendarService;
+}
+
+function makeMockJobExecutorService(
+  overrides: Partial<JobExecutorService> = {}
+): JobExecutorService {
+  return {
+    executeJob: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as JobExecutorService;
+}
+
+const PROJECT_PATH = '/test/project';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('calendar routes', () => {
+  let calendarService: CalendarService;
+  let jobExecutorService: JobExecutorService;
+  let router: ReturnType<typeof createCalendarRoutes>;
+
+  beforeEach(() => {
+    calendarService = makeMockCalendarService();
+    jobExecutorService = makeMockJobExecutorService();
+    router = createCalendarRoutes(calendarService, jobExecutorService);
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /list
+  // -------------------------------------------------------------------------
+
+  describe('POST /list', () => {
+    it('returns events with no filters', async () => {
+      const events = [
+        {
+          id: 'event-1',
+          projectPath: PROJECT_PATH,
+          title: 'Event 1',
+          date: '2026-03-10',
+          type: 'milestone',
+          createdAt: '2026-03-10T00:00:00.000Z',
+          updatedAt: '2026-03-10T00:00:00.000Z',
+        },
+      ];
+      vi.mocked(calendarService.listEvents).mockResolvedValue(events as any);
+
+      const req = makeReq({ projectPath: PROJECT_PATH });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/list');
+      expect(handler).toBeDefined();
+      await handler!(req, res as Response);
+
+      expect(calendarService.listEvents).toHaveBeenCalledWith(PROJECT_PATH, {
+        startDate: undefined,
+        endDate: undefined,
+        types: undefined,
+      });
+      expect(res.json).toHaveBeenCalledWith({ success: true, events });
+    });
+
+    it('passes date range to calendarService.listEvents', async () => {
+      const req = makeReq({
+        projectPath: PROJECT_PATH,
+        startDate: '2026-03-01',
+        endDate: '2026-03-31',
+      });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/list');
+      await handler!(req, res as Response);
+
+      expect(calendarService.listEvents).toHaveBeenCalledWith(PROJECT_PATH, {
+        startDate: '2026-03-01',
+        endDate: '2026-03-31',
+        types: undefined,
+      });
+    });
+
+    it('passes type filters to calendarService.listEvents', async () => {
+      const req = makeReq({
+        projectPath: PROJECT_PATH,
+        types: ['milestone', 'feature'],
+      });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/list');
+      await handler!(req, res as Response);
+
+      expect(calendarService.listEvents).toHaveBeenCalledWith(PROJECT_PATH, {
+        startDate: undefined,
+        endDate: undefined,
+        types: ['milestone', 'feature'],
+      });
+    });
+
+    it('passes both date range and type filters together', async () => {
+      const req = makeReq({
+        projectPath: PROJECT_PATH,
+        startDate: '2026-03-01',
+        endDate: '2026-03-31',
+        types: ['job'],
+      });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/list');
+      await handler!(req, res as Response);
+
+      expect(calendarService.listEvents).toHaveBeenCalledWith(PROJECT_PATH, {
+        startDate: '2026-03-01',
+        endDate: '2026-03-31',
+        types: ['job'],
+      });
+    });
+
+    it('returns 400 when projectPath is missing', async () => {
+      const req = makeReq({});
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/list');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'projectPath is required',
+      });
+    });
+
+    it('returns 500 when calendarService.listEvents throws', async () => {
+      vi.mocked(calendarService.listEvents).mockRejectedValue(new Error('DB read failed'));
+
+      const req = makeReq({ projectPath: PROJECT_PATH });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/list');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'DB read failed' });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /create
+  // -------------------------------------------------------------------------
+
+  describe('POST /create', () => {
+    it('creates a non-job event with all required fields', async () => {
+      const createdEvent = {
+        id: 'event-abc',
+        projectPath: PROJECT_PATH,
+        title: 'Sprint Review',
+        date: '2026-03-20',
+        type: 'milestone',
+        createdAt: '2026-03-10T00:00:00.000Z',
+        updatedAt: '2026-03-10T00:00:00.000Z',
+      };
+      vi.mocked(calendarService.createEvent).mockResolvedValue(createdEvent as any);
+
+      const req = makeReq({
+        projectPath: PROJECT_PATH,
+        title: 'Sprint Review',
+        date: '2026-03-20',
+        type: 'milestone',
+      });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/create');
+      await handler!(req, res as Response);
+
+      expect(calendarService.createEvent).toHaveBeenCalledWith(
+        PROJECT_PATH,
+        expect.objectContaining({ title: 'Sprint Review', date: '2026-03-20', type: 'milestone' })
+      );
+      expect(res.json).toHaveBeenCalledWith({ success: true, event: createdEvent });
+    });
+
+    it('returns 400 when projectPath is missing', async () => {
+      const req = makeReq({ title: 'Event', date: '2026-03-20', type: 'milestone' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/create');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'projectPath is required' });
+    });
+
+    it('returns 400 when title is missing', async () => {
+      const req = makeReq({ projectPath: PROJECT_PATH, date: '2026-03-20', type: 'milestone' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/create');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'title is required' });
+    });
+
+    it('returns 400 when date is missing', async () => {
+      const req = makeReq({
+        projectPath: PROJECT_PATH,
+        title: 'Event',
+        type: 'milestone',
+      });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/create');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'date is required' });
+    });
+
+    it('returns 400 when type is missing', async () => {
+      const req = makeReq({ projectPath: PROJECT_PATH, title: 'Event', date: '2026-03-20' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/create');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'type is required' });
+    });
+
+    it('returns 400 when type is job but time is missing', async () => {
+      const req = makeReq({
+        projectPath: PROJECT_PATH,
+        title: 'Nightly Build',
+        date: '2026-03-20',
+        type: 'job',
+        jobAction: { type: 'run-command', command: 'npm run build' },
+      });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/create');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'time is required for job events',
+      });
+    });
+
+    it('returns 400 when type is job but jobAction is missing', async () => {
+      const req = makeReq({
+        projectPath: PROJECT_PATH,
+        title: 'Nightly Build',
+        date: '2026-03-20',
+        type: 'job',
+        time: '02:00',
+      });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/create');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'jobAction is required for job events',
+      });
+    });
+
+    it('returns 400 when type is job but jobAction.type is missing', async () => {
+      const req = makeReq({
+        projectPath: PROJECT_PATH,
+        title: 'Nightly Build',
+        date: '2026-03-20',
+        type: 'job',
+        time: '02:00',
+        jobAction: {},
+      });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/create');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'jobAction is required for job events',
+      });
+    });
+
+    it('creates a job event with all required job-specific fields', async () => {
+      const jobEvent = {
+        id: 'event-job-1',
+        projectPath: PROJECT_PATH,
+        title: 'Nightly Build',
+        date: '2026-03-20',
+        time: '02:00',
+        type: 'job',
+        jobAction: { type: 'run-command', command: 'npm run build' },
+        jobStatus: 'pending',
+        createdAt: '2026-03-10T00:00:00.000Z',
+        updatedAt: '2026-03-10T00:00:00.000Z',
+      };
+      vi.mocked(calendarService.createEvent).mockResolvedValue(jobEvent as any);
+
+      const req = makeReq({
+        projectPath: PROJECT_PATH,
+        title: 'Nightly Build',
+        date: '2026-03-20',
+        type: 'job',
+        time: '02:00',
+        jobAction: { type: 'run-command', command: 'npm run build' },
+      });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/create');
+      await handler!(req, res as Response);
+
+      expect(calendarService.createEvent).toHaveBeenCalledWith(
+        PROJECT_PATH,
+        expect.objectContaining({
+          type: 'job',
+          time: '02:00',
+          jobStatus: 'pending',
+          jobAction: { type: 'run-command', command: 'npm run build' },
+        })
+      );
+      expect(res.json).toHaveBeenCalledWith({ success: true, event: jobEvent });
+    });
+
+    it('returns 500 when calendarService.createEvent throws', async () => {
+      vi.mocked(calendarService.createEvent).mockRejectedValue(new Error('Write failed'));
+
+      const req = makeReq({
+        projectPath: PROJECT_PATH,
+        title: 'Event',
+        date: '2026-03-20',
+        type: 'milestone',
+      });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/create');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Write failed' });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /update
+  // -------------------------------------------------------------------------
+
+  describe('POST /update', () => {
+    it('updates an event and returns the updated event', async () => {
+      const updatedEvent = {
+        id: 'event-123',
+        projectPath: PROJECT_PATH,
+        title: 'Updated Title',
+        date: '2026-03-25',
+        type: 'milestone',
+        createdAt: '2026-03-10T00:00:00.000Z',
+        updatedAt: '2026-03-15T00:00:00.000Z',
+      };
+      vi.mocked(calendarService.updateEvent).mockResolvedValue(updatedEvent as any);
+
+      const req = makeReq({
+        projectPath: PROJECT_PATH,
+        id: 'event-123',
+        title: 'Updated Title',
+        date: '2026-03-25',
+      });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/update');
+      await handler!(req, res as Response);
+
+      expect(calendarService.updateEvent).toHaveBeenCalledWith(
+        PROJECT_PATH,
+        'event-123',
+        expect.objectContaining({ title: 'Updated Title', date: '2026-03-25' })
+      );
+      expect(res.json).toHaveBeenCalledWith({ success: true, event: updatedEvent });
+    });
+
+    it('returns 400 when projectPath is missing', async () => {
+      const req = makeReq({ id: 'event-123', title: 'Updated' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/update');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'projectPath is required' });
+    });
+
+    it('returns 400 when id is missing', async () => {
+      const req = makeReq({ projectPath: PROJECT_PATH, title: 'Updated' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/update');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'id is required' });
+    });
+
+    it('does not pass projectPath or id as update fields', async () => {
+      const req = makeReq({
+        projectPath: PROJECT_PATH,
+        id: 'event-123',
+        title: 'Updated',
+      });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/update');
+      await handler!(req, res as Response);
+
+      const updateArg = vi.mocked(calendarService.updateEvent).mock.calls[0]?.[2];
+      expect(updateArg).not.toHaveProperty('projectPath');
+      expect(updateArg).not.toHaveProperty('id');
+    });
+
+    it('returns 500 when calendarService.updateEvent throws', async () => {
+      vi.mocked(calendarService.updateEvent).mockRejectedValue(
+        new Error('Calendar event event-999 not found')
+      );
+
+      const req = makeReq({ projectPath: PROJECT_PATH, id: 'event-999', title: 'X' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/update');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'Calendar event event-999 not found',
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /delete
+  // -------------------------------------------------------------------------
+
+  describe('POST /delete', () => {
+    it('deletes an event and returns success', async () => {
+      const req = makeReq({ projectPath: PROJECT_PATH, id: 'event-123' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/delete');
+      await handler!(req, res as Response);
+
+      expect(calendarService.deleteEvent).toHaveBeenCalledWith(PROJECT_PATH, 'event-123');
+      expect(res.json).toHaveBeenCalledWith({ success: true });
+    });
+
+    it('returns 400 when projectPath is missing', async () => {
+      const req = makeReq({ id: 'event-123' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/delete');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'projectPath is required' });
+    });
+
+    it('returns 400 when id is missing', async () => {
+      const req = makeReq({ projectPath: PROJECT_PATH });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/delete');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'id is required' });
+    });
+
+    it('returns 500 when calendarService.deleteEvent throws', async () => {
+      vi.mocked(calendarService.deleteEvent).mockRejectedValue(
+        new Error('Calendar event event-999 not found')
+      );
+
+      const req = makeReq({ projectPath: PROJECT_PATH, id: 'event-999' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/delete');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'Calendar event event-999 not found',
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /run-job
+  // -------------------------------------------------------------------------
+
+  describe('POST /run-job', () => {
+    const pendingJob = {
+      id: 'job-1',
+      projectPath: PROJECT_PATH,
+      title: 'Nightly Build',
+      date: '2026-03-20',
+      time: '02:00',
+      type: 'job',
+      jobAction: { type: 'run-command', command: 'npm run build' },
+      jobStatus: 'pending',
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    };
+
+    it('starts execution for a pending job and returns success immediately', async () => {
+      vi.mocked(calendarService.listEvents).mockResolvedValue([pendingJob] as any);
+
+      const req = makeReq({ projectPath: PROJECT_PATH, id: 'job-1' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/run-job');
+      await handler!(req, res as Response);
+
+      expect(jobExecutorService.executeJob).toHaveBeenCalledWith(PROJECT_PATH, pendingJob);
+      expect(res.json).toHaveBeenCalledWith({ success: true, message: 'Job execution started' });
+    });
+
+    it('rejects a job that is not pending (running status)', async () => {
+      const runningJob = { ...pendingJob, jobStatus: 'running' };
+      vi.mocked(calendarService.listEvents).mockResolvedValue([runningJob] as any);
+
+      const req = makeReq({ projectPath: PROJECT_PATH, id: 'job-1' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/run-job');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'Job is not pending (status: running)',
+      });
+      expect(jobExecutorService.executeJob).not.toHaveBeenCalled();
+    });
+
+    it('rejects a job that is not pending (completed status)', async () => {
+      const completedJob = { ...pendingJob, jobStatus: 'completed' };
+      vi.mocked(calendarService.listEvents).mockResolvedValue([completedJob] as any);
+
+      const req = makeReq({ projectPath: PROJECT_PATH, id: 'job-1' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/run-job');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'Job is not pending (status: completed)',
+      });
+    });
+
+    it('returns 404 when event is not found', async () => {
+      vi.mocked(calendarService.listEvents).mockResolvedValue([]);
+
+      const req = makeReq({ projectPath: PROJECT_PATH, id: 'missing-job' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/run-job');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'Event missing-job not found',
+      });
+    });
+
+    it('returns 400 when event is not a job type', async () => {
+      const milestoneEvent = {
+        ...pendingJob,
+        type: 'milestone',
+        jobStatus: undefined,
+      };
+      vi.mocked(calendarService.listEvents).mockResolvedValue([milestoneEvent] as any);
+
+      const req = makeReq({ projectPath: PROJECT_PATH, id: 'job-1' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/run-job');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'Event is not a job',
+      });
+    });
+
+    it('returns 400 when projectPath is missing', async () => {
+      const req = makeReq({ id: 'job-1' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/run-job');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'projectPath is required' });
+    });
+
+    it('returns 400 when id is missing', async () => {
+      const req = makeReq({ projectPath: PROJECT_PATH });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/run-job');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'id is required' });
+    });
+
+    it('returns 500 when calendarService.listEvents throws', async () => {
+      vi.mocked(calendarService.listEvents).mockRejectedValue(new Error('Read error'));
+
+      const req = makeReq({ projectPath: PROJECT_PATH, id: 'job-1' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/run-job');
+      await handler!(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Read error' });
+    });
+
+    it('does not await executeJob — responds immediately even if execution would take long', async () => {
+      // executeJob never resolves during this test
+      vi.mocked(calendarService.listEvents).mockResolvedValue([pendingJob] as any);
+      vi.mocked(jobExecutorService.executeJob).mockReturnValue(new Promise(() => {}));
+
+      const req = makeReq({ projectPath: PROJECT_PATH, id: 'job-1' });
+      const res = makeRes();
+
+      const handler = getHandler(router, 'post', '/run-job');
+      await handler!(req, res as Response);
+
+      // Response should already be sent without awaiting executeJob
+      expect(res.json).toHaveBeenCalledWith({ success: true, message: 'Job execution started' });
+    });
+  });
+});

--- a/apps/server/tests/unit/lib/settings-helpers.test.ts
+++ b/apps/server/tests/unit/lib/settings-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getMCPServersFromSettings } from '@/lib/settings-helpers.js';
+import { getMCPServersFromSettings, getWorkflowSettings } from '@/lib/settings-helpers.js';
 import type { SettingsService } from '@/services/settings-service.js';
+import { DEFAULT_WORKFLOW_SETTINGS } from '@protolabsai/types';
 
 // Mock the logger
 vi.mock('@protolabsai/utils', async () => {
@@ -302,6 +303,90 @@ describe('settings-helpers.ts', () => {
         args: undefined,
         env: undefined,
       });
+    });
+  });
+
+  describe('getWorkflowSettings', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should return DEFAULT_WORKFLOW_SETTINGS when settingsService is null', async () => {
+      const result = await getWorkflowSettings('/some/path', null);
+      expect(result).toEqual(DEFAULT_WORKFLOW_SETTINGS);
+    });
+
+    it('should return DEFAULT_WORKFLOW_SETTINGS when no workflow settings configured', async () => {
+      const mockSettingsService = {
+        getProjectSettings: vi.fn().mockResolvedValue({}),
+      } as unknown as SettingsService;
+
+      const result = await getWorkflowSettings('/some/path', mockSettingsService);
+      expect(result).toEqual(DEFAULT_WORKFLOW_SETTINGS);
+    });
+
+    it('should preserve preFlightChecks=true through merge when set explicitly', async () => {
+      const mockSettingsService = {
+        getProjectSettings: vi.fn().mockResolvedValue({
+          workflow: { preFlightChecks: true },
+        }),
+      } as unknown as SettingsService;
+
+      const result = await getWorkflowSettings('/some/path', mockSettingsService);
+      expect(result.preFlightChecks).toBe(true);
+    });
+
+    it('should preserve preFlightChecks=false through merge when set explicitly', async () => {
+      const mockSettingsService = {
+        getProjectSettings: vi.fn().mockResolvedValue({
+          workflow: { preFlightChecks: false },
+        }),
+      } as unknown as SettingsService;
+
+      const result = await getWorkflowSettings('/some/path', mockSettingsService);
+      expect(result.preFlightChecks).toBe(false);
+    });
+
+    it('should default preFlightChecks to true when field is missing from workflow settings', async () => {
+      const mockSettingsService = {
+        getProjectSettings: vi.fn().mockResolvedValue({
+          workflow: {
+            // preFlightChecks intentionally omitted — should default to true
+            postMergeVerification: false,
+          },
+        }),
+      } as unknown as SettingsService;
+
+      const result = await getWorkflowSettings('/some/path', mockSettingsService);
+      expect(result.preFlightChecks).toBe(true);
+    });
+
+    it('should return DEFAULT_WORKFLOW_SETTINGS on error', async () => {
+      const mockSettingsService = {
+        getProjectSettings: vi.fn().mockRejectedValue(new Error('Settings read error')),
+      } as unknown as SettingsService;
+
+      const result = await getWorkflowSettings('/some/path', mockSettingsService);
+      expect(result).toEqual(DEFAULT_WORKFLOW_SETTINGS);
+    });
+
+    it('should merge other workflow fields alongside preFlightChecks', async () => {
+      const mockSettingsService = {
+        getProjectSettings: vi.fn().mockResolvedValue({
+          workflow: {
+            preFlightChecks: false,
+            postMergeVerification: false,
+            pipeline: { goalGatesEnabled: false },
+          },
+        }),
+      } as unknown as SettingsService;
+
+      const result = await getWorkflowSettings('/some/path', mockSettingsService);
+      expect(result.preFlightChecks).toBe(false);
+      expect(result.postMergeVerification).toBe(false);
+      // Other pipeline defaults should be preserved
+      expect(result.pipeline.checkpointEnabled).toBe(true);
+      expect(result.pipeline.goalGatesEnabled).toBe(false);
     });
   });
 });

--- a/apps/server/tests/unit/services/ava-world-state-builder.test.ts
+++ b/apps/server/tests/unit/services/ava-world-state-builder.test.ts
@@ -92,43 +92,43 @@ describe('AvaWorldStateBuilder', () => {
   // ── getFullBriefing() — structure ──────────────────────────────────
 
   describe('getFullBriefing() — structure', () => {
-    it('should include top-level heading', () => {
-      const briefing = builder.getFullBriefing();
+    it('should include top-level heading', async () => {
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('# Ava Full Briefing');
     });
 
-    it('should include PM layer section', () => {
-      const briefing = builder.getFullBriefing();
+    it('should include PM layer section', async () => {
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('## Project Management Layer');
     });
 
-    it('should include Engineering layer section', () => {
-      const briefing = builder.getFullBriefing();
+    it('should include Engineering layer section', async () => {
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('## Engineering Layer');
     });
 
-    it('should include Strategic Context section', () => {
-      const briefing = builder.getFullBriefing();
+    it('should include Strategic Context section', async () => {
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('## Strategic Context');
     });
 
-    it('should include Team Health subsection', () => {
-      const briefing = builder.getFullBriefing();
+    it('should include Team Health subsection', async () => {
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('### Team Health');
     });
 
-    it('should include Cross-Project Dependencies subsection', () => {
-      const briefing = builder.getFullBriefing();
+    it('should include Cross-Project Dependencies subsection', async () => {
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('### Cross-Project Dependencies');
     });
 
-    it('should include Brand & Content subsection', () => {
-      const briefing = builder.getFullBriefing();
+    it('should include Brand & Content subsection', async () => {
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('### Brand & Content');
     });
 
-    it('should include a generation timestamp', () => {
-      const briefing = builder.getFullBriefing();
+    it('should include a generation timestamp', async () => {
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toMatch(/_Generated: \d{4}-\d{2}-\d{2}/);
     });
   });
@@ -136,25 +136,25 @@ describe('AvaWorldStateBuilder', () => {
   // ── getFullBriefing() — aggregation ──────────────────────────────────
 
   describe('getFullBriefing() — aggregation', () => {
-    it('should include PM distilled summary content', () => {
-      const briefing = builder.getFullBriefing();
+    it('should include PM distilled summary content', async () => {
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('## Project Status');
       expect(briefing).toContain('test-project');
     });
 
-    it('should call pmBuilder.getDistilledSummary()', () => {
-      builder.getFullBriefing();
+    it('should call pmBuilder.getDistilledSummary()', async () => {
+      await builder.getFullBriefing();
       expect(vi.mocked(pmBuilder.getDistilledSummary)).toHaveBeenCalledOnce();
     });
 
-    it('should include LE world state summary content', () => {
-      const briefing = builder.getFullBriefing();
+    it('should include LE world state summary content', async () => {
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('## Engineering');
       expect(briefing).toContain('3 features in progress');
     });
 
-    it('should call leProvider.getWorldStateSummary()', () => {
-      builder.getFullBriefing();
+    it('should call leProvider.getWorldStateSummary()', async () => {
+      await builder.getFullBriefing();
       expect(vi.mocked(leProvider.getWorldStateSummary)).toHaveBeenCalledOnce();
     });
   });
@@ -162,22 +162,22 @@ describe('AvaWorldStateBuilder', () => {
   // ── Team health ──────────────────────────────────────────────────────
 
   describe('team health metrics', () => {
-    it('should show active agents count', () => {
-      const briefing = builder.getFullBriefing();
+    it('should show active agents count', async () => {
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('Active Agents: 0');
     });
 
-    it('should show escalations count', () => {
-      const briefing = builder.getFullBriefing();
+    it('should show escalations count', async () => {
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('Escalations: 0');
     });
 
-    it('should flag errorBudgetExhausted=true when no projects exist', () => {
-      const briefing = builder.getFullBriefing();
+    it('should flag errorBudgetExhausted=true when no projects exist', async () => {
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('Error Budget Exhausted: Yes');
     });
 
-    it('should flag errorBudgetExhausted=false when projects exist', () => {
+    it('should flag errorBudgetExhausted=false when projects exist', async () => {
       pmBuilder = makeMockPmBuilder({
         projects: {
           'my-project': {
@@ -189,7 +189,7 @@ describe('AvaWorldStateBuilder', () => {
         },
       });
       builder = new AvaWorldStateBuilder(pmBuilder, leProvider);
-      const briefing = builder.getFullBriefing();
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('Error Budget Exhausted: No');
     });
   });
@@ -197,18 +197,18 @@ describe('AvaWorldStateBuilder', () => {
   // ── Cross-project dependencies ───────────────────────────────────────
 
   describe('cross-project dependencies', () => {
-    it('should show no-dependency placeholder with single project', () => {
+    it('should show no-dependency placeholder with single project', async () => {
       pmBuilder = makeMockPmBuilder({
         projects: {
           solo: { status: 'active', phase: 'dev', milestoneCount: 0, completedMilestones: 0 },
         },
       });
       builder = new AvaWorldStateBuilder(pmBuilder, leProvider);
-      const briefing = builder.getFullBriefing();
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('_No cross-project dependencies detected_');
     });
 
-    it('should flag multiple active projects', () => {
+    it('should flag multiple active projects', async () => {
       pmBuilder = makeMockPmBuilder({
         projects: {
           'proj-a': { status: 'active', phase: 'dev', milestoneCount: 1, completedMilestones: 0 },
@@ -216,7 +216,7 @@ describe('AvaWorldStateBuilder', () => {
         },
       });
       builder = new AvaWorldStateBuilder(pmBuilder, leProvider);
-      const briefing = builder.getFullBriefing();
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('2 active projects');
       expect(briefing).toContain('shared dependencies');
     });
@@ -225,36 +225,36 @@ describe('AvaWorldStateBuilder', () => {
   // ── Brand & content status ───────────────────────────────────────────
 
   describe('brand & content status', () => {
-    it('should show no-deadlines placeholder when none exist', () => {
-      const briefing = builder.getFullBriefing();
+    it('should show no-deadlines placeholder when none exist', async () => {
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('_No brand/content deadlines on the horizon_');
     });
 
-    it('should show upcoming deadlines from PM state', () => {
+    it('should show upcoming deadlines from PM state', async () => {
       pmBuilder = makeMockPmBuilder({
         upcomingDeadlines: [
           { projectSlug: 'content', label: 'Blog Post Launch', dueAt: '2099-06-01T00:00:00.000Z' },
         ],
       });
       builder = new AvaWorldStateBuilder(pmBuilder, leProvider);
-      const briefing = builder.getFullBriefing();
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('Blog Post Launch');
       expect(briefing).toContain('2099-06-01');
       expect(briefing).toContain('content');
     });
 
-    it('should not show past deadlines in brand section', () => {
+    it('should not show past deadlines in brand section', async () => {
       pmBuilder = makeMockPmBuilder({
         upcomingDeadlines: [
           { projectSlug: 'old', label: 'Past Launch', dueAt: '2020-01-01T00:00:00.000Z' },
         ],
       });
       builder = new AvaWorldStateBuilder(pmBuilder, leProvider);
-      const briefing = builder.getFullBriefing();
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('_No brand/content deadlines on the horizon_');
     });
 
-    it('should limit brand deadlines to 3 entries', () => {
+    it('should limit brand deadlines to 3 entries', async () => {
       const deadlines = Array.from({ length: 5 }, (_, i) => ({
         projectSlug: 'proj',
         label: `Deadline ${i + 1}`,
@@ -262,7 +262,7 @@ describe('AvaWorldStateBuilder', () => {
       }));
       pmBuilder = makeMockPmBuilder({ upcomingDeadlines: deadlines });
       builder = new AvaWorldStateBuilder(pmBuilder, leProvider);
-      const briefing = builder.getFullBriefing();
+      const briefing = await builder.getFullBriefing();
       const matches = briefing.match(/^- 2099-\d{2}-\d{2}/gm) ?? [];
       expect(matches.length).toBeLessThanOrEqual(3);
     });
@@ -271,16 +271,16 @@ describe('AvaWorldStateBuilder', () => {
   // ── Strategic context ────────────────────────────────────────────────
 
   describe('strategic context', () => {
-    it('should not include Strategic Directives section when not configured', () => {
-      const briefing = builder.getFullBriefing();
+    it('should not include Strategic Directives section when not configured', async () => {
+      const briefing = await builder.getFullBriefing();
       expect(briefing).not.toContain('### Strategic Directives');
     });
 
-    it('should include Strategic Directives when configured', () => {
+    it('should include Strategic Directives when configured', async () => {
       builder = new AvaWorldStateBuilder(pmBuilder, leProvider, {
         strategicContext: 'Focus on revenue-generating features this sprint.',
       });
-      const briefing = builder.getFullBriefing();
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('### Strategic Directives');
       expect(briefing).toContain('Focus on revenue-generating features');
     });
@@ -289,27 +289,27 @@ describe('AvaWorldStateBuilder', () => {
   // ── Error resilience ─────────────────────────────────────────────────
 
   describe('error resilience', () => {
-    it('should show PM unavailable message when getDistilledSummary throws', () => {
+    it('should show PM unavailable message when getDistilledSummary throws', async () => {
       vi.mocked(pmBuilder.getDistilledSummary).mockImplementation(() => {
         throw new Error('PM disk failure');
       });
-      const briefing = builder.getFullBriefing();
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('_PM summary unavailable_');
     });
 
-    it('should show LE unavailable message when getWorldStateSummary throws', () => {
+    it('should show LE unavailable message when getWorldStateSummary throws', async () => {
       vi.mocked(leProvider.getWorldStateSummary).mockImplementation(() => {
         throw new Error('LE service unavailable');
       });
-      const briefing = builder.getFullBriefing();
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('_Engineering summary unavailable_');
     });
 
-    it('should still produce a complete briefing despite PM failure', () => {
+    it('should still produce a complete briefing despite PM failure', async () => {
       vi.mocked(pmBuilder.getDistilledSummary).mockImplementation(() => {
         throw new Error('oops');
       });
-      const briefing = builder.getFullBriefing();
+      const briefing = await builder.getFullBriefing();
       expect(briefing).toContain('## Strategic Context');
       expect(briefing).toContain('### Team Health');
     });

--- a/apps/server/tests/unit/services/calendar-service.test.ts
+++ b/apps/server/tests/unit/services/calendar-service.test.ts
@@ -470,4 +470,261 @@ describe('calendar-service.ts', () => {
       );
     });
   });
+
+  describe('getDueJobs', () => {
+    function makeJobEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+      return {
+        id: 'job-1',
+        title: 'Test Job',
+        date: '2026-03-10',
+        time: '09:00',
+        type: 'job',
+        jobStatus: 'pending',
+        jobAction: { type: 'start-agent', featureId: 'feature-123' },
+        projectPath,
+        createdAt: '2026-03-01T00:00:00Z',
+        updatedAt: '2026-03-01T00:00:00Z',
+        ...overrides,
+      };
+    }
+
+    it('should return pending job events that are due', async () => {
+      // Create a "now" that is definitely after the job's scheduled time
+      // Parse date+time the same way as the service: new Date(`${date}T${time}:00`)
+      // Then set now to be 1 hour after that
+      const jobDt = new Date('2026-03-10T09:00:00');
+      const now = new Date(jobDt.getTime() + 60 * 60 * 1000); // 1hr later
+      const dueJob = makeJobEvent({ date: '2026-03-10', time: '09:00' });
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: [dueJob],
+        recovered: false,
+        source: 'main',
+      });
+
+      const jobs = await service.getDueJobs(projectPath, now);
+
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].id).toBe('job-1');
+    });
+
+    it('should exclude job events with time in the future', async () => {
+      // now is before the job's scheduled time
+      const jobDt = new Date('2026-03-10T09:00:00');
+      const now = new Date(jobDt.getTime() - 60 * 60 * 1000); // 1hr before
+      const futureJob = makeJobEvent({ date: '2026-03-10', time: '09:00' });
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: [futureJob],
+        recovered: false,
+        source: 'main',
+      });
+
+      const jobs = await service.getDueJobs(projectPath, now);
+
+      expect(jobs).toHaveLength(0);
+    });
+
+    it('should exclude non-job type events', async () => {
+      const jobDt = new Date('2026-03-10T09:00:00');
+      const now = new Date(jobDt.getTime() + 60 * 60 * 1000);
+      const customEvent = makeJobEvent({ type: 'custom' });
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: [customEvent],
+        recovered: false,
+        source: 'main',
+      });
+
+      const jobs = await service.getDueJobs(projectPath, now);
+
+      expect(jobs).toHaveLength(0);
+    });
+
+    it('should exclude job events with non-pending status', async () => {
+      const jobDt = new Date('2026-03-10T09:00:00');
+      const now = new Date(jobDt.getTime() + 60 * 60 * 1000);
+      const runningJob = makeJobEvent({ id: 'job-running', jobStatus: 'running' });
+      const completedJob = makeJobEvent({ id: 'job-completed', jobStatus: 'completed' });
+      const failedJob = makeJobEvent({ id: 'job-failed', jobStatus: 'failed' });
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: [runningJob, completedJob, failedJob],
+        recovered: false,
+        source: 'main',
+      });
+
+      const jobs = await service.getDueJobs(projectPath, now);
+
+      expect(jobs).toHaveLength(0);
+    });
+
+    it('should exclude job events without a time field', async () => {
+      const now = new Date('2026-03-10T10:00:00');
+      const noTimeJob = makeJobEvent({ time: undefined });
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: [noTimeJob],
+        recovered: false,
+        source: 'main',
+      });
+
+      const jobs = await service.getDueJobs(projectPath, now);
+
+      expect(jobs).toHaveLength(0);
+    });
+
+    it('should return only due jobs when mixed events are present', async () => {
+      const jobDt = new Date('2026-03-10T09:00:00');
+      const now = new Date(jobDt.getTime() + 30 * 60 * 1000); // 09:30 — after 09:00, before 11:00
+      const dueJob = makeJobEvent({ id: 'job-due', date: '2026-03-10', time: '09:00' });
+      const futureJob = makeJobEvent({ id: 'job-future', date: '2026-03-10', time: '11:00' });
+      const customEvent = makeJobEvent({ id: 'custom-1', type: 'custom' });
+      const completedJob = makeJobEvent({ id: 'job-done', jobStatus: 'completed' });
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: [dueJob, futureJob, customEvent, completedJob],
+        recovered: false,
+        source: 'main',
+      });
+
+      const jobs = await service.getDueJobs(projectPath, now);
+
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].id).toBe('job-due');
+    });
+  });
+
+  describe('isDateInRange (via listEvents)', () => {
+    it('should include all events when no date range is specified', async () => {
+      const events: CalendarEvent[] = [
+        {
+          id: 'event-past',
+          title: 'Past',
+          date: '2020-01-01',
+          type: 'custom',
+          projectPath,
+          createdAt: '2020-01-01T00:00:00Z',
+          updatedAt: '2020-01-01T00:00:00Z',
+        },
+        {
+          id: 'event-future',
+          title: 'Future',
+          date: '2030-01-01',
+          type: 'custom',
+          projectPath,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ];
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: events,
+        recovered: false,
+        source: 'main',
+      });
+
+      const result = await service.listEvents(projectPath, {});
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('should include event exactly on startDate boundary', async () => {
+      const events: CalendarEvent[] = [
+        {
+          id: 'event-boundary',
+          title: 'Boundary',
+          date: '2026-03-01',
+          type: 'custom',
+          projectPath,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ];
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: events,
+        recovered: false,
+        source: 'main',
+      });
+
+      const result = await service.listEvents(projectPath, { startDate: '2026-03-01' });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('event-boundary');
+    });
+
+    it('should include event exactly on endDate boundary', async () => {
+      const events: CalendarEvent[] = [
+        {
+          id: 'event-end',
+          title: 'End',
+          date: '2026-03-31',
+          type: 'custom',
+          projectPath,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ];
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: events,
+        recovered: false,
+        source: 'main',
+      });
+
+      const result = await service.listEvents(projectPath, { endDate: '2026-03-31' });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('event-end');
+    });
+
+    it('should exclude event strictly before startDate', async () => {
+      const events: CalendarEvent[] = [
+        {
+          id: 'event-before',
+          title: 'Before',
+          date: '2026-02-28',
+          type: 'custom',
+          projectPath,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ];
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: events,
+        recovered: false,
+        source: 'main',
+      });
+
+      const result = await service.listEvents(projectPath, { startDate: '2026-03-01' });
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should exclude event strictly after endDate', async () => {
+      const events: CalendarEvent[] = [
+        {
+          id: 'event-after',
+          title: 'After',
+          date: '2026-04-01',
+          type: 'custom',
+          projectPath,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ];
+      vi.mocked(secureFs.access).mockResolvedValue(undefined);
+      vi.mocked(readJsonWithRecovery).mockResolvedValue({
+        data: events,
+        recovered: false,
+        source: 'main',
+      });
+
+      const result = await service.listEvents(projectPath, { endDate: '2026-03-31' });
+
+      expect(result).toHaveLength(0);
+    });
+  });
 });

--- a/apps/server/tests/unit/services/job-executor-service.test.ts
+++ b/apps/server/tests/unit/services/job-executor-service.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { JobExecutorService, sanitizeCommand } from '@/services/job-executor-service.js';
+import type { CalendarService } from '@/services/calendar-service.js';
+import type { AutoModeService } from '@/services/auto-mode-service.js';
+import type { AutomationService } from '@/services/automation-service.js';
+import type { SettingsService } from '@/services/settings-service.js';
+import type { CalendarEvent } from '@protolabsai/types';
+import { createMockEventEmitter } from '../../helpers/mock-factories.js';
+
+// Mock node:child_process so run-command tests don't spawn real processes
+// Use importOriginal to preserve other exports (execFile, spawn, etc.)
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    exec: vi.fn(),
+  };
+});
+
+// Import after mock so vi.mocked() works
+import { exec } from 'node:child_process';
+
+// Silence logger output during tests
+vi.mock('@protolabsai/utils', async () => {
+  const actual = await vi.importActual<typeof import('@protolabsai/utils')>('@protolabsai/utils');
+  return {
+    ...actual,
+    createLogger: vi.fn(() => ({
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    })),
+  };
+});
+
+describe('JobExecutorService', () => {
+  let service: JobExecutorService;
+  let mockCalendarService: Partial<CalendarService>;
+  let mockAutoModeService: Partial<AutoModeService>;
+  let mockAutomationService: Partial<AutomationService>;
+  let mockSettingsService: Partial<SettingsService>;
+  let mockEvents: ReturnType<typeof createMockEventEmitter>;
+
+  const projectPath = '/test/project';
+
+  function makeJob(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+    return {
+      id: 'job-1',
+      title: 'Test Job',
+      date: '2026-03-10',
+      time: '09:00',
+      type: 'job',
+      jobStatus: 'pending',
+      jobAction: { type: 'start-agent', featureId: 'feature-123' },
+      projectPath,
+      createdAt: '2026-03-01T00:00:00Z',
+      updatedAt: '2026-03-01T00:00:00Z',
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockCalendarService = {
+      updateEvent: vi.fn().mockResolvedValue({}),
+      emitReminder: vi.fn(),
+      getDueJobs: vi.fn().mockResolvedValue([]),
+    };
+
+    mockAutoModeService = {
+      executeFeature: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockAutomationService = {
+      executeAutomation: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockSettingsService = {
+      getGlobalSettings: vi.fn().mockResolvedValue({ projects: [] }),
+    };
+
+    mockEvents = createMockEventEmitter();
+
+    service = new JobExecutorService(
+      mockCalendarService as CalendarService,
+      mockAutoModeService as AutoModeService,
+      mockAutomationService as AutomationService,
+      mockSettingsService as SettingsService,
+      mockEvents
+    );
+  });
+
+  describe('executeJob', () => {
+    describe('action dispatch', () => {
+      it('dispatches start-agent action to autoModeService.executeFeature', async () => {
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feature-abc' } });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockAutoModeService.executeFeature).toHaveBeenCalledWith(
+          projectPath,
+          'feature-abc',
+          true
+        );
+      });
+
+      it('dispatches run-automation action to automationService.executeAutomation', async () => {
+        const job = makeJob({
+          jobAction: { type: 'run-automation', automationId: 'automation-xyz' },
+        });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockAutomationService.executeAutomation).toHaveBeenCalledWith(
+          'automation-xyz',
+          'scheduler'
+        );
+      });
+
+      it('dispatches run-command action via exec', async () => {
+        const mockExec = vi.mocked(exec);
+        mockExec.mockImplementation((_cmd: string, _opts: unknown, callback: unknown) => {
+          (callback as (err: null, stdout: string, stderr: string) => void)(null, 'ok', '');
+          return {} as ReturnType<typeof exec>;
+        });
+
+        const job = makeJob({
+          jobAction: { type: 'run-command', command: 'npm run build' },
+        });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockExec).toHaveBeenCalledWith(
+          'npm run build',
+          expect.objectContaining({ timeout: expect.any(Number) }),
+          expect.any(Function)
+        );
+      });
+    });
+
+    describe('status transitions', () => {
+      it('marks job as running before dispatch', async () => {
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feat-1' } });
+
+        await service.executeJob(projectPath, job);
+
+        // First updateEvent call should set status to 'running'
+        expect(mockCalendarService.updateEvent).toHaveBeenNthCalledWith(
+          1,
+          projectPath,
+          job.id,
+          expect.objectContaining({ jobStatus: 'running' })
+        );
+      });
+
+      it('marks job as completed after successful dispatch', async () => {
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feat-1' } });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockCalendarService.updateEvent).toHaveBeenCalledWith(
+          projectPath,
+          job.id,
+          expect.objectContaining({ jobStatus: 'completed' })
+        );
+      });
+
+      it('marks job as failed when dispatch throws', async () => {
+        mockAutoModeService.executeFeature = vi.fn().mockRejectedValue(new Error('Agent failed'));
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feat-fail' } });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockCalendarService.updateEvent).toHaveBeenCalledWith(
+          projectPath,
+          job.id,
+          expect.objectContaining({ jobStatus: 'failed' })
+        );
+      });
+
+      it('includes error message in jobResult when job fails', async () => {
+        const errorMsg = 'Something broke';
+        mockAutoModeService.executeFeature = vi.fn().mockRejectedValue(new Error(errorMsg));
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feat-fail' } });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockCalendarService.updateEvent).toHaveBeenCalledWith(
+          projectPath,
+          job.id,
+          expect.objectContaining({
+            jobStatus: 'failed',
+            jobResult: expect.objectContaining({ error: errorMsg }),
+          })
+        );
+      });
+
+      it('includes timing info in jobResult on success', async () => {
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feat-1' } });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockCalendarService.updateEvent).toHaveBeenCalledWith(
+          projectPath,
+          job.id,
+          expect.objectContaining({
+            jobStatus: 'completed',
+            jobResult: expect.objectContaining({
+              startedAt: expect.any(String),
+              completedAt: expect.any(String),
+              durationMs: expect.any(Number),
+            }),
+          })
+        );
+      });
+    });
+
+    describe('event emission', () => {
+      it('emits job:started and job:completed events on success', async () => {
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feat-1' } });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockEvents.emit).toHaveBeenCalledWith(
+          'job:started',
+          expect.objectContaining({ jobId: job.id, projectPath })
+        );
+        expect(mockEvents.emit).toHaveBeenCalledWith(
+          'job:completed',
+          expect.objectContaining({ jobId: job.id, projectPath })
+        );
+      });
+
+      it('emits job:started and job:failed events on failure', async () => {
+        mockAutoModeService.executeFeature = vi.fn().mockRejectedValue(new Error('fail'));
+        const job = makeJob({ jobAction: { type: 'start-agent', featureId: 'feat-1' } });
+
+        await service.executeJob(projectPath, job);
+
+        expect(mockEvents.emit).toHaveBeenCalledWith(
+          'job:started',
+          expect.objectContaining({ jobId: job.id })
+        );
+        expect(mockEvents.emit).toHaveBeenCalledWith(
+          'job:failed',
+          expect.objectContaining({ jobId: job.id, error: 'fail' })
+        );
+      });
+    });
+
+    it('skips execution if job has no jobAction', async () => {
+      const job = makeJob({ jobAction: undefined });
+
+      await service.executeJob(projectPath, job);
+
+      expect(mockAutoModeService.executeFeature).not.toHaveBeenCalled();
+      expect(mockAutomationService.executeAutomation).not.toHaveBeenCalled();
+      expect(mockCalendarService.updateEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sanitizeCommand', () => {
+    describe('allows valid commands', () => {
+      it('allows a simple npm command', () => {
+        expect(() => sanitizeCommand('npm run build')).not.toThrow();
+      });
+
+      it('allows git commands', () => {
+        expect(() => sanitizeCommand('git status')).not.toThrow();
+      });
+
+      it('allows commands with flags', () => {
+        expect(() => sanitizeCommand('ls -la')).not.toThrow();
+      });
+
+      it('allows python scripts', () => {
+        expect(() => sanitizeCommand('python3 scripts/migrate.py')).not.toThrow();
+      });
+
+      it('returns the command unchanged when valid', () => {
+        const cmd = 'npm run build';
+        expect(sanitizeCommand(cmd)).toBe(cmd);
+      });
+
+      it('accepts a command at exactly the max length (1024 chars)', () => {
+        const exactCommand = 'a'.repeat(1024);
+        expect(() => sanitizeCommand(exactCommand)).not.toThrow();
+      });
+    });
+
+    describe('rejects shell metacharacters', () => {
+      it('rejects commands with semicolons', () => {
+        expect(() => sanitizeCommand('npm run build; rm -rf /')).toThrow(
+          /unescaped shell metacharacters/
+        );
+      });
+
+      it('rejects commands with pipe operator', () => {
+        expect(() => sanitizeCommand('cat /etc/passwd | grep root')).toThrow(
+          /unescaped shell metacharacters/
+        );
+      });
+
+      it('rejects commands with output redirect', () => {
+        expect(() => sanitizeCommand('echo hello > /tmp/file')).toThrow(
+          /unescaped shell metacharacters/
+        );
+      });
+
+      it('rejects commands with input redirect', () => {
+        expect(() => sanitizeCommand('cat < /etc/passwd')).toThrow(
+          /unescaped shell metacharacters/
+        );
+      });
+
+      it('rejects commands with $ variable expansion', () => {
+        expect(() => sanitizeCommand('echo $HOME')).toThrow(/unescaped shell metacharacters/);
+      });
+
+      it('rejects commands with backtick substitution', () => {
+        expect(() => sanitizeCommand('echo `whoami`')).toThrow(/unescaped shell metacharacters/);
+      });
+
+      it('rejects commands with && chaining', () => {
+        expect(() => sanitizeCommand('npm run build && npm run test')).toThrow(
+          /unescaped shell metacharacters/
+        );
+      });
+    });
+
+    describe('rejects oversized commands', () => {
+      it('rejects a command exceeding the 1024-character limit', () => {
+        const longCommand = 'a'.repeat(1025);
+        expect(() => sanitizeCommand(longCommand)).toThrow(/exceeds maximum length/);
+      });
+    });
+  });
+});

--- a/apps/server/tests/unit/services/pm-le-integration.test.ts
+++ b/apps/server/tests/unit/services/pm-le-integration.test.ts
@@ -1,0 +1,351 @@
+/**
+ * PM ↔ LE Bidirectional Integration — unit tests
+ *
+ * Covers:
+ * - PM can query LE for execution status (PM → LE direction)
+ * - LE can query PM for next assignable phase (LE → PM direction)
+ * - No circular dependencies: both directions wired via interface injection
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'node:fs/promises';
+
+// ────────────────────────── Module Mocks ──────────────────────────
+
+vi.mock('node:fs/promises');
+
+vi.mock('@protolabsai/utils', async () => {
+  const actual = await vi.importActual<typeof import('@protolabsai/utils')>('@protolabsai/utils');
+  return {
+    ...actual,
+    createLogger: vi.fn(() => ({
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    })),
+  };
+});
+
+vi.mock('child_process', () => ({ exec: vi.fn(), execFile: vi.fn(), spawn: vi.fn() }));
+vi.mock('util', () => ({ promisify: (fn: unknown) => fn }));
+vi.mock('@/lib/settings-helpers.js', () => ({ getWorkflowSettings: vi.fn() }));
+
+import {
+  PMWorldStateBuilder,
+  type ILeadEngineerStatusProvider,
+  type LEExecutionStatusSummary,
+} from '@/services/pm-world-state-builder.js';
+
+import {
+  LeadEngineerService,
+  type IPMWorldStateProvider,
+} from '@/services/lead-engineer-service.js';
+
+import {
+  createMockFeatureLoader,
+  createMockSettingsService,
+  createMockProjectService,
+  createMockMetricsService,
+} from '../../helpers/mock-factories.js';
+
+import type { EventType } from '@protolabsai/types';
+
+// ────────────────────────── Helpers ──────────────────────────
+
+function createMockEvents() {
+  return {
+    emit: vi.fn(),
+    subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),
+    on: vi.fn(() => ({ unsubscribe: vi.fn() })),
+  };
+}
+
+function setupEmptyMockFs() {
+  vi.mocked(fs.readdir).mockRejectedValue(new Error('ENOENT'));
+  vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT'));
+}
+
+function setupMilestoneFs(
+  milestones: Array<{
+    slug: string;
+    title: string;
+    phases: number;
+    completed: number;
+    dueAt?: string;
+  }>
+) {
+  vi.mocked(fs.readdir).mockImplementation(async (dirPath) => {
+    const p = String(dirPath);
+    if (p.endsWith('projects')) {
+      return [
+        { name: 'test-project', isDirectory: () => true },
+      ] as unknown as import('node:fs').Dirent[];
+    }
+    return [];
+  });
+
+  const projectJson = JSON.stringify({
+    status: 'active',
+    phase: 'development',
+    milestones: milestones.map((ms) => ({
+      slug: ms.slug,
+      title: ms.title,
+      dueAt: ms.dueAt,
+      phases: Array.from({ length: ms.phases }, (_, i) => ({
+        featureId: `f-${ms.slug}-${i}`,
+        status: i < ms.completed ? 'done' : 'pending',
+      })),
+    })),
+  });
+
+  vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
+    const p = String(filePath);
+    if (p.endsWith('project.json')) return projectJson;
+    throw new Error('ENOENT');
+  });
+}
+
+// ────────────────────────── Tests ──────────────────────────
+
+describe('PM → LE: queryLEExecutionStatus()', () => {
+  let pm: PMWorldStateBuilder;
+
+  beforeEach(() => {
+    pm = new PMWorldStateBuilder({ projectRoot: '/fake/root' });
+    setupEmptyMockFs();
+  });
+
+  it('returns null when no LE status provider is set', () => {
+    expect(pm.queryLEExecutionStatus()).toBeNull();
+  });
+
+  it('returns the summary from the injected provider', () => {
+    const summary: LEExecutionStatusSummary = {
+      activeProjectCount: 2,
+      activeFeaturesCount: 5,
+      projectStatuses: [
+        { projectPath: '/p1', projectSlug: 'proj-a', flowState: 'running' },
+        { projectPath: '/p2', projectSlug: 'proj-b', flowState: 'running' },
+      ],
+    };
+
+    const provider: ILeadEngineerStatusProvider = {
+      getExecutionStatusSummary: vi.fn().mockReturnValue(summary),
+    };
+
+    pm.setLeadEngineerStatusProvider(provider);
+
+    const result = pm.queryLEExecutionStatus();
+    expect(result).toEqual(summary);
+    expect(provider.getExecutionStatusSummary).toHaveBeenCalledOnce();
+  });
+
+  it('provider can be replaced and new provider is used', () => {
+    const providerA: ILeadEngineerStatusProvider = {
+      getExecutionStatusSummary: vi
+        .fn()
+        .mockReturnValue({ activeProjectCount: 1, activeFeaturesCount: 1, projectStatuses: [] }),
+    };
+    const providerB: ILeadEngineerStatusProvider = {
+      getExecutionStatusSummary: vi
+        .fn()
+        .mockReturnValue({ activeProjectCount: 99, activeFeaturesCount: 99, projectStatuses: [] }),
+    };
+
+    pm.setLeadEngineerStatusProvider(providerA);
+    pm.setLeadEngineerStatusProvider(providerB);
+
+    const result = pm.queryLEExecutionStatus();
+    expect(result?.activeProjectCount).toBe(99);
+    expect(providerA.getExecutionStatusSummary).not.toHaveBeenCalled();
+    expect(providerB.getExecutionStatusSummary).toHaveBeenCalledOnce();
+  });
+});
+
+describe('PM.getNextAssignablePhase()', () => {
+  let pm: PMWorldStateBuilder;
+
+  beforeEach(() => {
+    pm = new PMWorldStateBuilder({ projectRoot: '/fake/root' });
+  });
+
+  it('returns null when state has no milestones', () => {
+    setupEmptyMockFs();
+    expect(pm.getNextAssignablePhase()).toBeNull();
+  });
+
+  it('returns the first incomplete milestone after state is built', async () => {
+    setupMilestoneFs([
+      {
+        slug: 'ms-one',
+        title: 'Milestone One',
+        phases: 3,
+        completed: 1,
+        dueAt: '2026-05-01T00:00:00.000Z',
+      },
+      { slug: 'ms-two', title: 'Milestone Two', phases: 2, completed: 0 },
+    ]);
+
+    await pm.buildState();
+
+    const result = pm.getNextAssignablePhase();
+    expect(result).not.toBeNull();
+    expect(result?.milestoneSlug).toBe('ms-one');
+    expect(result?.milestoneTitle).toBe('Milestone One');
+    expect(result?.remainingPhases).toBe(2); // 3 - 1
+    expect(result?.dueAt).toBe('2026-05-01T00:00:00.000Z');
+  });
+
+  it('returns null when all milestones are complete', async () => {
+    setupMilestoneFs([{ slug: 'ms-done', title: 'Done Milestone', phases: 2, completed: 2 }]);
+
+    await pm.buildState();
+
+    expect(pm.getNextAssignablePhase()).toBeNull();
+  });
+
+  it('skips fully-complete milestones and returns first incomplete one', async () => {
+    setupMilestoneFs([
+      { slug: 'ms-complete', title: 'Complete', phases: 2, completed: 2 },
+      { slug: 'ms-partial', title: 'Partial', phases: 4, completed: 1 },
+    ]);
+
+    await pm.buildState();
+
+    const result = pm.getNextAssignablePhase();
+    expect(result?.milestoneSlug).toBe('ms-partial');
+    expect(result?.remainingPhases).toBe(3);
+  });
+});
+
+describe('LE → PM: queryPMNextAssignment()', () => {
+  let le: LeadEngineerService;
+
+  beforeEach(() => {
+    const events = createMockEvents();
+    le = new LeadEngineerService(
+      events as unknown as Parameters<
+        typeof LeadEngineerService.prototype.initialize
+      >[0] extends never
+        ? never
+        : any,
+      createMockFeatureLoader(),
+      { isRunning: vi.fn().mockReturnValue(false), getConfig: vi.fn() } as any,
+      createMockProjectService(),
+      { launch: vi.fn() } as any,
+      createMockSettingsService(),
+      createMockMetricsService()
+    );
+  });
+
+  it('returns null when no PM provider is set', () => {
+    expect(le.queryPMNextAssignment()).toBeNull();
+  });
+
+  it('returns the phase from the injected PM provider', () => {
+    const provider: IPMWorldStateProvider = {
+      getNextAssignablePhase: vi.fn().mockReturnValue({
+        milestoneSlug: 'ms-alpha',
+        milestoneTitle: 'Alpha Milestone',
+        remainingPhases: 3,
+        dueAt: '2026-06-01T00:00:00.000Z',
+      }),
+    };
+
+    le.setPMWorldStateProvider(provider);
+
+    const result = le.queryPMNextAssignment();
+    expect(result).toEqual({
+      milestoneSlug: 'ms-alpha',
+      milestoneTitle: 'Alpha Milestone',
+      remainingPhases: 3,
+      dueAt: '2026-06-01T00:00:00.000Z',
+    });
+    expect(provider.getNextAssignablePhase).toHaveBeenCalledOnce();
+  });
+
+  it('returns null when PM provider reports no assignable phase', () => {
+    const provider: IPMWorldStateProvider = {
+      getNextAssignablePhase: vi.fn().mockReturnValue(null),
+    };
+
+    le.setPMWorldStateProvider(provider);
+
+    expect(le.queryPMNextAssignment()).toBeNull();
+  });
+});
+
+describe('LE.getExecutionStatusSummary()', () => {
+  let le: LeadEngineerService;
+  let events: ReturnType<typeof createMockEvents>;
+
+  beforeEach(() => {
+    events = createMockEvents();
+    le = new LeadEngineerService(
+      events as any,
+      createMockFeatureLoader(),
+      { isRunning: vi.fn().mockReturnValue(false), getConfig: vi.fn() } as any,
+      createMockProjectService(),
+      { launch: vi.fn() } as any,
+      createMockSettingsService(),
+      createMockMetricsService()
+    );
+  });
+
+  it('returns zero counts when no sessions are active', () => {
+    const summary = le.getExecutionStatusSummary();
+    expect(summary.activeProjectCount).toBe(0);
+    expect(summary.activeFeaturesCount).toBe(0);
+    expect(summary.projectStatuses).toEqual([]);
+  });
+
+  it('satisfies ILeadEngineerStatusProvider interface (can be injected into PM)', () => {
+    // Validate LE can be used as an ILeadEngineerStatusProvider without type errors.
+    const provider: ILeadEngineerStatusProvider = {
+      getExecutionStatusSummary: () => le.getExecutionStatusSummary(),
+    };
+
+    const pm = new PMWorldStateBuilder({ projectRoot: '/fake/root' });
+    pm.setLeadEngineerStatusProvider(provider);
+
+    const result = pm.queryLEExecutionStatus();
+    expect(result).toBeDefined();
+    expect(result?.activeProjectCount).toBe(0);
+  });
+});
+
+describe('Full wiring: PM ↔ LE round-trip', () => {
+  it('PM can call LE and LE can call PM with no circular import', async () => {
+    setupEmptyMockFs();
+
+    const pm = new PMWorldStateBuilder({ projectRoot: '/fake/root' });
+    const events = createMockEvents();
+    const le = new LeadEngineerService(
+      events as any,
+      createMockFeatureLoader(),
+      { isRunning: vi.fn().mockReturnValue(false), getConfig: vi.fn() } as any,
+      createMockProjectService(),
+      { launch: vi.fn() } as any,
+      createMockSettingsService(),
+      createMockMetricsService()
+    );
+
+    // Wire LE → PM
+    le.setPMWorldStateProvider(pm);
+
+    // Wire PM → LE
+    pm.setLeadEngineerStatusProvider({
+      getExecutionStatusSummary: () => le.getExecutionStatusSummary(),
+    });
+
+    // PM queries LE
+    const leStatus = pm.queryLEExecutionStatus();
+    expect(leStatus).not.toBeNull();
+    expect(leStatus?.activeProjectCount).toBe(0);
+
+    // LE queries PM
+    const pmPhase = le.queryPMNextAssignment();
+    expect(pmPhase).toBeNull(); // no milestones loaded
+  });
+});

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -36,7 +36,12 @@ export default defineConfig({
       },
     },
     include: ['tests/**/*.test.ts', 'tests/**/*.spec.ts'],
-    exclude: ['**/node_modules/**', '**/dist/**'],
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      // Tests requiring native modules (better-sqlite3) not rebuilt in CI
+      'tests/knowledge-flow-pipeline.test.ts',
+    ],
     mockReset: true,
     restoreMocks: true,
     clearMocks: true,

--- a/apps/ui/src/components/views/calendar-view/use-calendar-events.ts
+++ b/apps/ui/src/components/views/calendar-view/use-calendar-events.ts
@@ -4,11 +4,17 @@
  * Fetches calendar events for a given month/year from the backend API.
  * Provides mutation functions for creating, updating, and deleting events.
  * Uses the apiFetch pattern consistent with the rest of the codebase.
+ *
+ * Also subscribes to WebSocket events (calendar:event:created/updated/deleted,
+ * job:started/job:completed/job:failed) and triggers a refetch when events
+ * arrive for the currently-active project path.
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { apiPost } from '@/lib/api-fetch';
+import { getHttpApiClient } from '@/lib/http-api-client';
 import type { CalendarEvent, CalendarEventType, JobAction } from '@protolabsai/types';
+import type { EventType } from '@protolabsai/types';
 
 interface CalendarListResponse {
   success: boolean;
@@ -92,9 +98,21 @@ function getMonthDateRange(month: number, year: number): { startDate: string; en
   return { startDate, endDate };
 }
 
+/** WebSocket event types that should trigger a calendar refetch */
+const CALENDAR_WS_EVENT_TYPES: EventType[] = [
+  'calendar:event:created',
+  'calendar:event:updated',
+  'calendar:event:deleted',
+  'job:started',
+  'job:completed',
+  'job:failed',
+];
+
 /**
  * Fetch calendar events for a given month from the backend.
  * Provides CRUD mutation functions that automatically refetch after success.
+ * Subscribes to WebSocket calendar/job events to keep the view in sync
+ * when changes originate from other clients or server-side processes.
  */
 export function useCalendarEvents({
   projectPath,
@@ -152,6 +170,28 @@ export function useCalendarEvents({
   useEffect(() => {
     fetchEvents();
   }, [fetchEvents]);
+
+  // Subscribe to WebSocket calendar and job events to refetch when the server
+  // signals a state change for the currently-active project.
+  useEffect(() => {
+    if (!projectPath) return;
+
+    const api = getHttpApiClient();
+
+    const unsubscribe = api.subscribeToEvents((type: EventType, payload: unknown) => {
+      if (!CALENDAR_WS_EVENT_TYPES.includes(type)) return;
+
+      // Only refetch if the event belongs to the current project
+      const p = payload as Record<string, unknown> | null;
+      if (p && p['projectPath'] && p['projectPath'] !== projectPath) return;
+
+      void fetchEvents();
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [projectPath, fetchEvents]);
 
   const createEvent = useCallback(
     async (input: CreateEventInput): Promise<CalendarEvent | null> => {

--- a/apps/ui/src/store/app-store.ts
+++ b/apps/ui/src/store/app-store.ts
@@ -338,7 +338,9 @@ export interface AppActions {
 
   // Server URL runtime override actions
   setServerUrlOverride: (url: string | null) => void;
+  clearServerUrlOverride: () => void; // Clears the server URL override (alias for setServerUrlOverride(null))
   addRecentServerUrl: (url: string) => void; // Adds to recentServerUrls (max 10, deduplicated)
+  removeRecentServerUrl: (url: string) => void; // Removes a URL from recentServerUrls
 
   // Server connection actions
   connectToServer: (url: string) => Promise<void>;
@@ -1360,8 +1362,22 @@ export const useAppStore = create<AppState & AppActions>()((set, get) => ({
     invalidateHttpClient();
   },
 
+  clearServerUrlOverride: () => {
+    get().setServerUrlOverride(null);
+  },
+
   addRecentServerUrl: (url) => {
     const recentServerUrls = [url, ...get().recentServerUrls.filter((u) => u !== url)].slice(0, 10);
+    try {
+      localStorage.setItem('automaker:recentServerUrls', JSON.stringify(recentServerUrls));
+    } catch {
+      // localStorage might be disabled
+    }
+    set({ recentServerUrls });
+  },
+
+  removeRecentServerUrl: (url) => {
+    const recentServerUrls = get().recentServerUrls.filter((u) => u !== url);
     try {
       localStorage.setItem('automaker:recentServerUrls', JSON.stringify(recentServerUrls));
     } catch {

--- a/libs/types/src/calendar.ts
+++ b/libs/types/src/calendar.ts
@@ -17,11 +17,48 @@ export type JobStatus = 'pending' | 'running' | 'completed' | 'failed';
 
 /**
  * Job action types
+ *
+ * ### `run-command` format
+ *
+ * The `command` field must be a **single, simple shell command** with no shell
+ * metacharacters. The executor enforces the following constraints at runtime:
+ *
+ * - Maximum length: 1024 characters
+ * - Disallowed (unescaped): `;`  `&&`  `||`  `|`  `>`  `<`  `$`  `` ` ``
+ *
+ * If a special character is required literally, prefix it with a backslash
+ * (e.g. `\$`). Shell features such as piping, redirection, variable expansion,
+ * and command chaining are **not** supported and will cause the job to fail.
+ *
+ * **Valid examples:**
+ * ```
+ * npm run build
+ * python3 scripts/migrate.py
+ * ./bin/run-task.sh --env production
+ * ```
+ *
+ * **Invalid examples (will be rejected):**
+ * ```
+ * npm run build && npm test   // && not allowed
+ * echo $HOME                  // $ not allowed
+ * cat file.txt | grep error   // | not allowed
+ * ```
  */
 export type JobAction =
   | { type: 'start-agent'; featureId: string }
   | { type: 'run-automation'; automationId: string }
-  | { type: 'run-command'; command: string; cwd?: string };
+  | {
+      type: 'run-command';
+      /**
+       * The shell command to execute.
+       * Must be a single command with no shell metacharacters.
+       * Maximum length: 1024 characters.
+       * @see {JobAction} for full format rules and examples.
+       */
+      command: string;
+      /** Optional working directory for the command */
+      cwd?: string;
+    };
 
 /**
  * Result of a job execution

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -315,6 +315,10 @@ export type EventType =
   // Sensor registry events (core sensor framework)
   | 'sensor:registered'
   | 'sensor:data-received'
+  // Calendar CRUD events (emitted by calendar routes after successful create/update/delete)
+  | 'calendar:event:created'
+  | 'calendar:event:updated'
+  | 'calendar:event:deleted'
   // Calendar job events (one-time scheduled actions)
   | 'job:started'
   | 'job:completed'

--- a/packages/mcp-server/plugins/automaker/commands/calendar-assistant.md
+++ b/packages/mcp-server/plugins/automaker/commands/calendar-assistant.md
@@ -12,7 +12,7 @@ allowed-tools:
   - mcp__plugin_protolabs_studio__list_features
   - mcp__plugin_protolabs_studio__get_feature
   - mcp__plugin_protolabs_studio__query_board
-  # Calendar operations (exclusive access)
+  # Calendar operations
   - mcp__plugin_protolabs_studio__list_calendar_events
   - mcp__plugin_protolabs_studio__create_calendar_event
   - mcp__plugin_protolabs_studio__update_calendar_event
@@ -21,47 +21,40 @@ allowed-tools:
 
 # Calendar Assistant
 
-You are the Calendar Assistant for protoLabs. You are the **sole entity** with access to calendar manipulation tools. Other agents must delegate calendar operations to you rather than calling calendar tools directly.
+You are the Calendar Assistant for protoLabs. You specialize in calendar operations — creating, updating, querying, and deleting calendar events, tracking deadlines, and coordinating scheduling across the project.
 
 ## Core Mandate
 
-**Your job: Manage all temporal data and calendar operations for the project.**
+**Your job: Manage temporal data and calendar operations for the project.**
 
 - List, create, update, and delete calendar events
 - Track project deadlines and milestones
 - Coordinate scheduling across features and agents
-- Provide deadline information to other agents when requested
+- Provide deadline information when requested
 - Maintain calendar integrity and consistency
 
-## Exclusive Tool Access
+## SDK-Native Invocation Model
 
-You are the **only agent** with access to calendar manipulation tools:
+Calendar tools are available to any agent that is granted access to them. This skill is the canonical specialist for calendar work — activating it gives you a focused, context-rich environment for calendar operations. Other agents that need occasional calendar access can be granted the relevant tools directly in their `allowed-tools` list and call them without routing through this skill.
 
-- `list_calendar_events` — Query calendar for events
-- `create_calendar_event` — Schedule new events
-- `update_calendar_event` — Modify existing events
-- `delete_calendar_event` — Remove events
+When calendar work is the primary concern, prefer activating this skill. For lightweight, one-off calendar reads inside another agent, granting `mcp__plugin_protolabs_studio__list_calendar_events` directly is acceptable.
 
-Other agents (engineers, PM, etc.) will delegate calendar operations to you by calling `execute_dynamic_agent` with your template name and describing what they need.
+## Calendar Tools
+
+- `mcp__plugin_protolabs_studio__list_calendar_events` — Query calendar for events
+- `mcp__plugin_protolabs_studio__create_calendar_event` — Schedule new events
+- `mcp__plugin_protolabs_studio__update_calendar_event` — Modify existing events
+- `mcp__plugin_protolabs_studio__delete_calendar_event` — Remove events
 
 ## Board Integration
 
 You have **read-only** access to the board to understand project context:
 
-- `list_features` — See features and their metadata
-- `get_feature` — Get detailed feature information
-- `query_board` — Query board state
+- `mcp__plugin_protolabs_studio__list_features` — See features and their metadata
+- `mcp__plugin_protolabs_studio__get_feature` — Get detailed feature information
+- `mcp__plugin_protolabs_studio__query_board` — Query board state
 
 Use these tools to correlate calendar events with feature work, deadlines, and milestones.
-
-## Delegation Pattern
-
-When other agents need calendar operations, they will:
-
-1. Call `execute_dynamic_agent` with `templateName: 'calendar-assistant'`
-2. Provide a prompt describing the calendar operation needed
-3. You handle the actual calendar manipulation
-4. Return the result to the requesting agent
 
 ## Responsibilities
 
@@ -128,18 +121,16 @@ You are **precise, reliable, and time-conscious.**
 
 - **Be clear about timing.** Use specific dates and times, not vague language.
 - **Prevent conflicts.** Always check for scheduling collisions.
-- **Own the calendar.** You are the authority on temporal data.
+- **Be the calendar expert.** You are the authority on temporal data when activated.
 - **Coordinate effectively.** Help agents understand timeline implications.
 - **Be proactive.** Suggest scheduling improvements when you see opportunities.
 
 ## On Activation
 
-When activated by another agent or user:
+When activated:
 
 1. Understand the calendar operation requested
 2. Validate the request and gather any missing information
 3. Execute the calendar operation(s)
 4. Return clear confirmation with event details
 5. Mention any conflicts or considerations
-
-You are the single source of truth for all project temporal data. Keep the calendar accurate, consistent, and helpful!

--- a/packages/mcp-server/plugins/automaker/tools/briefing.ts
+++ b/packages/mcp-server/plugins/automaker/tools/briefing.ts
@@ -1,0 +1,106 @@
+/**
+ * Briefing Tool — Layered World State Briefing
+ *
+ * Extends the /briefing MCP endpoint with layered world state from all three layers:
+ *   Layer 1 — Ava (strategic): cross-project rollups, team health, brand/content status
+ *   Layer 2 — PM (project management): project status, milestone progress, upcoming deadlines
+ *   Layer 3 — LE (engineering execution): active features, agent state, PR status
+ *
+ * Usage: build a BriefingWorldStateProvider backed by AvaWorldStateBuilder and
+ * call buildLayeredBriefing() to get enriched world state alongside the event digest.
+ *
+ * This module is framework-agnostic — no direct imports from apps/server.
+ * The caller wires in a BriefingWorldStateProvider implementation.
+ */
+
+// ────────────────────────── Interfaces ──────────────────────────
+
+/**
+ * Provider interface that wraps AvaWorldStateBuilder.
+ * Implement this with a real AvaWorldStateBuilder instance in production.
+ */
+export interface BriefingWorldStateProvider {
+  /** Get the full layered briefing markdown from AvaWorldStateBuilder */
+  getFullBriefing(): Promise<string>;
+}
+
+// ────────────────────────── Result Types ──────────────────────────
+
+/** A single named layer of the briefing (Ava, PM, or LE) */
+export interface BriefingLayer {
+  /** Layer identifier: 'ava' | 'pm' | 'le' */
+  name: string;
+  /** Markdown summary for this layer */
+  summary: string;
+}
+
+/**
+ * Full layered briefing result returned by buildLayeredBriefing().
+ * Contains the complete aggregated markdown plus individual layer summaries.
+ */
+export interface LayeredBriefingResult {
+  /** Full briefing markdown aggregating all three world state layers */
+  markdown: string;
+  /** Individual layer summaries (one per layer) */
+  layers: BriefingLayer[];
+  /** ISO timestamp of when this briefing was generated */
+  generatedAt: string;
+}
+
+// ────────────────────────── Functions ──────────────────────────
+
+/**
+ * Build a layered world state briefing.
+ *
+ * Aggregates data from all three world state layers via BriefingWorldStateProvider
+ * (backed by AvaWorldStateBuilder in production, or a stub in tests).
+ *
+ * @param provider - Backed by AvaWorldStateBuilder; provides getFullBriefing()
+ * @returns LayeredBriefingResult with markdown and layer breakdown
+ */
+export async function buildLayeredBriefing(
+  provider: BriefingWorldStateProvider
+): Promise<LayeredBriefingResult> {
+  const generatedAt = new Date().toISOString();
+
+  let markdown: string;
+  try {
+    markdown = await provider.getFullBriefing();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    markdown = `# Briefing\n\n_World state unavailable: ${msg}_`;
+  }
+
+  // Expose the aggregated markdown as the Ava layer (AvaWorldStateBuilder covers all 3)
+  const layers: BriefingLayer[] = [{ name: 'ava', summary: markdown }];
+
+  return { markdown, layers, generatedAt };
+}
+
+// ────────────────────────── MCP Tool Definition ──────────────────────────
+
+/**
+ * MCP tool definition for the world-state-enriched briefing.
+ *
+ * Supplements the existing get_briefing (event digest) with layered world state
+ * from AvaWorldStateBuilder. Register alongside get_briefing in the MCP server.
+ */
+export const BRIEFING_WORLD_STATE_TOOL = {
+  name: 'get_briefing_world_state',
+  description:
+    'Get a comprehensive world state briefing from all three layers: ' +
+    'Ava (strategic), PM (project management), and LE (engineering execution). ' +
+    'Returns layered markdown with project rollups, milestone progress, ' +
+    'engineering execution state, team health, and strategic context. ' +
+    'Use this at session start for a full situational picture beyond the event digest.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      projectPath: {
+        type: 'string',
+        description: 'Absolute path to the project directory',
+      },
+    },
+    required: ['projectPath'],
+  },
+} as const;

--- a/packages/mcp-server/src/tools/calendar-tools.ts
+++ b/packages/mcp-server/src/tools/calendar-tools.ts
@@ -34,7 +34,7 @@ export const calendarTools: Tool[] = [
           type: 'array',
           items: {
             type: 'string',
-            enum: ['custom', 'feature_due_date', 'milestone', 'job'],
+            enum: ['custom', 'feature', 'google', 'ceremony', 'milestone', 'job'],
           },
           description: 'Optional array of event types to filter by. If omitted, returns all types.',
         },

--- a/packages/mcp-server/src/tools/feature-tools.ts
+++ b/packages/mcp-server/src/tools/feature-tools.ts
@@ -189,6 +189,11 @@ export const featureTools: Tool[] = [
           description:
             'Priority level: 0 = No priority, 1 = Urgent, 2 = High, 3 = Normal, 4 = Low. Pass null to clear.',
         },
+        epicId: {
+          type: ['string', 'null'],
+          description:
+            'ID of parent epic to group this feature under. Pass null to remove from epic.',
+        },
         isFoundation: {
           type: 'boolean',
           description:


### PR DESCRIPTION
## Summary
Full promotion of staging to main. Includes:

- Calendar domain hardening: WebSocket broadcast, ceremony integration, Google Calendar sync, cancelled event cleanup
- Skill rewrite: calendar-assistant rewritten for SDK-native agent patterns
- Test coverage: CalendarService unit tests + calendar API route integration tests
- Ava Entry Point & PM-LE Status Bridge wiring
- Agent fixes: prettier formatting, shell injection, model alias resolution, CRDT project scoping
- Knowledge indexing, role-scoped context injection, pre-flight checks fix
- epicId exposed on update_feature MCP tool for retroactive epic assignment

Conflicts resolved: all .automaker/memory drift + source divergence resolved by accepting staging.

## Merge Strategy
Merge commit (not squash) to preserve DAG.

## Test plan
- [x] CI passes on staging
- [ ] CI passes on this PR
- [ ] Auto-deploy to production succeeds

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar events now auto-sync in real-time via WebSocket
  * Google Calendar integration now deletes cancelled and out-of-window events
  * Added Epic ID support for feature creation and updates
  * Enhanced project briefing with knowledge-based insights
  * Improved command execution with security validation
  * New calendar event categories: Google, Ceremony, and Feature events

* **Bug Fixes**
  * Fixed stale Google Calendar event retention issue

* **Documentation**
  * Added Prettier Before Commit formatting guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->