### PR TITLE
feat(templates): docs starter kit CI, agent context, and StarterKitType export

### DIFF
--- a/libs/templates/src/index.ts
+++ b/libs/templates/src/index.ts
@@ -47,6 +47,9 @@ export { getCodingRules } from './coding-rules.js';
 // CI templates
 export { getDocsCI, getExtensionCI } from './ci.js';
 
+// Starter kit context files (write to .automaker/CONTEXT.md in new projects)
+export { getDocsStarterContext } from './starters.js';
+
 // Design tokens
 export { getDesignTokensCss, getDesignTokensThemeBlock, designTokens } from './design-tokens.js';
 export type { DesignTokens } from './design-tokens.js';

--- a/libs/templates/src/starters.ts
+++ b/libs/templates/src/starters.ts
@@ -1,0 +1,103 @@
+/**
+ * Starter Kit Context Files
+ *
+ * Returns the content of .automaker/CONTEXT.md for each starter kit type.
+ * Scaffolding tools write these to the project root so agents understand
+ * the project's framework, routing, and conventions.
+ */
+
+/**
+ * Get the agent context file content for the Starlight docs starter kit.
+ * Write this to `.automaker/CONTEXT.md` in the new project.
+ */
+export function getDocsStarterContext(): string {
+  return `# Docs Starter Kit — Agent Context
+
+This project is a **Starlight documentation site** built with Astro 5 and Starlight 0.37.
+
+## Project Structure
+
+\`\`\`
+src/
+  content/
+    docs/          ← All documentation pages live here
+      index.mdx    ← Root page (maps to /)
+      guides/      ← How-to guides
+      reference/   ← Reference pages
+      tutorials/   ← Step-by-step tutorials
+  styles/
+    global.css     ← Theme overrides (CSS variables + Tailwind v4 @theme block)
+  content.config.ts ← Collection schema (docsLoader + docsSchema)
+  assets/          ← Images and static files
+astro.config.mjs   ← Starlight + Astro config
+\`\`\`
+
+## Content Collections
+
+All docs use Astro's **content collections** via \`src/content.config.ts\`. The \`docs\` collection uses Starlight's \`docsLoader()\` and \`docsSchema()\`:
+
+\`\`\`ts
+import { defineCollection } from 'astro:content';
+import { docsLoader, docsSchema } from '@astrojs/starlight/loaders';
+
+export const collections = {
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+};
+\`\`\`
+
+## Page Frontmatter
+
+Every \`.mdx\` / \`.md\` file in \`src/content/docs/\` requires at minimum:
+
+\`\`\`yaml
+---
+title: Page Title
+description: Short description for SEO and sidebar tooltips
+---
+\`\`\`
+
+Optional fields: \`sidebar\` (label, order, badge, hidden), \`hero\`, \`tableOfContents\`, \`editUrl\`, \`prev\`, \`next\`.
+
+## Routing
+
+Starlight auto-generates routes from the file tree:
+- \`src/content/docs/index.mdx\` → \`/\`
+- \`src/content/docs/guides/add-a-page.mdx\` → \`/guides/add-a-page/\`
+- \`src/content/docs/reference/configuration.mdx\` → \`/reference/configuration/\`
+
+## Theming
+
+Theme customization lives in \`src/styles/global.css\`. Starlight exposes \`--sl-*\` CSS variables. Override them inside a \`[data-theme='light']\` or \`[data-theme='dark']\` selector, or globally:
+
+\`\`\`css
+:root {
+  --sl-color-accent: 124, 58, 237;  /* violet accent */
+}
+\`\`\`
+
+A Tailwind v4 \`@theme\` block can also be added for utility classes.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| \`npm run dev\` | Start local dev server |
+| \`npm run build\` | Build production site to \`dist/\` |
+| \`npm run preview\` | Preview the production build |
+| \`npm run format\` | Format all files with Prettier |
+| \`npm run format:check\` | Check formatting (used in CI) |
+| \`npm run lint:md\` | Lint markdown/MDX content with markdownlint-cli2 |
+
+## CI/CD
+
+\`.github/workflows/ci.yml\` runs **build**, **format**, and **lint** jobs on every PR and push to \`main\`. On merge to \`main\`, a **deploy** job pushes to Cloudflare Pages using \`CLOUDFLARE_API_TOKEN\` and \`CLOUDFLARE_ACCOUNT_ID\` secrets.
+
+## Key Constraints
+
+- Starlight is pinned to \`^0.37.0\` (last Astro 5-compatible release). Do not upgrade to 0.38+ without also upgrading Astro to v6.
+- Zod is pinned to \`^3.25.0\` because Starlight 0.37 requires Zod v3 (monorepo root has v4).
+- \`*.astro\` files are excluded from Prettier — \`prettier-plugin-astro\` is installed locally but not at the monorepo root.
+- New pages go in \`src/content/docs/\`. Do not create pages in \`src/pages/\` — Starlight handles routing.
+- Search is powered by Pagefind, auto-enabled at build time. No config required.
+`;
+}

