### PR TITLE
refactor: fix updatePhaseClaim and saveProjectMilestones to broadcast to peers

### DIFF
--- a/apps/server/src/services/project-service.ts
+++ b/apps/server/src/services/project-service.ts
@@ -420,6 +420,20 @@ export class ProjectService {
       }
     }
 
+    // Update CRDT doc and emit event so peers receive the milestone update
+    if (this._isCrdtEnabled(projectPath)) {
+      const doc = await this._ensureDoc(projectPath);
+      const newDoc = Automerge.change(doc, (d) => {
+        (d.projects as Record<string, unknown>)[projectSlug] = this._toAutomergeValue(updated);
+      });
+      this._docs.set(projectPath, newDoc);
+      this._crdtEvents?.emit('project:updated', {
+        projectSlug,
+        projectPath,
+        project: updated,
+      });
+    }
+
     logger.info(`Saved ${milestones.length} milestones for project: ${projectSlug}`);
     return updated;
   }
@@ -450,6 +464,20 @@ export class ProjectService {
 
     const jsonPath = getProjectJsonPath(projectPath, projectSlug);
     await secureFs.writeFile(jsonPath, JSON.stringify(project, null, 2));
+
+    // Update CRDT doc and emit event so peers receive the claim update
+    if (this._isCrdtEnabled(projectPath)) {
+      const doc = await this._ensureDoc(projectPath);
+      const newDoc = Automerge.change(doc, (d) => {
+        (d.projects as Record<string, unknown>)[projectSlug] = this._toAutomergeValue(project);
+      });
+      this._docs.set(projectPath, newDoc);
+      this._crdtEvents?.emit('project:updated', {
+        projectSlug,
+        projectPath,
+        project,
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fix `updatePhaseClaim()` and `saveProjectMilestones()` in `project-service.ts` to sync changes to CRDT and emit `project:updated` events
- Without this, phase claims silently stay local — two instances can claim the same phase simultaneously

## Test plan
- [ ] Verify `npm run typecheck` passes
- [ ] Verify `npm run test:server` passes
- [ ] Verify phase claim changes propagate to remote instances via event bridge

Generated by protoLabs Studio auto-mode agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project state synchronization and event handling for milestone updates, phase claim modifications, and project deletion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->