### PR TITLE
Memory usage stats in Metrics CRDT domain

### DIFF
--- a/apps/server/src/routes/metrics/dora.ts
+++ b/apps/server/src/routes/metrics/dora.ts
@@ -709,6 +709,7 @@ export function createDoraMetricsRoute(deps: DoraRouteDependencies): Router {
       try {
         const handle = await deps.crdtStore.getOrCreate<MetricsDocument>('metrics', 'dora', {
           instanceReports: {},
+          memoryStats: {},
           updatedAt: new Date().toISOString(),
         });
         const doc = handle.doc();

--- a/apps/server/src/services/crdt-store.module.ts
+++ b/apps/server/src/services/crdt-store.module.ts
@@ -23,8 +23,14 @@
 import { join } from 'node:path';
 import { WebSocketServer } from 'ws';
 import { CRDTStore, WebSocketServerAdapter } from '@protolabsai/crdt';
+import type { MetricsDocument } from '@protolabsai/crdt';
 import { loadProtoConfig } from '@protolabsai/platform';
 import { createLogger } from '@protolabsai/utils';
+import type {
+  MemoryStatsCrdtWriter,
+  MemoryStatsAggregateReader,
+  UsageStats,
+} from '@protolabsai/utils';
 import type { ServiceContainer } from '../server/services.js';
 
 const logger = createLogger('CrdtStoreModule');
@@ -32,9 +38,25 @@ const logger = createLogger('CrdtStoreModule');
 /** Default port offset from the CrdtSyncService sync port */
 const CRDT_STORE_PORT_OFFSET = 1;
 
+/** Domain and document ID used for the shared metrics document */
+const METRICS_DOMAIN = 'metrics' as const;
+const METRICS_DOC_ID = 'dora';
+
 export interface CrdtStoreModuleResult {
   store: CRDTStore;
   close: () => Promise<void>;
+  /**
+   * Write a memory file stat increment to the CRDT Metrics document.
+   * Writes under the local instanceId key — each instance owns its own slice.
+   * Pass to incrementUsageStat / recordMemoryUsage for hivemind-wide tracking.
+   */
+  memoryStatsCrdtWriter: MemoryStatsCrdtWriter;
+  /**
+   * Read aggregated memory file usage stats from the CRDT Metrics document.
+   * Aggregates across ALL instanceId keys to produce the hivemind-wide total.
+   * Pass to loadRelevantMemory for better cross-instance scoring.
+   */
+  memoryStatsAggregateReader: MemoryStatsAggregateReader;
 }
 
 /**
@@ -174,5 +196,65 @@ export async function register(container: ServiceContainer): Promise<CrdtStoreMo
     logger.info('CRDTStore shut down');
   };
 
-  return { store, close };
+  // ---------------------------------------------------------------------------
+  // Memory stats CRDT callbacks
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Writes a single stat increment for filename under the local instanceId key
+   * in memoryStats of the shared metrics CRDT document (domain='metrics', id='dora').
+   */
+  const memoryStatsCrdtWriter: MemoryStatsCrdtWriter = async (
+    filename: string,
+    stat: keyof UsageStats
+  ): Promise<void> => {
+    await store.change<MetricsDocument>(METRICS_DOMAIN, METRICS_DOC_ID, (doc) => {
+      if (!doc.memoryStats) {
+        doc.memoryStats = {};
+      }
+      if (!doc.memoryStats[instanceId]) {
+        doc.memoryStats[instanceId] = {};
+      }
+      const instanceStats = doc.memoryStats[instanceId];
+      if (!instanceStats[filename]) {
+        instanceStats[filename] = { loaded: 0, referenced: 0, successfulFeatures: 0 };
+      }
+      instanceStats[filename][stat]++;
+    });
+  };
+
+  /**
+   * Reads and aggregates memory file usage stats across ALL instanceId keys
+   * so callers see the combined signal from every hivemind instance.
+   */
+  const memoryStatsAggregateReader: MemoryStatsAggregateReader = async (
+    filename: string
+  ): Promise<UsageStats | null> => {
+    const handle = await store.getOrCreate<MetricsDocument>(METRICS_DOMAIN, METRICS_DOC_ID);
+    const doc = handle.doc();
+    if (!doc) return null;
+
+    const memoryStats = doc.memoryStats ?? {};
+    let loaded = 0;
+    let referenced = 0;
+    let successfulFeatures = 0;
+    let hasAnyData = false;
+
+    for (const instanceStats of Object.values(memoryStats)) {
+      const fileStat = instanceStats[filename];
+      if (fileStat) {
+        loaded += fileStat.loaded;
+        referenced += fileStat.referenced;
+        successfulFeatures += fileStat.successfulFeatures;
+        hasAnyData = true;
+      }
+    }
+
+    if (!hasAnyData) return null;
+    return { loaded, referenced, successfulFeatures };
+  };
+
+  logger.info('Memory stats CRDT callbacks created (domain=metrics, id=dora)');
+
+  return { store, close, memoryStatsCrdtWriter, memoryStatsAggregateReader };
 }

--- a/libs/crdt/src/documents.ts
+++ b/libs/crdt/src/documents.ts
@@ -399,6 +399,17 @@ export const normalizeTodosDocument: SchemaNormalizer<TodosDocument> = (raw) => 
 // ---------------------------------------------------------------------------
 
 /**
+ * Per-file memory usage statistics for a single instance.
+ * Mirrors UsageStats from @protolabsai/utils but is kept local to avoid
+ * a circular package dependency.
+ */
+export interface MemoryUsageStat {
+  loaded: number;
+  referenced: number;
+  successfulFeatures: number;
+}
+
+/**
  * MetricsDocument stores aggregated DORA metrics across all instances.
  *
  * Use domain='metrics', document id='dora' for the aggregate DORA store.
@@ -417,6 +428,13 @@ export interface MetricsDocument extends CRDTDocumentRoot {
       doneCount: number;
     }
   >;
+  /**
+   * Per-instance memory file usage stats.
+   * Outer key: instanceId. Inner key: filename (basename, e.g. "gotchas.md").
+   * Each instance writes only to its own instanceId key.
+   * Read path: aggregate across all instanceId keys to get total usage counts.
+   */
+  memoryStats: Record<string, Record<string, MemoryUsageStat>>;
   /** ISO timestamp of last aggregate update */
   updatedAt: string;
 }
