### PR TITLE
Promote dev to staging: sitrep escalations + log errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,43 @@ See `docs/dev/branch-strategy.md` for the full strategy.
 - Before committing, run `git status` and verify only intended files are staged. Watch for accidentally staged deletions from previously merged PRs.
 - `.automaker/memory/` files are updated by agents during autonomous work. Include memory changes in your commits alongside related code changes — don't leave them as unstaged drift.
 
+## Release Workflow
+
+Releases follow a two-step CI workflow. Version bumps happen on staging BEFORE promotion to main.
+
+### Step 1: Prepare Release (bump version on staging)
+
+Trigger the `prepare-release.yml` workflow on staging. This bumps `version` in all `package.json` files across the monorepo (root, apps, libs), commits, and optionally syncs the bump to dev.
+
+```bash
+# Trigger version bump (auto-detects next minor from git tags)
+gh workflow run prepare-release.yml --ref staging
+
+# Or dry run first
+gh workflow run prepare-release.yml --ref staging -f dry_run=true
+```
+
+Wait for the workflow to complete before proceeding.
+
+### Step 2: Promote staging to main
+
+Create a merge-commit PR from staging to main. The PR title should include the version.
+
+```bash
+gh pr create --base main --head staging --title "Promote staging to main (vX.Y.Z)"
+gh pr merge <number> --merge --auto
+```
+
+### Step 3: Auto Release (automatic)
+
+When the staging→main PR merges, `auto-release.yml` fires automatically. It reads the version from `package.json`, creates a git tag (`vX.Y.Z`), and publishes a GitHub Release.
+
+If the tag already exists, the workflow skips with `WARNING: vX.Y.Z is already tagged. Skipping.` — this means Step 1 was missed or the version wasn't bumped.
+
+### Common Mistake
+
+Promoting staging→main WITHOUT running prepare-release first. The auto-release sees the existing tag and does nothing. Always bump version on staging first.
+
 ## Session Continuation
 
 - When continuing a previous session or autonomous loop, always check MCP server connectivity and board status FIRST before attempting any agent launches or API calls.

--- a/apps/server/src/routes/chat/sitrep.ts
+++ b/apps/server/src/routes/chat/sitrep.ts
@@ -16,6 +16,9 @@ import { getExecutionStatePath } from '@protolabsai/platform';
 import type { ExecutionState, Feature } from '@protolabsai/types';
 import { FeatureLoader } from '../../services/feature-loader.js';
 import * as secureFs from '../../lib/secure-fs.js';
+import { getEscalationRouter } from '../../services/escalation-router.js';
+import { open } from 'node:fs/promises';
+import { getServerLogPath } from '../../lib/server-log.js';
 
 const logger = createLogger('Sitrep');
 
