### PR TITLE
Promote dev to staging: TipTap inline editor for Resources docs

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -45,9 +45,9 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@automerge/prosemirror": "^0.2.0",
     "@ai-sdk/anthropic": "^3.0.45",
     "@ai-sdk/react": "^3.0.92",
+    "@automerge/prosemirror": "^0.2.0",
     "@codemirror/lang-css": "^6.3.1",
     "@codemirror/lang-javascript": "^6.2.4",
     "@codemirror/lang-json": "^6.0.2",
@@ -141,6 +141,7 @@
     "rehype-raw": "7.0.0",
     "sonner": "2.0.7",
     "tailwind-merge": "3.4.0",
+    "tiptap-markdown": "^0.9.0",
     "usehooks-ts": "3.1.1",
     "zod": "^4.3.6",
     "zustand": "5.0.9"

--- a/apps/ui/src/components/views/projects-view/tabs/resources-tab.tsx
+++ b/apps/ui/src/components/views/projects-view/tabs/resources-tab.tsx
@@ -15,7 +15,6 @@ import {
   Button,
   Card,
   Input,
-  Textarea,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -34,7 +33,7 @@ import StarterKit from '@tiptap/starter-kit';
 import Link from '@tiptap/extension-link';
 import TaskList from '@tiptap/extension-task-list';
 import TaskItem from '@tiptap/extension-task-item';
-import { marked } from 'marked';
+import { Markdown } from 'tiptap-markdown';
 
 interface DocEntry {
   id: string;
@@ -101,38 +100,58 @@ export function ResourcesTab({ projectSlug, project }: { projectSlug: string; pr
 }
 
 /**
- * Converts a markdown string to HTML using `marked` and renders it
- * inside a read-only TipTap editor so that TipTap extensions (TaskList,
- * Link, etc.) handle interactive elements consistently.
+ * TipTap-based document editor with editable toggle.
+ * Content is stored as markdown — the Markdown extension handles
+ * parsing on load and serialisation on save via `editor.storage.markdown.getMarkdown()`.
  */
-function MarkdownViewer({ content }: { content: string }) {
-  const html = marked.parse(content, { async: false }) as string;
-
+function DocumentEditor({
+  content,
+  editable,
+  onUpdate,
+}: {
+  content: string;
+  editable: boolean;
+  onUpdate: (markdown: string) => void;
+}) {
   const editor = useEditor({
     extensions: [
       StarterKit,
       Link.configure({
-        openOnClick: true,
+        openOnClick: !editable,
         HTMLAttributes: { class: 'text-[var(--status-info)] hover:underline' },
       }),
       TaskList,
       TaskItem.configure({ nested: true }),
+      Markdown,
     ],
-    content: html,
-    editable: false,
+    content,
+    editable,
     editorProps: {
       attributes: {
-        class: 'prose prose-sm max-w-none focus:outline-none px-3 py-2',
+        class: cn(
+          'prose prose-sm max-w-none focus:outline-none px-3 py-2 min-h-[240px]',
+          editable && 'cursor-text'
+        ),
       },
+    },
+    onUpdate: ({ editor: e }) => {
+      onUpdate(e.storage.markdown.getMarkdown());
     },
   });
 
-  // Sync when content changes (doc selection)
+  // Toggle editable when prop changes
   useEffect(() => {
-    if (editor && html !== editor.getHTML()) {
-      editor.commands.setContent(html, false);
+    if (editor) {
+      editor.setEditable(editable);
     }
-  }, [html, editor]);
+  }, [editable, editor]);
+
+  // Sync content when document selection changes (content prop changes externally)
+  useEffect(() => {
+    if (editor && content !== editor.storage.markdown.getMarkdown()) {
+      editor.commands.setContent(content, false);
+    }
+  }, [content, editor]);
 
   return (
     <div className="w-full h-full overflow-y-auto [&_.is-editor-empty]:hidden">
@@ -335,16 +354,11 @@ function DocumentsSection({
                     </Button>
                   </div>
                   <div className="flex-1 overflow-y-auto">
-                    {isEditing ? (
-                      <Textarea
-                        value={editContent}
-                        onChange={(e) => handleContentChange(e.target.value)}
-                        className="w-full h-full min-h-[240px] border-none shadow-none bg-transparent focus-visible:ring-0 resize-none"
-                        placeholder="Start writing markdown..."
-                      />
-                    ) : (
-                      <MarkdownViewer content={editContent} />
-                    )}
+                    <DocumentEditor
+                      content={editContent}
+                      editable={isEditing}
+                      onUpdate={handleContentChange}
+                    />
                   </div>
                 </>
               ) : (

--- a/package-lock.json
+++ b/package-lock.json
@@ -740,6 +740,7 @@
         "rehype-raw": "7.0.0",
         "sonner": "2.0.7",
         "tailwind-merge": "3.4.0",
+        "tiptap-markdown": "^0.9.0",
         "usehooks-ts": "3.1.1",
         "zod": "^4.3.6",
         "zustand": "5.0.9"
@@ -25737,6 +25738,12 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/markdown-it-task-lists": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
+      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==",
+      "license": "ISC"
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -31899,6 +31906,46 @@
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }
+    },
+    "node_modules/tiptap-markdown": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/tiptap-markdown/-/tiptap-markdown-0.9.0.tgz",
+      "integrity": "sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "dependencies": {
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.1.0",
+        "markdown-it-task-lists": "^2.1.1",
+        "prosemirror-markdown": "^1.11.1"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.0.1"
+      }
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/linkify-it": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
+      "license": "MIT"
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/markdown-it": {
+      "version": "13.0.9",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.9.tgz",
+      "integrity": "sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^3",
+        "@types/mdurl": "^1"
+      }
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/mdurl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.5",


### PR DESCRIPTION
## Summary
- Replace Textarea + MarkdownViewer split with single TipTap editor that toggles `editable`
- Add `tiptap-markdown` extension for bidirectional markdown/HTML conversion
- Content stays as markdown — no storage format change

## Test plan
- [ ] Open a project Resources tab, select a document
- [ ] Verify markdown renders formatted in read-only mode (checkboxes, headings, links)
- [ ] Click Pencil icon to enter edit mode — verify inline editing works in TipTap
- [ ] Edit content, wait 1s — verify auto-save fires
- [ ] Click Eye icon to return to read-only — verify content preserved
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document resources now include an editable Markdown editor with toggle functionality between read-only and edit modes
  * Replaced HTML-based rendering with native Markdown support for improved document management and editing capabilities
  * Editor state automatically synchronizes when content or edit mode changes externally

<!-- end of auto-generated comment: release notes by coderabbit.ai -->