### PR TITLE
Migrate remaining services to central config

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -134,6 +134,77 @@ DISCORD_CHANNEL_INFRA=
 # LANGFUSE_SYNC_CI_TRIGGER=
 
 # ============================================
+# OPTIONAL - Timeout Configuration
+# ============================================
+# All values are in milliseconds unless noted.
+# Defaults match the previous hardcoded values — no change in behaviour unless set.
+
+# Maximum wall-clock time for a single agent execution run (default: 1800000 = 30 min)
+# EXECUTE_TIMEOUT_MS=1800000
+
+# Feature scheduler sleep intervals
+# SLEEP_INTERVAL_CAPACITY_MS=5000
+# SLEEP_INTERVAL_IDLE_MS=30000
+# SLEEP_INTERVAL_NORMAL_MS=2000
+# SLEEP_INTERVAL_ERROR_MS=5000
+
+# Lead engineer review polling
+# REVIEW_POLL_DELAY_MS=30000
+# REVIEW_PENDING_TIMEOUT_MINUTES=45
+
+# Event hook timeouts
+# EVENT_HOOK_SHELL_TIMEOUT_MS=30000
+# EVENT_HOOK_HTTP_TIMEOUT_MS=10000
+
+# Merge retry delay
+# MERGE_RETRY_DELAY_MS=60000
+
+# CRDT sync server
+# CRDT_HEARTBEAT_MS=30000
+# CRDT_TTL_MS=120000
+# CRDT_RECONNECT_INTERVAL_MS=5000
+# CRDT_TTL_CHECK_INTERVAL_MS=10000
+
+# Health monitor
+# HEALTH_CHECK_INTERVAL_MS=30000
+# STUCK_FEATURE_THRESHOLD_MS=1800000
+
+# Archival service
+# ARCHIVAL_CHECK_INTERVAL_MS=600000
+
+# Worktree lifecycle
+# WORKTREE_CLEANUP_DELAY_MS=10000
+# WORKTREE_DRIFT_CHECK_INTERVAL_MS=21600000
+
+# PR feedback service
+# PR_FEEDBACK_POLL_INTERVAL_MS=60000
+# PR_FEEDBACK_CI_POLL_INTERVAL_MS=60000
+# PR_FEEDBACK_CI_MAX_WAIT_MS=600000
+# MISSING_CI_CHECK_THRESHOLD_MINUTES=30
+
+# PR watcher service
+# PR_WATCHER_POLL_INTERVAL_MS=30000
+# PR_WATCHER_TIMEOUT_MS=1800000
+
+# Work intake service
+# WORK_INTAKE_TICK_INTERVAL_MS=30000
+# WORK_INTAKE_CLAIM_TIMEOUT_MS=1800000
+
+# Stream observer (agent stall detection)
+# STREAM_OBSERVER_STALL_TIMEOUT_MS=300000
+
+# Authority agents
+# EM_POLL_INTERVAL_MS=10000
+# PROJM_POLL_INTERVAL_MS=15000
+
+# Ava channel reactor
+# AVA_REACTOR_RESUBSCRIBE_BASE_MS=5000
+# AVA_REACTOR_RESUBSCRIBE_MAX_MS=60000
+# AVA_REACTOR_HEARTBEAT_INTERVAL_MS=60000
+# AVA_REACTOR_DORA_REPORT_INTERVAL_MS=3600000
+# AVA_REACTOR_HEALTH_ALERT_PAUSE_MS=300000
+
+# ============================================
 # OPTIONAL - Debugging
 # ============================================
 

