### PR TITLE
Update docs after: Open SWE Lessons: Agent Execution Hardening

### DIFF
--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -9,6 +9,7 @@ usageStats:
   referenced: 108
   successfulFeatures: 108
 ---
+
 <!-- domain: API Design & Integration | GitHub GraphQL, REST endpoints, HTTP client patterns -->
 
 # api
@@ -39,17 +40,17 @@ usageStats:
 - **Why:** Returning boolean for known failure states (channel not found, permissions) allows callers to decide response. Throwing only on unexpected errors preserves the distinction.
 - **Breaking if changed:** If changed to throw on every failure, event processing could crash if Discord is unreachable. If changed to never throw, unexpected errors become silent.
 
-### System prompt prepended (not replaced) when role template provided (2026-02-12)
+### System prompt prepended (not replaced) when a role-specific prompt is provided to AgentService (2026-02-12, updated 2026-03-11)
 
-- **Context:** AgentTemplate includes systemPrompt; AgentService already had a systemPrompt parameter for the base send operation.
-- **Why:** Prepending preserves existing system prompt semantics while adding template directives. Allows templates to augment, not override. Backward compatible.
-- **Breaking if changed:** If changed to replacement, all role-based agent executions would lose the original system prompt, breaking agents that rely on base directives.
+- **Context:** AgentService accepts an optional systemPrompt override alongside the base session prompt. Role prompts from `@protolabsai/prompts` are prepended rather than replacing the base prompt. (Note: the dynamic AgentTemplate/RoleRegistryService system was removed in commit 2a1563ca — role prompts are now hardcoded functions in `libs/prompts/src/agents/`.)
+- **Why:** Prepending preserves existing system prompt semantics while adding role directives. Allows role context to augment, not override. Backward compatible.
+- **Breaking if changed:** If changed to replacement, role-based agent executions would lose the original system prompt, breaking agents that rely on base directives.
 
 #### [Gotcha] API method names are inconsistent across query hooks — getAll() vs list() vs status(). Must review existing hooks before implementing new data fetching to avoid using non-existent methods. (2026-02-12)
 
 - **Situation:** Initially attempted to use api.features.list() and api.autoMode.getRunningAgents() which don't exist.
 - **Root cause:** Codebase has organic growth with different naming conventions across different API endpoints. No centralized API spec or TypeScript types enforce consistency.
-- **How to avoid:** Examine existing use-*.ts hook files before implementing new API calls.
+- **How to avoid:** Examine existing use-\*.ts hook files before implementing new API calls.
 
 ### Error handling in data fetching throws Error when API result.success is false, rather than returning error state directly (2026-02-12)
 
@@ -105,28 +106,32 @@ usageStats:
 - **Root cause:** GitHub GraphQL requires explicit cursor-based pagination. There's no way to fetch all items without implementing pagination loop.
 - **How to avoid:** For most PRs, 100 threads is sufficient. Add `pageInfo { hasNextPage, endCursor }` to query and implement pagination loop if thread count regularly exceeds 100.
 
-
 #### [Pattern] getServerUrl() implements strict precedence: localStorage override > cached value > environment variable. The precedence order is non-configurable and critical. (2026-03-11)
+
 - **Problem solved:** Resolving multiple server URL sources with different specificity levels
 - **Why this works:** Precedence chain implements proper specificity: user intent (override) > transient state (cache) > static config (env). Prevents static config from shadowing user choice.
 - **Trade-offs:** Gained: Clean override semantics without code changes. Lost: Hidden state machine - source of truth is precedence-dependent, complicates debugging
 
 #### [Pattern] Activation deactivates on any space in input (`!input.includes(' ')`), limiting to single-word search queries (2026-03-11)
