### PR TITLE
Fix prBaseBranch default and resolution

### DIFF
--- a/apps/server/src/lib/settings-helpers.ts
+++ b/apps/server/src/lib/settings-helpers.ts
@@ -839,21 +839,26 @@ export async function getEffectivePrBaseBranch(
 ): Promise<string> {
   if (settingsService) {
     try {
-      // 1. Check per-project workflow settings first
+      // 1. Check per-project gitWorkflow settings
       const projectSettings = await settingsService.getProjectSettings(projectPath);
       const projectBranch = projectSettings.workflow?.gitWorkflow?.prBaseBranch;
       if (projectBranch) {
         logger.debug(`${logPrefix} Using project-level prBaseBranch: ${projectBranch}`);
         return projectBranch;
       }
-      // NOTE: Intentionally skip global settings — global prBaseBranch belongs to the
-      // automaker project and must not bleed into other projects with a different branch.
+      // 2. Check global gitWorkflow settings
+      const globalSettings = await settingsService.getGlobalSettings();
+      const globalBranch = globalSettings.gitWorkflow?.prBaseBranch;
+      if (globalBranch) {
+        logger.debug(`${logPrefix} Using global-level prBaseBranch: ${globalBranch}`);
+        return globalBranch;
+      }
     } catch (err) {
       logger.warn(`${logPrefix} Failed to read settings for prBaseBranch:`, err);
     }
   }
 
-  // 2. Auto-detect from remote HEAD
+  // 4. Auto-detect from remote HEAD
   try {
     const { stdout } = await execFileAsync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
       cwd: projectPath,
@@ -870,6 +875,6 @@ export async function getEffectivePrBaseBranch(
     // origin/HEAD not set or git not available — fall through to default
   }
 
-  // 3. Final fallback
+  // 5. Final fallback
   return DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch;
 }

--- a/apps/server/tests/unit/lib/settings-helpers.test.ts
+++ b/apps/server/tests/unit/lib/settings-helpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getMCPServersFromSettings, getWorkflowSettings } from '@/lib/settings-helpers.js';
+import {
+  getMCPServersFromSettings,
+  getWorkflowSettings,
+  getEffectivePrBaseBranch,
+} from '@/lib/settings-helpers.js';
 import type { SettingsService } from '@/services/settings-service.js';
 import { DEFAULT_WORKFLOW_SETTINGS } from '@protolabsai/types';
 
@@ -387,6 +391,76 @@ describe('settings-helpers.ts', () => {
       // Other pipeline defaults should be preserved
       expect(result.pipeline.checkpointEnabled).toBe(true);
       expect(result.pipeline.goalGatesEnabled).toBe(false);
+    });
+  });
+
+  describe('getEffectivePrBaseBranch', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should return DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch (dev) when settingsService is null and git detect fails', async () => {
+      const result = await getEffectivePrBaseBranch('/some/path', null);
+      expect(result).toBe('dev');
+    });
+
+    it('should return project-level prBaseBranch when set in project workflow gitWorkflow settings', async () => {
+      const mockSettingsService = {
+        getProjectSettings: vi.fn().mockResolvedValue({
+          workflow: { gitWorkflow: { prBaseBranch: 'feature-branch' } },
+        }),
+        getGlobalSettings: vi.fn().mockResolvedValue({}),
+      } as unknown as SettingsService;
+
+      const result = await getEffectivePrBaseBranch('/some/path', mockSettingsService);
+      expect(result).toBe('feature-branch');
+      expect(mockSettingsService.getGlobalSettings).not.toHaveBeenCalled();
+    });
+
+    it('should return global-level prBaseBranch when project has none but global does', async () => {
+      const mockSettingsService = {
+        getProjectSettings: vi.fn().mockResolvedValue({}),
+        getGlobalSettings: vi.fn().mockResolvedValue({
+          gitWorkflow: { prBaseBranch: 'staging' },
+        }),
+      } as unknown as SettingsService;
+
+      const result = await getEffectivePrBaseBranch('/some/path', mockSettingsService);
+      expect(result).toBe('staging');
+    });
+
+    it('should fall back to dev when neither project nor global settings define prBaseBranch and git detect fails', async () => {
+      const mockSettingsService = {
+        getProjectSettings: vi.fn().mockResolvedValue({}),
+        getGlobalSettings: vi.fn().mockResolvedValue({}),
+      } as unknown as SettingsService;
+
+      const result = await getEffectivePrBaseBranch('/nonexistent/path', mockSettingsService);
+      expect(result).toBe('dev');
+    });
+
+    it('should fall back to dev when settings service throws', async () => {
+      const mockSettingsService = {
+        getProjectSettings: vi.fn().mockRejectedValue(new Error('Settings read error')),
+        getGlobalSettings: vi.fn().mockRejectedValue(new Error('Settings read error')),
+      } as unknown as SettingsService;
+
+      const result = await getEffectivePrBaseBranch('/nonexistent/path', mockSettingsService);
+      expect(result).toBe('dev');
+    });
+
+    it('should prefer project-level over global-level when both are set', async () => {
+      const mockSettingsService = {
+        getProjectSettings: vi.fn().mockResolvedValue({
+          workflow: { gitWorkflow: { prBaseBranch: 'project-branch' } },
+        }),
+        getGlobalSettings: vi.fn().mockResolvedValue({
+          gitWorkflow: { prBaseBranch: 'global-branch' },
+        }),
+      } as unknown as SettingsService;
+
+      const result = await getEffectivePrBaseBranch('/some/path', mockSettingsService);
+      expect(result).toBe('project-branch');
     });
   });
 });

--- a/libs/types/src/git-settings.ts
+++ b/libs/types/src/git-settings.ts
@@ -74,7 +74,7 @@ export const DEFAULT_GIT_WORKFLOW_SETTINGS: Required<GitWorkflowSettings> = {
   autoMergePR: true,
   prMergeStrategy: 'squash',
   waitForCI: true,
-  prBaseBranch: 'main',
+  prBaseBranch: 'dev',
   maxPRLinesChanged: 500,
   maxPRFilesTouched: 20,
   excludeFromStaging: [],


### PR DESCRIPTION
## Summary

**Milestone:** Critical Bug Fixes

Change DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch to 'dev'. Update getEffectivePrBaseBranch() to check global gitWorkflow. Add unit tests.

**Files to Modify:**
- libs/types/src/git-settings.ts
- apps/server/src/lib/settings-helpers.ts
- apps/server/tests/unit/settings-helpers.test.ts

**Acceptance Criteria:**
- [ ] Default prBaseBranch is 'dev'
- [ ] Resolution: feature > project > global > git detect > 'dev'
- [ ] New unit tests cover all levels
- [ ] npm run...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for global pull request base branch settings that apply across projects.

* **Bug Fixes**
  * Updated the default pull request base branch from 'main' to 'dev'.

* **Tests**
  * Added comprehensive test coverage for PR base branch resolution logic, including fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->