### PR TITLE
Promote dev to staging: MCP authority removal + pipeline fixes

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -78,92 +78,9 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// ---------------------------------------------------------------------------
-// Trust tier enforcement for destructive tools
-// ---------------------------------------------------------------------------
-
-/** Minimum trust level (0-3) required for each destructive tool */
-const DESTRUCTIVE_TOOL_TRUST_REQUIREMENTS: Record<string, number> = {
-  delete_feature: 2,
-  delete_project: 2,
-  clear_queue: 2,
-  promote_to_main: 3,
-};
-
-/**
- * Check if the calling agent/user has sufficient trust for a destructive action.
- *
- * If a `requestingAgentId` is provided, we submit a proposal to the authority
- * service (`/authority/propose`) and return the policy decision.
- *
- * If no agent context is provided, we default to trust level 0 (most restrictive)
- * and create an approval request via the authority propose endpoint.
- *
- * Returns { allowed: true } when the action can proceed, or
- * { allowed: false, verdict, reason, requestId? } when blocked/pending approval.
- */
-async function checkDestructiveTrustTier(
-  toolName: string,
-  projectPath: string | undefined,
-  requestingAgentId?: string
-): Promise<{ allowed: boolean; verdict?: string; reason?: string; requestId?: string }> {
-  const requiredTrust = DESTRUCTIVE_TOOL_TRUST_REQUIREMENTS[toolName];
-  if (requiredTrust === undefined) {
-    // Not a guarded destructive tool — allow
-    return { allowed: true };
-  }
-
-  // Map tool names to risk levels for the authority proposal
-  const toolRiskLevel: Record<string, string> = {
-    delete_feature: 'medium',
-    delete_project: 'high',
-    clear_queue: 'medium',
-    promote_to_main: 'high',
-  };
-
-  const actionRisk = toolRiskLevel[toolName] ?? 'high';
-  const resolvedProjectPath = projectPath ?? process.env.AUTOMAKER_ROOT ?? '';
-
-  if (!resolvedProjectPath) {
-    // No project context — cannot check authority, allow with warning
-    return { allowed: true };
-  }
-
-  const agentId = requestingAgentId ?? 'mcp-caller';
-
-  try {
-    const result = (await apiCall('/authority/propose', {
-      projectPath: resolvedProjectPath,
-      proposal: {
-        who: agentId,
-        what: 'modify_architecture',
-        target: toolName,
-        justification: `Executing destructive MCP tool: ${toolName}`,
-        risk: actionRisk,
-      },
-    })) as { decision?: { verdict?: string; reason?: string; approver?: string } };
-
-    const decision = result.decision;
-    if (!decision) {
-      // Authority service unavailable or returned unexpected shape — allow
-      return { allowed: true };
-    }
-
-    if (decision.verdict === 'allow') {
-      return { allowed: true };
-    }
-
-    return {
-      allowed: false,
-      verdict: decision.verdict,
-      reason: decision.reason,
-      requestId: decision.approver,
-    };
-  } catch {
-    // Authority service not available — allow and log
-    return { allowed: true };
-  }
-}
+// Trust tier enforcement removed — MCP callers are trusted by default.
+// The authority system was blocking legitimate MCP tool calls because the
+// hardcoded 'mcp-caller' identity was never registered in agents.json.
 
 // Helper for API calls with retry logic
 async function apiCall(
@@ -371,27 +288,11 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
       });
     }
 
-    case 'delete_feature': {
-      const deleteFeatureTrust = await checkDestructiveTrustTier(
-        'delete_feature',
-        args.projectPath as string | undefined,
-        args.requestingAgentId as string | undefined
-      );
-      if (!deleteFeatureTrust.allowed) {
-        return {
-          success: false,
-          blocked: true,
-          verdict: deleteFeatureTrust.verdict,
-          reason: deleteFeatureTrust.reason,
-          requestId: deleteFeatureTrust.requestId,
-          message: `delete_feature blocked: insufficient trust tier. ${deleteFeatureTrust.reason ?? ''}${deleteFeatureTrust.requestId ? ` Approval request created: ${deleteFeatureTrust.requestId}` : ''}`,
-        };
-      }
+    case 'delete_feature':
       return apiCall('/features/delete', {
         projectPath: args.projectPath,
         featureId: args.featureId,
       });
-    }
 
     case 'move_feature':
       return apiCall('/features/update', {
@@ -476,24 +377,8 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
     case 'list_queue':
       return apiCall('/agent/queue/list', {});
 
-    case 'clear_queue': {
-      const clearQueueTrust = await checkDestructiveTrustTier(
-        'clear_queue',
-        args.projectPath as string | undefined,
-        args.requestingAgentId as string | undefined
-      );
-      if (!clearQueueTrust.allowed) {
-        return {
-          success: false,
-          blocked: true,
-          verdict: clearQueueTrust.verdict,
-          reason: clearQueueTrust.reason,
-          requestId: clearQueueTrust.requestId,
-          message: `clear_queue blocked: insufficient trust tier. ${clearQueueTrust.reason ?? ''}${clearQueueTrust.requestId ? ` Approval request created: ${clearQueueTrust.requestId}` : ''}`,
-        };
-      }
+    case 'clear_queue':
       return apiCall('/agent/queue/clear', {});
-    }
 
     // Context Files
     case 'list_context_files':
@@ -695,27 +580,11 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
       });
     }
 
