### PR TITLE
Restructure Global Settings navigation

### DIFF
--- a/apps/ui/src/components/views/settings-view/config/navigation.ts
+++ b/apps/ui/src/components/views/settings-view/config/navigation.ts
@@ -46,13 +46,9 @@ export interface NavigationGroup {
 // Global settings organized into groups
 export const GLOBAL_NAV_GROUPS: NavigationGroup[] = [
   {
-    label: 'Model & Prompts',
+    label: 'AI and Models',
     items: [
-      { id: 'defaults', label: 'Feature Defaults', icon: FlaskConical },
       { id: 'model-defaults', label: 'Model Defaults', icon: Workflow },
-      { id: 'worktrees', label: 'Worktrees', icon: GitBranch },
-      { id: 'prompts', label: 'Prompt Customization', icon: MessageSquareText },
-      { id: 'api-keys', label: 'API Keys', icon: Key },
       {
         id: 'providers',
         label: 'AI Providers',
@@ -66,6 +62,8 @@ export const GLOBAL_NAV_GROUPS: NavigationGroup[] = [
           { id: 'openai-compatible-provider', label: 'OpenAI-Compatible', icon: Server },
         ],
       },
+      { id: 'api-keys', label: 'API Keys', icon: Key },
+      { id: 'prompts', label: 'Prompt Customization', icon: MessageSquareText },
       { id: 'mcp-servers', label: 'MCP Servers', icon: Server },
     ],
   },
@@ -76,35 +74,35 @@ export const GLOBAL_NAV_GROUPS: NavigationGroup[] = [
       { id: 'terminal', label: 'Terminal', icon: SquareTerminal },
       { id: 'keyboard', label: 'Keyboard Shortcuts', icon: Settings2 },
       { id: 'audio', label: 'Audio', icon: Volume2 },
-      { id: 'event-hooks', label: 'Event Hooks', icon: Webhook },
-      { id: 'integrations', label: 'Integrations', icon: Plug },
     ],
   },
   {
-    label: 'Account & Security',
+    label: 'Pipeline and Automation',
     items: [
-      { id: 'account', label: 'Account', icon: User },
-      { id: 'profile', label: 'User Profile', icon: UserCog },
-      { id: 'security', label: 'Security', icon: Shield },
-    ],
-  },
-  {
-    label: 'System',
-    items: [
-      { id: 'health', label: 'Health', icon: Activity },
+      { id: 'defaults', label: 'Feature Defaults', icon: FlaskConical },
+      { id: 'worktrees', label: 'Worktrees', icon: GitBranch },
       {
         id: 'workflow',
         label: 'Workflow',
         icon: Cog,
         description: 'Per-project pipeline settings',
       },
+      { id: 'automations', label: 'Automations', icon: Zap },
+      { id: 'sensors', label: 'Sensors', icon: Radio },
+      { id: 'event-hooks', label: 'Event Hooks', icon: Webhook },
     ],
   },
   {
-    label: 'Advanced',
+    label: 'Integrations',
+    items: [{ id: 'integrations', label: 'Integrations', icon: Plug }],
+  },
+  {
+    label: 'System',
     items: [
-      { id: 'automations', label: 'Automations', icon: Zap },
-      { id: 'sensors', label: 'Sensors', icon: Radio },
+      { id: 'health', label: 'Health', icon: Activity },
+      { id: 'account', label: 'Account', icon: User },
+      { id: 'profile', label: 'User Profile', icon: UserCog },
+      { id: 'security', label: 'Security', icon: Shield },
       { id: 'developer', label: 'Developer', icon: Code2 },
     ],
   },


### PR DESCRIPTION
## Summary

**Milestone:** Domain-Contextual Settings UI

Reorganize into domain groups: AI and Models, Interface, Pipeline and Automation, Integrations, System. Distribute Developer section contents.

**Files to Modify:**
- apps/ui/src/components/views/settings-view/config/navigation.ts

**Acceptance Criteria:**
- [ ] Navigation organized by domain
- [ ] Developer section distributed
- [ ] All existing settings still accessible

**Complexity:** small

**Guardrails:** If this phase involves new or changed b...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized settings navigation structure with renamed group labels ("Model & Prompts" to "AI and Models", "Advanced" to "Integrations") and reordered navigation items. Introduced a new "Pipeline and Automation" group and consolidated related settings sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->