### PR TITLE
Retrieval Tools (grep, describe, expand)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -45,6 +45,7 @@
     "@opentelemetry/exporter-trace-otlp-http": "^0.212.0",
     "@opentelemetry/sdk-node": "^0.212.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
+    "@protolabsai/context-engine": "^0.68.1",
     "@protolabsai/dependency-resolver": "^0.69.0",
     "@protolabsai/error-tracking": "^0.53.16",
     "@protolabsai/flows": "^0.69.0",

--- a/apps/server/src/routes/context-engine.ts
+++ b/apps/server/src/routes/context-engine.ts
@@ -1,0 +1,235 @@
+/**
+ * Context-engine retrieval routes — HTTP API for agent retrieval tools.
+ *
+ * Exposes the three `lcm_*` retrieval operations over HTTP:
+ *
+ *   POST /api/context-engine/grep     — lcm_grep: full-text search
+ *   POST /api/context-engine/describe — lcm_describe: summary metadata + provenance
+ *   POST /api/context-engine/expand   — lcm_expand: bounded DAG walk / full content
+ *
+ * All endpoints accept a `dbPath` field in the request body pointing to the
+ * SQLite database file opened by `ConversationStore`.  The routes open a
+ * short-lived read-only connection per request (better-sqlite3 is synchronous
+ * so this is safe and efficient for agent call patterns).
+ *
+ * Mounted at `/api/context-engine` in `server/routes.ts`.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import * as BetterSqlite3 from 'better-sqlite3';
+import { createLogger } from '@protolabsai/utils';
+import {
+  runMigrations,
+  ContextGrep,
+  ContextDescriber,
+  ContextExpander,
+} from '@protolabsai/context-engine';
+
+const logger = createLogger('ContextEngineRoutes');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Open a better-sqlite3 database at `dbPath`, run pending migrations, and
+ * return the database handle.  Throws if `dbPath` is missing or the file
+ * cannot be opened.
+ */
+function openDb(dbPath: string): BetterSqlite3.Database {
+  const db = new BetterSqlite3.default(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  return db;
+}
+
+function badRequest(res: Response, message: string): void {
+  res.status(400).json({ success: false, error: message });
+}
+
+function serverError(res: Response, message: string): void {
+  res.status(500).json({ success: false, error: message });
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /api/context-engine/grep
+ *
+ * Body:
+ * ```json
+ * {
+ *   "dbPath": "/path/to/conversations.db",
+ *   "query": "search terms",
+ *   "conversationId": "optional-uuid",
+ *   "limit": 10,
+ *   "searchNodes": true,
+ *   "searchLargeFiles": true
+ * }
+ * ```
+ */
+function handleGrep(req: Request, res: Response): void {
+  const { dbPath, query, conversationId, limit, searchNodes, searchLargeFiles } =
+    req.body as {
+      dbPath?: string;
+      query?: string;
+      conversationId?: string;
+      limit?: number;
+      searchNodes?: boolean;
+      searchLargeFiles?: boolean;
+    };
+
+  if (!dbPath) return badRequest(res, 'dbPath is required');
+  if (!query || typeof query !== 'string' || query.trim() === '') {
+    return badRequest(res, 'query must be a non-empty string');
+  }
+
+  let db: BetterSqlite3.Database | null = null;
+  try {
+    db = openDb(dbPath);
+    const grepper = new ContextGrep(db);
+    const result = grepper.search({
+      query: query.trim(),
+      conversationId,
+      limit: typeof limit === 'number' ? limit : 10,
+      searchNodes: searchNodes !== false,
+      searchLargeFiles: searchLargeFiles !== false,
+    });
+    res.json({ success: true, ...result });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error(`lcm_grep error: ${msg}`);
+    serverError(res, msg);
+  } finally {
+    db?.close();
+  }
+}
+
+/**
+ * POST /api/context-engine/describe
+ *
+ * Body:
+ * ```json
+ * {
+ *   "dbPath": "/path/to/conversations.db",
+ *   "nodeId": "uuid",
+ *   "includeParents": false,
+ *   "maxParentDepth": 3
+ * }
+ * ```
+ */
+function handleDescribe(req: Request, res: Response): void {
+  const { dbPath, nodeId, includeParents, maxParentDepth } = req.body as {
+    dbPath?: string;
+    nodeId?: string;
+    includeParents?: boolean;
+    maxParentDepth?: number;
+  };
+
+  if (!dbPath) return badRequest(res, 'dbPath is required');
+  if (!nodeId || typeof nodeId !== 'string') {
+    return badRequest(res, 'nodeId must be a non-empty string');
+  }
+
+  let db: BetterSqlite3.Database | null = null;
+  try {
+    db = openDb(dbPath);
+    const describer = new ContextDescriber(db);
+    const description = describer.describe(nodeId, {
+      includeParents: includeParents === true,
+      maxParentDepth: typeof maxParentDepth === 'number' ? maxParentDepth : 3,
+    });
+
+    if (!description) {
+      res.status(404).json({ success: false, error: `Node not found: ${nodeId}` });
+      return;
+    }
+
+    res.json({ success: true, description });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error(`lcm_describe error: ${msg}`);
+    serverError(res, msg);
+  } finally {
+    db?.close();
+  }
+}
+
+/**
+ * POST /api/context-engine/expand
+ *
+ * Body:
+ * ```json
+ * {
+ *   "dbPath": "/path/to/conversations.db",
+ *   "nodeId": "uuid",
+ *   "question": "optional focused question",
+ *   "tokenCap": 50000,
+ *   "ttlMs": 10000
+ * }
+ * ```
+ */
+function handleExpand(req: Request, res: Response): void {
+  const { dbPath, nodeId, question, tokenCap, ttlMs } = req.body as {
+    dbPath?: string;
+    nodeId?: string;
+    question?: string;
+    tokenCap?: number;
+    ttlMs?: number;
+  };
+
+  if (!dbPath) return badRequest(res, 'dbPath is required');
+  if (!nodeId || typeof nodeId !== 'string') {
+    return badRequest(res, 'nodeId must be a non-empty string');
+  }
+
+  let db: BetterSqlite3.Database | null = null;
+  try {
+    db = openDb(dbPath);
+    const expander = new ContextExpander(db);
+    const result = expander.expand({
+      nodeId,
+      question: typeof question === 'string' ? question : undefined,
+      tokenCap: typeof tokenCap === 'number' ? tokenCap : undefined,
+      ttlMs: typeof ttlMs === 'number' ? ttlMs : undefined,
+    });
+
+    if (!result) {
+      res.status(404).json({ success: false, error: `Node not found: ${nodeId}` });
+      return;
+    }
+
+    res.json({ success: true, ...result });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error(`lcm_expand error: ${msg}`);
+    serverError(res, msg);
+  } finally {
+    db?.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Router factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the context-engine router.
+ *
+ * Mounted at `/api/context-engine` in `server/routes.ts`:
+ * ```typescript
+ * app.use('/api/context-engine', createContextEngineRoutes());
+ * ```
+ */
+export function createContextEngineRoutes(): Router {
+  const router = Router();
+
+  router.post('/grep', handleGrep);
+  router.post('/describe', handleDescribe);
+  router.post('/expand', handleExpand);
+
+  return router;
+}

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -94,6 +94,7 @@ import { createDoraRoutes } from '../routes/dora/index.js';
 import { createAgentRoutes } from '../routes/agents.js';
 import { createOpsRoutes } from '../routes/ops/index.js';
 import { createQaRoutes } from '../routes/qa/index.js';
+import { createContextEngineRoutes } from '../routes/context-engine.js';
 
 const logger = createLogger('Server:Routes');
 
@@ -453,6 +454,10 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   // QA check aggregation (consolidated report for Quinn QA agent)
   app.use('/api/qa', createQaRoutes(services));
   logger.info('QA routes mounted at /api/qa');
+
+  // Context-engine retrieval tools (lcm_grep, lcm_describe, lcm_expand)
+  app.use('/api/context-engine', createContextEngineRoutes());
+  logger.info('Context-engine routes mounted at /api/context-engine');
 
   // Note: Sentry v8 automatically captures Express errors - no manual error handler needed
 }

--- a/apps/server/tsconfig.build.json
+++ b/apps/server/tsconfig.build.json
@@ -14,7 +14,8 @@
       "@protolabsai/templates": ["../../libs/templates/src/index.ts"],
       "@protolabsai/tools": ["../../libs/tools/dist/index.d.ts"],
       "@protolabsai/types": ["../../libs/types/dist/index.d.ts"],
-      "@protolabsai/utils": ["../../libs/utils/dist/index.d.ts"]
+      "@protolabsai/utils": ["../../libs/utils/dist/index.d.ts"],
+      "@protolabsai/context-engine": ["../../libs/context-engine/dist/index.d.ts"]
     }
   }
 }

