### PR TITLE
Gateway Action Executor + Feature Flag

### DIFF
--- a/apps/server/src/services/ava-gateway-service.ts
+++ b/apps/server/src/services/ava-gateway-service.ts
@@ -23,12 +23,39 @@ import { CircuitBreaker } from '../lib/circuit-breaker.js';
 const logger = createLogger('AvaGatewayService');
 
 /**
+ * Types of autonomous actions the gateway executor can perform
+ */
+export type GatewayActionType = 'unblock_feature' | 'retry_agent' | 'merge_ready_pr';
+
+/**
+ * Structured action recommendation produced during heartbeat analysis
+ */
+export interface GatewayActionRecommendation {
+  type: GatewayActionType;
+  featureId: string;
+  reason: string;
+  priority: number; // 1–10, higher = more urgent
+}
+
+/**
+ * Result of an executed gateway action (append-only audit entry)
+ */
+export interface GatewayActionResult {
+  type: GatewayActionType;
+  featureId: string;
+  success: boolean;
+  reason: string;
+  timestamp: string;
+}
+
+/**
  * Heartbeat evaluation result from Ava
  */
 export interface HeartbeatResult {
   status: 'ok' | 'alert';
   message?: string;
   alerts?: HeartbeatAlert[];
+  actionRecommendations?: GatewayActionRecommendation[];
 }
 
 /**
@@ -57,6 +84,81 @@ export interface GatewayStatus {
     isOpen: boolean;
     failureCount: number;
   };
+  /** Append-only audit log of all executed gateway actions */
+  actionAuditLog: GatewayActionResult[];
+}
+
+/**
+ * Executes structured action recommendations produced by the heartbeat.
+ * Enforces a per-cycle budget and emits events for each action taken.
+ */
+export class GatewayActionExecutor {
+  private static readonly ACTION_BUDGET = 3;
+
+  constructor(
+    private readonly events: EventEmitter,
+    private readonly auditLog: GatewayActionResult[]
+  ) {}
+
+  /**
+   * Execute up to ACTION_BUDGET recommendations, sorted by priority descending.
+   * Returns the results of attempted actions.
+   */
+  async execute(recommendations: GatewayActionRecommendation[]): Promise<GatewayActionResult[]> {
+    const sorted = [...recommendations].sort((a, b) => b.priority - a.priority);
+    const batch = sorted.slice(0, GatewayActionExecutor.ACTION_BUDGET);
+    const results: GatewayActionResult[] = [];
+
+    for (const rec of batch) {
+      const result = await this.executeOne(rec);
+      results.push(result);
+      // Append to audit log (append-only)
+      this.auditLog.push(result);
+      // Emit event for each action
+      this.events.emit('gateway:action-executed', {
+        type: result.type,
+        featureId: result.featureId,
+        success: result.success,
+        reason: result.reason,
+        timestamp: result.timestamp,
+      });
+    }
+
+    return results;
+  }
+
+  private async executeOne(rec: GatewayActionRecommendation): Promise<GatewayActionResult> {
+    const timestamp = new Date().toISOString();
+    try {
+      switch (rec.type) {
+        case 'unblock_feature':
+          this.events.emit('gateway:action:unblock-feature', { featureId: rec.featureId });
+          break;
+        case 'retry_agent':
+          this.events.emit('gateway:action:retry-agent', { featureId: rec.featureId });
+          break;
+        case 'merge_ready_pr':
+          this.events.emit('gateway:action:merge-pr', { featureId: rec.featureId });
+          break;
+      }
+      return {
+        type: rec.type,
+        featureId: rec.featureId,
+        success: true,
+        reason: rec.reason,
+        timestamp,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        type: rec.type,
+        featureId: rec.featureId,
+        success: false,
+        reason: message,
+        timestamp,
+      };
+    }
+  }
 }
 
 /**
@@ -113,6 +215,9 @@ export class AvaGatewayService {
   // Phase 9: Circuit breaker
   private circuitBreaker: CircuitBreaker;
   private backoffDelayMs = 0;
+
+  // Action audit log (append-only)
+  private actionAuditLog: GatewayActionResult[] = [];
 
   // Rate limiting for real-time notifications
   private lastNotificationPost: Map<string, number> = new Map();
@@ -254,7 +359,49 @@ export class AvaGatewayService {
         isOpen: this.circuitBreaker.isCircuitOpen(),
         failureCount: this.circuitBreaker.getFailureCount(),
       },
+      actionAuditLog: [...this.actionAuditLog],
     };
+  }
+
+  /**
+   * Generate structured action recommendations from board state.
+   * Blocked features → unblock_feature
+   * Stale in-progress features → retry_agent
+   * Features in review with a PR → merge_ready_pr
+   */
+  generateActionRecommendations(summary: BoardSummary): GatewayActionRecommendation[] {
+    const recommendations: GatewayActionRecommendation[] = [];
+
+    // Blocked features should be unblocked
+    for (const feature of summary.staleFeatures) {
+      if (feature.status === 'blocked') {
+        recommendations.push({
+          type: 'unblock_feature',
+          featureId: feature.id,
+          reason: `Feature has been blocked for ${feature.daysSinceUpdate} days`,
+          priority: 8,
+        });
+      } else if (feature.status === 'in_progress') {
+        recommendations.push({
+          type: 'retry_agent',
+          featureId: feature.id,
+          reason: `Feature has been in progress for ${feature.daysSinceUpdate} days without update`,
+          priority: 6,
+        });
+      }
+    }
+
+    // PRs in review are candidates for merge
+    for (const pr of summary.failedPRs) {
+      recommendations.push({
+        type: 'merge_ready_pr',
+        featureId: pr.id,
+        reason: `PR #${pr.prNumber ?? 'unknown'} is ready for merge`,
+        priority: 7,
+      });
+    }
+
+    return recommendations;
   }
 
   /**
@@ -708,6 +855,35 @@ export class AvaGatewayService {
         if (this.events) {
           this.events.emit('ava-gateway:heartbeat-ok', {
             message: result.message,
+          });
+        }
+      }
+
+      // Produce structured action recommendations when gatewayAutoRemediate flag is enabled
+      const globalSettings = this.settingsService
+        ? await this.settingsService.getGlobalSettings()
+        : null;
+      const autoRemediateEnabled = globalSettings?.featureFlags?.gatewayAutoRemediate ?? false;
+
+      if (autoRemediateEnabled && this.events) {
+        const recommendations = this.generateActionRecommendations(summary);
+        result.actionRecommendations = recommendations;
+
+        if (recommendations.length > 0) {
+          logger.info(`Generated ${recommendations.length} action recommendation(s)`, {
+            types: recommendations.map((r) => r.type),
+          });
+
+          const executor = new GatewayActionExecutor(this.events, this.actionAuditLog);
+          const actionResults = await executor.execute(recommendations);
+
+          logger.info(`Executed ${actionResults.length} action(s)`, {
+            successful: actionResults.filter((r) => r.success).length,
+          });
+
+          this.events.emit('ava-gateway:actions-executed', {
+            count: actionResults.length,
+            results: actionResults,
           });
         }
       }

--- a/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
+++ b/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
@@ -36,6 +36,11 @@ const FEATURE_FLAG_LABELS: Record<keyof FeatureFlags, { label: string; descripti
     description:
       'Enable human-in-the-loop interrupt forms from PM Agent, Signal Intake, and Lead Engineer. When off, gated actions are auto-approved or escalated to Ava.',
   },
+  gatewayAutoRemediate: {
+    label: 'Gateway Auto-Remediate',
+    description:
+      'Allow Ava Gateway to automatically act on board issues each heartbeat cycle (unblock features, retry agents, merge ready PRs). Budget: max 3 actions per cycle.',
+  },
 };
 
 // Role badge colour mapping

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -10,6 +10,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
+      "@protolabsai/types": ["../../libs/types/src/index.ts"],
       "@protolabsai/ui/organisms": ["../../libs/ui/src/organisms/index.ts"]
     },
     "moduleResolution": "bundler",

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -320,6 +320,12 @@ export type EventType =
   | 'ava-gateway:alerts'
   | 'ava-gateway:heartbeat-ok'
   | 'ava-gateway:emergency-stop'
+  | 'ava-gateway:actions-executed'
+  // Ava Gateway action executor events (autonomous remediation)
+  | 'gateway:action-executed'
+  | 'gateway:action:unblock-feature'
+  | 'gateway:action:retry-agent'
+  | 'gateway:action:merge-pr'
   // Sensor registry events (core sensor framework)
   | 'sensor:registered'
   | 'sensor:data-received'

--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -213,6 +213,13 @@ export interface FeatureFlags {
    * are auto-approved or escalated to Ava instead. Off by default.
    */
   hitlForms: boolean;
