### PR TITLE
fix: reset stale feature state on staging deploy restart

### DIFF
--- a/scripts/setup-staging.sh
+++ b/scripts/setup-staging.sh
@@ -215,6 +215,17 @@ start_services() {
   info "Starting services..."
   cd "$PROJECT_ROOT"
 
+  # Reset staging board state — features are gitignored runtime artifacts.
+  # The staging server modifies .automaker/features/ via bind mount. Without
+  # this cleanup, stale feature status survives across deploys and the board
+  # drifts out of sync with the actual codebase.
+  local project_path="${AUTOMAKER_PROJECT_PATH:-}"
+  if [ -n "$project_path" ] && [ -d "$project_path/.automaker/features" ]; then
+    info "Cleaning stale feature state from $project_path/.automaker/features/"
+    rm -rf "$project_path/.automaker/features/"
+    ok "Feature state reset (CRDT will rebuild from clean state)"
+  fi
+
   # Ensure named volumes exist (external: true in compose won't auto-create them)
   for vol in automaker-data automaker-claude-config automaker-cursor-config \
              automaker-opencode-data automaker-opencode-config automaker-opencode-cache; do


### PR DESCRIPTION
## Summary
- Wipes `.automaker/features/` in the bind-mounted project path before container start in `setup-staging.sh`
- The staging server writes feature.json files at runtime via bind mount, causing the board to show ~30 stale features that are actually done after deploys
- CRDT rebuilds from clean state on every restart, so no data is lost

## Context
Features are gitignored runtime artifacts. The staging server modifies them via bind mount at `AUTOMAKER_PROJECT_PATH`. Without cleanup, stale status survives across deploys and the board drifts.

## Test plan
- [x] Verified on staging: wiped features, restarted container, board shows 0 features (clean)
- [ ] Next deploy should automatically clean features before start

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced staging environment initialization to ensure clean state setup during container recreation, improving deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->