### PR TITLE
Remove CRDT dual-write from notes routes

### DIFF
--- a/apps/server/src/routes/notes/index.ts
+++ b/apps/server/src/routes/notes/index.ts
@@ -3,25 +3,11 @@
  *
  * ## Storage Model
  *
- * **Primary:** CRDT (Automerge)
- *   - Domain: `notes`
- *   - Document ID: `workspace`
- *   - Full registry key: `notes:workspace`
- *   - Seeded on first startup via `hydrateNotesWorkspace()` in crdt-store.module.ts
- *   - Provides multi-instance eventual consistency via the CRDTStore sync mesh
+ * **Primary:** Disk — `.automaker/notes/workspace.json`
+ *   - All reads and writes go directly to disk
+ *   - Always available, no external dependencies
  *
- * **Fallback (routes):** Disk — `.automaker/notes/workspace.json`
- *   - Routes read from and write to disk directly (synchronous, always available)
- *   - Disk writes fire-and-forget into the CRDT store for replication
- *   - When CRDT is unavailable, disk is the durable source of truth
- *
- * **Conflict semantics:** Last-write-wins (LWW) per tab field.
- *   Tab content, name, and permissions are independent Automerge fields — the
- *   last mutation to each field wins if two instances write concurrently.
- *
- * **TipTap CRDT binding (deferred):** Tab content is currently stored as a plain
- *   HTML string. Per-character collaborative editing via TipTap's Y.js integration
- *   is planned but not yet implemented — content fields remain LWW until then.
+ * **Conflict semantics:** Last-write-wins (LWW) per full workspace save.
  */
 
 import { Router, type Request, type Response } from 'express';
@@ -34,33 +20,11 @@ import {
 } from '@protolabsai/platform';
 import type { NotesWorkspace, NoteTab, NoteTabPermissions } from '@protolabsai/types';
 import type { EventEmitter } from '../../lib/events.js';
-import type { CRDTStore, CRDTDocumentRoot, DomainName } from '@protolabsai/crdt';
 
 const logger = createLogger('NotesRoutes');
 
 // ---------------------------------------------------------------------------
