### PR TITLE
Command Autocomplete Hook

### DIFF
--- a/apps/ui/src/hooks/use-slash-commands.ts
+++ b/apps/ui/src/hooks/use-slash-commands.ts
@@ -91,9 +91,7 @@ export function useSlashCommands(input: string): UseSlashCommandsReturn {
 
     const lower = query.toLowerCase();
     return allCommands.filter(
-      (c) =>
-        c.name.toLowerCase().includes(lower) ||
-        c.description.toLowerCase().includes(lower)
+      (c) => c.name.toLowerCase().includes(lower) || c.description.toLowerCase().includes(lower)
     );
   }, [isActive, query, allCommands]);
 

--- a/apps/ui/src/lib/clients/ava-client.ts
+++ b/apps/ui/src/lib/clients/ava-client.ts
@@ -71,7 +71,6 @@ export const withAvaClient = <TBase extends Constructor<BaseHttpClient>>(Base: T
        * Fetch the list of registered slash commands for the autocomplete dropdown.
        * Returns SlashCommandSummary[] (body field excluded for payload efficiency).
        */
-      fetchCommands: (): Promise<SlashCommandSummary[]> =>
-        this.get('/api/chat/commands'),
+      fetchCommands: (): Promise<SlashCommandSummary[]> => this.get('/api/chat/commands'),
     };
   };


### PR DESCRIPTION
## Summary
- Add `useSlashCommands` hook that fetches commands from the chat commands endpoint with React Query SWR caching
- Detects slash prefix in input and filters commands by name/description substring match
- Exposes: commands, isActive, query, selectedIndex, select()
- Add `fetchCommands` method to ava-client

## Files
- `apps/ui/src/hooks/use-slash-commands.ts` (new)
- `apps/ui/src/lib/clients/ava-client.ts` (modified)

<!-- automaker:owner instance=aaccab48-6c90-478b-8aa2-5df343794454 team= created=2026-03-11T07:44:57.738Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added slash-command autocomplete functionality that fetches available commands from the server and displays filtered suggestions as users type, with keyboard navigation support for command selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->