### PR TITLE
Add project badge to feature cards

### DIFF
--- a/apps/ui/src/components/views/board-view/components/kanban-card/card-badges.tsx
+++ b/apps/ui/src/components/views/board-view/components/kanban-card/card-badges.tsx
@@ -22,6 +22,7 @@ import {
   FileText,
   XCircle,
   Server,
+  FolderOpen,
 } from 'lucide-react';
 import { getBlockingDependencies } from '@protolabsai/dependency-resolver';
 import { useShallow } from 'zustand/react/shallow';
@@ -148,6 +149,34 @@ function isHumanInterventionRequired(reason: string): boolean {
   );
 }
 
+/** Palette for deterministic project badge colors */
+const PROJECT_BADGE_COLORS = [
+  '#6366f1',
+  '#8b5cf6',
+  '#ec4899',
+  '#14b8a6',
+  '#f97316',
+  '#06b6d4',
+  '#84cc16',
+  '#f43f5e',
+];
+
+/** Deterministic color from project slug */
+function getProjectColor(slug: string): string {
+  let hash = 0;
+  for (let i = 0; i < slug.length; i++) {
+    hash = ((hash * 31 + slug.charCodeAt(i)) >>> 0) & 0xffffffff;
+  }
+  return PROJECT_BADGE_COLORS[hash % PROJECT_BADGE_COLORS.length];
+}
+
+/** Abbreviate a slug to at most 2 dash-segments, max 14 chars */
+function abbreviateSlug(slug: string): string {
+  const parts = slug.split('-');
+  const short = parts.length <= 2 ? slug : parts.slice(0, 2).join('-');
+  return short.length > 14 ? short.slice(0, 14) : short;
+}
+
 interface CardBadgesProps {
   feature: Feature;
   onPRDClick?: () => void;
@@ -158,6 +187,7 @@ interface CardBadgesProps {
  * Note: Blocked/Lock badges are now shown in PriorityBadges for visual consistency
  */
 export const CardBadges = memo(function CardBadges({ feature, onPRDClick }: CardBadgesProps) {
+  const boardProjectFilter = useAppStore(useShallow((state) => state.boardProjectFilter));
   const hasEpic = !!feature.epicId;
   const hasError = !!feature.error;
   const hasDueDate = !!feature.dueDate;
@@ -168,6 +198,7 @@ export const CardBadges = memo(function CardBadges({ feature, onPRDClick }: Card
   const isNeedsAction =
     feature.status === 'blocked' && isHumanInterventionRequired(feature.statusChangeReason ?? '');
   const hasAssignedInstance = !!feature.assignedInstance;
+  const hasProject = !!feature.projectSlug && feature.projectSlug !== boardProjectFilter;
 
   if (
     !hasError &&
@@ -176,7 +207,8 @@ export const CardBadges = memo(function CardBadges({ feature, onPRDClick }: Card
     !hasCost &&
     !hasWorkItemState &&
     !isNeedsAction &&
-    !hasAssignedInstance
+    !hasAssignedInstance &&
+    !hasProject
   ) {
     return null;
   }
@@ -189,10 +221,38 @@ export const CardBadges = memo(function CardBadges({ feature, onPRDClick }: Card
     ? getWorkItemStateBadge(feature.workItemState!)
     : null;
 
+  // Project badge color
+  const projectColor = hasProject ? getProjectColor(feature.projectSlug!) : undefined;
+
   return (
     <div className="flex flex-wrap items-center gap-1.5 px-3 pt-1.5 min-h-[24px]">
       {/* Epic badge - shows parent epic for child features */}
       {hasEpic && <EpicBadge feature={feature} />}
+
+      {/* Project badge - shows which project plan this feature belongs to */}
+      {hasProject && (
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className="inline-flex items-center gap-1 px-1.5 h-5 rounded text-[10px] font-medium border"
+                style={{
+                  backgroundColor: `${projectColor}1a`,
+                  color: projectColor,
+                  borderColor: `${projectColor}40`,
+                }}
+                data-testid={`project-badge-${feature.id}`}
+              >
+                <FolderOpen className="w-2.5 h-2.5" />
+                {abbreviateSlug(feature.projectSlug!)}
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              <p>Project: {feature.projectSlug}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
 
       {/* Instance badge - shows which instance owns this feature (cross-instance dashboard) */}
       {hasAssignedInstance && (

--- a/apps/ui/src/components/views/board-view/components/list-view/list-row.tsx
+++ b/apps/ui/src/components/views/board-view/components/list-view/list-row.tsx
@@ -2,10 +2,37 @@
 import { memo, useCallback, useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@protolabsai/ui/atoms';
-import { AlertCircle, Lock, Hand, Sparkles, FileText } from 'lucide-react';
+import { AlertCircle, Lock, Hand, Sparkles, FileText, FolderOpen } from 'lucide-react';
+import { useAppStore } from '@/store/app-store';
+import { useShallow } from 'zustand/react/shallow';
 import type { Feature } from '@/store/types';
 import { RowActions, type RowActionHandlers } from './row-actions';
 import { getColumnWidth, getColumnAlign } from './list-header';
+
+const PROJECT_BADGE_COLORS = [
+  '#6366f1',
+  '#8b5cf6',
+  '#ec4899',
+  '#14b8a6',
+  '#f97316',
+  '#06b6d4',
+  '#84cc16',
+  '#f43f5e',
+];
+
+function getProjectColor(slug: string): string {
+  let hash = 0;
+  for (let i = 0; i < slug.length; i++) {
+    hash = ((hash * 31 + slug.charCodeAt(i)) >>> 0) & 0xffffffff;
+  }
+  return PROJECT_BADGE_COLORS[hash % PROJECT_BADGE_COLORS.length];
+}
+
+function abbreviateSlug(slug: string): string {
+  const parts = slug.split('-');
+  const short = parts.length <= 2 ? slug : parts.slice(0, 2).join('-');
+  return short.length > 14 ? short.slice(0, 14) : short;
+}
 
 export interface ListRowProps {
   /** The feature to display */
@@ -211,6 +238,7 @@ export const ListRow = memo(function ListRow({
   blockingDependencies = [],
   className,
 }: ListRowProps) {
+  const boardProjectFilter = useAppStore(useShallow((state) => state.boardProjectFilter));
   const handleRowClick = useCallback(
     (e: React.MouseEvent) => {
       // Don't trigger row click if clicking on checkbox or actions
@@ -310,6 +338,35 @@ export const ListRow = memo(function ListRow({
               {feature.description}
             </p>
           )}
+          {/* Project badge - shown when feature belongs to a project plan and board isn't filtered to it */}
+          {feature.projectSlug &&
+            feature.projectSlug !== boardProjectFilter &&
+            (() => {
+              const color = getProjectColor(feature.projectSlug);
+              return (
+                <TooltipProvider delayDuration={200}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        className="inline-flex items-center gap-1 px-1.5 h-4 rounded text-[10px] font-medium border mt-1"
+                        style={{
+                          backgroundColor: `${color}1a`,
+                          color,
+                          borderColor: `${color}40`,
+                        }}
+                        data-testid={`list-row-project-badge-${feature.id}`}
+                      >
+                        <FolderOpen className="w-2.5 h-2.5" />
+                        {abbreviateSlug(feature.projectSlug)}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="text-xs">
+                      <p>Project: {feature.projectSlug}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              );
+            })()}
         </div>
       </div>
 

--- a/apps/ui/src/store/app-store.ts
+++ b/apps/ui/src/store/app-store.ts
@@ -157,6 +157,7 @@ export interface AppState {
   // Hivemind / Cross-instance dashboard
   peers: HivemindPeer[];
   instanceFilter: 'all' | 'mine'; // 'all' = show features from all instances, 'mine' = local only
+  boardProjectFilter: string | null; // null = show all projects, slug = hide project badge for that project
   selfInstanceId: string | null; // The instanceId of this Automaker instance
 
   // Server URL runtime override
@@ -331,6 +332,7 @@ export interface AppActions {
   // Hivemind / Cross-instance dashboard actions
   setPeers: (peers: HivemindPeer[]) => void;
   setInstanceFilter: (filter: 'all' | 'mine') => void;
+  setBoardProjectFilter: (slug: string | null) => void;
   fetchPeers: () => Promise<void>;
   setSelfInstanceId: (id: string | null) => void;
   fetchSelfInstanceId: () => Promise<void>;
@@ -424,6 +426,7 @@ const initialState: AppState = {
   // Hivemind / Cross-instance dashboard
   peers: [],
   instanceFilter: 'all',
+  boardProjectFilter: null,
   selfInstanceId: null,
   // Server URL runtime override
   serverUrlOverride: (() => {
@@ -1301,6 +1304,7 @@ export const useAppStore = create<AppState & AppActions>()((set, get) => ({
   // Hivemind / Cross-instance dashboard actions
   setPeers: (peers) => set({ peers }),
   setInstanceFilter: (instanceFilter) => set({ instanceFilter }),
+  setBoardProjectFilter: (boardProjectFilter) => set({ boardProjectFilter }),
   fetchPeers: async () => {
     try {
       const api = getHttpApiClient();


### PR DESCRIPTION
## Summary

**Milestone:** Board Project Awareness

In apps/ui/src/components/views/board-view/components/kanban-card/kanban-card.tsx, add a compact project badge when the feature has a projectSlug. Show a shortened project name (abbreviated slug). Style like the existing epic badge — small, colored pill. Use a deterministic color from a palette based on slug hash. Hide the badge when the board is already filtered to that project. Also add project info to the list-view row.

**Files to Modify:**
- apps/ui/s...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-15T01:24:52.270Z -->