### PR TITLE
Fix auto-mode scheduler race condition preventing second concurrent slot

### DIFF
--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -257,8 +257,14 @@ export class FeatureScheduler {
           branchName
         );
 
-        // Count features that are in the process of being started
-        const startingCount = projectState.startingFeatures.size;
+        // Count features that are in the process of being started but not yet
+        // tracked by the ConcurrencyManager. Exclude any feature that has already
+        // acquired a running lease — it is already counted by getRunningCountForWorktree
+        // and adding it again here causes double-counting that blocks the second
+        // concurrent slot when maxConcurrency >= 2.
+        const startingCount = [...projectState.startingFeatures].filter(
+          (id) => !this.callbacks.isFeatureRunning(id)
+        ).length;
 
         // Total occupied slots = running + starting
         const totalOccupied = projectRunningCount + startingCount;
@@ -387,7 +393,9 @@ export class FeatureScheduler {
             projectPath,
             branchName
           );
-          const currentStartingCount = projectState.startingFeatures.size;
+          const currentStartingCount = [...projectState.startingFeatures].filter(
+            (id) => !this.callbacks.isFeatureRunning(id)
+          ).length;
           const currentTotalOccupied = currentRunningCount + currentStartingCount;
 
           if (currentTotalOccupied >= projectState.config.maxConcurrency) {


### PR DESCRIPTION
## Summary

**Bug Report**

The FeatureScheduler's auto-loop has a race condition that prevents the second concurrent slot from filling when `maxConcurrency >= 2`.

**Root Cause:**
When the scheduler starts a feature, it increments the "starting" count. On the next iteration (within milliseconds), it sees `1 running + 1 starting = 2/2` capacity and skips the second eligible feature. The "starting" state never clears fast enough for the second slot to fill.

**Evidence from logs:**
```
[FeatureScheduler] [Au...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=e9eaef06-17da-4539-a9ae-dd577c7440f4 team= created=2026-03-13T23:42:19.287Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where features in starting state were being double-counted, which could prevent additional concurrent operations from executing when concurrency limits are set to 2 or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->