### PR TITLE
Fix HITL form service test — remove pipeline flag gate tests

### DIFF
--- a/apps/server/tests/unit/services/hitl-form-service.test.ts
+++ b/apps/server/tests/unit/services/hitl-form-service.test.ts
@@ -84,29 +84,6 @@ describe('HITLFormService', () => {
     vi.useRealTimers();
   });
 
-  // ---------- create() — feature flag gate ----------
-
-  describe('create() — feature flag gate', () => {
-    it('should return null when pipeline flag is false', async () => {
-      service.setSettingsService(createMockSettingsService(false) as any);
-      const result = await service.create(createValidInput());
-      expect(result).toBeNull();
-    });
-
-    it('should return null when settingsService is not wired', async () => {
-      const ungatedService = new HITLFormService(createMockDeps());
-      const result = await ungatedService.create(createValidInput());
-      expect(result).toBeNull();
-      ungatedService.shutdown();
-    });
-
-    it('should create a form when pipeline flag is true', async () => {
-      const form = await service.create(createValidInput());
-      expect(form).not.toBeNull();
-      expect(form!.id).toMatch(/^hitl-/);
-    });
-  });
-
   // ---------- create() ----------
 
   describe('create', () => {


### PR DESCRIPTION
## Summary

The pipeline feature flag was removed in the server pipeline deletion epic, but `hitl-form-service.test.ts` still has a 'feature flag gate' describe block (lines 89-108) that tests pipeline flag behavior. These tests now fail because the guard was removed.

**Fix:** Delete the entire `create() — feature flag gate` describe block from `apps/server/tests/unit/services/hitl-form-service.test.ts`. The 'should create a form when pipeline flag is true' test is redundant with 'should create a form with...

---
*Recovered automatically by Automaker post-agent hook*