### PR TITLE
feat: wire ai-agent-app into scaffold route, UI picker, and starter features

### DIFF
--- a/apps/server/src/routes/setup/routes/scaffold-starter.ts
+++ b/apps/server/src/routes/setup/routes/scaffold-starter.ts
@@ -7,13 +7,14 @@ import {
   scaffoldPortfolioStarter,
   scaffoldLandingPageStarter,
   scaffoldGeneralStarter,
+  scaffoldAiAgentAppStarter,
 } from '@protolabsai/templates';
 
 const logger = createLogger('setup:scaffold-starter');
 
 interface ScaffoldStarterRequest {
   projectPath: string;
-  kitType: 'docs' | 'portfolio' | 'landing-page' | 'general';
+  kitType: 'docs' | 'portfolio' | 'landing-page' | 'general' | 'ai-agent-app';
   projectName?: string;
 }
 
@@ -47,12 +48,16 @@ export function createScaffoldStarterHandler(): RequestHandler<
         return;
       }
 
-      if (!kitType || !['docs', 'portfolio', 'landing-page', 'general'].includes(kitType)) {
+      if (
+        !kitType ||
+        !['docs', 'portfolio', 'landing-page', 'general', 'ai-agent-app'].includes(kitType)
+      ) {
         res.status(400).json({
           success: false,
           outputDir: '',
           filesCreated: [],
-          error: 'kitType must be "docs", "portfolio", "landing-page", or "general"',
+          error:
+            'kitType must be "docs", "portfolio", "landing-page", "general", or "ai-agent-app"',
         });
         return;
       }
@@ -108,6 +113,7 @@ export function createScaffoldStarterHandler(): RequestHandler<
         portfolio: scaffoldPortfolioStarter,
         'landing-page': scaffoldLandingPageStarter,
         general: scaffoldGeneralStarter,
+        'ai-agent-app': scaffoldAiAgentAppStarter,
       };
       const result = await scaffolders[kitType](options);
 

