### PR TITLE
feat: add discord reaction endpoint and conditional discord loading

### DIFF
--- a/apps/server/src/routes/discord/index.ts
+++ b/apps/server/src/routes/discord/index.ts
@@ -8,6 +8,7 @@ import { createSendDMHandler } from './routes/send-dm.js';
 import { createReadDMsHandler } from './routes/read-dms.js';
 import { createSendChannelMessageHandler } from './routes/send-channel-message.js';
 import { createReadChannelMessagesHandler } from './routes/read-channel-messages.js';
+import { createAddReactionHandler } from './routes/add-reaction.js';
 
 export function createDiscordRoutes(discordBotService?: DiscordBotService): Router {
   const router = Router();
@@ -37,6 +38,7 @@ export function createDiscordRoutes(discordBotService?: DiscordBotService): Rout
   router.post('/read-dms', createReadDMsHandler(discordBotService));
   router.post('/send-channel-message', createSendChannelMessageHandler(discordBotService));
   router.post('/read-channel-messages', createReadChannelMessagesHandler(discordBotService));
+  router.post('/add-reaction', createAddReactionHandler(discordBotService));
 
   return router;
 }

--- a/apps/server/src/routes/discord/routes/add-reaction.ts
+++ b/apps/server/src/routes/discord/routes/add-reaction.ts
@@ -1,0 +1,31 @@
+import type { Request, Response } from 'express';
+import type { DiscordBotService } from '../../../services/discord-bot-service.js';
+
+export function createAddReactionHandler(discordBotService: DiscordBotService) {
+  return async (req: Request, res: Response) => {
+    const { channelId, messageId, emoji } = req.body;
+
+    if (!channelId || typeof channelId !== 'string') {
+      res.status(400).json({ success: false, error: 'channelId is required' });
+      return;
+    }
+
+    if (!messageId || typeof messageId !== 'string') {
+      res.status(400).json({ success: false, error: 'messageId is required' });
+      return;
+    }
+
+    if (!emoji || typeof emoji !== 'string') {
+      res.status(400).json({ success: false, error: 'emoji is required' });
+      return;
+    }
+
+    try {
+      const success = await discordBotService.addReaction(channelId, messageId, emoji);
+      res.json({ success });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      res.status(500).json({ success: false, error: message });
+    }
+  };
+}