@@ -434,6 +452,7 @@ export const normalizeMetricsDocument: SchemaNormalizer<MetricsDocument> = (raw)
     schemaVersion: 1,
     _meta,
     instanceReports: doc.instanceReports ?? {},
+    memoryStats: doc.memoryStats ?? {},
     updatedAt: doc.updatedAt ?? _meta.updatedAt,
   };
 };

--- a/libs/crdt/src/index.ts
+++ b/libs/crdt/src/index.ts
@@ -27,6 +27,7 @@ export type {
   CalendarDocument,
   TodosDocument,
   MetricsDocument,
+  MemoryUsageStat,
 } from './documents.js';
 
 export type {

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -113,6 +113,8 @@ export {
   type SimpleMemoryFile,
   type DedupChecker,
   type IndexRebuilder,
+  type MemoryStatsCrdtWriter,
+  type MemoryStatsAggregateReader,
 } from './memory-loader.js';
 
 // String utilities

--- a/libs/utils/src/memory-loader.ts
+++ b/libs/utils/src/memory-loader.ts
@@ -36,6 +36,26 @@ export interface UsageStats {
 }
 
 /**
+ * Callback for writing a single stat increment to the CRDT Metrics document.
+ * The callee writes to memoryStats[instanceId][filename][stat]++.
+ *
+ * @param filename - Basename of the memory file (e.g. "gotchas.md")
+ * @param stat     - Which counter to increment
+ */
+export type MemoryStatsCrdtWriter = (filename: string, stat: keyof UsageStats) => Promise<void>;
+
+/**
+ * Callback for reading aggregated usage stats for a file from the CRDT
+ * Metrics document.  Aggregates across ALL instanceId keys so callers see
+ * the combined count from every instance in the hivemind.
+ *
+ * Returns null when CRDT is unavailable or the file has no recorded stats yet.
+ *
+ * @param filename - Basename of the memory file (e.g. "gotchas.md")
+ */
+export type MemoryStatsAggregateReader = (filename: string) => Promise<UsageStats | null>;
+
+/**
  * Metadata stored in YAML frontmatter of memory files
  */
 export interface MemoryMetadata {
@@ -345,16 +365,22 @@ export function calculateUsageScore(stats: UsageStats): number {
  * - Tag matching with feature keywords (weight: 3)
  * - RelevantTo matching (weight: 2)
  * - Summary matching (weight: 1)
- * - Usage score (multiplier)
+ * - Usage score (multiplier) — reads from CRDT when crdtReader is provided,
+ *   otherwise falls back to YAML frontmatter stats
  * - Importance (multiplier)
  *
  * Always includes gotchas.md
+ *
+ * @param crdtReader - Optional callback to read aggregated CRDT usage stats.
+ *   When provided, CRDT stats replace the per-file YAML frontmatter stats for
+ *   scoring so that hivemind-wide usage signal is used instead of local-only stats.
  */
 export async function loadRelevantMemory(
   projectPath: string,
   featureTitle: string,
   featureDescription: string,
-  fsModule: MemoryFsModule
+  fsModule: MemoryFsModule,
+  crdtReader?: MemoryStatsAggregateReader
 ): Promise<MemoryLoadResult> {
   const memoryDir = getMemoryDir(projectPath);
 
@@ -386,8 +412,16 @@ export async function loadRelevantMemory(
       const summaryTerms = extractTerms(metadata.summary);
       const summaryScore = countMatches(summaryTerms, featureTerms);
 
-      // Usage-based scoring
-      const usageScore = calculateUsageScore(metadata.usageStats);
+      // Usage-based scoring — prefer aggregated CRDT stats when available so
+      // hivemind-wide signal (all instances combined) is used for ranking.
+      let statsForScoring = metadata.usageStats;
+      if (crdtReader) {
+        const crdtStats = await crdtReader(file).catch(() => null);
+        if (crdtStats !== null) {
+          statsForScoring = crdtStats;
+        }
+      }
+      const usageScore = calculateUsageScore(statsForScoring);
 
       // Combined score
       const score = (tagScore + relevantToScore + summaryScore) * metadata.importance * usageScore;
@@ -461,14 +495,24 @@ ${sections.join('\n\n---\n\n')}
 }
 
 /**
- * Increment a usage stat in a memory file
- * Uses file locking to prevent race conditions from concurrent updates
+ * Increment a usage stat in a memory file.
+ *
+ * Always updates the YAML frontmatter on disk for backwards compatibility.
+ * When crdtWriter is provided, also increments the stat in the shared CRDT
+ * Metrics document under the local instanceId key.
+ *
+ * @param filePath   - Absolute path to the memory file
+ * @param stat       - Which counter to increment
+ * @param fsModule   - File system abstraction
+ * @param crdtWriter - Optional callback to write the increment to CRDT
  */
 export async function incrementUsageStat(
   filePath: string,
   stat: keyof UsageStats,
-  fsModule: MemoryFsModule
+  fsModule: MemoryFsModule,
+  crdtWriter?: MemoryStatsCrdtWriter
 ): Promise<void> {
+  // Update YAML frontmatter on disk (backwards compat / graceful degradation)
   await withFileLock(filePath, async () => {
     try {
       const content = (await fsModule.readFile(filePath, 'utf-8')) as string;
@@ -483,6 +527,14 @@ export async function incrementUsageStat(
       // File doesn't exist or can't be updated - that's fine
     }
   });
+
+  // Also write to CRDT when available (fire-and-forget, best-effort)
+  if (crdtWriter) {
+    const filename = path.basename(filePath);
+    crdtWriter(filename, stat).catch((err) => {
+      logger.warn(`CRDT memory stat write failed for ${filename}.${stat}:`, err);
+    });
+  }
 }
 
 /**
@@ -494,15 +546,21 @@ export interface SimpleMemoryFile {
 }
 
 /**
- * Record memory usage after feature completion
- * Updates usage stats based on what was actually referenced
+ * Record memory usage after feature completion.
+ * Updates usage stats based on what was actually referenced.
+ *
+ * Writes to both disk YAML frontmatter (backwards compat) and, when
+ * crdtWriter is provided, to the shared CRDT Metrics document.
+ *
+ * @param crdtWriter - Optional callback to write stat increments to CRDT
  */
 export async function recordMemoryUsage(
   projectPath: string,
   loadedFiles: SimpleMemoryFile[],
   agentOutput: string,
   success: boolean,
-  fsModule: MemoryFsModule
+  fsModule: MemoryFsModule,
+  crdtWriter?: MemoryStatsCrdtWriter
 ): Promise<void> {
   const memoryDir = getMemoryDir(projectPath);
 
@@ -516,9 +574,9 @@ export async function recordMemoryUsage(
     const wasReferenced = countMatches(fileTerms, outputTerms) >= 3;
 
     if (wasReferenced) {
-      await incrementUsageStat(filePath, 'referenced', fsModule);
+      await incrementUsageStat(filePath, 'referenced', fsModule, crdtWriter);
       if (success) {
-        await incrementUsageStat(filePath, 'successfulFeatures', fsModule);
+        await incrementUsageStat(filePath, 'successfulFeatures', fsModule, crdtWriter);
       }
     }
   }


### PR DESCRIPTION
## Summary

**Milestone:** Lightweight Sync Extensions

Extend MetricsDocument in libs/crdt/src/documents.ts to add a memoryStats field: Record<instanceId, Record<filename, { loaded: number, referenced: number, successfulFeatures: number }>>. Update memory-loader.ts (libs/utils/src/memory-loader.ts) to write usage stat increments to the CRDT Metrics document via a callback/injected function instead of (or in addition to) writing to disk YAML frontmatter. Each instance writes to its own instanceId key. Read ...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=aaccab48-6c90-478b-8aa2-5df343794454 team= created=2026-03-12T18:25:46.039Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic memory usage statistics tracking and cross-instance aggregation for system-wide visibility
  * Usage metrics are now persistently stored, significantly improving feature relevance and recommendation accuracy
  * Centralized analytics collection from multiple instances enables better insights into feature adoption
  * Implemented robust dual-storage system to ensure consistency and reliability of usage data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->