### PR TITLE
docs: update docs after CRDT/Automerge removal

### DIFF
--- a/docs/archived/ava-channel-reactor.md
+++ b/docs/archived/ava-channel-reactor.md
@@ -1,3 +1,7 @@
+> **Archived March 2026** — AvaChannelReactorService was removed along with the Ava Channel infrastructure. Fleet coordination via the CRDT-backed Ava Channel is no longer active. WorkIntakeService handles phase-claiming coordination independently. See [Work Intake Service](../server/work-intake-service.md) and [Distributed Sync](../dev/distributed-sync.md).
+
+---
+
 # Ava Channel Reactor
 
 Reactive orchestrator that makes Ava instances responsive to each other and coordinates fleet-level work distribution across the multi-instance mesh.

--- a/docs/archived/ava-channel.md
+++ b/docs/archived/ava-channel.md
@@ -1,3 +1,7 @@
+> **Archived March 2026** — The Ava Channel (AvaChannelService, HTTP routes, CRDT-backed message store, and backchannel infrastructure) was removed. Multi-instance coordination now uses the PeerMeshService WebSocket layer only. See [Peer Mesh Service](../server/peer-mesh-service.md) and [Distributed Sync](../dev/distributed-sync.md).
+
+---
+
 # Ava Channel
 
 Private coordination channel for multi-instance Ava communication, CRDT-backed message storage, and automatic System Improvements ticket filing.

--- a/docs/dev/distributed-sync.md
+++ b/docs/dev/distributed-sync.md
@@ -1,45 +1,36 @@
 # Distributed Sync
 
-How protoLabs synchronizes state across multiple instances using Automerge CRDTs, partition detection, reconnection resilience, and pull-based work intake.
+How protoLabs synchronizes state across multiple instances using the peer mesh, leader election, partition detection, and pull-based work intake.
+
+> **Updated March 2026:** The Automerge/CRDT layer (CRDTStore, Automerge binary sync, AvaChannelService, CalendarService CRDT injection, TodoService CRDT injection) was removed. The sync mesh now consists of a single WebSocket layer (`PeerMeshService`) for event broadcasting, heartbeats, and leader election. Document state is disk-based on each instance; coordination uses the pull-based `WorkIntakeService`.
 
 ## Architecture Overview
 
-protoLabs uses a two-layer WebSocket sync mesh when hivemind mode is enabled:
+protoLabs uses a single-layer WebSocket sync mesh when hivemind mode is enabled:
 
-| Layer                | Service                         | Port                 | Purpose                                          |
-| -------------------- | ------------------------------- | -------------------- | ------------------------------------------------ |
-| **Sync mesh**        | `CrdtSyncService`               | `:4444` (default)    | Peer heartbeat, leader election, event broadcast |
-| **CRDT binary sync** | `CRDTStore` (crdt-store.module) | `:4445` (syncPort+1) | Automerge binary protocol for document state     |
+| Layer         | Service           | Port              | Purpose                                          |
+| ------------- | ----------------- | ----------------- | ------------------------------------------------ |
+| **Sync mesh** | `PeerMeshService` | `:4444` (default) | Peer heartbeat, leader election, event broadcast |
 
-One instance acts as **primary** and others connect as **workers**. Instances exchange CRDT changes for **projects and coordination data** in real time. Features are always instance-local — they never cross the wire.
+One instance acts as **primary** and others connect as **workers**. Instances exchange feature and project events in real time. Features are always instance-local — they never cross the wire.
 
 ```
 Worker A ──────┐
                ▼
-Worker B ────▶ Primary (:4444 CrdtSyncService / :4445 CRDTStore)
+Worker B ────▶ Primary (:4444 PeerMeshService)
                ▲
 Worker C ──────┘
 ```
 
-Fleet coordination (capacity advertising, escalations, scheduling) is layered on top via the Ava Channel — a daily-sharded CRDT document that all instances write to and the `AvaChannelReactorService` subscribes to. Work distribution uses a **pull-based intake model**: instances claim phases from shared project documents rather than pushing features to each other.
+Work distribution uses a **pull-based intake model**: instances claim phases from shared project documents (via `WorkIntakeService`) rather than pushing features to each other.
 
 ### Layered Services
 
-The distributed system is composed of interconnected services, each building on the layer below:
-
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│                    AvaChannelReactorService                          │  ← Reactive orchestrator
-│                    (classifier chain, loop prevention, DORA)         │
+│                    WorkIntakeService                                  │  ← Phase claiming (pull-based)
 ├─────────────────────────────────────────────────────────────────────┤
-│                    FleetSchedulerService                             │  ← Feature + phase scheduling
-│            (schedule_assignment, failover, conflict resolution)      │
-├─────────────────────────────────────────────────────────────────────┤
-│  AvaChannelService  CalendarService  TodoService                     │  ← Document services (CRDT-injected)
-├─────────────────────────────────────────────────────────────────────┤
-│               CRDTStore (crdt-store.module)                         │  ← Automerge document persistence
-├─────────────────────────────────────────────────────────────────────┤
-│               CrdtSyncService (:4444)                               │  ← Peer mesh + leader election
+│               PeerMeshService (:4444)                                │  ← Peer mesh + leader election
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -61,101 +52,6 @@ hivemind:
     - ws://100.64.0.3:4444 # worker-2
 ```
 
-## CRDT Store and Service Injection
-
-`crdt-store.module.ts` initializes the `CRDTStore` (Automerge document persistence) when hivemind mode is enabled, then injects the store into three services via their `setCrdtStore()` hook:
-
-- `AvaChannelService` — daily-sharded coordination messages
-- `CalendarService` — shared calendar events synced under `doc:calendar/shared`
-- `TodoService` — shared todo workspace synced under `doc:todos/workspace`
-
-Projects use EventBus-based sync handled by `crdt-sync.module.ts` (project events only). Features are instance-local and are **not** synced via CRDT — they are created locally from claimed project phases.
-
-## Registry Sync (Split-Brain Prevention)
-
-When a worker reconnects to the primary, the primary immediately sends a `registry_sync` message containing its entire CRDTStore document registry (a map of `"domain:id"` → storage URL). The worker merges this registry into its local `CRDTStore` via `adoptRemoteRegistry()`, resolving cases where both instances independently created Automerge documents for the same `domain:id` with different URLs.
-
-This is wired in `crdt-store.module.ts`:
-
-- **Primary**: calls `crdtSyncService.setRegistryProvider(() => store.getRegistry())`.
-- **Worker**: calls `crdtSyncService.onRegistryReceived((remoteRegistry) => store.adoptRemoteRegistry(remoteRegistry))`.
-
-The `adoptRemoteRegistry()` call returns `{ adopted, conflicts }` counts that are logged. No manual wiring is needed beyond the module bootstrap order — `crdt-store.module` must register before `ava-channel-reactor.module`.
-
-## Ava Channel Reactor
-
-`AvaChannelReactorService` is the reactive orchestrator for multi-instance coordination. It subscribes to the CRDT-backed daily-sharded Ava Channel (`doc:ava-channel/YYYY-MM-DD`), detects new messages, and dispatches responses with three-layer loop prevention:
-
-1. **Classifier chain** — configurable `MessageClassifierRule[]` rules (regex + source filter) determine `MessageIntent`. Messages with intent `inform` or `system_alert` from other instances are typically suppressed.
-2. **Per-thread cooldown** — configurable `threadCooldownMs` prevents responding twice to the same thread within the window.
-3. **Busy gate** — a `processingMessage` flag serializes responses to prevent overlapping work on a single instance.
-
-Self-healing: on subscription failure, the reactor retries with exponential backoff (5 s base, 60 s cap).
-
-### Enabling the Reactor
-
-The reactor requires **both** conditions:
-
-1. `hivemind.enabled: true` in `proto.config.yaml`
-2. `featureFlags.reactorEnabled: true` in global settings (checked via `SettingsService.getGlobalSettings()`)
-
-The reactor is started by `ava-channel-reactor.module.ts`, which must run after `crdt-store.module` so `container._crdtStore` is available.
-
-### Bug Report Forwarding
-
-`CrdtSyncService.attachAvaChannelBugReporter(callback)` registers a callback that is invoked whenever a `bug:reported` event fires on the attached `EventBus`. The callback receives `(content: string, featureId?: string)` and posts the report to the Ava Channel as a system message. This wires the internal event bus to the CRDT-backed channel without additional module coupling.
-
-## Fleet Scheduler
-
-`FleetSchedulerService` handles fleet-level feature distribution and project phase scheduling. It runs inside `ava-channel-reactor.module` alongside the reactor.
-
-### Role
-
-- **Primary** (`role: primary` in `proto.config.yaml`): starts as the active scheduler immediately.
-- **Worker**: waits for failover. If the primary's `scheduler_heartbeat` is absent for >10 minutes, the longest-running worker (by uptime) takes over scheduling. Tiebreaker: lower `instanceId` (lexicographic) wins.
-
-### Schedule Cycle
-
-Every 5 minutes the active scheduler:
-
-1. Collects live `work_inventory` snapshots from all peers (TTL = 6 minutes).
-2. Computes an assignment: unassigned backlog features (dependency order) are distributed to instances with spare capacity (`maxConcurrency - activeCount`).
-3. Broadcasts a `schedule_assignment` message; each instance applies its own slice.
-
-### Conflict Resolution
-
-When two instances both claim the same feature, the detecting instance broadcasts a `schedule_conflict`. The instance with the **higher** `instanceId` (lexicographic) releases the claim and sets the feature back to `backlog`.
-
-### Project Phase Distribution
-
-When a new project is created, the active scheduler distributes its milestone phases across fleet instances:
-
-1. Phases are grouped into parallel waves using Kahn's BFS (topological sort on the dependency DAG).
-2. Parallel waves are distributed round-robin across available instances.
-3. A `schedule_assignment` is broadcast encoding phase identifiers as `projectSlug/milestoneSlug/phaseName` strings.
-
-### Project Fleet Status API
-
-`GET /api/projects/:slug/fleet-status` returns the aggregated phase progress for a project:
-
-```json
-{
-  "success": true,
-  "projectSlug": "my-project",
-  "phases": [
-    {
-      "milestoneSlug": "m1",
-      "phaseName": "implementation",
-      "instanceId": "prod-01",
-      "status": "done",
-      "timestamp": "2026-03-09T10:00:00.000Z"
-    }
-  ]
-}
-```
-
-Phases are broadcast via `project_progress` messages and aggregated in-memory on every instance. The last-writer-wins (by `timestamp`) for each `projectSlug:milestoneSlug:phaseName` key.
-
 ## Sync Health Metrics
 
 Sync health is exposed at `GET /api/health/detailed` under the `sync` key:
@@ -171,23 +67,17 @@ Sync health is exposed at `GET /api/health/detailed` under the `sync` key:
     "isLeader": false,
     "peerCapacitySummary": [...],
     "partitionSince": null,
-    "queuedChanges": 0,
-    "compactionDiagnostics": {
-      "lastCompactionAt": "2026-03-07T12:00:00.000Z",
-      "totalSizeBytes": 204800,
-      "alertCount": 0
-    }
+    "queuedChanges": 0
   }
 }
 ```
 
