### PR TITLE
Type the _builtIn flag on ProjectAgent

### DIFF
--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -44,7 +44,7 @@ export function createAgentRoutes(featureLoader: FeatureLoader): Router {
         extends: role,
         description: ROLE_CAPABILITIES[role]?.description ?? '',
         _builtIn: true,
-      })) as unknown as ProjectAgent[];
+      }));
 
       const service = getAgentManifestService();
       const manifest = await service.getAgentsForProject(projectPath);

--- a/apps/ui/src/components/views/board-view/components/kanban-card/agent-suggestion.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/agent-suggestion.tsx
@@ -47,6 +47,7 @@ export const AgentSuggestion = memo(function AgentSuggestion({
   if (!suggestion) return null;
 
   const roleLabel = ROLE_LABELS[suggestion.role] || suggestion.role;
+  const isBuiltIn = suggestion.role in ROLE_LABELS;
   const confidencePercent = Math.round(suggestion.confidence * 100);
 
   const handleOverride = useCallback(
@@ -75,6 +76,11 @@ export const AgentSuggestion = memo(function AgentSuggestion({
       >
         <Bot className={`w-3 h-3 shrink-0 ${getConfidenceColor(suggestion.confidence)}`} />
         <span className="text-[11px] font-medium truncate">{roleLabel}</span>
+        {isBuiltIn && (
+          <span className="text-[9px] px-1 py-px rounded bg-muted text-muted-foreground border border-border shrink-0">
+            built-in
+          </span>
+        )}
         <TooltipProvider delayDuration={200}>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/libs/types/src/agent-manifest.ts
+++ b/libs/types/src/agent-manifest.ts
@@ -45,6 +45,12 @@ export interface ProjectAgent {
 
   /** Rules for automatically matching this agent to work items */
   match?: AgentMatchRules;
+
+  /**
+   * True when this entry represents a built-in role (synthetic, not from the project manifest).
+   * Set by the API layer; never present in user-authored agent manifests.
+   */
+  _builtIn?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

**Milestone:** Type Safety and Scoring

Add _builtIn?: boolean to the ProjectAgent type in agent-manifest.ts. Remove the unsafe casts in routes/agents.ts and the UI's agent-suggestion.tsx.

**Files to Modify:**
- libs/types/src/agent-manifest.ts
- apps/server/src/routes/agents.ts
- apps/ui/src/components/views/board-view/components/kanban-card/agent-suggestion.tsx

**Acceptance Criteria:**
- [ ] No more 'as unknown as' casts for _builtIn
- [ ] TypeScript compiles cleanly
- [ ] UI displays built-...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=e9eaef06-17da-4539-a9ae-dd577c7440f4 team= created=2026-03-13T23:13:31.350Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual "built-in" badge to identify built-in agents in the board view, helping users distinguish between system-provided and user-created agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->