--- a/libs/templates/starters/docs/.automaker/CONTEXT.md
+++ b/libs/templates/starters/docs/.automaker/CONTEXT.md
@@ -1,0 +1,88 @@
+# Docs Starter Kit — Agent Context
+
+This project is a **Starlight documentation site** built with Astro 5 and Starlight 0.37.
+
+## Project Structure
+
+```
+src/
+  content/
+    docs/          ← All documentation pages live here
+      index.mdx    ← Root page (maps to /)
+      guides/      ← How-to guides
+      reference/   ← Reference pages
+      tutorials/   ← Step-by-step tutorials
+  styles/
+    global.css     ← Theme overrides (CSS variables + Tailwind v4 @theme block)
+  content.config.ts ← Collection schema (docsLoader + docsSchema)
+  assets/          ← Images and static files
+astro.config.mjs   ← Starlight + Astro config
+```
+
+## Content Collections
+
+All docs use Astro's **content collections** via `src/content.config.ts`. The `docs` collection uses Starlight's `docsLoader()` and `docsSchema()`:
+
+```ts
+import { defineCollection } from 'astro:content';
+import { docsLoader, docsSchema } from '@astrojs/starlight/loaders';
+
+export const collections = {
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+};
+```
+
+## Page Frontmatter
+
+Every `.mdx` / `.md` file in `src/content/docs/` requires at minimum:
+
+```yaml
+---
+title: Page Title
+description: Short description for SEO and sidebar tooltips
+---
+```
+
+Optional fields: `sidebar` (label, order, badge, hidden), `hero`, `tableOfContents`, `editUrl`, `prev`, `next`.
+
+## Routing
+
+Starlight auto-generates routes from the file tree:
+- `src/content/docs/index.mdx` → `/`
+- `src/content/docs/guides/add-a-page.mdx` → `/guides/add-a-page/`
+- `src/content/docs/reference/configuration.mdx` → `/reference/configuration/`
+
+## Theming
+
+Theme customization lives in `src/styles/global.css`. Starlight exposes `--sl-*` CSS variables. Override them inside a `[data-theme='light']` or `[data-theme='dark']` selector, or globally:
+
+```css
+:root {
+  --sl-color-accent: 124, 58, 237;  /* violet accent */
+}
+```
+
+A Tailwind v4 `@theme` block can also be added for utility classes.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `npm run dev` | Start local dev server |
+| `npm run build` | Build production site to `dist/` |
+| `npm run preview` | Preview the production build |
+| `npm run format` | Format all files with Prettier |
+| `npm run format:check` | Check formatting (used in CI) |
+| `npm run lint:md` | Lint markdown/MDX content with markdownlint-cli2 |
+
+## CI/CD
+
+`.github/workflows/ci.yml` runs **build**, **format**, and **lint** jobs on every PR and push to `main`. On merge to `main`, a **deploy** job pushes to Cloudflare Pages using `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets.
+
+## Key Constraints
+
+- Starlight is pinned to `^0.37.0` (last Astro 5-compatible release). Do not upgrade to 0.38+ without also upgrading Astro to v6.
+- Zod is pinned to `^3.25.0` because Starlight 0.37 requires Zod v3 (monorepo root has v4).
+- `*.astro` files are excluded from Prettier (see `.prettierrc`) — `prettier-plugin-astro` is installed locally but not at the monorepo root.
+- New pages go in `src/content/docs/`. Do not create pages in `src/pages/` — Starlight handles routing.
+- Search is powered by Pagefind, auto-enabled at build time. No config required.

--- a/libs/templates/starters/docs/.github/workflows/ci.yml
+++ b/libs/templates/starters/docs/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run format:check
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run lint:md
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: [build, format, lint]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=${{ github.event.repository.name }}


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` to the docs (Starlight) starter kit with **build**, **format**, **lint**, and **deploy** jobs (Cloudflare Pages on merge to main)
- Add `.automaker/CONTEXT.md` explaining Starlight structure, content collections, routing, theming, commands, and key constraints for agents working on docs projects
- Add `getDocsStarterContext()` function in `libs/templates/src/starters.ts` that returns the context content as a string for scaffolding tools
- Export `getDocsStarterContext` from `libs/templates/src/index.ts`

## Test plan

- [ ] CI workflow has build, format, lint, and deploy jobs
- [ ] Agent context file covers Starlight structure (routing, content collections, frontmatter, theming)
- [ ] `getDocsStarterContext()` is importable from `@protolabsai/templates`
- [ ] `libs/templates` builds cleanly: `npm run build --workspace=libs/templates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Docs Starter Kit template with built-in documentation structure and configuration guidance.
  * Added automated CI/CD pipeline to starter projects, enabling build checks, formatting validation, linting, and deployment to Cloudflare Pages on every push.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->