### PR TITLE
Render markdown in Resources documents

### DIFF
--- a/apps/ui/src/components/views/projects-view/tabs/resources-tab.tsx
+++ b/apps/ui/src/components/views/projects-view/tabs/resources-tab.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import {
   Plus,
   Trash2,
@@ -8,6 +8,8 @@ import {
   ChevronDown,
   ChevronRight,
   MoreHorizontal,
+  Pencil,
+  Eye,
 } from 'lucide-react';
 import {
   Button,
@@ -27,6 +29,12 @@ import { useAppStore } from '@/store/app-store';
 import { getHttpApiClient } from '@/lib/http-api-client';
 import { toast } from 'sonner';
 import type { Project, ProjectLink } from '@protolabsai/types';
+import { useEditor, EditorContent } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import Link from '@tiptap/extension-link';
+import TaskList from '@tiptap/extension-task-list';
+import TaskItem from '@tiptap/extension-task-item';
+import { marked } from 'marked';
 
 interface DocEntry {
   id: string;
@@ -92,6 +100,47 @@ export function ResourcesTab({ projectSlug, project }: { projectSlug: string; pr
   );
 }
 
+/**
+ * Converts a markdown string to HTML using `marked` and renders it
+ * inside a read-only TipTap editor so that TipTap extensions (TaskList,
+ * Link, etc.) handle interactive elements consistently.
+ */
+function MarkdownViewer({ content }: { content: string }) {
+  const html = marked.parse(content, { async: false }) as string;
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      Link.configure({
+        openOnClick: true,
+        HTMLAttributes: { class: 'text-[var(--status-info)] hover:underline' },
+      }),
+      TaskList,
+      TaskItem.configure({ nested: true }),
+    ],
+    content: html,
+    editable: false,
+    editorProps: {
+      attributes: {
+        class: 'prose prose-sm max-w-none focus:outline-none px-3 py-2',
+      },
+    },
+  });
+
+  // Sync when content changes (doc selection)
+  useEffect(() => {
+    if (editor && html !== editor.getHTML()) {
+      editor.commands.setContent(html, false);
+    }
+  }, [html, editor]);
+
+  return (
+    <div className="w-full h-full overflow-y-auto [&_.is-editor-empty]:hidden">
+      <EditorContent editor={editor} />
+    </div>
+  );
+}
+
 function DocumentsSection({
   projectSlug,
   open,
@@ -105,6 +154,7 @@ function DocumentsSection({
   const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
   const [editContent, setEditContent] = useState('');
   const [editTitle, setEditTitle] = useState('');
+  const [isEditing, setIsEditing] = useState(false);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const docsData = docsQuery.data as
@@ -139,6 +189,7 @@ function DocumentsSection({
     setSelectedDocId(doc.id);
     setEditTitle(doc.title);
     setEditContent(doc.content);
+    setIsEditing(false);
   }, []);
 
   const handleDelete = useCallback(
@@ -262,21 +313,38 @@ function DocumentsSection({
             <Card className="flex-1 overflow-hidden py-0">
               {selectedDoc ? (
                 <>
-                  <div className="px-3 py-2 border-b border-border/20">
+                  <div className="px-3 py-2 border-b border-border/20 flex items-center gap-2">
                     <Input
                       value={editTitle}
                       onChange={(e) => handleTitleChange(e.target.value)}
-                      className="border-none shadow-none bg-transparent font-medium focus-visible:ring-0"
+                      className="border-none shadow-none bg-transparent font-medium focus-visible:ring-0 flex-1"
                       placeholder="Document title..."
                     />
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-6 w-6 p-0 shrink-0"
+                      onClick={() => setIsEditing((v) => !v)}
+                      aria-label={isEditing ? 'Switch to preview' : 'Switch to edit'}
+                    >
+                      {isEditing ? (
+                        <Eye className="w-3.5 h-3.5" />
+                      ) : (
+                        <Pencil className="w-3.5 h-3.5" />
+                      )}
+                    </Button>
                   </div>
-                  <div className="flex-1 overflow-y-auto p-3">
-                    <Textarea
-                      value={editContent}
-                      onChange={(e) => handleContentChange(e.target.value)}
-                      className="w-full h-full border-none shadow-none bg-transparent focus-visible:ring-0"
-                      placeholder="Start writing..."
-                    />
+                  <div className="flex-1 overflow-y-auto">
+                    {isEditing ? (
+                      <Textarea
+                        value={editContent}
+                        onChange={(e) => handleContentChange(e.target.value)}
+                        className="w-full h-full min-h-[240px] border-none shadow-none bg-transparent focus-visible:ring-0 resize-none"
+                        placeholder="Start writing markdown..."
+                      />
+                    ) : (
+                      <MarkdownViewer content={editContent} />
+                    )}
                   </div>
                 </>
               ) : (


### PR DESCRIPTION
## Summary

**Problem:** The Resources tab Documents section uses a plain `<Textarea>` to display document content. Markdown like `- [ ]` checkboxes renders as raw text.

**IMPORTANT: Use TipTap, NOT ReactMarkdown.** This codebase already has a TipTap rich text editor used in the Notes view. Do NOT add `react-markdown` or `remark-gfm` as new dependencies.

**Implementation:**
1. Look at `apps/ui/src/components/views/notes-view/` for the existing TipTap editor setup
2. Reuse the TipTap editor component or it...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documents now fully support Markdown rendering with rich text preview capabilities and formatting support
  * Introduced an intuitive edit/preview toggle feature enabling seamless switching between editing and viewing modes with clear visual indicators
  * Enhanced document editor layout with improved visual organization and workspace usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->