### PR TITLE
Wire assignedRole into getModelForFeature()

### DIFF
--- a/apps/server/src/lib/settings-helpers.ts
+++ b/apps/server/src/lib/settings-helpers.ts
@@ -788,6 +788,7 @@ export async function getWorkflowSettings(
         preFlightChecks:
           projectSettings.workflow.preFlightChecks ?? DEFAULT_WORKFLOW_SETTINGS.preFlightChecks,
         toolProfile: projectSettings.workflow.toolProfile ?? DEFAULT_WORKFLOW_SETTINGS.toolProfile,
+        agentConfig: projectSettings.workflow.agentConfig,
       };
     }
     return DEFAULT_WORKFLOW_SETTINGS;

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -84,6 +84,7 @@ import { gitWorkflowService } from '../git-workflow-service.js';
 import type { KnowledgeStoreService } from '../knowledge-store-service.js';
 import { writeLock } from '../../lib/worktree-lock.js';
 import { getReactiveSpawnerService } from '../reactive-spawner-service.js';
+import { getAgentManifestService } from '../agent-manifest-service.js';
 
 import { TypedEventBus } from './typed-event-bus.js';
 import { PostExecutionMiddleware } from './post-execution-middleware.js';
@@ -3350,20 +3351,58 @@ After generating the revised spec, output:
    * Priority: explicit feature.model > failure escalation > architectural > settings > complexity
    */
   private async getModelForFeature(
-    feature: { model?: string; complexity?: string; failureCount?: number },
+    feature: { model?: string; complexity?: string; failureCount?: number; assignedRole?: string },
     projectPath?: string
   ): Promise<{ model: string; providerId?: string }> {
+    // 1. Explicit per-feature model override
     if (feature.model) {
       return { model: resolveModelString(feature.model, DEFAULT_MODELS.autoMode) };
     }
+    // 2. Failure escalation: 2+ failures → opus
     if (feature.failureCount && feature.failureCount >= 2) {
       logger.info(`Escalating to opus after ${feature.failureCount} failures`);
       return { model: DEFAULT_MODELS.claude };
     }
+    // 3. Architectural complexity → opus
     if (feature.complexity === 'architectural') {
       logger.info('Using opus for architectural feature');
       return { model: DEFAULT_MODELS.claude };
     }
+    // 4. AssignedRole model override (manifest takes precedence over settings)
+    if (feature.assignedRole && projectPath) {
+      try {
+        const agentManifestService = getAgentManifestService();
+        const agent = await agentManifestService.getAgent(projectPath, feature.assignedRole);
+        if (agent?.model) {
+          logger.info(
+            `Using manifest model override "${agent.model}" for role "${feature.assignedRole}"`
+          );
+          return { model: resolveModelString(agent.model, DEFAULT_MODELS.autoMode) };
+        }
+      } catch (err) {
+        logger.warn(
+          `Failed to read agent manifest model for role "${feature.assignedRole}": ${err}`
+        );
+      }
+      // 4b. Settings roleModelOverrides fallback
+      try {
+        const workflowSettings = await getWorkflowSettings(projectPath, this.settingsService);
+        const roleOverride =
+          workflowSettings.agentConfig?.roleModelOverrides?.[feature.assignedRole];
+        if (roleOverride?.model) {
+          logger.info(
+            `Using settings roleModelOverride "${roleOverride.model}" for role "${feature.assignedRole}"`
+          );
+          return {
+            model: resolveModelString(roleOverride.model, DEFAULT_MODELS.autoMode),
+            providerId: roleOverride.providerId,
+          };
+        }
+      } catch (err) {
+        logger.warn(`Failed to read roleModelOverrides for role "${feature.assignedRole}": ${err}`);
+      }
+    }
+    // 5. phaseModels.agentExecutionModel from settings
     try {
       const { phaseModel } = await getPhaseModelWithOverrides(
         'agentExecutionModel',
@@ -3379,6 +3418,7 @@ After generating the revised spec, output:
     } catch (err) {
       logger.warn(`Failed to read agentExecutionModel setting, using fallback: ${err}`);
     }
+    // 6. Complexity fallback
     if (feature.complexity === 'small') {
       logger.info('Using haiku for small feature');
       return { model: DEFAULT_MODELS.trivial };

--- a/apps/server/tests/unit/services/execution-service.test.ts
+++ b/apps/server/tests/unit/services/execution-service.test.ts
@@ -93,8 +93,13 @@ vi.mock('@/lib/sdk-options.js', () => ({
   createAutoModeOptions: vi.fn(() => ({})),
 }));
 
+const mockGetWorkflowSettings = vi.hoisted(() => vi.fn(async () => ({})));
+const mockGetPhaseModelWithOverrides = vi.hoisted(() =>
+  vi.fn(async () => ({ phaseModel: { model: '' }, isProjectOverride: false }))
+);
+
 vi.mock('@/lib/settings-helpers.js', () => ({
-  getWorkflowSettings: vi.fn(async () => ({})),
+  getWorkflowSettings: mockGetWorkflowSettings,
   getAutoLoadClaudeMdSetting: vi.fn(async () => false),
   filterClaudeMdFromContext: vi.fn(() => ''),
   getMCPServersFromSettings: vi.fn(async () => []),
@@ -112,6 +117,16 @@ vi.mock('@/lib/settings-helpers.js', () => ({
     },
   })),
   getProviderByModelId: vi.fn(async () => null),
+  getPhaseModelWithOverrides: mockGetPhaseModelWithOverrides,
+}));
+
+// Mock AgentManifestService
+const mockGetAgent = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock('@/services/agent-manifest-service.js', () => ({
+  getAgentManifestService: vi.fn(() => ({
+    getAgent: mockGetAgent,
+  })),
 }));
 
 vi.mock('@/lib/secure-fs.js', () => ({
@@ -591,5 +606,167 @@ describe('ExecutionService - merge pre-flight', () => {
       FEATURE_ID,
       expect.objectContaining({ status: 'blocked' })
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getModelForFeature — assignedRole model override tests
+// ---------------------------------------------------------------------------
+
+describe('ExecutionService - getModelForFeature assignedRole', () => {
+  const PROJECT_PATH = '/tmp/test-project';
+
+  function makeTestService(): ExecutionService {
+    const feature = makeFeature();
+    const callbacks = makeCallbacks(feature);
+    const featureLoader = makeFeatureLoader(feature);
+    const recoveryService = makeRecoveryService();
+    return makeService(callbacks, featureLoader, recoveryService);
+  }
+
+  beforeEach(() => {
+    mockGetAgent.mockReset();
+    mockGetWorkflowSettings.mockReset();
+    mockGetPhaseModelWithOverrides.mockReset();
+    // Default: no phase model override
+    mockGetPhaseModelWithOverrides.mockResolvedValue({
+      phaseModel: { model: '' },
+      isProjectOverride: false,
+    });
+    // Default: no workflow settings overrides
+    mockGetWorkflowSettings.mockResolvedValue({});
+    // Default: no manifest agent
+    mockGetAgent.mockResolvedValue(undefined);
+  });
+
+  it('uses manifest model override when agent has a model', async () => {
+    mockGetAgent.mockResolvedValue({
+      name: 'frontend-dev',
+      extends: 'developer',
+      model: 'claude-opus-4-5',
+    });
+
+    const svc = makeTestService();
+    const result = await (svc as any).getModelForFeature(
+      { assignedRole: 'frontend-dev' },
+      PROJECT_PATH
+    );
+
+    expect(result.model).toContain('claude-opus-4-5');
+    expect(mockGetAgent).toHaveBeenCalledWith(PROJECT_PATH, 'frontend-dev');
+  });
+
+  it('uses settings roleModelOverrides when no manifest model is set', async () => {
+    mockGetAgent.mockResolvedValue({ name: 'backend-dev', extends: 'developer' }); // no model
+    mockGetWorkflowSettings.mockResolvedValue({
+      agentConfig: {
+        roleModelOverrides: {
+          'backend-dev': { model: 'claude-haiku-4-5', providerId: 'anthropic' },
+        },
+      },
+    });
+
+    const svc = makeTestService();
+    const result = await (svc as any).getModelForFeature(
+      { assignedRole: 'backend-dev' },
+      PROJECT_PATH
+    );
+
+    expect(result.model).toContain('claude-haiku-4-5');
+    expect(result.providerId).toBe('anthropic');
+  });
+
+  it('manifest model takes precedence over settings roleModelOverrides when both exist', async () => {
+    mockGetAgent.mockResolvedValue({
+      name: 'full-stack',
+      extends: 'developer',
+      model: 'claude-opus-4-5',
+    });
+    mockGetWorkflowSettings.mockResolvedValue({
+      agentConfig: {
+        roleModelOverrides: {
+          'full-stack': { model: 'claude-haiku-4-5' },
+        },
+      },
+    });
+
+    const svc = makeTestService();
+    const result = await (svc as any).getModelForFeature(
+      { assignedRole: 'full-stack' },
+      PROJECT_PATH
+    );
+
+    // Manifest wins
+    expect(result.model).toContain('claude-opus-4-5');
+    // Settings override should NOT have been consulted for model
+    expect(mockGetWorkflowSettings).not.toHaveBeenCalled();
+  });
+
+  it('falls through to agentExecutionModel setting when role has no manifest and no settings override', async () => {
+    mockGetAgent.mockResolvedValue(undefined); // unknown role
+    mockGetWorkflowSettings.mockResolvedValue({ agentConfig: { roleModelOverrides: {} } });
+    mockGetPhaseModelWithOverrides.mockResolvedValue({
+      phaseModel: { model: 'claude-sonnet-4-6' },
+      isProjectOverride: false,
+    });
+
+    const svc = makeTestService();
+    const result = await (svc as any).getModelForFeature(
+      { assignedRole: 'unknown-role' },
+      PROJECT_PATH
+    );
+
+    expect(result.model).toContain('claude-sonnet-4-6');
+    expect(mockGetPhaseModelWithOverrides).toHaveBeenCalledWith(
+      'agentExecutionModel',
+      null,
+      PROJECT_PATH
+    );
+  });
+
+  it('features without assignedRole behave exactly as before (no manifest lookup)', async () => {
+    mockGetPhaseModelWithOverrides.mockResolvedValue({
+      phaseModel: { model: 'claude-sonnet-4-6' },
+      isProjectOverride: false,
+    });
+
+    const svc = makeTestService();
+    const result = await (svc as any).getModelForFeature({ complexity: 'medium' }, PROJECT_PATH);
+
+    expect(result.model).toContain('claude-sonnet-4-6');
+    expect(mockGetAgent).not.toHaveBeenCalled();
+    expect(mockGetWorkflowSettings).not.toHaveBeenCalled();
+  });
+
+  it('explicit feature.model override still takes highest priority over assignedRole', async () => {
+    mockGetAgent.mockResolvedValue({ name: 'dev', extends: 'developer', model: 'claude-opus-4-5' });
+
+    const svc = makeTestService();
+    const result = await (svc as any).getModelForFeature(
+      { model: 'claude-haiku-4-5', assignedRole: 'dev' },
+      PROJECT_PATH
+    );
+
+    expect(result.model).toContain('claude-haiku-4-5');
+    expect(mockGetAgent).not.toHaveBeenCalled();
+  });
+
+  it('failure escalation still takes priority over assignedRole', async () => {
+    mockGetAgent.mockResolvedValue({
+      name: 'dev',
+      extends: 'developer',
+      model: 'claude-haiku-4-5',
+    });
+
+    const svc = makeTestService();
+    const result = await (svc as any).getModelForFeature(
+      { failureCount: 2, assignedRole: 'dev' },
+      PROJECT_PATH
+    );
+
+    // Should be opus due to failure escalation, not haiku from manifest
+    expect(mockGetAgent).not.toHaveBeenCalled();
+    // The model should be the claude (opus) default
+    expect(result.model).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

**Milestone:** Execution Wiring

Modify getModelForFeature() in apps/server/src/services/auto-mode/execution-service.ts to check the assigned role's model override BEFORE falling back to complexity-based selection.

New priority chain:
1. feature.model (explicit per-feature override) — unchanged
2. Failure escalation (2+ failures → opus) — unchanged
3. Architectural complexity → opus — unchanged
4. **NEW: assignedRole model override** — if feature.assignedRole is set, check:
   a. AgentManifestS...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for agent role-based model assignments with manifest override capabilities.
  * Implemented enhanced fallback model resolution that escalates to Claude based on failures and architectural complexity.

* **Tests**
  * Comprehensive test coverage for new agent role assignment and model override scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->