### PR TITLE
Refactor execution-service prompts to use PromptBuilder

### DIFF
--- a/apps/server/src/lib/prompt-builder.ts
+++ b/apps/server/src/lib/prompt-builder.ts
@@ -1,0 +1,85 @@
+/**
+ * PromptBuilder - Modular prompt construction with named sections and phase awareness.
+ *
+ * Supports three execution phases:
+ * - EXECUTE: Coding standards, commit rules, verification instructions
+ * - PLAN: Analysis and architecture sections
+ * - REVIEW: Review criteria and quality checks
+ *
+ * Sections can be restricted to specific phases. Sections without a phase list
+ * are included in all phases.
+ */
+
+/**
+ * Execution phase that determines which prompt sections are included.
+ */
+export type ExecutionPhase = 'EXECUTE' | 'PLAN' | 'REVIEW';
+
+/**
+ * A named section of a prompt, optionally scoped to specific phases.
+ */
+interface PromptSection {
+  /** Unique name identifying this section (e.g. 'FEATURE_HEADER', 'CONTEXT') */
+  name: string;
+  /** The text content of this section */
+  content: string;
+  /**
+   * Optional list of phases this section applies to.
+   * If omitted, the section is included in all phases.
+   */
+  phases?: ExecutionPhase[];
+}
+
+/**
+ * Builds a prompt from named sections, with optional phase-aware filtering.
+ *
+ * Usage:
+ * ```ts
+ * const prompt = new PromptBuilder('EXECUTE')
+ *   .addSection('CONTEXT', contextContent)
+ *   .addSection('FEATURE_HEADER', headerContent)
+ *   .addSection('CODING_STANDARDS', standardsContent, ['EXECUTE'])
+ *   .build();
+ * ```
+ */
+export class PromptBuilder {
+  private sections: PromptSection[] = [];
+  private phase: ExecutionPhase;
+
+  /**
+   * @param phase The execution phase for this prompt. Defaults to 'EXECUTE'.
+   */
+  constructor(phase: ExecutionPhase = 'EXECUTE') {
+    this.phase = phase;
+  }
+
+  /**
+   * Add a named section to the prompt.
+   *
+   * Sections with empty or whitespace-only content are silently skipped.
+   *
+   * @param name    Section identifier (e.g. 'CONTEXT', 'CODING_STANDARDS')
+   * @param content Text content of the section
+   * @param phases  Optional phase filter — section is only included when the builder's
+   *                phase matches one of these values. Omit to include in all phases.
+   * @returns this (fluent interface)
+   */
+  addSection(name: string, content: string, phases?: ExecutionPhase[]): this {
+    if (content && content.trim()) {
+      this.sections.push({ name, content, phases });
+    }
+    return this;
+  }
+
+  /**
+   * Assemble the final prompt string from all sections that pass the phase filter.
+   *
+   * Sections are concatenated in insertion order.
+   */
+  build(): string {
+    return this.sections
+      .filter((s) => !s.phases || s.phases.includes(this.phase))
+      .map((s) => s.content)
+      .join('');
+  }
+}

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -60,6 +60,7 @@ import {
   agentExecutionsTotal,
 } from '../../lib/prometheus.js';
 import { createAutoModeOptions, validateWorkingDirectory } from '../../lib/sdk-options.js';
+import { PromptBuilder } from '../../lib/prompt-builder.js';
 import { FeatureLoader } from '../feature-loader.js';
 import type { SettingsService } from '../settings-service.js';
 import type { AuthorityService } from '../authority-service.js';
