### PR TITLE
fix: autonomous board management — zero-intervention pipeline

### DIFF
--- a/.automaker/memory/api.md
+++ b/.automaker/memory/api.md
@@ -5,9 +5,9 @@ relevantTo: [api]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 521
-  referenced: 132
-  successfulFeatures: 132
+  loaded: 534
+  referenced: 141
+  successfulFeatures: 141
 ---
 <!-- domain: API Design & Integration | GitHub GraphQL, REST endpoints, HTTP client patterns -->
 
@@ -247,3 +247,15 @@ usageStats:
 - **Rejected:** Alternative: Let git diff exceptions propagate and crash the feature transition. Rejected: would make the system fragile to unexpected git states.
 - **Trade-offs:** Easier: robust error handling. Harder: developers might not see which files conflicted if git diff fails (though the conflict itself is still blocked).
 - **Breaking if changed:** Removing the try/catch would make a git diff failure during conflict handling crash the entire feature execution, leaving the system in an undefined state.
+
+### MCPToolEntry interface uses JSON Schema (not Zod) because it represents the wire format MCP clients expect. The adapter is responsible for the Zod→JSON Schema conversion boundary. (2026-03-14)
+- **Context:** SharedTool carries Zod types (compile-time + runtime validation); MCP SDK expects JSON Schema objects (serializable, wire-compatible). These two schemas serve different purposes.
+- **Why:** Zod is an internal implementation detail for the libs/tools layer. When crossing the adapter boundary to external systems (MCP, LangGraph), the contract must be in a portable format. JSON Schema is the standard wire format.
+- **Rejected:** Could expose Zod schemas directly to MCP (creates coupling, Zod is not part of MCP SDK contract) or skip the conversion and validate raw JSON (loses type safety benefits).
+- **Trade-offs:** Requires conversion logic in toMCPTool() but keeps Zod internal to libs/tools. Clients never see Zod; adapters handle translation. Cleaner boundaries at cost of a conversion step.
+- **Breaking if changed:** If you remove the conversion and pass Zod schemas directly to MCP, external clients must understand Zod (dependency leak). If you remove Zod entirely from SharedTool, you lose runtime validation before schema conversion.
+
+#### [Pattern] Enforce symmetrical input and output schema definitions for every tool (2026-03-14)
+- **Problem solved:** Tools define what they accept but sometimes output validation is skipped as optional
+- **Why this works:** Input schema validates data from tool consumer; output schema validates data from tool provider. Without output schema, return values are unvalidated, breaking type safety on consumer side.
+- **Trade-offs:** More schema code to maintain, but ensures bidirectional type coverage

--- a/.automaker/memory/architecture.md
+++ b/.automaker/memory/architecture.md
@@ -5,9 +5,9 @@ relevantTo: [architecture]
 importance: 0.9
 relatedFiles: []
 usageStats:
-  loaded: 497
-  referenced: 92
-  successfulFeatures: 92
+  loaded: 510
+  referenced: 101
+  successfulFeatures: 101
 ---
 <!-- domain: Architecture Decisions | System-wide structural decisions that have breaking consequences if changed -->
 
@@ -884,3 +884,149 @@ usageStats:
 - **Situation:** Without clearing, if the same merge_conflict pattern recurs after being resolved, the new issue filed would include context from the old, resolved issue, creating confusion.
 - **Root cause:** The accumulator map persists across pattern occurrences as a class member. If you file an issue and resolve the pattern without clearing the map, the next occurrence adds to the stale data.
 - **How to avoid:** Easier: cleaner issue descriptions. Harder: requires explicit state cleanup logic.
