### PR TITLE
Bug: Feature PRs target wrong branch on multi-project setups

### DIFF
--- a/apps/server/src/lib/settings-helpers.ts
+++ b/apps/server/src/lib/settings-helpers.ts
@@ -815,9 +815,13 @@ export async function getWorkflowSettings(
  *
  * Resolution order:
  *   1. Per-project workflow.gitWorkflow.prBaseBranch (from .automaker/settings.json)
- *   2. Global gitWorkflow.prBaseBranch (from data/settings.json)
- *   3. Auto-detect from remote HEAD via `git symbolic-ref refs/remotes/origin/HEAD`
- *   4. DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch ('dev')
+ *   2. Auto-detect from remote HEAD via `git symbolic-ref refs/remotes/origin/HEAD`
+ *   3. DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch ('dev')
+ *
+ * Global settings are intentionally excluded from the fallback chain. The global
+ * gitWorkflow.prBaseBranch belongs to the automaker project itself and must not
+ * bleed into other projects with a different default branch (e.g. mythxengine uses
+ * 'main', not 'dev').
  *
  * @param projectPath - Absolute path to the project (used for project settings + git detection)
  * @param settingsService - Settings service instance
@@ -838,20 +842,14 @@ export async function getEffectivePrBaseBranch(
         logger.debug(`${logPrefix} Using project-level prBaseBranch: ${projectBranch}`);
         return projectBranch;
       }
-
-      // 2. Fall back to global settings
-      const globalSettings = await settingsService.getGlobalSettings();
-      const globalBranch = globalSettings.gitWorkflow?.prBaseBranch;
-      if (globalBranch) {
-        logger.debug(`${logPrefix} Using global prBaseBranch: ${globalBranch}`);
-        return globalBranch;
-      }
+      // NOTE: Intentionally skip global settings — global prBaseBranch belongs to the
+      // automaker project and must not bleed into other projects with a different branch.
     } catch (err) {
       logger.warn(`${logPrefix} Failed to read settings for prBaseBranch:`, err);
     }
   }
 
-  // 3. Auto-detect from remote HEAD
+  // 2. Auto-detect from remote HEAD
   try {
     const { stdout } = await execFileAsync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
       cwd: projectPath,
@@ -868,6 +866,6 @@ export async function getEffectivePrBaseBranch(
     // origin/HEAD not set or git not available — fall through to default
   }
 
-  // 4. Final fallback
+  // 3. Final fallback
   return DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch;
 }

--- a/apps/server/src/routes/setup/routes/project.ts
+++ b/apps/server/src/routes/setup/routes/project.ts
@@ -2,12 +2,16 @@ import type { RequestHandler } from 'express';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import crypto from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { createLogger } from '@protolabsai/utils';
 import { ensureAutomakerDir, writeProtoConfig, type ProtoConfig } from '@protolabsai/platform';
 import { SettingsService } from '../../../services/settings-service.js';
-import type { RepoResearchResult } from '@protolabsai/types';
+import type { RepoResearchResult, ProjectSettings } from '@protolabsai/types';
 import { DEFAULT_GIT_WORKFLOW_SETTINGS } from '@protolabsai/types';
 import { generateSpecMd, researchRepo } from '../../../services/repo-research-service.js';
+
+const execFileAsync = promisify(execFile);
 
 const logger = createLogger('setup:project');
 
@@ -225,7 +229,52 @@ export function createSetupProjectHandler(
         // Don't fail the whole operation if .gitignore update fails
       }
 
-      // 4. Add project to Automaker settings if not already present
+      // 4. Detect and persist the repo's default branch as prBaseBranch.
+      //    Resolution: research.git.defaultBranch → git symbolic-ref → skip (auto-detect at runtime).
+      //    This ensures feature PRs target the correct branch for this project, not the global default.
+      try {
+        let detectedBranch: string | undefined = research?.git?.defaultBranch;
+
+        if (!detectedBranch) {
+          try {
+            const { stdout } = await execFileAsync(
+              'git',
+              ['symbolic-ref', 'refs/remotes/origin/HEAD'],
+              { cwd: realPath, timeout: 5000, encoding: 'utf-8' }
+            );
+            const ref = stdout.trim(); // e.g., refs/remotes/origin/main
+            const branch = ref.replace('refs/remotes/origin/', '');
+            if (branch) detectedBranch = branch;
+          } catch {
+            // origin/HEAD not configured — leave unset; runtime auto-detect will handle it
+          }
+        }
+
+        if (detectedBranch) {
+          const existingSettings = await settingsService.getProjectSettings(realPath);
+          await settingsService.updateProjectSettings(realPath, {
+            workflow: {
+              ...existingSettings.workflow,
+              gitWorkflow: {
+                ...existingSettings.workflow?.gitWorkflow,
+                prBaseBranch: detectedBranch,
+              },
+            } as ProjectSettings['workflow'],
+          });
+          logger.info('Wrote prBaseBranch to project settings', {
+            projectPath: realPath,
+            prBaseBranch: detectedBranch,
+          });
+          filesCreated.push(`.automaker/settings.json (prBaseBranch: ${detectedBranch})`);
+        }
+      } catch (error) {
+        logger.warn('Failed to write prBaseBranch to project settings', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        // Non-fatal — runtime auto-detect in getEffectivePrBaseBranch will still work
+      }
+
+      // 5. Add project to Automaker settings if not already present
       let projectAdded = false;
 
       try {

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -1065,9 +1065,12 @@ export class ExecutionService {
             }
           }
 
-          // Resolve per-project prBaseBranch override
-          const projectSettings = await this.settingsService.getProjectSettings(projectPath);
-          const projectPrBaseBranch = projectSettings.workflow?.gitWorkflow?.prBaseBranch;
+          // Resolve per-project prBaseBranch: project settings → auto-detect (never global)
+          const projectPrBaseBranch = await getEffectivePrBaseBranch(
+            projectPath,
+            this.settingsService,
+            '[PostCompletion]'
+          );
 
           gitWorkflowResult = await gitWorkflowService.runPostCompletionWorkflow(
             projectPath,


### PR DESCRIPTION
## Summary

**Reported by:** mythxengine team during monitoring session (2026-03-18)

**Problem:** The global `prBaseBranch: dev` setting causes ALL projects' feature PRs to target `dev`, even projects that should target a different branch (e.g., `main`). On mythxengine, PRs #100 and #91 had to be manually retargeted.

**Context:** PR #2842 added per-project prBaseBranch override with auto-detect fallback. However, this doesn't fully solve the problem:
1. New projects onboarded via `/setuplab` may not get t...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cross-project configuration leaks by removing global settings from PR base-branch resolution.

* **New Features**
  * Automatically detect and persist a repository's default PR base branch during project setup.
  * Make detection non-fatal on failure and use the centralized PR base-branch resolver in post-completion flows for more reliable branch selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->