### PR TITLE
[linear] Analytics: Umami self-hosted + UTM attribution system

### DIFF
--- a/docs/internal/protolabs/utm-conventions.md
+++ b/docs/internal/protolabs/utm-conventions.md
@@ -1,0 +1,157 @@
+# UTM Parameter Conventions
+
+This page covers how protoLabs tracks marketing campaign attribution using UTM parameters. After reading it, you will understand the naming conventions, how to add new campaigns, and how to generate properly tagged links for social media sharing.
+
+## What are UTM parameters?
+
+UTM parameters are query string values appended to URLs that tell Umami analytics where traffic originated. Example:
+
+```
+https://protolabs.studio?utm_source=twitter&utm_medium=social&utm_campaign=launch
+```
+
+Umami captures these values automatically — no code changes needed. They appear in the dashboard under "Query Parameters" and can be used to filter all metrics by source, medium, or campaign.
+
+## Parameter definitions
+
+### utm_source (required)
+
+Where the link appears or where the traffic originates.
+
+| Value         | When to use                                                |
+| ------------- | ---------------------------------------------------------- |
+| `protolabs`   | Links FROM our site to external destinations (nav, footer) |
+| `twitter`     | Links shared on Twitter/X                                  |
+| `twitch`      | Links in Twitch stream descriptions                        |
+| `youtube`     | Links in YouTube video descriptions                        |
+| `substack`    | Links in Substack newsletter                               |
+| `github`      | Links in GitHub READMEs or issues                          |
+| `linkedin`    | Links shared on LinkedIn                                   |
+| `discord`     | Links shared in Discord                                    |
+| `hacker-news` | Links posted to Hacker News                                |
+
+### utm_medium (required)
+
+The marketing channel type.
+
+| Value        | When to use                                                |
+| ------------ | ---------------------------------------------------------- |
+| `social`     | Social media posts (Twitter, LinkedIn)                     |
+| `video`      | Video platforms (Twitch, YouTube)                          |
+| `newsletter` | Email newsletter (Substack)                                |
+| `community`  | Community forums (Discord, Hacker News)                    |
+| `referral`   | Cross-site links between protoLabs subdomains              |
+| `website`    | Links from our site to external destinations (nav, footer) |
+
+### utm_campaign (required)
+
+The specific campaign or placement context.
+
+| Value                  | When to use                              |
+| ---------------------- | ---------------------------------------- |
+| `nav`                  | Header navigation links                  |
+| `footer`               | Footer links                             |
+| `cross-nav`            | Links between protoLabs subdomains       |
+| `github-nav`           | Links to GitHub org/repos from site      |
+| `social-nav`           | Links to social media profiles from site |
+| `launch`               | Product launch campaigns                 |
+| `feature-announcement` | New feature releases                     |
+| `changelog-update`     | Monthly changelog update posts           |
+| `roadmap-update`       | Roadmap milestone announcements          |
+| `weekly-update`        | Regular weekly newsletter                |
+| `organic`              | Non-campaign organic shares              |
+
+## Core rules
+
+1. **Lowercase only** — `twitter` not `Twitter`
+2. **Dashes for spaces** — `feature-announcement` not `feature announcement`
+3. **No special characters** — avoid `&`, `=`, `?` in values
+4. **External links only** — never add UTM params to same-page anchors or JavaScript
+5. **Consistent naming** — use values from this list or add them to `utm-config.json` first
+
+## Automated injection
+
+The build script `site/scripts/add-utm-params.mjs` automatically injects UTM parameters into all external links in the site HTML files. It runs as the final step of `npm run stats:generate`.
+
+```bash
+# Run UTM injection manually
+npm run add-utm-params
+
+# Run as part of full site generation
+npm run stats:generate
+```
+
+The script reads rules from `site/scripts/utm-config.json` and is idempotent — running it multiple times produces the same output.
+
+## Inbound campaign links
+
+When sharing protoLabs content on social media, tag the link before sharing:
+
+```
+# Sharing on Twitter after a changelog update
+https://changelog.protolabs.studio?utm_source=twitter&utm_medium=social&utm_campaign=changelog-update
+
+# Sharing roadmap update in Twitch stream description
+https://roadmap.protolabs.studio?utm_source=twitch&utm_medium=video&utm_campaign=roadmap-update
+
+# Sharing in Substack newsletter
+https://protolabs.studio?utm_source=substack&utm_medium=newsletter&utm_campaign=weekly-update
+
+# Posting on Hacker News
+https://protolabs.studio?utm_source=hacker-news&utm_medium=community&utm_campaign=launch
+```
+
+## Adding a new campaign
+
+1. Add the campaign name to the `campaign` array in `site/scripts/utm-config.json`
+2. Use the new campaign value when generating tagged links
+3. Run `npm run test:utm` to confirm no convention violations
+
+To add a new tracked destination (e.g., a new external link added to the site nav):
+
+1. Add a rule to the `rules` array in `site/scripts/utm-config.json`:
+   ```json
+   {
+     "match": "example.com/your-profile",
+     "source": "protolabs",
+     "medium": "website",
+     "campaign": "nav",
+     "description": "Link from site nav to your profile"
+   }
+   ```
+2. Run `npm run add-utm-params` to apply to HTML files
+3. Run `npm run test:utm` to verify
+
+## Validation
+
+Run the automated test suite to verify all UTM parameters are correct:
+
+```bash
+npm run test:utm
+```
+
+Expected output:
+
+```
+ok 1 - All external links matching rules have UTM parameters
+ok 2 - All UTM parameter values are lowercase
+ok 3 - All UTM values match utm-config.json conventions
+ok 4 - Script is idempotent — running twice produces identical output
+
+1..4
+# tests 4
+# pass  4
+```
+
+## Viewing data in Umami
+
+1. Log in to `umami.proto-labs.ai`
+2. Select a website (e.g., protolabs.studio)
+3. Navigate to "Query Parameters" in the left sidebar
+4. UTM parameters appear as filterable dimensions
+5. Click any value to filter the entire dashboard by that campaign
+
+## Next steps
+
+- **[Content pipeline](./content-pipeline.md)** — How content is produced and published
+- **[Brand guidelines](./brand.md)** — Voice, naming conventions, and brand rules

