### PR TITLE
fix: add pipeline feature flag gate to HITLFormService.create()

### DIFF
--- a/apps/server/src/services/hitl-form-service.ts
+++ b/apps/server/src/services/hitl-form-service.ts
@@ -92,6 +92,11 @@ export class HITLFormService {
    * Create a new form request.
    */
   async create(input: HITLFormRequestInput): Promise<HITLFormRequest | null> {
+    // Feature flag gate — pipeline must be enabled
+    if (!this.settingsService) return null;
+    const settings = await this.settingsService.getGlobalSettings();
+    if (!settings.featureFlags?.pipeline) return null;
+
     if (!input.title || !input.steps?.length) {
       throw new Error('title and at least one step are required');
     }


### PR DESCRIPTION
## Summary

- `HITLFormService.create()` was missing the `settingsService` / `featureFlags.pipeline` guard
- When pipeline flag is false or `settingsService` is not wired, the method now correctly returns `null`
- Fixes intermittent CI failures on tests at lines 93 and 99 of `hitl-form-service.test.ts`

## Root Cause

The `create()` method signature declared `Promise<HITLFormRequest | null>` but never actually returned `null` — the feature flag gate code path was simply absent. All 54 unit tests now pass.

## Test plan
- [x] `npx vitest --run apps/server/tests/unit/services/hitl-form-service.test.ts` — 54/54 pass
- [x] `npm run build:server` — exits 0, no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)