### PR TITLE
[Auto] Recovery escalated: [Auto] Recovery escalated: Remove execute_dynamic_agent MCP tool and agent template tools

### DIFF
--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -120,3 +120,8 @@ usageStats:
 - **Situation:** Spec requires 'case-insensitive substring match' but naive implementation would use case-sensitive includes()
 - **Root cause:** JavaScript's includes() is case-sensitive; case-insensitive search requires normalizing both sides to same case
 - **How to avoid:** toLowerCase() on every filter call is cheap; adds minimal complexity; regex alternative more powerful but harder to read and maintain
+
+#### [Pattern] getServerUrl() uses explicit precedence chain: override → env var → window.location.origin, not boolean flags or computed defaults (2026-03-11)
+- **Problem solved:** Multiple sources of server URL truth: user selection (override), deployment config (env), browser location. Need predictable resolution.
+- **Why this works:** Explicit chain makes precedence obvious and testable. User's explicit choice wins, deployment config is fallback, browser is last resort.
+- **Trade-offs:** Flat chain is less DRY than config object, but more readable and harder to get wrong

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,9 +5,9 @@ relevantTo: [architecture]
 importance: 0.9
 relatedFiles: []
 usageStats:
-  loaded: 176
-  referenced: 57
-  successfulFeatures: 57
+  loaded: 178
+  referenced: 59
+  successfulFeatures: 59
 ---
 <!-- domain: Architecture Decisions | System-wide structural decisions that have breaking consequences if changed -->
 
@@ -218,3 +218,27 @@ usageStats:
 - **Problem solved:** Multiple apps/extensions may use same localStorage in browser; must prevent silent data corruption
 - **Why this works:** Raw keys like 'serverUrlOverride' could collide with other code (third-party scripts, extensions, other apps in same domain). Collision would cause one app to overwrite another's data silently. Prefix isolates namespace.
 - **Trade-offs:** Slightly longer keys, but prevents silent data corruption. Easy to adopt (just prepend prefix everywhere).
