### PR TITLE
Worktree cleanup on failed creation or agent abort

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -2935,6 +2935,18 @@ Format your response as a structured markdown document.`;
       // Create worktrees directory if it doesn't exist
       await secureFs.mkdir(worktreesDir, { recursive: true });
 
+      // Pre-creation check: remove orphaned directory from a previous failed creation.
+      // A valid worktree has a .git file (not directory) pointing back to the main repo.
+      // If the directory exists without one, it's a partial remnant that will block retry.
+      if (fs.existsSync(worktreePath) && !fs.existsSync(path.join(worktreePath, '.git'))) {
+        logger.warn(`Removing orphaned worktree directory (no .git file): ${worktreePath}`);
+        try {
+          await fs.promises.rm(worktreePath, { recursive: true, force: true });
+        } catch (cleanupErr) {
+          logger.error(`Failed to remove orphaned worktree directory: ${worktreePath}`, cleanupErr);
+        }
+      }
+
       // Check if branch exists
       let branchExists = false;
       try {
@@ -2955,47 +2967,65 @@ Format your response as a structured markdown document.`;
         GIT_COMMITTER_EMAIL: 'automaker@localhost',
       };
 
-      if (branchExists) {
-        // Use existing branch
-        await execAsync(`git worktree add "${worktreePath}" "${branchName}"`, {
-          cwd: projectPath,
-          env: gitEnv,
-        });
-      } else {
-        // Determine base branch: use epic branch if feature belongs to an epic,
-        // otherwise use the project's configured prBaseBranch as the canonical base
-        // (never HEAD which would inherit whatever branch is currently checked out in the main repo).
-        const resolvedPrBaseBranch = await getEffectivePrBaseBranch(
-          projectPath,
-          this.settingsService,
-          '[createWorktreeForBranch]'
-        );
-        let baseBranch = `origin/${resolvedPrBaseBranch}`;
-        if (feature?.epicId && !feature.isEpic) {
-          try {
-            const epicFeature = await this.featureLoader.get(projectPath, feature.epicId);
-            if (epicFeature?.branchName) {
-              // Verify the epic branch exists before using it as base
-              await execAsync(`git rev-parse --verify "${epicFeature.branchName}"`, {
-                cwd: projectPath,
-              });
-              baseBranch = epicFeature.branchName;
-              logger.info(
-                `Feature ${feature.id} belongs to epic, branching from epic branch: ${baseBranch}`
+      try {
+        if (branchExists) {
+          // Use existing branch
+          await execAsync(`git worktree add "${worktreePath}" "${branchName}"`, {
+            cwd: projectPath,
+            env: gitEnv,
+          });
+        } else {
+          // Determine base branch: use epic branch if feature belongs to an epic,
+          // otherwise use the project's configured prBaseBranch as the canonical base
+          // (never HEAD which would inherit whatever branch is currently checked out in the main repo).
+          const resolvedPrBaseBranch = await getEffectivePrBaseBranch(
+            projectPath,
+            this.settingsService,
+            '[createWorktreeForBranch]'
+          );
+          let baseBranch = `origin/${resolvedPrBaseBranch}`;
+          if (feature?.epicId && !feature.isEpic) {
+            try {
+              const epicFeature = await this.featureLoader.get(projectPath, feature.epicId);
+              if (epicFeature?.branchName) {
+                // Verify the epic branch exists before using it as base
+                await execAsync(`git rev-parse --verify "${epicFeature.branchName}"`, {
+                  cwd: projectPath,
+                });
+                baseBranch = epicFeature.branchName;
+                logger.info(
+                  `Feature ${feature.id} belongs to epic, branching from epic branch: ${baseBranch}`
+                );
+              }
+            } catch {
+              logger.warn(
+                `Epic branch not found for feature ${feature.id} (epicId: ${feature.epicId}), falling back to HEAD`
               );
             }
-          } catch {
-            logger.warn(
-              `Epic branch not found for feature ${feature.id} (epicId: ${feature.epicId}), falling back to HEAD`
+          }
+
+          // Create new branch from base (epic branch or HEAD)
+          await execAsync(`git worktree add -b "${branchName}" "${worktreePath}" ${baseBranch}`, {
+            cwd: projectPath,
+            env: gitEnv,
+          });
+        }
+      } catch (worktreeAddError) {
+        // Post-failure cleanup: remove partially-created directory to prevent permanent blocking
+        if (fs.existsSync(worktreePath)) {
+          logger.warn(
+            `Cleaning up partial worktree directory after failed creation: ${worktreePath}`
+          );
+          try {
+            await fs.promises.rm(worktreePath, { recursive: true, force: true });
+          } catch (cleanupErr) {
+            logger.error(
+              `Failed to clean up partial worktree directory: ${worktreePath}`,
+              cleanupErr
             );
           }
         }
-
-        // Create new branch from base (epic branch or HEAD)
-        await execAsync(`git worktree add -b "${branchName}" "${worktreePath}" ${baseBranch}`, {
-          cwd: projectPath,
-          env: gitEnv,
-        });
+        throw worktreeAddError;
       }
 
       logger.info(`Created worktree for branch "${branchName}" at: ${worktreePath}`);

--- a/apps/server/src/services/auto-mode/post-execution-middleware.ts
+++ b/apps/server/src/services/auto-mode/post-execution-middleware.ts
@@ -13,6 +13,7 @@
  *   [PostExecution] <featureId>: <step description>
  */
 
+import fs from 'node:fs';
 import path from 'path';
 import { createLogger } from '@protolabsai/utils';
 import type { Feature } from '@protolabsai/types';
@@ -309,6 +310,32 @@ export class PostExecutionMiddleware {
         await removeLock(worktreePath);
       } catch (lockError) {
         logger.error(`[PostExecution] ${featureId}: failed to remove worktree lock:`, lockError);
+      }
+    }
+
+    // -------------------------------------------------------------------------
+    // Step 3.5: Remove incomplete worktree directories
+    // If an agent was aborted mid-creation (or the worktree add command failed
+    // silently), the directory may exist without a .git file. This partial
+    // directory permanently blocks future worktree creation for the feature.
+    // Clean it up so retries can succeed.
+    // -------------------------------------------------------------------------
+    if (
+      worktreePath &&
+      fs.existsSync(worktreePath) &&
+      !fs.existsSync(path.join(worktreePath, '.git'))
+    ) {
+      logger.warn(
+        `[PostExecution] ${featureId}: removing incomplete worktree directory (no .git file): ${worktreePath}`
+      );
+      try {
+        await fs.promises.rm(worktreePath, { recursive: true, force: true });
+        logger.info(`[PostExecution] ${featureId}: incomplete worktree directory removed`);
+      } catch (rmError) {
+        logger.error(
+          `[PostExecution] ${featureId}: failed to remove incomplete worktree directory:`,
+          rmError
+        );
       }
     }
 


### PR DESCRIPTION
## Summary

**Bug: Partial worktree directories left on disk after failed creation or agent abort, permanently blocking the feature.**

## Root Cause

When worktree creation fails partway through (or an agent is aborted mid-execution), the partially-created worktree directory is left on disk. The directory contains partial files (e.g. apps/) but no .git file, so git does not recognize it as a worktree. Every subsequent retry detects the directory exists, attempts worktree creation, fails, and blocks the fea...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced worktree creation error handling with automatic cleanup of incomplete operations, enabling failed attempts to be cleaned up and retried.
  * Improved detection and removal of orphaned directories from initialization failures.
  * Strengthened post-execution cleanup to more effectively remove incomplete worktree directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->