### PR TITLE
fix: activate session in chat slot handlers

### DIFF
--- a/apps/ui/src/components/views/chat-overlay/chat-session-slot.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-session-slot.tsx
@@ -139,14 +139,16 @@ export function ChatSessionSlot({
   }, [stop]);
 
   const handleNewChat = useCallback(() => {
-    createSession(modelAlias, projectId);
-  }, [createSession, modelAlias, projectId]);
+    const session = createSession(modelAlias, projectId);
+    activateSession(session.id);
+  }, [createSession, activateSession, modelAlias, projectId]);
 
   const handleSelectSession = useCallback(
     (id: string) => {
       switchSession(id);
+      activateSession(id);
     },
-    [switchSession]
+    [switchSession, activateSession]
   );
 
   const handleDeleteSession = useCallback(


### PR DESCRIPTION
## Summary
- Fix blank chat area when creating new session or selecting from history inside a chat slot
- handleNewChat and handleSelectSession now call activateSession to register the session in the pool

## Test plan
- [ ] Create new chat via pencil icon — tab bar appears, chat content visible
- [ ] Switch sessions from history panel — content stays visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)