### PR TITLE
Expand git add pathspec to exclude worktree directories

### DIFF
--- a/apps/server/src/lib/git-staging-utils.ts
+++ b/apps/server/src/lib/git-staging-utils.ts
@@ -10,18 +10,33 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 
 /**
- * Builds a git add command that stages all changes except .automaker/,
- * then re-includes .automaker/memory/ and .automaker/skills/ only if those
- * directories exist in the working tree. This prevents a fatal pathspec error
- * when a directory is absent (e.g. in a fresh worktree).
+ * Default directories to exclude from `git add`.
+ * Prevents worktree `.git` files and internal automaker directories from
+ * being staged as broken submodules (causing CI failures on Cloudflare Pages etc.)
  */
-export function buildGitAddCommand(workDir: string): string {
-  const parts = ["git add -A -- ':!.automaker/'"];
-  if (existsSync(join(workDir, '.automaker/memory'))) {
-    parts.push("'.automaker/memory/'");
+export const DEFAULT_STAGING_EXCLUSIONS = ['.automaker/', '.claude/worktrees/', '.worktrees/'];
+
+/**
+ * Builds a git add command that stages all changes except the directories in
+ * `excludeFromStaging`, then re-includes `.automaker/memory/` and
+ * `.automaker/skills/` only if `.automaker/` is excluded and those directories
+ * exist in the working tree. This prevents a fatal pathspec error when a
+ * directory is absent (e.g. in a fresh worktree).
+ */
+export function buildGitAddCommand(workDir: string, excludeFromStaging?: string[]): string {
+  const exclusions = excludeFromStaging ?? DEFAULT_STAGING_EXCLUSIONS;
+  const exclusionPathspecs = exclusions.map((dir) => `':!${dir}'`).join(' ');
+  const parts = [`git add -A -- ${exclusionPathspecs}`];
+
+  // Re-include .automaker/memory/ and .automaker/skills/ when .automaker/ is excluded
+  if (exclusions.includes('.automaker/')) {
+    if (existsSync(join(workDir, '.automaker/memory'))) {
+      parts.push("'.automaker/memory/'");
+    }
+    if (existsSync(join(workDir, '.automaker/skills'))) {
+      parts.push("'.automaker/skills/'");
+    }
   }
-  if (existsSync(join(workDir, '.automaker/skills'))) {
-    parts.push("'.automaker/skills/'");
-  }
+
   return parts.join(' ');
 }

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -254,6 +254,10 @@ export class GitWorkflowService {
         featureOverride.maxPRFilesTouched ??
         global.maxPRFilesTouched ??
         DEFAULT_GIT_WORKFLOW_SETTINGS.maxPRFilesTouched,
+      excludeFromStaging:
+        featureOverride.excludeFromStaging ??
+        global.excludeFromStaging ??
+        DEFAULT_GIT_WORKFLOW_SETTINGS.excludeFromStaging,
     };
   }
 
@@ -437,7 +441,12 @@ export class GitWorkflowService {
     try {
       // Step 1: Commit changes
       let commitHash: string | null;
-      commitHash = await this.commitChanges(workDir, feature, projectPath);
+      commitHash = await this.commitChanges(
+        workDir,
+        feature,
+        projectPath,
+        gitSettings.excludeFromStaging
+      );
 
       if (!commitHash) {
         // Agent may have already committed. Check for unpushed commits before bailing out.
@@ -464,7 +473,8 @@ export class GitWorkflowService {
             workDir,
             branchName,
             prBaseBranch,
-            projectPath
+            projectPath,
+            gitSettings.excludeFromStaging
           );
           const { stdout: headAfterFmt } = await execAsync('git rev-parse --short HEAD', {
             cwd: workDir,
@@ -476,7 +486,7 @@ export class GitWorkflowService {
           logger.info(
             `No uncommitted changes but found unpushed commits for feature ${featureId}, continuing pipeline`
           );
-          await this.formatAndAmendLastCommit(workDir, projectPath);
+          await this.formatAndAmendLastCommit(workDir, projectPath, gitSettings.excludeFromStaging);
           commitHash = unpushedHash;
         }
       }
@@ -1082,7 +1092,8 @@ export class GitWorkflowService {
   private async commitChanges(
     workDir: string,
     feature: Feature,
-    projectPath: string
+    projectPath: string,
+    excludeFromStaging?: string[]
   ): Promise<string | null> {
     // Check for changes - include untracked files explicitly
     const { stdout: status } = await execAsync('git status --porcelain --untracked-files=all', {
@@ -1100,8 +1111,11 @@ export class GitWorkflowService {
     const title = feature.title || extractTitleFromDescription(feature.description);
     const commitMessage = `feat: ${title}\n\nImplemented by Automaker auto-mode\nFeature ID: ${feature.id}`;
 
-    // Stage all changes - exclude .automaker/ except memory/ and skills/ (if they exist).
-    await execAsync(buildGitAddCommand(workDir), { cwd: workDir, env: execEnv });
+    // Stage all changes - exclude configured directories (worktrees, .automaker/ except memory/ and skills/).
+    await execAsync(buildGitAddCommand(workDir, excludeFromStaging), {
+      cwd: workDir,
+      env: execEnv,
+    });
 
     // Auto-format staged files before committing (matches CI prettier behavior)
     try {
@@ -1120,7 +1134,10 @@ export class GitWorkflowService {
           }
         );
         // Re-stage after formatting
-        await execAsync(buildGitAddCommand(workDir), { cwd: workDir, env: execEnv });
+        await execAsync(buildGitAddCommand(workDir, excludeFromStaging), {
+          cwd: workDir,
+          env: execEnv,
+        });
         logger.debug(`Auto-formatted ${files.length} staged files`);
       }
     } catch (fmtError) {
@@ -1306,7 +1323,11 @@ export class GitWorkflowService {
    * Run prettier on all changed files and amend the last commit.
    * Used when the agent committed without formatting.
    */
-  private async formatAndAmendLastCommit(workDir: string, projectPath: string): Promise<void> {
+  private async formatAndAmendLastCommit(
+    workDir: string,
+    projectPath: string,
+    excludeFromStaging?: string[]
+  ): Promise<void> {
     try {
       // Get files changed in the last commit
       const { stdout: changedFiles } = await execAsync(
@@ -1331,7 +1352,10 @@ export class GitWorkflowService {
       if (!status.trim()) return; // No formatting changes needed
 
       // Stage and amend
-      await execAsync(buildGitAddCommand(workDir), { cwd: workDir, env: execEnv });
+      await execAsync(buildGitAddCommand(workDir, excludeFromStaging), {
+        cwd: workDir,
+        env: execEnv,
+      });
       await execAsync('git commit --no-verify --amend --no-edit', { cwd: workDir, env: execEnv });
       logger.info(`Formatted and amended last commit (${files.length} files checked)`);
     } catch (error) {
@@ -1381,7 +1405,8 @@ export class GitWorkflowService {
     workDir: string,
     branchName: string,
     prBaseBranch: string,
-    projectPath: string
+    projectPath: string,
+    excludeFromStaging?: string[]
   ): Promise<void> {
     try {
       // Make sure local branch tracks the remote commits
@@ -1421,7 +1446,10 @@ export class GitWorkflowService {
       }
 
       // Stage and push a new commit (cannot amend — already on remote)
-      await execAsync(buildGitAddCommand(workDir), { cwd: workDir, env: execEnv });
+      await execAsync(buildGitAddCommand(workDir, excludeFromStaging), {
+        cwd: workDir,
+        env: execEnv,
+      });
       await execAsync('git commit --no-verify -m "fix(format): prettier on agent-created files"', {
         cwd: workDir,
         env: execEnv,

--- a/apps/server/tests/unit/lib/git-staging-utils.test.ts
+++ b/apps/server/tests/unit/lib/git-staging-utils.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { buildGitAddCommand } from '../../../src/lib/git-staging-utils.js';
+import {
+  buildGitAddCommand,
+  DEFAULT_STAGING_EXCLUSIONS,
+} from '../../../src/lib/git-staging-utils.js';
 
 describe('buildGitAddCommand', () => {
   let tempDir: string;
@@ -15,30 +18,71 @@ describe('buildGitAddCommand', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('should return base exclude command when no .automaker dirs exist', () => {
-    expect(buildGitAddCommand(tempDir)).toBe("git add -A -- ':!.automaker/'");
+  describe('default exclusions', () => {
+    it('should exclude .automaker/, .claude/worktrees/, and .worktrees/ by default', () => {
+      expect(buildGitAddCommand(tempDir)).toBe(
+        "git add -A -- ':!.automaker/' ':!.claude/worktrees/' ':!.worktrees/'"
+      );
+    });
+
+    it('should include .automaker/memory/ when that directory exists', () => {
+      mkdirSync(join(tempDir, '.automaker', 'memory'), { recursive: true });
+      expect(buildGitAddCommand(tempDir)).toBe(
+        "git add -A -- ':!.automaker/' ':!.claude/worktrees/' ':!.worktrees/' '.automaker/memory/'"
+      );
+    });
+
+    it('should include .automaker/skills/ when that directory exists', () => {
+      mkdirSync(join(tempDir, '.automaker', 'skills'), { recursive: true });
+      expect(buildGitAddCommand(tempDir)).toBe(
+        "git add -A -- ':!.automaker/' ':!.claude/worktrees/' ':!.worktrees/' '.automaker/skills/'"
+      );
+    });
+
+    it('should include both memory and skills when both directories exist', () => {
+      mkdirSync(join(tempDir, '.automaker', 'memory'), { recursive: true });
+      mkdirSync(join(tempDir, '.automaker', 'skills'), { recursive: true });
+      expect(buildGitAddCommand(tempDir)).toBe(
+        "git add -A -- ':!.automaker/' ':!.claude/worktrees/' ':!.worktrees/' '.automaker/memory/' '.automaker/skills/'"
+      );
+    });
+
+    it('should not re-include memory/skills when only .automaker/ exists (no subdirs)', () => {
+      mkdirSync(join(tempDir, '.automaker'), { recursive: true });
+      expect(buildGitAddCommand(tempDir)).toBe(
+        "git add -A -- ':!.automaker/' ':!.claude/worktrees/' ':!.worktrees/'"
+      );
+    });
   });
 
-  it('should include .automaker/memory/ when that directory exists', () => {
-    mkdirSync(join(tempDir, '.automaker', 'memory'), { recursive: true });
-    expect(buildGitAddCommand(tempDir)).toBe("git add -A -- ':!.automaker/' '.automaker/memory/'");
+  describe('configurable exclusions', () => {
+    it('should use custom exclusion list when provided', () => {
+      expect(buildGitAddCommand(tempDir, ['.automaker/'])).toBe("git add -A -- ':!.automaker/'");
+    });
+
+    it('should re-include .automaker/memory/ when .automaker/ is in custom list and dir exists', () => {
+      mkdirSync(join(tempDir, '.automaker', 'memory'), { recursive: true });
+      expect(buildGitAddCommand(tempDir, ['.automaker/'])).toBe(
+        "git add -A -- ':!.automaker/' '.automaker/memory/'"
+      );
+    });
+
+    it('should not re-include .automaker subdirs when .automaker/ is not in custom list', () => {
+      mkdirSync(join(tempDir, '.automaker', 'memory'), { recursive: true });
+      mkdirSync(join(tempDir, '.automaker', 'skills'), { recursive: true });
+      expect(buildGitAddCommand(tempDir, ['.worktrees/'])).toBe("git add -A -- ':!.worktrees/'");
+    });
+
+    it('should handle empty exclusion list', () => {
+      expect(buildGitAddCommand(tempDir, [])).toBe('git add -A -- ');
+    });
   });
 
-  it('should include .automaker/skills/ when that directory exists', () => {
-    mkdirSync(join(tempDir, '.automaker', 'skills'), { recursive: true });
-    expect(buildGitAddCommand(tempDir)).toBe("git add -A -- ':!.automaker/' '.automaker/skills/'");
-  });
-
-  it('should include both when both directories exist', () => {
-    mkdirSync(join(tempDir, '.automaker', 'memory'), { recursive: true });
-    mkdirSync(join(tempDir, '.automaker', 'skills'), { recursive: true });
-    expect(buildGitAddCommand(tempDir)).toBe(
-      "git add -A -- ':!.automaker/' '.automaker/memory/' '.automaker/skills/'"
-    );
-  });
-
-  it('should not include memory when only .automaker/ exists (no subdirs)', () => {
-    mkdirSync(join(tempDir, '.automaker'), { recursive: true });
-    expect(buildGitAddCommand(tempDir)).toBe("git add -A -- ':!.automaker/'");
+  describe('DEFAULT_STAGING_EXCLUSIONS', () => {
+    it('should include .automaker/, .claude/worktrees/, and .worktrees/', () => {
+      expect(DEFAULT_STAGING_EXCLUSIONS).toContain('.automaker/');
+      expect(DEFAULT_STAGING_EXCLUSIONS).toContain('.claude/worktrees/');
+      expect(DEFAULT_STAGING_EXCLUSIONS).toContain('.worktrees/');
+    });
   });
 });

--- a/libs/types/src/git-settings.ts
+++ b/libs/types/src/git-settings.ts
@@ -49,6 +49,12 @@ export interface GitWorkflowSettings {
    * Set to 0 to disable the check. (default: 20)
    */
   maxPRFilesTouched?: number;
+  /**
+   * Directories to exclude from `git add` during staging.
+   * Prevents worktree `.git` files and internal directories from being staged as broken submodules.
+   * Default: [".automaker/", ".claude/worktrees/", ".worktrees/"]
+   */
+  excludeFromStaging?: string[];
 }
 
 /**
@@ -64,6 +70,7 @@ export const DEFAULT_GIT_WORKFLOW_SETTINGS: Required<GitWorkflowSettings> = {
   prBaseBranch: 'dev',
   maxPRLinesChanged: 500,
   maxPRFilesTouched: 20,
+  excludeFromStaging: ['.automaker/', '.claude/worktrees/', '.worktrees/'],
 };
 
 /**


### PR DESCRIPTION
## Summary

**Problem:** Agents running `git add` can accidentally stage worktree directories (`.claude/worktrees/`, `.worktrees/`) that contain `.git` files. When pushed, CI systems like Cloudflare Pages interpret these as broken submodules and fail with `fatal: No url found for submodule path`.

**Solution:** In `apps/server/src/services/git-workflow-service.ts`, expand the `git add` pathspec exclusion list to include worktree directories alongside the existing `.automaker/` exclusions.

The exclusion lis...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable directory exclusions for git staging. Users can now customize which directories to exclude from git add operations through workflow settings, enabling finer control over staged changes. Default exclusions include `.automaker/`, `.claude/worktrees/`, and `.worktrees/`. Supports per-project overrides and global defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->