+
 - **Problem solved:** Need simple rule to detect slash-command mode vs regular text input
 - **Why this works:** Simple binary check; avoids complex command parsing logic. Prevents confusion between `/command arg1 arg2` (command execution) vs `/quer` (autocomplete search)
 - **Trade-offs:** Simpler activation logic vs limited search capability (can't search multi-word command names like 'Create New File'); clear UX boundary
 
 #### [Gotcha] Case-insensitive filtering requires toLowerCase() on both query and field, but natural include() is case-sensitive (2026-03-11)
+
 - **Situation:** Spec requires 'case-insensitive substring match' but naive implementation would use case-sensitive includes()
 - **Root cause:** JavaScript's includes() is case-sensitive; case-insensitive search requires normalizing both sides to same case
 - **How to avoid:** toLowerCase() on every filter call is cheap; adds minimal complexity; regex alternative more powerful but harder to read and maintain
 
 #### [Pattern] getServerUrl() uses explicit precedence chain: override → env var → window.location.origin, not boolean flags or computed defaults (2026-03-11)
+
 - **Problem solved:** Multiple sources of server URL truth: user selection (override), deployment config (env), browser location. Need predictable resolution.
 - **Why this works:** Explicit chain makes precedence obvious and testable. User's explicit choice wins, deployment config is fallback, browser is last resort.
 - **Trade-offs:** Flat chain is less DRY than config object, but more readable and harder to get wrong
 
 ### Hook result mapped through normalizer before passing to ChatInput: extracts {name, description, source, argHint} only (2026-03-11)
+
 - **Context:** useSlashCommands returns SlashCommand with internal structure; ChatInput receives UseSlashCommandsResult with normalized subset
 - **Why:** Decouples ChatInput from hook's internal structure. ChatInput only needs to know what it displays (name, description, etc.). If hook internals change, ChatInput remains unaffected. Contract is explicit via UseSlashCommandsResult type.
 - **Rejected:** Passing raw hook commands directly to ChatInput; exporting full SlashCommand type through the boundary

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -9,11 +9,13 @@ usageStats:
   referenced: 60
   successfulFeatures: 60
 ---
+
 <!-- domain: Architecture Decisions | System-wide structural decisions that have breaking consequences if changed -->
 
 # architecture
 
 ### External backup system replaces git-based recovery for feature.json (2026-02-10)
+
 - **Context:** Feature data loss incidents revealed git-tracking was fundamentally incompatible with runtime file mutations. Worktree operations and concurrent agent execution corrupted git state while modifying feature.json on disk.
 - **Why:** Git is designed for developer-controlled changes with clear commit boundaries. Runtime systems that write continuously conflict with git's atomic commit model. External backups at `.automaker/.backups/features/{featureId}/` provide point-in-time recovery without git overhead.
 - **Rejected:** Keeping git-tracked feature.json with gitignore rules — git operations continue conflicting with server writes.
@@ -21,123 +23,146 @@ usageStats:
 - **Breaking if changed:** If `readJsonWithRecovery()` is removed and replaced with direct disk reads, recovery capability disappears silently. If backups directory deleted, feature-loader.ts falls back to disk reads with no resilience.
 
 ### Exclude `.automaker/` from all git operations via pathspec, not just .gitignore (2026-02-10)
+
 - **Context:** Multiple git operations (auto-mode-service.ts, git-workflow-service.ts) need to avoid staging .automaker runtime files.
 - **Why:** Code-level pathspec exclusions (`git add -A -- ':!.automaker/'`) are explicit and documented. They survive .gitignore refactors. .gitignore is a safety net, not the primary mechanism.
 - **Rejected:** Relying solely on .gitignore — fragile to rule order and hard to debug.
 - **Breaking if changed:** If `-- ':!.automaker/'` is removed from any git operation, that operation stages .automaker runtime files, corrupting git history (server writes continuously change them).
 
 ### 50% feature count drop threshold chosen as critical breach trigger (2026-02-10)
+
 - **Context:** Need to detect catastrophic data loss (Feb 10 incident: 141 features deleted) while avoiding false positives from normal cleanup.
 - **Why:** 50% is high enough to ignore gradual cleanup but low enough to catch mass deletion. 100% threshold misses partial catastrophes; 10% triggers on every cleanup cycle.
 - **Breaking if changed:** Lowering to 20% triggers false alarms on legitimate cleanup, blocking auto-mode. Raising to 80% misses the 50-70% range where significant work is lost but recovery is still possible.
 
 ### CodeRabbit resolver is a separate service (CodeRabbitResolverService), not inline in git-workflow-service (2026-02-10)
+
 - **Context:** Need to resolve bot review threads that block auto-merge without cluttering the main workflow orchestrator.
 - **Why:** Separation of concerns allows the resolver to be independently tested, reused, and modified without touching workflow logic.
 - **Breaking if changed:** If CodeRabbitResolverService is removed, auto-merge workflow blocks on bot review threads — PR-to-merge gap reappears.
 
 ### Auto-merge task polls 'review' features rather than listening to status-change events (2026-02-10)
+
 - **Context:** Decision between event-driven (react to status changes) vs polling (periodic evaluation).
 - **Why:** Polling is more resilient to missed events, handles edge cases like manual setting changes, and integrates cleanly with existing SchedulerService cron pattern. Consistent with all other maintenance tasks.
 - **Breaking if changed:** Switching to pure event-driven requires comprehensive event emission across all status-change paths; gaps cause silent failures.
 
 ### Per-project auto-merge flag (webhookSettings.autoMerge.enabled), not global server setting (2026-02-10)
+
 - **Context:** Needed granular control — some projects want auto-merge, others don't.
 - **Why:** Per-project settings allow gradual rollout, testing on pilot projects, and respecting team preferences.
 - **Breaking if changed:** Removing per-project check and making it global auto-merges PRs on all projects — risky if some teams opted out.
 
 ### Setter injection (setAutoModeService) instead of constructor injection to break circular dependencies (2026-02-10)
+
 - **Context:** PRFeedbackService needs to call AutoModeService.executeFeature(), but both are initialized at startup and wired together after construction.
 - **Why:** Constructor injection would create circular dependency: PRFeedbackService → AutoModeService. Setter injection decouples construction from wiring.
 - **Breaking if changed:** If setAutoModeService() is never called, processReviewStatus() falls back to event-only mode — loses direct automation but service still functions.
 
 ### Transient error detection is stateless drift detection (WorldStateMonitor), not a retry state machine (2026-02-10)
+
 - **Context:** Auto-retry for blocked features needs to distinguish transient (network, rate limit) from permanent (merge conflict, auth) failures.
 - **Why:** Drift-based approach integrates cleanly with existing tick-based architecture. Avoids separate state machine complexity and race conditions between services.
 - **Breaking if changed:** If WorldStateMonitor tick interval becomes too long (>5min), retry window detection becomes unreliable. Minimum tick frequency of 30s is critical.
 
 ### Opus escalation at retry count >= 2 (after 2nd failure), not at 3 (after 3rd failure) (2026-02-10)
+
 - **Context:** Features can be retried up to 3 times. Need to escalate to stronger model before last retry.
 - **Why:** Escalate BEFORE the final chance, not after exhausting retries. Gives opus one opportunity to solve persistent issues.
 - **Breaking if changed:** If max retry limit is reduced to 2, escalation at count>=2 means every feature gets escalated. Logic needs: escalate at count >= (MAX_RETRIES - 1).
 
 ### Continuation prompt injection via executeFeature options, not new agent creation (2026-02-10)
+
 - **Context:** Agent needs to receive PR feedback without restarting from default system prompt.
 - **Why:** AutoModeService.executeFeature() supports continuationPrompt which appends feedback to existing context rather than replacing the system prompt. Preserves feature state, branch context, and worktree continuity.
 - **Breaking if changed:** If continuationPrompt parameter is removed from executeFeature options, PR feedback injection requires a new integration point.
 
 ### Use type-only imports to break circular dependency chains (2026-02-12)
+
 - **Context:** DiscordBotService is created after AvaGatewayService in the initialization sequence.
 - **Why:** Type-only imports are stripped at runtime, so they don't create actual module dependencies. Allows AvaGatewayService to reference the type for setter parameter typing without circular module dependency.
 - **Breaking if changed:** If type import is converted to regular import without adding DiscordBotService to the constructor, Discord operations fail silently.
 
-### Registry-first pattern for role prompts: templates store systemPrompt; router checks registry before hardcoded switch cases (2026-02-12)
-- **Context:** Discord thread routing needed to map role names to system prompts without hardcoding logic in the router.
-- **Why:** Decouples prompt management from router logic. Adding new roles only requires registering a template — no router changes needed.
-- **Breaking if changed:** If a template is registered without systemPrompt, registry-first check fails and falls through to switch cases; if switch case also missing, role gets generic fallback prompt.
+### Hardcoded prompt resolution in AgentDiscordRouter: role names map directly to prompt functions from @protolabsai/prompts (2026-03-11)
+
+- **Context:** Discord thread routing maps role names to system prompts. The RoleRegistryService and dynamic template system were removed (commit 2a1563ca) — dynamic agent templates are superseded by Claude Code's native Agent tool and CLI skills.
+- **Why:** Hardcoded prompt resolution is simpler and avoids the complexity of a dynamic registry. All roles have statically-defined prompts in `libs/prompts/src/agents/`. Adding a new role requires code changes across `libs/types`, `libs/prompts`, and `apps/server/src/services/agent-discord-router.ts`.
+- **Breaking if changed:** If a new role is added to `AgentRole` union without wiring a prompt function, the router throws at runtime — no silent fallback.
 
 ### Fire-and-forget async agent spawning via void IIFE pattern in event handler (2026-02-12)
+
 - **Context:** Need to spawn Frank agent on critical health events without blocking event loop.
 - **Why:** Event handlers must return quickly. `void (async () => {})()` allows non-blocking spawn with error isolation.
 - **Breaking if changed:** If changed to await, event loop blocks during Frank initialization (5-10s), health checks queue up, metrics become stale, critical events can be missed.
 
 ### In-memory cooldown timestamp for Frank spawn throttling (not persistent state) (2026-02-12)
+
 - **Context:** Prevent spawn storms when critical health persists for hours.
 - **Why:** In-memory is sufficient because Frank is diagnostic-only; cooldown resets on server restart (when issues often resolve); no cross-session tracking needed.
 - **Breaking if changed:** If cooldown is removed, rapid critical events spawn Frank every 5 minutes — spawn storms can worsen cascading failures.
 
 ### Dual ESM/CJS builds with separate tsconfig files and output directories (2026-02-13)
+
 - **Context:** Package declared as type:module but needs to support both import and require consumers.
 - **Why:** ESM-declared packages treat .js files as ES modules. CJS consumers cannot use .js files directly. Separate outputs allow correct extensions (.js for ESM, .cjs for CJS).
 - **Breaking if changed:** Removing separate tsconfig.cjs.json breaks CJS consumers — they'd require .js files from an ESM package, failing silently or with module errors.
 
 ### Copy type definitions inline in create-protolab rather than import from @protolabsai/types (2026-02-13)
+
 - **Context:** create-protolab package needs setup pipeline types but cannot import @protolabsai/types in all execution contexts (standalone CLI runs).
 - **Why:** Type duplication avoids runtime import failures when package manager workspace resolution fails.
 - **Breaking if changed:** If types are updated in libs/types/src/setup.ts without updating the copy, create-protolab uses stale interfaces — type mismatches at feature creation time.
 
 ### AgentSelector and AgentModelSelector coexist as separate components used mutually exclusively (2026-02-12)
+
 - **Context:** Could have modified AgentModelSelector to show both templates and raw models, or replaced it entirely.
 - **Why:** Separation of concerns: AgentSelector (template-based) and AgentModelSelector (raw model) have different responsibilities and APIs.
 - **Breaking if changed:** If a future requirement demands showing both selectors at once, the mutual exclusion pattern becomes a blocker requiring significant refactoring.
 
 ### Internal FeatureState (8 states) vs simplified public board status (5 states) (2026-03-09)
+
 - **Context:** Need comprehensive internal state tracking for complex feature lifecycle while presenting simplified interface to users.
 - **Why:** Internal 8-state machine (INTAKE, PLAN, EXECUTE, REVIEW, MERGE, DEPLOY, VERIFY, DONE) captures all transition paths. Public 5-state board (backlog, in_progress, review, blocked, done) is user-digestible.
 - **Breaking if changed:** If internal states change without updating public board status mapping, UI shows stale feature progress even though backend state is updated.
 
 ### PhaseHandoff verdict system (APPROVE/WARN/BLOCK) explicitly gates pipeline progression (2026-03-09)
+
 - **Context:** Feature pipeline progresses through multiple agent phases — need explicit gates to prevent bad work from advancing.
 - **Why:** Verdict system makes progression decisions visible and auditable. Each phase explicitly approves or blocks before next phase starts.
 - **Breaking if changed:** Removing verdict system and reverting to implicit checks loses visibility into why features get stuck and makes debugging phase failures much harder.
 
 ### Singleton pattern: export both class AND getter for test isolation (DataIntegrityWatchdogService) (2026-02-10)
+
 - **Context:** Need production singleton behavior but tests require isolated instances without shared state between test cases.
 - **Why:** Tests calling `new DataIntegrityWatchdogService(tmpDataDir)` get isolated instances; production uses singleton getter. Avoids mocking complexity and test pollution.
 - **Breaking if changed:** If only getter is exported, tests lose isolation and fail with state cross-contamination. If only class is exported, production loses singleton guarantees — multiple instances spawn duplicate monitoring and redundant Discord alerts.
 
 ### Emit per-action events AND aggregate task completion event separately (2026-02-10)
+
 - **Context:** Providing audit trail and UI feedback for autonomous cleanup operations.
 - **Why:** Dual-event approach enables (1) real-time UI updates via individual events and (2) health monitoring via completion event with aggregate counts.
 - **Breaking if changed:** Removing individual events loses real-time UI feedback. Removing completion event loses health/monitoring signal. Both matter for different consumers.
 
-
 #### [Pattern] localStorage used as neutral bridge between auth.ts and app-store.ts. getServerUrl() reads from 'automaker:serverUrlOverride', setServerUrlOverride() writes to same key. No direct import between layers. (2026-03-11)
+
 - **Problem solved:** Multiple layers (auth, state management) need access to same server URL override without creating circular dependency or tight coupling.
 - **Why this works:** Avoids circular imports and direct service coupling. Creates implicit contract on localStorage key as decoupling mechanism.
 - **Trade-offs:** One indirection (localStorage lookup) vs. zero import coupling; implicit key contract harder to refactor than explicit exports
 
 #### [Pattern] HTTP client fully invalidated (recreated) on setServerUrlOverride(), not just base URL patched. Calls invalidateHttpClient() which triggers WebSocket reconnection. (2026-03-11)
+
 - **Problem solved:** User switches server URL at runtime. Old connections/interceptors/middleware were initialized with original origin and need reset.
 - **Why this works:** HTTP clients cache connections, configure TLS/auth per-origin, bind request middleware to specific base URL. Can't patch URL property; full recreation required.
 - **Trade-offs:** Immediate fresh connection (good UX, correct state) vs. more expensive (full recreation vs. shallow update)
 
 #### [Gotcha] Recent URLs deduplication removes old occurrence and appends new one. Array persisted to localStorage with max 10 entries. Deduplication via array filter + push, not Set or Map. (2026-03-11)
+
 - **Situation:** User may switch to same server URL multiple times. Need clean dropdown UI without duplicates and bounded storage usage.
 - **Root cause:** Array approach preserves insertion order (most recent at end) for UX. Set would lose order. 10-entry cap prevents localStorage quota creep. Filter+push is simpler than index tracking.
 - **How to avoid:** Simple ordered dedup vs. unbounded storage; old entries lost when max reached
 
 ### When serverUrlOverride changes, setServerUrlOverride() explicitly calls invalidateHttpClient() to force recreation of both HTTP and WebSocket clients, rather than having clients auto-detect and reconnect. (2026-03-11)
+
 - **Context:** Ensuring both HTTP and WebSocket stay synchronized when switching servers at runtime
 - **Why:** Clients cache server URL internally at instantiation; explicit invalidation guarantees both client types get fresh instances pointing to new URL. Prevents subtle bugs where HTTP migrates but WebSocket stays on old server.
 - **Rejected:** Reactive auto-reconnect pattern (clients watch serverUrlOverride store change) - too implicit, risk of partial state divergence; URL property mutation (clients don't know to reconnect); separate invalidation per client (easy to forget one)
@@ -145,11 +170,13 @@ usageStats:
 - **Breaking if changed:** If invalidateHttpClient() call is removed, clients remain connected to original server despite URL change, silently failing requests
 
 #### [Gotcha] invalidateHttpClient() must be called AFTER serverUrlOverride state is set in store, not before. Calling before means new clients read stale URL from store. (2026-03-11)
+
 - **Situation:** Ordering of state mutation vs client recreation
 - **Root cause:** New HTTP/WebSocket clients read serverUrlOverride from store during instantiation. If invalidate is called before state update, new clients get old URL.
 - **How to avoid:** Gained: Clients always read fresh state. Lost: Implicit ordering dependency that's not obvious in code
 
 ### SDK single-level constraint enforced via synchronous interface design: LeadEngineerWorldStateProvider.getWorldStateSummary() is deliberately synchronous (not async/async-generator) to structurally prevent it from being implemented as a subagent. (2026-03-11)
+
 - **Context:** Anthropic SDK enforces single-level of subagents. Need to allow LE queries within Ava's PM delegated flow without violating this constraint.
 - **Why:** Synchronous interface makes subagent implementation impossible at the type level. This uses the type system as constraint enforcement rather than relying on documentation or runtime checks.
 - **Rejected:** Could implement LE as async subagent (SDK violation) or document the constraint. Type-level enforcement prevents accidental misuse.
@@ -157,16 +184,19 @@ usageStats:
 - **Breaking if changed:** Converting to async interface would require SDK restructuring to separate Ava's PM context from LE query evaluation, violating single-level constraint.
 
 #### [Pattern] Three-layer briefing with independent failure degradation: PM layer, LE layer, and strategic context layer each fail independently with graceful markdown fallback ('_World state unavailable: provider error_') rather than cascade failure. (2026-03-11)
+
 - **Problem solved:** Ava entry point aggregates heterogeneous world state (project management + engineering execution + brand context). Any layer could be unavailable or slow.
 - **Why this works:** Each layer has different SLA and failure modes. PM might be stale, LE might be slow. Degrading independently ensures Ava can operate with partial information rather than blocking.
 - **Trade-offs:** Adds error handling complexity in each layer but preserves Ava operability. Briefing output clarity slightly reduced when layer unavailable.
 
 #### [Pattern] Adapter pattern via BriefingWorldStateProvider interface: briefing.ts remains framework-agnostic (no imports from apps/server, no direct service dependencies) by delegating to provided interface implementation rather than instantiating services directly. (2026-03-11)
+
 - **Problem solved:** Briefing framework must live in packages/mcp-server (MCP tool registration) but world state assembly lives in apps/server (PM/LE services). Module boundary violation if direct coupling.
 - **Why this works:** Adapter pattern inverts dependency: framework depends on interface contract, not concrete implementation. Allows apps/server to provide implementation without cyclic imports.
 - **Trade-offs:** Extra abstraction layer adds indirection (BriefingWorldStateProvider interface) but enables clean module separation. Interface contract becomes documentation.
 
 ### PMProjectQueryService uses synchronous service boundary (queries LeadEngineerWorldStateProvider via sync call) rather than spawning LE as child subagent, even though PM is itself delegated by Ava. (2026-03-11)
+
 - **Context:** Ava delegates to PM, PM needs LE status. Could structure as: Ava→PM(subagent)→LE(subagent), but SDK limits to single subagent level.
 - **Why:** SDK single-level constraint means LE cannot be a child subagent of PM subagent. Synchronous service call stays within single level: Ava delegates to PM (one level), PM queries LE as service (not subagent).
 - **Rejected:** Async subagent model (Ava→PM→LE hierarchy) violates SDK. Sequential async/await in PM would require LE to be subagent.
@@ -174,16 +204,19 @@ usageStats:
 - **Breaking if changed:** Removing SDK single-level constraint would allow LE to become child subagent, enabling async parallelism and tool use within LE context.
 
 #### [Pattern] Client reconnection on URL change: invalidateHttpClient() calls reconnect() on existing singleton before nulling it, ensuring WebSocket gracefully switches to new URL rather than just creating a new client (2026-03-11)
+
 - **Problem solved:** When user changes server URL at runtime, HTTP client must reconnect to new origin without losing in-flight request context
 - **Why this works:** Simply nulling and recreating the client doesn't guarantee graceful reconnection. Explicit reconnect() signals active client to switch endpoints before being replaced. Prevents race conditions between old/new connections.
 - **Trade-offs:** Slightly more complex invalidation logic but ensures clean connection switching. Without this, users might see hung requests when switching URLs.
 
 #### [Pattern] localStorage-as-side-channel pattern: Store writes serverUrlOverride to localStorage, auth layer reads from localStorage instead of store directly (2026-03-11)
+
 - **Problem solved:** Multiple layers (UI, auth, HTTP client) need access to current server URL. Store is UI state source-of-truth, but auth.ts must resolve URL before store might be initialized
 - **Why this works:** Avoids circular dependencies and initialization order issues. localStorage acts as a fast side-channel for auth layer to get current URL without depending on store availability. Store manages UI state; localStorage manages runtime configuration.
 - **Trade-offs:** Adds localStorage sync overhead but decouples layers. Easier to reason about when store writes, auth reads, without waiting for store hydration.
 
 ### Multi-level fallback chain for server URL: localStorage → Electron IPC cache → VITE_SERVER_URL env var → hostname default (2026-03-11)
+
 - **Context:** App runs in multiple environments (web, Electron, local dev). Each has different configuration source. Need single getServerUrl() that works everywhere.
 - **Why:** Progressive specificity: localStorage is most specific (user override), Electron IPC is app-level (Electron main process config), env var is build-time, hostname default is bare-minimum fallback. Each level handles a specific deployment scenario.
 - **Rejected:** Single source of truth (e.g., only env var) - would require rebuilds for server changes in Electron, wouldn't support user overrides
@@ -191,11 +224,13 @@ usageStats:
 - **Breaking if changed:** Removing any fallback level breaks that deployment scenario. Removing localhost default breaks offline-first behavior. Removing env var breaks web builds.
 
 #### [Pattern] Guard integrated into BOTH `createAutoModeOptions()` and `createChatOptions()` to apply across all execution contexts (agents and chat). (2026-03-11)
+
 - **Problem solved:** Worktree isolation needed for multiple SDK consumer types. Could apply guard only to agent execution but that leaves chat mode vulnerable.
 - **Why this works:** Defense in depth across all contexts that can spawn agents or tools. Single vulnerability surface (one guard implementation) applied universally.
 - **Trade-offs:** Slightly broader hook surface (some overhead in non-agent chat) but uniform security posture. Simpler to maintain and audit.
 
 ### Used @tanstack/react-query with 5-minute stale time instead of SWR (spec suggested SWR pattern) (2026-03-11)
+
 - **Context:** Hook needed SWR-like caching behavior for command list
 - **Why:** Project standardizes on React Query. 5-minute stale time approximates SWR's revalidation strategy while using the established data-fetching library
 - **Rejected:** Implement SWR directly; useEffect + useState fetch pattern
@@ -203,6 +238,7 @@ usageStats:
 - **Breaking if changed:** Switching to SWR would require rewriting hook entirely; changing stale time affects how often command list refreshes
 
 ### Fallback chain for server URL resolution: localStorage override → Electron IPC → env var → relative URL (2026-03-11)
+
 - **Context:** Need to support runtime switching (localhost → staging → prod), build-time configuration, and fallback to relative paths
 - **Why:** Runtime override must win (user explicitly chose), then build-time config (dev/staging/prod builds), then sensible default (relative URLs work in all contexts). Order matters because earlier sources take precedence.
 - **Rejected:** Single config source would simplify but eliminate runtime switching; hard-coded URL would require rebuild for each server change
@@ -210,21 +246,25 @@ usageStats:
 - **Breaking if changed:** Removing localStorage check breaks runtime overrides entirely. Removing IPC breaks Electron-packaged builds. Removing env fallback makes server URL always relative.
 
 #### [Pattern] App-store is single source of truth (SSoT) for server URL state; localStorage is persistence layer only (2026-03-11)
+
 - **Problem solved:** Server URL override needs to survive page reloads and be accessible to all components
 - **Why this works:** Reading from app-store ensures all components see same value and react to changes. localStorage is only for persistence. Alternative of reading localStorage directly would bypass state updates and create stale reads.
 - **Trade-offs:** App-store is initialized from localStorage on boot (extra load path), but all runtime access goes through SSoT. Easier to test (mock app-store, not localStorage).
 
 #### [Pattern] localStorage keys are namespaced with 'automaker:' prefix to avoid collisions (2026-03-11)
+
 - **Problem solved:** Multiple apps/extensions may use same localStorage in browser; must prevent silent data corruption
 - **Why this works:** Raw keys like 'serverUrlOverride' could collide with other code (third-party scripts, extensions, other apps in same domain). Collision would cause one app to overwrite another's data silently. Prefix isolates namespace.
 - **Trade-offs:** Slightly longer keys, but prevents silent data corruption. Easy to adopt (just prepend prefix everywhere).
 
 #### [Pattern] Dual-layer connection invalidation: HTTP client cache AND WebSocket reconnection triggered atomically in single setServerUrlOverride() action, not as separate concerns (2026-03-11)
+
 - **Problem solved:** Server URL changes require both HTTP and WebSocket connections to be reset. If only one is invalidated, stale connections persist.
 - **Why this works:** Clients use both HTTP (REST) and WebSocket (long-lived) for communication. Either being stale breaks the app. Atomic action ensures consistency.
 - **Trade-offs:** Tighter coupling in action handler, but guarantees consistency. Alternative is distributed invalidation logic (harder to reason about)
 
 ### State shape separates serverUrlOverride (transient selection) from recentServerUrls (persistent history) rather than merging into single state object (2026-03-11)
+
 - **Context:** Need to track current server URL override separately from user's browsing history of server URLs for dropdown UI
 - **Why:** Separates concerns: override is ephemeral app state (doesn't persist on reload), recentServerUrls is user preference (persisted to localStorage). Different lifecycles require different shapes.
 - **Rejected:** Single recentServers array with 'active' flag would conflate current choice with history
@@ -232,6 +272,7 @@ usageStats:
 - **Breaking if changed:** If merged into one array/object, setting override would add it to history, filling history with transient choices instead of intentional visits
 
 ### HTTP client invalidation via singleton recreation + explicit WebSocket closure rather than creating new client instances (2026-03-11)
+
 - **Context:** Runtime server URL switching requires disconnecting old WebSocket and establishing new connection
 - **Why:** Preserves other client state and connection pool efficiency. Singleton pattern ensures single source of truth for HTTP/WebSocket connections across entire app.
 - **Rejected:** Create new HTTP client instance per URL change - would abandon connection pooling and force re-initialization of all client middleware
@@ -239,11 +280,31 @@ usageStats:
 - **Breaking if changed:** Removing explicit WebSocket close leaves dangling connections; removing singleton pattern breaks connection pooling assumptions throughout codebase
 
 #### [Pattern] Layered configuration precedence: localStorage (runtime override) > env vars (build time) > Electron cache (platform persistence) (2026-03-11)
+
 - **Problem solved:** Supporting multiple override sources (users switching servers at runtime, CI passing config, platform-specific storage) without conflicts
 - **Why this works:** Allows high-priority runtime changes (localStorage) to shadow build-time config without requiring env var updates. Each layer has appropriate lifetime and trust level.
 - **Trade-offs:** Gained: flexibility across deployment models; lost: potential confusion about which source is active
 
 #### [Pattern] Context-bridging wrapper component: ChatInputWithSlashCommands placed inside PromptInputProvider to bridge useSlashCommands hook (context-dependent) to ChatInput's component-prop interface (2026-03-11)
+
 - **Problem solved:** useSlashCommands needs input value from context, but ChatInput expects props; mismatch between hook and component APIs
 - **Why this works:** Keeps context dependencies localized within provider scope. Alternatives (prop-drilling value/setValue down) would create prop tunneling and tight coupling between parent and ChatInput. Wrapper makes the context dependency explicit and contained.
 - **Trade-offs:** One extra wrapper component adds indirection, but clear separation of concerns—PromptInputProvider owns state, wrapper owns the bridge logic
+
+### PromptBuilder used for phase-aware prompt assembly in execution-service; replaces inline string concatenation (2026-03-11)
+
+- **Context:** ExecutionService builds prompts for EXECUTE, PLAN, and REVIEW phases. Previously used inline string concatenation; refactored to use `PromptBuilder` from `apps/server/src/lib/prompt-builder.ts` (commit 94c5833cb).
+- **Why:** Named sections make prompt structure explicit and auditable. Phase filtering (`phases?: ExecutionPhase[]`) automatically excludes sections not relevant to the current phase — e.g., coding standards are EXECUTE-only, review criteria are REVIEW-only.
+- **Breaking if changed:** If PromptBuilder is removed, phase-aware filtering must be re-implemented inline. If section names are changed, debugging prompt content requires reading source rather than matching section names in logs.
+
+### PostExecutionMiddleware extracted from ExecutionService.executeFeature() finally block (2026-03-11)
+
+- **Context:** The cleanup logic that runs on every agent exit path (success, error, timeout, abort) was previously inline in `executeFeature()`. Extracted to `PostExecutionMiddleware` in `apps/server/src/services/auto-mode/post-execution-middleware.ts` (commit 5f2d2e46b).
+- **Why:** Guarantees cleanup runs on ALL exit paths. Five steps in order: (1) recover uncommitted work, (2) fire abort controller, (3) remove worktree lock, (4) remove from runningFeatures map, (5) persist execution state.
+- **Breaking if changed:** If PostExecutionMiddleware is bypassed or steps removed, lock files accumulate blocking future agent runs, running features map becomes stale, and uncommitted work is silently stranded.
+
+### ToolRegistry error boundary converts thrown exceptions to structured error responses (2026-03-11)
+
+- **Context:** Tool execution errors previously propagated as exceptions that could crash the agent session. `ToolRegistry.execute()` now wraps all tool calls in an error boundary (commit befe3e279).
+- **Why:** The LLM should receive structured error context (toolName, errorMessage, recoveryHint) to attempt recovery rather than the session crashing. Always resolves; never throws.
+- **Breaking if changed:** If error boundary is removed, tool errors crash the agent session rather than giving the LLM a chance to recover. If recoveryHint is removed from metadata, LLM has less guidance on how to proceed after a failure.

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -9,11 +9,19 @@ usageStats:
   referenced: 318
   successfulFeatures: 318
 ---
+
 <!-- domain: Gotchas & Pitfalls | Known traps, anti-patterns, and hard-won lessons across all domains -->
 
 # gotchas
 
-#### [Gotcha] Worktree node_modules/@protolabsai/* symlinks resolve to MAIN repo, not worktree (2026-03-10)
+#### [Gotcha] apps/server has TWO tsconfig files: tsconfig.json (src paths, for tsx dev + IDE) and tsconfig.build.json (dist paths, for tsc build). Do NOT point tsconfig.json paths at dist/ — tsx crashes executing .d.ts files. (2026-03-11)
+
+- **Situation:** tsconfig.json previously had paths pointing at `dist/index.d.ts`. tsx (used by the dev server) resolves paths at runtime and crashes trying to execute `.d.ts` files as JavaScript.
+- **Root cause:** tsx and tsc have different resolution needs. tsx needs `src/index.ts` (source files). tsc build needs `dist/index.d.ts` (type declarations, required because they live outside rootDir).
+- **Fix:** `tsconfig.json` paths → `src/index.ts` (used by tsx + IDE). `tsconfig.build.json` extends it, overriding paths to `dist/index.d.ts` (used by `tsc -p tsconfig.build.json`).
+- **How to avoid:** When adding a new `@protolabsai/*` path alias to apps/server, add src path to `tsconfig.json` AND dist path to `tsconfig.build.json`. Do not put dist paths in `tsconfig.json`.
+
+#### [Gotcha] Worktree node_modules/@protolabsai/\* symlinks resolve to MAIN repo, not worktree (2026-03-10)
 
 - **Situation:** When working in a git worktree and adding new exports to a shared package (e.g. `@protolabsai/types`), `npm run build:server` fails with "cannot find module" or "export not found" even though you just added it.
 - **Root cause:** Git worktrees share the parent repo's `node_modules/` via Node.js directory traversal (Node walks up from `.worktrees/feature-xxx/` to `/automaker/node_modules/`). The symlink `node_modules/@protolabsai/types → /automaker/libs/types/dist/` points to the MAIN REPO's dist, not the worktree's. New exports in the worktree's `libs/types/src/` are invisible at compile time.
@@ -624,193 +632,230 @@ usageStats:
 - **Root cause:** Without checking Set membership before cleanup, timeout firing after legitimate completion could corrupt state machine (double removal, or re-lock an already-running feature). The check prevents this.
 - **How to avoid:** Gained: Safety from race conditions, self-healing on hangs. Lost: Slight complexity in cleanup logic (must check Set membership).
 
-
 #### [Gotcha] Silent guards with no diagnostic context are worse than incomplete pattern matching. A failure dropped silently is harder to debug than a failure marked as 'unknown' with the raw reason visible. (2026-03-09)
+
 - **Situation:** The friction-tracker service silently returned on 'unknown' patterns without logging. Combined with debug-level logging in the classifier, unclassified failures were invisible end-to-end.
 - **Root cause:** When a failure is silently dropped, nobody knows it happened. When it's logged at warn level with context ('unclassified: needs human input'), operators and monitoring can detect the gap and request pattern expansion.
 - **How to avoid:** Easier to spot failure gaps now, but requires disciplined log analysis. Trade-off is worth it because it unblocks system improvement.
 
 #### [Gotcha] Auto-generated feature descriptions reference completed projects that no longer exist in .automaker/projects/ (e.g., automation-control-plane-consolidation, automations-upgrade, ava-chat-context-window-management). (2026-03-09)
+
 - **Situation:** Documentation review feature was generated from git history but included stale project file references that have since been removed.
 - **Root cause:** Completed projects are cleaned up from the projects directory to keep active work list current. Feature metadata was generated at a point-in-time before cleanup.
 - **How to avoid:** Clean project directory (-historical audit trail) vs. historical reference preservation (+storage, +navigation complexity)
 
 #### [Gotcha] Pre-existing git merge conflict in tool-invocation-part.tsx (containing git stash markers: <<<<<<< Updated upstream / >>>>>>> Stashed changes) was blocking the entire build, even though the conflict was unrelated to the feature being implemented. (2026-03-09)
+
 - **Situation:** Parallel development created stashed changes that weren't properly merged during rebase/merge operations.
 - **Root cause:** Git stash markers are not valid TypeScript syntax and prevent tsc from parsing the file, killing the entire monorepo build.
 - **How to avoid:** Spending 5 mins to resolve merge conflict (keep both import/registration sets) vs. hours of blocked CI/CD. The additive merge is safe because both sitrep-card and health-check-card files exist and their tool IDs don't collide.
 
 #### [Gotcha] useEffect dependencies on incrementally-updated streaming content (e.g., `code` prop) re-fire on every token, not just on initial mount. Expensive operations like Prism.js highlight thrashing occur at every token delivery. (2026-03-09)
+
 - **Situation:** Code block receives streaming tokens character-by-character; the `code` dependency genuinely changes on each token, triggering effects.
 - **Root cause:** Root cause: useEffect correctly identifies `code` as a dependency that changed. The gotcha is that streaming creates high-frequency changes, not low-frequency initialization.
 - **How to avoid:** Understanding: recognize that streaming is high-frequency state change, not initialization. Solution complexity: requires `isStreaming` flag to distinguish initialization from streaming completion.
 
 #### [Gotcha] Category names use spaces in string literals ('Work Steal', not 'WorkSteal') in TypeScript union type (2026-03-09)
+
 - **Situation:** CATEGORY_TAG_MAP and ProtocolCategory type definition use space-containing strings like 'Work Steal' as enum-like values
 - **Root cause:** Display names come from product spec (human-readable UI labels) rather than code identifiers. Reusing display names as type keys avoided separate mapping layer.
 - **How to avoid:** One source of truth for category names reduces sync bugs. However, space-in-identifiers violates JavaScript naming conventions and breaks developer mental models (unusual in codebases).
 
 #### [Gotcha] Feature description referenced files at 'apps/server/src/server/services/' but actual implementation lives at 'apps/server/src/services/' (2026-03-09)
+
 - **Situation:** Audit followed documented paths and couldn't find files initially, wasted time searching worktree
 - **Root cause:** Likely a refactoring moved services up one level in directory hierarchy, but feature description wasn't updated
 - **How to avoid:** Extra path searches cost time, but revealed documentation drift
 
 #### [Gotcha] WorkIntakeService phase claims require a 200ms settle delay then a verify read — skipping the verify causes false positive claims where two instances both believe they own the phase (2026-03-09)
+
 - **Situation:** Automerge CRDT merges are eventually consistent. After writing a claim, another instance may have simultaneously written its own claim. Without reading back after a brief settle, the instance proceeds as though it won the claim even when Automerge resolved to a different winner.
 - **Root cause:** CRDT last-writer-wins semantics means two simultaneous claims resolve to one, but neither writer knows which won until they re-read. The 200ms delay (`CLAIM_VERIFY_DELAY_MS`) gives the WebSocket sync round-trip time to complete before the verify read.
 - **How to avoid:** Always use the full `claimAndMaterialize` flow: write claim → wait 200ms → read back → check `holdsClaim(phase, instanceId)`. Never skip the verify step, even in tests or one-off scripts.
 
 #### [Gotcha] WorkIntakeService features are LOCAL only — phases are the cross-instance coordination unit, NOT features (2026-03-09)
+
 - **Situation:** It's tempting to sync features via CRDT like other entities. The pull-based model deliberately does NOT do this. Each instance creates its own local feature from a claimed phase and never broadcasts that feature to peers.
 - **Root cause:** Features are execution artifacts specific to one instance. Syncing them would cause every instance to see (and potentially try to execute) every other instance's work. Phases, by contrast, are coordination primitives shared via project CRDT documents.
 - **How to avoid:** If you see a feature appearing on multiple instances unexpectedly, check whether CRDT feature sync was accidentally re-enabled. The rule: projects (and their phases) cross the wire, features never do.
 
 #### [Gotcha] WorkIntakeService stale claim recovery silently skips everything if getPeerStatus() returns an empty map (2026-03-09)
+
 - **Situation:** `reclaimStalePhases()` calls `isReclaimable(phase, peerStatus, claimTimeoutMs)`. The `peerStatus` map is used to check whether the claiming instance is still online. If the map is empty (e.g., CrdtSyncService not connected), no stale claims are ever reclaimed regardless of timeout.
 - **Root cause:** The design is conservative: don't reclaim if you can't verify the peer is truly offline. An empty peer map means "we don't know who's online" not "everyone is offline."
 - **How to avoid:** If stale claims are piling up in the project doc, first check whether CrdtSyncService is connected and peers are being tracked. `workIntakeService` reclaim only activates once peer presence data is available.
 
 #### [Gotcha] Performance narrative (React 'never re-reconciles' static HTML) was masking a hidden feature regression (loss of custom component renderers in completed messages) (2026-03-09)
+
 - **Situation:** The original code included a comment justifying dangerouslySetInnerHTML with 'React never re-reconciles this' — treating it as an optimization feature. This framing normalized accepting limited rendering capability (no CodeBlock, table, or citation components) in completed messages
 - **Root cause:** The optimization comment was technically true but created false justification for code that actually broke feature parity. Developers reading the code would see 'optimization' and assume the limitation was worth it, without questioning whether the trade-off was necessary
 - **How to avoid:** Gained code clarity and unified features; lost a narrow optimization that wasn't delivering value. The narrative loss is the real cost — developers in future codebases may keep similar 'optimized' dual paths without questioning them
 
 #### [Gotcha] Type assertion evolution: code initially used `as any` for form steps (step={firstStep as any}), then refined to `as HITLFormStep`. Indicates type wasn't imported or understood during initial implementation. (2026-03-09)
+
 - **Situation:** Implementing form rendering component without full type information available or imported.
 - **Root cause:** Rapid iteration. Start with loose types to unblock implementation, tighten as you understand the data shape. `as any` is a common escape hatch when types aren't available.
 - **How to avoid:** Fast iteration vs. type safety. Loose types hide errors but allow development to proceed. Type refinement happens naturally once types are discovered.
 
 #### [Gotcha] The `includeProtocol: true` flag on `avaChannel.getMessages()` is REQUIRED to surface backchannel messages in results (2026-03-09)
+
 - **Situation:** Polling for responses in the response-waiting loop relies on protocol messages appearing in getMessages results
 - **Root cause:** By default getMessages filters out protocol/backchannel messages. Flag was discovered via debugging.
 - **How to avoid:** Flag inclusion adds clarity but is non-obvious API design. Without it, feature silently fails (polls timeout with no responses found).
 
 #### [Gotcha] Infrastructure partially existed before plumbing completed: PRWatcherService already had sessionId on WatchEntry and emitted it in events, but HTTP/tool layers weren't connected (2026-03-09)
+
 - **Situation:** Feature required only connecting layers, not building storage mechanism. Developers found sessionId already in wire format but not flowing through buildAvaTools → watch_pr tool.
 - **Root cause:** Suggests sessionId was added to PRWatcherService separately (possibly for future use or incomplete PR). Missing connection prevented feature activation.
 - **How to avoid:** Partial implementations can silently exist (feature half-works). Good: saves rework. Bad: obscures incomplete features, makes it unclear who 'owns' finishing them.
 
 #### [Gotcha] Build + lint verification was done before committing changes; without this step, TypeScript errors or prettier/eslint violations would not surface until CI (2026-03-10)
+
 - **Situation:** Committed 4 files with ~1000 LOC of new code; build passed cleanly
 - **Root cause:** Worktree isolation means local environment might diverge from CI—pre-commit build verification catches issues before push and avoids CI loop delay
 - **How to avoid:** Adds ~2min overhead locally to catch issues immediately vs 5-10min waiting for CI to run; prevents broken commits on branch
 
 #### [Gotcha] Discord channel IDs table existed in both the LLM prompt and in memory/MEMORY.md, creating a duplicate data maintenance burden. Removing from prompt eliminates sync risk. (2026-03-10)
+
 - **Situation:** System configuration scattered across multiple files — channel IDs in prompt, same IDs in memory file. Updates to either location could desynchronize.
 - **Root cause:** System prompts are code and should follow DRY principle. Reference data that changes independently (channel IDs, config) should have a single source of truth. LLM prompts should reference stable facts, not configuration that ops teams might update.
 - **How to avoid:** Prompt is smaller and cleaner vs. if Ava needs channel IDs at runtime, must query them from MCP or memory rather than having them inline.
 
 #### [Gotcha] Bootstrap synchronization: `serverUrlOverride` is initialized from localStorage in store setup. If store hydration is not guaranteed before HTTP client makes first request, race condition exists where client uses fallback URL while store is still syncing. (2026-03-10)
+
 - **Situation:** App startup sequence: store initialization, HTTP client creation, first API call. Order matters.
 - **Root cause:** localStorage is async in some contexts (though typically sync in browsers); if hydration is deferred, early requests use old URL.
 - **How to avoid:** Hydration adds small startup cost. If not handled carefully, can cause race conditions. The summary doesn't specify how hydration is guaranteed to complete before first request.
 
 #### [Gotcha] emit() and broadcast() coexist on the same EventEmitter object, making it easy to pick the wrong method when handling events that cross server-client boundaries (2026-03-10)
+
 - **Situation:** Developer modifying event emission in ava-tools.ts has two methods available with similar names but different scopes
 - **Root cause:** EventEmitter surface area is large. Without explicit documentation/comments, caller doesn't know their event audience (server-only vs broadcast).
 - **How to avoid:** Generic EventEmitter is reusable across projects but requires developer knowledge of when to use emit vs broadcast. Specificity would reduce confusion but reduce reusability.
 
 #### [Gotcha] WebSocket events that don't match the UI's narrowed EventType union are silently dropped (never dispatched to callbacks), with no error or warning (2026-03-10)
+
 - **Situation:** When 'chat:user-input-request' was missing from the UI's EventType union, the server was sending these events but the client was discarding them without trace
 - **Root cause:** The EventHandler filters incoming messages by type-checking against the union; unmatched types fail the type guard and are never delivered to registered callbacks
 - **How to avoid:** Silent dropping is less disruptive than runtime errors, but makes debugging much harder - events disappear with no signal to developer
 
 #### [Gotcha] Script named 'dev:headless' runs NODE_ENV=production. The 'dev:' prefix refers to 'running in local development workflow', not 'development environment mode'. Easy misinterpretation. (2026-03-10)
+
 - **Situation:** Codebase convention uses 'dev:' prefix for local-execution scripts, but this variant must run production environment to accurately test deployed configuration
 - **Root cause:** Enables testing production behavior (AUTO_MODE=true, NODE_ENV=production) locally before CI deployment. Validates server correctness in its actual runtime environment, not a mock dev environment.
 - **How to avoid:** Consistent naming across root scripts vs. explicit environment signaling in script name
 
 #### [Gotcha] staleForMs might be 0 or imprecise, so fallback to 'some time' instead of computing staleHours; loses precision in user-facing message (2026-03-10)
+
 - **Situation:** Drift data structure has optional staleForMs field; value could be missing, zero, or calculated inaccurately from timestamps
 - **Root cause:** Defensive: avoid showing '0 hours' or NaN in comment body; vague message still readable
 - **How to avoid:** User sees less precise info ('some time' vs '72 hours'), but message degrades gracefully instead of erroring or misleading
 
 #### [Gotcha] Deferred signals are stored in-memory in the SignalIntakeService instance and do not persist across server restarts (2026-03-10)
+
 - **Situation:** getDeferredQueue() returns in-memory array; no database or file persistence implemented
 - **Root cause:** Simpler initial implementation; deferred queue is a temporary holding pattern expected to be processed by human review within a session; external persistence adds DB dependency
 - **How to avoid:** Gained: zero persistence overhead, simple to implement. Lost: queue lost on server crash; no audit trail of deferrals
 
 #### [Gotcha] LeadEngineerRule contract (pure function, no side effects beyond logging) prevents errorBudgetExhausted rule from actually enforcing budget (auto-pause) (2026-03-10)
+
 - **Situation:** Feature spec includes auto-pause when budget exhausted, but rule can only emit warn log. Full enforcement requires FeatureScheduler integration (separate work outside described scope).
 - **Root cause:** Rule engine designed for simplicity/testability/determinism. Complex enforcement (skipping non-bugfix features) requires scheduler access (scheduler orchestrates feature selection). Rules are evaluation-only.
 - **How to avoid:** Simpler rule engine in exchange for limited rule capabilities. Enforcement requires two-phase architecture: rules report state → scheduler acts on state.
 
 #### [Gotcha] libs/types dist files were stale, causing TypeScript errors. Needed explicit rebuild via `cd libs/types && npm run build` even though monorepo is linked. (2026-03-10)
+
 - **Situation:** Working in worktree with @protolabsai/types as published package + local libs/types source.
 - **Root cause:** Node module resolution and npm hoisting mean the published .d.ts files in node_modules/@protolabsai/types/dist/ are not auto-synced with source changes. Build step required.
 - **How to avoid:** Explicit rebuild step adds friction but catches type drift. Better than silent type errors.
 
 #### [Gotcha] Recent URLs deduplication uses O(n) .filter() scan on each addition despite only storing max 10 items: [url, ...recent.filter(u => u !== url)].slice(0, 10) (2026-03-10)
+
 - **Situation:** Maintaining deduplicated recent server URLs list for UI dropdown
 - **Root cause:** Simple, readable code sufficient for 10-item bounded list. Algorithm complexity was sacrificed for maintainability.
 - **How to avoid:** Clear, easy-to-read code vs. technically inefficient algorithm; works fine at 10 items, breaks visibly if list grows to 100s; synchronous localStorage means no async overhead
 
 #### [Gotcha] Review queue depth uses count of features with status='review' as proxy for PR queue depth. Assumes 1:1 mapping of feature→PR. (2026-03-10)
+
 - **Situation:** Code: `allFeatures.filter((f) => f.status === 'review').length`. No accounting for draft PRs, stacked PRs, or features with zero PRs.
 - **Root cause:** Simple and fast. Feature status is the single source of truth; avoids expensive GitHub API queries per feature.
 - **How to avoid:** Easier: O(1) memory/compute. Harder: doesn't detect PRs opened outside the feature system, or multiple PRs per feature.
 
 #### [Gotcha] Portfolio gate's `deferredQueue` is in-memory only — deferred signals are lost on server restart (2026-03-10)
+
 - **Situation:** SignalIntakeService defers incoming signals to `deferredQueue` when capacity or error-budget checks fail. Queue is not persisted to disk or database.
 - **Root cause:** Simpler initial implementation; can optimize based on observed deferral patterns before adding persistence layer. Assumption is that deferred signals are low-priority and will be re-submitted by users if important.
 - **How to avoid:** Simpler code and faster iteration on gate thresholds now, but users must re-submit deferred signals after server restart. Loss is acceptable for non-critical signals.
+
 #### [Gotcha] Features in 'review' status must have prNumber field populated; no validation of this invariant in task (2026-02-10)
+
 - **Situation:** Task assumes feature.prNumber exists if feature.status === 'review'. No defensive checks.
 - **Root cause:** Assumed board-health system maintains this invariant (features only marked 'review' after PR created). Defensive checks add noise.
 - **How to avoid:** Trust the invariant vs defensive programming. Silence if invariant breaks (prNumber undefined = skipped feature, hard to debug). Documented in notes to avoid later confusion.
 
 #### [Gotcha] npm install failed with 'node-pty rebuild requiring Python' when installing dagre dependencies. Required --ignore-scripts --legacy-peer-deps flags. (2026-02-19)
+
 - **Situation:** Adding dagre and @types/dagre to package.json triggered post-install build scripts that needed Python toolchain.
 - **Root cause:** node-pty is a transitive dependency of some package that requires native compilation. The --ignore-scripts flag skips post-install scripts, --legacy-peer-deps allows peer dependency resolution.
 - **How to avoid:** Use --ignore-scripts --legacy-peer-deps for deps with native transitive dependencies.
 
 #### [Gotcha] Build failures don't necessarily indicate code correctness — distinguish environment issue (missing p-limit in node_modules) from actual code problems by verifying only changed files' errors. (2026-02-21)
+
 - **Situation:** Build failed during verification but all feature changes were isolated to apps/ui; libs/platform/secure-fs.ts error indicated upstream dependency problem.
 - **Root cause:** Dependency resolution failures occur independently of code changes; git diff provides objective proof of which files changed vs where errors occur.
 - **How to avoid:** If error file wasn't modified, it's likely environmental — check git diff before attributing blame.
 
 #### [Gotcha] OG meta tags must use absolute URLs, not relative URLs, because social media crawlers are external services without context to resolve relative URLs. (2026-02-24)
+
 - **Situation:** Implementing og:image meta tags for social sharing across landing pages.
 - **Root cause:** Social platforms crawl pages from their own servers and cannot resolve relative URLs the way a browser would.
 - **How to avoid:** Absolute URLs required for external crawlers; hardcode domain or use environment variable for base URL.
 
 #### [Gotcha] Same satisfiedStatuses list appears in 3+ separate functions within single resolver.ts file. Each function keeps this in sync independently. (2026-02-24)
+
 - **Situation:** Three functions (areDependenciesSatisfied, getBlockingDependencies, getBlockingDependenciesFromMap) each had their own copy of which statuses count as 'satisfied'.
 - **Root cause:** Each function evolved independently. Extracting to constant seemed premature until a change revealed the cost.
 - **How to avoid:** DRY principle violation — maintain single STATUS_SATISFIED constant.
 
 #### [Gotcha] ProjectSettingsPanel and ProjectSettingsView are separate components on different routes, risking duplication of webhook settings UI logic. (2026-03-07)
+
 - **Situation:** /project-settings uses ProjectSettingsView with ProjectWebhooksSection; new ProjectSettingsPanel is milestone component with same webhook validation.
 - **Root cause:** Feature built incrementally; ProjectSettingsPanel is new milestone piece for future Project Page Hub; old route unchanged.
 - **How to avoid:** Incrementally ship without touching stable routes, but document the duplication risk.
 
 #### [Gotcha] Feature creation logic duplicated: blocked features use `status: 'blocked'` + `blockingReason` while passed features use `status: 'backlog'` with no blocking fields. Both branches exist in same method. (2026-03-10)
+
 - **Situation:** Gate decision requires different feature metadata for blocked vs. passed features.
 - **Root cause:** Blocked features need explicit reason tracking; passed features don't. Cannot use single feature constructor.
 - **How to avoid:** Explicit metadata per path vs. code duplication; easier to understand each path vs. harder to maintain when feature creation logic changes.
 
 #### [Gotcha] Portfolio gate's deferredQueue is in-memory only — deferred signals are lost on server restart. (2026-03-10)
+
 - **Situation:** SignalIntakeService defers incoming signals to deferredQueue when capacity or error-budget checks fail. Queue is not persisted.
 - **Root cause:** Simpler initial implementation; assumption is that deferred signals are low-priority and will be re-submitted by users if important.
 - **How to avoid:** Users must re-submit deferred signals after server restart. Add persistence if deferral rate increases.
 
-
 #### [Gotcha] recentServerUrls deduplication on add: if user re-selects same server URL, old entry is removed and new one appended (maintains insertion order, prevents duplicates) (2026-03-11)
+
 - **Situation:** Maintaining recent server history without duplicates. User might frequently switch between 2-3 servers.
 - **Root cause:** Prevents cluttering the dropdown with repeated URLs. Moving to end of list (LRU-like behavior) makes recently-used servers more discoverable.
 - **How to avoid:** More intuitive UX (recent = at bottom) but requires O(n) search to find and remove existing entry before append. For max-10 list, negligible.
 
 #### [Gotcha] setServerUrlOverride() must call invalidateHttpClient() to reconnect WebSocket to new server (2026-03-11)
+
 - **Situation:** Multiple transport layers exist (HTTP client, WebSocket). Changing server URL in state doesn't auto-update live connections.
 - **Root cause:** WebSocket client holds a reference to the old server URL. If only localStorage/state changes, WebSocket silently continues connecting to old server. invalidateHttpClient() closes old connection and creates new singleton, forcing reconnection.
 - **How to avoid:** Coupling setServerUrlOverride() to HTTP client layer (tight dependency), but ensures correctness. Forgetting this call causes silent data loss—app stops receiving updates without error.
 
 #### [Gotcha] Recent URLs deduplication (max 10 limit) is only applied when setServerUrlOverride() is called; manual localStorage edits bypass it (2026-03-11)
+
 - **Situation:** User experience feature: remember recent servers for quick switching. Constraint of max 10 prevents unbounded growth.
 - **Root cause:** Implementation: [newUrl, ...stored.filter(u => u !== newUrl)].slice(0, 10). Deduplication moves matching URL to front, then slice enforces max. But if someone manually edits localStorage to add 11+ URLs, constraint isn't enforced until next state update.
 - **How to avoid:** Simple implementation (one-liner filter+slice) vs. reactive enforcement. Edge case only occurs if localStorage is manually edited (rare) or if feature is scripted externally.
 
 #### [Gotcha] WebSocket connections must be explicitly closed before creating new client pointing to different URL (2026-03-11)
+
 - **Situation:** If you recreate HTTP client without closing previous WebSocket, stale connections persist and can interfere with routing
 - **Root cause:** WebSocket close is not automatic on object destruction; browser keeps connection alive until explicitly terminated
 - **How to avoid:** Gained: clean connection lifecycle; lost: ability to assume cleanup on object disposal

--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -1,6 +1,6 @@
 ---
 tags: []
-summary: "relevantTo: []"
+summary: 'relevantTo: []'
 relevantTo: []
 importance: 0.5
 relatedFiles: []
@@ -9,11 +9,12 @@ usageStats:
   referenced: 66
   successfulFeatures: 66
 ---
+
 <!-- domain: GTM Signal Intelligence | Go-to-market signal processing and routing -->
 
 # GTM Signal Intelligence & Content Operations
 
-## Status: ACTIVE — Linear project created, content pipeline running
+## Status: ACTIVE — content pipeline running (Note: Linear deprecated 2026-03-04; project management moved to in-app board)
 
 ## Date: 2026-02-21
 


### PR DESCRIPTION
## Summary

72 doc-relevant files changed recently.

Changed files requiring docs review:
- .automaker/memory/api.md
- .automaker/memory/architecture.md
- .automaker/memory/documentation.md
- .automaker/memory/gotchas.md
- .automaker/memory/gtm-signal-intelligence-project.md
- .automaker/memory/resilience.md
- .automaker/memory/testing.md
- .automaker/projects/autonomous-pipeline-idea-to-production/milestones/01-pre-requisites-fix-broken-wiring/milestone.md
- .automaker/projects/autonomous-pipeline-idea-to-...

---
*Recovered automatically by Automaker post-agent hook*