### PR TITLE
Upgrade @automerge packages to latest 3.x

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -45,6 +45,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@automerge/prosemirror": "^0.2.0",
     "@ai-sdk/anthropic": "^3.0.45",
     "@ai-sdk/react": "^3.0.92",
     "@codemirror/lang-css": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -646,6 +646,7 @@
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.45",
         "@ai-sdk/react": "^3.0.92",
+        "@automerge/prosemirror": "^0.2.0",
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-javascript": "^6.2.4",
         "@codemirror/lang-json": "^6.0.2",
@@ -1730,6 +1731,24 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@automerge/prosemirror": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@automerge/prosemirror/-/prosemirror-0.2.0.tgz",
+      "integrity": "sha512-Mixxftvfs12tKi7DsStobrQxFayoLJXhEjbrnmNnaQbMzwHrUzuwac+OUvw6ujbtXaulWX+JE8hAuHFAGRDsvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@automerge/automerge": "^3.1",
+        "ordered-map": "^0.1.0",
+        "prosemirror-changeset": "^2.2.1",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-model": "^1.25.2",
+        "prosemirror-schema-basic": "^1.2.2",
+        "prosemirror-schema-list": "^1.3.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-transform": "^1.7.3",
+        "prosemirror-view": "^1.40.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -27830,6 +27849,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ordered-map": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ordered-map/-/ordered-map-0.1.0.tgz",
+      "integrity": "sha512-ttpssyEqKXIeTapKeFTFG+oUCnrC+Fmyy1DPjys0vPJtccBE3baKDFTbJPDuKd9/XHbnKKe+KPQKTzBLri6Mtw==",
+      "license": "MIT"
     },
     "node_modules/orderedmap": {
       "version": "2.1.1",


### PR DESCRIPTION
## Summary

**Milestone:** Test Coverage and Automerge Upgrade

Upgrade all four @automerge packages in libs/crdt/package.json to latest 3.x versions: @automerge/automerge, @automerge/automerge-repo, @automerge/automerge-repo-network-websocket, @automerge/automerge-repo-storage-nodefs. Check Automerge 3.x CHANGELOG for breaking changes (the Text class rename from v3.0 may affect our code — check for any RawString or Text usage). Verify the file format is backwards compatible with existing .automaker/crdt/ c...

---
*Recovered automatically by Automaker post-agent hook*