-| Field                   | Description                                         |
-| ----------------------- | --------------------------------------------------- |
-| `role`                  | `primary` or `worker`                               |
-| `connected`             | Whether this instance is connected to the sync mesh |
-| `partitionSince`        | ISO timestamp when connectivity was lost, or `null` |
-| `queuedChanges`         | Number of changes buffered while disconnected       |
-| `compactionDiagnostics` | CRDT document size summary (see Compaction section) |
+| Field            | Description                                         |
+| ---------------- | --------------------------------------------------- |
+| `role`           | `primary` or `worker`                               |
+| `connected`      | Whether this instance is connected to the sync mesh |
+| `partitionSince` | ISO timestamp when connectivity was lost, or `null` |
+| `queuedChanges`  | Number of changes buffered while disconnected       |
 
 ## Partition Detection and UI Indicator
 
@@ -223,138 +113,17 @@ If a worker cannot reach the primary and the TTL has expired, it checks whether 
 2. Starts a WebSocket server on `syncPort`.
 3. Workers receive the promotion message and reconnect to the new primary.
 
-## Compaction Diagnostics
-
-`MaintenanceTracker` (in `libs/crdt/src/maintenance.ts`) records size data after each compaction pass and fires alerts when a document exceeds the threshold.
-
-### How to Wire It
-
-```typescript
-import { MaintenanceTracker } from '@protolabsai/crdt';
-
-const tracker = new MaintenanceTracker({ alertThresholdBytes: 10 * 1024 * 1024 });
-
-// After each CRDTStore.compact() call:
-const sizeMap = store.getDocumentSizes(); // Record<string, number>
-tracker.recordCompaction(sizeMap);
-
-// Expose to health endpoint:
-crdtSyncService.setCompactionDiagnosticsProvider(() => {
-  const diag = tracker.getDiagnostics();
-  return {
-    lastCompactionAt: diag.lastCompaction?.timestamp ?? null,
-    totalSizeBytes: diag.totalSizeBytes,
-    alertCount: diag.alerts.length,
-  };
-});
-```
-
-### Diagnostics Object
-
-```typescript
-interface CompactionDiagnostics {
-  lastCompaction: {
-    timestamp: string;
-    docCount: number;
-    totalSizeBytes: number;
-    docSizeMap: Record<string, number>; // "domain:id" -> bytes
-  } | null;
-  history: CompactionRecord[]; // Rolling 20-entry history
-  totalSizeBytes: number;
-  alerts: CompactionAlert[]; // Unacknowledged threshold violations
-}
-```
-
-Acknowledge alerts after operator review:
-
-```typescript
-tracker.clearAlerts();
-```
-
-## Time-Travel Debugging with Automerge.getHistory
-
-Every Automerge document retains its full change history. Use `Automerge.getHistory(doc)` for time-travel debugging in distributed incidents:
-
-```typescript
-import * as Automerge from '@automerge/automerge';
-
-const handle = store.getHandle('features', featureId);
-const doc = handle.doc();
-
-const history = Automerge.getHistory(doc);
-// history: Array<{ change: Change; snapshot: Doc }>
-
-for (const entry of history) {
-  console.log(entry.change.hash, entry.change.timestamp, entry.snapshot);
-}
-```
-
-Each entry includes:
-
-- `change.hash` — unique change identifier
-- `change.timestamp` — wall clock time at the originating instance
-- `change.actor` — `instanceId` of the authoring instance (from CRDT actor ID)
-- `snapshot` — the full document state after this change was applied
-
-This is useful for diagnosing merge conflicts, identifying the source of unexpected state, and reconstructing the sequence of events during a network partition.
-
-## Fleet Coordination via Ava Channel
-
-While the CRDT sync mesh handles state replication, **fleet coordination** (which instance works on which features) is handled through the **Ava Channel** — a daily-sharded CRDT document (`doc:ava-channel/YYYY-MM-DD`) that all instances read and write. The `AvaChannelReactorService` subscribes to this document and dispatches coordination messages.
-
-The reactor is activated by `ava-channel-reactor.module.ts`, which requires **all three** conditions to be met:
-
-1. The `reactorEnabled` feature flag is `true` in global settings.
-2. `proto.config.yaml` exists with `hivemind.enabled: true`.
-3. The `CRDTStore` has been registered by `crdt-store.module` (i.e. `crdt-store.module` must run first).
-
-The `FleetSchedulerService` is instantiated and started inside the same module registration and shares the same lifecycle.
-
-### Ava Channel Document
-
-Each message in the Ava Channel has:
-
-```typescript
-interface AvaChatMessage {
-  id: string;
-  instanceId: string;
-  instanceName: string;
-  content: string;
-  context?: AvaChannelContext; // optional machine-readable metadata
-  source: 'ava' | 'operator' | 'system';
-  timestamp: string; // ISO 8601
-  intent?: MessageIntent; // request | inform | response | coordination | escalation | system_alert
-  inReplyTo?: string; // ID of the parent message in a thread
-  expectsResponse?: boolean;
-  conversationDepth?: number;
-}
-```
-
-`AvaChannelContext` carries optional structured metadata alongside the free-form `content`:
-
-```typescript
-interface AvaChannelContext {
-  featureId?: string;
-  boardSummary?: string;
-  capacity?: { runningAgents: number; maxAgents: number; backlogCount: number };
-}
-```
-
-The reactor classifies incoming messages via a rule chain of `MessageClassifierRule` patterns and dispatches appropriate responses. Loop prevention is enforced at three layers: (1) classifier chain (`shouldRespond` result), (2) per-thread cooldown timer, and (3) a busy gate that queues one pending message while a response is in-flight.
-
-**Protocol message filtering**: Messages with `source='system'` that start with a `[bracket_prefix]` (e.g. `[capacity_heartbeat]`, `[schedule_assignment]`, `[dora_report]`) are intercepted before reaching the classifier chain. These machine-to-machine protocol messages are dispatched directly to their typed handlers and never generate a classifier response.
-
-### Work Intake Protocol
+## Work Intake Protocol
 
 Work distribution uses a **pull-based intake model** via `WorkIntakeService`. Each instance independently claims phases from shared project documents — no centralized coordinator pushes work.
 
 **How it works:**
 
 1. `WorkIntakeService` runs on a configurable tick (default 30s) when auto-mode is active.
