### PR TITLE
Remove dead GlobalSettings fields

### DIFF
--- a/apps/server/src/lib/settings-helpers.ts
+++ b/apps/server/src/lib/settings-helpers.ts
@@ -423,7 +423,9 @@ export async function getActiveClaudeApiProfile(
   try {
     const globalSettings = await settingsService.getGlobalSettings();
     const credentials = await settingsService.getCredentials();
-    const profiles = globalSettings.claudeApiProfiles || [];
+    // claudeApiProfiles was removed from GlobalSettings; access raw data for legacy migration
+    const rawGlobal = globalSettings as unknown as Record<string, unknown>;
+    const profiles = (rawGlobal.claudeApiProfiles as ClaudeApiProfile[] | undefined) || [];
 
     // Check for project-level override first
     let activeProfileId: string | null | undefined;
@@ -439,8 +441,9 @@ export async function getActiveClaudeApiProfile(
     }
 
     // Fall back to global if project doesn't specify
+    // activeClaudeApiProfileId was removed from GlobalSettings; access raw data for legacy migration
     if (activeProfileId === undefined && !isProjectOverride) {
-      activeProfileId = globalSettings.activeClaudeApiProfileId;
+      activeProfileId = rawGlobal.activeClaudeApiProfileId as string | null | undefined;
     }
 
     // No active profile selected - use direct Anthropic API

--- a/apps/server/src/services/settings-service.ts
+++ b/apps/server/src/services/settings-service.ts
@@ -215,12 +215,16 @@ export class SettingsService {
     // Migration v4 -> v5: Auto-create "Direct Anthropic" profile for existing users
     // If user has an Anthropic API key in credentials but no profiles, create a
     // "Direct Anthropic" profile that references the credentials and set it as active.
+    // NOTE: claudeApiProfiles/activeClaudeApiProfileId removed from GlobalSettings interface;
+    // access raw disk data via type cast for migration purposes only.
+    const raw = result as unknown as Record<string, unknown>;
     if (storedVersion < 5) {
       try {
         const credentials = await this.getCredentials();
         const hasAnthropicKey = !!credentials.apiKeys?.anthropic;
-        const hasNoProfiles = !result.claudeApiProfiles || result.claudeApiProfiles.length === 0;
-        const hasNoActiveProfile = !result.activeClaudeApiProfileId;
+        const legacyProfiles = raw.claudeApiProfiles as ClaudeApiProfile[] | undefined;
+        const hasNoProfiles = !legacyProfiles || legacyProfiles.length === 0;
+        const hasNoActiveProfile = !raw.activeClaudeApiProfileId;
 
         if (hasAnthropicKey && hasNoProfiles && hasNoActiveProfile) {
           const directAnthropicProfile = {
@@ -231,8 +235,8 @@ export class SettingsService {
             useAuthToken: false,
           };
 
-          result.claudeApiProfiles = [directAnthropicProfile];
-          result.activeClaudeApiProfileId = directAnthropicProfile.id;
+          raw.claudeApiProfiles = [directAnthropicProfile];
+          raw.activeClaudeApiProfileId = directAnthropicProfile.id;
 
           logger.info(
             'Migration v4->v5: Created "Direct Anthropic" profile using existing credentials'
@@ -251,7 +255,8 @@ export class SettingsService {
     // The new system uses a models[] array instead of modelMappings, and removes
     // the "active profile" concept - models are selected directly in phase model configs.
     if (storedVersion < 6) {
-      const legacyProfiles = settings.claudeApiProfiles || [];
+      const rawSettings = settings as unknown as Record<string, unknown>;
+      const legacyProfiles = (rawSettings.claudeApiProfiles as ClaudeApiProfile[]) || [];
       if (
         legacyProfiles.length > 0 &&
         (!result.claudeCompatibleProviders || result.claudeCompatibleProviders.length === 0)
@@ -262,9 +267,9 @@ export class SettingsService {
         result.claudeCompatibleProviders = this.migrateProfilesToProviders(legacyProfiles);
       }
       // Remove the deprecated activeClaudeApiProfileId field
-      if (result.activeClaudeApiProfileId) {
+      if (raw.activeClaudeApiProfileId) {
         logger.info('Migration v5->v6: Removing deprecated activeClaudeApiProfileId');
-        delete result.activeClaudeApiProfileId;
+        delete raw.activeClaudeApiProfileId;
       }
       needsSave = true;
     }
@@ -273,7 +278,11 @@ export class SettingsService {
     // If global settings has personaOverrides with any enabled entries, copy them to the
     // current project's .automaker/settings.json under agentConfig.rolePromptOverrides,
     // then remove personaOverrides from global settings.
-    const enabledPersonaOverrides = Object.entries(result.personaOverrides ?? {}).filter(
+    // NOTE: personaOverrides removed from GlobalSettings interface; access via raw cast.
+    const rawPersonaOverrides = raw.personaOverrides as
+      | Record<string, { value: string; enabled: boolean }>
+      | undefined;
+    const enabledPersonaOverrides = Object.entries(rawPersonaOverrides ?? {}).filter(
       ([, v]) => v.enabled
     );
     if (enabledPersonaOverrides.length > 0 && result.currentProjectId && result.projects) {
@@ -312,17 +321,38 @@ export class SettingsService {
         }
       }
       // Remove the global personaOverrides field
-      delete result.personaOverrides;
+      delete raw.personaOverrides;
       needsSave = true;
-    } else if (result.personaOverrides && Object.keys(result.personaOverrides).length > 0) {
+    } else if (rawPersonaOverrides && Object.keys(rawPersonaOverrides).length > 0) {
       // No enabled entries but field exists — remove it
-      delete result.personaOverrides;
+      delete raw.personaOverrides;
       needsSave = true;
     }
 
     // Update version if any migration occurred
     if (needsSave) {
       result.version = SETTINGS_VERSION;
+    }
+
+    // Strip deprecated fields that may exist on disk but are no longer part of GlobalSettings.
+    // This ensures callers never see stale legacy properties from old settings files.
+    const deprecated = [
+      'agentExposure',
+      'hivemind',
+      'avaChannelReactor',
+      'windowBounds',
+      'defaultSkipTests',
+      'defaultPlanningMode',
+      'defaultRequirePlanApproval',
+      'defaultFeatureModel',
+      'enhancementModel',
+      'validationModel',
+      'claudeApiProfiles',
+      'activeClaudeApiProfileId',
+      'personaOverrides',
+    ] as const;
+    for (const key of deprecated) {
+      delete raw[key];
     }
 
     // Save migrated settings if needed
@@ -375,14 +405,19 @@ export class SettingsService {
     }
 
     // Migrate legacy fields if phaseModels doesn't exist
-    // These were the only two legacy fields that existed
-    if (settings.enhancementModel) {
-      result.enhancementModel = this.toPhaseModelEntry(settings.enhancementModel);
-      logger.debug(`Migrated legacy enhancementModel: ${settings.enhancementModel}`);
+    // These fields were removed from GlobalSettings but may exist on disk
+    const rawSettings = settings as Record<string, unknown>;
+    if (rawSettings.enhancementModel) {
+      result.enhancementModel = this.toPhaseModelEntry(
+        rawSettings.enhancementModel as string | PhaseModelEntry
+      );
+      logger.debug(`Migrated legacy enhancementModel: ${rawSettings.enhancementModel}`);
     }
-    if (settings.validationModel) {
-      result.validationModel = this.toPhaseModelEntry(settings.validationModel);
-      logger.debug(`Migrated legacy validationModel: ${settings.validationModel}`);
+    if (rawSettings.validationModel) {
+      result.validationModel = this.toPhaseModelEntry(
+        rawSettings.validationModel as string | PhaseModelEntry
+      );
+      logger.debug(`Migrated legacy validationModel: ${rawSettings.validationModel}`);
     }
 
     return result;
@@ -683,7 +718,6 @@ export class SettingsService {
     ignoreEmptyArrayOverwrite('recentFolders');
     ignoreEmptyArrayOverwrite('mcpServers');
     ignoreEmptyArrayOverwrite('enabledCursorModels');
-    ignoreEmptyArrayOverwrite('claudeApiProfiles');
     // Note: claudeCompatibleProviders intentionally NOT guarded - users should be able to delete all providers
 
     // Empty object overwrite guard
@@ -1132,8 +1166,6 @@ export class SettingsService {
         theme: (appState.theme as GlobalSettings['theme']) || 'dark',
         sidebarOpen: appState.sidebarOpen !== undefined ? (appState.sidebarOpen as boolean) : true,
         maxConcurrency: (appState.maxConcurrency as number) || DEFAULT_MAX_CONCURRENCY,
-        defaultSkipTests:
-          appState.defaultSkipTests !== undefined ? (appState.defaultSkipTests as boolean) : true,
         enableDependencyBlocking:
           appState.enableDependencyBlocking !== undefined
             ? (appState.enableDependencyBlocking as boolean)
@@ -1144,12 +1176,7 @@ export class SettingsService {
             : false,
         useWorktrees:
           appState.useWorktrees !== undefined ? (appState.useWorktrees as boolean) : true,
-        defaultPlanningMode:
-          (appState.defaultPlanningMode as GlobalSettings['defaultPlanningMode']) || 'skip',
-        defaultRequirePlanApproval: (appState.defaultRequirePlanApproval as boolean) || false,
         muteDoneSound: (appState.muteDoneSound as boolean) || false,
-        enhancementModel:
-          (appState.enhancementModel as GlobalSettings['enhancementModel']) || 'sonnet',
         keyboardShortcuts:
           (appState.keyboardShortcuts as KeyboardShortcuts) ||
           DEFAULT_GLOBAL_SETTINGS.keyboardShortcuts,

--- a/apps/ui/src/hooks/use-settings-migration.ts
+++ b/apps/ui/src/hooks/use-settings-migration.ts
@@ -172,15 +172,10 @@ export function parseLocalStorageSettings(): Partial<GlobalSettings> | null {
       theme: state.theme as GlobalSettings['theme'],
       sidebarOpen: state.sidebarOpen as boolean,
       maxConcurrency: state.maxConcurrency as number,
-      defaultSkipTests: state.defaultSkipTests as boolean,
       enableDependencyBlocking: state.enableDependencyBlocking as boolean,
       skipVerificationInAutoMode: state.skipVerificationInAutoMode as boolean,
       useWorktrees: state.useWorktrees as boolean,
-      defaultPlanningMode: state.defaultPlanningMode as GlobalSettings['defaultPlanningMode'],
-      defaultRequirePlanApproval: state.defaultRequirePlanApproval as boolean,
       muteDoneSound: state.muteDoneSound as boolean,
-      enhancementModel: state.enhancementModel as GlobalSettings['enhancementModel'],
-      validationModel: state.validationModel as GlobalSettings['validationModel'],
       phaseModels: state.phaseModels as GlobalSettings['phaseModels'],
       enabledCursorModels: state.enabledCursorModels as GlobalSettings['enabledCursorModels'],
       cursorDefaultModel: state.cursorDefaultModel as GlobalSettings['cursorDefaultModel'],
@@ -206,11 +201,7 @@ export function parseLocalStorageSettings(): Partial<GlobalSettings> | null {
         worktreePanelCollapsed === 'true' || (state.worktreePanelCollapsed as boolean),
       lastProjectDir: lastProjectDir || (state.lastProjectDir as string),
       recentFolders: recentFolders ? JSON.parse(recentFolders) : (state.recentFolders as string[]),
-      // Claude API Profiles (legacy)
-      claudeApiProfiles: (state.claudeApiProfiles as GlobalSettings['claudeApiProfiles']) ?? [],
-      activeClaudeApiProfileId:
-        (state.activeClaudeApiProfileId as GlobalSettings['activeClaudeApiProfileId']) ?? null,
-      // Claude Compatible Providers (new system)
+      // Claude Compatible Providers
       claudeCompatibleProviders:
         (state.claudeCompatibleProviders as GlobalSettings['claudeCompatibleProviders']) ?? [],
       // OpenAI Compatible Providers
@@ -334,20 +325,6 @@ export function mergeSettings(
   // Preserve current project ID from localStorage if server doesn't have one
   if (!serverSettings.currentProjectId && localSettings.currentProjectId) {
     merged.currentProjectId = localSettings.currentProjectId;
-  }
-
-  // Claude API Profiles - preserve from localStorage if server is empty
-  if (
-    (!serverSettings.claudeApiProfiles || serverSettings.claudeApiProfiles.length === 0) &&
-    localSettings.claudeApiProfiles &&
-    localSettings.claudeApiProfiles.length > 0
-  ) {
-    merged.claudeApiProfiles = localSettings.claudeApiProfiles;
-  }
-
-  // Active Claude API Profile ID - preserve from localStorage if server doesn't have one
-  if (!serverSettings.activeClaudeApiProfileId && localSettings.activeClaudeApiProfileId) {
-    merged.activeClaudeApiProfileId = localSettings.activeClaudeApiProfileId;
   }
 
   // Claude Compatible Providers - preserve from localStorage if server is empty
@@ -715,14 +692,8 @@ export function hydrateStoreFromSettings(settings: GlobalSettings): void {
   // Hydrate AppStore (only properties owned by AppState)
   useAppStore.setState({
     sidebarOpen: settings.sidebarOpen ?? true,
-    defaultSkipTests: settings.defaultSkipTests ?? true,
     enableDependencyBlocking: settings.enableDependencyBlocking ?? true,
     skipVerificationInAutoMode: settings.skipVerificationInAutoMode ?? false,
-    defaultPlanningMode: settings.defaultPlanningMode ?? 'skip',
-    defaultRequirePlanApproval: settings.defaultRequirePlanApproval ?? false,
-    defaultFeatureModel: migratePhaseModelEntry(settings.defaultFeatureModel) ?? {
-      model: 'claude-opus',
-    },
     muteDoneSound: settings.muteDoneSound ?? false,
     serverLogLevel: settings.serverLogLevel ?? 'info',
     enableRequestLogging: settings.enableRequestLogging ?? true,
@@ -752,8 +723,6 @@ export function hydrateStoreFromSettings(settings: GlobalSettings): void {
   });
 
   useAIModelsStore.setState({
-    enhancementModel: settings.enhancementModel ?? 'claude-sonnet',
-    validationModel: settings.validationModel ?? 'claude-opus',
     phaseModels: settings.phaseModels ?? currentAIModels.phaseModels,
     enabledCursorModels: allCursorModels,
     cursorDefaultModel: sanitizedCursorDefaultModel,
@@ -763,8 +732,6 @@ export function hydrateStoreFromSettings(settings: GlobalSettings): void {
     disabledProviders: settings.disabledProviders ?? [],
     autoLoadClaudeMd: settings.autoLoadClaudeMd ?? false,
     skipSandboxWarning: settings.skipSandboxWarning ?? false,
-    claudeApiProfiles: settings.claudeApiProfiles ?? [],
-    activeClaudeApiProfileId: settings.activeClaudeApiProfileId ?? null,
     claudeCompatibleProviders: settings.claudeCompatibleProviders ?? [],
     openaiCompatibleProviders: settings.openaiCompatibleProviders ?? [],
   });
@@ -828,8 +795,6 @@ function buildSettingsUpdateFromStore(): Record<string, unknown> {
     fontFamilySans: themeState.fontFamilySans,
     fontFamilyMono: themeState.fontFamilyMono,
     // AI models store
-    enhancementModel: aiState.enhancementModel,
-    validationModel: aiState.validationModel,
     phaseModels: aiState.phaseModels,
     enabledCursorModels: aiState.enabledCursorModels,
     cursorDefaultModel: aiState.cursorDefaultModel,
@@ -838,8 +803,6 @@ function buildSettingsUpdateFromStore(): Record<string, unknown> {
     enabledDynamicModelIds: aiState.enabledDynamicModelIds,
     disabledProviders: aiState.disabledProviders,
     autoLoadClaudeMd: aiState.autoLoadClaudeMd,
-    claudeApiProfiles: aiState.claudeApiProfiles,
-    activeClaudeApiProfileId: aiState.activeClaudeApiProfileId,
     claudeCompatibleProviders: aiState.claudeCompatibleProviders,
     openaiCompatibleProviders: aiState.openaiCompatibleProviders,
     // Worktree store
@@ -852,11 +815,8 @@ function buildSettingsUpdateFromStore(): Record<string, unknown> {
     defaultTerminalId: terminalState.defaultTerminalId,
     // App store (remaining fields)
     sidebarOpen: state.sidebarOpen,
-    defaultSkipTests: state.defaultSkipTests,
     enableDependencyBlocking: state.enableDependencyBlocking,
     skipVerificationInAutoMode: state.skipVerificationInAutoMode,
-    defaultPlanningMode: state.defaultPlanningMode,
-    defaultRequirePlanApproval: state.defaultRequirePlanApproval,
     muteDoneSound: state.muteDoneSound,
     serverLogLevel: state.serverLogLevel,
     enableRequestLogging: state.enableRequestLogging,

--- a/apps/ui/src/hooks/use-settings-sync.ts
+++ b/apps/ui/src/hooks/use-settings-sync.ts
@@ -51,18 +51,12 @@ const SETTINGS_FIELDS_TO_SYNC = [
   'maxConcurrency',
   'systemMaxConcurrency',
   'autoModeByWorktree', // Per-worktree auto mode settings (only maxConcurrency is persisted)
-  'defaultSkipTests',
   'enableDependencyBlocking',
   'skipVerificationInAutoMode',
   'useWorktrees',
-  'defaultPlanningMode',
-  'defaultRequirePlanApproval',
-  'defaultFeatureModel',
   'muteDoneSound',
   'serverLogLevel',
   'enableRequestLogging',
-  'enhancementModel',
-  'validationModel',
   'phaseModels',
   'enabledCursorModels',
   'cursorDefaultModel',
@@ -77,8 +71,6 @@ const SETTINGS_FIELDS_TO_SYNC = [
   'defaultTerminalId',
   'promptCustomization',
   'eventHooks',
-  'claudeApiProfiles',
-  'activeClaudeApiProfileId',
   'projects',
   'trashedProjects',
   'currentProjectId', // ID of currently open project
@@ -131,8 +123,6 @@ function getSettingsFieldValue(
 
   // AI models store fields
   if (
-    field === 'enhancementModel' ||
-    field === 'validationModel' ||
     field === 'phaseModels' ||
     field === 'enabledCursorModels' ||
     field === 'cursorDefaultModel' ||
@@ -140,9 +130,7 @@ function getSettingsFieldValue(
     field === 'opencodeDefaultModel' ||
     field === 'enabledDynamicModelIds' ||
     field === 'disabledProviders' ||
-    field === 'autoLoadClaudeMd' ||
-    field === 'claudeApiProfiles' ||
-    field === 'activeClaudeApiProfileId'
+    field === 'autoLoadClaudeMd'
   ) {
     const aiState = useAIModelsStore.getState();
     return aiState[field as keyof typeof aiState];
@@ -207,8 +195,6 @@ function hasSettingsFieldChanged(
 
   // AI models store fields
   if (
-    field === 'enhancementModel' ||
-    field === 'validationModel' ||
     field === 'phaseModels' ||
     field === 'enabledCursorModels' ||
     field === 'cursorDefaultModel' ||
@@ -216,9 +202,7 @@ function hasSettingsFieldChanged(
     field === 'opencodeDefaultModel' ||
     field === 'enabledDynamicModelIds' ||
     field === 'disabledProviders' ||
-    field === 'autoLoadClaudeMd' ||
-    field === 'claudeApiProfiles' ||
-    field === 'activeClaudeApiProfileId'
+    field === 'autoLoadClaudeMd'
   ) {
     const key = field as keyof typeof newSnap.aiModels;
     return newSnap.aiModels[key] !== prevSnap.aiModels[key];
@@ -754,8 +738,6 @@ export async function refreshSettingsFromServer(): Promise<boolean> {
 
     // Hydrate AI models store
     useAIModelsStore.setState({
-      enhancementModel: serverSettings.enhancementModel,
-      validationModel: serverSettings.validationModel,
       phaseModels: migratedPhaseModels ?? serverSettings.phaseModels,
       enabledCursorModels: allCursorModels, // Always use ALL cursor models
       cursorDefaultModel: sanitizedCursorDefault,
@@ -764,8 +746,6 @@ export async function refreshSettingsFromServer(): Promise<boolean> {
       enabledDynamicModelIds: sanitizedDynamicModelIds,
       disabledProviders: serverSettings.disabledProviders ?? [],
       autoLoadClaudeMd: serverSettings.autoLoadClaudeMd ?? false,
-      claudeApiProfiles: serverSettings.claudeApiProfiles ?? [],
-      activeClaudeApiProfileId: serverSettings.activeClaudeApiProfileId ?? null,
     });
 
     // Hydrate worktree store
@@ -798,15 +778,9 @@ export async function refreshSettingsFromServer(): Promise<boolean> {
     // Hydrate app store (only fields that remain in app-store)
     useAppStore.setState({
       sidebarOpen: serverSettings.sidebarOpen,
-      defaultSkipTests: serverSettings.defaultSkipTests,
       enableDependencyBlocking: serverSettings.enableDependencyBlocking,
       skipVerificationInAutoMode: serverSettings.skipVerificationInAutoMode,
       systemMaxConcurrency: serverSettings.systemMaxConcurrency ?? 10,
-      defaultPlanningMode: serverSettings.defaultPlanningMode,
-      defaultRequirePlanApproval: serverSettings.defaultRequirePlanApproval,
-      defaultFeatureModel: serverSettings.defaultFeatureModel
-        ? migratePhaseModelEntry(serverSettings.defaultFeatureModel)
-        : { model: 'claude-opus' },
       muteDoneSound: serverSettings.muteDoneSound,
       serverLogLevel: serverSettings.serverLogLevel ?? 'info',
       enableRequestLogging: serverSettings.enableRequestLogging ?? true,

--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -17,29 +17,16 @@ import { getAllOpencodeModelIds, DEFAULT_OPENCODE_MODEL } from './opencode-model
 import type { PromptCustomization } from './prompts.js';
 import type { CodexSandboxMode, CodexApprovalPolicy } from './codex.js';
 import type { UserProfile } from './user-profile.js';
-import type { CustomPrompt } from './prompts.js';
 
 // Domain file imports
-import type {
-  ThemeMode,
-  PlanningMode,
-  ServerLogLevel,
-  WindowBounds,
-  KeyboardShortcuts,
-} from './ui-settings.js';
+import type { ThemeMode, ServerLogLevel, KeyboardShortcuts } from './ui-settings.js';
 import { DEFAULT_KEYBOARD_SHORTCUTS } from './ui-settings.js';
-import type {
-  PhaseModelEntry,
-  PhaseModelConfig,
-  ModelProvider,
-  DeploymentEnvironment,
-} from './agent-settings.js';
+import type { PhaseModelConfig, ModelProvider, DeploymentEnvironment } from './agent-settings.js';
 import { DEFAULT_PHASE_MODELS } from './agent-settings.js';
 import type { GitWorkflowSettings } from './git-settings.js';
 import { DEFAULT_GIT_WORKFLOW_SETTINGS } from './git-settings.js';
 import type {
   ClaudeCompatibleProvider,
-  ClaudeApiProfile,
   MCPServerConfig,
   OpenAICompatibleConfig,
 } from './provider-settings.js';
@@ -346,8 +333,6 @@ export interface GlobalSettings {
   maxConcurrency: number;
   /** User-configurable system-wide maximum concurrent agents (overrides env var default) */
   systemMaxConcurrency?: number;
-  /** Default: skip tests during feature generation */
-  defaultSkipTests: boolean;
   /** Default: enable dependency blocking */
   enableDependencyBlocking: boolean;
   /** Skip verification requirement in auto-mode (treat 'completed' same as 'verified') */
@@ -360,12 +345,6 @@ export interface GlobalSettings {
   autoModePickupCooldownMs?: number;
   /** Default: use git worktrees for feature branches */
   useWorktrees: boolean;
-  /** Default: planning approach (skip/lite/spec/full) */
-  defaultPlanningMode: PlanningMode;
-  /** Default: require manual approval before generating */
-  defaultRequirePlanApproval: boolean;
-  /** Default model and thinking level for new feature cards */
-  defaultFeatureModel: PhaseModelEntry;
 
   // Knowledge Store / Learning Settings
   /**
@@ -393,12 +372,6 @@ export interface GlobalSettings {
   // AI Model Selection (per-phase configuration)
   /** Phase-specific AI model configuration */
   phaseModels: PhaseModelConfig;
-
-  // Legacy AI Model Selection (deprecated - use phaseModels instead)
-  /** @deprecated Use phaseModels.enhancementModel instead */
-  enhancementModel: ModelAlias;
-  /** @deprecated Use phaseModels.validationModel instead */
-  validationModel: ModelAlias;
 
   // Cursor CLI Settings (global)
   /** Which Cursor models are available in feature modal (empty = all) */
@@ -445,10 +418,6 @@ export interface GlobalSettings {
   // Session Tracking
   /** Maps project path -> last selected session ID in that project */
   lastSelectedSessionByProject: Record<string, string>;
-
-  // Window State (Electron only)
-  /** Persisted window bounds for restoring position/size across sessions */
-  windowBounds?: WindowBounds;
 
   // Claude Agent SDK Settings
   /** Auto-load CLAUDE.md files using SDK's settingSources option */
@@ -547,34 +516,6 @@ export interface GlobalSettings {
    * Supports local providers (Ollama, LM Studio) and cloud providers (Together AI, etc.)
    */
   openaiCompatibleProviders?: OpenAICompatibleConfig[];
-
-  // Deprecated Claude API Profiles (kept for migration)
-  /**
-   * @deprecated Use claudeCompatibleProviders instead.
-   * Kept for backward compatibility during migration.
-   */
-  claudeApiProfiles?: ClaudeApiProfile[];
-
-  /**
-   * @deprecated No longer used. Models are selected per-phase via phaseModels.
-   * Each PhaseModelEntry can specify a providerId for provider-specific models.
-   */
-  activeClaudeApiProfileId?: string | null;
-
-  /**
-   * Runtime overrides for agent exposure (CLI skills + Discord slash commands).
-   * Key: agent template name (e.g., "ava", "jon").
-   * Overrides the template's built-in exposure config.
-   */
-  agentExposure?: Record<
-    string,
-    {
-      /** Override Discord slash command registration */
-      discord?: boolean;
-      /** Override allowed Discord users */
-      allowedUsers?: string[];
-    }
-  >;
 
   /**
    * Per-worktree auto mode settings
@@ -697,24 +638,11 @@ export interface GlobalSettings {
    */
   prOwnershipStaleTtlHours?: number;
 
-  /**
-   * Hivemind mesh configuration for multi-instance coordination.
-   * @see HivemindConfig
-   */
-  hivemind?: import('./hivemind.js').HivemindConfig;
-
   /** User profile for agent personalization — replaces hardcoded values in persona prompts */
   userProfile?: UserProfile;
 
   /** User's name for assignment and display purposes (resolved from settings, env, or git) */
   userName?: string;
-
-  /**
-   * @deprecated Use project-level agentConfig.rolePromptOverrides instead.
-   * Kept temporarily so the migration in SettingsService can read and copy
-   * any enabled entries to the active project before removing this field.
-   */
-  personaOverrides?: Record<string, CustomPrompt>;
 
   /**
    * Promotion pipeline configuration for staging/production candidate tracking.
@@ -735,14 +663,6 @@ export interface GlobalSettings {
    * @see SchedulerSettings
    */
   schedulerSettings?: SchedulerSettings;
-
-  /**
-   * Ava Channel reactor settings.
-   * Controls whether this instance auto-responds to incoming Ava Channel messages
-   * and at what depth/cadence.
-   * @see AvaChannelReactorSettings
-   */
-  avaChannelReactor?: AvaChannelReactorSettings;
 
   /**
    * Global ceremony configuration.
@@ -779,20 +699,14 @@ export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
   sidebarOpen: true,
   maxConcurrency: DEFAULT_MAX_CONCURRENCY,
   systemMaxConcurrency: 10,
-  defaultSkipTests: true,
   enableDependencyBlocking: true,
   skipVerificationInAutoMode: false,
   useWorktrees: true,
-  defaultPlanningMode: 'skip',
-  defaultRequirePlanApproval: false,
-  defaultFeatureModel: { model: 'claude-opus' }, // Use canonical ID
   muteDoneSound: false,
   serverLogLevel: 'info',
   enableRequestLogging: true,
   enableAiCommitMessages: true,
   phaseModels: DEFAULT_PHASE_MODELS,
-  enhancementModel: 'sonnet', // Legacy alias still supported
-  validationModel: 'opus', // Legacy alias still supported
   enabledCursorModels: getAllCursorModelIds(), // Returns prefixed IDs
   cursorDefaultModel: 'cursor-auto', // Use canonical prefixed ID
   enabledOpencodeModels: getAllOpencodeModelIds(), // Returns prefixed IDs
@@ -828,9 +742,6 @@ export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
   // New provider system
   claudeCompatibleProviders: [],
   openaiCompatibleProviders: [],
-  // Deprecated - kept for migration
-  claudeApiProfiles: [],
-  activeClaudeApiProfileId: null,
   autoModeByWorktree: {},
   // Git workflow automation (enabled by default)
   gitWorkflow: DEFAULT_GIT_WORKFLOW_SETTINGS,


### PR DESCRIPTION
## Summary

**Milestone:** Dead Code Cleanup

Remove agentExposure, hivemind, avaChannelReactor, windowBounds, defaultSkipTests, defaultPlanningMode, defaultRequirePlanApproval, defaultFeatureModel, enhancementModel, validationModel, claudeApiProfiles, activeClaudeApiProfileId, personaOverrides from GlobalSettings. Update SettingsService to gracefully ignore unknown fields.

**Files to Modify:**
- libs/types/src/global-settings.ts
- apps/server/src/services/settings-service.ts

**Acceptance Criteria:**
- [ ...

---
*Recovered automatically by Automaker post-agent hook*