### PR TITLE
Bug: AtomicWriter should auto-recover features directory from backups

### DIFF
--- a/libs/utils/src/atomic-writer.ts
+++ b/libs/utils/src/atomic-writer.ts
@@ -404,6 +404,7 @@ export async function readJsonWithRecovery<T>(
           // Optionally restore main file from backup
           if (autoRestore) {
             try {
+              await mkdirSafe(path.dirname(resolvedPath));
               await secureFs.copyFile(backupPath, resolvedPath);
               logger.info(`Restored main file from backup: ${backupPath}`);
             } catch (restoreError) {


### PR DESCRIPTION
## Summary

When `.automaker/features/` directory is deleted or missing, AtomicWriter logs `Failed to restore main file from backup: ENOENT` and gives up. The backup data exists in `.automaker/.backups/features/` but the target directory doesn't exist.\n\nFix: AtomicWriter should `mkdir -p` the target directory before attempting copyFile. The backup recovery path already finds the .bak1 file — it just fails on the final copy because the parent dir is gone.\n\nImpact: Loss of features directory kills all run...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-14T22:30:16.715Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of data recovery functionality to prevent errors during file restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->