+
+#### [Pattern] Dual-layer connection invalidation: HTTP client cache AND WebSocket reconnection triggered atomically in single setServerUrlOverride() action, not as separate concerns (2026-03-11)
+- **Problem solved:** Server URL changes require both HTTP and WebSocket connections to be reset. If only one is invalidated, stale connections persist.
+- **Why this works:** Clients use both HTTP (REST) and WebSocket (long-lived) for communication. Either being stale breaks the app. Atomic action ensures consistency.
+- **Trade-offs:** Tighter coupling in action handler, but guarantees consistency. Alternative is distributed invalidation logic (harder to reason about)
+
+### State shape separates serverUrlOverride (transient selection) from recentServerUrls (persistent history) rather than merging into single state object (2026-03-11)
+- **Context:** Need to track current server URL override separately from user's browsing history of server URLs for dropdown UI
+- **Why:** Separates concerns: override is ephemeral app state (doesn't persist on reload), recentServerUrls is user preference (persisted to localStorage). Different lifecycles require different shapes.
+- **Rejected:** Single recentServers array with 'active' flag would conflate current choice with history
+- **Trade-offs:** Slightly more verbose state definitions, but clearer intent and prevents accidental history pollution
+- **Breaking if changed:** If merged into one array/object, setting override would add it to history, filling history with transient choices instead of intentional visits
+
+### HTTP client invalidation via singleton recreation + explicit WebSocket closure rather than creating new client instances (2026-03-11)
+- **Context:** Runtime server URL switching requires disconnecting old WebSocket and establishing new connection
+- **Why:** Preserves other client state and connection pool efficiency. Singleton pattern ensures single source of truth for HTTP/WebSocket connections across entire app.
+- **Rejected:** Create new HTTP client instance per URL change - would abandon connection pooling and force re-initialization of all client middleware
+- **Trade-offs:** Requires explicit closure logic (must call invalidateHttpClient) vs simpler new-instance approach; gained: connection reuse and state preservation; lost: simplicity of stateless creation
+- **Breaking if changed:** Removing explicit WebSocket close leaves dangling connections; removing singleton pattern breaks connection pooling assumptions throughout codebase
+
+#### [Pattern] Layered configuration precedence: localStorage (runtime override) > env vars (build time) > Electron cache (platform persistence) (2026-03-11)
+- **Problem solved:** Supporting multiple override sources (users switching servers at runtime, CI passing config, platform-specific storage) without conflicts
+- **Why this works:** Allows high-priority runtime changes (localStorage) to shadow build-time config without requiring env var updates. Each layer has appropriate lifetime and trust level.
+- **Trade-offs:** Gained: flexibility across deployment models; lost: potential confusion about which source is active

--- a/.automaker/memory/auth.md
+++ b/.automaker/memory/auth.md
@@ -5,9 +5,9 @@ relevantTo: [auth]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 64
-  referenced: 26
-  successfulFeatures: 26
+  loaded: 66
+  referenced: 28
+  successfulFeatures: 28
 ---
 <!-- domain: Authentication & Authorization | OAuth, token management, access control -->
 
@@ -92,3 +92,8 @@ usageStats:
 - **Problem solved:** Runtime server URL switching for development/hivemind testing
 - **Why this works:** localStorage persistence survives page reloads without server round-trip; React state provides immediate reactivity; dual sync avoids redundant reads on every render
 - **Trade-offs:** Gained: Survival across restarts without server cost. Lost: Must manage sync between two sources of truth; synchronous localStorage blocks if data is large
+
+#### [Pattern] localStorage key namespacing with colon prefix (`automaker:serverUrlOverride`) isolates feature data from global scope (2026-03-11)
+- **Problem solved:** Avoid collisions with other localStorage keys in shared browser environment (esp. with iframes or multiple tabs)
+- **Why this works:** Prevents accidental overwrites from other scripts; makes feature keys searchable and auditable in DevTools
+- **Trade-offs:** Gained: namespace isolation and discoverability; lost: shorter keys

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 1139
-  referenced: 315
-  successfulFeatures: 315
+  loaded: 1141
+  referenced: 317
+  successfulFeatures: 317
 ---
 <!-- domain: Gotchas & Pitfalls | Known traps, anti-patterns, and hard-won lessons across all domains -->
 
@@ -809,3 +809,8 @@ usageStats:
 - **Situation:** User experience feature: remember recent servers for quick switching. Constraint of max 10 prevents unbounded growth.
 - **Root cause:** Implementation: [newUrl, ...stored.filter(u => u !== newUrl)].slice(0, 10). Deduplication moves matching URL to front, then slice enforces max. But if someone manually edits localStorage to add 11+ URLs, constraint isn't enforced until next state update.
 - **How to avoid:** Simple implementation (one-liner filter+slice) vs. reactive enforcement. Edge case only occurs if localStorage is manually edited (rare) or if feature is scripted externally.
+
+#### [Gotcha] WebSocket connections must be explicitly closed before creating new client pointing to different URL (2026-03-11)
+- **Situation:** If you recreate HTTP client without closing previous WebSocket, stale connections persist and can interfere with routing
+- **Root cause:** WebSocket close is not automatic on object destruction; browser keeps connection alive until explicitly terminated
+- **How to avoid:** Gained: clean connection lifecycle; lost: ability to assume cleanup on object disposal

--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -5,9 +5,9 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 280
-  referenced: 64
-  successfulFeatures: 64
+  loaded: 282
+  referenced: 66
+  successfulFeatures: 66
 ---
 <!-- domain: GTM Signal Intelligence | Go-to-market signal processing and routing -->
 

--- a/.automaker/memory/persistence.md
+++ b/.automaker/memory/persistence.md
@@ -29,3 +29,10 @@ usageStats:
 - **Problem solved:** User sets server URL at runtime via UI; must survive reload and not require env var re-injection.
 - **Why this works:** localStorage provides client-side persistence; namespace prevents collisions with other apps. Enables 'set once, forget' UX without rebuild/redeploy cycle.
 - **Trade-offs:** Pro: simple, no server required. Con: cleared if user clears browser cache; namespace is convention not enforced.
+
+### recentServerUrls persisted via browser localStorage (per-origin key-value) rather than IndexedDB or server-side user preferences (2026-03-11)
+- **Context:** UI needs quick access to recent server URLs for dropdown, but doesn't require cross-device sync or complex queries
+- **Why:** localStorage is synchronous, no async overhead, no server round-trip. Meets UX requirement of instant dropdown population. Scoped to origin (secure by design).
+- **Rejected:** IndexedDB: over-engineered for simple key-value. Server storage: unnecessary latency for UI dropdowns, requires auth/sync logic.
+- **Trade-offs:** Lost on browser clear/incognito. Per-origin isolation (https://localhost:3000 and :3001 have separate histories). Survives only within same origin.
+- **Breaking if changed:** If persisted to server instead, need auth integration and sync strategy. If cleared, user loses context but app still works.

--- a/.automaker/memory/security.md
+++ b/.automaker/memory/security.md
@@ -161,3 +161,17 @@ usageStats:
 - **Situation:** Server URL override enables multi-origin scenarios (single app, multiple servers). CORS config must match architecture.
 - **Root cause:** hivemindEnabled implies distributed multi-origin setup where CORS must be open. Without hivemind flag, app is single-origin and should restrict CORS. Coupling to proto.config.yaml makes this implicit.
 - **How to avoid:** Feature-flag gating hides the CORS decision in config—easy to miss when reviewing middleware code. Prevents accidental open CORS in single-origin deployments.
+
+### CORS wildcard (Access-Control-Allow-Origin: *) gated by process.env.HIVEMIND_ENABLED flag, not enabled by default (2026-03-11)
+- **Context:** Headless server needs to accept cross-origin requests from remote clients, but wildcard CORS is a security risk in normal operation
+- **Why:** HIVEMIND_ENABLED is an operational mode flag. Wildcard CORS only enabled when system is explicitly configured for it. Prevents accidental exposure.
+- **Rejected:** Always enable CORS, or require explicit CORS_ORIGIN config per client - too risky or inflexible
+- **Trade-offs:** Env flag coupling (operational mode affects security policy). Simple implementation but creates implicit coupling between features.
+- **Breaking if changed:** Removing the flag check exposes API to any origin indefinitely. Leaving flag false when hivemind needed breaks remote client connectivity.
+
+### CORS `allowAllOrigins` feature gated behind `hivemind.enabled` config flag, not hardcoded or always-on (2026-03-11)
+- **Context:** Server requires permissive CORS for certain features, but should not expose all origins by default
+- **Why:** Ties security-relevant setting to product feature lifecycle. When hivemind is disabled, CORS restrictions apply automatically.
+- **Rejected:** Hardcoded allowAllOrigins=true (security risk); environment variable (harder to audit feature dependencies)
+- **Trade-offs:** Gained: security boundary tied to product feature; lost: flexibility if CORS needed independent of hivemind
+- **Breaking if changed:** Removing feature flag coupling means CORS config must be maintained separately, risking desync where feature is enabled but CORS isn't

--- a/.automaker/memory/ui.md
+++ b/.automaker/memory/ui.md
@@ -15,3 +15,8 @@ usageStats:
 - **Situation:** Hook needs to communicate whether a command is pre-selected in the dropdown
 - **Root cause:** -1 is semantically clearer than 0; 0 would auto-select first item on activation, causing unexpected behavior
 - **How to avoid:** Downstream UI components must handle -1 specially; can't directly use `commands[selectedIndex]` without bounds check
+
+#### [Pattern] Deduped recent server URLs array (max 10) prevents duplicate entries from repeated 'set server' clicks (2026-03-11)
+- **Problem solved:** Users switching between servers frequently (dev/staging/prod workflows) benefit from quick-access list
+- **Why this works:** Deduplication indicates expected user behavior (clicking 'set server' multiple times with same URL). Size limit (10) balances UX density with memory.
+- **Trade-offs:** Gained: clean recent list UX; lost: ability to see frequency of server usage

--- a/.automaker/projects/headless-server-remote-client-architecture/project.json
+++ b/.automaker/projects/headless-server-remote-client-architecture/project.json
@@ -31,7 +31,7 @@
           ],
           "complexity": "medium",
           "claimedBy": "mac-dev",
-          "claimedAt": "2026-03-11T08:20:55.543Z",
+          "claimedAt": "2026-03-11T15:20:56.558Z",
           "executionStatus": "in_progress",
           "lastError": "Reclaimed from offline instance mac-dev"
         },
