### PR TITLE
Extract Langfuse wrapper and built-in tracing

### DIFF
--- a/libs/templates/starters/ai-agent-app/packages/server/src/routes/traces.ts
+++ b/libs/templates/starters/ai-agent-app/packages/server/src/routes/traces.ts
@@ -1,0 +1,68 @@
+/**
+ * GET /api/traces — trace viewer data endpoint.
+ *
+ * Returns all trace records written to the `.traces/` directory by
+ * `FileTracer`.  Useful for a local trace viewer or debugging dashboard.
+ *
+ * ## Response
+ * ```json
+ * {
+ *   "traces": [ { "traceId": "…", "name": "chat", "model": "…", … } ],
+ *   "count": 3
+ * }
+ * ```
+ *
+ * ## Configuration
+ * Set the `TRACES_DIR` environment variable to change the directory.
+ * Defaults to `.traces` relative to `process.cwd()`.
+ *
+ * ## Mount
+ * ```ts
+ * import { tracesHandler } from './routes/traces.js';
+ * app.get('/api/traces', tracesHandler);
+ * ```
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Request, Response } from 'express';
+
+const TRACES_DIR = process.env['TRACES_DIR'] ?? join(process.cwd(), '.traces');
+
+/**
+ * Express handler — reads all `trace-*.json` files and returns them as an
+ * array, sorted newest-first (by filename, which includes a UUID whose
+ * creation order roughly matches insertion order via the FileTracer naming
+ * convention `trace-<traceId>.json`).
+ */
+export async function tracesHandler(_req: Request, res: Response): Promise<void> {
+  let files: string[];
+
+  try {
+    files = await readdir(TRACES_DIR);
+  } catch {
+    // Directory doesn't exist yet — no traces written
+    res.json({ traces: [], count: 0 });
+    return;
+  }
+
+  const jsonFiles = files
+    .filter((f) => f.startsWith('trace-') && f.endsWith('.json'))
+    .sort()
+    .reverse();
+
+  const results = await Promise.all(
+    jsonFiles.map(async (file) => {
+      try {
+        const content = await readFile(join(TRACES_DIR, file), 'utf-8');
+        return JSON.parse(content) as unknown;
+      } catch {
+        return null;
+      }
+    })
+  );
+
+  const traces = results.filter(Boolean);
+
+  res.json({ traces, count: traces.length });
+}

