### PR TITLE
Categories via event bridge

### DIFF
--- a/apps/server/src/routes/categories/index.ts
+++ b/apps/server/src/routes/categories/index.ts
@@ -1,0 +1,125 @@
+/**
+ * Categories Routes — CRUD for the per-project categories list
+ *
+ * Storage: .automaker/categories.json (simple string array per project)
+ * Every mutation broadcasts a `categories:updated` event so the CRDT sync
+ * bridge can propagate the full array to remote instances (LWW semantics).
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { createLogger } from '@protolabsai/utils';
+import { validatePath } from '@protolabsai/platform';
+import { join } from 'node:path';
+import { readFile, writeFile } from 'node:fs/promises';
+import type { EventEmitter } from '../../lib/events.js';
+
+const logger = createLogger('CategoriesRoutes');
+
+function getCategoriesPath(projectPath: string): string {
+  return join(projectPath, '.automaker', 'categories.json');
+}
+
+async function readCategories(projectPath: string): Promise<string[]> {
+  try {
+    const raw = await readFile(getCategoriesPath(projectPath), 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeCategories(projectPath: string, categories: string[]): Promise<void> {
+  await writeFile(getCategoriesPath(projectPath), JSON.stringify(categories, null, 2), 'utf-8');
+}
+
+export function createCategoriesRoutes(events: EventEmitter): Router {
+  const router = Router();
+
+  /**
+   * POST /api/categories/list
+   * Returns the full categories array for a project.
+   */
+  router.post('/list', async (req: Request, res: Response) => {
+    try {
+      const { projectPath } = req.body as { projectPath?: string };
+      if (!projectPath) {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+      validatePath(projectPath);
+      const categories = await readCategories(projectPath);
+      res.json({ success: true, categories });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Failed to list categories:', error);
+      res.status(500).json({ success: false, error: message });
+    }
+  });
+
+  /**
+   * POST /api/categories/create
+   * Adds a new category to the list and broadcasts `categories:updated`.
+   */
+  router.post('/create', async (req: Request, res: Response) => {
+    try {
+      const { projectPath, category } = req.body as {
+        projectPath?: string;
+        category?: string;
+      };
+      if (!projectPath || !category) {
+        res.status(400).json({ success: false, error: 'projectPath and category are required' });
+        return;
+      }
+      validatePath(projectPath);
+      const existing = await readCategories(projectPath);
+      if (existing.includes(category)) {
+        res.status(409).json({ success: false, error: 'Category already exists' });
+        return;
+      }
+      const updated = [...existing, category];
+      await writeCategories(projectPath, updated);
+      events.broadcast('categories:updated', { projectPath, categories: updated });
+      logger.info(`Category created: "${category}" in ${projectPath}`);
+      res.json({ success: true, categories: updated });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Failed to create category:', error);
+      res.status(500).json({ success: false, error: message });
+    }
+  });
+
+  /**
+   * POST /api/categories/delete
+   * Removes a category from the list and broadcasts `categories:updated`.
+   */
+  router.post('/delete', async (req: Request, res: Response) => {
+    try {
+      const { projectPath, category } = req.body as {
+        projectPath?: string;
+        category?: string;
+      };
+      if (!projectPath || !category) {
+        res.status(400).json({ success: false, error: 'projectPath and category are required' });
+        return;
+      }
+      validatePath(projectPath);
+      const existing = await readCategories(projectPath);
+      const updated = existing.filter((c) => c !== category);
+      if (updated.length === existing.length) {
+        res.status(404).json({ success: false, error: 'Category not found' });
+        return;
+      }
+      await writeCategories(projectPath, updated);
+      events.broadcast('categories:updated', { projectPath, categories: updated });
+      logger.info(`Category deleted: "${category}" from ${projectPath}`);
+      res.json({ success: true, categories: updated });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Failed to delete category:', error);
+      res.status(500).json({ success: false, error: message });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/services/crdt-sync.module.ts
+++ b/apps/server/src/services/crdt-sync.module.ts
@@ -1,6 +1,8 @@
 // CRDT sync module — wires EventBus to CrdtSyncService for cross-instance event propagation.
 // Features are LOCAL only — only project events cross the wire.
 
+import { join } from 'node:path';
+import { writeFile } from 'node:fs/promises';
 import type { Project } from '@protolabsai/types';
 import { createLogger } from '@protolabsai/utils';
 import type { ServiceContainer } from '../server/services.js';
@@ -46,6 +48,21 @@ export async function register(container: ServiceContainer): Promise<void> {
         logger.info(`[CRDT] Persisting remote project:deleted ${projectSlug}`);
         container.projectService.persistRemoteDelete(projectPath, projectSlug).catch((err) => {
           logger.error(`[CRDT] Failed to persist remote project:deleted ${projectSlug}: ${err}`);
+        });
+        break;
+      }
+      case 'categories:updated': {
+        const categories = payload.categories;
+        if (!Array.isArray(categories)) {
+          logger.warn(
+            '[CRDT] Received categories:updated without valid categories array, skipping'
+          );
+          break;
+        }
+        logger.info('[CRDT] Overwriting local categories from remote categories:updated');
+        const categoriesPath = join(projectPath, '.automaker', 'categories.json');
+        writeFile(categoriesPath, JSON.stringify(categories, null, 2), 'utf-8').catch((err) => {
+          logger.error(`[CRDT] Failed to write remote categories: ${err}`);
         });
         break;
       }

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -347,7 +347,9 @@ export type EventType =
   | 'error_budget:exhausted'
   | 'error_budget:recovered'
   // Project failover events (auto-claim of orphaned projects)
-  | 'project:failover';
+  | 'project:failover'
+  // Categories sync events (lightweight LWW config sync via CRDT bridge)
+  | 'categories:updated';
 
 export type EventCallback = (type: EventType, payload: unknown) => void;
 

--- a/libs/types/src/events.ts
+++ b/libs/types/src/events.ts
@@ -17,6 +17,7 @@ export const CRDT_SYNCED_EVENT_TYPES: ReadonlySet<EventType> = new Set<EventType
   'project:created',
   'project:updated',
   'project:deleted',
+  'categories:updated',
 ]);
 
 /**


### PR DESCRIPTION
## Summary

**Milestone:** Lightweight Sync Extensions

Add categories:updated to CRDT_SYNCED_EVENT_TYPES in libs/types/src/events.ts. The categories file (.automaker/categories.json) is a simple string array. When a category is added or deleted, the categories route should broadcast the full updated array as a categories:updated event. Add a handler in crdt-sync.module.ts that on receiving a remote categories:updated event, calls the categories service to overwrite local categories (simple LWW for a small ...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=aaccab48-6c90-478b-8aa2-5df343794454 team= created=2026-03-12T18:18:24.455Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added category management system for projects with create, list, and delete operations.
  * Implemented real-time synchronization of category changes across distributed instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->