### PR TITLE
Per-tab streaming indicators and floating badge update

### DIFF
--- a/apps/ui/src/components/layout/chat-modal.tsx
+++ b/apps/ui/src/components/layout/chat-modal.tsx
@@ -20,7 +20,8 @@ import { cn } from '@/lib/utils';
 export function ChatModal() {
   const chatModalOpen = useChatStore((s) => s.chatModalOpen);
   const setChatModalOpen = useChatStore((s) => s.setChatModalOpen);
-  const activeStreamingSessionId = useChatStore((s) => s.activeStreamingSessionId);
+  const sessionStreamingMap = useChatStore((s) => s.sessionStreamingMap);
+  const streamingCount = Object.values(sessionStreamingMap).filter(Boolean).length;
 
   const handleClose = useCallback(() => {
     setChatModalOpen(false);
@@ -66,7 +67,7 @@ export function ChatModal() {
       </div>
 
       {/* Streaming indicator — visible when panel is closed but Ava is working */}
-      {!chatModalOpen && activeStreamingSessionId && (
+      {!chatModalOpen && streamingCount > 0 && (
         <button
           type="button"
           onClick={() => setChatModalOpen(true)}
@@ -79,7 +80,7 @@ export function ChatModal() {
           title="Ava is working — click to view (Ctrl+K)"
         >
           <span className="size-2 rounded-full bg-primary-foreground animate-pulse" />
-          Ava is working...
+          {streamingCount > 1 ? `Ava is working (${streamingCount} sessions)` : 'Ava is working...'}
         </button>
       )}
     </>

--- a/apps/ui/src/components/views/chat-overlay/chat-session-slot.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-session-slot.tsx
@@ -12,6 +12,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
+import { toast } from 'sonner';
 import { useChatStore } from '@/store/chat-store';
 import { getAuthHeaders } from '@/lib/api-fetch';
 import { AskAvaTab } from './ask-ava-tab';
@@ -72,9 +73,12 @@ export function ChatSessionSlot({
   });
 
   const isStreaming = status === 'streaming' || status === 'submitted';
+  const chatModalOpen = useChatStore((s) => s.chatModalOpen);
 
   // Track whether we've already seeded messages from the store on first mount
   const seededRef = useRef(false);
+  // Track previous streaming state to detect transitions
+  const prevStreamingRef = useRef(false);
 
   // Seed messages from store on first mount
   useEffect(() => {
@@ -96,6 +100,22 @@ export function ChatSessionSlot({
   useEffect(() => {
     setSessionStreaming(sessionId, isStreaming);
   }, [sessionId, isStreaming, setSessionStreaming]);
+
+  // Toast when a background session finishes (modal was closed during streaming)
+  useEffect(() => {
+    const wasStreaming = prevStreamingRef.current;
+    if (wasStreaming && !isStreaming && !chatModalOpen) {
+      const title = session?.title ?? 'Chat session';
+      toast(`${title} complete`, {
+        description: 'Ava finished responding. Click to open.',
+        action: {
+          label: 'Open',
+          onClick: () => useChatStore.getState().setChatModalOpen(true),
+        },
+      });
+    }
+    prevStreamingRef.current = isStreaming;
+  }, [isStreaming, chatModalOpen, session?.title]);
 
   // Persist messages to the store whenever they change
   const messagesRef = useRef(messages);

--- a/apps/ui/src/components/views/chat-overlay/chat-tab-bar.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-tab-bar.tsx
@@ -6,6 +6,7 @@
  * and a [+] button to create a new session.
  */
 
+import { useEffect, useRef, useState } from 'react';
 import { Plus, X } from 'lucide-react';
 import { useChatStore } from '@/store/chat-store';
 import { cn } from '@/lib/utils';
@@ -18,6 +19,14 @@ interface ChatTabBarProps {
   className?: string;
 }
 
+/** Format elapsed seconds as m:ss */
+function formatElapsed(startMs: number): string {
+  const secs = Math.floor((Date.now() - startMs) / 1000);
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
 export function ChatTabBar({ projectId, modelAlias, className }: ChatTabBarProps) {
   const activeSessions = useChatStore((s) => s.activeSessions);
   const currentSessionId = useChatStore((s) => s.currentSessionId);
@@ -26,6 +35,37 @@ export function ChatTabBar({ projectId, modelAlias, className }: ChatTabBarProps
   const switchSession = useChatStore((s) => s.switchSession);
   const deleteSession = useChatStore((s) => s.deleteSession);
   const createSession = useChatStore((s) => s.createSession);
+
+  // Track when each session started streaming (wall-clock ms)
+  const streamingStartTimesRef = useRef<Record<string, number>>({});
+  // Tick state drives re-renders every second while any session is streaming
+  const [, setTick] = useState(0);
+
+  // Maintain streaming start times: record on first true, clear on false
+  useEffect(() => {
+    const map = sessionStreamingMap;
+    for (const [id, streaming] of Object.entries(map)) {
+      if (streaming && streamingStartTimesRef.current[id] === undefined) {
+        streamingStartTimesRef.current[id] = Date.now();
+      } else if (!streaming) {
+        delete streamingStartTimesRef.current[id];
+      }
+    }
+    // Clear stale entries for sessions no longer in the map
+    for (const id of Object.keys(streamingStartTimesRef.current)) {
+      if (!map[id]) {
+        delete streamingStartTimesRef.current[id];
+      }
+    }
+  }, [sessionStreamingMap]);
+
+  // Tick every second while any session is streaming so elapsed times update
+  useEffect(() => {
+    const anyStreaming = Object.values(sessionStreamingMap).some(Boolean);
+    if (!anyStreaming) return;
+    const interval = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(interval);
+  }, [sessionStreamingMap]);
 
   // Only show tabs for active sessions; optionally filtered by project
   const visibleIds = activeSessions.filter((id) => {
@@ -85,6 +125,13 @@ export function ChatTabBar({ projectId, modelAlias, className }: ChatTabBarProps
 
             {/* Session title — truncated */}
             <span className="min-w-0 flex-1 truncate text-left">{title}</span>
+
+            {/* Elapsed time — shown while streaming */}
+            {isStreaming && streamingStartTimesRef.current[sessionId] !== undefined && (
+              <span className="shrink-0 font-mono text-[10px] text-green-500">
+                {formatElapsed(streamingStartTimesRef.current[sessionId])}
+              </span>
+            )}
 
             {/* Close button */}
             <span


### PR DESCRIPTION
## Summary

Multi-stream badge count, elapsed time per tab, toast on background session completion.\n\nFiles to Modify: chat-modal.tsx, chat-tab-bar.tsx, chat-session-slot.tsx'
<parameter name='complexity'>medium

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "Ava is working..." indicator now displays the number of active sessions when multiple sessions are streaming simultaneously.
  * Toast notifications appear when chat sessions complete, allowing you to quickly open the finished session.
  * Streaming session tabs now display real-time elapsed time counters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->