### PR TITLE
get_portfolio_sitrep MCP tool + PortfolioWorldStateBuilder

### DIFF
--- a/apps/server/src/routes/portfolio/sitrep.ts
+++ b/apps/server/src/routes/portfolio/sitrep.ts
@@ -1,0 +1,77 @@
+/**
+ * Portfolio Sitrep Route — Fleet-wide status aggregation.
+ * GET /api/portfolio/sitrep
+ *
+ * Returns a PortfolioSitrep aggregating per-project status in parallel.
+ * Projects are sourced from GlobalSettings.projects[] or from the optional
+ * projectPaths query parameter.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { createLogger } from '@protolabsai/utils';
+import type { SettingsService } from '../../services/settings-service.js';
+import { PortfolioWorldStateBuilder } from '../../services/portfolio-world-state-builder.js';
+
+const logger = createLogger('PortfolioSitrepRoute');
+
+const DEFAULT_PORT = process.env.PORT || '3008';
+const DEFAULT_BASE_URL = `http://localhost:${DEFAULT_PORT}`;
+
+interface PortfolioSitrepOptions {
+  settingsService: SettingsService;
+}
+
+export function createPortfolioSitrepRoutes({ settingsService }: PortfolioSitrepOptions): Router {
+  const router = Router();
+
+  router.get('/', async (req: Request, res: Response) => {
+    try {
+      let projectPaths: string[];
+
+      if (req.query.projectPaths !== undefined) {
+        // Prefer explicitly provided projectPaths query param
+        const raw = req.query.projectPaths;
+        if (Array.isArray(raw)) {
+          projectPaths = raw.map(String).filter(Boolean);
+        } else {
+          projectPaths = String(raw)
+            .split(',')
+            .map((p) => p.trim())
+            .filter(Boolean);
+        }
+
+        if (projectPaths.length === 0) {
+          res.json({
+            generatedAt: new Date().toISOString(),
+            projects: [],
+            portfolioMetrics: {
+              totalActiveAgents: 0,
+              globalWipUtilization: 0,
+              portfolioFlowEfficiency: 0,
+              topConstraint: null,
+            },
+            pendingHumanDecisions: [],
+          });
+          return;
+        }
+      } else {
+        const settings = await settingsService.getGlobalSettings();
+        const refs = settings.projects ?? [];
+        projectPaths = refs.map((p) => p.path).filter(Boolean);
+      }
+
+      const builder = new PortfolioWorldStateBuilder({
+        projectPaths,
+        automakerBaseUrl: DEFAULT_BASE_URL,
+      });
+
+      const sitrep = await builder.aggregate();
+      res.json(sitrep);
+    } catch (err) {
+      logger.error('Portfolio sitrep failed:', err);
+      res.status(500).json({ error: 'Failed to generate portfolio sitrep' });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -79,6 +79,7 @@ import { createAIRoutes } from '../routes/ai/index.js';
 import { createNotesRoutes } from '../routes/notes/index.js';
 import { createTodoRoutes } from '../routes/todo/index.js';
 import { createSitrepRoutes } from '../routes/sitrep/index.js';
+import { createPortfolioSitrepRoutes } from '../routes/portfolio/sitrep.js';
 import { createLeadEngineerRoutes } from '../routes/lead-engineer/index.js';
 import { createPrometheusRoute } from '../routes/metrics/prometheus.js';
 import { createAutomationsRoutes } from '../routes/automations/index.js';
@@ -411,6 +412,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api/notes', createNotesRoutes(events));
   app.use('/api/todos', createTodoRoutes(todoService));
   app.use('/api/sitrep', createSitrepRoutes({ featureLoader, autoModeService, repoRoot }));
+  app.use('/api/portfolio/sitrep', createPortfolioSitrepRoutes({ settingsService }));
   // Knowledge store routes (chunked retrieval)
   if (knowledgeStoreService) {
     app.use('/api/knowledge', createKnowledgeRoutes(knowledgeStoreService));

--- a/apps/server/src/services/portfolio-world-state-builder.ts
+++ b/apps/server/src/services/portfolio-world-state-builder.ts
@@ -95,7 +95,13 @@ export class PortfolioWorldStateBuilder {
   private readonly automakerBaseUrl: string;
   private readonly apiKey: string;
 
-  constructor({ projectPaths, automakerBaseUrl }: { projectPaths: string[]; automakerBaseUrl: string }) {
+  constructor({
+    projectPaths,
+    automakerBaseUrl,
+  }: {
+    projectPaths: string[];
+    automakerBaseUrl: string;
+  }) {
     this.projectPaths = projectPaths;
     this.automakerBaseUrl = automakerBaseUrl;
     this.apiKey = process.env.AUTOMAKER_API_KEY || DEFAULT_API_KEY;
@@ -207,7 +213,10 @@ export class PortfolioWorldStateBuilder {
     if (sitrep.board.blocked > 0 || errorBudgetStatus === 'exhausted') {
       return 'red';
     }
-    if (sitrep.board.backlog > 10 || (sitrep.autoMode.runningCount === 0 && sitrep.board.backlog > 0)) {
+    if (
+      sitrep.board.backlog > 10 ||
+      (sitrep.autoMode.runningCount === 0 && sitrep.board.backlog > 0)
+    ) {
       return 'yellow';
     }
     return 'green';
@@ -255,7 +264,9 @@ export class PortfolioWorldStateBuilder {
     return `${maxBlocked} feature${maxBlocked !== 1 ? 's' : ''} blocked in ${slug}${reasonSuffix}`;
   }
 
-  private aggregatePendingDecisions(results: FetchResult[]): PortfolioSitrep['pendingHumanDecisions'] {
+  private aggregatePendingDecisions(
+    results: FetchResult[]
+  ): PortfolioSitrep['pendingHumanDecisions'] {
     const decisions: PortfolioSitrep['pendingHumanDecisions'] = [];
 
     for (const { projectPath, sitrep, error } of results) {

--- a/apps/server/src/services/portfolio-world-state-builder.ts
+++ b/apps/server/src/services/portfolio-world-state-builder.ts
@@ -1,0 +1,305 @@
+/**
+ * PortfolioWorldStateBuilder — Aggregates per-project sitreps into a single
+ * fleet-wide status snapshot. Fetches all project sitreps in parallel via the
+ * Automaker API and computes portfolio-level metrics.
+ */
+
+import { createLogger } from '@protolabsai/utils';
+import path from 'node:path';
+
+const logger = createLogger('PortfolioWorldStateBuilder');
+
+const DEFAULT_API_KEY = 'protoLabs_studio_key';
+
+interface ProjectSitrep {
+  board: {
+    total: number;
+    backlog: number;
+    inProgress: number;
+    review: number;
+    blocked: number;
+    done: number;
+  };
+  autoMode: {
+    running: boolean;
+    loopRunning: boolean;
+    runningCount: number;
+    maxConcurrency: number;
+    humanBlockedCount: number;
+  };
+  blockedFeatures: Array<{
+    id: string;
+    title: string;
+    reason: string;
+    failureCount: number;
+  }>;
+  reviewFeatures: Array<{
+    id: string;
+    title: string;
+    prNumber?: number;
+    prUrl?: string;
+  }>;
+  escalations: Array<{
+    id: string;
+    title: string;
+    status: string;
+    failureCount: number;
+    reason: string;
+    classification?: string;
+  }>;
+  stagingDelta: {
+    commitsAhead: number;
+    commits: string[];
+  };
+}
+
+export interface ProjectPortfolioEntry {
+  slug: string;
+  name: string;
+  path: string;
+  health: 'green' | 'yellow' | 'red';
+  activeAgents: number;
+  backlogDepth: number;
+  blockedCount: number;
+  errorBudgetStatus: 'healthy' | 'warning' | 'exhausted';
+  topReadyFeature: { id: string; title: string } | null;
+  stagingLagCommits: number;
+  weeklyThroughput: number;
+}
+
+export interface PortfolioSitrep {
+  generatedAt: string;
+  projects: ProjectPortfolioEntry[];
+  portfolioMetrics: {
+    totalActiveAgents: number;
+    globalWipUtilization: number;
+    portfolioFlowEfficiency: number;
+    topConstraint: string | null;
+  };
+  pendingHumanDecisions: Array<{
+    projectSlug: string;
+    type: 'pr_review' | 'escalation' | 'prioritization_needed';
+    ageMs: number;
+    description: string;
+  }>;
+}
+
+type FetchResult = {
+  projectPath: string;
+  sitrep: ProjectSitrep | null;
+  error?: string;
+};
+
+export class PortfolioWorldStateBuilder {
+  private readonly projectPaths: string[];
+  private readonly automakerBaseUrl: string;
+  private readonly apiKey: string;
+
+  constructor({ projectPaths, automakerBaseUrl }: { projectPaths: string[]; automakerBaseUrl: string }) {
+    this.projectPaths = projectPaths;
+    this.automakerBaseUrl = automakerBaseUrl;
+    this.apiKey = process.env.AUTOMAKER_API_KEY || DEFAULT_API_KEY;
+  }
+
+  async aggregate(): Promise<PortfolioSitrep> {
+    if (this.projectPaths.length === 0) {
+      return {
+        generatedAt: new Date().toISOString(),
+        projects: [],
+        portfolioMetrics: {
+          totalActiveAgents: 0,
+          globalWipUtilization: 0,
+          portfolioFlowEfficiency: 0,
+          topConstraint: null,
+        },
+        pendingHumanDecisions: [],
+      };
+    }
+
+    // Fetch all project sitreps in parallel
+    const results = await Promise.all(
+      this.projectPaths.map((projectPath) => this.fetchProjectSitrep(projectPath))
+    );
+
+    const projects: ProjectPortfolioEntry[] = results.map((result) => {
+      const slug = path.basename(result.projectPath);
+      if (result.error || !result.sitrep) {
+        return {
+          slug,
+          name: slug,
+          path: result.projectPath,
+          health: 'red' as const,
+          activeAgents: 0,
+          backlogDepth: 0,
+          blockedCount: 0,
+          errorBudgetStatus: 'exhausted' as const,
+          topReadyFeature: null,
+          stagingLagCommits: 0,
+          weeklyThroughput: 0,
+        };
+      }
+      const sitrep = result.sitrep;
+      return {
+        slug,
+        name: slug,
+        path: result.projectPath,
+        health: this.calculateHealthStatus(sitrep),
+        activeAgents: sitrep.autoMode.runningCount,
+        backlogDepth: sitrep.board.backlog,
+        blockedCount: sitrep.board.blocked,
+        errorBudgetStatus: this.calculateErrorBudgetStatus(sitrep),
+        topReadyFeature: null,
+        stagingLagCommits: sitrep.stagingDelta.commitsAhead,
+        weeklyThroughput: sitrep.board.done,
+      };
+    });
+
+    const totalActiveAgents = projects.reduce((sum, p) => sum + p.activeAgents, 0);
+    const systemMaxConcurrency = this.deriveSystemMaxConcurrency(results);
+    const globalWipUtilization =
+      systemMaxConcurrency > 0 ? totalActiveAgents / systemMaxConcurrency : 0;
+
+    const topConstraint = this.deriveTopConstraint(results);
+    const pendingHumanDecisions = this.aggregatePendingDecisions(results);
+
+    return {
+      generatedAt: new Date().toISOString(),
+      projects,
+      portfolioMetrics: {
+        totalActiveAgents,
+        globalWipUtilization,
+        portfolioFlowEfficiency: 0,
+        topConstraint,
+      },
+      pendingHumanDecisions,
+    };
+  }
+
+  private async fetchProjectSitrep(projectPath: string): Promise<FetchResult> {
+    try {
+      const response = await fetch(`${this.automakerBaseUrl}/api/sitrep`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': this.apiKey,
+        },
+        body: JSON.stringify({ projectPath }),
+        signal: AbortSignal.timeout(15000),
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => 'unknown error');
+        logger.error(`Sitrep fetch failed for ${projectPath}: HTTP ${response.status} — ${text}`);
+        return { projectPath, sitrep: null, error: `HTTP ${response.status}` };
+      }
+
+      const sitrep = (await response.json()) as ProjectSitrep;
+      return { projectPath, sitrep };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(`Sitrep fetch failed for ${projectPath}:`, message);
+      return { projectPath, sitrep: null, error: message };
+    }
+  }
+
+  private calculateHealthStatus(sitrep: ProjectSitrep): 'green' | 'yellow' | 'red' {
+    const errorBudgetStatus = this.calculateErrorBudgetStatus(sitrep);
+    if (sitrep.board.blocked > 0 || errorBudgetStatus === 'exhausted') {
+      return 'red';
+    }
+    if (sitrep.board.backlog > 10 || (sitrep.autoMode.runningCount === 0 && sitrep.board.backlog > 0)) {
+      return 'yellow';
+    }
+    return 'green';
+  }
+
+  private calculateErrorBudgetStatus(sitrep: ProjectSitrep): 'healthy' | 'warning' | 'exhausted' {
+    if (sitrep.escalations.length >= 3 || sitrep.board.blocked > 5) {
+      return 'exhausted';
+    }
+    if (sitrep.escalations.length > 0 || sitrep.board.blocked > 0) {
+      return 'warning';
+    }
+    return 'healthy';
+  }
+
+  private deriveSystemMaxConcurrency(results: FetchResult[]): number {
+    for (const { sitrep } of results) {
+      if (sitrep && sitrep.autoMode.maxConcurrency > 0) {
+        return sitrep.autoMode.maxConcurrency;
+      }
+    }
+    return 10;
+  }
+
+  private deriveTopConstraint(results: FetchResult[]): string | null {
+    let topProjectPath: string | null = null;
+    let topSitrep: ProjectSitrep | null = null;
+    let maxBlocked = 0;
+
+    for (const { projectPath, sitrep } of results) {
+      if (sitrep && sitrep.board.blocked > maxBlocked) {
+        maxBlocked = sitrep.board.blocked;
+        topProjectPath = projectPath;
+        topSitrep = sitrep;
+      }
+    }
+
+    if (!topProjectPath || !topSitrep || maxBlocked === 0) {
+      return null;
+    }
+
+    const slug = path.basename(topProjectPath);
+    const firstBlockedReason = topSitrep.blockedFeatures[0]?.reason;
+    const reasonSuffix = firstBlockedReason ? ` — ${firstBlockedReason}` : '';
+    return `${maxBlocked} feature${maxBlocked !== 1 ? 's' : ''} blocked in ${slug}${reasonSuffix}`;
+  }
+
+  private aggregatePendingDecisions(results: FetchResult[]): PortfolioSitrep['pendingHumanDecisions'] {
+    const decisions: PortfolioSitrep['pendingHumanDecisions'] = [];
+
+    for (const { projectPath, sitrep, error } of results) {
+      const slug = path.basename(projectPath);
+
+      if (error || !sitrep) {
+        decisions.push({
+          projectSlug: slug,
+          type: 'escalation',
+          ageMs: 0,
+          description: `Sitrep fetch failed: ${error ?? 'unknown error'}`,
+        });
+        continue;
+      }
+
+      for (const rf of sitrep.reviewFeatures) {
+        decisions.push({
+          projectSlug: slug,
+          type: 'pr_review',
+          ageMs: 0,
+          description: `PR review needed: ${rf.title}${rf.prNumber ? ` (#${rf.prNumber})` : ''}`,
+        });
+      }
+
+      for (const esc of sitrep.escalations) {
+        decisions.push({
+          projectSlug: slug,
+          type: 'escalation',
+          ageMs: 0,
+          description: `Feature escalated: ${esc.title} (${esc.failureCount} failures) — ${esc.reason}`,
+        });
+      }
+
+      if (sitrep.board.backlog > 10) {
+        decisions.push({
+          projectSlug: slug,
+          type: 'prioritization_needed',
+          ageMs: 0,
+          description: `Backlog depth ${sitrep.board.backlog} exceeds threshold in ${slug}`,
+        });
+      }
+    }
+
+    // Sort by ageMs descending (oldest first)
+    return decisions.sort((a, b) => b.ageMs - a.ageMs);
+  }
+}

