### PR TITLE
Update docs after: Project-Level Agent Extensions

### DIFF
--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -9,6 +9,7 @@ usageStats:
   referenced: 123
   successfulFeatures: 123
 ---
+
 <!-- domain: API Design & Integration | GitHub GraphQL, REST endpoints, HTTP client patterns -->
 
 # api
@@ -173,38 +174,44 @@ usageStats:
 - **Why this works:** Gradual adoption: callers like auto-mode-service can pass callbacks when available; other callers (existing, or those without CRDT context) don't pass them. No big-bang refactoring.
 - **Trade-offs:** Optional callbacks: low friction adoption vs caller must know to pass them to get CRDT benefit. Type-safe callback params vs implicit dependency.
 
-
 #### [Gotcha] getResearchMdPath duplicates getResearchFilePath functionality — both return identical path (.automaker/projects/{slug}/research.md). Two functions, one return value. (2026-03-13)
+
 - **Situation:** Added getResearchMdPath as a 'more descriptive name' for research path access, but identical function already exists as getResearchFilePath.
 - **Root cause:** Unclear naming convention or API design — suggests ambiguity about which function callers should use going forward.
 - **How to avoid:** Easier to find via both names (discoverability) but harder to maintain — both must be updated if path convention changes. Creates decision fatigue for API consumers.
 
 #### [Gotcha] Research route must be registered BEFORE the lifecycle sub-router in Express. Registering after the sub-router causes Express to match the sub-router first and the specific route never executes. (2026-03-13)