--- a/package.json
+++ b/package.json
@@ -85,8 +85,10 @@
     "changeset:publish": "changeset publish",
     "changeset:status": "changeset status",
     "release:prepare": "node scripts/prepare-release-changeset.mjs",
-    "stats:generate": "node site/scripts/generate-stats.mjs && node site/scripts/generate-changelog.mjs && node site/scripts/generate-roadmap.mjs",
-    "stats:generate:full": "node site/scripts/generate-stats.mjs --with-ledger && node site/scripts/generate-changelog.mjs && node site/scripts/generate-roadmap.mjs"
+    "add-utm-params": "node site/scripts/add-utm-params.mjs",
+    "test:utm": "node --test site/scripts/validate-utm.test.mjs",
+    "stats:generate": "node site/scripts/generate-stats.mjs && node site/scripts/generate-changelog.mjs && node site/scripts/generate-roadmap.mjs && node site/scripts/add-utm-params.mjs",
+    "stats:generate:full": "node site/scripts/generate-stats.mjs --with-ledger && node site/scripts/generate-changelog.mjs && node site/scripts/generate-roadmap.mjs && node site/scripts/add-utm-params.mjs"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mts,cts,json,css,md,html,yml,yaml}": [

--- a/site/changelog/index.html
+++ b/site/changelog/index.html
@@ -140,7 +140,7 @@
     <nav class="fixed top-0 w-full z-50 border-b border-white/5 bg-surface-0/80 backdrop-blur-xl">
       <div class="max-w-5xl mx-auto px-6 h-14 flex items-center justify-between">
         <a
-          href="https://protolabs.studio"
+          href="https://protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
           class="flex items-center gap-2 text-white font-semibold tracking-tight"
         >
           <svg
@@ -166,20 +166,20 @@
           <span>proto<span class="text-accent">Labs</span></span>
         </a>
         <div class="flex items-center gap-6 text-sm text-muted">
-          <a href="https://protolabs.studio" class="hover:text-white transition-colors">Home</a>
+          <a href="https://protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" class="hover:text-white transition-colors">Home</a>
           <a
-            href="https://docs.protolabs.studio"
+            href="https://docs.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-white transition-colors"
             >Docs</a
           >
           <span class="text-white font-medium">Changelog</span>
-          <a href="https://roadmap.protolabs.studio" class="hover:text-white transition-colors"
+          <a href="https://roadmap.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" class="hover:text-white transition-colors"
             >Roadmap</a
           >
           <a
-            href="https://x.com/protoLabsAI"
+            href="https://x.com/protoLabsAI?utm_source=protolabs&utm_medium=social&utm_campaign=social-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-white transition-colors"
@@ -267,7 +267,7 @@
           <p>
             We forked
             <a
