### PR TITLE
ChatInput Slash Command Integration

### DIFF
--- a/apps/ui/src/components/views/chat-overlay/ask-ava-tab.tsx
+++ b/apps/ui/src/components/views/chat-overlay/ask-ava-tab.tsx
@@ -5,7 +5,7 @@
  * Contains: queue panel, conversation history panel, settings panel, chat area.
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { UIMessage } from 'ai';
 import {
   ChatMessageList,
@@ -13,7 +13,10 @@ import {
   SuggestionList,
   PromptInputProvider,
   QueueView,
+  usePromptInput,
   type BranchInfo,
+  type UseSlashCommandsResult,
+  type SlashCommand,
 } from '@protolabsai/ui/ai';
 import { cn } from '@/lib/utils';
 import { ChatModelSelect } from '@/components/views/chat/components/chat-model-select';
@@ -24,6 +27,7 @@ import { AvaSettingsPanel } from './ava-settings-panel';
 import type { ChatSession } from '@/store/chat-store';
 import type { SuggestionItem } from '@protolabsai/ui/ai';
 import type { PendingSubagentApproval } from '@/hooks/use-chat-session';
+import { useSlashCommands } from '@/hooks/use-slash-commands';
 
 /** Displays a live "Waiting Xs" counter from a receivedAt ISO timestamp. */
 function WaitingTimer({ receivedAt }: { receivedAt: string }) {
@@ -37,6 +41,120 @@ function WaitingTimer({ receivedAt }: { receivedAt: string }) {
     return () => clearInterval(id);
   }, [receivedAt]);
   return <span className="text-xs text-status-warning/80">Waiting {seconds}s</span>;
+}
+
+/**
+ * Inner component that lives inside PromptInputProvider so it can read the
+ * current input value and wire it into useSlashCommands.
+ */
+function ChatInputWithSlashCommands({
+  onSubmit,
+  onStop,
+  isStreaming,
+  modelAlias,
+  tokenUsage,
+  shortcutHint,
+  onModelChange,
+}: {
+  onSubmit: (text: string) => void;
+  onStop: () => void;
+  isStreaming: boolean;
+  modelAlias: string;
+  tokenUsage: { total: number; input: number; output: number; estimated: boolean };
+  shortcutHint: string;
+  onModelChange: (alias: string) => void;
+}) {
+  const { value, setValue } = usePromptInput();
+  const hookResult = useSlashCommands(value);
+
+  // Build the navigate handler: moves selectedIndex up/down with wrap-around.
+  const navigate = useCallback(
+    (direction: 'up' | 'down') => {
+      const count = hookResult.commands.length;
+      if (count === 0) return;
+      hookResult.select(
+        direction === 'up'
+          ? (hookResult.selectedIndex - 1 + count) % count
+          : (hookResult.selectedIndex + 1) % count
+      );
+    },
+    [hookResult]
+  );
+
+  // Build the close handler: reset selection index (isActive derives from input value).
+  const close = useCallback(() => {
+    hookResult.select(-1);
+  }, [hookResult]);
+
+  // Build the select handler: inserts the selected command name into the input,
+  // leaving a trailing space so the user can type arguments immediately.
+  const handleSelect = useCallback(
+    (cmd: SlashCommand) => {
+      setValue(`/${cmd.name} `);
+      hookResult.select(-1);
+    },
+    [setValue, hookResult]
+  );
+
+  // Normalise selectedIndex: clamp to 0 when active and no explicit selection.
+  const normalizedIndex =
+    hookResult.isActive && hookResult.selectedIndex === -1 ? 0 : hookResult.selectedIndex;
+
+  const slashCommands: UseSlashCommandsResult = {
+    isActive: hookResult.isActive,
+    commands: hookResult.commands.map((c) => ({
+      name: c.name,
+      description: c.description,
+      source: c.source,
+      argHint: c.argumentHint,
+    })),
+    selectedIndex: normalizedIndex,
+    onSelect: handleSelect,
+    onClose: close,
+    onNavigate: navigate,
+  };
+
+  return (
+    <ChatInput
+      onSubmit={onSubmit}
+      onStop={onStop}
+      isStreaming={isStreaming}
+      placeholder="Ask Ava..."
+      autoFocus
+      slashCommands={slashCommands}
+      actions={
+        <>
+          <ChatModelSelect value={modelAlias} onValueChange={onModelChange} />
+          {tokenUsage.total > 0 && (
+            <span
+              className={cn(
+                'text-xs tabular-nums',
+                tokenUsage.total > 100_000
+                  ? 'text-destructive font-medium'
+                  : tokenUsage.total > 50_000
+                    ? 'text-status-warning'
+                    : 'text-muted-foreground'
+              )}
+              title={
+                tokenUsage.estimated
+                  ? `~${tokenUsage.total.toLocaleString()} estimated context size`
+                  : `Context: ${tokenUsage.input.toLocaleString()} tokens (last response: ${tokenUsage.output.toLocaleString()} output)`
+              }
+            >
+              {tokenUsage.estimated && '~'}
+              {tokenUsage.total >= 1000
+                ? `${(tokenUsage.total / 1000).toFixed(1)}k`
+                : tokenUsage.total}{' '}
+              tokens
+            </span>
+          )}
+          <span className="text-xs text-muted-foreground">
+            {isStreaming ? 'Streaming...' : `Enter to send \u00B7 ${shortcutHint}`}
+          </span>
+        </>
+      }
+    />
+  );
 }
 
 export interface AskAvaTabProps {
@@ -224,43 +342,14 @@ export function AskAvaTab({
 
         {/* PromptInputProvider scopes input state to this chat area */}
         <PromptInputProvider>
-          <ChatInput
+          <ChatInputWithSlashCommands
             onSubmit={onSubmit}
             onStop={onStop}
             isStreaming={isStreaming}
-            placeholder="Ask Ava..."
-            autoFocus
-            actions={
-              <>
-                <ChatModelSelect value={modelAlias} onValueChange={onModelChange} />
-                {tokenUsage.total > 0 && (
-                  <span
-                    className={cn(
-                      'text-xs tabular-nums',
-                      tokenUsage.total > 100_000
-                        ? 'text-destructive font-medium'
-                        : tokenUsage.total > 50_000
-                          ? 'text-status-warning'
-                          : 'text-muted-foreground'
-                    )}
-                    title={
-                      tokenUsage.estimated
-                        ? `~${tokenUsage.total.toLocaleString()} estimated context size`
-                        : `Context: ${tokenUsage.input.toLocaleString()} tokens (last response: ${tokenUsage.output.toLocaleString()} output)`
-                    }
-                  >
-                    {tokenUsage.estimated && '~'}
-                    {tokenUsage.total >= 1000
-                      ? `${(tokenUsage.total / 1000).toFixed(1)}k`
-                      : tokenUsage.total}{' '}
-                    tokens
-                  </span>
-                )}
-                <span className="text-xs text-muted-foreground">
-                  {isStreaming ? 'Streaming...' : `Enter to send \u00B7 ${shortcutHint}`}
-                </span>
-              </>
-            }
+            modelAlias={modelAlias}
+            tokenUsage={tokenUsage}
+            shortcutHint={shortcutHint}
+            onModelChange={onModelChange}
           />
         </PromptInputProvider>
       </div>

--- a/libs/ui/src/ai/chat-input.tsx
+++ b/libs/ui/src/ai/chat-input.tsx
@@ -6,6 +6,10 @@
  * Auto-resizes up to 8 lines; beyond that the textarea scrolls internally.
  * The bottom toolbar houses the actions slot (e.g. model selector) on the
  * left and the submit/stop button on the right.
+ *
+ * When `slashCommands` is provided, the component renders a SlashCommandDropdown
+ * above the input when a slash command is active and intercepts keyboard events
+ * for navigation and selection.
  */
 
 import { useCallback, useEffect, useRef } from 'react';
@@ -13,6 +17,7 @@ import { Send, Square } from 'lucide-react';
 import { cn } from '../lib/utils.js';
 import { Button } from '../atoms/button.js';
 import { usePromptInput } from './prompt-input-context.js';
+import { SlashCommandDropdown, type UseSlashCommandsResult } from './slash-command-dropdown.js';
 
 /** Maximum textarea height — 8 lines × ~24 px line-height. */
 const MAX_HEIGHT_PX = 192;
@@ -27,6 +32,7 @@ export function ChatInput({
   actions,
   className,
   autoFocus,
+  slashCommands,
 }: {
   /** Called with the trimmed message text when the user submits. */
   onSubmit: (text: string) => void;
@@ -37,11 +43,14 @@ export function ChatInput({
   actions?: React.ReactNode;
   className?: string;
   autoFocus?: boolean;
+  /** Optional slash command autocomplete state. Rendered above the textarea when active. */
+  slashCommands?: UseSlashCommandsResult;
 }) {
   const { value, setValue, clear } = usePromptInput();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isDisabled = disabled || isStreaming;
   const canSubmit = value.trim().length > 0 && !isDisabled;
+  const commandMode = !!slashCommands?.isActive;
 
   // Auto-resize up to MAX_HEIGHT_PX; textarea handles its own overflow beyond that.
   useEffect(() => {
@@ -69,32 +78,68 @@ export function ChatInput({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // When the slash command dropdown is active, intercept navigation keys.
+      if (slashCommands?.isActive) {
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          slashCommands.onNavigate('up');
+          return;
+        }
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          slashCommands.onNavigate('down');
+          return;
+        }
+        if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
+          e.preventDefault();
+          const cmd = slashCommands.commands[slashCommands.selectedIndex];
+          if (cmd) {
+            slashCommands.onSelect(cmd);
+          }
+          return;
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          slashCommands.onClose();
+          return;
+        }
+      }
+
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         handleSubmitInternal();
       }
     },
-    [handleSubmitInternal]
+    [handleSubmitInternal, slashCommands]
   );
 
   return (
     <div
       data-slot="chat-input"
-      className={cn('border-t border-border bg-background p-3', className)}
+      className={cn(
+        'border-t bg-background p-3',
+        commandMode ? 'border-primary' : 'border-border',
+        className
+      )}
     >
-      {/* Textarea row */}
-      <textarea
-        ref={textareaRef}
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onKeyDown={handleKeyDown}
-        placeholder={placeholder}
-        disabled={isDisabled}
-        rows={1}
-        autoFocus={autoFocus}
-        className="w-full resize-none bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none disabled:opacity-50"
-        style={{ maxHeight: MAX_HEIGHT_PX, overflowY: 'auto' }}
-      />
+      {/* Slash command dropdown — rendered above the textarea when active */}
+      <div className="relative">
+        {slashCommands?.isActive && <SlashCommandDropdown slashCommands={slashCommands} />}
+
+        {/* Textarea row */}
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={isDisabled}
+          rows={1}
+          autoFocus={autoFocus}
+          className="w-full resize-none bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none disabled:opacity-50"
+          style={{ maxHeight: MAX_HEIGHT_PX, overflowY: 'auto' }}
+        />
+      </div>
 
       {/* Bottom toolbar: actions left, submit/stop right */}
       <div className="mt-1 flex items-center justify-between gap-2">

--- a/libs/ui/src/ai/index.ts
+++ b/libs/ui/src/ai/index.ts
@@ -113,6 +113,6 @@ export {
 export {
   SlashCommandDropdown,
   type SlashCommand,
-  type UseSlashCommandsResult,
   type SlashCommandDropdownProps,
+  type UseSlashCommandsResult,
 } from './slash-command-dropdown.js';


### PR DESCRIPTION
## Summary
- Wires SlashCommandDropdown into ChatInput via optional `slashCommands` prop
- Keyboard interception: ArrowUp/Down navigate, Tab/Enter select, Escape closes
- Visual indicator: border changes to primary color when in command mode
- ask-ava-tab.tsx bridges useSlashCommands hook to ChatInput's dropdown interface
- Selection inserts `/{cmd}` into input so users can continue typing arguments

## Test plan
- [ ] Type `/` in ChatInput and verify dropdown appears
- [ ] Arrow keys navigate the dropdown
- [ ] Tab/Enter selects a command and inserts it into input
- [ ] Escape closes the dropdown
- [ ] Normal text input works unchanged (no regression)


<!-- automaker:owner instance=aaccab48-6c90-478b-8aa2-5df343794454 team= created=2026-03-11T16:23:23.561Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added slash command dropdown interface to chat input with keyboard navigation support.
  * Users can now browse available commands using arrow keys and select with Tab or Enter.
  * Visual indicator displays when chat input is in command selection mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->