### PR TITLE
Promote dev to staging (Ava tool group fix)

### DIFF
--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -162,7 +162,7 @@ export interface AvaToolsConfig {
   delegateToPm?: boolean;
   /** Enable delegation tool group (delegate_to_pm) — preferred alias for delegateToPm */
   delegation?: boolean;
-  /** Enable scheduling tools (list_timers, pause_timer, resume_timer) */
+  /** Enable scheduling tools (schedule_task, cancel_task, list_scheduled_tasks, trigger_task) */
   scheduling?: boolean;
   /** Enable memory tools (remember, recall, forget) */
   memory?: boolean;

--- a/apps/ui/src/components/views/chat-overlay/ava-settings-panel.tsx
+++ b/apps/ui/src/components/views/chat-overlay/ava-settings-panel.tsx
@@ -65,6 +65,11 @@ const TOOL_GROUP_ENTRIES: Array<{
   { key: 'contextFiles', label: 'Context Files', description: 'Manage agent context files' },
   { key: 'projects', label: 'Projects', description: 'List, view, and create projects' },
   { key: 'briefing', label: 'Briefing', description: 'Daily briefing and event digest' },
+  { key: 'discord', label: 'Discord', description: 'Send messages to Discord channels' },
+  { key: 'health', label: 'Health', description: 'Health monitoring and diagnostics' },
+  { key: 'settings', label: 'Settings', description: 'Access and modify global settings' },
+  { key: 'delegation', label: 'Delegation', description: 'Delegate tasks to PM agent' },
+  { key: 'scheduling', label: 'Scheduling', description: 'Create and manage recurring tasks' },
   { key: 'memory', label: 'Memory', description: 'Persistent memory across chat sessions' },
 ];
 

--- a/apps/ui/src/lib/clients/ava-client.ts
+++ b/apps/ui/src/lib/clients/ava-client.ts
@@ -23,6 +23,10 @@ export interface AvaToolGroups {
   contextFiles: boolean;
   projects: boolean;
   briefing: boolean;
+  discord: boolean;
+  health: boolean;
+  settings: boolean;
+  delegation: boolean;
   scheduling: boolean;
   memory: boolean;
 }


### PR DESCRIPTION
## Summary
- Add missing Ava tool group toggles (discord, health, settings, delegation, scheduling) to settings panel
- Fix stale JSDoc on scheduling config field

## Test plan
- [x] Full typecheck passes (21/21)
- [x] Server builds clean
- [x] Lint-staged passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added five new tool capabilities (Discord, Health, Settings, Delegation, and Scheduling) to the chat settings panel, now available as toggleable options in the Capabilities section.

* **Documentation**
  * Updated scheduling tool documentation to reflect current capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->