### PR TITLE
fix: deduplicate changeset entries and fix Docker version path

### DIFF
--- a/apps/server/src/lib/version.ts
+++ b/apps/server/src/lib/version.ts
@@ -23,14 +23,30 @@ export function getVersion(): string {
     return cachedVersion;
   }
 
-  try {
-    const packageJsonPath = join(__dirname, '..', '..', 'package.json');
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
-    const version = packageJson.version || '0.0.0';
-    cachedVersion = version;
-    return version;
-  } catch (error) {
-    logger.warn('Failed to read version from package.json:', error);
-    return '0.0.0';
+  // Try multiple candidate paths: the compiled output may be nested
+  // deeper than src (e.g. dist/apps/server/src/lib/ in Docker builds).
+  const candidates = [
+    join(__dirname, '..', '..', 'package.json'),
+    join(__dirname, '..', '..', '..', '..', 'package.json'),
+    join(__dirname, '..', '..', '..', '..', '..', 'package.json'),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      const packageJson = JSON.parse(readFileSync(candidate, 'utf-8'));
+      if (packageJson.name?.includes('server') || packageJson.name?.includes('protolabs')) {
+        const version = packageJson.version || '0.0.0';
+        cachedVersion = version;
+        return version;
+      }
+    } catch {
+      // Try next candidate
+    }
   }
+
+  logger.warn(
+    'Failed to read version from package.json, tried:',
+    candidates.map((c) => ({ path: c }))
+  );
+  return '0.0.0';
 }

--- a/scripts/prepare-release-changeset.mjs
+++ b/scripts/prepare-release-changeset.mjs
@@ -80,7 +80,10 @@ function getCommitsSince(ref) {
     }
   }
 
-  return subjects;
+  // Deduplicate: the linear log walk and the merge expansion can collect
+  // the same commit subject twice (once from the linear walk, once from
+  // expanding the merge). Remove duplicates while preserving order.
+  return [...new Set(subjects)];
 }
 
 function classifyBump(commits) {


### PR DESCRIPTION
## Summary
- **Changeset dedup**: `prepare-release-changeset.mjs` collects commits via both linear log walk and merge expansion, producing duplicate entries. Fix: deduplicate with `Set` before grouping.
- **Version path**: `version.ts` uses `__dirname` relative path that breaks in Docker builds (`dist/apps/server/src/lib/` → wrong `package.json` path). Fix: try multiple candidate paths and validate package name.

## Test plan
- [ ] CI passes
- [ ] Next `prepare-release.yml` run produces clean changelogs (no duplicates)
- [ ] `/api/health/ready` no longer warns about missing package.json in Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version detection to support multiple configuration paths and validate package information
  * Removed duplicate entries from commit subjects in release processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->