### PR TITLE
feat(templates): Milestone — Shared Design System (Astro components)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -60,3 +60,6 @@ blob-report/
 # Electron
 dist-electron/
 server-bundle/
+
+# Astro components — no prettier-plugin-astro installed in this monorepo
+*.astro

--- a/libs/templates/package.json
+++ b/libs/templates/package.json
@@ -9,8 +9,13 @@
     ".": {
       "import": "./dist/index.js",
       "default": "./dist/index.js"
-    }
+    },
+    "./components/*": "./src/components/*"
   },
+  "files": [
+    "dist",
+    "src/components"
+  ],
   "scripts": {
     "build": "tsup",
     "build:check": "tsc --noEmit",
@@ -21,7 +26,9 @@
   "keywords": [
     "protolabs",
     "templates",
-    "starter-kit"
+    "starter-kit",
+    "astro",
+    "design-system"
   ],
   "publishConfig": {
     "access": "public"
@@ -36,8 +43,25 @@
   },
   "devDependencies": {
     "@types/node": "22.19.3",
+    "@types/react": "^18.3.0",
     "tsup": "^8.5.1",
     "typescript": "5.9.3",
     "vitest": "^4.0.0"
+  },
+  "peerDependencies": {
+    "astro": ">=4.0.0",
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "astro": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
   }
 }

