### PR TITLE
Command Discovery API Endpoint

### DIFF
--- a/apps/server/src/routes/chat/index.ts
+++ b/apps/server/src/routes/chat/index.ts
@@ -641,5 +641,21 @@ export function createChatRoutes(services: ServiceContainer): Router {
     res.json({ ok: true });
   });
 
+  /**
+   * GET /api/chat/commands
+   *
+   * Returns the registered slash command registry as a typed array for the
+   * ChatInput autocomplete dropdown. Each entry includes name, description,
+   * argumentHint, and source. The body field is excluded to keep payloads small.
+   *
+   * Response: SlashCommandSummary[]
+   */
+  router.get('/commands', (_req: Request, res: Response) => {
+    const commands = services.commandRegistryService
+      .getAll()
+      .map(({ body: _body, ...summary }) => summary);
+    res.json(commands);
+  });
+
   return router;
 }

--- a/libs/types/src/chat.ts
+++ b/libs/types/src/chat.ts
@@ -49,3 +49,9 @@ export interface SlashCommand {
   /** Full markdown body of the command file (undefined for built-in commands) */
   body?: string;
 }
+
+/**
+ * A lightweight summary of a slash command for the ChatInput autocomplete dropdown.
+ * Omits the `body` field to keep API payloads small.
+ */
+export type SlashCommandSummary = Omit<SlashCommand, 'body'>;

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -7,7 +7,7 @@
 export type { AgentDefinitionContext, WorldStateSlice } from './agent.js';
 
 // Chat / slash command types
-export type { SlashCommand, SlashCommandSource } from './chat.js';
+export type { SlashCommand, SlashCommandSource, SlashCommandSummary } from './chat.js';
 
 // Ava Channel types — private multi-instance communication channel
 export type {


### PR DESCRIPTION
## Summary

Create a GET endpoint at the chat commands path (router.get in apps/server/src/routes/chat/index.ts) that returns the command registry as a typed array for the ChatInput autocomplete dropdown.\n\nEach entry includes: name, description, argumentHint, source (builtin, plugin, skill, project). The endpoint calls CommandRegistryService.getCommands() and returns the list (excluding the body field to keep payloads small).\n\nFiles to modify:\n- apps/server/src/routes/chat/index.ts (add GET route for c...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve registered slash commands, enabling clients to discover and autocomplete available commands in the chat interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->