### PR TITLE
Stuck PR detection maintenance check

### DIFF
--- a/libs/types/src/notification.ts
+++ b/libs/types/src/notification.ts
@@ -12,7 +12,8 @@ export type NotificationType =
   | 'feature_waiting_approval'
   | 'feature_verified'
   | 'spec_regeneration_complete'
-  | 'agent_complete';
+  | 'agent_complete'
+  | 'maintenance_alert';
 
 /**
  * Notification - A single notification entry

--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -415,6 +415,19 @@ export interface WorkflowSettings {
     /** Base branch for PR creation (overrides global gitWorkflow.prBaseBranch) */
     prBaseBranch?: string;
   };
+  /**
+   * Maintenance check configuration.
+   * Controls thresholds and behavior for automated board health checks.
+   */
+  maintenance?: {
+    /**
+     * Minutes a PR can remain in review without auto-merge enabled before the stuck-PR
+     * maintenance check triggers and attempts to enable auto-merge.
+     * Set higher for projects with slow CI pipelines where 30 minutes in review is normal.
+     * @default 30
+     */
+    stuckPrThresholdMinutes?: number;
+  };
 }
 
 /** Default workflow settings */


### PR DESCRIPTION
## Summary

**Problem:** PRs can sit in review indefinitely if auto-merge wasn't enabled and all required checks are passing. There's no automated detection for this 'stuck' state. The pipeline appears healthy (feature in review, PR open) but nothing is actually progressing.

**Solution:** Add a maintenance check module that detects stuck PRs and either auto-fixes them or escalates:

**Detection criteria:**
- Feature in `review` status for > N minutes (configurable, default 30)
- Associated PR exists and is...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for maintenance alerts as a new notification type
  * Introduced maintenance configuration settings, including the ability to define thresholds for monitoring stuck pull requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->