--- a/apps/server/src/config/timeouts.ts
+++ b/apps/server/src/config/timeouts.ts
@@ -1,0 +1,250 @@
+/**
+ * Central timeout configuration for the server.
+ *
+ * All timeout and sleep-interval constants are defined here.
+ * Each reads from a named environment variable with the previous
+ * hardcoded value as the default, so no behavioural change occurs
+ * unless the operator explicitly sets the variable.
+ *
+ * Grouped by domain:
+ *   - execution      : agent run budgets
+ *   - polling        : loop sleep intervals and retry delays
+ *   - networking     : shell command and HTTP request timeouts
+ *   - cleanup        : post-merge / maintenance delays
+ *   - crdt           : sync server heartbeat/reconnect timing
+ *   - health         : health monitor check intervals
+ *   - archival       : feature archival check intervals
+ *   - worktree       : worktree lifecycle timing
+ *   - pr-feedback    : pull request review polling and CI wait timing
+ *   - pr-watcher     : background PR CI monitor timing
+ *   - work-intake    : phase claiming timing
+ *   - stream-observer: agent stream stall detection
+ *   - agents         : authority agent poll intervals
+ *   - ava            : Ava channel reactor timing
+ */
+
+// ── Execution ────────────────────────────────────────────────────────────────
+
+/** Maximum wall-clock time for a single agent execution run (default: 30 min). */
+export const EXECUTE_TIMEOUT_MS = parseInt(
+  process.env.EXECUTE_TIMEOUT_MS ?? String(30 * 60 * 1000),
+  10
+);
+
+// ── Polling ───────────────────────────────────────────────────────────────────
+
+/** Sleep duration when the scheduler is at concurrency capacity (default: 5 s). */
+export const SLEEP_INTERVAL_CAPACITY_MS = parseInt(
+  process.env.SLEEP_INTERVAL_CAPACITY_MS ?? '5000',
+  10
+);
+
+/** Sleep duration when the scheduler is idle — no features pending (default: 30 s). */
+export const SLEEP_INTERVAL_IDLE_MS = parseInt(process.env.SLEEP_INTERVAL_IDLE_MS ?? '30000', 10);
+
+/** Normal sleep interval between scheduler ticks (default: 2 s). */
+export const SLEEP_INTERVAL_NORMAL_MS = parseInt(
+  process.env.SLEEP_INTERVAL_NORMAL_MS ?? '2000',
+  10
+);
+
+/** Sleep interval after a scheduling error (default: 5 s). */
+export const SLEEP_INTERVAL_ERROR_MS = parseInt(process.env.SLEEP_INTERVAL_ERROR_MS ?? '5000', 10);
+
+/** Delay between review-state polls for CI / approval status (default: 30 s). */
+export const REVIEW_POLL_DELAY_MS = parseInt(
+  process.env.REVIEW_POLL_DELAY_MS ?? String(30 * 1000),
+  10
+);
+
+/**
+ * Maximum time a feature can remain in REVIEW before auto-escalating (default: 45 min).
+ * Configurable via REVIEW_PENDING_TIMEOUT_MINUTES (takes precedence if set).
+ */
+export const REVIEW_PENDING_TIMEOUT_MS = (() => {
+  const minutes = parseInt(process.env.REVIEW_PENDING_TIMEOUT_MINUTES ?? '45', 10);
+  return (isNaN(minutes) || minutes <= 0 ? 45 : minutes) * 60 * 1000;
+})();
+
+// ── Networking ────────────────────────────────────────────────────────────────
+
+/** Default timeout for event-hook shell commands (default: 30 s). */
+export const EVENT_HOOK_SHELL_TIMEOUT_MS = parseInt(
+  process.env.EVENT_HOOK_SHELL_TIMEOUT_MS ?? '30000',
+  10
+);
+
+/** Default timeout for event-hook HTTP requests (default: 10 s). */
+export const EVENT_HOOK_HTTP_TIMEOUT_MS = parseInt(
+  process.env.EVENT_HOOK_HTTP_TIMEOUT_MS ?? '10000',
+  10
+);
+
+// ── Cleanup ───────────────────────────────────────────────────────────────────
+
+/** Delay between merge retry attempts (default: 60 s). */
+export const MERGE_RETRY_DELAY_MS = parseInt(
+  process.env.MERGE_RETRY_DELAY_MS ?? String(60 * 1000),
+  10
+);
+
+// ── CRDT Sync ─────────────────────────────────────────────────────────────────
+
+/** Interval between heartbeat pings in the CRDT sync server (default: 30 s). */
+export const CRDT_HEARTBEAT_MS = parseInt(process.env.CRDT_HEARTBEAT_MS ?? '30000', 10);
+
+/** Time-to-live for a peer without a heartbeat before eviction (default: 120 s). */
+export const CRDT_TTL_MS = parseInt(process.env.CRDT_TTL_MS ?? '120000', 10);
+
+/** Delay before attempting to reconnect to the CRDT sync server (default: 5 s). */
+export const CRDT_RECONNECT_INTERVAL_MS = parseInt(
+  process.env.CRDT_RECONNECT_INTERVAL_MS ?? '5000',
+  10
+);
+
+/** Interval at which peer TTLs are checked and expired peers evicted (default: 10 s). */
+export const CRDT_TTL_CHECK_INTERVAL_MS = parseInt(
+  process.env.CRDT_TTL_CHECK_INTERVAL_MS ?? '10000',
+  10
+);
+
+// ── Health Monitor ────────────────────────────────────────────────────────────
+
+/** How often the health monitor checks for stuck features and resource usage (default: 30 s). */
+export const HEALTH_CHECK_INTERVAL_MS = parseInt(
+  process.env.HEALTH_CHECK_INTERVAL_MS ?? String(30 * 1000),
+  10
+);
+
+/** How long a feature can be in_progress without activity before being considered stuck (default: 30 min). */
+export const STUCK_FEATURE_THRESHOLD_MS = parseInt(
+  process.env.STUCK_FEATURE_THRESHOLD_MS ?? String(30 * 60 * 1000),
+  10
+);
+
+// ── Archival ──────────────────────────────────────────────────────────────────
+
+/** How often the archival service checks for features eligible for archival (default: 10 min). */
+export const ARCHIVAL_CHECK_INTERVAL_MS = parseInt(
+  process.env.ARCHIVAL_CHECK_INTERVAL_MS ?? String(10 * 60 * 1000),
+  10
+);
+
+// ── Worktree Lifecycle ────────────────────────────────────────────────────────
+
+/** Delay after PR merge before worktree cleanup to allow CI/webhooks to settle (default: 10 s). */
+export const WORKTREE_CLEANUP_DELAY_MS = parseInt(
+  process.env.WORKTREE_CLEANUP_DELAY_MS ?? '10000',
+  10
+);
+
+/** How often to scan for phantom / orphaned worktrees (default: 6 h). */
+export const WORKTREE_DRIFT_CHECK_INTERVAL_MS = parseInt(
+  process.env.WORKTREE_DRIFT_CHECK_INTERVAL_MS ?? String(6 * 60 * 60 * 1000),
+  10
+);
+
+// ── PR Feedback ───────────────────────────────────────────────────────────────
+
+/** How often PR Feedback Service polls GitHub for review status (default: 60 s). */
+export const PR_FEEDBACK_POLL_INTERVAL_MS = parseInt(
+  process.env.PR_FEEDBACK_POLL_INTERVAL_MS ?? '60000',
+  10
+);
+
+/** How often to poll for CI check status in PR Feedback Service (default: 60 s). */
+export const PR_FEEDBACK_CI_POLL_INTERVAL_MS = parseInt(
+  process.env.PR_FEEDBACK_CI_POLL_INTERVAL_MS ?? '60000',
+  10
+);
+
+/** Maximum time to wait for CI checks to complete in PR Feedback Service (default: 10 min). */
+export const PR_FEEDBACK_CI_MAX_WAIT_MS = parseInt(
+  process.env.PR_FEEDBACK_CI_MAX_WAIT_MS ?? String(10 * 60 * 1000),
+  10
+);
+
+/**
+ * How long a PR can wait before alerting on required CI checks that never registered (default: 30 min).
+ * Configurable via MISSING_CI_CHECK_THRESHOLD_MINUTES env variable.
+ */
+export const PR_FEEDBACK_MISSING_CI_CHECK_THRESHOLD_MS = (() => {
+  const minutes = parseInt(process.env.MISSING_CI_CHECK_THRESHOLD_MINUTES ?? '30', 10);
+  return (isNaN(minutes) || minutes <= 0 ? 30 : minutes) * 60 * 1000;
+})();
+
+// ── PR Watcher ────────────────────────────────────────────────────────────────
+
+/** How often PR Watcher Service polls CI state for watched PRs (default: 30 s). */
+export const PR_WATCHER_POLL_INTERVAL_MS = parseInt(
+  process.env.PR_WATCHER_POLL_INTERVAL_MS ?? '30000',
+  10
+);
+
+/** Maximum time before a PR watch auto-expires (default: 30 min). */
+export const PR_WATCHER_TIMEOUT_MS = parseInt(
+  process.env.PR_WATCHER_TIMEOUT_MS ?? String(30 * 60 * 1000),
+  10
+);
+
+// ── Work Intake ───────────────────────────────────────────────────────────────
+
+/** How often Work Intake Service checks for claimable phases (default: 30 s). */
+export const WORK_INTAKE_TICK_INTERVAL_MS = parseInt(
+  process.env.WORK_INTAKE_TICK_INTERVAL_MS ?? '30000',
+  10
+);
+
+/** How long before a stale phase claim becomes reclaimable (default: 30 min). */
+export const WORK_INTAKE_CLAIM_TIMEOUT_MS = parseInt(
+  process.env.WORK_INTAKE_CLAIM_TIMEOUT_MS ?? String(30 * 60 * 1000),
+  10
+);
+
+// ── Stream Observer ───────────────────────────────────────────────────────────
+
+/** How long with no tool_use events before declaring an agent stall (default: 5 min). */
+export const STREAM_OBSERVER_STALL_TIMEOUT_MS = parseInt(
+  process.env.STREAM_OBSERVER_STALL_TIMEOUT_MS ?? String(5 * 60 * 1000),
+  10
+);
+
+// ── Authority Agents ──────────────────────────────────────────────────────────
+
+/** How often EM agent polls for ready features (default: 10 s). */
+export const EM_POLL_INTERVAL_MS = parseInt(process.env.EM_POLL_INTERVAL_MS ?? '10000', 10);
+
+/** How often ProjM agent polls for approved features and milestone completion (default: 15 s). */
+export const PROJM_POLL_INTERVAL_MS = parseInt(process.env.PROJM_POLL_INTERVAL_MS ?? '15000', 10);
+
+// ── Ava Channel Reactor ───────────────────────────────────────────────────────
+
+/** Base delay for exponential backoff on CRDT subscription errors (default: 5 s). */
+export const AVA_REACTOR_RESUBSCRIBE_BASE_MS = parseInt(
+  process.env.AVA_REACTOR_RESUBSCRIBE_BASE_MS ?? '5000',
+  10
+);
+
+/** Maximum delay cap for exponential backoff on subscription errors (default: 60 s). */
+export const AVA_REACTOR_RESUBSCRIBE_MAX_MS = parseInt(
+  process.env.AVA_REACTOR_RESUBSCRIBE_MAX_MS ?? '60000',
+  10
+);
+
+/** Interval at which capacity heartbeats are broadcast to the Ava channel (default: 60 s). */
+export const AVA_REACTOR_HEARTBEAT_INTERVAL_MS = parseInt(
+  process.env.AVA_REACTOR_HEARTBEAT_INTERVAL_MS ?? '60000',
+  10
+);
+
+/** Interval at which DORA reports are broadcast (default: 1 h). */
+export const AVA_REACTOR_DORA_REPORT_INTERVAL_MS = parseInt(
+  process.env.AVA_REACTOR_DORA_REPORT_INTERVAL_MS ?? String(60 * 60 * 1000),
+  10
+);
+
+/** Duration to pause work-stealing from a degraded peer (default: 5 min). */
+export const AVA_REACTOR_HEALTH_ALERT_PAUSE_MS = parseInt(
+  process.env.AVA_REACTOR_HEALTH_ALERT_PAUSE_MS ?? String(5 * 60 * 1000),
+  10
+);

