### PR TITLE
fix: skip project wizard for ongoing projects

### DIFF
--- a/apps/ui/src/routes/project-management.$slug.tsx
+++ b/apps/ui/src/routes/project-management.$slug.tsx
@@ -22,9 +22,12 @@ function ProjectSlugRoute() {
     );
   }
 
-  // New/drafting projects with no PRD or milestones get the wizard
+  // New/drafting projects with no PRD or milestones get the wizard.
+  // Ongoing projects (e.g. Bugs) skip the wizard — they're persistent containers.
   const isNewProject =
     project &&
+    project.status !== 'ongoing' &&
+    project.type !== 'ongoing' &&
     WIZARD_STATUSES.includes(project.status ?? '') &&
     !project.prd &&
     (!project.milestones || project.milestones.length === 0);


### PR DESCRIPTION
## Summary
Ongoing projects (like "Bugs") are persistent containers — skip the Research/PRD/Plan wizard when `project.status === 'ongoing'` or `project.type === 'ongoing'`.

## Test plan
- [ ] CI passes
- [ ] "Bugs" project opens directly to active view, not wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated project display behavior to prevent ongoing projects from entering the project setup wizard, ensuring proper project type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->