### PR TITLE
[linear] Feature Request: Plugin format should support shipping hooks

### DIFF
--- a/.automaker/skills/plugin-management.md
+++ b/.automaker/skills/plugin-management.md
@@ -25,38 +25,45 @@ claude plugin install protolabs
 # Update (picks up new tools, commands)
 claude plugin update protolabs
 
-# Full reinstall (required after hooks.json changes)
+# Full reinstall (required after plugin.json hooks changes)
 claude plugin uninstall protolabs && claude plugin install protolabs
 
 # Check installed versions
 claude plugin list
 ```
 
-## hooks.json Format
+## Hook Configuration
 
-Plugin hooks require a `"hooks"` wrapper key at top level. Events go INSIDE the wrapper:
+Hooks are defined in `plugin.json` (`.claude-plugin/plugin.json`), not in `hooks.json`. The `hooks` field sits alongside `mcpServers`:
 
 ```json
 {
+  "name": "protolabs",
+  "mcpServers": { ... },
   "hooks": {
-    "SessionStart": [...],
+    "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/block-dangerous.sh\"" }] }],
     "PostToolUse": [...],
-    "PreToolUse": [...]
+    "SessionStart": [...],
+    "SessionEnd": [...],
+    "PreCompact": [...],
+    "PostToolUseFailure": [...]
   }
 }
 ```
 
 Use `${CLAUDE_PLUGIN_ROOT}` for paths to hook scripts within the plugin directory.
 
+`hooks/hooks.json` is deprecated -- kept only for backward compatibility. All new hooks go in `plugin.json`.
+
 ## When to Reinstall vs Update
 
-| Change                  | Action                               |
-| ----------------------- | ------------------------------------ |
-| New MCP tool added      | `claude plugin update protolabs`     |
-| Tool schema changed     | `claude plugin update protolabs`     |
-| hooks.json modified     | Full reinstall (uninstall + install) |
-| New command/skill added | `claude plugin update protolabs`     |
-| Plugin .env changed     | Restart Claude Code session          |
+| Change                       | Action                               |
+| ---------------------------- | ------------------------------------ |
+| New MCP tool added           | `claude plugin update protolabs`     |
+| Tool schema changed          | `claude plugin update protolabs`     |
+| Hooks changed in plugin.json | Full reinstall (uninstall + install) |
+| New command/skill added      | `claude plugin update protolabs`     |
+| Plugin .env changed          | Restart Claude Code session          |
 
 **`update` alone doesn't pick up hooks changes.** Always do full reinstall for hooks.
 

--- a/docs/integrations/claude-plugin.md
+++ b/docs/integrations/claude-plugin.md
@@ -212,11 +212,11 @@ The plugin configuration is in `packages/mcp-server/plugins/automaker/.claude-pl
 
 ```json
 {
-  "name": "automaker",
-  "description": "protoLabs Studio — AI Development Studio. Manage Kanban boards, AI agents, and feature orchestration.",
-  "version": "1.1.1",
+  "name": "protolabs",
+  "description": "protoLabs Studio - AI Development Studio...",
+  "version": "0.69.0",
   "mcpServers": {
-    "automaker": {
+    "studio": {
       "command": "bash",
       "args": ["${AUTOMAKER_ROOT}/packages/mcp-server/plugins/automaker/hooks/start-mcp.sh"],
       "env": {
@@ -226,11 +226,43 @@ The plugin configuration is in `packages/mcp-server/plugins/automaker/.claude-pl
         "ENABLE_TOOL_SEARCH": "auto:10"
       }
     }