--- a/apps/ui/src/lib/clients/setup-client.ts
+++ b/apps/ui/src/lib/clients/setup-client.ts
@@ -457,7 +457,7 @@ export const withSetupClient = <TBase extends Constructor<BaseHttpClient>>(Base:
 
       scaffoldStarterKit: (
         projectPath: string,
-        kitType: 'docs' | 'portfolio' | 'landing-page' | 'general',
+        kitType: 'docs' | 'portfolio' | 'landing-page' | 'general' | 'ai-agent-app',
         projectName?: string
       ): Promise<{
         success: boolean;

--- a/apps/ui/src/lib/templates.ts
+++ b/apps/ui/src/lib/templates.ts
@@ -13,7 +13,7 @@ export interface StarterTemplate {
   /** How the template is provisioned */
   source: 'scaffold' | 'clone';
   /** Kit type for scaffold source — maps to scaffold endpoint */
-  kitType?: 'docs' | 'portfolio' | 'landing-page' | 'extension';
+  kitType?: 'docs' | 'portfolio' | 'landing-page' | 'extension' | 'ai-agent-app';
   /** GitHub URL for clone source */
   repoUrl?: string;
   techStack: string[];
@@ -79,6 +79,37 @@ export const starterTemplates: StarterTemplate[] = [
       'Geist font family (sans + mono)',
     ],
     category: 'frontend',
+    author: 'protoLabs',
+  },
+  {
+    id: 'ai-agent-app',
+    name: 'AI Agent App',
+    description:
+      'Full-stack agentic chat application with a streaming React UI, Express server running an Anthropic tool-use loop, shared tool definitions (MCP/LangGraph/Express adapters), LangGraph flows, prompt registry, and Langfuse tracing.',
+    source: 'scaffold',
+    kitType: 'ai-agent-app',
+    techStack: [
+      'React 19',
+      'Vite',
+      'TanStack Router',
+      'Express',
+      'Anthropic SDK',
+      'LangGraph',
+      'Vercel AI SDK',
+      'Langfuse',
+      'Tailwind CSS 4',
+    ],
+    features: [
+      'Streaming chat UI with tool invocation progress labels (WebSocket sideband)',
+      'Server-side Anthropic agentic loop with multi-turn tool use',
+      'defineSharedTool — define once, deploy to MCP, LangGraph, and Express',
+      'LangGraph flow builder with linear, loop, and branching topologies',
+      'Prompt registry with YAML frontmatter and {{variable}} interpolation',
+      'Langfuse observability with FileTracer fallback (zero-infra dev experience)',
+      'Session persistence with LRU eviction (localStorage)',
+      'Slash command system with system-prompt expansion',
+    ],
+    category: 'ai',
     author: 'protoLabs',
   },
   {

--- a/libs/templates/src/features.ts
+++ b/libs/templates/src/features.ts
@@ -94,6 +94,39 @@ const PORTFOLIO_FEATURES: StarterFeature[] = [
   },
 ];
 
+const AI_AGENT_APP_FEATURES: StarterFeature[] = [
+  {
+    title: 'Connect your first tool',
+    description:
+      'Define a custom tool using `defineSharedTool` in `packages/tools/src/`. Wire it into the server agentic loop and verify it appears in chat. Add a progress label so the UI shows live tool execution status.',
+    complexity: 'medium',
+  },
+  {
+    title: 'Add a LangGraph flow',
+    description:
+      'Create a multi-step LangGraph flow in `packages/flows/src/flows/`. Use `createLinearGraph` or `createBranchingGraph` from the flows package. Add a server route that invokes the flow and streams results back to the UI.',
+    complexity: 'large',
+  },
+  {
+    title: 'Add Langfuse tracing',
+    description:
+      'Configure Langfuse observability by setting `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_HOST` environment variables. Verify traces appear in the Langfuse dashboard after sending a chat message.',
+    complexity: 'small',
+  },
+  {
+    title: 'Customize the system prompt',
+    description:
+      'Edit `packages/prompts/src/` to add a role-specific system prompt. Register it in the prompt registry. Wire it to the chat route so the agent responds with the custom persona.',
+    complexity: 'medium',
+  },
+  {
+    title: 'Deploy to production',
+    description:
+      'Containerize the server with a Dockerfile. Set up environment variables for API keys and Langfuse. Deploy the UI as a static build (Vite `npm run build`) and the server as a Node.js container. Configure CORS for the production domain.',
+    complexity: 'large',
+  },
+];
+
 const EXTENSION_FEATURES: StarterFeature[] = [
   {
     title: 'Add options page settings',
@@ -144,7 +177,7 @@ export function getStarterFeatures(type: StarterKitType): StarterFeature[] {
     case 'general':
       return [...UNIVERSAL_FEATURES];
     case 'ai-agent-app':
-      return [...UNIVERSAL_FEATURES];
+      return [...UNIVERSAL_FEATURES, ...AI_AGENT_APP_FEATURES];
   }
 }
 

--- a/libs/templates/src/index.ts
+++ b/libs/templates/src/index.ts
@@ -49,7 +49,11 @@ export { getCodingRules } from './coding-rules.js';
 export { getDocsCI, getExtensionCI } from './ci.js';
 
 // Starter kit context files (write to .automaker/CONTEXT.md in new projects)
-export { getDocsStarterContext, getPortfolioStarterContext } from './starters.js';
+export {
+  getDocsStarterContext,
+  getPortfolioStarterContext,
+  getAiAgentAppStarterContext,
+} from './starters.js';
 
 // Starter kit scaffolding (copies Astro projects with name/config substitution)
 export {

--- a/libs/templates/src/starters.ts
+++ b/libs/templates/src/starters.ts
@@ -86,6 +86,63 @@ Design tokens live in \`src/styles/global.css\` as CSS custom properties and a T
 }
 
 /**
+ * Get the agent context file content for the AI Agent App starter kit.
+ * Write this to `.automaker/CONTEXT.md` in the new project.
+ */
+export function getAiAgentAppStarterContext(): string {
+  return `# AI Agent App Starter Kit — Agent Context
+
+This project is an **AI agentic chat application** with a multi-package monorepo structure.
+
+## Project Structure
+
+\`\`\`
+packages/
+  server/    ← Express server with Anthropic agentic loop (POST /chat)
+  ui/        ← Vite + React + TanStack Router chat UI with streaming
+  tools/     ← Shared tool definitions (MCP, LangGraph, Express adapters)
+  flows/     ← LangGraph workflow definitions
+  prompts/   ← Prompt registry with YAML frontmatter + {{variable}} templates
+  tracing/   ← Langfuse + FileTracer observability (zero-dependency fallback)
+  app/       ← Cross-package app entrypoint
+\`\`\`
+
+## Key Patterns
+
+### Tools
+Tools are defined once with \`defineSharedTool\` and deployed to MCP, LangGraph, and Express via adapters. Register tools via \`registerTool()\` in the ToolRegistry. Use \`toolProgress.emit()\` to broadcast live progress to the UI over WebSocket sideband (port 3002).
+
+### Chat Server
+The agentic loop lives in \`packages/server/src/routes/chat.ts\`. It calls Anthropic, detects \`tool_use\` blocks, executes via ToolRegistry, feeds results back, and repeats until \`end_turn\`. Streaming uses the Vercel AI SDK (\`streamText\` → \`pipeUIMessageStreamToResponse\`).
+
+### Flows
+LangGraph flows live in \`packages/flows/src/flows/\`. Use \`createLinearGraph\`, \`createLoopGraph\`, or \`createBranchingGraph\` factory functions. State reducers (\`appendReducer\`, \`counterReducer\`, etc.) handle state merging.
+
+### Prompts
+Prompts are Markdown files in \`packages/prompts/src/prompts/\` with YAML frontmatter. Load via \`PromptLoader\` and register in \`PromptRegistry\`. Slash commands expand via system-prompt prepending.
+
+### Tracing
+Pass \`LANGFUSE_PUBLIC_KEY\` + \`LANGFUSE_SECRET_KEY\` to enable Langfuse. Fallback: \`FileTracer\` writes JSON traces to \`packages/tracing/traces/\`.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| \`npm run dev\` | Start server (port 3001) + UI dev server (port 5173) |
+| \`npm run build\` | Build all packages |
+| \`npm run typecheck\` | TypeScript check across all packages |
+| \`npm run test\` | Run Vitest test suite |
+
+## Key Constraints
+
+- Server port: 3001. UI dev server: 5173. WebSocket sideband: 3002.
+- Zero \`@protolabsai/*\` internal imports — this package is standalone.
+- CSS theming uses \`bg-[var(--primary)]\` Tailwind arbitrary syntax (no design system dependency).
+- \`@@PROJECT_NAME\` placeholders in package names should be replaced with your project name.
+`;
+}
+
+/**
  * Get the agent context file content for the Starlight docs starter kit.
  * Write this to `.automaker/CONTEXT.md` in the new project.
  */

--- a/packages/create-protolab/src/phases/scaffold.ts
+++ b/packages/create-protolab/src/phases/scaffold.ts
@@ -13,8 +13,10 @@ import {
   scaffoldDocsStarter,
   scaffoldPortfolioStarter,
   scaffoldLandingPageStarter,
+  scaffoldAiAgentAppStarter,
   getDocsStarterContext,
   getPortfolioStarterContext,
+  getAiAgentAppStarterContext,
   getStarterFeatures,
 } from '@protolabsai/templates';
 
@@ -88,6 +90,18 @@ export async function scaffoldStarter(
       };
     }
     filesCreated = result.filesCreated;
+  } else if (kitType === 'ai-agent-app') {
+    const result = await scaffoldAiAgentAppStarter({ projectName, outputDir });
+    if (!result.success) {
+      return {
+        success: false,
+        outputDir,
+        filesCreated: result.filesCreated,
+        starterFeatures: [],
+        error: result.error,
+      };
+    }
+    filesCreated = result.filesCreated;
   }
 
   // Write .automaker/CONTEXT.md
@@ -100,6 +114,8 @@ export async function scaffoldStarter(
       contextContent = getDocsStarterContext();
     } else if (kitType === 'portfolio') {
       contextContent = getPortfolioStarterContext();
+    } else if (kitType === 'ai-agent-app') {
+      contextContent = getAiAgentAppStarterContext();
     }
 
     if (contextContent !== null) {


### PR DESCRIPTION
## Summary

- **Scaffold route** accepts `ai-agent-app` kitType and routes to `scaffoldAiAgentAppStarter`
- **UI template picker** shows AI Agent App in the starter template list (category: `ai`) with full tech stack and feature list
- **5 starter features** populate the board on creation: connect a tool, add a LangGraph flow, add Langfuse tracing, customize the system prompt, and deploy to production
- **`getAiAgentAppStarterContext()`** writes `.automaker/CONTEXT.md` describing the monorepo structure, key patterns, and commands
- **`create-protolab` scaffold phase** handles `ai-agent-app` kit type with scaffolding + context file

## Test plan

- [ ] `npm run build:packages` passes (verified ✓)
- [ ] `npm run typecheck` passes — 20/20 tasks (verified ✓)
- [ ] `POST /api/setup/scaffold-starter` with `kitType: "ai-agent-app"` returns 200
- [ ] UI template picker shows "AI Agent App" card in the `ai` category
- [ ] Creating a project with this template populates 8 board features (3 universal + 5 specific)

<!-- automaker:owner instance=local team=protoLabsAI created=2026-03-15T00:00:00.000Z -->