### PR TITLE
fix: remove electron-idle sensor tests

### DIFF
--- a/apps/server/tests/unit/services/context-aggregator.test.ts
+++ b/apps/server/tests/unit/services/context-aggregator.test.ts
@@ -56,30 +56,6 @@ describe('ContextAggregator', () => {
     expect(state.sensors).toContain('ext:presence');
   });
 
-  it('detects idle status when electron-idle reports high idle time', () => {
-    registry.startBuiltinSensors();
-    // Simulate a connected client (not headless)
-    registry.notifyWebSocketClientCount(1);
-
-    // Manually report high idle time to the electron-idle sensor
-    registry.report({ sensorId: 'builtin:electron-idle', data: { idleSeconds: 400 } });
-
-    const state = aggregator.getPresenceState();
-    expect(state.status).toBe('idle');
-    expect(state.sensors).toContain('builtin:electron-idle');
-  });
-
-  it('does not report idle when electron-idle reports low idle time', () => {
-    registry.startBuiltinSensors();
-    registry.notifyWebSocketClientCount(1);
-
-    // Report low idle time (below threshold)
-    registry.report({ sensorId: 'builtin:electron-idle', data: { idleSeconds: 60 } });
-
-    const state = aggregator.getPresenceState();
-    expect(state.status).toBe('active');
-  });
-
   it('applies precedence: headless > afk', () => {
     registry.startBuiltinSensors();
     // Keep 0 WebSocket clients (headless)
@@ -93,19 +69,16 @@ describe('ContextAggregator', () => {
     expect(state.status).toBe('headless');
   });
 
-  it('applies precedence: afk > idle', () => {
+  it('applies precedence: afk > active', () => {
     registry.startBuiltinSensors();
     registry.notifyWebSocketClientCount(1); // Not headless
 
-    // Report high idle time
-    registry.report({ sensorId: 'builtin:electron-idle', data: { idleSeconds: 400 } });
-
-    // Also have an away sensor
+    // Have an away sensor
     registry.register({ id: 'ext:presence', name: 'Presence Sensor' });
     registry.report({ sensorId: 'ext:presence', data: { presence: 'away' } });
 
     const state = aggregator.getPresenceState();
-    // afk takes priority over idle
+    // afk takes priority over active
     expect(state.status).toBe('afk');
   });
 
@@ -114,7 +87,7 @@ describe('ContextAggregator', () => {
     registry.notifyWebSocketClientCount(1);
 
     const before = new Date().toISOString();
-    registry.report({ sensorId: 'builtin:electron-idle', data: { idleSeconds: 10 } });
+    registry.report({ sensorId: 'builtin:websocket-clients', data: { clientCount: 2 } });
     const after = new Date().toISOString();
 
     const state = aggregator.getPresenceState();


### PR DESCRIPTION
## Summary
- Remove 2 tests for the `builtin:electron-idle` sensor that was deleted in #2946
- Update remaining tests to use `builtin:websocket-clients` sensor instead of the removed electron-idle sensor

## Test plan
- [ ] CI passes (the failing test is the one being removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed tests for idle behavior detection
  * Updated status precedence test assertions
  * Modified test data inputs for validation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->