### PR TITLE
Phase execution status sync from feature events

### DIFF
--- a/apps/server/src/services/project-service.ts
+++ b/apps/server/src/services/project-service.ts
@@ -63,10 +63,111 @@ export class ProjectService {
     events?: EventEmitter
   ) {
     this._crdtEvents = events ?? null;
+
+    // Listen for feature status changes and mirror them onto the linked phase
+    if (events) {
+      events.on('feature:status-changed', (payload) => {
+        const { featureId, newStatus, projectPath } = payload;
+        if (!projectPath || !newStatus) return;
+        this._syncPhaseFromFeatureStatus(projectPath, featureId, newStatus).catch((err) =>
+          logger.warn(`Failed to sync phase execution status for feature ${featureId}:`, err)
+        );
+      });
+    }
   }
 
   setCalendarService(calendarService: CalendarService): void {
     this.calendarService = calendarService;
+  }
+
+  // ─── Feature status → phase execution status sync ──────────────────────────
+
+  /**
+   * Map a feature status to a phase executionStatus value.
+   * Returns null when the feature status has no ceremony-automation mapping.
+   */
+  private _mapFeatureStatusToPhaseExecution(
+    featureStatus: string
+  ): import('@protolabsai/types').Phase['executionStatus'] | null {
+    switch (featureStatus) {
+      case 'backlog':
+        return 'pending';
+      case 'in_progress':
+        return 'in-progress';
+      case 'review':
+        return 'in-review';
+      case 'done':
+        return 'completed';
+      case 'blocked':
+        return 'blocked';
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Find the project phase linked to the given featureId and update its
+   * executionStatus to mirror the feature's new status. Writes project.json
+   * to disk and emits project:updated via CRDT sync.
+   *
+   * No-op when no phase has a matching featureId.
+   */
+  private async _syncPhaseFromFeatureStatus(
+    projectPath: string,
+    featureId: string,
+    featureStatus: string
+  ): Promise<void> {
+    const executionStatus = this._mapFeatureStatusToPhaseExecution(featureStatus);
+    if (!executionStatus) return;
+
+    const slugs = await this._listSlugsFromDisk(projectPath);
+
+    for (const slug of slugs) {
+      const project = await this.getProject(projectPath, slug);
+      if (!project) continue;
+
+      let found = false;
+      for (const milestone of project.milestones) {
+        for (const phase of milestone.phases) {
+          if (phase.featureId === featureId) {
+            phase.executionStatus = executionStatus;
+            found = true;
+            break;
+          }
+        }
+        if (found) break;
+      }
+
+      if (!found) continue;
+
+      project.updatedAt = new Date().toISOString();
+
+      // Write project.json to disk
+      const jsonPath = getProjectJsonPath(projectPath, slug);
+      await secureFs.writeFile(jsonPath, JSON.stringify(project, null, 2));
+
+      // Update CRDT doc and emit project:updated so peer instances see the update
+      if (this._isCrdtEnabled(projectPath)) {
+        const doc = await this._ensureDoc(projectPath);
+        const newDoc = Automerge.change(doc, (d) => {
+          (d.projects as Record<string, unknown>)[slug] = this._toAutomergeValue(project);
+        });
+        this._docs.set(projectPath, newDoc);
+        this._crdtEvents?.broadcast('project:updated', {
+          projectSlug: slug,
+          projectPath,
+          project,
+        });
+      }
+
+      logger.debug(
+        `Synced phase executionStatus for feature ${featureId}: ${featureStatus} → ${executionStatus} (project: ${slug})`
+      );
+      return; // phase found and updated — stop searching
+    }
+
+    // No phase linked to this featureId — no-op
+    logger.debug(`No phase linked to feature ${featureId} in ${projectPath}, skipping sync`);
   }
 
   // ─── CRDT helpers ──────────────────────────────────────────────────────────

--- a/libs/types/src/project.ts
+++ b/libs/types/src/project.ts
@@ -127,8 +127,18 @@ export interface Phase {
   /** ISO timestamp when the phase was claimed */
   claimedAt?: string;
 
-  /** Execution status for mesh coordination */
-  executionStatus?: 'unclaimed' | 'claimed' | 'in_progress' | 'done' | 'failed';
+  /** Execution status for mesh coordination and ceremony automation */
+  executionStatus?:
+    | 'unclaimed'
+    | 'claimed'
+    | 'in_progress'
+    | 'done'
+    | 'failed'
+    | 'pending'
+    | 'in-progress'
+    | 'in-review'
+    | 'completed'
+    | 'blocked';
 
   /** PR URL created by the executing instance */
   prUrl?: string;


### PR DESCRIPTION
## Summary

**Milestone:** Ceremony Automation

Add a feature:status-changed event listener in ProjectService that finds the project and phase linked to the changed feature (via phase.featureId) and updates phase.executionStatus to mirror the feature status: backlog→pending, in_progress→in-progress, review→in-review, done→completed, blocked→blocked. Write the updated project.json to disk and emit project:updated via CRDT sync.

**Files to Modify:**
- apps/server/src/services/project-service.ts

**Acceptance...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature status changes now automatically synchronize with linked phases.
  * Phase execution statuses expanded to include: pending, in-progress, in-review, completed, and blocked alongside existing statuses.
  * Enhanced real-time synchronization for collaborative project updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->