-2. Each tick, the service reads shared project docs (local Automerge replica) and finds claimable phases using pure functions from `@protolabsai/utils`.
+2. Each tick, the service reads shared project docs and finds claimable phases using pure functions from `@protolabsai/utils`.
 3. Phases are claimable when: unclaimed, dependencies satisfied, and role/tag affinity matches.
-4. The instance writes `claimedBy=myInstanceId` to the shared project doc via Automerge.
-5. After a 200ms settle delay, it verifies the claim survived Automerge merge (LWW resolution).
+4. The instance writes `claimedBy=myInstanceId` to the shared project doc.
+5. After a 200ms settle delay, it verifies the claim survived merge (LWW resolution).
 6. If the claim is held, the phase is materialized as a **local feature** on the instance's board.
 7. On completion, the shared phase is updated: `executionStatus='done'`, `prUrl=...`.
 
@@ -366,7 +135,7 @@ Work distribution uses a **pull-based intake model** via `WorkIntakeService`. Ea
 | ----------------------------------------------------------- | ----------------------------------------------------- |
 | `getClaimablePhases(project, instanceId, role, tags)`       | Filter phases this instance can claim                 |
 | `roleMatchesPhase(role, tags, phase)`                       | Check role/tag affinity against `phase.filesToModify` |
-| `holdsClaim(phase, instanceId)`                             | Verify claim survived Automerge merge                 |
+| `holdsClaim(phase, instanceId)`                             | Verify claim survived merge                           |
 | `materializeFeature(project, milestone, phase, instanceId)` | Convert phase to local Feature data                   |
 | `phaseDepsAreSatisfied(phase, milestone, project)`          | Check all phase deps are `done`                       |
 | `isReclaimable(phase, peerStatus, claimTimeoutMs)`          | Check if stale claim can be reclaimed                 |
@@ -391,117 +160,12 @@ Roles are configured in `proto.config.yaml` under `instance.role`. A `frontend` 
 
 When an instance is blocked on a feature (e.g., waiting for a human decision) and cannot make progress:
 
-1. The blocked instance posts an `EscalationRequest` to the Ava Channel.
+1. The blocked instance posts an `EscalationRequest` via the escalation router.
 2. Any instance with capacity responds with an `EscalationOffer`.
 3. The blocked instance replies with `EscalationAccept`, transferring ownership.
 4. The accepting instance takes over the feature from its current state.
 
 This prevents features from stalling when an individual instance is stuck.
