### PR TITLE
Fix ExecuteProcessor waitForCompletion race and pre-flight shouldContinue

### DIFF
--- a/apps/server/src/services/lead-engineer-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-execute-processor.ts
@@ -535,7 +535,7 @@ export class ExecuteProcessor implements StateProcessor {
         ctx.escalationReason = `Pre-flight check failed: ${preFlightResult.reason}`;
         return {
           nextState: 'ESCALATE',
-          shouldContinue: false,
+          shouldContinue: true,
           reason: ctx.escalationReason,
         };
       }
@@ -547,8 +547,23 @@ export class ExecuteProcessor implements StateProcessor {
     if (executionGateEnabled) {
       const gateResult = await this.runExecutionGate(ctx);
       if (!gateResult.passed) {
+        ctx.gateRejectionCount = (ctx.gateRejectionCount ?? 0) + 1;
+        if (ctx.gateRejectionCount >= 3) {
+          ctx.escalationReason = `Execution gate rejected ${ctx.gateRejectionCount} consecutive times: ${gateResult.reason}`;
+          logger.warn('[EXECUTE] Execution gate rejected 3+ times — escalating', {
+            featureId: ctx.feature.id,
+            gateRejectionCount: ctx.gateRejectionCount,
+            reason: gateResult.reason,
+          });
+          return {
+            nextState: 'ESCALATE',
+            shouldContinue: true,
+            reason: ctx.escalationReason,
+          };
+        }
         logger.warn('[EXECUTE] Execution gate blocked feature — returning to backlog', {
           featureId: ctx.feature.id,
+          gateRejectionCount: ctx.gateRejectionCount,
           reason: gateResult.reason,
         });
         await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
@@ -1346,12 +1361,19 @@ export class ExecuteProcessor implements StateProcessor {
       let unsubscribe: (() => void) | null = null;
       let timedOut = false;
 
-      // Track the execution promise so we can chain resolves through it.
-      // This prevents a race condition where the EXECUTE processor retries before
-      // concurrencyManager.release() runs in executeFeature()'s finally block:
-      // event fires → outer promise resolves → retry calls acquire() → lease still held.
-      // By chaining through executionSettled, we guarantee the finally block has run.
-      let executionSettled: Promise<void> = Promise.resolve();
+      // Deferred promise for executionSettled — created BEFORE the event subscription so
+      // safeResolve always chains through the real execution lifecycle even when an event
+      // fires synchronously (e.g. in tests) before executeFeature() is called.
+      //
+      // Without this, if the event fires before the `executionSettled = executeFeature(…)`
+      // assignment below, safeResolve chains through Promise.resolve() and the outer
+      // promise resolves immediately — before concurrencyManager.release() runs in
+      // executeFeature()'s finally block.  The next retry then calls acquire() while the
+      // lease is still held, causing a deadlock.
+      let resolveSettled!: () => void;
+      const executionSettled = new Promise<void>((r) => {
+        resolveSettled = r;
+      });
 
       const safeResolve = (result: { success: boolean; error?: string }) => {
         executionSettled.then(() => resolve(result)).catch(() => resolve(result));
@@ -1464,15 +1486,19 @@ export class ExecuteProcessor implements StateProcessor {
       const recoveryContext = contextParts.length > 0 ? contextParts.join('\n\n') : undefined;
 
       // Start execution (bypasses lead engineer delegation — calls executeFeature directly).
-      // Store as executionSettled so safeResolve waits for the concurrency lease to be
-      // released before unblocking the EXECUTE processor's retry attempt.
-      executionSettled = this.serviceContext.autoModeService
+      // Resolve the deferred executionSettled promise when executeFeature settles so that
+      // safeResolve (called from the event subscriber above) waits for the concurrency
+      // lease to be released before unblocking the EXECUTE processor's retry attempt.
+      this.serviceContext.autoModeService
         .executeFeature(ctx.projectPath, ctx.feature.id, true, false, undefined, {
           recoveryContext,
           retryCount: ctx.retryCount,
         })
-        .then(() => {})
+        .then(() => {
+          resolveSettled();
+        })
         .catch((err: unknown) => {
+          resolveSettled(); // settle so any pending safeResolve unblocks
           clearTimeout(timeout);
           if (!timedOut && unsubscribe) {
             unsubscribe();

--- a/apps/server/src/services/lead-engineer-types.ts
+++ b/apps/server/src/services/lead-engineer-types.ts
@@ -161,6 +161,8 @@ export interface StateContext {
   structuredPlan?: StructuredPlan;
   /** Context window utilization metrics from the most recent execution attempt */
   contextMetrics?: ContextMetrics;
+  /** Number of consecutive times the execution gate has rejected this feature. Escalates after 3. */
+  gateRejectionCount?: number;
 }
 
 /**

--- a/apps/server/tests/unit/services/lead-engineer-execute-processor.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-execute-processor.test.ts
@@ -25,7 +25,19 @@ vi.mock('@protolabsai/platform', () => ({
 }));
 
 vi.mock('node:child_process', () => ({
-  exec: vi.fn(),
+  // Default: call the callback with empty stdout so promisify(exec) resolves immediately.
+  // Existing tests never call exec (gate/pre-flight disabled), so this is backward-compatible.
+  exec: vi.fn(
+    (
+      _cmd: string,
+      _opts: unknown,
+      cb: (err: null, result: { stdout: string; stderr: string }) => void
+    ) => {
+      if (typeof cb === 'function') {
+        cb(null, { stdout: '', stderr: '' });
+      }
+    }
+  ),
 }));
 
 import { ExecuteProcessor } from '../../../src/services/lead-engineer-execute-processor.js';
@@ -332,5 +344,122 @@ describe('ExecuteProcessor — runtime cap (maxRuntimeMinutesPerFeature)', () =>
       'runtime:exceeded',
       expect.objectContaining({ capMinutes: 60 })
     );
+  });
+});
+
+describe('ExecuteProcessor — pre-flight failure (Bug 2: shouldContinue:true)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns shouldContinue:true so ESCALATE state actually runs on pre-flight failure', async () => {
+    // Enable pre-flight but make it fail by returning a blocked feature with unmerged
+    // foundation dependencies. featureLoader.getAll returns a dep with isFoundation:true
+    // and status 'in_progress' (not merged), which triggers the dep-check failure.
+    const { ctx } = makeServiceContext({
+      preFlightChecks: true,
+      executionGate: false,
+    });
+
+    // Override getAll to return a foundation dep that is not yet merged
+    const depFeature = makeFeature({
+      id: 'dep-001',
+      status: 'in_progress' as const,
+      isFoundation: true,
+    });
+    (ctx.featureLoader.getAll as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makeFeature(),
+      depFeature,
+    ]);
+
+    const processor = new ExecuteProcessor(ctx);
+    // Feature has a dep on dep-001 so the foundation dep check triggers
+    const stateCtx = makeCtx({
+      feature: makeFeature({ dependencies: ['dep-001'] }),
+    });
+    const result = await processor.process(stateCtx);
+
+    // Must return ESCALATE with shouldContinue:true so the state machine continues
+    expect(result.nextState).toBe('ESCALATE');
+    expect(result.shouldContinue).toBe(true);
+    expect(result.reason).toMatch(/pre-flight/i);
+  });
+});
+
+describe('ExecuteProcessor — execution gate rejection tracking (Bug 3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns to backlog on first gate rejection (count < 3)', async () => {
+    // Gate enabled. featureLoader.getAll returns 6 features in 'review' (> default maxPendingReviews=5).
+    const reviewFeatures = Array.from({ length: 6 }, (_, i) =>
+      makeFeature({ id: `feat-review-${i}`, status: 'review' as const })
+    );
+    const { ctx, featureLoader } = makeServiceContext({
+      executionGate: true,
+      preFlightChecks: false,
+    });
+    (featureLoader.getAll as ReturnType<typeof vi.fn>).mockResolvedValue(reviewFeatures);
+
+    const processor = new ExecuteProcessor(ctx);
+    const stateCtx = makeCtx({ gateRejectionCount: 0 });
+    const result = await processor.process(stateCtx);
+
+    expect(result.nextState).toBeNull();
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reason).toMatch(/review queue saturated/i);
+    expect(stateCtx.gateRejectionCount).toBe(1);
+
+    expect(featureLoader.update).toHaveBeenCalledWith(
+      '/test/project',
+      'feat-001',
+      expect.objectContaining({ status: 'backlog' })
+    );
+  });
+
+  it('escalates after 3rd consecutive gate rejection', async () => {
+    const reviewFeatures = Array.from({ length: 6 }, (_, i) =>
+      makeFeature({ id: `feat-review-${i}`, status: 'review' as const })
+    );
+    const { ctx, featureLoader } = makeServiceContext({
+      executionGate: true,
+      preFlightChecks: false,
+    });
+    (featureLoader.getAll as ReturnType<typeof vi.fn>).mockResolvedValue(reviewFeatures);
+
+    const processor = new ExecuteProcessor(ctx);
+    // Simulate 2 prior rejections already tracked on ctx
+    const stateCtx = makeCtx({ gateRejectionCount: 2 });
+    const result = await processor.process(stateCtx);
+
+    expect(result.nextState).toBe('ESCALATE');
+    expect(result.shouldContinue).toBe(true);
+    expect(result.reason).toMatch(/3/);
+    expect(stateCtx.gateRejectionCount).toBe(3);
+
+    // Must NOT return to backlog on escalation
+    expect(featureLoader.update).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ status: 'backlog' })
+    );
+  });
+
+  it('increments gateRejectionCount from undefined on first rejection', async () => {
+    const reviewFeatures = Array.from({ length: 6 }, (_, i) =>
+      makeFeature({ id: `feat-review-${i}`, status: 'review' as const })
+    );
+    const { ctx } = makeServiceContext({
+      executionGate: true,
+      preFlightChecks: false,
+    });
+    (ctx.featureLoader.getAll as ReturnType<typeof vi.fn>).mockResolvedValue(reviewFeatures);
+
+    const processor = new ExecuteProcessor(ctx);
+    const stateCtx = makeCtx(); // gateRejectionCount not set → undefined
+    await processor.process(stateCtx);
+
+    expect(stateCtx.gateRejectionCount).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

**Milestone:** Concurrency and Race Condition Fixes

Three bugs: (1) executionSettled assigned AFTER event subscription creating race. Use deferred promise pattern. (2) Pre-flight failure returns shouldContinue:false with ESCALATE but ESCALATE never runs. Change to shouldContinue:true. (3) Execution gate failure silently returns to backlog creating infinite loop. Track rejections and escalate after 3.

**Files to Modify:**
- apps/server/src/services/lead-engineer-execute-processor.ts
- apps/serv...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved pre-flight failure handling to continue processing instead of immediate escalation.
  * Added execution gate rejection tracking; tasks escalate after three consecutive rejections.
  * Fixed potential deadlock issues in concurrent execution scenarios.

* **Tests**
  * Added test coverage for pre-flight failure and execution gate rejection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->