### PR TITLE
refactor: remove dead code from AutomergeFeatureStore

### DIFF
--- a/apps/server/src/services/automerge-feature-store.ts
+++ b/apps/server/src/services/automerge-feature-store.ts
@@ -3,7 +3,6 @@
  *
  * Reads are served from the in-memory Automerge doc (no disk I/O after init).
  * Writes go through the parent FeatureLoader for disk persistence, then update the CRDT doc.
- * Remote peer changes can be merged in via applyRemoteChanges(), which emits feature:updated events.
  *
  * Falls back to the parent FeatureLoader for all operations when no proto.config.yaml is present
  * at the projectPath (single-instance mode).
@@ -197,11 +196,10 @@ export class AutomergeFeatureStore extends FeatureLoader {
   // ─── claim / release ─────────────────────────────────────────────────────
 
   /**
-   * Optimistic CRDT claim:
+   * Claim a feature for exclusive execution by this instance.
    *   1. Check the in-memory doc — reject immediately if already claimed by another instance.
    *   2. Write the claim (to disk + CRDT doc).
-   *   3. Wait ~200ms for sync to settle.
-   *   4. Re-read from the CRDT doc; if another instance won, release and return false.
+   *   3. Return true. Features are local; no remote peers update this doc.
    */
   override async claim(
     projectPath: string,
@@ -223,20 +221,6 @@ export class AutomergeFeatureStore extends FeatureLoader {
     // Write the claim
     await this.update(projectPath, featureId, { claimedBy: instanceId });
 
-    // Wait for sync to settle
-    await new Promise<void>((resolve) => setTimeout(resolve, 200));
-
-    // Re-read and verify ownership
-    const verifiedDoc = await this.ensureDoc(projectPath);
-    const verified = (verifiedDoc.features || {})[featureId] as Feature | undefined;
-    if (!verified) {
-      return false;
-    }
-    if (verified.claimedBy !== instanceId) {
-      await this.release(projectPath, featureId);
-      return false;
-    }
-
     return true;
   }
 
@@ -247,61 +231,7 @@ export class AutomergeFeatureStore extends FeatureLoader {
     await this.update(projectPath, featureId, { claimedBy: undefined });
   }
 
-  // ─── Peer sync ────────────────────────────────────────────────────────────
-
-  /**
-   * Apply changes received from a remote peer (delivered by the sync layer).
-   * Merges the changes into the local Automerge doc and emits feature:updated
-   * events for any features that changed.
-   *
-   * Called by the wiring layer when 'crdt:remote-changes' fires on the EventBus.
-   */
-  applyRemoteChanges(projectPath: string, changes: Uint8Array[]): void {
-    let doc = this.docs.get(projectPath);
-    const isNew = !doc;
-
-    if (!doc) {
-      // Initialise an empty doc; caller is responsible for applying a full snapshot
-      doc = Automerge.init<FeaturesDoc>();
-      // Mark as initialised so ensureDoc skips disk load
-      this.initPromises.set(projectPath, Promise.resolve());
-    }
-
-    const oldFeatures = doc.features || {};
-    const [newDoc] = Automerge.applyChanges<FeaturesDoc>(doc, changes);
-    this.docs.set(projectPath, newDoc);
-
-    const newFeatures = newDoc.features || {};
-    const allIds = new Set([...Object.keys(oldFeatures), ...Object.keys(newFeatures)]);
-
-    for (const featureId of allIds) {
-      const oldRaw = isNew ? undefined : oldFeatures[featureId];
-      const newRaw = newFeatures[featureId];
-      const unchanged =
-        !isNew &&
-        oldRaw !== undefined &&
-        newRaw !== undefined &&
-        JSON.stringify(oldRaw) === JSON.stringify(newRaw);
-      if (!unchanged) {
-        const feature = newRaw ? (newRaw as Feature) : null;
-        this.crdtEvents.emit('feature:updated', { featureId, projectPath, feature });
-      }
-    }
-
-    logger.debug(
-      `Applied ${changes.length} remote change(s) for ${projectPath}, ` +
-        `${allIds.size} feature(s) in scope`
-    );
-  }
-
-  /**
-   * Returns the binary Automerge snapshot for a project's doc.
-   * Used by tests and the sync layer to obtain changes to send to peers.
-   */
-  async getDocBinary(projectPath: string): Promise<Uint8Array> {
-    const doc = await this.ensureDoc(projectPath);
-    return Automerge.save(doc);
-  }
+  // ─── Doc management ───────────────────────────────────────────────────────
 
   /**
    * Invalidate the cached doc for a project (forces re-init from disk on next access).

--- a/apps/server/tests/unit/services/automerge-feature-store.test.ts
+++ b/apps/server/tests/unit/services/automerge-feature-store.test.ts
@@ -4,14 +4,13 @@
  * Tests are split into two suites:
  *  - CRDT disabled (no proto.config.yaml): all operations delegate to FeatureLoader
  *  - CRDT enabled (proto.config.yaml present): reads from Automerge doc, writes go to
- *    disk then update in-memory CRDT doc; applyRemoteChanges merges peer changes.
+ *    disk then update in-memory CRDT doc.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import * as Automerge from '@automerge/automerge';
 
 import { AutomergeFeatureStore } from '../../../src/services/automerge-feature-store.js';
 import { createEventEmitter } from '../../../src/lib/events.js';
@@ -224,70 +223,6 @@ describe('AutomergeFeatureStore — CRDT enabled (proto.config.yaml present)', (
 
       const ok = await store.claim(tempDir, feature.id, 'instance-b');
       expect(ok).toBe(true);
-    });
-  });
-
-  describe('applyRemoteChanges — integration', () => {
-    it('feature created on instance A appears on instance B', async () => {
-      // Instance A creates a feature
-      const eventsB = createEventEmitter();
-      const receivedOnB: string[] = [];
-      eventsB.on('feature:updated', (d: { featureId: string }) => receivedOnB.push(d.featureId));
-      const storeB = new AutomergeFeatureStore(eventsB);
-
-      // A creates a feature
-      const featureA = await store.create(tempDir, { title: 'Cross-Instance Feature' });
-
-      // Get A's Automerge binary
-      const binaryA = await store.getDocBinary(tempDir);
-
-      // Derive changes from A's full doc
-      const docA = Automerge.load<{ features: Record<string, unknown> }>(binaryA);
-      const changes = Automerge.getAllChanges(docA);
-
-      // Apply to B
-      storeB.applyRemoteChanges(tempDir, changes);
-
-      // B can see the feature (from CRDT doc, not disk)
-      const allB = await storeB.getAll(tempDir);
-      expect(allB.some((f) => f.id === featureA.id)).toBe(true);
-      expect(allB.find((f) => f.id === featureA.id)?.title).toBe('Cross-Instance Feature');
-
-      // B emitted a feature:updated event
-      expect(receivedOnB).toContain(featureA.id);
-    });
-
-    it('merges concurrent changes from two instances', async () => {
-      const eventsB = createEventEmitter();
-      const storeB = new AutomergeFeatureStore(eventsB);
-
-      // Both start with the same base
-      const base = await store.getDocBinary(tempDir);
-      storeB.applyRemoteChanges(tempDir, Automerge.getAllChanges(Automerge.load(base)));
-
-      // A creates feature-1, B creates feature-2
-      const f1 = await store.create(tempDir, { title: 'From A' });
-      const f2 = await storeB.create(tempDir, { title: 'From B' });
-
-      // Exchange changes
-      const binaryA = await store.getDocBinary(tempDir);
-      const binaryB = await storeB.getDocBinary(tempDir);
-
-      const docA = Automerge.load<{ features: Record<string, unknown> }>(binaryA);
-      const docB = Automerge.load<{ features: Record<string, unknown> }>(binaryB);
-
-      // A applies B's changes, B applies A's changes
-      store.applyRemoteChanges(tempDir, Automerge.getAllChanges(docB));
-      storeB.applyRemoteChanges(tempDir, Automerge.getAllChanges(docA));
-
-      const allA = await store.getAll(tempDir);
-      const allB = await storeB.getAll(tempDir);
-
-      // Both instances should have both features
-      expect(allA.some((f) => f.id === f1.id)).toBe(true);
-      expect(allA.some((f) => f.id === f2.id)).toBe(true);
-      expect(allB.some((f) => f.id === f1.id)).toBe(true);
-      expect(allB.some((f) => f.id === f2.id)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary\n\n- Remove `applyRemoteChanges()` and `getDocBinary()` from AutomergeFeatureStore — dead code from the abandoned feature-sync model (db8801061)\n- Remove `CLAIM_VERIFY_DELAY_MS` and the 200ms settle delay in `claim()` — features are instance-local, no remote sync happens\n- Remove corresponding test cases (2 tests removed, 17 remain passing)\n- Net: -139 lines of dead code\n\n## Part of\n\nCRDT Pipeline Formalization project — Milestone 1: Dead Code Removal (Phase 1 of 3)\n\n## Test plan\n\n- [x] `npm run typecheck` passes (20/20)\n- [x] `automerge-feature-store.test.ts` passes (17/17)\n- [x] `claim()` still rejects if feature already claimed by another instance

<!-- automaker:owner instance=aaccab48-6c90-478b-8aa2-5df343794454 team= created=2026-03-12T17:27:38.821Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document cache invalidation capability for manual reinitialization.

* **Refactor**
  * Streamlined claim processing flow and removed associated post-write delays.
  * Simplified remote synchronization handling and consolidated document management structure.

* **Tests**
  * Updated test coverage to reflect architectural changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->