### PR TITLE
Tool error wrapper in provider layer

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -88,6 +88,7 @@ import type {
   IAutoModeCallbacks,
   ExecuteFeatureOptions,
 } from './execution-types.js';
+import type { ToolRegistry, ToolContext, ToolResult } from '@protolabsai/tools';
 
 const logger = createLogger('AutoMode');
 
@@ -3314,5 +3315,56 @@ You can use the Read tool to view these images at any time during implementation
       branchName,
       content,
     });
+  }
+
+  /**
+   * Execute a tool from a registry with a structured error boundary.
+   *
+   * Wraps registry.execute() so that tool errors are caught and converted to
+   * structured error responses instead of propagating exceptions. This prevents
+   * tool failures from crashing the agent session — the LLM receives error
+   * context (tool name, message, and recovery hint) and can decide how to
+   * proceed.
+   *
+   * Original errors are logged server-side for debugging, while a clean
+   * structured message is returned to the caller.
+   *
+   * @param registry - The ToolRegistry instance to execute against
+   * @param toolName - Name of the tool to execute
+   * @param input - Input data for the tool
+   * @param context - Optional execution context for dependency injection
+   * @returns Structured tool result that always resolves (never throws)
+   */
+  async executeToolWithErrorBoundary<TOutput = unknown>(
+    registry: ToolRegistry,
+    toolName: string,
+    input: unknown,
+    context: ToolContext = {}
+  ): Promise<ToolResult<TOutput>> {
+    try {
+      const result = await registry.execute<unknown, TOutput>(toolName, input, context);
+      return result;
+    } catch (error) {
+      // Catch any exception that escapes the registry's own error boundary
+      // (e.g. if a future refactor removes the try/catch there)
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+
+      logger.error(`[ExecutionService] Tool '${toolName}' execution failed unexpectedly:`, {
+        toolName,
+        errorMessage,
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+
+      return {
+        success: false,
+        error: `Tool '${toolName}' failed: ${errorMessage}`,
+        metadata: {
+          toolName,
+          originalError: error,
+          errorMessage,
+          recoveryHint: `The tool '${toolName}' failed unexpectedly. Check inputs and tool configuration. If the session is degraded, consider retrying or using an alternative tool.`,
+        },
+      } as ToolResult<TOutput>;
+    }
   }
 }

--- a/libs/tools/src/registry.ts
+++ b/libs/tools/src/registry.ts
@@ -104,11 +104,19 @@ export class ToolRegistry {
   /**
    * Execute a tool by name with the provided input and context.
    *
+   * Includes an error boundary that catches tool execution errors and converts
+   * them to structured error responses instead of propagating exceptions. This
+   * ensures the LLM receives error context rather than causing a session crash.
+   *
+   * The structured error response includes:
+   * - toolName: the name of the tool that failed
+   * - errorMessage: the original error message for debugging
+   * - recoveryHint: a suggested action to recover from the error
+   *
    * @param name - The name of the tool to execute
    * @param input - The input data for the tool
    * @param context - The execution context for dependency injection
-   * @returns The tool execution result
-   * @throws Error if the tool is not found
+   * @returns The tool execution result, always resolves (never throws)
    */
   async execute<TInput = unknown, TOutput = unknown>(
     name: string,
@@ -121,19 +129,61 @@ export class ToolRegistry {
       return {
         success: false,
         error: `Tool '${name}' not found in registry`,
+        metadata: {
+          toolName: name,
+          recoveryHint: `Verify the tool name is correct and the tool has been registered. Available tools can be listed via the registry.`,
+        },
       };
     }
 
     try {
-      return await tool.execute(input, context);
+      const result = await tool.execute(input, context);
+
+      // If the tool returned a failure result (e.g. caught internally by defineSharedTool),
+      // enrich it with structured error metadata so the LLM gets full context.
+      if (!result.success) {
+        const errorMessage = result.error ?? 'Tool returned a failure result';
+
+        // Log for server-side debugging
+        console.error(`[ToolRegistry] Tool '${name}' returned a failure result:`, {
+          toolName: name,
+          errorMessage,
+        });
+
+        return {
+          ...result,
+          error: `Tool '${name}' failed: ${errorMessage}`,
+          metadata: {
+            ...result.metadata,
+            toolName: name,
+            errorMessage,
+            recoveryHint:
+              (result.metadata?.recoveryHint as string | undefined) ??
+              `The tool '${name}' encountered an error. Check the inputs and try again. If the problem persists, the tool may need reconfiguration.`,
+          },
+        };
+      }
+
+      return result;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+      const errorStack = error instanceof Error ? error.stack : undefined;
+
+      // Log original error for debugging — preserve full details server-side
+      console.error(`[ToolRegistry] Tool '${name}' threw an unexpected error:`, {
+        toolName: name,
+        errorMessage,
+        stack: errorStack,
+      });
 
       return {
         success: false,
-        error: `Failed to execute tool '${name}': ${errorMessage}`,
+        error: `Tool '${name}' failed: ${errorMessage}`,
         metadata: {
+          toolName: name,
           originalError: error,
+          errorMessage,
+          recoveryHint: `The tool '${name}' encountered an error. Check the inputs and try again. If the problem persists, the tool may need reconfiguration.`,
         },
       };
     }


### PR DESCRIPTION
## Summary

**Milestone:** Tool Error Resilience

Add a tool error boundary in the provider layer (base-provider.ts or execution-service.ts tool handling) that catches tool execution errors and converts them to structured error responses instead of propagating exceptions. The error response should include: tool name, error message, suggested recovery action. Log the original error for debugging but present a clean message to the LLM. This should wrap around the existing tool registry execute() calls.

**Fil...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Strengthened tool execution error handling with comprehensive error boundaries preventing unhandled exceptions and system crashes
  * Tool execution failures now return structured, predictable responses with helpful recovery guidance
  * Enhanced server-side error logging and diagnostics for improved troubleshooting and monitoring
  * Increased system resilience by ensuring tools always complete safely with meaningful error information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->