### PR TITLE
feat: Notes as CRDT Domain

### DIFF
--- a/apps/server/src/services/crdt-store.module.ts
+++ b/apps/server/src/services/crdt-store.module.ts
@@ -21,9 +21,10 @@
  */
 
 import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
 import { WebSocketServer } from 'ws';
 import { CRDTStore, WebSocketServerAdapter } from '@protolabsai/crdt';
-import type { MetricsDocument } from '@protolabsai/crdt';
+import type { MetricsDocument, NotesWorkspaceDocument, NoteTab } from '@protolabsai/crdt';
 import { loadProtoConfig } from '@protolabsai/platform';
 import { createLogger } from '@protolabsai/utils';
 import type {
@@ -150,6 +151,9 @@ export async function register(container: ServiceContainer): Promise<CrdtStoreMo
 
   logger.info('CRDTStore injected into AvaChannelService, CalendarService, TodoService');
 
+  // Hydrate notes workspace from disk — fire-and-forget, non-blocking
+  void hydrateNotesWorkspace(store, repoRoot);
+
   // Wire registry sync via CrdtSyncService to prevent split-brain.
   // Primary: broadcasts its document registry when a peer connects.
   // Worker: adopts the primary's registry on receipt, resolving URL conflicts.
@@ -257,4 +261,98 @@ export async function register(container: ServiceContainer): Promise<CrdtStoreMo
   logger.info('Memory stats CRDT callbacks created (domain=metrics, id=dora)');
 
   return { store, close, memoryStatsCrdtWriter, memoryStatsAggregateReader };
+}
+
+// ---------------------------------------------------------------------------
+// Notes workspace hydration
+// ---------------------------------------------------------------------------
+
+/** Disk format for a single note tab (from .automaker/notes/workspace.json) */
+interface DiskNoteTab {
+  id: string;
+  name: string;
+  content: string;
+  permissions?: { agentRead?: boolean; agentWrite?: boolean };
+  metadata?: {
+    createdAt?: number;
+    updatedAt?: number;
+    wordCount?: number;
+    characterCount?: number;
+  };
+}
+
+/** Disk format for the notes workspace */
+interface DiskNotesWorkspace {
+  version?: number;
+  activeTabId?: string | null;
+  tabOrder?: string[];
+  tabs?: Record<string, DiskNoteTab>;
+}
+
+/**
+ * Hydrate the notes CRDT document from the existing disk workspace on first start.
+ *
+ * Idempotent: only seeds if the document does not already exist in the registry
+ * (i.e. the registry has no 'notes:workspace' entry). Subsequent calls are no-ops.
+ */
+async function hydrateNotesWorkspace(store: CRDTStore, repoRoot: string): Promise<void> {
+  const NOTES_DOC_ID = 'workspace';
+
+  // Check idempotency: if the document is already in the registry, skip hydration
+  const registry = store.getRegistry();
+  if (registry['notes:workspace']) {
+    logger.debug('[NotesHydration] notes:workspace already in registry — skipping');
+    return;
+  }
+
+  const workspacePath = join(repoRoot, '.automaker', 'notes', 'workspace.json');
+  let diskWorkspace: DiskNotesWorkspace | null = null;
+
+  try {
+    const raw = await readFile(workspacePath, 'utf-8');
+    diskWorkspace = JSON.parse(raw) as DiskNotesWorkspace;
+  } catch {
+    // File does not exist or is unreadable — seed an empty workspace
+    logger.debug('[NotesHydration] No existing workspace.json — seeding empty notes document');
+  }
+
+  const now = new Date().toISOString();
+
+  // Map disk tabs to CRDT NoteTab format
+  const tabs: Record<string, NoteTab> = {};
+  const diskTabs = diskWorkspace?.tabs ?? {};
+  for (const [id, diskTab] of Object.entries(diskTabs)) {
+    if (!diskTab) continue;
+    const createdAtMs = diskTab.metadata?.createdAt;
+    const updatedAtMs = diskTab.metadata?.updatedAt;
+    tabs[id] = {
+      id: diskTab.id ?? id,
+      name: diskTab.name ?? '',
+      content: diskTab.content ?? '',
+      permissions: {
+        agentRead: diskTab.permissions?.agentRead ?? true,
+        agentWrite: diskTab.permissions?.agentWrite ?? false,
+      },
+      createdAt: createdAtMs ? new Date(createdAtMs).toISOString() : now,
+      updatedAt: updatedAtMs ? new Date(updatedAtMs).toISOString() : now,
+      wordCount: diskTab.metadata?.wordCount ?? 0,
+      characterCount: diskTab.metadata?.characterCount ?? 0,
+    };
+  }
+
+  const initialData: Omit<NotesWorkspaceDocument, 'schemaVersion' | '_meta'> = {
+    tabs,
+    tabOrder: Array.isArray(diskWorkspace?.tabOrder) ? diskWorkspace.tabOrder : Object.keys(tabs),
+    activeTabId: diskWorkspace?.activeTabId ?? null,
+    updatedAt: now,
+  };
+
+  try {
+    await store.getOrCreate<NotesWorkspaceDocument>('notes', NOTES_DOC_ID, initialData);
+    logger.info(
+      `[NotesHydration] Seeded notes:workspace with ${Object.keys(tabs).length} tab(s) from disk`
+    );
+  } catch (err) {
+    logger.warn('[NotesHydration] Failed to seed notes:workspace:', err);
+  }
 }

