### PR TITLE
fix: auto-mode concurrency slots locked by orphaned in_progress features

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -4052,13 +4052,15 @@ You can use the Read tool to view these images at any time during implementation
                 `Found interrupted feature: ${feature.id} (${feature.title}) - status: ${feature.status}`
               );
             } catch {
-              // No context file — still include interrupted features (they get started fresh)
-              if (feature.status === 'interrupted') {
-                interruptedFeatures.push(feature);
-                logger.info(`Interrupted feature ${feature.id} has no context, will restart fresh`);
-              } else {
-                logger.info(`Interrupted feature ${feature.id} has no context, will restart fresh`);
-              }
+              // No context file — include all interrupted/in_progress features so they
+              // are either resumed (if context materialises later) or restarted fresh.
+              // Previously, in_progress features without agent-output.md were silently
+              // skipped, leaving them stuck as in_progress forever and blocking the
+              // auto-loop capacity check (hasInProgressFeatures).
+              interruptedFeatures.push(feature);
+              logger.info(
+                `Feature ${feature.id} (${feature.status}) has no context file, will restart fresh`
+              );
             }
           }
         }

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -1200,6 +1200,20 @@ export class ExecutionService {
           });
         }
       } else if (errorInfo.isAbort) {
+        // Release the in_progress status so the slot is freed and the auto loop can
+        // proceed.  When the agent is stopped by the user (or by an AbortError from
+        // an unexpected process exit), leaving the feature as in_progress would cause
+        // the scheduler to wait indefinitely for a status transition that never comes.
+        // Reset to 'backlog' so it can be retried; if it was never started (no work
+        // was committed) this is the safest fallback.
+        try {
+          await this.callbacks.updateFeatureStatus(projectPath, featureId, 'backlog');
+        } catch (statusError) {
+          logger.warn(
+            `[Abort] Failed to reset feature ${featureId} to backlog after abort:`,
+            statusError
+          );
+        }
         this.typedEventBus.emitAutoModeEvent('auto_mode_feature_complete', {
           featureId,
           featureName: feature?.title,


### PR DESCRIPTION
## Summary

When an agent process exits (turn limit, clean completion without PR, mid-run failure), the feature remains in in_progress status and the concurrency slot is not released. Auto-mode treats those features as actively running and won't start new agents.

**Impact**: Configured concurrency (e.g. 4) silently degrades to 0-1 effective agents. The board looks healthy (features in in_progress, auto-mode running: true) while the pipeline is stalled.

**Current recovery**: Health sweep detects the mismat...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted and in-progress operations to ensure proper resumption and retry capability
  * Enhanced scheduler reliability by ensuring aborted operations properly release resources for subsequent retry attempts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->