### PR TITLE
feat: compose chat view with streaming, tool progress, and weather card

### DIFF
--- a/libs/templates/starters/ai-agent-app/packages/app/package.json
+++ b/libs/templates/starters/ai-agent-app/packages/app/package.json
@@ -5,22 +5,26 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -p tsconfig.json && vite build",
+    "build": "vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ai-sdk/react": "^3.0.0",
-    "ai": "^6.0.0",
+    "@ai-sdk/react": "^1.0.0",
+    "@tanstack/react-router": "^1.114.0",
+    "ai": "^4.0.0",
+    "lucide-react": "^0.511.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "zustand": "^5.0.0"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.0.0",
+    "@tanstack/router-vite-plugin": "^1.114.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",
+    "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^7.0.0"
   }
 }

--- a/libs/templates/starters/ai-agent-app/packages/app/src/hooks/use-tool-progress.ts
+++ b/libs/templates/starters/ai-agent-app/packages/app/src/hooks/use-tool-progress.ts
@@ -1,0 +1,141 @@
+/**
+ * useToolProgress — Subscribe to tool progress events from the WebSocket sideband.
+ *
+ * Opens a WebSocket connection to the tool-progress sideband server and
+ * maintains a map of toolName → latest progress message string.
+ *
+ * The sideband is **optional** — if the WebSocket server is not running the
+ * hook silently handles connection failures and returns empty state.  Chat
+ * continues to function normally without progress updates.
+ *
+ * ## Usage
+ *
+ * ```tsx
+ * const { getProgressByToolName } = useToolProgress();
+ *
+ * // Pass to ChatMessageList:
+ * <ChatMessageList
+ *   messages={messages}
+ *   getToolProgressLabel={(toolCallId) => {
+ *     const toolName = resolveToolName(toolCallId, messages);
+ *     return getProgressByToolName(toolName);
+ *   }}
+ * />
+ * ```
+ *
+ * ## WebSocket URL
+ *
+ * Defaults to `ws://localhost:3002` (the default `WS_PORT` of the sideband
+ * server).  Override by passing a `wsUrl` argument or setting the
+ * `VITE_WS_URL` environment variable in your `.env` file.
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Shape of events broadcast by the WebSocket sideband server. */
+export interface ToolProgressEvent {
+  /** Discriminator — always `"tool:progress"`. */
+  type: 'tool:progress';
+  /** Name of the tool emitting the update. */
+  toolName: string;
+  /** Human-readable status message (e.g. "Fetching results…"). */
+  message: string;
+  /** Unix timestamp (ms) when this event was created. */
+  timestamp: number;
+  /** Optional structured payload — tool-specific metadata. */
+  data?: unknown;
+}
+
+export interface UseToolProgressResult {
+  /**
+   * Latest progress message keyed by tool name.
+   *
+   * Example: `{ "get_weather": "Fetching forecast for London…" }`
+   */
+  progressByTool: Record<string, string>;
+
+  /**
+   * Look up the latest progress label for a given tool name.
+   * Returns `undefined` when no progress has been received for the tool.
+   */
+  getProgressByToolName: (toolName: string) => string | undefined;
+
+  /** Whether the WebSocket connection is currently open. */
+  connected: boolean;
+}
+
+// ─── Default URL ──────────────────────────────────────────────────────────────
+
+const DEFAULT_WS_URL =
+  // Allow apps to override via VITE_WS_URL environment variable
+  (typeof import.meta !== 'undefined' &&
+    (import.meta as { env?: { VITE_WS_URL?: string } }).env?.VITE_WS_URL) ||
+  'ws://localhost:3002';
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Subscribe to the WebSocket tool-progress sideband.
+ *
+ * @param wsUrl - WebSocket server URL (default: `ws://localhost:3002`)
+ */
+export function useToolProgress(wsUrl: string = DEFAULT_WS_URL): UseToolProgressResult {
+  const [progressByTool, setProgressByTool] = useState<Record<string, string>>({});
+  const [connected, setConnected] = useState(false);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let ws: WebSocket | undefined;
+
+    try {
+      ws = new WebSocket(wsUrl);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        if (!cancelled) setConnected(true);
+      };
+
+      ws.onclose = () => {
+        if (!cancelled) setConnected(false);
+      };
+
+      ws.onerror = () => {
+        // Connection failed (e.g. sideband server not started) — no-op
+        if (!cancelled) setConnected(false);
+      };
+
+      ws.onmessage = (event: MessageEvent<string>) => {
+        if (cancelled) return;
+        try {
+          const data = JSON.parse(event.data) as ToolProgressEvent;
+          if (data.type === 'tool:progress' && typeof data.toolName === 'string') {
+            setProgressByTool((prev) => ({
+              ...prev,
+              [data.toolName]: data.message,
+            }));
+          }
+        } catch {
+          // Ignore malformed messages
+        }
+      };
+    } catch {
+      // WebSocket constructor threw (unsupported env, bad URL) — no-op
+    }
+
+    return () => {
+      cancelled = true;
+      wsRef.current = null;
+      ws?.close();
+    };
+  }, [wsUrl]);
+
+  const getProgressByToolName = useCallback(
+    (toolName: string): string | undefined => progressByTool[toolName],
+    [progressByTool]
+  );
+
+  return { progressByTool, getProgressByToolName, connected };
+}

