### PR TITLE
feat: project lifecycle tracing via Langfuse sessions

### DIFF
--- a/apps/server/src/providers/simple-query-service.ts
+++ b/apps/server/src/providers/simple-query-service.ts
@@ -84,11 +84,13 @@ export interface SimpleQueryOptions {
    * Tools that are explicitly disallowed for this execution.
    */
   disallowedTools?: string[];
-  /** Trace context for Langfuse enrichment (feature ID, role, tags) */
+  /** Trace context for Langfuse enrichment (feature ID, role, project, phase) */
   traceContext?: {
     featureId?: string;
     featureName?: string;
     agentRole?: string;
+    projectSlug?: string;
+    phase?: string;
   };
 }
 

--- a/apps/server/src/providers/traced-provider.ts
+++ b/apps/server/src/providers/traced-provider.ts
@@ -18,6 +18,8 @@ export interface TracedProviderContext {
   featureId?: string;
   featureName?: string;
   agentRole?: string;
+  projectSlug?: string;
+  phase?: string;
 }
 
 /**
@@ -27,6 +29,7 @@ export class TracedProvider extends BaseProvider {
   private wrapped: BaseProvider;
   private tracingConfig: TracingConfig;
   private _lastTraceId: string | null = null;
+  private _langfuseSessionId: string | undefined;
 
   constructor(wrapped: BaseProvider, tracingConfig: TracingConfig) {
     super(wrapped.getConfig());
@@ -63,6 +66,19 @@ export class TracedProvider extends BaseProvider {
         `role:${ctx.agentRole}`,
       ];
     }
+    if (ctx.projectSlug) {
+      this._langfuseSessionId = `project:${ctx.projectSlug}`;
+      this.tracingConfig.defaultTags = [
+        ...(this.tracingConfig.defaultTags ?? []),
+        `project:${ctx.projectSlug}`,
+      ];
+    }
+    if (ctx.phase) {
+      this.tracingConfig.defaultTags = [
+        ...(this.tracingConfig.defaultTags ?? []),
+        `phase:${ctx.phase}`,
+      ];
+    }
   }
 
   getName(): string {
@@ -86,7 +102,7 @@ export class TracedProvider extends BaseProvider {
       model,
       traceId,
       traceName: `provider:${this.getName()}`,
-      sessionId: options.sdkSessionId,
+      sessionId: this._langfuseSessionId || options.sdkSessionId,
       metadata: {
         provider: this.getName(),
         originalModel: options.originalModel,

--- a/apps/server/src/routes/projects/lifecycle/generate-prd.ts
+++ b/apps/server/src/routes/projects/lifecycle/generate-prd.ts
@@ -68,6 +68,7 @@ export function createGeneratePrdHandler(
         model: PRD_MODEL,
         cwd: projectPath,
         maxTurns: 1,
+        traceContext: { projectSlug, phase: 'prd', agentRole: 'prd-generator' },
       });
 
       const text = result.text || '';

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -13,6 +13,7 @@
 
 import * as v8 from 'node:v8';
 import { ProviderFactory } from '../../providers/provider-factory.js';
+import { TracedProvider } from '../../providers/traced-provider.js';
 import { simpleQuery } from '../../providers/simple-query-service.js';
 import { StreamObserver } from '../stream-observer-service.js';
 import { getWorkflowSettings, getEffectivePrBaseBranch } from '../../lib/settings-helpers.js';
@@ -2179,6 +2180,18 @@ This mock response was generated because AUTOMAKER_MOCK_AGENT=true was set.
 
     // Get provider for this model
     const provider = ProviderFactory.getProviderForModel(finalModel);
+
+    // Enrich trace with feature + project context
+    if (provider instanceof TracedProvider) {
+      const featureForTrace = await this.featureLoader.get(finalProjectPath, featureId);
+      provider.setContext({
+        featureId,
+        featureName: featureForTrace?.title,
+        agentRole: 'engineer',
+        projectSlug: featureForTrace?.projectSlug,
+        phase: 'execute',
+      });
+    }
 
     // Strip provider prefix - providers should receive bare model IDs
     const bareModel = stripProviderPrefix(finalModel);

--- a/apps/server/src/services/lead-engineer-deploy-processor.ts
+++ b/apps/server/src/services/lead-engineer-deploy-processor.ts
@@ -283,6 +283,8 @@ Return ONLY the JSON array, no other text.`;
           featureId: ctx.feature.id,
           featureName: ctx.feature.title,
           agentRole: 'goal-verification',
+          projectSlug: ctx.feature.projectSlug,
+          phase: 'deploy',
         },
       });
 
@@ -434,6 +436,8 @@ ${summary}`,
           featureId: ctx.feature.id,
           featureName: ctx.feature.title,
           agentRole: 'reflection',
+          projectSlug: ctx.feature.projectSlug,
+          phase: 'deploy',
         },
       });
 

--- a/apps/server/src/services/project-lifecycle-service.ts
+++ b/apps/server/src/services/project-lifecycle-service.ts
@@ -373,6 +373,7 @@ Search the codebase for relevant patterns and integration points, then research 
         cwd: projectPath,
         maxTurns: 40,
         allowedTools: RESEARCH_TOOLS,
+        traceContext: { projectSlug, phase: 'research', agentRole: 'researcher' },
       });
 
       const researchText = result.text || '';

--- a/apps/server/tests/unit/providers/traced-provider.test.ts
+++ b/apps/server/tests/unit/providers/traced-provider.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TracedProvider } from '@/providers/traced-provider.js';
+import { BaseProvider } from '@/providers/base-provider.js';
+import type {
+  ExecuteOptions,
+  ProviderMessage,
+  InstallationStatus,
+  ModelDefinition,
+  ProviderConfig,
+} from '@protolabsai/types';
+import type { TracingConfig } from '@protolabsai/observability';
+
+// Minimal stub provider for testing
+class StubProvider extends BaseProvider {
+  getName(): string {
+    return 'stub';
+  }
+
+  async *executeQuery(_options: ExecuteOptions): AsyncGenerator<ProviderMessage> {
+    yield { type: 'result', subtype: 'success', result: 'ok' } as ProviderMessage;
+  }
+
+  async detectInstallation(): Promise<InstallationStatus> {
+    return { installed: true };
+  }
+
+  getAvailableModels(): ModelDefinition[] {
+    return [];
+  }
+}
+
+function createStubProvider(): StubProvider {
+  return new StubProvider({ id: 'stub', name: 'Stub' } as ProviderConfig);
+}
+
+// Captures the options passed to wrapProviderWithTracing
+function createSpyTracingConfig(): { config: TracingConfig; capturedOptions: any[] } {
+  const capturedOptions: any[] = [];
+  const mockClient = {
+    isAvailable: () => true,
+    createTrace: vi.fn(),
+    createGeneration: vi.fn(),
+    updateTrace: vi.fn(),
+    flush: vi.fn(),
+  };
+
+  const config: TracingConfig = {
+    enabled: true,
+    client: mockClient as any,
+    defaultTags: [],
+    defaultMetadata: {},
+  };
+
+  return { config, capturedOptions };
+}
+
+describe('TracedProvider', () => {
+  describe('setContext — projectSlug', () => {
+    it('sets _langfuseSessionId from projectSlug', async () => {
+      const { config } = createSpyTracingConfig();
+      const provider = new TracedProvider(createStubProvider(), config);
+
+      provider.setContext({ projectSlug: 'ci-reaction-engine' });
+
+      // Execute to trigger wrapProviderWithTracing and verify sessionId
+      // We check the config was updated with tags
+      expect(config.defaultTags).toContain('project:ci-reaction-engine');
+      expect(config.defaultMetadata).toMatchObject({ projectSlug: 'ci-reaction-engine' });
+    });
+
+    it('adds project tag to defaultTags', () => {
+      const { config } = createSpyTracingConfig();
+      const provider = new TracedProvider(createStubProvider(), config);
+
+      provider.setContext({ projectSlug: 'my-project' });
+
+      expect(config.defaultTags).toContain('project:my-project');
+    });
+  });
+
+  describe('setContext — phase', () => {
+    it('adds phase tag to defaultTags', () => {
+      const { config } = createSpyTracingConfig();
+      const provider = new TracedProvider(createStubProvider(), config);
+
+      provider.setContext({ phase: 'research' });
+
+      expect(config.defaultTags).toContain('phase:research');
+    });
+  });
+
+  describe('setContext — combined projectSlug + phase', () => {
+    it('adds both project and phase tags plus metadata', () => {
+      const { config } = createSpyTracingConfig();
+      const provider = new TracedProvider(createStubProvider(), config);
+
+      provider.setContext({
+        featureId: 'feat-123',
+        agentRole: 'engineer',
+        projectSlug: 'ci-engine',
+        phase: 'execute',
+      });
+
+      expect(config.defaultTags).toContain('feature:feat-123');
+      expect(config.defaultTags).toContain('role:engineer');
+      expect(config.defaultTags).toContain('project:ci-engine');
+      expect(config.defaultTags).toContain('phase:execute');
+      expect(config.defaultMetadata).toMatchObject({
+        featureId: 'feat-123',
+        projectSlug: 'ci-engine',
+        phase: 'execute',
+      });
+    });
+  });
+
+  describe('executeQuery — sessionId override', () => {
+    it('uses project sessionId when projectSlug is set', async () => {
+      const mockClient = {
+        isAvailable: () => true,
+        createTrace: vi.fn(),
+        createGeneration: vi.fn(),
+        updateTrace: vi.fn(),
+        flush: vi.fn(),
+      };
+
+      const config: TracingConfig = {
+        enabled: true,
+        client: mockClient as any,
+        defaultTags: [],
+        defaultMetadata: {},
+      };
+
+      const provider = new TracedProvider(createStubProvider(), config);
+      provider.setContext({ projectSlug: 'lifecycle-test' });
+
+      // Consume the generator to trigger tracing
+      const options: ExecuteOptions = {
+        prompt: 'test',
+        model: 'sonnet',
+        cwd: '/tmp',
+        maxTurns: 1,
+        allowedTools: [],
+        sdkSessionId: 'sdk-session-original',
+      };
+
+      for await (const _msg of provider.executeQuery(options)) {
+        // consume
+      }
+
+      // The trace should have been created with the project session ID
+      expect(mockClient.createTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: 'project:lifecycle-test',
+        })
+      );
+    });
+
+    it('falls back to sdkSessionId when no projectSlug', async () => {
+      const mockClient = {
+        isAvailable: () => true,
+        createTrace: vi.fn(),
+        createGeneration: vi.fn(),
+        updateTrace: vi.fn(),
+        flush: vi.fn(),
+      };
+
+      const config: TracingConfig = {
+        enabled: true,
+        client: mockClient as any,
+        defaultTags: [],
+        defaultMetadata: {},
+      };
+
+      const provider = new TracedProvider(createStubProvider(), config);
+      // No setContext call — no projectSlug
+
+      const options: ExecuteOptions = {
+        prompt: 'test',
+        model: 'sonnet',
+        cwd: '/tmp',
+        maxTurns: 1,
+        allowedTools: [],
+        sdkSessionId: 'original-session',
+      };
+
+      for await (const _msg of provider.executeQuery(options)) {
+        // consume
+      }
+
+      expect(mockClient.createTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: 'original-session',
+        })
+      );
+    });
+
+    it('uses undefined sessionId when neither projectSlug nor sdkSessionId set', async () => {
+      const mockClient = {
+        isAvailable: () => true,
+        createTrace: vi.fn(),
+        createGeneration: vi.fn(),
+        updateTrace: vi.fn(),
+        flush: vi.fn(),
+      };
+
+      const config: TracingConfig = {
+        enabled: true,
+        client: mockClient as any,
+        defaultTags: [],
+        defaultMetadata: {},
+      };
+
+      const provider = new TracedProvider(createStubProvider(), config);
+
+      const options: ExecuteOptions = {
+        prompt: 'test',
+        model: 'sonnet',
+        cwd: '/tmp',
+        maxTurns: 1,
+        allowedTools: [],
+      };
+
+      for await (const _msg of provider.executeQuery(options)) {
+        // consume
+      }
+
+      expect(mockClient.createTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: undefined,
+        })
+      );
+    });
+  });
+});

--- a/docs/internal/dev/observability-package.md
+++ b/docs/internal/dev/observability-package.md
@@ -210,6 +210,61 @@ interface CreateScoreOptions {
 }
 ```
 
+## Project Lifecycle Tracing
+
+When an LLM call originates from a project lifecycle phase (research, PRD generation, agent execution, deploy verification), the trace is tagged with project and phase context. This groups all traces under a single Langfuse session, enabling end-to-end cost and timeline visibility.
+
+### How It Works
+
+Pass `projectSlug` and `phase` in the `traceContext` option of `simpleQuery()` or `streamingQuery()`:
+
+```typescript
+const result = await streamingQuery({
+  prompt,
+  model: RESEARCH_MODEL,
+  cwd: projectPath,
+  traceContext: {
+    projectSlug: 'ci-reaction-engine',
+    phase: 'research',
+    agentRole: 'researcher',
+  },
+});
+```
+
+For direct provider usage (e.g., `ExecutionService.runAgent`), call `setContext()` on the `TracedProvider`:
+
+```typescript
+if (provider instanceof TracedProvider) {
+  provider.setContext({
+    featureId,
+    featureName: feature.title,
+    agentRole: 'engineer',
+    projectSlug: feature.projectSlug,
+    phase: 'execute',
+  });
+}
+```
+
+### What Happens
+
+- `projectSlug` sets `sessionId` to `project:{slug}` and adds a `project:{slug}` tag
+- `phase` adds a `phase:{phase}` tag
+- Both values are stored in `defaultMetadata` for the trace
+- Features without `projectSlug` fall back to the existing `sdkSessionId` behavior
+
+### Viewing in Langfuse
+
+Filter the Sessions tab by `project:{slug}` to see all lifecycle phases grouped together with cumulative cost.
+
+### Phase Values
+
+| Phase      | Source                               |
+| ---------- | ------------------------------------ |
+| `research` | `ProjectLifecycleService.research()` |
+| `prd`      | `generate-prd` route handler         |
+| `execute`  | `ExecutionService.runAgent()`        |
+| `deploy`   | `DeployProcessor` (reflection, goal) |
+
 ## Known Gotchas
 
 - **Langfuse SDK types lag runtime API** — `getPrompt()` accepts 3 args at runtime but TS types only declare 2. Use `(client as any).getPrompt()` for the label overload. Same for `score()`.

--- a/docs/server/tracing.md
+++ b/docs/server/tracing.md
@@ -1,0 +1,64 @@
+# Tracing
+
+All LLM calls in protoLabs Studio are traced via Langfuse when configured. Tracing is transparent — the application behaves identically whether Langfuse is available or not.
+
+## What Gets Traced
+
+Every call through the provider layer (`simpleQuery`, `streamingQuery`, or direct `TracedProvider.executeQuery`) creates a Langfuse trace with:
+
+- **Model** and token usage (input, output, total)
+- **Cost** calculated from configurable per-model pricing
+- **Tags** for filtering: `feature:{id}`, `role:{agentRole}`, `project:{slug}`, `phase:{phase}`
+- **Metadata** including feature ID, feature name, project slug, and phase
+- **Errors** with stack traces when the provider call fails
+
+## Session Grouping
+
+Traces are grouped into Langfuse sessions for timeline and cost aggregation.
+
+### Project Sessions
+
+When a trace originates from a project lifecycle phase, it is assigned to session `project:{slug}`. All phases of the same project share one session:
+
+```
+Session: project:ci-reaction-engine
+  Trace [phase:research]  — codebase analysis
+  Trace [phase:prd]       — SPARC PRD generation
+  Trace [phase:execute]   — agent implementation (per feature)
+  Trace [phase:deploy]    — post-merge verification + reflection
+```
+
+Filter the Langfuse Sessions tab by session ID to see the full project lifecycle with cumulative cost.
+
+### Feature Traces Without a Project
+
+Features that are not part of a project (no `projectSlug`) fall back to the SDK-provided session ID, or no session at all. They are still individually traceable by the `feature:{id}` tag.
+
+## Phase Tags
+
+| Tag              | When Applied                                           |
+| ---------------- | ------------------------------------------------------ |
+| `phase:research` | Deep research session for a project                    |
+| `phase:prd`      | SPARC PRD generation                                   |
+| `phase:execute`  | Agent implementation of a feature                      |
+| `phase:deploy`   | Post-merge verification, goal checking, and reflection |
+
+## Configuration
+
+Tracing is enabled when Langfuse environment variables are set:
+
+| Variable              | Required | Description              |
+| --------------------- | -------- | ------------------------ |
+| `LANGFUSE_PUBLIC_KEY` | Yes      | Langfuse public key      |
+| `LANGFUSE_SECRET_KEY` | Yes      | Langfuse secret key      |
+| `LANGFUSE_BASE_URL`   | No       | API URL (default: cloud) |
+
+When these variables are absent, all tracing calls silently no-op.
+
+## Graceful Fallback
+
+The tracing layer never blocks or fails the primary operation. If Langfuse is unavailable:
+
+- `wrapProviderWithTracing` passes the generator through unmodified
+- `createTrace`, `createGeneration`, and `createScore` return `null`
+- No errors are thrown or logged beyond initial connection warnings


### PR DESCRIPTION
## Summary
- Wire `projectSlug` and `phase` into `TracedProvider.setContext()` so all project lifecycle LLM calls are grouped under Langfuse session `project:{slug}` with `phase:{phase}` tags
- Add traceContext to research, PRD generation, agent execution, and deploy processor call sites
- Add 7 unit tests covering sessionId override, tag injection, and fallback behavior

## Test plan
- [x] `npm run build:server` — clean compile
- [x] `npm run test:server` — 2924 tests pass, 0 failures
- [x] Prettier check passes
- [ ] CI passes
- [ ] Manual: create project, run research + PRD, verify Langfuse Sessions tab shows `project:{slug}` grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced LLM trace organization with project slug and execution phase tracking for better observability across different agent workflows.

* **Tests**
  * Added comprehensive test coverage for trace context handling and sessionization behavior.

* **Documentation**
  * Added documentation for end-to-end LLM tracing capabilities and project lifecycle phase tracking in observability tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->