--- a/apps/server/src/services/archival-service.ts
+++ b/apps/server/src/services/archival-service.ts
@@ -18,10 +18,11 @@ import type { FeatureLoader } from './feature-loader.js';
 import type { LedgerService } from './ledger-service.js';
 import type { SettingsService } from './settings-service.js';
 import type { EventEmitter } from '../lib/events.js';
+import { ARCHIVAL_CHECK_INTERVAL_MS } from '../config/timeouts.js';
 
 const logger = createLogger('ArchivalService');
 
-const CHECK_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
+const CHECK_INTERVAL_MS = ARCHIVAL_CHECK_INTERVAL_MS;
 const DEFAULT_RETENTION_HOURS = 2;
 
 export class ArchivalService {

--- a/apps/server/src/services/authority-agents/em-agent.ts
+++ b/apps/server/src/services/authority-agents/em-agent.ts
@@ -30,11 +30,12 @@ import {
   withProcessingGuard,
   type AgentState,
 } from './agent-utils.js';
+import { EM_POLL_INTERVAL_MS } from '../../config/timeouts.js';
 
 const logger = createLogger('EMAgent');
 
 /** Polling interval for checking ready features */
-const POLL_INTERVAL_MS = 10_000;
+const POLL_INTERVAL_MS = EM_POLL_INTERVAL_MS;
 
 /** Default WIP limit per project */
 const DEFAULT_WIP_LIMIT = 3;

--- a/apps/server/src/services/authority-agents/projm-agent.ts
+++ b/apps/server/src/services/authority-agents/projm-agent.ts
@@ -33,11 +33,12 @@ import {
   withProcessingGuard,
   type AgentState,
 } from './agent-utils.js';
+import { PROJM_POLL_INTERVAL_MS } from '../../config/timeouts.js';
 
 const logger = createLogger('ProjMAgent');
 
 /** Polling interval for checking planned/approved features and milestone completion */
-const POLL_INTERVAL_MS = 15_000;
+const POLL_INTERVAL_MS = PROJM_POLL_INTERVAL_MS;
 
 /** Model used for milestone planning */
 const PLANNING_MODEL = resolveModelString('sonnet');

--- a/apps/server/src/services/ava-channel-reactor-service.ts
+++ b/apps/server/src/services/ava-channel-reactor-service.ts
@@ -39,17 +39,24 @@ import {
   type MessageClassification,
 } from './ava-channel-classifiers.js';
 import type { AvaChannelService } from './ava-channel-service.js';
+import {
+  AVA_REACTOR_RESUBSCRIBE_BASE_MS,
+  AVA_REACTOR_RESUBSCRIBE_MAX_MS,
+  AVA_REACTOR_HEARTBEAT_INTERVAL_MS,
+  AVA_REACTOR_DORA_REPORT_INTERVAL_MS,
+  AVA_REACTOR_HEALTH_ALERT_PAUSE_MS,
+} from '../config/timeouts.js';
 
 const logger = createLogger('AvaChannelReactor');
 
 /** Base delay for exponential backoff on subscription errors */
-const RESUBSCRIBE_BASE_MS = 5_000;
+const RESUBSCRIBE_BASE_MS = AVA_REACTOR_RESUBSCRIBE_BASE_MS;
 /** Maximum delay for exponential backoff */
-const RESUBSCRIBE_MAX_MS = 60_000;
+const RESUBSCRIBE_MAX_MS = AVA_REACTOR_RESUBSCRIBE_MAX_MS;
 /** Capacity heartbeat broadcast interval */
-const HEARTBEAT_INTERVAL_MS = 60_000;
+const HEARTBEAT_INTERVAL_MS = AVA_REACTOR_HEARTBEAT_INTERVAL_MS;
 /** DORA report broadcast interval (1 hour) */
-const DORA_REPORT_INTERVAL_MS = 60 * 60 * 1000;
+const DORA_REPORT_INTERVAL_MS = AVA_REACTOR_DORA_REPORT_INTERVAL_MS;
 /** Maximum features to steal per work-steal cycle */
 const MAX_STEAL_PER_CYCLE = 2;
 /** Memory threshold (%) above which a health_alert is broadcast */
@@ -57,7 +64,7 @@ const HEALTH_ALERT_MEMORY_THRESHOLD = 85;
 /** CPU threshold (%) above which a health_alert is broadcast */
 const HEALTH_ALERT_CPU_THRESHOLD = 90;
 /** Duration (ms) to pause work-stealing from a degraded peer */
-const HEALTH_ALERT_PAUSE_MS = 5 * 60 * 1000;
+const HEALTH_ALERT_PAUSE_MS = AVA_REACTOR_HEALTH_ALERT_PAUSE_MS;
 /** Number of blocked features in a project that triggers a project_blocked broadcast */
 const PROJECT_BLOCKED_THRESHOLD = 3;
 

--- a/apps/server/src/services/crdt-sync-service.ts
+++ b/apps/server/src/services/crdt-sync-service.ts
@@ -23,14 +23,20 @@ import type {
 } from '@protolabsai/types';
 import { CRDT_SYNCED_EVENT_TYPES } from '@protolabsai/types';
 import type { EventEmitter } from '../lib/events.js';
+import {
+  CRDT_HEARTBEAT_MS,
+  CRDT_TTL_MS,
+  CRDT_RECONNECT_INTERVAL_MS,
+  CRDT_TTL_CHECK_INTERVAL_MS,
+} from '../config/timeouts.js';
 
 const logger = createLogger('CrdtSyncService');
 
-const DEFAULT_HEARTBEAT_MS = 30_000;
-const DEFAULT_TTL_MS = 120_000;
+const DEFAULT_HEARTBEAT_MS = CRDT_HEARTBEAT_MS;
+const DEFAULT_TTL_MS = CRDT_TTL_MS;
 const DEFAULT_SYNC_PORT = 4444;
-const RECONNECT_INTERVAL_MS = 5_000;
-const TTL_CHECK_INTERVAL_MS = 10_000;
+const RECONNECT_INTERVAL_MS = CRDT_RECONNECT_INTERVAL_MS;
+const TTL_CHECK_INTERVAL_MS = CRDT_TTL_CHECK_INTERVAL_MS;
 
 interface PeerMessage {
   type: 'heartbeat' | 'goodbye' | 'identity' | 'promote';

--- a/apps/server/src/services/health-monitor-service.ts
+++ b/apps/server/src/services/health-monitor-service.ts
@@ -25,15 +25,13 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import v8 from 'v8';
 import { getReactiveSpawnerService } from './reactive-spawner-service.js';
+import { HEALTH_CHECK_INTERVAL_MS, STUCK_FEATURE_THRESHOLD_MS } from '../config/timeouts.js';
 
 const execAsync = promisify(exec);
 const logger = createLogger('HealthMonitor');
 
 /** Default interval for health checks (30 seconds for faster memory monitoring) */
-const DEFAULT_CHECK_INTERVAL_MS = 30 * 1000;
-
-/** Threshold for considering a feature stuck (30 minutes) */
-const STUCK_FEATURE_THRESHOLD_MS = 30 * 60 * 1000;
+const DEFAULT_CHECK_INTERVAL_MS = HEALTH_CHECK_INTERVAL_MS;
 
 /** Maximum memory usage before warning (80% of heap) */
 const MEMORY_WARNING_THRESHOLD = 0.8;

--- a/apps/server/src/services/pr-feedback-service.ts
+++ b/apps/server/src/services/pr-feedback-service.ts
@@ -35,6 +35,12 @@ import {
 } from './pr-status-checker.js';
 import { FeedbackAggregator } from './feedback-aggregator.js';
 import { ThreadResolver } from './thread-resolver.js';
+import {
+  PR_FEEDBACK_POLL_INTERVAL_MS,
+  PR_FEEDBACK_CI_POLL_INTERVAL_MS,
+  PR_FEEDBACK_CI_MAX_WAIT_MS,
+  PR_FEEDBACK_MISSING_CI_CHECK_THRESHOLD_MS,
+} from '../config/timeouts.js';
 
 const logger = createLogger('PRFeedbackRemediation');
 
@@ -63,7 +69,7 @@ interface PersistedPRTracking {
 }
 
 /** How often to poll for PR reviews */
-const POLL_INTERVAL_MS = 60_000;
+const POLL_INTERVAL_MS = PR_FEEDBACK_POLL_INTERVAL_MS;
 
 /** Max iterations before escalating to CTO - prevents infinite feedback loops */
 const MAX_PR_ITERATIONS = 2;
@@ -72,20 +78,17 @@ const MAX_PR_ITERATIONS = 2;
 const MAX_TOTAL_REMEDIATION_CYCLES = 4;
 
 /** How often to poll for CI check status (60s) */
-const CI_POLL_INTERVAL_MS = 60_000;
+const CI_POLL_INTERVAL_MS = PR_FEEDBACK_CI_POLL_INTERVAL_MS;
 
 /** Max time to wait for CI checks to complete (10 minutes) */
-const CI_MAX_WAIT_MS = 10 * 60 * 1000;
+const CI_MAX_WAIT_MS = PR_FEEDBACK_CI_MAX_WAIT_MS;
 
 /**
  * How long a PR can wait before we alert on required CI checks that never registered.
  * A check is considered "permanently missing" when it has been absent this long.
  * Configurable via MISSING_CI_CHECK_THRESHOLD_MINUTES env variable (default: 30).
  */
-const MISSING_CI_CHECK_THRESHOLD_MS = (() => {
-  const minutes = parseInt(process.env.MISSING_CI_CHECK_THRESHOLD_MINUTES ?? '30', 10);
-  return (isNaN(minutes) || minutes <= 0 ? 30 : minutes) * 60 * 1000;
-})();
+const MISSING_CI_CHECK_THRESHOLD_MS = PR_FEEDBACK_MISSING_CI_CHECK_THRESHOLD_MS;
 
 export class PRFeedbackService {
   private readonly events: EventEmitter;

--- a/apps/server/src/services/pr-watcher-service.ts
+++ b/apps/server/src/services/pr-watcher-service.ts
@@ -12,14 +12,15 @@
 import { createLogger } from '@protolabsai/utils';
 import { githubMergeService } from './github-merge-service.js';
 import type { EventEmitter } from '../lib/events.js';
+import { PR_WATCHER_POLL_INTERVAL_MS, PR_WATCHER_TIMEOUT_MS } from '../config/timeouts.js';
 
 const logger = createLogger('PRWatcherService');
 
 /** Default polling interval: 30 seconds */
-const DEFAULT_POLL_INTERVAL_MS = 30_000;
+const DEFAULT_POLL_INTERVAL_MS = PR_WATCHER_POLL_INTERVAL_MS;
 
 /** Auto-expire watches after 30 minutes */
-const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_TIMEOUT_MS = PR_WATCHER_TIMEOUT_MS;
 
 interface WatchEntry {
   /** The chat session ID that initiated the watch (used to route the notification) */

--- a/apps/server/src/services/stream-observer-service.ts
+++ b/apps/server/src/services/stream-observer-service.ts
@@ -10,12 +10,13 @@
 
 import { createLogger } from '@protolabsai/utils';
 import { createHash } from 'node:crypto';
+import { STREAM_OBSERVER_STALL_TIMEOUT_MS } from '../config/timeouts.js';
 
 const logger = createLogger('StreamObserver');
 
 const LOOP_WINDOW = 8;
 const LOOP_THRESHOLD = 3;
-const STALL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const STALL_TIMEOUT_MS = STREAM_OBSERVER_STALL_TIMEOUT_MS;
 
 /**
  * Tools excluded from loop detection.

--- a/apps/server/src/services/work-intake-service.ts
+++ b/apps/server/src/services/work-intake-service.ts
@@ -22,12 +22,14 @@ import {
 import type { Project, Phase, Milestone, InstanceRole } from '@protolabsai/types';
 import type { EventEmitter } from '../lib/events.js';
 
+import { WORK_INTAKE_TICK_INTERVAL_MS, WORK_INTAKE_CLAIM_TIMEOUT_MS } from '../config/timeouts.js';
+
 const logger = createLogger('WorkIntakeService');
 
 /** Default tick interval for checking claimable phases */
-const DEFAULT_TICK_INTERVAL_MS = 30_000;
+const DEFAULT_TICK_INTERVAL_MS = WORK_INTAKE_TICK_INTERVAL_MS;
 /** Default timeout before a stale claim becomes reclaimable */
-const DEFAULT_CLAIM_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+const DEFAULT_CLAIM_TIMEOUT_MS = WORK_INTAKE_CLAIM_TIMEOUT_MS;
 /** Delay after claiming to verify the claim survived Automerge merge */
 const CLAIM_VERIFY_DELAY_MS = 200;
 

--- a/apps/server/src/services/worktree-lifecycle-service.ts
+++ b/apps/server/src/services/worktree-lifecycle-service.ts
@@ -20,14 +20,15 @@ import * as secureFs from '../lib/secure-fs.js';
 import type { EventEmitter } from '../lib/events.js';
 import type { FeatureLoader } from './feature-loader.js';
 import { isWorktreeLocked } from '../lib/worktree-lock.js';
+import { WORKTREE_CLEANUP_DELAY_MS, WORKTREE_DRIFT_CHECK_INTERVAL_MS } from '../config/timeouts.js';
 
 const logger = createLogger('WorktreeLifecycle');
 
 /** Delay after PR merge before cleanup (allow CI/webhooks to settle) */
-const CLEANUP_DELAY_MS = 10_000;
+const CLEANUP_DELAY_MS = WORKTREE_CLEANUP_DELAY_MS;
 
 /** Periodic drift detection interval (6 hours) */
-const DRIFT_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const DRIFT_CHECK_INTERVAL_MS = WORKTREE_DRIFT_CHECK_INTERVAL_MS;
 
 /** Worktree drift detection results */
 export interface WorktreeDrift {


### PR DESCRIPTION
## Summary

**Milestone:** Timeout Configuration

Update all remaining services that define their own timeout constants to import from the central config module. Includes crdt-sync, health-monitor, archival, worktree-lifecycle, pr-feedback, pr-watcher, work-intake, stream-observer, and authority agents.

**Files to Modify:**
- apps/server/src/services/crdt-sync-service.ts
- apps/server/src/services/health-monitor-service.ts
- apps/server/src/services/archival-service.ts
- apps/server/src/services/worktree-l...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-14T03:27:26.980Z -->