### PR TITLE
Fix: Worktrees missing build artifacts crash MCP on external projects

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -130,6 +130,7 @@ import {
 import { AutoModeCoordinator } from './auto-mode/auto-mode-coordinator.js';
 import { FeatureStateManager } from './auto-mode/feature-state-manager.js';
 import { ExecutionService } from './auto-mode/execution-service.js';
+import { symlinkBuildArtifacts } from './worktree-lifecycle-service.js';
 import type {
   RunningFeature,
   PendingApproval,
@@ -1652,6 +1653,12 @@ export class AutoModeService {
       if (worktreePath) {
         workDir = worktreePath;
         logger.info(`Follow-up using existing worktree for branch "${branchName}": ${workDir}`);
+        // Ensure build artifacts are present in pre-existing worktrees
+        try {
+          await symlinkBuildArtifacts(projectPath, worktreePath);
+        } catch (err) {
+          logger.debug('Failed to symlink build artifacts into worktree (non-fatal):', err);
+        }
       } else {
         // Auto-create worktree if it doesn't exist
         logger.info(`Follow-up auto-creating worktree for branch "${branchName}"`);
@@ -3071,6 +3078,15 @@ Format your response as a structured markdown document.`;
         }
       } catch (err) {
         logger.debug('Failed to copy .env files to worktree (non-fatal):', err);
+      }
+
+      // Symlink gitignored build artifacts (node_modules, dist, etc.) from the
+      // main project so that external projects' MCP servers and build tools work
+      // inside the worktree without requiring a full npm install + build.
+      try {
+        await symlinkBuildArtifacts(projectPath, worktreePath);
+      } catch (err) {
+        logger.debug('Failed to symlink build artifacts into worktree (non-fatal):', err);
       }
 
       return path.resolve(worktreePath);

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -89,6 +89,7 @@ import { getAgentManifestService } from '../agent-manifest-service.js';
 import { TypedEventBus } from './typed-event-bus.js';
 import { PostExecutionMiddleware } from './post-execution-middleware.js';
 import { TrajectoryQueryService } from '../trajectory-query-service.js';
+import { symlinkBuildArtifacts } from '../worktree-lifecycle-service.js';
 import type {
   RunningFeature,
   ParsedTask,
@@ -501,6 +502,17 @@ export class ExecutionService {
           projectSlug: feature?.projectSlug,
         });
         return;
+      }
+
+      // Ensure build artifacts (node_modules, dist, etc.) are present in the worktree.
+      // New worktrees get symlinks during creation, but existing worktrees from earlier
+      // sessions may be missing them. This is a no-op if symlinks already exist.
+      if (worktreePath) {
+        try {
+          await symlinkBuildArtifacts(projectPath, worktreePath);
+        } catch (err) {
+          logger.debug('Failed to symlink build artifacts into worktree (non-fatal):', err);
+        }
       }
 
       // Ensure workDir is always an absolute path for cross-platform compatibility

--- a/apps/server/src/services/worktree-lifecycle-service.ts
+++ b/apps/server/src/services/worktree-lifecycle-service.ts
@@ -13,6 +13,7 @@
  * - Health check API for monitoring worktree state
  */
 
+import fs from 'node:fs';
 import path from 'path';
 import { exec, execFile, execSync } from 'child_process';
 import { createLogger } from '@protolabsai/utils';
@@ -611,4 +612,84 @@ export class WorktreeLifecycleService {
       });
     });
   }
+}
+
+/**
+ * Directories that are gitignored but required at runtime for MCP servers
+ * and build tooling. These are symlinked from the main project into worktrees
+ * after creation so that external projects' toolchains work correctly.
+ *
+ * Only top-level directories are symlinked. Nested node_modules (inside
+ * workspace packages) are resolved transitively through the root symlink.
+ */
+const BUILD_ARTIFACT_DIRS = ['node_modules', 'dist', 'build', '.next', '.nuxt', 'out'] as const;
+
+/**
+ * Symlink gitignored build artifacts from the main project into a worktree.
+ *
+ * Git worktrees share the git history but NOT the working tree, so directories
+ * listed in .gitignore (node_modules, dist, build, etc.) are absent in fresh
+ * worktrees. For external projects whose MCP servers or build tools depend on
+ * these artifacts, the agent will fail immediately with exit code 1.
+ *
+ * This function creates directory symlinks for each artifact that:
+ * 1. Exists in the main project (source must be present)
+ * 2. Does NOT already exist in the worktree (no clobbering)
+ *
+ * Symlinks are preferred over copying because they are instant, use no extra
+ * disk space, and always reflect the current state of the main project's
+ * artifacts.
+ *
+ * @param projectPath - Absolute path to the main project root
+ * @param worktreePath - Absolute path to the worktree directory
+ * @returns List of directories that were successfully symlinked
+ */
+export async function symlinkBuildArtifacts(
+  projectPath: string,
+  worktreePath: string
+): Promise<string[]> {
+  const symlinked: string[] = [];
+
+  for (const dir of BUILD_ARTIFACT_DIRS) {
+    const sourcePath = path.join(projectPath, dir);
+    const targetPath = path.join(worktreePath, dir);
+
+    try {
+      // Check if source exists in main project
+      await fs.promises.access(sourcePath);
+    } catch {
+      // Source doesn't exist in main project -- nothing to symlink
+      continue;
+    }
+
+    try {
+      // Check if target already exists in worktree (real dir, symlink, or file)
+      await fs.promises.lstat(targetPath);
+      // Already exists -- skip to avoid clobbering
+      continue;
+    } catch {
+      // Target doesn't exist -- proceed with symlink creation
+    }
+
+    try {
+      // Use 'junction' type on Windows for directory symlinks (no admin required),
+      // 'dir' type on Unix (default for symlink when target is a directory).
+      const symlinkType = process.platform === 'win32' ? 'junction' : 'dir';
+      await fs.promises.symlink(sourcePath, targetPath, symlinkType);
+      symlinked.push(dir);
+    } catch (error) {
+      // Non-fatal: log and continue with remaining directories
+      logger.warn(
+        `Failed to symlink ${dir} from ${projectPath} to ${worktreePath}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  if (symlinked.length > 0) {
+    logger.info(
+      `Symlinked build artifacts into worktree ${path.basename(worktreePath)}: ${symlinked.join(', ')}`
+    );
+  }
+
+  return symlinked;
 }


### PR DESCRIPTION
## Summary

External projects' MCP servers fail in worktrees because dist/ and node_modules/ aren't present (gitignored). Agent execution fails instantly (exit code 1).\n\nFix: Post-worktree-creation hook that runs install + build, or symlink dist/node_modules from main repo.\n\nFiles: execution-service.ts, auto-mode-service.ts, worktree-lifecycle-service.ts\n\nGH Issue: #3040

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build artifacts are now automatically symlinked into worktrees when creating or reusing worktrees.
  * Required artifact directories are prepared and available before feature execution begins.
  * Symlinking failures are treated as non-fatal and logged for troubleshooting, preserving workflow continuity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->