### PR TITLE
Create MCP server example

### DIFF
--- a/libs/templates/starters/ai-agent-app/packages/mcp/package.json
+++ b/libs/templates/starters/ai-agent-app/packages/mcp/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@@PROJECT_NAME-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "@@PROJECT_NAME-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@@PROJECT_NAME-tools": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/libs/templates/starters/ai-agent-app/packages/mcp/src/index.ts
+++ b/libs/templates/starters/ai-agent-app/packages/mcp/src/index.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * MCP server for @@PROJECT_NAME.
+ *
+ * Exposes registered tools via the Model Context Protocol over stdio.
+ *
+ * ## Connect to Claude Code
+ * Add to ~/.claude/settings.json → mcpServers:
+ *   "@@PROJECT_NAME": { "command": "node", "args": ["/path/to/packages/mcp/dist/index.js"] }
+ *
+ * ## Connect to Claude Desktop
+ * Add to ~/Library/Application Support/Claude/claude_desktop_config.json → mcpServers
+ * (same format as above).
+ *
+ * ## Development (no build step)
+ *   "@@PROJECT_NAME": { "command": "npx", "args": ["tsx", "/path/to/packages/mcp/src/index.ts"] }
+ *
+ * ## Adding tools
+ *   import { myTool } from '@@PROJECT_NAME-tools';
+ *   registry.register(myTool);
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { ToolRegistry, toMCPTools, getWeatherTool, searchWebTool } from '@@PROJECT_NAME-tools';
+
+// ─── Registry ─────────────────────────────────────────────────────────────────
+
+const registry = new ToolRegistry();
+
+// Register example tools — remove or replace with your own
+registry.registerMany([getWeatherTool, searchWebTool]);
+
+// ─── MCP Server ───────────────────────────────────────────────────────────────
+
+const server = new Server(
+  { name: '@@PROJECT_NAME', version: '0.1.0' },
+  { capabilities: { tools: {} } }
+);
+
+const mcpTools = toMCPTools(registry.listTools());
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: mcpTools.map(({ name, description, inputSchema }) => ({
+    name,
+    description,
+    inputSchema,
+  })),
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+  const tool = mcpTools.find((t) => t.name === name);
+
+  if (!tool) {
+    throw new Error(`Tool not found: ${name}`);
+  }
+
+  const result = await tool.handler(args ?? {}, {});
+
+  if (!result.success) {
+    throw new Error(result.error ?? 'Tool execution failed');
+  }
+
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(result.data, null, 2) }],
+  };
+});
+
+// ─── Connect ──────────────────────────────────────────────────────────────────
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/libs/templates/starters/ai-agent-app/packages/mcp/tsconfig.json
+++ b/libs/templates/starters/ai-agent-app/packages/mcp/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

**Milestone:** MCP Server + Documentation

Create packages/mcp/ in the starter kit with a minimal MCP server (~50-80 lines) that: imports Server and StdioServerTransport from @modelcontextprotocol/sdk, loads tools from the tools package registry, converts them using toMCPTool adapter, registers ListToolsRequestSchema and CallToolRequestSchema handlers. Include the example tools (get_weather, search_web) auto-registered. Add a bin entry so users can run it as a CLI. Document how to connect it to ...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=f5e50c6f-c914-4eb1-9af6-a052b03a0d8b team= created=2026-03-15T10:03:03.722Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces MCP (Model Context Protocol) server for the AI agent app starter template
  * Exposes tools via stdio transport enabling external client connections
  * Includes example tools for weather lookup and web search functionality
  * Provides tool listing and execution request handling capabilities
  * Configured with complete Node.js package setup, TypeScript support, and build scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->