+  },
+  "hooks": {
+    "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "..." }] }],
+    "PostToolUse": [
+      { "matcher": "Edit|Write", "hooks": [{ "type": "command", "command": "..." }] }
+    ],
+    "SessionStart": [{ "matcher": "startup", "hooks": [{ "type": "command", "command": "..." }] }],
+    "SessionEnd": [{ "hooks": [{ "type": "command", "command": "..." }] }],
+    "PreCompact": [{ "hooks": [{ "type": "command", "command": "..." }] }],
+    "PostToolUseFailure": [
+      {
+        "matcher": "mcp__plugin_protolabs_studio__",
+        "hooks": [{ "type": "command", "command": "..." }]
+      }
+    ]
   }
 }
 ```
 
 The MCP server is launched via `start-mcp.sh` which handles path resolution and env loading automatically.
+
+### Plugin-Distributed Hooks
+
+Hooks ship alongside MCP servers in `plugin.json`. When you install the plugin, hooks are automatically registered -- no manual configuration needed. The `hooks` field supports all Claude Code lifecycle events:
+
+| Event                | Purpose                                    |
+| -------------------- | ------------------------------------------ |
+| `SessionStart`       | Diagnostics, context injection on startup  |
+| `PreToolUse`         | Safety guards before tool execution        |
+| `PostToolUse`        | Post-processing (formatting, agent launch) |
+| `PreCompact`         | Snapshot state before context compression  |
+| `SessionEnd`         | Persist session summary and history        |
+| `PostToolUseFailure` | Diagnostic output on MCP tool failures     |
+
+Hook scripts live in `packages/mcp-server/plugins/automaker/hooks/` and use `${CLAUDE_PLUGIN_ROOT}` for path resolution. See [Plugin Deep Dive](./plugin-deep-dive.md) for the full hook reference.
+
+**Plugin hooks and project hooks both run.** If your project has hooks in `.claude/settings.json`, they execute after plugin hooks. If any hook returns exit code 2, the tool call is blocked.
 
 ## Docker Deployment
 

--- a/docs/integrations/plugin-deep-dive.md
+++ b/docs/integrations/plugin-deep-dive.md
@@ -19,7 +19,7 @@ packages/mcp-server/
     ├── .claude-plugin/
     │   └── plugin.json       # Plugin manifest (name, version, mcpServers, hooks)
     ├── hooks/
-    │   ├── hooks.json        # Hook configuration (mirrors plugin.json)
+    │   ├── hooks.json        # DEPRECATED — plugin.json is authoritative
     │   ├── start-mcp.sh      # MCP server launcher
     │   ├── check-mcp-health.sh
     │   ├── session-context.sh
@@ -185,7 +185,9 @@ Hooks are shell scripts (or Node.js scripts) that fire at Claude Code lifecycle 
 
 ### Hook Configuration
 
-Hooks are defined in both `plugin.json` and `hooks.json`. The plugin manifest is authoritative; `hooks.json` is a development-readable copy kept in sync.
+Hooks are defined in the `hooks` field of `plugin.json` (`.claude-plugin/plugin.json`). This is the single source of truth. A legacy `hooks/hooks.json` file exists for backward compatibility but is deprecated -- all new hooks go in `plugin.json`.
+
+Hook commands use `${CLAUDE_PLUGIN_ROOT}` for path resolution to scripts within the plugin directory. A future Claude Code release will support `{{pluginDir}}` as a standardized variable -- at that point, all paths will migrate to the new format.
 
 ### Lifecycle Events
 
@@ -421,18 +423,23 @@ Reinstall the plugin: `claude plugin uninstall protolabs && claude plugin instal
 
 1. Create the script in `packages/mcp-server/plugins/automaker/hooks/`
 2. Make it executable: `chmod +x hooks/my-hook.sh`
-3. Register in both `plugin.json` and `hooks.json`:
+3. Register in `plugin.json` (`.claude-plugin/plugin.json`) under the appropriate event:
 
 ```json
 {
-  "event": "PostToolUse",
-  "matcher": "ToolPattern",
-  "hooks": [
-    {
-      "type": "command",
-      "command": "bash ${AUTOMAKER_ROOT}/packages/mcp-server/plugins/automaker/hooks/my-hook.sh"
-    }
-  ]
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "ToolPattern",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/my-hook.sh\""
+          }
+        ]
+      }
+    ]
+  }
 }
 ```
 

--- a/packages/mcp-server/plugins/automaker/hooks/hooks.json
+++ b/packages/mcp-server/plugins/automaker/hooks/hooks.json
@@ -1,4 +1,5 @@
 {
+  "_deprecated": "This file is superseded by plugin.json. The hooks field in .claude-plugin/plugin.json is the single source of truth. This file is kept for backward compatibility with Claude Code versions that read hooks.json separately. When Claude Code supports {{pluginDir}} variable substitution in plugin.json hooks, this file will be removed.",
   "description": "Automaker operational hooks — autonomous operation, safety guards, context injection",
   "hooks": {
     "SessionStart": [


### PR DESCRIPTION
## Summary

# PRD: Plugin Format Support for Hooks

## Situation: Current State

### Plugin Architecture

The Claude Code plugin system currently supports distributing MCP servers via `plugin.json`:

```json
{
  'name': 'automaker',
  'version': '1.0.7',
  'mcpServers': {
    'automaker': { ... },
    'discord': { ... },
    'linear': { ... }
  }
}
```

**Location**: `packages/mcp-server/plugins/automaker/.claude-plugin/plugin.json`

### Hook Configuration Layers

Hooks exist in **two separate locations** t...

---
*Recovered automatically by Automaker post-agent hook*