### PR TITLE
Bug: Epics don't auto-complete when no epic branch exists

### DIFF
--- a/apps/server/src/services/maintenance/checks/epic-completion-check.ts
+++ b/apps/server/src/services/maintenance/checks/epic-completion-check.ts
@@ -6,13 +6,19 @@
  *
  * Auto-fix behavior:
  * - Epics WITHOUT a git branch: automatically set to 'done'
- * - Epics WITH a git branch: NOT auto-fixable — delegate to CompletionDetectorService
- *   which handles the epic-to-dev PR creation flow.
+ * - Epics WITH a git branch that DOES NOT exist on remote: automatically set to 'done'
+ *   (children merged directly to the base branch — no epic branch was created)
+ * - Epics WITH a git branch that EXISTS on remote: NOT auto-fixable — delegate to
+ *   CompletionDetectorService which handles the epic-to-dev PR creation flow.
  */
 
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { createLogger } from '@protolabsai/utils';
 import type { FeatureLoader } from '../../feature-loader.js';
 import type { MaintenanceCheck, MaintenanceIssue } from '../types.js';
+
+const execFileAsync = promisify(execFile);
 
 const logger = createLogger('EpicCompletionCheck');
 
@@ -22,6 +28,27 @@ export class EpicCompletionCheck implements MaintenanceCheck {
   readonly id = 'epic-completion';
 
   constructor(private readonly featureLoader: FeatureLoader) {}
+
+  /**
+   * Returns true if the given branch exists on the remote (origin).
+   * An empty result from git ls-remote means the branch is absent.
+   */
+  private async epicBranchExistsOnRemote(
+    projectPath: string,
+    branchName: string
+  ): Promise<boolean> {
+    try {
+      const { stdout } = await execFileAsync(
+        'git',
+        ['ls-remote', '--heads', 'origin', branchName],
+        { cwd: projectPath, timeout: 15000 }
+      );
+      return stdout.trim().length > 0;
+    } catch {
+      // If the git command fails (no remote, no network), assume branch absent
+      return false;
+    }
+  }
 
   async run(projectPath: string): Promise<MaintenanceIssue[]> {
     const issues: MaintenanceIssue[] = [];
@@ -42,21 +69,36 @@ export class EpicCompletionCheck implements MaintenanceCheck {
 
         const hasGitBranch = !!epic.branchName;
 
+        // For git-backed epics, check if the branch actually exists on the remote.
+        // When prBaseBranch targets dev directly, children merge to dev and the epic
+        // branch is never pushed — in that case we can auto-fix by marking done directly.
+        let branchExistsOnRemote = false;
+        if (hasGitBranch) {
+          branchExistsOnRemote = await this.epicBranchExistsOnRemote(projectPath, epic.branchName!);
+        }
+
+        // Auto-fixable when:
+        // - Epic has no git branch (manual/non-git epic), OR
+        // - Epic has a branch but it doesn't exist on remote (children merged directly to base)
+        const autoFixable = !hasGitBranch || !branchExistsOnRemote;
+
         issues.push({
           checkId: this.id,
           severity: 'warning',
           featureId: epic.id,
           message: `Epic "${epic.title || epic.id}" has ${children.length} child(ren), all done, but epic status is '${epic.status}'`,
-          autoFixable: !hasGitBranch,
-          fixDescription: hasGitBranch
-            ? 'Delegate to CompletionDetectorService for epic-to-dev PR creation'
-            : 'Set epic status to done',
+          autoFixable,
+          fixDescription:
+            hasGitBranch && branchExistsOnRemote
+              ? 'Delegate to CompletionDetectorService for epic-to-dev PR creation'
+              : 'Set epic status to done',
           context: {
             featureId: epic.id,
             epicTitle: epic.title,
             currentStatus: epic.status,
             childCount: children.length,
             hasGitBranch,
+            branchExistsOnRemote,
             projectPath,
           },
         });
@@ -72,17 +114,25 @@ export class EpicCompletionCheck implements MaintenanceCheck {
     const featureId = issue.featureId;
     if (!featureId) return;
 
-    // Only fix epics without a git branch — git-backed epics need CompletionDetectorService
     const hasGitBranch = issue.context?.hasGitBranch as boolean | undefined;
-    if (hasGitBranch) {
+    const branchExistsOnRemote = issue.context?.branchExistsOnRemote as boolean | undefined;
+
+    // Git-backed epic whose branch exists on remote — needs CompletionDetectorService
+    // to create the epic-to-dev PR. Cannot auto-fix here.
+    if (hasGitBranch && branchExistsOnRemote) {
       logger.warn(
-        `Skipping auto-fix for git-backed epic ${featureId} — delegate to CompletionDetectorService`
+        `Skipping auto-fix for git-backed epic ${featureId} (branch exists on remote) — delegate to CompletionDetectorService`
       );
       return;
     }
 
-    logger.info(`Setting epic ${featureId} status to done`);
+    // Either no branch, or branch doesn't exist on remote (children merged directly to base).
+    // Mark done directly, same path as CompletionDetectorService.checkEpicCompletion().
+    const reason = hasGitBranch
+      ? `children merged directly to base branch (epic branch not found on remote)`
+      : `no git branch`;
+    logger.info(`Setting epic ${featureId} to done (${reason})`);
     await this.featureLoader.update(projectPath, featureId, { status: 'done' });
-    logger.info(`Set epic ${featureId} status to done`);
+    logger.info(`Epic ${featureId} set to done`);
   }
 }


### PR DESCRIPTION
## Summary

**Reported by:** mythxengine team during monitoring session (2026-03-18)

**Problem:** When `prBaseBranch: dev` is set globally or per-project, feature PRs target `dev` directly instead of the epic branch. This means the epic branch is never created, so `CompletionDetectorService` has nothing to detect — it looks for all children merged into the epic branch, but they merged into `dev` instead. The epic sits in `backlog` forever with all children `done`.

**Observed:** M3 and M6 epics on mythxeng...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved epic completion detection with enhanced Git branch status validation.
  * Expanded automatic fixing for epics missing or with invalid remote branches.
  * Enhanced error handling and diagnostic logging for completion checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->