--- a/libs/context-engine/src/index.ts
+++ b/libs/context-engine/src/index.ts
@@ -25,3 +25,5 @@
 
 export * from './store/index.js';
 export * from './compaction/index.js';
+export * from './retrieval/index.js';
+export * from './interception/index.js';

--- a/libs/context-engine/src/retrieval/describe.ts
+++ b/libs/context-engine/src/retrieval/describe.ts
@@ -1,0 +1,264 @@
+/**
+ * ContextDescriber — surface summary metadata with provenance chain.
+ *
+ * Given a node ID (from an `[lcm_expand: <id>]` reference in the context window),
+ * returns the stored summary, depth, compaction mode, source IDs, token counts,
+ * and optionally the full provenance chain (parent nodes that condensed this node
+ * into a higher-depth summary).
+ *
+ * Looks up both `context_nodes` (CompactedNode / CondensedNode) and `large_files`.
+ *
+ * Tool: `lcm_describe`
+ */
+
+import * as BetterSqlite3 from 'better-sqlite3';
+import { createLogger } from '@protolabsai/utils';
+
+const logger = createLogger('ContextDescriber');
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type NodeType = 'compacted' | 'condensed' | 'large_file';
+
+export interface NodeDescription {
+  /** UUID of the node. */
+  id: string;
+  /** Semantic type: compacted (depth=0), condensed (depth>=1), or large_file. */
+  type: NodeType;
+  /**
+   * Compaction depth.
+   *   0 = leaf summary from LeafCompactor
+   *   1+ = cascaded condensation from CondensationEngine
+   *   0 for large_file nodes
+   */
+  depth: number;
+  /** Stored summary text. */
+  summary: string;
+  /**
+   * Expand footer appended to the summary in the context window.
+   * Format: "[lcm_expand: <id>] Topics: ... (compressed N → ? tokens, mode: ...)"
+   */
+  expandFooter: string;
+  /**
+   * IDs of the source items this node was produced from:
+   *   - depth=0 (compacted): message IDs from the messages table
+   *   - depth>=1 (condensed): context_node IDs
+   *   - large_file: empty array
+   */
+  sourceIds: string[];
+  /** Token count of the original source content before compaction. */
+  originalTokens: number;
+  /** Token count of this summary (including the expand footer). */
+  summaryTokens: number;
+  /**
+   * Compaction mode used to produce this node.
+   * One of 'normal' | 'aggressive' | 'deterministic' for depth=0 nodes.
+   * Undefined for condensed or large_file nodes.
+   */
+  mode?: string;
+  /** ISO 8601 timestamp when this node was stored. */
+  storedAt: string;
+  /** Conversation this node belongs to, if known. */
+  conversationId?: string;
+  /**
+   * Parent nodes in the provenance chain — nodes that condensed this node
+   * into a higher-depth summary.  Only populated when `includeParents=true`
+   * is passed to `describe()`.
+   */
+  parents?: NodeDescription[];
+}
+
+export interface DescribeOptions {
+  /**
+   * Walk UP the DAG and include parent nodes that condensed this node.
+   * Default: false.
+   */
+  includeParents?: boolean;
+  /**
+   * Maximum levels of parent provenance to include (default: 3).
+   * Prevents unbounded DAG traversal.
+   */
+  maxParentDepth?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal DB row types
+// ---------------------------------------------------------------------------
+
+interface DbContextNode {
+  id: string;
+  conversation_id: string | null;
+  depth: number;
+  summary: string;
+  expand_footer: string;
+  source_ids: string;
+  original_tokens: number;
+  summary_tokens: number;
+  mode: string | null;
+  stored_at: string;
+}
+
+interface DbLargeFile {
+  id: string;
+  conversation_id: string | null;
+  summary: string;
+  token_count: number;
+  stored_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// ContextDescriber
+// ---------------------------------------------------------------------------
+
+export class ContextDescriber {
+  constructor(private readonly db: BetterSqlite3.Database) {}
+
+  /**
+   * Describe a node by ID.
+   *
+   * Checks `context_nodes` first, then `large_files`.
+   *
+   * @param nodeId         UUID visible in an `[lcm_expand: <id>]` reference.
+   * @param options        Optional provenance chain settings.
+   * @returns              NodeDescription, or null if not found.
+   */
+  describe(nodeId: string, options: DescribeOptions = {}): NodeDescription | null {
+    const includeParents = options.includeParents ?? false;
+    const maxParentDepth = options.maxParentDepth ?? 3;
+
+    // Try context_nodes
+    const nodeRow = this.db
+      .prepare('SELECT * FROM context_nodes WHERE id = ?')
+      .get(nodeId) as DbContextNode | undefined;
+
+    if (nodeRow) {
+      const desc = this.mapContextNode(nodeRow);
+      if (includeParents) {
+        desc.parents = this.findParents(nodeId, maxParentDepth);
+      }
+      logger.debug(`lcm_describe: found context_node id=${nodeId} depth=${nodeRow.depth}`);
+      return desc;
+    }
+
+    // Try large_files
+    const fileRow = this.db
+      .prepare('SELECT * FROM large_files WHERE id = ?')
+      .get(nodeId) as DbLargeFile | undefined;
+
+    if (fileRow) {
+      logger.debug(`lcm_describe: found large_file id=${nodeId}`);
+      return this.mapLargeFile(fileRow);
+    }
+
+    logger.warn(`lcm_describe: no node found for id=${nodeId}`);
+    return null;
+  }
+
+  /**
+   * List all context nodes for a conversation, ordered by stored_at ascending.
+   * Useful for surfacing the full compaction history.
+   */
+  listNodesForConversation(conversationId: string): NodeDescription[] {
+    const rows = this.db
+      .prepare('SELECT * FROM context_nodes WHERE conversation_id = ? ORDER BY stored_at ASC')
+      .all(conversationId) as DbContextNode[];
+
+    return rows.map((r) => this.mapContextNode(r));
+  }
+
+  /**
+   * List all context nodes at a given depth for a conversation.
+   */
+  listNodesByDepth(conversationId: string, depth: number): NodeDescription[] {
+    const rows = this.db
+      .prepare(
+        'SELECT * FROM context_nodes WHERE conversation_id = ? AND depth = ? ORDER BY stored_at ASC'
+      )
+      .all(conversationId, depth) as DbContextNode[];
+
+    return rows.map((r) => this.mapContextNode(r));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Walk UP the DAG: find nodes whose source_ids contain `nodeId`.
+   * Bounded by `remainingDepth` to prevent cycles / runaway traversal.
+   */
+  private findParents(nodeId: string, remainingDepth: number): NodeDescription[] {
+    if (remainingDepth <= 0) return [];
+
+    // We need to find all context_nodes whose source_ids JSON array contains nodeId.
+    // SQLite doesn't natively query inside JSON arrays so we use LIKE on the raw text.
+    // This is safe because UUIDs are unique enough to avoid false positives.
+    const likePattern = `%"${nodeId}"%`;
+
+    const rows = this.db
+      .prepare('SELECT * FROM context_nodes WHERE source_ids LIKE ?')
+      .all(likePattern) as DbContextNode[];
+
+    const parents: NodeDescription[] = [];
+
+    for (const row of rows) {
+      // Double-check: parse JSON and confirm membership
+      let sourceIds: string[];
+      try {
+        sourceIds = JSON.parse(row.source_ids) as string[];
+      } catch {
+        continue;
+      }
+
+      if (!sourceIds.includes(nodeId)) continue;
+
+      const desc = this.mapContextNode(row);
+      desc.parents = this.findParents(row.id, remainingDepth - 1);
+      parents.push(desc);
+    }
+
+    return parents;
+  }
+
+  private mapContextNode(row: DbContextNode): NodeDescription {
+    let sourceIds: string[];
+    try {
+      sourceIds = JSON.parse(row.source_ids) as string[];
+    } catch {
+      sourceIds = [];
+    }
+
+    const type: NodeType = row.depth === 0 ? 'compacted' : 'condensed';
+
+    return {
+      id: row.id,
+      type,
+      depth: row.depth,
+      summary: row.summary,
+      expandFooter: row.expand_footer,
+      sourceIds,
+      originalTokens: row.original_tokens,
+      summaryTokens: row.summary_tokens,
+      mode: row.mode ?? undefined,
+      storedAt: row.stored_at,
+      conversationId: row.conversation_id ?? undefined,
+    };
+  }
+
+  private mapLargeFile(row: DbLargeFile): NodeDescription {
+    return {
+      id: row.id,
+      type: 'large_file',
+      depth: 0,
+      summary: row.summary,
+      expandFooter: `[lcm_expand: "${row.id}"] Large file (~${row.token_count.toLocaleString()} tokens — call lcm_expand to retrieve full content)`,
+      sourceIds: [],
+      originalTokens: row.token_count,
+      summaryTokens: Math.ceil(row.summary.length / 4),
+      storedAt: row.stored_at,
+      conversationId: row.conversation_id ?? undefined,
+    };
+  }
+}

--- a/libs/context-engine/src/retrieval/expand.ts
+++ b/libs/context-engine/src/retrieval/expand.ts
@@ -1,0 +1,467 @@
+/**
+ * ContextExpander — bounded DAG walk for full content retrieval.
+ *
+ * Given a node ID (from an `[lcm_expand: <id>]` footer in the context window),
+ * retrieves the original content up to a configurable `tokenCap`:
+ *
+ *   - **large_file nodes**: returns the stored `original_content` directly.
+ *   - **depth=0 context_nodes** (CompactedNode): retrieves all source messages from
+ *     `message_parts`, concatenated in order.
+ *   - **depth≥1 context_nodes** (CondensedNode): recursively expands source nodes down
+ *     to the leaf messages, collecting text as it goes.
+ *
+ * Expansion terminates early (setting `truncated=true`) when:
+ *   - `tokenCap` is reached, or
+ *   - the `ttlMs` wall-clock deadline is exceeded.
+ *
+ * ## ContextNodeStore
+ *
+ * `ContextNodeStore` is a companion class for persisting `CompactedNode` and
+ * `CondensedNode` objects produced by `LeafCompactor` / `CondensationEngine` to the
+ * `context_nodes` SQLite table, making them available for later retrieval via
+ * `lcm_describe` and `lcm_expand`.
+ *
+ * Wire it into your workflow:
+ * ```typescript
+ * const result = await leafCompactor.compact(messages, config);
+ * if (result) {
+ *   nodeStore.saveNodes(result.nodes);
+ * }
+ * ```
+ *
+ * Tool: `lcm_expand`
+ */
+
+import * as BetterSqlite3 from 'better-sqlite3';
+import { createLogger } from '@protolabsai/utils';
+import { estimateTokens } from '../store/conversation-store.js';
+
+const logger = createLogger('ContextExpander');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default token cap for expand results (~50 K tokens). */
+export const DEFAULT_EXPAND_TOKEN_CAP = 50_000;
+
+/** Default wall-clock deadline for a single expand call (10 seconds). */
+export const DEFAULT_EXPAND_TTL_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// ContextNodeStore — persistence for CompactedNode / CondensedNode
+// ---------------------------------------------------------------------------
+
+/**
+ * A node that can be persisted to the `context_nodes` table.
+ * Matches the shape of both `CompactedNode` (depth=0) and `CondensedNode` (depth≥1).
+ */
+export interface StorableNode {
+  /** UUID from the compactor/condensation engine. */
+  id: string;
+  /** Conversation this node belongs to. */
+  conversationId?: string;
+  /** 0 for leaf (CompactedNode), 1+ for condensed (CondensedNode). */
+  depth: number;
+  /** Compact summary text. */
+  summary: string;
+  /** Expand footer injected into the context window. */
+  expandFooter: string;
+  /**
+   * IDs of the items compressed into this node:
+   *   - depth=0: message IDs
+   *   - depth≥1: context_node IDs
+   */
+  sourceIds: string[];
+  /** Token count of the original content before compaction. */
+  originalTokens: number;
+  /** Token count of this summary + footer. */
+  summaryTokens: number;
+  /** Compaction mode (depth=0 only): 'normal' | 'aggressive' | 'deterministic'. */
+  mode?: string;
+}
+
+interface DbContextNode {
+  id: string;
+  conversation_id: string | null;
+  depth: number;
+  summary: string;
+  expand_footer: string;
+  source_ids: string;
+  original_tokens: number;
+  summary_tokens: number;
+  mode: string | null;
+  stored_at: string;
+}
+
+/**
+ * Persists and retrieves `CompactedNode` / `CondensedNode` objects to/from the
+ * `context_nodes` SQLite table.
+ *
+ * Use `saveNodes()` after each compaction/condensation pass to keep the DB in sync
+ * with the in-memory node collection.
+ */
+export class ContextNodeStore {
+  constructor(private readonly db: BetterSqlite3.Database) {}
+
+  /**
+   * Persist a single node.  Uses INSERT OR REPLACE so calling this with an
+   * existing ID is safe (idempotent update).
+   */
+  saveNode(node: StorableNode): void {
+    const now = new Date().toISOString();
+    this.db
+      .prepare(
+        `INSERT OR REPLACE INTO context_nodes
+           (id, conversation_id, depth, summary, expand_footer, source_ids,
+            original_tokens, summary_tokens, mode, stored_at, metadata)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        node.id,
+        node.conversationId ?? null,
+        node.depth,
+        node.summary,
+        node.expandFooter,
+        JSON.stringify(node.sourceIds),
+        node.originalTokens,
+        node.summaryTokens,
+        node.mode ?? null,
+        now,
+        '{}'
+      );
+    logger.debug(`ContextNodeStore: saved node id=${node.id} depth=${node.depth}`);
+  }
+
+  /**
+   * Persist multiple nodes in a single transaction.
+   */
+  saveNodes(nodes: StorableNode[]): void {
+    const tx = this.db.transaction(() => {
+      for (const node of nodes) {
+        this.saveNode(node);
+      }
+    });
+    tx();
+    logger.debug(`ContextNodeStore: saved ${nodes.length} nodes`);
+  }
+
+  /**
+   * Retrieve a node by ID, or null if not found.
+   */
+  getNode(id: string): StorableNode | null {
+    const row = this.db
+      .prepare('SELECT * FROM context_nodes WHERE id = ?')
+      .get(id) as DbContextNode | undefined;
+
+    return row ? this.mapRow(row) : null;
+  }
+
+  /**
+   * Delete a node by ID.
+   * @returns true if a row was deleted, false if not found.
+   */
+  deleteNode(id: string): boolean {
+    const result = this.db.prepare('DELETE FROM context_nodes WHERE id = ?').run(id);
+    return result.changes > 0;
+  }
+
+  /**
+   * List all nodes for a conversation ordered by stored_at ascending.
+   */
+  listForConversation(conversationId: string): StorableNode[] {
+    const rows = this.db
+      .prepare('SELECT * FROM context_nodes WHERE conversation_id = ? ORDER BY stored_at ASC')
+      .all(conversationId) as DbContextNode[];
+
+    return rows.map((r) => this.mapRow(r));
+  }
+
+  private mapRow(row: DbContextNode): StorableNode {
+    let sourceIds: string[];
+    try {
+      sourceIds = JSON.parse(row.source_ids) as string[];
+    } catch {
+      sourceIds = [];
+    }
+
+    return {
+      id: row.id,
+      conversationId: row.conversation_id ?? undefined,
+      depth: row.depth,
+      summary: row.summary,
+      expandFooter: row.expand_footer,
+      sourceIds,
+      originalTokens: row.original_tokens,
+      summaryTokens: row.summary_tokens,
+      mode: row.mode ?? undefined,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ContextExpander — public types
+// ---------------------------------------------------------------------------
+
+export interface ExpandOptions {
+  /** UUID from an `[lcm_expand: <id>]` reference in the context window. */
+  nodeId: string;
+  /**
+   * Optional focused question.  When provided, a focus hint is prepended to the
+   * returned content so downstream consumers know the retrieval intent.
+   */
+  question?: string;
+  /** Maximum tokens to include in the returned content (default: 50 000). */
+  tokenCap?: number;
+  /** Maximum wall-clock time for the DAG walk in milliseconds (default: 10 000). */
+  ttlMs?: number;
+}
+
+export interface ExpandResult {
+  /** The node ID that was expanded. */
+  nodeId: string;
+  /** Whether the node came from large_files or context_nodes. */
+  nodeType: 'large_file' | 'context_node';
+  /**
+   * Full expanded content, possibly truncated.
+   * Includes a focus-question header when `question` was provided.
+   */
+  content: string;
+  /** True when output was cut short by `tokenCap` or `ttlMs`. */
+  truncated: boolean;
+  /** Estimated token count of the returned content. */
+  tokens: number;
+  /**
+   * Number of leaf source items (messages) that were expanded.
+   * For large_file this is always 1.
+   */
+  sourceCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// ContextExpander
+// ---------------------------------------------------------------------------
+
+export class ContextExpander {
+  constructor(private readonly db: BetterSqlite3.Database) {}
+
+  /**
+   * Expand a node to its full content.
+   *
+   * Automatically detects whether the ID belongs to a `large_files` row or a
+   * `context_nodes` row and handles each case appropriately.
+   *
+   * @returns ExpandResult, or null if the ID is not found in either table.
+   */
+  expand(options: ExpandOptions): ExpandResult | null {
+    const tokenCap = options.tokenCap ?? DEFAULT_EXPAND_TOKEN_CAP;
+    const ttlMs = options.ttlMs ?? DEFAULT_EXPAND_TTL_MS;
+    const deadline = Date.now() + ttlMs;
+
+    // ── Try large_files first ─────────────────────────────────────────────
+    const largeFileRow = this.db
+      .prepare('SELECT original_content, token_count FROM large_files WHERE id = ?')
+      .get(options.nodeId) as { original_content: string; token_count: number } | undefined;
+
+    if (largeFileRow) {
+      logger.debug(
+        `lcm_expand: large_file id=${options.nodeId} original_tokens=${largeFileRow.token_count}`
+      );
+
+      const raw = largeFileRow.original_content;
+      const charLimit = tokenCap * 4;
+      const truncated = raw.length > charLimit;
+      const content = truncated ? raw.slice(0, charLimit) : raw;
+
+      return {
+        nodeId: options.nodeId,
+        nodeType: 'large_file',
+        content: this.wrapContent(content, options.question, truncated),
+        truncated,
+        tokens: estimateTokens(content),
+        sourceCount: 1,
+      };
+    }
+
+    // ── Try context_nodes ─────────────────────────────────────────────────
+    const nodeRow = this.db
+      .prepare('SELECT * FROM context_nodes WHERE id = ?')
+      .get(options.nodeId) as DbContextNode | undefined;
+
+    if (nodeRow) {
+      const { content, truncated, sourceCount } = this.walkNode(
+        nodeRow,
+        tokenCap,
+        deadline
+      );
+
+      logger.debug(
+        `lcm_expand: context_node id=${options.nodeId} depth=${nodeRow.depth} ` +
+          `sourceCount=${sourceCount} truncated=${truncated}`
+      );
+
+      return {
+        nodeId: options.nodeId,
+        nodeType: 'context_node',
+        content: this.wrapContent(content, options.question, truncated),
+        truncated,
+        tokens: estimateTokens(content),
+        sourceCount,
+      };
+    }
+
+    logger.warn(`lcm_expand: no node found for id=${options.nodeId}`);
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: DAG walk
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Recursively walks down a context_node to collect source content.
+   *
+   * @param node         The node row to expand.
+   * @param tokenCap     Remaining token budget for this sub-tree.
+   * @param deadline     Epoch ms after which we stop and set truncated=true.
+   */
+  private walkNode(
+    node: DbContextNode,
+    tokenCap: number,
+    deadline: number
+  ): { content: string; truncated: boolean; sourceCount: number } {
+    let sourceIds: string[];
+    try {
+      sourceIds = JSON.parse(node.source_ids) as string[];
+    } catch {
+      sourceIds = [];
+    }
+
+    if (sourceIds.length === 0) {
+      // Leaf with no recorded sources — return the summary as best effort
+      return { content: node.summary, truncated: false, sourceCount: 0 };
+    }
+
+    const lines: string[] = [
+      `[Context node: ${node.id} | depth=${node.depth}${node.mode ? ` | mode=${node.mode}` : ''}]`,
+      `Summary: ${node.summary}`,
+      '',
+      '─── Expanded source content ───',
+    ];
+
+    let tokensSoFar = estimateTokens(lines.join('\n'));
+    let sourceCount = 0;
+    let truncated = false;
+
+    for (let i = 0; i < sourceIds.length; i++) {
+      const sourceId = sourceIds[i];
+
+      // Wall-clock check
+      if (Date.now() > deadline) {
+        const remaining = sourceIds.length - i;
+        lines.push(
+          `\n[Truncated: TTL exceeded — ${remaining} source(s) not expanded. ` +
+            `Call lcm_expand with a higher ttlMs to retrieve more.]`
+        );
+        truncated = true;
+        break;
+      }
+
+      if (node.depth === 0) {
+        // depth=0: sourceIds are message IDs → retrieve message parts
+        const msgContent = this.expandMessage(sourceId);
+        if (!msgContent) continue;
+
+        const chunk = `\n[Message ${sourceId}]\n${msgContent}`;
+        const chunkTokens = estimateTokens(chunk);
+
+        if (tokensSoFar + chunkTokens > tokenCap) {
+          const remaining = sourceIds.length - i;
+          lines.push(
+            `\n[Truncated: token cap reached — ${remaining} message(s) not expanded. ` +
+              `Call lcm_expand with a higher tokenCap to retrieve more.]`
+          );
+          truncated = true;
+          break;
+        }
+
+        lines.push(chunk);
+        tokensSoFar += chunkTokens;
+        sourceCount++;
+      } else {
+        // depth≥1: sourceIds are context_node IDs → recurse
+        const childRow = this.db
+          .prepare('SELECT * FROM context_nodes WHERE id = ?')
+          .get(sourceId) as DbContextNode | undefined;
+
+        if (!childRow) continue;
+
+        const remainingBudget = tokenCap - tokensSoFar;
+        const child = this.walkNode(childRow, remainingBudget, deadline);
+        const chunkTokens = estimateTokens(child.content);
+
+        if (tokensSoFar + chunkTokens > tokenCap) {
+          const remaining = sourceIds.length - i;
+          lines.push(
+            `\n[Truncated: token cap reached — ${remaining} sub-node(s) not expanded.]`
+          );
+          truncated = true;
+          break;
+        }
+
+        lines.push('', child.content);
+        tokensSoFar += chunkTokens;
+        sourceCount += child.sourceCount;
+
+        if (child.truncated) {
+          truncated = true;
+          break;
+        }
+      }
+    }
+
+    return { content: lines.join('\n'), truncated, sourceCount };
+  }
+
+  /**
+   * Retrieve all parts of a message and return them as concatenated text.
+   * Returns null if the message has no parts.
+   */
+  private expandMessage(messageId: string): string | null {
+    const rows = this.db
+      .prepare(
+        'SELECT content FROM message_parts WHERE message_id = ? ORDER BY position ASC'
+      )
+      .all(messageId) as Array<{ content: string }>;
+
+    if (rows.length === 0) return null;
+    return rows.map((r) => r.content).join('\n');
+  }
+
+  /**
+   * Wrap the expanded content with optional focus-question header and
+   * truncation footer.
+   */
+  private wrapContent(
+    content: string,
+    question: string | undefined,
+    truncated: boolean
+  ): string {
+    const parts: string[] = [];
+
+    if (question) {
+      parts.push(`[Focus question: ${question}]`, '');
+    }
+
+    parts.push(content);
+
+    if (truncated) {
+      parts.push(
+        '',
+        '[Content was truncated. Call lcm_expand with a higher tokenCap or ttlMs to retrieve more.]'
+      );
+    }
+
+    return parts.join('\n');
+  }
+}

--- a/libs/context-engine/src/retrieval/grep.ts
+++ b/libs/context-engine/src/retrieval/grep.ts
@@ -1,0 +1,488 @@
+/**
+ * ContextGrep — full-text search across conversation history.
+ *
+ * Searches three sources in a single call:
+ *   1. `message_parts` — raw message content (via FTS5 when indexed, LIKE fallback)
+ *   2. `context_nodes` — compacted/condensed summaries
+ *   3. `large_files`   — large-file interception summaries
+ *
+ * FTS5 is used for `message_parts` when the `messages_fts` virtual table has been
+ * populated via `ContextFtsIndex.index()`.  For the other two tables LIKE is used
+ * directly (they are typically small).
+ *
+ * Tool: `lcm_grep`
+ */
+
+import * as BetterSqlite3 from 'better-sqlite3';
+import { createLogger } from '@protolabsai/utils';
+
+const logger = createLogger('ContextGrep');
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface GrepOptions {
+  /** Search query string. For FTS5: standard FTS5 query syntax (e.g. "foo AND bar"). */
+  query: string;
+  /** Restrict results to a specific conversation. */
+  conversationId?: string;
+  /** Maximum results per source table (default: 10). */
+  limit?: number;
+  /** Include context_nodes in search (default: true). */
+  searchNodes?: boolean;
+  /** Include large_files in search (default: true). */
+  searchLargeFiles?: boolean;
+}
+
+export type GrepMatchType = 'message_part' | 'context_node' | 'large_file';
+
+export interface GrepMatch {
+  /** Source table this match came from. */
+  type: GrepMatchType;
+  /** Row ID (part ID, node ID, or large_file ID). */
+  id: string;
+  /** Message ID — only present for message_part matches. */
+  messageId?: string;
+  /** Conversation the match belongs to. */
+  conversationId?: string;
+  /**
+   * ~200-character snippet of the matching content, centred on the first
+   * occurrence of the query term.
+   */
+  snippet: string;
+  /** Estimated token count of the snippet. */
+  tokens: number;
+  /**
+   * FTS5 rank (lower = more relevant).  0 for LIKE-based matches where
+   * relevance ranking is unavailable.
+   */
+  rank: number;
+}
+
+export interface GrepResult {
+  matches: GrepMatch[];
+  query: string;
+  totalMatches: number;
+  /** True when FTS5 was used for message_parts; false when LIKE was used. */
+  ftsUsed: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SNIPPET_CHARS = 200;
+const SNIPPET_CONTEXT = 60; // chars before the match
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildSnippet(content: string, queryFirstWord: string): string {
+  const lower = content.toLowerCase();
+  const wordLower = queryFirstWord.toLowerCase();
+  const idx = lower.indexOf(wordLower);
+
+  if (idx === -1) {
+    return content.slice(0, SNIPPET_CHARS);
+  }
+
+  const start = Math.max(0, idx - SNIPPET_CONTEXT);
+  const end = Math.min(content.length, start + SNIPPET_CHARS);
+  const text = content.slice(start, end);
+  return start > 0 ? `\u2026${text}` : text;
+}
+
+function estimateSnippetTokens(snippet: string): number {
+  return Math.ceil(snippet.length / 4);
+}
+
+// ---------------------------------------------------------------------------
+// ContextFtsIndex — helper for populating the messages_fts virtual table
+// ---------------------------------------------------------------------------
+
+/**
+ * Manages the FTS5 index for message_parts content.
+ *
+ * Call `index(conversationId)` after inserting messages to keep the FTS5
+ * virtual table up to date.  Already-indexed parts are skipped via a
+ * NOT EXISTS check so the call is idempotent.
+ */
+export class ContextFtsIndex {
+  constructor(private readonly db: BetterSqlite3.Database) {}
+
+  /**
+   * Index all message_parts for a conversation that are not yet in messages_fts.
+   *
+   * @returns Number of parts newly indexed.
+   */
+  index(conversationId: string): number {
+    const rows = this.db
+      .prepare(
+        `SELECT mp.id AS part_id, mp.message_id, m.conversation_id, mp.content
+         FROM message_parts mp
+         JOIN messages m ON mp.message_id = m.id
+         WHERE m.conversation_id = ?
+           AND NOT EXISTS (
+             SELECT 1 FROM messages_fts WHERE part_id = mp.id
+           )`
+      )
+      .all(conversationId) as Array<{
+      part_id: string;
+      message_id: string;
+      conversation_id: string;
+      content: string;
+    }>;
+
+    if (rows.length === 0) return 0;
+
+    const insert = this.db.prepare(
+      'INSERT INTO messages_fts (part_id, message_id, conversation_id, content) VALUES (?, ?, ?, ?)'
+    );
+
+    const tx = this.db.transaction(() => {
+      for (const row of rows) {
+        insert.run(row.part_id, row.message_id, row.conversation_id, row.content);
+      }
+    });
+    tx();
+
+    logger.debug(`ContextFtsIndex: indexed ${rows.length} parts for conversation=${conversationId}`);
+    return rows.length;
+  }
+
+  /**
+   * Remove all FTS5 entries for a conversation (e.g. when a conversation is deleted).
+   */
+  removeConversation(conversationId: string): void {
+    this.db
+      .prepare("DELETE FROM messages_fts WHERE conversation_id = ?")
+      .run(conversationId);
+  }
+
+  /**
+   * Rebuild the entire FTS5 index from scratch.
+   * Useful after bulk imports or schema repairs.
+   */
+  rebuild(): number {
+    this.db.prepare("DELETE FROM messages_fts").run();
+
+    const rows = this.db
+      .prepare(
+        `SELECT mp.id AS part_id, mp.message_id, m.conversation_id, mp.content
+         FROM message_parts mp
+         JOIN messages m ON mp.message_id = m.id`
+      )
+      .all() as Array<{
+      part_id: string;
+      message_id: string;
+      conversation_id: string;
+      content: string;
+    }>;
+
+    if (rows.length === 0) return 0;
+
+    const insert = this.db.prepare(
+      'INSERT INTO messages_fts (part_id, message_id, conversation_id, content) VALUES (?, ?, ?, ?)'
+    );
+
+    const tx = this.db.transaction(() => {
+      for (const row of rows) {
+        insert.run(row.part_id, row.message_id, row.conversation_id, row.content);
+      }
+    });
+    tx();
+
+    logger.info(`ContextFtsIndex: rebuilt index with ${rows.length} parts`);
+    return rows.length;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ContextGrep
+// ---------------------------------------------------------------------------
+
+export class ContextGrep {
+  constructor(private readonly db: BetterSqlite3.Database) {}
+
+  /**
+   * Search conversation history for `options.query`.
+   *
+   * Results are drawn from `message_parts` (via FTS5 or LIKE), `context_nodes`,
+   * and `large_files`, each capped at `options.limit` matches.
+   */
+  search(options: GrepOptions): GrepResult {
+    const { query, conversationId, limit = 10 } = options;
+    const searchNodes = options.searchNodes !== false;
+    const searchLargeFiles = options.searchLargeFiles !== false;
+
+    const queryFirstWord = query.split(/\s+/)[0] ?? query;
+    const matches: GrepMatch[] = [];
+    let ftsUsed = false;
+
+    // ── 1. message_parts (FTS5 preferred, LIKE fallback) ──────────────────
+    const ftsMatches = this.searchMessagesFts(query, conversationId, limit, queryFirstWord);
+    if (ftsMatches !== null) {
+      matches.push(...ftsMatches);
+      ftsUsed = true;
+    } else {
+      matches.push(...this.searchMessagesParts(query, conversationId, limit, queryFirstWord));
+    }
+
+    // ── 2. context_nodes ──────────────────────────────────────────────────
+    if (searchNodes) {
+      matches.push(...this.searchContextNodes(query, conversationId, limit, queryFirstWord));
+    }
+
+    // ── 3. large_files ────────────────────────────────────────────────────
+    if (searchLargeFiles) {
+      matches.push(...this.searchLargeFiles(query, conversationId, limit, queryFirstWord));
+    }
+
+    logger.debug(
+      `lcm_grep: query="${query}" fts=${ftsUsed} → ${matches.length} matches`
+    );
+
+    return { matches, query, totalMatches: matches.length, ftsUsed };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: per-source search methods
+  // ---------------------------------------------------------------------------
+
+  /**
+   * FTS5 search of `messages_fts`.
+   * Returns null if the FTS table is empty (triggers LIKE fallback).
+   */
+  private searchMessagesFts(
+    query: string,
+    conversationId: string | undefined,
+    limit: number,
+    queryFirstWord: string
+  ): GrepMatch[] | null {
+    try {
+      // Check if FTS table has any rows before using it
+      const count = this.db
+        .prepare('SELECT COUNT(*) AS n FROM messages_fts')
+        .get() as { n: number };
+
+      if (count.n === 0) return null;
+
+      let sql: string;
+      let params: unknown[];
+
+      if (conversationId) {
+        sql = `
+          SELECT part_id, message_id, conversation_id, content, rank
+          FROM messages_fts
+          WHERE messages_fts MATCH ?
+            AND conversation_id = ?
+          ORDER BY rank
+          LIMIT ?
+        `;
+        params = [query, conversationId, limit];
+      } else {
+        sql = `
+          SELECT part_id, message_id, conversation_id, content, rank
+          FROM messages_fts
+          WHERE messages_fts MATCH ?
+          ORDER BY rank
+          LIMIT ?
+        `;
+        params = [query, limit];
+      }
+
+      const rows = this.db.prepare(sql).all(...params) as Array<{
+        part_id: string;
+        message_id: string;
+        conversation_id: string;
+        content: string;
+        rank: number;
+      }>;
+
+      return rows.map((row) => {
+        const s = buildSnippet(row.content, queryFirstWord);
+        return {
+          type: 'message_part' as const,
+          id: row.part_id,
+          messageId: row.message_id,
+          conversationId: row.conversation_id,
+          snippet: s,
+          tokens: estimateSnippetTokens(s),
+          rank: row.rank,
+        };
+      });
+    } catch (err) {
+      logger.warn(`FTS5 search failed (${(err as Error).message}); falling back to LIKE`);
+      return null;
+    }
+  }
+
+  /** LIKE-based fallback search of `message_parts`. */
+  private searchMessagesParts(
+    query: string,
+    conversationId: string | undefined,
+    limit: number,
+    queryFirstWord: string
+  ): GrepMatch[] {
+    const likeQuery = `%${query.replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
+
+    try {
+      let sql: string;
+      let params: unknown[];
+
+      if (conversationId) {
+        sql = `
+          SELECT mp.id, mp.message_id, mp.content, m.conversation_id
+          FROM message_parts mp
+          JOIN messages m ON mp.message_id = m.id
+          WHERE mp.content LIKE ? ESCAPE '\\'
+            AND m.conversation_id = ?
+          LIMIT ?
+        `;
+        params = [likeQuery, conversationId, limit];
+      } else {
+        sql = `
+          SELECT mp.id, mp.message_id, mp.content, m.conversation_id
+          FROM message_parts mp
+          JOIN messages m ON mp.message_id = m.id
+          WHERE mp.content LIKE ? ESCAPE '\\'
+          LIMIT ?
+        `;
+        params = [likeQuery, limit];
+      }
+
+      const rows = this.db.prepare(sql).all(...params) as Array<{
+        id: string;
+        message_id: string;
+        content: string;
+        conversation_id: string;
+      }>;
+
+      return rows.map((row) => {
+        const s = buildSnippet(row.content, queryFirstWord);
+        return {
+          type: 'message_part' as const,
+          id: row.id,
+          messageId: row.message_id,
+          conversationId: row.conversation_id,
+          snippet: s,
+          tokens: estimateSnippetTokens(s),
+          rank: 0,
+        };
+      });
+    } catch (err) {
+      logger.warn(`message_parts LIKE search failed: ${(err as Error).message}`);
+      return [];
+    }
+  }
+
+  private searchContextNodes(
+    query: string,
+    conversationId: string | undefined,
+    limit: number,
+    queryFirstWord: string
+  ): GrepMatch[] {
+    const likeQuery = `%${query.replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
+
+    try {
+      let sql: string;
+      let params: unknown[];
+
+      if (conversationId) {
+        sql = `
+          SELECT id, conversation_id, summary
+          FROM context_nodes
+          WHERE summary LIKE ? ESCAPE '\\'
+            AND conversation_id = ?
+          LIMIT ?
+        `;
+        params = [likeQuery, conversationId, limit];
+      } else {
+        sql = `
+          SELECT id, conversation_id, summary
+          FROM context_nodes
+          WHERE summary LIKE ? ESCAPE '\\'
+          LIMIT ?
+        `;
+        params = [likeQuery, limit];
+      }
+
+      const rows = this.db.prepare(sql).all(...params) as Array<{
+        id: string;
+        conversation_id: string | null;
+        summary: string;
+      }>;
+
+      return rows.map((row) => {
+        const s = buildSnippet(row.summary, queryFirstWord);
+        return {
+          type: 'context_node' as const,
+          id: row.id,
+          conversationId: row.conversation_id ?? undefined,
+          snippet: s,
+          tokens: estimateSnippetTokens(s),
+          rank: 0,
+        };
+      });
+    } catch (err) {
+      logger.warn(`context_nodes search failed: ${(err as Error).message}`);
+      return [];
+    }
+  }
+
+  private searchLargeFiles(
+    query: string,
+    conversationId: string | undefined,
+    limit: number,
+    queryFirstWord: string
+  ): GrepMatch[] {
+    const likeQuery = `%${query.replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
+
+    try {
+      let sql: string;
+      let params: unknown[];
+
+      if (conversationId) {
+        sql = `
+          SELECT id, conversation_id, summary
+          FROM large_files
+          WHERE summary LIKE ? ESCAPE '\\'
+            AND conversation_id = ?
+          LIMIT ?
+        `;
+        params = [likeQuery, conversationId, limit];
+      } else {
+        sql = `
+          SELECT id, conversation_id, summary
+          FROM large_files
+          WHERE summary LIKE ? ESCAPE '\\'
+          LIMIT ?
+        `;
+        params = [likeQuery, limit];
+      }
+
+      const rows = this.db.prepare(sql).all(...params) as Array<{
+        id: string;
+        conversation_id: string | null;
+        summary: string;
+      }>;
+
+      return rows.map((row) => {
+        const s = buildSnippet(row.summary, queryFirstWord);
+        return {
+          type: 'large_file' as const,
+          id: row.id,
+          conversationId: row.conversation_id ?? undefined,
+          snippet: s,
+          tokens: estimateSnippetTokens(s),
+          rank: 0,
+        };
+      });
+    } catch (err) {
+      logger.warn(`large_files search failed: ${(err as Error).message}`);
+      return [];
+    }
+  }
+}

--- a/libs/context-engine/src/retrieval/index.ts
+++ b/libs/context-engine/src/retrieval/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Retrieval tools for context-engine.
+ *
+ * Exports the three agent retrieval tools (`lcm_grep`, `lcm_describe`, `lcm_expand`)
+ * and supporting classes (`ContextNodeStore`, `ContextFtsIndex`).
+ *
+ * ## Quick reference
+ *
+ * | Export              | Tool         | Description                                            |
+ * |---------------------|--------------|--------------------------------------------------------|
+ * | `ContextGrep`       | `lcm_grep`   | Full-text search across message history                |
+ * | `ContextFtsIndex`   | —            | FTS5 index management (populate/rebuild messages_fts)  |
+ * | `ContextDescriber`  | `lcm_describe` | Summary metadata + provenance chain                  |
+ * | `ContextExpander`   | `lcm_expand` | Bounded DAG walk — retrieve original content           |
+ * | `ContextNodeStore`  | —            | Persist CompactedNode / CondensedNode to context_nodes |
+ */
+
+export * from './grep.js';
+export * from './describe.js';
+export * from './expand.js';

--- a/libs/context-engine/src/store/migrations.ts
+++ b/libs/context-engine/src/store/migrations.ts
@@ -72,6 +72,67 @@ export const MIGRATIONS: Migration[] = [
         ON message_parts(message_id, position);
     `,
   },
+  {
+    version: 2,
+    description: 'Create large_files table for LargeFileHandler interception',
+    up: `
+      -- Large files: stores full content of tool results that exceed the token threshold.
+      -- The agent is given a compact reference instead and can call lcm_expand(<id>)
+      -- to retrieve the original content.
+      CREATE TABLE IF NOT EXISTS large_files (
+        id TEXT PRIMARY KEY,
+        part_id TEXT,
+        conversation_id TEXT,
+        original_content TEXT NOT NULL,
+        token_count INTEGER NOT NULL DEFAULT 0,
+        summary TEXT NOT NULL DEFAULT '',
+        stored_at TEXT NOT NULL,
+        metadata TEXT NOT NULL DEFAULT '{}'
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_large_files_conversation_id
+        ON large_files(conversation_id, stored_at);
+    `,
+  },
+  {
+    version: 3,
+    description: 'Create context_nodes table and messages_fts FTS5 index for retrieval tools',
+    up: `
+      -- Context nodes: persists CompactedNode (depth=0) and CondensedNode (depth>=1)
+      -- produced by LeafCompactor and CondensationEngine.
+      -- source_ids is a JSON array of IDs (message IDs for depth=0, node IDs for depth>0).
+      CREATE TABLE IF NOT EXISTS context_nodes (
+        id TEXT PRIMARY KEY,
+        conversation_id TEXT,
+        depth INTEGER NOT NULL DEFAULT 0,
+        summary TEXT NOT NULL DEFAULT '',
+        expand_footer TEXT NOT NULL DEFAULT '',
+        source_ids TEXT NOT NULL DEFAULT '[]',
+        original_tokens INTEGER NOT NULL DEFAULT 0,
+        summary_tokens INTEGER NOT NULL DEFAULT 0,
+        mode TEXT,
+        stored_at TEXT NOT NULL,
+        metadata TEXT NOT NULL DEFAULT '{}'
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_context_nodes_conversation_id
+        ON context_nodes(conversation_id, stored_at);
+
+      CREATE INDEX IF NOT EXISTS idx_context_nodes_depth
+        ON context_nodes(depth, conversation_id);
+
+      -- FTS5 virtual table for full-text search across message_parts (lcm_grep).
+      -- Content is indexed via ContextFtsIndex.index() after message creation.
+      -- Uses porter stemmer for English-language token matching.
+      CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+        part_id UNINDEXED,
+        message_id UNINDEXED,
+        conversation_id UNINDEXED,
+        content,
+        tokenize = 'porter ascii'
+      );
+    `,
+  },
 ];
 
 /**

--- a/packages/mcp-server/plugins/automaker/tools/context-engine.ts
+++ b/packages/mcp-server/plugins/automaker/tools/context-engine.ts
@@ -1,0 +1,197 @@
+/**
+ * Context-engine MCP tool definitions — lcm_grep, lcm_describe, lcm_expand.
+ *
+ * These tools are registered on the AutoMaker MCP server so agents can:
+ *
+ *   `lcm_grep`    — full-text search across the full message/summary history
+ *   `lcm_describe` — inspect a summary node's metadata and provenance chain
+ *   `lcm_expand`  — retrieve full original content for a large file or compacted node
+ *
+ * Each tool hits the corresponding `/api/context-engine/*` HTTP endpoint on the
+ * AutoMaker server.  The caller must supply `dbPath` pointing to the SQLite file
+ * managed by `ConversationStore`.
+ *
+ * Tool naming follows the `lcm_` prefix convention established by the context
+ * compaction system (`[lcm_expand: <id>]` footers in summaries).
+ */
+
+// ---------------------------------------------------------------------------
+// lcm_grep
+// ---------------------------------------------------------------------------
+
+/**
+ * MCP tool definition for `lcm_grep`.
+ *
+ * Full-text search across the complete conversation history.  Searches:
+ *   - Raw message content (`message_parts`) via FTS5 (porter stemmer) or LIKE
+ *   - Compacted/condensed summaries (`context_nodes`)
+ *   - Large-file interception summaries (`large_files`)
+ *
+ * Returns a ranked list of matches with ~200-character snippets.
+ */
+export const LCM_GREP_TOOL = {
+  name: 'lcm_grep',
+  description:
+    'Search the full conversation history for a keyword or phrase. ' +
+    'Searches raw message content, compaction summaries, and large-file summaries. ' +
+    'Returns ranked snippets so you can locate relevant context before deciding ' +
+    'whether to call lcm_expand for the full content. ' +
+    'Use FTS5 query syntax for precise matching (e.g. "error AND sqlite", "foo OR bar").',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      dbPath: {
+        type: 'string',
+        description: 'Absolute path to the SQLite database file (conversations.db).',
+      },
+      query: {
+        type: 'string',
+        description:
+          'Search query. Supports FTS5 syntax (AND, OR, NOT, prefix*, "phrase"). ' +
+          'Falls back to LIKE for simple substring matching.',
+      },
+      conversationId: {
+        type: 'string',
+        description: 'Optional UUID to restrict the search to a single conversation.',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum results per source table (default: 10, max: 50).',
+      },
+      searchNodes: {
+        type: 'boolean',
+        description: 'Include context_nodes (compacted summaries) in results. Default: true.',
+      },
+      searchLargeFiles: {
+        type: 'boolean',
+        description: 'Include large_files summaries in results. Default: true.',
+      },
+    },
+    required: ['dbPath', 'query'],
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// lcm_describe
+// ---------------------------------------------------------------------------
+
+/**
+ * MCP tool definition for `lcm_describe`.
+ *
+ * Returns metadata for a summary node referenced by an `[lcm_expand: <id>]`
+ * footer — its summary text, depth, compaction mode, source IDs, token counts,
+ * and optionally the provenance chain (parent nodes that absorbed this node into
+ * a higher-depth condensation).
+ */
+export const LCM_DESCRIBE_TOOL = {
+  name: 'lcm_describe',
+  description:
+    'Show metadata for a compacted summary node. ' +
+    'Given a node ID from an [lcm_expand: <id>] reference, returns the summary text, ' +
+    'compaction depth (0 = leaf, 1+ = condensed), mode, source IDs, and token counts. ' +
+    'Set includeParents=true to see the full provenance chain — which higher-level ' +
+    'summaries absorbed this node. ' +
+    'Use this before lcm_expand to decide whether you need the full content or ' +
+    'the summary is already sufficient.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      dbPath: {
+        type: 'string',
+        description: 'Absolute path to the SQLite database file (conversations.db).',
+      },
+      nodeId: {
+        type: 'string',
+        description:
+          'UUID of the node to describe. Copy this from an [lcm_expand: "<id>"] footer ' +
+          'or from a [LARGE FILE INTERCEPTED] reference.',
+      },
+      includeParents: {
+        type: 'boolean',
+        description:
+          'Walk UP the DAG and include parent nodes that condensed this node. Default: false.',
+      },
+      maxParentDepth: {
+        type: 'number',
+        description: 'Maximum provenance chain levels to return (default: 3).',
+      },
+    },
+    required: ['dbPath', 'nodeId'],
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// lcm_expand
+// ---------------------------------------------------------------------------
+
+/**
+ * MCP tool definition for `lcm_expand`.
+ *
+ * Retrieves the full original content for a node ID:
+ *
+ *   - **large_file**: returns the complete intercepted tool result.
+ *   - **context_node (depth=0)**: retrieves the original messages that were
+ *     compacted into this leaf summary, concatenated in order.
+ *   - **context_node (depth≥1)**: recursively walks DOWN the summary DAG to the
+ *     leaf messages and returns the assembled content.
+ *
+ * Bounded by `tokenCap` (default 50 000 tokens) and `ttlMs` (default 10 s)
+ * to prevent runaway retrieval.  When either limit is hit, `truncated=true`
+ * is returned and a truncation notice is appended.
+ */
+export const LCM_EXPAND_TOOL = {
+  name: 'lcm_expand',
+  description:
+    'Retrieve the full original content for a compacted summary or intercepted large file. ' +
+    'Pass a node ID from an [lcm_expand: "<id>"] footer or a [LARGE FILE INTERCEPTED] block. ' +
+    'For large files: returns the full original tool result. ' +
+    'For compacted summaries: walks the summary DAG and returns the original messages. ' +
+    'Results are bounded by tokenCap to protect the context window — check truncated=true ' +
+    'and increase tokenCap if you need more. ' +
+    'Optionally provide a question to prepend a focus hint to the returned content.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      dbPath: {
+        type: 'string',
+        description: 'Absolute path to the SQLite database file (conversations.db).',
+      },
+      nodeId: {
+        type: 'string',
+        description:
+          'UUID of the node to expand. Copy from [lcm_expand: "<id>"] or ' +
+          '[LARGE FILE INTERCEPTED] File ID references.',
+      },
+      question: {
+        type: 'string',
+        description:
+          'Optional focused question. When set, a retrieval hint is prepended ' +
+          'to the returned content to help orient downstream consumers.',
+      },
+      tokenCap: {
+        type: 'number',
+        description:
+          'Maximum tokens to return (default: 50 000). Increase if you need more context; ' +
+          'decrease to save context window space.',
+      },
+      ttlMs: {
+        type: 'number',
+        description:
+          'Maximum wall-clock time for the DAG walk in milliseconds (default: 10 000). ' +
+          'Increase for deeply nested or large node graphs.',
+      },
+    },
+    required: ['dbPath', 'nodeId'],
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Convenience array (register all three at once)
+// ---------------------------------------------------------------------------
+
+/** All three context-engine retrieval tools for bulk registration. */
+export const CONTEXT_ENGINE_TOOLS = [
+  LCM_GREP_TOOL,
+  LCM_DESCRIBE_TOOL,
+  LCM_EXPAND_TOOL,
+] as const;


### PR DESCRIPTION
## Summary

**Milestone:** Retrieval Tools & Large File Handling

Three agent retrieval tools: lcm_grep (FTS5 search across messages and summaries), lcm_describe (summary metadata and lineage), lcm_expand (bounded sub-agent DAG walk). Expose all via MCP server.

**Files to Modify:**
- libs/context-engine/src/retrieval/grep.ts
- libs/context-engine/src/retrieval/describe.ts
- libs/context-engine/src/retrieval/expand.ts
- libs/context-engine/src/retrieval/index.ts
- apps/server/src/routes/context-engine.ts
- ...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-03-16T21:50:41.521Z -->