### PR TITLE
fix: chat input visibility on first tab

### DIFF
--- a/apps/ui/src/components/views/chat-overlay/chat-session-pool.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-session-pool.tsx
@@ -20,7 +20,7 @@ export function ChatSessionPool({ projectPath, projectId }: ChatSessionPoolProps
   const currentSessionId = useChatStore((s) => s.currentSessionId);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       {activeSessions.map((sessionId) => (
         <ChatSessionSlot
           key={sessionId}

--- a/apps/ui/src/components/views/chat-overlay/chat-session-slot.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-session-slot.tsx
@@ -196,7 +196,7 @@ export function ChatSessionSlot({
   );
 
   return (
-    <div className={cn('flex min-h-0 flex-1 flex-col', !visible && 'hidden')}>
+    <div className={cn('flex min-h-0 flex-1 flex-col overflow-hidden', !visible && 'hidden')}>
       <AskAvaTab
         displayedMessages={messages}
         isStreaming={isStreaming}


### PR DESCRIPTION
## Summary
- Add overflow-hidden to ChatSessionPool and ChatSessionSlot containers
- Prevents chat input from being pushed below the modal on initial render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined chat overlay styling to improve content display and visual organization within chat sessions. Enhanced container styling to prevent content overflow by adding specific content constraint properties, ensuring all chat elements remain properly contained within defined boundaries. This provides a cleaner, more organized interface with better overall layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->