### PR TITLE
feat: TinaCMS site builder for design-system starter kit

### DIFF
--- a/libs/templates/starters/design-system/content/pages/index.md
+++ b/libs/templates/starters/design-system/content/pages/index.md
@@ -1,0 +1,52 @@
+---
+title: Welcome to @@PROJECT_NAME
+description: A design system for building beautiful, consistent user interfaces.
+order: '1'
+---
+
+# Welcome to @@PROJECT_NAME
+
+This design system provides reusable components, design tokens, and guidelines to help you build consistent, accessible user interfaces.
+
+## Getting Started
+
+Browse the component library to explore available components. Each component includes:
+
+- **Live examples** — See the component in action in the Playground
+- **Props reference** — Complete documentation of all available props
+- **Design guidelines** — Learn when and how to use each component
+
+## What's Included
+
+- **Component Playground** — Interactive workbench for exploring and testing components
+- **Design Tokens** — Colors, typography, spacing, and motion as CSS custom properties
+- **Component Docs** — Usage guidelines for every component
+- **Design Guidelines** — Principles for color, typography, accessibility, and more
+- **Changelog** — Version history and release notes
+
+## Project Structure
+
+```
+packages/
+  app/          ← Playground + documentation site (this app)
+  codegen/      ← .pen → React component generator
+  color/        ← OKLCH color science engine
+  tokens/       ← DTCG-spec design token system
+
+content/
+  pages/        ← Site pages (CMS-managed)
+  components/   ← Component documentation (CMS-managed)
+  guidelines/   ← Design guidelines (CMS-managed)
+  changelog/    ← Release notes (CMS-managed)
+```
+
+## Editing Content
+
+Content is stored as Markdown files in the `content/` directory and managed via TinaCMS.
+
+To start editing:
+
+1. Run `npx tinacms dev -c "vite"` from the `packages/app/` directory
+2. Open [http://localhost:4001/admin](http://localhost:4001/admin)
+3. Edit pages, components, and guidelines visually
+4. Changes are saved directly to the git-tracked Markdown files

--- a/libs/templates/starters/design-system/packages/app/package.json
+++ b/libs/templates/starters/design-system/packages/app/package.json
@@ -5,13 +5,16 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:cms": "tinacms dev -c \"vite --port 5174\"",
     "build": "tsc --noEmit && vite build",
+    "build:cms": "tinacms build && vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   },
   "dependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "tinacms": "^2.6.0"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/libs/templates/starters/design-system/packages/app/src/main.tsx
+++ b/libs/templates/starters/design-system/packages/app/src/main.tsx
@@ -1,13 +1,47 @@
-import React from 'react';
+/**
+ * Entry point — minimal hash-based router.
+ *
+ * Routes:
+ *   #/           → Component Playground (default)
+ *   #/site       → Documentation site (git-backed content via TinaCMS)
+ *   #/admin      → TinaCMS admin panel launcher
+ */
+
+import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import './styles/tokens.css';
 import { PlaygroundRoute } from './routes/playground';
+import { SiteRoute } from './routes/site';
+import { AdminRoute } from './routes/admin';
+
+type Route = '/' | '/site' | '/admin';
+
+function getRoute(): Route {
+  const hash = window.location.hash.replace('#', '') || '/';
+  if (hash === '/site') return '/site';
+  if (hash === '/admin') return '/admin';
+  return '/';
+}
+
+function App() {
+  const [route, setRoute] = useState<Route>(getRoute);
+
+  useEffect(() => {
+    const onHashChange = () => setRoute(getRoute());
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
+  if (route === '/site') return <SiteRoute />;
+  if (route === '/admin') return <AdminRoute />;
+  return <PlaygroundRoute />;
+}
 
 const root = document.getElementById('root');
 if (!root) throw new Error('No #root element found');
 
 createRoot(root).render(
   <React.StrictMode>
-    <PlaygroundRoute />
+    <App />
   </React.StrictMode>
 );

--- a/libs/templates/starters/design-system/packages/app/src/routes/admin.tsx
+++ b/libs/templates/starters/design-system/packages/app/src/routes/admin.tsx
@@ -1,0 +1,317 @@
+/**
+ * AdminRoute — TinaCMS admin panel entry point.
+ *
+ * In self-hosted mode, TinaCMS runs a local backend server that serves the
+ * admin panel at http://localhost:4001/admin. This route acts as a landing
+ * page that:
+ *
+ *   1. Detects whether TinaCMS is running (by probing its health endpoint).
+ *   2. Redirects to the admin panel if it is running.
+ *   3. Shows setup instructions if it isn't.
+ *
+ * To start TinaCMS:
+ *   cd packages/app
+ *   npx tinacms dev -c "vite --port 5174"
+ *
+ * Once running:
+ *   - Admin panel: http://localhost:4001/admin
+ *   - Vite dev server: http://localhost:5174
+ *   - Visual editing: navigate pages via the admin, edits save to content/*.md
+ */
+
+import { useEffect, useState } from 'react';
+
+// ─── TinaCMS health check ─────────────────────────────────────────────────────
+
+type AdminStatus = 'checking' | 'running' | 'offline';
+
+const TINA_ADMIN_URL = 'http://localhost:4001/admin';
+const TINA_HEALTH_URL = 'http://localhost:4001/api/tina/gql';
+
+async function checkTinaHealth(): Promise<boolean> {
+  try {
+    const res = await fetch(TINA_HEALTH_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: '{ __typename }' }),
+      signal: AbortSignal.timeout(2000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// ─── Setup steps ──────────────────────────────────────────────────────────────
+
+const SETUP_STEPS = [
+  {
+    step: 1,
+    title: 'Install TinaCMS',
+    code: 'npm install tinacms @tinacms/auth',
+    description: 'Add TinaCMS and its auth package to the project.',
+  },
+  {
+    step: 2,
+    title: 'Start the dev server',
+    code: 'npx tinacms dev -c "vite --port 5174"',
+    description:
+      'This starts the TinaCMS backend (port 4001) alongside your Vite dev server (port 5174).',
+  },
+  {
+    step: 3,
+    title: 'Open the admin panel',
+    code: 'open http://localhost:4001/admin',
+    description:
+      'TinaCMS provides a full visual editor. Edits are saved as Markdown/JSON in the content/ directory.',
+  },
+  {
+    step: 4,
+    title: 'Build for production',
+    code: 'npx tinacms build && vite build',
+    description: 'Compiles the admin panel into public/admin/ alongside your static site build.',
+  },
+] as const;
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const S = {
+  shell: {
+    minHeight: '100vh',
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+    fontSize: 14,
+    color: 'var(--pg-fg, #0f172a)',
+    background: 'var(--pg-bg, #f8fafc)',
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center',
+    padding: '48px 24px',
+  } as React.CSSProperties,
+
+  card: {
+    background: 'var(--pg-sidebar, #fff)',
+    border: '1px solid var(--pg-border, #e2e8f0)',
+    borderRadius: 12,
+    padding: 32,
+    width: '100%',
+    maxWidth: 640,
+    marginBottom: 24,
+  } as React.CSSProperties,
+
+  statusDot: (status: AdminStatus): React.CSSProperties => ({
+    width: 10,
+    height: 10,
+    borderRadius: '50%',
+    background: status === 'running' ? '#22c55e' : status === 'offline' ? '#ef4444' : '#f59e0b',
+    display: 'inline-block',
+    marginRight: 8,
+    animation: status === 'checking' ? 'pulse 1s infinite' : 'none',
+  }),
+
+  stepCard: {
+    border: '1px solid var(--pg-border, #e2e8f0)',
+    borderRadius: 8,
+    padding: 20,
+    marginBottom: 16,
+    background: 'var(--pg-bg, #f8fafc)',
+  } as React.CSSProperties,
+
+  stepNumber: {
+    width: 28,
+    height: 28,
+    borderRadius: '50%',
+    background: 'var(--primary, #6366f1)',
+    color: '#fff',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontWeight: 700,
+    fontSize: 13,
+    marginRight: 12,
+    flexShrink: 0,
+  } as React.CSSProperties,
+
+  code: {
+    display: 'block',
+    background: '#1e293b',
+    color: '#e2e8f0',
+    borderRadius: 6,
+    padding: '10px 14px',
+    fontFamily: '"SF Mono", "Fira Code", Menlo, monospace',
+    fontSize: 13,
+    marginTop: 10,
+    marginBottom: 6,
+    overflowX: 'auto' as const,
+    whiteSpace: 'pre' as const,
+  } as React.CSSProperties,
+
+  primaryButton: {
+    display: 'inline-block',
+    background: 'var(--primary, #6366f1)',
+    color: '#fff',
+    padding: '10px 20px',
+    borderRadius: 8,
+    textDecoration: 'none',
+    fontWeight: 600,
+    fontSize: 14,
+    border: 'none',
+    cursor: 'pointer',
+    marginRight: 12,
+  } as React.CSSProperties,
+
+  outlineButton: {
+    display: 'inline-block',
+    background: 'transparent',
+    color: 'var(--primary, #6366f1)',
+    padding: '10px 20px',
+    borderRadius: 8,
+    textDecoration: 'none',
+    fontWeight: 600,
+    fontSize: 14,
+    border: '1px solid var(--primary, #6366f1)',
+    cursor: 'pointer',
+  } as React.CSSProperties,
+} as const;
+
+// ─── AdminRoute ───────────────────────────────────────────────────────────────
+
+export function AdminRoute() {
+  const [status, setStatus] = useState<AdminStatus>('checking');
+
+  useEffect(() => {
+    void checkTinaHealth().then((ok) => {
+      setStatus(ok ? 'running' : 'offline');
+      if (ok) {
+        // Redirect to TinaCMS admin panel
+        window.location.href = TINA_ADMIN_URL;
+      }
+    });
+  }, []);
+
+  return (
+    <div style={S.shell}>
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+
+      {/* ── Status card ── */}
+      <div style={S.card}>
+        <h1 style={{ margin: '0 0 8px', fontSize: 22, fontWeight: 700 }}>TinaCMS Admin</h1>
+        <p style={{ margin: '0 0 20px', opacity: 0.6 }}>Visual content editor backed by git</p>
+
+        <div style={{ display: 'flex', alignItems: 'center', marginBottom: 20 }}>
+          <span style={S.statusDot(status)} />
+          <span style={{ fontWeight: 500 }}>
+            {status === 'checking' && 'Checking TinaCMS status…'}
+            {status === 'running' && 'TinaCMS is running — redirecting to admin…'}
+            {status === 'offline' && 'TinaCMS is not running'}
+          </span>
+        </div>
+
+        {status === 'running' && (
+          <a href={TINA_ADMIN_URL} style={S.primaryButton}>
+            Open Admin Panel →
+          </a>
+        )}
+
+        {status === 'offline' && (
+          <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' as const, gap: 8 }}>
+            <a href="/" style={S.outlineButton}>
+              ← Back to Site
+            </a>
+            <button
+              style={S.outlineButton}
+              onClick={() => {
+                setStatus('checking');
+                void checkTinaHealth().then((ok) => {
+                  setStatus(ok ? 'running' : 'offline');
+                  if (ok) window.location.href = TINA_ADMIN_URL;
+                });
+              }}
+            >
+              Retry
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* ── Setup instructions ── */}
+      {status !== 'running' && (
+        <div style={S.card}>
+          <h2 style={{ margin: '0 0 4px', fontSize: 16, fontWeight: 700 }}>How to start TinaCMS</h2>
+          <p style={{ margin: '0 0 20px', opacity: 0.6, fontSize: 13 }}>
+            TinaCMS runs as a local server that provides visual editing for your git-backed Markdown
+            content. No external services required.
+          </p>
+
+          {SETUP_STEPS.map(({ step, title, code, description }) => (
+            <div key={step} style={S.stepCard}>
+              <div style={{ display: 'flex', alignItems: 'flex-start' }}>
+                <span style={S.stepNumber}>{step}</span>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontWeight: 600, marginBottom: 4 }}>{title}</div>
+                  <div style={{ opacity: 0.65, fontSize: 13, marginBottom: 4 }}>{description}</div>
+                  <code style={S.code}>{code}</code>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* ── Content schema overview ── */}
+      <div style={S.card}>
+        <h2 style={{ margin: '0 0 16px', fontSize: 16, fontWeight: 700 }}>Content Schema</h2>
+        <p style={{ margin: '0 0 16px', opacity: 0.6, fontSize: 13 }}>
+          TinaCMS manages these four content types. All content is stored as Markdown files in the{' '}
+          <code>content/</code> directory.
+        </p>
+
+        {[
+          {
+            label: 'Pages',
+            path: 'content/pages/*.md',
+            desc: 'General site pages with title, description, and body',
+          },
+          {
+            label: 'Component Docs',
+            path: 'content/components/*.md',
+            desc: 'Per-component documentation with category, status, and usage examples',
+          },
+          {
+            label: 'Design Guidelines',
+            path: 'content/guidelines/*.md',
+            desc: 'Design principles covering color, typography, spacing, and accessibility',
+          },
+          {
+            label: 'Changelog',
+            path: 'content/changelog/*.md',
+            desc: 'Version history with release type (major / minor / patch) and date',
+          },
+        ].map(({ label, path, desc }) => (
+          <div
+            key={label}
+            style={{
+              display: 'flex',
+              gap: 16,
+              padding: '12px 0',
+              borderBottom: '1px solid var(--pg-border, #e2e8f0)',
+            }}
+          >
+            <div style={{ width: 120, flexShrink: 0 }}>
+              <div style={{ fontWeight: 600 }}>{label}</div>
+              <div style={{ fontSize: 11, opacity: 0.5, marginTop: 2, fontFamily: 'monospace' }}>
+                {path}
+              </div>
+            </div>
+            <div style={{ opacity: 0.7, fontSize: 13 }}>{desc}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/libs/templates/starters/design-system/packages/app/src/routes/site.tsx
+++ b/libs/templates/starters/design-system/packages/app/src/routes/site.tsx
@@ -1,0 +1,503 @@
+/**
+ * SiteRoute — public-facing documentation site.
+ *
+ * Reads content from the git-tracked Markdown files under content/:
+ *   content/pages/       → rendered as site pages
+ *   content/components/  → component documentation
+ *   content/guidelines/  → design guidelines
+ *   content/changelog/   → release notes
+ *
+ * Content is loaded at build time via Vite's import.meta.glob (?raw).
+ * When TinaCMS is running, the useTina hook enables live visual editing.
+ *
+ * To enable visual editing:
+ *   npx tinacms dev -c "vite --port 5174"  (from packages/app/)
+ *   Then navigate to http://localhost:4001/admin
+ */
+
+import { useMemo, useState } from 'react';
+
+// ─── Frontmatter parser ───────────────────────────────────────────────────────
+// Zero-dependency YAML frontmatter extraction. Handles key: value pairs and
+// quoted string values. Sufficient for the content schema defined in tina/schema.ts.
+
+interface Frontmatter {
+  title?: string;
+  description?: string;
+  order?: string;
+  category?: string;
+  version?: string;
+  date?: string;
+  type?: string;
+  status?: string;
+}
+
+function parseFrontmatter(raw: string): { frontmatter: Frontmatter; body: string } {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(raw);
+  if (!match) return { frontmatter: {}, body: raw };
+
+  const yamlBlock = match[1] ?? '';
+  const body = match[2] ?? '';
+  const frontmatter: Record<string, string> = {};
+
+  for (const line of yamlBlock.split('\n')) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const value = line
+      .slice(colonIdx + 1)
+      .trim()
+      .replace(/^["']|["']$/g, '');
+    if (key) frontmatter[key] = value;
+  }
+
+  return { frontmatter: frontmatter as Frontmatter, body };
+}
+
+// ─── Minimal Markdown renderer ────────────────────────────────────────────────
+// Converts a subset of Markdown to HTML for display. No external dependencies.
+// Supported: headings (h1–h3), bold, italic, inline code, links, unordered lists,
+// fenced code blocks, paragraphs.
+
+function renderMarkdown(text: string): string {
+  // Fenced code blocks
+  let html = text.replace(/```(\w*)\n([\s\S]*?)```/g, (_m, _lang, code: string) => {
+    const escaped = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return `<pre><code>${escaped}</code></pre>`;
+  });
+
+  // Headings
+  html = html
+    .replace(/^### (.+)$/gm, '<h3>$1</h3>')
+    .replace(/^## (.+)$/gm, '<h2>$1</h2>')
+    .replace(/^# (.+)$/gm, '<h1>$1</h1>');
+
+  // Inline
+  html = html
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank" rel="noreferrer">$1</a>');
+
+  // Unordered lists
+  html = html.replace(/^- (.+)$/gm, '<li>$1</li>');
+  html = html.replace(/((<li>.*<\/li>\n?)+)/g, '<ul>$1</ul>');
+
+  // Paragraphs — wrap non-block lines
+  const lines = html.split('\n');
+  const out: string[] = [];
+  let inBlock = false;
+  for (const line of lines) {
+    const isBlock = /^<(h[1-6]|ul|ol|li|pre|blockquote)/.test(line);
+    if (isBlock) {
+      inBlock = true;
+      out.push(line);
+    } else if (line.trim() === '') {
+      inBlock = false;
+      out.push('');
+    } else if (!inBlock) {
+      out.push(`<p>${line}</p>`);
+    } else {
+      out.push(line);
+    }
+  }
+  return out.join('\n');
+}
+
+// ─── Content loading ──────────────────────────────────────────────────────────
+
+interface ContentEntry {
+  slug: string;
+  frontmatter: Frontmatter;
+  body: string;
+  html: string;
+}
+
+type ContentSection = 'pages' | 'components' | 'guidelines' | 'changelog';
+
+// Vite glob imports — content files are resolved relative to this source file.
+// Path: packages/app/src/routes/ → ../../../../content/
+const rawPages = import.meta.glob<string>('../../../../content/pages/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
+const rawComponents = import.meta.glob<string>('../../../../content/components/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
+const rawGuidelines = import.meta.glob<string>('../../../../content/guidelines/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
+const rawChangelog = import.meta.glob<string>('../../../../content/changelog/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
+
+function loadEntries(modules: Record<string, string>): ContentEntry[] {
+  return Object.entries(modules)
+    .map(([path, raw]) => {
+      const slug = path.split('/').pop()?.replace('.md', '') ?? 'index';
+      const { frontmatter, body } = parseFrontmatter(raw);
+      return { slug, frontmatter, body, html: renderMarkdown(body) };
+    })
+    .sort((a, b) => {
+      const ao = Number(a.frontmatter.order ?? 99);
+      const bo = Number(b.frontmatter.order ?? 99);
+      return ao - bo;
+    });
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const S = {
+  shell: {
+    display: 'flex',
+    height: '100vh',
+    overflow: 'hidden',
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+    fontSize: 14,
+    color: 'var(--pg-fg, #0f172a)',
+    background: 'var(--pg-bg, #f8fafc)',
+  } as React.CSSProperties,
+
+  sidebar: {
+    width: 240,
+    flexShrink: 0,
+    borderRight: '1px solid var(--pg-border, #e2e8f0)',
+    overflowY: 'auto' as const,
+    background: 'var(--pg-sidebar, #fff)',
+    display: 'flex',
+    flexDirection: 'column' as const,
+  } as React.CSSProperties,
+
+  sidebarHeader: {
+    padding: '16px 16px 8px',
+    borderBottom: '1px solid var(--pg-border, #e2e8f0)',
+  } as React.CSSProperties,
+
+  siteTitle: {
+    margin: 0,
+    fontSize: 13,
+    fontWeight: 700,
+    letterSpacing: '0.05em',
+    textTransform: 'uppercase' as const,
+    color: 'var(--pg-fg, #0f172a)',
+    opacity: 0.5,
+  } as React.CSSProperties,
+
+  navSection: {
+    padding: '8px 0',
+  } as React.CSSProperties,
+
+  navSectionLabel: {
+    padding: '6px 16px',
+    fontSize: 11,
+    fontWeight: 600,
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.08em',
+    color: 'var(--pg-fg, #0f172a)',
+    opacity: 0.4,
+  } as React.CSSProperties,
+
+  navItem: (active: boolean): React.CSSProperties => ({
+    display: 'block',
+    width: '100%',
+    padding: '6px 16px',
+    textAlign: 'left',
+    background: active ? 'var(--pg-accent, #f1f5f9)' : 'transparent',
+    color: active ? 'var(--primary, #6366f1)' : 'inherit',
+    fontWeight: active ? 600 : 400,
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: 13,
+    borderRadius: 0,
+  }),
+
+  main: {
+    flex: 1,
+    overflow: 'auto',
+    padding: '32px 48px',
+    maxWidth: 800,
+  } as React.CSSProperties,
+
+  badge: (type: string): React.CSSProperties => ({
+    display: 'inline-block',
+    padding: '2px 8px',
+    borderRadius: 4,
+    fontSize: 11,
+    fontWeight: 600,
+    background:
+      type === 'stable'
+        ? '#dcfce7'
+        : type === 'beta'
+          ? '#fef9c3'
+          : type === 'deprecated'
+            ? '#fee2e2'
+            : type === 'major'
+              ? '#fee2e2'
+              : type === 'minor'
+                ? '#e0f2fe'
+                : '#f1f5f9',
+    color:
+      type === 'stable'
+        ? '#166534'
+        : type === 'beta'
+          ? '#854d0e'
+          : type === 'deprecated'
+            ? '#991b1b'
+            : type === 'major'
+              ? '#991b1b'
+              : type === 'minor'
+                ? '#0c4a6e'
+                : '#475569',
+  }),
+
+  empty: {
+    color: 'var(--pg-fg, #0f172a)',
+    opacity: 0.4,
+    fontStyle: 'italic',
+    padding: '32px 0',
+  } as React.CSSProperties,
+} as const;
+
+// ─── Components ───────────────────────────────────────────────────────────────
+
+function NavSection({
+  label,
+  entries,
+  selected,
+  onSelect,
+}: {
+  label: string;
+  entries: ContentEntry[];
+  selected: string | null;
+  onSelect: (key: string) => void;
+}) {
+  if (entries.length === 0) return null;
+  return (
+    <div style={S.navSection}>
+      <div style={S.navSectionLabel}>{label}</div>
+      {entries.map((e) => (
+        <button
+          key={e.slug}
+          style={S.navItem(selected === e.slug)}
+          onClick={() => onSelect(e.slug)}
+        >
+          {e.frontmatter.title ?? e.slug}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function MarkdownContent({ html }: { html: string }) {
+  return (
+    <div
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: html }}
+      style={{
+        lineHeight: 1.7,
+        color: 'var(--pg-fg, #0f172a)',
+      }}
+    />
+  );
+}
+
+function PageView({ entry }: { entry: ContentEntry }) {
+  return (
+    <article>
+      <h1 style={{ marginTop: 0, fontSize: 28, fontWeight: 700 }}>{entry.frontmatter.title}</h1>
+      {entry.frontmatter.description && (
+        <p style={{ fontSize: 16, opacity: 0.7, marginTop: -8, marginBottom: 24 }}>
+          {entry.frontmatter.description}
+        </p>
+      )}
+      <MarkdownContent html={entry.html} />
+    </article>
+  );
+}
+
+function ComponentView({ entry }: { entry: ContentEntry }) {
+  return (
+    <article>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4 }}>
+        <h1 style={{ margin: 0, fontSize: 28, fontWeight: 700 }}>{entry.frontmatter.title}</h1>
+        {entry.frontmatter.status && (
+          <span style={S.badge(entry.frontmatter.status)}>{entry.frontmatter.status}</span>
+        )}
+      </div>
+      {entry.frontmatter.category && (
+        <div style={{ fontSize: 12, opacity: 0.5, marginBottom: 8 }}>
+          {entry.frontmatter.category}
+        </div>
+      )}
+      {entry.frontmatter.description && (
+        <p style={{ fontSize: 16, opacity: 0.7, marginBottom: 24 }}>
+          {entry.frontmatter.description}
+        </p>
+      )}
+      <MarkdownContent html={entry.html} />
+    </article>
+  );
+}
+
+function GuidelineView({ entry }: { entry: ContentEntry }) {
+  return (
+    <article>
+      <div style={{ marginBottom: 4 }}>
+        {entry.frontmatter.category && (
+          <div style={{ fontSize: 12, opacity: 0.5, marginBottom: 4 }}>
+            {entry.frontmatter.category}
+          </div>
+        )}
+        <h1 style={{ margin: 0, fontSize: 28, fontWeight: 700 }}>{entry.frontmatter.title}</h1>
+      </div>
+      {entry.frontmatter.description && (
+        <p style={{ fontSize: 16, opacity: 0.7, marginBottom: 24 }}>
+          {entry.frontmatter.description}
+        </p>
+      )}
+      <MarkdownContent html={entry.html} />
+    </article>
+  );
+}
+
+function ChangelogView({ entry }: { entry: ContentEntry }) {
+  return (
+    <article
+      style={{
+        marginBottom: 48,
+        borderBottom: '1px solid var(--pg-border, #e2e8f0)',
+        paddingBottom: 48,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4 }}>
+        <h2 style={{ margin: 0, fontSize: 22, fontWeight: 700 }}>v{entry.frontmatter.version}</h2>
+        {entry.frontmatter.type && (
+          <span style={S.badge(entry.frontmatter.type)}>{entry.frontmatter.type}</span>
+        )}
+      </div>
+      {entry.frontmatter.date && (
+        <div style={{ fontSize: 12, opacity: 0.5, marginBottom: 16 }}>
+          {new Date(entry.frontmatter.date).toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+          })}
+        </div>
+      )}
+      <MarkdownContent html={entry.html} />
+    </article>
+  );
+}
+
+// ─── SiteRoute ────────────────────────────────────────────────────────────────
+
+export function SiteRoute() {
+  const pages = useMemo(() => loadEntries(rawPages as Record<string, string>), []);
+  const components = useMemo(() => loadEntries(rawComponents as Record<string, string>), []);
+  const guidelines = useMemo(() => loadEntries(rawGuidelines as Record<string, string>), []);
+  const changelog = useMemo(() => loadEntries(rawChangelog as Record<string, string>), []);
+
+  const [section, setSection] = useState<ContentSection>('pages');
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(pages[0]?.slug ?? null);
+
+  function selectEntry(s: ContentSection, slug: string) {
+    setSection(s);
+    setSelectedSlug(slug);
+  }
+
+  const currentEntries =
+    section === 'pages'
+      ? pages
+      : section === 'components'
+        ? components
+        : section === 'guidelines'
+          ? guidelines
+          : changelog;
+
+  const selected = currentEntries.find((e) => e.slug === selectedSlug) ?? currentEntries[0] ?? null;
+
+  return (
+    <div style={S.shell}>
+      {/* ── Sidebar navigation ── */}
+      <nav style={S.sidebar}>
+        <div style={S.sidebarHeader}>
+          <p style={S.siteTitle}>Design System</p>
+        </div>
+
+        <NavSection
+          label="Pages"
+          entries={pages}
+          selected={section === 'pages' ? selectedSlug : null}
+          onSelect={(slug) => selectEntry('pages', slug)}
+        />
+        <NavSection
+          label="Components"
+          entries={components}
+          selected={section === 'components' ? selectedSlug : null}
+          onSelect={(slug) => selectEntry('components', slug)}
+        />
+        <NavSection
+          label="Guidelines"
+          entries={guidelines}
+          selected={section === 'guidelines' ? selectedSlug : null}
+          onSelect={(slug) => selectEntry('guidelines', slug)}
+        />
+        <NavSection
+          label="Changelog"
+          entries={changelog}
+          selected={section === 'changelog' ? selectedSlug : null}
+          onSelect={(slug) => selectEntry('changelog', slug)}
+        />
+
+        <div
+          style={{
+            marginTop: 'auto',
+            padding: '16px',
+            borderTop: '1px solid var(--pg-border, #e2e8f0)',
+          }}
+        >
+          <a
+            href="/admin"
+            style={{ fontSize: 12, opacity: 0.5, textDecoration: 'none', color: 'inherit' }}
+          >
+            ✏️ Edit content
+          </a>
+        </div>
+      </nav>
+
+      {/* ── Main content area ── */}
+      <main style={S.main}>
+        {!selected && (
+          <p style={S.empty}>No content found. Add Markdown files to the content/ directory.</p>
+        )}
+
+        {/* Changelog shows all entries stacked */}
+        {section === 'changelog' && changelog.length > 0 && (
+          <div>
+            <h1 style={{ marginTop: 0, fontSize: 28, fontWeight: 700 }}>Changelog</h1>
+            {changelog.map((e) => (
+              <ChangelogView key={e.slug} entry={e} />
+            ))}
+          </div>
+        )}
+
+        {/* All other sections show the selected entry */}
+        {section !== 'changelog' && selected && (
+          <>
+            {section === 'pages' && <PageView entry={selected} />}
+            {section === 'components' && <ComponentView entry={selected} />}
+            {section === 'guidelines' && <GuidelineView entry={selected} />}
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/libs/templates/starters/design-system/packages/app/tina/config.ts
+++ b/libs/templates/starters/design-system/packages/app/tina/config.ts
@@ -1,0 +1,53 @@
+/**
+ * TinaCMS configuration — self-hosted mode (no TinaCloud required).
+ *
+ * Self-hosted setup:
+ *   1. Install dependencies:
+ *        npm install tinacms @tinacms/auth
+ *   2. Start the CMS in dev mode:
+ *        npx tinacms dev -c "vite --port 5174"
+ *   3. Open the admin panel:
+ *        http://localhost:4001/admin
+ *   4. Content edits are saved as markdown/JSON in the content/ directory.
+ *
+ * Production build:
+ *   npx tinacms build && vite build
+ *   The compiled admin panel lands in public/admin/.
+ *
+ * Content structure (all git-tracked):
+ *   content/pages/       → Site pages
+ *   content/components/  → Component documentation
+ *   content/guidelines/  → Design guidelines
+ *   content/changelog/   → Release notes
+ */
+
+import { defineConfig } from 'tinacms';
+import { collections } from './schema';
+
+export default defineConfig({
+  // Branch used for content edits — override via GITHUB_BRANCH env var
+  branch: process.env.GITHUB_BRANCH ?? process.env.HEAD ?? 'main',
+
+  // Self-hosted: clientId and token are intentionally omitted.
+  // Uncomment and set these only if you opt into TinaCloud hosting:
+  // clientId: process.env.NEXT_PUBLIC_TINA_CLIENT_ID,
+  // token: process.env.TINA_TOKEN,
+
+  build: {
+    // Admin panel is compiled into public/admin/
+    outputFolder: 'admin',
+    publicFolder: 'public',
+  },
+
+  media: {
+    // Media files are stored in public/images/
+    tina: {
+      mediaRoot: 'images',
+      publicFolder: 'public',
+    },
+  },
+
+  schema: {
+    collections,
+  },
+});

--- a/libs/templates/starters/design-system/packages/app/tina/schema.ts
+++ b/libs/templates/starters/design-system/packages/app/tina/schema.ts
@@ -1,0 +1,171 @@
+/**
+ * TinaCMS content schema — defines the data model for git-backed content.
+ *
+ * Collections:
+ *  - page          → content/pages/*.md       (site pages)
+ *  - componentDoc  → content/components/*.md  (component documentation)
+ *  - guideline     → content/guidelines/*.md  (design guidelines)
+ *  - changelog     → content/changelog/*.md   (version history)
+ *
+ * Usage: imported by tina/config.ts
+ */
+
+import type { TinaCollection } from 'tinacms';
+
+// ─── Pages ────────────────────────────────────────────────────────────────────
+
+export const pageCollection: TinaCollection = {
+  name: 'page',
+  label: 'Pages',
+  path: 'content/pages',
+  format: 'md',
+  fields: [
+    {
+      type: 'string',
+      name: 'title',
+      label: 'Title',
+      isTitle: true,
+      required: true,
+    },
+    {
+      type: 'string',
+      name: 'description',
+      label: 'Description',
+      ui: { component: 'textarea' },
+    },
+    {
+      type: 'string',
+      name: 'order',
+      label: 'Navigation Order',
+      description: 'Numeric order in the navigation sidebar (e.g. "1", "2")',
+    },
+    {
+      type: 'rich-text',
+      name: 'body',
+      label: 'Body',
+      isBody: true,
+    },
+  ],
+};
+
+// ─── Component Documentation ──────────────────────────────────────────────────
+
+export const componentDocCollection: TinaCollection = {
+  name: 'componentDoc',
+  label: 'Component Docs',
+  path: 'content/components',
+  format: 'md',
+  fields: [
+    {
+      type: 'string',
+      name: 'title',
+      label: 'Component Name',
+      isTitle: true,
+      required: true,
+    },
+    {
+      type: 'string',
+      name: 'category',
+      label: 'Category',
+      options: ['Atoms', 'Molecules', 'Organisms', 'Utilities'],
+    },
+    {
+      type: 'string',
+      name: 'description',
+      label: 'Short Description',
+      ui: { component: 'textarea' },
+    },
+    {
+      type: 'string',
+      name: 'status',
+      label: 'Status',
+      options: ['stable', 'beta', 'deprecated'],
+    },
+    {
+      type: 'rich-text',
+      name: 'body',
+      label: 'Documentation',
+      isBody: true,
+    },
+  ],
+};
+
+// ─── Design Guidelines ────────────────────────────────────────────────────────
+
+export const guidelineCollection: TinaCollection = {
+  name: 'guideline',
+  label: 'Design Guidelines',
+  path: 'content/guidelines',
+  format: 'md',
+  fields: [
+    {
+      type: 'string',
+      name: 'title',
+      label: 'Title',
+      isTitle: true,
+      required: true,
+    },
+    {
+      type: 'string',
+      name: 'category',
+      label: 'Category',
+      options: ['Color', 'Typography', 'Spacing', 'Motion', 'Accessibility', 'Writing'],
+    },
+    {
+      type: 'string',
+      name: 'description',
+      label: 'Description',
+      ui: { component: 'textarea' },
+    },
+    {
+      type: 'rich-text',
+      name: 'body',
+      label: 'Content',
+      isBody: true,
+    },
+  ],
+};
+
+// ─── Changelog ────────────────────────────────────────────────────────────────
+
+export const changelogCollection: TinaCollection = {
+  name: 'changelog',
+  label: 'Changelog',
+  path: 'content/changelog',
+  format: 'md',
+  fields: [
+    {
+      type: 'string',
+      name: 'version',
+      label: 'Version',
+      isTitle: true,
+      required: true,
+    },
+    {
+      type: 'datetime',
+      name: 'date',
+      label: 'Release Date',
+    },
+    {
+      type: 'string',
+      name: 'type',
+      label: 'Release Type',
+      options: ['major', 'minor', 'patch'],
+    },
+    {
+      type: 'rich-text',
+      name: 'body',
+      label: 'Changes',
+      isBody: true,
+    },
+  ],
+};
+
+// ─── Exported collections ─────────────────────────────────────────────────────
+
+export const collections: TinaCollection[] = [
+  pageCollection,
+  componentDocCollection,
+  guidelineCollection,
+  changelogCollection,
+];


### PR DESCRIPTION
## Summary

Integrates TinaCMS in self-hosted mode (no TinaCloud) into the design-system starter kit, adding a git-backed CMS with a public documentation site and admin panel.

- **`tina/schema.ts`** — Four content collections: pages, componentDocs, guidelines, changelog
- **`tina/config.ts`** — Self-hosted config (no clientId/token), outputs admin to `public/admin/`
- **`src/routes/site.tsx`** — Public documentation site; reads markdown via Vite glob, inline frontmatter parser, minimal markdown renderer, section navigation
- **`src/routes/admin.tsx`** — Admin landing page with live TinaCMS health check, auto-redirect when running, setup instructions when offline
- **`src/main.tsx`** — Minimal hash router: `#/` playground, `#/site` docs, `#/admin` CMS
- **`content/pages/index.md`** — Sample welcome page with `@@PROJECT_NAME` placeholder
- **`package.json`** — Adds `tinacms ^2.6.0`, `dev:cms` and `build:cms` scripts

## Test plan

- [x] TypeScript: `tsc --noEmit` passes with zero errors
- [x] Build: `vite build` succeeds (38 modules, 229KB bundle)
- [x] Playwright (5/5 pass):
  - Playground route renders at `#/`
  - Site route renders sidebar at `#/site`
  - Admin route shows "TinaCMS Admin" at `#/admin`
  - Admin shows setup steps including `tinacms dev`
  - Site has correct nav structure
- [x] All 7 changed files are within stated scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated TinaCMS for managing design system content
  * Added admin panel with health-check functionality and setup instructions
  * New documentation site view with markdown support
  * Enabled content editing for pages, components, guidelines, and changelog entries
  * Added CMS-specific development and build workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->