### PR TITLE
Build WebSocket sideband for tool progress

### DIFF
--- a/libs/templates/starters/ai-agent-app/packages/server/package.json
+++ b/libs/templates/starters/ai-agent-app/packages/server/package.json
@@ -17,12 +17,14 @@
     "cors": "^2.8.5",
     "express": "^5.0.0",
     "openai": "^4.77.0",
+    "ws": "^8.18.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.13",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"
   }

--- a/libs/templates/starters/ai-agent-app/packages/server/src/tools/progress.ts
+++ b/libs/templates/starters/ai-agent-app/packages/server/src/tools/progress.ts
@@ -1,0 +1,148 @@
+/**
+ * ToolProgressEmitter — rate-limited tool progress broadcaster.
+ *
+ * Wraps `broadcastProgress()` from the WebSocket sideband with a 150 ms
+ * throttle so high-frequency updates (e.g. per-chunk LLM calls, tight loops)
+ * don't overwhelm WebSocket clients.
+ *
+ * ## Throttle behaviour
+ *
+ * - The **first** call after a quiet period is sent immediately.
+ * - Subsequent calls within the 150 ms window are coalesced: only the
+ *   **latest** pending update is buffered and sent once the window expires.
+ * - Calling `flush()` at the end of a tool's `execute` function guarantees the
+ *   final progress message is delivered before the tool result is returned.
+ *
+ * ## Usage
+ *
+ * Import the module-level singleton `toolProgress` in any tool's `execute`:
+ *
+ * ```typescript
+ * import { toolProgress } from './progress.js';
+ *
+ * execute: async (input) => {
+ *   toolProgress.emit('my_tool', 'Starting…');
+ *   // … do work …
+ *   toolProgress.emit('my_tool', 'Halfway there…', { percent: 50 });
+ *   // … more work …
+ *   toolProgress.flush(); // ensure last update reaches clients
+ *   return result;
+ * }
+ * ```
+ *
+ * Or create a per-tool instance when you need independent rate-limit windows:
+ *
+ * ```typescript
+ * const emitter = new ToolProgressEmitter();
+ * emitter.emit('tool_a', 'Step 1');
+ * ```
+ */
+
+import { broadcastProgress, type ToolProgressEvent } from '../ws.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Minimum interval between emitted WebSocket messages (milliseconds). */
+export const PROGRESS_RATE_LIMIT_MS = 150;
+
+// ─── ToolProgressEmitter ──────────────────────────────────────────────────────
+
+export class ToolProgressEmitter {
+  private _lastEmitAt = 0;
+  private _pending: ToolProgressEvent | null = null;
+  private _timer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Emit a progress update for the given tool.
+   *
+   * If called within 150 ms of the previous emission the update is buffered.
+   * Only the most recent buffered update is kept — intermediate values are
+   * dropped to reduce noise.
+   *
+   * @param toolName  Name of the tool emitting the update.
+   * @param message   Human-readable status string.
+   * @param data      Optional structured payload (tool-specific metadata).
+   */
+  emit(toolName: string, message: string, data?: unknown): void {
+    const now = Date.now();
+    const event: ToolProgressEvent = {
+      type: 'tool:progress',
+      toolName,
+      message,
+      timestamp: now,
+      data,
+    };
+
+    const elapsed = now - this._lastEmitAt;
+
+    if (elapsed >= PROGRESS_RATE_LIMIT_MS) {
+      // Enough time has passed — send immediately.
+      this._sendNow(event, now);
+    } else {
+      // Too soon — buffer this update, replacing any previous pending event.
+      this._pending = event;
+
+      if (this._timer === null) {
+        // Schedule a deferred send for the remainder of the rate-limit window.
+        this._timer = setTimeout(() => {
+          const pending = this._pending;
+          this._pending = null;
+          this._timer = null;
+
+          if (pending) {
+            this._sendNow(pending, Date.now());
+          }
+        }, PROGRESS_RATE_LIMIT_MS - elapsed);
+      }
+    }
+  }
+
+  /**
+   * Flush any pending buffered event immediately.
+   *
+   * Call this at the end of a tool's `execute` function to guarantee the last
+   * progress update is delivered before the tool result is returned to the
+   * model.
+   */
+  flush(): void {
+    if (this._timer !== null) {
+      clearTimeout(this._timer);
+      this._timer = null;
+    }
+
+    const pending = this._pending;
+    this._pending = null;
+
+    if (pending) {
+      this._sendNow(pending, Date.now());
+    }
+  }
+
+  /** Reset internal state (useful for testing). */
+  reset(): void {
+    if (this._timer !== null) {
+      clearTimeout(this._timer);
+      this._timer = null;
+    }
+    this._pending = null;
+    this._lastEmitAt = 0;
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────────────
+
+  private _sendNow(event: ToolProgressEvent, now: number): void {
+    this._lastEmitAt = now;
+    broadcastProgress(event);
+  }
+}
+
+// ─── Module-level singleton ───────────────────────────────────────────────────
+
+/**
+ * Shared `ToolProgressEmitter` instance.
+ *
+ * Import this directly in tool `execute` functions for the simplest usage.
+ * All tools sharing this instance share the same 150 ms rate-limit window —
+ * create a `new ToolProgressEmitter()` per tool if you need independent windows.
+ */
+export const toolProgress = new ToolProgressEmitter();

--- a/libs/templates/starters/ai-agent-app/packages/server/src/ws.ts
+++ b/libs/templates/starters/ai-agent-app/packages/server/src/ws.ts
@@ -1,0 +1,137 @@
+/**
+ * WebSocket sideband server — optional tool progress channel.
+ *
+ * Runs alongside the Express HTTP server to stream `tool:progress` events to
+ * connected browser clients in real time.  The sideband is completely optional:
+ * if the server is never started (or no clients connect), all `broadcast()`
+ * calls are silent no-ops and chat continues to work normally via HTTP/SSE.
+ *
+ * ## Quick start
+ *
+ * In your server entry point (index.ts), call `startWebSocketServer()` after
+ * the HTTP server is listening:
+ *
+ * ```typescript
+ * import { startWebSocketServer } from './ws.js';
+ *
+ * const PORT = parseInt(process.env['PORT'] ?? '3001', 10);
+ * app.listen(PORT, () => {
+ *   // Optional: start WS sideband on WS_PORT (default 3002)
+ *   startWebSocketServer();
+ * });
+ * ```
+ *
+ * Clients can connect to `ws://localhost:<WS_PORT>` and will receive
+ * `ToolProgressEvent` payloads as JSON strings.
+ */
+
+import { WebSocketServer, WebSocket } from 'ws';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Payload emitted to WebSocket clients for each tool progress update. */
+export interface ToolProgressEvent {
+  /** Discriminator — always `"tool:progress"`. */
+  type: 'tool:progress';
+  /** Name of the tool emitting the update. */
+  toolName: string;
+  /** Human-readable status message (e.g. "Fetching results…"). */
+  message: string;
+  /** Unix timestamp (ms) when this event was created. */
+  timestamp: number;
+  /** Optional structured payload — tool-specific metadata. */
+  data?: unknown;
+}
+
+// ─── Module state ─────────────────────────────────────────────────────────────
+
+let _wss: WebSocketServer | null = null;
+const _clients = new Set<WebSocket>();
+
+// ─── Server lifecycle ─────────────────────────────────────────────────────────
+
+/**
+ * Start the WebSocket sideband server.
+ *
+ * Reads the port from the `WS_PORT` environment variable (default: `3002`).
+ * Calling this more than once returns the existing server without creating a
+ * duplicate.
+ *
+ * @returns The `WebSocketServer` instance.
+ */
+export function startWebSocketServer(
+  port: number = parseInt(process.env['WS_PORT'] ?? '3002', 10)
+): WebSocketServer {
+  if (_wss) return _wss;
+
+  _wss = new WebSocketServer({ port });
+
+  _wss.on('connection', (ws: WebSocket) => {
+    _clients.add(ws);
+
+    ws.on('close', () => _clients.delete(ws));
+    ws.on('error', () => _clients.delete(ws));
+  });
+
+  _wss.on('listening', () => {
+    console.log(`WebSocket sideband listening on ws://localhost:${port}`);
+  });
+
+  return _wss;
+}
+
+/**
+ * Stop the WebSocket server and close all client connections.
+ * Primarily useful for graceful shutdown and testing.
+ */
+export function stopWebSocketServer(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!_wss) {
+      resolve();
+      return;
+    }
+    for (const ws of _clients) {
+      ws.terminate();
+    }
+    _clients.clear();
+    _wss.close((err) => {
+      _wss = null;
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+// ─── Broadcasting ─────────────────────────────────────────────────────────────
+
+/**
+ * Broadcast a `ToolProgressEvent` to all connected WebSocket clients.
+ *
+ * **No-op** when:
+ * - The WebSocket server has not been started (`startWebSocketServer()` was
+ *   never called), or
+ * - No clients are currently connected.
+ *
+ * This guarantee ensures that chat functions correctly without the sideband.
+ */
+export function broadcastProgress(event: ToolProgressEvent): void {
+  if (_clients.size === 0) return;
+
+  const payload = JSON.stringify(event);
+
+  for (const ws of _clients) {
+    // WebSocket.OPEN === 1; compare numerically to avoid importing the enum
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(payload);
+    }
+  }
+}
+
+/**
+ * Return the number of currently connected WebSocket clients.
+ * Useful for conditional logic in tools (e.g. skip heavy progress reporting
+ * when no clients are listening).
+ */
+export function connectedClientCount(): number {
+  return _clients.size;
+}


### PR DESCRIPTION
## Summary

**Milestone:** Server + Claude Agent SDK Streaming

Add WebSocket server (ws package) to the Express server for tool progress events. Create ToolProgressEmitter that rate-limits progress updates to 150ms. The sideband is optional — chat works without it.

**Files to Modify:**
- libs/templates/starters/ai-agent-app/packages/server/src/ws.ts
- libs/templates/starters/ai-agent-app/packages/server/src/tools/progress.ts

**Acceptance Criteria:**
- [ ] WebSocket server runs alongside Express
- [ ] too...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=f5e50c6f-c914-4eb1-9af6-a052b03a0d8b team= created=2026-03-15T08:43:23.378Z -->