### PR TITLE
Build slash command system

### DIFF
--- a/libs/templates/starters/ai-agent-app/packages/server/src/commands/example.ts
+++ b/libs/templates/starters/ai-agent-app/packages/server/src/commands/example.ts
@@ -1,0 +1,73 @@
+/**
+ * Example slash commands.
+ *
+ * Import this module to register all built-in commands into the registry.
+ * The side-effect import pattern ensures commands are available as soon as
+ * any route that needs them loads this file.
+ *
+ * To add a new command:
+ *   registerCommand({
+ *     name: 'mycommand',
+ *     description: 'What this command does',
+ *     expand: (args) => `System prompt text injected before the conversation…`,
+ *   });
+ */
+
+import { registerCommand } from './registry.js';
+
+// ─── /summarize ───────────────────────────────────────────────────────────────
+
+/**
+ * /summarize
+ *
+ * Instructs the model to produce a concise summary of the conversation so far.
+ * The expansion is injected as a system-prompt prefix, so the model receives
+ * the instruction before seeing any of the conversation messages.
+ */
+registerCommand({
+  name: 'summarize',
+  description: 'Summarize the conversation so far with key points and action items.',
+  expand: (_args: string): string =>
+    'Please provide a concise, well-structured summary of the conversation so far. ' +
+    'Include: key topics discussed, decisions made, open questions, and any action items. ' +
+    'Use clear headings if there are multiple distinct topics. ' +
+    'Keep the summary focused and easy to scan.',
+});
+
+// ─── /eli5 ────────────────────────────────────────────────────────────────────
+
+/**
+ * /eli5 [topic]
+ *
+ * Instructs the model to explain a concept in simple, plain language.
+ * If args are provided they specify the topic; otherwise the model explains
+ * whatever was most recently discussed.
+ */
+registerCommand({
+  name: 'eli5',
+  description: "Explain a concept in simple language (Explain Like I'm 5).",
+  expand: (args: string): string => {
+    const topic = args.trim();
+    return topic
+      ? `Please explain "${topic}" in very simple, plain language that anyone can understand. ` +
+          'Avoid jargon. Use short sentences, everyday analogies, and concrete examples.'
+      : 'Please re-explain the most recent concept in very simple, plain language that anyone can understand. ' +
+          'Avoid jargon. Use short sentences, everyday analogies, and concrete examples.';
+  },
+});
+
+// ─── /bullets ─────────────────────────────────────────────────────────────────
+
+/**
+ * /bullets
+ *
+ * Instructs the model to respond using bullet points instead of prose.
+ */
+registerCommand({
+  name: 'bullets',
+  description: 'Ask the assistant to respond in concise bullet points.',
+  expand: (_args: string): string =>
+    'Respond using concise bullet points. ' +
+    'Each bullet should be one clear, self-contained idea. ' +
+    'Avoid long paragraphs or unnecessary filler text.',
+});

