### PR TITLE
fix: install rollup native binary in docs CI

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Build docs
         run: |
           npm ci --ignore-scripts
+          npm install --ignore-scripts --no-save @rollup/rollup-linux-x64-gnu@$(node -p "require('./node_modules/rollup/package.json').version")
           npm run docs:build
 
       - name: Deploy to Cloudflare Pages


### PR DESCRIPTION
Follow-up fix for docs deploy CI on GitHub Actions Linux runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process configuration for documentation deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->