### PR TITLE
fix: resolve get_server_logs log path via server api, not monorepo root

### DIFF
--- a/apps/server/src/routes/health/index.ts
+++ b/apps/server/src/routes/health/index.ts
@@ -9,6 +9,7 @@ import { Router } from 'express';
 import { createIndexHandler } from './routes/index.js';
 import { createEnvironmentHandler } from './routes/environment.js';
 import { createReadyHandler } from './routes/ready.js';
+import { createLogPathHandler } from './routes/log-path.js';
 
 /**
  * Create unauthenticated health routes (basic check only)
@@ -26,6 +27,10 @@ export function createHealthRoutes(): Router {
   // Environment info including containerization status
   // This is unauthenticated so the UI can check on startup
   router.get('/environment', createEnvironmentHandler());
+
+  // Log file path — unauthenticated so the MCP tool can resolve the correct
+  // absolute path without knowing the server's working directory
+  router.get('/log-path', createLogPathHandler());
 
   return router;
 }

--- a/apps/server/src/routes/health/routes/log-path.ts
+++ b/apps/server/src/routes/health/routes/log-path.ts
@@ -1,0 +1,17 @@
+/**
+ * GET /log-path endpoint - Return the absolute server log file path
+ *
+ * Unauthenticated so the MCP tool can discover the correct log path
+ * even when calling from the monorepo root (different CWD than the server).
+ */
+
+import type { Request, Response } from 'express';
+import { getServerLogPath } from '../../../lib/server-log.js';
+
+export function createLogPathHandler() {
+  return (_req: Request, res: Response): void => {
+    res.json({
+      logPath: getServerLogPath(),
+    });
+  };
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -764,10 +764,33 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
       const fs = await import('fs');
       const path = await import('path');
 
-      // Resolve log file path: DATA_DIR/server.log
-      const dataDir =
-        process.env.DATA_DIR || path.join(process.env.AUTOMAKER_ROOT || process.cwd(), 'data');
-      const logPath = path.join(dataDir, 'server.log');
+      // Resolve log file path by asking the running server for its absolute path.
+      // The server runs from apps/server/ so its DATA_DIR resolves differently than
+      // the MCP server's CWD (monorepo root). Asking the server eliminates the mismatch.
+      // Falls back to a computed path if the server is down.
+      let logPath: string;
+      try {
+        const logPathResult = (await apiCall('/health/log-path', {}, 'GET')) as {
+          logPath: string;
+        };
+        logPath = logPathResult.logPath;
+      } catch {
+        // Server is down — compute best-guess path.
+        // Server CWD is apps/server/ and DATA_DIR defaults to ./data (relative to that).
+        const dataDirEnv = process.env.DATA_DIR;
+        if (dataDirEnv && path.isAbsolute(dataDirEnv)) {
+          // Absolute DATA_DIR: both server and MCP agree on this path
+          logPath = path.join(dataDirEnv, 'server.log');
+        } else {
+          // Relative or unset DATA_DIR: resolve relative to apps/server/ within AUTOMAKER_ROOT
+          const serverRoot = path.join(
+            process.env.AUTOMAKER_ROOT || process.cwd(),
+            'apps',
+            'server'
+          );
+          logPath = path.join(serverRoot, dataDirEnv || 'data', 'server.log');
+        }
+      }
 
       if (!fs.existsSync(logPath)) {
         return {


### PR DESCRIPTION
## Summary

- **Root cause**: MCP `get_server_logs` computed the log path using `DATA_DIR` relative to the monorepo root (MCP's CWD), but the server runs from `apps/server/` so its `./data` directory resolves to `apps/server/data/server.log` — completely different. Result: 12+ hours of live logs were invisible; the tool read a stale file from the previous server PID.
- **Fix (option 1)**: Add `GET /api/health/log-path` (unauthenticated) that returns `getServerLogPath()` — the server's own absolute resolved path. MCP tool calls this first, so it always gets the exact path regardless of working directory differences.
- **Fallback**: When the server is down, the tool now computes `AUTOMAKER_ROOT/apps/server/DATA_DIR/server.log` (correctly relative to `apps/server/`), fixing the stale-log-when-offline case too.

## Files Changed

- `apps/server/src/routes/health/routes/log-path.ts` — new unauthenticated handler
- `apps/server/src/routes/health/index.ts` — register `GET /log-path`
- `packages/mcp-server/src/index.ts` — `get_server_logs` calls API first, falls back to corrected path

## Test plan

- [ ] `get_server_logs` returns lines from the currently-running server's log (last-modified seconds ago, not 12 hours ago)
- [ ] `GET /api/health/log-path` returns an absolute path matching what `getServerLogPath()` would return
- [ ] With server stopped: `get_server_logs` falls back to `AUTOMAKER_ROOT/apps/server/data/server.log` and reads successfully
- [ ] Build passes (verified: `npm run build:server` ✅, `npm run build --workspace=packages/mcp-server` ✅)

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team=protoLabsAI created=2026-03-12T17:50:31.000Z -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/health/log-path` health endpoint that returns the server log file location in JSON format

* **Improvements**
  * Enhanced server log path resolution to dynamically retrieve paths from the running server
  * Implemented fallback behavior to compute log paths when the server is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->