### PR TITLE
Migrate PRFeedbackService and ArchivalService timers

### DIFF
--- a/apps/server/src/services/archival-service.ts
+++ b/apps/server/src/services/archival-service.ts
@@ -19,6 +19,7 @@ import type { LedgerService } from './ledger-service.js';
 import type { SettingsService } from './settings-service.js';
 import type { EventEmitter } from '../lib/events.js';
 import { ARCHIVAL_CHECK_INTERVAL_MS } from '../config/timeouts.js';
+import type { SchedulerService } from './scheduler-service.js';
 
 const logger = createLogger('ArchivalService');
 
@@ -32,6 +33,9 @@ export class ArchivalService {
   private events: EventEmitter;
   private timer: ReturnType<typeof setInterval> | null = null;
   private aborted = false;
+  private schedulerService: SchedulerService | null = null;
+
+  private static readonly INTERVAL_ID = 'archival:check';
 
   constructor(
     featureLoader: FeatureLoader,
@@ -46,17 +50,43 @@ export class ArchivalService {
   }
 
   /**
+   * Set the scheduler service for managed interval tracking
+   */
+  setSchedulerService(schedulerService: SchedulerService): void {
+    this.schedulerService = schedulerService;
+  }
+
+  /**
    * Start the archival check interval
    */
   start(): void {
-    if (this.timer) return;
+    if (this.schedulerService) {
+      const existing = this.schedulerService
+        .listAll()
+        .find((e) => e.id === ArchivalService.INTERVAL_ID);
+      if (existing) return;
+    } else if (this.timer) {
+      return;
+    }
     this.aborted = false;
 
-    this.timer = setInterval(() => {
-      this.runArchivalCycle().catch((err) => {
-        logger.error('Archival cycle failed:', err);
-      });
-    }, CHECK_INTERVAL_MS);
+    if (this.schedulerService) {
+      this.schedulerService.registerInterval(
+        ArchivalService.INTERVAL_ID,
+        'Archival Check',
+        CHECK_INTERVAL_MS,
+        () =>
+          this.runArchivalCycle().catch((err) => {
+            logger.error('Archival cycle failed:', err);
+          })
+      );
+    } else {
+      this.timer = setInterval(() => {
+        this.runArchivalCycle().catch((err) => {
+          logger.error('Archival cycle failed:', err);
+        });
+      }, CHECK_INTERVAL_MS);
+    }
 
     logger.info('ArchivalService started (10min interval)');
   }
@@ -66,7 +96,9 @@ export class ArchivalService {
    */
   stop(): void {
     this.aborted = true;
-    if (this.timer) {
+    if (this.schedulerService) {
+      this.schedulerService.unregisterInterval(ArchivalService.INTERVAL_ID);
+    } else if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
     }

--- a/apps/server/src/services/pr-feedback-service.ts
+++ b/apps/server/src/services/pr-feedback-service.ts
@@ -41,6 +41,7 @@ import {
   PR_FEEDBACK_CI_MAX_WAIT_MS,
   PR_FEEDBACK_MISSING_CI_CHECK_THRESHOLD_MS,
 } from '../config/timeouts.js';
+import type { SchedulerService } from './scheduler-service.js';
 
 const logger = createLogger('PRFeedbackRemediation');
 
@@ -103,6 +104,9 @@ export class PRFeedbackService {
   private trackedPRs = new Map<string, TrackedPR>();
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private initialized = false;
+  private schedulerService: SchedulerService | null = null;
+
+  private static readonly INTERVAL_ID = 'pr-feedback:poll';
 
   /** Features currently under remediation - prevents concurrent remediation */
   private remediatingFeatures = new Set<string>();
@@ -126,6 +130,10 @@ export class PRFeedbackService {
 
   setAutoModeService(service: AutoModeService): void {
     this.autoModeService = service;
+  }
+
+  setSchedulerService(schedulerService: SchedulerService): void {
+    this.schedulerService = schedulerService;
   }
 
   setLeadEngineerService(service: { isFeatureActive(featureId: string): boolean }): void {
@@ -209,15 +217,26 @@ export class PRFeedbackService {
       }
     });
 
-    this.pollTimer = setInterval(() => {
-      void this.pollAllPRs();
-    }, POLL_INTERVAL_MS);
+    if (this.schedulerService) {
+      this.schedulerService.registerInterval(
+        PRFeedbackService.INTERVAL_ID,
+        'PR Feedback Poll',
+        POLL_INTERVAL_MS,
+        () => this.pollAllPRs()
+      );
+    } else {
+      this.pollTimer = setInterval(() => {
+        void this.pollAllPRs();
+      }, POLL_INTERVAL_MS);
+    }
 
     logger.info('PR Feedback Service initialized (webhook + poll)');
   }
 
   stop(): void {
-    if (this.pollTimer) {
+    if (this.schedulerService) {
+      this.schedulerService.unregisterInterval(PRFeedbackService.INTERVAL_ID);
+    } else if (this.pollTimer) {
       clearInterval(this.pollTimer);
       this.pollTimer = null;
     }

--- a/apps/server/src/services/scheduler.module.ts
+++ b/apps/server/src/services/scheduler.module.ts
@@ -25,6 +25,8 @@ export function register(container: ServiceContainer): void {
     healthMonitorService,
     specGenerationMonitor,
     leadEngineerService,
+    prFeedbackService,
+    archivalService,
   } = container;
 
   // Wire schedulerService into interval-tracked services so their timers
@@ -36,6 +38,8 @@ export function register(container: ServiceContainer): void {
   if (prWatcher) {
     prWatcher.setSchedulerService(schedulerService);
   }
+  prFeedbackService.setSchedulerService(schedulerService);
+  archivalService.setSchedulerService(schedulerService);
 
   // Scheduler Service initialization and task registration via AutomationService
   schedulerService.initialize(events, dataDir);


### PR DESCRIPTION
## Summary

**Milestone:** Migrate Raw Timers to Scheduler

Migrate PRFeedbackService (60s poll at pr-feedback-service.ts:212) and ArchivalService (10min at archival-service.ts:55) from raw setInterval to schedulerService.registerInterval(). Both are long-lived system timers that should be visible in Ops Dashboard. Replace the setInterval call with registerInterval, store the cleanup function, and call it on destroy/stop. Preserve existing behavior exactly.

**Files to Modify:**
- apps/server/src/services/p...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-03-17T02:49:53.386Z -->