### PR TITLE
Promote dev to staging — orphan spam fix + alert batching

### DIFF
--- a/apps/server/src/services/ava-gateway-service.ts
+++ b/apps/server/src/services/ava-gateway-service.ts
@@ -838,8 +838,34 @@ export class AvaGatewayService {
         const duration = Date.now() - startTime;
         logger.info(`Heartbeat identified ${result.alerts.length} alert(s) (${duration}ms)`);
 
+        // Batch alerts by type to avoid Discord spam. If 3+ alerts share the same
+        // title prefix, consolidate into a single message with a count.
+        const alertsByType = new Map<string, HeartbeatAlert[]>();
         for (const alert of result.alerts) {
-          await this.postToDiscord(alert);
+          const key = alert.title.replace(/:.*/s, '').trim();
+          const group = alertsByType.get(key) ?? [];
+          group.push(alert);
+          alertsByType.set(key, group);
+        }
+
+        for (const [type, alerts] of alertsByType) {
+          if (alerts.length >= 3) {
+            // Consolidate: post a single summary instead of N individual messages
+            await this.postToDiscord({
+              severity: alerts[0].severity,
+              title: `${type} (${alerts.length} issues)`,
+              description:
+                alerts
+                  .slice(0, 5)
+                  .map((a) => `- ${a.description}`)
+                  .join('\n') + (alerts.length > 5 ? `\n- ... and ${alerts.length - 5} more` : ''),
+              suggestedAction: alerts[0].suggestedAction,
+            });
+          } else {
+            for (const alert of alerts) {
+              await this.postToDiscord(alert);
+            }
+          }
         }
 
         if (this.events) {

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -1102,7 +1102,8 @@ export class FeatureLoader implements FeatureStore {
     preloadedFeatures?: Feature[]
   ): Promise<Feature[]> {
     const features = preloadedFeatures ?? (await this.getAll(projectPath));
-    const featuresWithBranch = features.filter((f) => f.branchName);
+    // Skip done features — branch deletion after PR merge is normal, not an orphan.
+    const featuresWithBranch = features.filter((f) => f.branchName && f.status !== 'done');
 
     if (featuresWithBranch.length === 0) {
       return [];


### PR DESCRIPTION
Fixes gateway Discord spam: skip done features in orphan detection, batch 3+ alerts of same type into single message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alert messages are now consolidated when multiple alerts of the same type are detected, combining them into a single notification with a summary and condensed details.

* **Bug Fixes**
  * Completed features are no longer incorrectly flagged as orphaned when their branches are deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->