### PR TITLE
Fix Workflow panel scope indication

### DIFF
--- a/apps/ui/src/components/views/settings-view.tsx
+++ b/apps/ui/src/components/views/settings-view.tsx
@@ -70,6 +70,7 @@ export function SettingsView() {
     systemMaxConcurrency,
     setSystemMaxConcurrency,
     featureFlags,
+    currentProject,
   } = useAppStore();
   const { skipSandboxWarning, setSkipSandboxWarning } = useAIModelsStore();
   const { theme, setTheme } = useThemeStore();
@@ -199,7 +200,17 @@ export function SettingsView() {
       case 'health':
         return <HealthSection />;
       case 'workflow':
-        return <WorkflowSettingsPanel />;
+        return (
+          <>
+            {currentProject && (
+              <div className="mb-4 px-3 py-2 rounded-lg bg-muted/40 border border-border/40 flex items-center gap-2">
+                <span className="text-xs text-muted-foreground">Per-project settings for:</span>
+                <span className="text-xs font-medium text-foreground">{currentProject.name}</span>
+              </div>
+            )}
+            <WorkflowSettingsPanel />
+          </>
+        );
       case 'automations':
         return <AutomationsSection />;
       case 'sensors':

--- a/apps/ui/src/components/views/settings-view/config/navigation.ts
+++ b/apps/ui/src/components/views/settings-view/config/navigation.ts
@@ -34,6 +34,7 @@ export type { SettingsNavigationItem };
 
 export type NavigationItem = SettingsNavigationItem & {
   id: SettingsViewId;
+  description?: string;
   subItems?: (SettingsNavigationItem & { id: SettingsViewId })[];
 };
 
@@ -91,7 +92,12 @@ export const GLOBAL_NAV_GROUPS: NavigationGroup[] = [
     label: 'System',
     items: [
       { id: 'health', label: 'Health', icon: Activity },
-      { id: 'workflow', label: 'Workflow', icon: Cog },
+      {
+        id: 'workflow',
+        label: 'Workflow',
+        icon: Cog,
+        description: 'Per-project pipeline settings',
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

**Milestone:** Critical Bug Fixes

Add clear project scope indicator to the Workflow settings section. Show which project settings apply to.

**Files to Modify:**
- apps/ui/src/components/views/settings-view/config/navigation.ts
- apps/ui/src/components/views/settings-view.tsx

**Acceptance Criteria:**
- [ ] Workflow section shows current project name
- [ ] Clear visual that these are per-project settings

**Complexity:** small

**Guardrails:** If this phase involves new or changed behavior, inc...

---
*Recovered automatically by Automaker post-agent hook*