+  /**
+   * Gateway Auto-Remediate — enables the GatewayActionExecutor to automatically
+   * act on structured action recommendations produced during heartbeat cycles.
+   * Actions: unblock_feature, retry_agent, merge_ready_pr. Budget: max 3 per cycle.
+   * Off by default.
+   */
+  gatewayAutoRemediate: boolean;
 }
 
 /** Default feature flags — all off by default, opt-in per environment */
@@ -221,6 +228,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   userPresenceDetection: false,
   reactorEnabled: false,
   hitlForms: false,
+  gatewayAutoRemediate: false,
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary

**Milestone:** Gateway Action Authority\n\nAdd gatewayAutoRemediate to FeatureFlags (default: false). Extend runHeartbeat() to produce structured action recommendations. Implement GatewayActionExecutor: unblock_feature, retry_agent, merge_ready_pr. Action budget (max 3 per cycle). Append-only audit on GatewayStatus. Emit events.\n\n**Files to Modify:**\n- libs/types/src/global-settings.ts\n- apps/server/src/services/ava-gateway-service.ts\n- apps/ui/src/components/views/settings/developer-sectio...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Ava Gateway can now automatically handle board issues by unblocking features, retrying agents, and merging ready pull requests. Executed actions are tracked in an audit log with a limit of 3 per cycle. This capability can be enabled via settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->