### PR TITLE
feat(types): make AgentRole extensible + add agent-manifest types

### DIFF
--- a/libs/types/src/agent-manifest.ts
+++ b/libs/types/src/agent-manifest.ts
@@ -1,0 +1,71 @@
+/**
+ * Agent manifest types for project-defined custom agents
+ *
+ * Allows projects to declare their own agents that extend built-in roles,
+ * override defaults, and define match rules for automatic assignment.
+ */
+
+import type { RoleCapabilities } from './agent-roles.js';
+
+/**
+ * Rules for automatically matching a ProjectAgent to incoming work.
+ */
+export interface AgentMatchRules {
+  /** Feature/issue categories that trigger this agent (e.g., "frontend", "infra") */
+  categories: string[];
+
+  /** Keywords in titles/descriptions that trigger this agent */
+  keywords: string[];
+
+  /** Glob patterns for files this agent specializes in */
+  filePatterns: string[];
+}
+
+/**
+ * A project-defined agent that extends a built-in role with custom configuration.
+ */
+export interface ProjectAgent {
+  /** Unique name for this agent within the project (e.g., "react-specialist") */
+  name: string;
+
+  /** Built-in role this agent extends (e.g., "frontend-engineer") */
+  extends: string;
+
+  /** Human-readable description of this agent's purpose */
+  description: string;
+
+  /** Model override for this agent (falls back to role default if omitted) */
+  model?: string;
+
+  /** Path to a custom prompt file for this agent (relative to project root) */
+  promptFile?: string;
+
+  /** Partial capabilities override — merged on top of the base role's capabilities */
+  capabilities?: Partial<Omit<RoleCapabilities, 'role'>>;
+
+  /** Rules for automatically matching this agent to work items */
+  match?: AgentMatchRules;
+}
+
+/**
+ * Project-level agent manifest (typically stored as .automaker/agents.yaml or similar).
+ */
+export interface AgentManifest {
+  /** Schema version for forward-compatibility */
+  version: string;
+
+  /** Project-defined agents */
+  agents: ProjectAgent[];
+}
+
+/**
+ * Sensible defaults for a new ProjectAgent entry.
+ */
+export const DEFAULT_PROJECT_AGENT: Omit<ProjectAgent, 'name' | 'extends'> = {
+  description: '',
+  match: {
+    categories: [],
+    keywords: [],
+    filePatterns: [],
+  },
+};

--- a/libs/types/src/agent-roles.ts
+++ b/libs/types/src/agent-roles.ts
@@ -5,9 +5,12 @@
  */
 
 /**
- * Agent role types
+ * Agent role type
  *
- * Each role has specific responsibilities in the development lifecycle:
+ * Extensible string type — allows both built-in roles and arbitrary project-defined roles.
+ * Use BUILT_IN_AGENT_ROLES for the canonical set of platform roles.
+ *
+ * Built-in roles and their responsibilities:
  * - product-manager: PRD creation, project orchestration, user communication
  * - engineering-manager: Feature breakdown, assignment, PR management, releases
  * - frontend-engineer: React, UI/UX implementation
@@ -15,16 +18,24 @@
  * - devops-engineer: CI/CD, infrastructure, deployment
  * - qa-engineer: Testing, PR review, quality assurance
  * - docs-engineer: Documentation, changelog generation
+ * - gtm-specialist: Content strategy, marketing, competitive research
  */
-export type AgentRole =
-  | 'product-manager'
-  | 'engineering-manager'
-  | 'frontend-engineer'
-  | 'backend-engineer'
-  | 'devops-engineer'
-  | 'qa-engineer'
-  | 'docs-engineer'
-  | 'gtm-specialist';
+export type AgentRole = string;
+
+/**
+ * The 8 built-in platform agent roles.
+ * Kept as a const array so callers can validate or enumerate the known roles.
+ */
+export const BUILT_IN_AGENT_ROLES = [
+  'product-manager',
+  'engineering-manager',
+  'frontend-engineer',
+  'backend-engineer',
+  'devops-engineer',
+  'qa-engineer',
+  'docs-engineer',
+  'gtm-specialist',
+] as const;
 
 /**
  * Agent task types
@@ -222,7 +233,7 @@ export interface RoleCapabilities {
 /**
  * Default role capabilities
  */
-export const ROLE_CAPABILITIES: Record<AgentRole, RoleCapabilities> = {
+export const ROLE_CAPABILITIES: Record<string, RoleCapabilities> = {
   'product-manager': {
     role: 'product-manager',
     tools: ['Read', 'Grep', 'Glob', 'WebSearch', 'WebFetch', 'Task'],

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -651,7 +651,11 @@ export type {
   WorkItem,
   RoleCapabilities,
 } from './agent-roles.js';
-export { ROLE_CAPABILITIES } from './agent-roles.js';
+export { BUILT_IN_AGENT_ROLES, ROLE_CAPABILITIES } from './agent-roles.js';
+
+// Agent manifest types (project-defined custom agents)
+export type { AgentMatchRules, ProjectAgent, AgentManifest } from './agent-manifest.js';
+export { DEFAULT_PROJECT_AGENT } from './agent-manifest.js';
 
 // Headsdown configuration types
 export type { HeadsdownLoopConfig, HeadsdownConfig, HeadsdownState } from './headsdown.js';


### PR DESCRIPTION
## Summary

- **AgentRole is now `string`** with `BUILT_IN_AGENT_ROLES` const array holding the 8 existing roles — allows arbitrary project-defined roles without type changes
- **ROLE_CAPABILITIES** updated to `Record<string, RoleCapabilities>` to match
- **New `agent-manifest.ts`** adds `AgentMatchRules`, `ProjectAgent`, `AgentManifest` interfaces and `DEFAULT_PROJECT_AGENT` constant
- All types exported from `@protolabsai/types` barrel

## Test plan
- [x] `npm run build:packages` — all 18 packages built cleanly
- [x] `npm run test:packages` — 57 test files, 1136 tests, 0 failures
- [x] Existing role lookups unchanged (BUILT_IN_AGENT_ROLES preserves all 8 roles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automaker:owner instance=local team=protoLabsAI created=$(date -u +%Y-%m-%dT%H:%M:%S.000Z) -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for custom agent definitions, allowing teams to configure project-specific agents with match rules and capability overrides.
  * Extended the agent system to support custom roles alongside built-in agent types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->