### PR TITLE
Add starter kit selection to create-protolab CLI interactive prompt

### DIFF
--- a/packages/create-protolab/package.json
+++ b/packages/create-protolab/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.0.1",
+    "@protolabsai/templates": "*",
     "picocolors": "^1.1.1",
     "yaml": "^2.6.1"
   },

--- a/packages/create-protolab/src/cli.ts
+++ b/packages/create-protolab/src/cli.ts
@@ -9,18 +9,22 @@ import { setupCI } from './phases/ci.js';
 import { generateCodeRabbitConfig } from './phases/coderabbit.js';
 import { createBranchProtectionRuleset } from './phases/branch-protection.js';
 import { executeDiscordPhase } from './phases/discord.js';
+import { scaffoldStarter } from './phases/scaffold.js';
+import type { StarterKitType } from './phases/scaffold.js';
 
 /**
  * CLI for ProtoLabs setup and initialization
  *
  * Interactive flow:
  * 1. Intro banner with project name and path
- * 2. Spinner for research phase
- * 3. Display gap analysis results (score, compliant items, gaps by severity)
- * 4. Multi-select prompt for which phases to run (pre-select all recommended)
- * 5. Spinner for each phase with status updates
- * 6. Summary with created files and next steps
- * 7. Outro
+ * 2. Starter kit type selection (docs, portfolio, extension, general)
+ * 3. If docs or portfolio: scaffold Astro project into outputDir
+ * 4. Spinner for research phase
+ * 5. Display gap analysis results (score, compliant items, gaps by severity)
+ * 6. Multi-select prompt for which phases to run (pre-select all recommended)
+ * 7. Spinner for each phase with status updates
+ * 8. Summary with created files and next steps
+ * 9. Outro
  */
 
 // Types (simplified for CLI - would normally import from @protolabsai/types)
