### PR TITLE
MergeProcessor respects prMergeStrategy and PR merge race guard

### DIFF
--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -8,7 +8,7 @@
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { createLogger } from '@protolabsai/utils';
-import type { EventType } from '@protolabsai/types';
+import type { EventType, PRMergeStrategy } from '@protolabsai/types';
 import type {
   ProcessorServiceContext,
   StateContext,
@@ -442,14 +442,15 @@ export class MergeProcessor implements StateProcessor {
       };
     }
 
+    // Resolve merge strategy: promotion PRs always use --merge
+    const mergeFlag = await this.resolveMergeFlag(ctx);
+
     logger.info(
-      `[MERGE] Attempting to merge PR #${ctx.prNumber} (attempt ${ctx.mergeRetryCount + 1}/${MAX_MERGE_RETRIES})`
+      `[MERGE] Attempting to merge PR #${ctx.prNumber} with ${mergeFlag} (attempt ${ctx.mergeRetryCount + 1}/${MAX_MERGE_RETRIES})`
     );
 
     try {
-      // Use --squash without --auto: we're in MERGE state after REVIEW approved,
-      // so checks should have passed. This ensures merge completes immediately.
-      await execAsync(`gh pr merge ${ctx.prNumber} --squash`, {
+      await execAsync(`gh pr merge ${ctx.prNumber} ${mergeFlag}`, {
         cwd: ctx.projectPath,
         timeout: 60000,
       });
@@ -527,5 +528,54 @@ export class MergeProcessor implements StateProcessor {
 
   async exit(_ctx: StateContext): Promise<void> {
     logger.info('[MERGE] Merge completed');
+  }
+
+  /**
+   * Resolve the gh CLI merge flag based on workflow settings and PR base branch.
+   * Promotion PRs (base is staging or main) always use --merge regardless of setting.
+   */
+  private async resolveMergeFlag(ctx: StateContext): Promise<string> {
+    // Check if this is a promotion PR — those must always use --merge
+    if (ctx.prNumber) {
+      try {
+        const { stdout } = await execAsync(
+          `gh pr view ${ctx.prNumber} --json baseRefName --jq '.baseRefName'`,
+          { cwd: ctx.projectPath, timeout: 15000 }
+        );
+        const baseBranch = stdout.trim();
+        if (baseBranch === 'staging' || baseBranch === 'main') {
+          logger.info(
+            `[MERGE] PR #${ctx.prNumber} targets ${baseBranch} — forcing --merge strategy`
+          );
+          return '--merge';
+        }
+      } catch (err) {
+        logger.warn(
+          '[MERGE] Failed to detect PR base branch, falling back to configured strategy:',
+          err
+        );
+      }
+    }
+
+    // Read prMergeStrategy from global settings
+    let strategy: PRMergeStrategy = 'squash';
+    if (this.serviceContext.settingsService) {
+      try {
+        const globalSettings = await this.serviceContext.settingsService.getGlobalSettings();
+        strategy = globalSettings.gitWorkflow?.prMergeStrategy ?? 'squash';
+      } catch (err) {
+        logger.warn(
+          '[MERGE] Failed to read global settings for merge strategy, defaulting to squash:',
+          err
+        );
+      }
+    }
+
+    const flagMap: Record<PRMergeStrategy, string> = {
+      squash: '--squash',
+      merge: '--merge',
+      rebase: '--rebase',
+    };
+    return flagMap[strategy] ?? '--squash';
   }
 }

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -637,6 +637,15 @@ export class LeadEngineerService {
 
         if (prData.state !== 'MERGED') continue;
 
+        // Skip if already handled (e.g., by ReviewProcessor or MergeProcessor)
+        const currentFeature = await this.featureLoader.get(projectPath, feature.id);
+        if (currentFeature?.status === 'done') {
+          logger.debug(
+            `[PRMergePoller] Feature "${feature.id}" already done, skipping duplicate processing`
+          );
+          continue;
+        }
+
         const prMergedAt = prData.mergedAt ?? new Date().toISOString();
 
         logger.info(

--- a/apps/server/tests/unit/services/lead-engineer-review-merge-processors.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-review-merge-processors.test.ts
@@ -92,13 +92,24 @@ function makeServiceContext(
 
 /**
  * Sets up the exec mock to simulate:
- *   1st call (gh pr merge): succeeds
- *   2nd call (gh pr view --json merged): returns `mergeResult`
+ *   1st call (gh pr view --json baseRefName): returns 'dev' (non-promotion branch)
+ *   2nd call (gh pr merge): succeeds
+ *   3rd call (gh pr view --json merged): returns `mergeResult`
  */
 function setupExecMock(mergeResult: string) {
   mockExec.mockReset();
   mockExec
-    // First call: gh pr merge
+    // First call: gh pr view --json baseRefName (promotion check)
+    .mockImplementationOnce(
+      (
+        _cmd: string,
+        _opts: unknown,
+        cb: (err: null, result: { stdout: string; stderr: string }) => void
+      ) => {
+        cb(null, { stdout: 'dev\n', stderr: '' });
+      }
+    )
+    // Second call: gh pr merge
     .mockImplementationOnce(
       (
         _cmd: string,
@@ -108,7 +119,7 @@ function setupExecMock(mergeResult: string) {
         cb(null, { stdout: '', stderr: '' });
       }
     )
-    // Second call: gh pr view --json merged
+    // Third call: gh pr view --json merged
     .mockImplementationOnce(
       (
         _cmd: string,


### PR DESCRIPTION
## Summary

**Milestone:** Merge and Review Hardening

M3: At lead-engineer-review-merge-processors.ts:452, the merge command is hardcoded as gh pr merge with --squash. The prMergeStrategy setting exists in libs/types/src/git-settings.ts:34-35 and git-workflow-service.ts already reads it. MergeProcessor should do the same.

Fix: Read prMergeStrategy from workflow settings. Map strategy to gh flag: squash to --squash, merge to --merge, rebase to --rebase. IMPORTANT: Promotion PRs (base is staging or main) mu...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PR merge strategy is now configurable through global settings (squash, merge, or rebase defaults to squash). Promotion pull requests always use standard merge behavior.

* **Bug Fixes**
  * Improved deduplication to prevent duplicate processing of already-completed features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->