### PR TITLE
projects.yaml schema extension + registry backfill

### DIFF
--- a/libs/flows/tests/unit/ava-review.test.ts
+++ b/libs/flows/tests/unit/ava-review.test.ts
@@ -57,34 +57,34 @@ describe('ava-review node', () => {
   describe('normal case', () => {
     it('should return approve verdict for low-risk PRD', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'approve',
-          sections: [
-            {
-              area: 'Capacity',
-              assessment: 'Team has sufficient bandwidth',
-              concerns: [],
-            },
-            {
-              area: 'Risk',
-              assessment: 'Low risk, well-understood domain',
-              concerns: [],
-            },
-            {
-              area: 'Tech Debt',
-              assessment: 'Neutral impact on tech debt',
-              concerns: [],
-            },
-            {
-              area: 'Feasibility',
-              assessment: 'Straightforward implementation',
-              concerns: [],
-            },
-          ],
-          comments: 'Clean, low-risk change. Ready to proceed.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <verdict>approve</verdict>
+  <sections>
+    <section>
+      <area>Capacity</area>
+      <assessment>Team has sufficient bandwidth</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>Risk</area>
+      <assessment>Low risk, well-understood domain</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>Tech Debt</area>
+      <assessment>Neutral impact on tech debt</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>Feasibility</area>
+      <assessment>Straightforward implementation</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>Clean, low-risk change. Ready to proceed.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {
@@ -104,37 +104,53 @@ describe('ava-review node', () => {
 
     it('should return approve-with-concerns verdict with recommendations', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'approve-with-concerns',
-          sections: [
-            {
-              area: 'Capacity',
-              assessment: 'Tight timeline but manageable',
-              concerns: ['May require overtime during peak sprint'],
-              recommendations: ['Add 1 week buffer to timeline'],
-            },
-            {
-              area: 'Risk',
-              assessment: 'Moderate risk with third-party API',
-              concerns: ['API rate limits not documented', 'No fallback mechanism'],
-              recommendations: ['Implement rate limiting', 'Add circuit breaker pattern'],
-            },
-            {
-              area: 'Tech Debt',
-              assessment: 'Will add some technical debt',
-              concerns: ['Quick implementation may skip best practices'],
-              recommendations: ['Schedule refactoring in next sprint'],
-            },
-            {
-              area: 'Feasibility',
-              assessment: 'Feasible with caveats',
-              concerns: ['Dependency on external team deliverable'],
-            },
-          ],
-          comments: 'Can proceed but monitor the identified concerns closely.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <verdict>approve-with-concerns</verdict>
+  <sections>
+    <section>
+      <area>Capacity</area>
+      <assessment>Tight timeline but manageable</assessment>
+      <concerns>
+        <item>May require overtime during peak sprint</item>
+      </concerns>
+      <recommendations>
+        <item>Add 1 week buffer to timeline</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Risk</area>
+      <assessment>Moderate risk with third-party API</assessment>
+      <concerns>
+        <item>API rate limits not documented</item>
+        <item>No fallback mechanism</item>
+      </concerns>
+      <recommendations>
+        <item>Implement rate limiting</item>
+        <item>Add circuit breaker pattern</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Tech Debt</area>
+      <assessment>Will add some technical debt</assessment>
+      <concerns>
+        <item>Quick implementation may skip best practices</item>
+      </concerns>
+      <recommendations>
+        <item>Schedule refactoring in next sprint</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Feasibility</area>
+      <assessment>Feasible with caveats</assessment>
+      <concerns>
+        <item>Dependency on external team deliverable</item>
+      </concerns>
+    </section>
+  </sections>
+  <comments>Can proceed but monitor the identified concerns closely.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {
@@ -156,38 +172,55 @@ describe('ava-review node', () => {
 
     it('should return revise verdict for PRDs needing changes', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'revise',
-          sections: [
-            {
-              area: 'Capacity',
-              assessment: 'Insufficient team capacity',
-              concerns: ['Team already at 120% capacity', 'No clear resource allocation plan'],
-              recommendations: ['Defer to next quarter', 'Hire additional engineer'],
-            },
-            {
-              area: 'Risk',
-              assessment: 'High risk, unclear requirements',
-              concerns: ['Vague success criteria', 'No rollback plan defined'],
-              recommendations: ['Define specific KPIs', 'Document rollback procedure'],
-            },
-            {
-              area: 'Tech Debt',
-              assessment: 'Will significantly increase tech debt',
-              concerns: ['Proposed shortcut will make future features harder'],
-            },
-            {
-              area: 'Feasibility',
-              assessment: 'Not feasible without infrastructure upgrade',
-              concerns: ['Current database cannot handle projected load'],
-              recommendations: ['Upgrade to scalable database solution first'],
-            },
-          ],
-          comments:
-            'PRD needs revision before we can commit resources. Address capacity, requirements clarity, and infrastructure concerns.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <verdict>revise</verdict>
+  <sections>
+    <section>
+      <area>Capacity</area>
+      <assessment>Insufficient team capacity</assessment>
+      <concerns>
+        <item>Team already at 120% capacity</item>
+        <item>No clear resource allocation plan</item>
+      </concerns>
+      <recommendations>
+        <item>Defer to next quarter</item>
+        <item>Hire additional engineer</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Risk</area>
+      <assessment>High risk, unclear requirements</assessment>
+      <concerns>
+        <item>Vague success criteria</item>
+        <item>No rollback plan defined</item>
+      </concerns>
+      <recommendations>
+        <item>Define specific KPIs</item>
+        <item>Document rollback procedure</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Tech Debt</area>
+      <assessment>Will significantly increase tech debt</assessment>
+      <concerns>
+        <item>Proposed shortcut will make future features harder</item>
+      </concerns>
+    </section>
+    <section>
+      <area>Feasibility</area>
+      <assessment>Not feasible without infrastructure upgrade</assessment>
+      <concerns>
+        <item>Current database cannot handle projected load</item>
+      </concerns>
+      <recommendations>
+        <item>Upgrade to scalable database solution first</item>
+      </recommendations>
+    </section>
+  </sections>
+  <comments>PRD needs revision before we can commit resources. Address capacity, requirements clarity, and infrastructure concerns.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {
@@ -204,42 +237,47 @@ describe('ava-review node', () => {
 
     it('should return reject verdict for unfeasible PRDs', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'reject',
-          sections: [
-            {
-              area: 'Capacity',
-              assessment: 'No available capacity',
-              concerns: [
-                'Would require 3 full-time engineers for 6 months',
-                'No engineers available',
-              ],
-            },
-            {
-              area: 'Risk',
-              assessment: 'Extreme risk',
-              concerns: [
-                'Would require complete system rewrite',
-                'High probability of data loss',
-                'Cannot guarantee backward compatibility',
-              ],
-            },
-            {
-              area: 'Tech Debt',
-              assessment: 'Would create massive technical debt',
-              concerns: ['Legacy approach being proposed', 'Will block future initiatives'],
-            },
-            {
-              area: 'Feasibility',
-              assessment: 'Not feasible with current technology',
-              concerns: ['Required technology does not exist', 'Physics constraints'],
-            },
-          ],
-          comments:
-            'Cannot recommend proceeding with this PRD. Fundamental issues with capacity, risk, and feasibility.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <verdict>reject</verdict>
+  <sections>
+    <section>
+      <area>Capacity</area>
+      <assessment>No available capacity</assessment>
+      <concerns>
+        <item>Would require 3 full-time engineers for 6 months</item>
+        <item>No engineers available</item>
+      </concerns>
+    </section>
+    <section>
+      <area>Risk</area>
+      <assessment>Extreme risk</assessment>
+      <concerns>
+        <item>Would require complete system rewrite</item>
+        <item>High probability of data loss</item>
+        <item>Cannot guarantee backward compatibility</item>
+      </concerns>
+    </section>
+    <section>
+      <area>Tech Debt</area>
+      <assessment>Would create massive technical debt</assessment>
+      <concerns>
+        <item>Legacy approach being proposed</item>
+        <item>Will block future initiatives</item>
+      </concerns>
+    </section>
+    <section>
+      <area>Feasibility</area>
+      <assessment>Not feasible with current technology</assessment>
+      <concerns>
+        <item>Required technology does not exist</item>
+        <item>Physics constraints</item>
+      </concerns>
+    </section>
+  </sections>
+  <comments>Cannot recommend proceeding with this PRD. Fundamental issues with capacity, risk, and feasibility.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {
@@ -253,23 +291,9 @@ describe('ava-review node', () => {
       expect(result.avaReview?.verdict).toBe('reject');
     });
 
-    it('should handle JSON in markdown code blocks', async () => {
+    it('should handle XML in markdown code blocks', async () => {
       const smartModel = new TestChatModel([
-        '```json\n' +
-          JSON.stringify({
-            reviewer: 'Ava',
-            verdict: 'approve',
-            sections: [
-              {
-                area: 'Capacity',
-                assessment: 'Good',
-                concerns: [],
-              },
-            ],
-            comments: 'Looks good',
-            timestamp: '2024-01-01T00:00:00.000Z',
-          }) +
-          '\n```',
+        '```xml\n<review>\n  <reviewer>Ava</reviewer>\n  <verdict>approve</verdict>\n  <sections>\n    <section>\n      <area>Capacity</area>\n      <assessment>Good</assessment>\n      <concerns></concerns>\n    </section>\n  </sections>\n  <comments>Looks good</comments>\n  <timestamp>2024-01-01T00:00:00.000Z</timestamp>\n</review>\n```',
       ]);
 
       const state: AvaReviewState = {
@@ -285,24 +309,31 @@ describe('ava-review node', () => {
   });
 
   describe('malformed LLM output', () => {
-    it('should throw error on invalid JSON', async () => {
-      const smartModel = new TestChatModel(['This is not valid JSON']);
+    it('should throw error on missing review root element', async () => {
+      const smartModel = new TestChatModel(['This is not valid XML']);
 
       const state: AvaReviewState = {
         prd: 'Some PRD',
         smartModel,
       };
 
-      await expect(avaReviewNode(state)).rejects.toThrow('Failed to parse JSON');
+      await expect(avaReviewNode(state)).rejects.toThrow('Failed to parse XML');
     });
 
-    it('should throw error on missing required fields', async () => {
+    it('should throw error on missing verdict field', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'approve',
-          // missing sections and comments
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <sections>
+    <section>
+      <area>Capacity</area>
+      <assessment>Good</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>Test</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {
@@ -315,13 +346,19 @@ describe('ava-review node', () => {
 
     it('should throw error on invalid verdict value', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'maybe', // invalid value
-          sections: [],
-          comments: 'Test',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <verdict>maybe</verdict>
+  <sections>
+    <section>
+      <area>Capacity</area>
+      <assessment>Good</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>Test</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {
@@ -332,28 +369,15 @@ describe('ava-review node', () => {
       await expect(avaReviewNode(state)).rejects.toThrow('Invalid review format');
     });
 
-    it('should throw error on invalid section structure', async () => {
-      const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'approve',
-          sections: [
-            {
-              // missing area and assessment
-              concerns: [],
-            },
-          ],
-          comments: 'Test',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
-      ]);
+    it('should throw error on empty review content', async () => {
+      const smartModel = new TestChatModel([`<review></review>`]);
 
       const state: AvaReviewState = {
         prd: 'Some PRD',
         smartModel,
       };
 
-      await expect(avaReviewNode(state)).rejects.toThrow('Invalid review format');
+      await expect(avaReviewNode(state)).rejects.toThrow('Failed to parse XML');
     });
   });
 
@@ -364,19 +388,21 @@ describe('ava-review node', () => {
 
       // Fast model provides valid response
       const fastModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'approve-with-concerns',
-          sections: [
-            {
-              area: 'Capacity',
-              assessment: 'From fast model - adequate capacity',
-              concerns: ['Minor concern'],
-            },
-          ],
-          comments: 'Fallback review from fast model',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <verdict>approve-with-concerns</verdict>
+  <sections>
+    <section>
+      <area>Capacity</area>
+      <assessment>From fast model - adequate capacity</assessment>
+      <concerns>
+        <item>Minor concern</item>
+      </concerns>
+    </section>
+  </sections>
+  <comments>Fallback review from fast model</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {
@@ -408,19 +434,19 @@ describe('ava-review node', () => {
 
     it('should work with only smart model provided', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'approve',
-          sections: [
-            {
-              area: 'Feasibility',
-              assessment: 'Looks good',
-              concerns: [],
-            },
-          ],
-          comments: 'All good',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <verdict>approve</verdict>
+  <sections>
+    <section>
+      <area>Feasibility</area>
+      <assessment>Looks good</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>All good</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {

--- a/libs/flows/tests/unit/consolidate.test.ts
+++ b/libs/flows/tests/unit/consolidate.test.ts
@@ -98,22 +98,21 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'PROCEED',
-          consensusAnalysis: {
-            agreement: [
-              'Both reviewers approve',
-              'No blocking concerns identified',
-              'Clear execution path and business value',
-            ],
-            disagreement: [],
-            resolution:
-              'Full consensus to proceed. Both operational and business perspectives aligned.',
-          },
-          finalPRD: 'Add loading spinner to submit button',
-          summary: 'Approved by both Ava and Jon. Ready to proceed with implementation.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>PROCEED</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>Both reviewers approve</item>
+      <item>No blocking concerns identified</item>
+      <item>Clear execution path and business value</item>
+    </agreement>
+    <disagreement></disagreement>
+    <resolution>Full consensus to proceed. Both operational and business perspectives aligned.</resolution>
+  </consensus_analysis>
+  <final_prd>Add loading spinner to submit button</final_prd>
+  <summary>Approved by both Ava and Jon. Ready to proceed with implementation.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -165,22 +164,23 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'PROCEED',
-          consensusAnalysis: {
-            agreement: [
-              'Both support moving forward',
-              'High customer value (Jon)',
-              'Execution is feasible (Ava)',
-            ],
-            disagreement: ['Ava notes capacity is tight but not blocking'],
-            resolution: 'Minor concerns do not warrant blocking. Proceed with monitoring plan.',
-          },
-          finalPRD: 'Add loading spinner to submit button',
-          summary:
-            'Approved with minor operational concerns. Monitor sprint velocity as recommended by Ava.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>PROCEED</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>Both support moving forward</item>
+      <item>High customer value (Jon)</item>
+      <item>Execution is feasible (Ava)</item>
+    </agreement>
+    <disagreement>
+      <item>Ava notes capacity is tight but not blocking</item>
+    </disagreement>
+    <resolution>Minor concerns do not warrant blocking. Proceed with monitoring plan.</resolution>
+  </consensus_analysis>
+  <final_prd>Add loading spinner to submit button</final_prd>
+  <summary>Approved with minor operational concerns. Monitor sprint velocity as recommended by Ava.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -235,23 +235,24 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'MODIFY',
-          consensusAnalysis: {
-            agreement: ['Both see value in the initiative'],
-            disagreement: [
-              'Ava: serious capacity and risk concerns',
-              'Jon: wants to proceed due to market timing',
-            ],
-            resolution:
-              "PRD needs modification to address Ava's operational concerns while preserving Jon's business objectives. Reduce scope or adjust timeline.",
-          },
-          finalPRD:
-            'MODIFIED: Launch real-time collaborative editing - PHASE 1 (reduced scope)\n\nAddress capacity by reducing initial scope to basic editing only. Full feature set deferred to Q2. Rollback plan documented in deployment guide.',
-          summary:
-            'Modified PRD to address capacity and risk concerns while maintaining business value. Phased approach reduces operational burden.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>MODIFY</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>Both see value in the initiative</item>
+    </agreement>
+    <disagreement>
+      <item>Ava: serious capacity and risk concerns</item>
+      <item>Jon: wants to proceed due to market timing</item>
+    </disagreement>
+    <resolution>PRD needs modification to address Ava's operational concerns while preserving Jon's business objectives. Reduce scope or adjust timeline.</resolution>
+  </consensus_analysis>
+  <final_prd>MODIFIED: Launch real-time collaborative editing - PHASE 1 (reduced scope)
+
+Address capacity by reducing initial scope to basic editing only. Full feature set deferred to Q2. Rollback plan documented in deployment guide.</final_prd>
+  <summary>Modified PRD to address capacity and risk concerns while maintaining business value. Phased approach reduces operational burden.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -300,23 +301,28 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'MODIFY',
-          consensusAnalysis: {
-            agreement: ['Both support the concept'],
-            disagreement: [
-              'Both raised concerns that need addressing',
-              'Ava: technical risk mitigation needed',
-              'Jon: business metrics unclear',
-            ],
-            resolution:
-              'While both approve conceptually, the combined concerns warrant PRD updates to de-risk and clarify expectations.',
-          },
-          finalPRD:
-            'MODIFIED: Integrate payment gateway\n\nUpdates:\n- Add circuit breaker pattern (Ava)\n- Define success metrics: 95% uptime, <2s latency (Jon)\n- Cost projection: $50K dev + $10K/mo operational',
-          summary: 'PRD updated to address both operational risk and business metrics concerns.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>MODIFY</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>Both support the concept</item>
+    </agreement>
+    <disagreement>
+      <item>Both raised concerns that need addressing</item>
+      <item>Ava: technical risk mitigation needed</item>
+      <item>Jon: business metrics unclear</item>
+    </disagreement>
+    <resolution>While both approve conceptually, the combined concerns warrant PRD updates to de-risk and clarify expectations.</resolution>
+  </consensus_analysis>
+  <final_prd>MODIFIED: Integrate payment gateway
+
+Updates:
+- Add circuit breaker pattern (Ava)
+- Define success metrics: 95% uptime, &lt;2s latency (Jon)
+- Cost projection: $50K dev + $10K/mo operational</final_prd>
+  <summary>PRD updated to address both operational risk and business metrics concerns.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -373,23 +379,21 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'REJECT',
-          consensusAnalysis: {
-            agreement: [
-              'Both reviewers recommend rejection',
-              'Ava: operationally not feasible',
-              'Jon: business case insufficient',
-            ],
-            disagreement: [],
-            resolution:
-              'Clear consensus to reject. Both operational and business perspectives align that this PRD should not proceed.',
-          },
-          finalPRD: 'Build internal tool for rarely-used workflow',
-          summary:
-            'Rejected by both reviewers. Operationally infeasible and poor business case. Recommend exploring alternative solutions.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>REJECT</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>Both reviewers recommend rejection</item>
+      <item>Ava: operationally not feasible</item>
+      <item>Jon: business case insufficient</item>
+    </agreement>
+    <disagreement></disagreement>
+    <resolution>Clear consensus to reject. Both operational and business perspectives align that this PRD should not proceed.</resolution>
+  </consensus_analysis>
+  <final_prd>Build internal tool for rarely-used workflow</final_prd>
+  <summary>Rejected by both reviewers. Operationally infeasible and poor business case. Recommend exploring alternative solutions.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -442,22 +446,22 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'REJECT',
-          consensusAnalysis: {
-            agreement: ['Technical execution is feasible (Ava)'],
-            disagreement: [
-              'Jon identifies fundamental business issues',
-              'Strategic misalignment and no customer value',
-            ],
-            resolution:
-              "Jon's rejection based on fundamental business concerns overrides Ava's operational approval. Cannot proceed with strategically misaligned initiative.",
-          },
-          finalPRD: 'Feature X',
-          summary:
-            'Rejected due to fundamental business concerns. Even though technically feasible, strategic misalignment and lack of customer value make this a non-starter.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>REJECT</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>Technical execution is feasible (Ava)</item>
+    </agreement>
+    <disagreement>
+      <item>Jon identifies fundamental business issues</item>
+      <item>Strategic misalignment and no customer value</item>
+    </disagreement>
+    <resolution>Jon's rejection based on fundamental business concerns overrides Ava's operational approval. Cannot proceed with strategically misaligned initiative.</resolution>
+  </consensus_analysis>
+  <final_prd>Feature X</final_prd>
+  <summary>Rejected due to fundamental business concerns. Even though technically feasible, strategic misalignment and lack of customer value make this a non-starter.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -521,20 +525,27 @@ describe('consolidate node', () => {
       ];
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'MODIFY',
-          consensusAnalysis: {
-            agreement: ['All approve the initiative', 'Ava and Jon have no concerns'],
-            disagreement: ['Security Team raises PII handling concerns'],
-            resolution:
-              "While Ava and Jon approve, Security Team's concerns about PII handling must be addressed. Modify PRD to include security requirements.",
-          },
-          finalPRD:
-            'MODIFIED: User profile feature\n\nAdded security section:\n- Encrypt PII at rest\n- Document data retention policy\n- Security review before launch',
-          summary:
-            'PRD modified to address security concerns while maintaining business and operational approval.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>MODIFY</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>All approve the initiative</item>
+      <item>Ava and Jon have no concerns</item>
+    </agreement>
+    <disagreement>
+      <item>Security Team raises PII handling concerns</item>
+    </disagreement>
+    <resolution>While Ava and Jon approve, Security Team's concerns about PII handling must be addressed. Modify PRD to include security requirements.</resolution>
+  </consensus_analysis>
+  <final_prd>MODIFIED: User profile feature
+
+Added security section:
+- Encrypt PII at rest
+- Document data retention policy
+- Security review before launch</final_prd>
+  <summary>PRD modified to address security concerns while maintaining business and operational approval.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -588,17 +599,20 @@ describe('consolidate node', () => {
       ];
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'PROCEED',
-          consensusAnalysis: {
-            agreement: ['All four reviewers approve', 'No concerns from any perspective'],
-            disagreement: [],
-            resolution: 'Full consensus across all reviewers. Ready to proceed.',
-          },
-          finalPRD: 'Feature with full approval',
-          summary: 'Approved by Ava, Jon, Security, and Legal. No concerns.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>PROCEED</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>All four reviewers approve</item>
+      <item>No concerns from any perspective</item>
+    </agreement>
+    <disagreement></disagreement>
+    <resolution>Full consensus across all reviewers. Ready to proceed.</resolution>
+  </consensus_analysis>
+  <final_prd>Feature with full approval</final_prd>
+  <summary>Approved by Ava, Jon, Security, and Legal. No concerns.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -628,7 +642,7 @@ describe('consolidate node', () => {
       await expect(consolidateNode(state)).rejects.toThrow('No reviews available');
     });
 
-    it('should throw error on invalid JSON', async () => {
+    it('should throw error on missing consolidation root element', async () => {
       const avaReview: ReviewerPerspective = {
         reviewer: 'Ava',
         verdict: 'approve',
@@ -637,7 +651,7 @@ describe('consolidate node', () => {
         timestamp: '2024-01-01T00:00:00.000Z',
       };
 
-      const smartModel = new TestChatModel(['This is not valid JSON']);
+      const smartModel = new TestChatModel(['This is not valid XML']);
 
       const state: ConsolidateState = {
         prd: 'Some PRD',
@@ -645,7 +659,7 @@ describe('consolidate node', () => {
         smartModel,
       };
 
-      await expect(consolidateNode(state)).rejects.toThrow('Failed to parse JSON');
+      await expect(consolidateNode(state)).rejects.toThrow('Failed to parse XML');
     });
 
     it('should throw error on missing required fields', async () => {
@@ -658,10 +672,15 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'PROCEED',
-          // missing consensusAnalysis, finalPRD, summary
-        }),
+        `<consolidation>
+  <consensus_analysis>
+    <agreement></agreement>
+    <disagreement></disagreement>
+    <resolution>Test</resolution>
+  </consensus_analysis>
+  <final_prd>Test</final_prd>
+  <summary>Test</summary>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -683,17 +702,17 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'MAYBE', // invalid value
-          consensusAnalysis: {
-            agreement: [],
-            disagreement: [],
-            resolution: 'Test',
-          },
-          finalPRD: 'Test',
-          summary: 'Test',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>MAYBE</verdict>
+  <consensus_analysis>
+    <agreement></agreement>
+    <disagreement></disagreement>
+    <resolution>Test</resolution>
+  </consensus_analysis>
+  <final_prd>Test</final_prd>
+  <summary>Test</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -705,7 +724,7 @@ describe('consolidate node', () => {
       await expect(consolidateNode(state)).rejects.toThrow('Invalid consolidation format');
     });
 
-    it('should handle JSON in markdown code blocks', async () => {
+    it('should handle XML in markdown code blocks', async () => {
       const avaReview: ReviewerPerspective = {
         reviewer: 'Ava',
         verdict: 'approve',
@@ -715,19 +734,7 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        '```json\n' +
-          JSON.stringify({
-            verdict: 'PROCEED',
-            consensusAnalysis: {
-              agreement: ['All good'],
-              disagreement: [],
-              resolution: 'Proceed',
-            },
-            finalPRD: 'Test PRD',
-            summary: 'Approved',
-            timestamp: '2024-01-01T00:00:00.000Z',
-          }) +
-          '\n```',
+        '```xml\n<consolidation>\n  <verdict>PROCEED</verdict>\n  <consensus_analysis>\n    <agreement><item>All good</item></agreement>\n    <disagreement></disagreement>\n    <resolution>Proceed</resolution>\n  </consensus_analysis>\n  <final_prd>Test PRD</final_prd>\n  <summary>Approved</summary>\n  <timestamp>2024-01-01T00:00:00.000Z</timestamp>\n</consolidation>\n```',
       ]);
 
       const state: ConsolidateState = {
@@ -757,17 +764,19 @@ describe('consolidate node', () => {
 
       // Fast model provides valid response
       const fastModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'PROCEED',
-          consensusAnalysis: {
-            agreement: ['From fast model - consensus reached'],
-            disagreement: [],
-            resolution: 'Fallback model resolved successfully',
-          },
-          finalPRD: 'Feature X',
-          summary: 'Consolidated by fast model',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>PROCEED</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>From fast model - consensus reached</item>
+    </agreement>
+    <disagreement></disagreement>
+    <resolution>Fallback model resolved successfully</resolution>
+  </consensus_analysis>
+  <final_prd>Feature X</final_prd>
+  <summary>Consolidated by fast model</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -817,17 +826,19 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'PROCEED',
-          consensusAnalysis: {
-            agreement: ['All approved'],
-            disagreement: [],
-            resolution: 'Ready to proceed',
-          },
-          finalPRD: 'Simple update',
-          summary: 'All good',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>PROCEED</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>All approved</item>
+    </agreement>
+    <disagreement></disagreement>
+    <resolution>Ready to proceed</resolution>
+  </consensus_analysis>
+  <final_prd>Simple update</final_prd>
+  <summary>All good</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {

--- a/workspace/projects.yaml
+++ b/workspace/projects.yaml
@@ -33,21 +33,21 @@ projects:
     defaultBranch: main
     status: active
     onboardedAt: '2026-04-07T00:00:00.000Z'
-    planeProjectId: "fe0a95b6-63a9-4a78-a0eb-36bad44228f2"
+    planeProjectId: 'fe0a95b6-63a9-4a78-a0eb-36bad44228f2'
     planeIdentifier: PRMKR
     projectPath: /home/josh/dev/ava
     agents: [ava, quinn, frank]
     discord:
-      dev: "1469080556720623699"
-      bug-reports: "1477837770704814162"
-      release: "1490893509337550859"
+      dev: '1469080556720623699'
+      bug-reports: '1477837770704814162'
+      release: '1490893509337550859'
     infisical:
-      projectId: ""
+      projectId: ''
     observability:
-      langfuseProjectId: ""
+      langfuseProjectId: ''
     googleWorkspace:
-      driveFolderId: ""
-      sharedDocId: ""
+      driveFolderId: ''
+      sharedDocId: ''
     capacity:
       priorityWeight: 1.0
       minConcurrency: 1
@@ -60,22 +60,22 @@ projects:
     defaultBranch: main
     status: active
     onboardedAt: '2026-04-06T00:00:00.000Z'
-    planeProjectId: ""
-    planeIdentifier: ""
+    planeProjectId: ''
+    planeIdentifier: ''
     projectPath: /home/josh/dev/labs/quinn
     agents: [ava, quinn]
     discord:
-      dev: "1490974550169485413"
-      release: "1490974552161783828"
+      dev: '1490974550169485413'
+      release: '1490974552161783828'
     webhooks:
-      release: "https://discord.com/api/webhooks/1490974745062146129/klLlR_jQkuJD2jbUXe-e9AQU6FBSvKXtADGAZWIAu5uVcMOBWcFYJ1vENCcSKxmFoZBn"
+      release: 'https://discord.com/api/webhooks/1490974745062146129/klLlR_jQkuJD2jbUXe-e9AQU6FBSvKXtADGAZWIAu5uVcMOBWcFYJ1vENCcSKxmFoZBn'
     infisical:
-      projectId: ""
+      projectId: ''
     observability:
-      langfuseProjectId: ""
+      langfuseProjectId: ''
     googleWorkspace:
-      driveFolderId: ""
-      sharedDocId: ""
+      driveFolderId: ''
+      sharedDocId: ''
     capacity:
       priorityWeight: 1.0
       minConcurrency: 1
@@ -88,22 +88,22 @@ projects:
     defaultBranch: main
     status: active
     onboardedAt: '2026-04-06T00:00:00.000Z'
-    planeProjectId: ""
-    planeIdentifier: ""
+    planeProjectId: ''
+    planeIdentifier: ''
     projectPath: /home/josh/dev/protoWorkstacean
     agents: [ava, quinn, frank]
     discord:
-      dev: "1490978896911405208"
-      release: "1490978898568286329"
+      dev: '1490978896911405208'
+      release: '1490978898568286329'
     webhooks:
-      release: "https://discord.com/api/webhooks/1490978900719964344/l2p3QUvp79kYpJFB6JsDpP6oSwwDBoNTwy8xmBfz2VX-edM7pT-q2XZYpJIILL_ScmCt"
+      release: 'https://discord.com/api/webhooks/1490978900719964344/l2p3QUvp79kYpJFB6JsDpP6oSwwDBoNTwy8xmBfz2VX-edM7pT-q2XZYpJIILL_ScmCt'
     infisical:
-      projectId: ""
+      projectId: ''
     observability:
-      langfuseProjectId: ""
+      langfuseProjectId: ''
     googleWorkspace:
-      driveFolderId: ""
-      sharedDocId: ""
+      driveFolderId: ''
+      sharedDocId: ''
     capacity:
       priorityWeight: 1.0
       minConcurrency: 1
@@ -116,21 +116,21 @@ projects:
     defaultBranch: main
     status: active
     onboardedAt: '2026-04-06T00:00:00.000Z'
-    planeProjectId: ""
-    planeIdentifier: ""
+    planeProjectId: ''
+    planeIdentifier: ''
     projectPath: /home/josh/dev/labs/protoUI
     agents: [ava, quinn]
     discord:
-      general: "1490601617567912050"
-      updates: "1490601619300286525"
-      dev: "1490601620927418428"
+      general: '1490601617567912050'
+      updates: '1490601619300286525'
+      dev: '1490601620927418428'
     infisical:
-      projectId: ""
+      projectId: ''
     observability:
-      langfuseProjectId: ""
+      langfuseProjectId: ''
     googleWorkspace:
-      driveFolderId: ""
-      sharedDocId: ""
+      driveFolderId: ''
+      sharedDocId: ''
     capacity:
       priorityWeight: 1.0
       minConcurrency: 1
@@ -143,20 +143,20 @@ projects:
     defaultBranch: main
     status: active
     onboardedAt: '2026-04-06T00:00:00.000Z'
-    planeProjectId: ""
-    planeIdentifier: ""
+    planeProjectId: ''
+    planeIdentifier: ''
     projectPath: /home/josh/dev/labs/protoContent
     agents: [jon, cindi]
     discord:
-      general: ""
-      dev: ""
+      general: ''
+      dev: ''
     infisical:
-      projectId: ""
+      projectId: ''
     observability:
-      langfuseProjectId: ""
+      langfuseProjectId: ''
     googleWorkspace:
-      driveFolderId: ""
-      sharedDocId: ""
+      driveFolderId: ''
+      sharedDocId: ''
     capacity:
       priorityWeight: 1.0
       minConcurrency: 1
@@ -169,22 +169,22 @@ projects:
     defaultBranch: main
     status: active
     onboardedAt: '2026-04-06T00:00:00.000Z'
-    planeProjectId: ""
-    planeIdentifier: ""
+    planeProjectId: ''
+    planeIdentifier: ''
     projectPath: /home/josh/dev/labs/protoResearcher
     agents: [ava, quinn]
     discord:
-      dev: "1490974553394905231"
-      release: "1490974554699599883"
+      dev: '1490974553394905231'
+      release: '1490974554699599883'
     webhooks:
-      release: "https://discord.com/api/webhooks/1490974746517700680/XIM4L7LfIvs0z49Ok_OBEMiThsfsRcgKt7LaiGkVku1be2J1uAWPv8JpbIzkIBERl3Pd"
+      release: 'https://discord.com/api/webhooks/1490974746517700680/XIM4L7LfIvs0z49Ok_OBEMiThsfsRcgKt7LaiGkVku1be2J1uAWPv8JpbIzkIBERl3Pd'
     infisical:
-      projectId: ""
+      projectId: ''
     observability:
-      langfuseProjectId: ""
+      langfuseProjectId: ''
     googleWorkspace:
-      driveFolderId: ""
-      sharedDocId: ""
+      driveFolderId: ''
+      sharedDocId: ''
     capacity:
       priorityWeight: 1.0
       minConcurrency: 1
@@ -197,22 +197,22 @@ projects:
     defaultBranch: main
     status: active
     onboardedAt: '2026-04-06T00:00:00.000Z'
-    planeProjectId: ""
-    planeIdentifier: ""
+    planeProjectId: ''
+    planeIdentifier: ''
     projectPath: /home/josh/dev/labs/protoCLI
     agents: [ava, quinn]
     discord:
-      dev: "1490974556306014290"
-      release: "1490974557920563312"
+      dev: '1490974556306014290'
+      release: '1490974557920563312'
     webhooks:
-      release: "https://discord.com/api/webhooks/1490974748841349290/ugcG9nNKyxqKOUoEzm3jNJnwDp4fNSZXd82iWcAomwpG-cMS9IpX5Q2CKEsdEHq2jmUi"
+      release: 'https://discord.com/api/webhooks/1490974748841349290/ugcG9nNKyxqKOUoEzm3jNJnwDp4fNSZXd82iWcAomwpG-cMS9IpX5Q2CKEsdEHq2jmUi'
     infisical:
-      projectId: ""
+      projectId: ''
     observability:
-      langfuseProjectId: ""
+      langfuseProjectId: ''
     googleWorkspace:
-      driveFolderId: ""
-      sharedDocId: ""
+      driveFolderId: ''
+      sharedDocId: ''
     capacity:
       priorityWeight: 1.0
       minConcurrency: 1
@@ -225,22 +225,22 @@ projects:
     defaultBranch: main
     status: active
     onboardedAt: '2026-04-06T00:00:00.000Z'
-    planeProjectId: ""
-    planeIdentifier: ""
+    planeProjectId: ''
+    planeIdentifier: ''
     projectPath: /home/josh/dev/labs/rabbit-hole.io
     agents: [ava, quinn]
     discord:
-      dev: "1490978889596539093"
-      release: "1490978891207282718"
+      dev: '1490978889596539093'
+      release: '1490978891207282718'
     webhooks:
-      release: "https://discord.com/api/webhooks/1490978892847120395/ftfQMs4Ys-XscwIdClRIp7tbWvKKMRjzZk5Nbqm_A-1-OBu54GIRcHiERWbIYU_K90Hj"
+      release: 'https://discord.com/api/webhooks/1490978892847120395/ftfQMs4Ys-XscwIdClRIp7tbWvKKMRjzZk5Nbqm_A-1-OBu54GIRcHiERWbIYU_K90Hj'
     infisical:
-      projectId: ""
+      projectId: ''
     observability:
-      langfuseProjectId: ""
+      langfuseProjectId: ''
     googleWorkspace:
-      driveFolderId: ""
-      sharedDocId: ""
+      driveFolderId: ''
+      sharedDocId: ''
     capacity:
       priorityWeight: 1.0
       minConcurrency: 1
@@ -253,22 +253,22 @@ projects:
     defaultBranch: main
     status: active
     onboardedAt: '2026-04-06T00:00:00.000Z'
-    planeProjectId: ""
-    planeIdentifier: ""
+    planeProjectId: ''
+    planeIdentifier: ''
     projectPath: /home/josh/dev/labs/mythxengine
     agents: [ava, quinn]
     discord:
-      dev: "1490978905371312179"
-      release: "1490978906419761262"
+      dev: '1490978905371312179'
+      release: '1490978906419761262'
     webhooks:
-      release: "https://discord.com/api/webhooks/1490978907862732871/cBKRdYSy7B-dUIVtDne-HOZ9pDarZItF2k8XXvR5UFlW2naSedCo09NMkeletFSEgKub"
+      release: 'https://discord.com/api/webhooks/1490978907862732871/cBKRdYSy7B-dUIVtDne-HOZ9pDarZItF2k8XXvR5UFlW2naSedCo09NMkeletFSEgKub'
     infisical:
-      projectId: ""
+      projectId: ''
     observability:
-      langfuseProjectId: ""
+      langfuseProjectId: ''
     googleWorkspace:
-      driveFolderId: ""
-      sharedDocId: ""
+      driveFolderId: ''
+      sharedDocId: ''
     capacity:
       priorityWeight: 1.0
       minConcurrency: 1

--- a/workspace/projects.yaml
+++ b/workspace/projects.yaml
@@ -5,52 +5,271 @@
 # Workstacean's A2APlugin reads this file at startup and rebuilds the index
 # every 5 seconds when the file changes — no restart required.
 #
+# NOTE: This file is synced from the authoritative Workstacean registry
+# (protoWorkstacean/workspace/projects.yaml). After P2 this will be read
+# from the Workstacean API directly — no more manual updates.
+#
 # Fields:
 #   slug          — kebab-case identifier derived from <owner>-<repo>
-#   title         — human-readable project name (from GitHub repo .name)
+#   title         — human-readable project name
 #   github        — <owner>/<repo> slug (used as the lookup key)
 #   defaultBranch — default branch at time of onboarding
 #   status        — active | archived | suspended
-#                   archived and suspended entries are excluded from the index
 #   onboardedAt   — ISO 8601 timestamp
-#   discord       — Discord channel IDs for routing GitHub events:
-#     dev           — general dev activity (@mentions, PRs, issues)
-#     alerts        — CI failures, error spikes, infra alerts
-#     releases      — release tags, deploy notifications
+#   planeProjectId — Plane project ID (empty = pending OnboardingPlugin)
+#   planeIdentifier — Plane project identifier
+#   projectPath   — absolute path on this host
+#   discord       — Discord channel IDs for routing GitHub events
+#   infisical     — Infisical integration config
+#   observability — Observability config (Langfuse)
+#   googleWorkspace — Google Drive integration config
+#   capacity      — Scheduler capacity settings
 
 projects:
+  - slug: protolabsai-protomaker
+    title: protoMaker
+    team: dev
+    github: protoLabsAI/protoMaker
+    defaultBranch: main
+    status: active
+    onboardedAt: '2026-04-07T00:00:00.000Z'
+    planeProjectId: "fe0a95b6-63a9-4a78-a0eb-36bad44228f2"
+    planeIdentifier: PRMKR
+    projectPath: /home/josh/dev/ava
+    agents: [ava, quinn, frank]
+    discord:
+      dev: "1469080556720623699"
+      bug-reports: "1477837770704814162"
+      release: "1490893509337550859"
+    infisical:
+      projectId: ""
+    observability:
+      langfuseProjectId: ""
+    googleWorkspace:
+      driveFolderId: ""
+      sharedDocId: ""
+    capacity:
+      priorityWeight: 1.0
+      minConcurrency: 1
+      maxConcurrency: 3
+
   - slug: protolabsai-quinn
-    title: quinn
+    title: Quinn
+    team: dev
     github: protoLabsAI/quinn
     defaultBranch: main
     status: active
     onboardedAt: '2026-04-06T00:00:00.000Z'
+    planeProjectId: ""
+    planeIdentifier: ""
+    projectPath: /home/josh/dev/labs/quinn
+    agents: [ava, quinn]
     discord:
-      channels:
-        general: ''
-        updates: ''
-        dev: ''
+      dev: "1490974550169485413"
+      release: "1490974552161783828"
+    webhooks:
+      release: "https://discord.com/api/webhooks/1490974745062146129/klLlR_jQkuJD2jbUXe-e9AQU6FBSvKXtADGAZWIAu5uVcMOBWcFYJ1vENCcSKxmFoZBn"
+    infisical:
+      projectId: ""
+    observability:
+      langfuseProjectId: ""
+    googleWorkspace:
+      driveFolderId: ""
+      sharedDocId: ""
+    capacity:
+      priorityWeight: 1.0
+      minConcurrency: 1
+      maxConcurrency: 3
 
   - slug: protolabsai-protoworkstacean
     title: protoWorkstacean
+    team: dev
     github: protoLabsAI/protoWorkstacean
-    defaultBranch: master
+    defaultBranch: main
     status: active
     onboardedAt: '2026-04-06T00:00:00.000Z'
+    planeProjectId: ""
+    planeIdentifier: ""
+    projectPath: /home/josh/dev/protoWorkstacean
+    agents: [ava, quinn, frank]
     discord:
-      channels:
-        general: ''
-        updates: ''
-        dev: ''
+      dev: "1490978896911405208"
+      release: "1490978898568286329"
+    webhooks:
+      release: "https://discord.com/api/webhooks/1490978900719964344/l2p3QUvp79kYpJFB6JsDpP6oSwwDBoNTwy8xmBfz2VX-edM7pT-q2XZYpJIILL_ScmCt"
+    infisical:
+      projectId: ""
+    observability:
+      langfuseProjectId: ""
+    googleWorkspace:
+      driveFolderId: ""
+      sharedDocId: ""
+    capacity:
+      priorityWeight: 1.0
+      minConcurrency: 1
+      maxConcurrency: 3
 
   - slug: protolabsai-protoui
     title: protoUI
+    team: dev
     github: protoLabsAI/protoUI
     defaultBranch: main
     status: active
     onboardedAt: '2026-04-06T00:00:00.000Z'
+    planeProjectId: ""
+    planeIdentifier: ""
+    projectPath: /home/josh/dev/labs/protoUI
+    agents: [ava, quinn]
     discord:
-      channels:
-        general: '1490601617567912050'
-        updates: '1490601619300286525'
-        dev: '1490601620927418428'
+      general: "1490601617567912050"
+      updates: "1490601619300286525"
+      dev: "1490601620927418428"
+    infisical:
+      projectId: ""
+    observability:
+      langfuseProjectId: ""
+    googleWorkspace:
+      driveFolderId: ""
+      sharedDocId: ""
+    capacity:
+      priorityWeight: 1.0
+      minConcurrency: 1
+      maxConcurrency: 3
+
+  - slug: protolabsai-protocontent
+    title: protoContent
+    team: gtm
+    github: protoLabsAI/protoContent
+    defaultBranch: main
+    status: active
+    onboardedAt: '2026-04-06T00:00:00.000Z'
+    planeProjectId: ""
+    planeIdentifier: ""
+    projectPath: /home/josh/dev/labs/protoContent
+    agents: [jon, cindi]
+    discord:
+      general: ""
+      dev: ""
+    infisical:
+      projectId: ""
+    observability:
+      langfuseProjectId: ""
+    googleWorkspace:
+      driveFolderId: ""
+      sharedDocId: ""
+    capacity:
+      priorityWeight: 1.0
+      minConcurrency: 1
+      maxConcurrency: 3
+
+  - slug: protolabsai-protoResearcher
+    title: protoResearcher
+    team: dev
+    github: protoLabsAI/protoResearcher
+    defaultBranch: main
+    status: active
+    onboardedAt: '2026-04-06T00:00:00.000Z'
+    planeProjectId: ""
+    planeIdentifier: ""
+    projectPath: /home/josh/dev/labs/protoResearcher
+    agents: [ava, quinn]
+    discord:
+      dev: "1490974553394905231"
+      release: "1490974554699599883"
+    webhooks:
+      release: "https://discord.com/api/webhooks/1490974746517700680/XIM4L7LfIvs0z49Ok_OBEMiThsfsRcgKt7LaiGkVku1be2J1uAWPv8JpbIzkIBERl3Pd"
+    infisical:
+      projectId: ""
+    observability:
+      langfuseProjectId: ""
+    googleWorkspace:
+      driveFolderId: ""
+      sharedDocId: ""
+    capacity:
+      priorityWeight: 1.0
+      minConcurrency: 1
+      maxConcurrency: 3
+
+  - slug: protolabsai-protoCLI
+    title: protoCLI
+    team: dev
+    github: protoLabsAI/protoCLI
+    defaultBranch: main
+    status: active
+    onboardedAt: '2026-04-06T00:00:00.000Z'
+    planeProjectId: ""
+    planeIdentifier: ""
+    projectPath: /home/josh/dev/labs/protoCLI
+    agents: [ava, quinn]
+    discord:
+      dev: "1490974556306014290"
+      release: "1490974557920563312"
+    webhooks:
+      release: "https://discord.com/api/webhooks/1490974748841349290/ugcG9nNKyxqKOUoEzm3jNJnwDp4fNSZXd82iWcAomwpG-cMS9IpX5Q2CKEsdEHq2jmUi"
+    infisical:
+      projectId: ""
+    observability:
+      langfuseProjectId: ""
+    googleWorkspace:
+      driveFolderId: ""
+      sharedDocId: ""
+    capacity:
+      priorityWeight: 1.0
+      minConcurrency: 1
+      maxConcurrency: 3
+
+  - slug: protolabsai-rabbit-hole-io
+    title: rabbit-hole.io
+    team: dev
+    github: protoLabsAI/rabbit-hole.io
+    defaultBranch: main
+    status: active
+    onboardedAt: '2026-04-06T00:00:00.000Z'
+    planeProjectId: ""
+    planeIdentifier: ""
+    projectPath: /home/josh/dev/labs/rabbit-hole.io
+    agents: [ava, quinn]
+    discord:
+      dev: "1490978889596539093"
+      release: "1490978891207282718"
+    webhooks:
+      release: "https://discord.com/api/webhooks/1490978892847120395/ftfQMs4Ys-XscwIdClRIp7tbWvKKMRjzZk5Nbqm_A-1-OBu54GIRcHiERWbIYU_K90Hj"
+    infisical:
+      projectId: ""
+    observability:
+      langfuseProjectId: ""
+    googleWorkspace:
+      driveFolderId: ""
+      sharedDocId: ""
+    capacity:
+      priorityWeight: 1.0
+      minConcurrency: 1
+      maxConcurrency: 3
+
+  - slug: protolabsai-mythxengine
+    title: mythxengine
+    team: dev
+    github: protoLabsAI/mythxengine
+    defaultBranch: main
+    status: active
+    onboardedAt: '2026-04-06T00:00:00.000Z'
+    planeProjectId: ""
+    planeIdentifier: ""
+    projectPath: /home/josh/dev/labs/mythxengine
+    agents: [ava, quinn]
+    discord:
+      dev: "1490978905371312179"
+      release: "1490978906419761262"
+    webhooks:
+      release: "https://discord.com/api/webhooks/1490978907862732871/cBKRdYSy7B-dUIVtDne-HOZ9pDarZItF2k8XXvR5UFlW2naSedCo09NMkeletFSEgKub"
+    infisical:
+      projectId: ""
+    observability:
+      langfuseProjectId: ""
+    googleWorkspace:
+      driveFolderId: ""
+      sharedDocId: ""
+    capacity:
+      priorityWeight: 1.0
+      minConcurrency: 1
+      maxConcurrency: 3


### PR DESCRIPTION
## Summary

Extend the Workstacean projects.yaml schema to cover all org layers, and fully backfill all 8 current projects with complete data.

**File:** `/home/josh/dev/protoWorkstacean/workspace/projects.yaml`

**Schema additions per project entry:**
```yaml
infisical:
  projectId: ''          # Infisical project ID holding this app's secrets
observability:
  langfuseProjectId: ''  # Langfuse project for cost/trace scoping
googleWorkspace:
  driveFolderId: ''      # per-project Drive folder (populated by ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Project registry schema expanded with richer metadata (team, IDs, paths, agents, capacity, nested integrations) and per-project configs populated.
  * Six new projects added to the portfolio; several existing entries updated (titles, defaults).
  * Discord channels restructured to per-role keys and webhooks added; default branch changed from master→main.

* **Tests**
  * Unit tests updated to use XML-formatted mock outputs and adjusted parse/error expectations accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->