### PR TITLE
Add ESLint rule to ban hardcoded PR base branch strings

### DIFF
--- a/apps/server/eslint.config.mjs
+++ b/apps/server/eslint.config.mjs
@@ -76,6 +76,19 @@ const eslintConfig = defineConfig([
       // imports packages not in this workspace's package.json.
       'n/no-extraneous-import': 'error',
 
+      // Ban hardcoded 'main' as a PR base branch fallback.
+      // Use getEffectivePrBaseBranch() from lib/settings-helpers.ts or
+      // DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch instead.
+      // See: apps/server/src/routes/worktree/routes/create-pr.ts (incident: wasted $9.81, blocked 3 features)
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "LogicalExpression[operator='||'] > Literal[value='main']",
+          message:
+            "Do not hardcode 'main' as a PR base branch fallback. Use getEffectivePrBaseBranch() from lib/settings-helpers.ts or DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch instead.",
+        },
+      ],
+
       // Ban direct imports of @ai-sdk/anthropic in route/service code.
       // Use getAnthropicModel() from lib/ai-provider.ts instead — it
       // resolves credentials via CLI OAuth, env vars, and credentials file.


### PR DESCRIPTION
## Summary

**Why:** A hardcoded `'main'` fallback in `create-pr.ts:148` caused PRs to target the wrong branch, wasting $9.81 and blocking 3 features. We need a lint rule to prevent this class of bug from recurring.

**Implementation:**

Create a custom ESLint rule (or use `no-restricted-syntax`) that flags any string literal `'main'` used as a fallback for PR base branch resolution in `apps/server/src/`.

**Approach — `no-restricted-syntax` in `.eslintrc`:**

```json
{
  'no-restricted-syntax': [
    'erro...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-03-19T04:25:26.232Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved linting rules to enforce more consistent code practices across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->