### PR TITLE
feat(server/tools): ToolDefinition + requiresConfirmation registry pattern

### DIFF
--- a/libs/templates/starters/ai-agent-app/packages/server/src/tools/example.ts
+++ b/libs/templates/starters/ai-agent-app/packages/server/src/tools/example.ts
@@ -95,7 +95,7 @@ export const getWeatherTool = Object.assign(
   // Flag this tool as requiring user confirmation before execution.
   // registry.ts tracks this in its `confirmationRequired` set and exposes
   // `toolRequiresConfirmation(name)` for callers to check.
-  { requiresConfirmation: true as const },
+  { requiresConfirmation: true as const }
 );
 
 // ---------------------------------------------------------------------------

--- a/libs/templates/starters/ai-agent-app/packages/server/src/tools/registry.ts
+++ b/libs/templates/starters/ai-agent-app/packages/server/src/tools/registry.ts
@@ -73,8 +73,10 @@ import { getCurrentTimeTool, getWeatherTool } from './example.js';
  * registerTool(sensitiveOp); // confirmation flag is preserved in the set
  * ```
  */
-export interface ToolDefinition<TInput = unknown, TOutput = unknown>
-  extends SharedTool<TInput, TOutput> {
+export interface ToolDefinition<TInput = unknown, TOutput = unknown> extends SharedTool<
+  TInput,
+  TOutput
+> {
   /**
    * When `true`, callers should request explicit user confirmation before
    * executing this tool.  Useful for tools with irreversible side effects
@@ -99,7 +101,9 @@ const confirmationRequired = new Set<string>();
  * silently dropped.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function registerTool(tool: SharedTool<any, any> & { requiresConfirmation?: boolean }): void {
+export function registerTool(
+  tool: SharedTool<any, any> & { requiresConfirmation?: boolean }
+): void {
   registry.register(tool);
   if (tool.requiresConfirmation) {
     confirmationRequired.add(tool.name);


### PR DESCRIPTION
## Summary

- Adds `ToolDefinition` interface to `registry.ts` — extends `SharedTool` with `requiresConfirmation?: boolean` for server-side human-in-the-loop gating
- Adds `registerTool()` helper that wraps `registry.register()` and tracks confirmation-required tool names in a `Set<string>`
- Adds `toolRequiresConfirmation(name)` and `getConfirmationRequiredTools()` query helpers for callers (e.g., chat route) to check before executing
- Adds server-local `get_weather` tool in `example.ts` with `requiresConfirmation: true` (using `Object.assign` on `defineSharedTool` to avoid circular imports)
- Adds tool profiles (`chat`, `execution`, `review`) and `getAnthropicToolsForProfile()` helper for role-scoped tool subsets
- All three tools (`get_weather`, `search_web`, `get_current_time`) registered via `registerTool()` — confirmation flag preserved

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc --noEmit` — only pre-existing `@google/generative-ai` error remains)
- [x] Only `example.ts` and `registry.ts` modified (2 files, +184 lines)
- [x] `registerTool(getWeatherTool)` → `toolRequiresConfirmation('get_weather')` returns `true`
- [x] `registerTool(searchWebTool)` / `registerTool(getCurrentTimeTool)` → not in confirmation set
- [x] `getAnthropicToolsForProfile('chat')` returns `get_current_time` + `get_weather`
- [x] `getAnthropicToolsForProfile('execution')` includes `search_web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a weather lookup tool to the AI agent application
  * Implemented user confirmation requirements for specific tool actions to enhance control and safety

<!-- end of auto-generated comment: release notes by coderabbit.ai -->