@@ -136,5 +136,5 @@
     }
   ],
   "createdAt": "2026-03-10T01:41:48.204Z",
-  "updatedAt": "2026-03-11T08:20:55.745Z"
+  "updatedAt": "2026-03-11T15:20:56.760Z"
 }

--- a/apps/server/.automaker/pr-tracking.json
+++ b/apps/server/.automaker/pr-tracking.json
@@ -6,7 +6,7 @@
       "prNumber": 2257,
       "prUrl": "https://github.com/protoLabsAI/protoMaker/pull/2257",
       "branchName": "",
-      "lastCheckedAt": 1773215847564,
+      "lastCheckedAt": 1773221069098,
       "reviewStatus": "pending",
       "remediationCount": 0,
       "trackedSince": 1773213826273
@@ -17,7 +17,7 @@
       "prNumber": 2259,
       "prUrl": "https://github.com/protoLabsAI/protoMaker/pull/2259",
       "branchName": "",
-      "lastCheckedAt": 1773215848105,
+      "lastCheckedAt": 1773221069738,
       "reviewStatus": "pending",
       "remediationCount": 0,
       "trackedSince": 1773214805229
@@ -28,11 +28,22 @@
       "prNumber": 2262,
       "prUrl": "https://github.com/protoLabsAI/protoMaker/pull/2262",
       "branchName": "",
