### PR TITLE
Promote dev to staging (heartbeat orphan fix)

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -1102,16 +1102,19 @@ export class FeatureLoader implements FeatureStore {
     preloadedFeatures?: Feature[]
   ): Promise<Feature[]> {
     const features = preloadedFeatures ?? (await this.getAll(projectPath));
-    // Skip done features — branch deletion after PR merge is normal, not an orphan.
+    // Only check features that have been worked on (in_progress, review, blocked).
+    // Skip done — branch deletion after PR merge is normal.
+    // Skip backlog — branches are created when agents start, not at feature creation.
     // Skip epics whose children are all done — epic branches may never have been created
     // when features PR directly to dev instead of the epic branch.
+    const nonOrphanStatuses = new Set(['done', 'backlog']);
     const doneChildIds = new Set(
       features.filter((f) => f.status === 'done' && f.epicId).map((f) => f.epicId!)
     );
     const featuresWithBranch = features.filter(
       (f) =>
         f.branchName &&
-        f.status !== 'done' &&
+        !nonOrphanStatuses.has(f.status ?? 'backlog') &&
         !(
           f.isEpic &&
           doneChildIds.has(f.id) &&


### PR DESCRIPTION
## Summary
- Skip backlog features in orphaned branch detection — branches don't exist until agents start
- Combined with prior dedup fix, this eliminates all heartbeat alert spam

## Test plan
- [x] Server builds clean
- [x] Logic: only in_progress/review/blocked features checked for orphaned branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected feature orphan detection logic to properly handle features with backlog status alongside completed features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->