### PR TITLE
Central timeout config module

### DIFF
--- a/apps/server/src/config/timeouts.ts
+++ b/apps/server/src/config/timeouts.ts
@@ -1,0 +1,79 @@
+/**
+ * Central timeout configuration for the server.
+ *
+ * All timeout and sleep-interval constants are defined here.
+ * Each reads from a named environment variable with the previous
+ * hardcoded value as the default, so no behavioural change occurs
+ * unless the operator explicitly sets the variable.
+ *
+ * Grouped by domain:
+ *   - execution  : agent run budgets
+ *   - polling    : loop sleep intervals and retry delays
+ *   - networking : shell command and HTTP request timeouts
+ *   - cleanup    : post-merge / maintenance delays
+ */
+
+// ── Execution ────────────────────────────────────────────────────────────────
+
+/** Maximum wall-clock time for a single agent execution run (default: 30 min). */
+export const EXECUTE_TIMEOUT_MS = parseInt(
+  process.env.EXECUTE_TIMEOUT_MS ?? String(30 * 60 * 1000),
+  10
+);
+
+// ── Polling ───────────────────────────────────────────────────────────────────
+
+/** Sleep duration when the scheduler is at concurrency capacity (default: 5 s). */
+export const SLEEP_INTERVAL_CAPACITY_MS = parseInt(
+  process.env.SLEEP_INTERVAL_CAPACITY_MS ?? '5000',
+  10
+);
+
+/** Sleep duration when the scheduler is idle — no features pending (default: 30 s). */
+export const SLEEP_INTERVAL_IDLE_MS = parseInt(process.env.SLEEP_INTERVAL_IDLE_MS ?? '30000', 10);
+
+/** Normal sleep interval between scheduler ticks (default: 2 s). */
+export const SLEEP_INTERVAL_NORMAL_MS = parseInt(
+  process.env.SLEEP_INTERVAL_NORMAL_MS ?? '2000',
+  10
+);
+
+/** Sleep interval after a scheduling error (default: 5 s). */
+export const SLEEP_INTERVAL_ERROR_MS = parseInt(process.env.SLEEP_INTERVAL_ERROR_MS ?? '5000', 10);
+
+/** Delay between review-state polls for CI / approval status (default: 30 s). */
+export const REVIEW_POLL_DELAY_MS = parseInt(
+  process.env.REVIEW_POLL_DELAY_MS ?? String(30 * 1000),
+  10
+);
+
+/**
+ * Maximum time a feature can remain in REVIEW before auto-escalating (default: 45 min).
+ * Configurable via REVIEW_PENDING_TIMEOUT_MINUTES (takes precedence if set).
+ */
+export const REVIEW_PENDING_TIMEOUT_MS = (() => {
+  const minutes = parseInt(process.env.REVIEW_PENDING_TIMEOUT_MINUTES ?? '45', 10);
+  return (isNaN(minutes) || minutes <= 0 ? 45 : minutes) * 60 * 1000;
+})();
+
+// ── Networking ────────────────────────────────────────────────────────────────
+
+/** Default timeout for event-hook shell commands (default: 30 s). */
+export const EVENT_HOOK_SHELL_TIMEOUT_MS = parseInt(
+  process.env.EVENT_HOOK_SHELL_TIMEOUT_MS ?? '30000',
+  10
+);
+
+/** Default timeout for event-hook HTTP requests (default: 10 s). */
+export const EVENT_HOOK_HTTP_TIMEOUT_MS = parseInt(
+  process.env.EVENT_HOOK_HTTP_TIMEOUT_MS ?? '10000',
+  10
+);
+
+// ── Cleanup ───────────────────────────────────────────────────────────────────
+
+/** Delay between merge retry attempts (default: 60 s). */
+export const MERGE_RETRY_DELAY_MS = parseInt(
+  process.env.MERGE_RETRY_DELAY_MS ?? String(60 * 1000),
+  10
+);

--- a/apps/server/src/services/event-hook-service.ts
+++ b/apps/server/src/services/event-hook-service.ts
@@ -37,6 +37,7 @@ import type {
   EventHookDiscordAction,
   EventSeverity,
 } from '@protolabsai/types';
+import { EVENT_HOOK_SHELL_TIMEOUT_MS, EVENT_HOOK_HTTP_TIMEOUT_MS } from '../config/timeouts.js';
 
 const execAsync = promisify(exec);
 const logger = createLogger('EventHooks');
@@ -154,11 +155,11 @@ function classifySeverity(trigger: EventHookTrigger): EventSeverity {
   return 'low';
 }
 