-      "lastCheckedAt": 0,
+      "lastCheckedAt": 1773221070370,
       "reviewStatus": "pending",
       "remediationCount": 0,
       "trackedSince": 1773215871529
+    },
+    {
+      "featureId": "feature-1773220855894-j5h4fl0d7",
+      "projectPath": "/Users/kj/dev/automaker",
+      "prNumber": 2263,
+      "prUrl": "https://github.com/protoLabsAI/protoMaker/pull/2263",
+      "branchName": "",
+      "lastCheckedAt": 0,
+      "reviewStatus": "pending",
+      "remediationCount": 0,
+      "trackedSince": 1773221105483
     }
   ],
-  "savedAt": "2026-03-11T07:57:51.530Z"
+  "savedAt": "2026-03-11T09:25:05.485Z"
 }


### PR DESCRIPTION
## Summary

## Auto-generated Bug Report

This bug was automatically filed by the failure-to-bug pipeline.

### Feature Details

| Field | Value |
|-------|-------|
| **Feature ID** | `feature-1773244558438-nn5il6op0` |
| **Title** | [Auto] Recovery escalated: Remove execute_dynamic_agent MCP tool and agent template tools |
| **Status** | in_progress |
| **Branch** | `feature/auto-recovery-escalated-remove` |

### Triage

- **Priority**: P3: Normal
- **Team**: general
- **Reason**: P3: Single feature blocke...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=aaccab48-6c90-478b-8aa2-5df343794454 team= created=2026-03-11T16:41:08.252Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal PR tracking timestamps and entries.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->