### PR TITLE
Bug: Timer migration wiring order — scheduler registration never fires

### DIFF
--- a/apps/server/src/services/archival-service.ts
+++ b/apps/server/src/services/archival-service.ts
@@ -50,10 +50,26 @@ export class ArchivalService {
   }
 
   /**
-   * Set the scheduler service for managed interval tracking
+   * Set the scheduler service for managed interval tracking.
+   * If start() already ran with a raw setInterval, migrates to the scheduler.
    */
   setSchedulerService(schedulerService: SchedulerService): void {
     this.schedulerService = schedulerService;
+    // Migrate to scheduler if start() already ran and is using a raw interval
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+      this.schedulerService.registerInterval(
+        ArchivalService.INTERVAL_ID,
+        'Archival Check',
+        CHECK_INTERVAL_MS,
+        () =>
+          this.runArchivalCycle().catch((err) => {
+            logger.error('Archival cycle failed:', err);
+          })
+      );
+      logger.info('ArchivalService: migrated timer to scheduler');
+    }
   }
 
   /**

--- a/apps/server/src/services/pr-feedback-service.ts
+++ b/apps/server/src/services/pr-feedback-service.ts
@@ -134,6 +134,18 @@ export class PRFeedbackService {
 
   setSchedulerService(schedulerService: SchedulerService): void {
     this.schedulerService = schedulerService;
+    // Migrate to scheduler if initialize() already ran and is using a raw interval
+    if (this.initialized && this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+      this.schedulerService.registerInterval(
+        PRFeedbackService.INTERVAL_ID,
+        'PR Feedback Poll',
+        POLL_INTERVAL_MS,
+        () => this.pollAllPRs()
+      );
+      logger.info('PR Feedback Service: migrated timer to scheduler');
+    }
   }
 
   setLeadEngineerService(service: { isFeatureActive(featureId: string): boolean }): void {


### PR DESCRIPTION
## Summary

PRFeedbackService and ArchivalService timers are not registered with SchedulerService despite the migration in PR #2799. Timers work via raw setInterval fallback but are invisible to the ops dashboard and cannot be paused or resumed centrally.

Root Cause: Wiring order in wiring.ts — registerLeadEngineer (line 39) calls prFeedbackService.initialize() which checks this.schedulerService (null at that point, so raw setInterval is used). registerScheduler (line 42) calls setSchedulerService() afterw...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-03-17T07:53:39.575Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal scheduling infrastructure to enhance system resource management and operational stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->