### PR TITLE
[linear] Automated post-project documentation ceremony

### DIFF
--- a/apps/server/src/services/ceremony-service.ts
+++ b/apps/server/src/services/ceremony-service.ts
@@ -15,7 +15,12 @@ import readline from 'readline';
 import { createLogger } from '@protolabsai/utils';
 import { secureFs, getProjectDir, getDataDirectory, getAutomakerDir } from '@protolabsai/platform';
 import { ChatAnthropic } from '@langchain/anthropic';
-import { createStandupFlow, createRetroFlow, createProjectRetroFlow } from '@protolabsai/flows';
+import {
+  createStandupFlow,
+  createRetroFlow,
+  createProjectRetroFlow,
+  createPostProjectDocsFlow,
+} from '@protolabsai/flows';
 import type { CeremonyState, MilestoneUpdateData, ProjectRetroData } from '@protolabsai/types';
 import { flowRegistry } from './automation-service.js';
 import type { EventEmitter } from '../lib/events.js';
@@ -256,6 +261,9 @@ export class CeremonyService {
     });
     flowRegistry.register('project-retro-flow', async (_modelConfig) => {
       logger.info('project-retro-flow: execution handled via ceremony event system');
+    });
+    flowRegistry.register('post-project-docs-flow', async (_modelConfig) => {
+      logger.info('post-project-docs-flow: execution handled via ceremony event system');
     });
 
     // Load persisted dedup state before subscribing to events
@@ -1046,6 +1054,13 @@ export class CeremonyService {
         projectPath,
         retroData: projectRetroData,
       });
