### PR TITLE
Fix built-in role capabilities in /api/agents/get

### DIFF
--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -118,7 +118,14 @@ export function createAgentRoutes(featureLoader: FeatureLoader): Router {
         return;
       }
 
-      const capabilities = await service.getResolvedCapabilities(projectPath, agent.name);
+      let capabilities = await service.getResolvedCapabilities(projectPath, agent.name);
+
+      // getResolvedCapabilities returns null when the agent isn't in the project manifest
+      // (i.e. it's a synthetic built-in). Fall back to direct ROLE_CAPABILITIES lookup so
+      // built-in roles always return their capabilities.
+      if (capabilities === null && ROLE_CAPABILITIES[agent.name]) {
+        capabilities = ROLE_CAPABILITIES[agent.name];
+      }
 
       res.json({
         success: true,


### PR DESCRIPTION
## Summary

**Milestone:** API and Lifecycle Fixes

When /api/agents/get falls back to a synthetic built-in agent, getResolvedCapabilities returns null because the agent isn't in the manifest cache. Add direct ROLE_CAPABILITIES lookup as fallback so built-in roles always return their capabilities.

**Files to Modify:**
- apps/server/src/routes/agents.ts

**Acceptance Criteria:**
- [ ] GET a built-in role returns non-null capabilities object
- [ ] GET a project-manifest agent still works as before
- [ ] Exis...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=e9eaef06-17da-4539-a9ae-dd577c7440f4 team= created=2026-03-13T23:00:24.794Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced agent capability retrieval with a fallback mechanism to ensure agents always have their capabilities available and properly displayed, even when the project manifest lacks explicit agent definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->