### PR TITLE
Dispose AgentManifestService on shutdown

### DIFF
--- a/apps/server/src/server/shutdown.ts
+++ b/apps/server/src/server/shutdown.ts
@@ -10,6 +10,7 @@ import { getTerminalService } from '../services/terminal-service.js';
 import { shutdownLangfuse } from '../lib/langfuse-singleton.js';
 import { shutdownOtel } from '../lib/otel.js';
 import { getReactiveSpawnerService } from '../services/reactive-spawner-service.js';
+import { getAgentManifestService } from '../services/agent-manifest-service.js';
 
 const logger = createLogger('Server:Shutdown');
 
@@ -86,6 +87,12 @@ async function gracefulShutdown(server: http.Server, services: ServiceContainer)
     }
   }
   await crdtSyncService.shutdown();
+  // Dispose AgentManifestService fs.watch handles to prevent leaked watchers
+  try {
+    getAgentManifestService().dispose();
+  } catch (err) {
+    logger.warn('[SHUTDOWN] AgentManifestService dispose failed:', err);
+  }
   await shutdownLangfuse();
   await shutdownOtel();
 


### PR DESCRIPTION
## Summary

**Milestone:** API and Lifecycle Fixes

Add getAgentManifestService().dispose() to the graceful shutdown sequence in shutdown.ts. This closes fs.watch handles and prevents leaked watchers in test environments.

**Files to Modify:**
- apps/server/src/server/shutdown.ts

**Acceptance Criteria:**
- [ ] dispose() called during graceful shutdown
- [ ] Server shuts down cleanly without open handle warnings
- [ ] Existing tests pass

**Complexity:** small

**Guardrails:** If this phase involves new or ...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=e9eaef06-17da-4539-a9ae-dd577c7440f4 team= created=2026-03-13T23:02:14.245Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved server shutdown procedure to ensure proper resource cleanup during graceful shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->