@@ -152,8 +155,66 @@ async function buildSitrep(projectPath: string): Promise<string> {
   lines.push('## Auto-Mode');
   lines.push('');
   lines.push(`**Status:** ${autoModeActive ? '🟢 Running' : '⚪ Stopped'}`);
+  lines.push('');
+
+  // Recent escalations from audit log
+  try {
+    const router = getEscalationRouter();
+    const entries = router.getLog(5);
+    if (entries.length > 0) {
+      lines.push('## Recent Escalations');
+      lines.push('');
+      for (const entry of entries) {
+        const ctx = entry.signal.context ?? {};
+        const title = (ctx.featureTitle as string) || (ctx.featureId as string) || 'Unknown';
+        const reason = (ctx.reason as string) || (ctx.message as string) || entry.signal.type;
+        const short = reason.length > 120 ? reason.slice(0, 120) + '...' : reason;
+        lines.push(`- [${entry.signal.severity}] **${title}** — ${short}`);
+      }
+      lines.push('');
+    }
+  } catch {
+    // Escalation router not available
+  }
+
+  // Recent server log errors
+  try {
+    const logErrors = await readRecentLogErrors(5);
+    if (logErrors.length > 0) {
+      lines.push('## Recent Server Errors');
+      lines.push('');
+      for (const line of logErrors) {
+        const short = line.length > 150 ? line.slice(0, 150) + '...' : line;
+        lines.push(`- \`${short}\``);
+      }
+      lines.push('');
+    }
+  } catch {
+    // Log file not available
+  }
 
   return lines.join('\n');
+}
+
+async function readRecentLogErrors(limit: number): Promise<string[]> {
+  let fh: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    const logPath = getServerLogPath();
+    fh = await open(logPath, 'r');
+    const { size } = await fh.stat();
+    const readSize = Math.min(size, 65536);
+    const buffer = Buffer.alloc(readSize);
+    await fh.read(buffer, 0, readSize, size - readSize);
+    await fh.close();
+    fh = null;
+    const lines = buffer.toString('utf-8').split('\n');
+    return lines
+      .filter((line) => line.includes('[ERROR]') || line.includes('[FATAL]'))
+      .slice(-limit);
+  } catch {
+    if (fh) await fh.close().catch(() => {});
+    return [];
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/apps/server/src/routes/sitrep/index.ts
+++ b/apps/server/src/routes/sitrep/index.ts
@@ -11,6 +11,9 @@ import { createLogger } from '@protolabsai/utils';
 import type { Feature } from '@protolabsai/types';
 import type { FeatureLoader } from '../../services/feature-loader.js';
 import type { AutoModeService } from '../../services/auto-mode-service.js';
+import { getEscalationRouter } from '../../services/escalation-router.js';
+import { open } from 'node:fs/promises';
+import { getServerLogPath } from '../../lib/server-log.js';
 
 const logger = createLogger('SitrepRoute');
 const execFileAsync = promisify(execFile);
@@ -37,16 +40,25 @@ export function createSitrepRoutes({
 
     try {
       // Gather everything in parallel for speed
-      const [allFeatures, autoStatus, runningAgents, prData, recentCommits, stagingDelta, health] =
-        await Promise.all([
-          featureLoader.getAll(projectPath).catch(() => [] as Feature[]),
-          getAutoModeStatus(autoModeService, projectPath),
-          getRunningAgents(autoModeService),
-          getOpenPRs(repoRoot),
-          getRecentCommits(repoRoot),
-          getStagingDelta(repoRoot),
-          getServerHealth(),
-        ]);
+      const [
+        allFeatures,
+        autoStatus,
+        runningAgents,
+        prData,
+        recentCommits,
+        stagingDelta,
+        health,
+        recentLogErrors,
+      ] = await Promise.all([
+        featureLoader.getAll(projectPath).catch(() => [] as Feature[]),
+        getAutoModeStatus(autoModeService, projectPath),
+        getRunningAgents(autoModeService),
+        getOpenPRs(repoRoot),
+        getRecentCommits(repoRoot),
+        getStagingDelta(repoRoot),
+        getServerHealth(),
+        getRecentLogErrors(10),
+      ]);
 
       // Filter by projectSlug when provided
       const features = projectSlug
@@ -107,6 +119,9 @@ export function createSitrepRoutes({
           classification: f.failureClassification?.category,
         }));
 
+      // Pull recent entries from the escalation router audit log
+      const recentEscalations = getRecentEscalations(10);
+
       res.json({
         timestamp: new Date().toISOString(),
         board,
@@ -115,6 +130,8 @@ export function createSitrepRoutes({
         blockedFeatures,
         reviewFeatures,
         escalations,
+        recentEscalations,
+        recentLogErrors,
         openPRs: prData,
         stagingDelta,
         recentCommits,
@@ -231,6 +248,54 @@ async function getStagingDelta(repoRoot: string) {
     return { commitsAhead: commits.length, commits: commits.slice(0, 5) };
   } catch {
     return { commitsAhead: 0, commits: [] };
+  }
+}
+
+function getRecentEscalations(limit: number) {
+  try {
+    const router = getEscalationRouter();
+    const entries = router.getLog(limit);
+    return entries.map((entry) => {
+      const ctx = entry.signal.context ?? {};
+      const failureAnalysis = ctx.failureAnalysis as Record<string, unknown> | undefined;
+      return {
+        type: entry.signal.type,
+        severity: entry.signal.severity,
+        source: entry.signal.source,
+        timestamp: entry.timestamp,
+        deduplicated: entry.deduplicated,
+        routedTo: entry.routedTo,
+        context: {
+          featureId: ctx.featureId as string | undefined,
+          featureTitle: ctx.featureTitle as string | undefined,
+          reason: (ctx.reason as string) || (ctx.message as string) || undefined,
+          projectPath: ctx.projectPath as string | undefined,
+          classification: failureAnalysis?.category as string | undefined,
+        },
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+async function getRecentLogErrors(limit: number): Promise<string[]> {
+  let fh: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    const logPath = getServerLogPath();
+    fh = await open(logPath, 'r');
+    const { size } = await fh.stat();
+    const readSize = Math.min(size, 65536);
+    const buffer = Buffer.alloc(readSize);
+    await fh.read(buffer, 0, readSize, size - readSize);
+    await fh.close();
+    fh = null;
+    const lines = buffer.toString('utf-8').split('\n');
+    const errorLines = lines.filter((line) => line.includes('[ERROR]') || line.includes('[FATAL]'));
+    return errorLines.slice(-limit);
+  } catch {
+    if (fh) await fh.close().catch(() => {});
+    return [];
   }
 }
 

--- a/packages/mcp-server/src/tools/utility-tools.ts
+++ b/packages/mcp-server/src/tools/utility-tools.ts
@@ -61,7 +61,7 @@ export const utilityTools: Tool[] = [
   {
     name: 'get_sitrep',
     description:
-      'Get a full operational status report in one call. Returns board summary, running agents, auto-mode status, blocked features, escalations, open PRs with CI status, staging delta, recent commits, and server health. Use this instead of calling get_board_summary + list_running_agents + get_auto_mode_status + check PRs separately.',
+      'Get a full operational status report in one call. Returns board summary, running agents, auto-mode status, blocked features, escalations (from feature state), recentEscalations (last 10 from escalation router audit log), recentLogErrors (last 10 ERROR/FATAL lines from server log), open PRs with CI status, staging delta, recent commits, and server health. Use this instead of calling multiple status tools separately.',
     inputSchema: {
       type: 'object',
       properties: {


### PR DESCRIPTION
## Summary
- Add recentEscalations (last 10 from audit log) to sitrep
- Add recentLogErrors (last 10 ERROR/FATAL lines) to sitrep  
- Both API and chat Ava sitrep get the same data
- Document release workflow in CLAUDE.md

## Test plan
- [ ] CI passes
- [ ] Sitrep returns new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sitrep reports now include "Recent Escalations" (up to 5 entries) and "Recent Server Errors" (up to 5 error lines) sections for improved system diagnostics and visibility.

* **Documentation**
  * Added release workflow documentation detailing the CI process for version management and promotion across the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->