### PR TITLE
feat: move runtime state files from .automaker/ to DATA_DIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,13 @@ docs/.vitepress/cache/
 # Instance-specific — each machine starts fresh
 .automaker/settings.json
 
+# Runtime state files — now stored in DATA_DIR (not git-tracked)
+.automaker/metrics/dora.json
+.automaker/metrics/error-budget.json
+.automaker/lead-engineer-sessions.json
+apps/server/.automaker/pr-tracking.json
+.automaker/projects/*/ceremony-state.json
+
 # Track shared knowledge (agent learning, skills, context, spec, projects)
 !.automaker/context/
 !.automaker/skills/

--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -327,11 +327,16 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   const doraMetricsService = new DoraMetricsService(featureLoader);
 
   // DORA Metrics Collection Service — event-driven time-series persistence
-  const metricsCollectionService = new MetricsCollectionService(events, featureLoader, repoRoot);
+  const metricsCollectionService = new MetricsCollectionService(
+    events,
+    featureLoader,
+    repoRoot,
+    dataDir
+  );
   metricsCollectionService.initialize();
 
-  // Error Budget Service — rolling change fail rate tracker (persists to .automaker/metrics/error-budget.json)
-  const errorBudgetService = new ErrorBudgetService(repoRoot);
+  // Error Budget Service — rolling change fail rate tracker (persists to DATA_DIR/metrics/error-budget.json)
+  const errorBudgetService = new ErrorBudgetService(dataDir);
   // Wire error budget into the event pipeline: record merges and CI failures
   events.subscribe((type, payload) => {
     const p = payload as Record<string, unknown>;
@@ -515,6 +520,8 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
 
   // Ceremony Audit Log and Ceremony Service
   const ceremonyAuditLog = new CeremonyAuditLogService();
+  // Wire DATA_DIR into ceremony service so state files write to DATA_DIR/ceremony-state/
+  ceremonyService.setDataDir(dataDir);
 
   // Completion Detector Service — cascades feature done → epic → milestone → project
   const completionDetectorService = new CompletionDetectorService();
@@ -536,7 +543,8 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
     projectService,
     projectLifecycleService,
     settingsService,
-    metricsService
+    metricsService,
+    dataDir
   );
   const pipelineCheckpointService = new PipelineCheckpointService();
 
@@ -561,7 +569,7 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   );
 
   // PR Feedback Service (monitors open PRs for review comments)
-  const prFeedbackService = new PRFeedbackService(events, featureLoader);
+  const prFeedbackService = new PRFeedbackService(events, featureLoader, dataDir);
 
   // Worktree Lifecycle Service (auto-cleanup after merge + recovery)
   const worktreeLifecycleService = new WorktreeLifecycleService(events, featureLoader, async () => {

--- a/apps/server/src/server/startup.ts
+++ b/apps/server/src/server/startup.ts
@@ -1,7 +1,7 @@
 // Startup sequence: settings migration, reconciliation, worktree recovery, auto-mode start, Codex cache
 
-import { access, unlink } from 'node:fs/promises';
-import { join } from 'node:path';
+import { access, unlink, rename, mkdir, readdir } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
 import { createLogger, setLogLevel, LogLevel } from '@protolabsai/utils';
 
 import type { ServiceContainer } from './services.js';
@@ -18,6 +18,58 @@ const LOG_LEVEL_MAP: Record<string, LogLevel> = {
   info: LogLevel.INFO,
   debug: LogLevel.DEBUG,
 };
+
+/**
+ * One-time migration: move runtime state files from .automaker/ into DATA_DIR.
+ * Safe to run multiple times — skips files that don't exist at old location.
+ */
+async function migrateRuntimeStateFiles(repoRoot: string, dataDir: string): Promise<void> {
+  const moves: Array<{ from: string; to: string }> = [
+    {
+      from: join(repoRoot, '.automaker', 'metrics', 'dora.json'),
+      to: join(dataDir, 'metrics', 'dora.json'),
+    },
+    {
+      from: join(repoRoot, '.automaker', 'metrics', 'error-budget.json'),
+      to: join(dataDir, 'metrics', 'error-budget.json'),
+    },
+    {
+      from: join(repoRoot, '.automaker', 'lead-engineer-sessions.json'),
+      to: join(dataDir, 'lead-engineer-sessions.json'),
+    },
+    {
+      from: join(repoRoot, 'apps', 'server', '.automaker', 'pr-tracking.json'),
+      to: join(dataDir, 'pr-tracking.json'),
+    },
+  ];
+
+  // Ceremony state: .automaker/projects/*/ceremony-state.json → DATA_DIR/ceremony-state/{slug}.json
+  try {
+    const projectsDir = join(repoRoot, '.automaker', 'projects');
+    const slugs = await readdir(projectsDir).catch(() => [] as string[]);
+    for (const slug of slugs) {
+      const fromPath = join(projectsDir, slug, 'ceremony-state.json');
+      moves.push({ from: fromPath, to: join(dataDir, 'ceremony-state', `${slug}.json`) });
+    }
+  } catch {
+    // No projects dir
+  }
+
+  for (const { from, to } of moves) {
+    try {
+      await access(from); // Check exists
+    } catch {
+      continue; // Source doesn't exist — skip
+    }
+    try {
+      await mkdir(dirname(to), { recursive: true });
+      await rename(from, to);
+      logger.info(`[MIGRATE] Moved ${from} → ${to}`);
+    } catch (err) {
+      logger.warn(`[MIGRATE] Failed to move ${from} → ${to}:`, err);
+    }
+  }
+}
 
 /**
  * Run async initialization: settings migration, knowledge store setup, feature reconciliation,
@@ -56,6 +108,13 @@ export async function runStartup(
     }
   } catch (err) {
     logger.warn('Failed to check for legacy settings migration:', err);
+  }
+
+  // Migrate runtime state files from .automaker/ to DATA_DIR
+  try {
+    await migrateRuntimeStateFiles(repoRoot, dataDir);
+  } catch (err) {
+    logger.warn('[MIGRATE] Runtime state migration failed:', err);
   }
 
   // Apply logging settings from saved settings

--- a/apps/server/src/services/ceremony-service.ts
+++ b/apps/server/src/services/ceremony-service.ts
@@ -351,8 +351,15 @@ export class CeremonyService {
   // CeremonyState persistence
   // ---------------------------------------------------------------------------
 
-  private getCeremonyStatePath(projectPath: string, projectSlug: string): string {
-    return path.join(getProjectDir(projectPath, projectSlug), CEREMONY_STATE_FILE);
+  setDataDir(dataDir: string): void {
+    this.dataDir = dataDir;
+  }
+
+  private getCeremonyStatePath(_projectPath: string, projectSlug: string): string {
+    if (this.dataDir) {
+      return path.join(this.dataDir, 'ceremony-state', `${projectSlug}.json`);
+    }
+    return path.join(getProjectDir(_projectPath, projectSlug), CEREMONY_STATE_FILE);
   }
 
   async getCeremonyState(projectPath: string, projectSlug: string): Promise<CeremonyState> {
@@ -381,10 +388,9 @@ export class CeremonyService {
     projectSlug: string,
     state: CeremonyState
   ): Promise<void> {
-    const projectDir = getProjectDir(projectPath, projectSlug);
-    // Ensure the directory exists (project dir under .automaker/projects/{slug})
-    await secureFs.mkdir(projectDir, { recursive: true });
-    const filePath = path.join(projectDir, CEREMONY_STATE_FILE);
+    const filePath = this.getCeremonyStatePath(projectPath, projectSlug);
+    const dir = path.dirname(filePath);
+    await secureFs.mkdir(dir, { recursive: true });
     await secureFs.writeFile(filePath, JSON.stringify(state, null, 2), 'utf-8');
   }
 

--- a/apps/server/src/services/error-budget-service.ts
+++ b/apps/server/src/services/error-budget-service.ts
@@ -57,8 +57,8 @@ function ensureDir(dir: string): void {
 // ---------------------------------------------------------------------------
 
 export class ErrorBudgetService extends EventEmitter {
-  /** Path to the project root — used to resolve `.automaker/metrics/error-budget.json`. */
-  private readonly projectPath: string;
+  /** DATA_DIR — runtime data directory for error-budget.json. */
+  private readonly dataDir: string;
 
   /** Rolling window in milliseconds (default: 7 days). */
   private readonly windowMs: number;