-              href="https://github.com/AutoMaker-Org/automaker"
+              href="https://github.com/AutoMaker-Org/automaker?utm_source=protolabs&utm_medium=website&utm_campaign=github-nav"
               target="_blank"
               rel="noopener"
               class="text-accent hover:text-white transition-colors"
@@ -32651,19 +32651,19 @@
           <span>AI-native development agency</span>
         </div>
         <div class="flex items-center gap-5 text-sm text-zinc-500">
-          <a href="https://protolabs.studio" class="hover:text-zinc-300 transition-colors">Home</a>
+          <a href="https://protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" class="hover:text-zinc-300 transition-colors">Home</a>
           <a
-            href="https://docs.protolabs.studio"
+            href="https://docs.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-zinc-300 transition-colors"
             >Docs</a
           >
-          <a href="https://roadmap.protolabs.studio" class="hover:text-zinc-300 transition-colors"
+          <a href="https://roadmap.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" class="hover:text-zinc-300 transition-colors"
             >Roadmap</a
           >
           <a
-            href="https://x.com/protoLabsAI"
+            href="https://x.com/protoLabsAI?utm_source=protolabs&utm_medium=social&utm_campaign=social-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-zinc-300 transition-colors"

--- a/site/consulting/index.html
+++ b/site/consulting/index.html
@@ -250,7 +250,7 @@
               </svg>
             </a>
             <a
-              href="https://protolabs.studio"
+              href="https://protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
               class="inline-flex items-center gap-2 px-5 py-3 border border-white/10 hover:border-white/20 text-zinc-300 hover:text-white text-sm font-medium rounded-lg transition-colors"
             >
               See the product
@@ -395,7 +395,7 @@
                 should stay human. You get a concrete assessment, not a generic playbook.
               </p>
               <a
-                href="https://report.protolabs.studio"
+                href="https://report.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
                 target="_blank"
                 rel="noopener"
                 class="inline-flex items-center gap-1.5 mt-3 text-accent hover:text-white text-sm transition-colors"
@@ -574,32 +574,32 @@
           <span>consulting</span>
         </div>
         <div class="flex items-center gap-5 text-sm text-zinc-500">
-          <a href="https://protolabs.studio" class="hover:text-zinc-300 transition-colors"
+          <a href="https://protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" class="hover:text-zinc-300 transition-colors"
             >Product</a
           >
           <a
-            href="https://report.protolabs.studio"
+            href="https://report.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-zinc-300 transition-colors"
             >Report</a
           >
           <a
-            href="https://docs.protolabs.studio"
+            href="https://docs.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-zinc-300 transition-colors"
             >Docs</a
           >
           <a
-            href="https://x.com/protoLabsAI"
+            href="https://x.com/protoLabsAI?utm_source=protolabs&utm_medium=social&utm_campaign=social-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-zinc-300 transition-colors"
             >X / Twitter</a
           >
           <a
-            href="https://github.com/protoLabsAI"
+            href="https://github.com/protoLabsAI?utm_source=protolabs&utm_medium=website&utm_campaign=github-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-zinc-300 transition-colors"

--- a/site/index.html
+++ b/site/index.html
@@ -334,34 +334,34 @@
         </a>
         <div class="flex items-center gap-6 text-sm text-muted">
           <a
-            href="https://docs.protolabs.studio"
+            href="https://docs.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-white transition-colors"
             >Docs</a
           >
           <a
-            href="https://protolabs.consulting"
+            href="https://protolabs.consulting?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-white transition-colors"
             >Consulting</a
           >
-          <a href="https://changelog.protolabs.studio" class="hover:text-white transition-colors"
+          <a href="https://changelog.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" class="hover:text-white transition-colors"
             >Changelog</a
           >
-          <a href="https://roadmap.protolabs.studio" class="hover:text-white transition-colors"
+          <a href="https://roadmap.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" class="hover:text-white transition-colors"
             >Roadmap</a
           >
           <a
-            href="https://report.protolabs.studio"
+            href="https://report.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-white transition-colors"
             >Report</a
           >
           <a
-            href="https://x.com/protoLabsAI"
+            href="https://x.com/protoLabsAI?utm_source=protolabs&utm_medium=social&utm_campaign=social-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-white transition-colors"
@@ -418,7 +418,7 @@
                 </svg>
               </a>
               <a