--- a/libs/templates/src/components.ts
+++ b/libs/templates/src/components.ts
@@ -1,0 +1,503 @@
+/**
+ * Astro Component Templates
+ *
+ * Template strings for Astro components that use the protoLabs design system
+ * CSS custom properties. Each function returns the string content of a component
+ * file ready to be written to disk during project scaffolding.
+ */
+
+/**
+ * Sticky header nav with gradient logo text and a React mobile menu island slot.
+ * File: Nav.astro
+ */
+export function getNavComponent(): string {
+  return `---
+export interface Props {
+  siteName?: string;
+  links?: Array<{ label: string; href: string }>;
+}
+const { siteName = 'ProtoLabs', links = [] } = Astro.props;
+---
+<header class="nav">
+  <div class="nav-inner">
+    <a href="/" class="nav-logo">{siteName}</a>
+    <nav class="nav-links" aria-label="Main navigation">
+      {links.map(link => (
+        <a href={link.href} class="nav-link">{link.label}</a>
+      ))}
+    </nav>
+    <div class="nav-mobile-toggle" id="mobile-menu-toggle">
+      <!-- NavMobileMenu client:load / -->
+    </div>
+  </div>
+</header>
+
+<style>
+  .nav {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: var(--color-surface-1);
+    border-bottom: 1px solid var(--color-surface-3);
+    backdrop-filter: blur(12px);
+  }
+  .nav-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+    height: 4rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .nav-logo {
+    font-size: 1.25rem;
+    font-weight: 700;
+    background: linear-gradient(135deg, var(--color-accent), var(--color-text-primary));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    text-decoration: none;
+  }
+  .nav-links {
+    display: flex;
+    gap: 2rem;
+    align-items: center;
+  }
+  .nav-link {
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    font-size: 0.875rem;
+    transition: color 0.2s;
+  }
+  .nav-link:hover {
+    color: var(--color-accent);
+  }
+  @media (max-width: 768px) {
+    .nav-links { display: none; }
+    .nav-mobile-toggle { display: block; }
+  }
+  @media (min-width: 769px) {
+    .nav-mobile-toggle { display: none; }
+  }
+</style>
+`;
+}
+
+/**
+ * React island for mobile menu toggle.
+ * File: NavMobileMenu.tsx
+ */
+export function getNavMobileMenuComponent(): string {
+  return `import { useState } from 'react';
+
+interface NavMobileMenuProps {
+  links?: Array<{ label: string; href: string }>;
+}
+
+export default function NavMobileMenu({ links = [] }: NavMobileMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        aria-label="Toggle menu"
+        style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-primary)' }}
+      >
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          {isOpen ? (
+            <path d="M18 6L6 18M6 6l12 12" />
+          ) : (
+            <path d="M4 6h16M4 12h16M4 18h16" />
+          )}
+        </svg>
+      </button>
+      {isOpen && (
+        <div style={{
+          position: 'absolute',
+          top: '4rem',
+          left: 0,
+          right: 0,
+          background: 'var(--color-surface-1)',
+          borderBottom: '1px solid var(--color-surface-3)',
+          padding: '1rem 1.5rem',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1rem',
+        }}>
+          {links.map(link => (
+            <a
+              key={link.href}
+              href={link.href}
+              style={{ color: 'var(--color-text-secondary)', textDecoration: 'none' }}
+            >
+              {link.label}
+            </a>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+`;
+}
+
+/**
+ * Configurable footer with nav links, social icons, and copyright.
+ * File: Footer.astro
+ */
+export function getFooterComponent(): string {
+  return `---
+export interface Props {
+  siteName?: string;
+  links?: Array<{ label: string; href: string }>;
+  socialLinks?: Array<{ label: string; href: string; icon: string }>;
+  copyright?: string;
+}
+const {
+  siteName = 'ProtoLabs',
+  links = [],
+  socialLinks = [],
+  copyright = \`© \${new Date().getFullYear()} ProtoLabs. All rights reserved.\`,
+} = Astro.props;
+---
+<footer class="footer">
+  <div class="footer-inner">
+    <div class="footer-brand">
+      <span class="footer-logo">{siteName}</span>
+    </div>
+    {links.length > 0 && (
+      <nav class="footer-links" aria-label="Footer navigation">
+        {links.map(link => (
+          <a href={link.href} class="footer-link">{link.label}</a>
+        ))}
+      </nav>
+    )}
+    {socialLinks.length > 0 && (
+      <div class="footer-social">
+        {socialLinks.map(link => (
+          <a href={link.href} aria-label={link.label} class="footer-social-link">
+            <span set:html={link.icon} />
+          </a>
+        ))}
+      </div>
+    )}
+    <p class="footer-copyright">{copyright}</p>
+  </div>
+</footer>
+
+<style>
+  .footer {
+    background: var(--color-surface-1);
+    border-top: 1px solid var(--color-surface-3);
+    padding: 3rem 0 2rem;
+  }
+  .footer-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    align-items: center;
+    text-align: center;
+  }
+  .footer-logo {
+    font-size: 1.125rem;
+    font-weight: 700;
+    background: linear-gradient(135deg, var(--color-accent), var(--color-text-primary));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .footer-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    justify-content: center;
+  }
+  .footer-link {
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    font-size: 0.875rem;
+    transition: color 0.2s;
+  }
+  .footer-link:hover {
+    color: var(--color-accent);
+  }
+  .footer-social {
+    display: flex;
+    gap: 1rem;
+  }
+  .footer-social-link {
+    color: var(--color-text-muted);
+    transition: color 0.2s;
+    display: flex;
+    align-items: center;
+  }
+  .footer-social-link:hover {
+    color: var(--color-accent);
+  }
+  .footer-copyright {
+    color: var(--color-text-muted);
+    font-size: 0.75rem;
+    margin: 0;
+  }
+</style>
+`;
+}
+
+/**
+ * SEO meta tags component — place inside <head>.
+ * File: SEO.astro
+ */
+export function getSEOComponent(): string {
+  return `---
+export interface Props {
+  title: string;
+  description?: string;
+  image?: string;
+  canonical?: string;
+  noindex?: boolean;
+  siteName?: string;
+}
+const {
+  title,
+  description = '',
+  image = '/og-image.png',
+  canonical,
+  noindex = false,
+  siteName = 'ProtoLabs',
+} = Astro.props;
+const canonicalURL = canonical ?? new URL(Astro.url.pathname, Astro.site);
+---
+<!-- Primary -->
+<title>{title} | {siteName}</title>
+<meta name="description" content={description} />
+{noindex && <meta name="robots" content="noindex,nofollow" />}
+{canonical && <link rel="canonical" href={canonicalURL} />}
+
+<!-- Open Graph -->
+<meta property="og:type" content="website" />
+<meta property="og:url" content={canonicalURL} />
+<meta property="og:title" content={title} />
+<meta property="og:description" content={description} />
+<meta property="og:image" content={image} />
+<meta property="og:site_name" content={siteName} />
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content={title} />
+<meta name="twitter:description" content={description} />
+<meta name="twitter:image" content={image} />
+`;
+}
+
+/**
+ * Button component with primary/secondary/ghost variants and sm/md/lg sizes.
+ * Renders as <a> when href is provided, otherwise <button>.
+ * File: Button.astro
+ */
+export function getButtonComponent(): string {
+  return `---
+export interface Props {
+  variant?: 'primary' | 'secondary' | 'ghost';
+  size?: 'sm' | 'md' | 'lg';
+  href?: string;
+  type?: 'button' | 'submit' | 'reset';
+  disabled?: boolean;
+  class?: string;
+}
+const {
+  variant = 'primary',
+  size = 'md',
+  href,
+  type = 'button',
+  disabled = false,
+  class: className = '',
+} = Astro.props;
+const Tag = href ? 'a' : 'button';
+---
+<Tag
+  class:list={['btn', \`btn-\${variant}\`, \`btn-\${size}\`, className]}
+  href={href}
+  type={!href ? type : undefined}
+  disabled={!href ? disabled : undefined}
+>
+  <slot />
+</Tag>
+
+<style>
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    font-family: var(--font-sans);
+    font-weight: 500;
+    border-radius: 0.5rem;
+    border: 1px solid transparent;
+    cursor: pointer;
+    text-decoration: none;
+    transition: all 0.2s;
+    white-space: nowrap;
+  }
+  .btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  /* Sizes */
+  .btn-sm { padding: 0.375rem 0.75rem; font-size: 0.75rem; }
+  .btn-md { padding: 0.625rem 1.25rem; font-size: 0.875rem; }
+  .btn-lg { padding: 0.875rem 1.75rem; font-size: 1rem; }
+  /* Variants */
+  .btn-primary {
+    background: var(--color-accent);
+    color: #fff;
+    border-color: var(--color-accent);
+  }
+  .btn-primary:hover:not(:disabled) {
+    background: var(--color-accent-hover);
+    border-color: var(--color-accent-hover);
+  }
+  .btn-secondary {
+    background: var(--color-surface-2);
+    color: var(--color-text-primary);
+    border-color: var(--color-surface-3);
+  }
+  .btn-secondary:hover:not(:disabled) {
+    background: var(--color-surface-3);
+  }
+  .btn-ghost {
+    background: transparent;
+    color: var(--color-text-secondary);
+    border-color: transparent;
+  }
+  .btn-ghost:hover:not(:disabled) {
+    background: var(--color-surface-2);
+    color: var(--color-text-primary);
+  }
+</style>
+`;
+}
+
+/**
+ * Badge component with default/accent/success/warning/danger color variants.
+ * File: Badge.astro
+ */
+export function getBadgeComponent(): string {
+  return `---
+export interface Props {
+  variant?: 'default' | 'accent' | 'success' | 'warning' | 'danger';
+  size?: 'sm' | 'md';
+  class?: string;
+}
+const {
+  variant = 'default',
+  size = 'md',
+  class: className = '',
+} = Astro.props;
+---
+<span class:list={['badge', \`badge-\${variant}\`, \`badge-\${size}\`, className]}>
+  <slot />
+</span>
+
+<style>
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-family: var(--font-sans);
+    font-weight: 500;
+    border-radius: 9999px;
+    border: 1px solid transparent;
+  }
+  .badge-sm { padding: 0.125rem 0.5rem; font-size: 0.625rem; }
+  .badge-md { padding: 0.25rem 0.75rem; font-size: 0.75rem; }
+  /* Variants */
+  .badge-default {
+    background: var(--color-surface-2);
+    color: var(--color-text-secondary);
+    border-color: var(--color-surface-3);
+  }
+  .badge-accent {
+    background: color-mix(in srgb, var(--color-accent) 15%, transparent);
+    color: var(--color-accent);
+    border-color: color-mix(in srgb, var(--color-accent) 30%, transparent);
+  }
+  .badge-success {
+    background: color-mix(in srgb, #22c55e 15%, transparent);
+    color: #22c55e;
+    border-color: color-mix(in srgb, #22c55e 30%, transparent);
+  }
+  .badge-warning {
+    background: color-mix(in srgb, #f59e0b 15%, transparent);
+    color: #f59e0b;
+    border-color: color-mix(in srgb, #f59e0b 30%, transparent);
+  }
+  .badge-danger {
+    background: color-mix(in srgb, #ef4444 15%, transparent);
+    color: #ef4444;
+    border-color: color-mix(in srgb, #ef4444 30%, transparent);
+  }
+</style>
+`;
+}
+
+/**
+ * Card component with surface-2 background and accent hover glow.
+ * Renders as <a> when href is provided, otherwise <div>.
+ * File: Card.astro
+ */
+export function getCardComponent(): string {
+  return `---
+export interface Props {
+  href?: string;
+  class?: string;
+}
+const { href, class: className = '' } = Astro.props;
+const Tag = href ? 'a' : 'div';
+---
+<Tag class:list={['card', className, { 'card-link': !!href }]} href={href}>
+  <slot />
+</Tag>
+
+<style>
+  .card {
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-surface-3);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    transition: box-shadow 0.2s, border-color 0.2s;
+  }
+  .card-link {
+    text-decoration: none;
+    color: inherit;
+    display: block;
+    cursor: pointer;
+  }
+  .card:hover {
+    box-shadow: 0 0 0 1px var(--color-accent),
+                0 4px 24px color-mix(in srgb, var(--color-accent) 20%, transparent);
+    border-color: var(--color-accent);
+  }
+</style>
+`;
+}
+
+/**
+ * Returns all Astro components as a record mapping filename to template string.
+ * Suitable for iterating over when scaffolding a new project.
+ */
+export function getAstroComponents(): Record<string, string> {
+  return {
+    'Nav.astro': getNavComponent(),
+    'NavMobileMenu.tsx': getNavMobileMenuComponent(),
+    'Footer.astro': getFooterComponent(),
+    'SEO.astro': getSEOComponent(),
+    'Button.astro': getButtonComponent(),
+    'Badge.astro': getBadgeComponent(),
+    'Card.astro': getCardComponent(),
+  };
+}

