### PR TITLE
fix: null phase model value crashes settings endpoint

### DIFF
--- a/apps/server/src/services/settings-service.ts
+++ b/apps/server/src/services/settings-service.ts
@@ -314,7 +314,7 @@ export class SettingsService {
           continue;
         }
         const value = settings.phaseModels[key];
-        if (value !== undefined) {
+        if (value != null) {
           // Convert string to PhaseModelEntry if needed (v2 -> v3 migration)
           merged[key] = this.toPhaseModelEntry(value as string | PhaseModelEntry);
         }
@@ -347,7 +347,10 @@ export class SettingsService {
    * @param value - Phase model value (string or PhaseModelEntry)
    * @returns PhaseModelEntry object with canonical model ID
    */
-  private toPhaseModelEntry(value: string | PhaseModelEntry): PhaseModelEntry {
+  private toPhaseModelEntry(value: string | PhaseModelEntry | null | undefined): PhaseModelEntry {
+    if (value == null) {
+      return { model: 'claude-sonnet' };
+    }
     if (typeof value === 'string') {
       // v2 format: just a model string - migrate to canonical ID
       return { model: migrateModelId(value) as PhaseModelEntry['model'] };


### PR DESCRIPTION
## Summary
- P1 hotfix: setting any `phaseModels` entry to `null` in `data/settings.json` crashes `GET /api/settings/global` with `TypeError: Cannot read properties of null (reading 'model')`
- Guard in `migratePhaseModels` changed from `value !== undefined` to `value != null`
- Defensive null check added to `toPhaseModelEntry` (returns sonnet default on null)
- Cascading impact: `getGlobalSettings()` called by FeatureScheduler every loop — one null takes down auto-mode + UI

## Test plan
- [x] Server builds clean
- [ ] Set `"agentExecutionModel": null` in `data/settings.json`, verify settings endpoint returns 200 with sonnet default
- [ ] Verify auto-mode loop runs without crash

Reported by thehimerus in #bug-reports.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete or missing settings values to prevent processing errors and ensure appropriate default configuration when values are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->