### PR TITLE
Promote dev to staging (per-project prBaseBranch + IaC M1)

### DIFF
--- a/apps/server/src/lib/settings-helpers.ts
+++ b/apps/server/src/lib/settings-helpers.ts
@@ -16,7 +16,15 @@ import type {
   Credentials,
   WorkflowSettings,
 } from '@protolabsai/types';
-import { DEFAULT_PHASE_MODELS, DEFAULT_WORKFLOW_SETTINGS } from '@protolabsai/types';
+import {
+  DEFAULT_PHASE_MODELS,
+  DEFAULT_WORKFLOW_SETTINGS,
+  DEFAULT_GIT_WORKFLOW_SETTINGS,
+} from '@protolabsai/types';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
 import {
   mergeAutoModePrompts,
   mergeAgentPrompts,
@@ -789,6 +797,10 @@ export async function getWorkflowSettings(
           projectSettings.workflow.preFlightChecks ?? DEFAULT_WORKFLOW_SETTINGS.preFlightChecks,
         toolProfile: projectSettings.workflow.toolProfile ?? DEFAULT_WORKFLOW_SETTINGS.toolProfile,
         agentConfig: projectSettings.workflow.agentConfig,
+        gitWorkflow: {
+          ...DEFAULT_WORKFLOW_SETTINGS.gitWorkflow,
+          ...projectSettings.workflow.gitWorkflow,
+        },
       };
     }
     return DEFAULT_WORKFLOW_SETTINGS;
@@ -796,4 +808,66 @@ export async function getWorkflowSettings(
     logger.warn(`${logPrefix} Failed to read workflow settings, using defaults:`, error);
     return DEFAULT_WORKFLOW_SETTINGS;
   }
+}
+
+/**
+ * Resolve the effective prBaseBranch for a project.
+ *
+ * Resolution order:
+ *   1. Per-project workflow.gitWorkflow.prBaseBranch (from .automaker/settings.json)
+ *   2. Global gitWorkflow.prBaseBranch (from data/settings.json)
+ *   3. Auto-detect from remote HEAD via `git symbolic-ref refs/remotes/origin/HEAD`
+ *   4. DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch ('dev')
+ *
+ * @param projectPath - Absolute path to the project (used for project settings + git detection)
+ * @param settingsService - Settings service instance
+ * @param logPrefix - Prefix for log messages
+ * @returns The resolved base branch name
+ */
+export async function getEffectivePrBaseBranch(
+  projectPath: string,
+  settingsService?: SettingsService | null,
+  logPrefix = '[PrBaseBranch]'
+): Promise<string> {
+  if (settingsService) {
+    try {
+      // 1. Check per-project workflow settings first
+      const projectSettings = await settingsService.getProjectSettings(projectPath);
+      const projectBranch = projectSettings.workflow?.gitWorkflow?.prBaseBranch;
+      if (projectBranch) {
+        logger.debug(`${logPrefix} Using project-level prBaseBranch: ${projectBranch}`);
+        return projectBranch;
+      }
+
+      // 2. Fall back to global settings
+      const globalSettings = await settingsService.getGlobalSettings();
+      const globalBranch = globalSettings.gitWorkflow?.prBaseBranch;
+      if (globalBranch) {
+        logger.debug(`${logPrefix} Using global prBaseBranch: ${globalBranch}`);
+        return globalBranch;
+      }
+    } catch (err) {
+      logger.warn(`${logPrefix} Failed to read settings for prBaseBranch:`, err);
+    }
+  }
+
+  // 3. Auto-detect from remote HEAD
+  try {
+    const { stdout } = await execFileAsync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
+      cwd: projectPath,
+      timeout: 5000,
+      encoding: 'utf-8',
+    });
+    const ref = stdout.trim(); // e.g., refs/remotes/origin/main
+    const branch = ref.replace('refs/remotes/origin/', '');
+    if (branch) {
+      logger.debug(`${logPrefix} Auto-detected prBaseBranch from remote HEAD: ${branch}`);
+      return branch;
+    }
+  } catch {
+    // origin/HEAD not set or git not available — fall through to default
+  }
+
+  // 4. Final fallback
+  return DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch;
 }

