### PR TITLE
promote: staging to main (hotfix null phase model + feature state drift)

### DIFF
--- a/apps/server/src/services/settings-service.ts
+++ b/apps/server/src/services/settings-service.ts
@@ -314,7 +314,7 @@ export class SettingsService {
           continue;
         }
         const value = settings.phaseModels[key];
-        if (value !== undefined) {
+        if (value != null) {
           // Convert string to PhaseModelEntry if needed (v2 -> v3 migration)
           merged[key] = this.toPhaseModelEntry(value as string | PhaseModelEntry);
         }
@@ -347,7 +347,10 @@ export class SettingsService {
    * @param value - Phase model value (string or PhaseModelEntry)
    * @returns PhaseModelEntry object with canonical model ID
    */
-  private toPhaseModelEntry(value: string | PhaseModelEntry): PhaseModelEntry {
+  private toPhaseModelEntry(value: string | PhaseModelEntry | null | undefined): PhaseModelEntry {
+    if (value == null) {
+      return { model: 'claude-sonnet' };
+    }
     if (typeof value === 'string') {
       // v2 format: just a model string - migrate to canonical ID
       return { model: migrateModelId(value) as PhaseModelEntry['model'] };

--- a/scripts/setup-staging.sh
+++ b/scripts/setup-staging.sh
@@ -215,6 +215,17 @@ start_services() {
   info "Starting services..."
   cd "$PROJECT_ROOT"
 
+  # Reset staging board state — features are gitignored runtime artifacts.
+  # The staging server modifies .automaker/features/ via bind mount. Without
+  # this cleanup, stale feature status survives across deploys and the board
+  # drifts out of sync with the actual codebase.
+  local project_path="${AUTOMAKER_PROJECT_PATH:-}"
+  if [ -n "$project_path" ] && [ -d "$project_path/.automaker/features" ]; then
+    info "Cleaning stale feature state from $project_path/.automaker/features/"
+    rm -rf "$project_path/.automaker/features/"
+    ok "Feature state reset (CRDT will rebuild from clean state)"
+  fi
+
   # Ensure named volumes exist (external: true in compose won't auto-create them)
   for vol in automaker-data automaker-claude-config automaker-cursor-config \
              automaker-opencode-data automaker-opencode-config automaker-opencode-cache; do


### PR DESCRIPTION
## Summary
- fix: null phase model value crashes settings endpoint (#2358)
- fix: reset stale feature state on staging deploy restart (#2353)
- fix: auto-mode concurrency race from premature startingFeatures timeout (#2327)
- fix: discord bot silent failure from env var mismatch (#2325)

## Promotion
staging -> main merge commit (no squash per branch strategy).

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling to gracefully manage edge cases with automatic sensible defaults.

* **Chores**
  * Optimized deployment initialization to ensure clean state and prevent stale configuration carryover between updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->