### PR TITLE
fix: gate HITL forms behind hitlForms feature flag

### DIFF
--- a/apps/server/src/services/hitl-form-service.ts
+++ b/apps/server/src/services/hitl-form-service.ts
@@ -92,6 +92,18 @@ export class HITLFormService {
    * Create a new form request.
    */
   async create(input: HITLFormRequestInput): Promise<HITLFormRequest | null> {
+    // Gate: HITL forms are disabled unless the hitlForms feature flag is enabled
+    if (this.settingsService) {
+      const settings = await this.settingsService.getGlobalSettings();
+      const hitlEnabled = settings?.featureFlags?.hitlForms ?? false;
+      if (!hitlEnabled) {
+        return null;
+      }
+    } else {
+      // No settings service wired — default to disabled
+      return null;
+    }
+
     if (!input.title || !input.steps?.length) {
       throw new Error('title and at least one step are required');
     }

--- a/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
+++ b/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
@@ -39,6 +39,11 @@ const FEATURE_FLAG_LABELS: Record<keyof FeatureFlags, { label: string; descripti
     description:
       'Enable the reactive orchestrator that monitors the Ava Channel and auto-responds to incoming messages. Requires hivemind mode.',
   },
+  hitlForms: {
+    label: 'HITL Forms',
+    description:
+      'Enable human-in-the-loop interrupt forms from PM Agent, Signal Intake, and Lead Engineer. When off, gated actions are auto-approved or escalated to Ava.',
+  },
 };
 
 // Role badge colour mapping

--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -207,6 +207,12 @@ export interface FeatureFlags {
    * Requires hivemind to be enabled in proto.config.yaml. Off by default.
    */
   reactorEnabled: boolean;
+  /**
+   * HITL Forms — enables human-in-the-loop interrupt forms from PM Agent,
+   * Signal Intake, and Lead Engineer. When disabled, HITL-gated actions
+   * are auto-approved or escalated to Ava instead. Off by default.
+   */
+  hitlForms: boolean;
 }
 
 /** Default feature flags — all off by default, opt-in per environment */
@@ -216,6 +222,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   systemView: false,
   userPresenceDetection: false,
   reactorEnabled: false,
+  hitlForms: false,
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Adds `hitlForms` feature flag to `FeatureFlags` (default: `false`)
- Re-adds HITL form creation guard in `hitl-form-service.ts` — returns `null` when flag is off
- Adds UI label in developer settings section

Pipeline flag removal (`featureFlags.pipeline`) inadvertently ungated HITL forms. They now fire on every feature action, blocking autonomous work with popup forms.

## Test plan

- [x] New flag defaults to false — HITL forms won't fire
- [x] Toggle on in Settings > Developer to re-enable
- [ ] Verify forms stop appearing after server restart with flag off


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HITL Forms feature flag, configurable via developer settings and disabled by default. Form creation is now controlled by this flag to manage human-in-the-loop functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->