### PR TITLE
Migrate shell-interpolated git commands to execFileAsync for injection safety

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -2950,7 +2950,7 @@ Format your response as a structured markdown document.`;
       // Check if branch exists
       let branchExists = false;
       try {
-        await execAsync(`git rev-parse --verify "${branchName}"`, {
+        await execFileAsync('git', ['rev-parse', '--verify', branchName], {
           cwd: projectPath,
         });
         branchExists = true;
@@ -2970,7 +2970,7 @@ Format your response as a structured markdown document.`;
       try {
         if (branchExists) {
           // Use existing branch
-          await execAsync(`git worktree add "${worktreePath}" "${branchName}"`, {
+          await execFileAsync('git', ['worktree', 'add', worktreePath, branchName], {
             cwd: projectPath,
             env: gitEnv,
           });
@@ -2989,7 +2989,7 @@ Format your response as a structured markdown document.`;
               const epicFeature = await this.featureLoader.get(projectPath, feature.epicId);
               if (epicFeature?.branchName) {
                 // Verify the epic branch exists before using it as base
-                await execAsync(`git rev-parse --verify "${epicFeature.branchName}"`, {
+                await execFileAsync('git', ['rev-parse', '--verify', epicFeature.branchName], {
                   cwd: projectPath,
                 });
                 baseBranch = epicFeature.branchName;
@@ -3005,10 +3005,14 @@ Format your response as a structured markdown document.`;
           }
 
           // Create new branch from base (epic branch or HEAD)
-          await execAsync(`git worktree add -B "${branchName}" "${worktreePath}" ${baseBranch}`, {
-            cwd: projectPath,
-            env: gitEnv,
-          });
+          await execFileAsync(
+            'git',
+            ['worktree', 'add', '-B', branchName, worktreePath, baseBranch],
+            {
+              cwd: projectPath,
+              env: gitEnv,
+            }
+          );
         }
       } catch (worktreeAddError) {
         // Post-failure cleanup: remove partially-created directory to prevent permanent blocking

--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -863,12 +863,14 @@ export class FeatureScheduler {
       const staleViaPrNumber = allFeatures.filter(
         (f) =>
           f.prNumber &&
+          !openPrNumbers.has(f.prNumber) &&
           (f.status === 'backlog' || f.status === 'blocked' || f.status === 'review') &&
           !alreadyReconciled.has(f.id)
       );
       for (const feature of staleViaPrNumber) {
         try {
           const prNum = String(feature.prNumber).replace(/[^0-9]/g, '');
+          if (!prNum) continue;
           const { stdout: prViewJson } = await execAsync(
             `gh pr view ${prNum} --json state,mergedAt`,
             { cwd: projectPath, timeout: 10000 }

--- a/apps/server/src/services/worktree-lifecycle-service.ts
+++ b/apps/server/src/services/worktree-lifecycle-service.ts
@@ -14,7 +14,7 @@
  */
 
 import path from 'path';
-import { exec, execSync } from 'child_process';
+import { exec, execFile, execSync } from 'child_process';
 import { createLogger } from '@protolabsai/utils';
 import * as secureFs from '../lib/secure-fs.js';
 import type { EventEmitter } from '../lib/events.js';
@@ -531,10 +531,14 @@ export class WorktreeLifecycleService {
     // This returns non-empty output when local HEAD has commits not on the remote.
     let unpushedOutput: string;
     try {
-      const result = await this.execAsync(`git log origin/${branchName}..HEAD --oneline`, {
-        cwd: worktreePath,
-        timeout: 15_000,
-      });
+      const result = await this.execFileAsync(
+        'git',
+        ['log', `origin/${branchName}..HEAD`, '--oneline'],
+        {
+          cwd: worktreePath,
+          timeout: 15_000,
+        }
+      );
       unpushedOutput = result.stdout.trim();
     } catch {
       // Remote tracking branch may not exist yet (brand-new branch that was
@@ -555,7 +559,7 @@ export class WorktreeLifecycleService {
 
     // Attempt push with --no-verify to skip hooks that may fail in worktrees
     try {
-      await this.execAsync(`git push --no-verify -u origin "${branchName}"`, {
+      await this.execFileAsync('git', ['push', '--no-verify', '-u', 'origin', branchName], {
         cwd: worktreePath,
         timeout: 60_000,
       });
@@ -580,6 +584,25 @@ export class WorktreeLifecycleService {
   ): Promise<{ stdout: string; stderr: string }> {
     return new Promise((resolve, reject) => {
       exec(command, options, (error: Error | null, stdout: string, stderr: string) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve({ stdout, stderr });
+        }
+      });
+    });
+  }
+
+  /**
+   * Promisified execFile for argv-based invocation (no shell parsing)
+   */
+  private execFileAsync(
+    file: string,
+    args: string[],
+    options: { cwd: string; timeout: number }
+  ): Promise<{ stdout: string; stderr: string }> {
+    return new Promise((resolve, reject) => {
+      execFile(file, args, options, (error: Error | null, stdout: string, stderr: string) => {
         if (error) {
           reject(error);
         } else {


### PR DESCRIPTION
## Summary

**Security Hardening**

Multiple git commands in server services use `execAsync` with template literal string interpolation, which passes arguments through the shell. While the interpolated values are currently internal (branch names from settings, not user input), this pattern is fragile — a branch name containing shell metacharacters could cause unexpected behavior.

**Affected call sites (from CodeRabbit review on PR #3029):**

1. `apps/server/src/services/auto-mode-service.ts:3008` — `git wo...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Strengthened Git operation reliability and security across worktree and branch management
  * Optimized pull request verification logic to skip unnecessary checks, improving performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->