### PR TITLE
Scheduling Config + Types

### DIFF
--- a/apps/server/src/routes/chat/ava-config.ts
+++ b/apps/server/src/routes/chat/ava-config.ts
@@ -94,6 +94,7 @@ export const DEFAULT_AVA_CONFIG: AvaConfig = {
     projectMgmt: false,
     agentDelegation: false,
     projects: false,
+    scheduling: true,
   },
   sitrepInjection: true,
   contextInjection: true,

--- a/apps/server/src/routes/chat/ava-prompt.md
+++ b/apps/server/src/routes/chat/ava-prompt.md
@@ -46,6 +46,7 @@ The following tool groups are available in the UI chat, gated by per-project `av
 | `calendar`        | `list_calendar_events`, `create_calendar_event`, `update_calendar_event`, `delete_calendar_event`  |
 | `health`          | `get_system_health`, `get_server_status`, `list_recent_errors`                                     |
 | `settings`        | `get_global_settings`, `update_global_settings`, `get_project_settings`, `update_project_settings` |
+| `scheduling`      | `list_timers`, `pause_timer`, `resume_timer`                                                       |
 
 Use only tools that are enabled for the current project's tool group configuration. Do not attempt MCP CLI tools — they are not available in this surface.
 

--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -36,6 +36,7 @@ import type { SettingsService } from '../../services/settings-service.js';
 import type { DiscordBotService } from '../../services/discord-bot-service.js';
 import type { HealthMonitorService } from '../../services/health-monitor-service.js';
 import type { CeremonyService } from '../../services/ceremony-service.js';
+import type { SchedulerService } from '../../services/scheduler-service.js';
 import type { ToolProgressEmitter } from './tool-progress.js';
 import { githubMergeService } from '../../services/github-merge-service.js';
 import { getPRWatcherService } from '../../services/pr-watcher-service.js';
@@ -107,6 +108,8 @@ export interface AvaToolsServices {
   discordBotService?: DiscordBotService;
   /** Health monitor service — optional, used for health tool group */
   healthMonitorService?: HealthMonitorService;
+  /** Scheduler service — optional, used for scheduling tool group */
+  schedulerService?: SchedulerService;
 }
 
 export interface AvaToolsConfig {
@@ -155,6 +158,8 @@ export interface AvaToolsConfig {
   delegateToPm?: boolean;
   /** Enable delegation tool group (delegate_to_pm) — preferred alias for delegateToPm */
   delegation?: boolean;
+  /** Enable scheduling tools (list_timers, pause_timer, resume_timer) */
+  scheduling?: boolean;
 }
 
 // Re-use the same status literals that the Feature type exposes

--- a/apps/ui/src/lib/clients/ava-client.ts
+++ b/apps/ui/src/lib/clients/ava-client.ts
@@ -23,6 +23,7 @@ export interface AvaToolGroups {
   contextFiles: boolean;
   projects: boolean;
   briefing: boolean;
+  scheduling: boolean;
 }
 
 export interface AvaConfig {

--- a/docs/internal/server/ava-chat.md
+++ b/docs/internal/server/ava-chat.md
@@ -62,6 +62,7 @@ interface AvaConfig {
     calendar: boolean; // Calendar event tools
     health: boolean; // Health monitoring tools
     settings: boolean; // Global settings access tools
+    scheduling: boolean; // list_timers, pause_timer, resume_timer
   };
   sitrepInjection: boolean;
   contextInjection: boolean;
@@ -80,7 +81,7 @@ All tool groups default to `true`. Model defaults to `sonnet`. `autoApproveTools
 | ---------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `apps/server/src/routes/chat/index.ts`                     | Main chat route — wires config, sitrep, tools, streamText              |
 | `apps/server/src/routes/chat/ava-config.ts`                | `loadAvaConfig` / `saveAvaConfig` with deep-merge defaults             |
-| `apps/server/src/routes/chat/ava-tools.ts`                 | `buildAvaTools(projectPath, services, config)` — 19 tool groups        |
+| `apps/server/src/routes/chat/ava-tools.ts`                 | `buildAvaTools(projectPath, services, config)` — 20 tool groups        |
 | `apps/server/src/routes/chat/sitrep.ts`                    | `getSitrep(projectPath)` — 5-min TTL cache, `invalidateSitrep()`       |
 | `apps/server/src/routes/chat/personas.ts`                  | `buildAvaSystemPrompt({ ctx, projectContext, sitrep, extension })`     |
 | `apps/server/src/routes/ava/index.ts`                      | `/api/ava/config/get` and `/api/ava/config/update` HTTP endpoints      |


### PR DESCRIPTION
## Summary

**Milestone:** Self-Scheduling Tool Group

Add the scheduling tool group flag to all config surfaces. Add scheduling: true to AvaToolsConfig interface in ava-tools.ts. Add to DEFAULT_AVA_CONFIG in ava-config.ts (default: true). Add to AvaToolGroups in ava-client.ts. Add schedulerService as optional field on AvaToolsServices interface. Update ava-prompt.md tool group table with scheduling row. Update ava-chat.md internal docs.

**Files to Modify:**
- apps/server/src/routes/chat/ava-tools.ts
- app...

---
*Recovered automatically by Automaker post-agent hook*