--- a/libs/crdt/src/documents.ts
+++ b/libs/crdt/src/documents.ts
@@ -458,6 +458,89 @@ export const normalizeMetricsDocument: SchemaNormalizer<MetricsDocument> = (raw)
 };
 
 // ---------------------------------------------------------------------------
+// Notes domain — shared notes workspace
+// ---------------------------------------------------------------------------
+
+/**
+ * NoteTab represents a single tab in the notes workspace.
+ * Content is HTML produced by TipTap.
+ */
+export interface NoteTab {
+  id: string;
+  name: string;
+  /** HTML content from TipTap editor */
+  content: string;
+  permissions: {
+    agentRead: boolean;
+    agentWrite: boolean;
+  };
+  /** ISO 8601 timestamp */
+  createdAt: string;
+  /** ISO 8601 timestamp */
+  updatedAt: string;
+  wordCount: number;
+  characterCount: number;
+}
+
+/**
+ * NotesWorkspaceDocument stores the shared notes workspace in a single CRDT document.
+ * Schema mirrors the existing disk format at .automaker/notes/workspace.json.
+ *
+ * Use domain='notes', document id='workspace' for the single shared workspace.
+ * Full document key: doc:notes/workspace
+ */
+export interface NotesWorkspaceDocument extends CRDTDocumentRoot {
+  schemaVersion: 1;
+  /** All note tabs keyed by tab ID */
+  tabs: Record<string, NoteTab>;
+  /** Ordered array of tab IDs */
+  tabOrder: string[];
+  /** Currently active tab ID, or null if none */
+  activeTabId: string | null;
+  /** ISO timestamp of last update to this document */
+  updatedAt: string;
+}
+
+export const normalizeNotesWorkspace: SchemaNormalizer<NotesWorkspaceDocument> = (raw) => {
+  const doc = raw as Partial<NotesWorkspaceDocument>;
+
+  const _meta = doc._meta ?? {
+    instanceId: 'unknown',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  // Normalize tabs — ensure each tab has all required fields
+  const rawTabs = doc.tabs ?? {};
+  const tabs: Record<string, NoteTab> = {};
+  for (const [id, tab] of Object.entries(rawTabs)) {
+    if (!tab) continue;
+    tabs[id] = {
+      id: tab.id ?? id,
+      name: tab.name ?? '',
+      content: tab.content ?? '',
+      permissions: {
+        agentRead: tab.permissions?.agentRead ?? true,
+        agentWrite: tab.permissions?.agentWrite ?? false,
+      },
+      createdAt: tab.createdAt ?? _meta.createdAt,
+      updatedAt: tab.updatedAt ?? _meta.updatedAt,
+      wordCount: tab.wordCount ?? 0,
+      characterCount: tab.characterCount ?? 0,
+    };
+  }
+
+  return {
+    schemaVersion: 1,
+    _meta,
+    tabs,
+    tabOrder: Array.isArray(doc.tabOrder) ? doc.tabOrder : Object.keys(tabs),
+    activeTabId: doc.activeTabId !== undefined ? doc.activeTabId : null,
+    updatedAt: doc.updatedAt ?? _meta.updatedAt,
+  };
+};
+
+// ---------------------------------------------------------------------------
 // Normalizer registry
 // ---------------------------------------------------------------------------
 
@@ -468,7 +551,8 @@ type AnyDocument =
   | AvaChannelDocument
   | CalendarDocument
   | TodosDocument
-  | MetricsDocument;
+  | MetricsDocument
+  | NotesWorkspaceDocument;
 
 const NORMALIZERS: Record<string, SchemaNormalizer<AnyDocument>> = {
   projects: normalizeProjectDocument as SchemaNormalizer<AnyDocument>,
@@ -478,6 +562,7 @@ const NORMALIZERS: Record<string, SchemaNormalizer<AnyDocument>> = {
   calendar: normalizeCalendarDocument as SchemaNormalizer<AnyDocument>,
   todos: normalizeTodosDocument as SchemaNormalizer<AnyDocument>,
   metrics: normalizeMetricsDocument as SchemaNormalizer<AnyDocument>,
+  notes: normalizeNotesWorkspace as SchemaNormalizer<AnyDocument>,
 };
 
 /**

--- a/libs/crdt/src/index.ts
+++ b/libs/crdt/src/index.ts
@@ -18,6 +18,7 @@ export {
   normalizeCalendarDocument,
   normalizeTodosDocument,
   normalizeMetricsDocument,
+  normalizeNotesWorkspace,
 } from './documents.js';
 
 export type {
@@ -28,6 +29,8 @@ export type {
   TodosDocument,
   MetricsDocument,
   MemoryUsageStat,
+  NotesWorkspaceDocument,
+  NoteTab,
 } from './documents.js';
 
 export type {

--- a/libs/crdt/src/types.ts
+++ b/libs/crdt/src/types.ts
@@ -39,7 +39,8 @@ export type DomainName =
   | 'ava-channel'
   | 'calendar'
   | 'todos'
-  | 'metrics';
+  | 'metrics'
+  | 'notes';
 
 /**
  * Configuration for a WebSocket sync peer (typically a Tailscale peer).


### PR DESCRIPTION
## Summary

- Add `NoteTab` and `NotesWorkspaceDocument` interfaces to `libs/crdt/src/documents.ts`
- Add `normalizeNotesWorkspace()` normalizer with schema-on-read migration (handles missing tabs, tabOrder, activeTabId)
- Add `'notes'` to `DomainName` union in `libs/crdt/src/types.ts`
- Wire hydration in `crdt-store.module.ts`: reads `.automaker/notes/workspace.json` and seeds CRDT doc on first start (idempotent, fire-and-forget)
- Export new types from `libs/crdt/src/index.ts`

## Test plan
- [x] `npm run build --workspace=libs/crdt` passes
- [x] `npm run test:packages` passes (57 test files, 1136 tests)
- [x] `'notes'` added to `DomainName` union
- [x] Hydration is idempotent (checks registry before seeding)

<!-- automaker:owner instance=local team=protoLabsAI created=2026-03-12T00:00:00.000Z -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notes workspace support with automatic, non-blocking hydration on startup for seamless recovery.
  * Workspace auto-initializes and seeds an empty workspace when no valid persisted state is found.
  * Notes include metadata handling (timestamps, permissions) and normalized tab ordering for consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->