### PR TITLE
feat: paper trail UI — grouped artifacts, markdown expand, download, filter

### DIFF
--- a/apps/ui/src/components/views/projects/project-artifact-viewer.tsx
+++ b/apps/ui/src/components/views/projects/project-artifact-viewer.tsx
@@ -2,7 +2,10 @@
  * ProjectArtifactViewer
  *
  * Renders ceremony reports and changelogs from a project's artifact list.
- * Uses existing atom/molecule components.
+ * - Grouped by artifact type (Standup, Ceremony Report, Changelog, Escalation, Research Report)
+ * - Expandable cards with Markdown content rendering
+ * - Download as Markdown per artifact
+ * - Type filter dropdown at top, default sort: date descending
  */
 
 import { useState } from 'react';
@@ -10,13 +13,31 @@ import {
   FileText,
   ScrollText,
   AlertTriangle,
-  Mic,
+  Clock,
+  Trophy,
   Search,
   ChevronDown,
   ChevronRight,
+  Download,
 } from 'lucide-react';
-import { Card } from '@protolabsai/ui/atoms';
+import {
+  Card,
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@protolabsai/ui/atoms';
+import { Markdown } from '@protolabsai/ui/molecules';
 import type { ArtifactIndexEntry, ArtifactType } from '@protolabsai/types';
+
+// ─── Extended entry type with optional content ───────────────────────────────
+
+export interface ArtifactEntry extends ArtifactIndexEntry {
+  /** Optional markdown content for expandable view */
+  content?: string;
+}
 
 // ─── Config ───────────────────────────────────────────────────────────────────
 
@@ -24,8 +45,13 @@ const ARTIFACT_CONFIG: Record<
   ArtifactType,
   { icon: React.ComponentType<{ className?: string }>; label: string; color: string }
 > = {
+  standup: {
+    icon: Clock,
+    label: 'Standup',
+    color: 'text-green-500',
+  },
   'ceremony-report': {
-    icon: Mic,
+    icon: Trophy,
     label: 'Ceremony Report',
     color: 'text-purple-500',
   },
@@ -38,11 +64,6 @@ const ARTIFACT_CONFIG: Record<
     icon: AlertTriangle,
     label: 'Escalation',
     color: 'text-amber-500',
-  },
-  standup: {
-    icon: FileText,
-    label: 'Standup',
-    color: 'text-green-500',
   },
   'research-report': {
     icon: Search,
@@ -57,72 +78,178 @@ const DEFAULT_ARTIFACT_CONFIG = {
   color: 'text-muted-foreground',
 };
 
-// ─── Sub-component: Artifact row ───────────────────────────────────────────────
+const TYPE_OPTIONS: Array<{ value: ArtifactType | 'all'; label: string }> = [
+  { value: 'all', label: 'All Types' },
+  { value: 'standup', label: 'Standup' },
+  { value: 'ceremony-report', label: 'Ceremony Report' },
+  { value: 'changelog', label: 'Changelog' },
+  { value: 'escalation', label: 'Escalation' },
+  { value: 'research-report', label: 'Research Report' },
+];
 
-function ArtifactRow({ entry }: { entry: ArtifactIndexEntry }) {
+// ─── Helper: download as markdown ────────────────────────────────────────────
+
+function downloadMarkdown(entry: ArtifactEntry): void {
+  const config = ARTIFACT_CONFIG[entry.type] ?? DEFAULT_ARTIFACT_CONFIG;
+  const date = new Date(entry.timestamp).toLocaleDateString();
+  const mdContent =
+    entry.content ?? `# ${config.label}\n\n**Date:** ${date}\n\n**File:** \`${entry.filename}\`\n`;
+  const blob = new Blob([mdContent], { type: 'text/markdown' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${entry.type}-${entry.id}.md`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ─── Sub-component: Type filter dropdown ─────────────────────────────────────
+
+function TypeFilterDropdown({
+  value,
+  onChange,
+}: {
+  value: ArtifactType | 'all';
+  onChange: (v: ArtifactType | 'all') => void;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-xs text-muted-foreground shrink-0">Filter by:</span>
+      <Select value={value} onValueChange={(v) => onChange(v as ArtifactType | 'all')}>
+        <SelectTrigger className="h-7 text-xs w-44">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {TYPE_OPTIONS.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value} className="text-xs">
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+// ─── Sub-component: Artifact card ─────────────────────────────────────────────
+
+function ArtifactCard({ entry }: { entry: ArtifactEntry }) {
   const [expanded, setExpanded] = useState(false);
   const config = ARTIFACT_CONFIG[entry.type] ?? DEFAULT_ARTIFACT_CONFIG;
   const Icon = config.icon;
   const Chevron = expanded ? ChevronDown : ChevronRight;
+  const date = new Date(entry.timestamp).toLocaleDateString();
+
+  const markdownContent = entry.content ?? `**Date:** ${date}\n\n**File:** \`${entry.filename}\``;
 
   return (
     <Card className="px-3 py-2.5">
-      <button
-        type="button"
-        className="w-full flex items-center gap-2 text-left"
-        onClick={() => setExpanded((v) => !v)}
-        aria-expanded={expanded}
-      >
-        <Icon className={`w-4 h-4 flex-shrink-0 ${config.color}`} />
-        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-          {config.label}
-        </span>
-        <span className="text-[10px] text-muted-foreground ml-auto mr-1">
-          {new Date(entry.timestamp).toLocaleDateString()}
-        </span>
-        <Chevron className="w-3 h-3 text-muted-foreground flex-shrink-0" />
-      </button>
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          className="flex-1 flex items-center gap-2 text-left min-w-0"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+        >
+          <Icon className={`w-4 h-4 flex-shrink-0 ${config.color}`} />
+          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate">
+            {config.label}
+          </span>
+          <span className="text-[10px] text-muted-foreground ml-auto mr-1 shrink-0">{date}</span>
+          <Chevron className="w-3 h-3 text-muted-foreground flex-shrink-0" />
+        </button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Download as Markdown"
+          onClick={() => downloadMarkdown(entry)}
+        >
+          <Download className="w-3 h-3" />
+        </Button>
+      </div>
       {expanded && (
         <div className="mt-2 pt-2 border-t border-border">
-          <p className="text-xs text-muted-foreground font-mono break-all">{entry.filename}</p>
+          <Markdown className="text-xs">{markdownContent}</Markdown>
         </div>
       )}
     </Card>
   );
 }
 
+// ─── Sub-component: Type group ────────────────────────────────────────────────
+
+function ArtifactGroup({ type, entries }: { type: ArtifactType; entries: ArtifactEntry[] }) {
+  const config = ARTIFACT_CONFIG[type] ?? DEFAULT_ARTIFACT_CONFIG;
+  const Icon = config.icon;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1.5 px-1 mb-1">
+        <Icon className={`w-3.5 h-3.5 ${config.color}`} />
+        <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+          {config.label}
+        </span>
+        <span className="text-[10px] text-muted-foreground/60 ml-auto">{entries.length}</span>
+      </div>
+      {entries.map((entry) => (
+        <ArtifactCard key={entry.id} entry={entry} />
+      ))}
+    </div>
+  );
+}
+
 // ─── Main component ────────────────────────────────────────────────────────────
 
 export interface ProjectArtifactViewerProps {
-  /** Full artifact index entry list */
-  artifacts: ArtifactIndexEntry[];
+  /** Full artifact entry list (may include optional content field) */
+  artifacts: ArtifactEntry[];
   /** If provided, only show entries matching these types */
   filterTypes?: ArtifactType[];
 }
 
 export function ProjectArtifactViewer({ artifacts, filterTypes }: ProjectArtifactViewerProps) {
-  const SUPPORTED: ArtifactType[] = filterTypes ?? ['ceremony-report', 'changelog'];
+  const [typeFilter, setTypeFilter] = useState<ArtifactType | 'all'>('all');
 
-  const filtered = artifacts.filter((a) => SUPPORTED.includes(a.type as ArtifactType));
+  const SUPPORTED: ArtifactType[] = filterTypes ?? [
+    'standup',
+    'ceremony-report',
+    'changelog',
+    'escalation',
+    'research-report',
+  ];
+
+  // Apply supported-type gate and user filter, then sort date-descending
+  const filtered = artifacts.filter(
+    (a) =>
+      SUPPORTED.includes(a.type as ArtifactType) && (typeFilter === 'all' || a.type === typeFilter)
+  );
 
   const sorted = [...filtered].sort(
     (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
   );
 
-  if (sorted.length === 0) {
-    return (
-      <div className="py-8 text-center" data-testid="artifact-viewer-empty">
-        <FileText className="w-8 h-8 text-muted-foreground/30 mx-auto mb-2" />
-        <p className="text-sm text-muted-foreground">No artifacts available.</p>
-      </div>
-    );
+  // Group by type (entries within each group remain date-descending)
+  const grouped = new Map<ArtifactType, ArtifactEntry[]>();
+  for (const entry of sorted) {
+    const type = entry.type as ArtifactType;
+    if (!grouped.has(type)) grouped.set(type, []);
+    grouped.get(type)!.push(entry);
   }
 
   return (
-    <div className="space-y-2" data-testid="artifact-viewer">
-      {sorted.map((entry) => (
-        <ArtifactRow key={entry.id} entry={entry} />
-      ))}
+    <div className="space-y-4" data-testid="artifact-viewer">
+      <TypeFilterDropdown value={typeFilter} onChange={setTypeFilter} />
+
+      {sorted.length === 0 ? (
+        <div className="py-8 text-center" data-testid="artifact-viewer-empty">
+          <FileText className="w-8 h-8 text-muted-foreground/30 mx-auto mb-2" />
+          <p className="text-sm text-muted-foreground">No artifacts available.</p>
+        </div>
+      ) : (
+        Array.from(grouped.entries()).map(([type, entries]) => (
+          <ArtifactGroup key={type} type={type} entries={entries} />
+        ))
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Groups artifacts by type (Standup, Ceremony Report, Changelog, Escalation, Research Report) with distinct icons per category
- Replaces the plain filename preview with expandable Markdown content rendering via `@protolabsai/ui/molecules/Markdown`
- Adds a **Download as Markdown** button per artifact card (uses `content` field if available, falls back to structured metadata markdown)
- Adds a **type filter dropdown** at the top to filter to a selected artifact type (default: All)
- Artifacts sorted date-descending (default unchanged); sorting is preserved within each group
- Exports `ArtifactEntry` extended type (adds optional `content?: string` to `ArtifactIndexEntry`) for future content enrichment by parent components

## Test plan
- [ ] Navigate to a project's Artifacts tab and verify artifacts appear grouped by type
- [ ] Expand a card and verify Markdown rendering (not raw filename text)
- [ ] Click Download button and verify `.md` file downloads
- [ ] Use filter dropdown to select a specific type and verify list filters correctly
- [ ] Verify "No artifacts available" empty state renders with filter dropdown visible
- [ ] Verify TypeScript typecheck passes (`npm run typecheck --workspace=apps/ui`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)