--- a/libs/templates/src/components/Badge.astro
+++ b/libs/templates/src/components/Badge.astro
@@ -1,0 +1,87 @@
+---
+/**
+ * Badge — Inline color-coded label with brand token variants.
+ *
+ * Zero client-side JavaScript.
+ *
+ * Usage:
+ *   import Badge from '@protolabsai/templates/components/Badge.astro';
+ *   <Badge color="purple">New</Badge>
+ *   <Badge color="green">Stable</Badge>
+ */
+
+type BadgeColor = 'default' | 'purple' | 'green' | 'yellow' | 'blue' | 'red';
+
+interface Props {
+  /** Color variant */
+  color?: BadgeColor;
+  /** Extra CSS class names */
+  class?: string;
+}
+
+const { color = 'default', class: className = '' } = Astro.props;
+
+const colorClass: Record<BadgeColor, string> = {
+  default: 'badge--default',
+  purple: 'badge--purple',
+  green: 'badge--green',
+  yellow: 'badge--yellow',
+  blue: 'badge--blue',
+  red: 'badge--red',
+};
+
+const classes = ['badge', colorClass[color as BadgeColor], className]
+  .filter(Boolean)
+  .join(' ');
+---
+
+<span class={classes}>
+  <slot />
+</span>
+
+<style>
+  .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 6px;
+    font-size: 11px;
+    font-weight: 500;
+    font-family: var(--font-family-sans, 'Geist', system-ui, sans-serif);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    line-height: 1.6;
+    white-space: nowrap;
+  }
+
+  /* ── Color variants ─────────────────────── */
+
+  .badge--default {
+    background: rgba(255, 255, 255, 0.08);
+    color: #a1a1aa;
+  }
+
+  .badge--purple {
+    background: rgba(167, 139, 250, 0.15);
+    color: var(--color-accent, #a78bfa);
+  }
+
+  .badge--green {
+    background: rgba(74, 222, 128, 0.15);
+    color: var(--color-success, #4ade80);
+  }
+
+  .badge--yellow {
+    background: rgba(250, 204, 21, 0.15);
+    color: var(--color-warning, #facc15);
+  }
+
+  .badge--blue {
+    background: rgba(96, 165, 250, 0.15);
+    color: var(--color-info, #60a5fa);
+  }
+
+  .badge--red {
+    background: rgba(248, 113, 113, 0.15);
+    color: var(--color-danger, #f87171);
+  }
+</style>

--- a/libs/templates/src/components/Button.astro
+++ b/libs/templates/src/components/Button.astro
@@ -1,0 +1,174 @@
+---
+/**
+ * Button — Primary, secondary, and ghost variants with brand tokens.
+ *
+ * Renders an <a> when `href` is supplied, otherwise a <button>.
+ * Zero client-side JavaScript.
+ *
+ * Usage:
+ *   import Button from '@protolabsai/templates/components/Button.astro';
+ *   <Button variant="primary" href="/get-started">Get started</Button>
+ *   <Button variant="ghost" type="submit">Submit</Button>
+ */
+
+interface Props {
+  /** Visual style of the button */
+  variant?: 'primary' | 'secondary' | 'ghost';
+  /** Size preset */
+  size?: 'sm' | 'md' | 'lg';
+  /** When set, renders as an <a> tag */
+  href?: string;
+  /** HTML button type (ignored when href is set) */
+  type?: 'button' | 'submit' | 'reset';
+  /** Disabled state (only meaningful for <button>) */
+  disabled?: boolean;
+  /** Extra CSS class names */
+  class?: string;
+  /** Open link in new tab */
+  target?: '_blank' | '_self' | '_parent' | '_top';
+  /** rel attribute (e.g. "noopener noreferrer") */
+  rel?: string;
+  /** aria-label override */
+  'aria-label'?: string;
+}
+
+const {
+  variant = 'primary',
+  size = 'md',
+  href,
+  type = 'button',
+  disabled = false,
+  class: className = '',
+  target,
+  rel,
+  'aria-label': ariaLabel,
+} = Astro.props;
+
+const classes = ['btn', `btn--${variant}`, `btn--${size}`, className]
+  .filter(Boolean)
+  .join(' ');
+
+// Infer safe rel for external links
+const resolvedRel = rel ?? (target === '_blank' ? 'noopener noreferrer' : undefined);
+---
+
+{
+  href ? (
+    <a
+      href={href}
+      class={classes}
+      target={target}
+      rel={resolvedRel}
+      aria-label={ariaLabel}
+    >
+      <slot />
+    </a>
+  ) : (
+    <button
+      type={type}
+      disabled={disabled}
+      class={classes}
+      aria-label={ariaLabel}
+    >
+      <slot />
+    </button>
+  )
+}
+
+<style>
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    font-family: var(--font-family-sans, 'Geist', system-ui, sans-serif);
+    font-weight: 600;
+    border: none;
+    border-radius: 8px;
+    text-decoration: none;
+    cursor: pointer;
+    white-space: nowrap;
+    line-height: 1;
+    transition:
+      opacity 0.15s ease,
+      transform 0.15s ease,
+      background 0.15s ease,
+      box-shadow 0.15s ease;
+    /* Prevent text selection on double-click */
+    user-select: none;
+  }
+
+  .btn:focus-visible {
+    outline: 2px solid var(--color-accent, #a78bfa);
+    outline-offset: 2px;
+  }
+
+  .btn:not(:disabled):hover {
+    transform: translateY(-1px);
+  }
+
+  .btn:not(:disabled):active {
+    transform: translateY(0);
+  }
+
+  .btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  /* ── Sizes ─────────────────────────────── */
+
+  .btn--sm {
+    padding: 6px 14px;
+    font-size: 13px;
+    border-radius: 6px;
+  }
+
+  .btn--md {
+    padding: 10px 20px;
+    font-size: 15px;
+  }
+
+  .btn--lg {
+    padding: 14px 28px;
+    font-size: 16px;
+    border-radius: 10px;
+  }
+
+  /* ── Variants ───────────────────────────── */
+
+  .btn--primary {
+    background: var(--color-accent, #a78bfa);
+    color: #09090b;
+    box-shadow: 0 0 20px rgba(167, 139, 250, 0.25);
+  }
+
+  .btn--primary:not(:disabled):hover {
+    opacity: 0.9;
+    box-shadow: 0 0 32px rgba(167, 139, 250, 0.4);
+  }
+
+  .btn--secondary {
+    background: rgba(255, 255, 255, 0.06);
+    color: #e4e4e7;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .btn--secondary:not(:disabled):hover {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.18);
+  }
+
+  .btn--ghost {
+    background: transparent;
+    color: #a1a1aa;
+    border: 1px solid transparent;
+  }
+
+  .btn--ghost:not(:disabled):hover {
+    color: #fafafa;
+    background: rgba(255, 255, 255, 0.05);
+    border-color: rgba(255, 255, 255, 0.08);
+  }
+</style>

--- a/libs/templates/src/components/Card.astro
+++ b/libs/templates/src/components/Card.astro
@@ -1,0 +1,102 @@
+---
+/**
+ * Card — Surface-2 content container with hover glow.
+ *
+ * Zero client-side JavaScript.
+ *
+ * Usage:
+ *   import Card from '@protolabsai/templates/components/Card.astro';
+ *   <Card>
+ *     <h3>Title</h3>
+ *     <p>Body text</p>
+ *   </Card>
+ *
+ *   <!-- With href, renders as a clickable anchor -->
+ *   <Card href="/features/automerge">...</Card>
+ */
+
+interface Props {
+  /** When set, wraps content in an <a> for a clickable card */
+  href?: string;
+  /** Controls the glow intensity on hover */
+  glow?: 'none' | 'subtle' | 'strong';
+  /** Extra CSS class names */
+  class?: string;
+  /** aria-label for linked cards */
+  'aria-label'?: string;
+}
+
+const {
+  href,
+  glow = 'subtle',
+  class: className = '',
+  'aria-label': ariaLabel,
+} = Astro.props;
+
+const classes = ['card', `card--glow-${glow}`, href ? 'card--link' : '', className]
+  .filter(Boolean)
+  .join(' ');
+---
+
+{
+  href ? (
+    <a href={href} class={classes} aria-label={ariaLabel}>
+      <slot />
+    </a>
+  ) : (
+    <div class={classes} aria-label={ariaLabel}>
+      <slot />
+    </div>
+  )
+}
+
+<style>
+  .card {
+    background: var(--color-surface-2, #18181b);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 24px;
+    color: inherit;
+    text-decoration: none;
+    transition:
+      border-color 0.2s ease,
+      box-shadow 0.2s ease,
+      transform 0.2s ease;
+  }
+
+  /* ── Hover glow variants ────────────────── */
+
+  .card--glow-none:hover {
+    border-color: rgba(255, 255, 255, 0.1);
+  }
+
+  .card--glow-subtle:hover {
+    border-color: rgba(167, 139, 250, 0.25);
+    box-shadow: 0 0 30px rgba(167, 139, 250, 0.08);
+  }
+
+  .card--glow-strong:hover {
+    border-color: rgba(167, 139, 250, 0.4);
+    box-shadow: 0 0 60px rgba(167, 139, 250, 0.15);
+  }
+
+  /* ── Linked card ────────────────────────── */
+
+  .card--link {
+    cursor: pointer;
+    display: block;
+  }
+
+  .card--link:hover {
+    transform: translateY(-2px);
+  }
+
+  .card--link:focus-visible {
+    outline: 2px solid var(--color-accent, #a78bfa);
+    outline-offset: 2px;
+  }
+
+  .card--link:active {
+    transform: translateY(0);
+  }
+</style>

--- a/libs/templates/src/components/Footer.astro
+++ b/libs/templates/src/components/Footer.astro
@@ -1,0 +1,306 @@
+---
+/**
+ * Footer — Configurable links, social icons, and copyright row.
+ *
+ * Zero client-side JavaScript.
+ *
+ * Usage:
+ *   import Footer from '@protolabsai/templates/components/Footer.astro';
+ *   <Footer
+ *     logoText="protoLabs"
+ *     copyright="protoLabs Studio"
+ *     columns={[
+ *       { heading: 'Product', links: [{ label: 'Docs', href: '/docs' }] },
+ *     ]}
+ *     socials={[{ platform: 'github', href: 'https://github.com/...' }]}
+ *   />
+ */
+
+type SocialPlatform = 'github' | 'twitter' | 'discord' | 'linkedin' | 'youtube';
+
+interface SocialLink {
+  platform: SocialPlatform;
+  href: string;
+  label?: string;
+}
+
+interface FooterLink {
+  label: string;
+  href: string;
+}
+
+interface LinkColumn {
+  heading: string;
+  links: FooterLink[];
+}
+
+interface Props {
+  /** Brand name shown top-left */
+  logoText?: string;
+  /** Route for the logo link */
+  logoHref?: string;
+  /** Short tagline below the logo */
+  tagline?: string;
+  /** Groups of links rendered as columns */
+  columns?: LinkColumn[];
+  /** Social platform icons */
+  socials?: SocialLink[];
+  /** Copyright holder name — year is injected automatically */
+  copyright?: string;
+  /** Extra CSS class names */
+  class?: string;
+}
+
+const {
+  logoText = 'protoLabs',
+  logoHref = '/',
+  tagline,
+  columns = [],
+  socials = [],
+  copyright,
+  class: className = '',
+} = Astro.props;
+
+const year = new Date().getFullYear();
+
+// SVG icon paths for social platforms
+const socialIcons: Record<SocialPlatform, { path: string; viewBox?: string }> = {
+  github: {
+    viewBox: '0 0 24 24',
+    path: 'M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z',
+  },
+  twitter: {
+    viewBox: '0 0 24 24',
+    path: 'M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.259 5.63zm-1.161 17.52h1.833L7.084 4.126H5.117z',
+  },
+  discord: {
+    viewBox: '0 0 24 24',
+    path: 'M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z',
+  },
+  linkedin: {
+    viewBox: '0 0 24 24',
+    path: 'M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z',
+  },
+  youtube: {
+    viewBox: '0 0 24 24',
+    path: 'M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z',
+  },
+};
+---
+
+<footer class={`footer ${className}`}>
+  <div class="footer-inner">
+    <!-- Brand column -->
+    <div class="footer-brand">
+      <a href={logoHref} class="footer-logo" aria-label={`${logoText} — home`}>
+        <span class="gradient-text">{logoText}</span>
+      </a>
+      {tagline && <p class="footer-tagline">{tagline}</p>}
+
+      <!-- Social icons -->
+      {
+        socials.length > 0 && (
+          <div class="footer-socials" role="list" aria-label="Social links">
+            {socials.map((social) => {
+              const icon = socialIcons[social.platform];
+              const label = social.label ?? social.platform;
+              return (
+                <a
+                  role="listitem"
+                  href={social.href}
+                  class="footer-social-link"
+                  aria-label={label}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox={icon.viewBox ?? '0 0 24 24'}
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path d={icon.path} />
+                  </svg>
+                </a>
+              );
+            })}
+          </div>
+        )
+      }
+    </div>
+
+    <!-- Link columns -->
+    {
+      columns.length > 0 && (
+        <nav class="footer-columns" aria-label="Footer navigation">
+          {columns.map((col) => (
+            <div class="footer-column">
+              <h3 class="footer-column-heading">{col.heading}</h3>
+              <ul role="list" class="footer-column-links">
+                {col.links.map((link) => (
+                  <li>
+                    <a href={link.href} class="footer-link">
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </nav>
+      )
+    }
+  </div>
+
+  <!-- Bottom bar -->
+  <div class="footer-bottom">
+    <p class="footer-copyright">
+      {copyright ? `© ${year} ${copyright}. All rights reserved.` : `© ${year}`}
+    </p>
+  </div>
+</footer>
+
+<style>
+  .footer {
+    background: var(--color-surface-1, #111113);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    color: #71717a;
+    font-family: var(--font-family-sans, 'Geist', system-ui, sans-serif);
+  }
+
+  .footer-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 48px 24px 32px;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 40px;
+  }
+
+  @media (min-width: 640px) {
+    .footer-inner {
+      grid-template-columns: 200px 1fr;
+    }
+  }
+
+  /* ── Brand ──────────────────────────────── */
+
+  .footer-logo {
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    text-decoration: none;
+    display: inline-block;
+    margin-bottom: 12px;
+  }
+
+  .footer-tagline {
+    font-size: 14px;
+    line-height: 1.5;
+    margin: 0 0 20px;
+    max-width: 220px;
+  }
+
+  .footer-socials {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .footer-social-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    color: #71717a;
+    text-decoration: none;
+    transition:
+      color 0.15s,
+      background 0.15s,
+      border-color 0.15s;
+  }
+
+  .footer-social-link:hover {
+    color: #fafafa;
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.12);
+  }
+
+  .footer-social-link:focus-visible {
+    outline: 2px solid var(--color-accent, #a78bfa);
+    outline-offset: 2px;
+  }
+
+  /* ── Link columns ───────────────────────── */
+
+  .footer-columns {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 32px;
+  }
+
+  .footer-column-heading {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #e4e4e7;
+    margin: 0 0 16px;
+  }
+
+  .footer-column-links {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .footer-link {
+    font-size: 14px;
+    color: #71717a;
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+
+  .footer-link:hover {
+    color: #fafafa;
+  }
+
+  .footer-link:focus-visible {
+    outline: 2px solid var(--color-accent, #a78bfa);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  /* ── Bottom bar ─────────────────────────── */
+
+  .footer-bottom {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px 24px;
+    border-top: 1px solid rgba(255, 255, 255, 0.04);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .footer-copyright {
+    font-size: 13px;
+    margin: 0;
+  }
+
+  /* gradient-text is defined in design-tokens — fallback if not loaded */
+  .gradient-text {
+    background: linear-gradient(135deg, #a78bfa 0%, #818cf8 50%, #6366f1 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+</style>

--- a/libs/templates/src/components/MobileMenu.tsx
+++ b/libs/templates/src/components/MobileMenu.tsx
@@ -1,0 +1,230 @@
+/**
+ * MobileMenu — React island for the Nav component's mobile drawer.
+ *
+ * Used internally by Nav.astro as `<MobileMenu client:load />`.
+ * Consumers should import Nav.astro rather than this component directly.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+
+interface NavLink {
+  label: string;
+  href: string;
+}
+
+interface MobileMenuProps {
+  links: NavLink[];
+  ctaLabel?: string;
+  ctaHref?: string;
+}
+
+export default function MobileMenu({ links, ctaLabel, ctaHref }: MobileMenuProps) {
+  const [open, setOpen] = useState(false);
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  // Prevent body scroll when drawer is open
+  useEffect(() => {
+    document.body.style.overflow = open ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [open]);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  return (
+    <div style={styles.wrapper}>
+      {/* Hamburger / close toggle */}
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-label={open ? 'Close menu' : 'Open menu'}
+        aria-expanded={open}
+        aria-controls="mobile-nav-drawer"
+        style={styles.toggle}
+      >
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 18 18"
+          fill="none"
+          aria-hidden="true"
+          style={{ display: 'block' }}
+        >
+          {open ? (
+            // X icon
+            <>
+              <line
+                x1="2"
+                y1="2"
+                x2="16"
+                y2="16"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+              <line
+                x1="16"
+                y1="2"
+                x2="2"
+                y2="16"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+            </>
+          ) : (
+            // Hamburger lines
+            <>
+              <line
+                x1="1"
+                y1="4"
+                x2="17"
+                y2="4"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+              <line
+                x1="1"
+                y1="9"
+                x2="17"
+                y2="9"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+              <line
+                x1="1"
+                y1="14"
+                x2="17"
+                y2="14"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+            </>
+          )}
+        </svg>
+      </button>
+
+      {/* Mobile nav drawer */}
+      {open && (
+        <>
+          {/* Backdrop */}
+          <div style={styles.backdrop} onClick={close} aria-hidden="true" />
+
+          {/* Drawer */}
+          <nav id="mobile-nav-drawer" style={styles.drawer} aria-label="Mobile navigation">
+            <ul role="list" style={styles.linkList}>
+              {links.map((link) => (
+                <li key={link.href}>
+                  <a href={link.href} style={styles.link} onClick={close}>
+                    {link.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+
+            {ctaLabel && ctaHref && (
+              <div style={styles.ctaWrapper}>
+                <a href={ctaHref} style={styles.cta} onClick={close}>
+                  {ctaLabel}
+                </a>
+              </div>
+            )}
+          </nav>
+        </>
+      )}
+    </div>
+  );
+}
+
+// Inline styles — no CSS-in-JS dependency required
+const styles = {
+  wrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    marginLeft: 'auto',
+  } satisfies React.CSSProperties,
+
+  toggle: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '40px',
+    height: '40px',
+    background: 'transparent',
+    border: '1px solid rgba(255,255,255,0.08)',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    color: '#a1a1aa',
+    padding: '0',
+    transition: 'border-color 0.15s, color 0.15s',
+    flexShrink: 0,
+  } satisfies React.CSSProperties,
+
+  backdrop: {
+    position: 'fixed',
+    inset: '64px 0 0 0',
+    background: 'rgba(0,0,0,0.6)',
+    zIndex: 48,
+  } satisfies React.CSSProperties,
+
+  drawer: {
+    position: 'fixed',
+    top: '64px',
+    left: '0',
+    right: '0',
+    background: 'rgba(9,9,11,0.97)',
+    borderBottom: '1px solid rgba(255,255,255,0.06)',
+    backdropFilter: 'blur(12px)',
+    padding: '16px 24px 24px',
+    zIndex: 49,
+  } satisfies React.CSSProperties,
+
+  linkList: {
+    listStyle: 'none',
+    margin: '0',
+    padding: '0',
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: '2px',
+  } satisfies React.CSSProperties,
+
+  link: {
+    display: 'block',
+    color: '#a1a1aa',
+    textDecoration: 'none',
+    fontSize: '16px',
+    fontWeight: '500',
+    padding: '12px 16px',
+    borderRadius: '8px',
+  } satisfies React.CSSProperties,
+
+  ctaWrapper: {
+    marginTop: '16px',
+    paddingTop: '16px',
+    borderTop: '1px solid rgba(255,255,255,0.06)',
+  } satisfies React.CSSProperties,
+
+  cta: {
+    display: 'block',
+    textAlign: 'center' as const,
+    padding: '12px 20px',
+    background: '#a78bfa',
+    color: '#09090b',
+    borderRadius: '8px',
+    fontSize: '15px',
+    fontWeight: '600',
+    textDecoration: 'none',
+  } satisfies React.CSSProperties,
+} as const;

--- a/libs/templates/src/components/Nav.astro
+++ b/libs/templates/src/components/Nav.astro
@@ -1,0 +1,229 @@
+---
+/**
+ * Nav — Sticky header with gradient logo text and a React mobile menu island.
+ *
+ * The desktop nav and CTA are pure HTML (zero JS).
+ * The mobile hamburger toggle uses a React island (`client:load`) so it
+ * stays lightweight on initial page load while fully interactive.
+ *
+ * Usage:
+ *   import Nav from '@protolabsai/templates/components/Nav.astro';
+ *   <Nav
+ *     logoText="protoLabs"
+ *     links={[{ label: 'Docs', href: '/docs' }, { label: 'Blog', href: '/blog' }]}
+ *     ctaLabel="Get started"
+ *     ctaHref="/get-started"
+ *   />
+ *
+ * Requires @astrojs/react integration for the MobileMenu island.
+ */
+
+import MobileMenu from './MobileMenu.tsx';
+
+interface NavLink {
+  label: string;
+  href: string;
+}
+
+interface Props {
+  /** Brand name shown as gradient text */
+  logoText?: string;
+  /** Route the logo links to */
+  logoHref?: string;
+  /** Navigation links shown in the desktop header */
+  links?: NavLink[];
+  /** CTA button label — hidden on mobile */
+  ctaLabel?: string;
+  /** CTA button href */
+  ctaHref?: string;
+  /** Extra CSS class names on the <header> */
+  class?: string;
+}
+
+const {
+  logoText = 'protoLabs',
+  logoHref = '/',
+  links = [],
+  ctaLabel,
+  ctaHref,
+  class: className = '',
+} = Astro.props;
+---
+
+<!-- Skip-to-content link for keyboard / screen reader users -->
+<a href="#main-content" class="skip-link">Skip to main content</a>
+
+<header class={`nav-wrapper ${className}`} id="site-nav">
+  <nav class="nav-inner" aria-label="Main navigation">
+    <!-- Logo -->
+    <a href={logoHref} class="nav-logo" aria-label={`${logoText} — home`}>
+      <span class="gradient-text">{logoText}</span>
+    </a>
+
+    <!-- Desktop link list -->
+    {
+      links.length > 0 && (
+        <ul class="nav-links" role="list" aria-label="Site pages">
+          {links.map((link) => (
+            <li>
+              <a href={link.href} class="nav-link">
+                {link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )
+    }
+
+    <!-- Desktop CTA — hidden below md breakpoint -->
+    {
+      ctaLabel && ctaHref && (
+        <a href={ctaHref} class="nav-cta" aria-label={ctaLabel}>
+          {ctaLabel}
+        </a>
+      )
+    }
+
+    <!-- Mobile menu React island (hamburger + drawer) -->
+    <MobileMenu links={links} ctaLabel={ctaLabel} ctaHref={ctaHref} client:load />
+  </nav>
+</header>
+
+<style>
+  /* ── Skip link (accessibility) ─────────── */
+  .skip-link {
+    position: absolute;
+    top: -100%;
+    left: 16px;
+    z-index: 100;
+    padding: 8px 16px;
+    background: var(--color-accent, #a78bfa);
+    color: #fff;
+    border-radius: 0 0 8px 8px;
+    font-size: 14px;
+    font-weight: 500;
+    text-decoration: none;
+    transition: top 0.2s;
+  }
+
+  .skip-link:focus {
+    top: 0;
+  }
+
+  /* ── Header wrapper ─────────────────────── */
+  .nav-wrapper {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    width: 100%;
+    background: rgba(9, 9, 11, 0.82);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  /* ── Inner flex row ─────────────────────── */
+  .nav-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 24px;
+    height: 64px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  /* ── Logo ───────────────────────────────── */
+  .nav-logo {
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    text-decoration: none;
+    flex-shrink: 0;
+    margin-right: 24px;
+  }
+
+  /* gradient-text: fallback if design-tokens CSS not loaded */
+  .gradient-text {
+    background: linear-gradient(135deg, #a78bfa 0%, #818cf8 50%, #6366f1 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  /* ── Desktop nav links ──────────────────── */
+  .nav-links {
+    display: none;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    gap: 2px;
+    flex: 1;
+  }
+
+  @media (min-width: 768px) {
+    .nav-links {
+      display: flex;
+    }
+  }
+
+  .nav-link {
+    display: inline-flex;
+    align-items: center;
+    color: #a1a1aa;
+    text-decoration: none;
+    font-size: 14px;
+    font-weight: 500;
+    padding: 6px 12px;
+    border-radius: 6px;
+    transition:
+      color 0.15s,
+      background 0.15s;
+    font-family: var(--font-family-sans, 'Geist', system-ui, sans-serif);
+  }
+
+  .nav-link:hover {
+    color: #fafafa;
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  .nav-link:focus-visible {
+    outline: 2px solid var(--color-accent, #a78bfa);
+    outline-offset: 2px;
+  }
+
+  /* ── Desktop CTA ────────────────────────── */
+  .nav-cta {
+    display: none;
+    align-items: center;
+    padding: 8px 18px;
+    background: var(--color-accent, #a78bfa);
+    color: #09090b;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    text-decoration: none;
+    white-space: nowrap;
+    margin-left: auto;
+    transition:
+      opacity 0.15s,
+      transform 0.15s;
+    font-family: var(--font-family-sans, 'Geist', system-ui, sans-serif);
+  }
+
+  @media (min-width: 768px) {
+    .nav-cta {
+      display: inline-flex;
+    }
+  }
+
+  .nav-cta:hover {
+    opacity: 0.9;
+    transform: translateY(-1px);
+  }
+
+  .nav-cta:focus-visible {
+    outline: 2px solid var(--color-accent, #a78bfa);
+    outline-offset: 2px;
+  }
+</style>

--- a/libs/templates/src/components/SEO.astro
+++ b/libs/templates/src/components/SEO.astro
@@ -1,0 +1,72 @@
+---
+/**
+ * SEO — Meta tag component for Astro pages.
+ *
+ * Renders <title>, description, Open Graph, Twitter Card, and canonical tags
+ * from strongly-typed props. Drop inside <head> on every page.
+ *
+ * Usage:
+ *   import SEO from '@protolabsai/templates/components/SEO.astro';
+ *   <SEO title="Home" description="..." image="/og.png" />
+ */
+
+interface Props {
+  /** Page title — used in <title> and og:title */
+  title: string;
+  /** Short description — used in meta description and og:description */
+  description?: string;
+  /** Absolute URL to the OG / Twitter card image */
+  image?: string;
+  /** Canonical URL for this page */
+  canonical?: string;
+  /** og:type — defaults to "website" */
+  type?: 'website' | 'article' | 'profile';
+  /** Twitter card style — defaults to "summary_large_image" */
+  twitterCard?: 'summary' | 'summary_large_image' | 'app' | 'player';
+  /** Twitter / X handle, e.g. "@protoLabsAI" */
+  twitterSite?: string;
+  /** Robots directive — defaults to "index, follow" */
+  robots?: string;
+  /** Optional site name shown in og:site_name */
+  siteName?: string;
+  /** Additional author meta value */
+  author?: string;
+}
+
+const {
+  title,
+  description,
+  image,
+  canonical,
+  type = 'website',
+  twitterCard = 'summary_large_image',
+  twitterSite,
+  robots = 'index, follow',
+  siteName,
+  author,
+} = Astro.props;
+
+const resolvedCanonical = canonical ?? Astro.url?.href;
+---
+
+<!-- Primary meta -->
+<title>{title}</title>
+{description && <meta name="description" content={description} />}
+{robots && <meta name="robots" content={robots} />}
+{author && <meta name="author" content={author} />}
+{resolvedCanonical && <link rel="canonical" href={resolvedCanonical} />}
+
+<!-- Open Graph -->
+<meta property="og:title" content={title} />
+{description && <meta property="og:description" content={description} />}
+<meta property="og:type" content={type} />
+{resolvedCanonical && <meta property="og:url" content={resolvedCanonical} />}
+{image && <meta property="og:image" content={image} />}
+{siteName && <meta property="og:site_name" content={siteName} />}
+
+<!-- Twitter / X Card -->
+<meta name="twitter:card" content={twitterCard} />
+<meta name="twitter:title" content={title} />
+{description && <meta name="twitter:description" content={description} />}
+{image && <meta name="twitter:image" content={image} />}
+{twitterSite && <meta name="twitter:site" content={twitterSite} />}

--- a/libs/templates/src/components/index.ts
+++ b/libs/templates/src/components/index.ts
@@ -1,0 +1,49 @@
+/**
+ * @protolabsai/templates — Shared Astro component type re-exports
+ *
+ * Astro components (.astro) and the React island (MobileMenu.tsx) are
+ * distributed as source files and imported directly in Astro projects:
+ *
+ *   import Nav    from '@protolabsai/templates/components/Nav.astro';
+ *   import Footer from '@protolabsai/templates/components/Footer.astro';
+ *   import SEO    from '@protolabsai/templates/components/SEO.astro';
+ *   import Button from '@protolabsai/templates/components/Button.astro';
+ *   import Badge  from '@protolabsai/templates/components/Badge.astro';
+ *   import Card   from '@protolabsai/templates/components/Card.astro';
+ *
+ * This file exports shared TypeScript interfaces used across components so
+ * consuming projects can type their own data structures.
+ */
+
+// ── Shared interfaces used across components ────────────────────────────────
+
+export interface NavLink {
+  label: string;
+  href: string;
+}
+
+export interface FooterLink {
+  label: string;
+  href: string;
+}
+
+export interface FooterColumn {
+  heading: string;
+  links: FooterLink[];
+}
+
+export type SocialPlatform = 'github' | 'twitter' | 'discord' | 'linkedin' | 'youtube';
+
+export interface SocialLink {
+  platform: SocialPlatform;
+  href: string;
+  /** Accessible label — defaults to platform name */
+  label?: string;
+}
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+export type BadgeColor = 'default' | 'purple' | 'green' | 'yellow' | 'blue' | 'red';
+
+export type CardGlow = 'none' | 'subtle' | 'strong';

--- a/libs/templates/src/index.ts
+++ b/libs/templates/src/index.ts
@@ -50,3 +50,29 @@ export { getDocsCI, getExtensionCI } from './ci.js';
 // Design tokens
 export { getDesignTokensCss, getDesignTokensThemeBlock, designTokens } from './design-tokens.js';
 export type { DesignTokens } from './design-tokens.js';
+
+// Astro component string templates (for project scaffolding — write to disk)
+export {
+  getNavComponent,
+  getNavMobileMenuComponent,
+  getFooterComponent,
+  getSEOComponent,
+  getButtonComponent,
+  getBadgeComponent,
+  getCardComponent,
+  getAstroComponents,
+} from './components.js';
+
+// Shared component prop interfaces (for typed usage in consuming Astro projects)
+// Astro components are imported directly: import Nav from '@protolabsai/templates/components/Nav.astro'
+export type {
+  NavLink,
+  FooterLink,
+  FooterColumn,
+  SocialPlatform,
+  SocialLink,
+  ButtonVariant,
+  ButtonSize,
+  BadgeColor,
+  CardGlow,
+} from './components/index.js';


### PR DESCRIPTION
## Summary

Adds reusable Astro UI components and string scaffolding templates to `@protolabsai/templates` for the protoLabs shared design system.

### New importable Astro components (`src/components/`)

| Component | Description |
|-----------|-------------|
| `Nav.astro` | Sticky header, gradient logo text, React mobile menu island |
| `MobileMenu.tsx` | React island — hamburger toggle + animated mobile drawer |
| `Footer.astro` | Configurable link columns, social icons (GitHub/X/Discord/LinkedIn/YouTube), copyright |
| `SEO.astro` | Full meta tag suite — OG, Twitter Card, canonical, robots |
| `Button.astro` | `primary / secondary / ghost` variants × `sm / md / lg` sizes |
| `Badge.astro` | `default / purple / green / yellow / blue / red` color variants |
| `Card.astro` | surface-2 background, `subtle / strong / none` hover glow, optional linked card |

Import via: `import Nav from '@protolabsai/templates/components/Nav.astro'`

### String scaffolding templates (`src/components.ts`)

`getNavComponent()`, `getFooterComponent()`, `getSEOComponent()`, `getButtonComponent()`, `getBadgeComponent()`, `getCardComponent()`, `getAstroComponents()` — returns component source as strings for writing to disk during project scaffolding.

### Package changes

- `exports` — adds `"./components/*"` → `"./src/components/*"` wildcard for direct Astro imports
- `files` — includes `src/components/` in published package
- `peerDependencies` — `astro ≥4`, `react ≥18`, `react-dom ≥18` (all optional)
- `src/index.ts` — re-exports shared prop interfaces (`NavLink`, `FooterColumn`, `SocialLink`, `ButtonVariant`, etc.)
- `.prettierignore` — adds `*.astro` (no `prettier-plugin-astro` in this monorepo)

## Acceptance criteria

- [x] Nav with sticky positioning and gradient logo text
- [x] Footer with configurable links and social icons
- [x] SEO component for all meta tags
- [x] Button, Badge, Card components with brand tokens
- [x] Zero JS for static components (only Nav's MobileMenu uses React)

## Test plan

- [x] `npm run build --workspace=libs/templates` → ⚡️ Build success (ESM + DTS)
- [x] `npm run build:check --workspace=libs/templates` → TypeScript check passes (0 errors)
- [x] `npm run test --workspace=libs/templates` → 22 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)