### PR TITLE
Types + Structured Plan Generator

### DIFF
--- a/apps/server/src/services/lead-engineer-processors.ts
+++ b/apps/server/src/services/lead-engineer-processors.ts
@@ -8,7 +8,7 @@
 import { createLogger } from '@protolabsai/utils';
 import { resolveModelString, DEFAULT_MODELS } from '@protolabsai/model-resolver';
 import { getBlockingDependencies } from '@protolabsai/dependency-resolver';
-import type { AgentRole, Feature } from '@protolabsai/types';
+import type { AgentRole, Feature, StructuredPlan } from '@protolabsai/types';
 import { getWorkflowSettings, getPhaseModelWithOverrides } from '../lib/settings-helpers.js';
 import { simpleQuery } from '../providers/simple-query-service.js';
 import type {
@@ -257,6 +257,18 @@ Keep it focused and actionable. If the feature description is too vague or uncle
       ctx.planOutput = `Feature: ${feature.title}\n\n${feature.description || 'Implement as described.'}`;
     }
 
+    // Attempt to generate a structured plan in parallel with validation
+    ctx.structuredPlan = (await this.generateStructuredPlan(ctx)) ?? undefined;
+    if (ctx.structuredPlan) {
+      logger.info('[PLAN] Structured plan generated successfully', {
+        featureId: feature.id,
+        taskCount: ctx.structuredPlan.tasks.length,
+        criteriaCount: ctx.structuredPlan.acceptanceCriteria.length,
+      });
+    } else {
+      logger.info('[PLAN] Structured plan generation failed or skipped — using freeform fallback');
+    }
+
     // Validate plan quality
     const gateResult = this.validatePlan(ctx);
 
@@ -436,6 +448,103 @@ Minor suggestions don't warrant rejection — only reject for issues that would 
       };
     }
 
+    // Validate structured plan fields if present
+    if (ctx.structuredPlan) {
+      if (!ctx.structuredPlan.goal || ctx.structuredPlan.goal.trim().length === 0) {
+        return { approved: false, shouldRetry: true, reason: 'Structured plan missing goal' };
+      }
+      if (!ctx.structuredPlan.tasks || ctx.structuredPlan.tasks.length === 0) {
+        return {
+          approved: false,
+          shouldRetry: true,
+          reason: 'Structured plan has no tasks',
+        };
+      }
+      if (
+        !ctx.structuredPlan.acceptanceCriteria ||
+        ctx.structuredPlan.acceptanceCriteria.length === 0
+      ) {
+        return {
+          approved: false,
+          shouldRetry: true,
+          reason: 'Structured plan has no acceptance criteria',
+        };
+      }
+    }
+
     return { approved: true, shouldRetry: false };
+  }
+
+  /**
+   * Attempt to generate a structured JSON plan from the feature description.
+   * Returns null on failure — callers fall back to the freeform planOutput.
+   */
+  private async generateStructuredPlan(ctx: StateContext): Promise<StructuredPlan | null> {
+    const { feature } = ctx;
+    try {
+      const result = await simpleQuery({
+        prompt: `Generate a structured implementation plan for this software feature.
+
+**Title:** ${feature.title || 'Untitled'}
+**Description:** ${feature.description || 'No description provided'}
+**Complexity:** ${feature.complexity || 'medium'}
+
+Return ONLY valid JSON matching this exact schema (no markdown, no explanation):
+{
+  "goal": "<one sentence describing the feature goal>",
+  "acceptanceCriteria": [
+    { "description": "<what must be true>", "verifyCommand": "<optional shell command>" }
+  ],
+  "tasks": [
+    {
+      "title": "<short task title>",
+      "description": "<what to do>",
+      "files": ["<file path>"],
+      "verifyCommand": "<optional shell command>"
+    }
+  ],
+  "deviationRules": [
+    { "condition": "<when this situation arises>", "action": "<what to do instead>" }
+  ]
+}
+
+Requirements:
+- goal: single clear sentence
+- acceptanceCriteria: at least 1 entry, each with a description
+- tasks: at least 1 entry, each with title, description, and files array
+- deviationRules: 0 or more entries (can be empty array)
+- verifyCommand fields are optional but encouraged when a shell check is obvious`,
+        model: resolveModelString('haiku'),
+        cwd: ctx.projectPath,
+        systemPrompt:
+          'You are a senior software engineer. Respond with only valid JSON. No markdown code fences, no explanation text.',
+        maxTurns: 1,
+        allowedTools: [],
+      });
+
+      const text = result.text.trim();
+      // Strip any accidental markdown fences
+      const jsonText = text.startsWith('```')
+        ? text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+        : text;
+
+      const parsed = JSON.parse(jsonText) as StructuredPlan;
+
+      // Basic shape validation before accepting
+      if (
+        typeof parsed.goal !== 'string' ||
+        !Array.isArray(parsed.acceptanceCriteria) ||
+        !Array.isArray(parsed.tasks) ||
+        !Array.isArray(parsed.deviationRules)
+      ) {
+        logger.warn('[PLAN] Structured plan JSON has unexpected shape — discarding');
+        return null;
+      }
+
+      return parsed;
+    } catch (err) {
+      logger.info('[PLAN] Could not generate structured plan, falling back to freeform', err);
+      return null;
+    }
   }
 }

