### PR TITLE
feat: timeline reliability — WebSocket auto-refresh and manual refresh button

### DIFF
--- a/apps/ui/src/components/views/projects-view/project-detail.tsx
+++ b/apps/ui/src/components/views/projects-view/project-detail.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import {
   FileText,
   Layers,
@@ -8,10 +8,14 @@ import {
   Activity,
   Archive,
   Milestone,
+  RefreshCw,
 } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@protolabsai/ui/atoms';
-import { Spinner } from '@protolabsai/ui/atoms';
+import { Spinner, Button } from '@protolabsai/ui/atoms';
+import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
+import { getHttpApiClient } from '@/lib/http-api-client';
+import type { EventType } from '@protolabsai/types';
 import { ProjectHeader } from './components/project-header';
 import { ProjectSidebar } from './components/project-sidebar';
 import { useProject, useProjectDelete } from './hooks/use-project';
@@ -44,12 +48,50 @@ export function ProjectDetail({
   const setPendingProjectSlug = useAvaChannelStore((s) => s.setPendingProjectSlug);
   const setLastActiveTab = useAvaChannelStore((s) => s.setLastActiveTab);
   const setChatModalOpen = useChatStore((s) => s.setChatModalOpen);
+  const queryClient = useQueryClient();
+  const [isRefreshingTimeline, setIsRefreshingTimeline] = useState(false);
 
   const handleOpenPmChat = () => {
     setPendingProjectSlug(projectSlug);
     setLastActiveTab('projects');
     setChatModalOpen(true);
   };
+
+  // ── Timeline refresh ─────────────────────────────────────────────────────────
+
+  const refreshTimeline = useCallback(() => {
+    setIsRefreshingTimeline(true);
+    queryClient
+      .invalidateQueries({ queryKey: ['project-timeline', projectPath, projectSlug] })
+      .finally(() => {
+        // Brief delay to let the spinner show before hiding
+        setTimeout(() => setIsRefreshingTimeline(false), 500);
+      });
+  }, [queryClient, projectPath, projectSlug]);
+
+  // Subscribe to WebSocket events that generate timeline entries and auto-refresh
+  useEffect(() => {
+    if (!projectPath || !projectSlug) return;
+
+    const TIMELINE_TRIGGER_EVENTS: EventType[] = [
+      'feature:status-changed',
+      'milestone:completed',
+      'ceremony:fired',
+      'pr:merged',
+      'escalation:signal-received',
+    ];
+
+    const api = getHttpApiClient();
+    const unsubscribe = api.subscribeToEvents((type: EventType) => {
+      if ((TIMELINE_TRIGGER_EVENTS as string[]).includes(type)) {
+        queryClient.invalidateQueries({ queryKey: ['project-timeline', projectPath, projectSlug] });
+      }
+    });
+
+    return unsubscribe;
+  }, [queryClient, projectPath, projectSlug]);
+
+  // ─────────────────────────────────────────────────────────────────────────────
 
   const handleDelete = () => {
     deleteMutation.mutate(projectSlug, {
@@ -170,6 +212,22 @@ export function ProjectDetail({
 
               <TabsContent value="timeline">
                 <div className="py-4">
+                  <div className="flex items-center justify-between mb-3">
+                    <span className="text-sm font-medium text-foreground">Activity Timeline</span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={refreshTimeline}
+                      disabled={isRefreshingTimeline}
+                      aria-label="Refresh timeline"
+                      data-testid="timeline-refresh-button"
+                    >
+                      <RefreshCw
+                        className={`w-4 h-4 mr-1 ${isRefreshingTimeline ? 'animate-spin' : ''}`}
+                      />
+                      Refresh
+                    </Button>
+                  </div>
                   <ProjectTimeline projectSlug={projectSlug} />
                 </div>
               </TabsContent>


### PR DESCRIPTION
## Summary

- Added WebSocket event subscription to `project-detail.tsx` that auto-invalidates the timeline query when relevant events fire (`feature:status-changed`, `milestone:completed`, `ceremony:fired`, `pr:merged`, `escalation:signal-received`)
- Added a **Refresh** button in the Timeline tab header that manually triggers a query invalidation with a 500ms spinner feedback
- `ProjectTimeline` component already handles loading and empty states correctly

## Acceptance Criteria

- [x] Project detail view shows timeline with real activity (via `ProjectTimeline` component)
- [x] Timeline auto-refreshes on WebSocket events (useEffect subscribes to relevant EventType events)
- [x] Manual refresh button works (Button with `data-testid="timeline-refresh-button"` and `refreshTimeline` callback)
- [x] Loading and empty states render correctly (handled inside `ProjectTimeline`)

## Test plan

- [x] TypeScript typecheck passes (`npm run typecheck --workspace=apps/ui`)
- [x] Server build passes (`npm run build:server`)
- [x] Playwright verification test ran (skipped gracefully — no projects in test env, which is expected)

<!-- automaker:owner instance=local team=protoLabsAI created=2026-03-14T02:16:00.000Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added manual refresh button in the Timeline tab to update project data on demand
  * Timeline automatically refreshes when relevant project events occur in real-time
  * Visual spinner feedback displays during timeline refresh operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->