### PR TITLE
Wire skills into tsconfig and create assets

### DIFF
--- a/.automaker/skills/monorepo-patterns/import-convention.ts
+++ b/.automaker/skills/monorepo-patterns/import-convention.ts
@@ -1,0 +1,39 @@
+/**
+ * Typed examples of correct import conventions for the Automaker monorepo.
+ * See imports.md for the full skill documentation.
+ */
+
+// Types from the shared types package — always use @protolabsai/* workspace paths
+import type { Feature, FeatureStatus } from '@protolabsai/types';
+
+/**
+ * Returns the display title for a feature, falling back to its id.
+ * Demonstrates: import type from @protolabsai/types (correct pattern).
+ */
+export function getFeatureTitle(feature: Feature): string {
+  return feature.title ?? feature.id;
+}
+
+/**
+ * Returns whether a feature status represents active work.
+ * Demonstrates: using FeatureStatus from @protolabsai/types.
+ */
+export function isActiveStatus(status: FeatureStatus): boolean {
+  return status === 'in_progress';
+}
+
+/**
+ * Groups features by their canonical status, skipping features with no status set.
+ * Demonstrates: composing types from @protolabsai/types in application logic.
+ */
+export function groupByStatus(features: Feature[]): Map<FeatureStatus, Feature[]> {
+  const groups = new Map<FeatureStatus, Feature[]>();
+  for (const feature of features) {
+    const status = feature.status as FeatureStatus | undefined;
+    if (status === undefined) continue;
+    const existing = groups.get(status) ?? [];
+    existing.push(feature);
+    groups.set(status, existing);
+  }
+  return groups;
+}

--- a/.automaker/skills/worktree/worktree-commit.ts
+++ b/.automaker/skills/worktree/worktree-commit.ts
@@ -1,0 +1,54 @@
+/**
+ * Typed examples of safe worktree commit patterns.
+ * See committing.md for the full skill documentation.
+ */
+import { execSync, ExecSyncOptions } from 'child_process';
+
+interface CommitOptions {
+  worktreePath: string;
+  /** Specific files to stage — never pass [] to avoid unintended no-op */
+  files: [string, ...string[]];
+  message: string;
+}
+
+const execOpts = (cwd: string): ExecSyncOptions => ({ cwd, stdio: 'inherit' });
+
+/**
+ * Format, stage specific files, and commit in a worktree.
+ *
+ * Rules enforced:
+ *  - Never `git add -A` / `git add .` (captures .automaker/ runtime state)
+ *  - Run prettier before staging (CI runs format:check on every PR)
+ */
+export function commitInWorktree(options: CommitOptions): void {
+  const { worktreePath, files, message } = options;
+
+  // Format before staging — CI will fail format:check if skipped
+  execSync(
+    `node "${worktreePath}/node_modules/.bin/prettier" --write --ignore-path /dev/null ${files.join(' ')}`,
+    execOpts(worktreePath),
+  );
+
+  // Stage specific files only
+  execSync(`git -C "${worktreePath}" add ${files.join(' ')}`, execOpts(worktreePath));
+  execSync(`git -C "${worktreePath}" commit -m "${message}"`, execOpts(worktreePath));
+}
+
+/**
+ * Persist-first status update pattern.
+ * Never mutate in-memory state before the disk write succeeds.
+ */
+export async function updateStatusSafe<T extends { status: string }>(
+  entity: T,
+  newStatus: string,
+  persist: (status: string) => Promise<void>,
+): Promise<void> {
+  const prevStatus = entity.status;
+  try {
+    await persist(newStatus);
+    entity.status = newStatus;
+  } catch (err) {
+    entity.status = prevStatus;
+    throw err;
+  }
+}

--- a/apps/server/tsconfig.build.json
+++ b/apps/server/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "../../",
     "paths": {
       "@protolabsai/crdt": ["../../libs/crdt/dist/index.d.ts"],
       "@protolabsai/dependency-resolver": ["../../libs/dependency-resolver/dist/index.d.ts"],

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
     "outDir": "./dist",
-    "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -29,6 +28,6 @@
       "@protolabsai/utils": ["../../libs/utils/src/index.ts"]
     }
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "../../.automaker/skills/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

**Milestone:** Typechecked Examples and Routing

Add .automaker/skills assets to tsconfig include. Create worktree-commit.ts and import-convention.ts examples that compile clean.

**Files to Modify:**
- tsconfig.json

**Acceptance Criteria:**
- [ ] tsconfig includes skill assets
- [ ] Both ts files compile
- [ ] npm run typecheck passes

**Complexity:** medium

**Guardrails:** If this phase involves new or changed behavior, include tests that verify correctness. If this phase adds, removes, or c...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated TypeScript build configuration for improved monorepo integration.
  * Added internal utilities for development workflows and best practices.

**Note:** This release contains internal infrastructure and tooling improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->