### PR TITLE
Lead engineer retries features with merged PRs, creating duplicate PRs

### DIFF
--- a/apps/server/src/services/lead-engineer-action-executor.ts
+++ b/apps/server/src/services/lead-engineer-action-executor.ts
@@ -100,6 +100,30 @@ export class ActionExecutor {
 
       case 'reset_feature': {
         try {
+          // Before resetting to backlog, check if the feature's branch already has a merged PR.
+          // This prevents zombie retry loops on already-merged work (e.g. feature manually set to
+          // done after merge, but failureClassification.retryable causes classifiedRecovery to keep
+          // resetting it back to backlog and spawning new agents).
+          const featureSnap = session.worldState.features[action.featureId];
+          if (featureSnap?.branchName) {
+            const mergedPR = await this.checkBranchMergedPR(
+              featureSnap.branchName,
+              session.projectPath
+            );
+            if (mergedPR) {
+              await this.deps.featureLoader.update(session.projectPath, action.featureId, {
+                status: 'done',
+                prMergedAt: mergedPR.mergedAt,
+                ...(!featureSnap.prNumber ? { prNumber: mergedPR.number } : {}),
+              });
+              logger.info(
+                `reset_feature skipped for ${action.featureId}: branch "${featureSnap.branchName}" ` +
+                  `has merged PR #${mergedPR.number} — marked done instead of retrying`
+              );
+              break;
+            }
+          }
+
           await this.deps.featureLoader.update(session.projectPath, action.featureId, {
             status: 'backlog',
           });
@@ -459,6 +483,31 @@ export class ActionExecutor {
       this.executeAction(session, action).catch((err) => {
         logger.error(`Action execution failed (${action.type}):`, err);
       });
+    }
+  }
+
+  /**
+   * Check if the given branch has a merged PR on GitHub.
+   * Queries by branch name (head), not by prNumber, so it works even when the
+   * feature's prNumber has been overwritten by a newer PR creation.
+   * Returns the first merged PR found, or null if none / on error (fail-open).
+   */
+  private async checkBranchMergedPR(
+    branchName: string,
+    projectPath: string
+  ): Promise<{ number: number; mergedAt: string } | null> {
+    try {
+      const { stdout } = await execAsync(
+        `gh pr list --head "${branchName}" --state merged --json number,mergedAt --limit 1`,
+        { cwd: projectPath, timeout: 15000 }
+      );
+      const trimmed = stdout.trim();
+      if (!trimmed || trimmed === '[]' || trimmed === 'null') return null;
+      const prs = JSON.parse(trimmed) as Array<{ number: number; mergedAt: string }>;
+      return prs.length > 0 ? (prs[0] ?? null) : null;
+    } catch {
+      // Fail-open: if the GitHub check fails, proceed with normal reset
+      return null;
     }
   }
 }

--- a/apps/server/tests/unit/services/lead-engineer-action-executor.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-action-executor.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { exec } from 'node:child_process';
 import type { LeadEngineerSession, PolicyDecision, WorkflowSettings } from '@protolabsai/types';
 import { ActionExecutor } from '@/services/lead-engineer-action-executor.js';
 import type { ActionExecutorDeps } from '@/services/lead-engineer-action-executor.js';
@@ -319,5 +320,242 @@ describe('ActionExecutor — authority service failure (fail-open)', () => {
     // On authority service error, fail-open: action proceeds
     expect(deps.featureLoader.update).toHaveBeenCalled();
     expect(session.actionsTaken).toBe(1);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests: reset_feature merged PR guard
+// Verifies that reset_feature marks the feature done (instead of backlog)
+// when the feature's branch already has a merged PR on GitHub.
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('ActionExecutor — reset_feature merged PR guard', () => {
+  beforeEach(() => {
+    vi.mocked(exec).mockReset();
+  });
+
+  it('marks feature done when branch has a merged PR', async () => {
+    // Arrange: exec returns a merged PR for the branch
+    vi.mocked(exec).mockResolvedValue({
+      stdout: '[{"number":111,"mergedAt":"2026-03-21T09:03:43Z"}]',
+      stderr: '',
+    } as unknown as ReturnType<typeof exec>);
+
+    const deps = createDeps();
+    const executor = new ActionExecutor(deps);
+    const session = createMockSession({
+      worldState: {
+        projectPath: '/test/project',
+        projectSlug: 'test-project',
+        updatedAt: new Date().toISOString(),
+        boardCounts: { backlog: 0, in_progress: 0, review: 0, done: 0, blocked: 0 },
+        features: {
+          'feat-merged': {
+            id: 'feat-merged',
+            status: 'blocked',
+            branchName: 'feature/install-serwist',
+          },
+        },
+        agents: [],
+        openPRs: [],
+        milestones: [],
+        metrics: { totalFeatures: 1, completedFeatures: 0, totalCostUsd: 0 },
+        autoModeRunning: false,
+        maxConcurrency: 3,
+      },
+    });
+
+    await executor.executeAction(session, {
+      type: 'reset_feature',
+      featureId: 'feat-merged',
+      reason: 'Auto-retry: flaky test',
+    });
+
+    // Should mark done, not backlog
+    expect(deps.featureLoader.update).toHaveBeenCalledWith('/test/project', 'feat-merged', {
+      status: 'done',
+      prMergedAt: '2026-03-21T09:03:43Z',
+      prNumber: 111,
+    });
+    // Should NOT emit escalation:signal-received (feature_reset)
+    const emitCalls = vi.mocked(deps.events.emit).mock.calls;
+    const resetEmitted = emitCalls.some(
+      ([eventType, payload]) =>
+        eventType === 'escalation:signal-received' &&
+        (payload as Record<string, unknown>).type === 'feature_reset'
+    );
+    expect(resetEmitted).toBe(false);
+  });
+
+  it('does not overwrite existing prNumber when marking done', async () => {
+    vi.mocked(exec).mockResolvedValue({
+      stdout: '[{"number":113,"mergedAt":"2026-03-21T10:00:00Z"}]',
+      stderr: '',
+    } as unknown as ReturnType<typeof exec>);
+
+    const deps = createDeps();
+    const executor = new ActionExecutor(deps);
+    const session = createMockSession({
+      worldState: {
+        projectPath: '/test/project',
+        projectSlug: 'test-project',
+        updatedAt: new Date().toISOString(),
+        boardCounts: { backlog: 0, in_progress: 0, review: 0, done: 0, blocked: 0 },
+        features: {
+          'feat-has-pr': {
+            id: 'feat-has-pr',
+            status: 'blocked',
+            branchName: 'feature/my-feature',
+            prNumber: 111, // already has a prNumber — should not be overwritten
+          },
+        },
+        agents: [],
+        openPRs: [],
+        milestones: [],
+        metrics: { totalFeatures: 1, completedFeatures: 0, totalCostUsd: 0 },
+        autoModeRunning: false,
+        maxConcurrency: 3,
+      },
+    });
+
+    await executor.executeAction(session, {
+      type: 'reset_feature',
+      featureId: 'feat-has-pr',
+      reason: 'Auto-retry',
+    });
+
+    // prNumber already set — should not be overwritten
+    expect(deps.featureLoader.update).toHaveBeenCalledWith('/test/project', 'feat-has-pr', {
+      status: 'done',
+      prMergedAt: '2026-03-21T10:00:00Z',
+    });
+  });
+
+  it('resets to backlog normally when branch has no merged PR', async () => {
+    // Arrange: exec returns empty array (no merged PR)
+    vi.mocked(exec).mockResolvedValue({
+      stdout: '[]',
+      stderr: '',
+    } as unknown as ReturnType<typeof exec>);
+
+    const deps = createDeps();
+    const executor = new ActionExecutor(deps);
+    const session = createMockSession({
+      worldState: {
+        projectPath: '/test/project',
+        projectSlug: 'test-project',
+        updatedAt: new Date().toISOString(),
+        boardCounts: { backlog: 0, in_progress: 0, review: 0, done: 0, blocked: 0 },
+        features: {
+          'feat-no-pr': {
+            id: 'feat-no-pr',
+            status: 'blocked',
+            branchName: 'feature/not-merged',
+          },
+        },
+        agents: [],
+        openPRs: [],
+        milestones: [],
+        metrics: { totalFeatures: 1, completedFeatures: 0, totalCostUsd: 0 },
+        autoModeRunning: false,
+        maxConcurrency: 3,
+      },
+    });
+
+    await executor.executeAction(session, {
+      type: 'reset_feature',
+      featureId: 'feat-no-pr',
+      reason: 'Auto-retry: flaky test',
+    });
+
+    // Should reset to backlog as usual
+    expect(deps.featureLoader.update).toHaveBeenCalledWith('/test/project', 'feat-no-pr', {
+      status: 'backlog',
+    });
+    // Should emit feature_reset escalation signal
+    const emitCalls = vi.mocked(deps.events.emit).mock.calls;
+    const resetEmitted = emitCalls.some(
+      ([eventType, payload]) =>
+        eventType === 'escalation:signal-received' &&
+        (payload as Record<string, unknown>).type === 'feature_reset'
+    );
+    expect(resetEmitted).toBe(true);
+  });
+
+  it('resets to backlog normally when feature has no branchName', async () => {
+    // exec should NOT be called when there is no branchName
+    const deps = createDeps();
+    const executor = new ActionExecutor(deps);
+    const session = createMockSession({
+      worldState: {
+        projectPath: '/test/project',
+        projectSlug: 'test-project',
+        updatedAt: new Date().toISOString(),
+        boardCounts: { backlog: 0, in_progress: 0, review: 0, done: 0, blocked: 0 },
+        features: {
+          'feat-no-branch': {
+            id: 'feat-no-branch',
+            status: 'blocked',
+            // no branchName
+          },
+        },
+        agents: [],
+        openPRs: [],
+        milestones: [],
+        metrics: { totalFeatures: 1, completedFeatures: 0, totalCostUsd: 0 },
+        autoModeRunning: false,
+        maxConcurrency: 3,
+      },
+    });
+
+    await executor.executeAction(session, {
+      type: 'reset_feature',
+      featureId: 'feat-no-branch',
+      reason: 'Auto-retry',
+    });
+
+    expect(vi.mocked(exec)).not.toHaveBeenCalled();
+    expect(deps.featureLoader.update).toHaveBeenCalledWith('/test/project', 'feat-no-branch', {
+      status: 'backlog',
+    });
+  });
+
+  it('resets to backlog (fail-open) when GitHub check throws', async () => {
+    vi.mocked(exec).mockRejectedValue(new Error('gh: not authenticated'));
+
+    const deps = createDeps();
+    const executor = new ActionExecutor(deps);
+    const session = createMockSession({
+      worldState: {
+        projectPath: '/test/project',
+        projectSlug: 'test-project',
+        updatedAt: new Date().toISOString(),
+        boardCounts: { backlog: 0, in_progress: 0, review: 0, done: 0, blocked: 0 },
+        features: {
+          'feat-gh-fail': {
+            id: 'feat-gh-fail',
+            status: 'blocked',
+            branchName: 'feature/something',
+          },
+        },
+        agents: [],
+        openPRs: [],
+        milestones: [],
+        metrics: { totalFeatures: 1, completedFeatures: 0, totalCostUsd: 0 },
+        autoModeRunning: false,
+        maxConcurrency: 3,
+      },
+    });
+
+    await executor.executeAction(session, {
+      type: 'reset_feature',
+      featureId: 'feat-gh-fail',
+      reason: 'Auto-retry',
+    });
+
+    // On gh check failure, fail-open: reset to backlog
+    expect(deps.featureLoader.update).toHaveBeenCalledWith('/test/project', 'feat-gh-fail', {
+      status: 'backlog',
+    });
   });
 });


### PR DESCRIPTION
## Summary

**Bug:** The lead engineer review loop keeps restarting agents on features whose PRs are already merged, creating duplicate PRs in the process.

**Observed on mythxengine:** Feature 'Install Serwist and Configure Caching' (feature-1773857462616-ru7txu6p9):
- PR #111 was merged at 2026-03-21T09:03:43Z
- Feature was manually set to 'done'
- Lead engineer reset it back to 'in_progress' and spawned new agents
- A new PR #113 was created for the same feature even though the work is on main
- Agent wa...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-03-21T09:16:25.623Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Features with merged pull requests are now automatically marked as complete, eliminating manual status updates.

* **Tests**
  * Added comprehensive test coverage for merged pull request detection and feature status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->