### PR TITLE
Bug: LeadEngineer checkpoint prevents feature retry after worktree cleanup

### DIFF
--- a/apps/server/src/routes/features/index.ts
+++ b/apps/server/src/routes/features/index.ts
@@ -25,6 +25,7 @@ import { createRollbackHandler, RollbackRequestSchema } from './routes/rollback.
 import { createHandoffHandler, HandoffRequestSchema } from './routes/handoff.js';
 import type { FeatureHealthService } from '../../services/feature-health-service.js';
 import type { TrustTierService } from '../../services/trust-tier-service.js';
+import type { PipelineCheckpointService } from '../../services/pipeline-checkpoint-service.js';
 
 export function createFeaturesRoutes(
   featureLoader: FeatureLoader,
@@ -32,7 +33,8 @@ export function createFeaturesRoutes(
   settingsService?: SettingsService,
   events?: EventEmitter,
   authorityService?: AuthorityService,
-  healthService?: FeatureHealthService
+  healthService?: FeatureHealthService,
+  checkpointService?: PipelineCheckpointService
 ): Router {
   const router = Router();
 
@@ -48,7 +50,14 @@ export function createFeaturesRoutes(
     '/update',
     validatePathParams('projectPath'),
     validateBody(UpdateRequestSchema),
-    createUpdateHandler(featureLoader, settingsService, authorityService, healthService, events)
+    createUpdateHandler(
+      featureLoader,
+      settingsService,
+      authorityService,
+      healthService,
+      events,
+      checkpointService
+    )
   );
   router.post(
     '/bulk-update',

--- a/apps/server/src/routes/features/routes/update.ts
+++ b/apps/server/src/routes/features/routes/update.ts
@@ -16,6 +16,7 @@ import type { AuthorityService } from '../../../services/authority-service.js';
 import type { SettingsService } from '../../../services/settings-service.js';
 import type { FeatureHealthService } from '../../../services/feature-health-service.js';
 import type { EventEmitter } from '../../../lib/events.js';
+import type { PipelineCheckpointService } from '../../../services/pipeline-checkpoint-service.js';
 import { getErrorMessage, logError } from '../common.js';
 import { createLogger } from '@protolabsai/utils';
 
@@ -45,7 +46,8 @@ export function createUpdateHandler(
   settingsService?: SettingsService,
   authorityService?: AuthorityService,
   healthService?: FeatureHealthService,
-  events?: EventEmitter
+  events?: EventEmitter,
+  checkpointService?: PipelineCheckpointService
 ) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
@@ -146,6 +148,19 @@ export function createUpdateHandler(
         enhancementMode,
         preEnhancementDescription
       );
+
+      // Clear pipeline checkpoint when resetting a feature to backlog.
+      // Without this, auto-mode would resume from the stale checkpoint (e.g. ESCALATE)
+      // and immediately re-block the feature instead of starting fresh from PREPARE.
+      if (newStatus === 'backlog' && previousStatus !== 'backlog' && checkpointService) {
+        try {
+          await checkpointService.delete(projectPath, featureId);
+          logger.info(`Cleared pipeline checkpoint for ${featureId} on reset to backlog`);
+        } catch (checkpointError) {
+          // Non-critical — log but don't fail the update
+          logger.error(`Failed to clear pipeline checkpoint for ${featureId}:`, checkpointError);
+        }
+      }
 
       // Trigger sync to app_spec.txt when status changes to done
       if (newStatus && SYNC_TRIGGER_STATUSES.includes(newStatus) && previousStatus !== newStatus) {

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -161,6 +161,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
     todoService,
     schedulerService,
     eventRouterService,
+    pipelineCheckpointService,
   } = services;
 
   // Run stale validation cleanup every hour to prevent memory leaks from crashed validations
@@ -247,7 +248,8 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
       settingsService,
       events,
       authorityService,
-      featureHealthService
+      featureHealthService,
+      pipelineCheckpointService
     )
   );
   app.post(


### PR DESCRIPTION
## Summary

## Bug Report

When a feature fails due to worktree creation failure, the LeadEngineerService saves a checkpoint at state `ESCALATE`. Resetting the feature to `backlog` (via `update_feature`) does NOT clear this checkpoint. When auto-mode picks the feature back up, it resumes from the `ESCALATE` checkpoint instead of starting fresh — immediately re-blocking the feature.

**Reproduction:**
1. Feature attempts to start, worktree creation fails (e.g., due to stale dev branch merge conflict)
2. Feat...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-03-18T19:06:23.440Z -->