### PR TITLE
Write documentation and README for design-system starter

### DIFF
--- a/libs/templates/starters/design-system/README.md
+++ b/libs/templates/starters/design-system/README.md
@@ -1,0 +1,147 @@
+# @@PROJECT_NAME Design System
+
+A full-stack design system starter kit with AI-powered code generation, OKLCH color science, and a live component playground.
+
+## What you get
+
+- **11 packages** covering every layer: design parsing, code generation, tokens, color science, accessibility, AI agents, and an MCP server
+- **Zero-dependency core libraries** — pen, color, xcl, and registry have no external dependencies
+- **Design-to-code pipeline** — parse `.pen` files from pencil.dev and generate React components automatically
+- **W3C DTCG token system** — export design tokens to CSS custom properties or Tailwind config
+- **OKLCH color science** — generate WCAG-compliant palettes with perceptually uniform scales
+- **AI agents** — Anthropic-powered agents for design generation, accessibility auditing, and code implementation
+- **Live playground** — interactive component explorer with props editor and docs site
+- **CMS-managed docs** — TinaCMS for git-backed, markdown-driven content
+
+## Architecture
+
+```
+@@PROJECT_NAME/
+├── packages/
+│   ├── pen/        ─── .pen file parser & traversal (zero deps)
+│   ├── codegen/    ─── .pen → React component generator
+│   ├── tokens/     ─── W3C DTCG token extractor & CSS/Tailwind exporter
+│   ├── color/      ─── OKLCH color science: scales, harmonies, WCAG contrast
+│   ├── xcl/        ─── XCL codec: ComponentDef ↔ XML ↔ TSX (zero deps)
+│   ├── registry/   ─── In-memory component registry (zero deps)
+│   ├── a11y/       ─── Accessibility auditing with axe-core
+│   ├── agents/     ─── AI agents: design, a11y, implement
+│   ├── mcp/        ─── MCP server for AI tool integration
+│   ├── server/     ─── Express backend for agent routes
+│   └── app/        ─── React 19 + Vite playground & docs site
+└── content/        ─── CMS-managed design docs (TinaCMS / git-backed)
+```
+
+**Design-to-code pipeline:**
+
+```
+pencil.dev  →  .pen file  →  pen/parser  →  codegen/react-generator  →  .tsx files
+                                                      ↓
+                                            tokens/extractor  →  CSS / Tailwind
+```
+
+**AI agent flow:**
+
+```
+designer intent  →  agents/design-agent   →  MCP tools  →  updated .pen file
+                 →  agents/a11y-agent    →  WCAG report
+                 →  agents/implement     →  refined .tsx files
+```
+
+## Prerequisites
+
+- Node.js 20+
+- An Anthropic API key (for AI agents only — the rest works without it)
+
+## Getting started
+
+### 1. Clone and rename
+
+```bash
+# Clone this template
+git clone <repo-url> my-design-system
+cd my-design-system
+
+# Replace @@PROJECT_NAME with your project name everywhere
+grep -rl '@@PROJECT_NAME' . --include='*.json' --include='*.ts' --include='*.md' \
+  | xargs sed -i 's/@@PROJECT_NAME/my-design-system/g'
+```
+
+### 2. Install dependencies
+
+```bash
+npm install
+```
+
+### 3. Start the dev environment
+
+```bash
+npm run dev
+```
+
+This starts two servers in parallel:
+
+- `packages/server` — Express backend on port 3001
+- `packages/app` — Vite dev server on port 5173
+
+Open `http://localhost:5173` to see the playground.
+
+### 4. (Optional) Enable AI agents
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Then start the MCP server to expose design system tools to Claude:
+
+```bash
+node packages/mcp/dist/index.js
+```
+
+## Documentation
+
+| Guide                                                      | What it covers                            |
+| ---------------------------------------------------------- | ----------------------------------------- |
+| [Quickstart](docs/getting-started/quickstart.md)           | Get running in 5 minutes                  |
+| [Design-to-code pipeline](docs/concepts/design-to-code.md) | How `.pen` files become React components  |
+| [Adding components](docs/guides/adding-components.md)      | Register and document a new component     |
+| [.pen format reference](docs/reference/pen-format.md)      | Complete `.pen` file format specification |
+
+## Package overview
+
+| Package                   | Purpose                                            | Dependencies                     |
+| ------------------------- | -------------------------------------------------- | -------------------------------- |
+| `@@PROJECT_NAME-pen`      | Parse and traverse `.pen` design files             | zero                             |
+| `@@PROJECT_NAME-codegen`  | Generate React `.tsx` from `.pen` documents        | pen, lucide-react (optional)     |
+| `@@PROJECT_NAME-tokens`   | Extract and export W3C DTCG design tokens          | pen                              |
+| `@@PROJECT_NAME-color`    | OKLCH color scales, harmonies, WCAG contrast       | zero                             |
+| `@@PROJECT_NAME-xcl`      | XCL codec: ComponentDef ↔ XML ↔ TSX                | zero                             |
+| `@@PROJECT_NAME-registry` | In-memory component store                          | zero                             |
+| `@@PROJECT_NAME-a11y`     | Accessibility audit (axe-core + semantic analysis) | axe-core, jsdom (peer, optional) |
+| `@@PROJECT_NAME-agents`   | AI design, a11y, and implementation agents         | @anthropic-ai/sdk                |
+| `@@PROJECT_NAME-mcp`      | MCP server for AI agent integration                | @modelcontextprotocol/sdk        |
+| `@@PROJECT_NAME-server`   | Express backend for agent HTTP routes              | express                          |
+| `app`                     | React playground, docs site, TinaCMS               | react, vite, tinacms             |
+
+## Scripts
+
+```bash
+npm run dev          # Start server + app in parallel
+npm run build        # Build all packages
+npm run typecheck    # Type-check all packages
+npm run test         # Run all tests
+```
+
+## Content management
+
+Design guidelines, component docs, and changelogs live in `content/` and are managed via [TinaCMS](https://tina.io). Start the CMS-enabled dev server:
+
+```bash
+npm run dev:cms --workspace=packages/app
+```
+
+Then open `http://localhost:4001/admin` to edit content in a visual interface. All edits commit directly to git.
+
+## License
+
+MIT — use this as the foundation for your own design system.

--- a/libs/templates/starters/design-system/docs/concepts/design-to-code.md
+++ b/libs/templates/starters/design-system/docs/concepts/design-to-code.md
@@ -1,0 +1,188 @@
+# Design-to-code pipeline
+
+This page explains how a `.pen` design file produced by pencil.dev travels through the system and becomes production-ready React components, CSS custom properties, and W3C design tokens.
+
+## Overview
+
+The pipeline has four stages:
+
+```
+.pen file  →  pen/parser  →  codegen/react-generator  →  .tsx files
+                  ↓
+           tokens/extractor  →  CSS custom properties
+                                 Tailwind config
+```
+
+Each stage is handled by an independent package with no hard coupling between them. You can use the parser alone, or plug in a custom code generator that consumes the same parsed document.
+
+## Stage 1: Parsing the .pen file
+
+A `.pen` file is a JSON document. The `@@PROJECT_NAME-pen` package reads it and validates its structure.
+
+```ts
+import { parsePenDocument } from '@@PROJECT_NAME-pen';
+
+const raw = JSON.parse(fs.readFileSync('design.pen', 'utf-8'));
+const doc = parsePenDocument(raw);
+// doc: PenDocument with typed nodes, resolved theme, validated structure
+```
+
+`parsePenDocument` returns a `PenDocument` with:
+
+- `doc.version` — the `.pen` format version (e.g. `"2.8"`)
+- `doc.themes` — available theme dimensions (e.g. `{ Mode: ['Light', 'Dark'] }`)
+- `doc.variables` — design token variable definitions
+- `doc.children` — the scene graph as a typed `PenNode[]` array
+
+All 15 node types are discriminated by their `type` field. See the [.pen format reference](../reference/pen-format.md) for the full type catalog.
+
+## Stage 2: Scene graph traversal
+
+The `@@PROJECT_NAME-pen` package provides a depth-first traversal utility:
+
+```ts
+import { traverse } from '@@PROJECT_NAME-pen';
+
+traverse(doc, (node, parent, depth) => {
+  if (node.type === 'frame' && node.reusable) {
+    console.log(`Component boundary: ${node.name} (depth ${depth})`);
+  }
+  // Return false to skip this subtree
+});
+```
+
+The traversal visitor receives the current node, its parent, and nesting depth. Returning `false` prunes the subtree — useful for skipping nested component definitions.
+
+## Stage 3: Code generation
+
+The `@@PROJECT_NAME-codegen` package takes a `PenDocument` and emits one `.tsx` file per component boundary (every `frame` with `reusable: true`).
+
+```ts
+import { generateFromDocument } from '@@PROJECT_NAME-codegen';
+
+const files = generateFromDocument(doc);
+// files: Array<{ filename: string; content: string }>
+```
+
+Internally, code generation runs five sub-passes:
+
+| Sub-pass           | What it does                                                                                      |
+| ------------------ | ------------------------------------------------------------------------------------------------- |
+| `css-extractor`    | Walks each node and extracts CSS rules (fills, strokes, layout, typography)                       |
+| `prop-extractor`   | Reads JSDoc `/** Overrides CSS var --btn-color */` comments to build a TypeScript props interface |
+| `import-generator` | Collects all required imports (React, Lucide icons, CSS file)                                     |
+| `jsx-serializer`   | Converts the node subtree to a JSX element tree                                                   |
+| `react-generator`  | Orchestrates the four passes and assembles the final `.tsx` source string                         |
+
+The output is valid TypeScript React code with:
+
+- BEM CSS class names scoped to the component
+- CSS custom properties (`var(--btn-color)`) for every design token
+- Optional props that override the tokens at runtime
+- Named Lucide icon imports for `icon_font` nodes
+
+### Component boundaries
+
+Only `frame` nodes with `reusable: true` become top-level components. Nested reusable frames are **not** recursively inlined — they are emitted as separate files and referenced by import name.
+
+```json
+{
+  "type": "frame",
+  "id": "btn-primary",
+  "name": "ButtonPrimary",
+  "reusable": true,
+  "children": [...]
+}
+```
+
+Generates `ButtonPrimary.tsx` with a `ButtonPrimary` export.
+
+## Stage 4: Token extraction and export
+
+The `@@PROJECT_NAME-tokens` package reads the `variables` section of the parsed document and exports tokens in your target format.
+
+```ts
+import { extractTokens, exportToCSS, exportToTailwind } from '@@PROJECT_NAME-tokens';
+
+const tokens = extractTokens(doc);
+
+// Write CSS custom properties
+fs.writeFileSync('tokens.css', exportToCSS(tokens));
+
+// Write Tailwind theme extension
+fs.writeFileSync('tailwind.tokens.js', exportToTailwind(tokens, { version: 4 }));
+```
+
+### Token naming convention
+
+Variable names in `.pen` follow CSS custom property conventions: `$--color-primary`, `$--spacing-4`. The extractor strips the `$` prefix and emits them as `--color-primary`, `--spacing-4` in the `:root {}` block.
+
+Semantic token names follow the pattern `--color-{role}-{variant}`:
+
+| Token                        | Role        | Variant                |
+| ---------------------------- | ----------- | ---------------------- |
+| `--color-primary`            | primary     | base                   |
+| `--color-primary-foreground` | primary     | text on top of primary |
+| `--color-primary-hover`      | primary     | hover state            |
+| `--color-destructive`        | destructive | base                   |
+| `--color-success`            | success     | base                   |
+
+### Tailwind support
+
+Both v3 (JS config `theme.extend`) and v4 (`@theme` CSS block) output formats are supported:
+
+```ts
+exportToTailwind(tokens, { version: 3 }); // → theme.extend object
+exportToTailwind(tokens, { version: 4 }); // → @theme { ... } CSS block
+```
+
+## Color system
+
+The `@@PROJECT_NAME-color` package generates the palette referenced by your design tokens. Colors are represented in OKLCH throughout — the perceptually uniform color space that makes WCAG contrast ratios predictable.
+
+```ts
+import { generateScale, checkContrast } from '@@PROJECT_NAME-color';
+
+// 11-step OKLCH scale (50–950)
+const violetScale = generateScale({ hue: 270, chroma: 0.18 });
+
+// WCAG contrast check
+const result = checkContrast(violetScale[900], violetScale[50]);
+// result.aa → true/false (4.5:1 ratio)
+// result.aaa → true/false (7:1 ratio)
+```
+
+The color package is zero-dependency and emits `oklch(...)` CSS strings directly.
+
+## AI agent integration
+
+The design-to-code pipeline can be driven by AI agents in the `@@PROJECT_NAME-agents` package:
+
+1. **design-agent** — takes a designer's description and iteratively updates a `.pen` file using MCP tools
+2. **implement-agent** — takes a `.pen` file, runs codegen, captures screenshots, and refines the output until it matches the design intent
+3. **a11y-agent** — audits generated components against WCAG guidelines and suggests remediation
+
+See [Running agents](../guides/running-agents.md) for setup and usage.
+
+## MCP integration
+
+The `@@PROJECT_NAME-mcp` package exposes the pipeline as MCP tools. When connected to Claude Code or Claude Desktop, these tools let an AI assistant call `generate_components`, `extract_tokens`, `check_contrast`, and more directly.
+
+Wire up your tools in `packages/mcp/src/index.ts` and start the server:
+
+```bash
+node packages/mcp/dist/index.js
+```
+
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "my-design-system": {
+      "command": "node",
+      "args": ["path/to/packages/mcp/dist/index.js"]
+    }
+  }
+}
+```

--- a/libs/templates/starters/design-system/docs/getting-started/quickstart.md
+++ b/libs/templates/starters/design-system/docs/getting-started/quickstart.md
@@ -1,0 +1,109 @@
+# Quickstart
+
+Get your design system running in five minutes. By the end you will have a working component playground, a generated React component from a `.pen` file, and a live docs site.
+
+## Prerequisites
+
+- Node.js 20 or later
+- Git
+
+## Step 1: Clone and rename
+
+```bash
+git clone <repo-url> my-design-system
+cd my-design-system
+```
+
+Replace `@@PROJECT_NAME` with your project name across all files:
+
+```bash
+grep -rl '@@PROJECT_NAME' . \
+  --include='*.json' --include='*.ts' --include='*.md' --include='*.tsx' \
+  | xargs sed -i 's/@@PROJECT_NAME/my-design-system/g'
+```
+
+## Step 2: Install dependencies
+
+```bash
+npm install
+```
+
+## Step 3: Start the dev environment
+
+```bash
+npm run dev
+```
+
+This starts two processes:
+
+| Process        | URL                   | What it runs                    |
+| -------------- | --------------------- | ------------------------------- |
+| Vite app       | http://localhost:5173 | Component playground, docs site |
+| Express server | http://localhost:3001 | Agent API routes                |
+
+Open http://localhost:5173 — you should see the component playground.
+
+## Step 4: Generate your first component
+
+Create a `.pen` file or use the example in `packages/codegen/examples/`:
+
+```ts
+import { parsePenDocument } from 'my-design-system-pen';
+import { generateFromDocument } from 'my-design-system-codegen';
+import { writeFileSync } from 'fs';
+
+const penJson = JSON.parse(readFileSync('my-button.pen', 'utf-8'));
+const doc = parsePenDocument(penJson);
+
+const files = generateFromDocument(doc);
+for (const file of files) {
+  writeFileSync(`src/components/${file.filename}`, file.content, 'utf-8');
+}
+```
+
+Each `frame` node marked `reusable: true` in your `.pen` file becomes a `.tsx` component file.
+
+## Step 5: Register the component
+
+```ts
+import { ComponentRegistry } from 'my-design-system-registry';
+
+const registry = new ComponentRegistry();
+registry.register({
+  id: 'button',
+  name: 'Button',
+  category: 'atom',
+  description: 'Primary action button',
+  props: [
+    { name: 'label', type: 'string', defaultValue: 'Click me' },
+    { name: 'disabled', type: 'boolean', defaultValue: false },
+  ],
+});
+```
+
+The component now appears in the playground sidebar at http://localhost:5173.
+
+## Step 6: (Optional) Enable AI agents
+
+Export your Anthropic API key:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Then run the implement agent against your `.pen` file:
+
+```ts
+import { createImplementAgent } from 'my-design-system-agents';
+
+const agent = createImplementAgent({ projectRoot: process.cwd() });
+await agent.run({ penFilePath: 'my-button.pen', outputDir: 'src/components' });
+```
+
+The agent reads your `.pen` file, iteratively generates components, captures screenshots, and verifies its output against the design.
+
+## Next steps
+
+- [Design-to-code pipeline](../concepts/design-to-code.md) — understand how `.pen` files become React components
+- [Adding components](../guides/adding-components.md) — add custom components to the playground
+- [.pen format reference](../reference/pen-format.md) — full specification of the `.pen` file format

--- a/libs/templates/starters/design-system/docs/guides/adding-components.md
+++ b/libs/templates/starters/design-system/docs/guides/adding-components.md
@@ -1,0 +1,243 @@
+# Adding components
+
+This guide shows you how to add a new component to the design system — from the `.pen` source design through code generation, registration, and playground documentation.
+
+## Prerequisites
+
+- A running dev environment (`npm run dev`)
+- Basic familiarity with the [design-to-code pipeline](../concepts/design-to-code.md)
+
+## Option A: Generate from a .pen file
+
+Use this path when you have a component designed in pencil.dev.
+
+### 1. Export your component
+
+In pencil.dev, select the frame you want to export and mark it `reusable: true` in the properties panel. Export the document as `.pen` (JSON format).
+
+### 2. Run code generation
+
+```ts
+import { parsePenDocument } from '@@PROJECT_NAME-pen';
+import { generateFromDocument } from '@@PROJECT_NAME-codegen';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+
+const raw = JSON.parse(readFileSync('designs/my-card.pen', 'utf-8'));
+const doc = parsePenDocument(raw);
+
+const files = generateFromDocument(doc);
+
+mkdirSync('packages/app/src/components', { recursive: true });
+for (const file of files) {
+  writeFileSync(`packages/app/src/components/${file.filename}`, file.content);
+  console.log(`Generated: ${file.filename}`);
+}
+```
+
+This emits one `.tsx` file per `reusable: true` frame in your design.
+
+### 3. Review the generated code
+
+Open the generated file. The generator produces:
+
+```tsx
+// packages/app/src/components/Card.tsx
+
+import React from 'react';
+import './Card.css';
+
+export interface CardProps {
+  /** Overrides CSS var --card-bg */
+  cardBg?: string;
+  children?: React.ReactNode;
+}
+
+export function Card({ cardBg, children }: CardProps) {
+  return (
+    <div className="card" style={{ '--card-bg': cardBg } as React.CSSProperties}>
+      {children}
+    </div>
+  );
+}
+```
+
+And a companion CSS file with BEM classes and CSS custom properties.
+
+Make any manual refinements needed — the generated code is a starting point, not a final artifact.
+
+## Option B: Write from scratch
+
+Use this path when you are building a component without a `.pen` source.
+
+### 1. Create the component file
+
+```tsx
+// packages/app/src/components/Badge.tsx
+
+import React from 'react';
+
+export interface BadgeProps {
+  label: string;
+  variant?: 'success' | 'warning' | 'error' | 'info';
+}
+
+export function Badge({ label, variant = 'info' }: BadgeProps) {
+  return <span className={`badge badge--${variant}`}>{label}</span>;
+}
+```
+
+### 2. Add CSS
+
+```css
+/* packages/app/src/components/Badge.css */
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.badge--success {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+}
+.badge--warning {
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+}
+.badge--error {
+  background: var(--color-error-bg);
+  color: var(--color-error);
+}
+.badge--info {
+  background: var(--color-info-bg);
+  color: var(--color-info);
+}
+```
+
+Use `var(--color-*)` tokens from your token system so the component respects theme changes.
+
+## Register the component in the playground
+
+Once your component files exist, register them so the playground can discover and display them.
+
+```ts
+// packages/app/src/registry.ts (or wherever you initialize the registry)
+import { ComponentRegistry } from '@@PROJECT_NAME-registry';
+
+const registry = new ComponentRegistry();
+
+registry.register({
+  id: 'badge',
+  name: 'Badge',
+  category: 'atom', // 'atom' | 'molecule' | 'organism' | 'page'
+  description: 'Status label with semantic color variants.',
+  props: [
+    {
+      name: 'label',
+      type: 'string',
+      required: true,
+      defaultValue: 'Status',
+      description: 'Display text inside the badge.',
+    },
+    {
+      name: 'variant',
+      type: 'string',
+      defaultValue: 'info',
+      description: 'Color variant: success, warning, error, or info.',
+    },
+  ],
+  tags: ['status', 'label', 'feedback'],
+});
+```
+
+The `category` field controls which sidebar section the component appears in:
+
+| Category   | Sidebar section | Typical examples            |
+| ---------- | --------------- | --------------------------- |
+| `atom`     | Atoms           | Button, Badge, Input, Label |
+| `molecule` | Molecules       | Card, Modal, Alert          |
+| `organism` | Organisms       | Navbar, Sidebar, DataTable  |
+| `page`     | Pages           | DashboardPage, SettingsPage |
+
+## Write a story
+
+Stories live in `packages/app/src/stories/` and drive the playground's live preview and docs page.
+
+```tsx
+// packages/app/src/stories/Badge.stories.tsx
+
+import { Badge } from '../components/Badge';
+
+export default {
+  title: 'Badge',
+  component: Badge,
+  category: 'atom',
+  parameters: {
+    docs: {
+      description: 'Compact label for displaying status or metadata.',
+    },
+  },
+  argTypes: {
+    label: { control: 'text' },
+    variant: {
+      control: 'select',
+      options: ['success', 'warning', 'error', 'info'],
+    },
+  },
+};
+
+export const Default = { args: { label: 'Active', variant: 'success' } };
+export const Warning = { args: { label: 'Pending', variant: 'warning' } };
+export const Error = { args: { label: 'Failed', variant: 'error' } };
+```
+
+Stories follow [Storybook CSF format](https://storybook.js.org/docs/react/api/csf). The playground auto-discovers all `*.stories.tsx` files under `src/stories/` via Vite's `import.meta.glob`.
+
+## Verify in the playground
+
+Open http://localhost:5173 and find your component in the sidebar. You should see:
+
+- Live preview rendering with the default args
+- Props editor for each registered prop
+- Component description from the story `parameters.docs.description`
+
+If the component does not appear, check:
+
+1. The story file is in `packages/app/src/stories/` and ends with `.stories.tsx`
+2. The `default` export has a `component` field
+3. The Vite dev server has restarted (it hot-reloads story files automatically)
+
+## Add content documentation (optional)
+
+For public-facing component docs, add a markdown file to `content/components/`:
+
+```markdown
+## <!-- content/components/badge.md -->
+
+title: Badge
+category: atom
+
+---
+
+Use Badge to show concise status labels alongside other UI elements.
+
+## When to use
+
+- To indicate the status of an item (active, pending, failed)
+- To show counts or metadata without breaking visual flow
+
+## Variants
+
+| Variant | Background | Meaning                    |
+| ------- | ---------- | -------------------------- |
+| success | green      | Completed or healthy state |
+| warning | amber      | Needs attention            |
+| error   | red        | Failure or critical state  |
+| info    | blue       | Neutral information        |
+```
+
+This file is managed via TinaCMS and appears in the public docs site at `/docs/atoms/badge`.

--- a/libs/templates/starters/design-system/docs/reference/pen-format.md
+++ b/libs/templates/starters/design-system/docs/reference/pen-format.md
@@ -1,0 +1,448 @@
+# .pen format reference
+
+The `.pen` file format is a JSON scene graph produced by [pencil.dev](https://pencil.dev). This reference covers all 15 node types, the document root structure, fill and stroke descriptors, variable system, and theme resolution as implemented in the `@@PROJECT_NAME-pen` package.
+
+## Document structure
+
+Every `.pen` file is a JSON object matching the `PenDocument` interface:
+
+```ts
+interface PenDocument {
+  version: string; // e.g. "2.8"
+  themes?: Record<string, string[]>; // theme dimensions
+  variables?: Record<string, PenVariable>; // design token variables
+  children: PenNode[]; // scene graph root nodes
+}
+```
+
+### `themes`
+
+Declares the available theme dimensions and their options:
+
+```json
+{
+  "themes": {
+    "Mode": ["Light", "Dark"],
+    "Base": ["Zinc", "Slate", "Stone"],
+    "Accent": ["Violet", "Blue", "Rose"]
+  }
+}
+```
+
+The active theme selection is provided at parse time via the `Theme` context object:
+
+```ts
+import { parsePenDocument, resolveVariables } from '@@PROJECT_NAME-pen';
+
+const doc = parsePenDocument(raw);
+const vars = resolveVariables(doc, { Mode: 'Dark', Base: 'Zinc' });
+```
+
+### `variables`
+
+Design token variables keyed by CSS-custom-property-style names:
+
+```json
+{
+  "variables": {
+    "--background": { "type": "color", "value": "#FFFFFF" },
+    "--sidebar": {
+      "type": "color",
+      "value": [
+        { "value": "#F8F8F8", "theme": { "Mode": "Light" } },
+        { "value": "#1A1A1A", "theme": { "Mode": "Dark" } }
+      ]
+    }
+  }
+}
+```
+
+Variables are referenced in node fill/stroke fields as `$--variable-name`. During rendering the parser resolves them against the active theme. The last matching `theme` entry wins.
+
+```ts
+interface PenVariable {
+  type: 'color' | 'number' | 'string';
+  value: string | number | ThemeDependent[];
+}
+
+interface ThemeDependent {
+  value: string | number;
+  theme: Record<string, string>;
+}
+```
+
+---
+
+## Common node properties
+
+All node types extend `BaseNode`:
+
+```ts
+interface BaseNode {
+  id: string;
+  type: string; // discriminant — see node types below
+  name?: string;
+  x?: number;
+  y?: number;
+  width?: number | 'fill_container' | 'fit_content' | { fit_content: number };
+  height?: number | 'fill_container' | 'fit_content' | { fit_content: number };
+  rotation?: number;
+  opacity?: number; // 0–1
+  enabled?: boolean;
+}
+```
+
+### Width and height sizing keywords
+
+| Value                  | CSS equivalent                                  |
+| ---------------------- | ----------------------------------------------- |
+| `number`               | `{n}px`                                         |
+| `"fill_container"`     | `flex: 1` (or `width: 100%` in non-flex parent) |
+| `"fit_content"`        | `width: auto`                                   |
+| `{ fit_content: 200 }` | `min-width: 200px; width: auto`                 |
+
+---
+
+## Node types
+
+### 1. `frame`
+
+The primary layout container. Renders as a `<div>` with optional flexbox layout.
+
+```ts
+interface FrameNode extends BaseNode {
+  type: 'frame';
+  children?: PenNode[];
+  layout?: 'none' | 'vertical' | 'horizontal';
+  gap?: number;
+  padding?: number | [h, v] | [top, right, bottom, left];
+  justifyContent?: 'start' | 'center' | 'end' | 'space_between' | 'space_around';
+  alignItems?: 'start' | 'center' | 'end';
+  fill?: string;
+  stroke?: Stroke | string;
+  cornerRadius?: number;
+  clip?: boolean;
+  reusable?: boolean; // true → component boundary (codegen creates a .tsx file)
+  theme?: Theme;
+  slot?: string[];
+}
+```
+
+`layout` controls the flex direction:
+
+| Value          | CSS                           |
+| -------------- | ----------------------------- |
+| `"none"`       | `position: absolute` children |
+| `"vertical"`   | `flex-direction: column`      |
+| `"horizontal"` | `flex-direction: row`         |
+
+### 2. `group`
+
+A container without fill or layout — used for logical grouping only.
+
+```ts
+interface GroupNode extends BaseNode {
+  type: 'group';
+  children?: PenNode[];
+  layout?: 'none' | 'vertical' | 'horizontal';
+}
+```
+
+### 3. `text`
+
+Text content. Can be a plain string or an array of styled runs.
+
+```ts
+interface TextNode extends BaseNode {
+  type: 'text';
+  content: string | TextStyle[];
+  fontFamily?: string;
+  fontSize?: number;
+  fontWeight?: string | number;
+  textAlign?: 'left' | 'center' | 'right' | 'justify';
+  fill?: string;
+  lineHeight?: number;
+  textAlignVertical?: 'top' | 'middle' | 'bottom';
+}
+
+interface TextStyle {
+  text: string;
+  fontFamily?: string;
+  fontSize?: number;
+  fontWeight?: string | number;
+  fill?: string;
+}
+```
+
+### 4. `icon_font`
+
+An icon from an icon font family. The `@@PROJECT_NAME-codegen` package maps Lucide icon names to `lucide-react` component imports.
+
+```ts
+interface IconFontNode extends BaseNode {
+  type: 'icon_font';
+  iconFontName: string; // e.g. "hexagon", "arrow-right"
+  iconFontFamily: string; // e.g. "lucide"
+  fill?: string;
+}
+```
+
+To resolve a Lucide icon: convert `iconFontName` to PascalCase (`arrow-right` → `ArrowRight`) and import from `lucide-react`.
+
+### 5. `ref`
+
+A component instance reference. Points to a `frame` with `reusable: true` elsewhere in the document.
+
+```ts
+interface RefNode extends BaseNode {
+  type: 'ref';
+  ref: string; // id of the source frame
+  descendants?: Record<string, Record<string, unknown>>; // property overrides
+}
+```
+
+`descendants` keys are either child IDs or `"parent-id/child-id"` paths. Values are partial node property overrides applied to that descendant.
+
+### 6. `rectangle`
+
+A filled rectangle. Renders as a `<div>` with `border-radius` if `cornerRadius` is set.
+
+```ts
+interface RectangleNode extends BaseNode {
+  type: 'rectangle';
+  fill?: string;
+  stroke?: Stroke | string;
+  cornerRadius?: number;
+}
+```
+
+### 7. `ellipse`
+
+An ellipse or arc shape. Renders as a `<div>` with `border-radius: 50%`, or as an SVG arc for partial angles.
+
+```ts
+interface EllipseNode extends BaseNode {
+  type: 'ellipse';
+  fill?: string;
+  stroke?: Stroke | string;
+  startAngle?: number; // degrees
+  endAngle?: number; // degrees
+}
+```
+
+### 8. `line`
+
+A straight line between two points. Renders as SVG.
+
+```ts
+interface LineNode extends BaseNode {
+  type: 'line';
+  x1?: number;
+  y1?: number;
+  x2?: number;
+  y2?: number;
+  stroke?: Stroke | string;
+}
+```
+
+### 9. `polygon`
+
+A regular polygon with `n` sides. Renders as SVG.
+
+```ts
+interface PolygonNode extends BaseNode {
+  type: 'polygon';
+  sides?: number;
+  fill?: string;
+  stroke?: Stroke | string;
+}
+```
+
+### 10. `path`
+
+An SVG-compatible path. Renders as an SVG `<path>` element.
+
+```ts
+interface PathNode extends BaseNode {
+  type: 'path';
+  d?: string; // SVG path data
+  path?: string; // alias for d
+  fill?: string;
+  stroke?: Stroke | string;
+}
+```
+
+### 11. `note`
+
+A design annotation. Not rendered in the output — used to add comments visible to designers and AI agents.
+
+```ts
+interface NoteNode extends BaseNode {
+  type: 'note';
+  content: string;
+}
+```
+
+### 12. `prompt`
+
+An AI prompt annotation. Not rendered in output. The `model` field optionally targets a specific model.
+
+```ts
+interface PromptNode extends BaseNode {
+  type: 'prompt';
+  content: string;
+  model?: string; // e.g. "claude-3-5-sonnet-20241022"
+}
+```
+
+### 13. `context`
+
+A context information annotation. Not rendered. Provides background information to AI agents processing the design.
+
+```ts
+interface ContextNode extends BaseNode {
+  type: 'context';
+  content: string;
+}
+```
+
+### 14. `vector`
+
+An imported vector graphic (SVG asset reference).
+
+```ts
+interface VectorNode extends BaseNode {
+  type: 'vector';
+  fill?: string;
+  stroke?: Stroke | string;
+}
+```
+
+### 15. `instance`
+
+A component instance with override properties.
+
+```ts
+interface InstanceNode extends BaseNode {
+  type: 'instance';
+  ref: string;
+  overrides?: Record<string, unknown>;
+}
+```
+
+---
+
+## Fill descriptors
+
+Node `fill` fields accept either a plain string (color, gradient, or `$variable`) or a structured `PenFill` object.
+
+### String fill values
+
+| Format       | Example        | Meaning                              |
+| ------------ | -------------- | ------------------------------------ |
+| Hex 6-digit  | `"#3B82F6"`    | RGB color                            |
+| Hex 8-digit  | `"#3B82F680"`  | RGBA color (last two digits = alpha) |
+| Hex 3-digit  | `"#38F"`       | Short RGB color                      |
+| Variable ref | `"$--primary"` | Resolved from `doc.variables`        |
+
+### Structured fills
+
+```ts
+type PenFill = PenSolidFill | PenGradientFill | PenImageFill;
+
+interface PenSolidFill {
+  type: 'solid';
+  color: string | PenColor;
+  opacity?: number;
+}
+
+interface PenGradientFill {
+  type: 'gradient';
+  gradientType: 'linear' | 'radial' | 'angular';
+  stops: Array<{ position: number; color: string | PenColor }>;
+  start?: { x: number; y: number };
+  end?: { x: number; y: number };
+  opacity?: number;
+}
+
+interface PenImageFill {
+  type: 'image';
+  imageRef: string; // asset reference ID
+  scaleMode?: 'fill' | 'fit' | 'crop' | 'tile';
+  opacity?: number;
+}
+```
+
+---
+
+## Stroke descriptors
+
+```ts
+interface Stroke {
+  fill?: string;
+  thickness?: number | StrokeThickness;
+  align?: 'inside' | 'outside' | 'center';
+}
+
+interface StrokeThickness {
+  top?: number;
+  right?: number;
+  bottom?: number;
+  left?: number;
+}
+```
+
+A stroke can also be a plain string, treated as a color value identical to the `fill` string formats above.
+
+---
+
+## Variable resolution
+
+Variables defined in `doc.variables` are resolved at render time against the active theme. The resolution algorithm:
+
+1. If `variable.value` is a scalar (`string | number`), return it directly.
+2. If `variable.value` is a `ThemeDependent[]`, iterate the array.
+3. For each entry, check if all keys in `entry.theme` match the active `Theme` selection.
+4. Return the value of the **last matching entry** (later entries override earlier ones).
+5. If no entry matches, fall back to the first entry's value.
+
+```ts
+import { resolveVariable } from '@@PROJECT_NAME-pen';
+
+// Resolve a single variable
+const value = resolveVariable(doc.variables['--sidebar'], { Mode: 'Dark' });
+// → "#1A1A1A"
+```
+
+---
+
+## Traversal API
+
+```ts
+import { traverse } from '@@PROJECT_NAME-pen';
+
+// Depth-first visitor
+traverse(doc, (node, parent, depth) => {
+  console.log(`${' '.repeat(depth! * 2)}${node.type}: ${node.name ?? node.id}`);
+  // Return false to skip children
+  if (node.type === 'ref') return false;
+});
+```
+
+The visitor signature:
+
+```ts
+type NodeVisitor = (node: PenNode, parent?: PenNode, depth?: number) => void | boolean;
+```
+
+---
+
+## Parser API
+
+```ts
+import { parsePenDocument } from '@@PROJECT_NAME-pen';
+
+const doc: PenDocument = parsePenDocument(rawJson);
+```
+
+`parsePenDocument` validates the top-level structure and returns a typed `PenDocument`. It does not mutate the input. Throws `Error` if the input is not a valid `.pen` document object.


### PR DESCRIPTION
## Summary

- README with architecture diagram and getting-started guide
- Diataxis docs: quickstart, design-to-code concepts, adding-components guide, .pen format reference
- 5 markdown files covering the full design-system platform

## Test plan

- [ ] Markdown renders correctly on GitHub
- [ ] All internal links valid
- [ ] Quickstart steps are followable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation suite for the design-system starter kit, including project overview, architecture, and getting-started guide
  * Added practical guides for adding components to the design system
  * Added detailed reference documentation for the design-to-code pipeline and .pen file format specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->