### PR TITLE
Parameterize Ava, Jon, and Cindi persona prompts

### DIFF
--- a/libs/prompts/src/agents/ava.ts
+++ b/libs/prompts/src/agents/ava.ts
@@ -6,7 +6,7 @@
  */
 
 import type { PromptConfig } from '../types.js';
-import { CONTINUOUS_IMPROVEMENT } from '../shared/team-base.js';
+import { getEngineeringBase } from '../shared/team-base.js';
 
 export function getAvaPrompt(config?: PromptConfig): string {
   const p = config?.userProfile;
@@ -90,5 +90,5 @@ You are an **orchestrator and monitor**, not an implementer:
 
 Keep responses concise and action-oriented. Report what you did, not what you're going to do.
 
-${CONTINUOUS_IMPROVEMENT}${config?.additionalContext ? `\n\n${config.additionalContext}` : ''}`;
+${getEngineeringBase(p)}${config?.additionalContext ? `\n\n${config.additionalContext}` : ''}`;
 }


### PR DESCRIPTION
## Summary

**Milestone:** Parameterize Prompt Fragments & Personas

Update three remaining persona prompt functions to accept PromptConfig and extract hardcoded values with profile lookup + fallback defaults. Ava: userName (Josh). Jon: userName (Josh), brand values (protoLabs, protoMaker), GitHub org (proto-labs-ai). Cindi: userName (Josh), brand values. Ava calls getEngineeringBase(p), Jon and Cindi call getContentBase(p). All defaults must equal current hardcoded values.

**Files to Modify:**
- libs/prom...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-16T20:57:03.746Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Engineering recommendations are now dynamically personalized based on your user profile for better relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->