### PR TITLE
Add protoClawX Ava Engine as alternative chat transport

### DIFF
--- a/apps/ui/src/hooks/use-chat-session.ts
+++ b/apps/ui/src/hooks/use-chat-session.ts
@@ -31,6 +31,12 @@ interface UseChatSessionOptions {
   projectPath?: string;
   /** Project ID used to scope sessions */
   projectId?: string;
+  /**
+   * Optional URL for the protoClawX Ava Engine (e.g. http://localhost:8318/api/chat).
+   * When set, chat sessions use this URL as the transport target instead of /api/chat.
+   * Both endpoints speak AI SDK Data Stream Protocol so all UI features work unchanged.
+   */
+  avaEngineUrl?: string;
 }
 
 export function useChatSession({
@@ -38,6 +44,7 @@ export function useChatSession({
   body,
   projectPath,
   projectId,
+  avaEngineUrl,
 }: UseChatSessionOptions = {}) {
   const {
     sessions,
@@ -77,20 +84,23 @@ export function useChatSession({
     [body, projectPath]
   );
 
-  // AI SDK v6 requires transport instead of api/headers/body
+  // AI SDK v6 requires transport instead of api/headers/body.
+  // When avaEngineUrl is provided, route to the protoClawX Ava Engine instead.
+  // X-Session-Id ensures session continuity on the engine side.
   const transport = useMemo(
     () =>
       new DefaultChatTransport({
-        api: '/api/chat',
+        api: avaEngineUrl ?? '/api/chat',
         headers: {
           ...getAuthHeaders(),
           'x-model-alias': modelAlias,
           'x-effort-level': effortLevel,
+          ...(avaEngineUrl && currentSessionId ? { 'X-Session-Id': currentSessionId } : {}),
         },
         body: transportBody,
         credentials: 'include',
       }),
-    [modelAlias, effortLevel, transportBody]
+    [modelAlias, effortLevel, transportBody, avaEngineUrl, currentSessionId]
   );
 
   const { messages, sendMessage, stop, status, setMessages, error, addToolApprovalResponse } =

--- a/libs/types/src/project-settings.ts
+++ b/libs/types/src/project-settings.ts
@@ -278,6 +278,15 @@ export interface ProjectSettings {
    * Set to `null` to explicitly disable the Docs viewer for this project.
    */
   docsPath?: string | null;
+
+  // Ava Engine Transport Override (per-project)
+  /**
+   * Optional URL for the protoClawX Ava Engine (e.g. http://localhost:8318/api/chat).
+   * When set, chat sessions for this project use a DefaultChatTransport pointing to
+   * this URL instead of the default /api/chat endpoint.
+   * Both transports speak AI SDK Data Stream Protocol so all UI features work unchanged.
+   */
+  avaEngineUrl?: string;
 }
 
 /** Default project settings (empty - all settings are optional and fall back to global) */


### PR DESCRIPTION
## Summary

The automaker UI already has a full Ask Ava chat system (useChatSession, chat-store, ChatOverlayContent, ChatModal). The protoClawX Ava Engine is now live on port 8318 speaking AI SDK Data Stream Protocol.

This feature adds it as an alternative transport target:
- Add avaEngineUrl to project settings (optional string)
- Modify use-chat-session.ts to check for engine URL override
- When engine URL is set, create DefaultChatTransport pointing to that URL
- Add X-Session-Id header for engine sessi...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-03-19T22:44:34.840Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to configure a custom chat engine endpoint per project for flexible chat transport routing.
  * Implemented automatic session preservation when using custom chat engines to maintain conversation continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->