### PR TITLE
Remove or implement manifestPaths setting

### DIFF
--- a/docs/agents/agent-manifests.md
+++ b/docs/agents/agent-manifests.md
@@ -196,17 +196,15 @@ Configure agent behavior in `.automaker/settings.json`:
     "roleModelOverrides": {
       "react-specialist": { "model": "claude-opus-4-6" },
       "api-specialist": { "model": "claude-sonnet-4-6" }
-    },
-    "manifestPaths": [".automaker/agents/"]
+    }
   }
 }
 ```
 
-| Setting              | Default                  | Description                                               |
-| -------------------- | ------------------------ | --------------------------------------------------------- |
-| `autoAssignEnabled`  | `true`                   | Enable/disable match rule auto-assignment                 |
-| `roleModelOverrides` | `{}`                     | Per-role model overrides (settings-level, below manifest) |
-| `manifestPaths`      | `[".automaker/agents/"]` | Additional directories to search for manifests            |
+| Setting              | Default | Description                                               |
+| -------------------- | ------- | --------------------------------------------------------- |
+| `autoAssignEnabled`  | `true`  | Enable/disable match rule auto-assignment                 |
+| `roleModelOverrides` | `{}`    | Per-role model overrides (settings-level, below manifest) |
 
 ## API Reference
 

--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -149,13 +149,6 @@ export interface AgentConfig {
    * @default true
    */
   autoAssignEnabled?: boolean;
-  /**
-   * Additional manifest file paths to search for agent definitions, beyond
-   * the default `.automaker/agents/` directory. Paths are relative to the
-   * project root.
-   * @default []
-   */
-  manifestPaths?: string[];
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

**Milestone:** Type Safety and Scoring

The manifestPaths field in AgentConfig is declared but never consumed by AgentManifestService. Either implement support for additional manifest directories or remove the field to avoid dead configuration.

**Files to Modify:**
- libs/types/src/workflow-settings.ts
- docs/agents/agent-manifests.md

**Acceptance Criteria:**
- [ ] No dead configuration fields
- [ ] If implemented: additional paths are searched for manifests
- [ ] If removed: docs updated to r...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=e9eaef06-17da-4539-a9ae-dd577c7440f4 team= created=2026-03-14T00:00:14.134Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed `manifestPaths` configuration option from project settings
  * Updated configuration documentation to reflect this change

<!-- end of auto-generated comment: release notes by coderabbit.ai -->