### PR TITLE
API routes for agent manifest

### DIFF
--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -1,0 +1,196 @@
+/**
+ * Agent Manifest API Routes
+ *
+ * Exposes discovered agents (built-in + project-defined) for a given project:
+ * - POST /api/agents/list  — all agents merged with project manifest overrides
+ * - POST /api/agents/get   — single agent by name with resolved capabilities
+ * - POST /api/agents/match — best-matching agent for a given feature ID
+ */
+
+import { Router } from 'express';
+import { createLogger } from '@protolabsai/utils';
+import { BUILT_IN_AGENT_ROLES, ROLE_CAPABILITIES } from '@protolabsai/types';
+import type { ProjectAgent } from '@protolabsai/types';
+import { getAgentManifestService } from '../services/agent-manifest-service.js';
+import type { FeatureLoader } from '../services/feature-loader.js';
+
+const logger = createLogger('AgentRoutes');
+
+export function createAgentRoutes(featureLoader: FeatureLoader): Router {
+  const router = Router();
+
+  /**
+   * POST /api/agents/list
+   *
+   * Returns all agents for a project: the 8 built-in roles (as synthetic ProjectAgent
+   * objects) merged with any project-manifest overrides. Project agents override built-in
+   * entries when their `name` matches a built-in role name.
+   *
+   * Body:
+   * - projectPath: string (required)
+   */
+  router.post('/list', async (req, res) => {
+    try {
+      const { projectPath } = req.body as { projectPath: string };
+
+      if (!projectPath) {
+        res.status(400).json({ error: 'projectPath is required' });
+        return;
+      }
+
+      // Build synthetic entries for each built-in role
+      const builtIns: ProjectAgent[] = BUILT_IN_AGENT_ROLES.map((role) => ({
+        name: role,
+        extends: role,
+        description: ROLE_CAPABILITIES[role]?.description ?? '',
+        _builtIn: true,
+      })) as unknown as ProjectAgent[];
+
+      const service = getAgentManifestService();
+      const manifest = await service.getAgentsForProject(projectPath);
+      const projectAgents = manifest?.agents ?? [];
+
+      // Merge: project agents with the same name as a built-in replace the built-in entry
+      const projectAgentNames = new Set(projectAgents.map((a) => a.name));
+      const merged: ProjectAgent[] = [
+        ...builtIns.filter((b) => !projectAgentNames.has(b.name)),
+        ...projectAgents,
+      ];
+
+      res.json({
+        success: true,
+        projectPath,
+        count: merged.length,
+        agents: merged,
+      });
+    } catch (error) {
+      logger.error('Failed to list agents:', error);
+      res.status(500).json({
+        error: 'Failed to list agents',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  /**
+   * POST /api/agents/get
+   *
+   * Returns a single agent by name along with its fully resolved capabilities.
+   * Built-in roles are always available as a fallback even without a project manifest.
+   *
+   * Body:
+   * - projectPath: string (required)
+   * - agentName:   string (required)
+   */
+  router.post('/get', async (req, res) => {
+    try {
+      const { projectPath, agentName } = req.body as {
+        projectPath: string;
+        agentName: string;
+      };
+
+      if (!projectPath) {
+        res.status(400).json({ error: 'projectPath is required' });
+        return;
+      }
+
+      if (!agentName) {
+        res.status(400).json({ error: 'agentName is required' });
+        return;
+      }
+
+      const service = getAgentManifestService();
+
+      // Try project manifest first
+      let agent = await service.getAgent(projectPath, agentName);
+
+      // Fall back to built-in role as a synthetic agent
+      if (!agent && ROLE_CAPABILITIES[agentName]) {
+        agent = {
+          name: agentName,
+          extends: agentName,
+          description: ROLE_CAPABILITIES[agentName].description ?? '',
+        };
+      }
+
+      if (!agent) {
+        res.status(404).json({ error: `Agent "${agentName}" not found` });
+        return;
+      }
+
+      const capabilities = await service.getResolvedCapabilities(projectPath, agent.name);
+
+      res.json({
+        success: true,
+        projectPath,
+        agent,
+        capabilities,
+      });
+    } catch (error) {
+      logger.error('Failed to get agent:', error);
+      res.status(500).json({
+        error: 'Failed to get agent',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  /**
+   * POST /api/agents/match
+   *
+   * Loads the feature identified by featureId and runs all project agent match rules
+   * against it, returning the highest-scoring agent. Returns null when no project
+   * agents match.
+   *
+   * Body:
+   * - projectPath: string (required)
+   * - featureId:   string (required)
+   */
+  router.post('/match', async (req, res) => {
+    try {
+      const { projectPath, featureId } = req.body as {
+        projectPath: string;
+        featureId: string;
+      };
+
+      if (!projectPath) {
+        res.status(400).json({ error: 'projectPath is required' });
+        return;
+      }
+
+      if (!featureId) {
+        res.status(400).json({ error: 'featureId is required' });
+        return;
+      }
+
+      const feature = await featureLoader.get(projectPath, featureId);
+      if (!feature) {
+        res.status(404).json({ error: `Feature "${featureId}" not found` });
+        return;
+      }
+
+      const service = getAgentManifestService();
+      const matched = await service.matchFeature(projectPath, {
+        category: feature.category,
+        title: feature.title ?? '',
+        description: feature.description,
+        filesToModify: feature.filesToModify,
+      });
+
+      res.json({
+        success: true,
+        projectPath,
+        featureId,
+        agent: matched,
+      });
+    } catch (error) {
+      logger.error('Failed to match agent for feature:', error);
+      res.status(500).json({
+        error: 'Failed to match agent for feature',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -91,6 +91,7 @@ import { createLedgerRoutes } from '../routes/ledger/index.js';
 import { createAvaChannelRoutes } from '../routes/ava-channel/index.js';
 import { createHivemindRoutes } from '../routes/hivemind/index.js';
 import { createDoraRoutes } from '../routes/dora/index.js';
+import { createAgentRoutes } from '../routes/agents.js';
 
 const logger = createLogger('Server:Routes');
 
@@ -439,6 +440,10 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   // DORA metrics routes (lead time, deployment frequency, change failure rate, recovery, rework)
   app.use('/api/dora', createDoraRoutes(services.doraMetricsService));
   logger.info('DORA metrics routes mounted at /api/dora');
+
+  // Agent manifest routes (list, get, match)
+  app.use('/api/agents', createAgentRoutes(featureLoader));
+  logger.info('Agent routes mounted at /api/agents');
 
   // Note: Sentry v8 automatically captures Express errors - no manual error handler needed
 }


### PR DESCRIPTION
## Summary

**Milestone:** Agent Manifest Service

Add Express routes to expose discovered agents:

1. POST /api/agents/list — returns all agents (built-in + project) for a given projectPath
2. POST /api/agents/get — returns a single agent by name with resolved capabilities
3. POST /api/agents/match — given a feature ID, returns the best-matching agent

All routes require projectPath in body. Built-in roles are always included in the list response, merged with any project manifest overrides.

Create route f...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent management API endpoints enabling users to list available agents, retrieve individual agent details, and match agents to specific features based on project-defined rules and built-in agent configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->