### PR TITLE
feat(types): add AgentConfig to WorkflowSettings for per-role model overrides

### DIFF
--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -5,6 +5,7 @@
  * retro feedback, cleanup, signal intake, bug tracking, and PRD trust boundaries.
  */
 
+import type { PhaseModelEntry } from './agent-settings.js';
 import type { PipelineGateConfig } from './pipeline-phase.js';
 import type { RiskLevel } from './policy.js';
 
@@ -123,6 +124,39 @@ export const DEFAULT_PHASE_TEMPERATURES: PhaseTemperaturesConfig = {
   EXECUTE: 0,
   REVIEW: 0.5,
 };
+
+// ============================================================================
+// Agent Configuration - Per-role model overrides and assignment behavior
+// ============================================================================
+
+/**
+ * AgentConfig — Per-project agent assignment and model override configuration.
+ *
+ * Stored in the project's .automaker/settings.json under `agentConfig`.
+ * All fields are optional; defaults apply when absent.
+ */
+export interface AgentConfig {
+  /**
+   * Per-role model overrides. Maps role name (string) to a PhaseModelEntry
+   * describing which model to use for that role's executions.
+   * Example: { 'frontend-engineer': { model: 'claude-opus-4-5', provider: 'anthropic' } }
+   */
+  roleModelOverrides?: Record<string, PhaseModelEntry>;
+  /**
+   * Whether automatic agent assignment via match rules is enabled.
+   * When true (default), the system evaluates manifest match rules to assign
+   * agents to features. When false, features are executed by the default agent.
+   * @default true
+   */
+  autoAssignEnabled?: boolean;
+  /**
+   * Additional manifest file paths to search for agent definitions, beyond
+   * the default `.automaker/agents/` directory. Paths are relative to the
+   * project root.
+   * @default []
+   */
+  manifestPaths?: string[];
+}
 
 // ============================================================================
 // Workflow Settings - Pipeline hardening configuration
@@ -306,6 +340,11 @@ export interface WorkflowSettings {
    * @default 'full'
    */
   toolProfile?: 'full' | 'execution';
+  /**
+   * Per-project agent configuration: role model overrides, auto-assignment behavior,
+   * and custom manifest paths. When absent, system defaults apply.
+   */
+  agentConfig?: AgentConfig;
 }
 
 /** Default workflow settings */


### PR DESCRIPTION
## Summary

- Adds `AgentConfig` interface to `libs/types/src/workflow-settings.ts` with three optional fields: `roleModelOverrides`, `autoAssignEnabled`, and `manifestPaths`
- Adds `agentConfig?: AgentConfig` to the `WorkflowSettings` interface (optional, absent = use defaults)
- Imports `PhaseModelEntry` from `agent-settings.ts` to type `roleModelOverrides`
- `DEFAULT_WORKFLOW_SETTINGS` is unchanged — `agentConfig` is intentionally omitted

## Test plan

- [x] `npm run build --workspace=libs/types` exits 0 (ESM + DTS both succeed)
- [x] `git diff --stat` shows exactly 1 file changed (39 insertions)
- [x] `agentConfig` is optional on `WorkflowSettings` ✓
- [x] `roleModelOverrides` maps `string` role names to `PhaseModelEntry` ✓
- [x] `autoAssignEnabled` defaults to `true` when `agentConfig` is present (documented in JSDoc) ✓
- [x] No changes to `DEFAULT_WORKFLOW_SETTINGS` beyond new optional field ✓

<!-- automaker:owner instance=local team=protoLabsAI created=2026-03-13T00:00:00.000Z -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-level agent configuration support, enabling customization of agent models by role, control over automatic agent assignment, and support for additional agent definition paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->