+
+#### [Gotcha] Nested mutex acquisition causes deadlock: calling a mutex-wrapped method from inside its own mutex lock hangs forever because the second call tries to enqueue behind itself (2026-03-14)
+- **Situation:** claim() needed to call update() atomically, but update() acquires the same per-feature mutex that claim() already holds
+- **Root cause:** Promise-chain mutex works by chaining onto prev.then(), but if the caller already holds the chain, enqueuing another call creates a cycle waiting for itself
+- **How to avoid:** Required extraction of _updateCore() helper, splitting public API from internal implementation, but made deadlock impossible
+
+#### [Pattern] Promise-chain mutex via Map<key, Promise>: prev.then(() => fn()) serializes all calls for the same key by chaining microtasks, not blocking threads (2026-03-14)
+- **Problem solved:** JavaScript is single-threaded; traditional mutex/lock primitives don't apply; need lightweight serialization of async I/O operations
+- **Why this works:** Promise chains are idiomatic in Node.js: leverages event loop, no active waiting, GC-friendly, and orders calls by microtask queue semantics without OS involvement
+- **Trade-offs:** Simple and standard JS idiom, but promise chain depth grows with queue length; ordering guaranteed by JS spec, no manual queue management
+
+### Mutex scoped to projectPath::featureId (per-feature) instead of global, allowing updates to different features to run concurrently (2026-03-14)
+- **Context:** Many features may be updated simultaneously; global lock would serialize all operations even on unrelated features
+- **Why:** Reduces artificial bottleneck: only features being modified concurrently need ordering; unrelated operations proceed in parallel for better throughput
+- **Rejected:** Global mutex (single Promise queue for all features) — simpler to implement but creates contention bottleneck even for independent features
+- **Trade-offs:** Requires Map maintenance and key composition (projectPath::featureId string), but eliminates unnecessary serialization of unrelated operations
+- **Breaking if changed:** Reverting to global would restore full serialization, killing concurrent updates entirely; per-feature scoping is essential for scaling
+
+#### [Pattern] Extract _Core() helper method containing original implementation; withMutex() wraps public API while _Core() allows internal callers to skip re-locking (2026-03-14)
+- **Problem solved:** claim() needs to invoke update logic atomically inside its own mutex context, but calling update() would attempt to acquire the same lock it already holds
+- **Why this works:** Decouples lock acquisition (public API concern) from business logic (shared implementation), allowing both mutex-wrapped and non-wrapped callers to reuse the same code
+- **Trade-offs:** Adds an internal method, complicating the public API surface slightly, but guarantees correctness and prevents accidental misuse by external callers
+
+#### [Gotcha] TOCTOU race in claim(): two concurrent callers both observe claimedBy as undefined, both succeed in writing their claim, final state is non-deterministic (2026-03-14)
+- **Situation:** get-check-write sequence in claim() spans multiple async boundaries without atomicity; if each step yields control, another caller can interleave
+- **Root cause:** Without mutex wrapping the entire sequence, the check (is claimedBy undefined?) and the write (set claimedBy) are not atomic; a second caller can read the old state between them
+- **How to avoid:** Mutex must enclose entire get+check+write, increasing lock hold time slightly, but guarantees exactly one claim succeeds
+
+#### [Gotcha] Two parallel tool definition patterns exist in the same codebase: factory-pattern tools (libs/tools) use defineSharedTool with Zod schemas; domain functions (domains/features) use raw async functions with TypeScript interfaces. These are not interchangeable. (2026-03-14)
+- **Situation:** Audit discovered 23 tools with Zod definitions across factories, but 8 domain functions cannot be adapted without migration.
+- **Root cause:** Different layers evolved independently. Domain functions were injected via ToolContext without schema requirements; factories had explicit contract enforcement. No unified pattern existed.
+- **How to avoid:** Domain layer keeps async function simplicity but sacrifices adapter compatibility. Factory tools require upfront schema definition but gain universal adapter access.
+
+### Zod schemas are a strict prerequisite for adapter compatibility (MCP, LangGraph). The adapter converts Zod → JSON Schema because MCP's wire protocol requires JSON Schema, not TypeScript type information. (2026-03-14)
+- **Context:** toMCPTool() and toLangGraphTool() cannot work with tools that only have TypeScript interfaces. This creates a hard architectural boundary.
+- **Why:** Zod provides serializable contracts at runtime. JSON Schema is the wire format MCP expects. TypeScript interfaces only exist at compile time and cannot be runtime-serialized reliably.
+- **Rejected:** Could use reflection or TS AST analysis to generate schemas from interfaces at build time (complex tooling, fragile, loses validation semantics) or accept unvalidated inputs (unsafe).
+- **Trade-offs:** Requires explicit schema definition upfront (more code) but guarantees type-safe serialization and enables multiple adapters without per-adapter schema logic.
+- **Breaking if changed:** If you remove Zod requirement, adapters must either lose type safety or implement their own schema reflection (complexity explosion). Removing the prerequisite cascades to all adapter implementations.
+
+#### [Pattern] Gap analysis documentation (8-item migration checklist) surfaces implicit technical debt as explicit action items, linked to a reference implementation (request-user-input.ts proves the pattern is viable in domain layer). (2026-03-14)
+- **Problem solved:** Before audit, developers could not know why their domain tool could not be adapted without attempting it. Failures would be discovered at integration time, not design time.
+- **Why this works:** Makes blockers predictable and prevents surprise failures downstream. The reference implementation proves the solution is possible; the checklist makes the work explicit and prioritizable.
+- **Trade-offs:** Additional documentation overhead but prevents integration-time surprises and creates a clear migration path. Developers know exactly which 8 tools block which adapters.
+
+#### [Gotcha] request-user-input.ts in domains/hitl/ is the ONLY domain tool that already uses defineSharedTool with Zod, proving the factory pattern is viable in domain layers but is not being consistently followed elsewhere. (2026-03-14)
+- **Situation:** 8 other domain functions use raw async signatures; request-user-input.ts uses defineSharedTool. This inconsistency exists within the same domains/ directory tree.
+- **Root cause:** Likely built later with explicit adapter requirements in mind, or by someone aware of the factory pattern. Earlier domain functions were written before the need for adapter compatibility was clear.
+- **How to avoid:** The split in patterns shows patterns can coexist but creates a mental model burden — developers must learn when each applies. request-user-input.ts serves as proof of correctness for the migration.
+
+### Use structural interface (AgentDeps) instead of importing concrete service class for tool dependencies (2026-03-14)
+- **Context:** libs/tools needs to reference methods from agent service, but mcp-server imports libs/tools, creating circular dependency risk
+- **Why:** Structural typing breaks circular dependency chain without sacrificing type safety. libs/tools depends only on the interface contract, not the concrete implementation.
+- **Rejected:** Import concrete AgentService class directly from mcp-server package
+- **Trade-offs:** Requires maintaining interface separately, but enables clean layered architecture where libs/tools doesn't import server packages
+- **Breaking if changed:** If AgentDeps interface methods don't match actual service signatures (typos, missing methods, parameter mismatches), all tools fail at runtime with opaque method-not-found errors
+
+#### [Pattern] Designate canonical reference implementation for cross-module tool definitions (2026-03-14)
+- **Problem solved:** Agent tools need to be defined consistently in both libs/tools and mcp-server, but no enforcement mechanism prevents drift
+- **Why this works:** Single source of truth (mcp-server implementation) prevents definitions diverging when server's actual capabilities change. libs/tools mirrors it.
+- **Trade-offs:** Requires discipline to consult canonical reference, but prevents silent type-safety violations
+
+### Extract parseGitHubRemote to shared @protolabsai/git-utils library instead of duplicating parseOwnerRepo in each service (2026-03-14)
+- **Context:** Both coderabbit-resolver-service and git-workflow-service implemented identical regex parsing of git remote URLs
+- **Why:** Creates single point of truth for URL parsing that can be security-reviewed once, audit-logged centrally, and updated without coordination. Both services already imported from this package, making extraction clean. Reduces surface area of injection-vulnerable code.
+- **Rejected:** Keep duplicate implementations in each service (standard DRY refactoring rejection) - but this also means security fixes must be duplicated/coordinated
+- **Trade-offs:** Adds a public export to shared library (potential coupling); makes library aware of GitHub-specific parsing (less generic); but eliminates 40+ lines of duplicate regex logic
+- **Breaking if changed:** If the shared library is removed, both services lose access to parseGitHubRemote and must re-implement or fail; the library export must be maintained through package versioning
+
+### Per-session Promise chain serialization using Map<string, Promise<void>> with enqueueForSession() helper (2026-03-14)
+- **Context:** Prevent concurrent race conditions when multiple events fire for the same session's world state
+- **Why:** Serialization ensures atomic updates to session world state; Map allows parallel processing across different sessions (scalability); Promise chaining naturally handles both sync and async tasks
+- **Rejected:** Global event queue (simple but would serialize all sessions, killing parallelism); mutex/locks (more verbose, less JS-idiomatic)
+- **Trade-offs:** Adds memory overhead of per-session chain pointers (minimal); enables true session-level parallelism; requires explicit cleanup on stop/destroy
+- **Breaking if changed:** Removing this chain would reintroduce race conditions where concurrent evaluateAndExecute calls corrupt session world state; two concurrent events could partially apply and leave inconsistent state
+
+#### [Gotcha] onEvent() is synchronous (returns void) but queues async work on the Promise chain; observers cannot await the result (2026-03-14)
+- **Situation:** Service API contracts that events are processed synchronously, but actual processing happens asynchronously on chain
+- **Root cause:** Sync API prevents blocking callers; async execution prevents blocking event loop; mismatch requires explicit chain flushing in tests
+- **How to avoid:** Fire-and-forget API is convenient but requires discipline in testing/observing; enables non-blocking event handling
+
+### Event whitelist approach: !type.startsWith('lead-engineer:') instead of blacklist of specific events (2026-03-14)
+- **Context:** Prevent cascading loops where internal events re-trigger rule evaluation
+- **Why:** Whitelist is more robust as new lead-engineer:* events are added; blacklist would require updating test suite and service code for each new event type; startsWith() pattern-matches entire namespace
+- **Rejected:** Blacklist ['lead-engineer:started', ...] (requires maintenance as events proliferate); allowlist with explicit checks (verbose)
+- **Trade-offs:** Whitelist is slightly slower (string prefix check) but more maintainable; requires conscious awareness of event naming conventions
+- **Breaking if changed:** If whitelist is removed, any lead-engineer:* event firing during evaluation would re-trigger evaluateAndExecute, causing cascading loops and potential infinite recursion
+
+#### [Pattern] Skip rule evaluation when world state refresh fails (worldStateRefreshFailed Set) until next successful refresh (2026-03-14)
+- **Problem solved:** World state refresh can throw errors (e.g., file system access, parsing); using stale/partial state for rule evaluation is dangerous
+- **Why this works:** Prevents rule evaluation on inconsistent data; Set is cleared only on successful refresh (guarantees eventual consistency); skipping is safer than retrying indefinitely
+- **Trade-offs:** Defers evaluation until state is consistent (may miss events); avoids cascading errors from bad state; adds per-session failure tracking
+
+#### [Pattern] Resource counters must use finally blocks instead of scattered symmetric decrements across success/error paths (2026-03-14)
+- **Problem solved:** activeWorkflows counter was decremented in happy path, catch block, but the early return for missing branchName had no decrement. This leaked counter state and broke subsequent workflow processing.
+- **Why this works:** finally block executes regardless of normal return, throw, or early return paths. Any new code path added later is automatically protected. Scattered decrements require explicit tracking and inevitably miss cases (as happened here).
+- **Trade-offs:** finally is slightly less explicit about increment/decrement pairing than synchronized blocks, but provides automatic correctness for any future code path added to the function
+
+#### [Gotcha] Queue advancement operations must execute in both success AND error paths—it is not a success-only operation (2026-03-14)
+- **Situation:** agent-service called setImmediate(() => processNextInQueue()) only after successful agent execution. Errors threw before calling it, permanently freezing the queue for that session's remaining prompts.
+- **Root cause:** Queue advancement is a state machine transition, decoupled from error handling. Errors must still allow the next queued item to be processed; the error propagates but queue machinery must continue. Treating it as success-only couples error handling to queue semantics.
+- **How to avoid:** Requires queue advancement call in both paths (or extract to finally), adding 1-2 lines of code. Benefit: queue remains live across error states.
+
+#### [Gotcha] Async callbacks that follow a synchronous guard check must re-validate that guard condition before mutating state (2026-03-14)
+- **Situation:** feature-scheduler checked isFeatureRunning synchronously, then spawned async isWorktreeLocked operation. While that async operation was pending, the feature transitioned to running state. The callback then executed and removed it from startingFeatures despite it being active.
+- **Root cause:** Time-of-check-time-of-use race: synchronous check passes, state changes during the async gap, callback executes with stale assumptions. Async boundaries break single-threaded reasoning; state must be re-validated before acting.
+- **How to avoid:** Requires condition duplicated in callback (checked twice: once before async, once in callback), adding defensive code. Benefit: prevents phantom cleanup and race-condition-induced state corruption.
+
+#### [Gotcha] String-based error classification from unstructured error messages requires increasingly specific pattern matching to avoid false positives (2026-03-14)
+- **Situation:** Error patterns like 'worktree' and 'timed out' were matching incidentally in error messages, causing incorrect fatal infrastructure failure classification
+- **Root cause:** Unstructured error messages from external systems cannot be safely matched with substring checks; false positives in error classification break state machine correctness
+- **How to avoid:** Specific string matching is maintainable within current codebase but remains brittle to upstream error message format changes; structured errors would be robust but impose integration burden
+
+#### [Pattern] Merge sequential state updates into atomic writes to prevent intermediate state visibility in state machines (2026-03-14)
+- **Problem solved:** Two sequential featureLoader.update() calls (status + failureCount + failureClassification) could be read partially by other processes, leaving system in inconsistent state
+- **Why this works:** State machine correctness depends on related state changes being visible as a unit; partial updates allow other processes to observe intermediate inconsistent states and make incorrect decisions
+- **Trade-offs:** Atomic merged writes are simpler and correct but couple state concerns; separate writes are more modular but require external transaction guarantees
+
+### Derive phase implicitly from context state signals instead of explicitly storing and updating phase on state entry (2026-03-14)
+- **Context:** EscalateProcessor.exit() needs to report originating phase but phase was hardcoded, requiring manual tracking across state transitions
+- **Why:** Implicit derivation avoids dual source of truth; phase is already encoded in observable context (mergeRetryCount > 0 means PUBLISH, prNumber means VERIFY, etc.), so explicitly storing it duplicates information
+- **Rejected:** Could explicitly store phase value at each state entry, making it unambiguous but adding state management complexity and synchronization requirements
+- **Trade-offs:** Implicit derivation is DRY and avoids state redundancy but depends on context signals being unambiguous; explicit storage is redundant but more defensive to ambiguous state
+- **Breaking if changed:** If multiple phases could produce the same context state (e.g., mergeRetryCount > 0 AND prNumber != null), derivation logic becomes ambiguous and reports wrong phase
+
+#### [Gotcha] Retry logic decision points must use explicit error string enumeration instead of broad keyword matching to avoid unintended retries (2026-03-14)
+- **Situation:** MergeProcessor used includes('check') || includes('pending') || includes('required') which matched incidentally in unrelated error messages, causing unintended merge retries
+- **Root cause:** Retry logic decisions are critical state machine transitions; false positives cause infinite retries or incorrect escalations. Keyword matching cannot distinguish intentional matches from incidental ones
+- **How to avoid:** Enumeration is verbose and requires maintenance for new error messages; keyword matching is concise but unsafe and fails unsafe (unintended retries)
+
+#### [Pattern] Use execution context flags (isRecursive parameter) to conditionally skip guards during continuation, rather than delete/re-add patterns on shared tracking state (2026-03-14)
+- **Problem solved:** Recursive feature execution where a feature needs to re-enter itself while maintaining a duplicate execution guard (runningFeatures map)
+- **Why this works:** Delete/re-add creates a critical race window: featureId is absent from runningFeatures between deletion and re-entry, allowing concurrent calls to see it as 'not running' and bypass the duplicate guard. A conditional flag skips the guard without state manipulation, eliminating the gap entirely
+- **Trade-offs:** Flag approach requires one extra parameter but guarantees state consistency; delete/re-add seems simpler initially but introduces subtle, hard-to-reproduce concurrency vulnerabilities
+
+#### [Gotcha] Any gap in tracking state visibility during async continuation creates a race condition vulnerability, even if the gap is microseconds long (2026-03-14)
+- **Situation:** Features need to track running state (runningFeatures.has(featureId)) to prevent concurrent duplicate execution, but recursive calls were deleting before re-entry
+- **Root cause:** In event-loop systems, 'delete then re-add immediately' is not atomic. Concurrent checks can execute in the gap between operations. The assumption that synchronous delete/re-add is safe ignores that other microtasks and I/O can yield control to event loop during the gap
+- **How to avoid:** Using conditional parameter passing adds one layer of explicitness but prevents entire class of race conditions; state mutation during continuation is simpler to reason about initially but creates fragile timing assumptions
+
+### 'review' status should not be classified as TERMINAL_STATUSES because auto-mode legitimately needs to restart execution when features fail CI review (2026-03-14)
+- **Context:** Features that reach 'review' status can fail validation and need re-execution, but TERMINAL_STATUSES blocks re-entry to execution
+- **Why:** Terminal status semantics assumed review is a final state, but in auto-mode flow, review is a transient checkpoint that can legitimately flow back to execution based on feedback. Blocking re-execution defeats auto-mode's core retry capability for failed reviews
+- **Rejected:** Keep review as terminal and implement separate retry logic outside the status machine; create bypass flags instead of removing from TERMINAL_STATUSES
+- **Trade-offs:** Removing review from terminal makes state machine more flexible and auto-mode simpler, but requires external logic to prevent infinite loop if a feature perpetually fails review; keeping it terminal prevents loops but requires special-case handling in auto-mode retry
+- **Breaking if changed:** If review is marked terminal, auto-mode cannot restart work on features that failed CI review, breaking the fundamental validation feedback loop that auto-mode depends on

