### PR TITLE
Bug: Project create route bypasses CRDT, causes getProject to return null

### DIFF
--- a/apps/server/src/routes/projects/index.ts
+++ b/apps/server/src/routes/projects/index.ts
@@ -58,13 +58,13 @@ export function createProjectsRoutes(
     '/create',
     validatePathParams('projectPath'),
     validateSlugs('slug?'), // slug is optional, derived from title if not provided
-    createCreateHandler()
+    createCreateHandler(projectService)
   );
   router.post(
     '/update',
     validatePathParams('projectPath'),
     validateSlugs('projectSlug'),
-    createUpdateHandler()
+    createUpdateHandler(projectService)
   );
   router.post(
     '/delete',

--- a/apps/server/src/routes/projects/routes/create.ts
+++ b/apps/server/src/routes/projects/routes/create.ts
@@ -26,6 +26,7 @@ import {
   generatePrdFile,
 } from '@protolabsai/utils';
 import { getErrorMessage, logError } from '../common.js';
+import type { ProjectService } from '../../../services/project-service.js';
 
 interface CreateProjectRequest {
   projectPath: string;
@@ -49,7 +50,7 @@ interface CreateProjectRequest {
   }>;
 }
 
-export function createCreateHandler() {
+export function createCreateHandler(projectService: ProjectService) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
       const {
@@ -201,6 +202,10 @@ export function createCreateHandler() {
         const researchFilePath = getResearchFilePath(projectPath, projectSlug);
         await secureFs.writeFile(researchFilePath, researchSummary, 'utf-8');
       }
+
+      // Sync the new project into the CRDT doc so getProject() returns it
+      // immediately without requiring a server restart
+      await projectService.syncProjectToCrdt(projectPath, project, 'project:created');
 
       res.json({ success: true, project });
     } catch (error) {

--- a/apps/server/src/routes/projects/routes/update.ts
+++ b/apps/server/src/routes/projects/routes/update.ts
@@ -3,17 +3,12 @@
  */
 
 import type { Request, Response } from 'express';
-import type { Project, UpdateProjectInput } from '@protolabsai/types';
-import {
-  getProjectJsonPath,
-  getProjectFilePath,
-  getPrdFilePath,
-  getResearchFilePath,
-  projectPlanExists,
-} from '@protolabsai/platform';
+import type { UpdateProjectInput } from '@protolabsai/types';
+import { getPrdFilePath, getResearchFilePath } from '@protolabsai/platform';
 import { secureFs } from '@protolabsai/platform';
-import { generateProjectFile, generatePrdFile } from '@protolabsai/utils';
+import { generatePrdFile } from '@protolabsai/utils';
 import { getErrorMessage, logError } from '../common.js';
+import type { ProjectService } from '../../../services/project-service.js';
 
 interface UpdateProjectRequest {
   projectPath: string;
@@ -21,7 +16,7 @@ interface UpdateProjectRequest {
   updates: UpdateProjectInput;
 }
 
-export function createUpdateHandler() {
+export function createUpdateHandler(projectService: ProjectService) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
       const { projectPath, projectSlug, updates } = req.body as UpdateProjectRequest;
@@ -39,53 +34,31 @@ export function createUpdateHandler() {
         return;
       }
 
-      // Check if project exists
-      const exists = await projectPlanExists(projectPath, projectSlug);
-      if (!exists) {
+      // Use ProjectService to apply the update — reads from CRDT-aware getProject(),
+      // writes project.json + project.md, and syncs the CRDT doc in one call.
+      let project;
+      try {
+        project = await projectService.updateProject(projectPath, projectSlug, updates);
+      } catch (error) {
+        logError(error, 'Update project failed');
+        res.status(500).json({ success: false, error: getErrorMessage(error) });
+        return;
+      }
+
+      if (!project) {
         res.status(404).json({ success: false, error: `Project "${projectSlug}" not found` });
         return;
       }
 
-      // Load existing project
-      const jsonPath = getProjectJsonPath(projectPath, projectSlug);
-      let project: Project;
-      try {
-        const jsonContent = (await secureFs.readFile(jsonPath, 'utf-8')) as string;
-        project = JSON.parse(jsonContent) as Project;
-      } catch {
-        res.status(500).json({ success: false, error: 'Failed to load project.json' });
-        return;
-      }
-
-      // Apply all updates via spread — UpdateProjectInput defines the allowed fields
-      const { prd: _prd, researchSummary: _rs, ...safeUpdates } = updates;
-      Object.assign(project, safeUpdates);
-      if (updates.prd !== undefined) {
-        project.prd = updates.prd;
-      }
-      if (updates.researchSummary !== undefined) {
-        project.researchSummary = updates.researchSummary;
-      }
-
-      project.updatedAt = new Date().toISOString();
-
-      // Save updated project.json
-      await secureFs.writeFile(jsonPath, JSON.stringify(project, null, 2), 'utf-8');
-
-      // Update project.md
-      const projectFilePath = getProjectFilePath(projectPath, projectSlug);
-      const projectContent = generateProjectFile(project);
-      await secureFs.writeFile(projectFilePath, projectContent, 'utf-8');
-
-      // Update prd.md if PRD field is present and has a value
-      // Note: We check for presence and truthy value since PRD is a complex object
+      // Write prd.md if PRD field is present and has a value.
+      // Note: We check for presence and truthy value since PRD is a complex object.
       if ('prd' in updates && updates.prd) {
         const prdFilePath = getPrdFilePath(projectPath, projectSlug);
         const prdContent = generatePrdFile(project.title, updates.prd);
         await secureFs.writeFile(prdFilePath, prdContent, 'utf-8');
       }
 
-      // Update research.md if research summary field is present (use 'in' to detect explicit clearing)
+      // Write research.md if research summary field is present (use 'in' to detect explicit clearing).
       if ('researchSummary' in updates) {
         const researchFilePath = getResearchFilePath(projectPath, projectSlug);
         await secureFs.writeFile(researchFilePath, updates.researchSummary ?? '', 'utf-8');

--- a/apps/server/src/services/project-service.ts
+++ b/apps/server/src/services/project-service.ts
@@ -238,6 +238,35 @@ export class ProjectService {
   // ─── Public API ────────────────────────────────────────────────────────────
 
   /**
+   * Sync a pre-built Project into the CRDT doc and emit an event.
+   *
+   * Use this when code outside of ProjectService (e.g. the create/update route
+   * handlers) has already written project.json to disk and just needs the
+   * in-memory Automerge doc to reflect that change. Calling this ensures
+   * getProject() returns the project immediately, without a server restart.
+   *
+   * No-ops when CRDT is not enabled for the given projectPath.
+   */
+  async syncProjectToCrdt(
+    projectPath: string,
+    project: Project,
+    eventType: 'project:created' | 'project:updated' = 'project:updated'
+  ): Promise<void> {
+    if (!this._isCrdtEnabled(projectPath)) return;
+    const doc = await this._ensureDoc(projectPath);
+    const newDoc = Automerge.change(doc, (d) => {
+      (d.projects as Record<string, unknown>)[project.slug] = this._toAutomergeValue(project);
+    });
+    this._docs.set(projectPath, newDoc);
+    this._crdtEvents?.emit(eventType, {
+      projectSlug: project.slug,
+      projectPath,
+      project,
+    });
+    logger.debug(`[CRDT] Synced project ${project.slug} into doc (${eventType})`);
+  }
+
+  /**
    * List all projects in a project path
    */
   async listProjects(projectPath: string): Promise<string[]> {


### PR DESCRIPTION
## Summary

The POST create project route in apps/server/src/routes/projects/routes/create.ts writes project.json directly to disk using secureFs.writeFile() instead of going through ProjectService.createProject(). When CRDT is enabled (proto.config.yaml exists), the Automerge doc is never updated with the new project.\n\nSymptoms:\n- create_project MCP tool succeeds (writes to disk)\n- list_projects works (may use a different code path or disk fallback)\n- create_project_features fails with 'Failed to load...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects now sync in real-time without requiring a server restart.

* **Bug Fixes**
  * Added input validation for project updates to prevent invalid data.

* **Improvements**
  * Simplified project update workflow for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->