### PR TITLE
Promote dev to staging — docs dead link fix

### DIFF
--- a/docs/guides/ava-autonomy.md
+++ b/docs/guides/ava-autonomy.md
@@ -217,5 +217,5 @@ If alerts are firing repeatedly, check `/api/ava/status` for `circuitBreaker.isO
 
 ## Next steps
 
-- **[Timer Registry](../internal/server/timer-registry.md)** — View and control scheduled tasks from the Ops Dashboard
-- **[Ava Chat System](../internal/server/ava-chat.md)** — Architecture reference for all Ava tool groups
+- **Timer Registry** — View and control scheduled tasks from the Ops Dashboard (internal docs: `docs/internal/server/timer-registry.md`)
+- **Ava Chat System** — Architecture reference for all Ava tool groups (internal docs: `docs/internal/server/ava-chat.md`)


### PR DESCRIPTION
Fix dead internal doc links in ava-autonomy guide that broke VitePress build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed internal navigation links in the autonomy guide to provide clearer access to related documentation resources for Timer Registry and Ava Chat System configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->