### PR TITLE
PR reconciliation layer in REVIEW processor

### DIFF
--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -6,10 +6,15 @@
  */
 
 import { exec } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { promisify } from 'node:util';
 import { createLogger } from '@protolabsai/utils';
 import type { EventType, PRMergeStrategy } from '@protolabsai/types';
 import { resolveMergeStrategy } from '../lib/merge-strategy.js';
+import {
+  parsePROwnershipWatermark,
+  buildPROwnershipWatermark,
+} from '../routes/github/utils/pr-ownership.js';
 import type {
   ProcessorServiceContext,
   StateContext,
@@ -143,6 +148,9 @@ export class ReviewProcessor implements StateProcessor {
         reason: ctx.escalationReason,
       };
     }
+
+    // Normalize PR: patch ownership watermark and enable auto-merge if missing
+    await this.normalizePR(ctx);
 
     // Query PRFeedbackService for tracked PR state (falls back to gh CLI)
     const reviewState = await this.getPRReviewState(ctx);
@@ -289,6 +297,115 @@ export class ReviewProcessor implements StateProcessor {
     logger.info('[REVIEW] Review phase completed');
     // Clean up review start timestamp when leaving REVIEW state
     this.reviewStartedAt.delete(ctx.feature.id);
+  }
+
+  /**
+   * Reconcile a PR into the expected managed state regardless of how it was created.
+   *
+   * 1. Appends the ownership watermark to the PR body if it is missing.
+   * 2. Enables auto-merge if it is not already enabled.
+   *
+   * This is idempotent — running it multiple times on the same PR is safe.
+   */
+  private async normalizePR(ctx: StateContext): Promise<void> {
+    if (!ctx.prNumber) return;
+
+    // Fetch current PR body and auto-merge status in one call
+    let body = '';
+    let autoMergeEnabled = false;
+    try {
+      const { stdout } = await execAsync(
+        `gh pr view ${ctx.prNumber} --json body,autoMergeRequest --jq '{body: .body, autoMerge: (.autoMergeRequest != null)}'`,
+        { cwd: ctx.projectPath, timeout: 15000 }
+      );
+      const data = JSON.parse(stdout.trim()) as { body: string; autoMerge: boolean };
+      body = data.body ?? '';
+      autoMergeEnabled = data.autoMerge ?? false;
+    } catch (err) {
+      logger.warn('[REVIEW] normalizePR: failed to fetch PR body/auto-merge status:', err);
+      return;
+    }
+
+    // 1. Patch ownership watermark if absent
+    const ownership = parsePROwnershipWatermark(body);
+    if (!ownership.instanceId) {
+      try {
+        let instanceId = `transient-${randomUUID().slice(0, 8)}`;
+        let teamId = '';
+        if (this.serviceContext.settingsService) {
+          const globalSettings = await this.serviceContext.settingsService.getGlobalSettings();
+          instanceId = globalSettings.instanceId ?? instanceId;
+          teamId = globalSettings.teamId ?? '';
+        }
+        const watermark = buildPROwnershipWatermark(instanceId, teamId);
+        const patchedBody = body ? `${body}\n\n${watermark}` : watermark;
+        // Write body via a temp file to avoid shell quoting issues with PR body content
+        const { writeFileSync, unlinkSync } = await import('node:fs');
+        const tmpFile = `/tmp/pr-body-${ctx.prNumber}-${Date.now()}.txt`;
+        writeFileSync(tmpFile, patchedBody, 'utf8');
+        try {
+          await execAsync(`gh pr edit ${ctx.prNumber} --body-file "${tmpFile}"`, {
+            cwd: ctx.projectPath,
+            timeout: 15000,
+          });
+        } finally {
+          try {
+            unlinkSync(tmpFile);
+          } catch {
+            /* ignore */
+          }
+        }
+        logger.info(
+          `[REVIEW] normalizePR: patched ownership watermark on PR #${ctx.prNumber} (instance=${instanceId})`
+        );
+      } catch (err) {
+        logger.warn('[REVIEW] normalizePR: failed to patch PR ownership watermark:', err);
+      }
+    }
+
+    // 2. Enable auto-merge if not already enabled
+    if (!autoMergeEnabled) {
+      try {
+        const mergeFlag = await this.resolveNormalizeMergeFlag(ctx);
+        await execAsync(`gh pr merge ${ctx.prNumber} --auto ${mergeFlag}`, {
+          cwd: ctx.projectPath,
+          timeout: 30000,
+        });
+        logger.info(
+          `[REVIEW] normalizePR: enabled auto-merge on PR #${ctx.prNumber} (${mergeFlag})`
+        );
+      } catch (err) {
+        logger.warn('[REVIEW] normalizePR: failed to enable auto-merge:', err);
+      }
+    }
+  }
+
+  /**
+   * Resolve merge flag for normalization (same logic as MergeProcessor.resolveMergeFlag).
+   * Promotion PRs always use --merge. Feature PRs use the configured prMergeStrategy.
+   */
+  private async resolveNormalizeMergeFlag(ctx: StateContext): Promise<string> {
+    if (ctx.prNumber) {
+      const baseBranchFlag = await resolveMergeStrategy(ctx.prNumber, ctx.projectPath);
+      if (baseBranchFlag === '--merge') return '--merge';
+    }
+
+    let strategy: PRMergeStrategy = 'squash';
+    if (this.serviceContext.settingsService) {
+      try {
+        const globalSettings = await this.serviceContext.settingsService.getGlobalSettings();
+        strategy = globalSettings.gitWorkflow?.prMergeStrategy ?? 'squash';
+      } catch (err) {
+        logger.warn('[REVIEW] normalizePR: failed to read merge strategy from settings:', err);
+      }
+    }
+
+    const flagMap: Record<PRMergeStrategy, string> = {
+      squash: '--squash',
+      merge: '--merge',
+      rebase: '--rebase',
+    };
+    return flagMap[strategy] ?? '--squash';
   }
 
   private async getPRReviewState(ctx: StateContext): Promise<string> {


### PR DESCRIPTION
## Summary

**Problem:** When agents create PRs via raw `gh pr create` instead of the managed git workflow service, the PR lacks:
1. Ownership watermark (``)
2. Auto-merge enablement
3. Standardized PR description/template

The REVIEW processor in the Lead Engineer state machine doesn't verify these properties, so PRs created outside the managed flow sit in review indefinitely with no auto-merge.

**Solution:** Add a PR normalization step to the REVIEW processor (`apps/server/src/services/lead-engineer/proc...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PRs now automatically normalize ownership watermarks if missing during processing
  * Auto-merge is automatically enabled for processed PRs when not already configured
  * Improved merge strategy selection logic for promotion PRs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->