### PR TITLE
Calculate confidence from match score

### DIFF
--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -188,7 +188,8 @@ export function createAgentRoutes(featureLoader: FeatureLoader): Router {
         success: true,
         projectPath,
         featureId,
-        agent: matched,
+        agent: matched?.agent ?? null,
+        confidence: matched?.confidence ?? null,
       });
     } catch (error) {
       logger.error('Failed to match agent for feature:', error);

--- a/apps/server/src/services/agent-manifest-service.ts
+++ b/apps/server/src/services/agent-manifest-service.ts
@@ -11,7 +11,7 @@
  *   - getAgentsForProject: Cached lookup with fs.watch-based invalidation
  *   - getAgent: Lookup a specific agent by name
  *   - getResolvedCapabilities: Merge project overrides onto base ROLE_CAPABILITIES
- *   - matchFeature: Run all match rules and return the best-matching agent
+ *   - matchFeature: Run all match rules and return the best-matching agent + normalized confidence
  */
 
 import path from 'path';
@@ -31,6 +31,21 @@ export interface MatchableFeature {
   title: string;
   description?: string;
   filesToModify?: string[];
+}
+
+/**
+ * Result returned by matchFeature: the best-matching agent plus a
+ * normalized confidence score in [0, 1) derived from the raw match score.
+ *
+ * Confidence uses a diminishing-returns formula: rawScore / (rawScore + 10)
+ *   rawScore=5  → ~0.33  (weak match, e.g. single keyword)
+ *   rawScore=10 → ~0.50  (moderate, e.g. one category hit)
+ *   rawScore=20 → ~0.67  (good, e.g. category + several keywords)
+ *   rawScore=30 → ~0.75  (strong, multiple signal types)
+ */
+export interface MatchResult {
+  agent: ProjectAgent;
+  confidence: number;
 }
 
 // ─── Service ─────────────────────────────────────────────────────────────────
@@ -154,14 +169,17 @@ export class AgentManifestService {
 
   /**
    * Scores all project agents' match rules against the given feature and returns
-   * the highest-scoring agent, or null if no agents match (score > 0).
+   * the highest-scoring agent with a normalized confidence, or null if no agents
+   * match (score > 0).
    *
    * Scoring:
    *   - Category match: +10 per matched category
    *   - Keyword match:  +5 per matched keyword (title + description)
    *   - File pattern:   +3 per (file × pattern) match via minimatch
+   *
+   * Confidence is normalized via diminishing-returns: rawScore / (rawScore + 10)
    */
-  async matchFeature(projectPath: string, feature: MatchableFeature): Promise<ProjectAgent | null> {
+  async matchFeature(projectPath: string, feature: MatchableFeature): Promise<MatchResult | null> {
     const manifest = await this.getAgentsForProject(projectPath);
     if (!manifest || manifest.agents.length === 0) return null;
 
@@ -176,7 +194,12 @@ export class AgentManifestService {
       }
     }
 
-    return bestMatch;
+    if (!bestMatch) return null;
+
+    return {
+      agent: bestMatch,
+      confidence: this._normalizeScore(bestScore),
+    };
   }
 
   /**
@@ -302,6 +325,18 @@ export class AgentManifestService {
       if (typeof obj['version'] === 'number') return String(obj['version']);
     }
     return '1';
+  }
+
+  /**
+   * Normalizes a raw match score to a [0, 1) confidence value using a
+   * diminishing-returns formula: rawScore / (rawScore + 10).
+   *
+   * This ensures low-score matches produce low confidence (< 0.5) while
+   * high-score matches approach — but never reach — 1.0.
+   */
+  private _normalizeScore(rawScore: number): number {
+    if (rawScore <= 0) return 0;
+    return rawScore / (rawScore + 10);
   }
 
   private _scoreMatch(agent: ProjectAgent, feature: MatchableFeature): number {

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -631,11 +631,11 @@ export class ExecutionService {
             filesToModify: feature.filesToModify,
           });
           if (matched) {
-            const assignedRole = matched.name as import('@protolabsai/types').AgentRole;
+            const assignedRole = matched.agent.name as import('@protolabsai/types').AgentRole;
             const routingSuggestion = {
               role: assignedRole,
-              confidence: 1.0,
-              reasoning: `Auto-assigned via manifest match rule (agent: ${matched.name})`,
+              confidence: matched.confidence,
+              reasoning: `Auto-assigned via manifest match rule (agent: ${matched.agent.name})`,
               autoAssigned: true,
               suggestedAt: new Date().toISOString(),
             };
@@ -649,7 +649,7 @@ export class ExecutionService {
               routingSuggestion,
             });
             logger.info(
-              `Auto-assigned role "${assignedRole}" to feature ${featureId} via manifest match`
+              `Auto-assigned role "${assignedRole}" to feature ${featureId} via manifest match (confidence: ${matched.confidence.toFixed(2)})`
             );
           }
         } catch (matchError) {
@@ -1656,11 +1656,11 @@ export class ExecutionService {
           filesToModify: feature.filesToModify,
         });
         if (matched) {
-          const assignedRole = matched.name as import('@protolabsai/types').AgentRole;
+          const assignedRole = matched.agent.name as import('@protolabsai/types').AgentRole;
           const routingSuggestion = {
             role: assignedRole,
-            confidence: 1.0,
-            reasoning: `Auto-assigned via manifest match rule (agent: ${matched.name})`,
+            confidence: matched.confidence,
+            reasoning: `Auto-assigned via manifest match rule (agent: ${matched.agent.name})`,
             autoAssigned: true,
             suggestedAt: new Date().toISOString(),
           };
@@ -1674,7 +1674,7 @@ export class ExecutionService {
             routingSuggestion,
           });
           logger.info(
-            `Auto-assigned role "${assignedRole}" to feature ${featureId} via manifest match (pipeline path)`
+            `Auto-assigned role "${assignedRole}" to feature ${featureId} via manifest match (pipeline path, confidence: ${matched.confidence.toFixed(2)})`
           );
         }
       } catch (matchError) {


### PR DESCRIPTION
## Summary

**Milestone:** Type Safety and Scoring

Replace the hardcoded confidence: 1.0 with a normalized score. Use a sigmoid or linear scale based on the raw match score (e.g., score / (score + 10) for diminishing returns). Return the score from matchFeature alongside the agent.

**Files to Modify:**
- apps/server/src/services/agent-manifest-service.ts
- apps/server/src/services/auto-mode/execution-service.ts

**Acceptance Criteria:**
- [ ] Confidence reflects actual match strength
- [ ] Low-score match...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=e9eaef06-17da-4539-a9ae-dd577c7440f4 team= created=2026-03-13T23:38:29.400Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent matching API now returns a confidence score (0-1) alongside matched agents, providing visibility into match quality and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->