### PR TITLE
Fix auto-mode event envelope mismatch

### DIFF
--- a/apps/server/src/services/auto-mode/typed-event-bus.ts
+++ b/apps/server/src/services/auto-mode/typed-event-bus.ts
@@ -10,7 +10,7 @@
  * - Rate-limits `auto_mode_progress` events to prevent WebSocket overload
  */
 
-import type { EventEmitter } from '../../lib/events.js';
+import type { EventEmitter, EventType } from '../../lib/events.js';
 
 /** Default minimum interval (ms) between progress events for the same feature. */
 const DEFAULT_PROGRESS_INTERVAL_MS = 100;
@@ -61,5 +61,14 @@ export class TypedEventBus {
       type: eventType,
       ...data,
     });
+
+    // Also emit the direct event type so subscribers (e.g. lead-engineer rules)
+    // can listen on e.g. 'auto-mode:stopped' instead of filtering 'auto-mode:event'.
+    // Normalize: auto_mode_stopped → auto-mode:stopped, auto_mode_idle → auto-mode:idle
+    if (eventType.startsWith('auto_mode_')) {
+      const directType =
+        `auto-mode:${eventType.slice('auto_mode_'.length).replace(/_/g, '-')}` as EventType;
+      this.events.emit(directType, data);
+    }
   }
 }


### PR DESCRIPTION
## Summary

**Milestone:** Event Bus Alignment

TypedEventBus (`typed-event-bus.ts:59-63`) wraps ALL auto-mode events in an auto-mode:event envelope. Lead Engineer rules (`lead-engineer-rules.ts:165`) listen for direct events like auto-mode:stopped and auto-mode:idle. The autoModeHealth rule never fires.

Fix: In TypedEventBus emitAutoModeEvent(), after emitting the auto-mode:event envelope, also emit the direct event type. Normalize event naming between TypedEventBus (may use underscores) and rule triggers...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-14T08:12:09.307Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced auto-mode event handling to support more specific state change notifications, allowing applications to respond more precisely to individual auto-mode transitions rather than generic broadcasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->