### PR TITLE
fix: block feature execution when pre-flight rebase detects merge conflicts

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -1904,10 +1904,16 @@ export class AutoModeService {
 
           if (!rebaseResult.success) {
             if (rebaseResult.hasConflicts) {
-              logger.warn(
-                `⚠️  Worktree has merge conflicts with main. Agent will execute on stale base. ` +
-                  `Feature: ${featureId}, Branch: ${branchName}`
-              );
+              const reason =
+                `Pre-flight rebase onto origin/main has conflicts — branch "${branchName}" must be manually rebased before the agent can proceed. ` +
+                `Blocking feature to prevent repeated merge_conflict failures.`;
+              logger.warn(`⚠️  ${reason} Feature: ${featureId}`);
+              await this.featureLoader.update(projectPath, featureId, {
+                status: 'blocked',
+                statusChangeReason: reason,
+              });
+              this.events.emit('feature:error', { projectPath, featureId, error: reason });
+              return;
             } else {
               logger.warn(
                 `Rebase failed (${rebaseResult.error}). Agent will execute on current base. ` +
@@ -2201,6 +2207,7 @@ export class AutoModeService {
     }
 
     // CRITICAL: Rebase worktree onto latest origin/main before follow-up execution
+    let followUpConflictReason: string | null = null;
     if (worktreePath) {
       try {
         logger.info(`Rebasing worktree onto latest origin/main: ${worktreePath}`);
@@ -2208,10 +2215,10 @@ export class AutoModeService {
 
         if (!rebaseResult.success) {
           if (rebaseResult.hasConflicts) {
-            logger.warn(
-              `⚠️  Worktree has merge conflicts with main. Follow-up will execute on stale base. ` +
-                `Feature: ${featureId}, Branch: ${branchName}`
-            );
+            followUpConflictReason =
+              `Pre-flight rebase onto origin/main has conflicts — branch "${branchName}" must be manually rebased before the follow-up can proceed. ` +
+              `Blocking feature to prevent repeated merge_conflict failures.`;
+            logger.warn(`⚠️  ${followUpConflictReason} Feature: ${featureId}`);
           } else {
             logger.warn(
               `Rebase failed (${rebaseResult.error}). Follow-up will execute on current base. ` +
@@ -2224,6 +2231,16 @@ export class AutoModeService {
       } catch (rebaseError) {
         logger.error(`Unexpected error during pre-execution rebase for ${featureId}:`, rebaseError);
       }
+    }
+
+    // Block follow-up execution if rebase conflicts were detected (outside try/catch so throw propagates)
+    if (followUpConflictReason) {
+      await this.featureLoader.update(projectPath, featureId, {
+        status: 'blocked',
+        statusChangeReason: followUpConflictReason,
+      });
+      this.events.emit('feature:error', { projectPath, featureId, error: followUpConflictReason });
+      throw new Error(followUpConflictReason);
     }
 
     // Load previous agent output if it exists

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -512,10 +512,16 @@ export class ExecutionService {
 
           if (!rebaseResult.success) {
             if (rebaseResult.hasConflicts) {
-              logger.warn(
-                `Worktree has merge conflicts with main. Agent will execute on stale base. ` +
-                  `Feature: ${featureId}, Branch: ${branchName}`
-              );
+              const reason =
+                `Pre-flight rebase onto origin/main has conflicts — branch "${branchName}" must be manually rebased before the agent can proceed. ` +
+                `Blocking feature to prevent repeated merge_conflict failures.`;
+              logger.warn(`${reason} Feature: ${featureId}`);
+              await this.featureLoader.update(projectPath, featureId, {
+                status: 'blocked',
+                statusChangeReason: reason,
+              });
+              this.events.emit('feature:error', { projectPath, featureId, error: reason });
+              return;
             } else {
               logger.warn(
                 `Rebase failed (${rebaseResult.error}). Agent will execute on current base. ` +
@@ -742,7 +748,7 @@ export class ExecutionService {
         } catch (rebaseError) {
           const rebaseMsg =
             rebaseError instanceof Error ? rebaseError.message : String(rebaseError);
-          // If rebase fails (conflicts), abort and let agent work on current state
+          // If rebase fails (conflicts), abort and block the feature to prevent repeated merge_conflict failures
           if (rebaseMsg.includes('conflict') || rebaseMsg.includes('CONFLICT')) {
             logger.warn(`Git rebase encountered conflicts for ${branchName}, aborting rebase`);
             try {
@@ -750,12 +756,21 @@ export class ExecutionService {
             } catch {
               // Abort failed — not much we can do
             }
+            const reason =
+              `Pre-flight rebase onto origin/dev has conflicts — branch "${branchName}" must be manually rebased before the agent can proceed. ` +
+              `Blocking feature to prevent repeated merge_conflict failures.`;
             this.typedEventBus.emitAutoModeEvent('sync_warning', {
               featureId,
               branchName,
-              message: `Rebase conflicts detected. Agent will work on current branch state.`,
+              message: reason,
               warning: true,
             });
+            await this.featureLoader.update(projectPath, featureId, {
+              status: 'blocked',
+              statusChangeReason: reason,
+            });
+            this.events.emit('feature:error', { projectPath, featureId, error: reason });
+            return;
           } else {
             logger.warn(`Git rebase failed for ${branchName}: ${rebaseMsg}`);
             this.typedEventBus.emitAutoModeEvent('sync_warning', {


### PR DESCRIPTION
## Summary

Fixes recurring \`merge_conflict\` failures caused by the **detection-without-blocking** pattern in pre-flight rebase checks.

### Root Cause

Three locations in the execution pipeline detected merge conflicts at pre-flight rebase time but only logged a warning and allowed execution to continue on a stale base:

- \`auto-mode-service.ts\` — initial pipeline execution
- \`auto-mode-service.ts\` — follow-up execution
- \`execution-service.ts\` — agent execution service

This caused a failure loop:
1. Pre-flight detects conflicts → logs warning → execution continues
2. Agent fails with \`merge_conflict\` (non-retryable) → feature escalated
3. Friction tracker counts the failure
4. After 3 occurrences → self-improvement feature filed
5. Feature retried → same conflict still present → cycle repeats

### Fix

At each pre-flight rebase check, when \`rebaseResult.hasConflicts\` is true:
- Feature is immediately marked \`status: 'blocked'\` with a clear \`statusChangeReason\`
- \`feature:error\` event is emitted
- Execution returns early (no agent spawned)

This breaks the loop: a conflicted branch gets blocked once with an actionable message, rather than failing repeatedly and triggering the friction tracker.

### Files Changed

- \`apps/server/src/services/auto-mode/execution-service.ts\` — block on conflict instead of warn+continue
- \`apps/server/src/services/auto-mode-service.ts\` — block on conflict in both initial and follow-up execution paths

## Test plan

- [ ] Verify build passes (\`npm run build:server\`)
- [ ] Test: feature with a conflicted worktree branch gets \`status: 'blocked'\` after execution attempt, not \`merge_conflict\` escalation
- [ ] Verify non-conflicting failed rebases still log-and-continue (non-blocking path unchanged)

<!-- automaker:owner instance=local team=protoLabsAI created=2026-03-12T00:00:00.000Z -->