### PR TITLE
fix: session pool layout + tab styling

### DIFF
--- a/apps/ui/src/components/views/chat-overlay/chat-session-pool.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-session-pool.tsx
@@ -20,7 +20,7 @@ export function ChatSessionPool({ projectPath, projectId }: ChatSessionPoolProps
   const currentSessionId = useChatStore((s) => s.currentSessionId);
 
   return (
-    <>
+    <div className="flex min-h-0 flex-1 flex-col">
       {activeSessions.map((sessionId) => (
         <ChatSessionSlot
           key={sessionId}
@@ -30,6 +30,6 @@ export function ChatSessionPool({ projectPath, projectId }: ChatSessionPoolProps
           projectId={projectId}
         />
       ))}
-    </>
+    </div>
   );
 }

--- a/apps/ui/src/components/views/chat-overlay/chat-tab-bar.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-tab-bar.tsx
@@ -110,10 +110,8 @@ export function ChatTabBar({ projectId, modelAlias, className }: ChatTabBarProps
   return (
     <>
       <div
-        className={cn(
-          'flex items-center gap-0.5 overflow-x-auto border-b border-border bg-background px-1 py-0.5',
-          className
-        )}
+        className={cn('flex items-center overflow-x-auto border-b border-border px-2', className)}
+        role="tablist"
         data-testid="chat-tab-bar"
       >
         {visibleIds.map((sessionId) => {
@@ -125,16 +123,19 @@ export function ChatTabBar({ projectId, modelAlias, className }: ChatTabBarProps
           return (
             <button
               key={sessionId}
+              type="button"
+              role="tab"
               onClick={() => {
                 switchSession(sessionId);
                 activateSession(sessionId);
               }}
               className={cn(
-                'group flex min-w-0 max-w-[160px] shrink-0 items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors',
+                'group flex min-w-0 max-w-[180px] shrink-0 items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors border-b-2 -mb-px',
                 isActive
-                  ? 'bg-accent text-accent-foreground'
-                  : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+                  ? 'border-primary text-foreground'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
               )}
+              aria-selected={isActive}
               title={title}
               data-testid={`chat-tab-${sessionId}`}
             >
@@ -181,8 +182,9 @@ export function ChatTabBar({ projectId, modelAlias, className }: ChatTabBarProps
 
         {/* New session button */}
         <button
+          type="button"
           onClick={handleNew}
-          className="flex shrink-0 items-center gap-1 rounded px-1.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+          className="flex shrink-0 items-center gap-1 px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground border-b-2 border-transparent -mb-px"
           title="New chat session"
           data-testid="chat-tab-new"
         >


### PR DESCRIPTION
## Summary
- Fix missing chat input: ChatSessionPool now wraps slots in a flex container
- Tab bar uses border-b-2 underline style matching the old Ask Ava / Projects / #backchannel tabs
- ARIA attributes for accessibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated chat tab bar styling and layout for improved visual consistency
  * Enhanced semantic HTML structure in the chat interface for better accessibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->