-    case 'delete_project': {
-      const deleteProjectTrust = await checkDestructiveTrustTier(
-        'delete_project',
-        args.projectPath as string | undefined,
-        args.requestingAgentId as string | undefined
-      );
-      if (!deleteProjectTrust.allowed) {
-        return {
-          success: false,
-          blocked: true,
-          verdict: deleteProjectTrust.verdict,
-          reason: deleteProjectTrust.reason,
-          requestId: deleteProjectTrust.requestId,
-          message: `delete_project blocked: insufficient trust tier. ${deleteProjectTrust.reason ?? ''}${deleteProjectTrust.requestId ? ` Approval request created: ${deleteProjectTrust.requestId}` : ''}`,
-        };
-      }
+    case 'delete_project':
       return apiCall('/projects/delete', {
         projectPath: args.projectPath,
         projectSlug: args.projectSlug,
       });
-    }
 
     case 'archive_project':
       return apiCall('/projects/archive', {
@@ -1511,12 +1380,14 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         action: args.action,
       });
 
-    // Idea Processing
+    // Idea Processing — authority pipeline removed, create feature directly
     case 'process_idea':
-      return apiCall('/authority/inject-idea', {
+      return apiCall('/features/create', {
         projectPath: args.projectPath,
         title: args.title,
         description: args.description,
+        category: 'idea',
+        status: 'backlog',
       });
 
     // Board Query
@@ -1802,30 +1673,6 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         reason: args.reason,
       });
 
-    case 'get_trust_tier': {
-      const tierResult = (await apiCall('/quarantine/trust-tiers/list', {})) as {
-        success?: boolean;
-        records?: Array<{ githubUsername: string; tier: number }>;
-      };
-      if (tierResult.success && tierResult.records) {
-        const record = tierResult.records.find((r) => r.githubUsername === args.githubUsername);
-        return {
-          success: true,
-          githubUsername: args.githubUsername,
-          tier: record ? record.tier : 0,
-        };
-      }
-      return { success: false, error: 'Failed to get trust tier' };
-    }
-
-    case 'set_trust_tier':
-      return apiCall('/quarantine/trust-tiers/set', {
-        githubUsername: args.githubUsername,
-        tier: args.tier,
-        grantedBy: args.grantedBy,
-        reason: args.reason,
-      });
-
     // File Operations
     case 'copy_file':
       return apiCall('/fs/copy', {
@@ -1868,27 +1715,11 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         batchId: args.batchId,
       });
 
-    case 'promote_to_main': {
-      const promoteToMainTrust = await checkDestructiveTrustTier(
-        'promote_to_main',
-        args.projectPath as string | undefined,
-        args.requestingAgentId as string | undefined
-      );
-      if (!promoteToMainTrust.allowed) {
-        return {
-          success: false,
-          blocked: true,
-          verdict: promoteToMainTrust.verdict,
-          reason: promoteToMainTrust.reason,
-          requestId: promoteToMainTrust.requestId,
-          message: `promote_to_main blocked: insufficient trust tier. ${promoteToMainTrust.reason ?? ''}${promoteToMainTrust.requestId ? ` Approval request created: ${promoteToMainTrust.requestId}` : ''}`,
-        };
-      }
+    case 'promote_to_main':
       return apiCall('/promotions/promote-to-main', {
         projectPath: args.projectPath,
         batchId: args.batchId,
       });
-    }
 
     case 'list_promotion_batches':
       return apiCall('/promotions/batches', {}, 'GET');