--- a/apps/server/src/services/lead-engineer-types.ts
+++ b/apps/server/src/services/lead-engineer-types.ts
@@ -4,7 +4,7 @@
  * All types shared across the lead-engineer subsystem files.
  */
 
-import type { Feature, AgentRole } from '@protolabsai/types';
+import type { Feature, AgentRole, StructuredPlan } from '@protolabsai/types';
 import type { EventEmitter } from '../lib/events.js';
 import type { FeatureLoader } from './feature-loader.js';
 import type { AutoModeService } from './auto-mode-service.js';
@@ -149,6 +149,8 @@ export interface StateContext {
   projectKnowledge?: string;
   /** ISO 8601 timestamp when processing started */
   startedAt?: string;
+  /** Structured plan produced by PlanProcessor, if parsing succeeded */
+  structuredPlan?: StructuredPlan;
 }
 
 /**

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -827,6 +827,10 @@ export type {
   LeadEngineerService,
   PhaseHandoff,
   PipelineResult,
+  AcceptanceCriterion,
+  DeviationRule,
+  PlanTask,
+  StructuredPlan,
 } from './lead-engineer.js';
 
 // Notes types (Tiptap-based project notes workspace)

--- a/libs/types/src/lead-engineer.ts
+++ b/libs/types/src/lead-engineer.ts
@@ -466,6 +466,51 @@ export interface LeadEngineerService {
   refreshWorldState(projectPath: string): Promise<LeadWorldState>;
 }
 
+// ────────────────────────── Structured Plan ──────────────────────────
+
+/** A single acceptance criterion for a feature plan */
+export interface AcceptanceCriterion {
+  /** Human-readable description of what must be true for acceptance */
+  description: string;
+  /** Optional verification command to confirm criterion is met */
+  verifyCommand?: string;
+}
+
+/** A rule that defines acceptable deviations from the original plan */
+export interface DeviationRule {
+  /** Description of what kind of deviation is allowed */
+  condition: string;
+  /** How to handle or adapt when this deviation occurs */
+  action: string;
+}
+
+/** A single implementation task within a structured plan */
+export interface PlanTask {
+  /** Short title describing this task */
+  title: string;
+  /** Detailed description of what needs to be done */
+  description: string;
+  /** Files to create or modify for this task */
+  files: string[];
+  /** Shell command to verify this task is complete */
+  verifyCommand?: string;
+}
+
+/**
+ * Structured implementation plan produced by PlanProcessor.
+ * Contains machine-parseable goal, acceptance criteria, tasks, and deviation rules.
+ */
+export interface StructuredPlan {
+  /** High-level goal statement for the feature */
+  goal: string;
+  /** Ordered list of acceptance criteria that must be satisfied */
+  acceptanceCriteria: AcceptanceCriterion[];
+  /** Ordered list of implementation tasks */
+  tasks: PlanTask[];
+  /** Rules for handling deviations from the plan */
+  deviationRules: DeviationRule[];
+}
+
 // ────────────────────────── Phase Handoff ──────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

**Milestone:** Structured Plan Format

Add structured plan types (StructuredPlan, PlanTask, AcceptanceCriterion, DeviationRule) to libs/types/src/lead-engineer.ts. Update StateContext with structuredPlan field. Implement structured plan generation in PlanProcessor using an engineered prompt that produces parseable JSON output with goal statement, acceptance criteria, task breakdown (file targets + verification commands), and deviation rules. Update plan validation to check structured fields. Pre...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plans now support a structured format with explicit goals, actionable tasks, acceptance criteria, and deviation rules for improved clarity.
  * Enhanced validation ensures plan quality and field completeness.
  * Graceful fallback preserves existing plan generation if structured format processing fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->