### PR TITLE
docs: update memory files with CRDT pipeline learnings

### DIFF
--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -496,3 +496,29 @@ usageStats:
 - **Problem solved:** Store registry holds documents from multiple domains (calendar, todos, avaChannel); needs to disambiguate notes documents
 - **Why this works:** Enables future documents under 'notes' domain (e.g., 'notes:trash', 'notes:archived') without key collisions. Scalable design.
 - **Trade-offs:** Clear namespacing vs. hardcoded separator logic; adding new document types requires updating hydration and registry lookup
+
+### Runtime state files migrated from .automaker/ subdirectories to DATA_DIR (2026-03-12)
+
+- **Context:** Previously, metrics, session, PR tracking, and ceremony state files were scattered under `.automaker/` in the repo root and `apps/server/.automaker/`. Moved to `DATA_DIR` (env var `DATA_DIR`, defaults to `./data`) so runtime state is cleanly separated from repo-tracked config.
+- **Affected services and new paths:**
+  - `ErrorBudgetService`: constructor takes `dataDir`; path is `DATA_DIR/metrics/error-budget.json`
+  - `MetricsCollectionService`: new `dataDir` parameter; path is `DATA_DIR/metrics/dora.json`
+  - `PRFeedbackService`: new `dataDir` parameter; path is `DATA_DIR/pr-tracking.json`
+  - `LeadEngineerSessionStore`: `deps.dataDir` required; path is `DATA_DIR/lead-engineer-sessions.json`
+  - `CeremonyService`: call `setDataDir(dataDir)` after construction; path is `DATA_DIR/ceremony-state/{slug}.json`
+- **One-time migration:** `migrateRuntimeStateFiles()` in `startup.ts` runs at server start, moving old files from `.automaker/` paths to new `DATA_DIR` paths. Idempotent — skips files that don't exist at old location.
+- **Breaking if changed:** If `dataDir` is not passed to these services (or `setDataDir()` not called on `CeremonyService`), services fall back to CWD-relative paths which diverge between MCP server and app server processes.
+
+### LeadEngineerSessionStore consolidated from per-project files to a single multi-project file (2026-03-12)
+
+- **Context:** Previously stored one `lead-engineer-sessions.json` per project path. Now uses a single `DATA_DIR/lead-engineer-sessions.json` with structure `{ sessions: Record<string, PersistedSessionData>, savedAt: string }`.
+- **Why:** Eliminates the need to enumerate all project paths at restore time. `findProjectsWithSessions()` was fragile — it scanned settings for project paths and checked each for a session file. Single file with keyed map is simpler and survives project path changes.
+- **Rejected:** Per-project files with a shared index; keyed map achieves the same lookup without extra indirection.
+- **Breaking if changed:** If the file format reverts to per-project, `restoreSessions()` must re-implement project enumeration. Old per-project files are migrated by `migrateRuntimeStateFiles()` at startup (only the top-level `lead-engineer-sessions.json`).
+
+### Pre-flight rebase conflict blocks feature execution instead of proceeding on stale base (2026-03-12)
+
+- **Context:** Previously, when a pre-flight rebase onto `origin/main` (or `origin/dev`) detected merge conflicts, auto-mode logged a warning and let the agent proceed on the conflict-ridden branch. This caused repeated `merge_conflict` failures wasting execution cycles.
+- **Why:** Setting status to `blocked` with a clear `statusChangeReason` stops the wasted execution and surfaces the required manual action (human must resolve conflicts and rebase). Both `AutoModeService` and `ExecutionService` apply this gate for initial execution and follow-up execution paths.
+- **Follow-up path detail:** `AutoModeService` captures the conflict reason in `followUpConflictReason` before the rebase try/catch block, then checks and throws after it — this ensures the block-and-throw runs outside the rebase catch scope.
+- **Breaking if changed:** Reverting to warning-only would resume repeated merge_conflict failures for stale branches. The `blocked` status is the only signal to the human that manual rebase is needed.

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -889,3 +889,15 @@ usageStats:
 - **Situation:** diskTab.metadata?.createdAt is numeric; mapped to Date constructor which expects milliseconds, then .toISOString()
 - **Root cause:** Likely historical: disk format designed separately, ISO strings are standard in CRDT/JSON contexts
 - **How to avoid:** Human-readable ISO strings in logs vs. precision loss if disk format ever changes to seconds or different epoch
+
+#### [Gotcha] 'notes' is not yet in the DomainName union in @protolabsai/crdt — must cast as `'notes' as unknown as DomainName` until types package is updated. (2026-03-12)
+
+- **Situation:** `apps/server/src/routes/notes/index.ts` uses `NOTES_CRDT_DOMAIN = 'notes' as unknown as DomainName` to satisfy the store's typed domain parameter.
+- **Root cause:** `DomainName` is a discriminated union in `@protolabsai/crdt` that doesn't include `'notes'` yet. Adding a new CRDT domain requires updating the types package and rebuilding.
+- **How to avoid:** The double-cast (`as unknown as DomainName`) is the accepted pattern for domains not yet in the union. When adding a new CRDT domain, add the string literal to `DomainName` in `libs/crdt/src/types.ts` and remove the cast.
+
+#### [Gotcha] Automerge doc properties are proxies — must spread/copy before returning to callers, or the values become invalid after the handle is released. (2026-03-12)
+
+- **Situation:** `docToWorkspace()` in `apps/server/src/routes/notes/index.ts` explicitly spreads all nested objects (tabOrder via `Array.from`, tab fields via object literal). Returning the proxy directly causes silent failures when callers access properties after the doc handle lifetime ends.
+- **Root cause:** Automerge wraps document fields in proxy objects for change tracking. The proxy is only valid within the document's active scope; external code reading after scope closure gets undefined or throws.
+- **How to avoid:** Any function that reads from an Automerge document and returns data to callers must copy all fields into plain JS values. Pattern: `Array.from(doc.tabOrder)` for arrays, `{ id: tab.id, name: tab.name, ... }` for objects — never return the proxy directly.