--- a/packages/mcp-server/src/tools/feature-tools.ts
+++ b/packages/mcp-server/src/tools/feature-tools.ts
@@ -210,8 +210,7 @@ export const featureTools: Tool[] = [
   },
   {
     name: 'delete_feature',
-    description:
-      'Delete a feature from the board. This is a destructive action — requires sufficient trust tier. If trust is insufficient, an approval request is created instead.',
+    description: 'Delete a feature from the board. This is a destructive action.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -222,11 +221,6 @@ export const featureTools: Tool[] = [
         featureId: {
           type: 'string',
           description: 'The feature ID (UUID)',
-        },
-        requestingAgentId: {
-          type: 'string',
-          description:
-            'Optional agent ID for trust tier enforcement. If the agent lacks sufficient trust, an approval request is created instead of executing.',
         },
       },
       required: ['projectPath', 'featureId'],

--- a/packages/mcp-server/src/tools/project-tools.ts
+++ b/packages/mcp-server/src/tools/project-tools.ts
@@ -174,8 +174,7 @@ export const projectTools: Tool[] = [
   },
   {
     name: 'delete_project',
-    description:
-      'Delete a project plan and all its files. This is a destructive action — requires sufficient trust tier. If trust is insufficient, an approval request is created instead.',
+    description: 'Delete a project plan and all its files. This is a destructive action.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -186,11 +185,6 @@ export const projectTools: Tool[] = [
         projectSlug: {
           type: 'string',
           description: 'The project slug to delete',
-        },
-        requestingAgentId: {
-          type: 'string',
-          description:
-            'Optional agent ID for trust tier enforcement. If the agent lacks sufficient trust, an approval request is created instead of executing.',
         },
       },
       required: ['projectPath', 'projectSlug'],

--- a/packages/mcp-server/src/tools/promotion-tools.ts
+++ b/packages/mcp-server/src/tools/promotion-tools.ts
@@ -80,7 +80,7 @@ export const promotionTools: Tool[] = [
   {
     name: 'promote_to_main',
     description:
-      'Creates the staging→main PR but does NOT merge. Human approval required via HITL form. Ava calls this to initiate a staging→main promotion, which opens a PR and fires a HITL form for a human to review and approve before any merge occurs. Requires sufficient trust tier — if trust is insufficient, an approval request is created instead.',
+      'Creates the staging→main PR but does NOT merge. Human approval required via HITL form. Ava calls this to initiate a staging→main promotion, which opens a PR and fires a HITL form for a human to review and approve before any merge occurs.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -91,11 +91,6 @@ export const promotionTools: Tool[] = [
         batchId: {
           type: 'string',
           description: 'The promotion batch ID to promote from staging to main.',
-        },
-        requestingAgentId: {
-          type: 'string',
-          description:
-            'Optional agent ID for trust tier enforcement. If the agent lacks sufficient trust, an approval request is created instead of executing.',
         },
       },
       required: ['projectPath', 'batchId'],

--- a/packages/mcp-server/src/tools/quarantine-tools.ts
+++ b/packages/mcp-server/src/tools/quarantine-tools.ts
@@ -1,12 +1,10 @@
 /**
  * Quarantine Management Tools
  *
- * Tools for managing quarantine entries and trust tiers:
+ * Tools for managing quarantine entries:
  * - list_quarantine_entries: List quarantine entries (with optional filtering)
  * - approve_quarantine_entry: Approve a pending entry
  * - reject_quarantine_entry: Reject with reason
- * - get_trust_tier: Get trust tier for a GitHub username
- * - set_trust_tier: Grant/upgrade tier
  */
 
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
@@ -15,7 +13,7 @@ export const quarantineTools: Tool[] = [
   {
     name: 'list_quarantine_entries',
     description:
-      'List all quarantine entries in a project. Can filter by result (pending, passed, failed, bypassed). Returns entries with violation details, trust tier, and sanitization information.',
+      'List all quarantine entries in a project. Can filter by result (pending, passed, failed, bypassed). Returns entries with violation details and sanitization information.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -81,51 +79,6 @@ export const quarantineTools: Tool[] = [
         },
       },
       required: ['projectPath', 'quarantineId', 'reviewedBy', 'reason'],
-    },
-  },
-  {
-    name: 'get_trust_tier',
-    description:
-      'Get the trust tier for a GitHub username. Returns tier level (0-4) where 0=anonymous, 1=github_user, 2=contributor, 3=maintainer, 4=system.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        githubUsername: {
-          type: 'string',
-          description: 'GitHub username to query',
-        },
-      },
-      required: ['githubUsername'],
-    },
-  },
-  {
-    name: 'set_trust_tier',
-    description:
-      'Grant or upgrade a trust tier for a GitHub username. Trust tiers: 0=anonymous, 1=github_user, 2=contributor, 3=maintainer, 4=system. Higher tiers bypass more validation stages.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        githubUsername: {
-          type: 'string',
-          description: 'GitHub username to grant tier to',
-        },
-        tier: {
-          type: 'number',
-          enum: [0, 1, 2, 3, 4],
-          description:
-            'Trust tier level: 0=anonymous, 1=github_user, 2=contributor, 3=maintainer, 4=system',
-        },
-        grantedBy: {
-          type: 'string',
-          description: 'Username of the person granting this tier',
-        },
-        reason: {
-          type: 'string',
-          description:
-            'Optional reason for granting this tier (e.g., "Consistent high-quality contributions")',
-        },
-      },
-      required: ['githubUsername', 'tier', 'grantedBy'],
     },
   },
 ];

