### PR TITLE
feat(tokens): W3C DTCG design token package for design-system starter

### DIFF
--- a/libs/templates/starters/design-system/packages/tokens/package.json
+++ b/libs/templates/starters/design-system/packages/tokens/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@@PROJECT_NAME-tokens",
+  "version": "0.1.0",
+  "description": "W3C DTCG design token extraction and export for the design system starter kit",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./dtcg": {
+      "import": "./dist/dtcg.js",
+      "types": "./dist/dtcg.d.ts"
+    },
+    "./extractor": {
+      "import": "./dist/extractor.js",
+      "types": "./dist/extractor.d.ts"
+    },
+    "./exporters/css": {
+      "import": "./dist/exporters/css.js",
+      "types": "./dist/exporters/css.d.ts"
+    },
+    "./exporters/tailwind": {
+      "import": "./dist/exporters/tailwind.js",
+      "types": "./dist/exporters/tailwind.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "typecheck": "tsc --project tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/libs/templates/starters/design-system/packages/tokens/src/dtcg.ts
+++ b/libs/templates/starters/design-system/packages/tokens/src/dtcg.ts
@@ -1,0 +1,377 @@
+/**
+ * W3C Design Tokens Community Group (DTCG) specification types and utilities.
+ * Based on the 2025.10 stable specification.
+ *
+ * @see https://design-tokens.github.io/community-group/format/
+ */
+
+// ---------------------------------------------------------------------------
+// Token types
+// ---------------------------------------------------------------------------
+
+/** All recognized DTCG token $type values (2025.10 spec). */
+export type DTCGTokenType =
+  | 'color'
+  | 'dimension'
+  | 'font-family'
+  | 'font-weight'
+  | 'font-style'
+  | 'number'
+  | 'duration'
+  | 'cubic-bezier'
+  | 'shadow'
+  | 'gradient'
+  | 'typography'
+  | 'border'
+  | 'string'
+  | 'transition';
+
+// ---------------------------------------------------------------------------
+// Composite value types
+// ---------------------------------------------------------------------------
+
+/** A single drop/box shadow. */
+export interface DTCGShadowValue {
+  color: string;
+  offsetX: string;
+  offsetY: string;
+  blur: string;
+  spread: string;
+  inset?: boolean;
+}
+
+/** A single gradient colour stop. */
+export interface DTCGGradientStop {
+  color: string;
+  /** Position in the gradient, expressed as a number between 0 and 1. */
+  position: number;
+}
+
+/** An array of gradient stops. */
+export type DTCGGradientValue = DTCGGradientStop[];
+
+/** Composite typography token. */
+export interface DTCGTypographyValue {
+  fontFamily?: string | string[];
+  fontSize?: string;
+  fontWeight?: number | string;
+  fontStyle?: string;
+  letterSpacing?: string;
+  lineHeight?: string | number;
+}
+
+/** Composite border token. */
+export interface DTCGBorderValue {
+  color: string;
+  width: string;
+  style: string;
+}
+
+/** Composite transition token. */
+export interface DTCGTransitionValue {
+  duration: string;
+  delay?: string;
+  timingFunction?: [number, number, number, number];
+}
+
+/** Union of all valid DTCG token $value types. */
+export type DTCGTokenValue =
+  | string
+  | number
+  | boolean
+  | [number, number, number, number] // cubic-bezier
+  | DTCGShadowValue
+  | DTCGShadowValue[] // multiple shadows
+  | DTCGGradientValue
+  | DTCGTypographyValue
+  | DTCGBorderValue
+  | DTCGTransitionValue;
+
+// ---------------------------------------------------------------------------
+// Core token / group structures
+// ---------------------------------------------------------------------------
+
+/** A leaf DTCG design token — has a $value. */
+export interface DTCGToken {
+  $value: DTCGTokenValue;
+  $type?: DTCGTokenType;
+  $description?: string;
+  /** Non-standard extensions (e.g. theme variants stored under $extensions.themes). */
+  $extensions?: Record<string, unknown>;
+}
+
+/**
+ * A DTCG token group — an object that contains tokens or nested groups.
+ * Does NOT have a $value property.
+ */
+export interface DTCGGroup {
+  $type?: DTCGTokenType;
+  $description?: string;
+  $extensions?: Record<string, unknown>;
+  [key: string]: DTCGToken | DTCGGroup | DTCGTokenType | string | unknown;
+}
+
+/** Root DTCG document — a group of groups / tokens. */
+export type DTCGDocument = DTCGGroup;
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+/** Returns `true` if `value` is a DTCG token (has a `$value` property). */
+export function isDTCGToken(value: unknown): value is DTCGToken {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) && '$value' in value;
+}
+
+/** Returns `true` if `value` is a DTCG group (object without `$value`). */
+export function isDTCGGroup(value: unknown): value is DTCGGroup {
+  return (
+    typeof value === 'object' && value !== null && !Array.isArray(value) && !('$value' in value)
+  );
+}
+
+/** Returns `true` if `key` is a DTCG reserved keyword (starts with `$`). */
+export function isDTCGReservedKey(key: string): boolean {
+  return key.startsWith('$');
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export interface DTCGValidationError {
+  /** Dot-separated path to the offending token/group (e.g. `color.brand.primary`). */
+  path: string;
+  message: string;
+}
+
+const VALID_TOKEN_TYPES = new Set<string>([
+  'color',
+  'dimension',
+  'font-family',
+  'font-weight',
+  'font-style',
+  'number',
+  'duration',
+  'cubic-bezier',
+  'shadow',
+  'gradient',
+  'typography',
+  'border',
+  'string',
+  'transition',
+]);
+
+/**
+ * Validates a DTCG document against the W3C spec.
+ *
+ * @param doc     The document to validate.
+ * @param options Pass `{ strict: true }` to enable deep value validation.
+ * @returns       An array of validation errors; empty means the document is valid.
+ */
+export function validateDTCGDocument(
+  doc: DTCGDocument,
+  options: { strict?: boolean } = {}
+): DTCGValidationError[] {
+  const errors: DTCGValidationError[] = [];
+  validateNode(doc, '', errors, options.strict ?? false);
+  return errors;
+}
+
+function validateNode(
+  node: unknown,
+  path: string,
+  errors: DTCGValidationError[],
+  strict: boolean
+): void {
+  if (typeof node !== 'object' || node === null || Array.isArray(node)) return;
+
+  const obj = node as Record<string, unknown>;
+
+  if (isDTCGToken(obj)) {
+    const type = obj.$type as DTCGTokenType | undefined;
+    if (type !== undefined && !VALID_TOKEN_TYPES.has(type)) {
+      errors.push({ path, message: `Unknown $type: "${type}"` });
+    }
+    if (strict) {
+      validateTokenValue(obj.$value, type, path, errors);
+    }
+  } else {
+    // Group — recurse into children
+    for (const [key, value] of Object.entries(obj)) {
+      if (isDTCGReservedKey(key)) continue;
+      const childPath = path ? `${path}.${key}` : key;
+      validateNode(value, childPath, errors, strict);
+    }
+  }
+}
+
+function validateTokenValue(
+  value: unknown,
+  type: DTCGTokenType | undefined,
+  path: string,
+  errors: DTCGValidationError[]
+): void {
+  if (value === undefined || value === null) {
+    errors.push({ path, message: '$value is required' });
+    return;
+  }
+
+  if (!type) return; // without a type we cannot do deeper validation
+
+  switch (type) {
+    case 'color':
+      if (typeof value !== 'string') {
+        errors.push({ path, message: 'color $value must be a string' });
+      } else if (!isValidColor(value)) {
+        errors.push({ path, message: `Invalid color value: "${value}"` });
+      }
+      break;
+
+    case 'dimension':
+      if (typeof value !== 'string') {
+        errors.push({ path, message: 'dimension $value must be a string (e.g. "16px")' });
+      } else if (!isValidDimension(value)) {
+        errors.push({ path, message: `Invalid dimension value: "${value}"` });
+      }
+      break;
+
+    case 'number':
+      if (typeof value !== 'number') {
+        errors.push({ path, message: 'number $value must be a number' });
+      }
+      break;
+
+    case 'font-weight':
+      if (typeof value !== 'number' && typeof value !== 'string') {
+        errors.push({ path, message: 'font-weight $value must be a number or string keyword' });
+      }
+      break;
+
+    case 'cubic-bezier':
+      if (
+        !Array.isArray(value) ||
+        value.length !== 4 ||
+        !(value as unknown[]).every((v) => typeof v === 'number')
+      ) {
+        errors.push({
+          path,
+          message: 'cubic-bezier $value must be an array of 4 numbers [x1, y1, x2, y2]',
+        });
+      }
+      break;
+
+    case 'duration':
+      if (typeof value !== 'string') {
+        errors.push({ path, message: 'duration $value must be a string (e.g. "200ms")' });
+      }
+      break;
+
+    case 'font-family':
+      if (typeof value !== 'string' && !Array.isArray(value)) {
+        errors.push({ path, message: 'font-family $value must be a string or array of strings' });
+      }
+      break;
+
+    default:
+      break;
+  }
+}
+
+// Accepts: hex, rgb(), rgba(), hsl(), hsla(), CSS vars, named keywords
+const COLOR_PATTERN = /^(#[0-9a-fA-F]{3,8}|rgb\(|rgba\(|hsl\(|hsla\(|oklch\(|lch\(|lab\(|var\(--)/;
+
+const CSS_COLOR_KEYWORDS = new Set([
+  'transparent',
+  'currentcolor',
+  'inherit',
+  'initial',
+  'unset',
+  'revert',
+  'black',
+  'white',
+  'red',
+  'green',
+  'blue',
+  'yellow',
+  'orange',
+  'purple',
+  'pink',
+  'gray',
+  'grey',
+]);
+
+function isValidColor(value: string): boolean {
+  return COLOR_PATTERN.test(value) || CSS_COLOR_KEYWORDS.has(value.toLowerCase());
+}
+
+// Number (with optional decimal) followed by a CSS length/time unit, or bare 0
+const DIMENSION_PATTERN =
+  /^-?(\d+\.?\d*|\.\d+)(px|em|rem|%|vw|vh|vmin|vmax|ch|ex|fr|pt|pc|cm|mm|in|lh|rlh|svh|svw|dvh|dvw|cqi|cqb|cqw|cqh|ms|s)$/;
+
+function isValidDimension(value: string): boolean {
+  return value === '0' || DIMENSION_PATTERN.test(value);
+}
+
+// ---------------------------------------------------------------------------
+// Document traversal
+// ---------------------------------------------------------------------------
+
+/**
+ * Walks every token in a DTCG document, calling `visitor` for each one.
+ *
+ * @param doc           The DTCG document (or sub-group) to walk.
+ * @param visitor       Called with `(token, dotPath, resolvedType)` for each token.
+ * @param inheritedType The `$type` inherited from a parent group (if any).
+ * @param currentPath   Internal recursion parameter — leave at default (`''`).
+ */
+export function walkTokens(
+  doc: DTCGDocument,
+  visitor: (token: DTCGToken, path: string, resolvedType: DTCGTokenType | undefined) => void,
+  inheritedType?: DTCGTokenType,
+  currentPath = ''
+): void {
+  for (const [key, value] of Object.entries(doc)) {
+    if (isDTCGReservedKey(key)) continue;
+
+    const childPath = currentPath ? `${currentPath}.${key}` : key;
+
+    if (isDTCGToken(value)) {
+      const resolvedType = (value.$type as DTCGTokenType | undefined) ?? inheritedType;
+      visitor(value, childPath, resolvedType);
+    } else if (isDTCGGroup(value)) {
+      const groupType = (value.$type as DTCGTokenType | undefined) ?? inheritedType;
+      walkTokens(value as DTCGDocument, visitor, groupType, childPath);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts a dot-separated token path to a CSS custom property name.
+ *
+ * @example `pathToCSSVar('color.brand.primary')` → `'--color-brand-primary'`
+ */
+export function pathToCSSVar(path: string): string {
+  return '--' + path.replace(/\./g, '-');
+}
+
+/**
+ * Converts a CSS custom property name to a dot-separated DTCG token path.
+ *
+ * @example `cssVarToPath('--color-brand-primary')` → `'color.brand.primary'`
+ */
+export function cssVarToPath(cssVar: string): string {
+  return cssVar.replace(/^--/, '').replace(/-/g, '.');
+}
+
+/**
+ * Converts a CSS variable name from a .pen file (e.g. `$--primary-color`)
+ * to a DTCG-compatible path segment (e.g. `primary-color`).
+ */
+export function penVarToPath(penVar: string): string {
+  return penVar.replace(/^\$?--/, '');
+}

--- a/libs/templates/starters/design-system/packages/tokens/src/exporters/css.ts
+++ b/libs/templates/starters/design-system/packages/tokens/src/exporters/css.ts
@@ -1,0 +1,372 @@
+/**
+ * Exports a DTCG token document as CSS custom properties.
+ *
+ * Supports:
+ * - Root :root block with all default values
+ * - Theme override blocks (data-attribute, class, or media-query strategy)
+ * - Both 'extensions' and 'groups' theme layouts from the extractor
+ */
+
+import { walkTokens, pathToCSSVar, isDTCGToken } from '../dtcg.js';
+import type { DTCGDocument, DTCGTokenType } from '../dtcg.js';
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface CSSExportOptions {
+  /**
+   * CSS selector for the default (light) token block.
+   * @default ':root'
+   */
+  rootSelector?: string;
+
+  /**
+   * Whether to emit theme override blocks for variants stored in
+   * `$extensions.themes`. Only applies when using the 'extensions' strategy.
+   * @default true
+   */
+  emitThemes?: boolean;
+
+  /**
+   * Strategy for targeting the dark/alternate theme:
+   * - `'data-attribute'` (default): `[data-theme="dark"]`
+   * - `'class'`: `.dark`
+   * - `'media'`: `@media (prefers-color-scheme: dark)`
+   */
+  darkThemeStrategy?: 'data-attribute' | 'class' | 'media';
+
+  /**
+   * The theme name used when building the dark-mode selector.
+   * @default 'dark'
+   */
+  darkThemeName?: string;
+
+  /**
+   * When `true`, `$description` values are emitted as CSS comments above
+   * each custom property.
+   * @default false
+   */
+  includeComments?: boolean;
+
+  /**
+   * Indentation string for property lines inside a selector block.
+   * @default '  ' (two spaces)
+   */
+  indent?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Result
+// ---------------------------------------------------------------------------
+
+export interface CSSExportResult {
+  /** The full CSS output string. */
+  css: string;
+  /** Number of tokens in the default (:root) block. */
+  tokenCount: number;
+  /** Number of tokens emitted inside theme override blocks. */
+  themeTokenCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Export: extensions strategy
+// ---------------------------------------------------------------------------
+
+/**
+ * Exports a DTCG document — extracted with `themeStrategy: 'extensions'` —
+ * as CSS custom properties.
+ *
+ * All tokens land in a single root selector block.  Non-default theme values
+ * (stored in `$extensions.themes`) are emitted in separate selector blocks.
+ *
+ * @example
+ * ```ts
+ * const { css } = exportToCSS(doc, { darkThemeStrategy: 'media' });
+ * fs.writeFileSync('tokens.css', css);
+ * ```
+ */
+export function exportToCSS(doc: DTCGDocument, options: CSSExportOptions = {}): CSSExportResult {
+  const rootSelector = options.rootSelector ?? ':root';
+  const emitThemes = options.emitThemes ?? true;
+  const darkThemeStrategy = options.darkThemeStrategy ?? 'data-attribute';
+  const darkThemeName = options.darkThemeName ?? 'dark';
+  const includeComments = options.includeComments ?? false;
+  const indent = options.indent ?? '  ';
+
+  const rootLines: string[] = [];
+  // modeKey (e.g. 'dark' | 'light/dark' | …) → property lines
+  const themeLines: Record<string, string[]> = {};
+  let tokenCount = 0;
+  let themeTokenCount = 0;
+
+  walkTokens(doc, (token, path, resolvedType) => {
+    const cssVar = pathToCSSVar(path);
+    const cssValue = tokenValueToCSS(token.$value, resolvedType);
+
+    if (includeComments && token.$description) {
+      rootLines.push(`${indent}/* ${token.$description} */`);
+    }
+    rootLines.push(`${indent}${cssVar}: ${cssValue};`);
+    tokenCount++;
+
+    // Emit alternate theme values from $extensions.themes
+    if (emitThemes && token.$extensions?.['themes']) {
+      const themeMap = token.$extensions['themes'] as Record<string, unknown>;
+      for (const [modeKey, modeValue] of Object.entries(themeMap)) {
+        // Skip the default/light entry (it is already in :root)
+        if (modeKey.includes('light')) continue;
+
+        if (!themeLines[modeKey]) themeLines[modeKey] = [];
+        const themeCSSValue = tokenValueToCSS(modeValue as string | number, resolvedType);
+        themeLines[modeKey].push(`${indent}${cssVar}: ${themeCSSValue};`);
+        themeTokenCount++;
+      }
+    }
+  });
+
+  // Assemble CSS
+  const parts: string[] = [`${rootSelector} {`, ...rootLines, '}'];
+
+  if (emitThemes) {
+    for (const [modeKey, lines] of Object.entries(themeLines)) {
+      if (lines.length === 0) continue;
+      parts.push('');
+      const selector = buildThemeSelector(darkThemeStrategy, darkThemeName, modeKey);
+      parts.push(`${selector} {`, ...lines, '}');
+    }
+  }
+
+  return { css: parts.join('\n') + '\n', tokenCount, themeTokenCount };
+}
+
+// ---------------------------------------------------------------------------
+// Export: groups strategy
+// ---------------------------------------------------------------------------
+
+/**
+ * Exports a DTCG document — extracted with `themeStrategy: 'groups'` —
+ * as CSS custom properties.
+ *
+ * Each top-level group (e.g. `light`, `dark`) becomes its own CSS selector
+ * block.  The group whose key matches `defaultGroupKey` is mapped to
+ * `rootSelector`.
+ *
+ * @example
+ * ```ts
+ * const { css } = exportGroupedToCSS(doc, {
+ *   defaultGroupKey: 'light',
+ *   darkThemeStrategy: 'class',
+ * });
+ * ```
+ */
+export function exportGroupedToCSS(
+  doc: DTCGDocument,
+  options: CSSExportOptions & {
+    /**
+     * The group key that should map to the default root selector.
+     * @default 'light'
+     */
+    defaultGroupKey?: string;
+    /**
+     * Override the generated selector for specific group keys.
+     * e.g. `{ 'dark': '[data-color-scheme="dark"]' }`
+     */
+    groupSelectors?: Record<string, string>;
+  } = {}
+): CSSExportResult {
+  const rootSelector = options.rootSelector ?? ':root';
+  const indent = options.indent ?? '  ';
+  const defaultGroupKey = options.defaultGroupKey ?? 'light';
+  const darkThemeStrategy = options.darkThemeStrategy ?? 'data-attribute';
+  const darkThemeName = options.darkThemeName ?? 'dark';
+
+  const parts: string[] = [];
+  let tokenCount = 0;
+  let themeTokenCount = 0;
+
+  for (const [groupKey, groupValue] of Object.entries(doc)) {
+    if (groupKey.startsWith('$')) continue;
+    if (!isDTCGToken(groupValue) && typeof groupValue !== 'object') continue;
+
+    const vars: string[] = [];
+
+    // Walk this group, stripping the leading group key from each path
+    walkTokens({ [groupKey]: groupValue } as DTCGDocument, (token, path, resolvedType) => {
+      // Remove the leading "groupKey." prefix
+      const trimmedPath = path.replace(new RegExp(`^${escapeRegex(groupKey)}\\.?`), '');
+      if (!trimmedPath) return;
+
+      const cssVar = pathToCSSVar(trimmedPath);
+      const cssValue = tokenValueToCSS(token.$value, resolvedType);
+      vars.push(`${indent}${cssVar}: ${cssValue};`);
+    });
+
+    if (vars.length === 0) continue;
+
+    const isDefault = groupKey === defaultGroupKey;
+    const selector = isDefault
+      ? rootSelector
+      : (options.groupSelectors?.[groupKey] ??
+        buildThemeSelector(darkThemeStrategy, darkThemeName, groupKey));
+
+    parts.push(`${selector} {`, ...vars, '}', '');
+
+    if (isDefault) tokenCount += vars.length;
+    else themeTokenCount += vars.length;
+  }
+
+  return { css: parts.join('\n'), tokenCount, themeTokenCount };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a CSS selector for an alternate theme (non-default mode).
+ */
+function buildThemeSelector(
+  strategy: 'data-attribute' | 'class' | 'media',
+  darkThemeName: string,
+  modeKey: string
+): string {
+  const isDark = modeKey.includes('dark');
+  const displayName = isDark ? darkThemeName : modeKey;
+
+  switch (strategy) {
+    case 'data-attribute':
+      return `[data-theme="${displayName}"]`;
+    case 'class':
+      return `.${displayName}`;
+    case 'media':
+      return `@media (prefers-color-scheme: ${isDark ? 'dark' : 'light'})`;
+  }
+}
+
+/**
+ * Converts a DTCG token `$value` to a CSS value string.
+ */
+export function tokenValueToCSS(value: unknown, type: DTCGTokenType | undefined): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'number') return String(value);
+  if (typeof value === 'string') return value;
+
+  if (Array.isArray(value)) {
+    // cubic-bezier: [x1, y1, x2, y2]
+    if (value.length === 4 && (value as unknown[]).every((v) => typeof v === 'number')) {
+      return `cubic-bezier(${(value as number[]).join(', ')})`;
+    }
+    // Gradient stops: [{ color, position }]
+    if (value.length > 0 && typeof value[0] === 'object' && 'color' in (value[0] as object)) {
+      return gradientToCSS(value as Array<{ color: string; position: number }>);
+    }
+    return value.join(', ');
+  }
+
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+
+    // Shadow composite
+    if ('offsetX' in obj) {
+      return shadowToCSS(
+        obj as {
+          color: string;
+          offsetX: string;
+          offsetY: string;
+          blur: string;
+          spread: string;
+          inset?: boolean;
+        }
+      );
+    }
+
+    // Typography composite
+    if ('fontFamily' in obj || 'fontSize' in obj) {
+      return typographyToCSS(
+        obj as {
+          fontFamily?: string | string[];
+          fontSize?: string;
+          fontWeight?: number | string;
+          fontStyle?: string;
+          letterSpacing?: string;
+          lineHeight?: string | number;
+        }
+      );
+    }
+
+    // Border composite
+    if ('width' in obj && 'style' in obj && 'color' in obj) {
+      return `${obj['width']} ${obj['style']} ${obj['color']}`;
+    }
+
+    // Transition composite
+    if ('duration' in obj) {
+      const t = obj as {
+        duration: string;
+        delay?: string;
+        timingFunction?: [number, number, number, number];
+      };
+      const parts = [t.duration];
+      if (t.delay) parts.push(t.delay);
+      if (t.timingFunction) {
+        parts.push(`cubic-bezier(${t.timingFunction.join(', ')})`);
+      }
+      return parts.join(' ');
+    }
+  }
+
+  return String(value);
+}
+
+function shadowToCSS(shadow: {
+  color: string;
+  offsetX: string;
+  offsetY: string;
+  blur: string;
+  spread: string;
+  inset?: boolean;
+}): string {
+  const parts = [
+    shadow.inset ? 'inset' : '',
+    shadow.offsetX,
+    shadow.offsetY,
+    shadow.blur,
+    shadow.spread,
+    shadow.color,
+  ].filter(Boolean);
+  return parts.join(' ');
+}
+
+function gradientToCSS(stops: Array<{ color: string; position: number }>): string {
+  const stopStr = stops.map((s) => `${s.color} ${Math.round(s.position * 100)}%`).join(', ');
+  return `linear-gradient(${stopStr})`;
+}
+
+function typographyToCSS(value: {
+  fontFamily?: string | string[];
+  fontSize?: string;
+  fontWeight?: number | string;
+  fontStyle?: string;
+  letterSpacing?: string;
+  lineHeight?: string | number;
+}): string {
+  const parts: string[] = [];
+  if (value.fontStyle) parts.push(value.fontStyle);
+  if (value.fontWeight) parts.push(String(value.fontWeight));
+  if (value.fontSize) {
+    const size = value.lineHeight ? `${value.fontSize}/${value.lineHeight}` : value.fontSize;
+    parts.push(size);
+  }
+  if (value.fontFamily) {
+    const families = Array.isArray(value.fontFamily)
+      ? value.fontFamily.map((f) => (f.includes(' ') ? `"${f}"` : f)).join(', ')
+      : value.fontFamily;
+    parts.push(families);
+  }
+  return parts.join(' ') || 'inherit';
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/libs/templates/starters/design-system/packages/tokens/src/exporters/tailwind.ts
+++ b/libs/templates/starters/design-system/packages/tokens/src/exporters/tailwind.ts
@@ -1,0 +1,385 @@
+/**
+ * Exports a DTCG token document as a Tailwind CSS configuration.
+ *
+ * Supports:
+ * - Tailwind v3 (`theme.extend` JS object / `module.exports` file)
+ * - Tailwind v4 (`@theme` CSS block)
+ * - CSS variable references (`var(--token-path)`) or raw values
+ */
+
+import { walkTokens, pathToCSSVar } from '../dtcg.js';
+import type { DTCGDocument, DTCGTokenType } from '../dtcg.js';
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface TailwindExportOptions {
+  /**
+   * Tailwind version to target.
+   * - `'v3'` (default): Emits a `theme.extend` JS object.
+   * - `'v4'`: Emits an `@theme` CSS block.
+   */
+  version?: 'v3' | 'v4';
+
+  /**
+   * When `true` (default), property values are emitted as `var(--token-name)`
+   * references so that runtime theming works via CSS custom properties.
+   * When `false`, raw DTCG values are inlined.
+   */
+  useCSSVarReferences?: boolean;
+
+  /**
+   * When `true`, wraps the output in a full `module.exports = { theme: { extend: { … } } }`.
+   * Only applies to Tailwind v3.
+   * @default false
+   */
+  wrapInConfig?: boolean;
+
+  /**
+   * Indentation string.
+   * @default '  ' (two spaces)
+   */
+  indent?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Result
+// ---------------------------------------------------------------------------
+
+export interface TailwindExportResult {
+  /** The generated Tailwind configuration string (JS or CSS). */
+  config: string;
+  /** The theme object for programmatic use (v3 only). */
+  themeObject: TailwindTheme;
+  /** Number of tokens that were mapped to a Tailwind section. */
+  tokenCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Theme shape (subset of Tailwind's theme)
+// ---------------------------------------------------------------------------
+
+export interface TailwindTheme {
+  colors?: Record<string, string | Record<string, string>>;
+  spacing?: Record<string, string | Record<string, string>>;
+  fontFamily?: Record<string, string | string[]>;
+  fontWeight?: Record<string, string | number>;
+  fontSize?: Record<string, string | Record<string, string>>;
+  lineHeight?: Record<string, string | Record<string, string>>;
+  letterSpacing?: Record<string, string | Record<string, string>>;
+  borderRadius?: Record<string, string | Record<string, string>>;
+  boxShadow?: Record<string, string | Record<string, string>>;
+  opacity?: Record<string, string | Record<string, string>>;
+  transitionDuration?: Record<string, string | Record<string, string>>;
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Section mapping
+// ---------------------------------------------------------------------------
+
+// DTCG type → default Tailwind theme section
+const DTCG_TYPE_TO_SECTION: Partial<Record<DTCGTokenType, string>> = {
+  color: 'colors',
+  'font-family': 'fontFamily',
+  'font-weight': 'fontWeight',
+  shadow: 'boxShadow',
+  duration: 'transitionDuration',
+};
+
+// Substrings in the token path that hint at a more specific section
+const PATH_HINTS: Array<[string, string]> = [
+  ['border-radius', 'borderRadius'],
+  ['rounded', 'borderRadius'],
+  ['radius', 'borderRadius'],
+  ['shadow', 'boxShadow'],
+  ['opacity', 'opacity'],
+  ['line-height', 'lineHeight'],
+  ['leading', 'lineHeight'],
+  ['letter-spacing', 'letterSpacing'],
+  ['tracking', 'letterSpacing'],
+  ['font-size', 'fontSize'],
+  ['text-size', 'fontSize'],
+  ['duration', 'transitionDuration'],
+  ['delay', 'transitionDelay'],
+  ['font-family', 'fontFamily'],
+  ['font-weight', 'fontWeight'],
+  ['font-style', 'fontStyle'],
+];
+
+// Tailwind v4 namespace for each v3 section key
+const V4_NAMESPACE: Record<string, string> = {
+  colors: 'color',
+  spacing: 'spacing',
+  fontFamily: 'font',
+  fontWeight: 'font-weight',
+  fontStyle: 'font-style',
+  fontSize: 'text',
+  lineHeight: 'leading',
+  letterSpacing: 'tracking',
+  borderRadius: 'radius',
+  boxShadow: 'shadow',
+  opacity: 'opacity',
+  transitionDuration: 'duration',
+  transitionDelay: 'delay',
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Exports a DTCG document as a Tailwind CSS configuration.
+ *
+ * @example
+ * ```ts
+ * // Tailwind v3 — full config file
+ * const { config } = exportToTailwind(doc, { wrapInConfig: true });
+ * fs.writeFileSync('tailwind.config.js', config);
+ *
+ * // Tailwind v4 — @theme block for your global CSS
+ * const { config } = exportToTailwind(doc, { version: 'v4' });
+ * fs.writeFileSync('tokens.css', config);
+ * ```
+ */
+export function exportToTailwind(
+  doc: DTCGDocument,
+  options: TailwindExportOptions = {}
+): TailwindExportResult {
+  const version = options.version ?? 'v3';
+  const useCSSVarReferences = options.useCSSVarReferences ?? true;
+  const wrapInConfig = options.wrapInConfig ?? false;
+  const indent = options.indent ?? '  ';
+
+  const theme: TailwindTheme = {};
+  let tokenCount = 0;
+
+  walkTokens(doc, (token, path, resolvedType) => {
+    const section = inferSection(path, resolvedType);
+    if (!section) return; // no mapping — skip
+
+    const value = useCSSVarReferences
+      ? `var(${pathToCSSVar(path)})`
+      : tokenValueToString(token.$value, resolvedType);
+
+    // Ensure the section bucket exists
+    if (!theme[section]) theme[section] = {};
+
+    // Build nested key path within the section
+    const keySegments = buildSectionPath(path.split('.'), section);
+    setNestedValue(theme[section] as Record<string, unknown>, keySegments, value);
+
+    tokenCount++;
+  });
+
+  const config =
+    version === 'v4' ? buildV4Config(theme, indent) : buildV3Config(theme, indent, wrapInConfig);
+
+  return { config, themeObject: theme, tokenCount };
+}
+
+// ---------------------------------------------------------------------------
+// Section inference
+// ---------------------------------------------------------------------------
+
+function inferSection(path: string, type: DTCGTokenType | undefined): string | null {
+  const lowerPath = path.toLowerCase();
+
+  // 1. Path hints take priority (more specific)
+  for (const [hint, section] of PATH_HINTS) {
+    if (lowerPath.includes(hint)) return section;
+  }
+
+  // 2. Dimension type: infer section from path keywords
+  if (type === 'dimension' || type === 'number') {
+    return 'spacing'; // fallback for dimensions without a clearer hint
+  }
+
+  // 3. Direct type mapping
+  if (type && DTCG_TYPE_TO_SECTION[type]) {
+    return DTCG_TYPE_TO_SECTION[type] as string;
+  }
+
+  return null;
+}
+
+/**
+ * Builds the nested key path inside a Tailwind section by stripping the
+ * leading segment(s) that name the section itself (e.g. for section 'colors',
+ * strip `color` / `colours` from the front of the path).
+ */
+function buildSectionPath(segments: string[], section: string): string[] {
+  const sectionAliases: Record<string, string[]> = {
+    colors: ['color', 'colour', 'colors', 'colours'],
+    spacing: ['spacing', 'space', 'gap', 'size'],
+    fontFamily: ['font-family', 'fontfamily', 'font', 'fonts'],
+    fontWeight: ['font-weight', 'fontweight', 'weight'],
+    fontSize: ['font-size', 'fontsize', 'text-size', 'textsize'],
+    lineHeight: ['line-height', 'lineheight', 'leading'],
+    letterSpacing: ['letter-spacing', 'letterspacing', 'tracking'],
+    borderRadius: ['border-radius', 'borderradius', 'rounded', 'radius'],
+    boxShadow: ['box-shadow', 'boxshadow', 'shadow', 'shadows'],
+    opacity: ['opacity'],
+    transitionDuration: ['duration', 'transition-duration', 'transitionduration'],
+  };
+
+  const aliases = sectionAliases[section] ?? [];
+  if (segments.length > 1 && aliases.includes(segments[0].toLowerCase())) {
+    return segments.slice(1);
+  }
+  return segments;
+}
+
+// ---------------------------------------------------------------------------
+// Tailwind v3 output
+// ---------------------------------------------------------------------------
+
+function buildV3Config(theme: TailwindTheme, indent: string, wrapInConfig: boolean): string {
+  const themeStr = serializeToJS(theme, indent, indent);
+
+  if (wrapInConfig) {
+    return [
+      "/** @type {import('tailwindcss').Config} */",
+      'module.exports = {',
+      `${indent}theme: {`,
+      `${indent}${indent}extend: ${themeStr
+        .split('\n')
+        .map((line, i) => (i === 0 ? line : `${indent}${indent}${line}`))
+        .join('\n')},`,
+      `${indent}},`,
+      '};',
+    ].join('\n');
+  }
+
+  return themeStr;
+}
+
+// ---------------------------------------------------------------------------
+// Tailwind v4 output
+// ---------------------------------------------------------------------------
+
+function buildV4Config(theme: TailwindTheme, indent: string): string {
+  const lines: string[] = ['@theme {'];
+
+  for (const [section, values] of Object.entries(theme)) {
+    const ns = V4_NAMESPACE[section];
+    if (!ns || typeof values !== 'object' || values === null) continue;
+
+    lines.push(`${indent}/* ${section} */`);
+    flattenObject(values as Record<string, unknown>, (path, value) => {
+      lines.push(`${indent}--${ns}-${path}: ${value};`);
+    });
+  }
+
+  lines.push('}');
+  return lines.join('\n') + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// Utility helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Sets a value at a nested path inside an object,
+ * creating intermediate objects as needed.
+ */
+function setNestedValue(obj: Record<string, unknown>, segments: string[], value: string): void {
+  let current = obj;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i];
+    if (typeof current[seg] !== 'object' || current[seg] === null) {
+      current[seg] = {};
+    }
+    current = current[seg] as Record<string, unknown>;
+  }
+  current[segments[segments.length - 1]] = value;
+}
+
+/**
+ * Walks a (possibly nested) object and calls `visitor` for each leaf string.
+ * The `path` argument uses `-` as separator (for CSS custom property names).
+ */
+function flattenObject(
+  obj: Record<string, unknown>,
+  visitor: (path: string, value: string) => void,
+  prefix = ''
+): void {
+  for (const [key, value] of Object.entries(obj)) {
+    const currentPath = prefix ? `${prefix}-${key}` : key;
+    if (typeof value === 'string') {
+      visitor(currentPath, value);
+    } else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      flattenObject(value as Record<string, unknown>, visitor, currentPath);
+    }
+  }
+}
+
+/** Converts a DTCG token $value to a plain string for use in Tailwind config. */
+function tokenValueToString(value: unknown, type: DTCGTokenType | undefined): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return String(value);
+
+  if (Array.isArray(value)) {
+    if (
+      type === 'cubic-bezier' &&
+      value.length === 4 &&
+      (value as unknown[]).every((v) => typeof v === 'number')
+    ) {
+      return `cubic-bezier(${(value as number[]).join(', ')})`;
+    }
+    if (type === 'font-family') {
+      return (value as string[]).map((f) => (f.includes(' ') ? `"${f}"` : f)).join(', ');
+    }
+    return value.join(', ');
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const obj = value as Record<string, unknown>;
+
+    if (type === 'shadow' && 'offsetX' in obj) {
+      const s = obj as {
+        color: string;
+        offsetX: string;
+        offsetY: string;
+        blur: string;
+        spread: string;
+        inset?: boolean;
+      };
+      return `${s.inset ? 'inset ' : ''}${s.offsetX} ${s.offsetY} ${s.blur} ${s.spread} ${s.color}`;
+    }
+  }
+
+  return JSON.stringify(value);
+}
+
+/**
+ * Serialises a plain JS object to a JavaScript object literal string,
+ * formatted with the given indentation.
+ */
+function serializeToJS(obj: unknown, indent: string, currentIndent: string): string {
+  if (typeof obj === 'string') return JSON.stringify(obj);
+  if (typeof obj === 'number' || typeof obj === 'boolean') return String(obj);
+  if (obj === null) return 'null';
+
+  if (Array.isArray(obj)) {
+    const items = obj.map((item) => serializeToJS(item, indent, currentIndent + indent));
+    return `[${items.join(', ')}]`;
+  }
+
+  if (typeof obj === 'object') {
+    const entries = Object.entries(obj as Record<string, unknown>);
+    if (entries.length === 0) return '{}';
+
+    const nextIndent = currentIndent + indent;
+    const lines = entries.map(([k, v]) => {
+      // Unquote simple identifiers
+      const key = /^[a-zA-Z_$][a-zA-Z0-9_$-]*$/.test(k) ? k : JSON.stringify(k);
+      return `${nextIndent}${key}: ${serializeToJS(v, indent, nextIndent)}`;
+    });
+
+    return `{\n${lines.join(',\n')}\n${currentIndent}}`;
+  }
+
+  return String(obj);
+}

--- a/libs/templates/starters/design-system/packages/tokens/src/extractor.ts
+++ b/libs/templates/starters/design-system/packages/tokens/src/extractor.ts
@@ -1,0 +1,352 @@
+/**
+ * Extracts W3C DTCG design tokens from .pen file variable declarations.
+ *
+ * Supports:
+ * - Plain scalar values (string / number)
+ * - Theme-conditional values (light / dark variants)
+ * - Automatic pen-type → DTCG-type mapping
+ * - Two theme strategies: 'extensions' (default) or 'groups'
+ */
+
+import { isDTCGReservedKey, penVarToPath } from './dtcg.js';
+import type { DTCGDocument, DTCGGroup, DTCGToken, DTCGTokenType } from './dtcg.js';
+
+// ---------------------------------------------------------------------------
+// .pen file types (the subset we need for extraction)
+// ---------------------------------------------------------------------------
+
+/** A theme-conditional value entry from a .pen variable. */
+export interface PenThemeValue {
+  value: string | number;
+  /** Maps theme dimension names to mode values, e.g. `{ "Mode": "Dark" }`. */
+  theme: Record<string, string>;
+}
+
+/** A single .pen file variable declaration. */
+export interface PenVariable {
+  type: string; // 'color' | 'dimension' | 'number' | …
+  value: string | number | PenThemeValue[];
+}
+
+/** The full variables map from a .pen document. */
+export type PenVariables = Record<string, PenVariable>;
+
+/**
+ * Theme declarations from a .pen document.
+ * e.g. `{ "Mode": ["Light", "Dark"], "Base": ["Zinc", "Slate"] }`
+ */
+export type PenThemes = Record<string, string[]>;
+
+// ---------------------------------------------------------------------------
+// Extraction options
+// ---------------------------------------------------------------------------
+
+export interface ExtractionOptions {
+  /**
+   * How theme variants are stored in the output DTCG document.
+   *
+   * - `'extensions'` (default): All values live at the same path; non-default
+   *   theme values are attached under `$extensions.themes`.
+   * - `'groups'`: Separate top-level groups are emitted per theme mode
+   *   (e.g. `{ light: { … }, dark: { … } }`).
+   */
+  themeStrategy?: 'extensions' | 'groups';
+
+  /**
+   * The theme dimension key used to detect light/dark variants.
+   * Defaults to `'Mode'`.
+   */
+  themeDimension?: string;
+
+  /**
+   * The mode value that represents the default (light) theme.
+   * Defaults to `'Light'`.
+   */
+  defaultThemeValue?: string;
+
+  /**
+   * Optional top-level group name to nest all extracted tokens under.
+   * e.g. `'brand'` → tokens appear at `brand.<name>`.
+   */
+  groupPrefix?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Result
+// ---------------------------------------------------------------------------
+
+export interface ExtractionResult {
+  /** The DTCG document containing the extracted tokens. */
+  document: DTCGDocument;
+
+  /**
+   * Theme modes discovered while processing the variables.
+   * Keys are dimension names (e.g. `'Mode'`), values are mode arrays
+   * (e.g. `['Light', 'Dark']`).
+   */
+  themes: Record<string, string[]>;
+
+  /** Total number of tokens extracted. */
+  tokenCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Type mapping
+// ---------------------------------------------------------------------------
+
+const PEN_TYPE_TO_DTCG: Record<string, DTCGTokenType> = {
+  color: 'color',
+  dimension: 'dimension',
+  number: 'number',
+  string: 'string',
+  'font-family': 'font-family',
+  'font-weight': 'font-weight',
+  'font-style': 'font-style',
+  duration: 'duration',
+  'cubic-bezier': 'cubic-bezier',
+};
+
+function mapPenTypeToDTCG(penType: string): DTCGTokenType | undefined {
+  return PEN_TYPE_TO_DTCG[penType.toLowerCase()];
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts design tokens from .pen file variables and returns a DTCG document.
+ *
+ * @param variables  The `variables` map from a parsed .pen file.
+ * @param penThemes  Optional `themes` map from the .pen file for mode discovery.
+ * @param options    Extraction options (theme strategy, dimension name, etc.).
+ *
+ * @example
+ * ```ts
+ * const { document, themes } = extractTokensFromPen(penDoc.variables, penDoc.themes);
+ * ```
+ */
+export function extractTokensFromPen(
+  variables: PenVariables,
+  penThemes?: PenThemes,
+  options: ExtractionOptions = {}
+): ExtractionResult {
+  const strategy = options.themeStrategy ?? 'extensions';
+  const themeDimension = options.themeDimension ?? 'Mode';
+  const defaultThemeValue = options.defaultThemeValue ?? 'Light';
+
+  // Seed discovered themes from the .pen themes declaration
+  const discoveredThemes: Record<string, Set<string>> = {};
+  if (penThemes) {
+    for (const [dimension, modes] of Object.entries(penThemes)) {
+      discoveredThemes[dimension] = new Set(modes);
+    }
+  }
+
+  // First pass: build flat token map
+  const flatTokens: Record<string, DTCGToken> = {};
+  let tokenCount = 0;
+
+  for (const [rawName, variable] of Object.entries(variables)) {
+    // Strip leading '--' if present (pen files sometimes include it)
+    const name = penVarToPath(rawName);
+    const dtcgType = mapPenTypeToDTCG(variable.type);
+
+    if (Array.isArray(variable.value)) {
+      // Theme-conditional: discover modes, then pick default value
+      const themeValues = variable.value as PenThemeValue[];
+
+      for (const tv of themeValues) {
+        for (const [dim, mode] of Object.entries(tv.theme)) {
+          if (!discoveredThemes[dim]) discoveredThemes[dim] = new Set();
+          discoveredThemes[dim].add(mode);
+        }
+      }
+
+      const defaultEntry =
+        themeValues.find((tv) => tv.theme[themeDimension] === defaultThemeValue) ?? themeValues[0];
+
+      if (!defaultEntry) continue;
+
+      const token: DTCGToken = {
+        $value: normalizeValue(defaultEntry.value, variable.type),
+      };
+      if (dtcgType) token.$type = dtcgType;
+
+      if (strategy === 'extensions') {
+        // Attach all theme variants under $extensions.themes
+        const themeExts: Record<string, string | number> = {};
+        for (const tv of themeValues) {
+          // Use the mode value as the key, lowercased
+          const modeKey = Object.values(tv.theme).join('/').toLowerCase().replace(/\s+/g, '-');
+          themeExts[modeKey] = normalizeValue(tv.value, variable.type);
+        }
+        token.$extensions = { themes: themeExts };
+      }
+
+      flatTokens[name] = token;
+    } else {
+      // Plain scalar value
+      const token: DTCGToken = {
+        $value: normalizeValue(variable.value as string | number, variable.type),
+      };
+      if (dtcgType) token.$type = dtcgType;
+      flatTokens[name] = token;
+    }
+
+    tokenCount++;
+  }
+
+  // Second pass: build the DTCG document
+  const document =
+    strategy === 'groups'
+      ? buildGroupedDocument(
+          flatTokens,
+          variables,
+          themeDimension,
+          defaultThemeValue,
+          options.groupPrefix
+        )
+      : buildNestedDocument(flatTokens, options.groupPrefix);
+
+  // Convert Sets → arrays
+  const themes: Record<string, string[]> = {};
+  for (const [dim, modes] of Object.entries(discoveredThemes)) {
+    themes[dim] = Array.from(modes);
+  }
+
+  return { document, themes, tokenCount };
+}
+
+// ---------------------------------------------------------------------------
+// Document builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a nested DTCG document from a flat token map.
+ * Token names are split on '-' to create nested groups.
+ * e.g. `'color-brand-primary'` → `{ color: { brand: { primary: <token> } } }`
+ */
+function buildNestedDocument(
+  tokens: Record<string, DTCGToken>,
+  groupPrefix?: string
+): DTCGDocument {
+  const doc: DTCGDocument = {};
+
+  for (const [name, token] of Object.entries(tokens)) {
+    const segments = name.split('-');
+    let current = doc as Record<string, unknown>;
+
+    if (groupPrefix) {
+      if (!current[groupPrefix]) current[groupPrefix] = {} as DTCGGroup;
+      current = current[groupPrefix] as Record<string, unknown>;
+    }
+
+    for (let i = 0; i < segments.length - 1; i++) {
+      const seg = segments[i];
+      if (!current[seg] || isDTCGReservedKey(seg)) {
+        current[seg] = {} as DTCGGroup;
+      }
+      current = current[seg] as Record<string, unknown>;
+    }
+
+    current[segments[segments.length - 1]] = token;
+  }
+
+  return doc;
+}
+
+/**
+ * Builds a DTCG document with separate top-level groups per theme mode.
+ * e.g. `{ light: { color: { … } }, dark: { color: { … } } }`
+ */
+function buildGroupedDocument(
+  defaultTokens: Record<string, DTCGToken>,
+  variables: PenVariables,
+  themeDimension: string,
+  defaultThemeValue: string,
+  groupPrefix?: string
+): DTCGDocument {
+  const doc: DTCGDocument = {};
+
+  // Build default (light) group
+  const defaultGroup: DTCGGroup = {};
+  for (const [name, token] of Object.entries(defaultTokens)) {
+    // Strip $extensions — they are unneeded in the group strategy
+    const { $extensions: _ext, ...base } = token;
+    setNestedToken(defaultGroup, name.split('-'), base as DTCGToken);
+  }
+
+  const defaultKey = defaultThemeValue.toLowerCase();
+  if (groupPrefix) {
+    doc[groupPrefix] = { [defaultKey]: defaultGroup } as DTCGGroup;
+  } else {
+    doc[defaultKey] = defaultGroup;
+  }
+
+  // Build per-mode groups for non-default theme values
+  for (const [rawName, variable] of Object.entries(variables)) {
+    if (!Array.isArray(variable.value)) continue;
+
+    const name = penVarToPath(rawName);
+    const dtcgType = mapPenTypeToDTCG(variable.type);
+
+    for (const tv of variable.value as PenThemeValue[]) {
+      const modeValue = tv.theme[themeDimension];
+      if (!modeValue || modeValue === defaultThemeValue) continue;
+
+      const groupKey = modeValue.toLowerCase().replace(/\s+/g, '-');
+      const targetDoc = groupPrefix ? (doc[groupPrefix] as DTCGGroup) : doc;
+
+      if (!targetDoc[groupKey]) {
+        (targetDoc as Record<string, unknown>)[groupKey] = {} as DTCGGroup;
+      }
+
+      const token: DTCGToken = {
+        $value: normalizeValue(tv.value, variable.type),
+      };
+      if (dtcgType) token.$type = dtcgType;
+
+      setNestedToken(
+        (targetDoc as Record<string, unknown>)[groupKey] as DTCGGroup,
+        name.split('-'),
+        token
+      );
+    }
+  }
+
+  return doc;
+}
+
+/** Writes a token into a group at the path described by `segments`. */
+function setNestedToken(group: DTCGGroup, segments: string[], token: DTCGToken): void {
+  let current = group as Record<string, unknown>;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i];
+    if (!current[seg]) current[seg] = {} as DTCGGroup;
+    current = current[seg] as Record<string, unknown>;
+  }
+  current[segments[segments.length - 1]] = token;
+}
+
+// ---------------------------------------------------------------------------
+// Value normalisation
+// ---------------------------------------------------------------------------
+
+/** Normalises a raw .pen value into a DTCG-compatible scalar. */
+function normalizeValue(value: string | number, type: string): string | number {
+  if (typeof value === 'number') return value;
+
+  // Expand shorthand hex colours (#RGB → #RRGGBB)
+  if (type === 'color' && /^#[0-9a-fA-F]{3}$/.test(value)) {
+    const [, r, g, b] = value.match(/^#(.)(.)(.)$/) ?? [];
+    if (r && g && b) return `#${r}${r}${g}${g}${b}${b}`;
+  }
+
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Re-exports for convenience
+// ---------------------------------------------------------------------------
+export type { DTCGDocument, DTCGGroup, DTCGToken, DTCGTokenType };

--- a/libs/templates/starters/design-system/packages/tokens/src/index.ts
+++ b/libs/templates/starters/design-system/packages/tokens/src/index.ts
@@ -1,0 +1,69 @@
+/**
+ * @@@PROJECT_NAME-tokens
+ *
+ * W3C DTCG design token extraction and export utilities for the design system
+ * starter kit.
+ *
+ * @example
+ * ```ts
+ * import { extractTokensFromPen, exportToCSS, exportToTailwind } from '@@PROJECT_NAME-tokens';
+ *
+ * const { document, themes } = extractTokensFromPen(penDoc.variables, penDoc.themes);
+ *
+ * const { css }    = exportToCSS(document, { darkThemeStrategy: 'media' });
+ * const { config } = exportToTailwind(document, { version: 'v3', wrapInConfig: true });
+ * ```
+ */
+
+// Core DTCG types and utilities
+export type {
+  DTCGDocument,
+  DTCGGroup,
+  DTCGToken,
+  DTCGTokenType,
+  DTCGTokenValue,
+  DTCGShadowValue,
+  DTCGGradientStop,
+  DTCGGradientValue,
+  DTCGTypographyValue,
+  DTCGBorderValue,
+  DTCGTransitionValue,
+  DTCGValidationError,
+} from './dtcg.js';
+
+export {
+  isDTCGToken,
+  isDTCGGroup,
+  isDTCGReservedKey,
+  validateDTCGDocument,
+  walkTokens,
+  pathToCSSVar,
+  cssVarToPath,
+  penVarToPath,
+} from './dtcg.js';
+
+// Extractor
+export type {
+  PenVariable,
+  PenVariables,
+  PenThemes,
+  PenThemeValue,
+  ExtractionOptions,
+  ExtractionResult,
+} from './extractor.js';
+
+export { extractTokensFromPen } from './extractor.js';
+
+// CSS exporter
+export type { CSSExportOptions, CSSExportResult } from './exporters/css.js';
+
+export { exportToCSS, exportGroupedToCSS, tokenValueToCSS } from './exporters/css.js';
+
+// Tailwind exporter
+export type {
+  TailwindExportOptions,
+  TailwindExportResult,
+  TailwindTheme,
+} from './exporters/tailwind.js';
+
+export { exportToTailwind } from './exporters/tailwind.js';

--- a/libs/templates/starters/design-system/packages/tokens/tsconfig.json
+++ b/libs/templates/starters/design-system/packages/tokens/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Adds a new `packages/tokens` library to the design-system starter kit implementing the W3C Design Tokens Community Group (DTCG) 2025.10 specification
- Covers token extraction from `.pen` variables, CSS custom property export, and Tailwind v3/v4 config generation with full light/dark theme support
- TypeScript strict mode (NodeNext / ES2022) — zero type errors

## What's in the box

| File | Purpose |
|------|---------|
| `src/dtcg.ts` | All 14 DTCG token types, composite value interfaces, `walkTokens`, `validateDTCGDocument`, CSS-var ↔ path helpers |
| `src/extractor.ts` | `.pen` variables → DTCG document; supports scalar & theme-conditional values, `extensions` and `groups` strategies |
| `src/exporters/css.ts` | CSS custom properties — `:root` + theme override blocks (data-attribute / class / media) |
| `src/exporters/tailwind.ts` | Tailwind v3 JS config (`theme.extend`) or v4 `@theme` CSS block |
| `src/index.ts` | Barrel re-exports for clean public API |
| `package.json` | ESM package with granular subpath exports (`./dtcg`, `./extractor`, `./exporters/css`, `./exporters/tailwind`) |
| `tsconfig.json` | Strict NodeNext / ES2022 — outputs to `dist/` |

## Acceptance criteria

- [x] Tokens extracted from `.pen` variables in DTCG format
- [x] CSS custom property export (`:root` + optional theme override blocks)
- [x] Tailwind config export (v3 JS object + v4 `@theme` CSS)
- [x] Light/dark theme support (both `extensions` and `groups` strategies)
- [x] Token validation against the W3C DTCG spec (`validateDTCGDocument`)
- [x] TypeScript strict mode — zero errors

## Test plan

- [ ] Import `extractTokensFromPen` with a `.pen` variables fixture and confirm the DTCG document structure matches expected token paths
- [ ] Run `exportToCSS(doc, { darkThemeStrategy: 'media' })` and verify `:root` block + `@media (prefers-color-scheme: dark)` override block are present
- [ ] Run `exportToTailwind(doc, { version: 'v4' })` and confirm `@theme { --color-*: … }` output
- [ ] Run `validateDTCGDocument(doc, { strict: true })` on a valid document and confirm empty errors array

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Feature**: `feature-1773570576078-mqttaz7yv` — Milestone: Design Tokens — W3C DTCG + Color Science

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added design tokens package with W3C Design Tokens Community Group specification support
  * Extract design tokens from variable declarations with automatic type mapping
  * Export tokens as CSS custom properties with multiple theming strategies
  * Generate Tailwind CSS configurations from design tokens, supporting both v3 and v4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->