--- a/.automaker/memory/audit.md
+++ b/.automaker/memory/audit.md
@@ -5,9 +5,9 @@ relevantTo: [audit]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 6
-  referenced: 1
-  successfulFeatures: 1
+  loaded: 7
+  referenced: 2
+  successfulFeatures: 2
 ---
 <!-- domain: Audit & Compliance | Audit trail patterns, decision logging, compliance tracking -->
 

--- a/.automaker/memory/documentation.md
+++ b/.automaker/memory/documentation.md
@@ -5,9 +5,9 @@ relevantTo: [documentation]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 370
-  referenced: 92
-  successfulFeatures: 92
+  loaded: 383
+  referenced: 101
+  successfulFeatures: 101
 ---
 <!-- domain: Documentation | Docs standards, structure, maintenance patterns -->
 

--- a/.automaker/memory/gotchas.md
+++ b/.automaker/memory/gotchas.md
@@ -5,9 +5,9 @@ relevantTo: [gotchas]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 1465
-  referenced: 354
-  successfulFeatures: 354
+  loaded: 1478
+  referenced: 363
+  successfulFeatures: 363
 ---
 <!-- domain: Gotchas & Pitfalls | Known traps, anti-patterns, and hard-won lessons across all domains -->
 
@@ -976,3 +976,8 @@ usageStats:
 - **Situation:** Feature depends on prior work (PR #2474) that should have been available but wasn't
 - **Root cause:** Worktree isolation or branch state didn't include the merged dependency—common when features are split across PRs with dependency ordering issues
 - **How to avoid:** Fresh creation saved time vs merge conflict resolution, but introduced divergence risk. Team had to manually reconcile which constants from PR #2474 to include.
+
+#### [Gotcha] Manual string escaping of GraphQL arguments (JSON.stringify().slice(1, -1)) is unreliable across edge cases like newlines, quotes, special chars in body text (2026-03-14)
+- **Situation:** Original replyAndResolveThread passed body via JSON.stringify(body).slice(1, -1), which fails on bodies containing quotes, backslashes, or control characters
+- **Root cause:** Escaping is context-dependent (GraphQL string context != JSON context). The slice pattern assumes stable JSON wrapper format which breaks under pressure.
+- **How to avoid:** Switching to CLI variables eliminates custom escaping logic entirely (simpler); but requires understanding that gh cli handles escaping, not the application

--- a/.automaker/memory/gtm-signal-intelligence-project.md
+++ b/.automaker/memory/gtm-signal-intelligence-project.md
@@ -5,7 +5,7 @@ relevantTo: []
 importance: 0.5
 relatedFiles: []
 usageStats:
-  loaded: 323
+  loaded: 324
   referenced: 83
   successfulFeatures: 83
 ---

--- a/.automaker/memory/pattern.md
+++ b/.automaker/memory/pattern.md
@@ -5,7 +5,7 @@ relevantTo: [pattern]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 3
+  loaded: 4
   referenced: 2
   successfulFeatures: 2
 ---

--- a/.automaker/memory/patterns.md
+++ b/.automaker/memory/patterns.md
@@ -5,9 +5,9 @@ relevantTo: [patterns]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 114
-  referenced: 25
-  successfulFeatures: 25
+  loaded: 116
+  referenced: 26
+  successfulFeatures: 26
 ---
 <!-- domain: Patterns & Best Practices | Reusable implementation patterns proven in this codebase -->
 

--- a/.automaker/memory/security.md
+++ b/.automaker/memory/security.md
@@ -5,9 +5,9 @@ relevantTo: [security]
 importance: 0.7
 relatedFiles: []
 usageStats:
-  loaded: 84
-  referenced: 24
-  successfulFeatures: 24
+  loaded: 86
+  referenced: 26
+  successfulFeatures: 26
 ---
 <!-- domain: Security | Auth guards, input validation, secure file operations, HMAC verification -->
 
@@ -209,3 +209,22 @@ usageStats:
 - **Situation:** Code had escaping logic but still vulnerable to backtick and $() injection in epic titles
 - **Root cause:** Shell injection isn't just about quote escaping; you must escape backticks, $(), all expansion syntax. It's hard to enumerate all dangerous patterns. The only secure approach is to not use a shell at all (execFile with args array).
 - **How to avoid:** Removing escaping entirely (not using a shell) is simpler and fundamentally safer than trying to escape correctly
+
+#### [Pattern] Using execFile with argument arrays as core pattern for preventing shell injection when spawning external commands with user-provided data (2026-03-14)
+- **Problem solved:** Running gh CLI to create PRs with user-provided epic titles and body text that may contain shell metacharacters like backticks, $(), pipes, redirects
+- **Why this works:** execFile never spawns a shell - arguments are passed directly as literal values to the executable process. This is fundamentally different from exec() which parses the entire string through a shell interpreter. The separation of command from argv prevents any string interpolation.
+- **Trade-offs:** execFile is less syntactically flexible (no pipes, redirects, shell globbing) but provides ironclad security by design. Requires thinking in terms of argument arrays rather than shell command strings.
+
+### Passing command arguments as distinct array elements ['pr', 'create', '--title', epicTitle, '--body', body] rather than pre-formatted strings or template-based option syntax (2026-03-14)
+- **Context:** gh command invocation with user-controlled title and body that must remain separate from command structure to prevent injection
+- **Why:** When arguments are separate array positions, they cannot be misinterpreted as command modifiers or shell syntax - gh receives them in argv. This is structurally enforced, not dependent on escaping logic. No amount of special characters in title can escape the argument boundary.
+- **Rejected:** String templates like `--title='${epicTitle}'` or shell option syntax require manual escaping/quoting and are fragile - easy to forget quotes or get escaping wrong in some edge case
+- **Trade-offs:** Array-based calling requires more verbose construction but eliminates the escaping/quoting problem entirely - the structure itself is the defense
+- **Breaking if changed:** If refactored to build a command string that's then parsed (even with exec) or to use string interpolation without quotes, requires defensive escaping everywhere user input appears and is a perpetual security liability
+
+### Use gh CLI's -f (string) and -F (typed) flags for GraphQL variable passing instead of string interpolation (2026-03-14)
+- **Context:** Multiple services were concatenating owner/repo/prNumber/body directly into GraphQL query strings, creating injection risk
+- **Why:** gh api graphql natively supports parameterized variables via CLI flags, eliminating the need for manual escaping or interpolation. This treats GraphQL variables as first-class, not text substitution.
+- **Rejected:** Continue using JSON.stringify(body).slice(1, -1) escaping or regex-based sanitization - both fragile and prone to edge cases
+- **Trade-offs:** Requires knowing gh CLI's variable syntax (-f for strings, -F for typed values); slightly more verbose execFileAsync calls; but gains provable safety without custom escaping logic
+- **Breaking if changed:** If gh CLI changes or doesn't support -f/-F flags, all variable passing breaks; if omitted, reverts to injection-vulnerable string interpolation

--- a/.automaker/memory/testing.md
+++ b/.automaker/memory/testing.md
@@ -201,3 +201,27 @@ usageStats:
 - **Situation:** Tests threw 'Cannot access before initialization' even though mockExecFile was defined before vi.mock() in source order
 - **Root cause:** Vitest/TypeScript hoists vi.mock() calls to the top of the module during transformation, putting them before any module-level const declarations. The const stays in its source position, creating a temporal dead zone. vi.hoisted() runs the callback during the hoisting phase.
 - **How to avoid:** vi.hoisted() adds a wrapper function (slightly less readable), but it's the idiomatic Vitest pattern and guarantees the mock is initialized in the right phase
+
+#### [Pattern] Adversarial payload testing for injection vulnerabilities - test suite includes specific dangerous inputs like '$(rm -rf /)' to prove they are treated as literal strings, not executed (2026-03-14)
+- **Problem solved:** Security tests need to prove that shell injection attacks actually FAIL, not just that normal inputs work. This requires passing inputs that WOULD execute if the vulnerability existed.
+- **Why this works:** Normal test cases with alphanumeric titles pass regardless of vulnerability. Only payload tests with shell metacharacters reveal whether escaping/parameterization is actually working. The test case with backticks and command substitution proves the literal argument is received by gh, not interpreted by a shell.
+- **Trade-offs:** Adversarial tests are more complex to write and may seem strange to developers unfamiliar with security testing, but they're mandatory for proving injection protections actually work
+
+### Skip UI/browser testing for pure library package changes (libs/tools) (2026-03-14)
+- **Context:** Build completed successfully; question was whether to run Playwright suite anyway
+- **Why:** libs/tools has no UI surface—it's a TypeScript type definitions and factory functions package. Build passing (type checking + compilation) is the appropriate verification gate. Playwright testing would test the wrong layer.
+- **Rejected:** Run full browser test suite regardless of what changed
+- **Trade-offs:** Faster verification cycle when changing libraries, but requires discipline to skip unnecessary test layers
+- **Breaking if changed:** Nothing breaks by skipping tests, but would waste CI time testing unrelated UI layer
+
+### Skip Playwright browser-based verification for pure server-side GraphQL construction changes (2026-03-14)
+- **Context:** After implementing GraphQL variable changes, team considered running full Playwright test suite but decided against it
+- **Why:** Changes are confined to CLI argument construction in server code with no UI surface. Playwright tests would not exercise the fixed code path (browser cannot see execFileAsync calls). Resources better spent on compile/typecheck verification.
+- **Rejected:** Run full Playwright suite anyway (test pyramid violation - testing UI paths that don't exercise the fix); or skip all verification (insufficient)
+- **Trade-offs:** Faster feedback (no browser test overhead); but team must have high confidence in compile/typecheck/code review to replace integration tests
+- **Breaking if changed:** If the changes were later modified to include UI-visible behavior (e.g., logging response body to frontend), Playwright tests become necessary but would have been disabled
+
+#### [Gotcha] Existing tests checking world state synchronously after firing events require vi.advanceTimersByTimeAsync(0) to flush Promise chain (2026-03-14)
+- **Situation:** Two tests (feature:status-changed, auto-mode events) were asserting state changes immediately after event firing; now events process asynchronously
+- **Root cause:** Promise chain queues work on next microtask; vi.advanceTimersByTimeAsync(0) flushes microtasks without advancing wall-clock time; necessary after switching to async serialization
+- **How to avoid:** Tests become slightly more verbose but accurately reflect async execution model; encourages realistic testing patterns; catches real bugs where callers assumed sync behavior

--- a/apps/server/src/services/feature-health-service.ts
+++ b/apps/server/src/services/feature-health-service.ts
@@ -180,7 +180,7 @@ export class FeatureHealthService {
     _featureMap: Map<string, Feature>
   ): HealthIssue[] {
     const issues: HealthIssue[] = [];
-    const doneStatuses = new Set(['done', 'completed', 'verified', 'review']);
+    const doneStatuses = new Set(['done', 'completed', 'verified']);
 
     const epics = features.filter((f) => f.isEpic);
 
@@ -192,13 +192,16 @@ export class FeatureHealthService {
 
       const allChildrenDone = children.every((c) => doneStatuses.has(c.status ?? ''));
       if (allChildrenDone) {
+        const hasGitBranch = !!epic.branchName;
         issues.push({
           type: 'epic_children_done',
           featureId: epic.id,
           featureTitle: epic.title ?? epic.id,
           message: `Epic has ${children.length} children, all done, but epic status is '${epic.status}'`,
-          autoFixable: true,
-          fix: 'Set epic status to done',
+          autoFixable: !hasGitBranch,
+          fix: hasGitBranch
+            ? 'Delegate to CompletionDetectorService for epic-to-dev PR creation'
+            : 'Set epic status to done',
         });
       }
     }

--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -112,6 +112,8 @@ export class FeatureScheduler {
   private runner: PipelineRunner;
   private callbacks: SchedulerCallbacks;
   private featureHealthAuditor: FeatureHealthAuditor | null = null;
+  /** Count of features skipped due to creation cooldown during the last loadPendingFeatures call. */
+  private lastCooldownSkippedCount = 0;
   /**
    * Instance identity for project-affinity filtering.
    * When null, no affinity filtering is applied (single-instance backward compat).
@@ -280,6 +282,18 @@ export class FeatureScheduler {
         );
 
         if (pendingFeatures.length === 0) {
+          // If features were skipped due to creation cooldown, don't emit idle —
+          // they'll become eligible once the cooldown window passes.
+          if (this.lastCooldownSkippedCount > 0) {
+            logger.info(
+              `[AutoLoop] ${this.lastCooldownSkippedCount} feature(s) in creation cooldown, waiting...`
+            );
+            await this.callbacks.sleep(
+              SLEEP_INTERVAL_NORMAL_MS,
+              projectState.abortController.signal
+            );
+            continue;
+          }
           const inProgress = await this.callbacks.hasInProgressFeatures(projectPath, branchName);
           if (projectRunningCount === 0 && !inProgress && !projectState.hasEmittedIdleEvent) {
             this.callbacks.emitAutoModeEvent('auto_mode_idle', {
@@ -605,6 +619,7 @@ export class FeatureScheduler {
     projectPath: string,
     branchName: string | null = null
   ): Promise<Feature[]> {
+    this.lastCooldownSkippedCount = 0;
     const featuresDir = getFeaturesDir(projectPath);
 
     const primaryBranch = await this.getCurrentBranch(projectPath);
@@ -684,7 +699,7 @@ export class FeatureScheduler {
       // ── Merged PR reconciliation ──
       const staleViaLinkedPr = allFeatures.filter(
         (f) =>
-          (f.status === 'blocked' || f.status === 'review') &&
+          (f.status === 'backlog' || f.status === 'blocked' || f.status === 'review') &&
           f.branchName &&
           mergedPrBranches.has(f.branchName)
       );
@@ -845,6 +860,7 @@ export class FeatureScheduler {
                 logger.info(
                   `[loadPendingFeatures] Skipping feature ${feature.id} - within creation cooldown (${remainingSec}s remaining)`
                 );
+                this.lastCooldownSkippedCount++;
                 continue;
               }
             }

--- a/apps/server/src/services/project-orchestration-service.ts
+++ b/apps/server/src/services/project-orchestration-service.ts
@@ -130,6 +130,15 @@ export async function orchestrateProjectFeatures(
   // Track created features for dependency resolution
   const createdFeatures: Map<string, Feature> = new Map();
 
+  // ── Idempotency: build lookup of existing features by branchName ──
+  const existingFeatures = await featureLoader.getAll(projectPath);
+  const existingByBranch = new Map<string, Feature>();
+  for (const f of existingFeatures) {
+    if (f.branchName && f.projectSlug === projectSlug) {
+      existingByBranch.set(f.branchName, f);
+    }
+  }
+
   // Phase 1: Create epics and features
   events?.emit('project:features:progress', {
     step: 'creating-features',
@@ -142,69 +151,96 @@ export async function orchestrateProjectFeatures(
 
     // Create epic feature for milestone if requested
     if (createEpics) {
-      try {
-        const epicFeature = await featureLoader.create(projectPath, {
-          title: `[Epic] ${milestone.title}`,
-          description: `# ${milestone.title}\n\n${milestone.description}\n\n## Phases\n${milestone.phases.map((p, i) => `${i + 1}. ${p.title}`).join('\n')}`,
-          category: 'Epic',
-          status: initialStatus,
-          isEpic: true,
-          epicColor: EPIC_COLORS[mi % EPIC_COLORS.length],
-          branchName: `epic/${slugify(milestone.title, 40)}`,
-          projectSlug,
-          milestoneSlug: milestone.slug,
-        });
-        epicId = epicFeature.id;
+      const epicBranch = `epic/${slugify(milestone.title, 40)}`;
+      const existingEpic = existingByBranch.get(epicBranch);
+      if (existingEpic) {
+        // Reuse existing epic — idempotent on re-run
+        epicId = existingEpic.id;
         result.milestoneEpicMap[milestone.slug] = epicId;
-        result.featuresCreated++;
-        createdFeatures.set(`epic:${milestone.slug}`, epicFeature);
-
+        createdFeatures.set(`epic:${milestone.slug}`, existingEpic);
         events?.emit('project:features:progress', {
           step: 'epic-created',
           milestoneSlug: milestone.slug,
           epicId,
         });
-      } catch (err) {
-        const errorMsg = `Failed to create epic for milestone ${milestone.slug}: ${getErrorMessage(err)}`;
-        result.errors?.push(errorMsg);
-        events?.emit('project:features:error', { error: errorMsg });
+      } else {
+        try {
+          const epicFeature = await featureLoader.create(projectPath, {
+            title: `[Epic] ${milestone.title}`,
+            description: `# ${milestone.title}\n\n${milestone.description}\n\n## Phases\n${milestone.phases.map((p, i) => `${i + 1}. ${p.title}`).join('\n')}`,
+            category: 'Epic',
+            status: initialStatus,
+            isEpic: true,
+            epicColor: EPIC_COLORS[mi % EPIC_COLORS.length],
+            branchName: epicBranch,
+            projectSlug,
+            milestoneSlug: milestone.slug,
+          });
+          epicId = epicFeature.id;
+          result.milestoneEpicMap[milestone.slug] = epicId;
+          result.featuresCreated++;
+          createdFeatures.set(`epic:${milestone.slug}`, epicFeature);
+
+          events?.emit('project:features:progress', {
+            step: 'epic-created',
+            milestoneSlug: milestone.slug,
+            epicId,
+          });
+        } catch (err) {
+          const errorMsg = `Failed to create epic for milestone ${milestone.slug}: ${getErrorMessage(err)}`;
+          result.errors?.push(errorMsg);
+          events?.emit('project:features:error', { error: errorMsg });
+        }
       }
     }
 
     // Process phases within milestone
     for (const phase of milestone.phases) {
       try {
-        // Build feature description from phase
-        const description = phaseToFeatureDescription(phase, milestone);
-
         // Generate unique key for this phase
         const phaseKey = `${milestone.slug}:${phase.name}`;
+        const phaseBranch = `feature/${slugify(milestone.title, 20)}-${slugify(phase.title, 20)}`;
+        const existingPhaseFeature = existingByBranch.get(phaseBranch);
 
-        // Create feature — Phase 1 of each milestone is marked as foundation
-        // so downstream phases wait for its PR to merge before starting
-        const feature = await featureLoader.create(projectPath, {
-          title: phase.title,
-          description,
-          category: milestone.title,
-          status: initialStatus,
-          isEpic: false,
-          epicId,
-          branchName: `feature/${slugify(milestone.title, 20)}-${slugify(phase.title, 20)}`,
-          isFoundation: phase.number === 1,
-          projectSlug,
-          milestoneSlug: milestone.slug,
-          phaseSlug: phase.name,
-        });
+        if (existingPhaseFeature) {
+          // Reuse existing feature — idempotent on re-run
+          result.phaseFeatureMap[phaseKey] = existingPhaseFeature.id;
+          createdFeatures.set(phaseKey, existingPhaseFeature);
+          events?.emit('project:features:progress', {
+            step: 'feature-created',
+            phaseKey,
+            featureId: existingPhaseFeature.id,
+          });
+        } else {
+          // Build feature description from phase
+          const description = phaseToFeatureDescription(phase, milestone);
 
-        result.phaseFeatureMap[phaseKey] = feature.id;
-        result.featuresCreated++;
-        createdFeatures.set(phaseKey, feature);
+          // Create feature — Phase 1 of each milestone is marked as foundation
+          // so downstream phases wait for its PR to merge before starting
+          const feature = await featureLoader.create(projectPath, {
+            title: phase.title,
+            description,
+            category: milestone.title,
+            status: initialStatus,
+            isEpic: false,
+            epicId,
+            branchName: phaseBranch,
+            isFoundation: phase.number === 1,
+            projectSlug,
+            milestoneSlug: milestone.slug,
+            phaseSlug: phase.name,
+          });
 
-        events?.emit('project:features:progress', {
-          step: 'feature-created',
-          phaseKey,
-          featureId: feature.id,
-        });
+          result.phaseFeatureMap[phaseKey] = feature.id;
+          result.featuresCreated++;
+          createdFeatures.set(phaseKey, feature);
+
+          events?.emit('project:features:progress', {
+            step: 'feature-created',
+            phaseKey,
+            featureId: feature.id,
+          });
+        }
       } catch (err) {
         const errorMsg = `Failed to create feature for phase ${phase.name}: ${getErrorMessage(err)}`;
         result.errors?.push(errorMsg);

--- a/apps/server/tests/unit/services/feature-health-service.test.ts
+++ b/apps/server/tests/unit/services/feature-health-service.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for FeatureHealthService
+ *
+ * Covers epic completion detection logic:
+ * - Children in 'review' should NOT count as done
+ * - Git-backed epics should NOT be auto-fixable (delegate to CompletionDetectorService)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FeatureHealthService } from '@/services/feature-health-service.js';
+import type { Feature } from '@protolabsai/types';
+
+describe('feature-health-service.ts', () => {
+  let service: FeatureHealthService;
+  let mockFeatureLoader: any;
+  let mockAutoModeService: any;
+
+  beforeEach(() => {
+    mockFeatureLoader = {
+      getAll: vi.fn(),
+      update: vi.fn().mockResolvedValue({}),
+    };
+    mockAutoModeService = {
+      getRunningAgents: vi.fn().mockResolvedValue([]),
+      releaseStaleLeases: vi.fn().mockReturnValue([]),
+    };
+    service = new FeatureHealthService(mockFeatureLoader, mockAutoModeService);
+  });
+
+  describe('checkEpicChildrenDone', () => {
+    it('does not flag epic as complete when children are in review', async () => {
+      const features: Partial<Feature>[] = [
+        { id: 'epic-1', title: 'Epic', isEpic: true, status: 'backlog', branchName: 'epic/test' },
+        { id: 'child-1', epicId: 'epic-1', status: 'done' },
+        { id: 'child-2', epicId: 'epic-1', status: 'review' },
+      ];
+      mockFeatureLoader.getAll.mockResolvedValue(features);
+
+      const report = await service.audit('/mock', false);
+
+      const epicIssues = report.issues.filter((i) => i.type === 'epic_children_done');
+      expect(epicIssues).toHaveLength(0);
+    });
+
+    it('flags epic as complete when all children are done', async () => {
+      const features: Partial<Feature>[] = [
+        { id: 'epic-1', title: 'Epic', isEpic: true, status: 'backlog', branchName: 'epic/test' },
+        { id: 'child-1', epicId: 'epic-1', status: 'done' },
+        { id: 'child-2', epicId: 'epic-1', status: 'done' },
+      ];
+      mockFeatureLoader.getAll.mockResolvedValue(features);
+
+      const report = await service.audit('/mock', false);
+
+      const epicIssues = report.issues.filter((i) => i.type === 'epic_children_done');
+      expect(epicIssues).toHaveLength(1);
+    });
+
+    it('marks git-backed epics as NOT auto-fixable', async () => {
+      const features: Partial<Feature>[] = [
+        { id: 'epic-1', title: 'Epic', isEpic: true, status: 'backlog', branchName: 'epic/test' },
+        { id: 'child-1', epicId: 'epic-1', status: 'done' },
+      ];
+      mockFeatureLoader.getAll.mockResolvedValue(features);
+
+      const report = await service.audit('/mock', false);
+
+      const epicIssue = report.issues.find((i) => i.type === 'epic_children_done');
+      expect(epicIssue).toBeDefined();
+      expect(epicIssue!.autoFixable).toBe(false);
+      expect(epicIssue!.fix).toContain('CompletionDetectorService');
+    });
+
+    it('marks non-git epics as auto-fixable', async () => {
+      const features: Partial<Feature>[] = [
+        { id: 'epic-1', title: 'Epic', isEpic: true, status: 'backlog' },
+        { id: 'child-1', epicId: 'epic-1', status: 'done' },
+      ];
+      mockFeatureLoader.getAll.mockResolvedValue(features);
+
+      const report = await service.audit('/mock', false);
+
+      const epicIssue = report.issues.find((i) => i.type === 'epic_children_done');
+      expect(epicIssue).toBeDefined();
+      expect(epicIssue!.autoFixable).toBe(true);
+      expect(epicIssue!.fix).toBe('Set epic status to done');
+    });
+
+    it('auto-fixes non-git epics but skips git-backed ones', async () => {
+      const features: Partial<Feature>[] = [
+        {
+          id: 'epic-git',
+          title: 'Git Epic',
+          isEpic: true,
+          status: 'backlog',
+          branchName: 'epic/test',
+        },
+        { id: 'child-1', epicId: 'epic-git', status: 'done' },
+        { id: 'epic-no-git', title: 'No Git Epic', isEpic: true, status: 'backlog' },
+        { id: 'child-2', epicId: 'epic-no-git', status: 'done' },
+      ];
+      mockFeatureLoader.getAll.mockResolvedValue(features);
+
+      const report = await service.audit('/mock', true);
+
+      // Only the non-git epic should have been auto-fixed
+      expect(report.fixed).toHaveLength(1);
+      expect(report.fixed[0].featureId).toBe('epic-no-git');
+
+      // update should only have been called for the non-git epic
+      const updateCalls = mockFeatureLoader.update.mock.calls.filter(
+        ([, id]: [string, string]) => id === 'epic-git'
+      );
+      expect(updateCalls).toHaveLength(0);
+    });
+  });
+});

--- a/apps/server/tests/unit/services/project-orchestration-service.test.ts
+++ b/apps/server/tests/unit/services/project-orchestration-service.test.ts
@@ -77,6 +77,7 @@ describe('project-orchestration-service.ts', () => {
       mockFeatureLoader = {
         create: mockCreate,
         update: mockUpdate,
+        getAll: vi.fn().mockResolvedValue([]),
       };
     });
 
@@ -197,6 +198,40 @@ describe('project-orchestration-service.ts', () => {
       expect(phaseCreateArgs).toMatchObject({
         phaseSlug: 'phase-setup',
       });
+    });
+
+    it('reuses existing features by branchName instead of creating duplicates', async () => {
+      const existingEpic = {
+        id: 'existing-epic-id',
+        branchName: 'epic/foundation',
+        projectSlug: PROJECT_SLUG,
+        isEpic: true,
+        dependencies: [],
+      };
+      const existingPhase = {
+        id: 'existing-phase-id',
+        branchName: 'feature/foundation-setup',
+        projectSlug: PROJECT_SLUG,
+        isEpic: false,
+        dependencies: [],
+      };
+
+      mockFeatureLoader.getAll = vi.fn().mockResolvedValue([existingEpic, existingPhase]);
+
+      const result = await orchestrateProjectFeatures(
+        makeProject() as any,
+        { projectPath: PROJECT_PATH, projectSlug: PROJECT_SLUG },
+        mockFeatureLoader
+      );
+
+      // Only the second phase (core) should be created — epic and first phase already exist
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const createdArgs = mockCreate.mock.calls[0][1];
+      expect(createdArgs.title).toBe('Core Implementation');
+
+      // But the maps should still include the reused features
+      expect(result.milestoneEpicMap['milestone-foundation']).toBe('existing-epic-id');
+      expect(result.phaseFeatureMap['milestone-foundation:phase-setup']).toBe('existing-phase-id');
     });
   });
 });

--- a/packages/mcp-server/plugins/automaker/commands/ava.md
+++ b/packages/mcp-server/plugins/automaker/commands/ava.md
@@ -183,44 +183,44 @@ All code examples below use `projectPath` as a variable — substitute the resol
 
 This is your routing table. For every signal, find the right row and delegate accordingly.
 
-| Signal                             | Route                                | How                                                       |
-| ---------------------------------- | ------------------------------------ | --------------------------------------------------------- |
-| **PR Pipeline**                    |                                      |                                                           |
-| Checks passing, no auto-merge      | PR Maintainer agent                  | `start_agent` or delegate via native Agent tool           |
-| Format failure in worktree         | PR Maintainer agent                  | `start_agent` or delegate via native Agent tool           |
-| Unresolved CodeRabbit threads      | PR Maintainer agent                  | `start_agent` or delegate via native Agent tool           |
-| PR behind main                     | PR Maintainer agent                  | `start_agent` or delegate via native Agent tool           |
-| Build failure (TypeScript)         | Feature agent retry or PR Maintainer | Retry first, delegate if mechanical                       |
-| Orphaned worktree with commits     | PR Maintainer agent                  | `start_agent` or delegate via native Agent tool           |
-| PR owned by another instance       | **Skip** (not stale)                 | Check `ownership.isOwnedByThisInstance` first             |
-| PR owned by another, stale >24h    | PR Maintainer agent                  | May reclaim — original owner inactive                     |
-| **Board Consistency**              |                                      |                                                           |
-| Review + PR merged, not done       | **Ava DIRECT**                       | `update_feature` → move to done                           |
-| In-progress, no running agent >4h  | **Ava DIRECT**                       | Restart agent or reset to backlog                         |
-| Broken dependency chain            | **Ava DIRECT**                       | `set_feature_dependencies` to fix                         |
-| Stale worktree blocking feature    | **Ava DIRECT**                       | Investigate and unblock                                   |
-| **Infrastructure**                 |                                      |                                                           |
-| Server health degraded             | **Ava DIRECT**                       | Check health, alert operator                              |
-| High memory/CPU                    | **Ava DIRECT**                       | Investigate, stop agents if needed                        |
-| Worktree cleanup needed            | **Ava DIRECT**                       | Handle directly or delegate via native Agent tool         |
-| Deploy verification                | **Ava DIRECT**                       | Handle directly or delegate via native Agent tool         |
-| **Feature Implementation**         |                                      |                                                           |
-| Backlog feature ready              | `start_agent` / auto-mode            | Already delegated                                         |
-| Agent needs context                | **Ava DIRECT**                       | `send_message_to_agent`                                   |
-| Agent failed                       | **Ava DIRECT**                       | Escalation decision                                       |
-| **Communication**                  |                                      |                                                           |
-| Status updates                     | **Ava DIRECT**                       | Discord post to project channels                          |
-| Infra alert                        | **Ava DIRECT**                       | Investigate and alert operator                            |
-| Operator coordination              | **Ava DIRECT**                       | Discord DM or project channel                             |
-| **Strategic/Orchestration**        |                                      |                                                           |
-| Auto-mode start/stop               | **Ava DIRECT**                       | Authority decision                                        |
-| Priority decisions                 | **Ava DIRECT**                       | Authority decision                                        |
-| Model routing                      | **Ava DIRECT**                       | Authority decision                                        |
-| **Promotion Pipeline**             |                                      |                                                           |
-| Staging candidates ready to review | **Ava DIRECT**                       | `list_staging_candidates`, assess readiness               |
-| Batch approved for staging         | **Ava DIRECT**                       | `create_promotion_batch` → `promote_to_staging`           |
-| Staging → main promotion needed    | **HITL GATE**                        | `promote_to_main` creates PR + HITL form — Ava stops here |
-| Human approves staging→main HITL   | Human only                           | Ava never merges staging→main herself                     |
+| Signal                             | Route                                | How                                                                          |
+| ---------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------- |
+| **PR Pipeline**                    |                                      |                                                                              |
+| Checks passing, no auto-merge      | PR Maintainer agent                  | `start_agent` or delegate via native Agent tool                              |
+| Format failure in worktree         | PR Maintainer agent                  | `start_agent` or delegate via native Agent tool                              |
+| Unresolved CodeRabbit threads      | PR Maintainer agent                  | `start_agent` or delegate via native Agent tool                              |
+| PR behind main                     | PR Maintainer agent                  | `start_agent` or delegate via native Agent tool                              |
+| Build failure (TypeScript)         | Feature agent retry or PR Maintainer | Retry first, delegate if mechanical                                          |
+| Orphaned worktree with commits     | PR Maintainer agent                  | `start_agent` or delegate via native Agent tool                              |
+| PR owned by another instance       | **Skip** (not stale)                 | Check `ownership.isOwnedByThisInstance` first                                |
+| PR owned by another, stale >24h    | PR Maintainer agent                  | May reclaim — original owner inactive                                        |
+| **Board Consistency**              |                                      |                                                                              |
+| Review + PR merged, not done       | **System bug**                       | File a bug ticket — merged PR reconciliation should catch this automatically |
+| In-progress, no running agent >4h  | **Ava DIRECT**                       | Restart agent or reset to backlog                                            |
+| Broken dependency chain            | **Ava DIRECT**                       | `set_feature_dependencies` to fix                                            |
+| Stale worktree blocking feature    | **Ava DIRECT**                       | Investigate and unblock                                                      |
+| **Infrastructure**                 |                                      |                                                                              |
+| Server health degraded             | **Ava DIRECT**                       | Check health, alert operator                                                 |
+| High memory/CPU                    | **Ava DIRECT**                       | Investigate, stop agents if needed                                           |
+| Worktree cleanup needed            | **Ava DIRECT**                       | Handle directly or delegate via native Agent tool                            |
+| Deploy verification                | **Ava DIRECT**                       | Handle directly or delegate via native Agent tool                            |
+| **Feature Implementation**         |                                      |                                                                              |
+| Backlog feature ready              | `start_agent` / auto-mode            | Already delegated                                                            |
+| Agent needs context                | **Ava DIRECT**                       | `send_message_to_agent`                                                      |
+| Agent failed                       | **Ava DIRECT**                       | Escalation decision                                                          |
+| **Communication**                  |                                      |                                                                              |
+| Status updates                     | **Ava DIRECT**                       | Discord post to project channels                                             |
+| Infra alert                        | **Ava DIRECT**                       | Investigate and alert operator                                               |
+| Operator coordination              | **Ava DIRECT**                       | Discord DM or project channel                                                |
+| **Strategic/Orchestration**        |                                      |                                                                              |
+| Auto-mode start/stop               | **Ava DIRECT**                       | Authority decision                                                           |
+| Priority decisions                 | **Ava DIRECT**                       | Authority decision                                                           |
+| Model routing                      | **Ava DIRECT**                       | Authority decision                                                           |
+| **Promotion Pipeline**             |                                      |                                                                              |
+| Staging candidates ready to review | **Ava DIRECT**                       | `list_staging_candidates`, assess readiness                                  |
+| Batch approved for staging         | **Ava DIRECT**                       | `create_promotion_batch` → `promote_to_staging`                              |
+| Staging → main promotion needed    | **HITL GATE**                        | `promote_to_main` creates PR + HITL form — Ava stops here                    |
+| Human approves staging→main HITL   | Human only                           | Ava never merges staging→main herself                                        |
 
 ## What Ava Does Directly (Never Delegates)
 
@@ -254,6 +254,16 @@ You are an **orchestrator and monitor**, not an implementer. Your authority:
 - Merge PRs when checks pass
 - Manage dependencies, queue, orchestration
 - Read code, logs, and config for diagnostics
+
+## Board State Autonomy
+
+The pipeline handles board state transitions autonomously. If you observe incorrect board state, it is a **system bug**, not an ops task.
+
+- **Merged PR not reflected as done:** The merged PR reconciliation sweep in `loadPendingFeatures` covers backlog, blocked, and review features. If a feature with a merged PR is not moving to done, file a bug.
+- **Epic not completing after all children done:** CompletionDetectorService creates the epic-to-dev PR. FeatureHealthService does NOT auto-fix git-backed epics — it defers to the PR flow. If the epic is stuck, file a bug.
+- **Duplicate features after re-running approve_project_prd:** The orchestration service is idempotent — it detects existing features by branch name and reuses them. If duplicates appear, file a bug.
+
+Do NOT use `update_feature` to manually fix board state that should be handled by the pipeline. File a bug ticket instead so the root cause gets fixed.
 
 ## Boundaries
 

--- a/packages/mcp-server/plugins/automaker/commands/headsdown.md
+++ b/packages/mcp-server/plugins/automaker/commands/headsdown.md
@@ -333,7 +333,8 @@ For features in `in_progress` or `review` with no activity > 24h:
 ### 5.2 Board Consistency Checks
 
 - **Done without PR**: Feature marked done but no merged PR -> verify manually or flag
-- **Review with merged PR**: PR already merged but feature still in review -> move to done
+- **Review with merged PR**: PR already merged but feature still in review -> this is a **system bug** in merged PR reconciliation. File a bug ticket. Do NOT manually `update_feature` to done.
+- **Backlog with merged PR**: Feature in backlog but its branch has a merged PR -> this is a **system bug**. The reconciliation sweep should catch backlog features too. File a bug ticket.
 - **In progress with no agent**: No running agent and no recent activity -> restart or reset
 - **Orphaned worktrees**: Worktrees for features that are already done -> note for cleanup
 


### PR DESCRIPTION
## Summary

Five fixes that remove manual board management from the autonomous pipeline:

- **Backlog reconciliation**: Merged PR sweep now checks `backlog` features (not just `blocked`/`review`), preventing agents from re-implementing already-completed work after `approve_project_prd` recreates features
- **Cooldown idle suppression**: When bulk-created features are in their 30s creation cooldown, the scheduler no longer falsely emits `auto_mode_idle` — it waits and retries instead of declaring the backlog complete
- **Epic PR flow preservation**: `FeatureHealthService` no longer auto-fixes git-backed epics to `done` directly — it defers to `CompletionDetectorService` for the proper epic-to-dev PR flow. Also removes `review` from the "done" status set so children with unmerged PRs aren't counted as complete
- **Idempotent feature orchestration**: `orchestrateProjectFeatures` now detects existing features by `branchName` and reuses them instead of creating duplicates on re-run
- **Prompt updates**: Ava and headsdown skill prompts now treat stale board state as system bugs (file a ticket) rather than ops tasks (manually fix with `update_feature`)

## Test plan
- [x] `npm run build:server` passes
- [x] `npm run test:server` passes (pre-existing provider-factory failures only)
- [x] New tests: 5 FeatureHealthService tests (epic completion, review exclusion, git-backed gating)
- [x] New test: orchestration idempotency (reuses existing features by branch)
- [ ] Integration: bulk-create features via `approve_project_prd`, start auto-mode, verify no false idle events
- [ ] Integration: verify git-backed epic waits for CompletionDetectorService instead of health auto-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)