### PR TITLE
Configurable soft CI checks for merge gate

### DIFF
--- a/apps/server/src/routes/github/routes/check-pr-status.ts
+++ b/apps/server/src/routes/github/routes/check-pr-status.ts
@@ -56,8 +56,19 @@ export function createCheckPRStatusHandler(settingsService?: SettingsService) {
 
       logger.info(`Checking PR #${prNumber} CI status`);
 
+      // Read soft checks from project settings
+      let softChecks: string[] = [];
+      if (settingsService) {
+        try {
+          const globalSettings = await settingsService.getGlobalSettings();
+          softChecks = globalSettings.gitWorkflow?.softChecks ?? [];
+        } catch {
+          // Settings unavailable — all checks treated as hard
+        }
+      }
+
       // Get PR check status
-      const checkStatus = await githubMergeService.checkPRStatus(projectPath, prNumber);
+      const checkStatus = await githubMergeService.checkPRStatus(projectPath, prNumber, softChecks);
 
       logger.info(
         `PR #${prNumber} status: ${checkStatus.passedCount} passed, ${checkStatus.failedCount} failed, ${checkStatus.pendingCount} pending`

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -258,6 +258,8 @@ export class GitWorkflowService {
         featureOverride.excludeFromStaging ??
         global.excludeFromStaging ??
         DEFAULT_GIT_WORKFLOW_SETTINGS.excludeFromStaging,
+      softChecks:
+        featureOverride.softChecks ?? global.softChecks ?? DEFAULT_GIT_WORKFLOW_SETTINGS.softChecks,
     };
   }
 

--- a/apps/server/src/services/github-merge-service.ts
+++ b/apps/server/src/services/github-merge-service.ts
@@ -33,16 +33,18 @@ async function isGhCliAvailable(): Promise<boolean> {
  * PR check status information
  */
 interface PRCheckStatus {
-  /** Whether all required checks have passed */
+  /** Whether all required checks have passed (soft check failures are excluded) */
   allChecksPassed: boolean;
   /** Number of checks that passed */
   passedCount: number;
-  /** Number of checks that failed */
+  /** Number of hard checks that failed (soft check failures are excluded) */
   failedCount: number;
   /** Number of checks still pending */
   pendingCount: number;
-  /** List of failed check names */
+  /** List of hard check names that failed */
   failedChecks: string[];
+  /** List of soft check names that failed (logged but do not block merge) */
+  softFailedChecks: string[];
 }
 
 /**
@@ -68,8 +70,16 @@ export interface PRMergeResult {
 export class GitHubMergeService {
   /**
    * Check the status of CI checks for a PR
+   *
+   * @param workDir - Working directory (worktree or project path)
+   * @param prNumber - PR number to check
+   * @param softChecks - Check names that should not block the merge gate (case-insensitive substring match)
    */
-  async checkPRStatus(workDir: string, prNumber: number): Promise<PRCheckStatus> {
+  async checkPRStatus(
+    workDir: string,
+    prNumber: number,
+    softChecks: string[] = []
+  ): Promise<PRCheckStatus> {
     try {
       // Use gh CLI to get PR check status
       const { stdout } = await execAsync(`gh pr view ${prNumber} --json statusCheckRollup`, {
@@ -84,19 +94,21 @@ export class GitHubMergeService {
       let failedCount = 0;
       let pendingCount = 0;
       const failedChecks: string[] = [];
+      const softFailedChecks: string[] = [];
 
       for (const check of checks) {
         const status = check.status?.toLowerCase();
         const conclusion = check.conclusion?.toLowerCase();
+        const checkName = check.name ?? check.context ?? '';
+        const checkIdentifier = checkName.toLowerCase();
 
         if (status === 'completed') {
           // Detect CodeRabbit FAILURE — treat as transient pending rather than a hard failure.
           // CodeRabbit commonly sets commit status to FAILURE when rate-limited by simultaneous
           // batch PRs. Counting it as a real failure would block merge unnecessarily.
-          const checkIdentifier = (check.name ?? check.context ?? '').toLowerCase();
           if (checkIdentifier.includes('coderabbit') && conclusion === 'failure') {
             logger.warn(
-              `[CodeRabbit] FAILURE status on '${check.name ?? check.context}' — ` +
+              `[CodeRabbit] FAILURE status on '${checkName}' — ` +
                 `treating as transient pending (possible rate-limit). Will not count as hard failure.`
             );
             pendingCount++;
@@ -106,8 +118,19 @@ export class GitHubMergeService {
           if (conclusion === 'success' || conclusion === 'neutral' || conclusion === 'skipped') {
             passedCount++;
           } else {
-            failedCount++;
-            failedChecks.push(check.name || 'Unknown check');
+            // Check if this is a soft check (failure should not block merge)
+            const isSoftCheck = softChecks.some((soft) =>
+              checkIdentifier.includes(soft.toLowerCase())
+            );
+            if (isSoftCheck) {
+              logger.info(
+                `[SoftCheck] '${checkName}' failed but is classified as a soft check — not blocking merge`
+              );
+              softFailedChecks.push(checkName || 'Unknown check');
+            } else {
+              failedCount++;
+              failedChecks.push(checkName || 'Unknown check');
+            }
           }
         } else {
           pendingCount++;
@@ -122,6 +145,7 @@ export class GitHubMergeService {
         failedCount,
         pendingCount,
         failedChecks,
+        softFailedChecks,
       };
     } catch (error) {
       logger.error(`Failed to check PR status: ${error}`);
@@ -132,6 +156,7 @@ export class GitHubMergeService {
         failedCount: 0,
         pendingCount: 0,
         failedChecks: [],
+        softFailedChecks: [],
       };
     }
   }

--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -426,7 +426,18 @@ export class ReviewProcessor implements StateProcessor {
       if (data.decision === 'APPROVED') return 'approved';
       if (data.decision === 'CHANGES_REQUESTED') return 'changes_requested';
 
-      // Separate CodeRabbit checks from real CI checks.
+      // Read soft checks from settings (failures logged but don't block approval)
+      let softChecks: string[] = [];
+      if (this.serviceContext.settingsService) {
+        try {
+          const globalSettings = await this.serviceContext.settingsService.getGlobalSettings();
+          softChecks = globalSettings.gitWorkflow?.softChecks ?? [];
+        } catch {
+          // Settings unavailable — all checks treated as hard
+        }
+      }
+
+      // Separate CodeRabbit checks and soft checks from real CI checks.
       // CodeRabbit rate-limit sets commit status to FAILURE, but this is transient
       // and should not block the approval flow.
       const checks = (data.checks || []) as Array<{ name: string; conclusion: string }>;
@@ -435,11 +446,13 @@ export class ReviewProcessor implements StateProcessor {
           c.name?.toLowerCase().includes('coderabbit') ||
           c.name?.toLowerCase().includes('code-rabbit')
       );
-      const ciChecks = checks.filter(
-        (c) =>
-          !c.name?.toLowerCase().includes('coderabbit') &&
-          !c.name?.toLowerCase().includes('code-rabbit')
-      );
+      const ciChecks = checks.filter((c) => {
+        const nameLower = c.name?.toLowerCase() ?? '';
+        if (nameLower.includes('coderabbit') || nameLower.includes('code-rabbit')) return false;
+        // Exclude soft checks from blocking CI evaluation
+        if (softChecks.some((soft) => nameLower.includes(soft.toLowerCase()))) return false;
+        return true;
+      });
 
       // Log transient CodeRabbit failures so operators can diagnose
       const codeRabbitFailures = codeRabbitChecks.filter(
@@ -455,8 +468,23 @@ export class ReviewProcessor implements StateProcessor {
         );
       }
 
+      // Log soft check failures for visibility
+      const softCheckFailures = checks.filter(
+        (c) =>
+          !codeRabbitChecks.includes(c) &&
+          !ciChecks.includes(c) &&
+          c.conclusion &&
+          c.conclusion !== 'SUCCESS'
+      );
+      if (softCheckFailures.length > 0) {
+        logger.info(`[REVIEW] Soft check(s) failed — not blocking approval`, {
+          prNumber: ctx.prNumber,
+          softChecks: softCheckFailures.map((c) => `${c.name}=${c.conclusion}`),
+        });
+      }
+
       // Require at least one human APPROVED review — CI passing alone is not sufficient.
-      // Only real CI checks (non-CodeRabbit) block approval.
+      // Only real CI checks (non-CodeRabbit, non-soft) block approval.
       const approvedCount = (data.approvedCount as number) ?? 0;
       if (
         approvedCount > 0 &&

--- a/apps/server/src/services/maintenance-tasks.ts
+++ b/apps/server/src/services/maintenance-tasks.ts
@@ -788,10 +788,19 @@ async function autoMergeEligiblePRs(
         totalChecked++;
 
         // Check merge eligibility using MergeEligibilityService
+        let softChecks: string[] = [];
+        try {
+          const globalSettings = await settingsService.getGlobalSettings();
+          softChecks = globalSettings.gitWorkflow?.softChecks ?? [];
+        } catch {
+          // Settings unavailable — all checks treated as hard
+        }
         const eligibilityResult = await mergeEligibilityService.evaluatePR(
           projectPath,
           feature.prNumber,
-          autoMergeSettings
+          autoMergeSettings,
+          undefined,
+          softChecks
         );
 
         logger.info(

--- a/apps/server/src/services/merge-eligibility-service.ts
+++ b/apps/server/src/services/merge-eligibility-service.ts
@@ -140,19 +140,26 @@ export class MergeEligibilityService {
 
   /**
    * Check if CI/CD checks are passing
+   *
+   * @param prDetails - PR details from GitHub
+   * @param softChecks - Check names that should not block merge (case-insensitive substring match)
    */
-  private checkCIPassing(prDetails: PRDetails): PRCheckStatus {
+  private checkCIPassing(prDetails: PRDetails, softChecks: string[] = []): PRCheckStatus {
     const checkType: AutoMergeCheckType = 'ci_passing';
+
+    const isSoftCheck = (name: string) =>
+      softChecks.some((soft) => name.toLowerCase().includes(soft.toLowerCase()));
 
     // Check status check rollup
     if (prDetails.statusCheckRollup) {
       const failedChecks = prDetails.statusCheckRollup.filter(
         (check) =>
-          check.state === 'FAILURE' ||
-          check.state === 'ERROR' ||
-          check.conclusion === 'FAILURE' ||
-          check.conclusion === 'TIMED_OUT' ||
-          check.conclusion === 'CANCELLED'
+          !isSoftCheck(check.context ?? '') &&
+          (check.state === 'FAILURE' ||
+            check.state === 'ERROR' ||
+            check.conclusion === 'FAILURE' ||
+            check.conclusion === 'TIMED_OUT' ||
+            check.conclusion === 'CANCELLED')
       );
 
       if (failedChecks.length > 0) {
@@ -184,10 +191,11 @@ export class MergeEligibilityService {
       if (contexts && contexts.length > 0) {
         const failedContexts = contexts.filter(
           (ctx) =>
-            ctx.state === 'FAILURE' ||
-            ctx.state === 'ERROR' ||
-            ctx.conclusion === 'FAILURE' ||
-            ctx.conclusion === 'TIMED_OUT'
+            !isSoftCheck(ctx.context ?? '') &&
+            (ctx.state === 'FAILURE' ||
+              ctx.state === 'ERROR' ||
+              ctx.conclusion === 'FAILURE' ||
+              ctx.conclusion === 'TIMED_OUT')
         );
 
         if (failedContexts.length > 0) {
@@ -348,7 +356,8 @@ export class MergeEligibilityService {
     workDir: string,
     prNumber: number,
     settings: AutoMergeSettings = DEFAULT_AUTO_MERGE_SETTINGS,
-    repo?: string
+    repo?: string,
+    softChecks: string[] = []
   ): Promise<MergeEligibilityResult> {
     // Check if gh CLI is available
     const ghAvailable = await this.isGhCliAvailable();
@@ -405,7 +414,7 @@ export class MergeEligibilityService {
 
       switch (checkType) {
         case 'ci_passing':
-          checkResult = this.checkCIPassing(prDetails);
+          checkResult = this.checkCIPassing(prDetails, softChecks);
           break;
         case 'reviews_approved':
           checkResult = this.checkReviewsApproved(prDetails, minApprovals);

--- a/libs/types/src/git-settings.ts
+++ b/libs/types/src/git-settings.ts
@@ -55,6 +55,13 @@ export interface GitWorkflowSettings {
    * Default: [".automaker/", ".claude/worktrees/", ".worktrees/"]
    */
   excludeFromStaging?: string[];
+  /**
+   * CI check names that should NOT block the merge gate.
+   * Failures from these checks are logged but do not prevent auto-merge.
+   * Matching is case-insensitive substring. Example: ["Cloudflare Pages", "codecov/patch"]
+   * Default: [] (all checks are hard — opt-in to soft classification)
+   */
+  softChecks?: string[];
 }
 
 /**
@@ -71,6 +78,7 @@ export const DEFAULT_GIT_WORKFLOW_SETTINGS: Required<GitWorkflowSettings> = {
   maxPRLinesChanged: 500,
   maxPRFilesTouched: 20,
   excludeFromStaging: ['.automaker/', '.claude/worktrees/', '.worktrees/'],
+  softChecks: [],
 };
 
 /**


### PR DESCRIPTION
## Summary

**Problem:** All CI checks are treated equally by the merge gate and Board Janitor. A Cloudflare Pages preview failure (cosmetic) blocks auto-merge the same way a test failure (critical) would. This causes the pipeline to stall on non-critical check failures that are irrelevant to code correctness.

**Solution:** Add a `gitWorkflow.softChecks` setting — an array of CI check names that should NOT block the merge gate. When evaluating PR readiness:
- Hard checks (not in the list): must pass for me...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configurable soft CI checks that don't block automatic PR merging. Soft check failures are now tracked and logged separately, allowing merge workflows to proceed while hard checks continue to enforce merge restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->