@@ -73,7 +73,7 @@ export class ErrorBudgetService extends EventEmitter {
   private _isExhaustedState = false;
 
   constructor(
-    projectPath: string,
+    dataDir: string,
     options: {
       /** Rolling window in days (default: 7) */
       windowDays?: number;
@@ -82,7 +82,7 @@ export class ErrorBudgetService extends EventEmitter {
     } = {}
   ) {
     super();
-    this.projectPath = projectPath;
+    this.dataDir = dataDir;
     this.windowMs = (options.windowDays ?? 7) * 24 * 60 * 60 * 1000;
     this.threshold = options.threshold ?? 0.2;
   }
@@ -211,7 +211,7 @@ export class ErrorBudgetService extends EventEmitter {
         `[ErrorBudget] Budget exhausted: failRate=${failRate.toFixed(3)} >= ${EXHAUSTION_BURN_RATE} — emitting error_budget:exhausted`
       );
       this.emit('error_budget:exhausted', {
-        projectPath: this.projectPath,
+        projectPath: this.dataDir,
         failRate,
         threshold: EXHAUSTION_BURN_RATE,
         totalMerges: total,
@@ -223,7 +223,7 @@ export class ErrorBudgetService extends EventEmitter {
         `[ErrorBudget] Budget recovered: failRate=${failRate.toFixed(3)} < ${RECOVERY_BURN_RATE} — emitting error_budget:recovered`
       );
       this.emit('error_budget:recovered', {
-        projectPath: this.projectPath,
+        projectPath: this.dataDir,
         failRate,
         threshold: EXHAUSTION_BURN_RATE,
         totalMerges: total,
@@ -245,7 +245,7 @@ export class ErrorBudgetService extends EventEmitter {
   }
 
   private getBudgetPath(): string {
-    return path.join(this.projectPath, '.automaker', 'metrics', 'error-budget.json');
+    return path.join(this.dataDir, 'metrics', 'error-budget.json');
   }
 
   private readDocument(): ErrorBudgetDocument {

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -135,7 +135,8 @@ export class LeadEngineerService {
     private projectService: ProjectService,
     private projectLifecycleService: ProjectLifecycleService,
     private settingsService: SettingsService,
-    private metricsService: MetricsService
+    private metricsService: MetricsService,
+    private dataDir: string = process.env.DATA_DIR ?? './data'
   ) {
     this.worldStateBuilder = new WorldStateBuilder({
       featureLoader,
@@ -144,7 +145,11 @@ export class LeadEngineerService {
       metricsService,
       settingsService,
     });
-    this.sessionStore = new LeadEngineerSessionStore({ featureLoader, settingsService });
+    this.sessionStore = new LeadEngineerSessionStore({
+      featureLoader,
+      settingsService,
+      dataDir: this.dataDir,
+    });
   }
 
   setCheckpointService(s: PipelineCheckpointService): void {

--- a/apps/server/src/services/lead-engineer-session-store.ts
+++ b/apps/server/src/services/lead-engineer-session-store.ts
@@ -7,7 +7,6 @@
 
 import path from 'node:path';
 import { createLogger, atomicWriteJson, readJsonWithRecovery } from '@protolabsai/utils';
-import { getAutomakerDir } from '@protolabsai/platform';
 import type { LeadEngineerSession } from '@protolabsai/types';
 import type { FeatureLoader } from './feature-loader.js';
 import type { SettingsService } from './settings-service.js';
@@ -19,24 +18,33 @@ const logger = createLogger('LeadEngineerService');
 export interface SessionStoreDeps {
   featureLoader: FeatureLoader;
   settingsService: SettingsService;
+  dataDir: string;
 }
 
 export class LeadEngineerSessionStore {
   constructor(private deps: SessionStoreDeps) {}
 
-  getSessionFilePath(projectPath: string): string {
-    return path.join(getAutomakerDir(projectPath), 'lead-engineer-sessions.json');
+  getSessionFilePath(_projectPath?: string): string {
+    return path.join(this.deps.dataDir, 'lead-engineer-sessions.json');
   }
 
   async save(session: LeadEngineerSession): Promise<void> {
     try {
+      const filePath = this.getSessionFilePath();
+      const result = await readJsonWithRecovery<{
+        sessions: Record<string, PersistedSessionData>;
+        savedAt: string;
+      } | null>(filePath, null);
+      const doc = result.data ?? { sessions: {}, savedAt: '' };
       const data: PersistedSessionData = {
         projectPath: session.projectPath,
         projectSlug: session.projectSlug,
         maxConcurrency: session.worldState.maxConcurrency,
         startedAt: session.startedAt,
       };
-      await atomicWriteJson(this.getSessionFilePath(session.projectPath), data);
+      doc.sessions[session.projectPath] = data;
+      doc.savedAt = new Date().toISOString();
+      await atomicWriteJson(filePath, doc);
     } catch (err) {
       logger.error(`Failed to save session for ${session.projectSlug}:`, err);
     }
@@ -44,8 +52,15 @@ export class LeadEngineerSessionStore {
 
   async remove(projectPath: string): Promise<void> {
     try {
-      const fs = await import('node:fs/promises');
-      await fs.unlink(this.getSessionFilePath(projectPath));
+      const filePath = this.getSessionFilePath();
+      const result = await readJsonWithRecovery<{
+        sessions: Record<string, PersistedSessionData>;
+        savedAt: string;
+      } | null>(filePath, null);
+      if (!result.data) return;
+      delete result.data.sessions[projectPath];
+      result.data.savedAt = new Date().toISOString();
+      await atomicWriteJson(filePath, result.data);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
         logger.error(`Failed to remove session for ${projectPath}:`, err);
@@ -61,22 +76,20 @@ export class LeadEngineerSessionStore {
     ) => Promise<void>
   ): Promise<void> {
     try {
-      const allProjects = await this.findProjectsWithSessions();
-      for (const projectPath of allProjects) {
-        try {
-          const result = await readJsonWithRecovery<PersistedSessionData | null>(
-            this.getSessionFilePath(projectPath),
-            null
-          );
-          if (!result.data) continue;
+      const filePath = this.getSessionFilePath();
+      const result = await readJsonWithRecovery<{
+        sessions: Record<string, PersistedSessionData>;
+        savedAt: string;
+      } | null>(filePath, null);
+      if (!result.data?.sessions) return;
 
-          const data = result.data;
-          const isCompleted = await this.isProjectCompleted(data.projectPath);
+      for (const [projectPath, data] of Object.entries(result.data.sessions)) {
+        try {
+          const isCompleted = await this.isProjectCompleted(projectPath);
           if (isCompleted) {
-            await this.remove(data.projectPath);
+            await this.remove(projectPath);
             continue;
           }
-
           logger.info(`Restoring Lead Engineer session for ${data.projectSlug}`);
           await startSession(data.projectPath, data.projectSlug, data.maxConcurrency);
         } catch (err) {
@@ -89,37 +102,17 @@ export class LeadEngineerSessionStore {
   }
 
   async findProjectsWithSessions(): Promise<string[]> {
-    const projects: string[] = [];
-    const fs = await import('node:fs/promises');
-
     try {
-      const globalSettings = await this.deps.settingsService.getGlobalSettings();
-      const projectPaths = new Set<string>();
-
-      for (const project of globalSettings.projects ?? []) {
-        if (project.path) projectPaths.add(project.path);
-      }
-      if (projectPaths.size === 0) projectPaths.add(process.cwd());
-
-      for (const projectPath of projectPaths) {
-        try {
-          await fs.access(projectPath);
-          await fs.access(this.getSessionFilePath(projectPath));
-          projects.push(projectPath);
-        } catch {
-          // No session file for this project
-        }
-      }
+      const filePath = this.getSessionFilePath();
+      const result = await readJsonWithRecovery<{
+        sessions: Record<string, PersistedSessionData>;
+        savedAt: string;
+      } | null>(filePath, null);
+      if (!result.data?.sessions) return [];
+      return Object.keys(result.data.sessions);
     } catch {
-      try {
-        await fs.access(this.getSessionFilePath(process.cwd()));
-        projects.push(process.cwd());
-      } catch {
-        // Nothing
-      }
+      return [];
     }
-
-    return projects;
   }
 
   async isProjectCompleted(projectPath: string): Promise<boolean> {

--- a/apps/server/src/services/metrics-collection-service.ts
+++ b/apps/server/src/services/metrics-collection-service.ts
@@ -65,8 +65,10 @@ interface FailureRecord {
 export class MetricsCollectionService {
   private readonly events: EventEmitter;
   private readonly featureLoader: FeatureLoader;
-  /** Path to the project root — used to locate `.automaker/metrics/dora.json`. */
+  /** Path to the project root — used for feature lookups. */
   private readonly projectPath: string;
+  /** DATA_DIR — runtime data directory for dora.json. */
+  private readonly dataDir: string;
 
   /** Per-day merge counters (keyed by YYYY-MM-DD). */
   private readonly dayCounters = new Map<string, number>();
@@ -85,10 +87,16 @@ export class MetricsCollectionService {
   /** Cleanup function returned by `events.subscribe`. */
   private unsubscribe?: () => void;
 
-  constructor(events: EventEmitter, featureLoader: FeatureLoader, projectPath: string) {
+  constructor(
+    events: EventEmitter,
+    featureLoader: FeatureLoader,
+    projectPath: string,
+    dataDir: string
+  ) {
     this.events = events;
     this.featureLoader = featureLoader;
     this.projectPath = projectPath;
+    this.dataDir = dataDir;
   }
 
   // ---------------------------------------------------------------------------
@@ -251,7 +259,7 @@ export class MetricsCollectionService {
   // ---------------------------------------------------------------------------
 
   private getDoraPath(): string {
-    return path.join(this.projectPath, '.automaker', 'metrics', 'dora.json');
+    return path.join(this.dataDir, 'metrics', 'dora.json');
   }
 
   private readDocument(): DoraTimeSeriesDocument {

--- a/apps/server/src/services/pr-feedback-service.ts
+++ b/apps/server/src/services/pr-feedback-service.ts
@@ -94,7 +94,7 @@ export class PRFeedbackService {
   private leadEngineerService: { isFeatureActive(featureId: string): boolean } | null = null;
 
   /** Path to persisted PR tracking state */
-  private readonly prTrackingPath = path.join(process.cwd(), '.automaker', 'pr-tracking.json');
+  private readonly prTrackingPath: string;
 
   /** PRs we're actively monitoring, keyed by featureId */
   private trackedPRs = new Map<string, TrackedPR>();
@@ -113,9 +113,10 @@ export class PRFeedbackService {
   private readonly feedbackAggregator: FeedbackAggregator;
   private readonly threadResolver: ThreadResolver;
 
-  constructor(events: EventEmitter, featureLoader: FeatureLoader) {
+  constructor(events: EventEmitter, featureLoader: FeatureLoader, dataDir: string) {
     this.events = events;
     this.featureLoader = featureLoader;
+    this.prTrackingPath = path.join(dataDir, 'pr-tracking.json');
     this.feedbackAggregator = new FeedbackAggregator(featureLoader);
     this.threadResolver = new ThreadResolver(events, featureLoader);
   }


### PR DESCRIPTION
## Summary

Moves 5 runtime state files from git-tracked `.automaker/` directories into `DATA_DIR` (default: `./data`). These files were the #1 source of \"automaker drift\" — merge conflicts on every rebase/PR because agents write to them continuously.

**Files moved:**
- `.automaker/metrics/dora.json` → `DATA_DIR/metrics/dora.json`
- `.automaker/metrics/error-budget.json` → `DATA_DIR/metrics/error-budget.json`
- `.automaker/lead-engineer-sessions.json` → `DATA_DIR/lead-engineer-sessions.json` (consolidated map, replaces per-project files)
- `apps/server/.automaker/pr-tracking.json` → `DATA_DIR/pr-tracking.json`
- `.automaker/projects/*/ceremony-state.json` → `DATA_DIR/ceremony-state/{slug}.json`

**What changed:**
- `MetricsCollectionService`: Added `dataDir` param (4th constructor arg); `getDoraPath()` uses `DATA_DIR/metrics/dora.json`
- `ErrorBudgetService`: Renamed `projectPath` → `dataDir`; `getBudgetPath()` uses `DATA_DIR/metrics/error-budget.json`
- `LeadEngineerSessionStore`: Rewrote to use single consolidated `DATA_DIR/lead-engineer-sessions.json` map instead of per-project files; `SessionStoreDeps` now requires `dataDir`
- `PRFeedbackService`: Added `dataDir` constructor param; `prTrackingPath` uses `DATA_DIR/pr-tracking.json`
- `CeremonyService`: Added `setDataDir()` setter; `getCeremonyStatePath()` returns `DATA_DIR/ceremony-state/{slug}.json` when `dataDir` set
- `server/services.ts`: Updated all affected service instantiations to pass `dataDir`; calls `ceremonyService.setDataDir(dataDir)`
- `server/startup.ts`: Added `migrateRuntimeStateFiles()` — one-time idempotent migration moves existing files from old `.automaker/` locations to new `DATA_DIR` paths at server startup
- `.gitignore`: Added old `.automaker/` paths for the moved files

<!-- automaker:owner instance=local team=protoLabsAI created=2026-03-12T00:00:00.000Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized runtime state file storage with centralized data directory
  * Implemented automatic migration of existing state files during startup to new consolidated location

<!-- end of auto-generated comment: release notes by coderabbit.ai -->