-                href="https://docs.protolabs.studio"
+                href="https://docs.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
                 target="_blank"
                 rel="noopener"
                 class="inline-flex items-center gap-2 px-5 py-2.5 border border-white/10 hover:border-white/20 text-zinc-300 hover:text-white text-sm font-medium rounded-lg transition-colors"
@@ -1152,7 +1152,7 @@
             methodology.
           </p>
           <a
-            href="https://docs.protolabs.studio"
+            href="https://docs.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
             target="_blank"
             rel="noopener"
             class="inline-flex items-center gap-2 mt-8 px-6 py-3 bg-accent hover:bg-accent-dim text-white text-sm font-medium rounded-lg transition-colors"
@@ -1194,7 +1194,7 @@
           </div>
           <div class="flex-shrink-0">
             <a
-              href="https://report.protolabs.studio"
+              href="https://report.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
               target="_blank"
               rel="noopener"
               class="inline-flex items-center gap-2 px-6 py-3 bg-accent hover:bg-accent-dim text-white text-sm font-medium rounded-lg transition-colors whitespace-nowrap"
@@ -1297,41 +1297,41 @@
         </div>
         <div class="flex items-center gap-5 text-sm text-zinc-500">
           <a
-            href="https://docs.protolabs.studio"
+            href="https://docs.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-zinc-300 transition-colors"
             >Docs</a
           >
           <a
-            href="https://protolabs.consulting"
+            href="https://protolabs.consulting?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-zinc-300 transition-colors"
             >Consulting</a
           >
-          <a href="https://changelog.protolabs.studio" class="hover:text-zinc-300 transition-colors"
+          <a href="https://changelog.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" class="hover:text-zinc-300 transition-colors"
             >Changelog</a
           >
-          <a href="https://roadmap.protolabs.studio" class="hover:text-zinc-300 transition-colors"
+          <a href="https://roadmap.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" class="hover:text-zinc-300 transition-colors"
             >Roadmap</a
           >
           <a
-            href="https://report.protolabs.studio"
+            href="https://report.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-zinc-300 transition-colors"
             >Report</a
           >
           <a
-            href="https://x.com/protoLabsAI"
+            href="https://x.com/protoLabsAI?utm_source=protolabs&utm_medium=social&utm_campaign=social-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-zinc-300 transition-colors"
             >X / Twitter</a
           >
           <a
-            href="https://github.com/protoLabsAI"
+            href="https://github.com/protoLabsAI?utm_source=protolabs&utm_medium=website&utm_campaign=github-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-zinc-300 transition-colors"

--- a/site/report/index.html
+++ b/site/report/index.html
@@ -26,7 +26,7 @@
       content="Automated gap analysis for your codebase against the protoLabs gold standard."
     />
     <meta name="twitter:image" content="https://protolabs.studio/images/og-report.png" />
-    <link rel="canonical" href="https://report.protolabs.studio" />
+    <link rel="canonical" href="https://report.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" />
     <link
       rel="icon"
       type="image/svg+xml"
@@ -243,7 +243,7 @@
           >
         </div>
         <a
-          href="https://protolabs.studio"
+          href="https://protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
           class="text-sm text-accent hover:text-white transition-colors font-medium"
         >
           Get your own report &rarr;
@@ -1049,13 +1049,13 @@
         </p>
         <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
           <a
-            href="https://protolabs.studio"
+            href="https://protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
             class="cta-btn px-6 py-3 rounded-lg text-white font-semibold text-sm"
           >
             Get Started Free
           </a>
           <a
-            href="https://protolabs.consulting"
+            href="https://protolabs.consulting?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
             class="px-6 py-3 rounded-lg border border-white/10 text-zinc-300 hover:text-white hover:border-white/20 transition-all text-sm font-medium"
           >
             Book a Consulting Session
@@ -1095,11 +1095,11 @@
           <span>AI-native development agency</span>
         </div>
         <div class="flex items-center gap-6 text-sm text-zinc-600">
-          <a href="https://protolabs.studio" class="hover:text-zinc-400 transition-colors">Home</a>
-          <a href="https://protolabs.consulting" class="hover:text-zinc-400 transition-colors"
+          <a href="https://protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" class="hover:text-zinc-400 transition-colors">Home</a>
+          <a href="https://protolabs.consulting?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" class="hover:text-zinc-400 transition-colors"
             >Consulting</a
           >
-          <a href="https://github.com/protoLabsAI" class="hover:text-zinc-400 transition-colors"
+          <a href="https://github.com/protoLabsAI?utm_source=protolabs&utm_medium=website&utm_campaign=github-nav" class="hover:text-zinc-400 transition-colors"
             >GitHub</a
           >
         </div>

