### PR TITLE
feat: paper trail UI — ceremony labels, artifact links, decision/escalation filters

### DIFF
--- a/apps/server/src/routes/projects/routes/timeline.ts
+++ b/apps/server/src/routes/projects/routes/timeline.ts
@@ -24,6 +24,10 @@ interface TimelineEvent {
   description?: string;
   occurredAt: string;
   author?: string;
+  /** URL to an associated artifact (e.g. ceremony report markdown) */
+  artifactUrl?: string;
+  /** Human-readable ceremony type label, e.g. "Standup", "Milestone Retro" */
+  ceremonyLabel?: string;
   metadata?: Record<string, unknown>;
 }
 
@@ -222,6 +226,19 @@ function toTimelineEvent(entry: EventLedgerEntry): TimelineEvent {
     case 'ceremony:fired': {
       const ceremonyType =
         (payload.ceremonyType as string) ?? (payload.type as string) ?? 'ceremony';
+
+      // Human-readable labels for known ceremony types
+      const CEREMONY_LABELS: Record<string, string> = {
+        standup: 'Standup',
+        milestone_retro: 'Milestone Retro',
+        project_retro: 'Project Retro',
+        epic_delivery: 'Epic Delivery',
+        epic_kickoff: 'Epic Kickoff',
+        content_brief: 'Content Brief',
+        post_project_docs: 'Post-Project Docs',
+      };
+      const ceremonyLabel = CEREMONY_LABELS[ceremonyType] ?? ceremonyType;
+
       // Map to more specific types for filtering
       let type: string = 'ceremony:fired';
       if (ceremonyType === 'standup') type = 'standup';
@@ -232,15 +249,24 @@ function toTimelineEvent(entry: EventLedgerEntry): TimelineEvent {
       )
         type = 'retro';
 
+      // Extract artifact URL from payload if present (ceremony report)
+      const artifactUrl =
+        (payload.artifactUrl as string | undefined) ??
+        (payload.reportUrl as string | undefined) ??
+        (payload.reportPath as string | undefined) ??
+        undefined;
+
       return {
         id: entry.id,
         type,
-        title: `Ceremony: ${ceremonyType}`,
+        title: `Ceremony: ${ceremonyLabel}`,
+        ceremonyLabel,
         description: entry.correlationIds.milestoneSlug
           ? `Milestone: ${entry.correlationIds.milestoneSlug}`
           : undefined,
         occurredAt: entry.timestamp,
         author: entry.source,
+        ...(artifactUrl !== undefined ? { artifactUrl } : {}),
       };
     }
 

--- a/apps/ui/src/components/views/projects/project-timeline.tsx
+++ b/apps/ui/src/components/views/projects/project-timeline.tsx
@@ -22,6 +22,7 @@ import {
   ChevronUp,
   UserCircle,
   Clock,
+  ExternalLink,
 } from 'lucide-react';
 import {
   getServerUrlSync,
@@ -129,11 +130,26 @@ function TimelineCard({ event, isLast }: { event: TimelineEvent; isLast: boolean
           <span
             className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${config.badgeClass}`}
           >
-            {config.label}
+            {/* Show ceremony type label in badge when available (e.g. "Standup", "Milestone Retro") */}
+            {event.ceremonyLabel ?? config.label}
           </span>
           <span className="text-sm font-medium text-foreground flex-1 min-w-0 mt-0.5">
             {event.title}
           </span>
+          {/* Artifact link for ceremony events */}
+          {event.artifactUrl && (
+            <a
+              href={event.artifactUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-[11px] text-primary hover:underline mt-0.5 flex-shrink-0"
+              aria-label="Open ceremony report"
+              data-testid="timeline-artifact-link"
+            >
+              <ExternalLink className="w-3 h-3" />
+              Report
+            </a>
+          )}
         </div>
 
         {/* Meta row: author + timestamp */}

--- a/apps/ui/src/components/views/projects/timeline-utils.ts
+++ b/apps/ui/src/components/views/projects/timeline-utils.ts
@@ -41,6 +41,10 @@ export interface TimelineEvent {
   occurredAt: string;
   /** Who authored / triggered this entry */
   author?: string;
+  /** URL to an associated artifact (e.g. ceremony report markdown) */
+  artifactUrl?: string;
+  /** Human-readable ceremony type label, e.g. "Standup", "Milestone Retro" */
+  ceremonyLabel?: string;
   metadata?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
## Summary

- **Ceremony type labels on timeline cards**: `ceremony:fired` events now show human-readable labels in the badge (e.g. \"Standup\", \"Milestone Retro\", \"Project Retro\") instead of the raw `config.label` generic string
- **Artifact links**: When a ceremony event's payload includes an artifact URL (`artifactUrl`, `reportUrl`, or `reportPath`), a \"Report\" link renders in the card header with an external link icon
- **Decision & Escalation filter categories**: Already present in `FILTER_CATEGORIES` — confirmed working, no change needed
- **Icon/color configs**: Already correct for `decision` and `escalation` types — no change needed

## Files Changed

- `apps/server/src/routes/projects/routes/timeline.ts` — `ceremony:fired` handler: human-readable label map, artifact URL extraction, `ceremonyLabel` field in response
- `apps/ui/src/components/views/projects/project-timeline.tsx` — `TimelineCard`: shows `ceremonyLabel` in badge, renders artifact link when present
- `apps/ui/src/components/views/projects/timeline-utils.ts` — `TimelineEvent` interface: added `artifactUrl?` and `ceremonyLabel?` fields

## Test plan

- [ ] Ceremony timeline cards show \"Standup\" / \"Milestone Retro\" / \"Project Retro\" labels in badge
- [ ] Ceremony cards with a report artifact show a clickable \"Report\" link in the header
- [ ] Ceremony cards without an artifact show no link
- [ ] Filter bar shows Decision and Escalation filter buttons
- [ ] Filtering by Decision / Escalation shows correct events
- [ ] Non-ceremony events unaffected (badge shows normal `config.label`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timeline events now display human-readable ceremony labels (e.g., Standup, Milestone Retro) for improved clarity
  * Ceremony event cards include optional links to associated artifacts and reports
  * External links open in new tabs with accessibility support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->