### PR TITLE
Fix ReviewProcessor external merge detection using wrong gh field

### DIFF
--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -367,11 +367,11 @@ export class ReviewProcessor implements StateProcessor {
 
     try {
       const { stdout } = await execAsync(
-        `gh pr list --head "${branchName}" --state merged --json number,merged --jq '.[0].merged // false'`,
+        `gh pr list --head "${branchName}" --state merged --json number,mergedAt --jq '.[0].mergedAt // ""'`,
         { cwd: ctx.projectPath, timeout: 15000 }
       );
       const result = stdout.trim();
-      if (result === 'true') {
+      if (result !== '' && result !== 'null') {
         // Also store the PR number if we don't have one yet
         if (!ctx.prNumber) {
           try {
@@ -457,11 +457,12 @@ export class MergeProcessor implements StateProcessor {
 
       // Verify merge actually completed
       const { stdout: mergeCheck } = await execAsync(
-        `gh pr view ${ctx.prNumber} --json merged --jq '.merged'`,
+        `gh pr view ${ctx.prNumber} --json mergedAt --jq '.mergedAt // ""'`,
         { cwd: ctx.projectPath, timeout: 15000 }
       );
 
-      if (mergeCheck.trim() !== 'true') {
+      const mergeCheckResult = mergeCheck.trim();
+      if (mergeCheckResult === '' || mergeCheckResult === 'null') {
         ctx.mergeRetryCount++;
         logger.warn(`[MERGE] PR #${ctx.prNumber} merge command succeeded but PR not yet merged`);
         await new Promise((r) => setTimeout(r, MERGE_RETRY_DELAY_MS));


### PR DESCRIPTION
## Summary

**Bug:** The Lead Engineer ReviewProcessor uses gh pr list --json number,merged but the gh CLI does not have a merged field — only mergedAt and mergedBy. This causes the external merge check to fail silently on every poll cycle with: Unknown JSON field: "merged". As a result, the ReviewProcessor never detects that a PR was merged externally and keeps polling reviewState: pending forever until the 45-minute timeout.

**Impact:** Features get stuck in review even though their PRs are already merge...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-14T17:17:52.741Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of pull request merge detection by implementing more reliable data validation for identifying successfully merged pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->