### PR TITLE
docs: add starter kit how-to guides to public documentation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -64,6 +64,7 @@ export default defineConfig({
       { text: 'Guides', link: '/guides/' },
       { text: 'Concepts', link: '/concepts/' },
       { text: 'Reference', link: '/reference/' },
+      { text: 'Starter Kits', link: '/templates/' },
       {
         text: 'More',
         items: [
@@ -109,6 +110,12 @@ export default defineConfig({
         {
           text: 'Self-Hosting',
           items: generateSidebar('self-hosting', '/self-hosting'),
+        },
+      ],
+      '/templates/': [
+        {
+          text: 'Starter Kits',
+          items: generateSidebar('templates', '/templates'),
         },
       ],
     },

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,14 @@
 | [Deployment Modes](./guides/deployment-modes.md) | Run in web, desktop, or headless mode    |
 | [Gotchas](./guides/gotchas.md)                   | Known pitfalls and workarounds           |
 
+## Starter Kits
+
+| Document                                              | Description                                          |
+| ----------------------------------------------------- | ---------------------------------------------------- |
+| [Overview](./templates/index.md)                      | Available starter kits and how to scaffold them      |
+| [Docs Starter](./templates/docs-starter.md)           | Create a documentation site with Starlight           |
+| [Portfolio Starter](./templates/portfolio-starter.md) | Create a portfolio/marketing site with Astro + React |
+
 ## Reference
 
 | Document                                              | Description                                  |

--- a/docs/templates/docs-starter.md
+++ b/docs/templates/docs-starter.md
@@ -1,0 +1,178 @@
+---
+outline: deep
+---
+
+# Create a documentation site
+
+This guide covers scaffolding and customizing the Starlight documentation starter. By the end you have a running Astro + Starlight site deployable to Cloudflare Pages, with agent context configured for protoLabs.
+
+## What the starter includes
+
+| Feature       | Detail                                                                         |
+| ------------- | ------------------------------------------------------------------------------ |
+| Framework     | Astro 5, Starlight 0.37 (last Astro-5-compatible release)                      |
+| Styling       | Tailwind CSS 4 (CSS-first config, no `tailwind.config.js`)                     |
+| Search        | Pagefind (auto-indexed at build time, zero config)                             |
+| Formatting    | Prettier 3 (`.astro` files excluded — no `prettier-plugin-astro` installed)    |
+| Linting       | markdownlint-cli2                                                              |
+| CI            | GitHub Actions: build, format check, markdown lint, deploy to Cloudflare Pages |
+| Agent context | `.automaker/CONTEXT.md` loaded into every agent prompt                         |
+
+Pre-loaded board features: configure CI, set up branch protection, write README, add a tutorial, add a how-to guide, configure custom domain, add search, create API reference.
+
+## Scaffold the project
+
+**Via CLI:**
+
+```bash
+npx create-protolab
+# Select: docs
+# Enter project name when prompted
+```
+
+**Via UI:**
+
+Open the New Project dialog → select **Docs** from the template dropdown → enter a project name → click Create.
+
+After scaffolding:
+
+```bash
+cd <your-project-name>
+npm install
+npm run dev
+```
+
+The dev server starts at `http://localhost:4321`.
+
+## Add pages
+
+All documentation pages live in `src/content/docs/`. Add a `.md` or `.mdx` file to create a new route.
+
+```bash
+# Creates /guides/my-guide
+touch src/content/docs/guides/my-guide.md
+```
+
+Every page requires a `title` in frontmatter:
+
+```markdown
+---
+title: My Guide
+description: A short description shown in meta tags and search results.
+---
+
+# My Guide
+
+Content here.
+```
+
+Starlight auto-generates the sidebar from the directory structure. No manual sidebar config is needed unless you want custom ordering.
+
+To control sidebar order and labels, edit `astro.config.mjs`:
+
+```js
+// astro.config.mjs
+starlight({
+  sidebar: [
+    {
+      label: 'Guides',
+      items: [
+        { label: 'Getting started', link: '/guides/getting-started/' },
+        { label: 'My Guide', link: '/guides/my-guide/' },
+      ],
+    },
+  ],
+});
+```
+
+## Customize the theme
+
+Brand colors, fonts, and dark/light mode tokens are defined in `src/styles/global.css`. Override Starlight's CSS variables in the `:root` and `[data-theme='dark']` selectors:
+
+```css
+/* src/styles/global.css */
+:root {
+  --sl-color-accent: oklch(55% 0.22 270);
+  --sl-color-accent-high: oklch(75% 0.18 270);
+  --sl-font: 'Geist', sans-serif;
+}
+
+[data-theme='dark'] {
+  --sl-color-bg: oklch(12% 0.01 270);
+  --sl-color-bg-sidebar: oklch(10% 0.01 270);
+}
+```
+
+To add custom fonts, import them at the top of `global.css`:
+
+```css
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@400;500;700&display=swap');
+```
+
+## Update site metadata
+
+Edit `astro.config.mjs` to set the site title, description, and base URL:
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import starlight from '@astrojs/starlight';
+
+export default defineConfig({
+  site: 'https://docs.example.com',
+  integrations: [
+    starlight({
+      title: 'My Docs',
+      description: 'Documentation for My Project.',
+      social: {
+        github: 'https://github.com/your-org/your-repo',
+      },
+      logo: {
+        src: './src/assets/logo.svg',
+      },
+    }),
+  ],
+});
+```
+
+## Deploy to Cloudflare Pages
+
+The scaffolded CI workflow (`.github/workflows/ci.yml`) handles deployment automatically on push to `main`.
+
+To set it up manually:
+
+1. Push the repo to GitHub.
+2. In Cloudflare Pages, click **Create a project** → **Connect to Git** → select your repo.
+3. Set build command: `npm run build`
+4. Set output directory: `dist`
+5. Add environment variables if needed (e.g., `SITE_URL`).
+
+For the GitHub Actions deployment path, add these secrets to your repo:
+
+| Secret                  | Value                                           |
+| ----------------------- | ----------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`  | Cloudflare API token with Pages:Edit permission |
+| `CLOUDFLARE_ACCOUNT_ID` | Your Cloudflare account ID                      |
+
+## How AI agents interact with this starter
+
+When an agent works on a feature in this project, protoLabs loads `.automaker/CONTEXT.md` into the agent's system prompt. The file explains the project structure, routing conventions, Starlight content collection schema, theming approach, and CI pipeline.
+
+The `.automaker/coding-rules.md` file enforces stack-specific rules: Astro-first component selection, no client-side hydration by default, Tailwind v4 CSS-first config.
+
+You can extend both files with project-specific rules. See [Context Files](../guides/context-files) for the full format.
+
+## Key constraints
+
+| Constraint                            | Reason                                                                          |
+| ------------------------------------- | ------------------------------------------------------------------------------- |
+| Starlight pinned to `^0.37.0`         | Starlight 0.38+ requires Astro 6, which is not yet supported                    |
+| Zod pinned to `^3.25.0`               | Starlight 0.37 uses Zod v3 internally; Zod v4 breaks it                         |
+| `.astro` files excluded from Prettier | `prettier-plugin-astro` is not installed; formatting `.astro` files would error |
+| New pages in `src/content/docs/`      | Starlight only serves pages from this directory, not `src/pages/`               |
+
+## Next steps
+
+- [Authoring Skills](../guides/authoring-skills) — teach agents project-specific patterns
+- [Context Files](../guides/context-files) — add project rules to agent prompts
+- [CI/CD](../self-hosting/ci-cd) — configure advanced deployment pipelines

--- a/docs/templates/index.md
+++ b/docs/templates/index.md
@@ -1,0 +1,45 @@
+---
+outline: deep
+---
+
+# Starter Kits
+
+protoLabs ships two starter kits for common project types. Each kit includes a pre-configured project scaffold, a `.automaker/CONTEXT.md` agent context file, and a board pre-loaded with initial features.
+
+## Available kits
+
+| Kit                              | Stack                              | Use case                                             |
+| -------------------------------- | ---------------------------------- | ---------------------------------------------------- |
+| [Docs](./docs-starter)           | Astro + Starlight + Tailwind CSS 4 | Documentation sites, API references, knowledge bases |
+| [Portfolio](./portfolio-starter) | Astro + React + Tailwind CSS 4     | Personal sites, marketing pages, project showcases   |
+
+## Scaffold a starter
+
+**Via CLI:**
+
+```bash
+npx create-protolab
+```
+
+Select a kit type when prompted. The CLI copies the starter into the current directory, substitutes your project name, and creates initial board features.
+
+**Via UI:**
+
+Open the New Project dialog in the protoLabs Studio board. Select a kit type from the template dropdown. The UI runs the same scaffold logic as the CLI.
+
+## What the scaffold creates
+
+Every kit scaffold produces:
+
+- A ready-to-run project directory with all dependencies listed
+- `.automaker/CONTEXT.md` — loaded into every agent prompt for that project
+- `.automaker/coding-rules.md` — stack-specific coding conventions
+- `.github/workflows/ci.yml` — CI pipeline targeting Cloudflare Pages
+- A set of initial board features (configure CI, write README, add first content, etc.)
+
+Run `npm install` inside the scaffolded directory before starting the dev server.
+
+## Next steps
+
+- [Create a documentation site](./docs-starter)
+- [Create a portfolio site](./portfolio-starter)

--- a/docs/templates/portfolio-starter.md
+++ b/docs/templates/portfolio-starter.md
@@ -1,0 +1,211 @@
+---
+outline: deep
+---
+
+# Create a portfolio site
+
+This guide covers scaffolding and customizing the portfolio/marketing starter. By the end you have a running Astro + React site deployable to Cloudflare Pages, with agent context configured for protoLabs.
+
+## What the starter includes
+
+| Feature       | Detail                                                                             |
+| ------------- | ---------------------------------------------------------------------------------- |
+| Framework     | Astro 5 (static output, pre-generated routes)                                      |
+| Interactivity | React 19 islands (`client:load`) for interactive sections only                     |
+| Styling       | Tailwind CSS 4 (CSS-first config via `@theme` block in `global.css`)               |
+| Content       | Astro Content Collections for blog posts, projects, testimonials, and site config  |
+| SEO           | Sitemap (`@astrojs/sitemap`) and RSS feed (`@astrojs/rss`) auto-generated at build |
+| CI            | GitHub Actions: build, format check, deploy to Cloudflare Pages                    |
+| Agent context | `.automaker/CONTEXT.md` loaded into every agent prompt                             |
+
+Pre-loaded board features: configure CI, set up branch protection, write README, customize site identity, add portfolio projects, write blog posts, configure custom domain, add testimonials.
+
+## Scaffold the project
+
+**Via CLI:**
+
+```bash
+npx create-protolab
+# Select: portfolio
+# Enter project name when prompted
+```
+
+**Via UI:**
+
+Open the New Project dialog → select **Portfolio** from the template dropdown → enter a project name → click Create.
+
+After scaffolding:
+
+```bash
+cd <your-project-name>
+npm install
+npm run dev
+```
+
+The dev server starts at `http://localhost:4321`.
+
+> The portfolio starter is a standalone project. Run `npm install` inside the scaffolded directory, not from the monorepo root.
+
+## Customize site identity
+
+Edit `src/content/siteConfig/config.json` to update author name, tagline, social links, and default SEO metadata:
+
+```json
+{
+  "name": "Your Name",
+  "tagline": "Full-stack engineer building things on the web.",
+  "email": "you@example.com",
+  "social": {
+    "github": "https://github.com/yourhandle",
+    "twitter": "https://twitter.com/yourhandle",
+    "linkedin": "https://linkedin.com/in/yourhandle"
+  }
+}
+```
+
+Update `astro.config.mjs` with your production domain:
+
+```js
+// astro.config.mjs
+export default defineConfig({
+  site: 'https://yourname.dev',
+  // ...
+});
+```
+
+## Add portfolio projects
+
+Create a new `.mdx` file in `src/content/projects/`:
+
+```bash
+touch src/content/projects/my-project.mdx
+```
+
+Required frontmatter fields:
+
+```mdx
+---
+title: My Project
+description: A short description shown on the projects grid.
+date: 2026-01-15
+tags: [TypeScript, React, Postgres]
+image: ./images/my-project.png
+githubUrl: https://github.com/you/my-project
+liveUrl: https://my-project.example.com
+featured: true
+---
+
+## Overview
+
+Write the full project write-up here in MDX. Use headings, code blocks, and images freely.
+```
+
+Set `featured: true` to pin the project to the top of the projects grid.
+
+## Write blog posts
+
+Create a new `.mdx` file in `src/content/blog/`:
+
+```bash
+touch src/content/blog/my-post.mdx
+```
+
+Required frontmatter fields:
+
+```mdx
+---
+title: My Post Title
+description: A summary for the blog index and meta tags.
+pubDate: 2026-03-14
+tags: [Astro, TypeScript]
+draft: false
+---
+
+Post content here.
+```
+
+Set `draft: true` to exclude a post from the production build while you write it.
+
+## Customize the theme
+
+Brand colors and design tokens are defined in `src/styles/global.css` using the Tailwind v4 `@theme` block:
+
+```css
+/* src/styles/global.css */
+@import 'tailwindcss';
+
+@theme {
+  --color-surface-0: oklch(12% 0.01 270);
+  --color-surface-1: oklch(16% 0.01 270);
+  --color-accent: oklch(65% 0.22 270);
+  --font-sans: 'Geist', system-ui, sans-serif;
+}
+```
+
+All color and spacing tokens defined here become available as Tailwind utility classes (e.g., `bg-surface-0`, `text-accent`).
+
+To add a custom font, import it before the `@theme` block:
+
+```css
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@400;500;700&display=swap');
+```
+
+## Add testimonials
+
+Create a `.json` file in `src/content/testimonials/`:
+
+```json
+{
+  "author": "Alex Chen",
+  "role": "CTO at Acme Corp",
+  "quote": "Shipped our entire redesign in two weeks. Remarkable.",
+  "avatar": "./images/alex-chen.jpg"
+}
+```
+
+Testimonials render in the home page `<Testimonials>` section automatically.
+
+## Deploy to Cloudflare Pages
+
+The scaffolded CI workflow (`.github/workflows/ci.yml`) handles deployment automatically on push to `main`.
+
+To set it up manually:
+
+1. Push the repo to GitHub.
+2. In Cloudflare Pages, click **Create a project** → **Connect to Git** → select your repo.
+3. Set build command: `npm run build`
+4. Set output directory: `dist`
+
+Add these secrets to your GitHub repo for the Actions deployment path:
+
+| Secret                  | Value                                           |
+| ----------------------- | ----------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`  | Cloudflare API token with Pages:Edit permission |
+| `CLOUDFLARE_ACCOUNT_ID` | Your Cloudflare account ID                      |
+
+The portfolio uses Astro's `output: 'static'` mode. All routes are pre-generated at build time. New blog posts and projects require a rebuild and redeploy to appear on the live site.
+
+## How AI agents interact with this starter
+
+When an agent works on a feature in this project, protoLabs loads `.automaker/CONTEXT.md` into the agent's system prompt. The file explains the Content Collections schema, component structure, island hydration strategy, Tailwind v4 token conventions, and CI pipeline.
+
+The `.automaker/coding-rules.md` file enforces Astro-specific rules: prefer zero-JS Astro components over React islands, use `client:load` only when interactivity is required on page load, never import `@automaker/types` (standalone project).
+
+You can extend both files with project-specific rules. See [Context Files](../guides/context-files) for the full format.
+
+## Content collection schema
+
+| Collection     | Location                    | Format | Key fields                                         |
+| -------------- | --------------------------- | ------ | -------------------------------------------------- |
+| `blog`         | `src/content/blog/`         | MDX    | `title`, `description`, `pubDate`, `tags`, `draft` |
+| `projects`     | `src/content/projects/`     | MDX    | `title`, `description`, `date`, `tags`, `featured` |
+| `testimonials` | `src/content/testimonials/` | JSON   | `author`, `role`, `quote`, `avatar`                |
+| `siteConfig`   | `src/content/siteConfig/`   | JSON   | `name`, `tagline`, `email`, `social`               |
+
+The schema for each collection is defined in `src/content/config.ts` using Zod. Build-time validation catches missing or mistyped frontmatter fields before they reach production.
+
+## Next steps
+
+- [Authoring Skills](../guides/authoring-skills) — teach agents project-specific patterns
+- [Context Files](../guides/context-files) — add project rules to agent prompts
+- [CI/CD](../self-hosting/ci-cd) — configure advanced deployment pipelines


### PR DESCRIPTION
## Summary

- Adds `docs/templates/` section with three new pages covering both starter kits
- `docs/templates/index.md`: overview table of available kits, scaffold commands (CLI and UI), what scaffolding produces
- `docs/templates/docs-starter.md`: step-by-step how-to for the Starlight docs starter (scaffold, add pages, customize theme, update metadata, deploy to Cloudflare Pages, agent context)
- `docs/templates/portfolio-starter.md`: step-by-step how-to for the portfolio starter (scaffold, customize site identity, add projects/posts/testimonials, theme, deploy, agent context)
- Updates `docs/.vitepress/config.mts` with a "Starter Kits" nav item and `/templates/` sidebar entry
- Updates `docs/README.md` with a Starter Kits section linking the new pages

All pages follow Diataxis how-to format: steps-only, second-person imperative, no marketing language, code-first.

## Test plan

- [ ] VitePress builds cleanly with the new pages
- [ ] `/templates/` sidebar appears with both starter guides
- [ ] "Starter Kits" nav item appears in top navigation
- [ ] Internal links to `../guides/context-files` and `../self-hosting/ci-cd` resolve correctly
- [ ] Frontmatter and markdown syntax is valid (no linting errors)

<!-- automaker:owner instance=local team=protoLabsAI created=2026-03-14T18:20:00.000Z -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Starter Kits section to navigation for easy access.
  * Introduced Docs Starter Kit for scaffolding and deploying documentation sites.
  * Introduced Portfolio Starter Kit for creating portfolio projects.
  * Added comprehensive guides covering project features, customization, deployment, and AI agent integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->