### PR TITLE
feat(templates): add portfolio starter kit type

### DIFF
--- a/libs/templates/src/ci.ts
+++ b/libs/templates/src/ci.ts
@@ -84,6 +84,72 @@ jobs:
 }
 
 /**
+ * Get portfolio site CI workflow (build + format check + Cloudflare Pages deploy).
+ */
+export function getPortfolioCI(): string {
+  return `name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run format:check
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: [build, format]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: \${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: \${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=\${{ github.event.repository.name }}
+`;
+}
+
+/**
  * Get browser extension CI workflow (build + lint + test + format check).
  */
 export function getExtensionCI(): string {

--- a/libs/templates/src/claude-md.ts
+++ b/libs/templates/src/claude-md.ts
@@ -79,6 +79,45 @@ npm run lint:md       # Lint markdown files
 }
 
 /**
+ * Common commands section for portfolio-type projects (Astro + React).
+ */
+export function getPortfolioCommandsSection(): string {
+  return `## Common Commands
+
+\`\`\`bash
+npm install           # Install dependencies (run inside portfolio directory)
+npm run dev           # Start dev server at localhost:4321
+npm run build         # Production build (static output to dist/)
+npm run preview       # Preview production build locally
+npm run format        # Format with Prettier (including .astro files)
+npm run format:check  # Check formatting (used in CI)
+\`\`\`
+
+## Project Structure
+
+\`\`\`
+src/
+  components/        # Astro section components + React islands
+  content/           # Content Collections (projects, blog, testimonials)
+  layouts/           # Base HTML layout (Layout.astro)
+  pages/             # Astro pages → file-based routing
+  styles/            # global.css with Tailwind v4 @theme tokens
+  content.config.ts  # Content Collection schemas
+dist/                # Production build output (gitignored)
+\`\`\`
+
+## Content Collections
+
+Add portfolio entries by creating files in \`src/content/\`:
+
+- \`src/content/projects/\` — project cards shown in ProjectGrid
+- \`src/content/blog/\` — blog posts with dynamic routes
+
+Schemas are defined in \`src/content.config.ts\`. Run \`npm run build\` after adding entries to validate frontmatter.
+`;
+}
+
+/**
  * Common commands section for extension-type projects.
  */
 export function getExtensionCommandsSection(): string {

--- a/libs/templates/src/coding-rules.ts
+++ b/libs/templates/src/coding-rules.ts
@@ -19,6 +19,8 @@ export function getCodingRules(type: CodingRulesType): string {
       return getTypeScriptCodingRules();
     case 'react':
       return getReactCodingRules();
+    case 'astro-react':
+      return getAstroReactCodingRules();
   }
 }
 
@@ -155,6 +157,65 @@ Rules for AI agents working on this codebase.
 
 - Write tests for all new functionality
 - Test behavior, not implementation
+`;
+}
+
+function getAstroReactCodingRules(): string {
+  return `# Coding Rules
+
+Rules for AI agents working on this Astro + React portfolio.
+
+## Astro vs React — When to Use Each
+
+- **Astro components (\`.astro\`)** — static sections, layouts, pages. Zero JavaScript shipped to client.
+- **React components (\`.tsx\`)** — interactive islands only. Use \`client:load\` for above-the-fold interactivity, \`client:visible\` for below-fold.
+- Default to Astro. Only reach for React when the component needs client-side state or event handling.
+
+## Astro Rules
+
+- Keep page components thin — orchestrate layout, delegate content to section components
+- Use Content Collections for all structured data (projects, blog, testimonials)
+  - Define schemas in \`src/content.config.ts\` with \`z\` from \`astro:content\`
+  - Use \`render()\` (Astro 5 API) not \`entry.render()\` for markdown content
+- Use \`<ViewTransitions />\` from \`astro:transitions\` for page transitions (built-in, no package needed)
+- Images: use \`<Image />\` from \`astro:assets\` for automatic optimization
+
+## React Island Rules
+
+- One component per file: \`ProjectGrid.tsx\`, not \`components.tsx\`
+- Use named exports for all island components
+- Keep islands small and focused — co-locate with the Astro section that uses them
+- Inline styles use \`satisfies React.CSSProperties\` for type safety
+
+## TypeScript
+
+- strict mode enabled — no \`any\` types
+- Explicit return types on exported functions
+- Use \`import type\` for type-only imports
+
+## Tailwind CSS v4
+
+- CSS-first configuration via \`@import 'tailwindcss'\` and \`@theme\` block in \`src/styles/global.css\`
+- No \`tailwind.config.js\` — Tailwind v4 is configured in CSS
+- Use semantic token names from \`@theme\` block; never hardcode hex values
+
+## Formatting
+
+- Prettier is configured — run \`npm run format\` before committing
+- \`.astro\` files: prettier-plugin-astro formats them automatically
+- Do NOT manually format code; let Prettier handle it
+
+## Build
+
+- Output mode is \`static\` — all routes must be known at build time
+- Dynamic routes require \`getStaticPaths()\` returning all slugs
+- Run \`npm run build\` to verify before committing
+
+## Deployment
+
+- Deploys to Cloudflare Pages via \`wrangler pages deploy\`
+- Build output: \`dist/\`
+- Environment variables: set in Cloudflare Pages dashboard, not committed
 `;
 }
 

