### PR TITLE
fix: update HITL test mock to use hitlForms flag

### DIFF
--- a/apps/server/tests/unit/services/hitl-form-service.test.ts
+++ b/apps/server/tests/unit/services/hitl-form-service.test.ts
@@ -29,10 +29,10 @@ vi.mock('@protolabsai/utils', () => ({
   }),
 }));
 
-function createMockSettingsService(pipelineEnabled = true) {
+function createMockSettingsService(hitlEnabled = true) {
   return {
     getGlobalSettings: vi.fn().mockResolvedValue({
-      featureFlags: { pipeline: pipelineEnabled },
+      featureFlags: { hitlForms: hitlEnabled },
     }),
   };
 }


### PR DESCRIPTION
One-line fix — test mock was using old `pipeline` flag instead of new `hitlForms` flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test fixtures with revised feature flag configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->