### PR TITLE
fix: persist Ava chat streaming when panel is closed

### DIFF
--- a/apps/ui/src/components/layout/chat-modal.tsx
+++ b/apps/ui/src/components/layout/chat-modal.tsx
@@ -1,38 +1,88 @@
 /**
- * ChatModal — Web fallback for the Ava Anywhere chat overlay.
+ * ChatModal — Persistent Ava chat panel.
  *
- * In Electron mode, the chat overlay runs in its own window.
- * In web mode, this Dialog-based modal provides the same experience.
+ * Always mounted so that streaming continues in the background when the
+ * user closes the panel.  Visibility is toggled via CSS (opacity + pointer-events),
+ * NOT via mount/unmount.  This keeps the `useChat` hook alive and the SSE fetch
+ * stream connected even while the panel is hidden.
+ *
+ * When Ava is streaming and the panel is closed, a small floating badge appears
+ * so the user knows work is in progress and can click to re-open.
+ *
  * Triggered via Cmd+K (macOS) or Ctrl+K (Windows/Linux).
  */
 
 import { useCallback, useEffect } from 'react';
-import { Dialog, DialogContent, DialogTitle } from '@protolabsai/ui/atoms';
 import { useChatStore } from '@/store/chat-store';
 import { ChatOverlayContent } from '@/components/views/chat-overlay/chat-overlay-content';
+import { cn } from '@/lib/utils';
 
 export function ChatModal() {
   const chatModalOpen = useChatStore((s) => s.chatModalOpen);
   const setChatModalOpen = useChatStore((s) => s.setChatModalOpen);
+  const activeStreamingSessionId = useChatStore((s) => s.activeStreamingSessionId);
 
   const handleClose = useCallback(() => {
     setChatModalOpen(false);
   }, [setChatModalOpen]);
 
+  // Auto-focus chat input when panel opens
+  useEffect(() => {
+    if (chatModalOpen) {
+      requestAnimationFrame(() => {
+        document.querySelector<HTMLTextAreaElement>('[data-slot="chat-input"] textarea')?.focus();
+      });
+    }
+  }, [chatModalOpen]);
+
   return (
-    <Dialog open={chatModalOpen} onOpenChange={setChatModalOpen}>
-      <DialogContent
-        showCloseButton={false}
-        className="max-w-2xl h-[70vh] p-0 gap-0 overflow-hidden"
-        onOpenAutoFocus={(e: Event) => {
-          e.preventDefault();
-          document.querySelector<HTMLTextAreaElement>('[data-slot="chat-input"] textarea')?.focus();
-        }}
+    <>
+      {/* Backdrop — only rendered when panel is open */}
+      {chatModalOpen && (
+        <div
+          className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm animate-in fade-in-0 duration-200"
+          onClick={handleClose}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Chat panel — always mounted so streaming persists in background */}
+      <div
+        role="dialog"
+        aria-label="Ava Chat"
+        aria-modal={chatModalOpen}
+        className={cn(
+          'fixed top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2',
+          'flex flex-col w-full max-w-[min(42rem,calc(100%-2rem))] h-[70vh] max-h-[calc(100vh-4rem)]',
+          'bg-card border border-border rounded-xl shadow-2xl overflow-hidden',
+          'shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)]',
+          'transition-[opacity,transform] duration-200',
+          chatModalOpen
+            ? 'visible opacity-100 scale-100'
+            : 'invisible opacity-0 scale-95 pointer-events-none'
+        )}
       >
-        <DialogTitle className="sr-only">Ava Chat</DialogTitle>
-        <ChatOverlayContent onHide={handleClose} isModal />
-      </DialogContent>
-    </Dialog>
+        <ChatOverlayContent onHide={handleClose} isModal isOpen={chatModalOpen} />
+      </div>
+
+      {/* Streaming indicator — visible when panel is closed but Ava is working */}
+      {!chatModalOpen && activeStreamingSessionId && (
+        <button
+          type="button"
+          onClick={() => setChatModalOpen(true)}
+          className={cn(
+            'fixed bottom-4 right-4 z-40 flex items-center gap-2',
+            'rounded-full bg-primary px-3 py-1.5 text-primary-foreground text-xs font-medium',
+            'shadow-lg hover:bg-primary/90 transition-colors cursor-pointer',
+            'animate-in fade-in-0 slide-in-from-bottom-2 duration-300'
+          )}
+          title="Ava is working — click to view (Ctrl+K)"
+        >
+          <span className="size-2 rounded-full bg-primary-foreground animate-pulse" />
+          Ava is working...
+        </button>
+      )}
+    </>
   );
 }
 

--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
@@ -40,9 +40,15 @@ export interface ChatOverlayContentProps {
   onHide: () => void;
   /** When true, renders in modal mode (no drag region, different hint text) */
   isModal?: boolean;
+  /** Whether the panel is currently visible — gates keyboard shortcuts to prevent interference when hidden */
+  isOpen?: boolean;
 }
 
-export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayContentProps) {
+export function ChatOverlayContent({
+  onHide,
+  isModal = false,
+  isOpen = true,
+}: ChatOverlayContentProps) {
   const currentProject = useAppStore((s) => s.currentProject);
   const features = useAppStore((s) => s.features);
 
@@ -310,8 +316,11 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
     // Negative feedback placeholder
   }, []);
 