--- a/libs/templates/src/features.ts
+++ b/libs/templates/src/features.ts
@@ -94,6 +94,45 @@ const EXTENSION_FEATURES: StarterFeature[] = [
   },
 ];
 
+const PORTFOLIO_FEATURES: StarterFeature[] = [
+  {
+    title: 'Add projects to the portfolio',
+    description:
+      'Populate src/content/projects/ with real project entries. Each entry needs title, description, tags, date, and an optional link. Update the ProjectGrid component to use live data from the content collection.',
+    complexity: 'small',
+  },
+  {
+    title: 'Configure custom domain',
+    description:
+      'Set up a custom domain for the portfolio on Cloudflare Pages. Update astro.config.mjs with the site URL and configure CNAME DNS records.',
+    complexity: 'small',
+  },
+  {
+    title: 'Add blog section',
+    description:
+      'Create src/content/blog/ content collection with schema. Add a BlogList section component and a dynamic /blog/[slug] route using Astro 5 render() API. Link from the homepage.',
+    complexity: 'medium',
+  },
+  {
+    title: 'Add dark mode toggle',
+    description:
+      'Implement a theme switcher React island that toggles between light and dark mode. Persist preference to localStorage. Use Tailwind dark: variants for styling.',
+    complexity: 'medium',
+  },
+  {
+    title: 'Add contact form',
+    description:
+      'Wire the Contact section form to a backend. Options: Formspree, Resend, or a Cloudflare Worker. Add honeypot spam protection and a success/error state in the UI.',
+    complexity: 'medium',
+  },
+  {
+    title: 'Add OG image generation',
+    description:
+      'Generate Open Graph images for blog posts and project pages. Use Satori or a Cloudflare Worker to render dynamic images from page metadata. Set og:image meta tags in the SEO component.',
+    complexity: 'large',
+  },
+];
+
 /**
  * Get starter features for a given kit type.
  * Returns universal features plus type-specific features.
@@ -104,6 +143,8 @@ export function getStarterFeatures(type: StarterKitType): StarterFeature[] {
       return [...UNIVERSAL_FEATURES, ...DOCS_FEATURES];
     case 'extension':
       return [...UNIVERSAL_FEATURES, ...EXTENSION_FEATURES];
+    case 'portfolio':
+      return [...UNIVERSAL_FEATURES, ...PORTFOLIO_FEATURES];
     case 'general':
       return [...UNIVERSAL_FEATURES];
   }

--- a/libs/templates/src/types.ts
+++ b/libs/templates/src/types.ts
@@ -7,12 +7,12 @@
 /**
  * Starter kit type determines which features and coding rules to include.
  */
-export type StarterKitType = 'docs' | 'extension' | 'general';
+export type StarterKitType = 'docs' | 'extension' | 'general' | 'portfolio';
 
 /**
  * Coding rules type determines which language/framework rules to include.
  */
-export type CodingRulesType = 'docs' | 'extension' | 'typescript' | 'react';
+export type CodingRulesType = 'docs' | 'extension' | 'typescript' | 'react' | 'astro-react';
 
 /**
  * A pre-written feature description for a starter kit.


### PR DESCRIPTION
## Summary

- Adds `'portfolio'` to `StarterKitType` union and `'astro-react'` to `CodingRulesType`
- Defines 6 portfolio-specific backlog features (projects content, blog, custom domain, dark mode, contact form, OG images)
- Adds `getAstroReactCodingRules()` covering Astro vs React island selection, Tailwind v4 CSS-first, Content Collections, static output, and Cloudflare Pages deployment
- Adds `getPortfolioCommandsSection()` CLAUDE.md fragment with commands and project structure
- Adds `getPortfolioCI()` GitHub Actions workflow (build + format check + Cloudflare Pages deploy)

## Test plan

- [x] `npm run build --workspace=libs/templates` exits 0, ESM + DTS build success
- [x] Only 5 intended files modified (`git diff --stat`)
- [x] Prettier reports all files unchanged (no formatting violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)