--- a/libs/templates/starters/ai-agent-app/packages/tracing/package.json
+++ b/libs/templates/starters/ai-agent-app/packages/tracing/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@@PROJECT_NAME-tracing",
+  "version": "0.1.0",
+  "description": "Observability package — Langfuse tracing and built-in file-based trace logging",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "dependencies": {},
+  "peerDependencies": {
+    "langfuse": ">=3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "langfuse": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "langfuse": "^3.31.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/libs/templates/starters/ai-agent-app/packages/tracing/src/file-tracer.ts
+++ b/libs/templates/starters/ai-agent-app/packages/tracing/src/file-tracer.ts
@@ -1,0 +1,185 @@
+/**
+ * FileTracer — built-in local tracing backend.
+ *
+ * Writes JSON trace records to `.traces/<traceId>.json` so you can inspect
+ * agent runs without configuring Langfuse.  This is the **default** backend
+ * when `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` are not set.
+ *
+ * ## Trace files
+ * Each flush writes one file per pending trace:
+ * ```
+ * .traces/
+ *   trace-<uuid>.json    ← full TraceRecord as pretty-printed JSON
+ * ```
+ *
+ * ## Usage
+ * ```ts
+ * const tracer = new FileTracer({ dir: '.traces' });
+ * const config: TracingConfig = { enabled: true, client: tracer };
+ * ```
+ */
+
+import { randomUUID } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type {
+  TracingClientInterface,
+  CreateTraceOptions,
+  CreateGenerationOptions,
+  CreateSpanOptions,
+  CreateScoreOptions,
+  TraceRecord,
+  SpanRecord,
+  Logger,
+} from './types.js';
+
+export interface FileTracerConfig {
+  /**
+   * Directory to write trace files.
+   * Defaults to `.traces` relative to `process.cwd()`.
+   */
+  dir?: string;
+  /** Logger for internal messages.  Defaults to `console`. */
+  logger?: Logger;
+}
+
+export class FileTracer implements TracingClientInterface {
+  private readonly dir: string;
+  private readonly logger: Logger;
+  /** In-memory accumulator: traceId → TraceRecord */
+  private readonly pending = new Map<string, TraceRecord>();
+
+  constructor(config: FileTracerConfig = {}) {
+    this.dir = config.dir ?? join(process.cwd(), '.traces');
+    this.logger = config.logger ?? console;
+  }
+
+  /** Always returns `true` — file tracing is always available. */
+  isAvailable(): boolean {
+    return true;
+  }
+
+  createTrace(options: CreateTraceOptions): TraceRecord {
+    const traceId = options.id ?? randomUUID();
+    const record: TraceRecord = {
+      traceId,
+      name: options.name ?? 'trace',
+      userId: options.userId,
+      sessionId: options.sessionId,
+      tags: options.tags,
+      metadata: options.metadata,
+      input: options.input,
+      output: options.output,
+      timestamp: new Date().toISOString(),
+      spans: [],
+    };
+    this.pending.set(traceId, record);
+    return record;
+  }
+
+  updateTrace(
+    traceId: string,
+    data: { input?: unknown; output?: unknown; metadata?: Record<string, unknown> }
+  ): void {
+    const record = this.pending.get(traceId);
+    if (!record) return;
+    if (data.input !== undefined) record.input = data.input;
+    if (data.output !== undefined) record.output = data.output;
+    if (data.metadata) {
+      record.metadata = { ...(record.metadata ?? {}), ...data.metadata };
+    }
+  }
+
+  createGeneration(options: CreateGenerationOptions): void {
+    const record = this.pending.get(options.traceId);
+    if (!record) return;
+
+    if (options.model) record.model = options.model;
+
+    if (
+      options.usage?.promptTokens !== undefined &&
+      options.usage?.completionTokens !== undefined
+    ) {
+      const pt = options.usage.promptTokens ?? 0;
+      const ct = options.usage.completionTokens ?? 0;
+      record.usage = {
+        promptTokens: pt,
+        completionTokens: ct,
+        totalTokens: options.usage.totalTokens ?? pt + ct,
+      };
+    }
+
+    const meta = options.metadata ?? {};
+    if (typeof meta['latencyMs'] === 'number') {
+      record.latencyMs = meta['latencyMs'];
+    }
+    if (typeof meta['cost'] === 'number') {
+      record.costUsd = meta['cost'];
+    }
+    if (typeof meta['error'] === 'string') {
+      record.error = meta['error'];
+    }
+  }
+
+  createSpan(options: CreateSpanOptions): void {
+    const record = this.pending.get(options.traceId);
+    if (!record) return;
+
+    const span: SpanRecord = {
+      spanId: options.id,
+      name: options.name ?? 'span',
+      input: options.input,
+      output: options.output,
+      metadata: options.metadata,
+      startTime: options.startTime?.toISOString(),
+      endTime: options.endTime?.toISOString(),
+    };
+
+    record.spans = record.spans ?? [];
+    record.spans.push(span);
+  }
+
+  /** Scores are a Langfuse-specific concept — no-op for file tracing. */
+  createScore(_options: CreateScoreOptions): void {
+    // no-op
+  }
+
+  /**
+   * Write all pending traces to disk and clear the in-memory buffer.
+   *
+   * Creates the target directory if it does not exist.
+   */
+  async flush(): Promise<void> {
+    if (this.pending.size === 0) return;
+
+    try {
+      await mkdir(this.dir, { recursive: true });
+    } catch (err) {
+      this.logger.error?.(`[FileTracer] Failed to create traces directory: ${this.dir}`, err);
+      return;
+    }
+
+    const records = Array.from(this.pending.values());
+    this.pending.clear();
+
+    for (const record of records) {
+      const filename = `trace-${record.traceId}.json`;
+      const filepath = join(this.dir, filename);
+      try {
+        await writeFile(filepath, JSON.stringify(record, null, 2), 'utf-8');
+        this.logger.debug?.(`[FileTracer] wrote ${filepath}`);
+      } catch (err) {
+        this.logger.error?.(`[FileTracer] Failed to write ${filepath}`, err);
+      }
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    await this.flush();
+  }
+
+  /** Return the directory where traces are written. */
+  getDir(): string {
+    return this.dir;
+  }
+}

--- a/libs/templates/starters/ai-agent-app/packages/tracing/src/index.ts
+++ b/libs/templates/starters/ai-agent-app/packages/tracing/src/index.ts
@@ -1,0 +1,107 @@
+/**
+ * @@PROJECT_NAME-tracing
+ *
+ * Observability for your AI agent app.
+ *
+ * ## Quick start
+ *
+ * ```ts
+ * import { createTracingConfig, wrapProviderWithTracing } from '@@PROJECT_NAME-tracing';
+ *
+ * // Auto-selects Langfuse when LANGFUSE_PUBLIC_KEY + LANGFUSE_SECRET_KEY are
+ * // set, otherwise falls back to local file tracing in .traces/
+ * const tracingConfig = await createTracingConfig();
+ *
+ * // Wrap any async-generator stream
+ * const stream = wrapProviderWithTracing(myStream, tracingConfig, { model });
+ * for await (const chunk of stream) { ... }
+ * ```
+ *
+ * @module
+ */
+
+export type {
+  Logger,
+  LangfuseConfig,
+  CreateTraceOptions,
+  CreateGenerationOptions,
+  CreateSpanOptions,
+  CreateScoreOptions,
+  TracingClientInterface,
+  TraceRecord,
+  SpanRecord,
+} from './types.js';
+
+export { LangfuseClient } from './langfuse-client.js';
+
+export { FileTracer } from './file-tracer.js';
+export type { FileTracerConfig } from './file-tracer.js';
+
+export {
+  calculateCost,
+  wrapProviderWithTracing,
+  createTracingContext,
+  completeTracingContext,
+} from './middleware.js';
+export type { TracingConfig, TracingContext, TracedInvocationResult } from './middleware.js';
+
+import { LangfuseClient } from './langfuse-client.js';
+import { FileTracer } from './file-tracer.js';
+import type { TracingConfig } from './middleware.js';
+import type { Logger } from './types.js';
+
+/**
+ * Create a `TracingConfig` for use with `wrapProviderWithTracing`.
+ *
+ * **Auto-selection logic:**
+ * - If `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` env vars are set →
+ *   initialises a `LangfuseClient` and returns a remote-tracing config.
+ * - Otherwise → returns a `FileTracer` config that writes JSON to `.traces/`.
+ *
+ * Set `TRACES_DIR` to override the directory used by `FileTracer`.
+ *
+ * @example
+ * ```ts
+ * // Server startup
+ * const tracingConfig = await createTracingConfig();
+ * app.locals.tracingConfig = tracingConfig;
+ * ```
+ */
+export async function createTracingConfig(
+  options: {
+    /** Override the file tracer directory (default: `process.env.TRACES_DIR ?? '.traces'`). */
+    dir?: string;
+    /** Logger passed to the selected backend.  Defaults to `console`. */
+    logger?: Logger;
+  } = {}
+): Promise<TracingConfig> {
+  const log: Logger = options.logger ?? console;
+  const publicKey = process.env['LANGFUSE_PUBLIC_KEY'];
+  const secretKey = process.env['LANGFUSE_SECRET_KEY'];
+
+  if (publicKey && secretKey) {
+    const client = new LangfuseClient(
+      {
+        publicKey,
+        secretKey,
+        baseUrl: process.env['LANGFUSE_BASE_URL'],
+      },
+      log
+    );
+
+    // Wait for the optional langfuse package to load before returning
+    await client.ready();
+
+    if (client.isAvailable()) {
+      log.info?.('[tracing] Langfuse tracing enabled');
+      return { enabled: true, client, logger: log };
+    }
+
+    log.warn?.('[tracing] Langfuse init failed — falling back to file tracing');
+  }
+
+  const tracesDir = options.dir ?? process.env['TRACES_DIR'];
+  const fileTracer = new FileTracer({ dir: tracesDir, logger: log });
+  log.info?.(`[tracing] file tracing enabled → ${fileTracer.getDir()}`);
+  return { enabled: true, client: fileTracer, logger: log };
+}

--- a/libs/templates/starters/ai-agent-app/packages/tracing/src/langfuse-client.ts
+++ b/libs/templates/starters/ai-agent-app/packages/tracing/src/langfuse-client.ts
@@ -1,0 +1,236 @@
+/**
+ * LangfuseClient — thin wrapper around the Langfuse SDK.
+ *
+ * `langfuse` is an **optional** peer dependency.  When the package is not
+ * installed, or when credentials are missing, the client silently disables
+ * itself and `isAvailable()` returns `false`.  Pair it with `FileTracer` as
+ * the fallback (see `createTracingConfig` in `index.ts`).
+ *
+ * ## Quick start
+ * ```ts
+ * const client = new LangfuseClient({
+ *   publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+ *   secretKey: process.env.LANGFUSE_SECRET_KEY,
+ * });
+ * await client.ready(); // wait for dynamic import to settle
+ * ```
+ */
+
+import { randomUUID } from 'node:crypto';
+import type {
+  LangfuseConfig,
+  CreateTraceOptions,
+  CreateGenerationOptions,
+  CreateSpanOptions,
+  CreateScoreOptions,
+  TracingClientInterface,
+  Logger,
+} from './types.js';
+
+export class LangfuseClient implements TracingClientInterface {
+  // The Langfuse SDK instance — typed as `any` to avoid a hard compile-time
+  // dependency on the `langfuse` package (it's an optional peer dep).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _client: any = null;
+  private _enabled: boolean;
+  private readonly _logger: Logger;
+  private readonly _initPromise: Promise<void>;
+
+  constructor(config: LangfuseConfig = {}, logger: Logger = console) {
+    this._logger = logger;
+    const hasCredentials = !!(config.publicKey && config.secretKey);
+    this._enabled = (config.enabled ?? true) && hasCredentials;
+
+    if (this._enabled) {
+      this._initPromise = this._init(config);
+    } else {
+      this._initPromise = Promise.resolve();
+      this._logger.info?.('[LangfuseClient] disabled or missing credentials');
+    }
+  }
+
+  private async _init(config: LangfuseConfig): Promise<void> {
+    try {
+      // Dynamic import so the module resolves gracefully even when langfuse
+      // is not installed.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mod: any = await import('langfuse');
+      this._client = new mod.Langfuse({
+        publicKey: config.publicKey!,
+        secretKey: config.secretKey!,
+        baseUrl: config.baseUrl,
+        flushAt: config.flushAt ?? 1,
+        flushInterval: config.flushInterval ?? 1000,
+      });
+      this._logger.info?.('[LangfuseClient] initialized successfully');
+    } catch (error) {
+      this._logger.error?.(
+        '[LangfuseClient] Failed to initialize. Is `langfuse` installed?',
+        error
+      );
+      this._enabled = false;
+    }
+  }
+
+  /**
+   * Wait for the async initialization to finish.
+   *
+   * Call `await client.ready()` before the first use when you need Langfuse
+   * to be available immediately (e.g. during server startup).
+   */
+  async ready(): Promise<this> {
+    await this._initPromise;
+    return this;
+  }
+
+  isAvailable(): boolean {
+    return this._enabled && this._client !== null;
+  }
+
+  createTrace(options: CreateTraceOptions): unknown {
+    if (!this.isAvailable()) return null;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const trace = (this._client as any).trace({
+        id: options.id ?? randomUUID(),
+        name: options.name,
+        userId: options.userId,
+        sessionId: options.sessionId,
+        metadata: options.metadata,
+        tags: options.tags,
+        input: options.input,
+        output: options.output,
+      });
+      this._logger.debug?.('[LangfuseClient] created trace', { traceId: options.id });
+      return trace;
+    } catch (error) {
+      this._logger.error?.('[LangfuseClient] failed to create trace', error);
+      return null;
+    }
+  }
+
+  updateTrace(
+    traceId: string,
+    data: { input?: unknown; output?: unknown; metadata?: Record<string, unknown> }
+  ): void {
+    if (!this.isAvailable()) return;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (this._client as any).trace({ id: traceId }).update(data);
+    } catch (error) {
+      this._logger.error?.('[LangfuseClient] failed to update trace', error);
+    }
+  }
+
+  createGeneration(options: CreateGenerationOptions): unknown {
+    if (!this.isAvailable()) return null;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const trace = (this._client as any).trace({ id: options.traceId });
+      const generation = trace.generation({
+        id: options.id,
+        name: options.name,
+        model: options.model,
+        modelParameters: options.modelParameters,
+        input: options.input,
+        output: options.output,
+        usage: options.usage,
+        metadata: options.metadata,
+        startTime: options.startTime,
+        endTime: options.endTime,
+      });
+      this._logger.debug?.('[LangfuseClient] created generation', {
+        traceId: options.traceId,
+        generationId: options.id,
+      });
+      return generation;
+    } catch (error) {
+      this._logger.error?.('[LangfuseClient] failed to create generation', error);
+      return null;
+    }
+  }
+
+  createSpan(options: CreateSpanOptions): unknown {
+    if (!this.isAvailable()) return null;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const trace = (this._client as any).trace({ id: options.traceId });
+      const span = trace.span({
+        id: options.id,
+        name: options.name,
+        input: options.input,
+        output: options.output,
+        metadata: options.metadata,
+        startTime: options.startTime,
+        endTime: options.endTime,
+      });
+      return span;
+    } catch (error) {
+      this._logger.error?.('[LangfuseClient] failed to create span', error);
+      return null;
+    }
+  }
+
+  createScore(options: CreateScoreOptions): void {
+    if (!this.isAvailable()) return;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (this._client as any).score({
+        traceId: options.traceId,
+        name: options.name,
+        value: options.value,
+        comment: options.comment,
+      });
+    } catch (error) {
+      this._logger.error?.('[LangfuseClient] failed to create score', error);
+    }
+  }
+
+  /**
+   * Create or upsert a dataset item in Langfuse.
+   * Note: not part of `TracingClientInterface` — Langfuse-specific feature.
+   */
+  async createDatasetItem(options: {
+    datasetName: string;
+    input?: Record<string, unknown>;
+    expectedOutput?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
+    sourceTraceId?: string;
+  }): Promise<void> {
+    if (!this.isAvailable()) return;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (this._client as any).createDatasetItem({
+        datasetName: options.datasetName,
+        input: options.input,
+        expectedOutput: options.expectedOutput,
+        metadata: options.metadata,
+        sourceTraceId: options.sourceTraceId,
+      });
+    } catch (error) {
+      this._logger.error?.('[LangfuseClient] failed to create dataset item', error);
+      throw error;
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (!this.isAvailable()) return;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (this._client as any).flushAsync();
+    } catch (error) {
+      this._logger.error?.('[LangfuseClient] failed to flush', error);
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.isAvailable()) return;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (this._client as any).shutdownAsync();
+      this._logger.info?.('[LangfuseClient] shutdown successfully');
+    } catch (error) {
+      this._logger.error?.('[LangfuseClient] failed to shutdown', error);
+    }
+  }
+}

