### PR TITLE
Bug: Stale scheduler task 'Auto-Merge Eligible PRs' references removed flow

### DIFF
--- a/apps/server/src/services/automation-service.ts
+++ b/apps/server/src/services/automation-service.ts
@@ -616,7 +616,45 @@ export class AutomationService {
       enabled: true,
     });
 
+    // Cleanup: remove persisted maintenance:* automations whose flowId is no longer registered.
+    // This handles cases where a built-in flow is removed from code but the persisted record
+    // and its scheduler task remain, causing recurring "Flow not registered" errors.
+    await this.purgeStaleBuiltIns();
+
     logger.info('Built-in automation records seeded');
+  }
+
+  /**
+   * Remove any persisted `maintenance:*` automation records whose flowId is not registered
+   * in the flow registry, and unregister their corresponding scheduler tasks.
+   * Called at the end of seedBuiltInAutomations() to clean up stale records left behind
+   * when built-in flows are removed from code.
+   */
+  private async purgeStaleBuiltIns(): Promise<void> {
+    const automations = await this.readAutomations();
+    const stale = automations.filter(
+      (a) => a.id.startsWith('maintenance:') && !flowRegistry.has(a.flowId)
+    );
+
+    if (stale.length === 0) return;
+
+    const staleIds = new Set(stale.map((a) => a.id));
+    const pruned = automations.filter((a) => !staleIds.has(a.id));
+    await this.writeAutomations(pruned);
+
+    for (const automation of stale) {
+      const taskId = `${AUTOMATION_TASK_PREFIX}${automation.id}`;
+      try {
+        await this.schedulerService.unregisterTask(taskId);
+      } catch {
+        // Task may not be registered — ignore
+      }
+      logger.warn(
+        `Purged stale built-in automation "${automation.name}" (${automation.id}): flow "${automation.flowId}" is no longer registered`
+      );
+    }
+
+    logger.info(`Purged ${stale.length} stale built-in automation(s) with unregistered flows`);
   }
 
   /**


### PR DESCRIPTION
## Summary

The `built-in:auto-merge-prs` flow was removed from code (Lead Engineer handles merges now), but the persisted scheduler task still references it, causing recurring errors:

```
Error: Flow not registered: built-in:auto-merge-prs
    at AutomationService.executeAutomation (automation-service.ts:339)
```

**Root cause:** `maintenance-tasks.ts` and `automation-service.ts` both have comments confirming removal, but `data/automations.json` and `data/scheduled-tasks.json` still contain the stale `mai...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-03-22T22:10:09.771Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Enhanced automation system maintenance by automatically removing stale automation records during system initialization that no longer have valid external references. This automatic cleanup process prevents unnecessary data accumulation and reduces the potential for system inconsistencies, thereby improving overall platform stability, reliability, and performance while optimizing resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->