-- **Situation:** Express matches routes in registration order. Sub-routers like /lifecycle catch all /lifecycle/* requests if registered first.
+
+- **Situation:** Express matches routes in registration order. Sub-routers like /lifecycle catch all /lifecycle/\* requests if registered first.
 - **Root cause:** Express routing is sequential. More specific routes must come before less specific ones (sub-routers). Reverse order means POST /lifecycle/research gets caught by router.use('/lifecycle', ...) handler.
 - **How to avoid:** Easier: clear route priority. Harder: route registration order becomes a hidden dependency.
 
 #### [Pattern] Establish projectSlug as the canonical key for locating project-scoped research artifacts (2026-03-13)
+
 - **Problem solved:** Research.md lookup gated on feature.projectSlug existence; path resolution via getResearchFilePath(projectPath, projectSlug)
 - **Why this works:** Creates a simple 1:1 convention for artifact discovery; avoids ID-based lookups or dynamic path resolution
 - **Trade-offs:** Slug-based is human-readable and versioning-stable, but assumes research always co-located with project; refactoring if research moves to centralized store
 
 #### [Gotcha] POST /api/projects/lifecycle/initiate returns localSlug (not project.slug) for post-creation navigation. Returns field name is non-intuitive. (2026-03-13)
+
 - **Situation:** Navigation after project creation requires the new project's path. Endpoint documentation/naming unclear about return value.
 - **Root cause:** Server-side design choice - localSlug is auto-generated from title. Full project slug may not be available yet or requires additional processing.
 - **How to avoid:** Gain: unique URL-safe identifier immediately available. Loss: developer must discover localSlug vs slug distinction.
 
 #### [Pattern] Event enrichment pattern: TimelineEvent interface extended with optional ceremony-specific fields (`ceremonyLabel?`, `artifactUrl?`) rather than creating separate ceremony event type. (2026-03-13)
+
 - **Problem solved:** Need to add ceremony-specific metadata (labels, artifact URLs) to timeline events without fragmenting event type system.
 - **Why this works:** Single TimelineEvent type for all timeline entries. Optional fields make it extensible for future enrichment without creating subtype explosion.
 - **Trade-offs:** TimelineEvent becomes less semantically pure but more pragmatic. UI must handle optional fields, but avoids discriminated union complexity.
 
 #### [Gotcha] HITL formId must be the FULL UUID (e.g., `hitl-abc12345-...`), not a short/truncated ID. Using a short ID causes form lookup to fail silently. (2026-03-13)
+
 - **Situation:** HITL form responses were lost because the form polling used a truncated formId rather than the full UUID returned by `request_user_input`.
 - **Root cause:** The full UUID is stored as the key in the form registry. Short IDs don't match, so `get_form_response()` returns `status: "pending"` indefinitely.
 - **How to avoid:** Always pass the exact `formId` string returned by `request_user_input` to subsequent `get_form_response()` calls. Do not truncate, hash, or reformat it.
 
 #### [Gotcha] Use `broadcast()` not `emit()` when events must cross the server→client WebSocket boundary. `emit()` is server-process-local only. (2026-03-13)
+
 - **Situation:** HITL and feature status events were emitted with `emit()` inside tool handlers. The UI never received them because they stayed within the Node.js process.
 - **Root cause:** `EventEmitter.emit()` dispatches to in-process listeners only. `broadcast()` serializes the event over WebSocket to all connected UI clients. Same-named methods with completely different scopes — easy to pick the wrong one.
 - **How to avoid:** Rule: if the event consumer is the browser UI, always use `broadcast()`. If the consumer is another server-side service (e.g., AutoModeService listening for feature status), use `emit()`. When in doubt, grep for existing call sites of the same event name.

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -9,6 +9,7 @@ usageStats:
   referenced: 79
   successfulFeatures: 79
 ---
+
 <!-- domain: Architecture Decisions | System-wide structural decisions that have breaking consequences if changed -->
 
 # architecture
@@ -521,13 +522,14 @@ usageStats:
 - **Follow-up path detail:** `AutoModeService` captures the conflict reason in `followUpConflictReason` before the rebase try/catch block, then checks and throws after it — this ensures the block-and-throw runs outside the rebase catch scope.
 - **Breaking if changed:** Reverting to warning-only would resume repeated merge_conflict failures for stale branches. The `blocked` status is the only signal to the human that manual rebase is needed.
 
-
 #### [Pattern] Path helpers delegate validation to composed parent function (getProjectDir → validateSlugInput). Validation is inherited implicitly, not validated at each helper level. (2026-03-13)
+
 - **Problem solved:** getResearchMdPath and getResearchArtifactDir both call getProjectDir internally, which handles slug validation automatically.
 - **Why this works:** Composition pattern reduces duplication — validate once at the base level, all derived paths inherit safety. Single source of validation rules.
 - **Trade-offs:** Implicit validation easier to maintain (rules in one place) but harder to trace — caller can't see validation happening without reading implementation.
 
 ### Introduced nested artifact directory convention: artifacts/research-report/ subdirectory under project slug, rather than flat artifact storage. (2026-03-13)
+
 - **Context:** getResearchArtifactDir returns .automaker/projects/{slug}/artifacts/research-report/, establishing a tiered structure for artifact categorization.
 - **Why:** Scalable for multiple artifact types (design-doc, specs, reports, etc.) without flat-dir name collision. Organizes by artifact purpose, not by project.
 - **Rejected:** Flat structure (.automaker/projects/{slug}/research-report/ or similar) — simpler initially but harder to scale if artifacts diversify.
@@ -535,6 +537,7 @@ usageStats:
 - **Breaking if changed:** Code expecting artifacts at project root (.automaker/projects/{slug}/research-report/) will fail. Paths are concrete; moving artifacts breaks all references.
 
 ### Implemented deep merge for nested `ceremonies` object in SettingsService instead of shallow merge/replacement (2026-03-13)
+
 - **Context:** Updating nested settings (ceremonies.dailyStandup) where multiple sibling properties (enabled, lastRunAt) must persist atomically
 - **Why:** Shallow merge would overwrite entire ceremonies.dailyStandup object, losing lastRunAt timestamp when toggling enabled flag. Deep merge preserves all properties in nested objects.
 - **Rejected:** Shallow merge or direct property assignment - these would lose sibling properties in the nested object hierarchy
@@ -542,11 +545,13 @@ usageStats:
 - **Breaking if changed:** If reverted to shallow merge, lastRunAt would be lost on every enabled toggle, causing ceremony automation to lose execution history
 
 #### [Gotcha] GlobalCeremoniesConfig type already existed in global-settings.ts but was not exported from package @protolabsai/types index (2026-03-13)
+
 - **Situation:** Monorepo with multiple packages consuming shared types; type defined in one module but not accessible to cross-package consumers
 - **Root cause:** Package index exports define the public API boundary; internal module definitions are invisible to consumers using package imports
 - **How to avoid:** Explicit exports in index.ts add maintenance burden (must keep in sync) but enforce clean architecture and prevent internal API leakage
 
 ### Placed CeremoniesSection component within Developer settings tab rather than creating dedicated /settings/ceremonies route (2026-03-13)
+
 - **Context:** Ceremony automation feature is new and currently scoped to single ceremony type (Daily Standup); room for future expansion to multiple ceremony types
 - **Why:** Current scope is minimal; co-locating with other developer settings reduces routing complexity. Component can be extracted later if ceremonies becomes first-class feature.
 - **Rejected:** Dedicated settings route - would be premature abstraction given current single-ceremony scope; adds routing maintenance without clear benefit
@@ -554,6 +559,7 @@ usageStats:
 - **Breaking if changed:** If ceremonies system expands to multiple ceremony types and dedicated UX, component placement becomes limiting and requires restructuring settings navigation
 
 ### Created synthetic StandupProjectService adapter to convert board-wide context into standup-flow LangGraph API format, rather than modifying the flow or changing data structures (2026-03-13)
+
 - **Context:** standup-flow expects project-scoped milestone and feature arrays; board context is cross-project and flat
 - **Why:** Allows standup-flow to remain independent and reusable without coupling to board architecture; adapter layer isolates API contract negotiation
 - **Rejected:** Modifying standup-flow to accept board-wide context directly would couple it to this specific board implementation
@@ -561,11 +567,13 @@ usageStats:
 - **Breaking if changed:** If standup-flow changes its input shape, the adapter is the single point of failure for the entire ceremony
 
 #### [Pattern] Multi-level fallback chain for Discord channel resolution: global discord integration → project settings → DISCORD_CHANNEL_DEV env var, with explicit cast to typed interface at each level (2026-03-13)
+
 - **Problem solved:** Discord channel could be configured at global or project level, with env var as safety net; need to resolve without null-coalescing errors
 - **Why this works:** Provides configuration flexibility (global team channels vs project-specific) while maintaining clear precedence; explicit typing at each level prevents silent config misses
 - **Trade-offs:** Easier deployment (many configs work); harder debugging (which level actually won?); type casting complexity increases but clarity improves
 
 ### Dual guards on cron execution: enabled flag AND 20+ hour window since lastRunAt, preventing both admin disable and ceremony fatigue (2026-03-13)
+
 - **Context:** Cron runs every 15 minutes; standup should fire ~once daily but user can pause via settings
 - **Why:** Prevents noisy standups even if somehow triggered multiple times; makes enabled flag meaningful beyond just disable; ensures ceremonies stay valuable
 - **Rejected:** Single enabled flag would allow accidental multiple-standups-per-day if someone forgets to disable; pure time-based would fire even if already ran that day
@@ -573,11 +581,13 @@ usageStats:
 - **Breaking if changed:** Removing the 20-hour window reverts to fire-on-demand behavior; removing enabled check removes operator control
 
 #### [Pattern] Cron task registration delegated to SchedulerModule during startup (scheduler.module.ts calls dailyStandupService.initialize), rather than service self-registering (2026-03-13)
+
 - **Problem solved:** Service exists independently; scheduler infrastructure is environment-specific (might not exist in tests or edge environments)
 - **Why this works:** Cleanly separates concerns: service logic doesn't depend on scheduler; scheduler module has single entry point for all cron tasks; enables testing service without scheduler infrastructure
 - **Trade-offs:** Cleaner testing; requires two files to understand the full flow (service + scheduler); initialization order becomes explicit dependency
 
 ### Board-wide standup aggregation (single aggregated standup across all projects) rather than per-project ceremonies (2026-03-13)
+
 - **Context:** Daily standup is implicit team ritual; board context is cross-project; most other features are project-scoped
 - **Why:** Standup needs to show team-wide activity to be useful; one daily cadence for whole team prevents ceremony fragmentation
 - **Rejected:** Per-project standups would allow project autonomy but fragment communication and require N running agents; project-scoped ceremonies don't capture cross-project dependencies
@@ -585,11 +595,13 @@ usageStats:
 - **Breaking if changed:** If the architecture moves to project isolation, this artifact model becomes incompatible
 
 #### [Pattern] Fire-and-forget HTTP endpoint with async background execution: endpoint validates input and returns {started: true} immediately while research runs async via runResearch(). Route is separate from service to isolate HTTP concerns. (2026-03-13)
+
 - **Problem solved:** Research operations can be long-running (minutes). Blocking HTTP response would cause client timeout.
 - **Why this works:** Decouples request/response cycle from operation duration. Client gets immediate confirmation of acceptance, work proceeds independently. Return value signals initiation success, not completion.
 - **Trade-offs:** Easier: client doesn't hang. Harder: client can't track research progress directly via response, needs separate polling or events.
 
 ### Double-run guard using researchStatus state flag: method checks if researchStatus === 'running' and returns {started: true} without re-queuing. Idempotent pattern prevents duplicate concurrent research on same project. (2026-03-13)
+
 - **Context:** Multiple API calls or auto-triggers could fire research on same project within milliseconds. Prevent resource waste and conflicting results.
 - **Why:** Simple state check is efficient for single-node scenarios. Idempotent behavior (caller gets same response whether it's new or already-running) is correct for async operations.
 - **Rejected:** Distributed locking via Redis would be over-engineered for single-node. Unique job IDs in queue would still allow duplicate queue entries.
@@ -597,11 +609,13 @@ usageStats:
 - **Breaking if changed:** If guard is removed, duplicate research jobs could run simultaneously on same project, wasting compute and producing conflicting outputs.
 
 #### [Pattern] Auto-trigger via event listener with conditional filtering: listens for project:lifecycle:initiated event, checks project.researchOnCreate flag before firing research. Decouples research initiation from project creation logic. (2026-03-13)
+
 - **Problem solved:** Want automated research for some projects (those marked for it) but not all. Don't want to hardcode auto-trigger into creation logic.
 - **Why this works:** Event-driven architecture allows optional behavior. Conditional flag (researchOnCreate) makes feature toggleable per-project without code changes. Service can subscribe/unsubscribe independently.
 - **Trade-offs:** Easier: feature is optional and configurable. Harder: requires event system and listener registration.
 
 ### ResearchStatus added to CreateProjectInput so initiate() can set researchStatus: 'idle' atomically at project creation. Status is pre-populated so auto-trigger listener knows project is ready without separate query. (2026-03-13)
+
 - **Context:** Auto-trigger checks researchStatus === 'idle' to decide whether to fire research. If status is set after creation via separate step, race condition where event fires before status is set.
 - **Why:** Ensures correct initial state at creation time. Eliminates race between project creation event and status initialization. Event listener can trust status is correct.
 - **Rejected:** Setting status in separate step after creation creates race window. Querying project to check status before triggering adds latency.
@@ -609,6 +623,7 @@ usageStats:
 - **Breaking if changed:** If researchStatus is removed from input, auto-trigger becomes racy: event fires before status can be set, trigger sees undefined/null and skips research.
 
 ### Use existing getResearchFilePath() instead of waiting for dedicated getResearchMdPath() function (2026-03-13)
+
 - **Context:** Feature spec referenced getResearchMdPath which doesn't exist yet; getResearchFilePath provides identical path semantics
 - **Why:** Pragmatic unblocking: both return same path, avoids cross-phase dependency wait, reduces implementation blocker
 - **Rejected:** Wait for platform helpers phase to deliver getResearchMdPath; build custom path resolver inline
@@ -616,6 +631,7 @@ usageStats:
 - **Breaking if changed:** If getResearchMdPath semantics differ when implemented, this becomes a hot-spot for bugs during refactoring
 
 ### Maintain dual research sections in PRD prompt: Codebase Research Findings (automated) vs. Research Findings (pre-existing docs) (2026-03-13)
+
 - **Context:** Added Research Findings section separate from existing Codebase Research Findings in prompt template
 - **Why:** Preserves source attribution: distinguishes between dynamically-analyzed code patterns vs. human-curated pre-research; avoids conflating data sources
 - **Rejected:** Merge both sections; replace codebase findings with research.md if available
@@ -623,16 +639,19 @@ usageStats:
 - **Breaking if changed:** If model training shifts to expect merged research sections, prompt structure becomes suboptimal; if source distinction becomes unimportant, dual sections waste context
 
 #### [Pattern] Optional enrichment files in project structure (research.md, artifacts/) enable specialized workflows without burdening all projects (2026-03-13)
+
 - **Problem solved:** Project lifecycle accommodates both minimal projects (just project.md, project.json) and feature-rich projects that generate research notes and ceremony artifacts
 - **Why this works:** Not all projects perform research phase or ceremonies; consumers (PM agent, CeremonyService) handle both cases gracefully. Keeps baseline project structure lightweight.
 - **Trade-offs:** Optional files increase documentation complexity (must explain when/why) but maximize flexibility. PM agent must check file existence before consuming.
 
 #### [Pattern] Single-source-of-truth path helpers (getResearchFilePath) in platform layer abstract path construction from consuming code (2026-03-13)
+
 - **Problem solved:** research.md location is computed via getResearchFilePath(projectPath, projectSlug) instead of having path format scattered across PM agent, setup handlers, and docs
 - **Why this works:** Path structure can change (e.g., new nesting) without updating every consumer. Centralizes validation of path format. Reduces coupling to path conventions.
 - **Trade-offs:** Adds single import/function call cost; gains refactoring safety and consistency. Forces developers to think about path abstraction instead of hardcoding.
 
 ### Under resource constraints (96 files changed, tight turn budget), scoped documentation to single file with concrete bugs rather than broad sweep of all affected docs (2026-03-13)
+
 - **Context:** Feature touched many components; could have attempted to update all 96 files' docs or just the one with duplicate section + research.md gaps
 - **Why:** One accurate, complete doc is better than 96 partially accurate docs. Correctness > coverage. Duplicate section removal is objective correctness fix, not opinion.
 - **Rejected:** Broad doc updates without prioritization would have risked shipping inaccurate docs at scale or missing the quality bar
@@ -640,6 +659,7 @@ usageStats:
 - **Breaking if changed:** If other docs remain inconsistent with project-lifecycle.md canonical source, new developers will have conflicting references. Single source of truth pattern requires discipline to update all references or none.
 
 ### Refactored NewProjectDialog from callback-based (onSubmit/isPending props) to self-contained hook pattern using useCreateProject internally. (2026-03-13)
+
 - **Context:** Dialog needed to handle submission, navigation, and toasts. Original design used parent component callbacks.
 - **Why:** Self-contained hooks pattern eliminates prop drilling, makes side effects (navigation, toasts) local to dialog, cleaner for features with internal complexity. Dialog becomes autonomous unit.
 - **Rejected:** Keep callback delegation pattern (onSubmit/isPending props from ProjectsList). Would require prop threading for each new side effect.
@@ -647,11 +667,13 @@ usageStats:
 - **Breaking if changed:** If future features need dialog to work with different submission logic (e.g., draft saving, different endpoints), you'd need to either parameterize the hook or break out callback pattern again.
 
 #### [Pattern] Multi-source artifact field extraction: Server checks three payload field names (`artifactUrl`, `reportUrl`, `reportPath`) for artifact URL, accepting the first present value. (2026-03-13)
+
 - **Problem solved:** Different ceremony services use different naming conventions for artifact/report URLs. Need to integrate with heterogeneous systems without version negotiation.
 - **Why this works:** Defensive programming for integration with multiple ceremony implementations. Centralizes compatibility logic on server where ceremony knowledge lives.
 - **Trade-offs:** Extraction logic slightly more complex, but supports multiple ceremony implementations without coupling or version negotiation.
 
 ### Server owns ceremony type → label mapping. Ceremony handler contains `CEREMONY_LABELS` dictionary, sends `ceremonyLabel` in TimelineEvent response. UI renders this label in badge. (2026-03-13)
+
 - **Context:** Ceremony type names (e.g., 'standup', 'milestone_retro') are not user-friendly. Need readable labels for timeline UI.
 - **Why:** Ceremony type semantics are business logic; centralizing on server prevents UI from needing to know ceremony taxonomy. Single source of truth for label definitions.
 - **Rejected:** Send raw ceremony type to UI, let client map it (creates duplicate label definitions, harder to maintain, UI depends on ceremony domain knowledge).
@@ -659,16 +681,19 @@ usageStats:
 - **Breaking if changed:** Moving labels to UI requires syncing definitions across systems; removing label logic entirely means UI shows raw ceremony type strings.
 
 #### [Gotcha] Decision and escalation filters were already implemented from prior session. Icon/color configs were already defined. Feature was 'missing last mile' — foundational pieces existed but weren't connected to ceremony events. (2026-03-13)
+
 - **Situation:** Implementing ceremony label and artifact link features. Expected to build filters from scratch; discovered they already existed in codebase.
 - **Root cause:** Parallel feature development with layered implementation. Filter system built, but not applied to ceremony events. No integration work until now.
 - **How to avoid:** Extra audit time up-front (reading existing code) saved duplicate implementation effort. Ensured consistency.
 
 #### [Pattern] Archive deprecated patterns with date/reason instead of deleting them; preserve underlying pattern knowledge while marking use case as inactive (2026-03-13)
+
 - **Problem solved:** Frank auto-spawn IIFE and cooldown patterns were deprecated (crew loops removed 2026-03-04), but the underlying fire-and-forget async pattern and in-memory cooldown approach remain valid for other use cases
 - **Why this works:** Prevents institutional knowledge loss; allows future developers to understand why patterns exist and reuse the pattern logic for similar problems. Archiving with [ARCHIVED — date] signals status without orphaning the technical insight.
 - **Trade-offs:** Requires more doc maintenance (marking sections as archived) but preserves pattern reusability and decision context for future work
 
 ### Rely on strategic decisions document as single source of truth for major changes (Linear removal, crew loops removal); don't require updates to all downstream references if patterns remain conceptually valid (2026-03-13)
+
 - **Context:** Explore agent found deprecated Linear/Frank references across 5+ docs (security.md, performance.md, gotchas.md). Rather than updating all, chose to update only key decision points (architecture.md, templates) and leave historical patterns intact
 - **Why:** Reduces update burden when strategic changes cascade widely. Historical patterns (rate limiting, diagnostic scoping, eventual consistency) remain valid even if specific implementation (Frank, Linear) is removed. Strategic decisions doc serves as authoritative changelog.
 - **Rejected:** Alternative of updating every downstream reference is high effort for low benefit, especially when the patterns themselves are reusable
@@ -676,6 +701,7 @@ usageStats:
 - **Breaking if changed:** If strategic decisions doc is not maintained as source of truth, readers have no way to understand which references are stale vs which patterns are still valid
 
 ### Accept ArtifactEntry with optional content field; provide metadata-as-markdown fallback when content unavailable (2026-03-13)
+
 - **Context:** Component needs to display expandable markdown views, but ArtifactIndexEntry has no content field. Parent component (project-detail.tsx) would need to fetch and enrich artifacts with real content.
 - **Why:** Enables gradual adoption: component is immediately useful with metadata fallback while allowing parent to add content enrichment later without requiring immediate parent refactor. Maintains type compatibility (ArtifactEntry extends ArtifactIndexEntry), so existing callsites work without changes.
 - **Rejected:** Could require content field (breaking change) or wrap ArtifactIndexEntry in separate enrichment type (requires parent coordination)
@@ -683,11 +709,13 @@ usageStats:
 - **Breaking if changed:** Removing metadata fallback would cause artifact cards without content to show nothing; expanding cards becomes pointless for non-enriched data
 
 #### [Pattern] Sort artifacts globally by date-descending before grouping by type; grouping preserves global sort order within each group (2026-03-13)
+
 - **Problem solved:** Need to show artifacts grouped by type (Standup, Ceremony Report, etc.) but also maintain consistent date ordering within and across groups.
 - **Why this works:** Single-pass sort maintains sort invariant across all group boundaries. Alternative (per-group sorting) would require map iteration + individual sorts, adding complexity. This pattern ensures if user views 'All' vs filtered view, relative date ordering is identical.
 - **Trade-offs:** Simpler code (one sort operation), but requires understanding that Map iteration order equals sort order. Makes it harder to implement non-date sorts later (would need post-group resort).
 
 ### Separate filterTypes prop (parent control) from typeFilter state (user control); allow independent filtering dimensions (2026-03-13)
+
 - **Context:** Parent may want to show only certain artifact types (e.g., 'ceremonies only'), while user wants to filter further within that set (e.g., 'standups only'). Both needs must be satisfied without coupling.
 - **Why:** Prop controls scope (what types are available), state controls user selection (which type to focus on). Allows parent to restrict domain (SUPPORTED types) while user navigates freely within it. Cleaner separation of concerns than trying to merge decisions into single state.
 - **Rejected:** Single filter state (requires parent to manage local UI state); no supported-types gate (leaks invalid types into UI)

--- a/.automaker/memory/testing.md
+++ b/.automaker/memory/testing.md
@@ -9,6 +9,7 @@ usageStats:
   referenced: 27
   successfulFeatures: 27
 ---
+
 <!-- domain: Testing Patterns | Unit test patterns, integration test strategies, test isolation -->
 
 # testing
@@ -139,19 +140,21 @@ usageStats:
 - **Why this works:** Mock events.broadcast() to verify correct event signatures; real Express server to verify HTTP behavior and file I/O together without stubbing filesystem
 - **Trade-offs:** Gained confidence in integration between routes and events; test setup more complex than pure unit tests
 
-
 #### [Gotcha] Playwright tests can't run against worktree code because dev server serves main repo, not worktree branch. Test infrastructure doesn't support per-worktree dev servers. (2026-03-13)
+
 - **Situation:** Attempted to verify dialog functionality with Playwright. Tests reused main repo dev server instead of worktree code.
 - **Root cause:** Dev server configured with fixed paths (main repo). Worktrees are isolated git copies but share same dev server infrastructure.
 - **How to avoid:** Gain: single dev server reduces resource overhead. Loss: can't test worktree changes in isolation without running separate server or static analysis.
 
 #### [Gotcha] Server build must explicitly copy `.md` asset files — TypeScript compiler only copies `.ts` source files. Missing copy step caused staging to 404 on markdown-based prompt/context files. (2026-03-13)
+
 - **Situation:** Staging deploy broke when new `.md` files were added to `apps/server/src/`. The server started but requests to endpoints that read those files returned 404.
 - **Root cause:** `tsc` compiles `.ts` → `.js` but ignores all other file types. Any non-TS assets (`.md`, `.json`, `.yaml`) must be copied separately via a build script step.
 - **Fix:** Added explicit `.md` asset copy to the server build script (PR #2124). Pattern: `cp -r src/**/*.md dist/` or equivalent in the build pipeline.
 - **How to avoid:** Any time you add a `.md`, `.json`, or `.yaml` file under `apps/server/src/`, verify it is included in the build copy step. Otherwise it only works in dev (tsx reads source directly) and silently breaks in staging/production.
 
 #### [Pattern] Use `waitForDocumentReady()` helper in CRDT tests to await Automerge document initialization before asserting state. Eliminates race-condition flakiness. (2026-03-13)
+
 - **Problem solved:** CRDT tests were flaky because assertions ran before the Automerge document was fully initialized and synced after creation.
 - **Why this works:** `waitForDocumentReady()` polls the document handle until it transitions from the loading state. Provides a deterministic synchronization point that `await` alone cannot guarantee for Automerge's async initialization.
 - **Trade-offs:** Small additional async overhead per test, but eliminates non-deterministic failures that made CI unreliable. Pattern is reusable across all CRDT service tests.


### PR DESCRIPTION
## Summary

83 doc-relevant files changed recently.

Changed files requiring docs review:
- .automaker/context/dependency-reuse.md
- .automaker/memory/api.md
- .automaker/memory/architecture.md
- .automaker/memory/content-pipeline-validation.md
- .automaker/memory/database.md
- .automaker/memory/documentation.md
- .automaker/memory/gotchas.md
- .automaker/memory/gtm-signal-intelligence-project.md
- .automaker/memory/patterns.md
- .automaker/memory/reliability.md
- .automaker/memory/security.md
- .automaker/...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=transient-0c95472f team= created=2026-03-13T18:43:48.694Z -->