--- a/libs/templates/starters/ai-agent-app/packages/app/src/routes/index.tsx
+++ b/libs/templates/starters/ai-agent-app/packages/app/src/routes/index.tsx
@@ -1,36 +1,170 @@
+/**
+ * Chat page — main route (`/`).
+ *
+ * Composes the full chat UI from the `@@PROJECT_NAME-ui` package:
+ *
+ * - **ChatMessageList** — scrollable message thread with stick-to-bottom
+ * - **ChatMessage** — role-based bubbles rendering all UIMessagePart types
+ *   including text (markdown), reasoning (ChainOfThought), tool calls
+ *   (ToolInvocationPart), and HITL confirmation cards (ConfirmationCard)
+ * - **ChatInput** — auto-resizing textarea with send/stop actions
+ * - **PromptInputProvider** — context provider for the input value
+ * - **WeatherCard** — registers custom renderer for the `get_weather` tool
+ *
+ * ## State management
+ *
+ * `useChat` from `@ai-sdk/react` drives the conversation: it streams messages
+ * from `POST /api/chat`, appends user turns, and exposes `status` so the UI
+ * can show loading indicators while the model is responding.
+ *
+ * ## Tool progress
+ *
+ * `useToolProgress` subscribes to the WebSocket sideband (`WS_PORT`, default
+ * 3002) and feeds live progress labels to tool invocation cards so users see
+ * e.g. "Fetching forecast…" while `get_weather` is running.
+ *
+ * ## HITL confirmation
+ *
+ * When the model requests approval for a destructive tool call, the streaming
+ * response includes an `approval-requested` state. `ToolInvocationPart`
+ * renders a `ConfirmationCard` with Approve/Reject buttons.  The handlers
+ * below send the decision back via `append()`.
+ */
+
 import { createFileRoute } from '@tanstack/react-router';
+import { useCallback, useMemo } from 'react';
+import { useChat } from '@ai-sdk/react';
+import type { UIMessage } from 'ai';
+
+// Import UI components via relative path.
+// In a scaffolded project these would be:  import { ... } from '@@PROJECT_NAME-ui';
+import { ChatMessageList, ChatInput, PromptInputProvider } from '../../ui/src/index.js';
+
+// Register the WeatherCard custom tool renderer (side-effect import)
+import '../../ui/src/tool-results/weather-card.js';
+
+import { useToolProgress } from '../hooks/use-tool-progress.js';
+
+// ─── Route ────────────────────────────────────────────────────────────────────
 
 export const Route = createFileRoute('/')({
   component: ChatPage,
 });
 
+// ─── Chat page ────────────────────────────────────────────────────────────────
+
 function ChatPage() {
+  // ── Streaming chat state ──────────────────────────────────────────────────
+  const { messages, append, stop, status } = useChat({
+    api: '/api/chat',
+  });
+
+  const isStreaming = status === 'streaming' || status === 'submitted';
+
+  // ── Tool progress from WebSocket sideband ─────────────────────────────────
+  const { getProgressByToolName } = useToolProgress();
+
+  /**
+   * Build a toolCallId → toolName lookup from the current message stream so
+   * we can map the toolCallId (used by ChatMessage) to the toolName key used
+   * by the progress map.
+   */
+  const toolCallIdToName = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const msg of messages) {
+      for (const part of msg.parts ?? []) {
+        const p = part as Record<string, unknown>;
+        if (typeof p.toolCallId === 'string' && typeof p.toolName === 'string') {
+          map.set(p.toolCallId, p.toolName);
+        }
+      }
+    }
+    return map;
+  }, [messages]);
+
+  const getToolProgressLabel = useCallback(
+    (toolCallId: string): string | undefined => {
+      const toolName = toolCallIdToName.get(toolCallId);
+      return toolName ? getProgressByToolName(toolName) : undefined;
+    },
+    [toolCallIdToName, getProgressByToolName]
+  );
+
+  // ── Input submission ──────────────────────────────────────────────────────
+  const handleSubmit = useCallback(
+    (text: string) => {
+      void append({ role: 'user', content: text });
+    },
+    [append]
+  );
+
+  // ── HITL tool approval ────────────────────────────────────────────────────
+  // When the model requests human-in-the-loop confirmation for a destructive
+  // tool call, the user's decision is sent back as a data message.
+  const handleToolApprove = useCallback(
+    (approvalId: string) => {
+      void append({
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: `Approved tool call ${approvalId}`,
+          },
+        ],
+        // Include the approval metadata for server-side processing
+        data: { type: 'tool-approval', approvalId, approved: true },
+      });
+    },
+    [append]
+  );
+
+  const handleToolReject = useCallback(
+    (approvalId: string) => {
+      void append({
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: `Rejected tool call ${approvalId}`,
+          },
+        ],
+        data: { type: 'tool-approval', approvalId, approved: false },
+      });
+    },
+    [append]
+  );
+
+  // ─────────────────────────────────────────────────────────────────────────
+
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        height: '100%',
-        padding: 24,
-      }}
-    >
-      <h1 style={{ fontSize: 18, fontWeight: 600, marginBottom: 16 }}>Chat</h1>
+    <PromptInputProvider>
       <div
         style={{
-          flex: 1,
-          borderRadius: 8,
-          border: '1px solid var(--border)',
-          backgroundColor: 'var(--surface)',
-          padding: 16,
           display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
+          flexDirection: 'column',
+          height: '100%',
+          overflow: 'hidden',
         }}
       >
