### PR TITLE
Timer Registry API routes and MCP tools

### DIFF
--- a/apps/server/src/routes/ops/index.ts
+++ b/apps/server/src/routes/ops/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Ops routes - Operational management endpoints
+ *
+ * /api/ops/timers - Timer registry (cron + interval listing, pause/resume)
+ */
+
+import { Router } from 'express';
+
+import type { SchedulerService } from '../../services/scheduler-service.js';
+import type { EventEmitter } from '../../lib/events.js';
+import { createTimersRoutes } from './routes/timers.js';
+
+export function createOpsRoutes(schedulerService: SchedulerService, events: EventEmitter): Router {
+  const router = Router();
+
+  router.use('/timers', createTimersRoutes(schedulerService, events));
+
+  return router;
+}

--- a/apps/server/src/routes/ops/routes/timers.ts
+++ b/apps/server/src/routes/ops/routes/timers.ts
@@ -1,0 +1,186 @@
+/**
+ * Timer Registry API routes
+ *
+ * Provides a unified view of all cron tasks and interval timers managed by the
+ * SchedulerService, along with pause/resume controls for individual and bulk operations.
+ *
+ * GET  /              - List all timers (cron + interval)
+ * POST /:id/pause     - Pause a specific cron timer
+ * POST /:id/resume    - Resume a specific cron timer
+ * POST /pause-all     - Pause all cron timers
+ * POST /resume-all    - Resume all cron timers
+ */
+
+import { Router } from 'express';
+import { createLogger } from '@protolabsai/utils';
+
+import type { SchedulerService } from '../../../services/scheduler-service.js';
+import type { EventEmitter } from '../../../lib/events.js';
+
+const logger = createLogger('Routes:Timers');
+
+export function createTimersRoutes(
+  schedulerService: SchedulerService,
+  events: EventEmitter
+): Router {
+  const router = Router();
+
+  // GET / - List all cron + interval timers
+  router.get('/', (_req, res) => {
+    try {
+      const timers = schedulerService.listAll().map((entry) => {
+        if (entry.kind === 'cron') {
+          return {
+            kind: entry.kind,
+            id: entry.id,
+            name: entry.name,
+            cronExpression: entry.cronExpression,
+            enabled: entry.enabled,
+            lastRun: entry.lastRun,
+            nextRun: entry.nextRun,
+            failureCount: entry.failureCount,
+            executionCount: entry.executionCount,
+            lastError: entry.lastError,
+          };
+        }
+        return {
+          kind: entry.kind,
+          id: entry.id,
+          name: entry.name,
+          intervalMs: entry.intervalMs,
+          registeredAt: entry.registeredAt,
+        };
+      });
+
+      res.json({ timers, count: timers.length });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error('Failed to list timers:', error);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  // POST /pause-all - Pause all cron timers (must be before /:id routes)
+  router.post('/pause-all', async (_req, res) => {
+    try {
+      const tasks = schedulerService.getAllTasks();
+      let pausedCount = 0;
+
+      for (const task of tasks) {
+        if (task.enabled) {
+          await schedulerService.disableTask(task.id);
+          pausedCount++;
+        }
+      }
+
+      events.emit('timer:all-paused', {
+        count: pausedCount,
+        timestamp: new Date().toISOString(),
+      });
+
+      logger.info(`Paused ${pausedCount} timers via bulk pause-all`);
+      res.json({ success: true, pausedCount });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error('Failed to pause all timers:', error);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  // POST /resume-all - Resume all cron timers (must be before /:id routes)
+  router.post('/resume-all', async (_req, res) => {
+    try {
+      const tasks = schedulerService.getAllTasks();
+      let resumedCount = 0;
+
+      for (const task of tasks) {
+        if (!task.enabled) {
+          await schedulerService.enableTask(task.id);
+          resumedCount++;
+        }
+      }
+
+      events.emit('timer:all-resumed', {
+        count: resumedCount,
+        timestamp: new Date().toISOString(),
+      });
+
+      logger.info(`Resumed ${resumedCount} timers via bulk resume-all`);
+      res.json({ success: true, resumedCount });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error('Failed to resume all timers:', error);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  // POST /:id/pause - Pause a specific cron timer by ID
+  router.post('/:id/pause', async (req, res) => {
+    try {
+      const id = req.params['id'] as string;
+      const task = schedulerService.getTask(id);
+
+      if (!task) {
+        res.status(404).json({ error: `Timer not found: ${id}` });
+        return;
+      }
+
+      if (!task.enabled) {
+        res.json({ success: true, message: 'Timer is already paused' });
+        return;
+      }
+
+      await schedulerService.disableTask(id);
+
+      events.emit('timer:paused', {
+        timerId: id,
+        timerName: task.name,
+        kind: 'cron',
+        timestamp: new Date().toISOString(),
+      });
+
+      logger.info(`Paused timer "${task.name}" (${id})`);
+      res.json({ success: true, id, name: task.name });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Failed to pause timer ${req.params['id']}:`, error);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  // POST /:id/resume - Resume a specific cron timer by ID
+  router.post('/:id/resume', async (req, res) => {
+    try {
+      const id = req.params['id'] as string;
+      const task = schedulerService.getTask(id);
+
+      if (!task) {
+        res.status(404).json({ error: `Timer not found: ${id}` });
+        return;
+      }
+
+      if (task.enabled) {
+        res.json({ success: true, message: 'Timer is already running' });
+        return;
+      }
+
+      await schedulerService.enableTask(id);
+
+      events.emit('timer:resumed', {
+        timerId: id,
+        timerName: task.name,
+        kind: 'cron',
+        timestamp: new Date().toISOString(),
+      });
+
+      logger.info(`Resumed timer "${task.name}" (${id})`);
+      res.json({ success: true, id, name: task.name });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Failed to resume timer ${req.params['id']}:`, error);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -92,6 +92,7 @@ import { createBackfillLedgerProjectSlugHandler } from '../routes/ledger/routes/
 import { createHivemindRoutes } from '../routes/hivemind/index.js';
 import { createDoraRoutes } from '../routes/dora/index.js';
 import { createAgentRoutes } from '../routes/agents.js';
+import { createOpsRoutes } from '../routes/ops/index.js';
 
 const logger = createLogger('Server:Routes');
 
@@ -156,6 +157,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
     projectPmService,
     crdtSyncService,
     todoService,
+    schedulerService,
   } = services;
 
   // Run stale validation cleanup every hour to prevent memory leaks from crashed validations
@@ -441,6 +443,10 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   // Agent manifest routes (list, get, match)
   app.use('/api/agents', createAgentRoutes(featureLoader));
   logger.info('Agent routes mounted at /api/agents');
+
+  // Ops routes (timer registry, operational controls)
+  app.use('/api/ops', createOpsRoutes(schedulerService, events));
+  logger.info('Ops routes mounted at /api/ops');
 
   // Note: Sentry v8 automatically captures Express errors - no manual error handler needed
 }

--- a/apps/server/tests/unit/routes/ops/timers.test.ts
+++ b/apps/server/tests/unit/routes/ops/timers.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Unit tests for Timer Registry API routes
+ *
+ * Verifies GET /api/ops/timers, POST pause/resume (individual and bulk),
+ * and WebSocket event emission on state changes.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Request, Response } from 'express';
+import { SchedulerService } from '@/services/scheduler-service.js';
+import { createTimersRoutes } from '@/routes/ops/routes/timers.js';
+import { createMockExpressContext } from '../../../utils/mocks.js';
+
+/** Minimal EventEmitter stub that tracks emitted events */
+function makeEvents() {
+  return {
+    emit: vi.fn(),
+    subscribe: vi.fn(),
+    on: vi.fn(),
+    broadcast: vi.fn(),
+  };
+}
+
+/**
+ * Helper: extract the route handler for a given method + path from the Express Router.
+ * Router.stack entries contain { route: { path, methods, stack: [{ handle }] } }.
+ */
+function getHandler(
+  router: ReturnType<typeof createTimersRoutes>,
+  method: 'get' | 'post',
+  path: string
+): (req: Request, res: Response) => Promise<void> | void {
+  const layer = (router as any).stack.find(
+    (l: any) => l.route?.path === path && l.route?.methods?.[method]
+  );
+  if (!layer) {
+    throw new Error(`No ${method.toUpperCase()} handler found for path "${path}"`);
+  }
+  return layer.route.stack[0].handle;
+}
+
+describe('Timer Registry API routes', () => {
+  let scheduler: SchedulerService;
+  let events: ReturnType<typeof makeEvents>;
+  let router: ReturnType<typeof createTimersRoutes>;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    scheduler = new SchedulerService();
+    events = makeEvents();
+    router = createTimersRoutes(scheduler, events as any);
+
+    // Register some test cron tasks
+    await scheduler.registerTask('task-a', 'Task A', '*/5 * * * *', () => {}, true);
+    await scheduler.registerTask('task-b', 'Task B', '0 * * * *', () => {}, true);
+  });
+
+  afterEach(() => {
+    scheduler.destroy();
+    vi.useRealTimers();
+  });
+
+  describe('GET / - list all timers', () => {
+    it('returns cron tasks', () => {
+      const { req, res } = createMockExpressContext();
+      const handler = getHandler(router, 'get', '/');
+
+      handler(req as Request, res as Response);
+
+      const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(payload.timers).toHaveLength(2);
+      expect(payload.count).toBe(2);
+      expect(payload.timers[0].kind).toBe('cron');
+      expect(payload.timers[0].id).toBe('task-a');
+    });
+
+    it('returns interval entries when registered', () => {
+      scheduler.registerInterval('int-1', 'Interval One', 5000, () => {});
+
+      const { req, res } = createMockExpressContext();
+      const handler = getHandler(router, 'get', '/');
+
+      handler(req as Request, res as Response);
+
+      const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(payload.count).toBe(3);
+
+      const intervalEntry = payload.timers.find((t: any) => t.kind === 'interval');
+      expect(intervalEntry).toBeDefined();
+      expect(intervalEntry.id).toBe('int-1');
+      expect(intervalEntry.intervalMs).toBe(5000);
+    });
+  });
+
+  describe('POST /:id/pause - pause a timer', () => {
+    it('pauses an enabled cron timer', async () => {
+      const { req, res } = createMockExpressContext();
+      req.params = { id: 'task-a' };
+      const handler = getHandler(router, 'post', '/:id/pause');
+
+      await handler(req as Request, res as Response);
+
+      const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(payload.success).toBe(true);
+      expect(payload.id).toBe('task-a');
+
+      // Verify the task is actually disabled
+      const task = scheduler.getTask('task-a');
+      expect(task?.enabled).toBe(false);
+
+      // Verify WebSocket event emitted
+      expect(events.emit).toHaveBeenCalledWith(
+        'timer:paused',
+        expect.objectContaining({
+          timerId: 'task-a',
+          timerName: 'Task A',
+          kind: 'cron',
+        })
+      );
+    });
+
+    it('returns success for already-paused timer', async () => {
+      await scheduler.disableTask('task-a');
+
+      const { req, res } = createMockExpressContext();
+      req.params = { id: 'task-a' };
+      const handler = getHandler(router, 'post', '/:id/pause');
+
+      await handler(req as Request, res as Response);
+
+      const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(payload.success).toBe(true);
+      expect(payload.message).toBe('Timer is already paused');
+    });
+
+    it('returns 404 for unknown timer', async () => {
+      const { req, res } = createMockExpressContext();
+      req.params = { id: 'nonexistent' };
+      const handler = getHandler(router, 'post', '/:id/pause');
+
+      await handler(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+
+  describe('POST /:id/resume - resume a timer', () => {
+    it('resumes a paused cron timer', async () => {
+      await scheduler.disableTask('task-b');
+
+      const { req, res } = createMockExpressContext();
+      req.params = { id: 'task-b' };
+      const handler = getHandler(router, 'post', '/:id/resume');
+
+      await handler(req as Request, res as Response);
+
+      const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(payload.success).toBe(true);
+      expect(payload.id).toBe('task-b');
+
+      // Verify the task is actually enabled
+      const task = scheduler.getTask('task-b');
+      expect(task?.enabled).toBe(true);
+
+      // Verify WebSocket event emitted
+      expect(events.emit).toHaveBeenCalledWith(
+        'timer:resumed',
+        expect.objectContaining({
+          timerId: 'task-b',
+          timerName: 'Task B',
+          kind: 'cron',
+        })
+      );
+    });
+
+    it('returns success for already-running timer', async () => {
+      const { req, res } = createMockExpressContext();
+      req.params = { id: 'task-a' };
+      const handler = getHandler(router, 'post', '/:id/resume');
+
+      await handler(req as Request, res as Response);
+
+      const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(payload.success).toBe(true);
+      expect(payload.message).toBe('Timer is already running');
+    });
+
+    it('returns 404 for unknown timer', async () => {
+      const { req, res } = createMockExpressContext();
+      req.params = { id: 'nonexistent' };
+      const handler = getHandler(router, 'post', '/:id/resume');
+
+      await handler(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+
+  describe('POST /pause-all - bulk pause', () => {
+    it('pauses all enabled cron timers', async () => {
+      const { req, res } = createMockExpressContext();
+      const handler = getHandler(router, 'post', '/pause-all');
+
+      await handler(req as Request, res as Response);
+
+      const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(payload.success).toBe(true);
+      expect(payload.pausedCount).toBe(2);
+
+      // Both tasks should be disabled
+      expect(scheduler.getTask('task-a')?.enabled).toBe(false);
+      expect(scheduler.getTask('task-b')?.enabled).toBe(false);
+
+      // Verify WebSocket event emitted
+      expect(events.emit).toHaveBeenCalledWith(
+        'timer:all-paused',
+        expect.objectContaining({ count: 2 })
+      );
+    });
+
+    it('reports zero when all timers are already paused', async () => {
+      await scheduler.disableTask('task-a');
+      await scheduler.disableTask('task-b');
+
+      const { req, res } = createMockExpressContext();
+      const handler = getHandler(router, 'post', '/pause-all');
+
+      await handler(req as Request, res as Response);
+
+      const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(payload.pausedCount).toBe(0);
+    });
+  });
+
+  describe('POST /resume-all - bulk resume', () => {
+    it('resumes all paused cron timers', async () => {
+      await scheduler.disableTask('task-a');
+      await scheduler.disableTask('task-b');
+
+      const { req, res } = createMockExpressContext();
+      const handler = getHandler(router, 'post', '/resume-all');
+
+      await handler(req as Request, res as Response);
+
+      const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(payload.success).toBe(true);
+      expect(payload.resumedCount).toBe(2);
+
+      // Both tasks should be enabled
+      expect(scheduler.getTask('task-a')?.enabled).toBe(true);
+      expect(scheduler.getTask('task-b')?.enabled).toBe(true);
+
+      // Verify WebSocket event emitted
+      expect(events.emit).toHaveBeenCalledWith(
+        'timer:all-resumed',
+        expect.objectContaining({ count: 2 })
+      );
+    });
+
+    it('reports zero when all timers are already running', async () => {
+      const { req, res } = createMockExpressContext();
+      const handler = getHandler(router, 'post', '/resume-all');
+
+      await handler(req as Request, res as Response);
+
+      const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(payload.resumedCount).toBe(0);
+    });
+  });
+});

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -79,6 +79,11 @@ export type EventType =
   | 'scheduler:task-failed'
   | 'scheduler:interval_registered'
   | 'scheduler:interval_unregistered'
+  // Timer registry events (pause/resume individual and bulk timers)
+  | 'timer:paused'
+  | 'timer:resumed'
+  | 'timer:all-paused'
+  | 'timer:all-resumed'
   | 'maintenance'
   | 'recovery_analysis'
   | 'recovery_started'
@@ -848,6 +853,28 @@ export interface EventPayloadMap {
     approvalId: string;
     approved: boolean;
     message?: string;
+  };
+
+  // Timer registry events (pause/resume individual and bulk timers)
+  'timer:paused': {
+    timerId: string;
+    timerName: string;
+    kind: 'cron' | 'interval';
+    timestamp: string;
+  };
+  'timer:resumed': {
+    timerId: string;
+    timerName: string;
+    kind: 'cron' | 'interval';
+    timestamp: string;
+  };
+  'timer:all-paused': {
+    count: number;
+    timestamp: string;
+  };
+  'timer:all-resumed': {
+    count: number;
+    timestamp: string;
   };
 
   // Ava Channel events (private multi-instance coordination channel)

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1524,7 +1524,7 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
 
     // Scheduler Management
     case 'get_scheduler_status':
-      return apiCall('/scheduler/status', {}, 'GET');
+      return apiCall('/ops/timers', {}, 'GET');
 
     case 'update_maintenance_task': {
       const taskId = args.taskId as string;
@@ -1541,10 +1541,10 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         }
       }
 
-      // Enable/disable if provided
+      // Enable/disable if provided (maps to resume/pause on the timer registry)
       if (args.enabled !== undefined) {
-        const endpoint = args.enabled ? 'enable' : 'disable';
-        const toggleResult = (await apiCall(`/scheduler/tasks/${taskId}/${endpoint}`, {})) as {
+        const endpoint = args.enabled ? 'resume' : 'pause';
+        const toggleResult = (await apiCall(`/ops/timers/${taskId}/${endpoint}`, {})) as {
           success?: boolean;
         };
         results.enabledUpdated = toggleResult.success;

--- a/packages/mcp-server/src/tools/scheduler-tools.ts
+++ b/packages/mcp-server/src/tools/scheduler-tools.ts
@@ -8,7 +8,7 @@ export const schedulerTools: Tool[] = [
   {
     name: 'get_scheduler_status',
     description:
-      'Get the status of all scheduled maintenance tasks including their schedules, enable/disable state, execution counts, and next run times.',
+      'Get the status of all scheduled timers (cron tasks and managed intervals) including their schedules, enable/disable state, execution counts, and next run times.',
     inputSchema: {
       type: 'object',
       properties: {},


### PR DESCRIPTION
## Summary

**Milestone:** Timer Registry Foundation

Add API routes: GET /api/ops/timers (list all), POST /api/ops/timers/:id/pause, POST /api/ops/timers/:id/resume, POST /api/ops/timers/pause-all, POST /api/ops/timers/resume-all. Update MCP tools to include interval tasks. Add WebSocket events for timer state changes.

**Files to Modify:**
- apps/server/src/routes/ops/index.ts
- apps/server/src/routes/ops/routes/timers.ts
- packages/mcp-server/src/tools/scheduler-tools.ts
- libs/types/src/event.ts

**Acce...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-15T22:51:53.122Z -->