### PR TITLE
docs: add starter kit template system documentation

### DIFF
--- a/docs/templates/add-a-starter.md
+++ b/docs/templates/add-a-starter.md
@@ -1,0 +1,221 @@
+# Add a new starter kit
+
+This guide explains how to add a new local scaffold template to the protoLabs starter kit system. Follow these steps when you want a new kit type to appear in the New Project dialog and be available via `npx create-protolab`.
+
+This guide covers adding a **scaffold** kit (files copied from a local directory). For a **clone** kit (provisioned via `git clone`), see [Register a clone-based kit](#register-a-clone-based-kit) at the end.
+
+## Prerequisites
+
+- Access to the `automaker` monorepo
+- Basic familiarity with the [template system architecture](./architecture)
+
+## Steps
+
+### 1. Create the starter source directory
+
+Add a new directory under `libs/templates/starters/` with your kit name:
+
+```bash
+mkdir -p libs/templates/starters/my-kit
+```
+
+Put the project files you want to ship inside it. The entire directory will be copied verbatim to the user's output path, except `node_modules/` and `package-lock.json` (those are always skipped).
+
+**Required files:**
+
+- `package.json` — the `name` field will be replaced with the user's project name at scaffold time
+
+**Recommended files:**
+
+- `.automaker/CONTEXT.md` — agent context file loaded into every prompt for this project
+- `.automaker/coding-rules.md` — stack-specific conventions for the agent
+- `.github/workflows/ci.yml` — CI pipeline for the project
+
+**Example structure:**
+
+```
+libs/templates/starters/my-kit/
+├── .automaker/
+│   ├── CONTEXT.md
+│   └── coding-rules.md
+├── .github/
+│   └── workflows/
+│       └── ci.yml
+├── src/
+│   └── index.ts
+├── package.json
+└── tsconfig.json
+```
+
+### 2. Add the scaffold function
+
+Open `libs/templates/src/scaffold.ts` and add a new exported function following the existing pattern:
+
+```typescript
+/**
+ * Scaffold a new **my-kit** starter at `options.outputDir`.
+ *
+ * Copies `starters/my-kit/` to the output directory, substituting
+ * `projectName` into package.json.
+ */
+export async function scaffoldMyKitStarter(options: ScaffoldOptions): Promise<ScaffoldResult> {
+  const { projectName, outputDir } = options;
+  const filesCreated: string[] = [];
+
+  try {
+    const starterDir = resolveStarterDir('my-kit');
+    await copyDir(starterDir, outputDir);
+    await applySubstitutions(outputDir, projectName);
+
+    const entries = await fs.readdir(outputDir);
+    filesCreated.push(...entries.map((e) => path.join(outputDir, e)));
+
+    return { success: true, outputDir, filesCreated };
+  } catch (error) {
+    return {
+      success: false,
+      outputDir,
+      filesCreated,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+```
+
+Update `resolveStarterDir` to accept your new kit name by adding it to the union type:
+
+```typescript
+function resolveStarterDir(kitName: 'docs' | 'portfolio' | 'general' | 'my-kit'): string {
+```
+
+### 3. Add the kit type to `StarterKitType`
+
+Open `libs/templates/src/types.ts` and add your kit name to the union:
+
+```typescript
+export type StarterKitType = 'docs' | 'portfolio' | 'extension' | 'general' | 'my-kit';
+```
+
+### 4. Register the kit in the server route
+
+Open `apps/server/src/routes/setup/routes/scaffold-starter.ts`.
+
+Add `'my-kit'` to the validation check and the scaffolders map:
+
+```typescript
+// Validation
+if (!kitType || !['docs', 'portfolio', 'general', 'my-kit'].includes(kitType)) {
+  // ...
+}
+
+// Scaffolders map
+const scaffolders = {
+  docs: scaffoldDocsStarter,
+  portfolio: scaffoldPortfolioStarter,
+  general: scaffoldGeneralStarter,
+  'my-kit': scaffoldMyKitStarter, // add this
+};
+```
+
+Update the import at the top:
+
+```typescript
+import {
+  scaffoldDocsStarter,
+  scaffoldPortfolioStarter,
+  scaffoldGeneralStarter,
+  scaffoldMyKitStarter, // add this
+} from '@protolabsai/templates';
+```
+
+Also update the `ScaffoldStarterRequest` type in the same file:
+
+```typescript
+interface ScaffoldStarterRequest {
+  projectPath: string;
+  kitType: 'docs' | 'portfolio' | 'general' | 'my-kit'; // add your kit
+  projectName?: string;
+}
+```
+
+### 5. Register the template in the UI
+
+Open `apps/ui/src/lib/templates.ts` and add an entry to `starterTemplates`:
+
+```typescript
+{
+  id: 'my-kit',
+  name: 'My Kit',
+  description: 'Short description shown in the New Project dialog.',
+  source: 'scaffold',
+  kitType: 'my-kit',
+  techStack: ['TypeScript', 'Node.js'],
+  features: [
+    'Feature one',
+    'Feature two',
+  ],
+  category: 'backend',  // 'fullstack' | 'frontend' | 'backend' | 'ai' | 'other'
+  author: 'protoLabs',
+},
+```
+
+### 6. Build and verify
+
+```bash
+# Rebuild the templates package
+npm run build --workspace=libs/templates
+
+# Rebuild the server
+npm run build:server
+
+# Run typecheck
+npm run typecheck
+```
+
+Test the scaffold via the server route:
+
+```bash
+curl -X POST http://localhost:3000/api/setup/scaffold-starter \
+  -H 'Content-Type: application/json' \
+  -d '{"projectPath": "/tmp/my-kit-test", "kitType": "my-kit", "projectName": "test-project"}'
+```
+
+Verify the output directory contains your starter files with the project name substituted.
+
+### 7. Add documentation
+
+Add a page at `docs/templates/my-kit-starter.md` documenting the kit. Follow the pattern of [docs-starter.md](./docs-starter) and [portfolio-starter.md](./portfolio-starter).
+
+Update `docs/templates/index.md` to include the new kit in the available kits table.
+
+---
+
+## Register a clone-based kit
+
+If your kit requires native build scripts or toolchain setup that makes local file copying impractical, register it as a clone-based template instead.
+
+Clone-based templates are provisioned via `git clone` and do not require changes to the server route or the `@protolabsai/templates` package. You only need to:
+
+1. Push the template repository to GitHub (e.g., `https://github.com/protoLabsAI/my-kit-template`)
+2. Add the entry to `apps/ui/src/lib/templates.ts` with `source: 'clone'` and `repoUrl`:
+
+```typescript
+{
+  id: 'my-kit',
+  name: 'My Kit',
+  description: 'Short description.',
+  source: 'clone',
+  repoUrl: 'https://github.com/protoLabsAI/my-kit-template',
+  techStack: ['WXT', 'TypeScript'],
+  features: ['Feature one', 'Feature two'],
+  category: 'frontend',
+  author: 'protoLabs',
+},
+```
+
+The UI handles the rest. No `kitType` field is needed for clone-based templates.
+
+## Related pages
+
+- [Architecture: how the template system works](./architecture)
+- [Starter Kits overview](./index)

--- a/docs/templates/architecture.md
+++ b/docs/templates/architecture.md
@@ -1,0 +1,206 @@
+# Architecture: how the template system works
+
+This page explains how starter kits are implemented — from the `@protolabsai/templates` package to the scaffold API endpoint to the UI template registry. Read this if you want to understand the internals or extend the system.
+
+## Overview
+
+The template system has three layers:
+
+```
+UI template registry (apps/ui/src/lib/templates.ts)
+        ↓  POST /api/setup/scaffold-starter
+Server scaffold route (apps/server/src/routes/setup/routes/scaffold-starter.ts)
+        ↓  imports
+@protolabsai/templates package (libs/templates/)
+        ↓  reads from
+Starter source files (libs/templates/starters/<kit>/)
+```
+
+The UI layer defines what templates to show and how to present them. The server layer validates the request and delegates to the templates package. The templates package does the actual file I/O.
+
+## The `@protolabsai/templates` package
+
+**Location:** `libs/templates/`
+
+The package exports three scaffold functions and the types they use.
+
+### Types
+
+**`StarterKitType`** — the union of valid kit names:
+
+```typescript
+type StarterKitType = 'docs' | 'portfolio' | 'extension' | 'general';
+```
+
+**`ScaffoldOptions`** — input to every scaffold function:
+
+```typescript
+interface ScaffoldOptions {
+  /** Project name — used as the package.json name and in config substitution. */
+  projectName: string;
+  /** Absolute path to the destination directory (must not already exist). */
+  outputDir: string;
+}
+```
+
+**`ScaffoldResult`** — return value of every scaffold function:
+
+```typescript
+interface ScaffoldResult {
+  success: boolean;
+  outputDir: string;
+  filesCreated: string[];
+  error?: string;
+}
+```
+
+### Scaffold functions
+
+| Function                            | Kit type    | Source directory      |
+| ----------------------------------- | ----------- | --------------------- |
+| `scaffoldDocsStarter(options)`      | `docs`      | `starters/docs/`      |
+| `scaffoldPortfolioStarter(options)` | `portfolio` | `starters/portfolio/` |
+| `scaffoldGeneralStarter(options)`   | `general`   | `starters/general/`   |
+
+All three functions follow the same pattern:
+
+1. Resolve the source directory path relative to the compiled package
+2. Recursively copy the directory to `outputDir`, skipping `node_modules` and `package-lock.json`
+3. Apply name substitutions to `package.json` and `astro.config.mjs`
+4. Return a `ScaffoldResult` with the list of top-level files created
+
+The `general` starter additionally writes an `app_spec.txt` with the project name and a placeholder structure.
+
+### Name substitution
+
+After copying, `applySubstitutions()` patches two files:
+
+- **`package.json`** — sets `name` to `projectName`
+- **`astro.config.mjs`** — updates the `site` URL, `title`, and `description` fields with `projectName`
+
+If either file is missing (the general starter has no `astro.config.mjs`), the substitution is silently skipped.
+
+### The `starters/` directory
+
+Each starter kit is a self-contained project directory under `libs/templates/starters/`:
+
+```
+libs/templates/starters/
+├── docs/
+│   ├── .automaker/
+│   │   └── CONTEXT.md
+│   ├── .github/
+│   │   └── workflows/
+│   │       └── ci.yml
+│   ├── src/
+│   │   └── content/
+│   │       └── docs/
+│   ├── astro.config.mjs
+│   └── package.json
+├── portfolio/
+│   ├── src/
+│   │   ├── components/
+│   │   ├── content/
+│   │   └── pages/
+│   ├── astro.config.mjs
+│   └── package.json
+└── general/
+    └── .automaker/
+        ├── settings.json
+        └── categories.json
+```
+
+These files are the exact files that get copied to the user's project. Edit them directly to change what a scaffolded project looks like.
+
+## The scaffold server route
+
+**Location:** `apps/server/src/routes/setup/routes/scaffold-starter.ts`
+
+**Endpoint:** `POST /api/setup/scaffold-starter`
+
+**Request body:**
+
+| Field         | Type                                 | Required | Description                                            |
+| ------------- | ------------------------------------ | -------- | ------------------------------------------------------ |
+| `projectPath` | `string`                             | Yes      | Absolute or relative path to the destination directory |
+| `kitType`     | `'docs' \| 'portfolio' \| 'general'` | Yes      | Which starter kit to scaffold                          |
+| `projectName` | `string`                             | No       | Overrides the name derived from the directory basename |
+
+**Response:**
+
+```typescript
+{
+  success: boolean;
+  outputDir: string;      // resolved absolute path
+  filesCreated: string[]; // top-level entries created
+  error?: string;
+}
+```
+
+The route:
+
+1. Validates `projectPath` and `kitType`
+2. Creates the target directory if it doesn't exist
+3. Resolves symlinks and checks against `ALLOWED_ROOT_DIRECTORY` (env var) to block path traversal
+4. Derives `projectName` from the directory basename if not provided
+5. Delegates to the matching scaffold function from `@protolabsai/templates`
+
+Note: `kitType: 'extension'` is not accepted by this endpoint. The browser extension kit uses `git clone` and is handled separately.
+
+## The UI template registry
+
+**Location:** `apps/ui/src/lib/templates.ts`
+
+Defines the `StarterTemplate` interface and the `starterTemplates` array that the New Project dialog consumes.
+
+```typescript
+interface StarterTemplate {
+  id: string;
+  name: string;
+  description: string;
+  source: 'scaffold' | 'clone';
+  kitType?: 'docs' | 'portfolio' | 'extension'; // for scaffold source
+  repoUrl?: string; // for clone source
+  techStack: string[];
+  features: string[];
+  category: 'fullstack' | 'frontend' | 'backend' | 'ai' | 'other';
+  author: string;
+}
+```
+
+The `source` field determines how the UI provisions the project:
+
+- `scaffold` — sends `POST /api/setup/scaffold-starter` with `kitType`
+- `clone` — runs `git clone repoUrl` at the target path
+
+Helper functions:
+
+```typescript
+getTemplateById(id: string): StarterTemplate | undefined
+getTemplatesByCategory(category: StarterTemplate['category']): StarterTemplate[]
+```
+
+## Scaffold flow end-to-end
+
+When a user creates a project from the New Project dialog:
+
+```
+1. User selects a template in new-project-modal.tsx
+2. UI reads template.source
+   ├── 'scaffold' → POST /api/setup/scaffold-starter { projectPath, kitType, projectName }
+   │     └── Server calls scaffoldDocsStarter / scaffoldPortfolioStarter / scaffoldGeneralStarter
+   │           └── copyDir(starters/<kit>/, outputDir) + applySubstitutions()
+   └── 'clone'    → git clone <repoUrl> <projectPath>
+3. On success, Studio opens the new project
+```
+
+## Related files
+
+| File                                                      | Purpose                                                |
+| --------------------------------------------------------- | ------------------------------------------------------ |
+| `libs/templates/src/scaffold.ts`                          | Scaffold functions and file I/O                        |
+| `libs/templates/src/types.ts`                             | `StarterKitType`, `ScaffoldOptions`, and related types |
+| `libs/templates/starters/`                                | Source files for each local scaffold kit               |
+| `apps/server/src/routes/setup/routes/scaffold-starter.ts` | HTTP endpoint                                          |
+| `apps/ui/src/lib/templates.ts`                            | UI template registry                                   |
+| `apps/ui/src/components/dialogs/new-project-modal.tsx`    | New Project dialog                                     |

--- a/docs/templates/index.md
+++ b/docs/templates/index.md
@@ -4,42 +4,97 @@ outline: deep
 
 # Starter Kits
 
-protoLabs ships two starter kits for common project types. Each kit includes a pre-configured project scaffold, a `.automaker/CONTEXT.md` agent context file, and a board pre-loaded with initial features.
+Starter kits are pre-configured project templates that protoLabs Studio uses to bootstrap new projects. Each kit ships with a ready-to-run project scaffold, a `.automaker/` agent configuration directory, and a board pre-loaded with initial features.
+
+This page covers what starter kits are, how to use them, and what each one includes.
 
 ## Available kits
 
-| Kit                              | Stack                              | Use case                                             |
-| -------------------------------- | ---------------------------------- | ---------------------------------------------------- |
-| [Docs](./docs-starter)           | Astro + Starlight + Tailwind CSS 4 | Documentation sites, API references, knowledge bases |
-| [Portfolio](./portfolio-starter) | Astro + React + Tailwind CSS 4     | Personal sites, marketing pages, project showcases   |
+| Kit                                               | Source   | Stack                              | Use case                                           |
+| ------------------------------------------------- | -------- | ---------------------------------- | -------------------------------------------------- |
+| [Documentation site](./docs-starter)              | scaffold | Astro + Starlight + Tailwind CSS 4 | Docs sites, API references, knowledge bases        |
+| [Portfolio / marketing site](./portfolio-starter) | scaffold | Astro + React 19 + Tailwind CSS 4  | Personal sites, marketing pages, project showcases |
+| [Browser extension](#browser-extension)           | clone    | WXT + React 19 + TypeScript        | Chrome + Firefox extensions (Manifest V3)          |
+| [General project](#general-project)               | scaffold | Blank `.automaker/` structure      | Bring-your-own codebase                            |
 
 ## Scaffold a starter
 
-**Via CLI:**
+**Via the CLI:**
 
 ```bash
 npx create-protolab
 ```
 
-Select a kit type when prompted. The CLI copies the starter into the current directory, substitutes your project name, and creates initial board features.
+Select a kit type when prompted. The CLI copies the starter into the current directory, substitutes your project name into `package.json` and `astro.config.mjs`, and creates the initial board features.
 
-**Via UI:**
+**Via the UI:**
 
-Open the New Project dialog in the protoLabs Studio board. Select a kit type from the template dropdown. The UI runs the same scaffold logic as the CLI.
+Open the **New Project** dialog in protoLabs Studio. Select a template from the dropdown. The UI calls the same scaffold endpoint as the CLI and opens the new project automatically.
 
-## What the scaffold creates
+## What the scaffold produces
 
-Every kit scaffold produces:
+Every scaffold creates:
 
-- A ready-to-run project directory with all dependencies listed
-- `.automaker/CONTEXT.md` — loaded into every agent prompt for that project
-- `.automaker/coding-rules.md` — stack-specific coding conventions
-- `.github/workflows/ci.yml` — CI pipeline targeting Cloudflare Pages
-- A set of initial board features (configure CI, write README, add first content, etc.)
+- A ready-to-run project directory with all source files and config
+- `.automaker/CONTEXT.md` — loaded into every agent prompt for this project
+- `.automaker/coding-rules.md` — stack-specific conventions
+- `.github/workflows/ci.yml` — CI pipeline (build, format, lint, deploy)
+- Initial board features (configure CI, write README, add first content, etc.)
 
 Run `npm install` inside the scaffolded directory before starting the dev server.
 
+## Kit details
+
+### Documentation site
+
+**Source:** scaffold (local copy)
+**Kit type:** `docs`
+**Stack:** Astro 5, Starlight, Tailwind CSS 4, MDX, Pagefind, Cloudflare Pages
+
+Creates a Starlight documentation site with Diataxis sidebar structure and Pagefind full-text search. The `.automaker/` config includes context tuned for docs writing: writing style conventions, page structure patterns, and frontmatter rules.
+
+See [Documentation site starter](./docs-starter) for a full walkthrough.
+
+### Portfolio / marketing site
+
+**Source:** scaffold (local copy)
+**Kit type:** `portfolio`
+**Stack:** Astro 5, React 19, Tailwind CSS 4, Content Collections, View Transitions
+
+Creates a portfolio site with React islands for interactive sections (project grid, contact form), Content Collections for blog posts and project data, and an RSS feed. Includes SEO meta tags, Open Graph, and Twitter Cards.
+
+See [Portfolio site starter](./portfolio-starter) for a full walkthrough.
+
+### Browser extension
+
+**Source:** clone (GitHub repository)
+**Kit type:** `extension`
+**Stack:** WXT, React 19, TypeScript, Tailwind CSS 4, Vitest, Playwright, web-ext
+
+Cloned from `https://github.com/protoLabsAI/browser-extension-template`. Because browser extension tooling requires native build scripts, this kit is provisioned via `git clone` rather than local file copy. The repository includes a background service worker, content script scaffold, popup and options pages, and CI pipelines for both the Chrome Web Store and Firefox AMO.
+
+### General project
+
+**Source:** scaffold (local copy)
+**Kit type:** `general`
+**Stack:** none (blank)
+
+Creates only the `.automaker/` directory structure: `settings.json`, `categories.json`, and a placeholder `app_spec.txt`. Use this when you want to add protoLabs Studio to an existing project or a project with a stack not covered by the other kits.
+
+The agent analyzes your codebase on the first run and populates `app_spec.txt` with what it finds.
+
+## Scaffold vs clone
+
+|                           | Scaffold                                           | Clone                        |
+| ------------------------- | -------------------------------------------------- | ---------------------------- |
+| How it works              | Files copied from `@protolabsai/templates` package | `git clone` from GitHub      |
+| Offline support           | Yes                                                | No — requires network access |
+| Project name substitution | Automatic (`package.json`, `astro.config.mjs`)     | Manual after clone           |
+| Used by                   | docs, portfolio, general                           | browser-extension            |
+
 ## Next steps
 
-- [Create a documentation site](./docs-starter)
-- [Create a portfolio site](./portfolio-starter)
+- [Documentation site starter](./docs-starter)
+- [Portfolio site starter](./portfolio-starter)
+- [Architecture: how the template system works](./architecture)
+- [Add a new starter kit](./add-a-starter)


### PR DESCRIPTION
## Summary

- Updates `docs/templates/index.md` to cover all 4 kit types (browser extension and general were missing), adds a scaffold-vs-clone comparison table, and links to the new pages
- Adds `docs/templates/architecture.md` explaining the end-to-end scaffold flow: `@protolabsai/templates` package internals, scaffold functions, `starters/` directory layout, server route API reference, and the UI template registry
- Adds `docs/templates/add-a-starter.md` with a step-by-step how-to guide for adding a new local scaffold kit or a clone-based kit

VitePress sidebar picks the new pages up automatically via `generateSidebar()` — no config changes required.

## Test plan

- [x] `npx vitepress build docs` — build completes with no errors or dead links
- [x] All 3 files pass prettier formatting
- [x] Sidebar auto-generation confirmed (config uses `generateSidebar('templates', '/templates')`)
- [x] Cross-links between the three new pages verified correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added step-by-step guide for creating and registering custom starter kits
  * Added architectural documentation explaining the template system design and workflow
  * Expanded starter kit reference with new kit options, source types, and feature comparisons including scaffold vs. clone options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->