-
-### Health Alerts
-
-Each instance monitors its own resource usage and posts `HealthAlert` messages when thresholds are exceeded (memory > 85%, CPU > 90%):
-
-```typescript
-interface HealthAlert {
-  instanceId: string;
-  memoryUsed: number; // percentage 0–100
-  cpuLoad: number; // percentage 0–100
-  alertTimestamp: string; // ISO 8601
-}
-```
-
-Peers that receive a `HealthAlert` avoid claiming work from the degraded instance for 5 minutes.
-
-### Self-Healing Subscription
-
-`AvaChannelReactorService` uses exponential backoff on subscription failure: 5-second base delay, capped at 60 seconds. If the daily-sharded document is unavailable at startup, the reactor retries automatically without manual intervention.
-
-## Fleet Scheduler
-
-`FleetSchedulerService` is a higher-level scheduler that distributes **project phases** across fleet instances. It runs on top of the Ava Channel and handles parallel execution of independent work. Epics are excluded from fleet scheduling; only concrete features are assigned.
-
-### How It Works
-
-1. **Inventory Broadcast**: Every instance periodically posts a `[work_inventory]` message describing its current backlog and active features (in dependency order).
-2. **Schedule Assignment**: The active scheduler runs `runScheduleCycle()` every 5 minutes, computing an optimal assignment of features to instances. It posts a `[schedule_assignment]` message mapping `instanceId → featureIds[]`.
-3. **Failover**: If no `[scheduler_heartbeat]` is received within 10 minutes, the longest-running worker instance takes over as active scheduler (last-writer-wins on uptime, with lower `instanceId` as tiebreaker).
-4. **Conflict Resolution**: If two instances both claim the same feature, a `[schedule_conflict]` is broadcast. The instance with the **higher** `instanceId` (lexicographic) releases the claim and moves the feature back to backlog.
-
-### Phase Parallelization
-
-When a new project is created, the fleet scheduler decomposes it into phases using a topological sort (Kahn's BFS). Independent phases are grouped and dispatched to separate instances simultaneously:
-
-```
-Phase 1 (setup)
-    ├── Phase 2a (feature-A)  → Instance prod-01
-    ├── Phase 2b (feature-B)  → Instance prod-02
-    └── Phase 2c (feature-C)  → Instance prod-03
-Phase 3 (integration) — starts after all Phase 2 complete
-```
-
-Progress is tracked via `ProjectProgressMsg`, which each instance posts when it completes a phase. The scheduler waits for all parallel phases to complete before unblocking dependent phases.
-
-### Fleet Status API
-
-```
-GET /api/projects/:slug/fleet-status
-```
-
-Returns the aggregated execution status of a project across all fleet instances:
-
-```json
-{
-  "projectSlug": "my-project",
-  "phases": [
-    {
-      "milestoneSlug": "milestone-1",
-      "phaseName": "feature-A",
-      "status": "done",
-      "instanceId": "prod-01",
-      "timestamp": "2026-03-09T10:00:00.000Z"
-    },
-    {
-      "milestoneSlug": "milestone-1",
-      "phaseName": "feature-B",
-      "status": "in_progress",
-      "instanceId": "prod-02",
-      "timestamp": "2026-03-09T10:05:00.000Z"
-    }
-  ]
-}
-```
-
-This endpoint is backed by `FleetSchedulerService.getProjectFleetStatus()`, which aggregates `ProjectProgress` (a.k.a. `ProjectProgressMsg`) entries received via the Ava Channel and stored in the in-memory `projectProgressByPhase` map.
-
-### Fleet Scheduler Message Types
-
-| Message Type            | Frequency    | Purpose                                        |
-| ----------------------- | ------------ | ---------------------------------------------- |
-| `WorkInventoryMsg`      | Per instance | Broadcast backlog + active features            |
-| `ScheduleAssignmentMsg` | Every 5 min  | Primary assigns features to instances          |
-| `SchedulerHeartbeatMsg` | Every 1 min  | Failover detection (absent >10 min = takeover) |
-| `ScheduleConflictMsg`   | On conflict  | Resolve double-claims (lower instanceId wins)  |
-| `ProjectProgressMsg`    | Per phase    | Track phase completion across instances        |
-
-### Key Timing Constants
-
-| Constant                 | Value      | Purpose                                       |
-| ------------------------ | ---------- | --------------------------------------------- |
-| Peer inventory TTL       | 6 minutes  | Stale inventory is ignored in schedule cycles |
-| Primary absent threshold | 10 minutes | No heartbeat for 10 min triggers failover     |
-| Schedule cycle interval  | 5 minutes  | How often the primary recomputes assignments  |
-| Scheduler heartbeat      | 1 minute   | Proves primary is still running the scheduler |
-
-## Observability: DORA Metrics and Friction Tracking
-
-`AvaChannelReactorService` also posts higher-level operational signals:
-
-- **`DoraReport`**: Deployment frequency, lead time, and blocked feature count. Broadcast as a `[dora_report]` system message **every hour**. Peers merge incoming reports into the aggregate CRDT entry under `domain='metrics', id='dora'`.
-- **`PatternResolved`**: Broadcast as a `[pattern_resolved]` system message when a System Improvement feature completes. Peers clear their local friction counters for the resolved pattern on receipt.
-- **Friction Tracker**: Monitors repeated failures via `FrictionTrackerService`. When the same failure pattern recurs, a System Improvement feature is automatically filed. Incoming `[friction_report]` messages from peers are used for de-duplication.
-
-These signals are visible in the Ava Channel for fleet-wide visibility and can be consumed by the metrics dashboard.
 
 ## Sync Events
 
@@ -511,196 +175,26 @@ These signals are visible in the Ava Channel for fleet-wide visibility and can b
 | -------------------------- | ------------------------------------- | ---------------------------------------------------------------- |
 | `sync:partition-recovered` | `{ instanceId, partitionDurationMs }` | Emitted after a network partition heals and changes are replayed |
 | `sync:peer-unreachable`    | `{ instanceId, lastSeen, peerTtlMs }` | Emitted when a peer exceeds its TTL                              |
-| `bug:reported`             | `{ content, featureId? }`             | Triggers Ava Channel bug report forwarding (if wired)            |
 
-These events are emitted on the internal `EventEmitter` passed to `crdtSyncService.attachEventBus()`.
+These events are emitted on the internal `EventEmitter` passed to `peerMeshService.attachEventBus()`.
 
-### Ava Channel coordination messages (wire protocol)
+### Wire message types
 
-Messages are posted as free-form strings with a `[type]` prefix so the reactor classifier can route them without a message-type enum.
+Feature and project events are serialized as `CrdtSyncWireMessage` with a `type: 'feature_event'` discriminant:
 
-| Message prefix          | Type                 | Description                                                |
-| ----------------------- | -------------------- | ---------------------------------------------------------- |
-| `[work_inventory]`      | `WorkInventory`      | Per-instance backlog + active feature snapshot             |
-| `[schedule_assignment]` | `ScheduleAssignment` | Primary → all workers: feature or phase assignments        |
-| `[scheduler_heartbeat]` | `SchedulerHeartbeat` | Active scheduler liveness (every 60 s, failover detection) |
-| `[schedule_conflict]`   | `ScheduleConflict`   | Conflict broadcast: two instances claimed the same feature |
-| `[project_progress]`    | `ProjectProgress`    | Phase status update (`in_progress` / `done` / `failed`)    |
-| `[capacity_heartbeat]`  | `CapacityHeartbeat`  | Per-instance CPU/memory/agent capacity broadcast (60 s)    |
-| `[escalation_request]`  | `EscalationRequest`  | Feature blocked (failCount >= 2) — requesting new owner    |
-| `[escalation_offer]`    | `EscalationOffer`    | Peer offers to take ownership of escalated feature         |
-| `[escalation_accept]`   | `EscalationAccept`   | Originator accepts offer; delegates ownership              |
-| `[health_alert]`        | `HealthAlert`        | Memory/CPU threshold exceeded — peers pause work intake    |
-| `[dora_report]`         | `DoraReport`         | Hourly DORA metrics broadcast                              |
-| `[pattern_resolved]`    | `PatternResolved`    | System Improvement done — peers clear friction counters    |
-
-All message types are defined in `libs/types/src/ava-channel.ts`.
-
-## CRDTStore Module
-
-`crdt-store.module.ts` is the second initialization layer, starting after `CrdtSyncService`. It provides Automerge document persistence and injects the store into higher-level services.
-
-### Initialization Flow
-
-1. Reads `proto.config.yaml` for role and port configuration.
-2. Checks `hivemind.enabled` — returns `null` in single-instance mode.
-3. Instantiates `CRDTStore` with storage at `{projectRoot}/.automaker/crdt`.
-4. If `role: primary`, starts a WebSocket server on port `syncPort + 1` (default **:4445**) for Automerge binary sync.
-5. **Registry sync**: primary broadcasts its full document registry to workers on connect, preventing split-brain from independent document creation.
-6. Injects store into `AvaChannelService`, `CalendarService`, and `TodoService`.
-
-### Document Key Format
-
-CRDT documents follow the pattern `{domain}:{id}`:
-
-| Domain            | Example Key                  | Service           |
-| ----------------- | ---------------------------- | ----------------- |
-| `doc:ava-channel` | `doc:ava-channel/2026-03-09` | AvaChannelService |
-| `todos`           | `todos:workspace`            | TodoService       |
-| `calendar`        | varies per workspace         | CalendarService   |
-
-## CRDT-Injected Document Services
-
-Three services support dual-mode operation: CRDT-backed when a store is available, filesystem fallback otherwise.
-
-### AvaChannelService
-
-Daily-sharded append-only message store for multi-instance Ava coordination.
-
-- **Document key**: `doc:ava-channel/YYYY-MM-DD` (new shard each day)
-- **CRDT mode**: messages appended via `store.change<AvaChannelDocument>()`
-- **Fallback**: in-memory `Map<date, AvaChatMessage[]>`
-- **Archive**: shards older than 30 days are written to `{archiveDir}/{YYYY-MM-DD}.json` and removed from CRDT storage
-- **Injection**: `AvaChannelService.setCrdtStore(store)` called by crdt-store.module
-
-**Message fields** (`AvaChatMessage`):
-
-| Field               | Description                                                                   |
-| ------------------- | ----------------------------------------------------------------------------- |
-| `instanceId`        | Originating instance                                                          |
-| `intent`            | `request \| inform \| response \| coordination \| escalation \| system_alert` |
-| `inReplyTo`         | Parent message id for threading                                               |
-| `conversationDepth` | Recursion guard (capped to prevent runaway loops)                             |
-| `expectsResponse`   | Whether a reply is expected                                                   |
-
-### CalendarService
-
-Manages calendar events with optional CRDT sync for cross-instance visibility.
-
-- **Dual-mode**: CRDT when store injected, else `{projectPath}/.automaker/calendar.json`
-- **Injection**: `CalendarService.getInstance().setCrdtStore(store)`
-- **Feature aggregation**: feature `dueDate` fields surfaced as read-only calendar entries (aggregated on demand, not cached)
-- **Job scheduling**: events with `type: 'job'` and `jobStatus: 'pending'` are queryable via `getDueJobs()`
-
-### TodoService
-
-Per-project todo lists with tiered write permissions.
-
-- **Dual-mode**: CRDT via `todos:workspace` document, else `{projectPath}/.automaker/todos/workspace.json`
-- **Injection**: `TodoService.getInstance().setCrdtStore(store)`
-- **Permission tiers**:
-  - `user` — user writes; Ava reads only
-  - `ava-instance` — owning instance + user write; other Ava instances cannot
-  - `shared` — any caller reads/writes
-- **Auto-provisioning**: `ensureAvaInstanceList()` creates a per-instance list on first Ava activation
-
-## AvaChannelReactorService
-
-Reactive orchestrator that subscribes to the Ava Channel and dispatches responses.
-
-### Message Classification Chain
-
-Each incoming message is evaluated by a classifier chain (rules evaluated in order, first match wins):
-
-1. **Self-loop guard** — drops messages from this instance
-2. **Thread cooldown** — per-thread 30s cooldown prevents rapid reply loops
-3. **Busy gate** — drops new requests while already processing
-4. **Intent classifiers** — routes `request`, `inform`, `coordination`, `escalation`, `system_alert` intents
-
-### Loop Prevention
-
-Three independent guards prevent runaway message loops:
-
-| Guard           | Mechanism                                              |
-| --------------- | ------------------------------------------------------ |
-| Self-loop       | `message.instanceId === this.instanceId` → skip        |
-| Thread cooldown | `replyTimestamps[threadId]` checked against 30s window |
-| Busy gate       | `processing` flag set during response generation       |
-| Depth cap       | `conversationDepth` incremented and capped per message |
-
-### Self-Healing
-
-On subscription failure the reactor implements exponential backoff:
-
-- Base delay: 5 seconds
-- Max delay: 60 seconds
-- Retries indefinitely until `stop()` is called
-
-### Fleet Integration
-
-The reactor delegates fleet-level operations to `FleetSchedulerService`:
-
-- Work intake → phase claiming via shared project documents
-- Escalation → `EscalationRequest` / `EscalationAccept` protocol
-- Project progress → `ProjectProgress` broadcast
-
-### Module Initialization (`ava-channel-reactor.module.ts`)
-
-The reactor only starts when all three conditions are met:
-
-1. `proto.config.yaml` exists
-2. `hivemind.enabled: true`
-3. `reactorEnabled` feature flag is active
-
-Depends on `crdt-store.module` completing first — the `CRDTStore` must already be in the container.
-
-## FleetSchedulerService
-
-Primary-elected scheduler that distributes features across fleet instances.
-
-### Scheduling Cycle (every 5 minutes)
-
-1. Each instance broadcasts `WorkInventory` (backlog count, active features, capacity snapshot).
-2. Primary collects inventories (6-minute TTL) and computes an optimal assignment.
-3. Primary broadcasts `ScheduleAssignment` to all peers.
-4. Each instance applies assignments addressed to its `instanceId`.
-
-### Failover
-
-If no `SchedulerHeartbeat` is received for 10 minutes, the longest-running worker self-elects as the new scheduler primary.
-
-### Conflict Resolution
-
-When two instances claim the same feature simultaneously:
-
-1. Both broadcast `ScheduleConflict`.
-2. The instance with the **lexicographically lower `instanceId`** retains the claim.
-3. The other instance releases the feature back to `backlog`.
-
-### Project Progress Tracking
-
-Each instance emits `ProjectProgress` on phase status changes. The scheduler aggregates these in `projectProgressByPhase` (keyed by `{milestoneSlug}:{instanceId}`) and exposes them via `getProjectProgress()`.
-
-### Fleet Status Endpoint
-
-```
-GET /api/projects/:slug/fleet-status
-```
-
-Returns aggregated phase statuses across all instances:
-
-```json
-{
-  "success": true,
-  "projectSlug": "my-project",
-  "phases": [
-    {
-      "milestoneSlug": "v1-auth",
-      "phaseName": "implementation",
-      "instanceId": "prod-01",
-      "status": "in_progress",
-      "timestamp": "2026-03-09T10:00:00.000Z"
-    }
-  ]
+```typescript
+interface CrdtSyncWireMessage {
+  type: 'feature_event';
+  instanceId: string;
+  eventType: string; // e.g. 'feature:created', 'project:updated'
+  payload: Record<string, unknown>;
+  timestamp: string;
+  projectName?: string; // scoping — reject if mismatch
 }
 ```
+
+## See Also
+
+- [Peer Mesh Service](../server/peer-mesh-service.md) — low-level WebSocket transport, heartbeat constants, callbacks
+- [Work Intake Service](../server/work-intake-service.md) — phase claiming protocol details
+- [Route Organization](../server/route-organization.md) — Express route registration patterns

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -17,8 +17,8 @@ Extend protoLabs. Architecture, packages, code standards, and how to contribute.
 
 ## Distributed Systems
 
-- **[Distributed Sync](./distributed-sync)** — CRDT sync mesh, partition detection, reconnection resilience, compaction diagnostics, and Automerge time-travel debugging
-- **[Notes Sync](./notes-sync)** — Notes CRDT domain: storage model, hydration, conflict semantics (LWW per tab), and deferred TipTap binding
+- **[Distributed Sync](./distributed-sync)** — Peer mesh architecture, partition detection, leader election, and pull-based work intake protocol
+- **[Notes Sync](./notes-sync)** — Notes workspace: disk-based storage model, read/write paths, and MCP tool reference
 
 ## Pipeline & Orchestration
 

--- a/docs/dev/notes-sync.md
+++ b/docs/dev/notes-sync.md
@@ -1,43 +1,24 @@
-# Notes CRDT Domain
+# Notes Workspace
 
-How the notes workspace is stored, replicated, and synchronized across protoLabs instances.
+How the notes workspace is stored and served across protoLabs instances.
+
+> **Updated March 2026:** CRDT/Automerge sync was removed from the notes routes. The workspace is now disk-only (`workspace.json`). Each instance maintains its own copy; there is no cross-instance replication of notes.
 
 ## Overview
 
-The notes workspace is backed by an **Automerge CRDT document** that provides eventual consistency across hivemind instances. Disk (`workspace.json`) remains the durable, always-available fallback that routes read and write to directly.
+The notes workspace is stored as a JSON file at `.automaker/notes/workspace.json`. All reads and writes go directly to disk — there is no in-memory CRDT layer.
 
 ```
 HTTP Request
      │
      ▼
 Notes Routes ──── read/write ────▶ Disk (.automaker/notes/workspace.json)
-     │                                      │
-     │ fire-and-forget                       │ hydrate on first start
-     ▼                                      ▼
-CRDTStore ◀──────────────────── hydrateNotesWorkspace()
-  domain=notes, id=workspace
-     │
-     ▼
-CrdtSyncService ──── broadcast to peers
 ```
-
-## Domain & Document Identity
-
-| Property       | Value                    |
-| -------------- | ------------------------ |
-| Domain         | `notes`                  |
-| Document ID    | `workspace`              |
-| Registry key   | `notes:workspace`        |
-| Full doc key   | `doc:notes/workspace`    |
-| Type           | `NotesWorkspaceDocument` |
-| Schema version | `1`                      |
-
-There is exactly **one** notes workspace document per protoLabs instance. It is not scoped by project — all projects share the same workspace document within a single instance. If per-project isolation is needed in the future, the document ID can be parameterized (e.g., `workspace:${projectSlug}`).
 
 ## TypeScript Types
 
 ```ts
-// libs/crdt/src/documents.ts
+// apps/server/src/routes/notes/index.ts
 
 interface NoteTab {
   id: string;
@@ -47,111 +28,89 @@ interface NoteTab {
     agentRead: boolean;
     agentWrite: boolean;
   };
-  createdAt: string; // ISO 8601
-  updatedAt: string; // ISO 8601
-  wordCount: number;
-  characterCount: number;
+  metadata: {
+    createdAt: string; // ISO 8601
+    updatedAt: string; // ISO 8601
+    wordCount: number;
+    characterCount: number;
+  };
 }
 
-interface NotesWorkspaceDocument extends CRDTDocumentRoot {
-  schemaVersion: 1;
+interface NotesWorkspace {
   tabs: Record<string, NoteTab>; // keyed by tab UUID
   tabOrder: string[]; // ordered tab IDs
   activeTabId: string | null;
-  updatedAt: string; // ISO 8601, workspace-level timestamp
+  version: number;
 }
 ```
 
-## Hydration
-
-When the server starts and `initCRDTStore()` is called, `hydrateNotesWorkspace()` seeds the CRDT document **once** from the existing disk file:
-
-1. Check `store.getRegistry()` for `notes:workspace` — if present, skip (idempotent)
-2. Read `.automaker/notes/workspace.json` from disk
-3. Map disk format (`DiskNotesWorkspace`) to CRDT format (`NotesWorkspaceDocument`):
-   - Numeric timestamps → ISO 8601 strings
-   - Missing permissions → default `agentRead: true, agentWrite: false`
-   - Missing tabs → empty `{}`
-4. Call `store.getOrCreate<NotesWorkspaceDocument>('notes', 'workspace', initialData)`
-
-If the disk file does not exist, an empty workspace is seeded.
-
-Hydration is **fire-and-forget** — it does not block server startup and failures are logged at `warn` level without crashing.
-
 ## Write Path (Routes)
 
-Notes routes write to **disk first**, then propagate to CRDT asynchronously:
+Notes routes write to disk and emit EventBus events:
 
 ```ts
-// Simplified pattern from notes routes
 await saveWorkspace(projectPath, workspace); // disk — synchronous, durable
-
-// CRDT propagation is not yet wired in routes.
-// The CRDTStore receives updates at hydration time only (server restart).
-// Per-mutation CRDT writes are planned for a follow-up feature.
+eventEmitter.broadcast('notes:tab-updated', { projectPath, tabId });
 ```
 
-This means the CRDT document reflects the disk state at last startup, not in real time. Route mutations are not immediately replicated to peers. Full real-time sync requires the route-level CRDT write integration (see [Deferred Work](#deferred-work) below).
+EventBus events emitted by notes routes:
+
+| Event                           | When                             |
+| ------------------------------- | -------------------------------- |
+| `notes:tab-created`             | New tab created                  |
+| `notes:tab-updated`             | Tab content written              |
+| `notes:tab-deleted`             | Tab deleted                      |
+| `notes:tab-renamed`             | Tab renamed                      |
+| `notes:tab-permissions-changed` | `agentRead`/`agentWrite` updated |
 
 ## Read Path (Routes)
 
-All five MCP note tools call routes that **read from disk**:
+All five MCP note tools call routes that read from disk:
 
-| MCP Tool          | Route                        | Notes                             |
-| ----------------- | ---------------------------- | --------------------------------- |
-| `list_note_tabs`  | `POST /api/notes/list-tabs`  | Filters by `agentRead` permission |
-| `read_note_tab`   | `POST /api/notes/get-tab`    | Enforces `agentRead` permission   |
-| `write_note_tab`  | `POST /api/notes/write-tab`  | Enforces `agentWrite` permission  |
-| `create_note_tab` | `POST /api/notes/create-tab` | Creates tab in disk workspace     |
-| `delete_note_tab` | `POST /api/notes/delete-tab` | Cannot delete last tab            |
+| MCP Tool            | Route                          | Notes                             |
+| ------------------- | ------------------------------ | --------------------------------- |
+| `list_note_tabs`    | `POST /api/notes/list-tabs`    | Filters by `agentRead` permission |
+| `read_note_tab`     | `POST /api/notes/get-tab`      | Enforces `agentRead` permission   |
+| `write_note_tab`    | `POST /api/notes/write-tab`    | Enforces `agentWrite` permission  |
+| `create_note_tab`   | `POST /api/notes/create-tab`   | Creates tab in disk workspace     |
+| `delete_note_tab`   | `POST /api/notes/delete-tab`   | Cannot delete last tab            |
+| `rename_note_tab`   | `POST /api/notes/rename-tab`   | Renames existing tab              |
+| `reorder_note_tabs` | `POST /api/notes/reorder-tabs` | Sets tabOrder array               |
 
 Reads come from `loadWorkspace()` which reads `.automaker/notes/workspace.json`. If the file does not exist, a default single-tab workspace is returned.
 
-## Conflict Semantics
+## Default Workspace
 
-Automerge uses **last-write-wins (LWW)** for scalar fields. This applies to all tab fields:
+If no `workspace.json` exists, routes return:
 
-| Field             | Conflict resolution                                             |
-| ----------------- | --------------------------------------------------------------- |
-| `tab.content`     | LWW — last writer wins (whole-field replacement)                |
-| `tab.name`        | LWW                                                             |
-| `tab.permissions` | LWW per sub-field (`agentRead`, `agentWrite`)                   |
-| `tab.updatedAt`   | LWW (monotonically increasing in practice)                      |
-| `tabOrder`        | Automerge list CRDT — concurrent insertions are both preserved  |
-| `tabs` (map)      | Automerge map CRDT — concurrent adds/removes are both preserved |
+```json
+{
+  "tabs": {
+    "<uuid>": {
+      "id": "<uuid>",
+      "name": "Notes",
+      "content": "",
+      "permissions": { "agentRead": true, "agentWrite": true },
+      "metadata": {
+        "createdAt": "<now>",
+        "updatedAt": "<now>",
+        "wordCount": 0,
+        "characterCount": 0
+      }
+    }
+  },
+  "tabOrder": ["<uuid>"],
+  "activeTabId": "<uuid>",
+  "version": 1
+}
+```
 
-Because `content` is LWW and not a character-level CRDT, two instances editing the same tab concurrently will lose one editor's changes. This is acceptable for the current use case (agents are the primary writers, not humans typing simultaneously).
+## Multi-Instance Behavior
 
-## Fallback Behavior
-
-When CRDT is unavailable (e.g., CRDTStore not initialized, storage error):
-
-1. Routes read from and write to disk as normal — no degradation in functionality
-2. Peers do not receive updates until CRDT is restored and routes are re-hydrated
-3. The disk file is always the single-instance source of truth
-
-The CRDT layer is additive — its absence does not break notes functionality for a single instance.
-
-## Deferred Work
-
-### TipTap Y.js Binding
-
-TipTap's collaborative editing uses [Y.js](https://yjs.dev/) for per-character OT/CRDT operations. The current implementation stores tab content as a plain HTML string and uses LWW semantics. A future integration would:
-
-1. Replace `NoteTab.content: string` with a Y.js document or encoded binary blob
-2. Wire TipTap's `CollaborationExtension` to the CRDTStore via a Y.js provider
-3. Enable real-time character-level merge across instances
-
-Until this binding is implemented, `NoteTab.content` remains a LWW scalar field.
-
-### Route-Level CRDT Writes
-
-Currently, mutations via the notes routes (write, create, delete, rename tabs) only update disk. A follow-up feature will add fire-and-forget CRDT writes to each mutation path so that changes replicate to peers without requiring a server restart.
+Notes are **not replicated** across Hivemind instances. Each instance has its own `workspace.json`. If you need the same notes on multiple instances, copy the file manually or use git to sync it.
 
 ## Related
 
-- [Distributed Sync](./distributed-sync.md) — CRDTStore architecture, peer mesh, and sync protocol
+- [Distributed Sync](./distributed-sync.md) — Peer mesh architecture and sync protocol
 - [Notes Panel](./notes-panel.md) — Frontend UI for the notes workspace
 - `apps/server/src/routes/notes/index.ts` — Route implementations
-- `apps/server/src/services/crdt-store.module.ts` — Hydration code (`hydrateNotesWorkspace`)
-- `libs/crdt/src/documents.ts` — `NotesWorkspaceDocument`, `NoteTab`, `normalizeNotesWorkspace`

--- a/docs/infra/multi-instance-deployment.md
+++ b/docs/infra/multi-instance-deployment.md
@@ -11,7 +11,7 @@ How to run multiple protoLabs instances in a synchronized hivemind mesh using Ta
 
 ## Architecture
 
-The Studio Mesh uses a primary/worker WebSocket topology. One instance runs the sync server (primary), and all others connect as clients (workers). All CRDT changes propagate through the primary in real time.
+The Studio Mesh uses a primary/worker WebSocket topology. One instance runs the sync server (primary), and all others connect as clients (workers). Feature and project events propagate through the primary in real time.
 
 ```
                           Tailscale mesh
@@ -26,20 +26,18 @@ The Studio Mesh uses a primary/worker WebSocket topology. One instance runs the 
                     └─────────────────────────┘
 ```
 
-### Synced domains
+### Synced data
 
-The mesh synchronizes these CRDT document domains:
+The mesh synchronizes feature and project events via `PeerMeshService`:
 
-| Domain        | Document ID     | Description                               |
-| ------------- | --------------- | ----------------------------------------- |
-| `projects`    | `<projectSlug>` | Project plans, PRD content, phase claims  |
-| `settings`    | `shared`        | Shared workflow settings (no credentials) |
-| `capacity`    | `<instanceId>`  | Per-instance capacity metrics             |
-| `ava-channel` | `YYYY-MM-DD`    | Daily-sharded Ava communication log       |
-| `calendar`    | `shared`        | Shared calendar events                    |
-| `todos`       | `workspace`     | Shared todo lists with permission tiers   |
+| Data type      | Mechanism                             | Description                                      |
+| -------------- | ------------------------------------- | ------------------------------------------------ |
+| Feature events | `CrdtSyncWireMessage` broadcast       | `feature:created/updated/deleted/status-changed` |
+| Project events | `CrdtSyncWireMessage` broadcast       | `project:created/updated/deleted`                |
+| Settings       | `CrdtSettingsEvent` (primary→workers) | Shared workflow settings (no credentials)        |
+| Peer capacity  | Heartbeat `PeerMessage`               | Per-instance capacity metrics                    |
 
-Features are **instance-local** and never synced via the mesh. Each instance creates features locally from claimed project phases.
+Features are **instance-local** and never pushed across the mesh. Each instance creates features locally from claimed project phases. Notes, calendar, and todos are disk-based per-instance with no cross-instance replication.
 
 ### Event types bridged across the mesh
 
@@ -61,11 +59,9 @@ protolab:
 
 ### Instance Attribution
 
-Every CRDT operation and sync message carries `instanceId`. This value is set in `proto.config.yaml` and included in:
+Every sync message carries `instanceId`. This value is set in `proto.config.yaml` and included in:
 
-- All CRDT document mutations (`_meta.instanceId`)
-- All sync wire messages (`heartbeat`, `project_event`, `identity`) — includes `name`, `role`, `tags`
-- Ava Channel messages (`instanceId` and `instanceName` fields)
+- All sync wire messages (`heartbeat`, `feature_event`, `project_event`, `identity`) — includes `name`, `role`, `tags`
 - The `sync:partition-recovered` and `sync:peer-unreachable` events
 
 ### Authority Tiers (Roadmap)

--- a/docs/server/index.md
+++ b/docs/server/index.md
@@ -14,12 +14,10 @@ The server is an Express 5 application with WebSocket streaming, organized into 
 - **[Automations](./automation-registry)** — Scheduled tasks, custom flows, run history, and the unified control plane
 - **[Calendar API](./calendar-api)** — Calendar events, Google Calendar sync, and MCP tools
 - **[Knowledge Store](./knowledge-store)** — SQLite FTS5 knowledge base for agent context retrieval
-- **[Ava Channel](./ava-channel)** — Multi-instance Ava coordination channel, CRDT-backed message store, and System Improvements auto-filing
-- **[Ava Channel Reactor](./ava-channel-reactor)** — Reactive orchestrator for fleet coordination: work intake, health monitoring, DORA reporting, and escalation protocol
 - **[DORA Metrics](./dora-metrics)** — Team health monitoring via feature-based proxy metrics (lead time, deployment frequency, change failure rate, recovery time, rework rate)
 - **[Auto Mode Service](./auto-mode-service)** — Autonomous feature execution engine: worktree lifecycle, concurrency management, circuit breaker, and multi-project auto-loops
-- **[CRDT Sync Service](./crdt-sync-service)** — WebSocket-based multi-instance sync: heartbeat protocol, feature event replication, settings broadcast, and network partition recovery
-- **[Project Service](./project-service)** — Project, milestone, and phase CRUD with Automerge-backed CRDT sync and Markdown generation
+- **[Peer Mesh Service](./peer-mesh-service)** — WebSocket-based multi-instance sync: heartbeat protocol, feature event replication, settings broadcast, and network partition recovery
+- **[Project Service](./project-service)** — Project, milestone, and phase CRUD with Markdown generation
 - **[Work Intake Service](./work-intake-service)** — Pull-based distributed work claiming: instances independently claim phases from shared project docs and create local features
 
 ## Key Technologies

--- a/docs/server/peer-mesh-service.md
+++ b/docs/server/peer-mesh-service.md
@@ -1,10 +1,14 @@
-# CRDT Sync Service
+# Peer Mesh Service
 
 WebSocket-based multi-instance coordination layer that keeps feature events, project changes, settings, and peer capacity in sync across the Hivemind mesh.
 
+> **Renamed:** `CrdtSyncService` was renamed to `PeerMeshService` in March 2026 and made conditional on `hivemind.enabled`. The CRDT binary sync layer (Automerge / CRDTStore on `:4445`) was removed at the same time — the mesh now handles only event broadcasting, heartbeats, and leader election.
+
 ## Overview
 
-`CrdtSyncService` manages the low-level peer-to-peer sync transport between protoLabs instances. It reads `proto.config.yaml` at startup to determine whether this instance is the **primary** (runs a WebSocket server) or a **worker** (connects as a client).
+`PeerMeshService` manages the low-level peer-to-peer sync transport between protoLabs instances. It reads `proto.config.yaml` at startup to determine whether this instance is the **primary** (runs a WebSocket server) or a **worker** (connects as a client).
+
+**When `hivemind.enabled` is `false` in `proto.config.yaml`, this service is a no-op** — no WebSocket server is started, no timers fire, and no peer connections are attempted.
 
 Key responsibilities:
 
@@ -12,8 +16,6 @@ Key responsibilities:
 - **Feature event sync** — broadcasts `feature:created`, `feature:updated`, `feature:deleted`, and `feature:status-changed` to all peers
 - **Project event sync** — broadcasts project CRUD events so all instances stay consistent
 - **Settings broadcast** — primary pushes shared settings to workers (no credentials included)
-- **Registry sync** — primary sends CRDTStore document registry to resolve split-brain URLs
-- **Bug report forwarding** — `bug:reported` events on the EventBus are forwarded to the Ava Channel
 - **Network partition handling** — queues outbound events while disconnected; replays on reconnect
 
 ## Architecture
@@ -23,10 +25,10 @@ proto.config.yaml
   --> role: primary → start WebSocket server (default port 4444)
   --> role: worker  → connect as WebSocket client to primary URL
 
-CrdtSyncService
+PeerMeshService
   ├── Heartbeat loop (30s)    → broadcasts PeerMessage{type: 'heartbeat', capacity}
   ├── TTL check loop (10s)    → evicts peers absent > 120s
-  ├── EventBus bridge         → CRDT_SYNCED_EVENT_TYPES trigger CrdtFeatureEvent broadcasts
+  ├── EventBus bridge         → CRDT_SYNCED_EVENT_TYPES trigger CrdtSyncWireMessage broadcasts
   └── Reconnect loop (5s)     → workers auto-reconnect on disconnect
 ```
 
@@ -37,7 +39,7 @@ CrdtSyncService
 | `primary` | Runs `WebSocketServer`; relays messages between all workers  |
 | `worker`  | Connects to primary URL; receives relay of all peer messages |
 
-Role is determined by the `instance.syncRole` (or `role`) field in `proto.config.yaml`. If the file is absent, the instance starts as a standalone worker (no sync).
+Role is determined by the `instance.syncRole` (or `role`) field in `proto.config.yaml`. If the file is absent, or if `hivemind.enabled` is `false`, the instance starts as a standalone (no sync).
 
 ## Wire Message Types
 
@@ -61,12 +63,12 @@ interface PeerMessage {
 
 `capacity` is populated on every heartbeat by the registered `_capacityProvider` callback.
 
-### CrdtFeatureEvent
+### CrdtSyncWireMessage
 
 Synced event types: `feature:created`, `feature:updated`, `feature:deleted`, `feature:status-changed`, plus project equivalents.
 
 ```typescript
-interface CrdtFeatureEvent {
+interface CrdtSyncWireMessage {
   type: 'feature_event';
   instanceId: string;
   eventType: string;
@@ -76,7 +78,7 @@ interface CrdtFeatureEvent {
 }
 ```
 
-**Project scoping:** The `projectName` field prevents cross-project CRDT contamination. Workers reject events whose `projectName` doesn't match their own.
+**Project scoping:** The `projectName` field prevents cross-project event contamination. Workers reject events whose `projectName` doesn't match their own.
 
 ### CrdtSettingsEvent
 
@@ -87,19 +89,6 @@ interface CrdtSettingsEvent {
   type: 'settings_event';
   instanceId: string;
   settings: Record<string, unknown>;
-  timestamp: string;
-}
-```
-
-### CrdtRegistrySyncEvent
-
-Primary → workers on connect. Resolves split-brain where both instances independently created Automerge documents for the same `domain:id` with different URLs.
-
-```typescript
-interface CrdtRegistrySyncEvent {
-  type: 'registry_sync';
-  instanceId: string;
-  registry: Record<string, string>;
   timestamp: string;
 }
 ```
@@ -141,21 +130,17 @@ When a worker is disconnected from the mesh:
 
 `attachEventBus(bus)` wires the sync service into the local event system:
 
-1. **Outbound** — `bus.setRemoteBroadcaster()` intercepts calls to `broadcast()` for synced types, serializes as `CrdtFeatureEvent`, and sends to peers
+1. **Outbound** — `bus.setRemoteBroadcaster()` intercepts calls to `broadcast()` for synced types, serializes as `CrdtSyncWireMessage`, and sends to peers
 2. **Inbound** — incoming `feature_event` messages call `bus.emit()` (NOT `broadcast()`) to prevent feedback loops
-3. **Bug reports** — `bus.on('bug:reported')` forwards to the Ava Channel via `_avaChannelBugReportCallback`
 
 ## Callbacks (must be set before `start()`)
 
-| Method                                 | When called                                           |
-| -------------------------------------- | ----------------------------------------------------- |
-| `onSettingsReceived(cb)`               | A remote peer sent a `settings_event`                 |
-| `onRemoteFeatureEvent(cb)`             | A remote peer sent a `feature_event`                  |
-| `setCapacityProvider(fn)`              | Each heartbeat — returns current `InstanceCapacity`   |
-| `setCompactionDiagnosticsProvider(fn)` | Each `getSyncStatus()` call                           |
-| `attachAvaChannelBugReporter(cb)`      | `bug:reported` events on the EventBus                 |
-| `setRegistryProvider(fn)`              | Primary calls this to supply registry for new workers |
-| `onRegistryReceived(cb)`               | Worker receives a `registry_sync` from primary        |
+| Method                                 | When called                                         |
+| -------------------------------------- | --------------------------------------------------- |
+| `onSettingsReceived(cb)`               | A remote peer sent a `settings_event`               |
+| `onRemoteFeatureEvent(cb)`             | A remote peer sent a `feature_event`                |
+| `setCapacityProvider(fn)`              | Each heartbeat — returns current `InstanceCapacity` |
+| `setCompactionDiagnosticsProvider(fn)` | Each `getSyncStatus()` call                         |
 
 ## `getSyncStatus()` Response
 
@@ -174,14 +159,14 @@ interface SyncServerStatus {
 
 ## Key Files
 
-| File                                            | Role                                                   |
-| ----------------------------------------------- | ------------------------------------------------------ |
-| `apps/server/src/services/crdt-sync-service.ts` | Core sync service — WebSocket server/client lifecycle  |
-| `apps/server/src/services/crdt-sync.module.ts`  | NestJS module wiring — injects dependencies at startup |
-| `libs/types/src/events.ts`                      | `CrdtFeatureEvent` wire type with `projectName` field  |
+| File                                            | Role                                                  |
+| ----------------------------------------------- | ----------------------------------------------------- |
+| `apps/server/src/services/peer-mesh-service.ts` | Core sync service — WebSocket server/client lifecycle |
+| `apps/server/src/services/crdt-sync.module.ts`  | Module wiring — injects dependencies at startup       |
+| `libs/types/src/events.ts`                      | `CrdtSyncWireMessage` wire type with `projectName`    |
 
 ## See Also
 
-- [Distributed Sync](../dev/distributed-sync.md) — CRDT mesh architecture and leader election protocol
-- [Ava Channel Reactor](./ava-channel-reactor) — capacity heartbeats and fleet coordination built on top of CRDT sync
-- [Work Intake Service](./work-intake-service) — uses project-scoped events to coordinate phase claiming
+- [Distributed Sync](../dev/distributed-sync.md) — Peer mesh architecture and leader election protocol
+- [Work Intake Service](./work-intake-service) — phase claiming coordination
+- [Hivemind API](./hivemind-api) — peer status HTTP endpoints

--- a/docs/server/project-service.md
+++ b/docs/server/project-service.md
@@ -1,18 +1,18 @@
 # Project Service
 
-Manages project orchestration data: CRUD operations for projects, milestones, and phases, with optional CRDT-backed multi-instance synchronization.
+Manages project orchestration data: CRUD operations for projects, milestones, and phases.
 
 ## Overview
 
-`ProjectService` is the persistence and coordination layer for protoLabs project documents. Projects are stored as Markdown and JSON files under `.automaker/projects/{slug}/`. When `proto.config.yaml` is present, the service wraps each project in an Automerge document for conflict-free multi-instance sync.
+`ProjectService` is the persistence and coordination layer for protoLabs project documents. Projects are stored as Markdown and JSON files under `.automaker/projects/{slug}/`. An in-memory cache (`Map<string, Project>`) accelerates reads; all writes go to disk first.
 
 Key responsibilities:
 
 - **Project CRUD** — create, read, update, delete projects and their sub-structure
 - **Milestone and phase management** — full lifecycle for milestones and phases within a project
-- **Automerge documents** — per-project CRDT state keyed by `projectPath`
-- **Remote sync** — emits CRDT events for changes; receives remote changes via EventBus
-- **Human-readable output** — generates Markdown files alongside the CRDT state for git history
+- **In-memory cache** — lazy-loaded read cache backed by disk as source of truth
+- **Event broadcasting** — emits project events via EventBus for multi-instance sync
+- **Human-readable output** — generates Markdown files alongside JSON for git history
 
 ## Storage Layout
 


### PR DESCRIPTION
## Summary

- **Archive** `ava-channel.md` and `ava-channel-reactor.md` — services were fully removed; archived with deprecation notice pointing to PeerMeshService
- **Rename** `crdt-sync-service.md` → `peer-mesh-service.md` — reflects the renamed service (`CrdtSyncService` → `PeerMeshService`), removes stale CRDT binary sync callbacks (`attachAvaChannelBugReporter`, `setRegistryProvider`, `onRegistryReceived`), adds no-op condition note
- **Rewrite** `distributed-sync.md` — removes CRDTStore, AvaChannelReactorService, FleetSchedulerService, CalendarService/TodoService CRDT injection, Automerge compaction, and time-travel debugging sections; keeps PeerMeshService, leader election, partition detection, and work intake protocol
- **Rewrite** `notes-sync.md` — removes CRDT hydration/conflict/deferred-work docs; now describes the disk-only model
- **Update** `multi-instance-deployment.md` — replaces stale CRDT synced-domains table with accurate event-broadcast table; removes Ava Channel instance attribution reference
- **Update** `server/index.md` — removes ava-channel and ava-channel-reactor entries; replaces crdt-sync-service with peer-mesh-service
- **Update** `project-service.md` — removes Automerge-backed sync description; reflects plain Map cache
- **Update** `dev/index.md` — updates distributed-sync and notes-sync descriptions

## Test plan

- [ ] Verify archived docs have correct deprecation headers and forward links
- [ ] Verify `peer-mesh-service.md` accurately reflects `PeerMeshService` source
- [ ] Verify `distributed-sync.md` no longer references removed services
- [ ] Verify `notes-sync.md` correctly describes disk-only model
- [ ] No broken cross-references between updated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated distributed sync architecture documentation to reflect shift from CRDT-based replication to mesh-based event broadcast with pull-based work coordination.
  * Archived Ava Channel and Ava Channel Reactor service documentation; functionality now managed by updated services.
  * Revised notes storage model documentation reflecting transition to disk-based workspace architecture.
  * Updated multi-instance deployment and service documentation to reflect new architecture patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->