### PR TITLE
feat: split remediation budgets — separate CI and review counters

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -118,6 +118,24 @@ export class FeatureLoader implements FeatureStore {
       }
     }
 
+    // Migrate legacy remediationCycleCount to split budgets on read.
+    // When a feature only has the old single counter and not the new split fields,
+    // initialize ciRemediationCount and reviewRemediationCount to 0 so that
+    // the RemediationBudgetEnforcer can use the legacy count for total-cap checking
+    // via the remediationCycleCount backward-compat path.
+    if (
+      typeof normalized.remediationCycleCount === 'number' &&
+      normalized.remediationCycleCount > 0 &&
+      normalized.ciRemediationCount == null &&
+      normalized.reviewRemediationCount == null
+    ) {
+      normalized = {
+        ...normalized,
+        ciRemediationCount: 0,
+        reviewRemediationCount: 0,
+      };
+    }
+
     return normalized;
   }
 

--- a/apps/server/src/services/lead-engineer-gtm-review-processor.ts
+++ b/apps/server/src/services/lead-engineer-gtm-review-processor.ts
@@ -18,7 +18,11 @@ import type {
   StateProcessor,
   StateTransitionResult,
 } from './lead-engineer-types.js';
-import { MAX_TOTAL_REMEDIATION_CYCLES } from './lead-engineer-types.js';
+import { getWorkflowSettings } from '../lib/settings-helpers.js';
+import {
+  RemediationBudgetEnforcer,
+  DEFAULT_CI_REACTION_SETTINGS,
+} from './remediation-budget-enforcer.js';
 
 const logger = createLogger('GtmReviewProcessor');
 
