### PR TITLE
fix: check legacy ongoing boolean in wizard bypass

### DIFF
--- a/apps/ui/src/routes/project-management.$slug.tsx
+++ b/apps/ui/src/routes/project-management.$slug.tsx
@@ -26,6 +26,7 @@ function ProjectSlugRoute() {
   // Ongoing projects (e.g. Bugs) skip the wizard — they're persistent containers.
   const isNewProject =
     project &&
+    !project.ongoing &&
     project.status !== 'ongoing' &&
     project.type !== 'ongoing' &&
     WIZARD_STATUSES.includes(project.status ?? '') &&


### PR DESCRIPTION
## Summary
Add missing `!project.ongoing` check that was dropped by squash merge of #2965. The Bugs project uses the legacy `ongoing: true` boolean field.

## Test plan
- [ ] CI passes
- [ ] Bugs project skips wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where projects marked as ongoing could incorrectly trigger the project setup wizard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->