### PR TITLE
promote: dev -> staging (port fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "_dev:electron:debug": "npm run dev:electron:debug --workspace=apps/ui",
     "_dev:electron:wsl": "npm run dev:electron:wsl --workspace=apps/ui",
     "_dev:electron:wsl:gpu": "npm run dev:electron:wsl:gpu --workspace=apps/ui",
-    "_dev:server": "PORT=3009 npm run dev --workspace=apps/server",
+    "_dev:server": "npm run dev --workspace=apps/server",
     "dev:web": "npm run build:packages && npm run _dev:web",
     "dev:electron": "npm run build:packages && npm run _dev:electron",
     "dev:electron:debug": "npm run build:packages && npm run _dev:electron:debug",


### PR DESCRIPTION
## Summary

- fix: remove PORT=3009 override from _dev:server script
- Server now uses default PORT 3008, matching start-automaker.sh health check and Vite proxy

## Merge strategy
Use **merge commit** (not squash) per branch-strategy.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development server configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->