### PR TITLE
fix(design-system): resolve build issues for end-to-end verification

### DIFF
--- a/libs/templates/starters/design-system/README.md
+++ b/libs/templates/starters/design-system/README.md
@@ -63,7 +63,8 @@ git clone <repo-url> my-design-system
 cd my-design-system
 
 # Replace @@PROJECT_NAME with your project name everywhere
-grep -rl '@@PROJECT_NAME' . --include='*.json' --include='*.ts' --include='*.md' \
+grep -rl '@@PROJECT_NAME' . \
+  --include='*.json' --include='*.ts' --include='*.tsx' --include='*.md' --include='*.html' \
   | xargs sed -i 's/@@PROJECT_NAME/my-design-system/g'
 ```
 

--- a/libs/templates/starters/design-system/docs/getting-started/quickstart.md
+++ b/libs/templates/starters/design-system/docs/getting-started/quickstart.md
@@ -18,7 +18,7 @@ Replace `@@PROJECT_NAME` with your project name across all files:
 
 ```bash
 grep -rl '@@PROJECT_NAME' . \
-  --include='*.json' --include='*.ts' --include='*.md' --include='*.tsx' \
+  --include='*.json' --include='*.ts' --include='*.tsx' --include='*.md' --include='*.html' \
   | xargs sed -i 's/@@PROJECT_NAME/my-design-system/g'
 ```
 

--- a/libs/templates/starters/design-system/packages/a11y/package.json
+++ b/libs/templates/starters/design-system/packages/a11y/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@types/jsdom": "^21.0.0",
+    "axe-core": "^4.0.0",
     "typescript": "^5.0.0"
   },
   "keywords": [

--- a/libs/templates/starters/design-system/packages/agents/src/a11y-agent.ts
+++ b/libs/templates/starters/design-system/packages/agents/src/a11y-agent.ts
@@ -414,12 +414,15 @@ function executeAnalyzeHtmlSemantics(input: Record<string, unknown>): Record<str
     const altMatch = tag.match(/alt="([^"]*)"/i);
     if (!altMatch) {
       checks.push('IMAGE_NO_ALT: Image element missing alt attribute entirely.');
-    } else if (altMatch[1].trim() === '') {
-      checks.push('IMAGE_DECORATIVE: Image has empty alt="" — verify it is truly decorative.');
-    } else if (/^image\d*$|\.png|\.jpg|\.svg/i.test(altMatch[1])) {
-      checks.push(
-        `IMAGE_BAD_ALT: Alt text "${altMatch[1]}" appears to be a filename or generic label.`
-      );
+    } else {
+      const altText = altMatch[1] ?? '';
+      if (altText.trim() === '') {
+        checks.push('IMAGE_DECORATIVE: Image has empty alt="" — verify it is truly decorative.');
+      } else if (/^image\d*$|\.png|\.jpg|\.svg/i.test(altText)) {
+        checks.push(
+          `IMAGE_BAD_ALT: Alt text "${altText}" appears to be a filename or generic label.`
+        );
+      }
     }
   }
 
@@ -447,9 +450,11 @@ function executeAnalyzeHtmlSemantics(input: Record<string, unknown>): Record<str
     );
   }
   for (let i = 1; i < levels.length; i++) {
-    if (levels[i] - levels[i - 1] > 1) {
+    const curr = levels[i] ?? 0;
+    const prev = levels[i - 1] ?? 0;
+    if (curr - prev > 1) {
       checks.push(
-        `HEADING_SKIPPED: Heading jumps from h${levels[i - 1]} to h${levels[i]} — skipped levels confuse screen reader navigation.`
+        `HEADING_SKIPPED: Heading jumps from h${prev} to h${curr} — skipped levels confuse screen reader navigation.`
       );
     }
   }

--- a/libs/templates/starters/design-system/packages/agents/tsconfig.json
+++ b/libs/templates/starters/design-system/packages/agents/tsconfig.json
@@ -17,7 +17,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": false,
     "skipLibCheck": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "composite": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- Extend scaffold `sed` command in README and quickstart to cover `*.tsx` and `*.html` — fixes `packages/app/index.html` retaining `@@PROJECT_NAME` tokens after substitution
- Add `axe-core` to `packages/a11y` devDependencies so TypeScript can resolve its types at build time (declared as optional peer dep, but tsc needs it at compile time)
- Add `"composite": true` to `packages/agents/tsconfig.json` so the server package's TypeScript project reference compiles without TS6306
- Fix `noUncheckedIndexedAccess` violations in `a11y-agent.ts`: use nullish coalescing for regex capture groups (`altMatch[1] ?? ''`) and heading-level loop vars

## Verification

- All 11 packages build cleanly via `npm run build --workspaces --if-present`
- `.pen → React` pipeline produces 46 `.tsx` components from `shadcn-kit.pen`
- Zero `@@PROJECT_NAME` tokens remain in scaffolded output after substitution
- Zero `@protolabsai` imports in output
- Main repo typecheck passes (20/20 tasks)

## Test plan
- [x] Scaffold into temp dir, run substitution, verify no leftover tokens
- [x] `npm install && npm run build` — all 11 packages pass
- [x] Pipeline: `parsePenFileFromPath` + `generateFromDocument` → 46 .tsx files
- [x] `grep -r '@protolabsai'` → no matches
- [x] Main repo `npm run typecheck` → 20/20 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated accessibility testing tools for enhanced quality assurance

* **Bug Fixes**
  * Strengthened accessibility analysis with improved error handling for edge cases

* **Documentation**
  * Updated quickstart and README documentation with expanded file type coverage

* **Chores**
  * Enhanced build configuration to support composite TypeScript modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->