### PR TITLE
fix: install @esbuild/linux-x64 in deploy-docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -44,7 +44,10 @@ jobs:
       - name: Build docs
         run: |
           npm ci --ignore-scripts
-          npm install --ignore-scripts --no-save @rollup/rollup-linux-x64-gnu@$(node -p "require('./node_modules/rollup/package.json').version")
+          # Install platform-specific binaries that --ignore-scripts skips
+          npm install --ignore-scripts --no-save \
+            @rollup/rollup-linux-x64-gnu@$(node -p "require('./node_modules/rollup/package.json').version") \
+            @esbuild/linux-x64@$(node -p "require('./node_modules/vitepress/node_modules/esbuild/package.json').version")
           npm run docs:build
 
       - name: Deploy to Cloudflare Pages


### PR DESCRIPTION
## Summary
Deploy Docs workflow fails because `npm ci --ignore-scripts` skips platform-specific esbuild binaries. Add `@esbuild/linux-x64` alongside the existing `@rollup/rollup-linux-x64-gnu` manual install.

## Test plan
- [ ] CI passes
- [ ] deploy-docs workflow succeeds on next main push

🤖 Generated with [Claude Code](https://claude.com/claude-code)