### PR TITLE
feat: auto-assign role via match rules before feature execution

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -683,6 +683,44 @@ export class ExecutionService {
         typeof img === 'string' ? img : img.path
       );
 
+      // Auto-assign agent role via manifest match rules (if not already assigned)
+      if (!feature.assignedRole && workflowSettings.agentConfig?.autoAssignEnabled !== false) {
+        try {
+          const agentManifestService = getAgentManifestService();
+          const matched = await agentManifestService.matchFeature(projectPath, {
+            category: feature.category,
+            title: feature.title ?? '',
+            description: feature.description,
+            filesToModify: feature.filesToModify,
+          });
+          if (matched) {
+            const assignedRole = matched.name as import('@protolabsai/types').AgentRole;
+            const routingSuggestion = {
+              role: assignedRole,
+              confidence: 1.0,
+              reasoning: `Auto-assigned via manifest match rule (agent: ${matched.name})`,
+              autoAssigned: true,
+              suggestedAt: new Date().toISOString(),
+            };
+            feature = {
+              ...feature,
+              assignedRole,
+              routingSuggestion,
+            };
+            await this.featureLoader.update(projectPath, featureId, {
+              assignedRole,
+              routingSuggestion,
+            });
+            logger.info(
+              `Auto-assigned role "${assignedRole}" to feature ${featureId} via manifest match`
+            );
+          }
+        } catch (matchError) {
+          // Non-fatal: log and proceed with default execution
+          logger.warn(`Match rule auto-assign failed for feature ${featureId}:`, matchError);
+        }
+      }
+
       // Get model based on feature complexity and failure count
       const modelResult = await this.getModelForFeature(feature, projectPath);
       const maxTurns = getTurnsForFeature(feature);

