### PR TITLE
Environment Sanitization

### DIFF
--- a/apps/server/src/providers/cli-provider.ts
+++ b/apps/server/src/providers/cli-provider.ts
@@ -27,6 +27,7 @@
  */
 
 import {
+  buildSafeEnv,
   createWslCommand,
   findCliInWsl,
   isWslAvailable,
@@ -452,13 +453,8 @@ export abstract class CliProvider extends BaseProvider {
 
     const cwd = options.cwd || process.cwd();
 
-    // Filter undefined values from process.env
-    const filteredEnv: Record<string, string> = {};
-    for (const [key, value] of Object.entries(process.env)) {
-      if (value !== undefined) {
-        filteredEnv[key] = value;
-      }
-    }
+    // Build sanitized environment — agents need ANTHROPIC_API_KEY to call Claude API
+    const filteredEnv = buildSafeEnv({ includeAnthropicKey: true });
 
     // Calculate dynamic timeout based on reasoning effort.
     // This addresses GitHub issue #530 where reasoning models with 'xhigh' effort would timeout.

--- a/apps/server/src/routes/worktree/common.ts
+++ b/apps/server/src/routes/worktree/common.ts
@@ -3,7 +3,7 @@
  */
 
 import { createLogger } from '@protolabsai/utils';
-import { spawnProcess } from '@protolabsai/platform';
+import { buildSafeEnv, spawnProcess } from '@protolabsai/platform';
 import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import { getErrorMessage as getErrorMessageShared, createLogError } from '../common.js';
@@ -95,15 +95,12 @@ const extendedPath = [process.env.PATH, ...additionalPaths.filter(Boolean)]
   .join(pathSeparator);
 
 /**
- * Environment variables with extended PATH for executing shell commands.
- * Electron apps don't inherit the user's shell PATH, so we need to add
- * common tool installation locations.
+ * Sanitized environment variables for executing shell commands.
+ * Only whitelisted vars are passed — prevents leaking API keys and secrets.
+ * Extended PATH ensures tools installed in common locations are findable,
+ * especially in Electron apps that don't inherit the user's full shell PATH.
  */
-export const execEnv = {
-  ...process.env,
-  PATH: extendedPath,
-  HUSKY: '0', // Disable husky hooks in worktrees — agents handle formatting themselves
-};
+export const execEnv = buildSafeEnv({ path: extendedPath });
 
 // ============================================================================
 // Validation utilities

--- a/libs/platform/src/index.ts
+++ b/libs/platform/src/index.ts
@@ -262,6 +262,9 @@ export {
   openInExternalTerminal,
 } from './terminal.js';
 
+// Safe environment builder for subprocess execution
+export { buildSafeEnv, type SafeEnvOptions } from './safe-env.js';
+
 // proto.config.yaml schema & loader
 export {
   loadProtoConfig,

--- a/libs/platform/src/safe-env.ts
+++ b/libs/platform/src/safe-env.ts
@@ -1,0 +1,75 @@
+/**
+ * Sanitized environment builder for subprocess execution.
+ *
+ * Prevents leaking sensitive env vars (API keys, tokens, credentials)
+ * to agent subprocesses by whitelisting only the variables they need.
+ */
+
+const SAFE_ENV_VARS = [
+  'PATH',
+  'HOME',
+  'USER',
+  'SHELL',
+  'LANG',
+  'LC_ALL',
+  'TERM',
+  'NODE_ENV',
+  'TMPDIR',
+  'GIT_AUTHOR_NAME',
+  'GIT_AUTHOR_EMAIL',
+  'GIT_COMMITTER_NAME',
+  'GIT_COMMITTER_EMAIL',
+  'HUSKY',
+] as const;
+
+export interface SafeEnvOptions {
+  /** Include ANTHROPIC_API_KEY — only for agent processes that call Claude API directly */
+  includeAnthropicKey?: boolean;
+  /** Override the PATH value (e.g., extended PATH with extra tool locations for Electron) */
+  path?: string;
+}
+
+/**
+ * Build a sanitized environment object for subprocess execution.
+ *
+ * Only whitelisted variables are included. ANTHROPIC_API_KEY is excluded
+ * by default and must be explicitly opted in for agent processes that need
+ * to call the Claude API directly.
+ *
+ * HUSKY is always set to '0' to disable git hooks in subprocesses.
+ *
+ * @example
+ * // General git/shell commands — no API key
+ * const env = buildSafeEnv({ path: extendedPath });
+ *
+ * // Agent subprocess — needs Claude API
+ * const env = buildSafeEnv({ includeAnthropicKey: true });
+ */
+export function buildSafeEnv(options: SafeEnvOptions = {}): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  for (const key of SAFE_ENV_VARS) {
+    const value = process.env[key];
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+
+  // Apply PATH override (e.g., extended PATH for Electron apps)
+  if (options.path !== undefined) {
+    env['PATH'] = options.path;
+  }
+
+  // Always disable husky hooks in subprocesses
+  env['HUSKY'] = '0';
+
+  // Only include ANTHROPIC_API_KEY for agent processes that require it
+  if (options.includeAnthropicKey) {
+    const apiKey = process.env['ANTHROPIC_API_KEY'];
+    if (apiKey !== undefined) {
+      env['ANTHROPIC_API_KEY'] = apiKey;
+    }
+  }
+
+  return env;
+}


### PR DESCRIPTION
## Summary

**Milestone:** Container Sandbox Hardening\n\nCreate buildSafeEnv() in libs/platform. Whitelist: PATH, HOME, USER, SHELL, LANG, LC_ALL, TERM, NODE_ENV, TMPDIR, GIT_AUTHOR_NAME/EMAIL, GIT_COMMITTER_NAME/EMAIL, HUSKY. ANTHROPIC_API_KEY only when agent needs Claude API. Replace execEnv in common.ts and buildEnv() in cli-provider.ts.\n\n**Files to Modify:**\n- libs/platform/src/safe-env.ts\n- apps/server/src/routes/worktree/common.ts\n- apps/server/src/providers/cli-provider.ts\n\n**Acceptance Crite...

---
*Recovered automatically by Automaker post-agent hook*