-/** Default timeout for shell commands (30 seconds) */
-const DEFAULT_SHELL_TIMEOUT = 30000;
+/** Default timeout for shell commands — sourced from central config. */
+const DEFAULT_SHELL_TIMEOUT = EVENT_HOOK_SHELL_TIMEOUT_MS;
 
-/** Default timeout for HTTP requests (10 seconds) */
-const DEFAULT_HTTP_TIMEOUT = 10000;
+/** Default timeout for HTTP requests — sourced from central config. */
+const DEFAULT_HTTP_TIMEOUT = EVENT_HOOK_HTTP_TIMEOUT_MS;
 
 /**
  * Context available for variable substitution in hooks

--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -41,15 +41,15 @@ import type { EventEmitter } from '../lib/events.js';
 import type { LoopState } from './auto-mode/auto-loop-coordinator.js';
 import type { RunningFeature } from './auto-mode/execution-types.js';
 import type { HealthReport } from './feature-health-service.js';
+import {
+  SLEEP_INTERVAL_CAPACITY_MS,
+  SLEEP_INTERVAL_IDLE_MS,
+  SLEEP_INTERVAL_NORMAL_MS,
+  SLEEP_INTERVAL_ERROR_MS,
+} from '../config/timeouts.js';
 
 const execAsync = promisify(exec);
 const logger = createLogger('FeatureScheduler');
-
-// Auto-loop sleep interval constants
-const SLEEP_INTERVAL_CAPACITY_MS = 5000;
-const SLEEP_INTERVAL_IDLE_MS = 30000;
-const SLEEP_INTERVAL_NORMAL_MS = 2000;
-const SLEEP_INTERVAL_ERROR_MS = 5000;
 
 // ── Public interfaces ──────────────────────────────────────────────────────
 

--- a/apps/server/src/services/lead-engineer-types.ts
+++ b/apps/server/src/services/lead-engineer-types.ts
@@ -17,27 +17,25 @@ import type { FactStoreService } from './fact-store-service.js';
 import type { LeadHandoffService } from './lead-handoff-service.js';
 import type { HITLFormService } from './hitl-form-service.js';
 import type { TrajectoryStoreService } from './trajectory-store-service.js';
+import {
+  EXECUTE_TIMEOUT_MS,
+  MERGE_RETRY_DELAY_MS,
+  REVIEW_POLL_DELAY_MS,
+  REVIEW_PENDING_TIMEOUT_MS,
+} from '../config/timeouts.js';
+
+// Re-export for consumers that import timing constants from this module.
+export {
+  EXECUTE_TIMEOUT_MS,
+  MERGE_RETRY_DELAY_MS,
+  REVIEW_POLL_DELAY_MS,
+  REVIEW_PENDING_TIMEOUT_MS,
+};
 
 // ────────────────────────── Budget / timing constants ──────────────────────────
 
-export const EXECUTE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 export const MAX_PR_ITERATIONS = 2;
 export const MAX_TOTAL_REMEDIATION_CYCLES = 4;
-export const MERGE_RETRY_DELAY_MS = 60 * 1000; // 60 seconds
-export const REVIEW_POLL_DELAY_MS = 30 * 1000; // 30 seconds
-
-/**
- * Maximum time a feature can remain in the REVIEW state (waiting for CI/approval)
- * before auto-escalating to ESCALATE with an actionable error message.
- *
- * Configurable via REVIEW_PENDING_TIMEOUT_MINUTES env variable (default: 45 minutes).
- * The previous implicit timeout was ~9 minutes due to polling interaction with
- * external timing constraints; this raises it to a safe configurable value.
- */
-export const REVIEW_PENDING_TIMEOUT_MS = (() => {
-  const minutes = parseInt(process.env.REVIEW_PENDING_TIMEOUT_MINUTES ?? '45', 10);
-  return (isNaN(minutes) || minutes <= 0 ? 45 : minutes) * 60 * 1000;
-})();
 
 // ────────────────────────── Retry limits ──────────────────────────
 


### PR DESCRIPTION
## Summary

**Milestone:** Timeout Configuration

Create `apps/server/src/config/timeouts.ts` that exports all timeout constants, reading from environment variables with existing values as defaults. Group by domain: execution, polling, networking, cleanup. Update lead-engineer-types.ts, feature-scheduler.ts, and event-hook-service.ts to import from the central module.

**Files to Modify:**
- apps/server/src/config/timeouts.ts
- apps/server/src/services/lead-engineer-types.ts
- apps/server/src/services/auto-...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-14T03:16:56.286Z -->