### PR TITLE
fix: prevent git add error when .automaker is in .gitignore

### DIFF
--- a/apps/server/src/lib/git-staging-utils.ts
+++ b/apps/server/src/lib/git-staging-utils.ts
@@ -17,26 +17,48 @@ import { join } from 'path';
 export const DEFAULT_STAGING_EXCLUSIONS = ['.automaker/', '.claude/worktrees/', '.worktrees/'];
 
 /**
+ * Directories that are already excluded by `.gitignore`.
+ * Using `:!dir/` pathspec exclusions for gitignored directories causes git to
+ * error: "The following paths are ignored by one of your .gitignore files: dir"
+ * These entries should still appear in `excludeFromStaging` to signal that
+ * their subdirectories (e.g. `.automaker/memory/`) may need re-inclusion,
+ * but they must NOT be emitted as pathspec arguments.
+ */
+const GITIGNORE_MANAGED_EXCLUSIONS = new Set(['.automaker/', '.worktrees/']);
+
+/**
  * Builds a git add command that stages all changes except the directories in
  * `excludeFromStaging`, then re-includes `.automaker/memory/` and
  * `.automaker/skills/` only if `.automaker/` is excluded and those directories
  * exist in the working tree. This prevents a fatal pathspec error when a
  * directory is absent (e.g. in a fresh worktree).
+ *
+ * Directories already covered by `.gitignore` are intentionally omitted from
+ * the pathspec exclusion list — git would throw an error if a gitignored path
+ * appeared in the pathspec (even as a `:!` exclude).
  */
 export function buildGitAddCommand(workDir: string, excludeFromStaging?: string[]): string {
   const exclusions = excludeFromStaging ?? DEFAULT_STAGING_EXCLUSIONS;
-  const exclusionPathspecs = exclusions.map((dir) => `':!${dir}'`).join(' ');
-  const parts = [`git add -A -- ${exclusionPathspecs}`];
 
-  // Re-include .automaker/memory/ and .automaker/skills/ when .automaker/ is excluded
+  // Collect all pathspec arguments into one array, then join at the end.
+  // Only emit exclusion pathspecs for dirs NOT already handled by .gitignore:
+  // using `:!dir/` for a gitignored path causes:
+  //   fatal: The following paths are ignored by one of your .gitignore files: dir
+  const pathspecArgs: string[] = exclusions
+    .filter((dir) => !GITIGNORE_MANAGED_EXCLUSIONS.has(dir))
+    .map((dir) => `':!${dir}'`);
+
+  // Re-include .automaker/memory/ and .automaker/skills/ when .automaker/ is excluded.
+  // These subdirs are git-tracked agent memory files that live under a gitignored
+  // parent directory and must be staged explicitly.
   if (exclusions.includes('.automaker/')) {
     if (existsSync(join(workDir, '.automaker/memory'))) {
-      parts.push("'.automaker/memory/'");
+      pathspecArgs.push("'.automaker/memory/'");
     }
     if (existsSync(join(workDir, '.automaker/skills'))) {
-      parts.push("'.automaker/skills/'");
+      pathspecArgs.push("'.automaker/skills/'");
     }
   }
 
-  return parts.join(' ');
+  return `git add -A -- ${pathspecArgs.join(' ')}`;
 }

