### PR TITLE
Add Linux-compatible file watching

### DIFF
--- a/apps/server/src/services/agent-manifest-service.ts
+++ b/apps/server/src/services/agent-manifest-service.ts
@@ -8,7 +8,7 @@
  *
  * Responsibilities:
  *   - loadManifest: Discovers and parses YAML, validates against ProjectAgent type
- *   - getAgentsForProject: Cached lookup with fs.watch-based invalidation
+ *   - getAgentsForProject: Cached lookup with polling-based invalidation
  *   - getAgent: Lookup a specific agent by name
  *   - getResolvedCapabilities: Merge project overrides onto base ROLE_CAPABILITIES
  *   - matchFeature: Run all match rules and return the best-matching agent + normalized confidence
@@ -20,6 +20,9 @@ import { createLogger } from '@protolabsai/utils';
 import type { AgentManifest, ProjectAgent, RoleCapabilities } from '@protolabsai/types';
 import { ROLE_CAPABILITIES } from '@protolabsai/types';
 import { minimatch } from 'minimatch';
+
+/** Poll interval for manifest file change detection (ms). */
+export const WATCH_POLL_INTERVAL_MS = 2000;
 
 const logger = createLogger('AgentManifestService');
 
@@ -52,7 +55,7 @@ export interface MatchResult {
 
 export class AgentManifestService {
   private cache = new Map<string, AgentManifest>();
-  private watchers = new Map<string, fs.FSWatcher>();
+  private watchers = new Map<string, ReturnType<typeof setInterval>>();
 
   // ── Public API ─────────────────────────────────────────────────────────────
 
@@ -389,47 +392,84 @@ export class AgentManifestService {
     const singleFile = path.join(projectPath, '.automaker', 'agents.yml');
     const dirPath = path.join(projectPath, '.automaker', 'agents');
 
-    const watchTarget = fs.existsSync(singleFile)
-      ? singleFile
-      : this._isDirectory(dirPath)
-        ? dirPath
-        : null;
-
-    if (!watchTarget) return;
-
-    try {
-      const watcher = fs.watch(watchTarget, { recursive: true }, (_eventType, filename) => {
-        if (
-          !filename ||
-          filename.endsWith('.yml') ||
-          filename.endsWith('.yaml') ||
-          watchTarget === singleFile
-        ) {
-          this.cache.delete(projectPath);
-          logger.info(`Agent manifest cache invalidated for ${projectPath} (file changed)`);
+    // Collect all files to track (single file OR all .yml files in directory).
+    // We record their mtime at watch-start and invalidate the cache if any of
+    // them change.  This mtime-polling approach is used instead of fs.watch
+    // because fs.watch({ recursive: true }) is a no-op on Linux prior to
+    // Node 22 and unreliable with certain native binding versions.
+    const getTrackedFiles = (): string[] => {
+      if (fs.existsSync(singleFile)) return [singleFile];
+      if (this._isDirectory(dirPath)) {
+        try {
+          return fs
+            .readdirSync(dirPath)
+            .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+            .map((f) => path.join(dirPath, f));
+        } catch {
+          return [];
         }
-      });
+      }
+      return [];
+    };
 
-      watcher.on('error', (err) => {
-        logger.warn(`Agent manifest watcher error for ${projectPath}:`, err);
-        this._stopWatcher(projectPath);
-      });
+    const initialFiles = getTrackedFiles();
+    if (initialFiles.length === 0) return;
 
-      this.watchers.set(projectPath, watcher);
-      logger.debug(`Watching agent manifest at ${watchTarget}`);
-    } catch (err) {
-      logger.warn(`Could not watch agent manifest for ${projectPath}:`, err);
+    // Snapshot mtime for each file at watch-start.
+    const mtimes = new Map<string, number>();
+    for (const f of initialFiles) {
+      try {
+        mtimes.set(f, fs.statSync(f).mtimeMs);
+      } catch {
+        mtimes.set(f, 0);
+      }
     }
+
+    const timer = setInterval(() => {
+      const currentFiles = getTrackedFiles();
+      let changed = currentFiles.length !== mtimes.size;
+
+      if (!changed) {
+        for (const f of currentFiles) {
+          try {
+            const mtime = fs.statSync(f).mtimeMs;
+            if (mtime !== mtimes.get(f)) {
+              changed = true;
+              break;
+            }
+          } catch {
+            changed = true; // file disappeared
+            break;
+          }
+        }
+      }
+
+      if (changed) {
+        this.cache.delete(projectPath);
+        logger.info(`Agent manifest cache invalidated for ${projectPath} (file changed)`);
+        // Refresh the mtime snapshot so we only fire once per actual change.
+        mtimes.clear();
+        for (const f of getTrackedFiles()) {
+          try {
+            mtimes.set(f, fs.statSync(f).mtimeMs);
+          } catch {
+            mtimes.set(f, 0);
+          }
+        }
+      }
+    }, WATCH_POLL_INTERVAL_MS);
+
+    // Don't hold the event loop open just for watching.
+    if (typeof timer.unref === 'function') timer.unref();
+
+    this.watchers.set(projectPath, timer);
+    logger.debug(`Polling agent manifest at ${initialFiles.join(', ')}`);
   }
 
   private _stopWatcher(projectPath: string): void {
-    const watcher = this.watchers.get(projectPath);
-    if (watcher) {
-      try {
-        watcher.close();
-      } catch {
-        // Ignore close errors during shutdown
-      }
+    const timer = this.watchers.get(projectPath);
+    if (timer) {
+      clearInterval(timer);
       this.watchers.delete(projectPath);
     }
   }

--- a/apps/server/tests/unit/services/agent-manifest-service.test.ts
+++ b/apps/server/tests/unit/services/agent-manifest-service.test.ts
@@ -16,6 +16,7 @@ import os from 'node:os';
 import {
   AgentManifestService,
   getAgentManifestService,
+  WATCH_POLL_INTERVAL_MS,
 } from '../../../src/services/agent-manifest-service.js';
 
 // ─── Mock logger ──────────────────────────────────────────────────────────────
@@ -281,6 +282,49 @@ agents:
       const second = await service.getAgentsForProject(tmpDir);
       expect(second!.agents).toHaveLength(2);
     });
+
+    it('invalidates cache when manifest file changes on disk (polling watcher)', async () => {
+      // This test verifies that the polling watcher correctly triggers cache
+      // invalidation when the file changes — the behavior that was broken by
+      // fs.watch({ recursive: true }) being a no-op on Linux.
+      //
+      // Strategy: use vi.useFakeTimers to advance the poll interval without
+      // waiting for real wall-clock time, making the test fast and deterministic.
+      vi.useFakeTimers();
+      try {
+        writeYaml(tmpDir, '.automaker/agents.yml', FRONTEND_AGENT_YAML);
+
+        // Warm the cache and start the polling watcher
+        const first = await service.getAgentsForProject(tmpDir);
+        expect(first!.agents).toHaveLength(1);
+
+        // Overwrite the manifest with a second agent
+        writeYaml(
+          tmpDir,
+          '.automaker/agents.yml',
+          `
+version: "1"
+agents:
+  - name: react-specialist
+    extends: frontend-engineer
+    description: First
+  - name: vue-specialist
+    extends: frontend-engineer
+    description: Second
+`
+        );
+
+        // Advance time past the poll interval so the setInterval fires
+        vi.advanceTimersByTime(WATCH_POLL_INTERVAL_MS + 100);
+
+        // Cache should now be invalidated; next load reads updated file
+        vi.useRealTimers();
+        const second = await service.getAgentsForProject(tmpDir);
+        expect(second!.agents).toHaveLength(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   // ── matchFeature: scoring rules ───────────────────────────────────────────
@@ -324,14 +368,15 @@ agents:
         title: 'Update the UI',
         category: 'frontend',
       });
-      expect(result?.name).toBe('react-specialist');
+      expect(result?.agent.name).toBe('react-specialist');
+      expect(result?.confidence).toBeGreaterThan(0);
     });
 
     it('matches agent by keyword in title', async () => {
       const result = await service.matchFeature(tmpDir, {
         title: 'Build react component for settings',
       });
-      expect(result?.name).toBe('react-specialist');
+      expect(result?.agent.name).toBe('react-specialist');
     });
 
     it('matches agent by keyword in description', async () => {
@@ -339,7 +384,7 @@ agents:
         title: 'New feature',
         description: 'Add a new endpoint for user data',
       });
-      expect(result?.name).toBe('api-specialist');
+      expect(result?.agent.name).toBe('api-specialist');
     });
 
     it('matches agent by filePatterns', async () => {
@@ -347,18 +392,21 @@ agents:
         title: 'Add settings panel',
         filesToModify: ['apps/ui/src/components/SettingsPanel.tsx'],
       });
-      expect(result?.name).toBe('react-specialist');
+      expect(result?.agent.name).toBe('react-specialist');
     });
 
     it('returns highest-scoring agent when multiple match', async () => {
-      // frontend agent: category=frontend (+10), keyword=react (+5), file=tsx (+3) = 18
+      // frontend agent: category=frontend (+10), keyword=react (+5), keyword=component (+5),
+      //                 file=*.tsx (+3) = 23 total
       // backend agent: no match
       const result = await service.matchFeature(tmpDir, {
         title: 'Build react component',
         category: 'frontend',
         filesToModify: ['apps/ui/src/components/MyComp.tsx'],
       });
-      expect(result?.name).toBe('react-specialist');
+      expect(result?.agent.name).toBe('react-specialist');
+      // confidence = 23 / (23 + 10) = 23/33 ≈ 0.697
+      expect(result?.confidence).toBeCloseTo(0.697, 2);
     });
 
     it('returns null when no agents match', async () => {
@@ -386,12 +434,12 @@ agents:
         title: 'Some task',
         category: 'FRONTEND',
       });