@@ -73,8 +77,30 @@ export class GtmReviewProcessor implements StateProcessor {
 
     // Score below threshold — send back to EXECUTE for revision
     // Check remediation budget to prevent unbounded revision loops
-    if (ctx.remediationAttempts >= MAX_TOTAL_REMEDIATION_CYCLES) {
-      ctx.escalationReason = `Max content remediation cycles exceeded (${MAX_TOTAL_REMEDIATION_CYCLES})`;
+    const gtmWorkflowSettings = await getWorkflowSettings(
+      ctx.projectPath,
+      this.serviceContext.settingsService,
+      '[GtmReviewProcessor]'
+    );
+    const gtmCiReactionSettings =
+      gtmWorkflowSettings.ciReactionSettings ?? DEFAULT_CI_REACTION_SETTINGS;
+
+    const gtmCiCount = (ctx.feature.ciRemediationCount as number | undefined) ?? 0;
+    const gtmReviewCount =
+      (ctx.feature.reviewRemediationCount as number | undefined) ?? ctx.remediationAttempts;
+    const gtmLegacyCount = (ctx.feature.remediationCycleCount as number | undefined) ?? 0;
+
+    const gtmEnforcer = new RemediationBudgetEnforcer(gtmCiReactionSettings);
+    const gtmBudgetResult = gtmEnforcer.checkAndIncrement({
+      type: 'review',
+      ciRemediationCount: gtmCiCount,
+      reviewRemediationCount: gtmReviewCount,
+      remediationCycleCount: gtmLegacyCount,
+      settings: gtmCiReactionSettings,
+    });
+
+    if (!gtmBudgetResult.allowed) {
+      ctx.escalationReason = `Max content remediation cycles exceeded: ${gtmBudgetResult.message}`;
       return {
         nextState: 'ESCALATE',
         shouldContinue: true,

--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -33,9 +33,12 @@ import {
   MERGE_RETRY_DELAY_MS,
   REVIEW_POLL_DELAY_MS,
   REVIEW_PENDING_TIMEOUT_MS,
-  MAX_TOTAL_REMEDIATION_CYCLES,
   MAX_PR_ITERATIONS,
 } from './lead-engineer-types.js';
+import {
+  RemediationBudgetEnforcer,
+  DEFAULT_CI_REACTION_SETTINGS,
+} from './remediation-budget-enforcer.js';
 
 const execAsync = promisify(exec);
 const logger = createLogger('LeadEngineerService');
@@ -218,9 +221,32 @@ export class ReviewProcessor implements StateProcessor {
         };
       }
 
-      // Check remediation budget
-      if (ctx.remediationAttempts >= MAX_TOTAL_REMEDIATION_CYCLES) {
-        ctx.escalationReason = `Max remediation cycles exceeded (${MAX_TOTAL_REMEDIATION_CYCLES})`;
+      // Check remediation budget using split budget enforcer
+      const reviewWorkflowSettings = await getWorkflowSettings(
+        ctx.projectPath,
+        this.serviceContext.settingsService,
+        '[ReviewProcessor]'
+      );
+      const reviewCiReactionSettings =
+        reviewWorkflowSettings.ciReactionSettings ?? DEFAULT_CI_REACTION_SETTINGS;
+
+      // Use persisted split counters from feature, falling back to in-memory remediationAttempts
+      const persistedCiCount = (ctx.feature.ciRemediationCount as number | undefined) ?? 0;
+      const persistedReviewCount =
+        (ctx.feature.reviewRemediationCount as number | undefined) ?? ctx.remediationAttempts;
+      const legacyCount = (ctx.feature.remediationCycleCount as number | undefined) ?? 0;
+
+      const reviewEnforcer = new RemediationBudgetEnforcer(reviewCiReactionSettings);
+      const reviewBudgetResult = reviewEnforcer.checkAndIncrement({
+        type: 'review',
+        ciRemediationCount: persistedCiCount,
+        reviewRemediationCount: persistedReviewCount,
+        remediationCycleCount: legacyCount,
+        settings: reviewCiReactionSettings,
+      });
+
+      if (!reviewBudgetResult.allowed) {
+        ctx.escalationReason = reviewBudgetResult.message;
         return {
           nextState: 'ESCALATE',
           shouldContinue: true,

--- a/apps/server/src/services/pr-feedback-service.ts
+++ b/apps/server/src/services/pr-feedback-service.ts
@@ -44,6 +44,10 @@ import {
 import type { SchedulerService } from './scheduler-service.js';
 import type { SettingsService } from './settings-service.js';
 import { getWorkflowSettings } from '../lib/settings-helpers.js';
+import {
+  RemediationBudgetEnforcer,
+  DEFAULT_CI_REACTION_SETTINGS,
+} from './remediation-budget-enforcer.js';
 
 const logger = createLogger('PRFeedbackRemediation');
 
@@ -559,24 +563,45 @@ export class PRFeedbackService {
         const fullFeedback = [feedbackSummary, coderabbitFeedback].filter(Boolean).join('\n---\n');
 
         const feature = await this.featureLoader.get(pr.projectPath, featureId);
-        const currentTotalCycles = (feature?.remediationCycleCount as number | undefined) || 0;
-        const totalCycles = currentTotalCycles + 1;
 
+        // Resolve split remediation settings from workflow config (fall back to defaults)
+        const workflowSettingsForReview = await getWorkflowSettings(
+          pr.projectPath,
+          this.settingsService
+        );
+        const ciReactionSettings =
+          workflowSettingsForReview.ciReactionSettings ?? DEFAULT_CI_REACTION_SETTINGS;
+
+        const currentCiRemediation = (feature?.ciRemediationCount as number | undefined) ?? 0;
+        const currentReviewRemediation =
+          (feature?.reviewRemediationCount as number | undefined) ?? 0;
+        const legacyCycleCount = (feature?.remediationCycleCount as number | undefined) ?? 0;
+
+        // Check review budget via enforcer
+        const enforcer = new RemediationBudgetEnforcer(ciReactionSettings);
+        const budgetResult = enforcer.checkAndIncrement({
+          type: 'review',
+          ciRemediationCount: currentCiRemediation,
+          reviewRemediationCount: currentReviewRemediation,
+          remediationCycleCount: legacyCycleCount,
+          settings: ciReactionSettings,
+        });
+
+        // Always persist latest feedback regardless of budget outcome
         await this.featureLoader.update(pr.projectPath, featureId, {
           lastReviewFeedback: fullFeedback.slice(0, 2000),
           prIterationCount: pr.iterationCount,
-          remediationCycleCount: totalCycles,
         });
 
-        if (totalCycles >= MAX_TOTAL_REMEDIATION_CYCLES) {
+        if (!budgetResult.allowed) {
           logger.warn(
-            `PR #${pr.prNumber} for ${featureId} exceeded total remediation budget (${totalCycles}/${MAX_TOTAL_REMEDIATION_CYCLES}), blocking`
+            `PR #${pr.prNumber} for ${featureId} exceeded review remediation budget: ${budgetResult.message}`
           );
 
           await this.featureLoader.update(pr.projectPath, featureId, {
             status: 'blocked',
             workItemState: 'blocked',
-            error: `Exceeded ${MAX_TOTAL_REMEDIATION_CYCLES} total remediation cycles (feedback + CI). Escalated.`,
+            error: budgetResult.message,
           });
 
           this.events.emit('authority:awaiting-approval', {
@@ -585,10 +610,10 @@ export class PRFeedbackService {
               who: 'pr-feedback-service',
               what: 'escalate',
               target: featureId,
-              justification: `PR #${pr.prNumber} exceeded ${MAX_TOTAL_REMEDIATION_CYCLES} total remediation cycles`,
+              justification: `PR #${pr.prNumber} exceeded remediation budget (${budgetResult.exhaustedBudget}): ${budgetResult.message}`,
               risk: 'high',
             },
-            decision: { verdict: 'require_approval', reason: `Total remediation budget exceeded` },
+            decision: { verdict: 'require_approval', reason: `Remediation budget exceeded` },
             blockerType: 'remediation_budget_exceeded',
             featureTitle: `PR #${pr.prNumber}`,
           });
@@ -597,6 +622,14 @@ export class PRFeedbackService {
           void this.savePrTracking();
           return;
         }
+
+        // Budget allows — persist incremented review counter
+        await this.featureLoader.update(pr.projectPath, featureId, {
+          reviewRemediationCount: budgetResult.nextReviewRemediationCount,
+          // Keep legacy field in sync for backward compatibility
+          remediationCycleCount:
+            budgetResult.nextCiRemediationCount + budgetResult.nextReviewRemediationCount,
+        });
 
         if (pr.iterationCount > MAX_PR_ITERATIONS) {
           logger.warn('Iteration budget exhausted, escalating', {
@@ -1235,16 +1268,34 @@ export class PRFeedbackService {
 
       pr.ciMonitoring = undefined;
 
-      const currentTotalCycles = (feature.remediationCycleCount as number | undefined) || 0;
-      if (currentTotalCycles >= MAX_TOTAL_REMEDIATION_CYCLES) {
+      // Resolve split remediation settings from workflow config (fall back to defaults)
+      const workflowSettings = await getWorkflowSettings(pr.projectPath, this.settingsService);
+      const ciReactionSettings =
+        workflowSettings.ciReactionSettings ?? DEFAULT_CI_REACTION_SETTINGS;
+
+      const currentCiRemediation = (feature.ciRemediationCount as number | undefined) ?? 0;
+      const currentReviewRemediation = (feature.reviewRemediationCount as number | undefined) ?? 0;
+      const legacyCycleCount = (feature.remediationCycleCount as number | undefined) ?? 0;
+
+      // Check CI budget via enforcer
+      const ciEnforcer = new RemediationBudgetEnforcer(ciReactionSettings);
+      const ciBudgetResult = ciEnforcer.checkAndIncrement({
+        type: 'ci',
+        ciRemediationCount: currentCiRemediation,
+        reviewRemediationCount: currentReviewRemediation,
+        remediationCycleCount: legacyCycleCount,
+        settings: ciReactionSettings,
+      });
+
+      if (!ciBudgetResult.allowed) {
         logger.warn(
-          `Feature ${featureId} exceeded total remediation budget (${currentTotalCycles}/${MAX_TOTAL_REMEDIATION_CYCLES}), blocking`
+          `Feature ${featureId} exceeded CI remediation budget: ${ciBudgetResult.message}`
         );
 
         await this.featureLoader.update(pr.projectPath, featureId, {
           status: 'blocked',
           workItemState: 'blocked',
-          error: `Exceeded ${MAX_TOTAL_REMEDIATION_CYCLES} total remediation cycles (feedback + CI). Escalated.`,
+          error: ciBudgetResult.message,
         });
 
         this.events.emit('authority:awaiting-approval', {
@@ -1253,10 +1304,10 @@ export class PRFeedbackService {
             who: 'pr-feedback-service',
             what: 'escalate',
             target: featureId,
-            justification: `PR #${pr.prNumber} exceeded ${MAX_TOTAL_REMEDIATION_CYCLES} total remediation cycles (feedback + CI failures)`,
+            justification: `PR #${pr.prNumber} exceeded CI remediation budget (${ciBudgetResult.exhaustedBudget}): ${ciBudgetResult.message}`,
             risk: 'high',
           },
-          decision: { verdict: 'require_approval', reason: `Total remediation budget exceeded` },
+          decision: { verdict: 'require_approval', reason: `CI remediation budget exceeded` },
           blockerType: 'remediation_budget_exceeded',
           featureTitle: `PR #${pr.prNumber}`,
         });
@@ -1268,13 +1319,13 @@ export class PRFeedbackService {
 
       const currentCiIterations = (feature.ciIterationCount as number | undefined) || 0;
       const ciIterationCount = currentCiIterations + 1;
-      const newTotalCycles = currentTotalCycles + 1;
+      const newCiRemediationCount = ciBudgetResult.nextCiRemediationCount;
+      const newTotalCycles = newCiRemediationCount + ciBudgetResult.nextReviewRemediationCount;
 
       logger.info(
-        `CI failure for PR #${pr.prNumber} (feature ${featureId}): iteration ${ciIterationCount}, total cycles ${newTotalCycles}/${MAX_TOTAL_REMEDIATION_CYCLES}`
+        `CI failure for PR #${pr.prNumber} (feature ${featureId}): iteration ${ciIterationCount}, ci cycles ${newCiRemediationCount}/${ciReactionSettings.maxCiRemediationCycles}, total ${newTotalCycles}/${ciReactionSettings.maxTotalRemediationCycles}`
       );
 
-      const workflowSettings = await getWorkflowSettings(pr.projectPath, this.settingsService);
       const classifiedChecks = await prStatusChecker.fetchFailedChecks(
         pr,
         data.headSha,
@@ -1304,6 +1355,8 @@ export class PRFeedbackService {
         status: 'backlog',
         workItemState: 'in_progress',
         ciIterationCount,
+        ciRemediationCount: newCiRemediationCount,
+        // Keep legacy field in sync for backward compatibility
         remediationCycleCount: newTotalCycles,
         lastCheckSuiteId: data.checkSuiteId,
         error: undefined,

--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -7,6 +7,7 @@
 
 import type { PhaseModelEntry } from './agent-settings.js';
 import type { CIClassificationConfig } from './ci-failure.js';
+import type { CIReactionSettings } from './ci-reaction.js';
 import type { DeviationRule } from './lead-engineer.js';
 import type { PipelineGateConfig } from './pipeline-phase.js';
 import type { RiskLevel } from './policy.js';
@@ -551,6 +552,15 @@ export interface WorkflowSettings {
      */
     readinessScoreThreshold?: number;
   };
+  /**
+   * Split remediation budget configuration for CI and review cycles.
+   * Controls per-class retry limits (CI failures vs PR review feedback) and a
+   * hard cap on combined total cycles. When absent, the default split budget
+   * (2 CI + 2 review = 4 total) is used, preserving backward compatibility
+   * with the legacy MAX_TOTAL_REMEDIATION_CYCLES of 4.
+   * @see CIReactionSettings
+   */
+  ciReactionSettings?: CIReactionSettings;
 }
 
 /** Default workflow settings */
@@ -596,5 +606,10 @@ export const DEFAULT_WORKFLOW_SETTINGS: WorkflowSettings = {
     incrementalMaxDepth: 3,
     leafChunkTokens: 25_000,
     largeFileThreshold: 25_000,
+  },
+  ciReactionSettings: {
+    maxCiRemediationCycles: 2,
+    maxReviewRemediationCycles: 2,
+    maxTotalRemediationCycles: 4,
   },
 };


### PR DESCRIPTION
## Summary\n\nSplits the shared remediation budget (MAX_TOTAL_REMEDIATION_CYCLES=4) into separate CI and review counters so CodeRabbit feedback doesn't starve CI fixes.\n\n- Added CIReactionSettings to WorkflowSettings with per-type budgets\n- PRFeedbackService uses ciRemediationCount for CI path\n- Review feedback uses reviewRemediationCount\n- Lead Engineer processors updated for split budgets\n- FeatureLoader migrates legacy remediationCycleCount on read\n\nPart of CI Reaction Engine project (M3: Split Remediation Budgets).

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-03-19T05:28:26.394Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Replaced fixed remediation cycle limits with separate, configurable budgets for CI failures and PR review cycles.
  * Implemented workflow-driven budget enforcement with improved escalation messaging when remediation limits are reached.

* **Bug Fixes**
  * Fixed data migration to properly initialize remediation counters when legacy cycle data is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->