### PR TITLE
Squash-merge PRs can produce empty commits when worktree code not pushed

### DIFF
--- a/apps/server/src/routes/worktree/routes/create-pr.ts
+++ b/apps/server/src/routes/worktree/routes/create-pr.ts
@@ -153,6 +153,41 @@ export function createCreatePRHandler(settingsService?: SettingsService) {
       const base =
         baseBranch ||
         (await getEffectivePrBaseBranch(effectiveProjectPath, settingsService, '[CreatePR]'));
+
+      // Verify the branch has commits ahead of the base branch before creating a PR.
+      // If there are no commits ahead, the PR diff would be empty, causing a squash-merge
+      // that produces a commit with no file changes — a silent data loss bug.
+      try {
+        await execAsync(`git fetch origin ${base}`, {
+          cwd: worktreePath,
+          env: execEnv,
+        });
+        const { stdout: aheadCountStr } = await execAsync(
+          `git rev-list --count origin/${base}..HEAD`,
+          { cwd: worktreePath, env: execEnv }
+        );
+        const aheadCount = parseInt(aheadCountStr.trim(), 10);
+        if (aheadCount <= 0) {
+          logger.warn(
+            `Branch ${branchName} has no commits ahead of ${base} — skipping PR creation to prevent empty squash-merge`
+          );
+          res.status(422).json({
+            success: false,
+            error: `Branch ${branchName} has no commits ahead of base branch ${base}. PR creation skipped to prevent empty squash-merge.`,
+            emptyDiff: true,
+          });
+          return;
+        }
+        logger.debug(`Branch ${branchName} is ${aheadCount} commit(s) ahead of ${base}`);
+      } catch (fetchErr) {
+        // If we can't verify, log a warning but allow PR creation to proceed.
+        // This avoids blocking legitimate PRs due to transient network errors.
+        logger.warn(
+          `Could not verify commits ahead of ${base}, proceeding with PR creation:`,
+          fetchErr
+        );
+      }
+
       const title = prTitle || branchName;
       const rawBody = prBody || `Changes from branch ${branchName}`;
 


### PR DESCRIPTION
## Summary

**Bug**: When an agent is stopped mid-work and a PR is auto-created from the worktree branch, the squash-merge on GitHub can produce an empty commit if the worktree had uncommitted changes or the branch wasn't pushed before the PR was created.

**Impact**: In a session shipping 15 PRs, several squash-merged PRs were empty — the commit message described the changes but no files were actually modified. The files existed locally (worktree bleed into the main working tree) but weren't in git history...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-03-24T07:33:21.564Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent PR creation when there are no new commits ahead of the base branch. The system now returns an error with an empty diff indicator in such cases, with graceful error handling for network issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->