### PR TITLE
Fix: pathToClaudeCodeExecutable uses fragile process.cwd()

### DIFF
--- a/apps/server/src/lib/sdk-options.ts
+++ b/apps/server/src/lib/sdk-options.ts
@@ -17,12 +17,23 @@
 
 import type { Options, HookCallback, PostToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
 import path from 'path';
+import { fileURLToPath } from 'node:url';
 import { createHash } from 'node:crypto';
 import { resolveModelString } from '@protolabsai/model-resolver';
 import { createLogger } from '@protolabsai/utils';
 import type { ToolExecutionEntry } from '../services/audit-service.js';
 
 const logger = createLogger('SdkOptions');
+
+/**
+ * Resolved at module load time so it remains stable when CWD shifts during
+ * worktree operations. Using import.meta.url anchors resolution to this file's
+ * location rather than the process working directory.
+ */
+const CLAUDE_CODE_EXECUTABLE = path.resolve(
+  fileURLToPath(import.meta.url),
+  '../../../../../node_modules/@anthropic-ai/claude-agent-sdk/cli.js'
+);
 
 /** Module-level tool execution logger, set via setToolExecutionLogger() from services.ts */
 let _toolExecutionLogger: ((entry: ToolExecutionEntry) => Promise<void>) | null = null;


### PR DESCRIPTION
## Summary

getBaseOptions() in sdk-options.ts resolves Claude Code executable using process.cwd() which breaks when CWD shifts during worktree operations.\n\nFix: Use import.meta.url or store resolved path at module load time.\n\nFile: apps/server/src/lib/sdk-options.ts lines 383-386\n\nGH Issue: #3009

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal preparation for future SDK functionality improvements. No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->