--- a/apps/server/src/services/discord-bot-service.ts
+++ b/apps/server/src/services/discord-bot-service.ts
@@ -1584,6 +1584,30 @@ export class DiscordBotService {
   }
 
   /**
+   * Add a reaction (emoji) to a message in a channel.
+   */
+  async addReaction(channelId: string, messageId: string, emoji: string): Promise<boolean> {
+    if (!this.client) return false;
+
+    try {
+      const channel = (await this.client.channels.fetch(channelId)) as TextChannel;
+      if (!channel?.isTextBased()) return false;
+
+      const message = await channel.messages.fetch(messageId);
+      await message.react(emoji);
+
+      logger.info(`Added reaction ${emoji} to message ${messageId} in channel ${channelId}`);
+      return true;
+    } catch (error) {
+      logger.error(
+        `Failed to add reaction to message ${messageId} in channel ${channelId}:`,
+        error
+      );
+      return false;
+    }
+  }
+
+  /**
    * Create a thread for an extended conversation.
    */
   async createThread(channelId: string, messageId: string, name: string): Promise<string | null> {

--- a/apps/server/src/services/discord.module.ts
+++ b/apps/server/src/services/discord.module.ts
@@ -29,13 +29,7 @@ export async function register(container: ServiceContainer): Promise<void> {
     integrationRegistryService,
   } = container;
 
-  // Discord Bot Service initialization
-  void discordBotService.initialize();
-
-  // Wire Discord bot service to Ava Gateway
-  avaGatewayService.setDiscordBot(discordBotService);
-
-  // Event Hook Service initialization (must be after DiscordBotService)
+  // Event Hook Service initialization — runs regardless of Discord (handles non-Discord hooks too)
   eventHookService.initialize(
     events,
     settingsService,
@@ -43,6 +37,22 @@ export async function register(container: ServiceContainer): Promise<void> {
     featureLoader,
     discordBotService
   );
+
+  // Skip all Discord wiring when no token is configured.
+  // DiscordBotService methods gracefully no-op when uninitialized,
+  // but there's no reason to wire event subscriptions, escalation channels,
+  // or agent routers that will never fire.
+  const hasDiscordToken = !!(process.env.DISCORD_BOT_TOKEN || process.env.DISCORD_TOKEN);
+  if (!hasDiscordToken) {
+    logger.info('Discord integration disabled (DISCORD_BOT_TOKEN / DISCORD_TOKEN not set)');
+    return;
+  }
+
+  // Discord Bot Service initialization
+  void discordBotService.initialize();
+
+  // Wire Discord bot service to Ava Gateway
+  avaGatewayService.setDiscordBot(discordBotService);
 
   // Bridge integration:discord events to Discord bot service
   events.subscribe(async (type, payload) => {
@@ -115,20 +125,14 @@ export async function register(container: ServiceContainer): Promise<void> {
     )
   );
 
-  // Start Discord channel signal monitoring when DISCORD_TOKEN is configured.
-  // The monitor polls only channels registered in integrationRegistryService.
-  // Configs start empty and are populated at runtime via setChannelConfigs().
-  if (process.env.DISCORD_BOT_TOKEN || process.env.DISCORD_TOKEN) {
-    const discordMonitor = new DiscordMonitor(events);
-    discordMonitor.setDiscordBotService(discordBotService);
+  // Start Discord channel signal monitoring.
+  const discordMonitor = new DiscordMonitor(events);
+  discordMonitor.setDiscordBotService(discordBotService);
 
-    const configs = integrationRegistryService.getAllEnabledChannelConfigs();
-    void discordMonitor.startChannelMonitoring(configs).catch((err) => {
-      logger.error('Failed to start Discord channel signal monitoring:', err);
-    });
+  const configs = integrationRegistryService.getAllEnabledChannelConfigs();
+  void discordMonitor.startChannelMonitoring(configs).catch((err) => {
+    logger.error('Failed to start Discord channel signal monitoring:', err);
+  });
 
-    logger.info(`Discord channel signal monitor started (${configs.length} channel(s) configured)`);
-  } else {
-    logger.info('Discord channel signal monitor skipped (DISCORD_TOKEN not set)');
-  }
+  logger.info(`Discord channel signal monitor started (${configs.length} channel(s) configured)`);
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1116,6 +1116,13 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         limit: args.limit || 10,
       });
 
+    case 'add_discord_reaction':
+      return apiCall('/discord/add-reaction', {
+        channelId: args.channelId,
+        messageId: args.messageId,
+        emoji: args.emoji,
+      });
+
     // Setup Pipeline
     case 'research_repo':
       return apiCall('/setup/research', {

--- a/packages/mcp-server/src/tools/integration-tools.ts
+++ b/packages/mcp-server/src/tools/integration-tools.ts
@@ -119,6 +119,30 @@ export const integrationTools: Tool[] = [
   },
 
   {
+    name: 'add_discord_reaction',
+    description:
+      'Add an emoji reaction to a Discord message. Use Unicode emoji (e.g. "✅", "👍") or custom emoji name.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        channelId: {
+          type: 'string',
+          description: 'Discord channel ID containing the message',
+        },
+        messageId: {
+          type: 'string',
+          description: 'Discord message ID to react to',
+        },
+        emoji: {
+          type: 'string',
+          description: 'Emoji to react with (Unicode emoji like "✅" or custom emoji name)',
+        },
+      },
+      required: ['channelId', 'messageId', 'emoji'],
+    },
+  },
+
+  {
     name: 'twitch_list_suggestions',
     description:
       'View Twitch chat suggestion queue with filtering. Use filter="unprocessed" to see only new suggestions, "approved" for processed ones, or "all" for everything.',


### PR DESCRIPTION
## Summary
- Adds `addReaction(channelId, messageId, emoji)` to DiscordBotService
- New route: `POST /api/discord/add-reaction`
- New MCP tool: `add_discord_reaction` for adding emoji reactions to messages
- Refactors `discord.module.ts` to skip all wiring when no `DISCORD_TOKEN` is set (not just the monitor — the entire module early-returns)
- EventHookService still initializes unconditionally (handles non-Discord hooks)

## Test plan
- [x] Server builds clean
- [x] MCP server builds clean
- [ ] With token: Discord bot connects, reaction endpoint works
- [ ] Without token: Server starts without Discord wiring, logs "Discord integration disabled"

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added ability to add emoji reactions to Discord messages
* Implemented reaction-based abilities with user permission validation
* Added support for creating threads from message reactions
* Enhanced Discord bot initialization with token validation checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->