### PR TITLE
Promote dev to staging (ongoing project wizard fix)

### DIFF
--- a/apps/ui/src/routes/project-management.$slug.tsx
+++ b/apps/ui/src/routes/project-management.$slug.tsx
@@ -22,9 +22,12 @@ function ProjectSlugRoute() {
     );
   }
 
-  // New/drafting projects with no PRD or milestones get the wizard
+  // New/drafting projects with no PRD or milestones get the wizard.
+  // Ongoing projects (e.g. Bugs) skip the wizard — they're persistent containers.
   const isNewProject =
     project &&
+    project.status !== 'ongoing' &&
+    project.type !== 'ongoing' &&
     WIZARD_STATUSES.includes(project.status ?? '') &&
     !project.prd &&
     (!project.milestones || project.milestones.length === 0);


### PR DESCRIPTION
- #2965 — Skip wizard for ongoing projects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the logic determining when the project wizard appears during project management workflows. Projects with certain statuses will now display the project view instead of the wizard interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->