### PR TITLE
Fix DeployProcessor DONE transition and clean up orphaned states

### DIFF
--- a/apps/server/src/services/lead-engineer-deploy-processor.ts
+++ b/apps/server/src/services/lead-engineer-deploy-processor.ts
@@ -42,7 +42,7 @@ export class DeployProcessor implements StateProcessor {
     const fresh = await this.serviceContext.featureLoader.get(ctx.projectPath, ctx.feature.id);
     if (fresh) ctx.feature = fresh;
 
-    if (fresh && fresh.status !== 'done' && fresh.status !== 'verified') {
+    if (fresh && fresh.status !== 'done') {
       await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
         status: 'done',
       });
@@ -75,7 +75,7 @@ export class DeployProcessor implements StateProcessor {
     void this.generateReflection(ctx);
 
     return {
-      nextState: null,
+      nextState: 'DONE',
       shouldContinue: false,
       reason: 'Feature deployed and verified',
     };

--- a/apps/server/src/services/lead-engineer-state-machine.ts
+++ b/apps/server/src/services/lead-engineer-state-machine.ts
@@ -293,6 +293,10 @@ export class FeatureStateMachine {
         }
 
         if (!result.shouldContinue || !result.nextState) {
+          // Capture the terminal state signaled by the processor (e.g. DONE from DEPLOY)
+          if (result.nextState) {
+            currentState = result.nextState;
+          }
           logger.info('Feature processing completed', {
             featureId: feature.id,
             finalState: currentState,

--- a/libs/types/src/lead-engineer.ts
+++ b/libs/types/src/lead-engineer.ts
@@ -294,12 +294,11 @@ export interface LeadRuleLogEntry {
  * Feature lifecycle states managed by the Lead Engineer
  *
  * Flow:
- * INTAKE → PLAN → EXECUTE → REVIEW → MERGE → DEPLOY → VERIFY → DONE
+ * INTAKE → PLAN → EXECUTE → REVIEW → MERGE → DEPLOY → DONE
  *
  * Short-circuits:
  * - Any state can → ESCALATE (on critical errors or max retries)
  * - ESCALATE → [appropriate state] (after human intervention)
- * - VERIFY → ESCALATE (on verification failure)
  */
 export enum FeatureState {
   /** Initial state: feature created, awaiting intake */
@@ -314,8 +313,6 @@ export enum FeatureState {
   MERGE = 'MERGE',
   /** Deploy phase: merged to main, deployment in progress */
   DEPLOY = 'DEPLOY',
-  /** Verification phase: post-deploy health checks and criteria validation */
-  VERIFY = 'VERIFY',
   /** Terminal state: feature fully deployed and verified */
   DONE = 'DONE',
   /** Escalation state: blocked, needs human intervention */


### PR DESCRIPTION
## Summary

**Milestone:** State Machine Terminal State Fix

Fix three interconnected issues in the state machine terminal state:

1. **DeployProcessor return value** (`lead-engineer-deploy-processor.ts:77-81`): Change `nextState: null` to `nextState: 'DONE'` and `shouldContinue: false`. The state machine in `lead-engineer-state-machine.ts` already handles `shouldContinue: false` as terminal — it just needs the correct final state.

2. **Remove VERIFY from FeatureState enum** (`libs/types/src/lead-engineer....

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the verification state from the deployment workflow, streamlining the feature lifecycle to: Intake → Plan → Execute → Review → Merge → Deploy → Done.
  * Fixed state machine transitions to ensure deployments properly complete and reach the final status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->