--- a/apps/server/tests/unit/lib/git-staging-utils.test.ts
+++ b/apps/server/tests/unit/lib/git-staging-utils.test.ts
@@ -19,23 +19,24 @@ describe('buildGitAddCommand', () => {
   });
 
   describe('default exclusions', () => {
-    it('should exclude .automaker/, .claude/worktrees/, and .worktrees/ by default', () => {
-      expect(buildGitAddCommand(tempDir)).toBe(
-        "git add -A -- ':!.automaker/' ':!.claude/worktrees/' ':!.worktrees/'"
-      );
+    it('should omit gitignore-managed dirs (.automaker/, .worktrees/) from pathspec and keep .claude/worktrees/', () => {
+      // .automaker/ and .worktrees/ are in .gitignore — using ':!dir/' pathspecs for
+      // gitignored dirs causes git to error. Only .claude/worktrees/ (not gitignored)
+      // appears as a pathspec exclusion.
+      expect(buildGitAddCommand(tempDir)).toBe("git add -A -- ':!.claude/worktrees/'");
     });
 
     it('should include .automaker/memory/ when that directory exists', () => {
       mkdirSync(join(tempDir, '.automaker', 'memory'), { recursive: true });
       expect(buildGitAddCommand(tempDir)).toBe(
-        "git add -A -- ':!.automaker/' ':!.claude/worktrees/' ':!.worktrees/' '.automaker/memory/'"
+        "git add -A -- ':!.claude/worktrees/' '.automaker/memory/'"
       );
     });
 
     it('should include .automaker/skills/ when that directory exists', () => {
       mkdirSync(join(tempDir, '.automaker', 'skills'), { recursive: true });
       expect(buildGitAddCommand(tempDir)).toBe(
-        "git add -A -- ':!.automaker/' ':!.claude/worktrees/' ':!.worktrees/' '.automaker/skills/'"
+        "git add -A -- ':!.claude/worktrees/' '.automaker/skills/'"
       );
     });
 
@@ -43,34 +44,40 @@ describe('buildGitAddCommand', () => {
       mkdirSync(join(tempDir, '.automaker', 'memory'), { recursive: true });
       mkdirSync(join(tempDir, '.automaker', 'skills'), { recursive: true });
       expect(buildGitAddCommand(tempDir)).toBe(
-        "git add -A -- ':!.automaker/' ':!.claude/worktrees/' ':!.worktrees/' '.automaker/memory/' '.automaker/skills/'"
+        "git add -A -- ':!.claude/worktrees/' '.automaker/memory/' '.automaker/skills/'"
       );
     });
 
     it('should not re-include memory/skills when only .automaker/ exists (no subdirs)', () => {
       mkdirSync(join(tempDir, '.automaker'), { recursive: true });
-      expect(buildGitAddCommand(tempDir)).toBe(
-        "git add -A -- ':!.automaker/' ':!.claude/worktrees/' ':!.worktrees/'"
-      );
+      expect(buildGitAddCommand(tempDir)).toBe("git add -A -- ':!.claude/worktrees/'");
     });
   });
 
   describe('configurable exclusions', () => {
-    it('should use custom exclusion list when provided', () => {
-      expect(buildGitAddCommand(tempDir, ['.automaker/'])).toBe("git add -A -- ':!.automaker/'");
+    it('should omit .automaker/ from pathspec when it is in custom list (gitignore-managed)', () => {
+      // .automaker/ is gitignore-managed — no pathspec exclusion is emitted for it
+      expect(buildGitAddCommand(tempDir, ['.automaker/'])).toBe('git add -A -- ');
     });
 
     it('should re-include .automaker/memory/ when .automaker/ is in custom list and dir exists', () => {
       mkdirSync(join(tempDir, '.automaker', 'memory'), { recursive: true });
       expect(buildGitAddCommand(tempDir, ['.automaker/'])).toBe(
-        "git add -A -- ':!.automaker/' '.automaker/memory/'"
+        "git add -A -- '.automaker/memory/'"
       );
     });
 
     it('should not re-include .automaker subdirs when .automaker/ is not in custom list', () => {
       mkdirSync(join(tempDir, '.automaker', 'memory'), { recursive: true });
       mkdirSync(join(tempDir, '.automaker', 'skills'), { recursive: true });
-      expect(buildGitAddCommand(tempDir, ['.worktrees/'])).toBe("git add -A -- ':!.worktrees/'");
+      // .worktrees/ is gitignore-managed too — no pathspec exclusion emitted
+      expect(buildGitAddCommand(tempDir, ['.worktrees/'])).toBe('git add -A -- ');
+    });
+
+    it('should emit pathspec for non-gitignore-managed dirs in custom list', () => {
+      expect(buildGitAddCommand(tempDir, ['.claude/worktrees/'])).toBe(
+        "git add -A -- ':!.claude/worktrees/'"
+      );
     });
 
     it('should handle empty exclusion list', () => {


### PR DESCRIPTION
Changes from branch feature/bug-git-workflow-fails-when-agent

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-03-19T06:05:23.055Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected git staging command generation to prevent redundant exclusions for directories already listed in .gitignore, ensuring cleaner and more efficient file staging operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->