### PR TITLE
Fix error classification breadth and merge retry logic

### DIFF
--- a/apps/server/src/services/lead-engineer-escalation.ts
+++ b/apps/server/src/services/lead-engineer-escalation.ts
@@ -35,14 +35,7 @@ export class EscalateProcessor implements StateProcessor {
   }
 
   async process(ctx: StateContext): Promise<StateTransitionResult> {
-    // Move feature to blocked with reason and failure tracking
-    await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
-      status: 'blocked',
-      statusChangeReason: ctx.escalationReason || 'Escalated by lead engineer',
-      failureCount: (ctx.feature.failureCount ?? 0) + 1,
-    });
-
-    // Classify the failure for structured analysis
+    // Classify the failure for structured analysis before writing
     const failureAnalysis = this.failureClassifier.classify(
       ctx.escalationReason || 'Unknown escalation reason',
       ctx.retryCount
@@ -55,8 +48,11 @@ export class EscalateProcessor implements StateProcessor {
       confidence: failureAnalysis.confidence,
     });
 
-    // Persist the structured failure classification to the feature ledger
+    // Single write: blocked status + failure tracking + classification
     await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
+      status: 'blocked',
+      statusChangeReason: ctx.escalationReason || 'Escalated by lead engineer',
+      failureCount: (ctx.feature.failureCount ?? 0) + 1,
       failureClassification: {
         category: failureAnalysis.category,
         confidence: failureAnalysis.confidence,
@@ -238,10 +234,21 @@ export class EscalateProcessor implements StateProcessor {
 
   async exit(ctx: StateContext): Promise<void> {
     logger.info('[ESCALATE] Escalation completed');
+    // Derive the originating pipeline phase from context clues.
+    // MERGE state leaves mergeRetryCount > 0; REVIEW state leaves prNumber set;
+    // PLAN state has planRequired but no planOutput; otherwise EXECUTE.
+    let originatingPhase: PipelinePhase = 'EXECUTE';
+    if (ctx.mergeRetryCount > 0) {
+      originatingPhase = 'PUBLISH';
+    } else if (ctx.prNumber != null) {
+      originatingPhase = 'VERIFY';
+    } else if (ctx.planRequired && ctx.planOutput == null) {
+      originatingPhase = 'PLAN';
+    }
     this.serviceContext.events.emit('pipeline:phase-skipped' as EventType, {
       featureId: ctx.feature.id,
       projectPath: ctx.projectPath,
-      phase: 'EXECUTE' as PipelinePhase,
+      phase: originatingPhase,
       branch: 'ops' as const,
       reason: ctx.escalationReason || 'Feature escalated — pipeline halted',
       timestamp: new Date().toISOString(),

--- a/apps/server/src/services/lead-engineer-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-execute-processor.ts
@@ -631,8 +631,8 @@ export class ExecuteProcessor implements StateProcessor {
         errorMsg.includes('authentication failed') ||
         errorMsg.includes('could not resolve host') ||
         errorMsg.includes('connection refused') ||
-        errorMsg.includes('worktree') ||
-        errorMsg.includes('timed out');
+        errorMsg.includes('fatal: worktree') ||
+        errorMsg.includes('connection timed out');
 
       if (isFatalInfraFailure) {
         ctx.escalationReason = `Infrastructure failure (not retryable): ${result.error}`;

--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -505,7 +505,12 @@ export class MergeProcessor implements StateProcessor {
       const errMsg = err instanceof Error ? err.message : String(err);
 
       // If checks are still pending, wait and retry
-      if (errMsg.includes('check') || errMsg.includes('pending') || errMsg.includes('required')) {
+      if (
+        errMsg.includes('required status check') ||
+        errMsg.includes('waiting for status') ||
+        errMsg.includes('pull request is not mergeable') ||
+        errMsg.includes('not yet mergeable')
+      ) {
         ctx.mergeRetryCount++;
         logger.info(
           `[MERGE] Checks pending on PR #${ctx.prNumber}, waiting ${MERGE_RETRY_DELAY_MS / 1000}s`


### PR DESCRIPTION
## Summary

**Milestone:** State Machine Correctness

Three fixes: (1) ExecuteProcessor isFatalInfraFailure patterns too broad. Use specific patterns. (2) MergeProcessor retry matches generic check. Use specific strings. (3) EscalateProcessor double update - combine into single write. Fix phase reporting to use originating state.

**Files to Modify:**
- apps/server/src/services/lead-engineer-execute-processor.ts
- apps/server/src/services/lead-engineer-review-merge-processors.ts
- apps/server/src/services/l...

---
*Recovered automatically by Automaker post-agent hook*