### PR TITLE
Per-phase temperature routing

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -41,7 +41,12 @@ import {
   type DedupChecker,
   type IndexRebuilder,
 } from '@protolabsai/utils';
-import { resolveModelString, resolvePhaseModel, DEFAULT_MODELS } from '@protolabsai/model-resolver';
+import {
+  resolveModelString,
+  resolvePhaseModel,
+  resolvePhaseTemperature,
+  DEFAULT_MODELS,
+} from '@protolabsai/model-resolver';
 import { getFeatureDir } from '@protolabsai/platform';
 import { rebaseWorktreeOnMain, extractTitleFromDescription } from '@protolabsai/git-utils';
 import { exec } from 'child_process';
@@ -784,6 +789,7 @@ export class ExecutionService {
           maxTurns,
           resume: resumeSessionId,
           providerId: modelResult.providerId,
+          phase: 'EXECUTE', // Apply EXECUTE phase temperature (deterministic implementation)
         }
       );
 
@@ -1695,6 +1701,7 @@ export class ExecutionService {
         autoLoadClaudeMd,
         thinkingLevel: feature.thinkingLevel,
         providerId: modelResult.providerId,
+        phase: 'REVIEW', // Apply REVIEW phase temperature (balanced evaluation)
       }
     );
 
@@ -1813,6 +1820,12 @@ Complete the pipeline step instructions above. Review the previous work and appl
       resume?: string;
       /** Provider ID from PhaseModelEntry for explicit provider lookup */
       providerId?: string;
