### PR TITLE
fix: align test mocks with runtime state extraction

### DIFF
--- a/apps/server/tests/unit/services/crdt-store-module.test.ts
+++ b/apps/server/tests/unit/services/crdt-store-module.test.ts
@@ -10,6 +10,9 @@ vi.mock('@protolabsai/crdt', () => {
     init: vi.fn().mockResolvedValue(undefined),
     close: vi.fn().mockResolvedValue(undefined),
     attachServerAdapter: vi.fn(),
+    // hydrateNotesWorkspace() runs fire-and-forget so these must survive restoreAllMocks()
+    getRegistry: () => ({}),
+    getOrCreate: async () => ({ doc: () => null }),
   };
   // Must use function (not arrow) so it can be called with `new`
   const CRDTStore = vi.fn(function () {

--- a/apps/server/tests/unit/services/error-budget-service.test.ts
+++ b/apps/server/tests/unit/services/error-budget-service.test.ts
@@ -189,7 +189,7 @@ describe('ErrorBudgetService', () => {
 
     // Manually write an old record to disk (8 days ago)
     const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
-    const budgetPath = path.join(tmpDir, '.automaker', 'metrics', 'error-budget.json');
+    const budgetPath = path.join(tmpDir, 'metrics', 'error-budget.json');
     fs.mkdirSync(path.dirname(budgetPath), { recursive: true });
     fs.writeFileSync(
       budgetPath,
@@ -214,7 +214,7 @@ describe('ErrorBudgetService', () => {
     const svc = new ErrorBudgetService(tmpDir, { windowDays: 7, threshold: 0.2 });
 
     const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
-    const budgetPath = path.join(tmpDir, '.automaker', 'metrics', 'error-budget.json');
+    const budgetPath = path.join(tmpDir, 'metrics', 'error-budget.json');
     fs.mkdirSync(path.dirname(budgetPath), { recursive: true });
     fs.writeFileSync(
       budgetPath,
@@ -251,10 +251,10 @@ describe('ErrorBudgetService', () => {
     expect(state.failRate).toBeCloseTo(0.5);
   });
 
-  it('persists to the correct path (.automaker/metrics/error-budget.json)', () => {
+  it('persists to the correct path (metrics/error-budget.json under dataDir)', () => {
     const svc = new ErrorBudgetService(tmpDir);
     svc.recordMerge('f1', false);
-    const expectedPath = path.join(tmpDir, '.automaker', 'metrics', 'error-budget.json');
+    const expectedPath = path.join(tmpDir, 'metrics', 'error-budget.json');
     expect(fs.existsSync(expectedPath)).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- Updates error-budget-service test path assertions from `.automaker/metrics/` to `metrics/` under dataDir (aligns with #2346)
- Adds `getRegistry`/`getOrCreate` to CRDTStore mock so fire-and-forget `hydrateNotesWorkspace()` calls don't throw unhandled rejections

Fixes CI failures on dev introduced by #2346 merge.

## Test plan
- [x] Both test files pass locally (37/37 tests, 0 errors)
- [ ] CI passes on this PR

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure and mocking to support asynchronous operations.
  * Adjusted test fixtures to align with updated file path expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->