@@ -257,12 +261,96 @@ async function main() {
   clack.log.info(`Project: ${pc.cyan(projectPath)}\n`);
 
   try {
-    // Phase 1: Research
+    // Step 1: Starter kit type selection
+    let selectedKit: StarterKitType = 'general';
+
+    if (options.yes) {
+      clack.log.info(pc.dim('Starter kit: general (--yes mode)'));
+    } else {
+      const kitSelection = await clack.select({
+        message: 'What type of project are you creating?',
+        options: [
+          {
+            value: 'docs' as StarterKitType,
+            label: 'Documentation site',
+            hint: 'Starlight + Astro — great for product docs',
+          },
+          {
+            value: 'portfolio' as StarterKitType,
+            label: 'Portfolio site',
+            hint: 'Astro + React + Tailwind — personal or agency portfolio',
+          },
+          {
+            value: 'extension' as StarterKitType,
+            label: 'Browser extension',
+            hint: 'Manifest v3, React popup + content script',
+          },
+          {
+            value: 'general' as StarterKitType,
+            label: 'General project',
+            hint: 'Any other project type',
+          },
+        ],
+      });
+
+      if (clack.isCancel(kitSelection)) {
+        clack.cancel('Setup cancelled');
+        process.exit(0);
+      }
+
+      selectedKit = kitSelection as StarterKitType;
+    }
+
+    // Step 2: Scaffold the Astro starter kit (docs and portfolio only)
+    const scaffoldCreatedFiles: string[] = [];
+    let scaffoldFeatureCount = 0;
+
+    if (selectedKit === 'docs' || selectedKit === 'portfolio') {
+      let projectName = '';
+
+      if (options.yes) {
+        // Derive a name from the project path
+        projectName = projectPath.split('/').pop() ?? 'my-project';
+      } else {
+        const nameInput = await clack.text({
+          message: 'Project name',
+          placeholder: projectPath.split('/').pop() ?? 'my-project',
+          validate(value) {
+            if (!value || !value.trim()) return 'Project name is required';
+            if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(value.trim())) {
+              return 'Use lowercase letters, numbers, and hyphens only';
+            }
+          },
+        });
+
+        if (clack.isCancel(nameInput)) {
+          clack.cancel('Setup cancelled');
+          process.exit(0);
+        }
+
+        projectName = (nameInput as string).trim();
+      }
+
+      const scaffoldResult = await runPhase(`Scaffolding ${selectedKit} starter kit...`, () =>
+        scaffoldStarter({
+          kitType: selectedKit,
+          projectName,
+          outputDir: projectPath,
+        })
+      );
+
+      if (scaffoldResult.filesCreated) {
+        scaffoldCreatedFiles.push(...scaffoldResult.filesCreated);
+      }
+      scaffoldFeatureCount = scaffoldResult.starterFeatures?.length ?? 0;
+    }
+
+    // Phase 3: Research
     const researchResult = await runPhase('Analyzing repository structure...', () =>
       researchRepo(projectPath)
     );
 
-    // Phase 2: Gap Analysis
+    // Phase 4: Gap Analysis
     const gapAnalysis = await runPhase('Running gap analysis...', () =>
       Promise.resolve(analyzeGaps(researchResult))
     );
@@ -316,15 +404,15 @@ async function main() {
       selectedPhases = phaseSelection as string[];
     }
 
-    if (selectedPhases.length === 0) {
+    if (selectedPhases.length === 0 && scaffoldCreatedFiles.length === 0) {
       clack.log.warn(pc.yellow('No phases selected'));
       clack.outro(pc.dim('Setup completed without changes'));
       process.exit(0);
     }
 
     // Execute selected phases
-    const createdFiles: string[] = [];
-    let featuresCreated = 0;
+    const createdFiles: string[] = [...scaffoldCreatedFiles];
+    let featuresCreated = scaffoldFeatureCount;
 
     if (selectedPhases.includes('automaker')) {
       const result = await runPhase('Initializing .automaker/ directory...', () =>
@@ -347,8 +435,8 @@ async function main() {
 
     if (selectedPhases.includes('features')) {
       // Features are created via Automaker API - this would require server access
-      // For now, just count the gaps
-      featuresCreated = gapAnalysis.gaps.length;
+      // For now, just count the gaps plus starter features
+      featuresCreated += gapAnalysis.gaps.length;
     }
 
     // Display summary

--- a/packages/create-protolab/src/phases/scaffold.ts
+++ b/packages/create-protolab/src/phases/scaffold.ts
@@ -1,0 +1,117 @@
+/**
+ * Phase: Scaffold Starter Kit
+ *
+ * Copies a starter kit (docs or portfolio) to the output directory,
+ * substituting project name in package.json and astro.config.mjs,
+ * then writes .automaker/CONTEXT.md with the kit-specific agent context.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import {
+  scaffoldDocsStarter,
+  scaffoldPortfolioStarter,
+  getDocsStarterContext,
+  getPortfolioStarterContext,
+  getStarterFeatures,
+} from '@protolabsai/templates';
+
+import type { StarterKitType, StarterFeature } from '@protolabsai/templates';
+
+export type { StarterKitType };
+
+export interface ScaffoldStarterOptions {
+  /** Starter kit type — 'docs' | 'portfolio' | 'extension' | 'general' */
+  kitType: StarterKitType;
+  /** Human-readable project name, used as package.json name and in config substitution. */
+  projectName: string;
+  /** Absolute path to the destination directory. */
+  outputDir: string;
+}
+
+export interface ScaffoldStarterResult {
+  success: boolean;
+  outputDir: string;
+  filesCreated: string[];
+  starterFeatures: StarterFeature[];
+  error?: string;
+}
+
+/**
+ * Scaffold a starter kit into outputDir, then write the .automaker/CONTEXT.md
+ * agent context file. Returns the list of starter features to create on the board.
+ */
+export async function scaffoldStarter(
+  options: ScaffoldStarterOptions
+): Promise<ScaffoldStarterResult> {
+  const { kitType, projectName, outputDir } = options;
+
+  // Only docs and portfolio have Astro scaffolding — extension and general
+  // produce only the .automaker/ directory and feature list.
+  let filesCreated: string[] = [];
+
+  if (kitType === 'docs') {
+    const result = await scaffoldDocsStarter({ projectName, outputDir });
+    if (!result.success) {
+      return {
+        success: false,
+        outputDir,
+        filesCreated: result.filesCreated,
+        starterFeatures: [],
+        error: result.error,
+      };
+    }
+    filesCreated = result.filesCreated;
+  } else if (kitType === 'portfolio') {
+    const result = await scaffoldPortfolioStarter({ projectName, outputDir });
+    if (!result.success) {
+      return {
+        success: false,
+        outputDir,
+        filesCreated: result.filesCreated,
+        starterFeatures: [],
+        error: result.error,
+      };
+    }
+    filesCreated = result.filesCreated;
+  }
+
+  // Write .automaker/CONTEXT.md
+  try {
+    const automakerDir = path.join(outputDir, '.automaker');
+    await fs.mkdir(automakerDir, { recursive: true });
+
+    let contextContent: string | null = null;
+    if (kitType === 'docs') {
+      contextContent = getDocsStarterContext();
+    } else if (kitType === 'portfolio') {
+      contextContent = getPortfolioStarterContext();
+    }
+
+    if (contextContent !== null) {
+      const contextPath = path.join(automakerDir, 'CONTEXT.md');
+      await fs.writeFile(contextPath, contextContent, 'utf-8');
+      filesCreated.push(path.join(outputDir, '.automaker', 'CONTEXT.md'));
+    } else {
+      filesCreated.push(path.join(outputDir, '.automaker') + '/');
+    }
+  } catch (error) {
+    return {
+      success: false,
+      outputDir,
+      filesCreated,
+      starterFeatures: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const starterFeatures = getStarterFeatures(kitType);
+
+  return {
+    success: true,
+    outputDir,
+    filesCreated,
+    starterFeatures,
+  };
+}


### PR DESCRIPTION
## Summary

The `create-protolab` CLI needs an interactive prompt that lets users select a starter kit type (docs, portfolio, extension, general) during project scaffolding. The scaffold functions already exist in `libs/templates/src/scaffold.ts` (`scaffoldDocsStarter()`, `scaffoldPortfolioStarter()`).

**Task:**
1. Update `packages/create-protolab/` to present starter kit choices in the interactive setup flow
2. When user selects 'docs' or 'portfolio', call the corresponding scaffold function to copy the A...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added starter kit selection during project creation (docs, portfolio, extension, general).
  * Automatic scaffolding of Astro projects for docs and portfolio templates.
  * Added project name prompt with validation; `--yes` flag skips interactive prompts.
  * Scaffolded features are now tracked and integrated into project metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->