### PR TITLE
Promote dev to staging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,9 @@ protoLabs Studio is a **platform for building apps**, not just our internal tool
 
 ## Planning & Approach
 
-- When creating plans, start with the minimal viable scope. Do NOT propose multi-phase plans unless explicitly asked. Default to the smallest, lowest-risk approach first.
-- Do not exit plan mode or transition away from planning until the user explicitly confirms the plan is complete and approved. Wait for user signal before proceeding to implementation.
-- **Plan completion verification**: Before committing a multi-step plan implementation, run the verification checklist in `.automaker/context/plan-completion-verification.md`. CI catches broken code but NOT unwired code — a service with passing tests can be completely disconnected from the runtime. Every new file must have a non-test importer. Every new service must have an integration test covering its wiring point.
+- When creating plans, start with the minimal viable scope. Prefer single-phase plans unless explicitly asked for more. Default to the smallest, lowest-risk approach first.
+- Stay in plan mode until the user explicitly confirms the plan is complete and approved. Wait for user signal before proceeding to implementation.
+- **Plan completion verification**: Before committing a multi-step plan implementation, verify wiring is complete. CI catches broken code but NOT unwired code — a service with passing tests can be completely disconnected from the runtime. Every new file must have a non-test importer. Every new service must have an integration test covering its wiring point.
 
 ## Git Workflow
 
@@ -209,9 +209,14 @@ The in-app docs viewer is the interface for internal docs. A page about "how to 
 
 ## Important Guidelines
 
-- **Dev Server Management**: NEVER start, stop, restart, or otherwise manage the dev server yourself. Always ask the user to manage it, or you will break it.
+- **Dev Server Management**: Do not start, stop, restart, or otherwise manage the dev server yourself. Always ask the user to manage it, or you will break it.
+- **Investigate before answering**: Never speculate about code you have not read. Before making claims about what a file contains, what a function does, or what an import path resolves to, read the file first. Before suggesting a fix, verify the current state of the code. This applies to all interactions — chat, implementation, and review.
+- **Admit uncertainty**: If you are unsure about how something works in this codebase, say so and investigate rather than guessing. "I'm not sure — let me check" is always better than a confident but wrong answer.
+- **Use only verified APIs**: Do not rely on general training knowledge about library APIs. Verify imports, function signatures, and module paths by reading the actual source or package.json in this project. Hallucinated imports are a common source of agent failures.
 - **Document as you build**: When adding or changing a feature, update the relevant docs in `docs/`. New services get a page in the appropriate section. New config options get added to env var tables. API changes get reflected in the server reference. Follow the rules in `docs/dev/docs-standard.md` — every page must belong to a sidebar section, use `kebab-case.md` naming, and stay under 800 lines. If no appropriate section exists, add the page to the closest match rather than creating a new root-level file.
 - **No emojis in docs or code**: Do not use emojis anywhere in documentation, markdown files, comments, or code. The only exceptions are ✅ and ❌ when used as status indicators in documentation tables or checklists.
+- **Context window management**: Your context window will be automatically compacted as it approaches its limit. Do not stop tasks early due to token budget concerns. Save progress to git commits before context refreshes. Always be persistent and complete tasks fully.
+- **Subagent usage**: Use subagents when tasks can run in parallel, require isolated context, or involve independent workstreams. For simple tasks, sequential operations, or single-file edits, work directly rather than delegating.
 
 ## Common Commands
 

--- a/apps/server/tests/unit/services/auto-mode-service-planning.test.ts
+++ b/apps/server/tests/unit/services/auto-mode-service-planning.test.ts
@@ -99,14 +99,14 @@ describe('auto-mode-service.ts - Planning Mode', () => {
       expect(result).toContain('## Feature Request');
     });
 
-    it('should instruct agent to NOT output exploration text', async () => {
+    it('should instruct agent to start directly with the format', async () => {
       const modes = ['lite', 'spec', 'full'] as const;
       for (const mode of modes) {
         const feature = { id: 'test', planningMode: mode };
         const result = await getPlanningPromptPrefix(service, feature);
-        // All modes should have the IMPORTANT instruction about not outputting exploration text
-        expect(result).toContain('IMPORTANT: Do NOT output exploration text');
-        expect(result).toContain('Silently analyze the codebase first');
+        // All modes should instruct the agent to start directly with the structured format
+        expect(result).toContain('Start directly with the');
+        expect(result).toContain('Analyze the codebase silently first');
       }
     });
   });

