### PR TITLE
Persistent Audit Trail

### DIFF
--- a/apps/server/src/lib/sdk-options.ts
+++ b/apps/server/src/lib/sdk-options.ts
@@ -15,12 +15,30 @@
  * security check that applies to ALL AI model invocations, regardless of provider.
  */
 
-import type { Options, HookCallback } from '@anthropic-ai/claude-agent-sdk';
+import type { Options, HookCallback, PostToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
 import path from 'path';
+import { createHash } from 'node:crypto';
 import { resolveModelString } from '@protolabsai/model-resolver';
 import { createLogger } from '@protolabsai/utils';
+import type { ToolExecutionEntry } from '../services/audit-service.js';
 
 const logger = createLogger('SdkOptions');
+
+/** Module-level tool execution logger, set via setToolExecutionLogger() from services.ts */
+let _toolExecutionLogger: ((entry: ToolExecutionEntry) => Promise<void>) | null = null;
+
+/**
+ * Wire in the AuditService tool execution logger.
+ * Called once during server startup from services.ts.
+ * When set, all agent tool calls are logged as audit entries.
+ */
+export function setToolExecutionLogger(logFn: (entry: ToolExecutionEntry) => Promise<void>): void {
+  _toolExecutionLogger = logFn;
+}
+
+// Re-export ToolExecutionEntry for consumers
+export type { ToolExecutionEntry };
+
 import {
   DEFAULT_MODELS,
   CLAUDE_MODEL_MAP,
@@ -518,10 +536,105 @@ function buildPreToolUseHooks(config: CreateSdkOptionsConfig): Partial<Options> 
 /**
  * Build worktree write guard hooks for SDK options.
  * Returns a hooks object if projectPath is set and differs from cwd (worktree mode).
- * @deprecated Use buildPreToolUseHooks instead — it includes both SSRF and worktree guards
+ * @deprecated Use buildAllHooks instead — it includes SSRF, worktree, and audit hooks
  */
 function buildWorktreeGuardHooks(config: CreateSdkOptionsConfig): Partial<Options> {
-  return buildPreToolUseHooks(config);
+  return buildAllHooks(config);
+}
+
+/**
+ * Build all SDK hooks: PreToolUse (SSRF guard + worktree write guard + audit timing)
+ * and PostToolUse (tool execution audit logging).
+ *
+ * Combines all hook types into a single hooks object to avoid spread conflicts.
+ */
+function buildAllHooks(config: CreateSdkOptionsConfig): Partial<Options> {
+  const preHooks: HookCallback[] = [];
+
+  // SSRF guard — always enabled
+  preHooks.push(createSsrfGuardHook());
+
+  // Worktree write guard — only when running in a worktree context
+  if (config.projectPath) {
+    const guard = createWorktreeWriteGuard(config.cwd, config.projectPath);
+    if (guard) {
+      logger.info(
+        `[WorktreeGuard] Enabled: writes blocked outside worktree ${config.cwd} (project: ${config.projectPath})`
+      );
+      preHooks.push(guard);
+    }
+  }
+
+  const postHooks: HookCallback[] = [];
+
+  // Tool execution audit hook — enabled when logger is wired and agentId/featureId are set
+  if (_toolExecutionLogger && config.agentId && config.featureId) {
+    const agentId = config.agentId;
+    const featureId = config.featureId;
+    const auditLogger = _toolExecutionLogger;
+
+    // Track call start times by tool_use_id for duration measurement
+    const pendingCalls = new Map<string, number>();
+
+    const preAuditHook: HookCallback = async (input, toolUseID) => {
+      if (input.hook_event_name !== 'PreToolUse') return {};
+      const key = toolUseID ?? `${input.tool_name}:${Date.now()}`;
+      pendingCalls.set(key, Date.now());
+      return {};
+    };
+
+    const postAuditHook: HookCallback = async (input, toolUseID) => {
+      if (input.hook_event_name !== 'PostToolUse') return {};
+
+      const postInput = input as PostToolUseHookInput;
+      const key = toolUseID ?? '';
+      let durationMs = 0;
+      if (key && pendingCalls.has(key)) {
+        durationMs = Date.now() - pendingCalls.get(key)!;
+        pendingCalls.delete(key);
+      }
+
+      const toolInput = postInput.tool_input as Record<string, unknown> | undefined;
+      const inputHash = createHash('sha256')
+        .update(JSON.stringify(toolInput ?? {}))
+        .digest('hex');
+
+      const toolResponse = postInput.tool_response as Record<string, unknown> | undefined;
+      let resultStatus: ToolExecutionEntry['resultStatus'] = 'success';
+      if (toolResponse?.is_error === true) {
+        resultStatus = 'error';
+      }
+
+      await auditLogger({
+        timestamp: new Date().toISOString(),
+        agentId,
+        featureId,
+        toolName: postInput.tool_name,
+        inputHash,
+        resultStatus,
+        durationMs,
+      }).catch((err: unknown) => {
+        logger.error('[ToolAudit] Failed to log tool execution:', err);
+      });
+
+      return {};
+    };
+
+    preHooks.push(preAuditHook);
+    postHooks.push(postAuditHook);
+  }
+
+  if (preHooks.length === 0 && postHooks.length === 0) return {};
+
+  const hooks: Partial<Record<'PreToolUse' | 'PostToolUse', Array<{ hooks: HookCallback[] }>>> = {};
+  if (preHooks.length > 0) {
+    hooks.PreToolUse = [{ hooks: preHooks }];
+  }
+  if (postHooks.length > 0) {
+    hooks.PostToolUse = [{ hooks: postHooks }];
+  }
+
+  return { hooks };
 }
 
 /**
@@ -632,6 +745,12 @@ export interface CreateSdkOptionsConfig {
    * - 'execution': execution-focused tools only (no Task/Skill orchestration)
    */
   toolProfile?: 'full' | 'execution';
+
+  /** Agent ID for tool execution audit logging. Required for audit entries. */
+  agentId?: string;
+
+  /** Feature ID for tool execution audit logging. Required for audit entries. */
+  featureId?: string;
 }
 
 // Re-export MCP types from @protolabsai/types for convenience

--- a/apps/server/src/routes/ops/index.ts
+++ b/apps/server/src/routes/ops/index.ts
@@ -3,6 +3,7 @@
  *
  * /api/ops/timers     - Timer registry (cron + interval listing, pause/resume)
  * /api/ops/deliveries - Webhook delivery tracking (list, detail, retry)
+ * /api/ops/audit      - Tool execution audit log (recent entries with filtering)
  */
 
 import { Router } from 'express';
@@ -10,18 +11,22 @@ import { Router } from 'express';
 import type { SchedulerService } from '../../services/scheduler-service.js';
 import type { EventEmitter } from '../../lib/events.js';
 import type { EventRouterService } from '../../services/event-router-service.js';
+import type { AuditService } from '../../services/audit-service.js';
 import { createTimersRoutes } from './routes/timers.js';
 import { createDeliveriesRoutes } from './routes/deliveries.js';
+import { createAuditRoutes } from './routes/audit.js';
 
 export function createOpsRoutes(
   schedulerService: SchedulerService,
   events: EventEmitter,
-  eventRouterService: EventRouterService
+  eventRouterService: EventRouterService,
+  auditService: AuditService
 ): Router {
   const router = Router();
 
   router.use('/timers', createTimersRoutes(schedulerService, events));
   router.use('/deliveries', createDeliveriesRoutes(eventRouterService));
+  router.use('/audit', createAuditRoutes(auditService));
 
   return router;
 }

--- a/apps/server/src/routes/ops/routes/audit.ts
+++ b/apps/server/src/routes/ops/routes/audit.ts
@@ -1,0 +1,46 @@
+/**
+ * Ops audit routes - Tool execution audit log endpoints
+ *
+ * GET / - List recent tool execution audit entries with optional filtering
+ *
+ * Query parameters:
+ *   agentId   - Filter by agent ID
+ *   featureId - Filter by feature ID
+ *   toolName  - Filter by tool name
+ *   since     - ISO 8601 timestamp lower bound
+ *   limit     - Max entries to return (default 100)
+ */
+
+import { Router } from 'express';
+import { createLogger } from '@protolabsai/utils';
+
+import type { AuditService } from '../../../services/audit-service.js';
+
+const logger = createLogger('Routes:Audit');
+
+export function createAuditRoutes(auditService: AuditService): Router {
+  const router = Router();
+
+  // GET / - List recent tool execution audit entries
+  router.get('/', async (req, res) => {
+    try {
+      const { agentId, featureId, toolName, since, limit } = req.query as Record<string, string>;
+
+      const entries = await auditService.queryToolExecutions({
+        agentId: agentId || undefined,
+        featureId: featureId || undefined,
+        toolName: toolName || undefined,
+        since: since || undefined,
+        limit: limit ? parseInt(limit, 10) : 100,
+      });
+
+      res.json({ entries, count: entries.length });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error('Failed to query audit entries:', error);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -433,7 +433,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   logger.info('Agent routes mounted at /api/agents');
 
   // Ops routes (timer registry, operational controls)
-  app.use('/api/ops', createOpsRoutes(schedulerService, events, eventRouterService));
+  app.use('/api/ops', createOpsRoutes(schedulerService, events, eventRouterService, auditService));
   logger.info('Ops routes mounted at /api/ops');
 
   // QA check aggregation (consolidated report for Quinn QA agent)

--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -116,6 +116,7 @@ import { CommandRegistryService } from '../services/command-registry-service.js'
 import { CheckpointService } from '../services/checkpoint-service.js';
 import { ProjectSlugResolver } from '../services/project-slug-resolver.js';
 import { DeviationRuleService } from '../services/deviation-rule-service.js';
+import { setToolExecutionLogger } from '../lib/sdk-options.js';
 
 const logger = createLogger('Server:Services');
 
@@ -492,8 +493,10 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   // Authority Service for trust-based policy enforcement
   const authorityService = new AuthorityService(events);
 
-  // Audit Trail (logs all authority events, tracks trust evolution)
-  const auditService = new AuditService(events);
+  // Audit Trail (logs all authority events, tracks trust evolution + tool execution audit)
+  const auditService = new AuditService(events, dataDir);
+  // Wire tool execution logger so all SDK agent runs emit audit entries
+  setToolExecutionLogger((entry) => auditService.logToolExecution(entry));
 
   // Authority Agents (AI executives)
   const pmAgent = new PMAuthorityAgent(

--- a/apps/server/src/services/audit-service.ts
+++ b/apps/server/src/services/audit-service.ts
@@ -8,6 +8,10 @@
  * Also tracks trust evolution: successful actions increase trust score,
  * escalations and failures decrease it. When score crosses threshold,
  * trust level is automatically promoted.
+ *
+ * Additionally provides tool execution audit logging for agent tool calls.
+ * Tool executions are stored in {dataDir}/audit/tool-executions.jsonl with
+ * SHA-256 hashed inputs (never full input content) and log rotation at 50MB.
  */
 
 import path from 'path';
@@ -21,6 +25,22 @@ const logger = createLogger('AuditService');
 
 const AUDIT_FILE = 'audit.jsonl';
 const AUTHORITY_DIR = 'authority';
+
+const TOOL_EXEC_FILE = 'tool-executions.jsonl';
+const TOOL_EXEC_DIR = 'audit';
+const ROTATION_SIZE_BYTES = 50 * 1024 * 1024; // 50MB
+
+/** An agent tool execution audit entry */
+export interface ToolExecutionEntry {
+  timestamp: string;
+  agentId: string;
+  featureId: string;
+  toolName: string;
+  /** SHA-256 hash of the tool input (never full input) */
+  inputHash: string;
+  resultStatus: 'success' | 'error' | 'blocked';
+  durationMs: number;
+}
 
 /** Trust score thresholds for auto-promotion */
 const TRUST_PROMOTION_THRESHOLDS: Record<number, number> = {
@@ -74,12 +94,14 @@ export class AuditService {
   private readonly events: EventEmitter;
   private authorityService: AuthorityService | null = null;
   private initialized = false;
+  private readonly dataDir: string | null;
 
   /** In-memory trust scores keyed by `${projectPath}:${agentId}` */
   private trustScores = new Map<string, TrustScore>();
 
-  constructor(events: EventEmitter) {
+  constructor(events: EventEmitter, dataDir?: string) {
     this.events = events;
+    this.dataDir = dataDir ?? null;
   }
 
   /**
@@ -568,6 +590,102 @@ export class AuditService {
 
       // Reset score after promotion
       score.score = 0;
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Tool Execution Audit
+  // --------------------------------------------------------------------------
+
+  /**
+   * Log a tool execution entry to the append-only JSONL audit file.
+   * Inputs are stored as SHA-256 hashes — never raw content.
+   * The file rotates automatically when it reaches 50MB.
+   */
+  async logToolExecution(entry: ToolExecutionEntry): Promise<void> {
+    if (!this.dataDir) return;
+    const filePath = this.getToolExecFilePath();
+    const dir = path.dirname(filePath);
+
+    try {
+      if (!secureFs.existsSync(dir)) {
+        await secureFs.mkdir(dir, { recursive: true });
+      }
+      await this.maybeRotateToolExecLog(filePath);
+      const line = JSON.stringify(entry) + '\n';
+      await secureFs.appendFile(filePath, line);
+    } catch (error) {
+      logger.error('Failed to write tool execution audit entry:', error);
+    }
+  }
+
+  /**
+   * Query recent tool execution entries with optional filtering.
+   */
+  async queryToolExecutions(options?: {
+    agentId?: string;
+    featureId?: string;
+    toolName?: string;
+    since?: string;
+    limit?: number;
+  }): Promise<ToolExecutionEntry[]> {
+    if (!this.dataDir) return [];
+    const filePath = this.getToolExecFilePath();
+
+    try {
+      if (!secureFs.existsSync(filePath)) return [];
+      const content = (await secureFs.readFile(filePath, 'utf-8')) as string;
+      const lines = content.split('\n').filter((l: string) => l.trim());
+
+      let entries = lines
+        .map((line) => {
+          try {
+            return JSON.parse(line) as ToolExecutionEntry;
+          } catch {
+            return null;
+          }
+        })
+        .filter((e): e is ToolExecutionEntry => e !== null);
+
+      if (options?.agentId) {
+        entries = entries.filter((e) => e.agentId === options.agentId);
+      }
+      if (options?.featureId) {
+        entries = entries.filter((e) => e.featureId === options.featureId);
+      }
+      if (options?.toolName) {
+        entries = entries.filter((e) => e.toolName === options.toolName);
+      }
+      if (options?.since) {
+        const sinceDate = new Date(options.since).getTime();
+        entries = entries.filter((e) => new Date(e.timestamp).getTime() >= sinceDate);
+      }
+      if (options?.limit) {
+        entries = entries.slice(-options.limit);
+      }
+
+      return entries;
+    } catch (error) {
+      logger.error('Failed to read tool execution audit log:', error);
+      return [];
+    }
+  }
+
+  private getToolExecFilePath(): string {
+    return path.join(this.dataDir!, TOOL_EXEC_DIR, TOOL_EXEC_FILE);
+  }
+
+  private async maybeRotateToolExecLog(filePath: string): Promise<void> {
+    try {
+      if (!secureFs.existsSync(filePath)) return;
+      const stats = await secureFs.stat(filePath);
+      if (stats.size >= ROTATION_SIZE_BYTES) {
+        const rotated = filePath + '.1';
+        await secureFs.rename(filePath, rotated);
+        logger.info(`Tool execution audit log rotated (was ${stats.size} bytes)`);
+      }
+    } catch {
+      // Never break audit logging due to rotation failure
     }
   }
 


### PR DESCRIPTION
## Summary

**Milestone:** Container Sandbox Hardening\n\nAppend-only JSONL audit for agent tool executions. AuditService on ServiceContainer. Entries: timestamp, agentId, featureId, toolName, inputHash (SHA-256, not full input), resultStatus, durationMs. Queryable via ops API endpoint. Log rotation at 50MB.\n\n**Files to Modify:**\n- apps/server/src/services/audit-service.ts\n- apps/server/src/routes/ops/index.ts\n- apps/server/src/server/services.ts\n- apps/server/src/lib/sdk-options.ts\n\n**Acceptance Cr...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tool execution audit logging to track and monitor all tool usage across agents.
  * New API endpoint to query tool execution history with filtering by agent, feature, and tool name.
  * Automatic log rotation for audit data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->