-  // Escape key: close history panel if open, otherwise hide the overlay
+  // Escape key: close history panel if open, otherwise hide the overlay.
+  // Only active when the panel is visible to prevent interference with other
+  // keyboard handlers when the chat is running in the background.
   useEffect(() => {
+    if (!isOpen) return;
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         if (historyOpen) {
@@ -323,7 +332,7 @@ export function ChatOverlayContent({ onHide, isModal = false }: ChatOverlayConte
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [historyOpen, setHistoryOpen, onHide]);
+  }, [isOpen, historyOpen, setHistoryOpen, onHide]);
 
   return (
     <div data-slot="chat-overlay-content" className="flex h-full w-full flex-col overflow-hidden">

--- a/apps/ui/src/hooks/use-chat-session.ts
+++ b/apps/ui/src/hooks/use-chat-session.ts
@@ -241,6 +241,15 @@ export function useChatSession({
     [removePendingApproval]
   );
 
+  // Sync streaming state to store for the background streaming indicator.
+  // External consumers (e.g., the minimized chat badge) read this to know
+  // whether Ava is actively working even when the panel is hidden.
+  useEffect(() => {
+    useChatStore
+      .getState()
+      .setActiveStreamingSession(isStreaming && currentSessionId ? currentSessionId : null);
+  }, [isStreaming, currentSessionId]);
+
   // When messages change, persist to store
   useEffect(() => {
     if (currentSessionId && activeSessionRef.current === currentSessionId && messages.length > 0) {

--- a/apps/ui/src/store/chat-store.ts
+++ b/apps/ui/src/store/chat-store.ts
@@ -36,6 +36,8 @@ interface ChatStoreState {
   currentSessionId: string | null;
   historyOpen: boolean;
   chatModalOpen: boolean;
+  /** Session ID that is currently streaming — used for the background streaming indicator */
+  activeStreamingSessionId: string | null;
 }
 
 interface ChatActions {
@@ -49,6 +51,7 @@ interface ChatActions {
   setHistoryOpen: (open: boolean) => void;
   toggleHistory: () => void;
   setChatModalOpen: (open: boolean) => void;
+  setActiveStreamingSession: (sessionId: string | null) => void;
   getCurrentSession: () => ChatSession | null;
   getSessionsForProject: (projectId: string) => ChatSession[];
 }
@@ -88,6 +91,7 @@ export const useChatStore = create<ChatStoreState & ChatActions>()(
       currentSessionId: null,
       historyOpen: false,
       chatModalOpen: false,
+      activeStreamingSessionId: null,
 
       createSession: (modelAlias = 'sonnet', projectId = 'default') => {
         const now = Date.now();
@@ -163,6 +167,7 @@ export const useChatStore = create<ChatStoreState & ChatActions>()(
       setHistoryOpen: (open) => set({ historyOpen: open }),
       toggleHistory: () => set({ historyOpen: !get().historyOpen }),
       setChatModalOpen: (open) => set({ chatModalOpen: open }),
+      setActiveStreamingSession: (sessionId) => set({ activeStreamingSessionId: sessionId }),
 
       getCurrentSession: () => {
         const state = get();


### PR DESCRIPTION
## Summary
- Replace Radix Dialog mount/unmount with always-mounted container using CSS visibility toggle — keeps `useChat` hook alive so SSE streams continue in the background
- Add floating "Ava is working..." badge when panel is closed but streaming is active
- Gate Escape key handler on `isOpen` prop to prevent interference when panel is hidden

## Test plan
- [ ] CI passes
- [ ] Open Ava chat, start a conversation, close panel mid-stream — verify stream continues (reopen to see progress)
- [ ] Verify "Ava is working..." badge appears when panel closed during streaming
- [ ] Verify Cmd+K / Ctrl+K toggle still works
- [ ] Verify Escape key closes panel when open, does not interfere when closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a floating "Ava is working…" indicator badge that appears when the chat panel is closed but an active conversation is streaming, allowing you to quickly re-open the panel.
  * Chat input now automatically focuses when opening the chat panel.

* **Bug Fixes**
  * Fixed escape key behavior to respect the chat panel's visibility state, preventing unintended interactions when the panel is hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->