--- a/libs/prompts/src/defaults.ts
+++ b/libs/prompts/src/defaults.ts
@@ -34,7 +34,7 @@ import { STATIC_PORT, SERVER_PORT } from '@protolabsai/types';
 
 export const DEFAULT_AUTO_MODE_PLANNING_LITE = `## Planning Phase (Lite Mode)
 
-IMPORTANT: Do NOT output exploration text, tool usage, or thinking before the plan. Start DIRECTLY with the planning outline format below. Silently analyze the codebase first, then output ONLY the structured plan.
+Start directly with the planning outline format below. Analyze the codebase silently first, then output the structured plan.
 
 Create a brief planning outline:
 
@@ -52,7 +52,7 @@ Then proceed with implementation.
 
 export const DEFAULT_AUTO_MODE_PLANNING_LITE_WITH_APPROVAL = `## Planning Phase (Lite Mode)
 
-IMPORTANT: Do NOT output exploration text, tool usage, or thinking before the plan. Start DIRECTLY with the planning outline format below. Silently analyze the codebase first, then output ONLY the structured plan.
+Start directly with the planning outline format below. Analyze the codebase silently first, then output the structured plan.
 
 Create a brief planning outline:
 
@@ -70,11 +70,13 @@ DO NOT proceed with implementation until you receive explicit approval.
 
 export const DEFAULT_AUTO_MODE_PLANNING_SPEC = `## Specification Phase (Spec Mode)
 
-IMPORTANT: Do NOT output exploration text, tool usage, or thinking before the spec. Start DIRECTLY with the specification format below. Silently analyze the codebase first, then output ONLY the structured specification.
+Start directly with the specification format below. Analyze the codebase silently first, then output the structured specification.
 
 **Before planning:** Check status.md at project root for current priorities and context.
 
-Generate a specification with an actionable task breakdown. WAIT for approval before implementing.
+**Grounding requirement:** Before writing the spec, read the files you plan to modify. Extract the relevant function signatures, type definitions, and patterns you will reference. Base your specification on what the code actually contains, not assumptions about what it should contain.
+
+Generate a specification with an actionable task breakdown. Wait for approval before implementing.
 
 ### Specification Format
 
@@ -126,7 +128,7 @@ This allows real-time progress tracking during implementation.
 
 export const DEFAULT_AUTO_MODE_PLANNING_FULL = `## Full Specification Phase (Full SDD Mode)
 
-IMPORTANT: Do NOT output exploration text, tool usage, or thinking before the spec. Start DIRECTLY with the specification format below. Silently analyze the codebase first, then output ONLY the structured specification.
+Start directly with the specification format below. Analyze the codebase silently first, then output the structured specification.
 
 Generate a comprehensive specification with phased task breakdown. WAIT for approval before implementing.
 
@@ -914,27 +916,47 @@ Begin implementing task {{taskId}} now.`;
 
 export const DEFAULT_IMPLEMENTATION_INSTRUCTIONS = `## Instructions
 
+<investigate_before_answering>
+Never speculate about code you have not opened. Before making any changes to a file, you
+MUST read that file first. Before importing a module, verify the import path exists by
+reading the source or checking package.json. Before calling a function, verify its signature
+by reading its definition. Never make claims about code you have not investigated.
+</investigate_before_answering>
+
+<external_knowledge_restriction>
+Only use information from files you have read in this session and the feature description.
+Do not rely on general knowledge about libraries or APIs — verify by reading the actual
+source files, package.json, or installed node_modules. If an import path or API looks
+correct based on your training data but you have not verified it exists in this project,
+check before using it.
+</external_knowledge_restriction>
+
 Implement this feature by:
-1. Read the feature description carefully - identify the specific files to create or modify
-2. Read ONLY those files (2-4 files max) to understand the existing patterns
-3. Write the code changes
+1. Read the feature description carefully — identify the specific files to create or modify
+2. Read those files to understand existing patterns and verify import paths
+3. Write the code changes, using only verified APIs and imports
 4. Build and verify the changes compile
 
-**CRITICAL: Scope Discipline**
-- Implement EXACTLY what the feature description says. Nothing more.
-- If the description says "create ServiceX", create ONLY ServiceX. Do NOT create routes, modify index.ts, or wire it into the server unless the description explicitly asks.
-- Other features in the backlog will handle remaining integration work. Over-delivering causes merge conflicts and blocks other agents working on those features.
-- When in doubt, do LESS, not more.
+**Scope Discipline**
+- Implement exactly what the feature description says — nothing more
+- If the description says "create ServiceX", create only ServiceX. Do not create routes, modify index.ts, or wire it into the server unless the description explicitly asks
+- Other features in the backlog handle remaining integration work. Over-delivering causes merge conflicts and blocks other agents
+- When in doubt, do less, not more
 