-        <p style={{ color: 'var(--text-muted)', fontSize: 14 }}>
-          Start a conversation with your AI agent.
-        </p>
+        {/* ── Message list ───────────────────────────────────────────────── */}
+        <ChatMessageList
+          messages={messages as UIMessage[]}
+          isStreaming={isStreaming}
+          getToolProgressLabel={getToolProgressLabel}
+          onToolApprove={handleToolApprove}
+          onToolReject={handleToolReject}
+          emptyMessage="Start a conversation with your AI agent…"
+        />
+
+        {/* ── Input area ─────────────────────────────────────────────────── */}
+        <ChatInput
+          onSubmit={handleSubmit}
+          onStop={stop}
+          isStreaming={isStreaming}
+          autoFocus
+          placeholder="Ask anything…"
+        />
       </div>
-    </div>
+    </PromptInputProvider>
   );
 }

--- a/libs/templates/starters/ai-agent-app/packages/ui/src/tool-results/weather-card.tsx
+++ b/libs/templates/starters/ai-agent-app/packages/ui/src/tool-results/weather-card.tsx
@@ -1,0 +1,217 @@
+/**
+ * WeatherCard — Custom tool result renderer for the `get_weather` tool.
+ *
+ * Registers itself with `toolResultRegistry` so `ToolInvocationPart`
+ * automatically displays it instead of the default JSON preview whenever
+ * the `get_weather` tool completes.
+ *
+ * ## Registration
+ *
+ * Import this file once in your app entry point (e.g. `main.tsx`) to
+ * register the card:
+ *
+ * ```typescript
+ * import '../packages/ui/src/tool-results/weather-card';
+ * // or from the ui package:
+ * import '@@PROJECT_NAME-ui/tool-results/weather-card';
+ * ```
+ *
+ * The side effect of the import calls `toolResultRegistry.register()`,
+ * so no further setup is required.
+ *
+ * ## Data shape
+ *
+ * The card handles two output shapes — both the bare output and the
+ * `{ success, data }` wrapper produced by `defineSharedTool`:
+ *
+ * ```json
+ * // Direct
+ * { "location": "London", "temperature": 22, "unit": "celsius", ... }
+ *
+ * // Wrapped (from defineSharedTool)
+ * { "success": true, "data": { "location": "London", ... } }
+ * ```
+ */
+
+import { Droplets, Wind, Cloud } from 'lucide-react';
+import {
+  toolResultRegistry,
+  type ToolResultRendererProps,
+} from '../components/tool-result-registry.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface WeatherData {
+  location: string;
+  temperature: number;
+  unit: 'celsius' | 'fahrenheit';
+  condition: string;
+  humidity: number;
+  windSpeed: number;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function parseWeatherOutput(output: unknown): WeatherData | null {
+  if (!output || typeof output !== 'object') return null;
+
+  const raw = output as Record<string, unknown>;
+
+  // Unwrap { success, data } envelope from defineSharedTool
+  const data =
+    'data' in raw && raw.data && typeof raw.data === 'object'
+      ? (raw.data as Record<string, unknown>)
+      : raw;
+
+  const location = typeof data.location === 'string' ? data.location : null;
+  const temperature = typeof data.temperature === 'number' ? data.temperature : null;
+  const unit = data.unit === 'celsius' || data.unit === 'fahrenheit' ? data.unit : 'celsius';
+  const condition = typeof data.condition === 'string' ? data.condition : 'Unknown';
+  const humidity = typeof data.humidity === 'number' ? data.humidity : null;
+  const windSpeed = typeof data.windSpeed === 'number' ? data.windSpeed : null;
+
+  if (location === null || temperature === null) return null;
+
+  return {
+    location,
+    temperature,
+    unit,
+    condition,
+    humidity: humidity ?? 0,
+    windSpeed: windSpeed ?? 0,
+  };
+}
+
+function unitSymbol(unit: 'celsius' | 'fahrenheit'): string {
+  return unit === 'celsius' ? '°C' : '°F';
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+function WeatherCard({ output, state }: ToolResultRendererProps) {
+  if (state !== 'output-available') return null;
+
+  const weather = parseWeatherOutput(output);
+
+  if (!weather) {
+    return (
+      <p style={{ fontSize: 12, color: 'var(--text-muted)' }}>Unable to parse weather data.</p>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        borderRadius: 8,
+        border: '1px solid var(--border)',
+        overflow: 'hidden',
+        fontSize: 13,
+        backgroundColor: 'var(--surface)',
+      }}
+    >
+      {/* Header: location + condition */}
+      <div
+        style={{
+          padding: '10px 12px 8px',
+          borderBottom: '1px solid var(--border)',
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: 8,
+        }}
+      >
+        <div>
+          <p
+            style={{
+              fontWeight: 600,
+              fontSize: 14,
+              color: 'var(--foreground)',
+              margin: 0,
+            }}
+          >
+            {weather.location}
+          </p>
+          <p
+            style={{
+              fontSize: 11,
+              color: 'var(--text-muted)',
+              margin: '2px 0 0',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 4,
+            }}
+          >
+            <Cloud size={11} />
+            {weather.condition}
+          </p>
+        </div>
+
+        {/* Temperature display */}
+        <p
+          style={{
+            fontSize: 28,
+            fontWeight: 700,
+            color: 'var(--primary)',
+            lineHeight: 1,
+            margin: 0,
+            flexShrink: 0,
+          }}
+        >
+          {weather.temperature}
+          <span style={{ fontSize: 16, fontWeight: 400 }}>{unitSymbol(weather.unit)}</span>
+        </p>
+      </div>
+
+      {/* Stats row: humidity + wind speed */}
+      <div
+        style={{
+          display: 'flex',
+          gap: 0,
+          padding: '6px 12px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 5,
+            color: 'var(--text-muted)',
+            fontSize: 11,
+            flex: 1,
+          }}
+        >
+          <Droplets size={13} style={{ color: 'var(--primary)', opacity: 0.8 }} />
+          <span>
+            Humidity <strong style={{ color: 'var(--foreground)' }}>{weather.humidity}%</strong>
+          </span>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 5,
+            color: 'var(--text-muted)',
+            fontSize: 11,
+            flex: 1,
+          }}
+        >
+          <Wind size={13} style={{ color: 'var(--primary)', opacity: 0.8 }} />
+          <span>
+            Wind <strong style={{ color: 'var(--foreground)' }}>{weather.windSpeed} km/h</strong>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Registration (side effect) ───────────────────────────────────────────────
+
+/**
+ * Register the WeatherCard renderer for the `get_weather` tool.
+ * This runs once when the module is first imported.
+ */
+toolResultRegistry.register('get_weather', WeatherCard);
+
+export { WeatherCard };


