### PR TITLE
Fix runningFeatures tracking gap in execution-service

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -303,7 +303,7 @@ export class ExecutionService {
     providedWorktreePath?: string,
     options?: ExecuteFeatureOptions
   ): Promise<void> {
-    if (this.runningFeatures.has(featureId)) {
+    if (this.runningFeatures.has(featureId) && !options?.isRecursive) {
       const existing = this.runningFeatures.get(featureId);
       const runtime = existing ? Math.floor((Date.now() - existing.startTime) / 1000) : 0;
       logger.warn(
@@ -362,7 +362,7 @@ export class ExecutionService {
       // Guard: refuse to execute features in terminal states.
       // This prevents zombie loops where done/verified features keep getting restarted
       // by health checks, reconciliation, or stale retry timers.
-      const TERMINAL_STATUSES = new Set(['done', 'verified', 'completed', 'review']);
+      const TERMINAL_STATUSES = new Set(['done', 'verified', 'completed']);
       if (TERMINAL_STATUSES.has(feature.status ?? '')) {
         logger.warn(
           `Refusing to execute feature ${featureId} — already in terminal status "${feature.status}". ` +
@@ -395,9 +395,10 @@ export class ExecutionService {
           continuationPrompt = continuationPrompt.replace(/\{\{userFeedback\}\}/g, '');
           continuationPrompt = continuationPrompt.replace(/\{\{approvedPlan\}\}/g, planContent);
 
-          // Recursively call executeFeature with the continuation prompt
-          // Remove from running features temporarily, it will be added back
-          this.runningFeatures.delete(featureId);
+          // Recursively call executeFeature with the continuation prompt.
+          // Pass isRecursive: true so the duplicate-execution guard is skipped —
+          // runningFeatures stays populated throughout with no gap that would
+          // allow a concurrent auto-loop tick to launch a duplicate agent.
           return this.executeFeature(
             projectPath,
             featureId,
@@ -406,6 +407,7 @@ export class ExecutionService {
             providedWorktreePath,
             {
               continuationPrompt,
+              isRecursive: true,
             }
           );
         }

--- a/apps/server/src/services/auto-mode/execution-types.ts
+++ b/apps/server/src/services/auto-mode/execution-types.ts
@@ -38,6 +38,12 @@ export interface ExecuteFeatureOptions {
   retryCount?: number;
   previousErrors?: string[];
   recoveryContext?: string;
+  /**
+   * When true, skip the duplicate-execution guard at the top of executeFeature.
+   * Used for recursive calls (e.g. continuation after plan approval) so that
+   * the featureId stays in runningFeatures throughout the handoff with no gap.
+   */
+  isRecursive?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/tests/unit/services/execution-service.test.ts
+++ b/apps/server/tests/unit/services/execution-service.test.ts
@@ -963,3 +963,128 @@ describe('ExecutionService - match rule auto-assign', () => {
     await expect(svc.executeFeature(PROJECT_PATH, FEATURE_ID)).resolves.not.toThrow();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Concurrency and runningFeatures tracking tests
+// ---------------------------------------------------------------------------
+
+describe('ExecutionService - concurrency and runningFeatures', () => {
+  const PROJECT_PATH = '/tmp/test-project';
+  const FEATURE_ID = 'feature-concurrency-test-1';
+
+  beforeEach(() => {
+    vi.stubEnv('AUTOMAKER_MOCK_AGENT', 'true');
+    mockMatchFeature.mockReset();
+    mockMatchFeature.mockResolvedValue(null);
+    mockGetWorkflowSettings.mockReset();
+    mockGetWorkflowSettings.mockResolvedValue({});
+  });
+
+  it('throws when feature is already running (no isRecursive flag)', async () => {
+    const feature = makeFeature({ id: FEATURE_ID });
+    const callbacks = makeCallbacks(feature);
+    const featureLoader = makeFeatureLoader(feature);
+    const runningFeatures = new Map<string, any>();
+
+    const svc = new ExecutionService(
+      makeEvents() as any,
+      null,
+      featureLoader,
+      null,
+      makeRecoveryService(),
+      null,
+      runningFeatures,
+      new Map(),
+      90,
+      95,
+      callbacks
+    );
+
+    // Seed the map to simulate an in-progress execution
+    runningFeatures.set(FEATURE_ID, {
+      featureId: FEATURE_ID,
+      projectPath: PROJECT_PATH,
+      worktreePath: null,
+      branchName: null,
+      abortController: new AbortController(),
+      isAutoMode: false,
+      startTime: Date.now(),
+      retryCount: 0,
+      previousErrors: [],
+    });
+
+    await expect(svc.executeFeature(PROJECT_PATH, FEATURE_ID)).rejects.toThrow(/already running/);
+  });
+
+  it('skips duplicate check when isRecursive is true', async () => {
+    const feature = makeFeature({ id: FEATURE_ID });
+    const callbacks = makeCallbacks(feature);
+    const featureLoader = makeFeatureLoader(feature);
+    const runningFeatures = new Map<string, any>();
+
+    const svc = new ExecutionService(
+      makeEvents() as any,
+      null,
+      featureLoader,
+      null,
+      makeRecoveryService(),
+      null,
+      runningFeatures,
+      new Map(),
+      90,
+      95,
+      callbacks
+    );
+
+    // Seed the map to simulate in-progress execution
+    runningFeatures.set(FEATURE_ID, {
+      featureId: FEATURE_ID,
+      projectPath: PROJECT_PATH,
+      worktreePath: null,
+      branchName: null,
+      abortController: new AbortController(),
+      isAutoMode: false,
+      startTime: Date.now(),
+      retryCount: 0,
+      previousErrors: [],
+    });
+
+    // Should NOT throw when isRecursive: true
+    await expect(
+      svc.executeFeature(PROJECT_PATH, FEATURE_ID, false, false, undefined, { isRecursive: true })
+    ).resolves.not.toThrow();
+  });
+
+  it('review status does not block execution (not in TERMINAL_STATUSES)', async () => {
+    const feature = makeFeature({ id: FEATURE_ID, status: 'review' });
+    const callbacks = makeCallbacks(feature);
+    const featureLoader = makeFeatureLoader(feature);
+    const svc = makeService(callbacks, featureLoader, makeRecoveryService());
+
+    // Should NOT return early — review is not terminal
+    await svc.executeFeature(PROJECT_PATH, FEATURE_ID);
+
+    // The feature must have been set to in_progress (execution proceeded)
+    expect(callbacks.updateFeatureStatus).toHaveBeenCalledWith(
+      PROJECT_PATH,
+      FEATURE_ID,
+      'in_progress'
+    );
+  });
+
+  it('done status blocks execution (remains in TERMINAL_STATUSES)', async () => {
+    const feature = makeFeature({ id: FEATURE_ID, status: 'done' });
+    const callbacks = makeCallbacks(feature);
+    const featureLoader = makeFeatureLoader(feature);
+    const svc = makeService(callbacks, featureLoader, makeRecoveryService());
+
+    await svc.executeFeature(PROJECT_PATH, FEATURE_ID);
+
+    // Should return early — done is terminal, so updateFeatureStatus never called with in_progress
+    expect(callbacks.updateFeatureStatus).not.toHaveBeenCalledWith(
+      PROJECT_PATH,
+      FEATURE_ID,
+      'in_progress'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

**Milestone:** Concurrency and Race Condition Fixes

During recursive executeFeature() calls, code deletes featureId from runningFeatures then re-adds it. This gap allows duplicate agents. Pass internal flag to skip duplicate check on recursive calls. Also align terminal status sets - remove review from TERMINAL_STATUSES since resume legitimately re-executes review features.

**Files to Modify:**
- apps/server/src/services/auto-mode/execution-service.ts
- apps/server/tests/unit/services/executio...

---
*Recovered automatically by Automaker post-agent hook*