-**CRITICAL: Turn Budget**
-- Do NOT spend more than 20% of your turns reading/exploring code
-- If you're still reading files after 8 turns, you're behind schedule
-- Do NOT try to understand the entire codebase - focus only on files relevant to your task
+**Turn Budget**
+- Spend no more than 20% of your turns reading/exploring code
+- If you are still reading files after 8 turns, you are behind schedule
+- Focus only on files relevant to your task
 
-**Risk Awareness:**
-- Flag unclear requirements immediately rather than guessing
-- If a task is taking longer than expected, assess why and document
-- If you encounter a blocker, stop and report it clearly
+**Uncertainty and Blockers**
+- If the feature description is ambiguous or lacks necessary information, say "I don't have enough information to confidently implement this" and flag it as a blocker — do not guess
+- If you are unsure whether a function exists or an API works a certain way, read the source to verify before using it
+- If you encounter a blocker, stop and report it clearly rather than making speculative changes
+
+**Commit to an Approach**
+- When deciding how to approach a problem, choose one approach and commit to it
+- Avoid revisiting decisions unless you encounter new information that directly contradicts your reasoning
+- If weighing two approaches, pick one and see it through — you can course-correct later if it fails
 
 **Self-Review (Before Verification)**
 After completing your implementation, review your own work before running verification gates:
@@ -947,9 +969,9 @@ After completing your implementation, review your own work before running verifi
 **Skill Creation:**
 If you discover a reusable pattern during implementation, consider creating a skill file at \`.automaker/skills/{name}.md\`. Good candidates: project-specific build patterns, common error fixes, integration techniques. See the skill format in the system prompt.
 
-## Verification Gates (MANDATORY)
+## Verification Gates
 
-Before writing your summary, you MUST complete ALL of these:
+Before writing your summary, complete all of these:
 
 1. Run \`npm run build:server\` (or the appropriate build command) and verify exit code 0
 2. Run tests if any exist for the modified files
@@ -957,21 +979,23 @@ Before writing your summary, you MUST complete ALL of these:
 4. If you claim "tests pass" — paste the actual test output
 5. If you claim "build succeeds" — paste the actual build output
 
-DO NOT write your summary until all gates pass. If a gate fails, fix the issue first.
+Do not write your summary until all gates pass. If a gate fails, fix the issue first.
 
 ## When Stuck
 
 If you have attempted 3+ fixes for the same error:
-- STOP attempting more fixes
+- Stop attempting more fixes
 - Document what you tried and what happened each time
 - Report this in your summary as a blocker
-- Do NOT continue making speculative changes
+- Do not continue making speculative changes
 
-## Red Flags — STOP if you catch yourself thinking:
-- "This should work" (without running it)
-- "I'm confident this is correct" (confidence is not evidence)
-- "The build will pass" (run it and prove it)
-- "I'll skip verification since the change is small" (small changes need verification too)
+**No-progress detection:** If you notice yourself re-reading the same files, re-running the same commands, or restating your plan without making forward progress, stop and escalate. These are signs you need a different approach or human input, not more iterations of the same approach.
+
+## Red Flags — Stop if you catch yourself:
+- Assuming code works without running it
+- Feeling confident without evidence (confidence is not evidence)
+- Predicting a build will pass without running it
+- Skipping verification because the change seems small
 
 When done, wrap your final summary in <summary> tags like this:
 
@@ -984,14 +1008,18 @@ When done, wrap your final summary in <summary> tags like this:
 ### Files Modified
 - [List of files]
 
+### Verification Results
+- Build: [pass/fail with output excerpt]
+- Tests: [pass/fail/skipped with output excerpt]
+
 ### Risks/Blockers Encountered
 - [Any issues that came up and how they were resolved]
 
 ### Learnings
 - [Key decisions made and why - useful for future similar work]
 
-### Notes for Developer
-- [Any important notes]
+### Needs Human Input (if any)
+- [Decisions you could not make autonomously, or blockers requiring human intervention]
 </summary>
 
 This helps parse your summary correctly in the output logs.`;


### PR DESCRIPTION
## Summary
- Hallucination reduction prompts (investigate-before-answering, external knowledge restriction)
- CLAUDE.md improvements (admit uncertainty, verified APIs, context window management, subagent guidance)
- Toned down aggressive prompt language for Opus 4.6 compatibility
- Version bump to v0.83.5 (changelogs)

## Test plan
- [x] 3008/3008 server tests pass
- [x] All 18 packages build clean
- [x] Prompt-only changes — no runtime code logic affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined AI planning and execution guidance with improved instructions for code investigation and verification processes.

* **Tests**
  * Updated planning mode unit tests to validate prompt directives across different configuration modes.

* **Refactor**
  * Enhanced auto-mode prompt instructions for improved planning, specification generation, and task execution with clearer verification and uncertainty handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->