### PR TITLE
Update docs after: CRDT Pipeline Formalization

### DIFF
--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -415,13 +415,13 @@ usageStats:
 - **Why this works:** Partial fixes create maintenance debt and confusion; when server is down, tool should still work correctly; fallback path serves the same purpose (reading logs) so it must have same fix
 - **Trade-offs:** Fixing fallback requires understanding root cause deeply (more work upfront), but prevents cascading bugs and ensures consistent behavior in all modes (server up/down)
 
-### Services (updatePhaseClaim, saveProjectMilestones) write to disk but do NOT auto-emit CRDT events. Callers (route handlers, WorkIntakeService) must manually emit project:updated or call syncProjectToCrdt. (2026-03-12)
+### Services (updatePhaseClaim, saveProjectMilestones) write to disk AND auto-emit project:updated when CRDT is enabled. syncProjectToCrdt() is the escape hatch for external callers that write project.json themselves and need to sync the in-memory doc. (2026-03-12, corrected 2026-03-12)
 
-- **Context:** Tests revealed that disk writes don't propagate to instances until events are explicitly fired
-- **Why:** Separation of concerns: persistence is orthogonal to event propagation. Different callers (HTTP, CLI, scheduled jobs) may need different event handling.
-- **Rejected:** Could have services auto-emit on every write, but this couples persistence to event logic and prevents batch operations
-- **Trade-offs:** Caller responsibility is more error-prone (easy to forget emit) but enables flexibility (batch writes without per-write events)
-- **Breaking if changed:** If a new caller (e.g., bulk import) doesn't emit events, those changes won't sync to other instances
+- **Context:** Both `updatePhaseClaim()` and `saveProjectMilestones()` in ProjectService include CRDT doc updates and `this._crdtEvents?.emit('project:updated', ...)` when `_isCrdtEnabled()` returns true. Emission is part of the service method, not the caller's responsibility.
+- **Why:** Atomicity: disk write + Automerge doc update + event emission are a single logical operation. Callers (WorkIntakeService, route handlers) don't need to remember to fire a separate event.
+- **syncProjectToCrdt() use case:** Routes that bypass the service (e.g., directly write project.json via the create/update route handler) and only need to sync the in-memory doc without a disk re-write should call `syncProjectToCrdt()` explicitly.
+- **Trade-offs:** Caller simplicity (one call does everything) vs reduced flexibility for batch operations that want to suppress intermediate events. `syncProjectToCrdt()` remains the escape hatch.
+- **Breaking if changed:** If `_crdtEvents?.emit(...)` calls are removed from these methods, WorkIntakeService phase claims and PM agent milestone saves will stop propagating to remote peers silently.
 
 #### [Pattern] Tests simulate event-driven sync (EventBus → persistRemoteProject) without real WebSockets. crdt-sync.module.ts wiring is tested indirectly through event flow, not transport layer. (2026-03-12)
 

--- a/.automaker/memory/database.md
+++ b/.automaker/memory/database.md
@@ -148,8 +148,6 @@ usageStats:
 - **Trade-offs:** Better query performance and simpler deployment vs limited horizontal scalability; schema version is immutable once data is written
 - **Breaking if changed:** Schema version must match across all Loki instances; changing schema requires data migration or reindexing
 
-<<<<<<< Updated upstream
-
 #### [Pattern] TrustTierService uses AtomicWriter (not direct fs.writeFile) for persisting trust-tiers.json. Data updates are atomic — partial writes cannot corrupt the file. Aligns with SettingsService and AnalyticsService pattern for security-critical persistent state. (2026-02-25)
 
 - **Problem solved:** Trust tier records are security-sensitive. Corruption or partial updates could grant unintended access. File-based storage chosen for simplicity and auditability.
@@ -160,7 +158,7 @@ usageStats:
 
 - **Problem solved:** Adding quarantine metadata to existing features requires migration or graceful degradation. No migration job was written.
 - **Why this works:** Implicit bypass via absence is safe default (old features continue working). Avoids complex migration logic. Clear data semantics: missing field means 'pre-quarantine era'.
-- # **Trade-offs:** Simpler deployment (no migration) vs audit ambiguity (can't distinguish 'bypassed' from 'never validated'). Acceptable because quarantine is a new security feature, not a fix for existing data.
+- **Trade-offs:** Simpler deployment (no migration) vs audit ambiguity (can't distinguish 'bypassed' from 'never validated'). Acceptable because quarantine is a new security feature, not a fix for existing data.
 
 ### Persisted git workflow errors directly to feature.json via featureLoader.update() rather than separate error tracking/logging system (2026-02-25)
 
@@ -169,7 +167,6 @@ usageStats:
 - **Rejected:** Separate error log file, database error table, or in-memory error registry - would require coordination with feature state and add potential sync issues
 - **Trade-offs:** feature.json includes error metadata (slightly larger JSON); error state travels with feature across systems; simplified debugging but feature.json schema now has optional error fields
 - **Breaking if changed:** Code that assumes feature.json only contains production-happy paths; serialization/deserialization must handle optional gitWorkflowError; migrations needed if schema versioning was strict
-  > > > > > > > Stashed changes
 
 ### Added `trackedSince?: number` timestamp to TrackedPR interface to record when PR tracking started. Used to compute elapsed time for MISSING_CI_CHECK_THRESHOLD_MS comparison. (2026-03-04)
 


### PR DESCRIPTION
## Summary

14 doc-relevant files changed recently.

Changed files requiring docs review:
- .automaker/memory/api.md
- .automaker/memory/architecture.md
- .automaker/memory/content-pipeline-validation.md
- .automaker/memory/database.md
- .automaker/memory/documentation.md
- .automaker/memory/gotchas.md
- .automaker/memory/gtm-signal-intelligence-project.md
- .automaker/memory/patterns.md
- .automaker/memory/persistence.md
- .automaker/memory/testing.md
- apps/server/src/routes/health/index.ts
- apps/server/...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=aaccab48-6c90-478b-8aa2-5df343794454 team= created=2026-03-12T19:24:58.837Z -->