### PR TITLE
Fix Discord bot sending empty messages to #dev channel

### DIFF
--- a/apps/server/src/services/discord-bot-service.ts
+++ b/apps/server/src/services/discord-bot-service.ts
@@ -1491,6 +1491,11 @@ export class DiscordBotService {
   async sendToChannel(channelId: string, content: string): Promise<boolean> {
     if (!this.client) return false;
 
+    if (!content || !content.trim()) {
+      logger.warn(`sendToChannel called with empty content for channel ${channelId} — skipping`);
+      return false;
+    }
+
     try {
       const channel = (await this.client.channels.fetch(channelId)) as TextChannel;
       if (!channel?.isTextBased()) return false;

--- a/apps/server/src/services/event-hook-service.ts
+++ b/apps/server/src/services/event-hook-service.ts
@@ -816,6 +816,13 @@ export class EventHookService {
     const channelId = this.substituteVariables(action.channelId, context);
     const message = this.substituteVariables(action.message, context);
 
+    if (!message || !message.trim()) {
+      logger.warn(
+        `Discord hook "${hookName}" skipped: message is empty after variable substitution`
+      );
+      return;
+    }
+
     logger.info(`Executing Discord hook "${hookName}" to channel ${channelId}`);
 
     try {


### PR DESCRIPTION
## Summary

**Bug Report** (from Josh via #bug-reports 2026-03-14)

The Discord #dev channel (1469080556720623699) is being spammed with empty/blank messages from the 'proto maker' bot. Multiple bursts of 2-4 empty messages appear throughout the day.

**Evidence:**
- 4 empty messages at 00:16:18-19 UTC
- 2 empty messages at 00:35:56 UTC
- 2 empty messages at 19:36:51 UTC
- 2 empty messages at 19:42:03-13 UTC
- Many more throughout the day

**Root Cause Analysis:**

1. `discord-bot-service.ts` `sendToChannel...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty or whitespace Discord messages from being sent to channels
  * Added validation to skip unnecessary Discord API calls when message content is empty, improving efficiency and avoiding empty notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->