### PR TITLE
Promote staging to main: CRDT crash fix

### DIFF
--- a/libs/crdt/src/crdt-store.ts
+++ b/libs/crdt/src/crdt-store.ts
@@ -307,9 +307,16 @@ export class CRDTStore extends EventEmitter {
       clearInterval(this.compactTimer);
       this.compactTimer = null;
     }
-    // Disconnect all network adapters to close WebSocket connections
+    // Disconnect all network adapters to close WebSocket connections.
+    // The WebSocketClientAdapter may throw or emit errors if the socket
+    // is still in CONNECTING state. Suppress both sync and async errors.
     for (const adapter of this.networkAdapters) {
       try {
+        // Suppress error events that fire asynchronously from ws.close()
+        const ws = (adapter as unknown as Record<string, unknown>).socket as
+          | { removeAllListeners?: (e: string) => void }
+          | undefined;
+        ws?.removeAllListeners?.('error');
         adapter.disconnect();
       } catch {
         // ignore disconnect errors


### PR DESCRIPTION
## Summary
- Fix CRDT store crash on headless server shutdown (suppress WebSocket errors during disconnect)
- Fix TypeScript DTS build error (double-cast through unknown)

## Promotion
`staging → main` merge commit (no squash)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during connection disconnection to prevent unhandled exceptions during network resource cleanup, ensuring more stable behavior during network transitions and application shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->