### PR TITLE
Add scheduler task enable/disable toggles to Ops Dashboard

### DIFF
--- a/apps/ui/src/components/views/ops-view/timer-panel.tsx
+++ b/apps/ui/src/components/views/ops-view/timer-panel.tsx
@@ -17,7 +17,7 @@ import {
   AlertTriangle,
   RefreshCw,
 } from 'lucide-react';
-import { Badge } from '@protolabsai/ui/atoms';
+import { Badge, Switch } from '@protolabsai/ui/atoms';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { useTimerStatus } from './use-timer-status';
@@ -74,20 +74,30 @@ function formatIntervalMs(ms: number): string {
 
 interface TimerRowProps {
   timer: TimerRegistryEntry;
+  persistentEnabled: boolean;
   onPause: (id: string) => Promise<void>;
   onResume: (id: string) => Promise<void>;
+  onToggleEnabled: (id: string, enabled: boolean) => Promise<void>;
   isMutating: boolean;
 }
 
-function TimerRow({ timer, onPause, onResume, isMutating }: TimerRowProps) {
+function TimerRow({
+  timer,
+  persistentEnabled,
+  onPause,
+  onResume,
+  onToggleEnabled,
+  isMutating,
+}: TimerRowProps) {
   const hasFailures = timer.failureCount > 0;
 
   return (
     <div
       className={cn(
-        'grid grid-cols-[1fr_80px_80px_100px_100px_60px_60px_40px] items-center gap-2 px-3 py-2 text-xs',
+        'grid grid-cols-[1fr_80px_80px_100px_100px_60px_60px_50px_40px] items-center gap-2 px-3 py-2 text-xs',
         'border-b border-border/30 last:border-b-0',
-        'hover:bg-accent/30 transition-colors'
+        'hover:bg-accent/30 transition-colors',
+        !persistentEnabled && 'opacity-50'
       )}
     >
       {/* Name */}
@@ -133,6 +143,16 @@ function TimerRow({ timer, onPause, onResume, isMutating }: TimerRowProps) {
       {/* Executions */}
       <div className="text-muted-foreground tabular-nums">{timer.executionCount}</div>
 
+      {/* Persistent Enable/Disable */}
+      <div>
+        <Switch
+          checked={persistentEnabled}
+          onCheckedChange={(checked) => onToggleEnabled(timer.id, checked)}
+          disabled={isMutating}
+          aria-label={persistentEnabled ? `Disable ${timer.name}` : `Enable ${timer.name}`}
+        />
+      </div>
+
       {/* Action */}
       <div>
         <button
@@ -155,16 +175,20 @@ function TimerRow({ timer, onPause, onResume, isMutating }: TimerRowProps) {
 interface CategorySectionProps {
   category: TimerCategory;
   timers: TimerRegistryEntry[];
+  taskOverrides: Record<string, { enabled?: boolean; cronExpression?: string }>;
   onPause: (id: string) => Promise<void>;
   onResume: (id: string) => Promise<void>;
+  onToggleEnabled: (id: string, enabled: boolean) => Promise<void>;
   isMutating: boolean;
 }
 
 function CategorySection({
   category,
   timers,
+  taskOverrides,
   onPause,
   onResume,
+  onToggleEnabled,
   isMutating,
 }: CategorySectionProps) {
   const [expanded, setExpanded] = useState(true);
@@ -206,7 +230,7 @@ function CategorySection({
       {expanded && (
         <div>
           {/* Column headers */}
-          <div className="grid grid-cols-[1fr_80px_80px_100px_100px_60px_60px_40px] gap-2 px-3 py-1.5 text-[10px] uppercase tracking-wider text-muted-foreground border-b border-border/30 bg-accent/10">
+          <div className="grid grid-cols-[1fr_80px_80px_100px_100px_60px_60px_50px_40px] gap-2 px-3 py-1.5 text-[10px] uppercase tracking-wider text-muted-foreground border-b border-border/30 bg-accent/10">
             <div>Name</div>
             <div>Schedule</div>
             <div>Status</div>
@@ -214,14 +238,17 @@ function CategorySection({
             <div>Next Run</div>
             <div>Fails</div>
             <div>Runs</div>
+            <div>On</div>
             <div />
           </div>
           {timers.map((timer) => (
             <TimerRow
               key={timer.id}
               timer={timer}
+              persistentEnabled={taskOverrides[timer.id]?.enabled ?? true}
               onPause={onPause}
               onResume={onResume}
+              onToggleEnabled={onToggleEnabled}
               isMutating={isMutating}
             />
           ))}
@@ -238,6 +265,7 @@ function CategorySection({
 export function TimerPanel() {
   const {
     timers,
+    taskOverrides,
     isLoading,
     isMutating,
     error,
@@ -246,6 +274,7 @@ export function TimerPanel() {
     resumeTimer,
     pauseAll,
     resumeAll,
+    setTaskEnabled,
     timersByCategory,
   } = useTimerStatus();
 
@@ -290,6 +319,18 @@ export function TimerPanel() {
       toast.error(err instanceof Error ? err.message : 'Failed to resume all timers');
     }
   }, [resumeAll]);
+
+  const handleToggleEnabled = useCallback(
+    async (id: string, enabled: boolean) => {
+      try {
+        await setTaskEnabled(id, enabled);
+        toast.success(enabled ? 'Task enabled' : 'Task disabled');
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : 'Failed to update task setting');
+      }
+    },
+    [setTaskEnabled]
+  );
 
   if (error) {
     return (
@@ -392,8 +433,10 @@ export function TimerPanel() {
               key={category}
               category={category}
               timers={categoryTimers}
+              taskOverrides={taskOverrides}
               onPause={handlePause}
               onResume={handleResume}
+              onToggleEnabled={handleToggleEnabled}
               isMutating={isMutating}
             />
           );

--- a/apps/ui/src/components/views/ops-view/use-timer-status.ts
+++ b/apps/ui/src/components/views/ops-view/use-timer-status.ts
@@ -7,7 +7,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { apiGet, apiPost } from '@/lib/api-fetch';
+import { apiGet, apiPost, apiPut } from '@/lib/api-fetch';
 import type { TimerRegistryEntry, TimerCategory } from '@protolabsai/types';
 
 interface TimersResponse {
@@ -22,8 +22,18 @@ interface TimerMutationResponse {
   resumedCount?: number;
 }
 
+interface GlobalSettingsResponse {
+  success: boolean;
+  settings?: {
+    schedulerSettings?: {
+      taskOverrides?: Record<string, { enabled?: boolean; cronExpression?: string }>;
+    };
+  };
+}
+
 interface UseTimerStatusResult {
   timers: TimerRegistryEntry[];
+  taskOverrides: Record<string, { enabled?: boolean; cronExpression?: string }>;
   isLoading: boolean;
   isMutating: boolean;
   error: string | null;
@@ -32,6 +42,7 @@ interface UseTimerStatusResult {
   resumeTimer: (id: string) => Promise<boolean>;
   pauseAll: () => Promise<boolean>;
   resumeAll: () => Promise<boolean>;
+  setTaskEnabled: (id: string, enabled: boolean) => Promise<boolean>;
   timersByCategory: Map<TimerCategory, TimerRegistryEntry[]>;
 }
 
@@ -55,6 +66,9 @@ function groupByCategory(timers: TimerRegistryEntry[]): Map<TimerCategory, Timer
 
 export function useTimerStatus(): UseTimerStatusResult {
   const [timers, setTimers] = useState<TimerRegistryEntry[]>([]);
+  const [taskOverrides, setTaskOverrides] = useState<
+    Record<string, { enabled?: boolean; cronExpression?: string }>
+  >({});
   const [isLoading, setIsLoading] = useState(false);
   const [isMutating, setIsMutating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -81,13 +95,25 @@ export function useTimerStatus(): UseTimerStatusResult {
     }
   }, []);
 
+  const fetchTaskOverrides = useCallback(async () => {
+    try {
+      const result = await apiGet<GlobalSettingsResponse>('/api/settings/global');
+      if (result.success && result.settings?.schedulerSettings?.taskOverrides) {
+        setTaskOverrides(result.settings.schedulerSettings.taskOverrides);
+      }
+    } catch {
+      // Non-fatal: overrides default to empty (all tasks enabled)
+    }
+  }, []);
+
   useEffect(() => {
     fetchTimers();
+    fetchTaskOverrides();
     intervalRef.current = setInterval(fetchTimers, REFRESH_INTERVAL_MS);
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
-  }, [fetchTimers]);
+  }, [fetchTimers, fetchTaskOverrides]);
 
   const pauseTimer = useCallback(
     async (id: string): Promise<boolean> => {
@@ -151,10 +177,37 @@ export function useTimerStatus(): UseTimerStatusResult {
     }
   }, [fetchTimers]);
 
+  const setTaskEnabled = useCallback(
+    async (id: string, enabled: boolean): Promise<boolean> => {
+      const prevOverrides = taskOverrides;
+      const newOverrides = {
+        ...taskOverrides,
+        [id]: { ...taskOverrides[id], enabled },
+      };
+      // Optimistic update
+      setTaskOverrides(newOverrides);
+      try {
+        const result = await apiPut<{ success: boolean; error?: string }>('/api/settings/global', {
+          schedulerSettings: { taskOverrides: newOverrides },
+        });
+        if (result.success) {
+          return true;
+        }
+        throw new Error(result.error ?? 'Failed to update task setting');
+      } catch (err) {
+        // Revert on failure
+        setTaskOverrides(prevOverrides);
+        throw err;
+      }
+    },
+    [taskOverrides]
+  );
+
   const timersByCategory = groupByCategory(timers);
 
   return {
     timers,
+    taskOverrides,
     isLoading,
     isMutating,
     error,
@@ -163,6 +216,7 @@ export function useTimerStatus(): UseTimerStatusResult {
     resumeTimer,
     pauseAll,
     resumeAll,
+    setTaskEnabled,
     timersByCategory,
   };
 }


### PR DESCRIPTION
## Summary

Add toggle controls to the Ops Dashboard Timers tab so users can enable/disable individual scheduler tasks from the UI instead of editing settings JSON manually.

**Current state:**
- Scheduler tasks are visible in Ops Dashboard Timers tab (read-only)
- Enable/disable is only possible via `schedulerSettings.taskOverrides` in `data/settings.json`
- MCP `update_settings` can toggle tasks but there's no UI control

**What to build:**
Add an enable/disable toggle switch to each task row in the Timer...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-17T07:50:59.159Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added individual timer enable/disable controls to the operations view. Users can now toggle each timer on or off using a new dedicated column with toggle switches. Disabled timers are visually distinguished with reduced opacity. All state changes are automatically persisted to ensure settings are retained across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->