### PR TITLE
docs: update server docs for lead engineer, HITL forms, and channel handlers

### DIFF
--- a/docs/internal/server/actionable-items.md
+++ b/docs/internal/server/actionable-items.md
@@ -35,6 +35,16 @@ hitl:form-responded     ──► (auto-resolve authority approvals)
 
 HITL forms are persisted to disk at `{projectPath}/.automaker/hitl-forms.json` using atomic writes (temp file then rename). The in-memory `Map` serves as a fast cache; disk is the source of truth on server restart.
 
+### Feature flag requirement
+
+HITL forms require the `hitlForms` feature flag to be enabled in global settings:
+
+```json
+{ "featureFlags": { "hitlForms": true } }
+```
+
+When the flag is disabled, `HITLFormService.create()` returns `null` and no form is stored or emitted. The flag is checked at creation time only — existing persisted forms are not affected.
+
 ### Lifecycle
 
 ```
@@ -46,6 +56,19 @@ create() ──► pending ──► submit() ──► submitted
 - **Default TTL**: 1 hour (configurable per form, max 24 hours)
 - **Disk sync**: Every mutation (create, submit, cancel, expire) writes to disk
 - **Startup recovery**: On service init, forms are loaded from disk for all known projects
+
+### Channel routing
+
+Forms with a `replyChannel` field are routed through the `ChannelRouter` to the appropriate handler instead of emitting `hitl:form-requested` to the UI. The channel router selects between two handlers:
+
+| Channel     | Handler                | Used when                                         |
+| ----------- | ---------------------- | ------------------------------------------------- |
+| `github`    | `GitHubChannelHandler` | Feature has a `githubIssueNumber` (issue-sourced) |
+| _(default)_ | `UIChannelHandler`     | No GitHub issue; form goes to the in-app inbox    |
+
+`GitHubChannelHandler` posts a comment on the originating GitHub issue and waits for `/approve` or `/reject` in subsequent `issue_comment` events. `UIChannelHandler` is a no-op that lets the HITL dialog render in the UI as normal.
+
+See [Channel Handlers](./channel-handlers.md) for the full reference.
 
 ### Dialog behavior
 

--- a/docs/internal/server/channel-handlers.md
+++ b/docs/internal/server/channel-handlers.md
@@ -1,0 +1,84 @@
+# Channel Handlers
+
+Channel handlers route HITL form requests and gate approvals to the correct delivery channel — either the in-app UI or a GitHub issue comment thread.
+
+## Architecture
+
+```
+HITLFormService.create()
+        │
+        │ form has replyChannel?
+        ▼
+  ChannelRouter.getHandler(feature)
+        │
+        ├── feature.githubIssueNumber exists?
+        │       ▼
+        │   GitHubChannelHandler
+        │       - posts gate-hold comment on GitHub issue
+        │       - listens for /approve or /reject in issue_comment events
+        │       - resolveGate() called to unblock the pipeline
+        │
+        └── no GitHub issue
+                ▼
+            UIChannelHandler (no-op)
+                - logs the skip; UI renders the HITL form dialog normally
+```
+
+The channel router is wired into `HITLFormService` via `setChannelRouter()` at startup (see `channel-handlers.module.ts`).
+
+## Handlers
+
+### `GitHubChannelHandler`
+
+Delivers HITL form requests and gate holds as GitHub issue comments.
+
+**Responsibilities:**
+
+- `requestApproval()` — posts a comment on the originating GitHub issue stating the pipeline is paused and waiting for approval
+- `sendHITLForm()` — posts the HITL form contents as a formatted issue comment
+- `cancelPending()` — posts a cancellation comment and removes the pending approval record
+
+**Pending approval tracking:** Approvals are tracked in-memory keyed by `featureId`. When a subsequent `issue_comment` webhook event contains `/approve` or `/reject`, `resolveGate()` is called to advance or reject the pipeline gate.
+
+**Fallback:** If `githubIssueNumber` is missing on the feature, `GitHubChannelHandler` delegates to `UIChannelHandler` automatically.
+
+### `UIChannelHandler`
+
+A no-op handler used when no GitHub issue is associated with the feature. It logs the skip and relies on the `hitl:form-requested` WebSocket event to surface the form in the in-app HITL dialog.
+
+## Interface
+
+Both handlers implement the `ChannelHandler` interface:
+
+```typescript
+interface ChannelHandler {
+  requestApproval(params: ApprovalParams): Promise<void>;
+  sendHITLForm(params: HITLFormParams): Promise<void>;
+  cancelPending(params: CancelParams): Promise<void>;
+}
+```
+
+## Module wiring
+
+`channel-handlers.module.ts` wires the `ChannelRouter` into `HITLFormService` at startup:
+
+```typescript
+export function register(container: ServiceContainer): void {
+  container.hitlFormService.setChannelRouter(container.channelRouter);
+}
+```
+
+This must run before any pipeline or HITL form service operations.
+
+## Key Files
+
+| File                                                                   | Role                                                                   |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `apps/server/src/services/channel-handlers/github-channel-handler.ts`  | `GitHubChannelHandler`, `UIChannelHandler`, `ChannelHandler` interface |
+| `apps/server/src/services/channel-handlers/channel-handlers.module.ts` | Startup wiring: sets `channelRouter` on `HITLFormService`              |
+| `apps/server/src/services/channel-router.ts`                           | Selects the appropriate handler per feature                            |
+
+## See Also
+
+- [Actionable Items and HITL Forms](./actionable-items.md) — feature flag requirement and form lifecycle
+- [Lead Engineer Pipeline](../dev/lead-engineer-pipeline.md) — ESCALATE phase creates HITL forms on non-retryable failures

--- a/docs/internal/server/lead-engineer-service.md
+++ b/docs/internal/server/lead-engineer-service.md
@@ -20,20 +20,42 @@ The Lead Engineer pipeline processes features through discrete state phases, eac
 ## Architecture
 
 ```text
