### PR TITLE
Migrate health and monitoring services to TimerRegistry

### DIFF
--- a/apps/server/src/services/health-monitor-service.ts
+++ b/apps/server/src/services/health-monitor-service.ts
@@ -26,6 +26,7 @@ import { promisify } from 'util';
 import v8 from 'v8';
 import { getReactiveSpawnerService } from './reactive-spawner-service.js';
 import { HEALTH_CHECK_INTERVAL_MS, STUCK_FEATURE_THRESHOLD_MS } from '../config/timeouts.js';
+import type { SchedulerService } from './scheduler-service.js';
 
 const execAsync = promisify(exec);
 const logger = createLogger('HealthMonitor');
@@ -117,6 +118,9 @@ export class HealthMonitorService {
   private config: Required<HealthMonitorConfig>;
   private lastCheckResult: HealthCheckResult | null = null;
   private isRunning = false;
+  private schedulerService: SchedulerService | null = null;
+
+  private static readonly INTERVAL_ID = 'health-monitor:check';
 
   constructor(featureLoader?: FeatureLoader, config?: HealthMonitorConfig) {
     this.featureLoader = featureLoader ?? new FeatureLoader();
@@ -133,6 +137,13 @@ export class HealthMonitorService {
    */
   setEventEmitter(events: EventEmitter): void {
     this.events = events;
+  }
+
+  /**
+   * Set the scheduler service for managed interval tracking
+   */
+  setSchedulerService(schedulerService: SchedulerService): void {
+    this.schedulerService = schedulerService;
   }
 
   /**
@@ -173,12 +184,25 @@ export class HealthMonitorService {
       logger.error('Initial health check failed:', error);
     });
 
-    // Set up periodic checks
-    this.intervalId = setInterval(() => {
-      this.runHealthCheck().catch((error) => {
-        logger.error('Periodic health check failed:', error);
-      });
-    }, this.config.checkIntervalMs);
+    // Set up periodic checks via schedulerService if available, else raw setInterval
+    if (this.schedulerService) {
+      this.schedulerService.registerInterval(
+        HealthMonitorService.INTERVAL_ID,
+        'Health Monitor',
+        this.config.checkIntervalMs,
+        () => {
+          this.runHealthCheck().catch((error) => {
+            logger.error('Periodic health check failed:', error);
+          });
+        }
+      );
+    } else {
+      this.intervalId = setInterval(() => {
+        this.runHealthCheck().catch((error) => {
+          logger.error('Periodic health check failed:', error);
+        });
+      }, this.config.checkIntervalMs);
+    }
   }
 
   /**
@@ -190,7 +214,9 @@ export class HealthMonitorService {
       return;
     }
 
-    if (this.intervalId) {
+    if (this.schedulerService) {
+      this.schedulerService.unregisterInterval(HealthMonitorService.INTERVAL_ID);
+    } else if (this.intervalId) {
       clearInterval(this.intervalId);
       this.intervalId = null;
     }

--- a/apps/server/src/services/pr-watcher-service.ts
+++ b/apps/server/src/services/pr-watcher-service.ts
@@ -13,6 +13,7 @@ import { createLogger } from '@protolabsai/utils';
 import { githubMergeService } from './github-merge-service.js';
 import type { EventEmitter } from '../lib/events.js';
 import { PR_WATCHER_POLL_INTERVAL_MS, PR_WATCHER_TIMEOUT_MS } from '../config/timeouts.js';
+import type { SchedulerService } from './scheduler-service.js';
 
 const logger = createLogger('PRWatcherService');
 
@@ -38,6 +39,9 @@ export class PRWatcherService {
   private pollingTimer: ReturnType<typeof setInterval> | null = null;
   private readonly pollIntervalMs: number;
   private readonly timeoutMs: number;
+  private schedulerService: SchedulerService | null = null;
+
+  private static readonly INTERVAL_ID = 'pr-watcher:poll';
 
   constructor(
     private readonly events: EventEmitter,
@@ -46,6 +50,13 @@ export class PRWatcherService {
   ) {
     this.pollIntervalMs = pollIntervalMs;
     this.timeoutMs = timeoutMs;
+  }
+
+  /**
+   * Set the scheduler service for managed interval tracking
+   */
+  setSchedulerService(schedulerService: SchedulerService): void {
+    this.schedulerService = schedulerService;
   }
 
   // ── Public API ────────────────────────────────────────────────────────────
@@ -103,21 +114,38 @@ export class PRWatcherService {
 
   /** Stop the background polling loop (e.g. for graceful shutdown). */
   stopPolling(): void {
-    if (this.pollingTimer) {
+    if (this.schedulerService) {
+      this.schedulerService.unregisterInterval(PRWatcherService.INTERVAL_ID);
+    } else if (this.pollingTimer) {
       clearInterval(this.pollingTimer);
       this.pollingTimer = null;
-      logger.debug('Polling loop stopped');
     }
+    logger.debug('Polling loop stopped');
   }
 
   // ── Private helpers ───────────────────────────────────────────────────────
 
   private ensurePolling(): void {
-    if (this.pollingTimer) return;
-    logger.debug(`Starting polling loop (interval: ${this.pollIntervalMs}ms)`);
-    this.pollingTimer = setInterval(() => {
-      void this.pollAll();
-    }, this.pollIntervalMs);
+    if (this.schedulerService) {
+      // Only register if not already registered
+      const existing = this.schedulerService
+        .listAll()
+        .find((e) => e.id === PRWatcherService.INTERVAL_ID);
+      if (existing) return;
+      logger.debug(`Starting polling loop via scheduler (interval: ${this.pollIntervalMs}ms)`);
+      this.schedulerService.registerInterval(
+        PRWatcherService.INTERVAL_ID,
+        'PR Watcher Poll',
+        this.pollIntervalMs,
+        () => this.pollAll()
+      );
+    } else {
+      if (this.pollingTimer) return;
+      logger.debug(`Starting polling loop (interval: ${this.pollIntervalMs}ms)`);
+      this.pollingTimer = setInterval(() => {
+        void this.pollAll();
+      }, this.pollIntervalMs);
+    }
   }
 
   private async pollAll(): Promise<void> {

--- a/apps/server/src/services/scheduler-service.ts
+++ b/apps/server/src/services/scheduler-service.ts
@@ -128,6 +128,22 @@ export interface SchedulerStatus {
 }
 
 /**
+ * An interval-based timer entry tracked by the scheduler
+ */
+export interface IntervalEntry {
+  kind: 'interval';
+  id: string;
+  name: string;
+  intervalMs: number;
+  registeredAt: string;
+}
+
+/**
+ * Unified timer entry returned by listAll() — either a cron task or an interval
+ */
+export type TimerEntry = (ScheduledTask & { kind: 'cron' }) | IntervalEntry;
+
+/**
  * Day of week name mappings
  */
 const DAY_NAMES: Record<string, number> = {
@@ -338,6 +354,9 @@ export class SchedulerService {
   private events: EventEmitter | null = null;
   private dataDir: string | null = null;
   private settingsService: SettingsService | null = null;
+
+  /** Managed interval entries (non-cron timers registered via registerInterval) */
+  private intervals: Map<string, { timerId: NodeJS.Timeout; meta: IntervalEntry }> = new Map();
 
   /** Check interval in milliseconds (default: 60 seconds) */
   private checkInterval = 60000;
@@ -672,6 +691,78 @@ export class SchedulerService {
   }
 
   /**
+   * Register a managed setInterval under a named id.
+   * The timer is tracked so it appears in listAll() and can be cleared via unregisterInterval().
+   * If an interval with the same id is already registered, it is replaced.
+   */
+  registerInterval(
+    id: string,
+    name: string,
+    intervalMs: number,
+    handler: () => Promise<void> | void
+  ): void {
+    // Clear any existing interval with the same id
+    const existing = this.intervals.get(id);
+    if (existing) {
+      clearInterval(existing.timerId);
+      logger.debug(`Replaced existing interval "${name}" (${id})`);
+    }
+
+    const timerId = setInterval(() => {
+      void Promise.resolve(handler()).catch((err) => {
+        logger.error(`Interval handler "${name}" (${id}) failed:`, err);
+      });
+    }, intervalMs);
+
+    const meta: IntervalEntry = {
+      kind: 'interval',
+      id,
+      name,
+      intervalMs,
+      registeredAt: new Date().toISOString(),
+    };
+
+    this.intervals.set(id, { timerId, meta });
+    logger.info(`Registered interval "${name}" (${id}) every ${intervalMs}ms`);
+
+    this.emitEvent('scheduler:interval_registered', { id, name, intervalMs });
+  }
+
+  /**
+   * Clear a managed interval registered via registerInterval().
+   * Returns true if the interval existed and was removed, false otherwise.
+   */
+  unregisterInterval(id: string): boolean {
+    const entry = this.intervals.get(id);
+    if (!entry) {
+      return false;
+    }
+
+    clearInterval(entry.timerId);
+    this.intervals.delete(id);
+    logger.info(`Unregistered interval "${entry.meta.name}" (${id})`);
+
+    this.emitEvent('scheduler:interval_unregistered', { id, name: entry.meta.name });
+    return true;
+  }
+
+  /**
+   * Return all tracked timers — both cron tasks and managed intervals — in a unified list.
+   */
+  listAll(): TimerEntry[] {
+    const cronEntries: TimerEntry[] = Array.from(this.tasks.values()).map((task) => ({
+      ...task,
+      kind: 'cron' as const,
+    }));
+
+    const intervalEntries: TimerEntry[] = Array.from(this.intervals.values()).map(
+      ({ meta }) => meta
+    );
+
+    return [...cronEntries, ...intervalEntries];
+  }
+
+  /**
    * Get scheduler status for health monitoring
    */
   getStatus(): SchedulerStatus {
@@ -945,6 +1036,11 @@ export class SchedulerService {
    */
   destroy(): void {
     this.stop();
+    // Clear all managed intervals
+    for (const { timerId } of this.intervals.values()) {
+      clearInterval(timerId);
+    }
+    this.intervals.clear();
     this.tasks.clear();
     this.parsedCrons.clear();
     this.persistedMetadata.clear();

--- a/apps/server/src/services/scheduler.module.ts
+++ b/apps/server/src/services/scheduler.module.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@protolabsai/utils';
 
 import type { ServiceContainer } from '../server/services.js';
+import { getPRWatcherService } from './pr-watcher-service.js';
 
 const logger = createLogger('Server:Wiring');
 
@@ -22,7 +23,18 @@ export function register(container: ServiceContainer): void {
     featureHealthService,
     integrityWatchdogService,
     featureLoader,
+    healthMonitorService,
+    specGenerationMonitor,
   } = container;
+
+  // Wire schedulerService into interval-tracked services so their timers
+  // appear in schedulerService.listAll() and can be inspected centrally.
+  healthMonitorService.setSchedulerService(schedulerService);
+  specGenerationMonitor.setSchedulerService(schedulerService);
+  const prWatcher = getPRWatcherService();
+  if (prWatcher) {
+    prWatcher.setSchedulerService(schedulerService);
+  }
 
   // Scheduler Service initialization and task registration via AutomationService
   schedulerService.initialize(events, dataDir);

--- a/apps/server/src/services/spec-generation-monitor.ts
+++ b/apps/server/src/services/spec-generation-monitor.ts
@@ -12,6 +12,7 @@
 import { createLogger } from '@protolabsai/utils';
 import type { EventEmitter } from '../lib/events.js';
 import { getSpecRegenerationStatus, setRunningState } from '../routes/app-spec/common.js';
+import type { SchedulerService } from './scheduler-service.js';
 
 const logger = createLogger('SpecGenerationMonitor');
 
@@ -44,6 +45,9 @@ export class SpecGenerationMonitor {
   private config: Required<SpecGenerationMonitorConfig>;
   private isRunning = false;
   private lastActivityTimestamps = new Map<string, number>();
+  private schedulerService: SchedulerService | null = null;
+
+  private static readonly INTERVAL_ID = 'spec-generation-monitor:check';
 
   constructor(events: EventEmitter, config?: SpecGenerationMonitorConfig) {
     this.events = events;
@@ -54,7 +58,7 @@ export class SpecGenerationMonitor {
     };
 
     // Subscribe to spec regeneration events to track activity
-    this.events.subscribe((type, payload) => {
+    this.events.subscribe((type, payload: unknown) => {
       if (type === 'spec-regeneration:event') {
         const eventPayload = payload as { projectPath?: string } | null;
         if (eventPayload?.projectPath) {
@@ -63,6 +67,13 @@ export class SpecGenerationMonitor {
         }
       }
     });
+  }
+
+  /**
+   * Set the scheduler service for managed interval tracking
+   */
+  setSchedulerService(schedulerService: SchedulerService): void {
+    this.schedulerService = schedulerService;
   }
 
   /**
@@ -82,12 +93,21 @@ export class SpecGenerationMonitor {
     this.isRunning = true;
     logger.info(`Starting SpecGenerationMonitor with interval of ${this.config.checkIntervalMs}ms`);
 
-    // Set up periodic checks
-    this.intervalId = setInterval(() => {
-      this.tick().catch((error) => {
-        logger.error('Periodic check failed:', error);
-      });
-    }, this.config.checkIntervalMs);
+    // Set up periodic checks via schedulerService if available, else raw setInterval
+    if (this.schedulerService) {
+      this.schedulerService.registerInterval(
+        SpecGenerationMonitor.INTERVAL_ID,
+        'Spec Generation Monitor',
+        this.config.checkIntervalMs,
+        () => this.tick()
+      );
+    } else {
+      this.intervalId = setInterval(() => {
+        this.tick().catch((error) => {
+          logger.error('Periodic check failed:', error);
+        });
+      }, this.config.checkIntervalMs);
+    }
 
     // Run initial check
     this.tick().catch((error) => {
@@ -104,7 +124,9 @@ export class SpecGenerationMonitor {
       return;
     }
 
-    if (this.intervalId) {
+    if (this.schedulerService) {
+      this.schedulerService.unregisterInterval(SpecGenerationMonitor.INTERVAL_ID);
+    } else if (this.intervalId) {
       clearInterval(this.intervalId);
       this.intervalId = null;
     }

--- a/apps/server/tests/unit/services/timer-registry-integration.test.ts
+++ b/apps/server/tests/unit/services/timer-registry-integration.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Integration test: Timer Registry - interval registration on startup
+ *
+ * Verifies that HealthMonitorService, SpecGenerationMonitor, and PRWatcherService
+ * register their intervals via schedulerService.registerInterval() so that
+ * schedulerService.listAll() reflects all three timers.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SchedulerService } from '../../../src/services/scheduler-service.js';
+import { HealthMonitorService } from '../../../src/services/health-monitor-service.js';
+import { SpecGenerationMonitor } from '../../../src/services/spec-generation-monitor.js';
+import { PRWatcherService } from '../../../src/services/pr-watcher-service.js';
+
+// Minimal stub EventEmitter
+const makeEvents = () => ({
+  emit: vi.fn(),
+  subscribe: vi.fn(),
+  on: vi.fn(),
+});
+
+describe('Timer Registry: interval registration', () => {
+  let scheduler: SchedulerService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    scheduler = new SchedulerService();
+  });
+
+  afterEach(() => {
+    scheduler.destroy();
+    vi.useRealTimers();
+  });
+
+  it('HealthMonitorService registers its interval on startMonitoring()', () => {
+    const events = makeEvents();
+    const svc = new HealthMonitorService(undefined, {
+      checkIntervalMs: 30_000,
+      projectPaths: [],
+    });
+    svc.setEventEmitter(events as never);
+    svc.setSchedulerService(scheduler);
+
+    svc.startMonitoring();
+
+    const entries = scheduler.listAll();
+    const found = entries.find((e) => e.id === 'health-monitor:check');
+    expect(found).toBeDefined();
+    expect(found?.kind).toBe('interval');
+
+    svc.stopMonitoring();
+    expect(scheduler.listAll().find((e) => e.id === 'health-monitor:check')).toBeUndefined();
+  });
+
+  it('SpecGenerationMonitor registers its interval on startMonitoring()', () => {
+    const events = makeEvents();
+    const svc = new SpecGenerationMonitor(events as never, {
+      checkIntervalMs: 30_000,
+      enabled: true,
+    });
+    svc.setSchedulerService(scheduler);
+
+    svc.startMonitoring();
+
+    const entries = scheduler.listAll();
+    const found = entries.find((e) => e.id === 'spec-generation-monitor:check');
+    expect(found).toBeDefined();
+    expect(found?.kind).toBe('interval');
+
+    svc.stopMonitoring();
+    expect(
+      scheduler.listAll().find((e) => e.id === 'spec-generation-monitor:check')
+    ).toBeUndefined();
+  });
+
+  it('PRWatcherService registers its interval when addWatch() is called', () => {
+    const events = makeEvents();
+    const svc = new PRWatcherService(events as never, 30_000, 30 * 60_000);
+    svc.setSchedulerService(scheduler);
+
+    // addWatch triggers ensurePolling -> registerInterval
+    svc.addWatch(42, '/some/project', 'session-1');
+
+    const entries = scheduler.listAll();
+    const found = entries.find((e) => e.id === 'pr-watcher:poll');
+    expect(found).toBeDefined();
+    expect(found?.kind).toBe('interval');
+
+    svc.stopPolling();
+    expect(scheduler.listAll().find((e) => e.id === 'pr-watcher:poll')).toBeUndefined();
+  });
+
+  it('listAll() returns all three intervals when all services are active', () => {
+    const events = makeEvents();
+
+    const healthSvc = new HealthMonitorService(undefined, { checkIntervalMs: 30_000 });
+    healthSvc.setEventEmitter(events as never);
+    healthSvc.setSchedulerService(scheduler);
+    healthSvc.startMonitoring();
+
+    const specSvc = new SpecGenerationMonitor(events as never, { checkIntervalMs: 30_000 });
+    specSvc.setSchedulerService(scheduler);
+    specSvc.startMonitoring();
+
+    const prSvc = new PRWatcherService(events as never, 30_000, 30 * 60_000);
+    prSvc.setSchedulerService(scheduler);
+    prSvc.addWatch(99, '/project', 'session-x');
+
+    const intervalEntries = scheduler.listAll().filter((e) => e.kind === 'interval');
+    const ids = intervalEntries.map((e) => e.id);
+
+    expect(ids).toContain('health-monitor:check');
+    expect(ids).toContain('spec-generation-monitor:check');
+    expect(ids).toContain('pr-watcher:poll');
+
+    healthSvc.stopMonitoring();
+    specSvc.stopMonitoring();
+    prSvc.stopPolling();
+  });
+});

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -77,6 +77,8 @@ export type EventType =
   | 'scheduler:task_started'
   | 'scheduler:task_completed'
   | 'scheduler:task-failed'
+  | 'scheduler:interval_registered'
+  | 'scheduler:interval_unregistered'
   | 'maintenance'
   | 'recovery_analysis'
   | 'recovery_started'


### PR DESCRIPTION
## Summary

**Milestone:** Timer Registry Foundation

Migrate HealthMonitorService (30s), PRWatcherService (30s), SpecGenerationMonitor (30s) to use schedulerService.registerInterval() instead of raw setInterval. Each service receives schedulerService via constructor or setter injection. Remove the internal setInterval calls. Preserve all existing behavior.

**Files to Modify:**
- apps/server/src/services/health-monitor-service.ts
- apps/server/src/services/pr-watcher-service.ts
- apps/server/src/services/s...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced scheduler service with centralized interval and timer management capabilities.
  * Background monitoring services (health checks, PR watching, spec generation) now integrated with the unified scheduler for coordinated interval tracking.
  * New event types for interval lifecycle tracking.

* **Tests**
  * Added integration tests validating interval registration and lifecycle across scheduler-managed services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->