### PR TITLE
Promote dev to staging (heartbeat fix + test fixes)

### DIFF
--- a/apps/server/src/services/ava-gateway-service.ts
+++ b/apps/server/src/services/ava-gateway-service.ts
@@ -223,6 +223,10 @@ export class AvaGatewayService {
   private lastNotificationPost: Map<string, number> = new Map();
   private readonly NOTIFICATION_RATE_LIMIT_MS = 5 * 60 * 1000; // 5 minutes
 
+  // Dedup for heartbeat alerts — suppress identical alerts until server restarts.
+  // Key = alert title. Prevents the same health issue from spamming Discord every cycle.
+  private postedAlertKeys = new Set<string>();
+
   constructor(
     featureLoader: FeatureLoader,
     settingsService?: SettingsService,
@@ -721,6 +725,14 @@ export class AvaGatewayService {
     if (!this.infraChannelId || !this.discordBotService) {
       return;
     }
+
+    // Dedup: suppress identical alerts. Critical alerts always post.
+    const alertKey = `${alert.title}::${alert.description}`;
+    if (alert.severity !== 'critical' && this.postedAlertKeys.has(alertKey)) {
+      logger.debug('Suppressing duplicate alert', { title: alert.title });
+      return;
+    }
+    this.postedAlertKeys.add(alertKey);
 
     const severityEmoji: Record<HeartbeatAlert['severity'], string> = {
       low: '🟢',

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -1103,7 +1103,21 @@ export class FeatureLoader implements FeatureStore {
   ): Promise<Feature[]> {
     const features = preloadedFeatures ?? (await this.getAll(projectPath));
     // Skip done features — branch deletion after PR merge is normal, not an orphan.
-    const featuresWithBranch = features.filter((f) => f.branchName && f.status !== 'done');
+    // Skip epics whose children are all done — epic branches may never have been created
+    // when features PR directly to dev instead of the epic branch.
+    const doneChildIds = new Set(
+      features.filter((f) => f.status === 'done' && f.epicId).map((f) => f.epicId!)
+    );
+    const featuresWithBranch = features.filter(
+      (f) =>
+        f.branchName &&
+        f.status !== 'done' &&
+        !(
+          f.isEpic &&
+          doneChildIds.has(f.id) &&
+          !features.some((c) => c.epicId === f.id && c.status !== 'done')
+        )
+    );
 
     if (featuresWithBranch.length === 0) {
       return [];


### PR DESCRIPTION
## Summary
- Fix heartbeat alert spam — dedup + skip epics with all children done
- Fix test failures from settings overhaul (prBaseBranch default, automation purge ordering)
- Additional settings overhaul features that landed after #3059

## Test plan
- [x] All tests pass locally
- [x] Server builds clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Alert deduplication mechanism now suppresses duplicate heartbeat notifications to Discord, reducing alert fatigue
  * Enhanced orphaned feature detection to better filter epic features with completed children, improving detection accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->