-LeadEngineerService
-  ├── IntakeProcessor       — entry point for every feature
-  ├── PlanProcessor         — plan generation + quality gate
-  ├── ExecuteProcessor      — agent invocation + monitoring
-  ├── ReviewProcessor       — PR monitoring and feedback cycles
-  ├── MergeProcessor        — CI verification and PR merge
-  ├── DeployProcessor       — post-merge verification → DONE
-  └── EscalateProcessor     — blocked/failed feature handling
+LeadEngineerService (orchestrator)
+  ├── FeatureStateMachine       — per-feature state transitions (lead-engineer-state-machine.ts)
+  │     ├── IntakeProcessor       — entry point for every feature
+  │     ├── PlanProcessor         — plan generation + quality gate
+  │     ├── ExecuteProcessor      — agent invocation + monitoring
+  │     ├── ReviewProcessor       — PR monitoring and feedback cycles
+  │     ├── MergeProcessor        — CI verification and PR merge
+  │     ├── DeployProcessor       — post-merge verification → DONE
+  │     └── EscalateProcessor     — blocked/failed feature handling
+  ├── WorldStateBuilder         — board snapshot + incremental updates
+  ├── ActionExecutor            — fast-path rule execution + supervisor
+  ├── CeremonyOrchestrator      — project completion ceremonies
+  └── LeadEngineerSessionStore  — session persistence (DATA_DIR/lead-engineer-sessions.json)
 
 Each processor implements StateProcessor:
   enter(ctx)   → side effects on state entry
   process(ctx) → returns StateTransitionResult { nextState, shouldContinue, reason }
   exit(ctx)    → cleanup on state exit
 ```
+
+### Goal Gates
+
+`FeatureStateMachine` validates pre- and post-conditions on each state transition via goal gates:
+
+| Gate ID         | When evaluated          | What it checks                                            |
+| --------------- | ----------------------- | --------------------------------------------------------- |
+| `execute-entry` | Before entering EXECUTE | Feature has a description or title                        |
+| `execute-exit`  | After leaving EXECUTE   | PR was created (`prNumber` exists); retry target: EXECUTE |
+| `review-exit`   | After leaving REVIEW    | Delegated to processor (always passes at gate level)      |
+| `merge-exit`    | After leaving MERGE     | Merge confirmed by processor; retry target: MERGE         |
+
+Goal gates can be disabled project-wide via `pipeline.goalGatesEnabled: false` in workflow settings.
+
+### Session Persistence
+
+`LeadEngineerSessionStore` persists active sessions to `DATA_DIR/lead-engineer-sessions.json` (a single multi-project file keyed by `projectPath`). On server restart, `restore()` replays all persisted sessions so auto-mode resumes automatically.
 
 ## INTAKE Phase
 
@@ -100,15 +122,16 @@ interface StateContext {
 
 ## Key Files
 
-| File                                                          | Role                                                                 |
-| ------------------------------------------------------------- | -------------------------------------------------------------------- |
-| `apps/server/src/services/lead-engineer-processors.ts`        | `IntakeProcessor` and `PlanProcessor`                                |
-| `apps/server/src/services/lead-engineer-execute-processor.ts` | `ExecuteProcessor`                                                   |
-| `apps/server/src/services/lead-engineer-review-processor.ts`  | `ReviewProcessor`                                                    |
-| `apps/server/src/services/lead-engineer-merge-processor.ts`   | `MergeProcessor`                                                     |
-| `apps/server/src/services/lead-engineer-deploy-processor.ts`  | `DeployProcessor`                                                    |
-| `apps/server/src/services/lead-engineer-types.ts`             | `StateProcessor`, `StateContext`, `StateTransitionResult` interfaces |
-| `apps/server/src/services/lead-engineer-service.ts`           | Main service wiring processors into state machine                    |
+| File                                                                | Role                                                                       |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `apps/server/src/services/lead-engineer-service.ts`                 | Orchestrator: wires `FeatureStateMachine`, `ActionExecutor`, session store |
+| `apps/server/src/services/lead-engineer-state-machine.ts`           | `FeatureStateMachine` class + default goal gate definitions                |
+| `apps/server/src/services/lead-engineer-processors.ts`              | `IntakeProcessor` and `PlanProcessor`                                      |
+| `apps/server/src/services/lead-engineer-execute-processor.ts`       | `ExecuteProcessor`                                                         |
+| `apps/server/src/services/lead-engineer-review-merge-processors.ts` | `ReviewProcessor` and `MergeProcessor`                                     |
+| `apps/server/src/services/lead-engineer-deploy-processor.ts`        | `DeployProcessor`                                                          |
+| `apps/server/src/services/lead-engineer-session-store.ts`           | Session persistence to `DATA_DIR/lead-engineer-sessions.json`              |
+| `apps/server/src/services/lead-engineer-types.ts`                   | `StateProcessor`, `StateContext`, `ProcessorServiceContext`, timing consts |
 
 ## See Also
 


### PR DESCRIPTION
## Summary

Reviewed 17 recently changed server-side files and updated internal documentation to reflect the current implementation.

**Key changes documented:**

- **`lead-engineer-service.md`** — updated architecture diagram to show the `FeatureStateMachine` extraction to `lead-engineer-state-machine.ts`; added goal gates reference table; added session persistence note; updated key files table with the correct filenames (`lead-engineer-review-merge-processors.ts`, `lead-engineer-session-store.ts`, `lead-engineer-state-machine.ts`)
- **`actionable-items.md`** — added `featureFlags.hitlForms` feature flag requirement that gates HITL form creation; added channel routing section documenting `GitHubChannelHandler` vs `UIChannelHandler`
- **`channel-handlers.md`** _(new)_ — full reference for the channel handler system: `GitHubChannelHandler`, `UIChannelHandler`, `ChannelRouter`, and `channel-handlers.module.ts` startup wiring

## Test plan

- [ ] Verify doc links resolve correctly in the in-app docs viewer
- [ ] Confirm `channel-handlers.md` cross-links back to `actionable-items.md` and `lead-engineer-pipeline.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)