--- a/apps/server/src/routes/settings/routes/workflow.ts
+++ b/apps/server/src/routes/settings/routes/workflow.ts
@@ -70,6 +70,7 @@ export function createUpdateWorkflowHandler(
         signalIntake: { ...current.signalIntake, ...workflow.signalIntake },
         bugs: { ...current.bugs, ...workflow.bugs },
         contextEngine: { enabled: false, ...current.contextEngine, ...workflow.contextEngine },
+        gitWorkflow: { ...current.gitWorkflow, ...workflow.gitWorkflow },
       };
 
       await settingsService.updateProjectSettings(projectPath, {

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -1886,6 +1886,10 @@ Address the follow-up instructions above. Review the previous work and make the 
             }
           }
 
+          // Resolve per-project prBaseBranch override
+          const projectSettings = await this.settingsService.getProjectSettings(projectPath);
+          const projectPrBaseBranch = projectSettings.workflow?.gitWorkflow?.prBaseBranch;
+
           gitWorkflowResult = await gitWorkflowService.runPostCompletionWorkflow(
             projectPath,
             featureId,
@@ -1893,7 +1897,8 @@ Address the follow-up instructions above. Review the previous work and make the 
             workDir,
             settings,
             epicBranchName,
-            this.events
+            this.events,
+            projectPrBaseBranch
           );
           if (gitWorkflowResult) {
             // Check if git workflow encountered conflicts

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -15,7 +15,7 @@ import * as v8 from 'node:v8';
 import { ProviderFactory } from '../../providers/provider-factory.js';
 import { simpleQuery } from '../../providers/simple-query-service.js';
 import { StreamObserver } from '../stream-observer-service.js';
-import { getWorkflowSettings } from '../../lib/settings-helpers.js';
+import { getWorkflowSettings, getEffectivePrBaseBranch } from '../../lib/settings-helpers.js';
 import { setFeatureContext } from '@protolabsai/error-tracking';
 import { LoopDetectedError } from '../auto-mode-service.js';
 
@@ -882,16 +882,12 @@ export class ExecutionService {
       // so that stranded work is committed and a PR is created if the agent
       // completed implementation but failed to run its own git workflow step.
       if (worktreePath) {
-        // Resolve prBaseBranch from settings for recovery PR target
-        let recoveryBaseBranch: string | undefined;
-        if (this.settingsService) {
-          try {
-            const settings = await this.settingsService.getGlobalSettings();
-            recoveryBaseBranch = settings.gitWorkflow?.prBaseBranch;
-          } catch {
-            /* use default */
-          }
-        }
+        // Resolve prBaseBranch from project settings, then global, then auto-detect
+        const recoveryBaseBranch = await getEffectivePrBaseBranch(
+          projectPath,
+          this.settingsService,
+          '[PostAgentHook]'
+        );
         const recoveryResult = await checkAndRecoverUncommittedWork(
           feature,
           workDir,
@@ -1069,6 +1065,10 @@ export class ExecutionService {
             }
           }
 
+          // Resolve per-project prBaseBranch override
+          const projectSettings = await this.settingsService.getProjectSettings(projectPath);
+          const projectPrBaseBranch = projectSettings.workflow?.gitWorkflow?.prBaseBranch;
+
           gitWorkflowResult = await gitWorkflowService.runPostCompletionWorkflow(
             projectPath,
             featureId,
@@ -1076,7 +1076,8 @@ export class ExecutionService {
             workDir,
             settings,
             epicBranchName,
-            this.events
+            this.events,
+            projectPrBaseBranch
           );
           if (gitWorkflowResult) {
             // Check if git workflow encountered conflicts
@@ -1560,12 +1561,9 @@ export class ExecutionService {
         abortController,
         getAutoLoopRunning: () => this.callbacks.getAutoLoopRunning(),
         saveExecutionState: (p) => this.callbacks.saveExecutionState(p),
-        getRecoveryBaseBranch: this.settingsService
-          ? async () => {
-              const settings = await this.settingsService!.getGlobalSettings();
-              return settings.gitWorkflow?.prBaseBranch;
-            }
-          : undefined,
+        getRecoveryBaseBranch: async () => {
+          return getEffectivePrBaseBranch(projectPath, this.settingsService, '[PostExecution]');
+        },
         updateFeatureStatus: (p, id, status) => this.callbacks.updateFeatureStatus(p, id, status),
         emitEvent: (eventType, data) => this.typedEventBus.emitAutoModeEvent(eventType, data),
       });

--- a/apps/server/src/services/completion-detector-service.ts
+++ b/apps/server/src/services/completion-detector-service.ts
@@ -20,6 +20,7 @@ import type { FeatureLoader } from './feature-loader.js';
 import type { ProjectService } from './project-service.js';
 import type { SettingsService } from './settings-service.js';
 import type { Feature, Milestone } from '@protolabsai/types';
+import { getEffectivePrBaseBranch } from '../lib/settings-helpers.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -382,16 +383,12 @@ export class CompletionDetectorService {
   ): Promise<{ prNumber: number; prUrl: string } | null> {
     const epicBranch = epic.branchName!;
 
-    // Resolve the base branch from settings (default: dev)
-    let baseBranch = 'dev';
-    if (this.settingsService) {
-      try {
-        const settings = await this.settingsService.getGlobalSettings();
-        baseBranch = settings.gitWorkflow?.prBaseBranch ?? 'dev';
-      } catch {
-        // fall back to dev
-      }
-    }
+    // Resolve the base branch: project settings > global settings > auto-detect > default
+    const baseBranch = await getEffectivePrBaseBranch(
+      projectPath,
+      this.settingsService,
+      '[CompletionDetector]'
+    );
 
     try {
       // Check if an open PR from this epic branch already exists

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -207,11 +207,17 @@ export class GitWorkflowService {
 
   /**
    * Resolve effective git workflow settings for a feature.
-   * Feature-level settings override global settings.
+   *
+   * Resolution order (first defined wins):
+   *   1. Feature-level override (feature.gitWorkflow)
+   *   2. Per-project override (projectPrBaseBranch — from .automaker/settings.json workflow.gitWorkflow)
+   *   3. Global settings (globalSettings.gitWorkflow)
+   *   4. DEFAULT_GIT_WORKFLOW_SETTINGS
    */
   resolveGitWorkflowSettings(
     feature: Feature,
-    globalSettings: GlobalSettings
+    globalSettings: GlobalSettings,
+    projectPrBaseBranch?: string
   ): Required<GitWorkflowSettings> {
     const global = globalSettings.gitWorkflow ?? DEFAULT_GIT_WORKFLOW_SETTINGS;
     const featureOverride = feature.gitWorkflow ?? {};
@@ -237,6 +243,7 @@ export class GitWorkflowService {
         featureOverride.waitForCI ?? global.waitForCI ?? DEFAULT_GIT_WORKFLOW_SETTINGS.waitForCI,
       prBaseBranch:
         featureOverride.prBaseBranch ??
+        projectPrBaseBranch ??
         global.prBaseBranch ??
         DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch,
       maxPRLinesChanged:
@@ -358,6 +365,7 @@ export class GitWorkflowService {
    * @param settings - Global settings containing git workflow config
    * @param epicBranchName - Optional epic branch name to use as PR base (for features in epics)
    * @param events - Optional event emitter for emitting workflow events
+   * @param projectPrBaseBranch - Optional per-project prBaseBranch override from workflow settings
    * @returns GitWorkflowResult with details of what was done, or null if no workflow needed
    */
   async runPostCompletionWorkflow(
@@ -367,9 +375,10 @@ export class GitWorkflowService {
     workDir: string,
     settings: GlobalSettings,
     epicBranchName?: string,
-    events?: EventEmitter
+    events?: EventEmitter,
+    projectPrBaseBranch?: string
   ): Promise<GitWorkflowResult | null> {
-    const gitSettings = this.resolveGitWorkflowSettings(feature, settings);
+    const gitSettings = this.resolveGitWorkflowSettings(feature, settings, projectPrBaseBranch);
 
     // Determine PR base branch:
     // - If feature belongs to an epic and epicBranchName is provided, use it

--- a/apps/server/src/services/maintenance-tasks.ts
+++ b/apps/server/src/services/maintenance-tasks.ts
@@ -23,6 +23,7 @@ import { promisify } from 'util';
 import type { FlowFactory } from '@protolabsai/types';
 import { DEFAULT_GIT_WORKFLOW_SETTINGS } from '@protolabsai/types';
 import type { EventEmitter } from '../lib/events.js';
+import { getEffectivePrBaseBranch } from '../lib/settings-helpers.js';
 import type { AutoModeService } from './auto-mode-service.js';
 import type { DataIntegrityWatchdogService } from './data-integrity-watchdog-service.js';
 import type { FeatureLoader } from './feature-loader.js';
@@ -92,22 +93,21 @@ async function isBranchFullyMerged(
 
 /**
  * Resolve the integration branch for a project.
- * Reads prBaseBranch from global settings, then verifies the branch exists locally.
- * Falls back to main → master if the configured branch doesn't exist.
+ * Reads prBaseBranch from project settings first, then global, then verifies
+ * the branch exists locally. Falls back to main -> master if the configured
+ * branch doesn't exist.
  */
 async function resolveIntegrationBranch(
   cwd: string,
   settingsService?: SettingsService
 ): Promise<string | null> {
-  // Read prBaseBranch from settings
-  const configuredBranch = settingsService
-    ? (await settingsService.getGlobalSettings().catch(() => null))?.gitWorkflow?.prBaseBranch
-    : undefined;
-  const candidates = [
-    configuredBranch ?? DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch,
-    'main',
-    'master',
-  ];
+  // Read prBaseBranch from project settings first, then global
+  const configuredBranch = await getEffectivePrBaseBranch(
+    cwd,
+    settingsService,
+    '[MaintenanceTasks]'
+  );
+  const candidates = [configuredBranch, 'main', 'master'];
   // Deduplicate (e.g., if prBaseBranch is already 'main')
   const unique = [...new Set(candidates)];
 
@@ -1423,6 +1423,8 @@ export async function scanWorktreesForCrashRecovery(
 
         try {
           const globalSettings = await settingsService.getGlobalSettings();
+          const projectSettings = await settingsService.getProjectSettings(projectPath);
+          const projectPrBaseBranch = projectSettings.workflow?.gitWorkflow?.prBaseBranch;
           const result = await gitWorkflowService.runPostCompletionWorkflow(
             projectPath,
             feature.id,
@@ -1430,7 +1432,8 @@ export async function scanWorktreesForCrashRecovery(
             worktree.path,
             globalSettings,
             undefined,
-            events
+            events,
+            projectPrBaseBranch
           );
 
           if (result) {

--- a/apps/server/tests/unit/services/completion-detector-service.test.ts
+++ b/apps/server/tests/unit/services/completion-detector-service.test.ts
@@ -196,6 +196,12 @@ describe('CompletionDetectorService', () => {
       // callback arg as the resolved value, so pass { stdout, stderr } as that arg.
       type ExecFileCb = (err: null, result: { stdout: string; stderr: string }) => void;
 
+      // git symbolic-ref (auto-detect default branch via getEffectivePrBaseBranch) → dev
+      mockExecFile.mockImplementationOnce(
+        (_cmd: string, _args: string[], _opts: object, cb: ExecFileCb) => {
+          cb(null, { stdout: 'refs/remotes/origin/dev', stderr: '' });
+        }
+      );
       // git ls-remote → branch exists on remote
       mockExecFile.mockImplementationOnce(
         (_cmd: string, _args: string[], _opts: object, cb: ExecFileCb) => {

--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -405,6 +405,16 @@ export interface WorkflowSettings {
    * @default { enabled: false }
    */
   contextEngine?: ContextEngineConfig;
+  /**
+   * Per-project git workflow overrides.
+   * When set, these values take precedence over the global gitWorkflow settings
+   * in data/settings.json. Projects that use a different default branch (e.g. `main`
+   * instead of `dev`) can set `prBaseBranch` here without affecting other projects.
+   */
+  gitWorkflow?: {
+    /** Base branch for PR creation (overrides global gitWorkflow.prBaseBranch) */
+    prBaseBranch?: string;
+  };
 }
 
 /** Default workflow settings */


### PR DESCRIPTION
## Summary
- fix: per-project prBaseBranch override with auto-detect fallback (P1 multi-project blocker)
- M1 Unified Infra Compose epic merged (Postgres, Langfuse, Umami, Grafana, Prometheus, Loki)
- fix: deploy-staging.yml rebuild step
- Timer migration wiring order bug fix
- Various agent-produced features and memory drift

## Test plan
- [ ] CI passes
- [ ] Deploy succeeds with new Dockerfile bindings
- [ ] prBaseBranch resolution works for both ava (dev) and mythxengine (main)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for per-project PR base branch configuration, allowing individual projects to override the global default.
  * Introduced automatic detection of the default Git branch, with intelligent fallback to project settings and global defaults.

* **Improvements**
  * Enhanced PR base branch resolution logic with consistent priority handling across all services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->