### PR TITLE
fix: textarea height 0px + duplicate tab on reload

### DIFF
--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
@@ -7,7 +7,7 @@
  * Used by the web fallback modal (ChatModal).
  */
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { History, X, Settings, ChevronUp, ChevronDown, SquarePen, ListOrdered } from 'lucide-react';
 import { Button } from '@protolabsai/ui/atoms';
 import { cn } from '@/lib/utils';
@@ -64,7 +64,13 @@ export function ChatOverlayContent({
   }, []); // Intentionally empty — bootstrap runs once on mount
 
   // Recovery: if all sessions are gone (user closed all tabs), auto-create one.
+  // Skip the first run — bootstrap effect handles initialization.
+  const bootstrapDoneRef = useRef(false);
   useEffect(() => {
+    if (!bootstrapDoneRef.current) {
+      bootstrapDoneRef.current = true;
+      return;
+    }
     if (activeSessions.length === 0) {
       const store = useChatStore.getState();
       const session = store.createSession('sonnet', currentProject?.id ?? 'default');

--- a/libs/ui/src/ai/chat-input.tsx
+++ b/libs/ui/src/ai/chat-input.tsx
@@ -53,11 +53,15 @@ export function ChatInput({
   const commandMode = !!slashCommands?.isActive;
 
   // Auto-resize up to MAX_HEIGHT_PX; textarea handles its own overflow beyond that.
+  // Uses a minimum of 1 line (~24px) to prevent collapse when mounted inside a
+  // hidden container (scrollHeight returns 0 when display:none).
+  const MIN_HEIGHT_PX = 24;
   useEffect(() => {
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = 'auto';
-    el.style.height = `${Math.min(el.scrollHeight, MAX_HEIGHT_PX)}px`;
+    const measured = el.scrollHeight;
+    el.style.height = `${Math.max(MIN_HEIGHT_PX, Math.min(measured, MAX_HEIGHT_PX))}px`;
   }, [value]);
 
   // Re-focus after streaming ends so the user can type the next message immediately.


### PR DESCRIPTION
## Summary
- ChatInput textarea had height: 0px on first tab after page reload (scrollHeight=0 when mounted in hidden container). Added 24px minimum height.
- Recovery effect fired before bootstrap, creating a duplicate "New chat" tab on every reload. Added skip-first-run guard.

## Test plan
- [ ] Refresh page, open chat — single tab with visible input
- [ ] Create second tab — both have visible inputs
- [ ] Close and reopen panel — input still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Chat input textarea** – Fixed an issue where the input field could collapse to an unusable size when initially rendered in certain conditions.
* **Session initialization** – Improved the timing of session setup to prevent unexpected automatic session switches on app startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->