### PR TITLE
fix: skip epic PR when children merged directly to dev

### DIFF
--- a/apps/server/src/services/completion-detector-service.ts
+++ b/apps/server/src/services/completion-detector-service.ts
@@ -230,12 +230,38 @@ export class CompletionDetectorService {
   }
 
   /**
+   * Returns true if the given branch exists on the remote (origin).
+   * Uses `git ls-remote --heads origin <branch>` — a ref is only printed
+   * when the branch exists on the remote, so an empty result means absent.
+   */
+  private async epicBranchExistsOnRemote(
+    projectPath: string,
+    branchName: string
+  ): Promise<boolean> {
+    try {
+      const { stdout } = await execFileAsync(
+        'git',
+        ['ls-remote', '--heads', 'origin', branchName],
+        { cwd: projectPath, timeout: 15000 }
+      );
+      return stdout.trim().length > 0;
+    } catch {
+      // If the git command fails (no remote, no network), assume branch absent
+      return false;
+    }
+  }
+
+  /**
    * Check if all children of an epic are done. If the epic has a branch,
    * create a PR from the epic branch to dev (or the configured base branch)
    * and move the epic to "review". The epic only reaches "done" when the
    * GitHub webhook detects that the epic-to-dev PR has merged.
    *
    * If the epic has no branch (manual or non-git epic), mark done directly.
+   *
+   * Special case: when children merged directly to the base branch
+   * (prBaseBranch = 'dev') the epic branch is never created on the remote.
+   * In that scenario we skip the PR step and mark the epic done immediately.
    */
   private async checkEpicCompletion(projectPath: string, epicId: string): Promise<void> {
     const dedupeKey = `${projectPath}:${epicId}`;
@@ -252,9 +278,38 @@ export class CompletionDetectorService {
     const epic = allFeatures.find((f) => f.id === epicId);
     if (!epic || epic.status === 'done' || epic.status === 'review') return;
 
-    // If the epic has a branch, create the epic-to-dev PR instead of marking done.
-    // Dedup is claimed only after a successful PR creation so that failures are retryable.
+    // If the epic has a branch, check whether it actually exists on the remote
+    // before attempting to create a PR. When prBaseBranch is 'dev', child PRs
+    // merge directly to dev and the epic branch is never pushed, so the branch
+    // won't exist. In that case skip the PR step and mark the epic done directly.
     if (epic.branchName) {
+      const branchExists = await this.epicBranchExistsOnRemote(projectPath, epic.branchName);
+
+      if (!branchExists) {
+        // Children merged directly to the base branch — no epic branch to PR from.
+        // Skip the PR step and mark the epic done immediately.
+        this.emittedEpics.add(dedupeKey);
+        this.appendLedgerEntry('epic', dedupeKey);
+        this.completionCounts.epics++;
+        await this.featureLoader!.update(projectPath, epicId, { status: 'done' });
+        logger.info(
+          `Epic "${epic.title}" completed — children merged directly to dev, skipping epic PR (branch ${epic.branchName} not found on remote)`
+        );
+        this.emitter!.emit('feature:completed', {
+          projectPath,
+          featureId: epicId,
+          featureTitle: epic.title,
+          projectSlug: epic.projectSlug,
+          isEpic: true,
+        });
+        if (epic.projectSlug && epic.milestoneSlug) {
+          await this.checkMilestoneCompletion(projectPath, epic.projectSlug, epic.milestoneSlug);
+        }
+        return;
+      }
+
+      // Branch exists on remote — create the epic-to-dev PR as normal.
+      // Dedup is claimed only after a successful PR creation so that failures are retryable.
       const result = await this.createEpicToDevPR(projectPath, epicId, epic);
       if (result) {
         // PR created successfully — claim dedup and move epic to review


### PR DESCRIPTION
## Summary

- Fixes epic blocking bug when `prBaseBranch` is `'dev'` and all child feature PRs merge directly to dev
- Before attempting to create an epic-to-dev PR, `CompletionDetectorService` now checks if the epic branch actually exists on the remote via `git ls-remote --heads origin <branchName>`
- If the branch doesn't exist (children merged directly to dev), the epic is marked done immediately with a clear log message: `"Epic completed — children merged directly to dev, skipping epic PR"`
- Normal flow (epic branch exists → create PR → auto-merge) is fully preserved

## Root Cause

When `prBaseBranch = 'dev'`, child feature PRs target `dev` directly rather than the epic branch. The epic branch is never pushed to the remote. `CompletionDetectorService` assumed `epic.branchName` being set meant a PR could be created, but the underlying branch didn't exist, causing `gh pr create` to fail and blocking the epic with "manual intervention required."

**Observed in:** AI Agent App Starter Kit M1 epic (`feature-1773556794314-uftu10zzb`)

## Test plan
- [ ] When `prBaseBranch = 'dev'` and all children are done/merged to dev → epic auto-marked done, no blocked state
- [ ] When epic branch exists on remote (normal flow) → PR creation proceeds as before, no regression
- [ ] Log message "children merged directly to dev, skipping epic PR" visible in server logs when branch absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Enhancements

* Epic completion workflow now automatically marks epics as complete when child features are merged directly to the base branch, eliminating unnecessary pull request creation and streamlining the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->