--- a/site/roadmap/index.html
+++ b/site/roadmap/index.html
@@ -152,7 +152,7 @@
     <nav class="fixed top-0 w-full z-50 border-b border-white/5 bg-surface-0/80 backdrop-blur-xl">
       <div class="max-w-5xl mx-auto px-6 h-14 flex items-center justify-between">
         <a
-          href="https://protolabs.studio"
+          href="https://protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
           class="flex items-center gap-2 text-white font-semibold tracking-tight"
         >
           <svg
@@ -178,20 +178,20 @@
           <span>proto<span class="text-accent">Labs</span></span>
         </a>
         <div class="flex items-center gap-6 text-sm text-muted">
-          <a href="https://protolabs.studio" class="hover:text-white transition-colors">Home</a>
+          <a href="https://protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" class="hover:text-white transition-colors">Home</a>
           <a
-            href="https://docs.protolabs.studio"
+            href="https://docs.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-white transition-colors"
             >Docs</a
           >
-          <a href="https://changelog.protolabs.studio" class="hover:text-white transition-colors"
+          <a href="https://changelog.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" class="hover:text-white transition-colors"
             >Changelog</a
           >
           <span class="text-white font-medium">Roadmap</span>
           <a
-            href="https://x.com/protoLabsAI"
+            href="https://x.com/protoLabsAI?utm_source=protolabs&utm_medium=social&utm_campaign=social-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-white transition-colors"
@@ -1015,19 +1015,19 @@
           <span>AI-native development agency</span>
         </div>
         <div class="flex items-center gap-5 text-sm text-zinc-500">
-          <a href="https://protolabs.studio" class="hover:text-zinc-300 transition-colors">Home</a>
+          <a href="https://protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" class="hover:text-zinc-300 transition-colors">Home</a>
           <a
-            href="https://docs.protolabs.studio"
+            href="https://docs.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-zinc-300 transition-colors"
             >Docs</a
           >
-          <a href="https://changelog.protolabs.studio" class="hover:text-zinc-300 transition-colors"
+          <a href="https://changelog.protolabs.studio?utm_source=protolabs&utm_medium=referral&utm_campaign=cross-nav" class="hover:text-zinc-300 transition-colors"
             >Changelog</a
           >
           <a
-            href="https://x.com/protoLabsAI"
+            href="https://x.com/protoLabsAI?utm_source=protolabs&utm_medium=social&utm_campaign=social-nav"
             target="_blank"
             rel="noopener"
             class="hover:text-zinc-300 transition-colors"

