### PR TITLE
Update docs after: Unified Operations Control Plane

### DIFF
--- a/docs/internal/server/automation-registry.md
+++ b/docs/internal/server/automation-registry.md
@@ -112,6 +112,173 @@ The `schedulerSettings` field lives inside `data/settings.json` under the top-le
 }
 ```
 
+## Timer Registry
+
+The Timer Registry is a unified view of all managed timers in the server — both cron-based scheduled tasks and interval-based polling timers. It is provided by `SchedulerService` and exposed via `/api/ops/timers`.
+
+### What It Tracks
+
+Before the Timer Registry, interval timers (used by monitoring services like `HealthMonitorService`, `GitHubMonitor`, and `LeadEngineerService`) were invisible — they existed only as raw `setInterval` handles with no observability. The Timer Registry makes all running timers inspectable from a single endpoint.
+
+| Timer type | Example consumers                                                                                                             | Schedule type              |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `cron`     | All maintenance tasks (e.g. `maintenance:auto-merge-prs`)                                                                     | 5-field cron expression    |
+| `interval` | `HealthMonitorService`, `DiscordMonitor`, `GitHubMonitor`, `LeadEngineerService`, `PRWatcherService`, `SpecGenerationMonitor` | Fixed millisecond interval |
+
+### SchedulerService — Timer Registry Methods
+
+In addition to the cron task methods documented above, `SchedulerService` exposes:
+
+```typescript
+// Register a managed setInterval under a named id.
+// If an interval with the same id already exists, it is replaced.
+registerInterval(id: string, name: string, intervalMs: number, handler: () => Promise<void> | void): void
+
+// Remove a managed interval registered via registerInterval().
+// Returns true if found and removed, false otherwise.
+unregisterInterval(id: string): boolean
+
+// Returns all timers — both cron tasks and interval entries — as a unified list.
+listAll(): TimerEntry[]
+
+// Get a specific cron task by id.
+getTask(id: string): ScheduledTask | undefined
+
+// Get all cron tasks.
+getAllTasks(): ScheduledTask[]
+```
+
+### Registering Services
+
+Monitoring services opt in to the Timer Registry by accepting an optional `SchedulerService` dependency via `setSchedulerService()`. When wired in, the service's `registerInterval()` calls route through `SchedulerService` instead of raw `setInterval`:
+
+```typescript
+// In scheduler.module.ts — wired at startup
+healthMonitorService.setSchedulerService(schedulerService);
+specGenerationMonitor.setSchedulerService(schedulerService);
+prWatcherService.setSchedulerService(schedulerService);
+leadEngineerService.setSchedulerService(schedulerService);
+githubMonitor.setSchedulerService(schedulerService);
+discordMonitor.setSchedulerService(schedulerService);
+```
+
+If `schedulerService` is unavailable (e.g. in unit tests), services fall back to raw `setInterval` — no behavioral change, just no centralized tracking.
+
+### Interval Timer IDs
+
+| Service                 | Timer ID pattern                                                                | Purpose                                  |
+| ----------------------- | ------------------------------------------------------------------------------- | ---------------------------------------- |
+| `HealthMonitorService`  | `health-monitor:*`                                                              | Server health polling                    |
+| `SpecGenerationMonitor` | `spec-generation-monitor:*`                                                     | Spec generation polling                  |
+| `PRWatcherService`      | `pr-watcher:*`                                                                  | PR status polling                        |
+| `GitHubMonitor`         | `github-monitor:poll`                                                           | GitHub PR label polling                  |
+| `DiscordMonitor`        | `discord-monitor:channel:{channelId}`                                           | Discord channel polling                  |
+| `LeadEngineerService`   | `lead-engineer:{projectPath}:refresh`, `lead-engineer:{projectPath}:supervisor` | Per-project refresh and supervisor loops |
+
+### TypeScript Types
+
+Defined in `libs/types/src/scheduler.ts`:
+
+```typescript
+export type TimerCategory = 'maintenance' | 'health' | 'monitor' | 'sync' | 'system';
+export type TimerType = 'cron' | 'interval';
+
+export interface TimerRegistryEntry {
+  id: string;
+  name: string;
+  type: TimerType;
+  intervalMs?: number; // set for type === 'interval'
+  expression?: string; // set for type === 'cron'
+  enabled: boolean;
+  lastRun?: string; // ISO timestamp
+  nextRun?: string; // ISO timestamp (cron only)
+  duration?: number; // last execution duration in ms
+  failureCount: number;
+  executionCount: number;
+  category: TimerCategory;
+}
+
+export interface TimerRegistryMetrics {
+  totalTimers: number;
+  enabledTimers: number;
+  pausedTimers: number;
+  totalExecutions: number;
+  totalFailures: number;
+  byCategory: Record<TimerCategory, number>;
+  byType: Record<TimerType, number>;
+}
+```
+
+### Timer Registry REST API
+
+Base path: `/api/ops/timers`
+
+All requests require the standard `X-API-Key` header.
+
+| Method | Path          | Description                       |
+| ------ | ------------- | --------------------------------- |
+| `GET`  | `/`           | List all timers (cron + interval) |
+| `POST` | `/:id/pause`  | Pause a specific cron timer       |
+| `POST` | `/:id/resume` | Resume a specific cron timer      |
+| `POST` | `/pause-all`  | Pause all enabled cron timers     |
+| `POST` | `/resume-all` | Resume all paused cron timers     |
+
+#### GET /api/ops/timers
+
+Returns a unified list of all cron tasks and interval timers.
+
+```json
+{
+  "timers": [
+    {
+      "kind": "cron",
+      "id": "maintenance:auto-merge-prs",
+      "name": "Auto-Merge Eligible PRs",
+      "enabled": true,
+      "cronExpression": "*/5 * * * *",
+      "nextRun": "2026-03-15T18:10:00.000Z",
+      "lastRun": "2026-03-15T18:05:01.234Z",
+      "executionCount": 312,
+      "failureCount": 0
+    },
+    {
+      "kind": "interval",
+      "id": "github-monitor:poll",
+      "name": "GitHub PR Monitor",
+      "intervalMs": 60000,
+      "registeredAt": "2026-03-15T17:00:00.000Z"
+    }
+  ],
+  "count": 2
+}
+```
+
+#### POST /api/ops/timers/:id/pause
+
+Pauses a cron task by ID. If the task is already paused, returns `{ success: true, message: "Timer is already paused" }` without error. Interval timers cannot be paused via this endpoint — they must be stopped by their owning service.
+
+#### POST /api/ops/timers/pause-all and /resume-all
+
+Bulk pause/resume all cron tasks. Returns `{ success: true, pausedCount: N }` or `{ success: true, resumedCount: N }`.
+
+### Timer Events
+
+The timer routes emit events on every state change:
+
+| Event               | When emitted            | Payload                                   |
+| ------------------- | ----------------------- | ----------------------------------------- |
+| `timer:paused`      | A cron timer is paused  | `{ timerId, timerName, kind, timestamp }` |
+| `timer:resumed`     | A cron timer is resumed | `{ timerId, timerName, kind, timestamp }` |
+| `timer:all-paused`  | Bulk pause completes    | `{ count, timestamp }`                    |
+| `timer:all-resumed` | Bulk resume completes   | `{ count, timestamp }`                    |
+
+These events are broadcast to WebSocket clients, allowing the UI to react to timer state changes in real time.
+
+**Route handler files:**
+
+- `apps/server/src/routes/ops/index.ts`
+- `apps/server/src/routes/ops/routes/timers.ts`
+
 ## UI
 
 The automations control plane is located at **Settings > System > Automations**. It has two sections:
@@ -452,19 +619,22 @@ The `modelConfig` object comes from the automation definition and is passed thro
 
 ## Key Files
 
-| File                                                                               | Purpose                                     |
-| ---------------------------------------------------------------------------------- | ------------------------------------------- |
-| `apps/server/src/services/automation-service.ts`                                   | CRUD layer, flow registry, automation sync  |
-| `apps/server/src/services/scheduler-service.ts`                                    | Cron engine, task execution, event emission |
-| `apps/server/src/services/maintenance-tasks.ts`                                    | Built-in task handler functions             |
-| `apps/server/src/services/scheduler.module.ts`                                     | Startup wiring and settings injection       |
-| `apps/server/src/routes/automations/`                                              | REST API route handlers                     |
-| `apps/server/src/routes/automations/routes/scheduler-status.ts`                    | Scheduler status endpoint handler           |
-| `apps/server/src/server/websockets.ts`                                             | WebSocket broadcast + Discord routing       |
-| `apps/ui/src/hooks/use-scheduler-status.ts`                                        | Scheduler status polling hook (30s)         |
-| `apps/ui/src/components/views/settings-view/automations/`                          | UI components (table, modal, history, grid) |
-| `apps/ui/src/components/views/settings-view/automations/scheduler-health-grid.tsx` | Health grid component                       |
-| `packages/mcp-server/src/tools/scheduler-tools.ts`                                 | MCP tool definitions                        |
-| `libs/types/src/automation.ts`                                                     | TypeScript types                            |
-| `libs/types/src/global-settings.ts`                                                | SchedulerSettings interface                 |
-| `libs/types/src/event.ts`                                                          | scheduler:task-failed EventType             |
+| File                                                                               | Purpose                                                         |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `apps/server/src/services/automation-service.ts`                                   | CRUD layer, flow registry, automation sync                      |
+| `apps/server/src/services/scheduler-service.ts`                                    | Cron engine, task execution, event emission                     |
+| `apps/server/src/services/maintenance-tasks.ts`                                    | Built-in task handler functions                                 |
+| `apps/server/src/services/scheduler.module.ts`                                     | Startup wiring and settings injection                           |
+| `apps/server/src/routes/automations/`                                              | REST API route handlers                                         |
+| `apps/server/src/routes/automations/routes/scheduler-status.ts`                    | Scheduler status endpoint handler                               |
+| `apps/server/src/server/websockets.ts`                                             | WebSocket broadcast + Discord routing                           |
+| `apps/ui/src/hooks/use-scheduler-status.ts`                                        | Scheduler status polling hook (30s)                             |
+| `apps/ui/src/components/views/settings-view/automations/`                          | UI components (table, modal, history, grid)                     |
+| `apps/ui/src/components/views/settings-view/automations/scheduler-health-grid.tsx` | Health grid component                                           |
+| `packages/mcp-server/src/tools/scheduler-tools.ts`                                 | MCP tool definitions                                            |
+| `libs/types/src/automation.ts`                                                     | TypeScript types                                                |
+| `libs/types/src/scheduler.ts`                                                      | Timer Registry types (TimerRegistryEntry, TimerRegistryMetrics) |
+| `apps/server/src/routes/ops/index.ts`                                              | Ops route module                                                |
+| `apps/server/src/routes/ops/routes/timers.ts`                                      | Timer Registry REST endpoints                                   |
+| `libs/types/src/global-settings.ts`                                                | SchedulerSettings interface                                     |
+| `libs/types/src/event.ts`                                                          | scheduler:task-failed EventType                                 |

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -283,10 +283,10 @@ Manages calendar events across custom, feature, milestone, and Google sources. T
 
 ## Scheduler (2 tools)
 
-| Tool                      | Description                           |
-| ------------------------- | ------------------------------------- |
-| `get_scheduler_status`    | Get scheduler status and active tasks |
-| `update_maintenance_task` | Update a scheduled maintenance task   |
+| Tool                      | Description                                                                                                                                           |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `get_scheduler_status`    | Get status of all scheduled timers (cron tasks and managed intervals) including schedules, enable/disable state, execution counts, and next run times |
+| `update_maintenance_task` | Update a scheduled maintenance task                                                                                                                   |
 
 ## Reports (2 tools)
 


### PR DESCRIPTION
## Summary

65 doc-relevant files changed recently.

Changed files requiring docs review:
- .automaker/memory/api.md
- .automaker/memory/architecture.md
- .automaker/memory/design.md
- .automaker/memory/documentation.md
- .automaker/memory/gotcha.md
- .automaker/memory/gotchas.md
- .automaker/memory/gtm-signal-intelligence-project.md
- .automaker/memory/testing.md
- .automaker/projects/design-system-platform-starter-kit/CHANGELOG-08-mcp-server-monorepo-skeleton.md
- .automaker/projects/design-system-platfor...

---
*Recovered automatically by Automaker post-agent hook*