### PR TITLE
Add QA Wiring panel to Ops Dashboard

### DIFF
--- a/apps/ui/src/components/views/ops-view/ops-view.tsx
+++ b/apps/ui/src/components/views/ops-view/ops-view.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useState } from 'react';
-import { Settings2, Timer, Webhook, Server, Activity, Rocket } from 'lucide-react';
+import { Settings2, Timer, Webhook, Server, Activity, Rocket, Unplug } from 'lucide-react';
 import { PanelHeader } from '@/components/shared/panel-header';
 import { cn } from '@/lib/utils';
 import { TimerPanel } from './timer-panel';
@@ -17,12 +17,13 @@ import { EventFlowPanel } from './event-flow-panel';
 import { MaintenancePanel } from './maintenance-panel';
 import { SystemHealthPanel } from './system-health-panel';
 import { DeploymentPanel } from './deployment-panel';
+import { WiringPanel } from './wiring-panel';
 
 // ============================================================================
 // Types
 // ============================================================================
 
-type OpsTab = 'timers' | 'events' | 'maintenance' | 'system' | 'deployments';
+type OpsTab = 'timers' | 'events' | 'maintenance' | 'system' | 'deployments' | 'wiring';
 
 interface TabDefinition {
   id: OpsTab;
@@ -40,6 +41,7 @@ const TABS: TabDefinition[] = [
   { id: 'maintenance', label: 'Maintenance', icon: Server },
   { id: 'system', label: 'System', icon: Activity },
   { id: 'deployments', label: 'Deploys', icon: Rocket },
+  { id: 'wiring', label: 'Wiring', icon: Unplug },
 ];
 
 // ============================================================================
@@ -102,6 +104,7 @@ export function OpsView() {
         {activeTab === 'maintenance' && <MaintenancePanel />}
         {activeTab === 'system' && <SystemHealthPanel />}
         {activeTab === 'deployments' && <DeploymentPanel />}
+        {activeTab === 'wiring' && <WiringPanel />}
       </div>
     </div>
   );

--- a/apps/ui/src/components/views/ops-view/wiring-panel.tsx
+++ b/apps/ui/src/components/views/ops-view/wiring-panel.tsx
@@ -1,0 +1,184 @@
+/**
+ * Wiring Panel
+ *
+ * Displays service instantiation status from the QA check endpoint.
+ * Shows a grid of service cards with green/red wired indicators,
+ * a wiring summary, and timer counts.
+ */
+
+import { CheckCircle2, XCircle, Unplug } from 'lucide-react';
+import { useAppStore } from '@/store/app-store';
+import { useQaCheck } from '@/hooks/queries/use-metrics';
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+interface ServiceCardProps {
+  name: string;
+  wired: boolean;
+}
+
+function ServiceCard({ name, wired }: ServiceCardProps) {
+  return (
+    <div
+      className={`flex items-center gap-2 rounded-lg border px-3 py-2 ${
+        wired ? 'border-border/50 bg-card' : 'border-destructive/40 bg-destructive/5'
+      }`}
+    >
+      {wired ? (
+        <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-500" />
+      ) : (
+        <XCircle className="h-3.5 w-3.5 shrink-0 text-destructive" />
+      )}
+      <span
+        className={`text-xs font-mono truncate ${
+          wired ? 'text-foreground-secondary' : 'text-destructive font-medium'
+        }`}
+      >
+        {name}
+      </span>
+    </div>
+  );
+}
+
+interface StatCardProps {
+  label: string;
+  value: string | number;
+  sub?: string;
+}
+
+function StatCard({ label, value, sub }: StatCardProps) {
+  return (
+    <div className="rounded-lg border border-border/50 bg-card px-4 py-3 flex flex-col gap-0.5">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="text-lg font-semibold tabular-nums">{value}</span>
+      {sub && <span className="text-xs text-muted-foreground">{sub}</span>}
+    </div>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export function WiringPanel() {
+  const projectPath = useAppStore((s) => s.currentProject?.path);
+  const { data, isLoading, error } = useQaCheck(projectPath);
+
+  if (!projectPath) {
+    return (
+      <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+        No project selected
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+        Loading wiring status...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center h-48 text-destructive text-sm">
+        Failed to load wiring status: {(error as Error).message}
+      </div>
+    );
+  }
+
+  const report = data?.report;
+  if (!report) {
+    return (
+      <div className="flex flex-col items-center justify-center h-48 text-muted-foreground gap-2">
+        <Unplug className="h-8 w-8 opacity-50" />
+        <p className="text-sm">No QA data available</p>
+      </div>
+    );
+  }
+
+  const { wiring, timers } = report;
+  const wiredCount = wiring.services.filter((s) => s.wired).length;
+  const totalCount = wiring.totalServices;
+  const allWired = wiredCount === totalCount;
+  const missingCount = totalCount - wiredCount;
+
+  const summaryLabel = allWired
+    ? `${wiredCount}/${totalCount} services wired`
+    : `${wiredCount}/${totalCount} — ${missingCount} missing`;
+
+  return (
+    <div className="space-y-5">
+      {/* Summary Cards */}
+      <div className="grid grid-cols-4 gap-3">
+        <StatCard
+          label="Wiring"
+          value={summaryLabel}
+          sub={allWired ? 'All services wired' : `${missingCount} service(s) not wired`}
+        />
+        <StatCard
+          label="Timers"
+          value={timers.total}
+          sub={`${timers.running} running / ${timers.paused} paused`}
+        />
+        <StatCard label="Signal Timers" value={timers.signalTimers.length} />
+        <StatCard label="Health Timers" value={timers.healthTimers.length} />
+      </div>
+
+      {/* Service Grid */}
+      <div>
+        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+          Service Wiring ({wiredCount}/{totalCount})
+        </h3>
+        <div className="grid grid-cols-2 gap-2">
+          {wiring.services.map((service) => (
+            <ServiceCard key={service.name} name={service.name} wired={service.wired} />
+          ))}
+        </div>
+      </div>
+
+      {/* Timer Detail */}
+      {(timers.signalTimers.length > 0 || timers.healthTimers.length > 0) && (
+        <div className="grid grid-cols-2 gap-4">
+          {timers.signalTimers.length > 0 && (
+            <div>
+              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+                Signal Timers
+              </h3>
+              <div className="space-y-1">
+                {timers.signalTimers.map((id) => (
+                  <div
+                    key={id}
+                    className="text-xs font-mono text-foreground-secondary px-2 py-1 rounded bg-muted/40"
+                  >
+                    {id}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          {timers.healthTimers.length > 0 && (
+            <div>
+              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+                Health Timers
+              </h3>
+              <div className="space-y-1">
+                {timers.healthTimers.map((id) => (
+                  <div
+                    key={id}
+                    className="text-xs font-mono text-foreground-secondary px-2 py-1 rounded bg-muted/40"
+                  >
+                    {id}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/hooks/queries/use-metrics.ts
+++ b/apps/ui/src/hooks/queries/use-metrics.ts
@@ -489,6 +489,27 @@ export function useActivityFeed(projectPath?: string, limit: number = 50) {
   });
 }
 
+const QA_CHECK_STALE_TIME = 30 * 1000; // 30 seconds
+
+/**
+ * Fetch consolidated QA check report (service wiring, timers, board state, signals).
+ * Uses GET /api/qa/check.
+ */
+export function useQaCheck(projectPath: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.qa.check(projectPath ?? ''),
+    queryFn: async () => {
+      if (!projectPath) throw new Error('No project path');
+      const api = getHttpApiClient();
+      return api.qa.check(projectPath);
+    },
+    enabled: !!projectPath,
+    staleTime: QA_CHECK_STALE_TIME,
+    refetchInterval: QA_CHECK_STALE_TIME,
+    refetchOnWindowFocus: false,
+  });
+}
+
 const DEPLOYMENTS_STALE_TIME = 60 * 1000; // 1 minute
 
 /**

--- a/apps/ui/src/lib/clients/system-client.ts
+++ b/apps/ui/src/lib/clients/system-client.ts
@@ -253,6 +253,60 @@ export const withSystemClient = <TBase extends Constructor<BaseHttpClient>>(Base
         }),
     };
 
+    // QA Check API
+    qa = {
+      check: (projectPath: string) =>
+        this.get<{
+          success: boolean;
+          report: {
+            timestamp: string;
+            projectPath: string;
+            health: { status: string; version: string; uptimeMs: number; memoryUsageMb: number };
+            wiring: {
+              totalServices: number;
+              services: Array<{ name: string; wired: boolean }>;
+            };
+            timers: {
+              total: number;
+              running: number;
+              paused: number;
+              signalTimers: string[];
+              healthTimers: string[];
+            };
+            deployments: {
+              total: number;
+              recentCount: number;
+              successRate: number;
+              lastDeploy: {
+                environment: string;
+                status: string;
+                timestamp: string;
+              } | null;
+            };
+            dora: {
+              deploymentFrequency: number;
+              changeFailureRate: number;
+              leadTime: number;
+              recoveryTime: number;
+            } | null;
+            board: {
+              total: number;
+              backlog: number;
+              inProgress: number;
+              review: number;
+              blocked: number;
+              done: number;
+            };
+            signals: {
+              totalPending: number;
+              exceptions: number;
+              decisions: number;
+              signalItems: number;
+            };
+          };
+        }>(`/api/qa/check?projectPath=${encodeURIComponent(projectPath)}`),
+    };
+
     // System API
     system = {
       healthDashboard: (projectPath?: string) =>

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -383,6 +383,14 @@ export const queryKeys = {
     feed: (projectPath?: string, limit?: number) =>
       ['activity', 'feed', projectPath, limit] as const,
   },
+
+  // ============================================
+  // QA Check
+  // ============================================
+  qa: {
+    /** Consolidated QA check report (wiring, timers, board, signals) */
+    check: (projectPath: string) => ['qa', 'check', projectPath] as const,
+  },
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Add a "Wiring" tab to the Ops Dashboard that displays service instantiation status from the QA check endpoint.

## What to build

1. **New `wiring-panel.tsx`** in `apps/ui/src/components/views/ops-view/`
   - Fetches from the QA check route via system client (GET method, qa/check path)
   - Displays a grid of service cards showing name + wired status (green/red indicator)
   - Shows summary: "20/20 services wired" or "18/20 — 2 missing"
   - Include the timer section: total timers, running/pause...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-16T19:00:15.301Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new Wiring tab in the Ops view displaying QA wiring status
  * Shows individual service wiring states (wired/unwired) and related metrics including timers and health information
  * Includes summary statistics and detailed service-level insights

<!-- end of auto-generated comment: release notes by coderabbit.ai -->