@@ -625,7 +626,12 @@ export class ExecutionService {
         logger.info(`Using continuation prompt for feature ${featureId}`);
       } else {
         // Normal flow: build prompt with planning phase
-        const featurePrompt = this.buildFeaturePrompt(feature, prompts.taskExecution);
+        // Context files are passed as the CONTEXT section in the PromptBuilder
+        const featurePrompt = this.buildFeaturePrompt(
+          feature,
+          prompts.taskExecution,
+          combinedSystemPrompt || undefined
+        );
         const planningPrefix = await this.getPlanningPromptPrefix(feature);
         prompt = planningPrefix + featurePrompt;
 
@@ -2836,32 +2842,50 @@ After generating the revised spec, output:
   }
 
   /**
-   * Build the main feature implementation prompt.
+   * Build the main feature implementation prompt using PromptBuilder.
+   *
+   * Sections:
+   * - CONTEXT (all phases): Optional project context files from loadContextFiles()
+   * - FEATURE_HEADER (all phases): Feature ID, title, description
+   * - SPEC (all phases): Feature specification when present
+   * - IMAGES (all phases): Context image attachments when present
+   * - CODING_STANDARDS (EXECUTE): Implementation instructions / coding standards
+   * - VERIFICATION (EXECUTE): Playwright verification instructions when tests are enabled
+   *
+   * @param feature              The feature to build a prompt for
+   * @param taskExecutionPrompts Implementation and verification instruction templates
+   * @param contextContent       Optional project context from loadContextFiles() — becomes
+   *                             the CONTEXT section when provided
    */
   buildFeaturePrompt(
     feature: Feature,
     taskExecutionPrompts: {
       implementationInstructions: string;
       playwrightVerificationInstructions: string;
-    }
+    },
+    contextContent?: string
   ): string {
     const title = extractTitleFromDescription(feature.description);
 
-    let prompt = `## Feature Implementation Task
+    const builder = new PromptBuilder('EXECUTE');
 
-**Feature ID:** ${feature.id}
-**Title:** ${title}
-**Description:** ${feature.description}
-`;
-
-    if (feature.spec) {
-      prompt += `
-**Specification:**
-${feature.spec}
-`;
+    // CONTEXT section — project files loaded via loadContextFiles() (all phases)
+    if (contextContent) {
+      builder.addSection('CONTEXT', contextContent);
     }
 
-    // Add images note (like old implementation)
+    // FEATURE_HEADER section — feature identity (all phases)
+    builder.addSection(
+      'FEATURE_HEADER',
+      `## Feature Implementation Task\n\n**Feature ID:** ${feature.id}\n**Title:** ${title}\n**Description:** ${feature.description}\n`
+    );
+
+    // SPEC section — feature specification when present (all phases)
+    if (feature.spec) {
+      builder.addSection('SPEC', `\n**Specification:**\n${feature.spec}\n`);
+    }
+
+    // IMAGES section — context image attachments when present (all phases)
     if (feature.imagePaths && feature.imagePaths.length > 0) {
       const imagesList = feature.imagePaths
         .map((img, idx) => {
@@ -2875,26 +2899,27 @@ ${feature.spec}
         })
         .join('\n');
 
-      prompt += `
-**Context Images Attached:**
-The user has attached ${feature.imagePaths.length} image(s) for context. These images are provided both visually (in the initial message) and as files you can read:
-
-${imagesList}
-
-You can use the Read tool to view these images at any time during implementation. Review them carefully before implementing.
-`;
+      builder.addSection(
+        'IMAGES',
+        `\n**Context Images Attached:**\nThe user has attached ${feature.imagePaths.length} image(s) for context. These images are provided both visually (in the initial message) and as files you can read:\n\n${imagesList}\n\nYou can use the Read tool to view these images at any time during implementation. Review them carefully before implementing.\n`
+      );
     }
 
-    // Add verification instructions based on testing mode
-    if (feature.skipTests) {
-      // Manual verification - just implement the feature
-      prompt += `\n${taskExecutionPrompts.implementationInstructions}`;
-    } else {
-      // Automated testing - implement and verify with Playwright
-      prompt += `\n${taskExecutionPrompts.implementationInstructions}\n\n${taskExecutionPrompts.playwrightVerificationInstructions}`;
+    // CODING_STANDARDS section — implementation instructions (EXECUTE phase only)
+    builder.addSection('CODING_STANDARDS', `\n${taskExecutionPrompts.implementationInstructions}`, [
+      'EXECUTE',
+    ]);
+
+    // VERIFICATION section — Playwright verification (EXECUTE phase only, skipped when skipTests)
+    if (!feature.skipTests) {
+      builder.addSection(
+        'VERIFICATION',
+        `\n\n${taskExecutionPrompts.playwrightVerificationInstructions}`,
+        ['EXECUTE']
+      );
     }
 
-    return prompt;
+    return builder.build();
   }
 
   /**
@@ -2931,7 +2956,11 @@ You can use the Read tool to view these images at any time during implementation
   }
 
   /**
-   * Build a focused prompt for a single task in multi-agent execution.
+   * Build a focused prompt for a single task in multi-agent execution using PromptBuilder.
+   *
+   * Sections:
+   * - TASK_PROMPT (EXECUTE): The fully substituted task prompt template, including task context,
+   *   completed/remaining task lists, user feedback, and plan content.
    */
   private buildTaskPrompt(
     task: ParsedTask,
@@ -2964,18 +2993,22 @@ You can use the Read tool to view these images at any time during implementation
     // Build user feedback string
     const userFeedbackStr = userFeedback ? `### User Feedback\n${userFeedback}\n` : '';
 
-    // Use centralized template with variable substitution
-    let prompt = taskPromptTemplate;
-    prompt = prompt.replace(/\{\{taskId\}\}/g, task.id);
-    prompt = prompt.replace(/\{\{taskDescription\}\}/g, task.description);
-    prompt = prompt.replace(/\{\{taskFilePath\}\}/g, task.filePath || '');
-    prompt = prompt.replace(/\{\{taskPhase\}\}/g, task.phase || '');
-    prompt = prompt.replace(/\{\{completedTasks\}\}/g, completedTasksStr);
-    prompt = prompt.replace(/\{\{remainingTasks\}\}/g, remainingTasksStr);
-    prompt = prompt.replace(/\{\{userFeedback\}\}/g, userFeedbackStr);
-    prompt = prompt.replace(/\{\{planContent\}\}/g, planContent);
+    // Perform template variable substitution
+    let taskPrompt = taskPromptTemplate;
+    taskPrompt = taskPrompt.replace(/\{\{taskId\}\}/g, task.id);
+    taskPrompt = taskPrompt.replace(/\{\{taskDescription\}\}/g, task.description);
+    taskPrompt = taskPrompt.replace(/\{\{taskFilePath\}\}/g, task.filePath || '');
+    taskPrompt = taskPrompt.replace(/\{\{taskPhase\}\}/g, task.phase || '');
+    taskPrompt = taskPrompt.replace(/\{\{completedTasks\}\}/g, completedTasksStr);
+    taskPrompt = taskPrompt.replace(/\{\{remainingTasks\}\}/g, remainingTasksStr);
+    taskPrompt = taskPrompt.replace(/\{\{userFeedback\}\}/g, userFeedbackStr);
+    taskPrompt = taskPrompt.replace(/\{\{planContent\}\}/g, planContent);
 
-    return prompt;
+    // Assemble via PromptBuilder — TASK_PROMPT is an EXECUTE-phase section
+    const builder = new PromptBuilder('EXECUTE');
+    builder.addSection('TASK_PROMPT', taskPrompt, ['EXECUTE']);
+
+    return builder.build();
   }
 
   /**


### PR DESCRIPTION
## Summary

**Milestone:** Modular Prompt Builder

Refactor buildFeaturePrompt() and buildTaskPrompt() in execution-service.ts to use the new PromptBuilder. Map existing prompt sections to named sections. Add phase-aware section inclusion so EXECUTE phase gets coding standards and commit rules, PLAN phase gets analysis and architecture sections, REVIEW phase gets review criteria. Context files loaded via loadContextFiles() become a CONTEXT section.

**Files to Modify:**
- apps/server/src/services/auto-mode/...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal prompt construction infrastructure with a modular, section-oriented builder that organizes content by execution phase (plan, execute, review). This replaces previous string concatenation logic for more flexible prompt assembly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->