-      expect(categoryResult?.name).toBe('react-specialist');
+      expect(categoryResult?.agent.name).toBe('react-specialist');
 
       const keywordResult = await service.matchFeature(tmpDir, {
         title: 'Build REACT Component',
       });
-      expect(keywordResult?.name).toBe('react-specialist');
+      expect(keywordResult?.agent.name).toBe('react-specialist');
     });
   });
 


### PR DESCRIPTION
## Summary

**Milestone:** Testing and Documentation

fs.watch with recursive:true is a no-op on Linux. Replace with chokidar or implement a polling fallback for the staging server. Only affects the agent manifest watcher, not the entire codebase.

**Files to Modify:**
- apps/server/src/services/agent-manifest-service.ts
- apps/server/package.json

**Acceptance Criteria:**
- [ ] Manifest cache invalidates on file changes on Linux
- [ ] No regression on macOS
- [ ] Watcher properly cleaned up on dispose()

*...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=e9eaef06-17da-4539-a9ae-dd577c7440f4 team= created=2026-03-13T23:57:03.031Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed polling interval constant for agent manifest monitoring (default: 2000ms).

* **Changes**
  * Agent matching results structure updated to include confidence scores and nested agent object format.

* **Improvements**
  * Implemented polling-based file change detection for agent manifests, replacing filesystem watch mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->