### PR TITLE
Category Summarization & Usage-Correlated Pruning

### DIFF
--- a/apps/server/src/routes/knowledge/routes/rebuild.ts
+++ b/apps/server/src/routes/knowledge/routes/rebuild.ts
@@ -12,8 +12,10 @@ interface RebuildRequest {
   projectPath: string;
 }
 
+const PRUNE_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
 export function createRebuildHandler(knowledgeStoreService: KnowledgeStoreService) {
-  return (req: Request, res: Response): void => {
+  return async (req: Request, res: Response): Promise<void> => {
     try {
       const { projectPath } = req.body as RebuildRequest;
 
@@ -30,7 +32,28 @@ export function createRebuildHandler(knowledgeStoreService: KnowledgeStoreServic
       knowledgeStoreService.rebuildIndex(projectPath);
       const stats = knowledgeStoreService.getStats();
 
-      res.json({ success: true, stats });
+      // Prune stale chunks if >7 days since last prune (or never pruned)
+      const shouldPrune =
+        !stats.lastPruneAt ||
+        Date.now() - new Date(stats.lastPruneAt).getTime() > PRUNE_INTERVAL_MS;
+
+      let pruneResult: { prunedCount: number } | undefined;
+      if (shouldPrune) {
+        try {
+          logger.info('Running stale chunk prune (>7 days since last prune)', { projectPath });
+          const prunedCount = knowledgeStoreService.pruneStaleChunks(projectPath);
+          if (prunedCount > 0) {
+            // Rebuild index after pruning to keep FTS5 in sync
+            knowledgeStoreService.rebuildIndex(projectPath);
+          }
+          pruneResult = { prunedCount };
+        } catch (pruneError) {
+          logger.warn('Stale chunk prune failed:', pruneError);
+        }
+      }
+
+      const finalStats = knowledgeStoreService.getStats();
+      res.json({ success: true, stats: finalStats, ...(pruneResult && { pruneResult }) });
     } catch (error) {
       logger.error('Rebuild index failed:', error);
       res.status(500).json({

--- a/apps/server/src/services/knowledge-store-service.ts
+++ b/apps/server/src/services/knowledge-store-service.ts
@@ -187,6 +187,14 @@ export class KnowledgeStoreService {
       END
     `);
 
+    // Metadata table for tracking operational timestamps (e.g. last_prune_at)
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS db_metadata (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      )
+    `);
+
     logger.debug('Database schema created successfully');
   }
 
@@ -248,6 +256,12 @@ export class KnowledgeStoreService {
       .get() as { last_updated: string | null };
     const lastUpdated = lastUpdatedRow?.last_updated || undefined;
 
+    // Last prune timestamp from metadata table
+    const lastPruneRow = this.db
+      .prepare("SELECT value FROM db_metadata WHERE key = 'last_prune_at'")
+      .get() as { value: string } | undefined;
+    const lastPruneAt = lastPruneRow?.value;
+
     return {
       totalChunks,
       totalSizeBytes,
@@ -260,6 +274,7 @@ export class KnowledgeStoreService {
       dbPath,
       enabledHybridRetrieval:
         this.settings.hybridRetrieval && this.embeddingOrchestrator.getEmbeddingService().isReady(),
+      lastPruneAt,
     };
   }
 
@@ -375,6 +390,13 @@ export class KnowledgeStoreService {
 
     const result = this.db!.prepare(sql).run();
     const deletedCount = result.changes;
+
+    // Record the prune timestamp
+    const now = new Date().toISOString();
+    this.db!.prepare(
+      `INSERT INTO db_metadata (key, value) VALUES ('last_prune_at', ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value`
+    ).run(now);
 
     logger.info(`Pruned ${deletedCount} stale chunks from knowledge store`);
     return deletedCount;

--- a/libs/types/src/knowledge.ts
+++ b/libs/types/src/knowledge.ts
@@ -97,6 +97,9 @@ export interface KnowledgeStoreStats {
 
   /** Whether hybrid retrieval is enabled */
   enabledHybridRetrieval: boolean;
+
+  /** Timestamp of last stale chunk prune */
+  lastPruneAt?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

**Milestone:** Memory Maintenance Pipeline

Add KnowledgeStoreService.compactCategory(projectPath, categoryFile) that: (1) counts tokens in the category (sum of chunk content lengths / 4), (2) if tokens exceed compactionThreshold (default 50000 tokens = ~200KB), calls Haiku with a summarization prompt asking it to compress all chunks from that category into a condensed version that preserves the most important patterns and lessons, then overwrites the .md file with the summary and triggers a reb...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-16T21:04:23.483Z -->