### PR TITLE
QA doc generator + launch hook

### DIFF
--- a/apps/server/src/services/project-lifecycle-service.ts
+++ b/apps/server/src/services/project-lifecycle-service.ts
@@ -201,6 +201,13 @@ export class ProjectLifecycleService {
       throw new Error('No features in backlog. Approve the PRD first to create features.');
     }
 
+    // Generate QA checklist doc (best-effort — never fails the launch)
+    try {
+      await this.generateQaDoc(projectPath, projectSlug, project);
+    } catch (err) {
+      logger.warn(`[ProjectLifecycle] Failed to generate QA doc for ${projectSlug}:`, err);
+    }
+
     // Start auto-mode
     let autoModeStarted = false;
     try {
@@ -372,6 +379,60 @@ Search the codebase for relevant patterns and integration points, then research 
         .updateProject(projectPath, projectSlug, { researchStatus: 'failed' })
         .catch(() => {});
     }
+  }
+
+  /**
+   * Generate a QA Checklist document from milestone/phase acceptance criteria.
+   * Idempotent: skips creation if a doc titled 'QA Checklist' already exists.
+   */
+  private async generateQaDoc(
+    projectPath: string,
+    projectSlug: string,
+    project: Project
+  ): Promise<void> {
+    // Idempotency check — skip if already exists
+    const docsFile = await this.projectService.listDocs(projectPath, projectSlug);
+    const alreadyExists = Object.values(docsFile.docs).some((d) => d.title === 'QA Checklist');
+    if (alreadyExists) {
+      logger.info(`[ProjectLifecycle] QA Checklist already exists for ${projectSlug}, skipping`);
+      return;
+    }
+
+    const milestones = project.milestones ?? [];
+
+    // Build markdown checklist from phases that have acceptance criteria
+    let hasAnyCriteria = false;
+    const lines: string[] = ['# QA Checklist\n'];
+
+    for (const milestone of milestones) {
+      const phasesWithCriteria = (milestone.phases ?? []).filter(
+        (p) => p.acceptanceCriteria && p.acceptanceCriteria.length > 0
+      );
+
+      if (phasesWithCriteria.length === 0) continue;
+
+      lines.push(`## Milestone ${milestone.number}: ${milestone.title}\n`);
+
+      for (const phase of phasesWithCriteria) {
+        lines.push(`### Phase ${phase.number}: ${phase.title}\n`);
+
+        for (const criterion of phase.acceptanceCriteria!) {
+          lines.push(`- [ ] ${criterion}`);
+          hasAnyCriteria = true;
+        }
+
+        lines.push('');
+      }
+    }
+
+    if (!hasAnyCriteria) {
+      lines.push('_No acceptance criteria found in milestones._');
+    }
+
+    const content = lines.join('\n');
+
+    await this.projectService.createDoc(projectPath, projectSlug, 'QA Checklist', content);
+    logger.info(`[ProjectLifecycle] Created QA Checklist for ${projectSlug}`);
   }
 
   /**


### PR DESCRIPTION
## Summary

**Milestone:** Implementation

Add a private `generateQaDoc(projectPath, project)` method to `ProjectLifecycleService`. The method reads project.milestones, iterates phases with acceptanceCriteria, and builds a markdown QA checklist string. It then calls `this.projectService.createDoc()` to save it as a document titled 'QA Checklist'. Hook the call into the existing `launch()` method after backlog features are confirmed, wrapped in try/catch so it never fails the launch. Add idempotency check: c...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=transient-780394dd team= created=2026-03-13T16:14:31.163Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic QA Checklist generation now occurs during project launch. Checklists are created from milestone acceptance criteria in Markdown format and generated only once per project. Generation errors do not impact project launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->