### PR TITLE
Server URL override in auth layer + app store

### DIFF
--- a/apps/ui/src/lib/storage/serverUrls.ts
+++ b/apps/ui/src/lib/storage/serverUrls.ts
@@ -13,7 +13,7 @@ export function getRecentServerUrls(): string[] {
 export function addRecentServerUrl(url: string): void {
   try {
     const existing = getRecentServerUrls();
-    const deduped = [url, ...existing.filter(u => u !== url)].slice(0, MAX_RECENT);
+    const deduped = [url, ...existing.filter((u) => u !== url)].slice(0, MAX_RECENT);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(deduped));
   } catch {
     // Gracefully handle localStorage quota exceeded


### PR DESCRIPTION
## Summary

Modify getServerUrl() in apps/ui/src/lib/clients/auth.ts to check a runtime override stored in app-store before falling back to env vars. Add serverUrlOverride state + setServerUrlOverride action to app-store. Add recentServerUrls array (max 10) persisted via localStorage. When override changes, invalidate cached HTTP client and WebSocket connection, trigger reconnection. Add CORS middleware on server to accept requests from any origin when hivemind is enabled.

**Project:** Headless Server + Re...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server URL history: the app now remembers up to 10 recent server URLs, deduplicates entries by promoting reused URLs to the front, and persists this list across sessions.
  * You can clear your saved server URL history manually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->