--- a/apps/server/tests/unit/services/execution-service.test.ts
+++ b/apps/server/tests/unit/services/execution-service.test.ts
@@ -122,10 +122,12 @@ vi.mock('@/lib/settings-helpers.js', () => ({
 
 // Mock AgentManifestService
 const mockGetAgent = vi.hoisted(() => vi.fn(async () => undefined));
+const mockMatchFeature = vi.hoisted(() => vi.fn(async () => null));
 
 vi.mock('@/services/agent-manifest-service.js', () => ({
   getAgentManifestService: vi.fn(() => ({
     getAgent: mockGetAgent,
+    matchFeature: mockMatchFeature,
   })),
 }));
 
@@ -768,5 +770,187 @@ describe('ExecutionService - getModelForFeature assignedRole', () => {
     expect(mockGetAgent).not.toHaveBeenCalled();
     // The model should be the claude (opus) default
     expect(result.model).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Match rule auto-assign tests
+// ---------------------------------------------------------------------------
+
+describe('ExecutionService - match rule auto-assign', () => {
+  const PROJECT_PATH = '/tmp/test-project';
+  const FEATURE_ID = 'feature-match-test-1';
+
+  let featureLoader: ReturnType<typeof makeFeatureLoader>;
+
+  beforeEach(() => {
+    vi.stubEnv('AUTOMAKER_MOCK_AGENT', 'true');
+    mockMatchFeature.mockReset();
+    mockMatchFeature.mockResolvedValue(null); // default: no match
+    mockGetWorkflowSettings.mockReset();
+    mockGetWorkflowSettings.mockResolvedValue({}); // default: no agentConfig
+  });
+
+  function makeMatchTestFeature(overrides: Partial<Feature> = {}): Feature {
+    return makeFeature({
+      id: FEATURE_ID,
+      category: 'frontend',
+      title: 'Add login form',
+      description: 'Create a login form with email and password fields',
+      filesToModify: ['apps/web/src/components/LoginForm.tsx'],
+      ...overrides,
+    });
+  }
+
+  it('category match: assigns role and persists routingSuggestion when matchFeature returns agent', async () => {
+    const feat = makeMatchTestFeature();
+    const callbacks = makeCallbacks(feat);
+    featureLoader = makeFeatureLoader(feat);
+    const svc = makeService(callbacks, featureLoader, makeRecoveryService());
+
+    mockMatchFeature.mockResolvedValue({
+      name: 'frontend-dev',
+      extends: 'developer',
+      description: 'Frontend specialist',
+    });
+
+    await svc.executeFeature(PROJECT_PATH, FEATURE_ID);
+
+    expect(featureLoader.update).toHaveBeenCalledWith(
+      PROJECT_PATH,
+      FEATURE_ID,
+      expect.objectContaining({
+        assignedRole: 'frontend-dev',
+        routingSuggestion: expect.objectContaining({
+          role: 'frontend-dev',
+          confidence: 1.0,
+          autoAssigned: true,
+          reasoning: expect.stringContaining('frontend-dev'),
+        }),
+      })
+    );
+  });
+
+  it('keyword match: assigns role based on keyword in title', async () => {
+    const feat = makeMatchTestFeature({ title: 'Fix database migration script' });
+    const callbacks = makeCallbacks(feat);
+    featureLoader = makeFeatureLoader(feat);
+    const svc = makeService(callbacks, featureLoader, makeRecoveryService());
+
+    mockMatchFeature.mockResolvedValue({
+      name: 'backend-dev',
+      extends: 'developer',
+      description: 'Backend specialist',
+    });
+
+    await svc.executeFeature(PROJECT_PATH, FEATURE_ID);
+
+    expect(featureLoader.update).toHaveBeenCalledWith(
+      PROJECT_PATH,
+      FEATURE_ID,
+      expect.objectContaining({ assignedRole: 'backend-dev' })
+    );
+  });
+
+  it('file pattern match: assigns role based on filesToModify', async () => {
+    const feat = makeMatchTestFeature({
+      filesToModify: ['apps/server/src/services/auth-service.ts'],
+    });
+    const callbacks = makeCallbacks(feat);
+    featureLoader = makeFeatureLoader(feat);
+    const svc = makeService(callbacks, featureLoader, makeRecoveryService());
+
+    mockMatchFeature.mockResolvedValue({
+      name: 'server-dev',
+      extends: 'developer',
+      description: 'Server specialist',
+    });
+
+    await svc.executeFeature(PROJECT_PATH, FEATURE_ID);
+
+    expect(featureLoader.update).toHaveBeenCalledWith(
+      PROJECT_PATH,
+      FEATURE_ID,
+      expect.objectContaining({ assignedRole: 'server-dev' })
+    );
+    expect(mockMatchFeature).toHaveBeenCalledWith(
+      PROJECT_PATH,
+      expect.objectContaining({
+        filesToModify: ['apps/server/src/services/auth-service.ts'],
+      })
+    );
+  });
+
+  it('no match: does not update assignedRole when matchFeature returns null', async () => {
+    const feat = makeMatchTestFeature();
+    const callbacks = makeCallbacks(feat);
+    featureLoader = makeFeatureLoader(feat);
+    const svc = makeService(callbacks, featureLoader, makeRecoveryService());
+
+    mockMatchFeature.mockResolvedValue(null);
+
+    await svc.executeFeature(PROJECT_PATH, FEATURE_ID);
+
+    const autoAssignCall = featureLoader.update.mock.calls.find(
+      ([, , updates]) => 'assignedRole' in updates
+    );
+    expect(autoAssignCall).toBeUndefined();
+  });
+
+  it('manual override respected: skips matchFeature when assignedRole is already set', async () => {
+    const feat = makeMatchTestFeature({ assignedRole: 'manual-role' as any });
+    const callbacks = makeCallbacks(feat);
+    featureLoader = makeFeatureLoader(feat);
+    const svc = makeService(callbacks, featureLoader, makeRecoveryService());
+
+    await svc.executeFeature(PROJECT_PATH, FEATURE_ID);
+
+    expect(mockMatchFeature).not.toHaveBeenCalled();
+  });
+
+  it('autoAssignEnabled=false: skips matchFeature when disabled in agentConfig', async () => {
+    const feat = makeMatchTestFeature();
+    const callbacks = makeCallbacks(feat);
+    featureLoader = makeFeatureLoader(feat);
+    const svc = makeService(callbacks, featureLoader, makeRecoveryService());
+
+    mockGetWorkflowSettings.mockResolvedValue({
+      agentConfig: { autoAssignEnabled: false },
+    });
+
+    await svc.executeFeature(PROJECT_PATH, FEATURE_ID);
+
+    expect(mockMatchFeature).not.toHaveBeenCalled();
+  });
+
+  it('autoAssignEnabled=true: matchFeature is called when explicitly enabled', async () => {
+    const feat = makeMatchTestFeature();
+    const callbacks = makeCallbacks(feat);
+    featureLoader = makeFeatureLoader(feat);
+    const svc = makeService(callbacks, featureLoader, makeRecoveryService());
+
+    mockGetWorkflowSettings.mockResolvedValue({
+      agentConfig: { autoAssignEnabled: true },
+    });
+    mockMatchFeature.mockResolvedValue(null);
+
+    await svc.executeFeature(PROJECT_PATH, FEATURE_ID);
+
+    expect(mockMatchFeature).toHaveBeenCalledWith(
+      PROJECT_PATH,
+      expect.objectContaining({ title: 'Add login form' })
+    );
+  });
+
+  it('match error is non-fatal: execution proceeds even when matchFeature throws', async () => {
+    const feat = makeMatchTestFeature();
+    const callbacks = makeCallbacks(feat);
+    featureLoader = makeFeatureLoader(feat);
+    const svc = makeService(callbacks, featureLoader, makeRecoveryService());
+
+    mockMatchFeature.mockRejectedValue(new Error('Manifest parse error'));
+
+    // Should not throw — execution continues normally
+    await expect(svc.executeFeature(PROJECT_PATH, FEATURE_ID)).resolves.not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- Before execution begins, `AgentManifestService.matchFeature()` is called to auto-assign a role when none is manually set
- Respects manual `assignedRole` assignments (never overwrites)
- Skips match evaluation when `workflowSettings.agentConfig?.autoAssignEnabled === false`
- Populates `routingSuggestion` with `confidence`, `reasoning`, `autoAssigned: true`, and `suggestedAt` timestamp
- Match errors are non-fatal — execution proceeds normally on failure

## Test plan
- [x] Category match: assigns role and persists `routingSuggestion`
- [x] Keyword match: assigns role based on title keywords
- [x] File pattern match: assigns role based on `filesToModify`
- [x] No match: `assignedRole` not modified when `matchFeature` returns null
- [x] Manual override respected: `matchFeature` not called when `assignedRole` already set
- [x] `autoAssignEnabled=false`: `matchFeature` not called when disabled
- [x] `autoAssignEnabled=true`: `matchFeature` called when explicitly enabled
- [x] Match error is non-fatal: execution resolves normally when `matchFeature` throws
- [x] 22/22 tests pass, build compiles cleanly

<!-- automaker:owner instance=local team=protoLabsAI created=2026-03-13T00:00:00.000Z -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)