--- a/packages/mcp-server/src/tools/queue-tools.ts
+++ b/packages/mcp-server/src/tools/queue-tools.ts
@@ -34,19 +34,13 @@ export const queueTools: Tool[] = [
   },
   {
     name: 'clear_queue',
-    description:
-      'Clear all features from the agent queue. This is a destructive action — requires sufficient trust tier. If trust is insufficient, an approval request is created instead.',
+    description: 'Clear all features from the agent queue. This is a destructive action.',
     inputSchema: {
       type: 'object',
       properties: {
         projectPath: {
           type: 'string',
-          description: 'Optional project path for trust tier enforcement',
-        },
-        requestingAgentId: {
-          type: 'string',
-          description:
-            'Optional agent ID for trust tier enforcement. If the agent lacks sufficient trust, an approval request is created instead of executing.',
+          description: 'Optional project path',
         },
       },
     },

--- a/packages/mcp-server/src/tools/utility-tools.ts
+++ b/packages/mcp-server/src/tools/utility-tools.ts
@@ -131,7 +131,7 @@ export const utilityTools: Tool[] = [
   {
     name: 'submit_prd',
     description:
-      'Submit a SPARC PRD from the Chief of Staff to the Project Manager for decomposition and execution. Creates a feature that enters the authority pipeline.',
+      'Submit a SPARC PRD from the Chief of Staff to the Project Manager for decomposition and execution. Creates a feature on the board.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/packages/mcp-server/src/tools/workspace-tools.ts
+++ b/packages/mcp-server/src/tools/workspace-tools.ts
@@ -281,7 +281,7 @@ export const workspaceTools: Tool[] = [
   {
     name: 'process_idea',
     description:
-      'Process an idea through the PM Agent pipeline. Creates a feature with idea state and triggers the PM Agent for research, PRD generation, and feature decomposition.',
+      'Process an idea by creating a feature on the board with idea category in backlog status.',
     inputSchema: {
       type: 'object',
       properties: {


### PR DESCRIPTION
## Summary
- fix: remove authority system from MCP tools (unblocks destructive tool calls for MCP callers)
- refactor: MergeProcessor respects prMergeStrategy and PR merge race guard
- refactor: remove dead rollbackTriggered rule and gate-tuning action type
- docs: update pipeline and lead engineer docs
- fix: include remainingMilestones and retroData in ceremony:fired events
- feat: emit specific lifecycle events from FeatureLoader on status changes
- fix: emit direct auto-mode events from TypedEventBus
- fix: bridge ErrorBudgetService events to shared app event bus
- refactor: Fix DeployProcessor DONE transition and clean up orphaned states
- docs: add system architecture reference and complete lead engineer pipeline docs
- chore: delete docs/archived/ directory
- docs: purge stale CRDT/Automerge references
- fix: remove stale libs/crdt references from Dockerfile and tsconfigs
- style: fix Prettier formatting in site HTML files

## Test plan
- [ ] Verify MCP destructive tools (delete_feature, delete_project, clear_queue, promote_to_main) work without authority errors
- [ ] Verify build passes
- [ ] Verify server starts cleanly

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Destructive operations including feature deletion, queue management, project deletion, and branch promotions now execute immediately without requiring prior approval checks.
  * Trust tier management system and related access control tools have been removed.
  * Idea processing simplified to directly create features on the board with backlog status and idea categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->