### PR TITLE
Bug: Auto-mode ignores assignee field, picks up human-assigned features

### DIFF
--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -861,6 +861,14 @@ export class FeatureScheduler {
             continue;
           }
 
+          // Skip features assigned to a human — only undefined, null, or "agent" are eligible
+          if (feature.assignee && feature.assignee !== 'agent') {
+            logger.info(
+              `[loadPendingFeatures] Skipping feature ${feature.id} — assigned to human: "${feature.assignee}"`
+            );
+            continue;
+          }
+
           // Creation cooldown: skip features created too recently to allow the creator time
           // to set dependencies, adjust properties, or batch-create related features.
           if (feature.createdAt) {

--- a/apps/server/tests/unit/services/scheduler-loop.test.ts
+++ b/apps/server/tests/unit/services/scheduler-loop.test.ts
@@ -772,3 +772,110 @@ describe('FeatureScheduler - project affinity filtering', () => {
     expect(ownIdx).toBeLessThan(overflowIdx);
   });
 });
+
+// ─── FeatureScheduler - human assignee filtering ─────────────────────────────
+
+describe('FeatureScheduler - human assignee filtering', () => {
+  let scheduler: FeatureScheduler;
+  const mockFeatureLoader = {
+    update: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn(),
+    getAll: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+  };
+  const mockEvents = {
+    subscribe: vi.fn(),
+    emit: vi.fn(),
+    on: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+    broadcast: vi.fn(),
+  };
+  const mockRunner: PipelineRunner = { run: vi.fn() };
+  const mockCallbacks: SchedulerCallbacks = {
+    getRunningCountForWorktree: vi.fn().mockResolvedValue(0),
+    hasInProgressFeatures: vi.fn().mockResolvedValue(false),
+    isFeatureRunning: vi.fn().mockReturnValue(false),
+    isFeatureFinished: vi.fn().mockReturnValue(false),
+    emitAutoModeEvent: vi.fn(),
+    getHeapUsagePercent: vi.fn().mockReturnValue(0),
+    getMostRecentRunningFeature: vi.fn().mockReturnValue(null),
+    recordSuccessForProject: vi.fn(),
+    trackFailureAndCheckPauseForProject: vi.fn().mockReturnValue(false),
+    signalShouldPauseForProject: vi.fn(),
+    sleep: vi.fn().mockResolvedValue(undefined),
+    HEAP_USAGE_STOP_NEW_AGENTS_THRESHOLD: 85,
+    HEAP_USAGE_ABORT_AGENTS_THRESHOLD: 92,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetFeaturesDir.mockReturnValue('/fake/project/.automaker/features');
+    mockEvents.on.mockReturnValue({ unsubscribe: vi.fn() });
+    mockFeatureLoader.update.mockResolvedValue(undefined);
+    scheduler = new FeatureScheduler({
+      featureLoader: mockFeatureLoader as never,
+      settingsService: null,
+      events: mockEvents as never,
+      runner: mockRunner,
+      callbacks: mockCallbacks,
+    });
+  });
+
+  it('skips a feature assigned to a human (e.g. "josh")', async () => {
+    const humanAssigned = makeFeature({ id: 'feat-human', assignee: 'josh' });
+    const unassigned = makeFeature({ id: 'feat-unassigned' });
+
+    setupDefaultExecMocks();
+    setupFeaturesOnDisk([humanAssigned, unassigned]);
+
+    const result = await scheduler.loadPendingFeatures('/fake/project');
+    const ids = result.map((f) => f.id);
+
+    expect(ids).not.toContain('feat-human');
+    expect(ids).toContain('feat-unassigned');
+  });
+
+  it('picks up a feature with assignee set to "agent"', async () => {
+    const agentAssigned = makeFeature({ id: 'feat-agent', assignee: 'agent' });
+
+    setupDefaultExecMocks();
+    setupFeaturesOnDisk([agentAssigned]);
+
+    const result = await scheduler.loadPendingFeatures('/fake/project');
+    const ids = result.map((f) => f.id);
+
+    expect(ids).toContain('feat-agent');
+  });
+
+  it('picks up a feature with no assignee (undefined)', async () => {
+    const noAssignee = makeFeature({ id: 'feat-noassignee' });
+    // Confirm no assignee field is set
+    expect(noAssignee.assignee).toBeUndefined();
+
+    setupDefaultExecMocks();
+    setupFeaturesOnDisk([noAssignee]);
+
+    const result = await scheduler.loadPendingFeatures('/fake/project');
+    const ids = result.map((f) => f.id);
+
+    expect(ids).toContain('feat-noassignee');
+  });
+
+  it('skips all human-assigned features and returns only eligible ones', async () => {
+    const josh = makeFeature({ id: 'feat-josh', assignee: 'josh' });
+    const matt = makeFeature({ id: 'feat-matt', assignee: 'matt' });
+    const agentPick = makeFeature({ id: 'feat-agent', assignee: 'agent' });
+    const unassigned = makeFeature({ id: 'feat-unassigned' });
+
+    setupDefaultExecMocks();
+    setupFeaturesOnDisk([josh, matt, agentPick, unassigned]);
+
+    const result = await scheduler.loadPendingFeatures('/fake/project');
+    const ids = result.map((f) => f.id);
+
+    expect(ids).not.toContain('feat-josh');
+    expect(ids).not.toContain('feat-matt');
+    expect(ids).toContain('feat-agent');
+    expect(ids).toContain('feat-unassigned');
+  });
+});

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -253,6 +253,14 @@ export interface Feature {
    */
   lastSessionId?: string;
   /**
+   * Human or agent assignee for this feature.
+   * If set to a human name (any string other than "agent"), auto-mode will skip this feature.
+   * Only features with `assignee: undefined`, `assignee: null`, or `assignee: "agent"` are
+   * eligible for automatic agent pickup.
+   * Example: `assignee: "josh"` → auto-mode skips; `assignee: "agent"` → auto-mode picks up.
+   */
+  assignee?: string;
+  /**
    * Assigned agent role (for headsdown agents)
    * Determines which specialized agent should work on this feature.
    */


### PR DESCRIPTION
## Summary

Auto-mode picks up features assigned to a human (e.g., `assignee: "josh"`) instead of skipping them. The `assignee` field is documented as: "If set to a human name, auto-mode will skip this feature."

Observed: Feature `feature-1773466156202-zasmzdevz` was explicitly assigned to "josh" via `update_feature({ assignee: "josh" })` and moved to backlog. Auto-mode immediately re-launched an agent for it, ignoring the assignee filter. This happened 5+ times in a single session, wasting API budget and ...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-03-16T20:37:33.743Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced assignee field for features, enabling human assignment designation.
  * Human-assigned features are now automatically excluded from auto-scheduling; only unassigned features or those assigned to "agent" remain eligible.

* **Tests**
  * Added test suite verifying correct filtering of human-assigned features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->