### PR TITLE
fix: replace pre-flight git rebase with git merge

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -503,17 +503,18 @@ export class ExecutionService {
         return;
       }
 
-      // CRITICAL: Rebase worktree onto latest origin/main before agent execution
-      // This prevents agents from executing against stale code when PRs merge in quick succession
+      // CRITICAL: Merge worktree with latest origin/main before agent execution
+      // This prevents agents from executing against stale code when PRs merge in quick succession.
+      // Uses merge instead of rebase to handle concurrent .automaker/ modifications gracefully.
       if (worktreePath) {
         try {
-          logger.info(`Rebasing worktree onto latest origin/main: ${worktreePath}`);
-          const rebaseResult = await rebaseWorktreeOnMain(worktreePath);
+          logger.info(`Merging worktree with latest origin/main: ${worktreePath}`);
+          const mergeResult = await rebaseWorktreeOnMain(worktreePath);
 
-          if (!rebaseResult.success) {
-            if (rebaseResult.hasConflicts) {
+          if (!mergeResult.success) {
+            if (mergeResult.hasConflicts) {
               const reason =
-                `Pre-flight rebase onto origin/main has conflicts — branch "${branchName}" must be manually rebased before the agent can proceed. ` +
+                `Pre-flight merge with origin/main has conflicts — branch "${branchName}" must be manually merged before the agent can proceed. ` +
                 `Blocking feature to prevent repeated merge_conflict failures.`;
               logger.warn(`${reason} Feature: ${featureId}`);
               await this.featureLoader.update(projectPath, featureId, {
@@ -524,19 +525,16 @@ export class ExecutionService {
               return;
             } else {
               logger.warn(
-                `Rebase failed (${rebaseResult.error}). Agent will execute on current base. ` +
+                `Merge failed (${mergeResult.error}). Agent will execute on current base. ` +
                   `Feature: ${featureId}`
               );
             }
           } else {
-            logger.info(`Worktree successfully rebased onto latest origin/main`);
+            logger.info(`Worktree successfully merged with latest origin/main`);
           }
-        } catch (rebaseError) {
+        } catch (mergeError) {
           // Log error but don't fail execution - agent can still work on stale base
-          logger.error(
-            `Unexpected error during pre-execution rebase for ${featureId}:`,
-            rebaseError
-          );
+          logger.error(`Unexpected error during pre-execution merge for ${featureId}:`, mergeError);
         }
       }
 
@@ -693,8 +691,8 @@ export class ExecutionService {
       // Persist the resolved model to the feature JSON so the UI can display it
       await this.featureLoader.update(projectPath, featureId, { model: modelResult.model });
 
-      // Rebase branch onto origin/dev before agent execution
-      // This keeps the branch fresh and reduces merge conflicts
+      // Merge branch with origin/dev before agent execution
+      // Uses merge instead of rebase to handle concurrent .automaker/ modifications gracefully
       if (branchName && useWorktrees) {
         logger.info(`Syncing branch ${branchName} before agent execution...`);
         this.typedEventBus.emitAutoModeEvent('sync_started', {
@@ -706,58 +704,26 @@ export class ExecutionService {
         try {
           await execAsync('git fetch origin', { cwd: workDir, timeout: 30000 });
 
-          // Stash unstaged changes before rebasing to prevent
-          // "cannot rebase: You have unstaged changes" errors
-          let stashed = false;
-          try {
-            const { stdout: statusOut } = await execAsync('git status --porcelain', {
-              cwd: workDir,
-              timeout: 10000,
-            });
-            if (statusOut.trim().length > 0) {
-              logger.info(`Unstaged changes detected in ${branchName}, stashing before rebase...`);
-              await execAsync('git stash --include-untracked', { cwd: workDir, timeout: 15000 });
-              stashed = true;
-            }
-          } catch (stashErr) {
-            logger.warn(
-              `Pre-rebase stash attempt failed for ${branchName}: ${stashErr instanceof Error ? stashErr.message : String(stashErr)}`
-            );
-          }
-
-          await execAsync('git rebase origin/dev', { cwd: workDir, timeout: 60000 });
-          logger.info(`Branch ${branchName} rebased onto origin/dev`);
-
-          // Pop the stash after a successful rebase
-          if (stashed) {
-            try {
-              await execAsync('git stash pop', { cwd: workDir, timeout: 15000 });
-              logger.info(`Stash popped successfully after rebase for ${branchName}`);
-            } catch (popErr) {
-              logger.warn(
-                `Stash pop had conflicts after rebase for ${branchName}: ${popErr instanceof Error ? popErr.message : String(popErr)}. Continuing with agent execution.`
-              );
-            }
-          }
+          await execAsync('git merge origin/dev', { cwd: workDir, timeout: 60000 });
+          logger.info(`Branch ${branchName} merged with origin/dev`);
 
           this.typedEventBus.emitAutoModeEvent('sync_completed', {
             featureId,
             branchName,
-            message: 'Branch rebased onto origin/dev',
+            message: 'Branch merged with origin/dev',
           });
-        } catch (rebaseError) {
-          const rebaseMsg =
-            rebaseError instanceof Error ? rebaseError.message : String(rebaseError);
-          // If rebase fails (conflicts), abort and block the feature to prevent repeated merge_conflict failures
-          if (rebaseMsg.includes('conflict') || rebaseMsg.includes('CONFLICT')) {
-            logger.warn(`Git rebase encountered conflicts for ${branchName}, aborting rebase`);
+        } catch (mergeError) {
+          const mergeMsg = mergeError instanceof Error ? mergeError.message : String(mergeError);
+          // If merge fails (conflicts), abort and block the feature to prevent repeated merge_conflict failures
+          if (mergeMsg.includes('conflict') || mergeMsg.includes('CONFLICT')) {
+            logger.warn(`Git merge encountered conflicts for ${branchName}, aborting merge`);
             try {
-              await execAsync('git rebase --abort', { cwd: workDir, timeout: 10000 });
+              await execAsync('git merge --abort', { cwd: workDir, timeout: 10000 });
             } catch {
               // Abort failed — not much we can do
             }
             const reason =
-              `Pre-flight rebase onto origin/dev has conflicts — branch "${branchName}" must be manually rebased before the agent can proceed. ` +
+              `Pre-flight merge with origin/dev has conflicts — branch "${branchName}" must be manually merged before the agent can proceed. ` +
               `Blocking feature to prevent repeated merge_conflict failures.`;
             this.typedEventBus.emitAutoModeEvent('sync_warning', {
               featureId,
@@ -772,11 +738,11 @@ export class ExecutionService {
             this.events.emit('feature:error', { projectPath, featureId, error: reason });
             return;
           } else {
-            logger.warn(`Git rebase failed for ${branchName}: ${rebaseMsg}`);
+            logger.warn(`Git merge failed for ${branchName}: ${mergeMsg}`);
             this.typedEventBus.emitAutoModeEvent('sync_warning', {
               featureId,
               branchName,
-              message: `Git rebase failed: ${rebaseMsg}. Continuing with agent execution.`,
+              message: `Git merge failed: ${mergeMsg}. Continuing with agent execution.`,
               warning: true,
             });
           }

--- a/apps/server/src/services/lead-engineer-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-execute-processor.ts
@@ -987,9 +987,9 @@ export class ExecuteProcessor implements StateProcessor {
       /* no upstream set — use default */
     }
 
-    // ── Commit .automaker/ drift before rebasing ──────────────────────────────
+    // ── Commit .automaker/ drift before merging ───────────────────────────────
     // Services write to .automaker/ (ledger, metrics, sessions, features) without
-    // committing. This drift causes "cannot rebase: You have unstaged changes".
+    // committing. This drift causes "cannot merge: You have unstaged changes".
     // The LE owns committing this drift as part of its pre-flight responsibility.
     try {
       const { stdout: driftStatus } = await execAsync(
@@ -997,7 +997,7 @@ export class ExecuteProcessor implements StateProcessor {
         { cwd: workDir, timeout: 10_000 }
       );
       if (driftStatus.trim().length > 0) {
-        logger.info('[EXECUTE][pre-flight] Committing .automaker/ drift before rebase', {
+        logger.info('[EXECUTE][pre-flight] Committing .automaker/ drift before merge', {
           featureId: feature.id,
           files: driftStatus.trim().split('\n').length,
         });
@@ -1005,7 +1005,7 @@ export class ExecuteProcessor implements StateProcessor {
           cwd: workDir,
           timeout: 10_000,
         });
-        await execAsync('git commit --no-verify -m "chore: commit automaker drift before rebase"', {
+        await execAsync('git commit --no-verify -m "chore: commit automaker drift before merge"', {
           cwd: workDir,
           timeout: 15_000,
         });
@@ -1024,70 +1024,24 @@ export class ExecuteProcessor implements StateProcessor {
       const behind = parseInt(revList.trim(), 10);
       if (!isNaN(behind) && behind > 0) {
         logger.info(
-          `[EXECUTE][pre-flight] Worktree is ${behind} commits behind origin/${baseBranch}, rebasing`,
+          `[EXECUTE][pre-flight] Worktree is ${behind} commits behind origin/${baseBranch}, merging`,
           { featureId: feature.id }
         );
-        // Stash any unstaged changes before rebasing to prevent
-        // "cannot rebase: You have unstaged changes" errors.
-        // Mirrors the same fix applied in execution-service.ts.
-        let stashed = false;
-        try {
-          const { stdout: remainingStatus } = await execAsync('git status --porcelain', {
-            cwd: workDir,
-            timeout: 10_000,
-          });
-          if (remainingStatus.trim().length > 0) {
-            logger.info('[EXECUTE][pre-flight] Stashing unstaged changes before rebase', {
-              featureId: feature.id,
-            });
-            await execAsync('git stash --include-untracked', { cwd: workDir, timeout: 15_000 });
-            stashed = true;
-          }
-        } catch (stashErr) {
-          const stashMsg = stashErr instanceof Error ? stashErr.message : String(stashErr);
-          logger.warn('[EXECUTE][pre-flight] Pre-rebase stash failed (non-fatal)', {
-            msg: stashMsg,
-          });
-        }
 
         try {
-          await execAsync(`git rebase origin/${baseBranch}`, { cwd: workDir, timeout: 60_000 });
-          logger.info('[EXECUTE][pre-flight] Rebase succeeded', { featureId: feature.id });
-
-          // Restore stashed changes after a successful rebase
-          if (stashed) {
-            try {
-              await execAsync('git stash pop', { cwd: workDir, timeout: 15_000 });
-              logger.info('[EXECUTE][pre-flight] Stash popped after rebase', {
-                featureId: feature.id,
-              });
-            } catch (popErr) {
-              const popMsg = popErr instanceof Error ? popErr.message : String(popErr);
-              logger.warn(
-                '[EXECUTE][pre-flight] Stash pop had conflicts after rebase (non-fatal, continuing)',
-                { msg: popMsg }
-              );
-            }
-          }
-        } catch (rebaseErr) {
-          // Abort the rebase to leave the worktree clean
+          await execAsync(`git merge origin/${baseBranch}`, { cwd: workDir, timeout: 60_000 });
+          logger.info('[EXECUTE][pre-flight] Merge succeeded', { featureId: feature.id });
+        } catch (mergeErr) {
+          // Abort the merge to leave the worktree clean
           try {
-            await execAsync('git rebase --abort', { cwd: workDir, timeout: 10_000 });
+            await execAsync('git merge --abort', { cwd: workDir, timeout: 10_000 });
           } catch {
             /* best-effort */
           }
-          // Restore stash even on failure so the worktree is not left empty
-          if (stashed) {
-            try {
-              await execAsync('git stash pop', { cwd: workDir, timeout: 15_000 });
-            } catch {
-              /* best-effort */
-            }
-          }
-          const rebaseMsg = rebaseErr instanceof Error ? rebaseErr.message : String(rebaseErr);
+          const mergeMsg = mergeErr instanceof Error ? mergeErr.message : String(mergeErr);
           return {
             passed: false,
-            reason: `Worktree rebase onto origin/${baseBranch} failed (conflicts or error): ${rebaseMsg}`,
+            reason: `Worktree merge with origin/${baseBranch} failed (conflicts or error): ${mergeMsg}`,
           };
         }
       }

--- a/apps/server/tests/unit/services/execution-service.test.ts
+++ b/apps/server/tests/unit/services/execution-service.test.ts
@@ -365,17 +365,16 @@ describe('ExecutionService - IAutoModeCallbacks contract', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Stash-rebase-pop flow tests
+// Merge pre-flight tests
 // ---------------------------------------------------------------------------
 
-describe('ExecutionService - stash-rebase-pop pre-flight', () => {
+describe('ExecutionService - merge pre-flight', () => {
   const PROJECT_PATH = '/tmp/test-project';
   const WORKTREE_PATH = '/tmp/test-project/.worktrees/feature-test-branch';
   const FEATURE_ID = 'feature-stash-test-1';
 
   beforeEach(() => {
     vi.stubEnv('AUTOMAKER_MOCK_AGENT', 'true');
-    // Default: no unstaged changes
     mockExecAsync.mockReset();
     mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
   });
@@ -383,8 +382,8 @@ describe('ExecutionService - stash-rebase-pop pre-flight', () => {
   function makeWorktreeFeature(overrides: Partial<Feature> = {}): Feature {
     return {
       id: FEATURE_ID,
-      title: 'Stash Test Feature',
-      description: 'Test stash-rebase-pop',
+      title: 'Merge Test Feature',
+      description: 'Test merge pre-flight',
       status: 'backlog',
       branchName: 'feature/test-branch',
       skipTests: true,
@@ -419,10 +418,62 @@ describe('ExecutionService - stash-rebase-pop pre-flight', () => {
     };
   }
 
-  it('stashes before rebase and pops after when unstaged changes exist', async () => {
+  it('runs git merge origin/dev during pre-flight sync', async () => {
     const feat = makeWorktreeFeature();
 
-    // Simulate unstaged changes on git status
+    mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
+    const callbacks = makeWorktreeCallbacks(feat);
+    const recoveryService = {
+      analyzeFailure: vi.fn(async () => ({
+        isRetryable: false,
+        maxRetries: 0,
+        suggestedDelay: 0,
+        category: 'execution',
+        confidence: 'high',
+        reason: 'test',
+      })),
+      executeRecovery: vi.fn(async () => ({ shouldRetry: false, actionTaken: 'none' })),
+      planRecovery: vi.fn(async () => null),
+    } as any;
+
+    const svc = new ExecutionService(
+      { subscribe: vi.fn(), emit: vi.fn() } as any,
+      null,
+      {
+        get: vi.fn(async () => feat),
+        update: vi.fn(async (_p: string, _id: string, updates: Record<string, unknown>) => ({
+          ...feat,
+          ...updates,
+        })),
+        list: vi.fn(async () => []),
+        save: vi.fn(async () => {}),
+      } as any,
+      null,
+      recoveryService,
+      null,
+      new Map(),
+      new Map(),
+      90,
+      95,
+      callbacks
+    );
+
+    await svc.executeFeature(PROJECT_PATH, FEATURE_ID, true /* useWorktrees */);
+
+    const commands: string[] = mockExecAsync.mock.calls.map(([cmd]) => cmd as string);
+
+    // Merge must be called; stash must NOT be called (merge handles concurrent edits natively)
+    expect(commands).toContain('git merge origin/dev');
+    expect(commands).not.toContain('git stash --include-untracked');
+    expect(commands).not.toContain('git stash pop');
+    expect(commands).not.toContain('git rebase origin/dev');
+  });
+
+  it('does not stash even when unstaged changes exist (merge handles them natively)', async () => {
+    const feat = makeWorktreeFeature();
+
+    // Simulate unstaged changes — merge should proceed without stashing
     mockExecAsync.mockImplementation(async (cmd: string) => {
       if (cmd === 'git status --porcelain') {
         return {
@@ -473,24 +524,32 @@ describe('ExecutionService - stash-rebase-pop pre-flight', () => {
 
     const commands: string[] = mockExecAsync.mock.calls.map(([cmd]) => cmd as string);
 
-    // All three git operations must have been called
-    expect(commands).toContain('git stash --include-untracked');
-    expect(commands).toContain('git rebase origin/dev');
-    expect(commands).toContain('git stash pop');
-
-    // Order: stash → rebase → pop
-    const stashIdx = commands.indexOf('git stash --include-untracked');
-    const rebaseIdx = commands.indexOf('git rebase origin/dev');
-    const popIdx = commands.indexOf('git stash pop');
-    expect(stashIdx).toBeLessThan(rebaseIdx);
-    expect(rebaseIdx).toBeLessThan(popIdx);
+    // Stash must never be called regardless of working tree state
+    expect(commands).not.toContain('git stash --include-untracked');
+    expect(commands).not.toContain('git stash pop');
+    // Merge still runs
+    expect(commands).toContain('git merge origin/dev');
   });
 
-  it('skips stash entirely when no unstaged changes exist', async () => {
+  it('blocks feature and aborts merge when merge conflicts occur', async () => {
     const feat = makeWorktreeFeature();
 
-    // git status returns empty (clean working tree)
-    mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
+    mockExecAsync.mockImplementation(async (cmd: string) => {
+      if (cmd === 'git merge origin/dev') {
+        throw new Error('CONFLICT (content): Merge conflict in apps/server/src/index.ts');
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const featureLoader = {
+      get: vi.fn(async () => feat),
+      update: vi.fn(async (_p: string, _id: string, updates: Record<string, unknown>) => ({
+        ...feat,
+        ...updates,
+      })),
+      list: vi.fn(async () => []),
+      save: vi.fn(async () => {}),
+    } as any;
 
     const callbacks = makeWorktreeCallbacks(feat);
     const recoveryService = {
@@ -509,15 +568,7 @@ describe('ExecutionService - stash-rebase-pop pre-flight', () => {
     const svc = new ExecutionService(
       { subscribe: vi.fn(), emit: vi.fn() } as any,
       null,
-      {
-        get: vi.fn(async () => feat),
-        update: vi.fn(async (_p: string, _id: string, updates: Record<string, unknown>) => ({
-          ...feat,
-          ...updates,
-        })),
-        list: vi.fn(async () => []),
-        save: vi.fn(async () => {}),
-      } as any,
+      featureLoader,
       null,
       recoveryService,
       null,
@@ -532,77 +583,13 @@ describe('ExecutionService - stash-rebase-pop pre-flight', () => {
 
     const commands: string[] = mockExecAsync.mock.calls.map(([cmd]) => cmd as string);
 
-    // Stash and pop must NOT be called when working tree is clean
-    expect(commands).not.toContain('git stash --include-untracked');
-    expect(commands).not.toContain('git stash pop');
-    // Rebase still runs
-    expect(commands).toContain('git rebase origin/dev');
-  });
-
-  it('logs warning and continues when stash pop fails after rebase', async () => {
-    const feat = makeWorktreeFeature();
-
-    mockExecAsync.mockImplementation(async (cmd: string) => {
-      if (cmd === 'git status --porcelain') {
-        return { stdout: ' M some-file.ts\n', stderr: '' };
-      }
-      if (cmd === 'git stash pop') {
-        throw new Error('CONFLICT (content): Merge conflict in some-file.ts');
-      }
-      return { stdout: '', stderr: '' };
-    });
-
-    const callbacks = makeWorktreeCallbacks(feat);
-    const recoveryService = {
-      analyzeFailure: vi.fn(async () => ({
-        isRetryable: false,
-        maxRetries: 0,
-        suggestedDelay: 0,
-        category: 'execution',
-        confidence: 'high',
-        reason: 'test',
-      })),
-      executeRecovery: vi.fn(async () => ({ shouldRetry: false, actionTaken: 'none' })),
-      planRecovery: vi.fn(async () => null),
-    } as any;
-
-    const svc = new ExecutionService(
-      { subscribe: vi.fn(), emit: vi.fn() } as any,
-      null,
-      {
-        get: vi.fn(async () => feat),
-        update: vi.fn(async (_p: string, _id: string, updates: Record<string, unknown>) => ({
-          ...feat,
-          ...updates,
-        })),
-        list: vi.fn(async () => []),
-        save: vi.fn(async () => {}),
-      } as any,
-      null,
-      recoveryService,
-      null,
-      new Map(),
-      new Map(),
-      90,
-      95,
-      callbacks
-    );
-
-    // Should not throw — stash pop failure is non-fatal
-    await expect(
-      svc.executeFeature(PROJECT_PATH, FEATURE_ID, true /* useWorktrees */)
-    ).resolves.not.toThrow();
-
-    // A warning should have been logged
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Stash pop had conflicts')
-    );
-
-    // Feature should still reach a terminal status (not throw/crash)
-    expect(callbacks.updateFeatureStatus).toHaveBeenCalledWith(
+    // Merge abort must be called to clean up the worktree
+    expect(commands).toContain('git merge --abort');
+    // Feature must be blocked
+    expect(featureLoader.update).toHaveBeenCalledWith(
       PROJECT_PATH,
       FEATURE_ID,
-      'in_progress'
+      expect.objectContaining({ status: 'blocked' })
     );
   });
 });

--- a/libs/git-utils/src/rebase.ts
+++ b/libs/git-utils/src/rebase.ts
@@ -1,5 +1,5 @@
 /**
- * Git rebase utilities
+ * Git merge utilities for pre-flight worktree synchronization
  */
 
 import { exec } from 'child_process';
@@ -7,26 +7,27 @@ import { promisify } from 'util';
 import { createLogger } from '@protolabsai/utils';
 
 const execAsync = promisify(exec);
-const logger = createLogger('GitRebase');
+const logger = createLogger('GitMerge');
 
 /**
- * Result of a rebase operation
+ * Result of a merge operation
  */
 export interface RebaseResult {
-  /** Whether the rebase was successful */
+  /** Whether the merge was successful */
   success: boolean;
-  /** Error message if rebase failed */
+  /** Error message if merge failed */
   error?: string;
   /** Whether conflicts were detected */
   hasConflicts?: boolean;
 }
 
 /**
- * Rebase a worktree onto the latest origin/main
- * This ensures agents execute against up-to-date code when PRs merge in quick succession
+ * Merge a worktree with the latest origin/main
+ * This ensures agents execute against up-to-date code when PRs merge in quick succession.
+ * Uses merge instead of rebase to handle concurrent .automaker/ modifications gracefully.
  *
- * @param worktreePath - Path to the worktree to rebase
- * @param targetBranch - Target branch to rebase onto (default: 'origin/main')
+ * @param worktreePath - Path to the worktree to merge
+ * @param targetBranch - Target branch to merge from (default: 'origin/main')
  * @returns RebaseResult indicating success/failure
  */
 export async function rebaseWorktreeOnMain(
@@ -42,30 +43,30 @@ export async function rebaseWorktreeOnMain(
         timeout: 30_000,
       });
     } catch (fetchError) {
-      // Fetch failure is non-critical - we'll try to rebase anyway
+      // Fetch failure is non-critical - we'll try to merge anyway
       const errorMsg = fetchError instanceof Error ? fetchError.message : String(fetchError);
       logger.warn(`git fetch failed (continuing anyway): ${errorMsg}`);
     }
 
-    // Step 2: Attempt rebase onto target branch
-    logger.info(`Rebasing worktree onto ${targetBranch}: ${worktreePath}`);
+    // Step 2: Attempt merge with target branch
+    logger.info(`Merging worktree with ${targetBranch}: ${worktreePath}`);
     try {
-      const { stdout, stderr } = await execAsync(`git rebase ${targetBranch}`, {
+      const { stdout, stderr } = await execAsync(`git merge ${targetBranch}`, {
         cwd: worktreePath,
         timeout: 60_000,
       });
 
-      // Check if rebase output indicates "Already up to date"
+      // Check if merge output indicates "Already up to date"
       const output = stdout + stderr;
-      if (output.includes('is up to date') || output.includes('Current branch')) {
+      if (output.includes('Already up to date') || output.includes('is up to date')) {
         logger.info(`Worktree already up to date: ${worktreePath}`);
       } else {
-        logger.info(`Successfully rebased worktree onto ${targetBranch}: ${worktreePath}`);
+        logger.info(`Successfully merged worktree with ${targetBranch}: ${worktreePath}`);
       }
 
       return { success: true };
-    } catch (rebaseError) {
-      const errorMsg = rebaseError instanceof Error ? rebaseError.message : String(rebaseError);
+    } catch (mergeError) {
+      const errorMsg = mergeError instanceof Error ? mergeError.message : String(mergeError);
 
       // Check if this is a conflict error
       const hasConflicts =
@@ -75,32 +76,32 @@ export async function rebaseWorktreeOnMain(
 
       if (hasConflicts) {
         logger.warn(
-          `Rebase conflicts detected in ${worktreePath}, aborting rebase. Agent will proceed on stale base.`
+          `Merge conflicts detected in ${worktreePath}, aborting merge. Agent will proceed on stale base.`
         );
 
-        // Abort the rebase to return worktree to clean state
+        // Abort the merge to return worktree to clean state
         try {
-          await execAsync('git rebase --abort', {
+          await execAsync('git merge --abort', {
             cwd: worktreePath,
             timeout: 30_000,
           });
-          logger.info(`Aborted rebase cleanly for ${worktreePath}`);
+          logger.info(`Aborted merge cleanly for ${worktreePath}`);
         } catch (abortError) {
           logger.error(
-            `Failed to abort rebase for ${worktreePath}:`,
+            `Failed to abort merge for ${worktreePath}:`,
             abortError instanceof Error ? abortError.message : String(abortError)
           );
         }
 
         return {
           success: false,
-          error: 'Rebase conflicts detected',
+          error: 'Merge conflicts detected',
           hasConflicts: true,
         };
       }
 
-      // Other rebase errors (not conflicts)
-      logger.warn(`Rebase failed for ${worktreePath}: ${errorMsg}`);
+      // Other merge errors (not conflicts)
+      logger.warn(`Merge failed for ${worktreePath}: ${errorMsg}`);
       return {
         success: false,
         error: errorMsg,
@@ -109,7 +110,7 @@ export async function rebaseWorktreeOnMain(
     }
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
-    logger.error(`Unexpected error during rebase for ${worktreePath}:`, errorMsg);
+    logger.error(`Unexpected error during merge for ${worktreePath}:`, errorMsg);
     return {
       success: false,
       error: errorMsg,


### PR DESCRIPTION
## Summary

- Replaces `git rebase origin/{baseBranch}` with `git merge origin/{baseBranch}` in all pre-flight sync paths
- Removes the stash/pop dance that surrounded rebase (not needed with merge — merge handles concurrent modifications natively)
- Aborts failed merges with `git merge --abort` to leave worktrees clean on conflict
- Updates tests: replaces the `stash-rebase-pop` test suite with a `merge pre-flight` suite covering: merge runs, no stashing, conflict blocking + abort

**Root cause fixed:** Rebase replays commits sequentially, so the `"chore: commit automaker drift before rebase"` commits from feature branches conflict with identical drift commits already on `origin/dev`. Merge treats concurrent `.automaker/` changes as straightforward auto-resolvable modifications.

<!-- automaker:owner instance=local team=protoLabsAI created=2026-03-12T13:15:00.000Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated worktree synchronization process to improve conflict detection and handling during pre-flight checks.
  * Enhanced system logging and user-facing messages related to synchronization operations.
  * Refined error handling and reporting for synchronization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->