### PR TITLE
Role prompt injection in agent system prompt

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -635,7 +635,13 @@ export class ExecutionService {
       // When autoLoadClaudeMd is enabled, filter out CLAUDE.md to avoid duplication
       // (SDK handles CLAUDE.md via settingSources), but keep other context files like CODE_QUALITY.md
       // Note: contextResult.formattedPrompt now includes both context AND memory
-      const combinedSystemPrompt = filterClaudeMdFromContext(contextResult, autoLoadClaudeMd);
+      const baseSystemPrompt = filterClaudeMdFromContext(contextResult, autoLoadClaudeMd);
+
+      // Prepend role-specific prompt when the feature has an assignedRole with a promptFile
+      const rolePromptPrefix = await this.loadRolePromptPrefix(projectPath, feature);
+      const combinedSystemPrompt = rolePromptPrefix
+        ? rolePromptPrefix + (baseSystemPrompt || '')
+        : baseSystemPrompt;
 
       if (options?.continuationPrompt) {
         // Continuation prompt is used when recovering from a plan approval
@@ -1600,7 +1606,13 @@ export class ExecutionService {
         description: feature.description ?? '',
       },
     });
-    const contextFilesPrompt = filterClaudeMdFromContext(contextResult, autoLoadClaudeMd);
+    const baseContextFilesPrompt = filterClaudeMdFromContext(contextResult, autoLoadClaudeMd);
+
+    // Prepend role-specific prompt when the feature has an assignedRole with a promptFile
+    const pipelineRolePromptPrefix = await this.loadRolePromptPrefix(projectPath, feature);
+    const contextFilesPrompt = pipelineRolePromptPrefix
+      ? pipelineRolePromptPrefix + (baseContextFilesPrompt || '')
+      : baseContextFilesPrompt;
 
     // Load previous agent output for context continuity
     const featureDir = getFeatureDir(projectPath, featureId);
@@ -3452,5 +3464,50 @@ After generating the revised spec, output:
       branchName,
       content,
     });
+  }
+
+  /**
+   * Build a role-specific prompt prefix when the feature has an assignedRole with a
+   * promptFile defined in the agent manifest.
+   *
+   * Format:
+   * ```
+   * ## Agent Role: {agent.name}
+   * {agent.description}
+   *
+   * {contents of agent.promptFile}
+   *
+   * ---
+   * ```
+   *
+   * Returns an empty string when no role prompt applies.
+   * Logs a warning and returns empty string if the promptFile cannot be read.
+   */
+  private async loadRolePromptPrefix(projectPath: string, feature: Feature): Promise<string> {
+    if (!feature.assignedRole) {
+      return '';
+    }
+    try {
+      const agentManifestService = getAgentManifestService();
+      const agent = await agentManifestService.getAgent(projectPath, feature.assignedRole);
+      if (!agent?.promptFile) {
+        return '';
+      }
+      const promptFilePath = path.join(projectPath, agent.promptFile);
+      let promptFileContents: string;
+      try {
+        promptFileContents = (await secureFs.readFile(promptFilePath, 'utf-8')) as string;
+      } catch (err) {
+        logger.warn(
+          `Role prompt file not found for role "${feature.assignedRole}" at ${promptFilePath}: ${err}`
+        );
+        return '';
+      }
+      const description = agent.description ? `${agent.description}\n\n` : '';
+      return `## Agent Role: ${agent.name}\n${description}${promptFileContents}\n\n---\n`;
+    } catch (err) {
+      logger.warn(`Failed to load role prompt for role "${feature.assignedRole}": ${err}`);
+      return '';
+    }
   }
 }


### PR DESCRIPTION
## Summary

**Milestone:** Execution Wiring

When a feature has an assignedRole with a prompt file defined in the manifest, load that prompt file and prepend it to the agent's system prompt.

Modify the prompt construction path in execution-service.ts where contextFilesPrompt is built. After loading .automaker/context/*.md files, also check if the feature's assignedRole has a promptFile in the manifest. If so, read the file and prepend it as a role-specific instruction block.

Prompt injection format:
```
#...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=e9eaef06-17da-4539-a9ae-dd577c7440f4 team= created=2026-03-13T19:27:59.675Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Features with assigned roles now dynamically incorporate role-specific prompts, enabling more context-aware and targeted AI agent behavior. Role-specific prompts are automatically applied during execution, allowing agents to adapt their responses and behavior based on the designated role assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->