### PR TITLE
Post-Execution Goal Verification

### DIFF
--- a/apps/server/src/services/lead-engineer-deploy-processor.ts
+++ b/apps/server/src/services/lead-engineer-deploy-processor.ts
@@ -13,6 +13,7 @@ import { getFeatureDir } from '@protolabsai/platform';
 import type { EventType } from '@protolabsai/types';
 import { simpleQuery } from '../providers/simple-query-service.js';
 import { getWorkflowSettings } from '../lib/settings-helpers.js';
+import type { GoalVerificationResult } from '@protolabsai/types';
 import type {
   ProcessorServiceContext,
   StateContext,
@@ -73,6 +74,9 @@ export class DeployProcessor implements StateProcessor {
 
     // Fire-and-forget reflection (non-blocking)
     void this.generateReflection(ctx);
+
+    // Fire-and-forget goal verification (non-blocking, advisory only)
+    void this.runGoalVerification(ctx);
 
     return {
       nextState: 'DONE',
@@ -201,6 +205,182 @@ ${failureSummary}
       logger.info(`[DEPLOY] Created bug-fix feature for verification failure of ${ctx.feature.id}`);
     } catch (err) {
       logger.warn(`[DEPLOY] Failed to create bug-fix feature:`, err);
+    }
+  }
+
+  /**
+   * Fire-and-forget goal-backward verification.
+   * Evaluates acceptance criteria against the merged git diff via haiku LLM call.
+   * Creates follow-up features for unmet criteria and stores the result in trajectory.
+   * Never blocks the DONE transition.
+   */
+  private async runGoalVerification(ctx: StateContext): Promise<void> {
+    try {
+      // Collect acceptance criteria — prefer structured plan, fall back to feature description
+      const criteria: string[] = [];
+
+      if (ctx.structuredPlan?.acceptanceCriteria?.length) {
+        for (const ac of ctx.structuredPlan.acceptanceCriteria) {
+          criteria.push(ac.description);
+        }
+      }
+
+      if (criteria.length === 0) {
+        logger.info(
+          `[DEPLOY] Goal verification skipped — no acceptance criteria for feature ${ctx.feature.id}`
+        );
+        return;
+      }
+
+      // Get git diff of merged changes
+      let gitDiff = '';
+      try {
+        const { stdout } = await execAsync('git diff HEAD~1 HEAD -- . ":(exclude).automaker"', {
+          cwd: ctx.projectPath,
+          timeout: 15_000,
+        });
+        // Truncate large diffs to keep LLM prompt manageable
+        gitDiff = stdout.length > 8000 ? stdout.slice(0, 8000) + '\n... (truncated)' : stdout;
+      } catch {
+        logger.warn(`[DEPLOY] Goal verification: could not get git diff, skipping`);
+        return;
+      }
+
+      if (!gitDiff.trim()) {
+        logger.info(`[DEPLOY] Goal verification: empty diff, skipping`);
+        return;
+      }
+
+      const criteriaList = criteria.map((c, i) => `${i + 1}. ${c}`).join('\n');
+
+      const prompt = `You are a strict acceptance criteria evaluator for a software feature.
+
+Feature: ${ctx.feature.title}
+Description: ${(ctx.feature.description ?? '').slice(0, 800)}
+
+Acceptance Criteria:
+${criteriaList}
+
+Git diff of merged changes:
+\`\`\`diff
+${gitDiff}
+\`\`\`
+
+Evaluate each acceptance criterion against the merged code changes. For each criterion, determine if it was met based solely on what is visible in the diff.
+
+Respond with a JSON array where each element matches this schema:
+{ "criterion": "<exact criterion text>", "met": true|false, "reason": "<one sentence>" }
+
+Return ONLY the JSON array, no other text.`;
+
+      const result = await simpleQuery({
+        prompt,
+        model: 'haiku',
+        cwd: ctx.projectPath,
+        maxTurns: 1,
+        allowedTools: [],
+        traceContext: {
+          featureId: ctx.feature.id,
+          featureName: ctx.feature.title,
+          agentRole: 'goal-verification',
+        },
+      });
+
+      // Parse LLM response
+      let criteriaResults: Array<{ criterion: string; met: boolean; reason: string }> = [];
+      try {
+        const jsonMatch = result.text.match(/\[[\s\S]*\]/);
+        if (jsonMatch) {
+          criteriaResults = JSON.parse(jsonMatch[0]) as typeof criteriaResults;
+        }
+      } catch {
+        logger.warn(`[DEPLOY] Goal verification: failed to parse LLM response`);
+        return;
+      }
+
+      const metCount = criteriaResults.filter((r) => r.met).length;
+      const unmet = criteriaResults.filter((r) => !r.met);
+      const followUpFeatureIds: string[] = [];
+
+      // Create follow-up features for unmet criteria
+      for (const gap of unmet) {
+        try {
+          const description = `## Goal Verification Gap
+
+Feature **${ctx.feature.title}** (${ctx.feature.id}) was merged but the following acceptance criterion was not satisfied:
+
+**Criterion:** ${gap.criterion}
+
+**Gap Analysis:** ${gap.reason}
+
+## Context
+- Original feature: ${ctx.feature.id}
+- PR: ${ctx.prNumber ? `#${ctx.prNumber}` : 'unknown'}
+`;
+
+          const followUp = await this.serviceContext.featureLoader.create(ctx.projectPath, {
+            title: `Gap: "${gap.criterion.slice(0, 60)}${gap.criterion.length > 60 ? '…' : ''}"`,
+            description,
+            category: 'bug',
+            complexity: 'small',
+            status: 'backlog',
+          });
+
+          followUpFeatureIds.push(followUp.id);
+        } catch (err) {
+          logger.warn(`[DEPLOY] Goal verification: failed to create follow-up feature:`, err);
+        }
+      }
+
+      // Build and store the verification result
+      const verificationResult: GoalVerificationResult = {
+        featureId: ctx.feature.id,
+        timestamp: new Date().toISOString(),
+        criteria: criteriaResults.map((r) => ({
+          criterion: r.criterion,
+          met: r.met,
+          reason: r.reason,
+        })),
+        metCount,
+        totalCount: criteriaResults.length,
+        allMet: unmet.length === 0,
+        followUpFeatureIds,
+      };
+
+      // Persist to trajectory directory
+      try {
+        const fs = await import('node:fs/promises');
+        const trajectoryDir = path.join(
+          ctx.projectPath,
+          '.automaker',
+          'trajectory',
+          ctx.feature.id
+        );
+        await fs.mkdir(trajectoryDir, { recursive: true });
+        await fs.writeFile(
+          path.join(trajectoryDir, 'goal-verification.json'),
+          JSON.stringify(verificationResult, null, 2),
+          'utf-8'
+        );
+      } catch (err) {
+        logger.warn(`[DEPLOY] Goal verification: failed to write result to disk:`, err);
+      }
+
+      this.serviceContext.events.emit('feature:goal-verification:complete' as EventType, {
+        featureId: ctx.feature.id,
+        projectPath: ctx.projectPath,
+        allMet: verificationResult.allMet,
+        metCount,
+        totalCount: verificationResult.totalCount,
+        followUpFeatureIds,
+      });
+
+      logger.info(
+        `[DEPLOY] Goal verification complete for ${ctx.feature.id}: ${metCount}/${verificationResult.totalCount} criteria met`,
+        { allMet: verificationResult.allMet, followUpCount: followUpFeatureIds.length }
+      );
+    } catch (err) {
+      logger.warn(`[DEPLOY] Goal verification failed:`, err);
     }
   }
 

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -25,6 +25,7 @@ export type EventType =
   | 'feature:follow-up-started'
   | 'feature:follow-up-completed'
   | 'feature:reflection:complete'
+  | 'feature:goal-verification:complete'
   | 'feature:committed'
   | 'feature:retry'
   | 'feature:recovery'

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -831,6 +831,8 @@ export type {
   DeviationRule,
   PlanTask,
   StructuredPlan,
+  GoalCriterionResult,
+  GoalVerificationResult,
 } from './lead-engineer.js';
 
 // Notes types (Tiptap-based project notes workspace)

--- a/libs/types/src/lead-engineer.ts
+++ b/libs/types/src/lead-engineer.ts
@@ -511,6 +511,41 @@ export interface StructuredPlan {
   deviationRules: DeviationRule[];
 }
 
+// ────────────────────────── Goal Verification ──────────────────────────
+
+/** A single criterion evaluated during goal-backward verification */
+export interface GoalCriterionResult {
+  /** The original criterion text */
+  criterion: string;
+  /** Whether the criterion was satisfied by the merged changes */
+  met: boolean;
+  /** Brief explanation of why it was or wasn't met */
+  reason: string;
+}
+
+/**
+ * Result of the goal-backward verification step run by DeployProcessor
+ * after post-merge typecheck passes.
+ *
+ * Stored at: .automaker/trajectory/{featureId}/goal-verification.json
+ */
+export interface GoalVerificationResult {
+  /** Feature ID this verification belongs to */
+  featureId: string;
+  /** ISO timestamp when verification ran */
+  timestamp: string;
+  /** Per-criterion pass/fail results */
+  criteria: GoalCriterionResult[];
+  /** Number of criteria that were met */
+  metCount: number;
+  /** Total number of criteria evaluated */
+  totalCount: number;
+  /** True when all criteria were met */
+  allMet: boolean;
+  /** IDs of follow-up features created for unmet criteria (empty if all met) */
+  followUpFeatureIds: string[];
+}
+
 // ────────────────────────── Phase Handoff ──────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

**Milestone:** Goal-Backward Verification

Add semantic verification step to DeployProcessor after typecheck passes. Run a lightweight haiku LLM call that evaluates whether the feature's acceptance criteria (from structured plan or feature description) were satisfied by the actual code changes (git diff of the merged PR). Fire-and-forget pattern matching existing reflection generation. If criteria are unmet, create follow-up features on the board with specific gap descriptions rather than blocki...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated goal verification after deployment that validates acceptance criteria against actual implementation changes.
  * System identifies unmet criteria and automatically generates follow-up features for identified gaps.
  * Verification runs asynchronously without blocking deployment completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->