-// CRDT document type
-// ---------------------------------------------------------------------------
-
-/**
- * NotesWorkspaceDocument is the CRDT representation of the notes workspace.
- * Fields mirror NotesWorkspace but extend CRDTDocumentRoot for attribution.
- * Domain key: 'notes:workspace'
- */
-interface NotesWorkspaceDocument extends CRDTDocumentRoot {
-  version: 1;
-  workspaceVersion?: number;
-  activeTabId: string | null;
-  tabOrder: string[];
-  tabs: Record<string, NoteTab>;
-}
-
-// 'notes' is not yet in the DomainName union — cast until the types package is updated.
-const NOTES_CRDT_DOMAIN = 'notes' as unknown as DomainName;
-const NOTES_CRDT_ID = 'workspace';
-
-// ---------------------------------------------------------------------------
-// Disk helpers (unchanged from original)
+// Disk helpers
 // ---------------------------------------------------------------------------
 
 function createDefaultWorkspace(): NotesWorkspace {
@@ -104,124 +68,10 @@ function bumpVersion(workspace: NotesWorkspace): void {
 }
 
 // ---------------------------------------------------------------------------
-// CRDT helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Convert an Automerge doc snapshot to a plain NotesWorkspace.
- * Spreads nested objects to produce plain JS values (not Automerge proxies).
- */
-function docToWorkspace(doc: NotesWorkspaceDocument): NotesWorkspace {
-  return {
-    version: 1,
-    workspaceVersion: doc.workspaceVersion,
-    activeTabId: doc.activeTabId,
-    tabOrder: Array.from(doc.tabOrder),
-    tabs: Object.fromEntries(
-      Object.entries(doc.tabs as Record<string, NoteTab>).map(([id, tab]) => [
-        id,
-        {
-          id: tab.id,
-          name: tab.name,
-          content: tab.content,
-          permissions: {
-            agentRead: tab.permissions.agentRead,
-            agentWrite: tab.permissions.agentWrite,
-          },
-          metadata: {
-            createdAt: tab.metadata.createdAt,
-            updatedAt: tab.metadata.updatedAt,
-            wordCount: tab.metadata.wordCount,
-            characterCount: tab.metadata.characterCount,
-          },
-        },
-      ])
-    ),
-  };
-}
-
-/**
- * Load notes workspace: try CRDT first, fall back to disk.
- * CRDT data is considered valid only if tabOrder has been populated (i.e. at least
- * one write has occurred via saveWorkspaceWithCrdt).
- */
-async function loadWorkspaceWithCrdt(
-  projectPath: string,
-  store?: CRDTStore
-): Promise<NotesWorkspace> {
-  if (store) {
-    try {
-      const handle = await store.getOrCreate<NotesWorkspaceDocument>(
-        NOTES_CRDT_DOMAIN,
-        NOTES_CRDT_ID
-      );
-      const doc = handle.doc();
-      // Only use CRDT data if the workspace has been seeded (tabOrder present and non-empty)
-      if (doc && Array.isArray(doc.tabOrder) && doc.tabOrder.length > 0 && doc.tabs) {
-        return docToWorkspace(doc);
-      }
-    } catch (err) {
-      logger.warn('[Notes CRDT] Read failed, falling back to disk:', err);
-    }
-  }
-  return loadWorkspace(projectPath);
-}
-
-/**
- * Save notes workspace: always write to disk (primary store), then fire-and-forget
- * CRDT update for multi-instance propagation.
- */
-async function saveWorkspaceWithCrdt(
-  projectPath: string,
-  workspace: NotesWorkspace,
-  store?: CRDTStore
-): Promise<void> {
-  // Primary store: disk — always succeeds before CRDT
-  await saveWorkspace(projectPath, workspace);
-
-  // Secondary store: CRDT — fire-and-forget, disk write already succeeded
-  if (store) {
-    store
-      .change<NotesWorkspaceDocument>(NOTES_CRDT_DOMAIN, NOTES_CRDT_ID, (doc) => {
-        // Use Record cast to allow setting fields that may not exist in fresh doc
-        const mutable = doc as unknown as Record<string, unknown>;
-        mutable['version'] = 1;
-        mutable['workspaceVersion'] = workspace.workspaceVersion;
-        mutable['activeTabId'] = workspace.activeTabId;
-        mutable['tabOrder'] = workspace.tabOrder.slice();
-        // Copy plain objects into CRDT — Automerge converts them to tracked structures
-        mutable['tabs'] = Object.fromEntries(
-          Object.entries(workspace.tabs).map(([id, tab]) => [
-            id,
-            {
-              id: tab.id,
-              name: tab.name,
-              content: tab.content,
-              permissions: {
-                agentRead: tab.permissions.agentRead,
-                agentWrite: tab.permissions.agentWrite,
-              },
-              metadata: {
-                createdAt: tab.metadata.createdAt,
-                updatedAt: tab.metadata.updatedAt,
-                wordCount: tab.metadata.wordCount,
-                characterCount: tab.metadata.characterCount,
-              },
-            },
-          ])
-        );
-      })
-      .catch((err) => {
-        logger.warn('[Notes CRDT] Write failed (disk write succeeded):', err);
-      });
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Route factory
 // ---------------------------------------------------------------------------
 
-export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Router {
+export function createNotesRoutes(events?: EventEmitter): Router {
   const router = Router();
 
   /**
@@ -236,7 +86,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
         return;
       }
       validatePath(projectPath);
-      const workspace = await loadWorkspaceWithCrdt(projectPath, store);
+      const workspace = await loadWorkspace(projectPath);
       res.json({ workspace });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
@@ -260,7 +110,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
         return;
       }
       validatePath(projectPath);
-      await saveWorkspaceWithCrdt(projectPath, workspace, store);
+      await saveWorkspace(projectPath, workspace);
       res.json({ success: true });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
@@ -281,7 +131,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
         return;
       }
       validatePath(projectPath);
-      const workspace = await loadWorkspaceWithCrdt(projectPath, store);
+      const workspace = await loadWorkspace(projectPath);
       const tab = workspace.tabs[tabId];
       if (!tab) {
         res.status(404).json({ error: 'Tab not found' });
@@ -314,7 +164,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
         return;
       }
       validatePath(projectPath);
-      const workspace = await loadWorkspaceWithCrdt(projectPath, store);
+      const workspace = await loadWorkspace(projectPath);
       const tabs: Array<{
         id: string;
         name: string;
@@ -360,7 +210,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
         return;
       }
       validatePath(projectPath);
-      const workspace = await loadWorkspaceWithCrdt(projectPath, store);
+      const workspace = await loadWorkspace(projectPath);
       const tab = workspace.tabs[tabId];
       if (!tab) {
         res.status(404).json({ error: 'Tab not found' });
@@ -381,7 +231,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
       tab.metadata.characterCount = plainText.length;
 
       bumpVersion(workspace);
-      await saveWorkspaceWithCrdt(projectPath, workspace, store);
+      await saveWorkspace(projectPath, workspace);
 
       if (events) {
         events.emit('notes:tab-updated', { projectPath, tabId, name: tab.name });
@@ -422,7 +272,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
         return;
       }
       validatePath(projectPath);
-      const workspace = await loadWorkspaceWithCrdt(projectPath, store);
+      const workspace = await loadWorkspace(projectPath);
 
       const now = Date.now();
       const tabId = crypto.randomUUID();
@@ -449,7 +299,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
       workspace.tabs[tabId] = newTab;
       workspace.tabOrder.push(tabId);
       bumpVersion(workspace);
-      await saveWorkspaceWithCrdt(projectPath, workspace, store);
+      await saveWorkspace(projectPath, workspace);
 
       if (events) {
         events.emit('notes:tab-created', { projectPath, tabId, name: tabName });
@@ -484,7 +334,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
         return;
       }
       validatePath(projectPath);
-      const workspace = await loadWorkspaceWithCrdt(projectPath, store);
+      const workspace = await loadWorkspace(projectPath);
 
       if (!workspace.tabs[tabId]) {
         res.status(404).json({ error: 'Tab not found' });
@@ -503,7 +353,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
       }
 
       bumpVersion(workspace);
-      await saveWorkspaceWithCrdt(projectPath, workspace, store);
+      await saveWorkspace(projectPath, workspace);
 
       if (events) {
         events.emit('notes:tab-deleted', { projectPath, tabId });
@@ -537,7 +387,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
         return;
       }
       validatePath(projectPath);
-      const workspace = await loadWorkspaceWithCrdt(projectPath, store);
+      const workspace = await loadWorkspace(projectPath);
       const tab = workspace.tabs[tabId];
       if (!tab) {
         res.status(404).json({ error: 'Tab not found' });
@@ -548,7 +398,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
       tab.metadata.updatedAt = Date.now();
 
       bumpVersion(workspace);
-      await saveWorkspaceWithCrdt(projectPath, workspace, store);
+      await saveWorkspace(projectPath, workspace);
 
       if (events) {
         events.emit('notes:tab-renamed', { projectPath, tabId, name });
@@ -582,7 +432,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
         return;
       }
       validatePath(projectPath);
-      const workspace = await loadWorkspaceWithCrdt(projectPath, store);
+      const workspace = await loadWorkspace(projectPath);
       const tab = workspace.tabs[tabId];
       if (!tab) {
         res.status(404).json({ error: 'Tab not found' });
@@ -598,7 +448,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
       tab.metadata.updatedAt = Date.now();
 
       bumpVersion(workspace);
-      await saveWorkspaceWithCrdt(projectPath, workspace, store);
+      await saveWorkspace(projectPath, workspace);
 
       if (events) {
         events.emit('notes:tab-permissions-changed', {
@@ -635,7 +485,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
         return;
       }
       validatePath(projectPath);
-      const workspace = await loadWorkspaceWithCrdt(projectPath, store);
+      const workspace = await loadWorkspace(projectPath);
 
       // Validate all IDs exist and no extra/missing IDs
       const existingIds = new Set(Object.keys(workspace.tabs));
@@ -653,7 +503,7 @@ export function createNotesRoutes(events?: EventEmitter, store?: CRDTStore): Rou
 
       workspace.tabOrder = tabOrder;
       bumpVersion(workspace);
-      await saveWorkspaceWithCrdt(projectPath, workspace, store);
+      await saveWorkspace(projectPath, workspace);
 
       res.json({
         success: true,

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -401,7 +401,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api/chat', createChatRoutes(services));
   app.use('/api/codex', createCodexRoutes());
   app.use('/api/ai', createAIRoutes());
-  app.use('/api/notes', createNotesRoutes(events, services._crdtStore));
+  app.use('/api/notes', createNotesRoutes(events));
   app.use('/api/todos', createTodoRoutes(todoService));
   app.use('/api/sitrep', createSitrepRoutes({ featureLoader, autoModeService, repoRoot }));
   // Knowledge store routes (chunked retrieval)


### PR DESCRIPTION
## Summary

**Milestone:** Strip CRDT from Consumer Services

Remove all CRDT imports and the saveWorkspaceWithCrdt helper from apps/server/src/routes/notes/index.ts. Replace CRDT reads with disk-only reads. Remove the duplicate NotesWorkspaceDocument type definition. All reads and writes go directly to .automaker/notes/workspace.json.

**Files to Modify:**
- apps/server/src/routes/notes/index.ts

**Acceptance Criteria:**
- [ ] No @protolabsai/crdt or @automerge imports in notes/index.ts
- [ ] Notes read/wr...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=transient-ef32ac24 team= created=2026-03-14T05:38:50.179Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated notes storage infrastructure to use disk-backed storage directly, simplifying the data persistence layer and streamlining how notes are loaded, saved, and managed across all operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->