### PR TITLE
feat: pm agent reads research.md before PRD generation

### DIFF
--- a/apps/server/src/services/authority-agents/pm-agent.ts
+++ b/apps/server/src/services/authority-agents/pm-agent.ts
@@ -32,6 +32,7 @@ import type { AuditService } from '../audit-service.js';
 import type { SettingsService } from '../settings-service.js';
 import type { HITLFormService } from '../hitl-form-service.js';
 import { simpleQuery, streamingQuery } from '../../providers/simple-query-service.js';
+import { getResearchFilePath, secureFs } from '@protolabsai/platform';
 import {
   createAgentState,
   initializeAgent,
@@ -881,6 +882,18 @@ Explore the project structure and relevant code, then provide a structured resea
       logger.debug('No context files loaded for PRD generation');
     }
 
+    // Load pre-existing research.md if available for this project
+    let researchFindings = '';
+    if (feature.projectSlug) {
+      try {
+        const researchPath = getResearchFilePath(projectPath, feature.projectSlug);
+        researchFindings = (await secureFs.readFile(researchPath, 'utf-8')) as string;
+        logger.debug(`Loaded research.md for project "${feature.projectSlug}"`);
+      } catch {
+        // research.md doesn't exist — proceed without it
+      }
+    }
+
     const systemPrompt = `You are a senior Product Manager creating a SPARC PRD (Product Requirements Document).
 ${contextRules ? `\n## Project-Specific Rules\n${contextRules}\n` : ''}
 SPARC Framework:
@@ -920,7 +933,7 @@ ${description}${attachmentContext}
 
 **Codebase Research Findings:**
 ${researchSummary}
-
+${researchFindings ? `\n**Research Findings:**\n${researchFindings}\n` : ''}
 Generate a comprehensive SPARC PRD as JSON.`;
 
     try {


### PR DESCRIPTION
## Summary

- PM Agent now checks for `research.md` at `getResearchFilePath(projectPath, feature.projectSlug)` before generating the SPARC PRD
- If the file exists, its content is included in the PRD generation prompt under a **Research Findings** section
- If the file does not exist or `feature.projectSlug` is not set, behavior is unchanged — graceful fallback with no error

## Files Modified
- `apps/server/src/services/authority-agents/pm-agent.ts`

## Test plan
- [ ] Feature with `projectSlug` and existing `research.md` → PRD prompt includes Research Findings section
- [ ] Feature with `projectSlug` but no `research.md` → PRD generation proceeds as before, no error
- [ ] Feature without `projectSlug` → PRD generation proceeds as before, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)