### PR TITLE
Fix ErrorBudgetService event bus wiring

### DIFF
--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -328,7 +328,7 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   metricsCollectionService.initialize();
 
   // Error Budget Service — rolling change fail rate tracker (persists to DATA_DIR/metrics/error-budget.json)
-  const errorBudgetService = new ErrorBudgetService(dataDir);
+  const errorBudgetService = new ErrorBudgetService(dataDir, events);
   // Wire error budget into the event pipeline: record merges and CI failures
   events.subscribe((type, payload) => {
     const p = payload as Record<string, unknown>;

--- a/apps/server/src/services/error-budget-service.ts
+++ b/apps/server/src/services/error-budget-service.ts
@@ -14,7 +14,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { EventEmitter } from 'node:events';
+import type { EventEmitter } from '../lib/events.js';
 import { createLogger } from '@protolabsai/utils';
 
 const logger = createLogger('ErrorBudgetService');
@@ -56,9 +56,12 @@ function ensureDir(dir: string): void {
 // Service
 // ---------------------------------------------------------------------------
 
-export class ErrorBudgetService extends EventEmitter {
+export class ErrorBudgetService {
   /** DATA_DIR — runtime data directory for error-budget.json. */
   private readonly dataDir: string;
+
+  /** Shared app event bus. Null for read-only ephemeral instances. */
+  private readonly events: EventEmitter | null;
 
   /** Rolling window in milliseconds (default: 7 days). */
   private readonly windowMs: number;
@@ -74,6 +77,7 @@ export class ErrorBudgetService extends EventEmitter {
 
   constructor(
     dataDir: string,
+    events?: EventEmitter | null,
     options: {
       /** Rolling window in days (default: 7) */
       windowDays?: number;
@@ -81,8 +85,8 @@ export class ErrorBudgetService extends EventEmitter {
       threshold?: number;
     } = {}
   ) {
-    super();
     this.dataDir = dataDir;
+    this.events = events ?? null;
     this.windowMs = (options.windowDays ?? 7) * 24 * 60 * 60 * 1000;
     this.threshold = options.threshold ?? 0.2;
   }
@@ -203,6 +207,7 @@ export class ErrorBudgetService extends EventEmitter {
    * the service was in the exhausted state.
    */
   private _checkAndEmitBudgetEvents(failRate: number): void {
+    if (!this.events) return;
     const { total, failed } = this.getWindowCounts();
 
     if (!this._isExhaustedState && failRate >= EXHAUSTION_BURN_RATE) {
@@ -210,7 +215,7 @@ export class ErrorBudgetService extends EventEmitter {
       logger.warn(
         `[ErrorBudget] Budget exhausted: failRate=${failRate.toFixed(3)} >= ${EXHAUSTION_BURN_RATE} — emitting error_budget:exhausted`
       );
-      this.emit('error_budget:exhausted', {
+      this.events.emit('error_budget:exhausted', {
         projectPath: this.dataDir,
         failRate,
         threshold: EXHAUSTION_BURN_RATE,
@@ -222,7 +227,7 @@ export class ErrorBudgetService extends EventEmitter {
       logger.info(
         `[ErrorBudget] Budget recovered: failRate=${failRate.toFixed(3)} < ${RECOVERY_BURN_RATE} — emitting error_budget:recovered`
       );
-      this.emit('error_budget:recovered', {
+      this.events.emit('error_budget:recovered', {
         projectPath: this.dataDir,
         failRate,
         threshold: EXHAUSTION_BURN_RATE,

--- a/apps/server/src/services/lead-engineer-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-execute-processor.ts
@@ -867,7 +867,7 @@ export class ExecuteProcessor implements StateProcessor {
     // ── (b) Error budget ──────────────────────────────────────────────────────
     try {
       const { ErrorBudgetService } = await import('./error-budget-service.js');
-      const errorBudget = new ErrorBudgetService(projectPath, {
+      const errorBudget = new ErrorBudgetService(projectPath, null, {
         windowDays: errorBudgetWindowDays,
         threshold: errorBudgetThreshold,
       });

--- a/apps/server/tests/unit/services/error-budget-service.test.ts
+++ b/apps/server/tests/unit/services/error-budget-service.test.ts
@@ -142,7 +142,7 @@ describe('ErrorBudgetService', () => {
   // ──────────────────────────── isExhausted / threshold ────────────────────────────
 
   it('isExhausted() returns false when fail rate is below threshold', () => {
-    const svc = new ErrorBudgetService(tmpDir, { threshold: 0.2 });
+    const svc = new ErrorBudgetService(tmpDir, null, { threshold: 0.2 });
     svc.recordMerge('f1', false);
     svc.recordMerge('f2', false);
     svc.recordMerge('f3', false);
@@ -153,7 +153,7 @@ describe('ErrorBudgetService', () => {
   });
 
   it('isExhausted() returns true when fail rate meets threshold', () => {
-    const svc = new ErrorBudgetService(tmpDir, { threshold: 0.2 });
+    const svc = new ErrorBudgetService(tmpDir, null, { threshold: 0.2 });
     // 1/5 = 20% >= 20%
     svc.recordMerge('f1', false);
     svc.recordMerge('f2', false);
@@ -164,7 +164,7 @@ describe('ErrorBudgetService', () => {
   });
 
   it('isExhausted() returns true when fail rate exceeds threshold', () => {
-    const svc = new ErrorBudgetService(tmpDir, { threshold: 0.2 });
+    const svc = new ErrorBudgetService(tmpDir, null, { threshold: 0.2 });
     // 2/4 = 50% > 20%
     svc.recordMerge('f1', false);
     svc.recordMerge('f2', false);
@@ -174,7 +174,7 @@ describe('ErrorBudgetService', () => {
   });
 
   it('custom threshold is respected', () => {
-    const svc = new ErrorBudgetService(tmpDir, { threshold: 0.5 });
+    const svc = new ErrorBudgetService(tmpDir, null, { threshold: 0.5 });
     svc.recordMerge('f1', true);
     svc.recordMerge('f2', false);
     // 1/2 = 50% — exactly at threshold
@@ -185,7 +185,7 @@ describe('ErrorBudgetService', () => {
 
   it('records outside the rolling window are excluded from fail rate', () => {
     // Use a 1-day window
-    const svc = new ErrorBudgetService(tmpDir, { windowDays: 1, threshold: 0.2 });
+    const svc = new ErrorBudgetService(tmpDir, null, { windowDays: 1, threshold: 0.2 });
 
     // Manually write an old record to disk (8 days ago)
     const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
@@ -211,7 +211,7 @@ describe('ErrorBudgetService', () => {
   });
 
   it('mixes old and recent records, only counting recent ones', () => {
-    const svc = new ErrorBudgetService(tmpDir, { windowDays: 7, threshold: 0.2 });
+    const svc = new ErrorBudgetService(tmpDir, null, { windowDays: 7, threshold: 0.2 });
 
     const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
     const budgetPath = path.join(tmpDir, 'metrics', 'error-budget.json');
@@ -239,12 +239,12 @@ describe('ErrorBudgetService', () => {
   // ──────────────────────────── Persistence ────────────────────────────
 
   it('persists state to disk and reads it back correctly', () => {
-    const svc1 = new ErrorBudgetService(tmpDir, { threshold: 0.2 });
+    const svc1 = new ErrorBudgetService(tmpDir, null, { threshold: 0.2 });
     svc1.recordMerge('f1', false);
     svc1.recordMerge('f2', true);
 
     // Create a new instance reading from the same directory
-    const svc2 = new ErrorBudgetService(tmpDir, { threshold: 0.2 });
+    const svc2 = new ErrorBudgetService(tmpDir, null, { threshold: 0.2 });
     const state = svc2.getState();
     expect(state.totalMerges).toBe(2);
     expect(state.failedMerges).toBe(1);
@@ -261,7 +261,7 @@ describe('ErrorBudgetService', () => {
   // ──────────────────────────── getState snapshot ────────────────────────────
 
   it('getState() returns exhausted=true when budget is exhausted', () => {
-    const svc = new ErrorBudgetService(tmpDir, { threshold: 0.2 });
+    const svc = new ErrorBudgetService(tmpDir, null, { threshold: 0.2 });
     svc.recordMerge('f1', false);
     svc.recordMerge('f2', false);
     svc.recordMerge('f3', false);
@@ -273,7 +273,7 @@ describe('ErrorBudgetService', () => {
   });
 
   it('getState() reflects custom windowDays option', () => {
-    const svc = new ErrorBudgetService(tmpDir, { windowDays: 14 });
+    const svc = new ErrorBudgetService(tmpDir, null, { windowDays: 14 });
     const state = svc.getState();
     expect(state.windowDays).toBe(14);
   });
@@ -282,9 +282,10 @@ describe('ErrorBudgetService', () => {
 
   it('emits error_budget:exhausted when burn rate reaches 1.0 (all merges failed)', () => {
     // Use threshold=0.2 for isExhausted() but the NEW exhausted event fires at 1.0 burn rate
-    const svc = new ErrorBudgetService(tmpDir);
+    const mockEvents = new EventEmitter() as unknown as import('@/lib/events.js').EventEmitter;
+    const svc = new ErrorBudgetService(tmpDir, mockEvents);
     const exhaustedListener = vi.fn();
-    svc.on('error_budget:exhausted', exhaustedListener);
+    mockEvents.on('error_budget:exhausted', exhaustedListener);
 
     // Drive all merges to failed → failRate = 1.0
     svc.recordMerge('f1', true);
@@ -302,9 +303,10 @@ describe('ErrorBudgetService', () => {
   });
 
   it('does not emit error_budget:exhausted twice without recovery in between', () => {
-    const svc = new ErrorBudgetService(tmpDir);
+    const mockEvents = new EventEmitter() as unknown as import('@/lib/events.js').EventEmitter;
+    const svc = new ErrorBudgetService(tmpDir, mockEvents);
     const exhaustedListener = vi.fn();
-    svc.on('error_budget:exhausted', exhaustedListener);
+    mockEvents.on('error_budget:exhausted', exhaustedListener);
 
     // First exhaustion: all merges fail
     svc.recordMerge('f1', true);
@@ -316,11 +318,12 @@ describe('ErrorBudgetService', () => {
   });
 
   it('emits error_budget:recovered when burn rate drops below 0.8 after exhaustion', () => {
-    const svc = new ErrorBudgetService(tmpDir);
+    const mockEvents = new EventEmitter() as unknown as import('@/lib/events.js').EventEmitter;
+    const svc = new ErrorBudgetService(tmpDir, mockEvents);
     const exhaustedListener = vi.fn();
     const recoveredListener = vi.fn();
-    svc.on('error_budget:exhausted', exhaustedListener);
-    svc.on('error_budget:recovered', recoveredListener);
+    mockEvents.on('error_budget:exhausted', exhaustedListener);
+    mockEvents.on('error_budget:recovered', recoveredListener);
 
     // Drive to 100% failure → exhausted
     svc.recordMerge('f1', true);
@@ -344,11 +347,12 @@ describe('ErrorBudgetService', () => {
   });
 
   it('does not emit error_budget:recovered if never exhausted', () => {
-    const svc = new ErrorBudgetService(tmpDir);
+    const mockEvents = new EventEmitter() as unknown as import('@/lib/events.js').EventEmitter;
+    const svc = new ErrorBudgetService(tmpDir, mockEvents);
     const exhaustedListener = vi.fn();
     const recoveredListener = vi.fn();
-    svc.on('error_budget:exhausted', exhaustedListener);
-    svc.on('error_budget:recovered', recoveredListener);
+    mockEvents.on('error_budget:exhausted', exhaustedListener);
+    mockEvents.on('error_budget:recovered', recoveredListener);
 
     // Start with successful merges so failRate never reaches 1.0
     // 1 failed / 4 total = 25% — below 100% exhaustion threshold


### PR DESCRIPTION
## Summary

**Milestone:** Event Bus Alignment

ErrorBudgetService (`error-budget-service.ts:59`) extends Node EventEmitter and emits error_budget:exhausted/error_budget:recovered on its own instance. AutoModeCoordinator (`auto-mode-coordinator.ts:33-37`) listens on the shared app event bus. The events never bridge.

Fix: Remove `extends EventEmitter` from ErrorBudgetService. Add a `private events: EventEmitter` constructor parameter. Change `this.emit(...)` calls to `this.events.emit(...)`. Update wiring t...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-14T08:07:49.648Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated error budget service event handling to use an external event emitter instead of internal event emission, improving the event pipeline architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->