### PR TITLE
Emit feature lifecycle events from status changes

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -756,6 +756,22 @@ export class FeatureLoader implements FeatureStore {
             : 'status updated',
         feature: updatedFeature,
       });
+
+      // Emit specific lifecycle events based on new status
+      const lifecyclePayload = {
+        featureId,
+        featureTitle: updatedFeature.title,
+        projectPath,
+        previousStatus: feature.status,
+        newStatus: updates.status,
+      };
+      if (updates.status === 'in_progress') {
+        this.events.broadcast('feature:started', lifecyclePayload);
+      } else if (updates.status === 'blocked') {
+        this.events.broadcast('feature:blocked', lifecyclePayload);
+      } else if (updates.status === 'done') {
+        this.events.broadcast('feature:stopped', lifecyclePayload);
+      }
     }
 
     // Auto-complete epic when all child features reach 'done'

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -542,6 +542,14 @@ export interface EventPayloadMap {
     featureId: string;
     projectPath: string;
   };
+  'feature:blocked': {
+    featureId: string;
+    featureTitle?: string;
+    projectPath?: string;
+    previousStatus?: string;
+    newStatus?: string;
+    reason?: string;
+  };
   'cost:exceeded': {
     featureId: string;
     projectPath: string;


### PR DESCRIPTION
## Summary

**Milestone:** Event Bus Alignment

Several services subscribe to feature:started, feature:stopped, and feature:blocked events, but these are never emitted. Only the generic feature:status-changed is emitted by FeatureLoader.

Subscribers expecting these events: escalation-router.ts:148-150 listens for feature:blocked. event-subscriptions.module.ts:16-44 listens for feature:stopped. event-hook-service.ts maps feature:started, feature:stopped, feature:blocked.

Fix: In FeatureLoader.update() (aro...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-14T08:19:51.406Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Feature lifecycle events now emit automatically when features transition to specific statuses (started, blocked, or stopped), including relevant contextual details such as feature ID, title, and status information for downstream integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->