--- a/libs/templates/starters/ai-agent-app/packages/tracing/src/middleware.ts
+++ b/libs/templates/starters/ai-agent-app/packages/tracing/src/middleware.ts
@@ -1,0 +1,478 @@
+/**
+ * Provider tracing middleware.
+ *
+ * Wrap any async-generator-based provider invocation with `wrapProviderWithTracing`
+ * to automatically record traces, generations, and per-tool spans.
+ *
+ * Supports both Langfuse (remote) and FileTracer (local) backends via the
+ * `TracingClientInterface`.
+ *
+ * ## Example
+ * ```ts
+ * const tracingConfig = await createTracingConfig();
+ *
+ * // Wrap your model call
+ * const stream = wrapProviderWithTracing(
+ *   anthropic.messages.stream({ model, messages }),
+ *   tracingConfig,
+ *   { model: 'claude-opus-4-5', traceId: sessionId, input: messages }
+ * );
+ * for await (const chunk of stream) { ... }
+ * ```
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { TracingClientInterface, CreateGenerationOptions, Logger } from './types.js';
+
+const TOOL_SPAN_MAX_BYTES = 2048;
+
+interface PendingToolCall {
+  toolName: string;
+  toolInput: unknown;
+  startTime: Date;
+  turnIndex: number;
+  toolCallIndex: number;
+}
+
+function truncateForSpan(value: unknown): { value: string; truncated?: true } {
+  const serialized = typeof value === 'string' ? value : (JSON.stringify(value) ?? '');
+  if (serialized.length <= TOOL_SPAN_MAX_BYTES) return { value: serialized };
+  return { value: serialized.slice(0, TOOL_SPAN_MAX_BYTES), truncated: true };
+}
+
+// ---------------------------------------------------------------------------
+// TracingConfig
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration passed to `wrapProviderWithTracing`.
+ *
+ * The `client` field accepts any `TracingClientInterface` implementation —
+ * use `LangfuseClient` for remote tracing or `FileTracer` for local JSON
+ * file tracing (the default when Langfuse env vars are not set).
+ */
+export interface TracingConfig {
+  /** Set to `false` to disable all tracing (passes the stream through unchanged). */
+  enabled: boolean;
+  /** Tracing backend.  Accepts `LangfuseClient` or `FileTracer`. */
+  client?: TracingClientInterface;
+  /** Logger for tracing internals.  Defaults to `console`. */
+  logger?: Logger;
+  /** Tags added to every trace. */
+  defaultTags?: string[];
+  /** Metadata merged into every trace. */
+  defaultMetadata?: Record<string, unknown>;
+  /**
+   * Custom pricing per 1 M tokens.  Keys are substrings matched against the
+   * model name (case-insensitive, first match wins).
+   *
+   * Overrides the built-in table returned by `calculateCost`.
+   */
+  pricing?: Record<string, { input: number; output: number }>;
+}
+
+// ---------------------------------------------------------------------------
+// TracingContext (for manual instrumentation)
+// ---------------------------------------------------------------------------
+
+export interface TracingContext {
+  traceId: string;
+  generationId: string;
+  startTime: Date;
+  metadata?: Record<string, unknown>;
+}
+
+export interface TracedInvocationResult<T> {
+  result: T;
+  traceId: string;
+  generationId: string;
+  latencyMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Token usage helpers
+// ---------------------------------------------------------------------------
+
+function extractUsageFromMessages(
+  messages: unknown[]
+): { promptTokens: number; completionTokens: number; totalTokens: number } | undefined {
+  let promptTokens = 0;
+  let completionTokens = 0;
+
+  for (const msg of messages) {
+    const m = msg as Record<string, unknown>;
+    const usage = m['usage'] as Record<string, number> | undefined;
+    if (usage) {
+      promptTokens += usage['input_tokens'] ?? usage['promptTokens'] ?? 0;
+      completionTokens += usage['output_tokens'] ?? usage['completionTokens'] ?? 0;
+    }
+    const tokenUsage = m['token_usage'] as Record<string, number> | undefined;
+    if (tokenUsage) {
+      promptTokens += tokenUsage['prompt_tokens'] ?? 0;
+      completionTokens += tokenUsage['completion_tokens'] ?? 0;
+    }
+  }
+
+  const totalTokens = promptTokens + completionTokens;
+  if (totalTokens === 0) return undefined;
+  return { promptTokens, completionTokens, totalTokens };
+}
+
+// ---------------------------------------------------------------------------
+// Pricing table
+// ---------------------------------------------------------------------------
+
+/**
+ * Built-in pricing table (per 1 M tokens, USD, as of early 2026).
+ *
+ * Keys are substrings matched case-insensitively against the model ID.
+ * **Order matters**: more-specific keys must appear before less-specific ones
+ * (e.g. `"gpt-4o-mini"` before `"gpt-4o"`).
+ */
+const DEFAULT_PRICING: Record<string, { input: number; output: number }> = {
+  // Claude
+  'claude-opus-4-6': { input: 15, output: 75 },
+  'opus-4-6': { input: 15, output: 75 },
+  'claude-opus-4-5': { input: 15, output: 75 },
+  'opus-4-5': { input: 15, output: 75 },
+  'claude-sonnet-4-6': { input: 3, output: 15 },
+  'sonnet-4-6': { input: 3, output: 15 },
+  'claude-sonnet-4-5': { input: 3, output: 15 },
+  'sonnet-4-5': { input: 3, output: 15 },
+  'claude-haiku-4-5': { input: 0.8, output: 4 },
+  'haiku-4-5': { input: 0.8, output: 4 },
+
+  // OpenAI — more-specific entries first
+  'gpt-4o-mini': { input: 0.15, output: 0.6 },
+  'gpt-4o': { input: 2.5, output: 10.0 },
+  'gpt-4-turbo': { input: 10.0, output: 30.0 },
+  'o3-mini': { input: 1.1, output: 4.4 },
+
+  // Google Gemini
+  'gemini-2.0-flash': { input: 0.1, output: 0.4 },
+  'gemini-2.0-flash-lite': { input: 0.075, output: 0.3 },
+  'gemini-1.5-pro': { input: 1.25, output: 5.0 },
+  'gemini-1.5-flash': { input: 0.075, output: 0.3 },
+
+  // Groq
+  'llama-3.3-70b-versatile': { input: 0.59, output: 0.79 },
+  'llama-3.1-8b-instant': { input: 0.05, output: 0.08 },
+  'mixtral-8x7b-32768': { input: 0.24, output: 0.24 },
+  'gemma2-9b-it': { input: 0.2, output: 0.2 },
+};
+
+/**
+ * Calculate the estimated cost in USD for a model invocation.
+ *
+ * Returns `undefined` when the model is not in the pricing table and no
+ * `customPricing` override matches.
+ *
+ * @param model - Model identifier (case-insensitive substring match)
+ * @param usage - Token counts
+ * @param customPricing - Optional overrides merged on top of the built-in table
+ */
+export function calculateCost(
+  model: string,
+  usage?: { promptTokens: number; completionTokens: number },
+  customPricing?: Record<string, { input: number; output: number }>
+): number | undefined {
+  if (!usage) return undefined;
+
+  const modelLower = model.toLowerCase();
+  const pricing = { ...DEFAULT_PRICING, ...customPricing };
+
+  let prices: { input: number; output: number } | undefined;
+  for (const [key, value] of Object.entries(pricing)) {
+    if (modelLower.includes(key)) {
+      prices = value;
+      break;
+    }
+  }
+
+  if (!prices) return undefined;
+
+  const inputCost = (usage.promptTokens / 1_000_000) * prices.input;
+  const outputCost = (usage.completionTokens / 1_000_000) * prices.output;
+  return inputCost + outputCost;
+}
+
+// ---------------------------------------------------------------------------
+// wrapProviderWithTracing
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap an async-generator provider invocation with automatic tracing.
+ *
+ * Yields all messages unchanged while recording a trace + generation span
+ * (and per-tool-call child spans) to the configured backend.  When
+ * `config.enabled` is `false` or no client is available the generator is
+ * passed through without any overhead.
+ */
+export async function* wrapProviderWithTracing<T>(
+  generator: AsyncGenerator<T>,
+  config: TracingConfig,
+  options: {
+    model: string;
+    traceId?: string;
+    traceName?: string;
+    sessionId?: string;
+    userId?: string;
+    metadata?: Record<string, unknown>;
+    tags?: string[];
+    input?: unknown;
+  }
+): AsyncGenerator<T> {
+  const log = config.logger ?? console;
+
+  if (!config.enabled || !config.client || !config.client.isAvailable()) {
+    yield* generator;
+    return;
+  }
+
+  const client = config.client;
+  const traceId = options.traceId ?? randomUUID();
+  const generationId = randomUUID();
+  const startTime = new Date();
+
+  client.createTrace({
+    id: traceId,
+    name: options.traceName ?? `model:${options.model}`,
+    userId: options.userId,
+    sessionId: options.sessionId,
+    metadata: {
+      model: options.model,
+      ...config.defaultMetadata,
+      ...options.metadata,
+    },
+    tags: [...(config.defaultTags ?? []), ...(options.tags ?? [])],
+  });
+
+  const messages: T[] = [];
+  let error: Error | undefined;
+  let turnIndex = -1;
+  const pendingToolCalls = new Map<string, PendingToolCall>();
+
+  try {
+    for await (const message of generator) {
+      messages.push(message);
+      yield message;
+
+      const msg = message as Record<string, unknown>;
+
+      // Track tool-use blocks so we can create per-call spans
+      if (
+        msg['type'] === 'assistant' &&
+        Array.isArray((msg['message'] as Record<string, unknown>)?.['content'])
+      ) {
+        turnIndex++;
+        let toolCallIndex = 0;
+        for (const block of (msg['message'] as Record<string, unknown>)['content'] as unknown[]) {
+          const b = block as Record<string, unknown>;
+          if (b['type'] === 'tool_use' && b['id']) {
+            pendingToolCalls.set(b['id'] as string, {
+              toolName: (b['name'] as string) ?? 'unknown',
+              toolInput: b['input'],
+              startTime: new Date(),
+              turnIndex,
+              toolCallIndex,
+            });
+            toolCallIndex++;
+          }
+        }
+      } else if (
+        msg['type'] === 'user' &&
+        Array.isArray((msg['message'] as Record<string, unknown>)?.['content'])
+      ) {
+        for (const block of (msg['message'] as Record<string, unknown>)['content'] as unknown[]) {
+          const b = block as Record<string, unknown>;
+          if (b['type'] === 'tool_result' && b['tool_use_id']) {
+            const pending = pendingToolCalls.get(b['tool_use_id'] as string);
+            if (pending) {
+              pendingToolCalls.delete(b['tool_use_id'] as string);
+              const endTime = new Date();
+              const inputResult = truncateForSpan(pending.toolInput);
+              const outputResult = truncateForSpan(b['content']);
+              client.createSpan({
+                traceId,
+                name: `tool:${pending.toolName}`,
+                input: {
+                  toolName: pending.toolName,
+                  toolInput: inputResult.value,
+                  ...(inputResult.truncated ? { truncated: true } : {}),
+                },
+                output: {
+                  result: outputResult.value,
+                  ...(outputResult.truncated ? { truncated: true } : {}),
+                },
+                metadata: {
+                  turnIndex: pending.turnIndex,
+                  toolCallIndex: pending.toolCallIndex,
+                },
+                startTime: pending.startTime,
+                endTime,
+              });
+            }
+          }
+        }
+      }
+    }
+  } catch (err) {
+    error = err as Error;
+    log.error?.('[tracing] Error in provider invocation', err);
+    throw err;
+  } finally {
+    const endTime = new Date();
+    const latencyMs = endTime.getTime() - startTime.getTime();
+
+    const usage = extractUsageFromMessages(messages as unknown[]);
+    const cost = calculateCost(
+      options.model,
+      usage,
+      config.pricing as Record<string, { input: number; output: number }> | undefined
+    );
+
+    const generationMetadata: Record<string, unknown> = {
+      latencyMs,
+      messageCount: messages.length,
+      ...config.defaultMetadata,
+      ...options.metadata,
+    };
+
+    if (cost !== undefined) {
+      generationMetadata['cost'] = cost;
+      generationMetadata['costCurrency'] = 'USD';
+    }
+
+    if (error) {
+      generationMetadata['error'] = error.message;
+      generationMetadata['errorStack'] = error.stack;
+    }
+
+    const generationOptions: CreateGenerationOptions = {
+      id: generationId,
+      traceId,
+      name: `generation:${options.model}`,
+      model: options.model,
+      input: options.input,
+      output: messages.length > 0 ? messages[messages.length - 1] : undefined,
+      usage: usage
+        ? {
+            promptTokens: usage.promptTokens,
+            completionTokens: usage.completionTokens,
+            totalTokens: usage.totalTokens,
+          }
+        : undefined,
+      metadata: generationMetadata,
+      startTime,
+      endTime,
+    };
+
+    client.createGeneration(generationOptions);
+
+    client.updateTrace(traceId, {
+      input: options.input,
+      output: messages.length > 0 ? messages[messages.length - 1] : undefined,
+    });
+
+    await client.flush();
+
+    log.debug?.('[tracing] invocation traced', {
+      traceId,
+      generationId,
+      latencyMs,
+      usage,
+      cost,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Manual instrumentation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a tracing context for manual (non-generator) instrumentation.
+ *
+ * Call `createTracingContext`, do your work, then `completeTracingContext`.
+ */
+export function createTracingContext(
+  client: TracingClientInterface,
+  options: {
+    traceName?: string;
+    sessionId?: string;
+    userId?: string;
+    metadata?: Record<string, unknown>;
+    tags?: string[];
+  } = {}
+): TracingContext {
+  const traceId = randomUUID();
+  const generationId = randomUUID();
+  const startTime = new Date();
+
+  if (client.isAvailable()) {
+    client.createTrace({
+      id: traceId,
+      name: options.traceName ?? 'manual-trace',
+      userId: options.userId,
+      sessionId: options.sessionId,
+      metadata: options.metadata,
+      tags: options.tags,
+    });
+  }
+
+  return { traceId, generationId, startTime, metadata: options.metadata };
+}
+
+/**
+ * Finalize a manually-instrumented trace.
+ */
+export async function completeTracingContext(
+  client: TracingClientInterface,
+  context: TracingContext,
+  options: {
+    model: string;
+    input?: unknown;
+    output?: unknown;
+    usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
+    error?: Error;
+  }
+): Promise<void> {
+  if (!client.isAvailable()) return;
+
+  const endTime = new Date();
+  const latencyMs = endTime.getTime() - context.startTime.getTime();
+  const cost = calculateCost(options.model, options.usage);
+
+  const generationMetadata: Record<string, unknown> = {
+    latencyMs,
+    ...context.metadata,
+  };
+  if (cost !== undefined) {
+    generationMetadata['cost'] = cost;
+    generationMetadata['costCurrency'] = 'USD';
+  }
+  if (options.error) {
+    generationMetadata['error'] = options.error.message;
+    generationMetadata['errorStack'] = options.error.stack;
+  }
+
+  client.createGeneration({
+    id: context.generationId,
+    traceId: context.traceId,
+    name: `generation:${options.model}`,
+    model: options.model,
+    input: options.input,
+    output: options.output,
+    usage: options.usage,
+    metadata: generationMetadata,
+    startTime: context.startTime,
+    endTime,
+  });
+
+  client.updateTrace(context.traceId, {
+    input: options.input,
+    output: options.output,
+  });
+
+  await client.flush();
+}

--- a/libs/templates/starters/ai-agent-app/packages/tracing/src/types.ts
+++ b/libs/templates/starters/ai-agent-app/packages/tracing/src/types.ts
@@ -1,0 +1,169 @@
+/**
+ * Tracing types for @@PROJECT_NAME.
+ *
+ * These interfaces define the contracts for both Langfuse-backed and
+ * file-based local tracing, so you can swap backends without changing
+ * application code.
+ */
+
+// ---------------------------------------------------------------------------
+// Logger
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal logger interface — compatible with `console` and any structured
+ * logger (pino, winston, etc.).  All methods are optional so you can pass
+ * a partial implementation.
+ */
+export interface Logger {
+  info?(msg: string, ...args: unknown[]): void;
+  error?(msg: string, ...args: unknown[]): void;
+  debug?(msg: string, ...args: unknown[]): void;
+  warn?(msg: string, ...args: unknown[]): void;
+}
+
+// ---------------------------------------------------------------------------
+// Langfuse client config
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for the Langfuse client.
+ * Supply `publicKey` and `secretKey` (from your Langfuse project) to enable
+ * remote tracing.  Leave them empty to fall back to file-based tracing.
+ */
+export interface LangfuseConfig {
+  publicKey?: string;
+  secretKey?: string;
+  /** Langfuse base URL.  Defaults to the Langfuse cloud endpoint. */
+  baseUrl?: string;
+  /** Set to `false` to explicitly disable the client. */
+  enabled?: boolean;
+  /** Number of events to batch before flushing.  Defaults to 1. */
+  flushAt?: number;
+  /** Flush interval in milliseconds.  Defaults to 1000. */
+  flushInterval?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Trace / generation / span / score options
+// ---------------------------------------------------------------------------
+
+export interface CreateTraceOptions {
+  /** Unique trace identifier.  Generated if omitted. */
+  id?: string;
+  /** Human-readable name (e.g. "chat", "summarize"). */
+  name?: string;
+  userId?: string;
+  sessionId?: string;
+  metadata?: Record<string, unknown>;
+  tags?: string[];
+  input?: unknown;
+  output?: unknown;
+}
+
+export interface CreateGenerationOptions {
+  /** Unique generation identifier. */
+  id?: string;
+  /** Trace this generation belongs to. */
+  traceId: string;
+  name?: string;
+  model?: string;
+  modelParameters?: {
+    temperature?: number;
+    maxTokens?: number;
+    [key: string]: unknown;
+  };
+  input?: unknown;
+  output?: unknown;
+  usage?: {
+    promptTokens?: number;
+    completionTokens?: number;
+    totalTokens?: number;
+  };
+  metadata?: Record<string, unknown>;
+  startTime?: Date;
+  endTime?: Date;
+}
+
+export interface CreateSpanOptions {
+  id?: string;
+  traceId: string;
+  name?: string;
+  input?: unknown;
+  output?: unknown;
+  metadata?: Record<string, unknown>;
+  startTime?: Date;
+  endTime?: Date;
+}
+
+export interface CreateScoreOptions {
+  traceId: string;
+  /** Score label (e.g. "quality", "success"). */
+  name: string;
+  /** Numeric score value. */
+  value: number;
+  comment?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Tracing client interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Common interface implemented by both `LangfuseClient` (remote tracing) and
+ * `FileTracer` (local JSON-file tracing).  Use this type in `TracingConfig`
+ * so you can swap backends without touching application code.
+ */
+export interface TracingClientInterface {
+  isAvailable(): boolean;
+  createTrace(options: CreateTraceOptions): unknown;
+  updateTrace(
+    traceId: string,
+    data: { input?: unknown; output?: unknown; metadata?: Record<string, unknown> }
+  ): void;
+  createGeneration(options: CreateGenerationOptions): unknown;
+  createSpan(options: CreateSpanOptions): unknown;
+  createScore(options: CreateScoreOptions): void;
+  flush(): Promise<void>;
+  shutdown(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// File tracer records (written to .traces/*.json)
+// ---------------------------------------------------------------------------
+
+export interface SpanRecord {
+  spanId?: string;
+  name: string;
+  input?: unknown;
+  output?: unknown;
+  metadata?: Record<string, unknown>;
+  startTime?: string;
+  endTime?: string;
+}
+
+/**
+ * A single trace record written to `.traces/<traceId>.json`.
+ */
+export interface TraceRecord {
+  traceId: string;
+  name: string;
+  model?: string;
+  userId?: string;
+  sessionId?: string;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  input?: unknown;
+  output?: unknown;
+  usage?: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+  costUsd?: number;
+  latencyMs?: number;
+  /** ISO 8601 timestamp of when the trace was created. */
+  timestamp: string;
+  spans?: SpanRecord[];
+  error?: string;
+}

--- a/libs/templates/starters/ai-agent-app/packages/tracing/tsconfig.json
+++ b/libs/templates/starters/ai-agent-app/packages/tracing/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

**Milestone:** Observability — Langfuse + Built-in Tracing

Create packages/tracing/ in the starter kit. Extract LangfuseClient wrapper, wrapProviderWithTracing, calculateCost with pricing table, and all tracing types from libs/observability/. Replace createLogger calls with a logger parameter (default to console). Add built-in file-based trace logger that writes JSON traces to .traces/ directory for local debugging without Langfuse. Add trace viewer data endpoint to the server (GET /api/traces)...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=f5e50c6f-c914-4eb1-9af6-a052b03a0d8b team= created=2026-03-15T08:35:11.300Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive observability and tracing system supporting both local file-based storage and remote Langfuse integration.
  * Added automatic cost calculation based on token usage for AI provider calls.
  * Introduced a new `/api/traces` endpoint to retrieve stored traces.
  * Implemented middleware for seamless tracing of AI provider interactions with automatic fallback to local storage when remote tracing is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->