+
+      // Fire post-project docs ceremony (fire-and-forget — failure never affects project status)
+      this.handlePostProjectDocs(payload).catch((err) =>
+        logger.warn(
+          `Post-project docs ceremony failed for ${projectSlug}: ${err instanceof Error ? err.message : String(err)}`
+        )
+      );
     } catch (err) {
       this.ceremonyCounts.discordPostFailures++;
       logger.warn(`Project retro flow failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -1062,6 +1077,94 @@ export class CeremonyService {
       });
     } finally {
       this.activeReflection = null;
+    }
+  }
+
+  /**
+   * Run the post-project docs ceremony.
+   *
+   * Creates a backlog feature with project PRD, merged PR summaries, and a list of
+   * doc files that reference changed code. An agent picks this up and opens a single
+   * documentation PR.
+   *
+   * Fire-and-forget: failure here never surfaces to the caller or affects project status.
+   */
+  private async handlePostProjectDocs(payload: ProjectCompletedPayload): Promise<void> {
+    if (!this.featureLoader || !this.settingsService) return;
+
+    const { projectPath, projectSlug, projectTitle } = payload;
+
+    const projectSettings = await this.settingsService.getProjectSettings(projectPath);
+    const ceremonySettings = projectSettings.ceremonySettings;
+    if (!ceremonySettings?.enabled || !ceremonySettings?.enablePostProjectDocs) {
+      logger.debug('Post-project docs ceremony disabled, skipping');
+      return;
+    }
+
+    this.ceremonyCounts.postProjectDocs++;
+    this.lastCeremonyAt = new Date().toISOString();
+    logger.info(`Running post-project docs ceremony for "${projectTitle}"`);
+
+    const correlationId = `post-project-docs-${projectSlug}-${Date.now()}`;
+
+    try {
+      const flow = createPostProjectDocsFlow({
+        featureLoader: this.featureLoader,
+        projectPath,
+        projectSlug,
+        projectTitle,
+        totalFeatures: payload.totalFeatures,
+        milestoneSummaries: payload.milestoneSummaries,
+      });
+
+      const result = await flow.invoke({});
+
+      this.emitter?.emit('ceremony:post-project-docs', {
+        projectPath,
+        projectSlug,
+        featureId: result.createdFeatureId ?? null,
+      });
+
+      this.auditLog?.record({
+        id: correlationId,
+        timestamp: new Date().toISOString(),
+        ceremonyType: 'post_project_docs',
+        projectPath,
+        projectSlug,
+        deliveryStatus: result.createdFeatureId ? 'delivered' : 'skipped',
+        payload: {
+          title: `Post-Project Docs: ${projectTitle}`,
+          summary: result.createdFeatureId
+            ? `Created docs update feature ${result.createdFeatureId}`
+            : 'No doc update feature created',
+        },
+      });
+
+      if (result.createdFeatureId) {
+        logger.info(
+          `Post-project docs ceremony: created feature ${result.createdFeatureId} for "${projectTitle}"`
+        );
+      }
+    } catch (err) {
+      logger.warn(
+        `Post-project docs ceremony failed for "${projectTitle}": ${err instanceof Error ? err.message : String(err)}`
+      );
+      this.auditLog?.record({
+        id: correlationId,
+        timestamp: new Date().toISOString(),
+        ceremonyType: 'post_project_docs',
+        projectPath,
+        projectSlug,
+        deliveryStatus: 'failed',
+        errorMessage: err instanceof Error ? err.message : String(err),
+        payload: { title: `Post-Project Docs: ${projectTitle}` },
+      });
+
+      this.emitter?.emit('ceremony:post-project-docs:failed', {
+        projectPath,
+        projectSlug,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/libs/flows/src/ceremonies/post-project-docs-flow.ts
+++ b/libs/flows/src/ceremonies/post-project-docs-flow.ts
@@ -1,0 +1,319 @@
+/**
+ * Post-project documentation ceremony LangGraph flow.
+ *
+ * Fires after a project completes (all features done). Gathers project context —
+ * PRD, merged PR summaries, changed files — then identifies doc files that reference
+ * the changed code and creates a backlog feature with rich context for a doc-update agent.
+ *
+ * Flow topology:
+ *   START -> loadProjectContext -> scanAffectedDocs -> createDocUpdateFeature -> END
+ *
+ * This is a fire-and-forget ceremony: any failure here does not affect project status.
+ *
+ * Usage (server-side):
+ * ```typescript
+ * import { createPostProjectDocsFlow } from '@protolabsai/flows';
+ *
+ * const flow = createPostProjectDocsFlow({
+ *   featureLoader,
+ *   projectPath: '/path/to/project',
+ *   projectSlug: 'my-project',
+ *   projectTitle: 'My Project',
+ *   totalFeatures: 10,
+ *   milestoneSummaries: [...],
+ * });
+ *
+ * await flow.invoke({});
+ * ```
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import { StateGraph, Annotation, END, START } from '@langchain/langgraph';
+import type { Feature } from '@protolabsai/types';
+
+// ---------------------------------------------------------------------------
+// Minimal structural interfaces (dependency injection without concrete imports)
+// ---------------------------------------------------------------------------
+
+/**
+ * Subset of FeatureLoader used by the post-project docs flow.
+ */
+export interface PostProjectDocsFeatureLoader {
+  getAll: (projectPath: string) => Promise<Feature[]>;
+  create: (projectPath: string, data: Partial<Feature>) => Promise<Feature>;
+}
+
+/**
+ * Summary of a milestone for context building.
+ */
+export interface PostProjectDocsMilestoneSummary {
+  milestoneTitle: string;
+  featureCount: number;
+  costUsd: number;
+}
+
+/**
+ * All dependencies required to create a post-project docs flow instance.
+ */
+export interface PostProjectDocsFlowDeps {
+  /** Feature loader for reading/creating features */
+  featureLoader: PostProjectDocsFeatureLoader;
+  /** Absolute path to the project directory */
+  projectPath: string;
+  /** Project slug identifier */
+  projectSlug: string;
+  /** Human-readable project title */
+  projectTitle: string;
+  /** Total number of features in the project */
+  totalFeatures: number;
+  /** Per-milestone summaries for context */
+  milestoneSummaries: PostProjectDocsMilestoneSummary[];
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const PostProjectDocsStateAnnotation = Annotation.Root({
+  // Input context
+  projectPath: Annotation<string>,
+  projectSlug: Annotation<string>,
+  projectTitle: Annotation<string>,
+  totalFeatures: Annotation<number>,
+  milestoneSummaries: Annotation<PostProjectDocsMilestoneSummary[]>,
+  // Loaded in loadProjectContext
+  features: Annotation<Feature[]>,
+  prdContent: Annotation<string>,
+  changedFiles: Annotation<string[]>,
+  mergedPrSummaries: Annotation<string>,
+  // Populated in scanAffectedDocs
+  affectedDocFiles: Annotation<string[]>,
+  // Set in createDocUpdateFeature
+  createdFeatureId: Annotation<string>,
+  // Error field
+  error: Annotation<string>,
+});
+
+type PostProjectDocsState = typeof PostProjectDocsStateAnnotation.State;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Read the project PRD markdown file if it exists. */
+function readPrdContent(projectPath: string, projectSlug: string): string {
+  const prdPath = path.join(projectPath, '.automaker', 'projects', projectSlug, 'prd.md');
+  try {
+    if (fs.existsSync(prdPath)) {
+      const raw = fs.readFileSync(prdPath, 'utf-8');
+      // Truncate to avoid overly large descriptions
+      return raw.length > 3000 ? raw.slice(0, 2997) + '...' : raw;
+    }
+  } catch {
+    // non-fatal
+  }
+  return '';
+}
+
+/**
+ * Get files changed in the last N commits on the current branch.
+ * Returns paths relative to the repository root.
+ */
+function getRecentlyChangedFiles(projectPath: string, commitDepth = 30): string[] {
+  try {
+    const output = execSync(`git diff --name-only HEAD~${commitDepth}..HEAD 2>/dev/null || true`, {
+      cwd: projectPath,
+      encoding: 'utf-8',
+      timeout: 10_000,
+    });
+    return output
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Find doc files in docs/ that reference any of the given keywords.
+ * Keywords are derived from changed file basenames (without extension).
+ * Returns paths relative to the repository root.
+ */
+function findAffectedDocFiles(projectPath: string, changedFiles: string[]): string[] {
+  if (changedFiles.length === 0) return [];
+
+  // Extract meaningful keywords from changed file paths
+  const keywords = changedFiles
+    .filter((f) => !f.startsWith('docs/') && !f.endsWith('.md'))
+    .map((f) => path.basename(f, path.extname(f)))
+    .filter((k) => k.length > 3) // skip trivial names like "src", "lib"
+    .filter((k) => !/^(index|types|utils|helpers|constants)$/.test(k));
+
+  if (keywords.length === 0) return [];
+
+  // Deduplicate
+  const uniqueKeywords = [...new Set(keywords)].slice(0, 20);
+  const docsDir = path.join(projectPath, 'docs');
+
+  if (!fs.existsSync(docsDir)) return [];
+
+  const affectedFiles = new Set<string>();
+
+  for (const keyword of uniqueKeywords) {
+    try {
+      // Use grep to find doc files referencing this keyword
+      const output = execSync(
+        `grep -rl --include="*.md" ${JSON.stringify(keyword)} . 2>/dev/null || true`,
+        { cwd: docsDir, encoding: 'utf-8', timeout: 5_000 }
+      );
+      output
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .forEach((f) => {
+          // Make path relative to repo root
+          const relPath = path.join('docs', f.replace(/^\.\//, ''));
+          affectedFiles.add(relPath);
+        });
+    } catch {
+      // non-fatal
+    }
+  }
+
+  return [...affectedFiles].slice(0, 20);
+}
+
+// ---------------------------------------------------------------------------
+// Node factories
+// ---------------------------------------------------------------------------
+
+/**
+ * loadProjectContext: Loads completed features, reads the project PRD,
+ * and collects recently changed files for context.
+ */
+function createLoadProjectContextNode(deps: PostProjectDocsFlowDeps) {
+  return async (_state: PostProjectDocsState): Promise<Partial<PostProjectDocsState>> => {
+    try {
+      const allFeatures = await deps.featureLoader.getAll(deps.projectPath);
+      const features = allFeatures.filter(
+        (f) => f.projectSlug === deps.projectSlug && f.status === 'done'
+      );
+
+      const prdContent = readPrdContent(deps.projectPath, deps.projectSlug);
+      const changedFiles = getRecentlyChangedFiles(deps.projectPath);
+
+      // Build PR summary from feature data (titles + PR URLs)
+      const prLines = features
+        .filter((f) => f.prUrl)
+        .map((f) => `- ${f.title || 'Untitled'} — ${f.prUrl}`)
+        .join('\n');
+      const mergedPrSummaries = prLines || '- No merged PRs recorded';
+
+      return { features, prdContent, changedFiles, mergedPrSummaries };
+    } catch (err) {
+      return {
+        error: err instanceof Error ? err.message : String(err),
+        features: [],
+        prdContent: '',
+        changedFiles: [],
+        mergedPrSummaries: '',
+      };
+    }
+  };
+}
+
+/**
+ * scanAffectedDocs: Finds documentation files that reference changed code modules.
+ */
+function createScanAffectedDocsNode(deps: PostProjectDocsFlowDeps) {
+  return async (state: PostProjectDocsState): Promise<Partial<PostProjectDocsState>> => {
+    if (state.error) return { affectedDocFiles: [] };
+
+    const affectedDocFiles = findAffectedDocFiles(deps.projectPath, state.changedFiles);
+    return { affectedDocFiles };
+  };
+}
+
+/**
+ * createDocUpdateFeature: Creates a backlog feature with full project context
+ * for a doc-update agent to pick up.
+ */
+function createDocUpdateFeatureNode(deps: PostProjectDocsFlowDeps) {
+  return async (state: PostProjectDocsState): Promise<Partial<PostProjectDocsState>> => {
+    if (state.error) return {};
+
+    const shippedCount = state.features.length;
+    const milestoneLine = deps.milestoneSummaries
+      .map((m) => `- ${m.milestoneTitle}: ${m.featureCount} features`)
+      .join('\n');
+
+    const affectedDocsSection =
+      state.affectedDocFiles.length > 0
+        ? `\n\n## Potentially Affected Doc Files\n\nGrep scan found these docs referencing changed modules:\n${state.affectedDocFiles.map((f) => `- \`${f}\``).join('\n')}`
+        : '\n\n## Potentially Affected Doc Files\n\nNo automatic matches found — review `docs/` manually.';
+
+    const prdSection = state.prdContent ? `\n\n## Project PRD\n\n${state.prdContent}` : '';
+
+    const description =
+      `All ${shippedCount} features in the **${deps.projectTitle}** project have merged. ` +
+      `Review the docs and update any pages affected by these changes.\n\n` +
+      `## Project Summary\n\n` +
+      `- Total features shipped: ${shippedCount} of ${deps.totalFeatures}\n` +
+      `- Milestones:\n${milestoneLine || '- (none)'}\n\n` +
+      `## Merged PRs\n\n${state.mergedPrSummaries}` +
+      affectedDocsSection +
+      prdSection +
+      `\n\n## Instructions\n\n` +
+      `1. Review each potentially affected doc file listed above\n` +
+      `2. Check the merged PRs for new services, routes, config options, or changed behavior\n` +
+      `3. Update all relevant pages in \`docs/\` (and \`docs/internal/\` if applicable)\n` +
+      `4. Open a single PR with all doc updates`;
+
+    const feature = await deps.featureLoader.create(deps.projectPath, {
+      title: `Update docs: ${deps.projectTitle} project complete`,
+      description,
+      status: 'backlog',
+      category: 'Documentation',
+      complexity: 'small',
+    });
+
+    return { createdFeatureId: feature.id };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates and compiles the post-project docs ceremony LangGraph flow.
+ *
+ * Flow topology:
+ *   START -> loadProjectContext -> scanAffectedDocs -> createDocUpdateFeature -> END
+ *
+ * @param deps - Flow dependencies (featureLoader, project identifiers, summaries)
+ * @returns Compiled StateGraph ready for .invoke({})
+ */
+export function createPostProjectDocsFlow(deps: PostProjectDocsFlowDeps) {
+  const graph = new StateGraph(PostProjectDocsStateAnnotation);
+
+  graph.addNode('loadProjectContext', createLoadProjectContextNode(deps));
+  graph.addNode('scanAffectedDocs', createScanAffectedDocsNode(deps));
+  graph.addNode('createDocUpdateFeature', createDocUpdateFeatureNode(deps));
+
+  // TypeScript's strict node-name literal inference requires casting here.
+  // Same pattern used in project-retro-flow.ts, maintenance-flow.ts, etc.
+  const g = graph as unknown as {
+    addEdge: (from: string, to: string) => void;
+  };
+
+  g.addEdge(START as unknown as string, 'loadProjectContext');
+  g.addEdge('loadProjectContext', 'scanAffectedDocs');
+  g.addEdge('scanAffectedDocs', 'createDocUpdateFeature');
+  g.addEdge('createDocUpdateFeature', END as unknown as string);
+
+  return graph.compile();
+}

--- a/libs/flows/src/index.ts
+++ b/libs/flows/src/index.ts
@@ -203,3 +203,10 @@ export {
   type ProjectRetroFeatureLoader,
   type ProjectRetroDiscordBot,
 } from './ceremonies/project-retro-flow.js';
+
+export {
+  createPostProjectDocsFlow,
+  type PostProjectDocsFlowDeps,
+  type PostProjectDocsFeatureLoader,
+  type PostProjectDocsMilestoneSummary,
+} from './ceremonies/post-project-docs-flow.js';


### PR DESCRIPTION
## Summary

Automated post-project documentation ceremony

## Problem

After a project's features all merge, documentation updates are manual and easy to forget. The context is freshest at project completion — which files changed, which docs reference them, what new patterns were introduced — but currently a human has to remember to go update 4+ doc files.

Example: The Git Workflow Reliability project (PRs #1103–#1126) added crash recovery, retry backoff, error surfacing, and worktree guard expansion. Docs...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-16T21:06:47.835Z -->