### PR TITLE
Promote dev to staging: CRDT crash fix

### DIFF
--- a/libs/crdt/src/crdt-store.ts
+++ b/libs/crdt/src/crdt-store.ts
@@ -313,7 +313,7 @@ export class CRDTStore extends EventEmitter {
     for (const adapter of this.networkAdapters) {
       try {
         // Suppress error events that fire asynchronously from ws.close()
-        const ws = (adapter as Record<string, unknown>).socket as
+        const ws = (adapter as unknown as Record<string, unknown>).socket as
           | { removeAllListeners?: (e: string) => void }
           | undefined;
         ws?.removeAllListeners?.('error');


### PR DESCRIPTION
## Summary
- Fix CRDT store crash on headless server shutdown
- Suppress WebSocket error events when disconnecting adapters still in CONNECTING state

## Promotion
`dev → staging` merge commit (no squash)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown to prevent spurious error events from surfacing during network disconnection, producing cleaner shutdown sequences.
  * Suppressed transient error notifications that could occur while disconnecting network adapters, reducing noise and improving overall stability and user-facing reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->