--- a/site/scripts/add-utm-params.mjs
+++ b/site/scripts/add-utm-params.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * add-utm-params.mjs
+ *
+ * Injects UTM parameters into external links across all site HTML files.
+ * Uses utm-config.json for centralized campaign configuration.
+ *
+ * Rules:
+ * - Only processes href="https://..." attributes (external links)
+ * - Skips URLs matching the skip list (PR links, CDNs, etc.)
+ * - Skips URLs that already have utm_source= (idempotent)
+ * - Appends UTM params with ? or & depending on existing query string
+ * - Handles fragment identifiers (#section) correctly
+ *
+ * Usage: node site/scripts/add-utm-params.mjs
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { createRequire } from 'module';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+const config = JSON.parse(readFileSync(resolve(__dirname, 'utm-config.json'), 'utf-8'));
+
+const HTML_FILES = [
+  resolve(__dirname, '../index.html'),
+  resolve(__dirname, '../changelog/index.html'),
+  resolve(__dirname, '../roadmap/index.html'),
+  resolve(__dirname, '../consulting/index.html'),
+  resolve(__dirname, '../report/index.html'),
+];
+
+/**
+ * Check if a URL should be skipped (not tagged with UTM params).
+ */
+function shouldSkip(url) {
+  for (const pattern of config.skip) {
+    if (url.includes(pattern)) return true;
+  }
+  return false;
+}
+
+/**
+ * Find the matching rule for a given URL.
+ * Returns null if no rule matches.
+ */
+function findRule(url) {
+  for (const rule of config.rules) {
+    if (url.includes(rule.match)) return rule;
+  }
+  return null;
+}
+
+/**
+ * Build the UTM query string from a rule.
+ */
+function buildUtmParams(rule) {
+  return `utm_source=${rule.source}&utm_medium=${rule.medium}&utm_campaign=${rule.campaign}`;
+}
+
+/**
+ * Append UTM parameters to a URL, handling existing query params and fragments.
+ *
+ * Examples:
+ *   https://example.com          -> https://example.com?utm_source=...
+ *   https://example.com?foo=bar  -> https://example.com?foo=bar&utm_source=...
+ *   https://example.com#section  -> https://example.com?utm_source=...#section
+ */
+function appendUtmParams(url, utmParams) {
+  // Separate fragment identifier if present
+  const hashIndex = url.indexOf('#');
+  const fragment = hashIndex !== -1 ? url.slice(hashIndex) : '';
+  const baseUrl = hashIndex !== -1 ? url.slice(0, hashIndex) : url;
+
+  const separator = baseUrl.includes('?') ? '&' : '?';
+  return `${baseUrl}${separator}${utmParams}${fragment}`;
+}
+
+/**
+ * Process a single HTML file, injecting UTM params into matching links.
+ * Returns the number of links tagged.
+ */
+function processFile(filePath) {
+  let content;
+  try {
+    content = readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    console.warn(`  SKIP ${filePath} (not found)`);
+    return 0;
+  }
+
+  let taggedCount = 0;
+
+  // Match all href="https://..." attributes
+  const result = content.replace(/href="(https:\/\/[^"]+)"/g, (match, url) => {
+    // Skip if already has UTM params (idempotent)
+    if (url.includes('utm_source=')) return match;
+
+    // Skip if URL matches skip list
+    if (shouldSkip(url)) return match;
+
+    // Find matching rule
+    const rule = findRule(url);
+    if (!rule) return match;
+
+    const utmParams = buildUtmParams(rule);
+    const taggedUrl = appendUtmParams(url, utmParams);
+    taggedCount++;
+    return `href="${taggedUrl}"`;
+  });
+
+  if (taggedCount > 0) {
+    writeFileSync(filePath, result, 'utf-8');
+  }
+
+  return taggedCount;
+}
+
+/**
+ * Main entry point.
+ */
+function main() {
+  console.log('Adding UTM parameters to external links...\n');
+
+  let totalTagged = 0;
+  const start = Date.now();
+
+  for (const filePath of HTML_FILES) {
+    const shortPath = filePath.replace(process.cwd() + '/', '');
+    const count = processFile(filePath);
+    if (count > 0) {
+      console.log(`  ${shortPath} — tagged ${count} link${count === 1 ? '' : 's'}`);
+    } else {
+      console.log(`  ${shortPath} — no changes`);
+    }
+    totalTagged += count;
+  }
+
+  const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+  console.log(`\nDone. Tagged ${totalTagged} link${totalTagged === 1 ? '' : 's'} in ${elapsed}s`);
+}
+
+main();