--- a/libs/flows/tests/unit/ava-review.test.ts
+++ b/libs/flows/tests/unit/ava-review.test.ts
@@ -57,34 +57,34 @@ describe('ava-review node', () => {
   describe('normal case', () => {
     it('should return approve verdict for low-risk PRD', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'approve',
-          sections: [
-            {
-              area: 'Capacity',
-              assessment: 'Team has sufficient bandwidth',
-              concerns: [],
-            },
-            {
-              area: 'Risk',
-              assessment: 'Low risk, well-understood domain',
-              concerns: [],
-            },
-            {
-              area: 'Tech Debt',
-              assessment: 'Neutral impact on tech debt',
-              concerns: [],
-            },
-            {
-              area: 'Feasibility',
-              assessment: 'Straightforward implementation',
-              concerns: [],
-            },
-          ],
-          comments: 'Clean, low-risk change. Ready to proceed.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <verdict>approve</verdict>
+  <sections>
+    <section>
+      <area>Capacity</area>
+      <assessment>Team has sufficient bandwidth</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>Risk</area>
+      <assessment>Low risk, well-understood domain</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>Tech Debt</area>
+      <assessment>Neutral impact on tech debt</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>Feasibility</area>
+      <assessment>Straightforward implementation</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>Clean, low-risk change. Ready to proceed.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {
@@ -104,37 +104,53 @@ describe('ava-review node', () => {
 
     it('should return approve-with-concerns verdict with recommendations', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'approve-with-concerns',
-          sections: [
-            {
-              area: 'Capacity',
-              assessment: 'Tight timeline but manageable',
-              concerns: ['May require overtime during peak sprint'],
-              recommendations: ['Add 1 week buffer to timeline'],
-            },
-            {
-              area: 'Risk',
-              assessment: 'Moderate risk with third-party API',
-              concerns: ['API rate limits not documented', 'No fallback mechanism'],
-              recommendations: ['Implement rate limiting', 'Add circuit breaker pattern'],
-            },
-            {
-              area: 'Tech Debt',
-              assessment: 'Will add some technical debt',
-              concerns: ['Quick implementation may skip best practices'],
-              recommendations: ['Schedule refactoring in next sprint'],
-            },
-            {
-              area: 'Feasibility',
-              assessment: 'Feasible with caveats',
-              concerns: ['Dependency on external team deliverable'],
-            },
-          ],
-          comments: 'Can proceed but monitor the identified concerns closely.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <verdict>approve-with-concerns</verdict>
+  <sections>
+    <section>
+      <area>Capacity</area>
+      <assessment>Tight timeline but manageable</assessment>
+      <concerns>
+        <item>May require overtime during peak sprint</item>
+      </concerns>
+      <recommendations>
+        <item>Add 1 week buffer to timeline</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Risk</area>
+      <assessment>Moderate risk with third-party API</assessment>
+      <concerns>
+        <item>API rate limits not documented</item>
+        <item>No fallback mechanism</item>
+      </concerns>
+      <recommendations>
+        <item>Implement rate limiting</item>
+        <item>Add circuit breaker pattern</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Tech Debt</area>
+      <assessment>Will add some technical debt</assessment>
+      <concerns>
+        <item>Quick implementation may skip best practices</item>
+      </concerns>
+      <recommendations>
+        <item>Schedule refactoring in next sprint</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Feasibility</area>
+      <assessment>Feasible with caveats</assessment>
+      <concerns>
+        <item>Dependency on external team deliverable</item>
+      </concerns>
+    </section>
+  </sections>
+  <comments>Can proceed but monitor the identified concerns closely.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {
@@ -156,38 +172,55 @@ describe('ava-review node', () => {
 
     it('should return revise verdict for PRDs needing changes', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'revise',
-          sections: [
-            {
-              area: 'Capacity',
-              assessment: 'Insufficient team capacity',
-              concerns: ['Team already at 120% capacity', 'No clear resource allocation plan'],
-              recommendations: ['Defer to next quarter', 'Hire additional engineer'],
-            },
-            {
-              area: 'Risk',
-              assessment: 'High risk, unclear requirements',
-              concerns: ['Vague success criteria', 'No rollback plan defined'],
-              recommendations: ['Define specific KPIs', 'Document rollback procedure'],
-            },
-            {
-              area: 'Tech Debt',
-              assessment: 'Will significantly increase tech debt',
-              concerns: ['Proposed shortcut will make future features harder'],
-            },
-            {
-              area: 'Feasibility',
-              assessment: 'Not feasible without infrastructure upgrade',
-              concerns: ['Current database cannot handle projected load'],
-              recommendations: ['Upgrade to scalable database solution first'],
-            },
-          ],
-          comments:
-            'PRD needs revision before we can commit resources. Address capacity, requirements clarity, and infrastructure concerns.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <verdict>revise</verdict>
+  <sections>
+    <section>
+      <area>Capacity</area>
+      <assessment>Insufficient team capacity</assessment>
+      <concerns>
+        <item>Team already at 120% capacity</item>
+        <item>No clear resource allocation plan</item>
+      </concerns>
+      <recommendations>
+        <item>Defer to next quarter</item>
+        <item>Hire additional engineer</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Risk</area>
+      <assessment>High risk, unclear requirements</assessment>
+      <concerns>
+        <item>Vague success criteria</item>
+        <item>No rollback plan defined</item>
+      </concerns>
+      <recommendations>
+        <item>Define specific KPIs</item>
+        <item>Document rollback procedure</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Tech Debt</area>
+      <assessment>Will significantly increase tech debt</assessment>
+      <concerns>
+        <item>Proposed shortcut will make future features harder</item>
+      </concerns>
+    </section>
+    <section>
+      <area>Feasibility</area>
+      <assessment>Not feasible without infrastructure upgrade</assessment>
+      <concerns>
+        <item>Current database cannot handle projected load</item>
+      </concerns>
+      <recommendations>
+        <item>Upgrade to scalable database solution first</item>
+      </recommendations>
+    </section>
+  </sections>
+  <comments>PRD needs revision before we can commit resources. Address capacity, requirements clarity, and infrastructure concerns.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {
@@ -204,42 +237,47 @@ describe('ava-review node', () => {
 
     it('should return reject verdict for unfeasible PRDs', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'reject',
-          sections: [
-            {
-              area: 'Capacity',
-              assessment: 'No available capacity',
-              concerns: [
-                'Would require 3 full-time engineers for 6 months',
-                'No engineers available',
-              ],
-            },
-            {
-              area: 'Risk',
-              assessment: 'Extreme risk',
-              concerns: [
-                'Would require complete system rewrite',
-                'High probability of data loss',
-                'Cannot guarantee backward compatibility',
-              ],
-            },
-            {
-              area: 'Tech Debt',
-              assessment: 'Would create massive technical debt',
-              concerns: ['Legacy approach being proposed', 'Will block future initiatives'],
-            },
-            {
-              area: 'Feasibility',
-              assessment: 'Not feasible with current technology',
-              concerns: ['Required technology does not exist', 'Physics constraints'],
-            },
-          ],
-          comments:
-            'Cannot recommend proceeding with this PRD. Fundamental issues with capacity, risk, and feasibility.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <verdict>reject</verdict>
+  <sections>
+    <section>
+      <area>Capacity</area>
+      <assessment>No available capacity</assessment>
+      <concerns>
+        <item>Would require 3 full-time engineers for 6 months</item>
+        <item>No engineers available</item>
+      </concerns>
+    </section>
+    <section>
+      <area>Risk</area>
+      <assessment>Extreme risk</assessment>
+      <concerns>
+        <item>Would require complete system rewrite</item>
+        <item>High probability of data loss</item>
+        <item>Cannot guarantee backward compatibility</item>
+      </concerns>
+    </section>
+    <section>
+      <area>Tech Debt</area>
+      <assessment>Would create massive technical debt</assessment>
+      <concerns>
+        <item>Legacy approach being proposed</item>
+        <item>Will block future initiatives</item>
+      </concerns>
+    </section>
+    <section>
+      <area>Feasibility</area>
+      <assessment>Not feasible with current technology</assessment>
+      <concerns>
+        <item>Required technology does not exist</item>
+        <item>Physics constraints</item>
+      </concerns>
+    </section>
+  </sections>
+  <comments>Cannot recommend proceeding with this PRD. Fundamental issues with capacity, risk, and feasibility.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {
@@ -253,23 +291,9 @@ describe('ava-review node', () => {
       expect(result.avaReview?.verdict).toBe('reject');
     });
 
-    it('should handle JSON in markdown code blocks', async () => {
+    it('should handle XML in markdown code blocks', async () => {
       const smartModel = new TestChatModel([
-        '```json\n' +
-          JSON.stringify({
-            reviewer: 'Ava',
-            verdict: 'approve',
-            sections: [
-              {
-                area: 'Capacity',
-                assessment: 'Good',
-                concerns: [],
-              },
-            ],
-            comments: 'Looks good',
-            timestamp: '2024-01-01T00:00:00.000Z',
-          }) +
-          '\n```',
+        '```xml\n<review>\n  <reviewer>Ava</reviewer>\n  <verdict>approve</verdict>\n  <sections>\n    <section>\n      <area>Capacity</area>\n      <assessment>Good</assessment>\n      <concerns></concerns>\n    </section>\n  </sections>\n  <comments>Looks good</comments>\n  <timestamp>2024-01-01T00:00:00.000Z</timestamp>\n</review>\n```',
       ]);
 
       const state: AvaReviewState = {
@@ -285,24 +309,31 @@ describe('ava-review node', () => {
   });
 
   describe('malformed LLM output', () => {
-    it('should throw error on invalid JSON', async () => {
-      const smartModel = new TestChatModel(['This is not valid JSON']);
+    it('should throw error on missing review root element', async () => {
+      const smartModel = new TestChatModel(['This is not valid XML']);
 
       const state: AvaReviewState = {
         prd: 'Some PRD',
         smartModel,
       };
 
-      await expect(avaReviewNode(state)).rejects.toThrow('Failed to parse JSON');
+      await expect(avaReviewNode(state)).rejects.toThrow('Failed to parse XML');
     });
 
-    it('should throw error on missing required fields', async () => {
+    it('should throw error on missing verdict field', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'approve',
-          // missing sections and comments
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <sections>
+    <section>
+      <area>Capacity</area>
+      <assessment>Good</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>Test</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {
@@ -315,13 +346,19 @@ describe('ava-review node', () => {
 
     it('should throw error on invalid verdict value', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'maybe', // invalid value
-          sections: [],
-          comments: 'Test',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <verdict>maybe</verdict>
+  <sections>
+    <section>
+      <area>Capacity</area>
+      <assessment>Good</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>Test</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {
@@ -332,28 +369,15 @@ describe('ava-review node', () => {
       await expect(avaReviewNode(state)).rejects.toThrow('Invalid review format');
     });
 
-    it('should throw error on invalid section structure', async () => {
-      const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'approve',
-          sections: [
-            {
-              // missing area and assessment
-              concerns: [],
-            },
-          ],
-          comments: 'Test',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
-      ]);
+    it('should throw error on empty review content', async () => {
+      const smartModel = new TestChatModel([`<review></review>`]);
 
       const state: AvaReviewState = {
         prd: 'Some PRD',
         smartModel,
       };
 
-      await expect(avaReviewNode(state)).rejects.toThrow('Invalid review format');
+      await expect(avaReviewNode(state)).rejects.toThrow('Failed to parse XML');
     });
   });
 
@@ -364,19 +388,21 @@ describe('ava-review node', () => {
 
       // Fast model provides valid response
       const fastModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'approve-with-concerns',
-          sections: [
-            {
-              area: 'Capacity',
-              assessment: 'From fast model - adequate capacity',
-              concerns: ['Minor concern'],
-            },
-          ],
-          comments: 'Fallback review from fast model',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <verdict>approve-with-concerns</verdict>
+  <sections>
+    <section>
+      <area>Capacity</area>
+      <assessment>From fast model - adequate capacity</assessment>
+      <concerns>
+        <item>Minor concern</item>
+      </concerns>
+    </section>
+  </sections>
+  <comments>Fallback review from fast model</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {
@@ -408,19 +434,19 @@ describe('ava-review node', () => {
 
     it('should work with only smart model provided', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Ava',
-          verdict: 'approve',
-          sections: [
-            {
-              area: 'Feasibility',
-              assessment: 'Looks good',
-              concerns: [],
-            },
-          ],
-          comments: 'All good',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Ava</reviewer>
+  <verdict>approve</verdict>
+  <sections>
+    <section>
+      <area>Feasibility</area>
+      <assessment>Looks good</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>All good</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: AvaReviewState = {

--- a/libs/flows/tests/unit/consolidate.test.ts
+++ b/libs/flows/tests/unit/consolidate.test.ts
@@ -98,22 +98,21 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'PROCEED',
-          consensusAnalysis: {
-            agreement: [
-              'Both reviewers approve',
-              'No blocking concerns identified',
-              'Clear execution path and business value',
-            ],
-            disagreement: [],
-            resolution:
-              'Full consensus to proceed. Both operational and business perspectives aligned.',
-          },
-          finalPRD: 'Add loading spinner to submit button',
-          summary: 'Approved by both Ava and Jon. Ready to proceed with implementation.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>PROCEED</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>Both reviewers approve</item>
+      <item>No blocking concerns identified</item>
+      <item>Clear execution path and business value</item>
+    </agreement>
+    <disagreement></disagreement>
+    <resolution>Full consensus to proceed. Both operational and business perspectives aligned.</resolution>
+  </consensus_analysis>
+  <final_prd>Add loading spinner to submit button</final_prd>
+  <summary>Approved by both Ava and Jon. Ready to proceed with implementation.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -165,22 +164,23 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'PROCEED',
-          consensusAnalysis: {
-            agreement: [
-              'Both support moving forward',
-              'High customer value (Jon)',
-              'Execution is feasible (Ava)',
-            ],
-            disagreement: ['Ava notes capacity is tight but not blocking'],
-            resolution: 'Minor concerns do not warrant blocking. Proceed with monitoring plan.',
-          },
-          finalPRD: 'Add loading spinner to submit button',
-          summary:
-            'Approved with minor operational concerns. Monitor sprint velocity as recommended by Ava.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>PROCEED</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>Both support moving forward</item>
+      <item>High customer value (Jon)</item>
+      <item>Execution is feasible (Ava)</item>
+    </agreement>
+    <disagreement>
+      <item>Ava notes capacity is tight but not blocking</item>
+    </disagreement>
+    <resolution>Minor concerns do not warrant blocking. Proceed with monitoring plan.</resolution>
+  </consensus_analysis>
+  <final_prd>Add loading spinner to submit button</final_prd>
+  <summary>Approved with minor operational concerns. Monitor sprint velocity as recommended by Ava.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -235,23 +235,24 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'MODIFY',
-          consensusAnalysis: {
-            agreement: ['Both see value in the initiative'],
-            disagreement: [
-              'Ava: serious capacity and risk concerns',
-              'Jon: wants to proceed due to market timing',
-            ],
-            resolution:
-              "PRD needs modification to address Ava's operational concerns while preserving Jon's business objectives. Reduce scope or adjust timeline.",
-          },
-          finalPRD:
-            'MODIFIED: Launch real-time collaborative editing - PHASE 1 (reduced scope)\n\nAddress capacity by reducing initial scope to basic editing only. Full feature set deferred to Q2. Rollback plan documented in deployment guide.',
-          summary:
-            'Modified PRD to address capacity and risk concerns while maintaining business value. Phased approach reduces operational burden.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>MODIFY</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>Both see value in the initiative</item>
+    </agreement>
+    <disagreement>
+      <item>Ava: serious capacity and risk concerns</item>
+      <item>Jon: wants to proceed due to market timing</item>
+    </disagreement>
+    <resolution>PRD needs modification to address Ava's operational concerns while preserving Jon's business objectives. Reduce scope or adjust timeline.</resolution>
+  </consensus_analysis>
+  <final_prd>MODIFIED: Launch real-time collaborative editing - PHASE 1 (reduced scope)
+
+Address capacity by reducing initial scope to basic editing only. Full feature set deferred to Q2. Rollback plan documented in deployment guide.</final_prd>
+  <summary>Modified PRD to address capacity and risk concerns while maintaining business value. Phased approach reduces operational burden.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -300,23 +301,28 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'MODIFY',
-          consensusAnalysis: {
-            agreement: ['Both support the concept'],
-            disagreement: [
-              'Both raised concerns that need addressing',
-              'Ava: technical risk mitigation needed',
-              'Jon: business metrics unclear',
-            ],
-            resolution:
-              'While both approve conceptually, the combined concerns warrant PRD updates to de-risk and clarify expectations.',
-          },
-          finalPRD:
-            'MODIFIED: Integrate payment gateway\n\nUpdates:\n- Add circuit breaker pattern (Ava)\n- Define success metrics: 95% uptime, <2s latency (Jon)\n- Cost projection: $50K dev + $10K/mo operational',
-          summary: 'PRD updated to address both operational risk and business metrics concerns.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>MODIFY</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>Both support the concept</item>
+    </agreement>
+    <disagreement>
+      <item>Both raised concerns that need addressing</item>
+      <item>Ava: technical risk mitigation needed</item>
+      <item>Jon: business metrics unclear</item>
+    </disagreement>
+    <resolution>While both approve conceptually, the combined concerns warrant PRD updates to de-risk and clarify expectations.</resolution>
+  </consensus_analysis>
+  <final_prd>MODIFIED: Integrate payment gateway
+
+Updates:
+- Add circuit breaker pattern (Ava)
+- Define success metrics: 95% uptime, &lt;2s latency (Jon)
+- Cost projection: $50K dev + $10K/mo operational</final_prd>
+  <summary>PRD updated to address both operational risk and business metrics concerns.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -373,23 +379,21 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'REJECT',
-          consensusAnalysis: {
-            agreement: [
-              'Both reviewers recommend rejection',
-              'Ava: operationally not feasible',
-              'Jon: business case insufficient',
-            ],
-            disagreement: [],
-            resolution:
-              'Clear consensus to reject. Both operational and business perspectives align that this PRD should not proceed.',
-          },
-          finalPRD: 'Build internal tool for rarely-used workflow',
-          summary:
-            'Rejected by both reviewers. Operationally infeasible and poor business case. Recommend exploring alternative solutions.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>REJECT</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>Both reviewers recommend rejection</item>
+      <item>Ava: operationally not feasible</item>
+      <item>Jon: business case insufficient</item>
+    </agreement>
+    <disagreement></disagreement>
+    <resolution>Clear consensus to reject. Both operational and business perspectives align that this PRD should not proceed.</resolution>
+  </consensus_analysis>
+  <final_prd>Build internal tool for rarely-used workflow</final_prd>
+  <summary>Rejected by both reviewers. Operationally infeasible and poor business case. Recommend exploring alternative solutions.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -442,22 +446,22 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'REJECT',
-          consensusAnalysis: {
-            agreement: ['Technical execution is feasible (Ava)'],
-            disagreement: [
-              'Jon identifies fundamental business issues',
-              'Strategic misalignment and no customer value',
-            ],
-            resolution:
-              "Jon's rejection based on fundamental business concerns overrides Ava's operational approval. Cannot proceed with strategically misaligned initiative.",
-          },
-          finalPRD: 'Feature X',
-          summary:
-            'Rejected due to fundamental business concerns. Even though technically feasible, strategic misalignment and lack of customer value make this a non-starter.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>REJECT</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>Technical execution is feasible (Ava)</item>
+    </agreement>
+    <disagreement>
+      <item>Jon identifies fundamental business issues</item>
+      <item>Strategic misalignment and no customer value</item>
+    </disagreement>
+    <resolution>Jon's rejection based on fundamental business concerns overrides Ava's operational approval. Cannot proceed with strategically misaligned initiative.</resolution>
+  </consensus_analysis>
+  <final_prd>Feature X</final_prd>
+  <summary>Rejected due to fundamental business concerns. Even though technically feasible, strategic misalignment and lack of customer value make this a non-starter.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -521,20 +525,27 @@ describe('consolidate node', () => {
       ];
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'MODIFY',
-          consensusAnalysis: {
-            agreement: ['All approve the initiative', 'Ava and Jon have no concerns'],
-            disagreement: ['Security Team raises PII handling concerns'],
-            resolution:
-              "While Ava and Jon approve, Security Team's concerns about PII handling must be addressed. Modify PRD to include security requirements.",
-          },
-          finalPRD:
-            'MODIFIED: User profile feature\n\nAdded security section:\n- Encrypt PII at rest\n- Document data retention policy\n- Security review before launch',
-          summary:
-            'PRD modified to address security concerns while maintaining business and operational approval.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>MODIFY</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>All approve the initiative</item>
+      <item>Ava and Jon have no concerns</item>
+    </agreement>
+    <disagreement>
+      <item>Security Team raises PII handling concerns</item>
+    </disagreement>
+    <resolution>While Ava and Jon approve, Security Team's concerns about PII handling must be addressed. Modify PRD to include security requirements.</resolution>
+  </consensus_analysis>
+  <final_prd>MODIFIED: User profile feature
+
+Added security section:
+- Encrypt PII at rest
+- Document data retention policy
+- Security review before launch</final_prd>
+  <summary>PRD modified to address security concerns while maintaining business and operational approval.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -588,17 +599,20 @@ describe('consolidate node', () => {
       ];
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'PROCEED',
-          consensusAnalysis: {
-            agreement: ['All four reviewers approve', 'No concerns from any perspective'],
-            disagreement: [],
-            resolution: 'Full consensus across all reviewers. Ready to proceed.',
-          },
-          finalPRD: 'Feature with full approval',
-          summary: 'Approved by Ava, Jon, Security, and Legal. No concerns.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>PROCEED</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>All four reviewers approve</item>
+      <item>No concerns from any perspective</item>
+    </agreement>
+    <disagreement></disagreement>
+    <resolution>Full consensus across all reviewers. Ready to proceed.</resolution>
+  </consensus_analysis>
+  <final_prd>Feature with full approval</final_prd>
+  <summary>Approved by Ava, Jon, Security, and Legal. No concerns.</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -628,7 +642,7 @@ describe('consolidate node', () => {
       await expect(consolidateNode(state)).rejects.toThrow('No reviews available');
     });
 
-    it('should throw error on invalid JSON', async () => {
+    it('should throw error on missing consolidation root element', async () => {
       const avaReview: ReviewerPerspective = {
         reviewer: 'Ava',
         verdict: 'approve',
@@ -637,7 +651,7 @@ describe('consolidate node', () => {
         timestamp: '2024-01-01T00:00:00.000Z',
       };
 
-      const smartModel = new TestChatModel(['This is not valid JSON']);
+      const smartModel = new TestChatModel(['This is not valid XML']);
 
       const state: ConsolidateState = {
         prd: 'Some PRD',
@@ -645,7 +659,7 @@ describe('consolidate node', () => {
         smartModel,
       };
 
-      await expect(consolidateNode(state)).rejects.toThrow('Failed to parse JSON');
+      await expect(consolidateNode(state)).rejects.toThrow('Failed to parse XML');
     });
 
     it('should throw error on missing required fields', async () => {
@@ -658,10 +672,15 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'PROCEED',
-          // missing consensusAnalysis, finalPRD, summary
-        }),
+        `<consolidation>
+  <consensus_analysis>
+    <agreement></agreement>
+    <disagreement></disagreement>
+    <resolution>Test</resolution>
+  </consensus_analysis>
+  <final_prd>Test</final_prd>
+  <summary>Test</summary>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -683,17 +702,17 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'MAYBE', // invalid value
-          consensusAnalysis: {
-            agreement: [],
-            disagreement: [],
-            resolution: 'Test',
-          },
-          finalPRD: 'Test',
-          summary: 'Test',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>MAYBE</verdict>
+  <consensus_analysis>
+    <agreement></agreement>
+    <disagreement></disagreement>
+    <resolution>Test</resolution>
+  </consensus_analysis>
+  <final_prd>Test</final_prd>
+  <summary>Test</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -705,7 +724,7 @@ describe('consolidate node', () => {
       await expect(consolidateNode(state)).rejects.toThrow('Invalid consolidation format');
     });
 
-    it('should handle JSON in markdown code blocks', async () => {
+    it('should handle XML in markdown code blocks', async () => {
       const avaReview: ReviewerPerspective = {
         reviewer: 'Ava',
         verdict: 'approve',
@@ -715,19 +734,7 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        '```json\n' +
-          JSON.stringify({
-            verdict: 'PROCEED',
-            consensusAnalysis: {
-              agreement: ['All good'],
-              disagreement: [],
-              resolution: 'Proceed',
-            },
-            finalPRD: 'Test PRD',
-            summary: 'Approved',
-            timestamp: '2024-01-01T00:00:00.000Z',
-          }) +
-          '\n```',
+        '```xml\n<consolidation>\n  <verdict>PROCEED</verdict>\n  <consensus_analysis>\n    <agreement><item>All good</item></agreement>\n    <disagreement></disagreement>\n    <resolution>Proceed</resolution>\n  </consensus_analysis>\n  <final_prd>Test PRD</final_prd>\n  <summary>Approved</summary>\n  <timestamp>2024-01-01T00:00:00.000Z</timestamp>\n</consolidation>\n```',
       ]);
 
       const state: ConsolidateState = {
@@ -757,17 +764,19 @@ describe('consolidate node', () => {
 
       // Fast model provides valid response
       const fastModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'PROCEED',
-          consensusAnalysis: {
-            agreement: ['From fast model - consensus reached'],
-            disagreement: [],
-            resolution: 'Fallback model resolved successfully',
-          },
-          finalPRD: 'Feature X',
-          summary: 'Consolidated by fast model',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>PROCEED</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>From fast model - consensus reached</item>
+    </agreement>
+    <disagreement></disagreement>
+    <resolution>Fallback model resolved successfully</resolution>
+  </consensus_analysis>
+  <final_prd>Feature X</final_prd>
+  <summary>Consolidated by fast model</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {
@@ -817,17 +826,19 @@ describe('consolidate node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          verdict: 'PROCEED',
-          consensusAnalysis: {
-            agreement: ['All approved'],
-            disagreement: [],
-            resolution: 'Ready to proceed',
-          },
-          finalPRD: 'Simple update',
-          summary: 'All good',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<consolidation>
+  <verdict>PROCEED</verdict>
+  <consensus_analysis>
+    <agreement>
+      <item>All approved</item>
+    </agreement>
+    <disagreement></disagreement>
+    <resolution>Ready to proceed</resolution>
+  </consensus_analysis>
+  <final_prd>Simple update</final_prd>
+  <summary>All good</summary>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</consolidation>`,
       ]);
 
       const state: ConsolidateState = {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -225,6 +225,7 @@ import { leadEngineerTools } from './tools/lead-engineer-tools.js';
 import { knowledgeTools } from './tools/knowledge-tools.js';
 import { qaTools } from './tools/qa-tools.js';
 import { discordTools } from './tools/discord-tools.js';
+import { portfolioTools } from './tools/portfolio-tools.js';
 
 // Aggregate all tools
 const tools: Tool[] = [
@@ -247,6 +248,7 @@ const tools: Tool[] = [
   ...knowledgeTools,
   ...qaTools,
   ...discordTools,
+  ...portfolioTools,
 ];
 
 // Tool implementations
@@ -776,6 +778,15 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         projectPath: args.projectPath,
         projectSlug: args.projectSlug,
       });
+
+    case 'get_portfolio_sitrep':
+      return apiCall(
+        '/portfolio/sitrep',
+        args.projectPaths !== undefined
+          ? { projectPaths: (args.projectPaths as string[]).join(',') }
+          : {},
+        'GET'
+      );
 
     // QA Tools
     case 'run_qa_check':

--- a/packages/mcp-server/src/tools/portfolio-tools.ts
+++ b/packages/mcp-server/src/tools/portfolio-tools.ts
@@ -1,0 +1,24 @@
+/**
+ * Portfolio Tools — Fleet-wide status and coordination tools
+ */
+
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+export const portfolioTools: Tool[] = [
+  {
+    name: 'get_portfolio_sitrep',
+    description:
+      'Get a fleet-wide portfolio status report aggregating all active projects in one call. Returns per-project health (green/yellow/red), active agents, backlog depth, blocked count, and staging lag. Also includes portfolio-level metrics (total active agents, WIP utilization, top constraint) and pending human decisions (PR reviews, escalations, prioritization needs) across all projects. Use this instead of calling get_sitrep for each project individually.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPaths: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Optional list of project paths to include. When provided, overrides GlobalSettings.projects[] and scopes the report to only these paths. Pass an empty array to return empty results without fetching any projects.',
+        },
+      },
+    },
+  },
+];


### PR DESCRIPTION
## Summary

Implement the fleet-wide status tool that replaces N individual get_sitrep calls. This is the highest-leverage single addition in the entire portfolio project.

**Files to create/modify:**
- `apps/server/src/services/portfolio-world-state-builder.ts` (new) — aggregates per-project PMWorldStateBuilder instances
- `apps/server/src/routes/portfolio/sitrep.ts` (new) — HTTP handler for GET /api/portfolio/sitrep
- `packages/mcp-server/src/tools/portfolio-tools.ts` (new) — MCP tool definitions for all ...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-07T16:37:41.912Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fleet-wide portfolio sitrep: aggregated project health, active agents, utilization, top constraints, and pending decisions.
  * Option to scope sitrep to specific projects or default to configured projects.
  * Exposed as a queryable tool for MCP clients to retrieve portfolio snapshots.

* **Tests**
  * Unit tests updated to use XML-formatted LLM outputs instead of JSON for review and consolidation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->