### PR TITLE
Job log fetcher implementation

### DIFF
--- a/apps/server/src/services/pr-status-checker.ts
+++ b/apps/server/src/services/pr-status-checker.ts
@@ -309,8 +309,14 @@ export class PRStatusChecker {
 
   /**
    * Fetch only failed CI check runs for a commit SHA, with output details.
+   * When ciProvider is 'github-actions' (default), fetches GHA job logs as a
+   * fallback for checks where the API output is insufficient.
    */
-  async fetchFailedChecks(pr: TrackedPR, headSha: string): Promise<FailedCheck[]> {
+  async fetchFailedChecks(
+    pr: TrackedPR,
+    headSha: string,
+    ciProvider: string = 'github-actions'
+  ): Promise<FailedCheck[]> {
     try {
       const { stdout } = await execFileAsync(
         'gh',
@@ -323,6 +329,7 @@ export class PRStatusChecker {
       );
 
       const checkRuns = JSON.parse(stdout) as Array<{
+        id: number;
         name: string;
         status: string;
         conclusion: string;
@@ -333,20 +340,124 @@ export class PRStatusChecker {
         };
       }>;
 
-      return checkRuns
-        .filter((check) => check.conclusion === 'failure')
-        .map((check) => ({
+      const failedRuns = checkRuns.filter((check) => check.conclusion === 'failure');
+      const results: FailedCheck[] = [];
+
+      for (const check of failedRuns) {
+        const apiOutput = [check.output?.title, check.output?.summary, check.output?.text]
+          .filter(Boolean)
+          .join('\n')
+          .slice(0, 1000);
+
+        // Use GHA job logs as fallback when check run API output is insufficient
+        let output = apiOutput;
+        if ((!output || output.trim().length < 50) && ciProvider === 'github-actions') {
+          const jobLogs = await this.fetchJobLogs(pr, check.id, ciProvider);
+          if (jobLogs) {
+            output = jobLogs;
+          }
+        }
+
+        results.push({
           name: check.name,
           conclusion: check.conclusion,
-          output: [check.output?.title, check.output?.summary, check.output?.text]
-            .filter(Boolean)
-            .join('\n')
-            .slice(0, 1000),
-        }));
+          output,
+        });
+      }
+
+      return results;
     } catch (error) {
       logger.debug(`Failed to fetch failed checks for ${headSha}: ${error}`);
       return [];
     }
+  }
+
+  /**
+   * Fetch GitHub Actions job logs for a specific check run (job ID).
+   * Parses the GHA log format (##[group] / ##[endgroup] / ##[error] markers),
+   * finds the failing step, and returns the last 200 lines of that step.
+   * Returns null for non-GHA providers or on fetch failure.
+   */
+  async fetchJobLogs(
+    pr: TrackedPR,
+    checkRunId: number,
+    ciProvider: string = 'github-actions'
+  ): Promise<string | null> {
+    if (ciProvider !== 'github-actions') {
+      return null;
+    }
+
+    try {
+      const { stdout } = await execFileAsync(
+        'gh',
+        ['api', `repos/{owner}/{repo}/actions/jobs/${checkRunId}/logs`],
+        {
+          cwd: pr.projectPath,
+          timeout: 30_000,
+          encoding: 'utf-8',
+          maxBuffer: 10 * 1024 * 1024, // 10 MB — GHA logs can be large
+        }
+      );
+
+      return this.parseGHAJobLogs(stdout);
+    } catch (error) {
+      logger.debug(`Failed to fetch job logs for check run ${checkRunId}: ${error}`);
+      return null;
+    }
+  }
+
+  /**
+   * Parse GitHub Actions log format to extract the failing step output.
+   *
+   * GHA log lines look like: "2024-01-01T00:00:00.0000000Z ##[group]Step name"
+   * Groups are delimited by ##[group] / ##[endgroup]. Errors appear as ##[error].
+   *
+   * Strategy:
+   * 1. Find the last group (step) that contains a ##[error] line.
+   * 2. Return the last 200 lines of that step's content.
+   * 3. If no step with errors is found, return the last 200 lines of all content.
+   */
+  private parseGHAJobLogs(rawLogs: string): string {
+    const lines = rawLogs.split('\n');
+
+    // Strip the ISO timestamp prefix from a log line to get the raw content.
+    const getContent = (line: string): string =>
+      line.replace(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z /, '');
+
+    let currentGroupStart = -1;
+    let failingGroupStart = -1;
+    let failingGroupEnd = -1;
+
+    for (let i = 0; i < lines.length; i++) {
+      const content = getContent(lines[i]);
+
+      if (content.startsWith('##[group]')) {
+        currentGroupStart = i;
+      } else if (content.startsWith('##[endgroup]')) {
+        currentGroupStart = -1;
+      } else if (content.startsWith('##[error]')) {
+        // Mark the enclosing group as the failing step, or use a local window.
+        if (currentGroupStart >= 0) {
+          failingGroupStart = currentGroupStart;
+          failingGroupEnd = i;
+        } else {
+          // Error outside a group — capture a window around it
+          failingGroupStart = Math.max(0, i - 10);
+          failingGroupEnd = i;
+        }
+      }
+    }
+
+    let relevantLines: string[];
+    if (failingGroupStart >= 0) {
+      const end = failingGroupEnd >= 0 ? failingGroupEnd + 1 : lines.length;
+      relevantLines = lines.slice(failingGroupStart, end);
+    } else {
+      relevantLines = lines;
+    }
+
+    // Truncate to last 200 lines of the relevant section
+    return relevantLines.slice(-200).join('\n');
   }
 
   private async getRemoteUrl(projectPath: string): Promise<string> {

--- a/apps/server/tests/unit/services/pr-status-checker.test.ts
+++ b/apps/server/tests/unit/services/pr-status-checker.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock child_process before importing the service so execFile is intercepted.
+// Mock util so promisify(execFile) === execFile (the mock).
+vi.mock('child_process', () => ({ execFile: vi.fn() }));
+vi.mock('util', () => ({ promisify: (fn: unknown) => fn }));
+
+import { execFile } from 'child_process';
+import { PRStatusChecker, type TrackedPR } from '../../../src/services/pr-status-checker.js';
+
+const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+
+const fakePR: TrackedPR = {
+  featureId: 'feat-1',
+  projectPath: '/fake/project',
+  prNumber: 42,
+  prUrl: 'https://github.com/owner/repo/pull/42',
+  branchName: 'feature/test',
+  lastCheckedAt: Date.now(),
+  reviewState: 'pending',
+  iterationCount: 0,
+};
+
+describe('PRStatusChecker', () => {
+  let checker: PRStatusChecker;
+
+  beforeEach(() => {
+    checker = new PRStatusChecker();
+    mockExecFile.mockReset();
+  });
+
+  describe('fetchJobLogs', () => {
+    it('returns null for non-GHA ciProvider without calling execFile', async () => {
+      const result = await checker.fetchJobLogs(fakePR, 12345, 'other');
+      expect(result).toBeNull();
+      expect(mockExecFile).not.toHaveBeenCalled();
+    });
+
+    it('returns null for unrecognized ciProvider', async () => {
+      const result = await checker.fetchJobLogs(fakePR, 12345, 'jenkins');
+      expect(result).toBeNull();
+    });
+
+    it('calls gh api for GHA job logs', async () => {
+      const rawLogs = [
+        '2024-01-01T00:00:00.0000000Z ##[group]Run npm test',
+        '2024-01-01T00:00:01.0000000Z npm test output line 1',
+        '2024-01-01T00:00:02.0000000Z ##[error]Tests failed: 3 failures',
+        '2024-01-01T00:00:03.0000000Z ##[endgroup]',
+      ].join('\n');
+
+      mockExecFile.mockResolvedValueOnce({ stdout: rawLogs, stderr: '' });
+
+      const result = await checker.fetchJobLogs(fakePR, 9999, 'github-actions');
+
+      expect(mockExecFile).toHaveBeenCalledWith(
+        'gh',
+        ['api', 'repos/{owner}/{repo}/actions/jobs/9999/logs'],
+        expect.objectContaining({ cwd: fakePR.projectPath })
+      );
+      expect(result).not.toBeNull();
+      expect(result).toContain('##[group]Run npm test');
+      expect(result).toContain('##[error]Tests failed: 3 failures');
+    });
+
+    it('defaults to github-actions ciProvider when not specified', async () => {
+      mockExecFile.mockResolvedValueOnce({ stdout: 'some log', stderr: '' });
+      const result = await checker.fetchJobLogs(fakePR, 1);
+      expect(mockExecFile).toHaveBeenCalled();
+      expect(result).not.toBeNull();
+    });
+
+    it('returns null on gh api failure', async () => {
+      mockExecFile.mockRejectedValueOnce(new Error('gh: not found'));
+      const result = await checker.fetchJobLogs(fakePR, 1, 'github-actions');
+      expect(result).toBeNull();
+    });
+
+    it('truncates to last 200 lines of failing step', async () => {
+      // Build a group containing 300 lines after the ##[error] marker
+      const logLines: string[] = [];
+      logLines.push('2024-01-01T00:00:00.0000000Z ##[group]Run big step');
+      logLines.push('2024-01-01T00:00:01.0000000Z ##[error]Something broke');
+      for (let i = 0; i < 300; i++) {
+        logLines.push(`2024-01-01T00:00:02.0000000Z output line ${i}`);
+      }
+      logLines.push('2024-01-01T00:00:03.0000000Z ##[endgroup]');
+
+      mockExecFile.mockResolvedValueOnce({ stdout: logLines.join('\n'), stderr: '' });
+
+      const result = await checker.fetchJobLogs(fakePR, 1, 'github-actions');
+      expect(result).not.toBeNull();
+
+      const resultLines = result!.split('\n');
+      expect(resultLines.length).toBeLessThanOrEqual(200);
+    });
+
+    it('returns last 200 lines when no ##[error] marker found', async () => {
+      const logLines: string[] = [];
+      for (let i = 0; i < 500; i++) {
+        logLines.push(`2024-01-01T00:00:00.0000000Z output line ${i}`);
+      }
+
+      mockExecFile.mockResolvedValueOnce({ stdout: logLines.join('\n'), stderr: '' });
+
+      const result = await checker.fetchJobLogs(fakePR, 1, 'github-actions');
+      expect(result).not.toBeNull();
+      const resultLines = result!.split('\n');
+      expect(resultLines.length).toBeLessThanOrEqual(200);
+    });
+  });
+
+  describe('fetchFailedChecks — GHA fallback', () => {
+    it('uses job logs as fallback when check run output is empty', async () => {
+      const checkRunsJson = JSON.stringify([
+        {
+          id: 777,
+          name: 'test / unit',
+          status: 'completed',
+          conclusion: 'failure',
+          output: { title: null, summary: null, text: null },
+        },
+      ]);
+
+      const jobLogContent = [
+        '2024-01-01T00:00:00.0000000Z ##[group]Run unit tests',
+        '2024-01-01T00:00:01.0000000Z ##[error]assertion failed',
+        '2024-01-01T00:00:02.0000000Z ##[endgroup]',
+      ].join('\n');
+
+      // First call: check-runs API; second call: actions/jobs logs API
+      mockExecFile.mockResolvedValueOnce({ stdout: checkRunsJson, stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: jobLogContent, stderr: '' });
+
+      const results = await checker.fetchFailedChecks(fakePR, 'abc123', 'github-actions');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('test / unit');
+      expect(results[0].output).toContain('##[error]assertion failed');
+    });
+
+    it('does not fetch job logs for non-GHA provider', async () => {
+      const checkRunsJson = JSON.stringify([
+        {
+          id: 888,
+          name: 'build',
+          status: 'completed',
+          conclusion: 'failure',
+          output: { title: null, summary: null, text: null },
+        },
+      ]);
+
+      mockExecFile.mockResolvedValueOnce({ stdout: checkRunsJson, stderr: '' });
+
+      const results = await checker.fetchFailedChecks(fakePR, 'abc123', 'other');
+
+      expect(mockExecFile).toHaveBeenCalledTimes(1);
+      expect(results).toHaveLength(1);
+      expect(results[0].output).toBe('');
+    });
+
+    it('skips fallback when API output is sufficient', async () => {
+      const richSummary = 'A'.repeat(200);
+      const checkRunsJson = JSON.stringify([
+        {
+          id: 999,
+          name: 'lint',
+          status: 'completed',
+          conclusion: 'failure',
+          output: { title: 'Lint failed', summary: richSummary, text: null },
+        },
+      ]);
+
+      mockExecFile.mockResolvedValueOnce({ stdout: checkRunsJson, stderr: '' });
+
+      const results = await checker.fetchFailedChecks(fakePR, 'def456', 'github-actions');
+
+      expect(mockExecFile).toHaveBeenCalledTimes(1);
+      expect(results[0].output).toContain('Lint failed');
+    });
+  });
+});

--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -499,7 +499,6 @@ export interface WorkflowSettings {
    */
   agentStartStaggerMs?: number;
   /**
-<<<<<<< HEAD
    * When true, the readiness gate in FeatureScheduler.loadPendingFeatures() is bypassed
    * and all features with satisfied dependencies are dispatched regardless of readinessScore.
    * Intended for debugging and projects that have not yet enabled readiness scoring.
@@ -515,8 +514,14 @@ export interface WorkflowSettings {
    */
   readinessThreshold?: number;
   /**
-=======
->>>>>>> origin/dev
+   * CI provider for this project. Used to determine which log-fetching
+   * strategy to use when diagnosing failing checks.
+   * - 'github-actions': Use GitHub Actions job log API (default)
+   * - 'other': Skip GHA log fetching, use check run output only
+   * @default 'github-actions'
+   */
+  ciProvider?: 'github-actions' | 'other';
+  /**
    * Maintenance check configuration.
    * Controls thresholds and behavior for automated board health checks.
    */


### PR DESCRIPTION
## Summary

**Milestone:** M2: GitHub Actions Log Fetching

Implement fetchJobLogs(pr, checkRunId) on PRStatusChecker. Calls gh api for job logs. Parses GitHub Actions format (##[group] markers). Truncates to last 200 lines of failing step. Returns null for non-GHA. Integrates as fallback in fetchFailedChecks. Add ciProvider to WorkflowSettings.

**Files to Modify:**
- apps/server/src/services/pr-status-checker.ts
- libs/types/src/workflow-settings.ts

**Acceptance Criteria:**
- [ ] fetchJobLogs returns par...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-03-18T22:57:01.761Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Fresh Eyes Review for PR quality checks with pass/concern/block verdicts
  * Implemented feature readiness scoring evaluating description, acceptance criteria, and specifications
  * Introduced trajectory-based pattern mining to learn from execution history
  * Added trajectory context injection to enrich agent prompts with past patterns

* **Improvements**
  * Enhanced agent scheduler with readiness gates and staggered dispatch to reduce thundering herd
  * Improved PR base branch resolution respecting per-project configuration
  * Added comprehensive CI log fetching with GitHub Actions fallback support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->