--- a/site/scripts/utm-config.json
+++ b/site/scripts/utm-config.json
@@ -1,0 +1,140 @@
+{
+  "conventions": {
+    "source": [
+      "twitter",
+      "twitch",
+      "youtube",
+      "substack",
+      "github",
+      "linkedin",
+      "discord",
+      "hacker-news",
+      "protolabs"
+    ],
+    "medium": ["social", "video", "newsletter", "community", "referral", "website"],
+    "campaign": [
+      "nav",
+      "footer",
+      "cross-nav",
+      "github-nav",
+      "social-nav",
+      "launch",
+      "feature-announcement",
+      "changelog-update",
+      "roadmap-update",
+      "weekly-update",
+      "organic"
+    ]
+  },
+  "skip": [
+    "github.com/protoLabsAI/protoMaker/pull/",
+    "github.com/AutoMaker-Org/automaker/pull/",
+    "fonts.googleapis.com",
+    "fonts.gstatic.com",
+    "cdn.tailwindcss.com",
+    "umami.proto-labs.ai"
+  ],
+  "rules": [
+    {
+      "match": "x.com/protoLabsAI",
+      "source": "protolabs",
+      "medium": "social",
+      "campaign": "social-nav",
+      "description": "Links from site nav/footer to Twitter/X profile"
+    },
+    {
+      "match": "github.com/protoLabsAI",
+      "source": "protolabs",
+      "medium": "website",
+      "campaign": "github-nav",
+      "description": "Links from site to GitHub organization"
+    },
+    {
+      "match": "github.com/AutoMaker-Org/automaker",
+      "source": "protolabs",
+      "medium": "website",
+      "campaign": "github-nav",
+      "description": "Links from site to legacy GitHub repo"
+    },
+    {
+      "match": "docs.protolabs.studio",
+      "source": "protolabs",
+      "medium": "referral",
+      "campaign": "cross-nav",
+      "description": "Cross-site navigation to docs subdomain"
+    },
+    {
+      "match": "changelog.protolabs.studio",
+      "source": "protolabs",
+      "medium": "referral",
+      "campaign": "cross-nav",
+      "description": "Cross-site navigation to changelog subdomain"
+    },
+    {
+      "match": "roadmap.protolabs.studio",
+      "source": "protolabs",
+      "medium": "referral",
+      "campaign": "cross-nav",
+      "description": "Cross-site navigation to roadmap subdomain"
+    },
+    {
+      "match": "report.protolabs.studio",
+      "source": "protolabs",
+      "medium": "referral",
+      "campaign": "cross-nav",
+      "description": "Cross-site navigation to report subdomain"
+    },
+    {
+      "match": "protolabs.consulting",
+      "source": "protolabs",
+      "medium": "referral",
+      "campaign": "cross-nav",
+      "description": "Cross-site navigation to consulting subdomain"
+    },
+    {
+      "match": "protolabs.studio",
+      "source": "protolabs",
+      "medium": "referral",
+      "campaign": "cross-nav",
+      "description": "Cross-site navigation back to main site"
+    }
+  ],
+  "outboundSharing": {
+    "twitter": {
+      "source": "twitter",
+      "medium": "social",
+      "campaign": "organic",
+      "description": "Links shared manually on Twitter/X"
+    },
+    "twitch": {
+      "source": "twitch",
+      "medium": "video",
+      "campaign": "stream",
+      "description": "Links in Twitch stream descriptions"
+    },
+    "youtube": {
+      "source": "youtube",
+      "medium": "video",
+      "campaign": "description",
+      "description": "Links in YouTube video descriptions"
+    },
+    "substack": {
+      "source": "substack",
+      "medium": "newsletter",
+      "campaign": "weekly-update",
+      "description": "Links in Substack newsletter"
+    },
+    "discord": {
+      "source": "discord",
+      "medium": "community",
+      "campaign": "organic",
+      "description": "Links shared in Discord"
+    },
+    "hacker-news": {
+      "source": "hacker-news",
+      "medium": "community",
+      "campaign": "organic",
+      "description": "Links posted on Hacker News"
+    }
+  }
+}