--- a/libs/templates/starters/ai-agent-app/packages/server/src/commands/registry.ts
+++ b/libs/templates/starters/ai-agent-app/packages/server/src/commands/registry.ts
@@ -1,0 +1,89 @@
+/**
+ * Slash Command Registry
+ *
+ * Defines the SlashCommand interface and a simple in-memory registry for
+ * command registration and lookup.
+ *
+ * Usage:
+ *   1. Define commands using `registerCommand()` (see commands/example.ts)
+ *   2. Detect `/command args` in chat messages using `parseSlashCommand()`
+ *   3. Expand to a system prompt prefix with `cmd.expand(args)`
+ *
+ * Wire into chat route:
+ *   const parsed = parseSlashCommand(lastUserMessage);
+ *   if (parsed) {
+ *     const cmd = getCommand(parsed.name);
+ *     if (cmd) systemPrompt = cmd.expand(parsed.args) + '\n\n' + (systemPrompt ?? '');
+ *   }
+ */
+
+// ─── Interface ────────────────────────────────────────────────────────────────
+
+/**
+ * A slash command that expands into a system prompt prefix.
+ *
+ * When a user types `/name [args]` in the chat input, the command's
+ * `expand()` function is called with the remaining text.  The returned string
+ * is prepended to the system prompt so the model receives additional
+ * instructions before the conversation messages.
+ */
+export interface SlashCommand {
+  /** Unique command name (without the leading slash). e.g. "summarize" */
+  name: string;
+  /** Short description shown in the autocomplete dropdown. */
+  description: string;
+  /**
+   * Expand the command into a system-prompt addition.
+   *
+   * @param args  Everything after `/name ` in the user's message.
+   * @returns     A string that will be prepended to the system prompt.
+   */
+  expand: (args: string) => string;
+}
+
+// ─── Registry ─────────────────────────────────────────────────────────────────
+
+const registry = new Map<string, SlashCommand>();
+
+/**
+ * Register a slash command.  If a command with the same name already exists
+ * it will be overwritten.
+ */
+export function registerCommand(cmd: SlashCommand): void {
+  registry.set(cmd.name, cmd);
+}
+
+/**
+ * Look up a command by name (without the leading slash).
+ * Returns `undefined` if no command is registered under that name.
+ */
+export function getCommand(name: string): SlashCommand | undefined {
+  return registry.get(name);
+}
+
+/**
+ * Return all registered commands as an array, sorted alphabetically by name.
+ */
+export function listCommands(): SlashCommand[] {
+  return Array.from(registry.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a `/command [args]` prefix from a chat message.
+ *
+ * Returns `{ name, args }` if the message starts with a slash command,
+ * or `null` if it does not.
+ *
+ * Examples:
+ *   parseSlashCommand('/summarize')            → { name: 'summarize', args: '' }
+ *   parseSlashCommand('/translate to Spanish') → { name: 'translate', args: 'to Spanish' }
+ *   parseSlashCommand('Hello, world!')          → null
+ */
+export function parseSlashCommand(message: string): { name: string; args: string } | null {
+  const trimmed = message.trimStart();
+  const match = trimmed.match(/^\/([a-zA-Z][\w-]*)(?:\s+([\s\S]*))?$/);
+  if (!match) return null;
+  return { name: match[1]!, args: (match[2] ?? '').trim() };
+}

--- a/libs/templates/starters/ai-agent-app/packages/server/src/index.ts
+++ b/libs/templates/starters/ai-agent-app/packages/server/src/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import { getDefaultModel } from './model-resolver.js';
 import chatRouter from './routes/chat.js';
 import tracesRouter from './routes/traces.js';
+import commandsRouter from './routes/commands.js';
 
 // ─── App factory ──────────────────────────────────────────────────────────────
 
@@ -35,6 +36,7 @@ export function createApp(): express.Application {
 
   app.use('/api/chat', chatRouter);
   app.use('/api/traces', tracesRouter);
+  app.use('/api/commands', commandsRouter);
 
   return app;
 }

--- a/libs/templates/starters/ai-agent-app/packages/server/src/routes/chat.ts
+++ b/libs/templates/starters/ai-agent-app/packages/server/src/routes/chat.ts
@@ -36,6 +36,10 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 import { z } from 'zod';
 import { traceStore } from '../tracing/trace-store.js';
 import { buildTrace, type StepData } from '../tracing/build-trace.js';
+import { getCommand, parseSlashCommand } from '../commands/registry.js';
+
+// Side-effect import: registers all built-in commands into the registry
+import '../commands/example.js';
 
 const router = Router();
 
@@ -86,6 +90,31 @@ router.post('/', async (req: Request, res: Response): Promise<void> => {
     apiKey: process.env['ANTHROPIC_API_KEY'],
   });
 
+  // ── Slash-command expansion ─────────────────────────────────────────────────
+  // If the last user message starts with `/commandname [args]`, expand it into
+  // a system-prompt prefix so the model receives the command's instruction
+  // before the conversation messages.
+  let resolvedSystem = system;
+  const lastUserMessage = [...messages].reverse().find((m) => m.role === 'user');
+  const lastUserText =
+    lastUserMessage && typeof lastUserMessage.content === 'string'
+      ? lastUserMessage.content
+      : lastUserMessage && Array.isArray(lastUserMessage.content)
+        ? lastUserMessage.content
+            .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+            .map((p) => p.text)
+            .join('')
+        : '';
+
+  const parsed = lastUserText ? parseSlashCommand(lastUserText) : null;
+  if (parsed) {
+    const cmd = getCommand(parsed.name);
+    if (cmd) {
+      const expansion = cmd.expand(parsed.args);
+      resolvedSystem = expansion + (resolvedSystem ? '\n\n' + resolvedSystem : '');
+    }
+  }
+
   // Trace bookkeeping — assign a unique ID and record the start time
   const traceId = crypto.randomUUID();
   const traceStartedAt = new Date();
@@ -99,7 +128,7 @@ router.post('/', async (req: Request, res: Response): Promise<void> => {
       execute: async ({ writer }) => {
         const result = streamText({
           model: provider(resolvedModelId),
-          system,
+          system: resolvedSystem,
           messages,
 
           // ── Tools available to the model ─────────────────────────────────

--- a/libs/templates/starters/ai-agent-app/packages/server/src/routes/commands.ts
+++ b/libs/templates/starters/ai-agent-app/packages/server/src/routes/commands.ts
@@ -1,0 +1,41 @@
+/**
+ * GET /api/commands — List registered slash commands.
+ *
+ * Returns the name and description of every registered slash command.
+ * The `expand` function is server-side only and is intentionally omitted
+ * from the response.
+ *
+ * Response:
+ *   {
+ *     commands: Array<{ name: string; description: string }>
+ *   }
+ *
+ * Used by the client's SlashCommandDropdown to populate the autocomplete list
+ * when the user types a leading `/` in the chat input.
+ *
+ * Example response:
+ *   {
+ *     "commands": [
+ *       { "name": "bullets",   "description": "Ask the assistant to respond in concise bullet points." },
+ *       { "name": "eli5",      "description": "Explain a concept in simple language (Explain Like I'm 5)." },
+ *       { "name": "summarize", "description": "Summarize the conversation so far with key points and action items." }
+ *     ]
+ *   }
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { listCommands } from '../commands/registry.js';
+
+// Side-effect import: registers all built-in commands into the registry
+import '../commands/example.js';
+
+const router = Router();
+
+// ─── GET / ────────────────────────────────────────────────────────────────────
+
+router.get('/', (_req: Request, res: Response): void => {
+  const commands = listCommands().map(({ name, description }) => ({ name, description }));
+  res.json({ commands });
+});
+
+export default router;


### PR DESCRIPTION
## Summary

**Milestone:** Advanced Features — Commands, Roles, Polish

Create packages/server/src/commands/registry.ts with SlashCommand interface. Create example /summarize command. Wire into chat route — detect /command prefix, call expand(), prepend to system prompt. Create GET /api/commands endpoint. Integrate SlashCommandDropdown in chat input.

**Files to Modify:**
- libs/templates/starters/ai-agent-app/packages/server/src/commands/registry.ts
- libs/templates/starters/ai-agent-app/packages/server/sr...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=f5e50c6f-c914-4eb1-9af6-a052b03a0d8b team= created=2026-03-15T09:20:43.052Z -->