### PR TITLE
[linear] Bug: Self-hosted CI runner congestion causes stuck builds

### DIFF
--- a/apps/server/src/services/maintenance-tasks.ts
+++ b/apps/server/src/services/maintenance-tasks.ts
@@ -21,7 +21,11 @@ import { createLogger } from '@protolabsai/utils';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import type { FlowFactory } from '@protolabsai/types';
-import { DEFAULT_GIT_WORKFLOW_SETTINGS } from '@protolabsai/types';
+import {
+  DEFAULT_GIT_WORKFLOW_SETTINGS,
+  EscalationSeverity,
+  EscalationSource,
+} from '@protolabsai/types';
 import type { EventEmitter } from '../lib/events.js';
 import type { AutoModeService } from './auto-mode-service.js';
 import type { DataIntegrityWatchdogService } from './data-integrity-watchdog-service.js';

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -368,7 +368,9 @@ export type EventType =
   | 'deploy:succeeded'
   | 'deploy:failed'
   // Signal dictionary events (portfolio attention engine)
-  | 'signal:triggered';
+  | 'signal:triggered'
+  // GitHub Actions runner health events (self-hosted CI monitoring)
+  | 'maintenance:runner-health';
 
 export type EventCallback = (type: EventType, payload: unknown) => void;
 
@@ -972,6 +974,29 @@ export interface EventPayloadMap {
     currentValue: number;
     category: import('./signal-dictionary.js').SignalCategory;
     context: import('./signal-dictionary.js').SignalContext;
+  };
+
+  // GitHub Actions runner health events (self-hosted CI monitoring)
+  'maintenance:runner-health': {
+    action: 'health-check' | 'cancel-stuck-run' | 'congestion-alert' | 'check-failed';
+    /** Total in-progress workflow runs */
+    totalRuns?: number;
+    /** Number of runs detected as stuck (>10 min no update) */
+    stuckRuns?: number;
+    /** Total self-hosted runners in the pool */
+    totalRunners?: number;
+    /** Number of runners currently busy */
+    busyRunners?: number;
+    /** Runner pool utilization ratio (0-1) */
+    utilization?: number;
+    /** Stuck run details (for cancel-stuck-run action) */
+    runId?: number;
+    runName?: string;
+    runNumber?: number;
+    elapsedMinutes?: number;
+    /** Error message (for check-failed action) */
+    error?: string;
+    timestamp: string;
   };
 }
 


### PR DESCRIPTION
## Summary

Bug: Self-hosted CI runner congestion causes stuck builds

## Problem

With 8 self-hosted CI runners and autonomous agents also consuming runner capacity (builds in worktrees, `npm install`, etc.), CI jobs can get stuck in queue or go unresponsive. Observed PR #1133's build job stuck 'in_progress' for 10+ minutes without any update — the runner likely picked up the job then hung.

### Impact

* Auto-merge PRs blocked indefinitely waiting on a stuck build
* Manual intervention required (cancel ru...

---
*Recovered automatically by Automaker post-agent hook*