### PR TITLE
feat(templates): add docs/ directory to docs and portfolio starter kits

### DIFF
--- a/libs/templates/starters/docs/docs/documentation-philosophy.md
+++ b/libs/templates/starters/docs/docs/documentation-philosophy.md
@@ -1,0 +1,116 @@
+# Documentation philosophy
+
+This page explains how this starter kit approaches documentation structure and writing. It covers the Diataxis framework, the protoLabs writing principles built on top of it, and the single metric that tells you if your docs are working.
+
+## The Diataxis framework
+
+[Diataxis](https://diataxis.fr) divides documentation into four distinct content types. Each type serves a different user need. Mixing them in a single page produces content that serves none of them well.
+
+| Type | Question it answers | Structure |
+|------|---------------------|-----------|
+| **Tutorial** | "Can you show me how to do this for the first time?" | Narrative walkthrough — the reader follows along and builds something |
+| **How-to guide** | "How do I accomplish X?" | Numbered steps — assumes competence, delivers a result |
+| **Reference** | "What are all the options?" | Structured facts — complete, accurate, terse |
+| **Explanation** | "Why does it work this way?" | Discursive prose — context, reasoning, trade-offs |
+
+### Recognising the wrong type
+
+The most common mistake is blending types. Use these tests:
+
+- If you are explaining concepts inside a how-to guide, extract the explanation to a separate page and link to it.
+- If your tutorial contains a table of every configuration option, move the table to reference and link to it.
+- If your reference page has a narrative section at the top, it should be its own explanation page.
+
+### How protoLabs implements Diataxis
+
+The canonical example is [docs.protolabs.studio](https://docs.protolabs.studio). The sidebar mirrors the four quadrants:
+
+- **Tutorials** → `Getting started` section (build something real in under 10 minutes)
+- **How-to guides** → `Guides` section (task-focused, numbered steps)
+- **Reference** → `Reference` section (API, config options, event types)
+- **Explanation** → `Concepts` section (architecture decisions, design rationale)
+
+This starter kit ships with the same sidebar structure. Replace the placeholder pages with your own content and keep each page in the correct quadrant.
+
+---
+
+## Writing principles
+
+### Code before prose
+
+Show the code first. Explain it after, in one to three sentences. Readers scan for code blocks first — if the code is buried in a paragraph, they miss it.
+
+```bash
+# Start the dev server
+npm run dev
+```
+
+Open [localhost:4321](http://localhost:4321) in your browser. The live-reload server rebuilds on every file save.
+
+### One idea per sentence
+
+Long sentences with multiple clauses slow readers down and make translation harder. Each sentence should carry one idea.
+
+**Avoid:**
+> The sidebar is generated automatically from the directory structure inside `src/content/docs/`, which means you never need to update a list by hand when adding new pages.
+
+**Prefer:**
+> The sidebar mirrors the directory structure inside `src/content/docs/`. Add a file and it appears automatically — no list to maintain.
+
+### Progressive disclosure
+
+Lead with the simplest, most common case. Put advanced options, edge cases, and caveats at the bottom of the page or on a separate page.
+
+Readers who want the defaults should be unblocked by the first code block. Readers who want to customise can keep reading.
+
+### Outcome-focused headings
+
+Headings are navigation aids, not labels. Use verb phrases that describe what the reader will achieve.
+
+| Avoid | Prefer |
+|-------|--------|
+| Sidebar configuration | Configure the sidebar |
+| Authentication | Add GitHub OAuth |
+| Environment variables | Set up your .env file |
+
+### Every page opens with orientation
+
+The first paragraph of every page answers three questions:
+
+1. What does this page cover?
+2. Who is it for?
+3. What will the reader have or know after reading it?
+
+One paragraph is enough. Skip it and readers don't know if they're in the right place.
+
+### No marketing language
+
+Describe what something does, not how impressive it is. Readers are engineers. They will notice and distrust adjectives like "powerful", "seamless", and "robust".
+
+**Avoid:** "The powerful built-in search gives your users a seamless discovery experience."
+
+**Prefer:** "Pagefind indexes your site at build time. Search results appear in under 50 ms with no server required."
+
+---
+
+## Time to First Hello World (TTFHW)
+
+TTFHW is the single number that tells you if your getting-started docs are working. It measures the elapsed time from "I found this project" to "I have something running on my machine."
+
+A good TTFHW is under five minutes. The getting-started tutorial in this starter kit targets three minutes.
+
+**What kills TTFHW:**
+
+- Prerequisites buried halfway through the page
+- Steps that assume context the reader doesn't have
+- A missing `npm install` between two other steps
+- Placeholder values that look like real values (e.g., `API_KEY=abc123`)
+
+**What helps TTFHW:**
+
+- Prerequisites listed at the top, with version numbers
+- One command per step, with expected output shown
+- A checkpoint after each step ("You should see X in the terminal")
+- A working demo at the end — not just a build, something the reader can interact with
+
+Run through your own tutorial from scratch, in an empty directory, with a timer. That number is your TTFHW. Optimise it before anything else.

--- a/libs/templates/starters/docs/docs/index.md
+++ b/libs/templates/starters/docs/docs/index.md
@@ -1,0 +1,34 @@
+# Docs Starter Kit
+
+Welcome to the in-app documentation for the protoLabs **docs starter kit** — an Astro Starlight site pre-configured with the protoLabs brand theme, Diataxis content structure, and Pagefind search.
+
+This folder is loaded by protoLabs Studio so you can read it here without leaving your workspace.
+
+## What's in here
+
+| Page | What it covers |
+|------|----------------|
+| [Documentation philosophy](./documentation-philosophy.md) | The Diataxis framework, protoLabs writing principles, and the TTFHW metric |
+| [Project structure](./project-structure.md) | Where files live, how the sidebar is generated, and how to add content |
+
+## Quick reference
+
+```bash
+# Install dependencies
+npm install
+
+# Start the dev server
+npm run dev
+
+# Build for production (outputs to dist/)
+npm run build
+```
+
+The dev server starts at [localhost:4321](http://localhost:4321). Pages are auto-discovered from `src/content/docs/` — no sidebar configuration needed for new files.
+
+## Next steps
+
+1. Read [Documentation philosophy](./documentation-philosophy.md) to understand how to structure content well.
+2. Read [Project structure](./project-structure.md) to understand where to put things.
+3. Replace the placeholder content in `src/content/docs/` with your own pages.
+4. Update `site` in `astro.config.mjs` with your production URL.

--- a/libs/templates/starters/docs/docs/project-structure.md
+++ b/libs/templates/starters/docs/docs/project-structure.md
@@ -1,0 +1,111 @@
+# Project structure
+
+This page covers the file layout of the docs starter kit and explains how the pieces fit together. After reading it you'll know where to add pages, how the sidebar is generated, and where to put styles and assets.
+
+## Directory layout
+
+```
+docs-starter/
+├── src/
+│   ├── content/
+│   │   └── docs/               ← your pages live here
+│   │       ├── index.mdx       ← home page (splash template)
+│   │       ├── tutorials/      ← step-by-step walkthroughs
+│   │       ├── guides/         ← task-focused how-to pages
+│   │       └── reference/      ← API and configuration reference
+│   ├── content.config.ts       ← Astro content collection schema
+│   └── styles/
+│       └── global.css          ← brand theme and Starlight variable overrides
+├── astro.config.mjs            ← Starlight configuration (title, sidebar, social links)
+├── package.json
+└── tsconfig.json
+```
+
+## Adding a page
+
+Create a `.mdx` file anywhere inside `src/content/docs/`. It appears automatically in the sidebar — no manual list to update.
+
+```bash
+# Add a new how-to guide
+touch src/content/docs/guides/deploy-to-cloudflare.mdx
+```
+
+Every page requires a frontmatter block:
+
+```mdx
+---
+title: Deploy to Cloudflare Pages
+description: Connect your repo to Cloudflare Pages and ship on every push.
+---
+
+Your content here.
+```
+
+`title` is required. `description` populates the `<meta>` description tag and the Pagefind search index.
+
+## Sidebar
+
+The sidebar in `astro.config.mjs` uses `autogenerate` to mirror each content subdirectory:
+
+```js
+sidebar: [
+  {
+    label: "Getting Started",
+    autogenerate: { directory: "tutorials" },
+  },
+  {
+    label: "How-to Guides",
+    autogenerate: { directory: "guides" },
+  },
+  {
+    label: "Reference",
+    autogenerate: { directory: "reference" },
+  },
+],
+```
+
+Files are sorted alphabetically by default. To control order, prefix filenames with numbers: `01-getting-started.mdx`, `02-configuration.mdx`.
+
+To add a new section, add a subdirectory under `src/content/docs/` and a matching `autogenerate` entry in the sidebar config.
+
+## Styles
+
+`src/styles/global.css` overrides Starlight's CSS variables to apply the protoLabs brand theme:
+
+- `--sl-color-accent-*` — violet accent colour scale
+- `--sl-color-bg-*` — surface and background colours
+- `--sl-font-*` — Geist font stack
+
+To change the theme, update the variable values in this file. Do not modify Starlight component files directly — CSS variable overrides survive Starlight version upgrades; component forks do not.
+
+## Content collection schema
+
+`src/content.config.ts` defines the `docs` collection using Starlight's `docsLoader` and `docsSchema`:
+
+```ts
+import { defineCollection } from "astro:content";
+import { docsLoader } from "@astrojs/starlight/loaders";
+import { docsSchema } from "@astrojs/starlight/schema";
+
+export const collections = {
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+};
+```
+
+This is required in Astro 5. Without it, Astro falls back to deprecated auto-generated collection behaviour and emits a build warning.
+
+## Search
+
+Pagefind search is enabled automatically. During `npm run build`, Pagefind crawls the HTML output and writes an index to `dist/pagefind/`. No configuration is required.
+
+To disable search, add `pagefind: false` to the Starlight config in `astro.config.mjs`.
+
+## Deployment
+
+The output is fully static (`output: 'static'`). The `dist/` folder can be deployed to any static host.
+
+```bash
+npm run build   # generates dist/
+```
+
+For Cloudflare Pages or Netlify, connect your Git repo and set the build command to `npm run build` and the output directory to `dist`.

--- a/libs/templates/starters/portfolio/docs/documentation-philosophy.md
+++ b/libs/templates/starters/portfolio/docs/documentation-philosophy.md
@@ -1,0 +1,119 @@
+# Documentation philosophy
+
+This page explains how this starter kit approaches documentation structure and writing. It covers the Diataxis framework, the protoLabs writing principles built on top of it, and the single metric that tells you if your docs are working.
+
+## The Diataxis framework
+
+[Diataxis](https://diataxis.fr) divides documentation into four distinct content types. Each type serves a different user need. Mixing them in a single page produces content that serves none of them well.
+
+| Type | Question it answers | Structure |
+|------|---------------------|-----------|
+| **Tutorial** | "Can you show me how to do this for the first time?" | Narrative walkthrough — the reader follows along and builds something |
+| **How-to guide** | "How do I accomplish X?" | Numbered steps — assumes competence, delivers a result |
+| **Reference** | "What are all the options?" | Structured facts — complete, accurate, terse |
+| **Explanation** | "Why does it work this way?" | Discursive prose — context, reasoning, trade-offs |
+
+### Recognising the wrong type
+
+The most common mistake is blending types. Use these tests:
+
+- If you are explaining concepts inside a how-to guide, extract the explanation to a separate page and link to it.
+- If your tutorial contains a table of every configuration option, move the table to reference and link to it.
+- If your reference page has a narrative section at the top, it should be its own explanation page.
+
+### How protoLabs implements Diataxis
+
+The canonical example is [docs.protolabs.studio](https://docs.protolabs.studio). The sidebar mirrors the four quadrants:
+
+- **Tutorials** → `Getting started` section (build something real in under 10 minutes)
+- **How-to guides** → `Guides` section (task-focused, numbered steps)
+- **Reference** → `Reference` section (API, config options, event types)
+- **Explanation** → `Concepts` section (architecture decisions, design rationale)
+
+For a portfolio site, the Diataxis lens applies to any project case studies, blog posts, or README files you write. A case study is an explanation — it answers "why did you make these decisions?" A setup guide is a how-to — it answers "how do I configure X?"
+
+---
+
+## Writing principles
+
+### Code before prose
+
+Show the code first. Explain it after, in one to three sentences. Readers scan for code blocks first — if the code is buried in a paragraph, they miss it.
+
+```bash
+# Add a new project entry
+touch src/content/projects/my-project.md
+```
+
+Populate the frontmatter, then add the body content. The project appears on the `/projects` page automatically.
+
+### One idea per sentence
+
+Long sentences with multiple clauses slow readers down and make translation harder. Each sentence should carry one idea.
+
+**Avoid:**
+> Content Collections enforce frontmatter schemas at build time using Zod, which means you get type errors in your editor when you omit required fields like `title` or `pubDate`.
+
+**Prefer:**
+> Content Collections validate frontmatter at build time using Zod. Omit a required field like `title` or `pubDate` and Astro reports a type error before the build completes.
+
+### Progressive disclosure
+
+Lead with the simplest, most common case. Put advanced options, edge cases, and caveats at the bottom of the page or on a separate page.
+
+Readers who want to add a blog post should be unblocked by the first code block. Readers who want to customise the collection schema can keep reading.
+
+### Outcome-focused headings
+
+Headings are navigation aids, not labels. Use verb phrases that describe what the reader will achieve.
+
+| Avoid | Prefer |
+|-------|--------|
+| Blog posts | Add a blog post |
+| Project data | Update your project list |
+| Testimonials | Add a testimonial |
+
+### Every page opens with orientation
+
+The first paragraph of every page answers three questions:
+
+1. What does this page cover?
+2. Who is it for?
+3. What will the reader have or know after reading it?
+
+One paragraph is enough. Skip it and readers don't know if they're in the right place.
+
+### No marketing language
+
+Describe what something does, not how impressive it is. Readers are engineers. They will notice and distrust adjectives like "powerful", "seamless", and "robust".
+
+**Avoid:** "The powerful Content Collections system provides a seamless, type-safe content authoring experience."
+
+**Prefer:** "Content Collections validate frontmatter at build time. Add a field to the Zod schema and Astro enforces it across every file in the collection."
+
+---
+
+## Time to First Hello World (TTFHW)
+
+TTFHW is the single number that tells you if your getting-started docs are working. It measures the elapsed time from "I found this project" to "I have something running on my machine."
+
+A good TTFHW is under five minutes. For a portfolio starter, the target is:
+
+1. `npm install` — under 60 seconds
+2. `npm run dev` — under 10 seconds
+3. See the personalised site with your name — under 2 minutes total
+
+**What kills TTFHW:**
+
+- Prerequisites buried halfway through the page
+- Requiring users to set up external accounts (CMS, database) before the dev server starts
+- Placeholder values that look like real values (e.g., `SITE_URL=https://yoursite.com`)
+- Missing a step like "update `main.json` with your name before you'll see real content"
+
+**What helps TTFHW:**
+
+- A single `npm install && npm run dev` that shows a working site immediately
+- Placeholder content that looks intentionally placeholder (clear it before you ship)
+- A checklist at the top of the README: "Before you publish, do these three things"
+
+Run through your own setup from scratch, in an empty directory, with a timer. That number is your TTFHW. Optimise it before anything else.

--- a/libs/templates/starters/portfolio/docs/index.md
+++ b/libs/templates/starters/portfolio/docs/index.md
@@ -1,0 +1,35 @@
+# Portfolio Starter Kit
+
+Welcome to the in-app documentation for the protoLabs **portfolio starter kit** — an Astro 5 site with Content Collections, typed data, and zero external CMS dependencies.
+
+This folder is loaded by protoLabs Studio so you can read it here without leaving your workspace.
+
+## What's in here
+
+| Page | What it covers |
+|------|----------------|
+| [Documentation philosophy](./documentation-philosophy.md) | The Diataxis framework, protoLabs writing principles, and the TTFHW metric |
+| [Project structure](./project-structure.md) | Where files live, how Content Collections work, and how to add projects and blog posts |
+
+## Quick reference
+
+```bash
+# Install dependencies (must run inside this directory — not from monorepo root)
+npm install
+
+# Start the dev server
+npm run dev
+
+# Build for production (outputs to dist/)
+npm run build
+```
+
+The dev server starts at [localhost:4321](http://localhost:4321).
+
+## Next steps
+
+1. Read [Documentation philosophy](./documentation-philosophy.md) to understand how to structure your content well.
+2. Read [Project structure](./project-structure.md) to understand where to put things.
+3. Update `src/content/siteConfig/main.json` with your name, bio, and links.
+4. Replace placeholder projects and blog posts in `src/content/` with your own.
+5. Update `site` in `astro.config.mjs` with your production URL.

--- a/libs/templates/starters/portfolio/docs/project-structure.md
+++ b/libs/templates/starters/portfolio/docs/project-structure.md
@@ -1,0 +1,130 @@
+# Project structure
+
+This page covers the file layout of the portfolio starter kit and explains how the pieces fit together. After reading it you'll know where to add projects, blog posts, and testimonials, and how the typed schema validation works.
+
+## Directory layout
+
+```
+portfolio-starter/
+├── src/
+│   ├── content/
+│   │   ├── config.ts           ← Zod schemas for all collections
+│   │   ├── blog/               ← blog posts (Markdown)
+│   │   ├── projects/           ← project case studies (Markdown)
+│   │   ├── siteConfig/         ← your name, bio, and nav links (JSON)
+│   │   └── testimonials/       ← client/colleague quotes (JSON)
+│   ├── components/             ← reusable Astro and React components
+│   ├── layouts/                ← page layout wrappers
+│   ├── pages/                  ← file-based routes
+│   │   ├── index.astro         ← home page
+│   │   ├── about.astro         ← about page
+│   │   ├── blog/               ← blog listing + post pages
+│   │   └── projects/           ← project listing + detail pages
+│   └── styles/                 ← global CSS and Tailwind theme tokens
+├── public/                     ← static assets (images, fonts, favicons)
+├── astro.config.mjs            ← Astro configuration
+└── package.json
+```
+
+## Content Collections
+
+The portfolio uses Astro Content Collections for all data. Each collection has a Zod schema defined in `src/content/config.ts`. Astro validates every file in the collection at build time — missing required fields produce a type error before the build completes.
+
+### Blog posts (`src/content/blog/`)
+
+```markdown
+---
+title: "Hello World"
+description: "Why I built this portfolio with Astro."
+pubDate: 2025-01-10
+tags: ["Astro", "Portfolio"]
+author: "Your Name"
+image: "/images/blog/hello-world.png"
+imageAlt: "Astro logo on a dark background"
+---
+
+Your post content here.
+```
+
+Required: `title`, `description`, `pubDate`, `author`. All other fields are optional.
+
+Add a `.md` file to `src/content/blog/` and it appears on the `/blog` listing page automatically.
+
+### Projects (`src/content/projects/`)
+
+```markdown
+---
+title: "Automaker"
+description: "An AI-powered software development platform."
+status: "active"
+tags: ["AI", "Developer Tools"]
+url: "https://protolabs.studio"
+startDate: 2024-01-01
+featured: true
+---
+
+Case study content here.
+```
+
+Required: `title`, `description`, `status`. Status must be one of `active`, `completed`, or `archived`.
+
+Set `featured: true` to surface the project on the home page hero section.
+
+### Site config (`src/content/siteConfig/main.json`)
+
+```json
+{
+  "name": "Your Name",
+  "title": "Software Engineer",
+  "bio": "I build developer tools and design systems.",
+  "email": "you@example.com",
+  "social": {
+    "github": "https://github.com/yourusername",
+    "twitter": "https://x.com/yourusername"
+  }
+}
+```
+
+This is the first file to update. Your name and bio appear on the home page, about page, and page `<title>` tags.
+
+### Testimonials (`src/content/testimonials/`)
+
+```json
+{
+  "author": "Alice Chen",
+  "role": "Engineering Manager",
+  "company": "Acme Corp",
+  "quote": "One of the sharpest engineers I've worked with.",
+  "featured": true
+}
+```
+
+Add one JSON file per testimonial. Set `featured: true` to include it in the home page testimonials section.
+
+## Pages and routing
+
+Astro uses file-based routing. The file at `src/pages/blog/index.astro` becomes the `/blog` route. Dynamic routes use bracket syntax: `src/pages/blog/[slug].astro` generates one page per blog post.
+
+You do not need to modify the page files to add content — edit the content collections instead. Only touch `src/pages/` if you want to change the page layout or add a new route entirely.
+
+## Styles
+
+The portfolio uses Tailwind CSS v4 with a CSS-first `@theme` configuration block in `src/styles/global.css`. Brand tokens (surface colours, accent colours, font stack) are defined there.
+
+Do not add raw colour utilities like `bg-gray-900` or `text-blue-600` in component files. Use the semantic tokens (`bg-background`, `text-foreground`, `text-muted-foreground`) so theme changes propagate everywhere.
+
+## Static output and deployment
+
+The site outputs fully static HTML (`output: 'static'`). The `dist/` folder can be deployed to any static host.
+
+```bash
+npm run build   # generates dist/
+```
+
+For Cloudflare Pages or Netlify:
+
+1. Connect your Git repo.
+2. Set build command to `npm run build`.
+3. Set output directory to `dist`.
+
+Because the portfolio is a standalone project (not a monorepo workspace), run `npm install` inside this directory, not from a parent repo root.


### PR DESCRIPTION
## Summary

- Adds `docs/` folder at the root of the **docs starter kit** (Starlight) and **portfolio starter kit** (Astro 5) for the protoLabs Studio in-app docs viewer
- Each kit gets three pages: `index.md` (landing + quick-start), `documentation-philosophy.md` (Diataxis + protoLabs writing principles), `project-structure.md` (kit-specific file layout and content authoring guide)
- The `documentation-philosophy.md` pages share the same core Diataxis content with kit-specific examples — TTFHW metric, code-before-prose rule, progressive disclosure, outcome-focused headings

## Test plan

- [ ] Open either starter kit in protoLabs Studio and confirm the in-app docs viewer loads `docs/index.md`
- [ ] Verify all three pages render and internal links between them resolve correctly
- [ ] Confirm no new TypeScript errors (`npm run build:packages` passes — ✅ verified)
- [ ] Confirm only the 6 new `.md` files were added (`git diff --stat` shows no modifications to existing files — ✅ verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)