### PR TITLE
Migrate external monitors and Lead Engineer timers

### DIFF
--- a/apps/server/src/services/discord-monitor.ts
+++ b/apps/server/src/services/discord-monitor.ts
@@ -12,6 +12,7 @@ import type {
   WorkItem,
 } from '@protolabsai/types';
 import { createLogger } from '@protolabsai/utils';
+import type { SchedulerService } from './scheduler-service.js';
 
 const logger = createLogger('DiscordMonitor');
 
@@ -62,11 +63,14 @@ export class DiscordMonitor {
   /** Last message ID seen per channel (to avoid processing duplicates) */
   private lastMessageIds = new Map<string, string>();
 
-  /** Active polling intervals */
+  /** Active polling intervals (only used when schedulerService is not available) */
   private intervals = new Map<string, NodeJS.Timeout>();
 
   /** Discord bot service for reading messages */
   private discordBotService: DiscordBotServiceLike | null = null;
+
+  /** Scheduler service for centralized timer tracking */
+  private schedulerService?: SchedulerService;
 
   constructor(private events: EventEmitter) {}
 
@@ -75,6 +79,14 @@ export class DiscordMonitor {
    */
   setDiscordBotService(service: DiscordBotServiceLike): void {
     this.discordBotService = service;
+  }
+
+  setSchedulerService(schedulerService: SchedulerService): void {
+    this.schedulerService = schedulerService;
+  }
+
+  private channelIntervalId(channelId: string): string {
+    return `discord-monitor:channel:${channelId}`;
   }
 
   /**
@@ -94,16 +106,24 @@ export class DiscordMonitor {
         logger.error(`Failed to fetch initial messages for channel ${channelId}:`, error);
       }
 
-      // Start polling loop
-      const interval = setInterval(async () => {
-        try {
-          await this.pollChannel(channelId, keywords);
-        } catch (error) {
-          logger.error(`Error polling Discord channel ${channelId}:`, error);
-        }
-      }, pollInterval);
-
-      this.intervals.set(channelId, interval);
+      // Start polling loop via schedulerService if available, else raw setInterval
+      if (this.schedulerService) {
+        this.schedulerService.registerInterval(
+          this.channelIntervalId(channelId),
+          `Discord Monitor: channel ${channelId}`,
+          pollInterval,
+          () => this.pollChannel(channelId, keywords)
+        );
+      } else {
+        const interval = setInterval(async () => {
+          try {
+            await this.pollChannel(channelId, keywords);
+          } catch (error) {
+            logger.error(`Error polling Discord channel ${channelId}:`, error);
+          }
+        }, pollInterval);
+        this.intervals.set(channelId, interval);
+      }
       logger.info(`Started monitoring Discord channel ${channelId}`);
     }
   }
@@ -112,12 +132,20 @@ export class DiscordMonitor {
    * Stop monitoring a Discord channel
    */
   stopMonitoring(channelId: string): void {
-    const interval = this.intervals.get(channelId);
-    if (interval) {
-      clearInterval(interval);
-      this.intervals.delete(channelId);
-      this.lastMessageIds.delete(channelId);
-      logger.info(`Stopped monitoring Discord channel ${channelId}`);
+    if (this.schedulerService) {
+      const removed = this.schedulerService.unregisterInterval(this.channelIntervalId(channelId));
+      if (removed) {
+        this.lastMessageIds.delete(channelId);
+        logger.info(`Stopped monitoring Discord channel ${channelId}`);
+      }
+    } else {
+      const interval = this.intervals.get(channelId);
+      if (interval) {
+        clearInterval(interval);
+        this.intervals.delete(channelId);
+        this.lastMessageIds.delete(channelId);
+        logger.info(`Stopped monitoring Discord channel ${channelId}`);
+      }
     }
   }
 
@@ -125,11 +153,18 @@ export class DiscordMonitor {
    * Stop all monitoring
    */
   stopAll(): void {
-    for (const [channelId, interval] of this.intervals.entries()) {
-      clearInterval(interval);
-      logger.info(`Stopped monitoring Discord channel ${channelId}`);
+    if (this.schedulerService) {
+      for (const channelId of this.lastMessageIds.keys()) {
+        this.schedulerService.unregisterInterval(this.channelIntervalId(channelId));
+        logger.info(`Stopped monitoring Discord channel ${channelId}`);
+      }
+    } else {
+      for (const [channelId, interval] of this.intervals.entries()) {
+        clearInterval(interval);
+        logger.info(`Stopped monitoring Discord channel ${channelId}`);
+      }
+      this.intervals.clear();
     }
-    this.intervals.clear();
     this.lastMessageIds.clear();
   }
 
@@ -165,16 +200,24 @@ export class DiscordMonitor {
         logger.error(`Failed to fetch initial messages for channel ${channelId}:`, error);
       }
 
-      // Start polling loop
-      const interval = setInterval(async () => {
-        try {
-          await this.pollChannelForSignals(config);
-        } catch (error) {
-          logger.error(`Error polling Discord channel ${channelId} for signals:`, error);
-        }
-      }, pollInterval);
-
-      this.intervals.set(channelId, interval);
+      // Start polling loop via schedulerService if available, else raw setInterval
+      if (this.schedulerService) {
+        this.schedulerService.registerInterval(
+          this.channelIntervalId(channelId),
+          `Discord Monitor: channel ${channelId} (${config.channelName})`,
+          pollInterval,
+          () => this.pollChannelForSignals(config)
+        );
+      } else {
+        const interval = setInterval(async () => {
+          try {
+            await this.pollChannelForSignals(config);
+          } catch (error) {
+            logger.error(`Error polling Discord channel ${channelId} for signals:`, error);
+          }
+        }, pollInterval);
+        this.intervals.set(channelId, interval);
+      }
       logger.info(
         `Started signal monitoring for Discord channel ${channelId} (${config.channelName})`
       );
@@ -311,13 +354,18 @@ export class DiscordMonitor {
    * Get all monitored channel IDs
    */
   getMonitoredChannels(): string[] {
-    return Array.from(this.intervals.keys());
+    return Array.from(this.lastMessageIds.keys());
   }
 
   /**
    * Check if a channel is being monitored
    */
   isMonitoring(channelId: string): boolean {
+    if (this.schedulerService) {
+      return this.schedulerService
+        .listAll()
+        .some((t) => t.id === this.channelIntervalId(channelId));
+    }
     return this.intervals.has(channelId);
   }
 }

--- a/apps/server/src/services/github-monitor.ts
+++ b/apps/server/src/services/github-monitor.ts
@@ -10,6 +10,7 @@ import type { GitHubMonitorConfig, WorkItem } from '@protolabsai/types';
 import { createLogger } from '@protolabsai/utils';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import type { SchedulerService } from './scheduler-service.js';
 
 const execFileAsync = promisify(execFile);
 const logger = createLogger('GitHubMonitor');
@@ -41,6 +42,8 @@ export interface GitHubPRItem {
  * - PRs ready for merge
  */
 export class GitHubMonitor {
+  static readonly INTERVAL_ID = 'github-monitor:poll';
+
   /** Last PR check timestamp */
   private lastCheckTime?: string;
 
@@ -50,7 +53,14 @@ export class GitHubMonitor {
   /** Project path for gh CLI execution */
   private projectPath?: string;
 
+  /** Scheduler service for centralized timer tracking */
+  private schedulerService?: SchedulerService;
+
   constructor(private events: EventEmitter) {}
+
+  setSchedulerService(schedulerService: SchedulerService): void {
+    this.schedulerService = schedulerService;
+  }
 
   /**
    * Set the project path for GitHub operations
@@ -65,14 +75,23 @@ export class GitHubMonitor {
   async startMonitoring(config: GitHubMonitorConfig): Promise<void> {
     const { pollInterval = 30000, labelFilter = [] } = config;
 
-    // Start polling loop
-    this.interval = setInterval(async () => {
-      try {
-        await this.pollPRs(labelFilter);
-      } catch (error) {
-        logger.error(`Error polling GitHub PRs:`, error);
-      }
-    }, pollInterval);
+    // Start polling loop via schedulerService if available, else raw setInterval
+    if (this.schedulerService) {
+      this.schedulerService.registerInterval(
+        GitHubMonitor.INTERVAL_ID,
+        'GitHub PR Monitor',
+        pollInterval,
+        () => this.pollPRs(labelFilter)
+      );
+    } else {
+      this.interval = setInterval(async () => {
+        try {
+          await this.pollPRs(labelFilter);
+        } catch (error) {
+          logger.error(`Error polling GitHub PRs:`, error);
+        }
+      }, pollInterval);
+    }
 
     logger.info(`Started monitoring GitHub PRs`);
   }
@@ -81,7 +100,10 @@ export class GitHubMonitor {
    * Stop monitoring
    */
   stopAll(): void {
-    if (this.interval) {
+    if (this.schedulerService) {
+      this.schedulerService.unregisterInterval(GitHubMonitor.INTERVAL_ID);
+      logger.info(`Stopped monitoring GitHub PRs`);
+    } else if (this.interval) {
       clearInterval(this.interval);
       this.interval = undefined;
       logger.info(`Stopped monitoring GitHub PRs`);
@@ -207,6 +229,9 @@ export class GitHubMonitor {
    * Check if monitoring is active
    */
   isMonitoring(): boolean {
+    if (this.schedulerService) {
+      return this.schedulerService.listAll().some((t) => t.id === GitHubMonitor.INTERVAL_ID);
+    }
     return this.interval !== undefined;
   }
 }

--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -53,6 +53,7 @@ import type {
 import { GtmReviewProcessor } from './lead-engineer-gtm-review-processor.js';
 import type { HITLFormService } from './hitl-form-service.js';
 import type { AuthorityService } from './authority-service.js';
+import type { SchedulerService } from './scheduler-service.js';
 
 export type { FeatureProcessingState, StateContext };
 export type { ProcessorServiceContext } from './lead-engineer-types.js';
@@ -107,6 +108,8 @@ export class LeadEngineerService {
   private supervisorIntervals = new Map<string, ReturnType<typeof setInterval>>();
   private prMergeIntervals = new Map<string, ReturnType<typeof setInterval>>();
   private activeFeatures = new Set<string>();
+
+  private schedulerService?: SchedulerService;
 
   private discordBotService?: {
     sendToChannel(channelId: string, content: string): Promise<boolean>;
@@ -192,6 +195,9 @@ export class LeadEngineerService {
   }
   setAuthorityService(s: AuthorityService): void {
     this.authorityService = s;
+  }
+  setSchedulerService(s: SchedulerService): void {
+    this.schedulerService = s;
   }
 
   // ────────────────────────── Bidirectional Integration ──────────────────────────
@@ -329,29 +335,37 @@ export class LeadEngineerService {
         .catch((err) => logger.warn(`Failed to start auto-mode for ${projectSlug}:`, err));
     }
 
-    this.refreshIntervals.set(
-      projectPath,
-      setInterval(async () => {
-        const s = this.sessions.get(projectPath);
-        if (!s || s.flowState !== 'running') return;
-        try {
-          s.worldState = await this.worldStateBuilder.build(
-            projectPath,
-            projectSlug,
-            s.worldState.maxConcurrency
-          );
-          this.getActionExecutor(undefined, projectPath).evaluateAndExecute(
-            s,
-            DEFAULT_RULES,
-            'lead-engineer:rule-evaluated',
-            {},
-            MAX_RULE_LOG_ENTRIES
-          );
-        } catch (err) {
-          logger.error(`WorldState refresh failed for ${projectSlug}:`, err);
-        }
-      }, WORLD_STATE_REFRESH_MS)
-    );
+    const refreshHandler = async () => {
+      const s = this.sessions.get(projectPath);
+      if (!s || s.flowState !== 'running') return;
+      try {
+        s.worldState = await this.worldStateBuilder.build(
+          projectPath,
+          projectSlug,
+          s.worldState.maxConcurrency
+        );
+        this.getActionExecutor(undefined, projectPath).evaluateAndExecute(
+          s,
+          DEFAULT_RULES,
+          'lead-engineer:rule-evaluated',
+          {},
+          MAX_RULE_LOG_ENTRIES
+        );
+      } catch (err) {
+        logger.error(`WorldState refresh failed for ${projectSlug}:`, err);
+      }
+    };
+
+    if (this.schedulerService) {
+      this.schedulerService.registerInterval(
+        `lead-engineer:${projectPath}:refresh`,
+        `Lead Engineer World State Refresh (${projectSlug})`,
+        WORLD_STATE_REFRESH_MS,
+        refreshHandler
+      );
+    } else {
+      this.refreshIntervals.set(projectPath, setInterval(refreshHandler, WORLD_STATE_REFRESH_MS));
+    }
 
     const workflowSettings = await getWorkflowSettings(
       projectPath,
@@ -362,26 +376,45 @@ export class LeadEngineerService {
 
     if (workflowSettings.pipeline.supervisorEnabled) {
       const executor = this.getActionExecutor(workflowSettings);
-      this.supervisorIntervals.set(
-        projectPath,
-        setInterval(() => {
-          const s = this.sessions.get(projectPath);
-          if (s?.flowState === 'running') executor.supervisorCheck(s, workflowSettings);
-        }, SUPERVISOR_CHECK_MS)
-      );
+      const supervisorHandler = () => {
+        const s = this.sessions.get(projectPath);
+        if (s?.flowState === 'running') executor.supervisorCheck(s, workflowSettings);
+      };
+
+      if (this.schedulerService) {
+        this.schedulerService.registerInterval(
+          `lead-engineer:${projectPath}:supervisor`,
+          `Lead Engineer Supervisor (${projectSlug})`,
+          SUPERVISOR_CHECK_MS,
+          supervisorHandler
+        );
+      } else {
+        this.supervisorIntervals.set(
+          projectPath,
+          setInterval(supervisorHandler, SUPERVISOR_CHECK_MS)
+        );
+      }
     }
 
-    this.prMergeIntervals.set(
-      projectPath,
-      setInterval(() => {
-        const s = this.sessions.get(projectPath);
-        if (s?.flowState === 'running') {
-          this.checkMergedPRs(projectPath).catch((err) =>
-            logger.error(`PR merge poll failed for ${projectSlug}:`, err)
-          );
-        }
-      }, PR_MERGE_POLL_MS)
-    );
+    const prMergeHandler = () => {
+      const s = this.sessions.get(projectPath);
+      if (s?.flowState === 'running') {
+        this.checkMergedPRs(projectPath).catch((err) =>
+          logger.error(`PR merge poll failed for ${projectSlug}:`, err)
+        );
+      }
+    };
+
+    if (this.schedulerService) {
+      this.schedulerService.registerInterval(
+        `lead-engineer:${projectPath}:pr-merge-poll`,
+        `Lead Engineer PR Merge Poll (${projectSlug})`,
+        PR_MERGE_POLL_MS,
+        prMergeHandler
+      );
+    } else {
+      this.prMergeIntervals.set(projectPath, setInterval(prMergeHandler, PR_MERGE_POLL_MS));
+    }
 
     await this.sessionStore.save(session);
     this.events.emit('lead-engineer:started', { projectPath, projectSlug });
@@ -596,20 +629,26 @@ export class LeadEngineerService {
   }
 
   private clearIntervals(projectPath: string): void {
-    const r = this.refreshIntervals.get(projectPath);
-    if (r) {
-      clearInterval(r);
-      this.refreshIntervals.delete(projectPath);
-    }
-    const s = this.supervisorIntervals.get(projectPath);
-    if (s) {
-      clearInterval(s);
-      this.supervisorIntervals.delete(projectPath);
-    }
-    const p = this.prMergeIntervals.get(projectPath);
-    if (p) {
-      clearInterval(p);
-      this.prMergeIntervals.delete(projectPath);
+    if (this.schedulerService) {
+      this.schedulerService.unregisterInterval(`lead-engineer:${projectPath}:refresh`);
+      this.schedulerService.unregisterInterval(`lead-engineer:${projectPath}:supervisor`);
+      this.schedulerService.unregisterInterval(`lead-engineer:${projectPath}:pr-merge-poll`);
+    } else {
+      const r = this.refreshIntervals.get(projectPath);
+      if (r) {
+        clearInterval(r);
+        this.refreshIntervals.delete(projectPath);
+      }
+      const s = this.supervisorIntervals.get(projectPath);
+      if (s) {
+        clearInterval(s);
+        this.supervisorIntervals.delete(projectPath);
+      }
+      const p = this.prMergeIntervals.get(projectPath);
+      if (p) {
+        clearInterval(p);
+        this.prMergeIntervals.delete(projectPath);
+      }
     }
   }
 

--- a/apps/server/src/services/scheduler.module.ts
+++ b/apps/server/src/services/scheduler.module.ts
@@ -25,12 +25,14 @@ export function register(container: ServiceContainer): void {
     featureLoader,
     healthMonitorService,
     specGenerationMonitor,
+    leadEngineerService,
   } = container;
 
   // Wire schedulerService into interval-tracked services so their timers
   // appear in schedulerService.listAll() and can be inspected centrally.
   healthMonitorService.setSchedulerService(schedulerService);
   specGenerationMonitor.setSchedulerService(schedulerService);
+  leadEngineerService.setSchedulerService(schedulerService);
   const prWatcher = getPRWatcherService();
   if (prWatcher) {
     prWatcher.setSchedulerService(schedulerService);


### PR DESCRIPTION
## Summary

**Milestone:** Timer Registry Foundation

Migrate GitHubMonitor (30s), DiscordMonitor (30s), and LeadEngineerService (3 timers: 5min world state refresh, 30s supervisor, 2.5min PR merge poll) to use schedulerService.registerInterval(). LeadEngineerService registers per-project timers with project-scoped IDs.

**Files to Modify:**
- apps/server/src/services/github-monitor.ts
- apps/server/src/services/discord-monitor.ts
- apps/server/src/services/lead-engineer-service.ts
- apps/server/src/service...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-15T22:44:56.826Z -->