### PR TITLE
Add platform helpers for research paths

### DIFF
--- a/libs/platform/src/index.ts
+++ b/libs/platform/src/index.ts
@@ -63,6 +63,8 @@ export {
   getProjectJsonPath,
   getProjectDocsPath,
   getResearchFilePath,
+  getResearchMdPath,
+  getResearchArtifactDir,
   getPrdFilePath,
   getMilestonesDir,
   getMilestoneDir,

--- a/libs/platform/src/projects.ts
+++ b/libs/platform/src/projects.ts
@@ -152,6 +152,28 @@ export function getResearchFilePath(projectPath: string, projectSlug: string): s
 }
 
 /**
+ * Get the research markdown file path
+ *
+ * @param projectPath - Absolute path to project directory
+ * @param slug - Project slug
+ * @returns Absolute path to {projectPath}/.automaker/projects/{slug}/research.md
+ */
+export function getResearchMdPath(projectPath: string, slug: string): string {
+  return path.join(getProjectDir(projectPath, slug), 'research.md');
+}
+
+/**
+ * Get the research report artifact directory path
+ *
+ * @param projectPath - Absolute path to project directory
+ * @param slug - Project slug
+ * @returns Absolute path to {projectPath}/.automaker/projects/{slug}/artifacts/research-report/
+ */
+export function getResearchArtifactDir(projectPath: string, slug: string): string {
+  return path.join(getProjectDir(projectPath, slug), 'artifacts', 'research-report');
+}
+
+/**
  * Get the SPARC PRD file path
  *
  * @param projectPath - Absolute path to project directory


### PR DESCRIPTION
## Summary

**Milestone:** Foundation

Add getResearchMdPath(projectPath, slug) and getResearchArtifactDir(projectPath, slug) helper functions to libs/platform/src/projects.ts. These return the paths for research.md and the research-report artifact directory respectively.

**Files to Modify:**
- libs/platform/src/projects.ts

**Acceptance Criteria:**
- [ ] getResearchMdPath() returns correct path to .automaker/projects/{slug}/research.md
- [ ] getResearchArtifactDir() returns correct path to .automaker/proj...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=aaccab48-6c90-478b-8aa2-5df343794454 team= created=2026-03-13T06:00:39.901Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added utility functions to the platform library for constructing and accessing research-related project paths and artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->