--- a/.automaker/memory/patterns.md
+++ b/.automaker/memory/patterns.md
@@ -73,3 +73,16 @@ usageStats:
 - **Problem solved:** Removing 'crdt:remote-changes' required confirming zero subscribers and zero emitters exist
 - **Why this works:** Event-driven architectures lack static type safety for event completeness; text search is the only reliable way to find all emit() and on() call sites across the codebase
 - **Trade-offs:** Labor-intensive manual search, but 100% reliable; false negatives are impossible if search is thorough
+
+#### [Pattern] Notes CRDT dual-write: disk is primary (always written first, awaited), CRDT is secondary (fire-and-forget for replication). CRDT read is guarded by seeded-check before use. (2026-03-12)
+
+- **Problem solved:** Notes workspace needs multi-instance eventual consistency via CRDT, but must remain reliable when CRDT is unavailable.
+- **Why this works:** `saveWorkspaceWithCrdt()` awaits the disk write first, then calls `store.change(...).catch(...)` without awaiting. Disk success is the durable guarantee; CRDT propagates asynchronously. On read, `loadWorkspaceWithCrdt()` only uses CRDT data if `doc.tabOrder` is non-empty (the seeded-check) — an empty tabOrder means the document was created by `getOrCreate` but never written via this service, so disk is the correct source.
+- **Trade-offs:** Brief window of inconsistency between disk and CRDT after a write. CRDT failures are logged but don't surface to callers. Read falls back silently to disk if CRDT is unavailable or un-seeded.
+- **Key implementation:** `apps/server/src/routes/notes/index.ts` — `loadWorkspaceWithCrdt()` and `saveWorkspaceWithCrdt()`.
+
+#### [Pattern] Setter injection for DATA_DIR on CeremonyService: `setDataDir(dataDir)` called post-construction in services.ts to avoid circular dependency at service initialization time. (2026-03-12)
+
+- **Problem solved:** `CeremonyService` needs to know `DATA_DIR` to write ceremony state to the correct location, but `dataDir` is resolved from the service container context after construction.
+- **Why this works:** Follows the same setter injection pattern used for `setAutoModeService()` — construction and wiring are decoupled. `getCeremonyStatePath()` falls back to the old `.automaker/projects/{slug}/ceremony-state.json` path if `dataDir` is not set, preserving backward compatibility.
+- **Trade-offs:** Easy to forget calling `setDataDir()` after construction (silent fallback to old path). Consistent with established service wiring pattern in the codebase.

--- a/.automaker/memory/persistence.md
+++ b/.automaker/memory/persistence.md
@@ -34,6 +34,14 @@ usageStats:
 - **Why this works:** localStorage provides client-side persistence; namespace prevents collisions with other apps. Enables 'set once, forget' UX without rebuild/redeploy cycle.
 - **Trade-offs:** Pro: simple, no server required. Con: cleared if user clears browser cache; namespace is convention not enforced.
 
+### lead-engineer-sessions.json uses a multi-project map format: { sessions: Record<projectPath, PersistedSessionData>, savedAt: string } (2026-03-12)
+
+- **Context:** Previously one file per project path at `.automaker/lead-engineer-sessions.json`. Now a single file at `DATA_DIR/lead-engineer-sessions.json` keyed by project path.
+- **Why:** Single file with keyed map eliminates the need to enumerate all known project paths at restore time. `save()` merges into the map (read-modify-write); `remove()` deletes the key; `restoreSessions()` iterates entries directly.
+- **Rejected:** Retaining per-project files with a discovery scan — fragile to missing settings, breaks when projects move.
+- **Trade-offs:** All sessions in one file means a single corrupt file affects all projects. `readJsonWithRecovery` provides crash resilience.
+- **Breaking if changed:** Old per-project format is migrated at startup by `migrateRuntimeStateFiles()` but only the single top-level `lead-engineer-sessions.json` — not legacy per-project files from older layouts.
+
 ### recentServerUrls persisted via browser localStorage (per-origin key-value) rather than IndexedDB or server-side user preferences (2026-03-11)
 
 - **Context:** UI needs quick access to recent server URLs for dropdown, but doesn't require cross-device sync or complex queries


### PR DESCRIPTION
## Summary

- Reviewed 24 recently-changed doc-relevant source files from commits #2338–#2348
- Captured new patterns, gotchas, and architectural decisions into 4 memory files

## What was documented

**architecture.md** (3 new entries):
- Runtime state files migrated from `.automaker/` to `DATA_DIR` (startup.ts one-time migration, all affected services)
- `LeadEngineerSessionStore` consolidated to single multi-project file
- Pre-flight rebase conflict now blocks features (not just warns)

**gotchas.md** (2 new entries):
- `'notes'` not yet in `DomainName` union — requires `as unknown as DomainName` double-cast
- Automerge doc properties are proxies — must spread/copy all fields before returning to callers

**patterns.md** (2 new entries):
- Notes CRDT dual-write pattern (disk primary, CRDT fire-and-forget, seeded-check guard on reads)
- Setter injection for DATA_DIR on `CeremonyService` via `setDataDir()`

**persistence.md** (1 new entry):
- `lead-engineer-sessions.json` multi-project map format and trade-offs

## Test plan
- [ ] Memory files are valid markdown and follow existing format conventions
- [ ] No existing entries were duplicated or removed

<!-- automaker:owner instance=local team=protoLabsAI created=2026-03-12T00:00:00.000Z -->