### PR TITLE
fix: discord bot silent failure from env var mismatch

### DIFF
--- a/apps/server/src/routes/discord/index.ts
+++ b/apps/server/src/routes/discord/index.ts
@@ -11,13 +11,32 @@ import { createReadChannelMessagesHandler } from './routes/read-channel-messages
 
 export function createDiscordRoutes(discordBotService?: DiscordBotService): Router {
   const router = Router();
-  // DM endpoints (require DiscordBotService)
-  if (discordBotService) {
-    router.post('/send-dm', createSendDMHandler(discordBotService));
-    router.post('/read-dms', createReadDMsHandler(discordBotService));
-    router.post('/send-channel-message', createSendChannelMessageHandler(discordBotService));
-    router.post('/read-channel-messages', createReadChannelMessagesHandler(discordBotService));
+
+  if (!discordBotService) {
+    // No bot service — all routes return a clear error
+    router.use((_req, res) => {
+      res.status(503).json({ success: false, error: 'Discord bot service not available' });
+    });
+    return router;
   }
+
+  // Guard: reject requests when bot is not connected
+  router.use((_req, res, next) => {
+    if (!discordBotService.isConnected()) {
+      res.status(503).json({
+        success: false,
+        error:
+          'Discord bot not connected. Check DISCORD_BOT_TOKEN (or DISCORD_TOKEN) is set in the server environment.',
+      });
+      return;
+    }
+    next();
+  });
+
+  router.post('/send-dm', createSendDMHandler(discordBotService));
+  router.post('/read-dms', createReadDMsHandler(discordBotService));
+  router.post('/send-channel-message', createSendChannelMessageHandler(discordBotService));
+  router.post('/read-channel-messages', createReadChannelMessagesHandler(discordBotService));
 
   return router;
 }

--- a/apps/server/src/server/websockets.ts
+++ b/apps/server/src/server/websockets.ts
@@ -99,7 +99,7 @@ export function setupWebSockets(server: http.Server, services: ServiceContainer)
   const DISCORD_INFRA_CHANNEL = '1469109809939742814';
   events.on('scheduler:task-failed', (payload) => {
     const { discordBotService } = services;
-    if (!discordBotService || !process.env.DISCORD_TOKEN) return;
+    if (!discordBotService?.isConnected()) return;
     const p = payload as { taskId: string; taskName: string; error: string; timestamp: string };
     const message = `Scheduler task failed: **${p.taskName}** (${p.taskId})\nError: ${p.error}\nTime: ${p.timestamp}`;
     discordBotService.sendToChannel(DISCORD_INFRA_CHANNEL, message).catch((err: Error) => {

--- a/apps/server/src/services/discord-bot-service.ts
+++ b/apps/server/src/services/discord-bot-service.ts
@@ -276,10 +276,10 @@ export class DiscordBotService {
   async initialize(): Promise<boolean> {
     if (this.initialized) return true;
 
-    const token = process.env.DISCORD_BOT_TOKEN;
+    const token = process.env.DISCORD_BOT_TOKEN || process.env.DISCORD_TOKEN;
     if (!token) {
       logger.info('DISCORD_BOT_TOKEN not set - Discord bot features disabled');
-      logger.info('Set DISCORD_BOT_TOKEN in .env to enable /idea command in Discord');
+      logger.info('Set DISCORD_BOT_TOKEN (or DISCORD_TOKEN) in .env to enable Discord integration');
       return false;
     }
 

--- a/apps/server/src/services/discord.module.ts
+++ b/apps/server/src/services/discord.module.ts
@@ -118,7 +118,7 @@ export async function register(container: ServiceContainer): Promise<void> {
   // Start Discord channel signal monitoring when DISCORD_TOKEN is configured.
   // The monitor polls only channels registered in integrationRegistryService.
   // Configs start empty and are populated at runtime via setChannelConfigs().
-  if (process.env.DISCORD_TOKEN) {
+  if (process.env.DISCORD_BOT_TOKEN || process.env.DISCORD_TOKEN) {
     const discordMonitor = new DiscordMonitor(events);
     discordMonitor.setDiscordBotService(discordBotService);
 


### PR DESCRIPTION
## Summary
- `DiscordBotService.initialize()` only checked `DISCORD_BOT_TOKEN` but Docker compose passes `DISCORD_TOKEN` — bot never connected
- All Discord read/send methods silently returned empty arrays (`[]`) or `false` when disconnected
- Discord routes now return `503` with a clear error when bot is not connected instead of `{ success: true, messages: [] }`
- Aligned env var checks across `discord-bot-service.ts`, `discord.module.ts`, and `websockets.ts`

## Test plan
- [ ] Deploy to staging with `DISCORD_TOKEN` set in Docker env
- [ ] Verify `read_discord_channel_messages` returns actual messages (not empty)
- [ ] Verify `send_discord_channel_message` sends messages
- [ ] Verify server without token returns `503` with descriptive error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Discord routes now return proper error responses when the bot is unavailable or not connected.
  * Enhanced connection state monitoring for Discord integrations.

* **Chores**
  * Added support for alternative Discord token environment variable names for greater flexibility.
  * Improved logging for Discord channel monitor initialization and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->