+      /**
+       * Pipeline phase for temperature resolution.
+       * PLAN=1.0 (creative), EXECUTE=0 (deterministic), REVIEW=0.5 (balanced).
+       * When provided, the phase temperature from WorkflowSettings.phaseTemperatures is applied.
+       */
+      phase?: 'PLAN' | 'EXECUTE' | 'REVIEW';
       /**
        * Middleware hook called immediately before the model call.
        * Return a non-null string to inject additional context into the prompt.
@@ -2014,6 +2027,27 @@ This mock response was generated because AUTOMAKER_MOCK_AGENT=true was set.
       ? stripProviderPrefix(providerResolvedModel)
       : bareModel;
 
+    // Resolve phase temperature from workflow settings when a phase is specified.
+    // This applies per-phase temperature config (PLAN=1.0, EXECUTE=0, REVIEW=0.5) to control
+    // model creativity vs determinism. Falls back to provider default when no phase or config.
+    let phaseTemperature: number | undefined;
+    if (options?.phase) {
+      const wfSettingsForTemp = await getWorkflowSettings(
+        finalProjectPath,
+        this.settingsService,
+        '[AutoMode]'
+      );
+      phaseTemperature = resolvePhaseTemperature(
+        options.phase,
+        wfSettingsForTemp.phaseTemperatures
+      );
+      if (phaseTemperature !== undefined) {
+        logger.info(
+          `[AutoMode] Phase temperature for ${options.phase}: ${phaseTemperature} (feature ${featureId})`
+        );
+      }
+    }
+
     const executeOptions: ExecuteOptions = {
       prompt: promptContent,
       model: effectiveBareModel,
@@ -2029,6 +2063,7 @@ This mock response was generated because AUTOMAKER_MOCK_AGENT=true was set.
       claudeCompatibleProvider, // Pass provider for alternative endpoint configuration (GLM, MiniMax, etc.)
       sdkSessionId: options?.resume, // Forward resume session ID for session continuity
       hooks: sdkOptions.hooks as ExecuteOptions['hooks'], // Worktree write guard
+      ...(phaseTemperature !== undefined && { temperature: phaseTemperature }), // Phase temperature
     };
 
     // Middleware hook point: allow callers to inject additional context before the model call.

--- a/libs/model-resolver/src/index.ts
+++ b/libs/model-resolver/src/index.ts
@@ -17,5 +17,6 @@ export {
   resolveModelString,
   getEffectiveModel,
   resolvePhaseModel,
+  resolvePhaseTemperature,
   type ResolvedPhaseModel,
 } from './resolver.js';

--- a/libs/model-resolver/src/resolver.ts
+++ b/libs/model-resolver/src/resolver.ts
@@ -26,6 +26,7 @@ import {
   migrateModelId,
   type PhaseModelEntry,
   type ThinkingLevel,
+  type PhaseTemperaturesConfig,
 } from '@protolabsai/types';
 
 // Pattern definitions for Codex/OpenAI models
@@ -218,4 +219,28 @@ export function resolvePhaseModel(
     model: resolveModelString(phaseModel.model, defaultModel),
     thinkingLevel: phaseModel.thinkingLevel,
   };
+}
+
+/**
+ * Resolve the temperature for a given pipeline phase.
+ *
+ * Returns the configured temperature for the specified phase, or undefined
+ * if no phase temperature config is provided (preserving default provider behavior).
+ *
+ * @param phase - Pipeline phase ('PLAN' | 'EXECUTE' | 'REVIEW')
+ * @param phaseTemperatures - Optional per-phase temperature config from WorkflowSettings
+ * @returns Temperature value for the phase, or undefined if not configured
+ *
+ * @example
+ * ```ts
+ * const temp = resolvePhaseTemperature('EXECUTE', workflowSettings.phaseTemperatures);
+ * // temp === 0 (deterministic implementation)
+ * ```
+ */
+export function resolvePhaseTemperature(
+  phase: 'PLAN' | 'EXECUTE' | 'REVIEW',
+  phaseTemperatures?: PhaseTemperaturesConfig
+): number | undefined {
+  if (!phaseTemperatures) return undefined;
+  return phaseTemperatures[phase];
 }

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -375,6 +375,7 @@ export type {
   ClaudeApiProfileTemplate,
   // Workflow settings types
   WorkflowSettings,
+  PhaseTemperaturesConfig,
   // Ava Channel reactor settings
   AvaChannelReactorSettings,
   SchedulerSettings,
@@ -407,6 +408,7 @@ export {
   DEFAULT_TRUST_BOUNDARY_CONFIG,
   // Workflow settings defaults
   DEFAULT_WORKFLOW_SETTINGS,
+  DEFAULT_PHASE_TEMPERATURES,
   // Ava Channel reactor settings defaults
   DEFAULT_AVA_CHANNEL_REACTOR_SETTINGS,
   DEFAULT_SCHEDULER_SETTINGS,

--- a/libs/types/src/provider.ts
+++ b/libs/types/src/provider.ts
@@ -282,6 +282,14 @@ export interface ExecuteOptions {
    * When a profile/provider has apiKeySource='credentials', the Anthropic key from this object is used.
    */
   credentials?: Credentials;
+  /**
+   * Model temperature for response generation (0–1).
+   * Lower values (e.g., 0) produce deterministic, focused output.
+   * Higher values (e.g., 1.0) produce more creative, varied output.
+   * When undefined, the provider uses its default temperature.
+   * Applies to providers that support temperature configuration.
+   */
+  temperature?: number;
 }
 
 /**

--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -97,6 +97,34 @@ export const DEFAULT_TRUST_BOUNDARY_CONFIG: TrustBoundaryConfig = {
 };
 
 // ============================================================================
+// Phase Temperature Configuration
+// ============================================================================
+
+/**
+ * PhaseTemperaturesConfig — Per-pipeline-phase temperature settings for agent execution.
+ *
+ * Controls model temperature (creativity vs determinism) for each major phase:
+ * - PLAN: Creative exploration for planning (default: 1.0)
+ * - EXECUTE: Deterministic implementation (default: 0)
+ * - REVIEW: Balanced evaluation (default: 0.5)
+ */
+export interface PhaseTemperaturesConfig {
+  /** Temperature for PLAN phase — creative exploration (default: 1.0) */
+  PLAN: number;
+  /** Temperature for EXECUTE phase — deterministic implementation (default: 0) */
+  EXECUTE: number;
+  /** Temperature for REVIEW phase — balanced evaluation (default: 0.5) */
+  REVIEW: number;
+}
+
+/** Default per-phase temperatures */
+export const DEFAULT_PHASE_TEMPERATURES: PhaseTemperaturesConfig = {
+  PLAN: 1.0,
+  EXECUTE: 0,
+  REVIEW: 0.5,
+};
+
+// ============================================================================
 // Workflow Settings - Pipeline hardening configuration
 // ============================================================================
 
@@ -264,6 +292,13 @@ export interface WorkflowSettings {
    * @default true
    */
   errorBudgetAutoFreeze?: boolean;
+  /**
+   * Per-phase temperature configuration for agent execution.
+   * Controls model temperature (creativity vs determinism) per pipeline phase.
+   * PLAN=1.0 (creative exploration), EXECUTE=0 (deterministic), REVIEW=0.5 (balanced).
+   * When absent, provider default temperature is used.
+   */
+  phaseTemperatures?: PhaseTemperaturesConfig;
 }
 
 /** Default workflow settings */
@@ -298,4 +333,5 @@ export const DEFAULT_WORKFLOW_SETTINGS: WorkflowSettings = {
   postMergeVerification: true,
   postMergeVerificationCommands: ['npm run typecheck'],
   preFlightChecks: true,
+  phaseTemperatures: DEFAULT_PHASE_TEMPERATURES,
 };


### PR DESCRIPTION
## Summary

**Milestone:** Message Queue & Temperature Routing

Add temperature configuration to WorkflowSettings in libs/types/src/global-settings.ts with per-phase defaults: PLAN=1.0, EXECUTE=0, REVIEW=0.5. Wire through execution-service.ts to pass temperature to the provider when spawning agents. Update model-resolver or provider factory to accept temperature parameter. Default to current behavior when no phase-specific temperature is set.

**Files to Modify:**
- libs/types/src/global-settings.ts
- apps/...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-phase temperature control for agent execution, allowing separate temperature settings for PLAN, EXECUTE, and REVIEW phases to control model behavior during different execution stages.
  * Configuration of phase-specific temperatures now available in workflow settings with sensible defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->