### PR TITLE
feat: ResearchTab 4-state UI with trigger hook

### DIFF
--- a/apps/ui/src/components/views/projects-view/hooks/use-project.ts
+++ b/apps/ui/src/components/views/projects-view/hooks/use-project.ts
@@ -98,6 +98,26 @@ export function useLaunchProject(projectSlug: string) {
   });
 }
 
+export function useResearchTrigger(projectSlug: string) {
+  const projectPath = useAppStore((s) => s.currentProject?.path) ?? '';
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const api = getHttpApiClient();
+      return api.lifecycle.triggerResearch(projectPath, projectSlug);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['project-detail', projectPath, projectSlug] });
+    },
+  });
+
+  return {
+    trigger: mutation.mutate,
+    isPending: mutation.isPending,
+  };
+}
+
 export function useCreateProject() {
   const projectPath = useAppStore((s) => s.currentProject?.path) ?? '';
   const queryClient = useQueryClient();

--- a/apps/ui/src/components/views/projects-view/tabs/research-tab.tsx
+++ b/apps/ui/src/components/views/projects-view/tabs/research-tab.tsx
@@ -1,20 +1,72 @@
+import { FlaskConical, RefreshCw } from 'lucide-react';
 import Markdown from 'react-markdown';
+import { Button, Spinner } from '@protolabsai/ui/atoms';
+import { toast } from 'sonner';
 import type { Project } from '@protolabsai/types';
+import { useResearchTrigger } from '../hooks/use-project';
+
+type ResearchStatus = 'idle' | 'running' | 'complete' | 'failed';
+
+type ProjectWithResearch = Project & {
+  researchStatus?: ResearchStatus;
+};
 
 export function ResearchTab({ project }: { project: Project }) {
-  if (!project.researchSummary) {
+  const p = project as ProjectWithResearch;
+  const researchStatus: ResearchStatus =
+    p.researchStatus ?? (p.researchSummary ? 'complete' : 'idle');
+
+  const { trigger, isPending } = useResearchTrigger(project.slug);
+
+  const handleTrigger = () => {
+    trigger(undefined, {
+      onError: () => {
+        toast.error('Failed to start research. Please try again.');
+      },
+    });
+  };
+
+  if (researchStatus === 'running' || isPending) {
     return (
-      <div className="text-center py-12">
-        <p className="text-sm text-muted-foreground">No research summary available yet.</p>
+      <div className="flex flex-col items-center justify-center py-16 gap-3">
+        <Spinner size="lg" />
+        <p className="text-sm text-muted-foreground">Research in progress…</p>
       </div>
     );
   }
 
-  return (
-    <div className="py-4">
-      <div className="prose prose-sm prose-invert max-w-none prose-p:text-foreground/90 prose-headings:text-foreground prose-li:text-foreground/90 prose-strong:text-foreground">
-        <Markdown>{project.researchSummary}</Markdown>
+  if (researchStatus === 'failed') {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 gap-4">
+        <FlaskConical className="w-10 h-10 text-destructive/40" />
+        <p className="text-sm text-destructive">Research failed. Please try again.</p>
+        <Button variant="outline" size="sm" onClick={handleTrigger} loading={isPending}>
+          <RefreshCw className="w-4 h-4" />
+          Retry Research
+        </Button>
       </div>
+    );
+  }
+
+  if (researchStatus === 'complete' && p.researchSummary) {
+    return (
+      <div className="py-4">
+        <div className="prose prose-sm prose-invert max-w-none prose-p:text-foreground/90 prose-headings:text-foreground prose-li:text-foreground/90 prose-strong:text-foreground">
+          <Markdown>{p.researchSummary}</Markdown>
+        </div>
+      </div>
+    );
+  }
+
+  // idle state (or complete with no summary yet)
+  return (
+    <div className="flex flex-col items-center justify-center py-16 gap-4">
+      <FlaskConical className="w-10 h-10 text-muted-foreground/40" />
+      <p className="text-sm text-muted-foreground">No research available yet.</p>
+      <Button variant="outline" size="sm" onClick={handleTrigger} loading={isPending}>
+        <FlaskConical className="w-4 h-4" />
+        Run Research
+      </Button>
     </div>
   );
 }

--- a/apps/ui/src/lib/clients/system-client.ts
+++ b/apps/ui/src/lib/clients/system-client.ts
@@ -420,6 +420,12 @@ export const withSystemClient = <TBase extends Constructor<BaseHttpClient>>(Base
       }> =>
         this.post('/api/projects/lifecycle/launch', { projectPath, projectSlug, maxConcurrency }),
 
+      triggerResearch: (
+        projectPath: string,
+        projectSlug: string
+      ): Promise<{ success: boolean; started?: boolean; error?: string }> =>
+        this.post('/api/projects/lifecycle/research', { projectPath, projectSlug }),
+
       // --- Shared tool routes (mounted via Express adapter) ---
 
       addLink: (projectPath: string, projectSlug: string, label: string, url: string) =>


### PR DESCRIPTION
## Summary

- **ResearchTab** now renders all four `researchStatus` states: `idle`, `running`, `complete`, `failed`
- **Idle**: empty state with "Run Research" button — triggers `POST /api/projects/lifecycle/research`
- **Running**: centered spinner + "Research in progress…" message
- **Complete**: Markdown-rendered `project.researchSummary`
- **Failed**: error message + "Retry Research" button
- Added `useResearchTrigger(projectSlug)` hook to `use-project.ts` — calls the research route and invalidates the project query on success
- Added `lifecycle.triggerResearch()` to `system-client.ts` — thin POST wrapper for `/api/projects/lifecycle/research`
- Backwards-compat: falls back to `complete` when `researchSummary` exists but no `researchStatus` field (handles existing data)

## Test plan

- [ ] Open a project → Research tab shows idle state with "Run Research" button
- [ ] Click "Run Research" → spinner + "Research in progress…" appears
- [ ] When `researchStatus === 'complete'` and `researchSummary` is populated → markdown renders
- [ ] When `researchStatus === 'failed'` → error + Retry button shown
- [ ] Existing projects with only `researchSummary` (no `researchStatus`) → falls back to complete/markdown view

## Notes

`project-detail.tsx` currently gates the Research tab on `project.researchSummary` existing — once `researchStatus` field lands from the foundation phase (milestone 01/phase 01), that gate should be updated to `project.researchStatus !== undefined` so the idle state is reachable from the UI.

<!-- automaker:owner instance=local team=protoLabsAI created=2026-03-13T00:04:00.000Z -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to trigger research on projects with a Run Research button
  * Implemented real-time visual feedback showing research progress with a spinner
  * Added automatic retry functionality for failed research attempts with error notifications
  * Research results now display properly upon completion with appropriate status indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->