### PR TITLE
Fix: pathToClaudeCodeExecutable uses fragile process.cwd()

### DIFF
--- a/apps/server/src/lib/sdk-options.ts
+++ b/apps/server/src/lib/sdk-options.ts
@@ -467,10 +467,7 @@ function getBaseOptions(): Partial<Options> {
   return {
     permissionMode: 'bypassPermissions',
     allowDangerouslySkipPermissions: true,
-    pathToClaudeCodeExecutable: path.resolve(
-      process.cwd(),
-      'node_modules/@anthropic-ai/claude-agent-sdk/cli.js'
-    ),
+    pathToClaudeCodeExecutable: CLAUDE_CODE_EXECUTABLE,
   };
 }
 


### PR DESCRIPTION
## Summary

getBaseOptions() in sdk-options.ts resolves Claude Code executable using process.cwd() which breaks when CWD shifts during worktree operations.\n\nFix: Use import.meta.url or store resolved path at module load time.\n\nFile: apps/server/src/lib/sdk-options.ts lines 383-386\n\nGH Issue: #3009

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-03-23T05:54:02.124Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executable path resolution for SDK operations to enhance reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->