--- a/site/scripts/validate-utm.test.mjs
+++ b/site/scripts/validate-utm.test.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * validate-utm.test.mjs
+ *
+ * Validates that UTM parameters are correctly applied across all site HTML files.
+ *
+ * Usage: node --test site/scripts/validate-utm.test.mjs
+ *   or:  npm run test:utm
+ */
+
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const config = JSON.parse(readFileSync(resolve(__dirname, 'utm-config.json'), 'utf-8'));
+
+const HTML_FILES = [
+  resolve(__dirname, '../index.html'),
+  resolve(__dirname, '../changelog/index.html'),
+  resolve(__dirname, '../roadmap/index.html'),
+  resolve(__dirname, '../consulting/index.html'),
+  resolve(__dirname, '../report/index.html'),
+];
+
+const INTERNAL_DOMAINS = [
+  'protolabs.studio',
+  'changelog.protolabs.studio',
+  'roadmap.protolabs.studio',
+  'report.protolabs.studio',
+  'docs.protolabs.studio',
+  'protolabs.consulting',
+];
+
+/** Extract all href="https://..." from an HTML string */
+function extractExternalHrefs(html) {
+  const matches = [];
+  const regex = /href="(https:\/\/[^"]+)"/g;
+  let m;
+  while ((m = regex.exec(html)) !== null) {
+    matches.push(m[1]);
+  }
+  return matches;
+}
+
+/** Check if a URL is a social/nav link that should have UTM params */
+function shouldHaveUtm(url) {
+  // Skip CDN/font URLs
+  for (const skip of config.skip) {
+    if (url.includes(skip)) return false;
+  }
+  // Skip OG image URLs (they're in meta content, not hrefs — but just in case)
+  if (url.includes('/images/og-')) return false;
+  // Must match a rule
+  return config.rules.some((rule) => url.includes(rule.match));
+}
+
+test('All external links matching rules have UTM parameters', () => {
+  const missing = [];
+
+  for (const filePath of HTML_FILES) {
+    let html;
+    try {
+      html = readFileSync(filePath, 'utf-8');
+    } catch {
+      continue; // file doesn't exist, skip
+    }
+
+    const hrefs = extractExternalHrefs(html);
+    for (const href of hrefs) {
+      if (!shouldHaveUtm(href)) continue;
+      if (!href.includes('utm_source=')) {
+        missing.push({ file: filePath.replace(process.cwd() + '/', ''), href });
+      }
+    }
+  }
+
+  if (missing.length > 0) {
+    const details = missing.map((m) => `  ${m.file}: ${m.href}`).join('\n');
+    assert.fail(`${missing.length} external link(s) missing UTM parameters:\n${details}`);
+  }
+});
+
+test('All UTM parameter values are lowercase', () => {
+  const violations = [];
+
+  for (const filePath of HTML_FILES) {
+    let html;
+    try {
+      html = readFileSync(filePath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const hrefs = extractExternalHrefs(html);
+    for (const href of hrefs) {
+      if (!href.includes('utm_')) continue;
+
+      const url = new URL(href);
+      const source = url.searchParams.get('utm_source');
+      const medium = url.searchParams.get('utm_medium');
+      const campaign = url.searchParams.get('utm_campaign');
+
+      for (const [key, val] of [
+        ['utm_source', source],
+        ['utm_medium', medium],
+        ['utm_campaign', campaign],
+      ]) {
+        if (val && val !== val.toLowerCase()) {
+          violations.push({
+            file: filePath.replace(process.cwd() + '/', ''),
+            key,
+            value: val,
+            href,
+          });
+        }
+      }
+    }
+  }
+
+  if (violations.length > 0) {
+    const details = violations.map((v) => `  ${v.file}: ${v.key}=${v.value}`).join('\n');
+    assert.fail(`${violations.length} UTM value(s) are not lowercase:\n${details}`);
+  }
+});
+
+test('All UTM values match utm-config.json conventions', () => {
+  const violations = [];
+  const allowed = config.conventions;
+
+  for (const filePath of HTML_FILES) {
+    let html;
+    try {
+      html = readFileSync(filePath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const hrefs = extractExternalHrefs(html);
+    for (const href of hrefs) {
+      if (!href.includes('utm_')) continue;
+
+      const url = new URL(href);
+      const source = url.searchParams.get('utm_source');
+      const medium = url.searchParams.get('utm_medium');
+      const campaign = url.searchParams.get('utm_campaign');
+
+      const shortFile = filePath.replace(process.cwd() + '/', '');
+
+      if (source && !allowed.source.includes(source)) {
+        violations.push(`  ${shortFile}: utm_source="${source}" not in allowed list`);
+      }
+      if (medium && !allowed.medium.includes(medium)) {
+        violations.push(`  ${shortFile}: utm_medium="${medium}" not in allowed list`);
+      }
+      if (campaign && !allowed.campaign.includes(campaign)) {
+        violations.push(`  ${shortFile}: utm_campaign="${campaign}" not in allowed list`);
+      }
+    }
+  }
+
+  if (violations.length > 0) {
+    assert.fail(`UTM convention violations:\n${violations.join('\n')}`);
+  }
+});
+
+test('Script is idempotent — running twice produces identical output', async () => {
+  // Run the add-utm-params script twice and verify it produces no additional changes
+  // We verify by checking that no URL has duplicate UTM params
+  for (const filePath of HTML_FILES) {
+    let html;
+    try {
+      html = readFileSync(filePath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const hrefs = extractExternalHrefs(html);
+    for (const href of hrefs) {
+      if (!href.includes('utm_source=')) continue;
+
+      // Count occurrences of utm_source= in the URL — should be exactly 1
+      const count = (href.match(/utm_source=/g) || []).length;
+      assert.strictEqual(
+        count,
+        1,
+        `URL has duplicate utm_source= (idempotency violation): ${href}`
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary

# SPARC PRD: Analytics & UTM Attribution System

## Situation: Current State

### What Exists Today

**✅ Umami Analytics - Already Deployed**

protoLabs has a fully operational, self-hosted Umami analytics instance at `umami.proto-labs.ai`. All three primary sites are already instrumented:

- **Main site** (`protolabs.studio`): `data-website-id='417982ad-56b0-47ea-9184-ca785e2fd1dc'`
- **Changelog** (`changelog.protolabs.studio`): `data-website-id='b576d642-fbca-4828-b198-00476a135ccc'`
- **Road...

---
*Recovered automatically by Automaker post-agent hook*