### PR DESCRIPTION
## Summary

- **Chat view** (`routes/index.tsx`): Full chat page composing `ChatMessageList`, `ChatInput`, and `PromptInputProvider` from `packages/ui`. Uses `useChat` from `@ai-sdk/react` for streaming conversation state.
- **Tool progress hook** (`hooks/use-tool-progress.ts`): WebSocket sideband subscriber (port 3002) that tracks live progress messages keyed by `toolName`. Gracefully handles connection failures — sideband is optional.
- **Progress label bridge**: Builds a `toolCallId → toolName` map via `useMemo` over messages, composing `getToolProgressLabel` so `ToolInvocationPart` receives the correct live label.
- **HITL wiring**: `onToolApprove`/`onToolReject` send approval data via `append()` with a `data: { type: 'tool-approval', approvalId, approved }` payload.
- **WeatherCard** (`packages/ui/src/tool-results/weather-card.tsx`): Custom renderer for `get_weather`, registered with `toolResultRegistry` via side-effect import. Handles both direct and `{ success, data }` wrapped output shapes from `defineSharedTool`.

## Test plan

- [ ] Scaffold a new project from the template and run `npm run dev`
- [ ] Verify chat messages stream correctly and the cursor appears during streaming
- [ ] Verify `ToolInvocationPart` cards collapse/expand and show custom renderer for `get_weather`
- [ ] Verify `WeatherCard` renders location, temperature, condition, humidity, and wind speed
- [ ] Verify HITL confirmation cards appear for destructive tools and approve/reject flows work
- [ ] Verify `useToolProgress` connects to the WebSocket sideband and shows live progress labels when the server is running
- [ ] Verify app starts without errors when the WebSocket sideband is not running (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)