### PR TITLE
Unify MCP server configuration

### DIFF
--- a/apps/server/src/lib/settings-helpers.ts
+++ b/apps/server/src/lib/settings-helpers.ts
@@ -171,11 +171,17 @@ function getDefaultMCPServers(): Record<string, McpServerConfig> {
  *
  * @param settingsService - Optional settings service instance
  * @param logPrefix - Prefix for log messages (e.g., '[AgentService]')
+ * @param options.context - Filter servers by context: 'agents' excludes servers with
+ *   enableForAgents=false; 'ava' excludes servers with enableForAva=false.
+ *   When omitted, all enabled servers are returned.
+ * @param options.projectPath - When provided, per-project mcpServers are merged in.
+ *   Project-level servers override global servers with the same name.
  * @returns Promise resolving to MCP servers in SDK format (keyed by name)
  */
 export async function getMCPServersFromSettings(
   settingsService?: SettingsService | null,
-  logPrefix = '[SettingsHelper]'
+  logPrefix = '[SettingsHelper]',
+  options?: { context?: 'agents' | 'ava'; projectPath?: string }
 ): Promise<Record<string, McpServerConfig>> {
   const defaults = getDefaultMCPServers();
 
@@ -185,10 +191,30 @@ export async function getMCPServersFromSettings(
 
   try {
     const globalSettings = await settingsService.getGlobalSettings();
-    const mcpServers = globalSettings.mcpServers || [];
+    let mcpServers = globalSettings.mcpServers || [];
 
-    // Filter to only enabled servers and convert to SDK format
-    const enabledServers = mcpServers.filter((s) => s.enabled !== false);
+    // Merge per-project MCP servers when a projectPath is provided.
+    // Project-level servers are keyed by name and override global entries.
+    if (options?.projectPath) {
+      const projectSettings = await settingsService.getProjectSettings(options.projectPath);
+      if (projectSettings.mcpServers && projectSettings.mcpServers.length > 0) {
+        const byName = new Map(mcpServers.map((s) => [s.name, s]));
+        for (const s of projectSettings.mcpServers) {
+          byName.set(s.name, s);
+        }
+        mcpServers = [...byName.values()];
+      }
+    }
+
+    // Filter to only enabled servers
+    let enabledServers = mcpServers.filter((s) => s.enabled !== false);
+
+    // Apply context-specific filtering
+    if (options?.context === 'agents') {
+      enabledServers = enabledServers.filter((s) => s.enableForAgents !== false);
+    } else if (options?.context === 'ava') {
+      enabledServers = enabledServers.filter((s) => s.enableForAva !== false);
+    }
 
     if (enabledServers.length === 0) {
       return defaults;

--- a/apps/server/src/routes/chat/ava-config.ts
+++ b/apps/server/src/routes/chat/ava-config.ts
@@ -14,7 +14,6 @@ import path from 'path';
 import { createLogger } from '@protolabsai/utils';
 import { getAutomakerDir, ensureAutomakerDir } from '@protolabsai/platform';
 import * as secureFs from '../../lib/secure-fs.js';
-import type { MCPServerConfig } from '@protolabsai/types';
 import type { AvaToolsConfig } from './ava-tools.js';
 
 export type { AvaToolsConfig };
@@ -44,8 +43,6 @@ export interface AvaConfig {
   systemPromptExtension: string;
   /** When true, destructive tools execute immediately without HITL confirmation */
   autoApproveTools: boolean;
-  /** MCP servers available to Ava and delegated inner agents */
-  mcpServers?: MCPServerConfig[];
   /**
    * Trust level for subagent tool execution.
    * - 'full': Subagents run with bypassPermissions (fully autonomous).
@@ -101,7 +98,6 @@ export const DEFAULT_AVA_CONFIG: AvaConfig = {
   contextInjection: true,
   systemPromptExtension: '',
   autoApproveTools: false,
-  mcpServers: [],
   subagentTrust: 'full',
 };
 

--- a/apps/server/src/routes/chat/index.ts
+++ b/apps/server/src/routes/chat/index.ts
@@ -41,6 +41,7 @@ import { buildAvaSystemPrompt, type NotesContext } from './personas.js';
 import { loadAvaConfig, DEFAULT_AVA_CONFIG, type AvaConfig } from './ava-config.js';
 import { getSitrep } from './sitrep.js';
 import { buildAvaTools } from './ava-tools.js';
+import { getMCPServersFromSettings } from '../../lib/settings-helpers.js';
 import type { PlanData } from './ava-tools.js';
 import {
   estimateTokens,
@@ -431,21 +432,19 @@ export function createChatRoutes(services: ServiceContainer): Router {
       } catch {
         // Settings unavailable — safe default (flag disabled)
       }
-      // Convert ava-specific mcpServers to the agent SDK format and merge with
-      // project-level MCP servers configured in global settings.  The converted
-      // list is passed down to tools so inner agents delegated
-      // from Ava chat can access the same additional MCP servers.
-      const avaMcpServers = (avaConfig.mcpServers ?? [])
-        .filter((s) => s.enabled !== false)
-        .map((s) => ({
-          name: s.name,
-          ...(s.type !== undefined && { type: s.type }),
-          ...(s.command !== undefined && { command: s.command }),
-          ...(s.args !== undefined && { args: s.args }),
-          ...(s.env !== undefined && { env: s.env }),
-          ...(s.url !== undefined && { url: s.url }),
-          ...(s.headers !== undefined && { headers: s.headers }),
-        }));
+      // Load MCP servers from the unified global list filtered to the 'ava' context.
+      // Per-project overrides (ProjectSettings.mcpServers) are merged in when projectPath
+      // is available. The converted list is passed down to tools so inner agents
+      // delegated from Ava chat can access the same additional MCP servers.
+      const avaMcpServersRecord = await getMCPServersFromSettings(
+        services.settingsService,
+        '[ChatRoute]',
+        { context: 'ava', projectPath }
+      );
+      const avaMcpServers = Object.entries(avaMcpServersRecord).map(([name, sdkConfig]) => ({
+        name,
+        ...sdkConfig,
+      }));
 
       // Instantiate AvaMemoryService per-request when a projectPath is available.
       // The service is lightweight (no state beyond the file path) so per-request

--- a/libs/types/src/project-settings.ts
+++ b/libs/types/src/project-settings.ts
@@ -11,6 +11,7 @@ import type { ProjectIntegrations, DiscordSettings } from './integration-setting
 import type { WorkflowSettings } from './workflow-settings.js';
 import type { AgentDefinition } from './provider.js';
 import type { PolicyConfig } from './policy.js';
+import type { MCPServerConfig } from './provider-settings.js';
 
 // ============================================================================
 // Worktree Info - Git worktree management
@@ -287,6 +288,14 @@ export interface ProjectSettings {
    * Both transports speak AI SDK Data Stream Protocol so all UI features work unchanged.
    */
   avaEngineUrl?: string;
+
+  // MCP Server Overrides (per-project)
+  /**
+   * Per-project MCP server additions. These servers are merged with the global
+   * mcpServers list for this project only. A project server with the same name
+   * as a global server overrides it for this project.
+   */
+  mcpServers?: MCPServerConfig[];
 }
 
 /** Default project settings (empty - all settings are optional and fall back to global) */

--- a/libs/types/src/provider-settings.ts
+++ b/libs/types/src/provider-settings.ts
@@ -487,6 +487,16 @@ export interface MCPServerConfig {
   headers?: Record<string, string>;
   /** Whether this server is enabled */
   enabled?: boolean;
+  /**
+   * When false, exclude this server from agent (inner agent) MCP server lists.
+   * Defaults to true (included for agents when not specified).
+   */
+  enableForAgents?: boolean;
+  /**
+   * When false, exclude this server from Ava chat MCP server lists.
+   * Defaults to true (included for Ava when not specified).
+   */
+  enableForAva?: boolean;
   /** Tools discovered from this server with their enabled states */
   tools?: MCPToolInfo[];
   /** Timestamp when tools were last fetched */


### PR DESCRIPTION
## Summary

**Milestone:** Settings Consolidation

Single canonical list with enableForAgents/enableForAva flags. Remove separate AvaConfig.mcpServers. Add per-project overrides. Migrate existing configs.

**Files to Modify:**
- libs/types/src/global-settings.ts
- apps/server/src/routes/chat/index.ts
- apps/server/src/routes/chat/ava-config.ts
- apps/server/src/lib/settings-helpers.ts
- libs/types/src/project-settings.ts

**Acceptance Criteria:**
- [ ] Single MCPServerConfig with context flags
- [ ] Ava and...

---
*Recovered automatically by Automaker post-agent hook*