### PR TITLE
org-architecture.md + fleet-architecture.md + ava-operating-model.md + portfolio-philosophy.md updates

### DIFF
--- a/docs/internal/index.md
+++ b/docs/internal/index.md
@@ -6,6 +6,7 @@ This directory is NOT included in the public VitePress build. Content here is fo
 
 ## Portfolio
 
+- [Org Architecture](./org-architecture.md)
 - [Portfolio Operating Model](./portfolio-philosophy.md)
 
 ## Agents
@@ -103,6 +104,8 @@ This directory is NOT included in the public VitePress build. Content here is fo
 - [Overview](./protolabs/index.md)
 - [Agency Overview](./protolabs/agency-overview.md)
 - [Agency Architecture](./protolabs/agency-architecture.md)
+- [Fleet Architecture](./protolabs/fleet-architecture.md)
+- [Ava Operating Model](./protolabs/ava-operating-model.md)
 - [Setup Pipeline](./protolabs/setup-pipeline.md)
 - [CI/CD Setup](./protolabs/ci-cd-setup.md)
 - [Flow Development Pattern](./protolabs/flow-development-pattern.md)

--- a/docs/internal/org-architecture.md
+++ b/docs/internal/org-architecture.md
@@ -82,12 +82,12 @@ Calendar, email, and docs integration planned for the Google Workspace plugin in
 
 Tunnels terminate in the homelab Docker network and forward to internal services. All public hostnames use HTTPS; internal traffic is plain HTTP.
 
-| Public Hostname | Internal Target | Service |
-| --- | --- | --- |
-| `ava.protoLabs.studio` | `automaker-server:3008` | protoMaker API + WebSocket |
-| `chat.protoLabs.studio` | `openwebui:3000` | OpenWebUI chat interface |
-| `search.protoLabs.studio` | `searxng:8080` | SearXNG metasearch |
-| `llm.protoLabs.studio` | `litellm:4000` | LiteLLM proxy |
+| Public Hostname           | Internal Target         | Service                    |
+| ------------------------- | ----------------------- | -------------------------- |
+| `ava.protoLabs.studio`    | `automaker-server:3008` | protoMaker API + WebSocket |
+| `chat.protoLabs.studio`   | `openwebui:3000`        | OpenWebUI chat interface   |
+| `search.protoLabs.studio` | `searxng:8080`          | SearXNG metasearch         |
+| `llm.protoLabs.studio`    | `litellm:4000`          | LiteLLM proxy              |
 
 **Config lives in**: `homelab-iac/stacks/cloudflare/` (Cloudflare tunnel credentials in Infisical).
 
@@ -147,24 +147,24 @@ It is NOT a Discord bot. Discord is one of several interface plugins connected t
 
 ### Bus Topics
 
-| Topic | Direction | Purpose |
-| --- | --- | --- |
-| `agent.request` | Plugin → Bus | Incoming signal from any interface |
-| `agent.response` | Bus → Plugin | Agent reply routed back to originating interface |
-| `hitl.request` | Bus → Plugin | Human-in-the-loop prompt |
-| `hitl.response` | Plugin → Bus | Human response to HITL prompt |
-| `event.internal` | Service → Bus | Internal system events (webhooks, cron signals) |
+| Topic            | Direction     | Purpose                                          |
+| ---------------- | ------------- | ------------------------------------------------ |
+| `agent.request`  | Plugin → Bus  | Incoming signal from any interface               |
+| `agent.response` | Bus → Plugin  | Agent reply routed back to originating interface |
+| `hitl.request`   | Bus → Plugin  | Human-in-the-loop prompt                         |
+| `hitl.response`  | Plugin → Bus  | Human response to HITL prompt                    |
+| `event.internal` | Service → Bus | Internal system events (webhooks, cron signals)  |
 
 ### Plugins
 
-| Plugin | Status | Transport | Notes |
-| --- | --- | --- | --- |
-| **Discord** | Active | WebSocket (discord.js) | Primary interface — embeds, threads, reactions |
-| **GitHub** | Active | Webhooks (`POST /webhook/github`) | Issue/PR events, bot comments |
-| **A2A** | Active | HTTP JSON-RPC 2.0 | Inter-agent communication |
-| **Plane** | Planned | Webhooks | Board-native intake |
-| **Onboarding** | Active | Internal | Runs `/setuplab` pipeline on new project signals |
-| **Google Workspace** | Roadmap | OAuth + API | Gmail intake, Calendar context |
+| Plugin               | Status  | Transport                         | Notes                                            |
+| -------------------- | ------- | --------------------------------- | ------------------------------------------------ |
+| **Discord**          | Active  | WebSocket (discord.js)            | Primary interface — embeds, threads, reactions   |
+| **GitHub**           | Active  | Webhooks (`POST /webhook/github`) | Issue/PR events, bot comments                    |
+| **A2A**              | Active  | HTTP JSON-RPC 2.0                 | Inter-agent communication                        |
+| **Plane**            | Planned | Webhooks                          | Board-native intake                              |
+| **Onboarding**       | Active  | Internal                          | Runs `/setuplab` pipeline on new project signals |
+| **Google Workspace** | Roadmap | OAuth + API                       | Gmail intake, Calendar context                   |
 
 ### OnboardingPlugin Pipeline
 
@@ -190,11 +190,11 @@ Single source of truth for all project metadata: team assignments, agent binding
 
 ### API Endpoints
 
-| Endpoint | Method | Description |
-| --- | --- | --- |
-| `/api/agents` | GET | Full agent registry |
-| `/api/projects` | GET | Full project registry |
-| `/publish` | POST | Inject message onto bus |
+| Endpoint        | Method | Description             |
+| --------------- | ------ | ----------------------- |
+| `/api/agents`   | GET    | Full agent registry     |
+| `/api/projects` | GET    | Full project registry   |
+| `/publish`      | POST   | Inject message onto bus |
 
 ### Deployment
 
@@ -268,14 +268,14 @@ The board engine and agent execution environment. Manages the full feature lifec
 
 ### Components
 
-| Component | Description |
-| --- | --- |
-| **Board** | Kanban-style feature tracker. Statuses: `backlog → in_progress → review → done / blocked` |
-| **Auto-mode** | Autonomous feature pickup loop. Processes features in dependency order. |
-| **Worktrees** | Isolated git worktrees per feature in `{projectPath}/.worktrees/{branch}` |
-| **Lead Engineer** | Production orchestrator. Fast-path rules (pure functions) for routine decisions. |
-| **PR Pipeline** | Automated PR creation, CI check monitoring, CodeRabbit review, auto-merge |
-| **Portfolio Scheduler** | Planned — roadmap integration with Plane for cross-project scheduling |
+| Component               | Description                                                                               |
+| ----------------------- | ----------------------------------------------------------------------------------------- |
+| **Board**               | Kanban-style feature tracker. Statuses: `backlog → in_progress → review → done / blocked` |
+| **Auto-mode**           | Autonomous feature pickup loop. Processes features in dependency order.                   |
+| **Worktrees**           | Isolated git worktrees per feature in `{projectPath}/.worktrees/{branch}`                 |
+| **Lead Engineer**       | Production orchestrator. Fast-path rules (pure functions) for routine decisions.          |
+| **PR Pipeline**         | Automated PR creation, CI check monitoring, CodeRabbit review, auto-merge                 |
+| **Portfolio Scheduler** | Planned — roadmap integration with Plane for cross-project scheduling                     |
 
 ### Key Services
 
@@ -303,12 +303,12 @@ Project management for strategic work items. Plane is used for the human-visible
 
 ### Workspace Structure
 
-| Identifier | Description |
-| --- | --- |
-| `protolabs` | Primary workspace |
-| `PROTO` | Core platform features |
-| `GTM` | Go-to-market initiatives |
-| `INFRA` | Infrastructure work |
+| Identifier  | Description              |
+| ----------- | ------------------------ |
+| `protolabs` | Primary workspace        |
+| `PROTO`     | Core platform features   |
+| `GTM`       | Go-to-market initiatives |
+| `INFRA`     | Infrastructure work      |
 
 ### Sync with Workstacean
 
@@ -420,10 +420,10 @@ Remote seedbox. Handles media and large file transfers.
 
 Three repos, three responsibilities. No overlap.
 
-| Boundary | Repo | Owns |
-| --- | --- | --- |
-| **Deployment** | `homelab-iac` | Docker Compose, volume mounts, env vars, network config, port mappings |
-| **Bus + Registry** | `protoWorkstacean` | Message routing, skill matching, interface plugins, `agents.yaml`, `projects.yaml`, correlationId minting |
+| Boundary                 | Repo               | Owns                                                                                                            |
+| ------------------------ | ------------------ | --------------------------------------------------------------------------------------------------------------- |
+| **Deployment**           | `homelab-iac`      | Docker Compose, volume mounts, env vars, network config, port mappings                                          |
+| **Bus + Registry**       | `protoWorkstacean` | Message routing, skill matching, interface plugins, `agents.yaml`, `projects.yaml`, correlationId minting       |
 | **Planning + Execution** | `ava` (protoMaker) | Planning pipeline, PRD generation, antagonistic review, board management, Lead Engineer, auto-mode, PR pipeline |
 
 ### What each repo does NOT own

--- a/docs/internal/org-architecture.md
+++ b/docs/internal/org-architecture.md
@@ -1,0 +1,433 @@
+# protoLabs Org Architecture
+
+Canonical reference for every layer of the protoLabs stack. Use this as the starting point when onboarding agents, new team members, or systems that need to understand how everything connects.
+
+Cross-links: [Fleet Architecture](./protolabs/fleet-architecture.md) | [Ava Operating Model](./protolabs/ava-operating-model.md) | [Portfolio Philosophy](./portfolio-philosophy.md)
+
+---
+
+## Full Stack Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  EXTERNAL SURFACE                                                   │
+│  Discord · GitHub · Google Workspace (roadmap)                      │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+┌──────────────────────────────▼──────────────────────────────────────┐
+│  CLOUDFLARE TUNNEL                                                  │
+│  ava.protoLabs.studio → automaker-server:3008                       │
+│  chat.protoLabs.studio → openwebui:3000                             │
+│  search.protoLabs.studio → searxng:8080                             │
+│  llm.protoLabs.studio   → litellm:4000                              │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+┌──────────────────────────────▼──────────────────────────────────────┐
+│  GATEWAY LAYER                                                      │
+│  LiteLLM · MCP Server · OpenWebUI · SearXNG                         │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+┌──────────────────────────────▼──────────────────────────────────────┐
+│  ORCHESTRATION LAYER                                                │
+│  Workstacean — message bus, skill router, agent/project registry    │
+└──────────┬──────────────────┬────────────────┬─────────────────────┘
+           │                  │                │
+┌──────────▼──────┐  ┌────────▼────────┐  ┌───▼─────────────────────┐
+│  AGENT LAYER    │  │  DEV TOOLING    │  │  STRATEGIC LAYER        │
+│  Ava Quinn Frank│  │  protoMaker     │  │  Plane (project mgmt)   │
+│  Jon Cindi      │  │  automaker      │  │                         │
+│  Researcher     │  │  Lead Engineer  │  │                         │
+└─────────────────┘  └─────────────────┘  └─────────────────────────┘
+                               │
+┌──────────────────────────────▼──────────────────────────────────────┐
+│  OBSERVABILITY CROSS-CUT                                            │
+│  Langfuse · MLflow · Prometheus+Grafana · Infisical                 │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+┌──────────────────────────────▼──────────────────────────────────────┐
+│  INFRASTRUCTURE                                                     │
+│  ava node · protolabs node · pve01 · pi · MinIO · Tailscale         │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## External Surface
+
+### Discord
+
+Primary human-agent interface. All agent conversations, project approvals, HITL prompts, and system alerts route through Discord.
+
+- **Guild ID**: `1070606339363049492`
+- **Key channels**: `#ava` (primary Ava interaction), `#dev` (code updates), `#infra` (alerts), `#bug-reports` (triage), `#deployments` (release notes)
+- **Bot accounts**: `protoava[bot]` (Ava), `protoquinn[bot]` (Quinn) — each agent gets its own bot identity (per-agent Discord bot pool is a roadmap item; currently all bots share one token)
+- **Connected to**: Workstacean Discord plugin (WebSocket, discord.js)
+
+### GitHub
+
+Event source for PR and issue lifecycle signals.
+
+- **Org**: `protolabsai`
+- **Primary repos**: `protoMaker` (automaker engine), `protoWorkstacean` (bus + registry), `homelab-iac` (deployment)
+- **Webhook targets**: Workstacean GitHub plugin (`POST /webhook/github`)
+- **Bot comments**: `protoava[bot]` and `protoquinn[bot]` post review and triage comments
+
+### Google Workspace (roadmap)
+
+Calendar, email, and docs integration planned for the Google Workspace plugin in Workstacean. Will enable task intake from Gmail and scheduling context from Calendar. Config location: `workspace/plugins/google.yaml` (not yet implemented).
+
+---
+
+## Cloudflare Tunnel
+
+Tunnels terminate in the homelab Docker network and forward to internal services. All public hostnames use HTTPS; internal traffic is plain HTTP.
+
+| Public Hostname | Internal Target | Service |
+| --- | --- | --- |
+| `ava.protoLabs.studio` | `automaker-server:3008` | protoMaker API + WebSocket |
+| `chat.protoLabs.studio` | `openwebui:3000` | OpenWebUI chat interface |
+| `search.protoLabs.studio` | `searxng:8080` | SearXNG metasearch |
+| `llm.protoLabs.studio` | `litellm:4000` | LiteLLM proxy |
+
+**Config lives in**: `homelab-iac/stacks/cloudflare/` (Cloudflare tunnel credentials in Infisical).
+
+---
+
+## Gateway Layer
+
+### LiteLLM
+
+Model routing proxy. Exposes a single `/v1/chat/completions` endpoint and routes to the correct backend (Anthropic, OpenAI, local vLLM) based on model alias.
+
+- **Port**: `4000` (internal), exposed via Cloudflare at `llm.protoLabs.studio`
+- **Auth**: API key validation. Keys stored in Infisical, mounted at startup.
+- **Model aliases**: `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-haiku-4-5-20251001`, `gpt-4o`, local models via vLLM on ava node
+- **Talks to**: Anthropic API (cloud), vLLM (local, ava node A6000)
+- **Talked to by**: OpenWebUI, any agent that needs non-Anthropic models
+- **Config lives in**: `homelab-iac/stacks/ai/litellm-config.yaml`
+
+### MCP Server
+
+Tool surface for Claude Code agents. Exposes ~159 tools organized by category (feature management, agent control, queue management, GitHub ops, observability).
+
+- **Port**: `3009` (internal), consumed by Claude Code plugin
+- **Talks to**: protoMaker API (`automaker-server:3008`)
+- **Talked to by**: Claude Code agents via MCP protocol
+- **Config lives in**: `packages/mcp-server/` in the `ava` repo
+
+### OpenWebUI
+
+Chat interface for direct LLM interaction. Backed by LiteLLM.
+
+- **Port**: `3000` (internal), exposed via Cloudflare at `chat.protoLabs.studio`
+- **Talks to**: LiteLLM (model proxy)
+- **Talked to by**: Josh (human), any browser
+- **Config lives in**: `homelab-iac/stacks/ai/docker-compose.yml`
+
+### SearXNG
+
+Privacy-respecting metasearch engine. Used by Researcher agent for deep research tasks.
+
+- **Port**: `8080` (internal), exposed via Cloudflare at `search.protoLabs.studio`
+- **Talks to**: Public search engines (proxied)
+- **Talked to by**: Researcher agent, OpenWebUI (via tool)
+- **Config lives in**: `homelab-iac/stacks/ai/searxng/`
+
+---
+
+## Orchestration Layer: Workstacean
+
+Workstacean is the central orchestration backbone. It does three things:
+
+1. **Route messages** from interface plugins to agents based on skill matching
+2. **Serve the registry** so any service can discover agents and projects
+3. **Mint correlationIds** that flow through every downstream artifact
+
+It is NOT a Discord bot. Discord is one of several interface plugins connected to the bus.
+
+### Bus Topics
+
+| Topic | Direction | Purpose |
+| --- | --- | --- |
+| `agent.request` | Plugin → Bus | Incoming signal from any interface |
+| `agent.response` | Bus → Plugin | Agent reply routed back to originating interface |
+| `hitl.request` | Bus → Plugin | Human-in-the-loop prompt |
+| `hitl.response` | Plugin → Bus | Human response to HITL prompt |
+| `event.internal` | Service → Bus | Internal system events (webhooks, cron signals) |
+
+### Plugins
+
+| Plugin | Status | Transport | Notes |
+| --- | --- | --- | --- |
+| **Discord** | Active | WebSocket (discord.js) | Primary interface — embeds, threads, reactions |
+| **GitHub** | Active | Webhooks (`POST /webhook/github`) | Issue/PR events, bot comments |
+| **A2A** | Active | HTTP JSON-RPC 2.0 | Inter-agent communication |
+| **Plane** | Planned | Webhooks | Board-native intake |
+| **Onboarding** | Active | Internal | Runs `/setuplab` pipeline on new project signals |
+| **Google Workspace** | Roadmap | OAuth + API | Gmail intake, Calendar context |
+
+### OnboardingPlugin Pipeline
+
+When Workstacean receives a signal with `skillHint: "onboard_project"`, the OnboardingPlugin runs the 5-phase setup pipeline:
+
+```
+1. scan   — detect tech stack, dependencies, project structure
+2. analyze — compare against quality standard (CI, types, testing, tooling)
+3. initialize — create .automaker/ context files, register in projects.yaml
+4. propose — create alignment features on the board
+5. execute — launch auto-mode to implement alignment work
+```
+
+Config: `workspace/plugins/onboarding.yaml`
+
+### Agent Registry (`workspace/agents.yaml`)
+
+Single source of truth for all agent metadata: name, team, URL, skills, chain rules. Consumed by the A2A plugin at startup. Live skills from `/.well-known/agent.json` override static definitions if available.
+
+### Project Registry (`workspace/projects.yaml`)
+
+Single source of truth for all project metadata: team assignments, agent bindings, Discord channels, repo metadata. Used by the skill router to map repos → projects → routing rules.
+
+### API Endpoints
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/api/agents` | GET | Full agent registry |
+| `/api/projects` | GET | Full project registry |
+| `/publish` | POST | Inject message onto bus |
+
+### Deployment
+
+Config in `homelab-iac/stacks/ai/docker-compose.yml`. Registry files mounted from `protoWorkstacean/workspace/`.
+
+---
+
+## Agent Layer
+
+All A2A agents expose `/.well-known/agent.json` and accept JSON-RPC 2.0 `message/send` calls.
+
+### Ava — Portfolio Orchestrator
+
+- **A2A Endpoint**: `http://automaker-server:3008/a2a`
+- **Team**: Dev (primary orchestrator across all teams)
+- **Skills**: `plan`, `plan_resume`, `sitrep`, `manage_feature`, `auto_mode`, `board_health`, `onboard_project`
+- **Projects served**: All — Ava is the single orchestration entry point
+- **Activation**: Receives signals from Workstacean bus; also directly addressable via A2A
+- **Config lives in**: `ava` repo, `.claude/commands/` for skill definitions
+
+### Quinn — QA Engineer / Bug Triage
+
+- **A2A Endpoint**: `http://quinn:7870/a2a`
+- **Team**: Dev
+- **Skills**: `bug_triage`, `pr_review`, `qa_report`, `board_audit`
+- **Projects served**: All — routes via `#bug-reports` Discord channel workflow
+- **Activation**: Workstacean routes GitHub issue events and `#bug-reports` signals directly to Quinn
+- **Config lives in**: `homelab-iac/stacks/ai/quinn/`
+
+### Frank — DevOps / Infrastructure
+
+- **A2A Endpoint**: `http://frank:7880/a2a`
+- **Team**: Dev
+- **Skills**: `infra_health`, `deploy`, `monitoring`
+- **Projects served**: All infrastructure — homelab, staging, production
+- **Activation**: Workstacean routes `#infra` and deployment signals to Frank
+- **Config lives in**: `homelab-iac/stacks/ai/frank/`
+
+### Jon — GTM Strategy
+
+- **A2A Endpoint**: internal (called by Ava as sub-agent)
+- **Team**: GTM
+- **Skills**: `market_review`, `positioning`, `antagonistic_review`
+- **Projects served**: All — provides strategic lens during planning pipeline
+- **Activation**: Ava calls Jon during antagonistic review in the `plan` skill
+- **Config lives in**: `ava` repo, `.claude/commands/jon.md`
+
+### Cindi — Content Execution
+
+- **A2A Endpoint**: internal (called by Ava as sub-agent)
+- **Team**: GTM
+- **Skills**: `blog`, `seo`, `content_review`
+- **Projects served**: protoLabs content pipeline, marketing, docs
+- **Activation**: Ava calls Cindi for content tasks; also triggered by content pipeline flows
+- **Config lives in**: `ava` repo, `.claude/commands/cindi.md`
+
+### Researcher — Deep Research
+
+- **A2A Endpoint**: internal (called by Ava or Quinn)
+- **Team**: Knowledge
+- **Skills**: `research`, `entity_extract`
+- **Projects served**: Any — called when deep research is needed before planning or triage
+- **Activation**: Ava or Quinn invoke Researcher before planning or complex triage
+- **Config lives in**: `ava` repo, `.claude/commands/researcher.md`
+
+---
+
+## Dev Tooling: protoMaker / Automaker
+
+The board engine and agent execution environment. Manages the full feature lifecycle from backlog to merged PR.
+
+### Components
+
+| Component | Description |
+| --- | --- |
+| **Board** | Kanban-style feature tracker. Statuses: `backlog → in_progress → review → done / blocked` |
+| **Auto-mode** | Autonomous feature pickup loop. Processes features in dependency order. |
+| **Worktrees** | Isolated git worktrees per feature in `{projectPath}/.worktrees/{branch}` |
+| **Lead Engineer** | Production orchestrator. Fast-path rules (pure functions) for routine decisions. |
+| **PR Pipeline** | Automated PR creation, CI check monitoring, CodeRabbit review, auto-merge |
+| **Portfolio Scheduler** | Planned — roadmap integration with Plane for cross-project scheduling |
+
+### Key Services
+
+- `LeadEngineerService` — state machine + fast-path rules
+- `AutoModeService` — feature pickup loop with concurrency control
+- `GitWorkflowService` — worktree creation, PR management
+- `FeatureLoader` — feature CRUD with status normalization
+
+### Ports
+
+- `3007` — UI (React, Vite)
+- `3008` — API + WebSocket + A2A endpoint
+
+### Config lives in
+
+- `ava` repo (protoMaker on GitHub)
+- `.automaker/` per managed project
+- `data/settings.json` for global settings
+
+---
+
+## Strategic Layer: Plane
+
+Project management for strategic work items. Plane is used for the human-visible project roadmap and cross-team coordination — not for auto-mode feature execution (that lives on the protoMaker board).
+
+### Workspace Structure
+
+| Identifier | Description |
+| --- | --- |
+| `protolabs` | Primary workspace |
+| `PROTO` | Core platform features |
+| `GTM` | Go-to-market initiatives |
+| `INFRA` | Infrastructure work |
+
+### Sync with Workstacean
+
+`workspace/projects.yaml` is the single source of truth for project metadata. Plane project identifiers are stored in `projects.yaml` under `plane.projectId` so Workstacean can cross-reference board features with Plane issues.
+
+**Direction**: Plane → Workstacean (via planned Plane plugin webhook). Bidirectional sync is a roadmap item.
+
+---
+
+## Observability Cross-Cut
+
+All layers emit telemetry to the observability stack. No layer is exempt.
+
+### Langfuse
+
+LLM traces and cost tracking. Every agent turn is traced with `correlationId`, model, input/output tokens, and cost.
+
+- **URL**: `https://cloud.langfuse.com` (cloud-hosted)
+- **Talked to by**: All agents via `@protolabsai/observability` package
+- **Key metrics**: Cost per feature, cost per project, total burn, trace success rate
+- **Config**: `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY` in Infisical
+
+### MLflow
+
+Experiment tracking for model evaluation and flow optimization.
+
+- **URL**: `http://mlflow:5000` (internal, homelab)
+- **Talked to by**: Flow development, model evaluation scripts
+- **Config lives in**: `homelab-iac/stacks/ai/docker-compose.yml`
+
+### Prometheus + Grafana
+
+Infrastructure and application metrics.
+
+- **Prometheus**: `http://prometheus:9090` (internal)
+- **Grafana**: `http://grafana:3001` (internal)
+- **Key dashboards**: Agent concurrency, queue depth, PR pipeline throughput, infra health
+- **Config lives in**: `homelab-iac/stacks/monitoring/`
+
+### Infisical
+
+Secrets management backbone. Every service that needs an API key or credential pulls from Infisical at startup.
+
+- **URL**: `https://app.infisical.com` (cloud-hosted)
+- **Talked to by**: All Docker Compose services via `infisical run --`
+- **Managed secrets**: Anthropic API key, GitHub tokens, Discord tokens, Cloudflare credentials, LiteLLM keys, Langfuse keys
+- **Config lives in**: `homelab-iac/stacks/` (each stack has an Infisical project ID)
+
+---
+
+## Infrastructure
+
+### ava node
+
+Primary compute node. Runs most homelab services.
+
+- **GPU**: NVIDIA A6000 (48GB VRAM) — local LLM inference via vLLM
+- **Storage**: 2 × 8TB (ZFS mirror)
+- **OS**: Ubuntu 22.04 (bare metal, not Proxmox guest)
+- **Key services**: protoMaker, Workstacean, Quinn, Frank, LiteLLM, OpenWebUI, SearXNG, MLflow, Prometheus, Grafana, MinIO
+
+### protolabs node
+
+High-VRAM inference node. Reserved for large model training and inference.
+
+- **GPU**: 2 × RTX PRO 6000 Blackwell (192GB VRAM total)
+- **Role**: Large model inference, fine-tuning, evaluation
+- **Status**: Partially integrated — vLLM endpoints registered in LiteLLM
+
+### pve01
+
+Proxmox hypervisor. Runs VMs for isolated workloads.
+
+- **Key VMs**: CI runners, isolated test environments
+- **Config lives in**: `homelab-iac/pve01/`
+
+### pi
+
+Raspberry Pi running Home Assistant. Not part of the AI stack directly.
+
+- **Role**: Home automation, ambient monitoring
+- **Integration**: Planned (smart home signals as Workstacean events)
+
+### MinIO
+
+S3-compatible object storage. Shared across all services.
+
+- **URL**: `http://minio:9000` (internal)
+- **Buckets**: `agent-outputs`, `langfuse-exports`, `mlflow-artifacts`, `media`
+- **Config lives in**: `homelab-iac/stacks/storage/`
+
+### Tailscale (MagicDNS)
+
+Zero-config mesh VPN. All nodes and services are reachable by MagicDNS names (`ava-node.tail…`, `pve01.tail…`).
+
+- **Role**: Secure inter-node communication without port forwarding
+- **Config**: Each node runs `tailscaled`; auth keys in Infisical
+
+### cupcake.usbx.me
+
+Remote seedbox. Handles media and large file transfers.
+
+- **Role**: External storage relay for large artifacts (model weights, dataset exports)
+- **Access**: rclone + SSH, credentials in Infisical
+
+---
+
+## Architecture Boundaries
+
+Three repos, three responsibilities. No overlap.
+
+| Boundary | Repo | Owns |
+| --- | --- | --- |
+| **Deployment** | `homelab-iac` | Docker Compose, volume mounts, env vars, network config, port mappings |
+| **Bus + Registry** | `protoWorkstacean` | Message routing, skill matching, interface plugins, `agents.yaml`, `projects.yaml`, correlationId minting |
+| **Planning + Execution** | `ava` (protoMaker) | Planning pipeline, PRD generation, antagonistic review, board management, Lead Engineer, auto-mode, PR pipeline |
+
+### What each repo does NOT own
+
+- `homelab-iac` — no agent logic, no skill definitions, no routing rules
+- `protoWorkstacean` — no plan execution, no board state, no agent runs
+- `ava` — no agent registry (reads from Workstacean API), no project registry, no message routing

--- a/docs/internal/portfolio-philosophy.md
+++ b/docs/internal/portfolio-philosophy.md
@@ -87,12 +87,12 @@ Cost of Delay captures the value destroyed by waiting. Job Duration captures the
 
 ### Mapping to protoLabs Feature Schema
 
-| WSJF Component | Feature Field | Scoring |
-| --- | --- | --- |
-| User/Business Value | `priority` | urgent=4, high=3, medium=2, low=1 |
-| Time Criticality | `dueDate` | overdue=+3, due ≤3d=+2, due ≤7d=+1, none=0 |
-| Risk Reduction | `complexity`, `isFoundation` | architectural=+2, isFoundation=+1, else=0 |
-| Job Duration | `complexity` | small=1, medium=3, large=8, architectural=13 |
+| WSJF Component      | Feature Field                | Scoring                                      |
+| ------------------- | ---------------------------- | -------------------------------------------- |
+| User/Business Value | `priority`                   | urgent=4, high=3, medium=2, low=1            |
+| Time Criticality    | `dueDate`                    | overdue=+3, due ≤3d=+2, due ≤7d=+1, none=0   |
+| Risk Reduction      | `complexity`, `isFoundation` | architectural=+2, isFoundation=+1, else=0    |
+| Job Duration        | `complexity`                 | small=1, medium=3, large=8, architectural=13 |
 
 ### Why Not SAFe Ceremonies?
 
@@ -107,6 +107,7 @@ SAFe's PI Planning, Program Increments, and Inspect & Adapt events are designed 
 ### The Problem With Distributed Registries
 
 Before unification, project metadata lived in three places:
+
 - Agent memory files (what Ava knew about a project)
 - Board features (what protoMaker tracked)
 - Discord channel config (what Workstacean used for routing)
@@ -116,6 +117,7 @@ When these diverged — and they always diverge — routing breaks. Quinn gets s
 ### The Solution: One Registry, Many Consumers
 
 `projects.yaml` is the authoritative record. Every consumer reads from it:
+
 - Workstacean reads it for skill routing and channel mapping
 - protoMaker reads it (via `/api/projects`) for board-level context
 - Quinn reads it for triage routing
@@ -132,8 +134,8 @@ No agent, service, or plugin maintains its own copy of project metadata. They al
   team: dev
   agents: [ava, quinn, frank]
   discord:
-    dev: "1469080556720623699"
-    bugReports: "1477837770704814162"
+    dev: '1469080556720623699'
+    bugReports: '1477837770704814162'
   repo:
     owner: protolabsai
     name: protoMaker
@@ -223,11 +225,12 @@ Flow efficiency > 40% is the practical target for an AI-driven portfolio. Human 
 ### Flow Efficiency in Practice
 
 Flow efficiency is computable from existing feature timestamps:
+
 - `startedAt` — when an agent began executing
 - `completedAt` / `blockedAt` — when execution stopped
 - Status transition history
 
-The DORA metrics system tracks lead time and deployment frequency. Flow efficiency is the complementary metric that explains *why* lead time is long when it is — it points directly to the constraint.
+The DORA metrics system tracks lead time and deployment frequency. Flow efficiency is the complementary metric that explains _why_ lead time is long when it is — it points directly to the constraint.
 
 ---
 

--- a/docs/internal/portfolio-philosophy.md
+++ b/docs/internal/portfolio-philosophy.md
@@ -49,6 +49,188 @@ Instance (server process)
 
 ---
 
+Cross-links: [Org Architecture](./org-architecture.md) | [Fleet Architecture](./protolabs/fleet-architecture.md) | [Ava Operating Model](./protolabs/ava-operating-model.md)
+
+## Operating Lens: Theory of Constraints
+
+The protoLabs portfolio operates through the Theory of Constraints (ToC) lens — not SAFe ceremonies, not sprint planning, not OKR theater.
+
+ToC's core insight: **a system's throughput is determined by its constraint.** Improving anything that is not the constraint does not improve the system's output. The job is to find the constraint, exploit it, subordinate everything else to it, and then elevate it.
+
+### The Five Focusing Steps (applied to protoLabs)
+
+1. **Identify the constraint** — What is preventing more features from shipping? Common constraints: review queue depth, concurrency limit, blocked dependencies, error budget breach, HITL approval backlog.
+2. **Exploit the constraint** — Get maximum throughput from the constraint without spending more. If the constraint is review queue depth, enable auto-merge for low-risk PRs. If it's concurrency, prioritize highest-WSJF features.
+3. **Subordinate everything else** — Don't start work that will pile up in front of the constraint. WIP limits enforce this.
+4. **Elevate the constraint** — If exploitation isn't enough, increase capacity. Raise concurrency limit, add a reviewer, split a large feature.
+5. **Repeat** — The constraint moves when you elevate it. Find the new one.
+
+### How This Changes Ava's Behavior
+
+Ava's primary job at activation is to find the portfolio constraint, not to enumerate all work in progress. The portfolio briefing format is structured around this: health table first, then **top constraint** per layer.
+
+Ava does not optimize individual app throughput in isolation. She asks: "What is the single thing preventing the most value from flowing through the system right now?"
+
+---
+
+## WSJF: Sequencing Within the Constraint
+
+When the constraint is capacity (more work queued than agents can process), features are sequenced by WSJF (Weighted Shortest Job First) — not by creation date or arbitrary priority.
+
+### Formula
+
+```
+WSJF = Cost of Delay / Job Duration
+```
+
+Cost of Delay captures the value destroyed by waiting. Job Duration captures the effort required.
+
+### Mapping to protoLabs Feature Schema
+
+| WSJF Component | Feature Field | Scoring |
+| --- | --- | --- |
+| User/Business Value | `priority` | urgent=4, high=3, medium=2, low=1 |
+| Time Criticality | `dueDate` | overdue=+3, due ≤3d=+2, due ≤7d=+1, none=0 |
+| Risk Reduction | `complexity`, `isFoundation` | architectural=+2, isFoundation=+1, else=0 |
+| Job Duration | `complexity` | small=1, medium=3, large=8, architectural=13 |
+
+### Why Not SAFe Ceremonies?
+
+SAFe's PI Planning, Program Increments, and Inspect & Adapt events are designed for large teams that need coordination rituals. protoLabs has one human operator and a fleet of AI agents. The coordination overhead of SAFe would consume more capacity than it creates. WSJF is the only SAFe artifact worth keeping — it makes sequencing decisions explicit and measurable.
+
+---
+
+## Registry Unification Rationale
+
+`workspace/projects.yaml` in protoWorkstacean is the single source of truth for all project metadata. This is not an accident.
+
+### The Problem With Distributed Registries
+
+Before unification, project metadata lived in three places:
+- Agent memory files (what Ava knew about a project)
+- Board features (what protoMaker tracked)
+- Discord channel config (what Workstacean used for routing)
+
+When these diverged — and they always diverge — routing breaks. Quinn gets signals meant for Frank. Ava creates features on the wrong board. Discord threads appear in the wrong channels.
+
+### The Solution: One Registry, Many Consumers
+
+`projects.yaml` is the authoritative record. Every consumer reads from it:
+- Workstacean reads it for skill routing and channel mapping
+- protoMaker reads it (via `/api/projects`) for board-level context
+- Quinn reads it for triage routing
+- The OnboardingPlugin writes to it when a new project is registered
+
+No agent, service, or plugin maintains its own copy of project metadata. They all query the registry.
+
+### Registry Fields That Matter for Routing
+
+```yaml
+# workspace/projects.yaml
+- slug: proto-maker
+  name: protoMaker
+  team: dev
+  agents: [ava, quinn, frank]
+  discord:
+    dev: "1469080556720623699"
+    bugReports: "1477837770704814162"
+  repo:
+    owner: protolabsai
+    name: protoMaker
+  plane:
+    projectId: PROTO
+```
+
+The `agents` list tells Workstacean which agents can receive signals about this project. The `discord` map tells interface plugins where to send responses.
+
+---
+
+## Cross-Repo Dependency Model
+
+Invisible blockers between repos are the number one source of latency in the portfolio. A feature in protoMaker that depends on a schema change in protoWorkstacean cannot be executed until that schema change lands — but if the dependency is not recorded, auto-mode will attempt it anyway, fail, and consume error budget.
+
+### Why Invisible Blockers Are the #1 Latency Source
+
+1. Agent executes feature, hits missing API or schema
+2. Feature fails, is marked blocked
+3. Ava or operator investigates
+4. Discovers the upstream dependency
+5. Creates a new feature in the upstream repo
+6. Waits for it to land
+7. Requeues the original feature
+
+Total latency: investigation time + upstream execution time + requeue time. All of it preventable.
+
+### The Fix: Declare Cross-Repo Dependencies
+
+Features support an `externalDependencies` field that records explicit cross-repo dependencies:
+
+```json
+{
+  "externalDependencies": [
+    {
+      "repo": "protoWorkstacean",
+      "description": "projects.yaml must include plane.projectId field before this feature can execute",
+      "status": "pending"
+    }
+  ]
+}
+```
+
+The dependency resolver checks `externalDependencies` before auto-mode picks up a feature. Features with unresolved external dependencies are held in `backlog` with a `statusChangeReason` explaining the blocker.
+
+### Cross-Repo Dependency Resolution Flow
+
+```
+1. Feature created with externalDependencies
+2. Dependency resolver marks feature as "waiting on external dep"
+3. Ava creates a corresponding feature in the upstream repo (if not already queued)
+4. When upstream feature merges, Ava updates externalDependency.status = "resolved"
+5. Feature becomes eligible for pickup
+```
+
+This makes the dependency graph visible and actionable. Portfolio health reports surface pending external dependencies as a first-class signal.
+
+---
+
+## Portfolio Flow Efficiency
+
+**Portfolio flow efficiency** is the key metric: what fraction of the total value-delivery pipeline is spent doing actual work vs. waiting?
+
+### Definition
+
+```
+Flow Efficiency = Active Time / (Active Time + Wait Time)
+
+Active Time = time features spend with an agent executing work
+Wait Time   = time features spend in queue (backlog), blocked, or in review without action
+```
+
+A portfolio with 90% flow efficiency has agents executing almost all the time. A portfolio with 20% efficiency has features sitting idle most of the time — usually due to WIP overload, blocked dependencies, or review queue depth.
+
+### Target
+
+Flow efficiency > 40% is the practical target for an AI-driven portfolio. Human teams average 5-15%. AI agents can run at higher efficiency because they don't have context-switch costs or calendar constraints — but they still block on PRs, CI, and HITL approvals.
+
+### How Ava Improves Flow Efficiency
+
+1. **WIP limits** — prevent new work from starting when the system is already saturated
+2. **WSJF sequencing** — ensure the highest-value work is always next in line
+3. **Constraint focus** — unblock the one thing preventing the most flow, not the ten things that are merely slow
+4. **Auto-merge** — reduce review wait time for low-risk changes
+5. **Dependency visibility** — surface invisible blockers before agents hit them
+
+### Flow Efficiency in Practice
+
+Flow efficiency is computable from existing feature timestamps:
+- `startedAt` — when an agent began executing
+- `completedAt` / `blockedAt` — when execution stopped
+- Status transition history
+
+The DORA metrics system tracks lead time and deployment frequency. Flow efficiency is the complementary metric that explains *why* lead time is long when it is — it points directly to the constraint.
+
+---
+
 ## Core Decisions
 
 Three architectural decisions shape the entire operating model:

--- a/docs/internal/protolabs/ava-operating-model.md
+++ b/docs/internal/protolabs/ava-operating-model.md
@@ -121,12 +121,12 @@ Job Duration  = estimated effort (complexity field: small=1, medium=3, large=8, 
 
 ### Mapping to protoLabs Feature Schema
 
-| WSJF Component | Feature Field | How Ava scores it |
-| --- | --- | --- |
-| User/Business Value | `priority` | urgent=4, high=3, medium=2, low=1 |
-| Time Criticality | `dueDate` | overdue=+3, due in 3d=+2, due in 7d=+1, no date=0 |
-| Risk Reduction | `complexity` | architectural=+2, isFoundation=+1, else=0 |
-| Job Duration | `complexity` | small=1, medium=3, large=8, architectural=13 |
+| WSJF Component      | Feature Field | How Ava scores it                                 |
+| ------------------- | ------------- | ------------------------------------------------- |
+| User/Business Value | `priority`    | urgent=4, high=3, medium=2, low=1                 |
+| Time Criticality    | `dueDate`     | overdue=+3, due in 3d=+2, due in 7d=+1, no date=0 |
+| Risk Reduction      | `complexity`  | architectural=+2, isFoundation=+1, else=0         |
+| Job Duration        | `complexity`  | small=1, medium=3, large=8, architectural=13      |
 
 ### WSJF in Practice
 
@@ -150,13 +150,13 @@ Ava manages concurrency allocation across apps subject to operator-configured bo
 
 ### Ava's Actions
 
-| Condition | Auto-Action | Requires Approval |
-| --- | --- | --- |
-| App idle, another app has queued work | Release slot to pool | No |
-| App WIP at limit | Block new feature pickup for that app | No |
-| App error budget >80% | Halve concurrency, freeze non-bug releases | Yes (Trust L1+) |
-| System cap reached | Block all new pickups | No |
-| Feature at 100% cost cap | Kill agent, mark feature blocked | No |
+| Condition                             | Auto-Action                                | Requires Approval |
+| ------------------------------------- | ------------------------------------------ | ----------------- |
+| App idle, another app has queued work | Release slot to pool                       | No                |
+| App WIP at limit                      | Block new feature pickup for that app      | No                |
+| App error budget >80%                 | Halve concurrency, freeze non-bug releases | Yes (Trust L1+)   |
+| System cap reached                    | Block all new pickups                      | No                |
+| Feature at 100% cost cap              | Kill agent, mark feature blocked           | No                |
 
 ---
 
@@ -196,11 +196,11 @@ Ava receives signal
 
 The Lead Engineer emits portfolio-level signals that Ava monitors:
 
-| Signal | Ava Action |
-| --- | --- |
-| `feature:blocked` | Check constraint, attempt unblock, or queue Decision |
-| `project:milestone:late` | Drill app, compute WSJF, surface to operator if at-risk |
-| `agent:stuck` | Kill and requeue (Trust L1+) or queue Exception |
-| `pr:stale` | Assign reviewer or enable auto-merge (Trust L1+) |
-| `budget:breach` | Freeze releases, queue Exception |
-| `project:completed` | Trigger reflection, generate changelog, surface to operator |
+| Signal                   | Ava Action                                                  |
+| ------------------------ | ----------------------------------------------------------- |
+| `feature:blocked`        | Check constraint, attempt unblock, or queue Decision        |
+| `project:milestone:late` | Drill app, compute WSJF, surface to operator if at-risk     |
+| `agent:stuck`            | Kill and requeue (Trust L1+) or queue Exception             |
+| `pr:stale`               | Assign reviewer or enable auto-merge (Trust L1+)            |
+| `budget:breach`          | Freeze releases, queue Exception                            |
+| `project:completed`      | Trigger reflection, generate changelog, surface to operator |

--- a/docs/internal/protolabs/ava-operating-model.md
+++ b/docs/internal/protolabs/ava-operating-model.md
@@ -1,0 +1,206 @@
+# Ava Operating Model
+
+How Ava activates, triages, and makes decisions when managing a multi-app portfolio.
+
+This document covers Ava's post-portfolio operating model — the behaviors and protocols that govern her work once the planning pipeline hands off to execution. For the full org stack, see [Org Architecture](../org-architecture.md). For the planning pipeline, see [Agency Overview](./agency-overview.md).
+
+---
+
+## Fleet-First Activation Sequence
+
+When Ava activates (session start, wake from idle, or explicit sitrep request), she follows a fixed sequence before doing anything else.
+
+```
+1. get_portfolio_sitrep          -- pull health table across all registered apps
+2. scan for RED (off-track)      -- any app with error budget >80% or 2+ milestones late
+3. scan for YELLOW (at-risk)     -- any app with error budget >50% or 1 milestone late
+4. drill RED apps first          -- read Lead Engineer state, blocked features, active PR status
+5. drill YELLOW apps second      -- identify constraint (what is blocking flow?)
+6. compose portfolio brief       -- health table + top constraint per layer
+7. surface exceptions only       -- interrupt if any exception-threshold signal is active
+```
+
+Ava does not start new work until this sequence completes. Portfolio state must be known before action is taken.
+
+### get_portfolio_sitrep
+
+The `sitrep` skill queries all registered apps and returns:
+
+- Feature counts by status (`backlog`, `in_progress`, `review`, `blocked`, `done`)
+- WIP vs limit for each app
+- Error budget burn rate
+- Milestone schedule health
+- Active agent count and concurrency headroom
+- Cost burn for current window
+
+### Drilling Into RED/YELLOW
+
+For each flagged app, Ava reads:
+
+1. **Lead Engineer state** — current world state snapshot (board counts, PR statuses, agent states)
+2. **Blocked features** — `statusChangeReason` for each blocked feature
+3. **Active PRs** — age, CI status, CodeRabbit threads, reviewer assignment
+4. **Concurrency** — is auto-mode running? are agents stuck?
+
+The goal is to identify the **constraint** — the single thing preventing flow — not to enumerate all problems.
+
+---
+
+## Portfolio Briefing Format
+
+After the activation sequence, Ava produces a portfolio brief. Format:
+
+```
+PORTFOLIO BRIEF — {date}
+
+HEALTH TABLE
+| App          | Status    | WIP   | Milestone  | Budget | Notes                    |
+|--------------|-----------|-------|------------|--------|--------------------------|
+| protoMaker   | on-track  | 2/4   | on-time    | 12%    |                          |
+| homeMaker    | at-risk   | 3/3   | +3d late   | 51%    | WIP at limit             |
+| mythxengine  | off-track | 5/4   | +9d late   | 83%    | budget breach, 3 blocked |
+
+TOP CONSTRAINT
+mythxengine: 3 features blocked on auth-middleware review (PR #47 stale 72h, no reviewer assigned).
+Action: assign Quinn to review PR #47, unblock auth-middleware, unblock 3 downstream features.
+
+EXCEPTIONS (requiring immediate action)
+[ ] mythxengine error budget at 83% — freeze non-bug releases (auto-action pending approval)
+
+DECISIONS (queue for daily review)
+[ ] homeMaker WIP at limit — approve adding 1 concurrency slot or reprioritize backlog
+```
+
+This brief is the only output Ava produces at activation unless an exception requires immediate action.
+
+---
+
+## Cross-App Authority
+
+Ava has explicit authority to act across all apps. These are the paths — not "contamination guards" to avoid, but explicit grants.
+
+### What Ava may do autonomously (Trust Level 1+)
+
+- Reassign Quinn to review a PR in any app
+- Enable auto-merge on a PR in any app
+- Kill a stuck agent in any app after signal thresholds are crossed
+- Requeue a failed feature in any app
+- Adjust WIP limits in any app (within bounds set by operator)
+
+### What requires operator approval (Trust Level 1)
+
+- Freeze releases in an app (error budget breach auto-action)
+- Kill a feature that has spent > 80% of cost cap
+- Reprioritize backlog across apps
+- Change trust level for any app
+
+### Cross-app contamination is a bug, not a feature
+
+Cross-app authority means Ava can act on any app she is registered to manage. It does NOT mean features, worktrees, or concurrency slots bleed across app boundaries. The isolation rules in [Portfolio Philosophy](../portfolio-philosophy.md) remain absolute:
+
+- Features live in `{projectPath}/.automaker/features/` — hard filesystem boundary
+- Worktrees live in `{projectPath}/.worktrees/` — hard filesystem boundary
+- Concurrency is tracked per-app by `ConcurrencyManager`
+
+Cross-app authority is "Ava can act on App B's board" — not "App B's features can run in App A's worktrees."
+
+---
+
+## WSJF Triage
+
+When the backlog has more work than capacity, Ava uses WSJF (Weighted Shortest Job First) to sequence features.
+
+### Formula
+
+```
+WSJF = Cost of Delay / Job Duration
+
+Cost of Delay = User/Business Value + Time Criticality + Risk Reduction
+Job Duration  = estimated effort (complexity field: small=1, medium=3, large=8, architectural=13)
+```
+
+### Mapping to protoLabs Feature Schema
+
+| WSJF Component | Feature Field | How Ava scores it |
+| --- | --- | --- |
+| User/Business Value | `priority` | urgent=4, high=3, medium=2, low=1 |
+| Time Criticality | `dueDate` | overdue=+3, due in 3d=+2, due in 7d=+1, no date=0 |
+| Risk Reduction | `complexity` | architectural=+2, isFoundation=+1, else=0 |
+| Job Duration | `complexity` | small=1, medium=3, large=8, architectural=13 |
+
+### WSJF in Practice
+
+Ava computes WSJF scores at each auto-mode pickup cycle. Features with higher WSJF scores are picked up first, within dependency order constraints. Features with unmet dependencies are excluded from the ranking regardless of score.
+
+The operator can override WSJF ordering by setting `priority: urgent` on a feature — urgent features always sort to the top within their dependency tier.
+
+---
+
+## Capacity Allocation Authority
+
+Ava manages concurrency allocation across apps subject to operator-configured bounds.
+
+### Allocation Rules
+
+1. System cap (`AUTOMAKER_MAX_CONCURRENCY`) is the absolute ceiling — never exceeded
+2. Each app has a configured budget (default: 1)
+3. Sum of per-app budgets may exceed system cap; fair-share applies when demand exceeds supply
+4. Idle apps (no backlog work) release slots to the shared pool
+5. Apps in error budget breach have their concurrency budget halved automatically
+
+### Ava's Actions
+
+| Condition | Auto-Action | Requires Approval |
+| --- | --- | --- |
+| App idle, another app has queued work | Release slot to pool | No |
+| App WIP at limit | Block new feature pickup for that app | No |
+| App error budget >80% | Halve concurrency, freeze non-bug releases | Yes (Trust L1+) |
+| System cap reached | Block all new pickups | No |
+| Feature at 100% cost cap | Kill agent, mark feature blocked | No |
+
+---
+
+## Delegation Tree
+
+Ava delegates to agents based on signal type. This is the routing map.
+
+```
+Ava receives signal
+  ├── Bug report / QA signal
+  │   └── delegate to Quinn (bug_triage, pr_review, qa_report)
+  │
+  ├── Infrastructure / deploy signal
+  │   └── delegate to Frank (infra_health, deploy, monitoring)
+  │
+  ├── Content request
+  │   └── delegate to Cindi (blog, seo, content_review)
+  │
+  ├── Market / strategy question
+  │   └── delegate to Jon (market_review, positioning)
+  │
+  ├── Research needed before planning
+  │   └── delegate to Researcher (research, entity_extract)
+  │       └── return to Ava for planning pipeline
+  │
+  ├── New project / feature idea
+  │   └── Ava runs planning pipeline
+  │       ├── Ava: SPARC PRD generation
+  │       ├── Ava + Jon: antagonistic review
+  │       └── if HITL needed: HITLRequest → originating interface
+  │
+  └── Portfolio health / board management
+      └── Ava acts directly (sitrep, manage_feature, auto_mode)
+```
+
+### Portfolio Signals from Lead Engineer
+
+The Lead Engineer emits portfolio-level signals that Ava monitors:
+
+| Signal | Ava Action |
+| --- | --- |
+| `feature:blocked` | Check constraint, attempt unblock, or queue Decision |
+| `project:milestone:late` | Drill app, compute WSJF, surface to operator if at-risk |
+| `agent:stuck` | Kill and requeue (Trust L1+) or queue Exception |
+| `pr:stale` | Assign reviewer or enable auto-merge (Trust L1+) |
+| `budget:breach` | Freeze releases, queue Exception |
+| `project:completed` | Trigger reflection, generate changelog, surface to operator |

--- a/docs/internal/protolabs/fleet-architecture.md
+++ b/docs/internal/protolabs/fleet-architecture.md
@@ -1,31 +1,41 @@
 # protoLabs Fleet Architecture
 
+Cross-links: [Org Architecture](../org-architecture.md) | [Ava Operating Model](./ava-operating-model.md) | [Agency Overview](./agency-overview.md)
+
 ## Agent Fleet
 
 Six agents organized into three teams. All A2A agents expose `/.well-known/agent.json` and accept JSON-RPC 2.0 `message/send` calls.
 
-| Agent          | Team      | Role                                                             | A2A Endpoint                       | Key Skills                                                                                        |
-| -------------- | --------- | ---------------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **Ava**        | Dev       | Chief of Staff — planning, orchestration, board management       | `http://automaker-server:3008/a2a` | `plan`, `plan_resume`, `sitrep`, `manage_feature`, `auto_mode`, `board_health`, `onboard_project` |
-| **Quinn**      | Dev       | QA Engineer — triage, review, audits                             | `http://quinn:7870/a2a`            | `bug_triage`, `pr_review`, `qa_report`, `board_audit`                                             |
-| **Frank**      | Dev       | DevOps — infrastructure, deploys, monitoring                     | `http://frank:7880/a2a`            | `infra_health`, `deploy`, `monitoring`                                                            |
-| **Jon**        | GTM       | Strategy — market positioning, ROI analysis, antagonistic review | internal (called by Ava)           | `market_review`, `positioning`, `antagonistic_review`                                             |
-| **Cindi**      | GTM       | Content — blog posts, technical docs, SEO                        | internal (called by Ava)           | `blog`, `seo`, `content_review`                                                                   |
-| **Researcher** | Knowledge | Deep research — entity extraction, knowledge graph               | internal (called by Ava)           | `research`, `entity_extract`                                                                      |
+| Agent          | Team      | Role                                                             | A2A Endpoint                       | Discord Bot      | Key Skills                                                                                        |
+| -------------- | --------- | ---------------------------------------------------------------- | ---------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------- |
+| **Ava**        | Dev       | Portfolio orchestrator — planning, board management, cross-app authority | `http://automaker-server:3008/a2a` | `protoava[bot]` | `plan`, `plan_resume`, `sitrep`, `manage_feature`, `auto_mode`, `board_health`, `onboard_project` |
+| **Quinn**      | Dev       | QA Engineer — triage, review, audits                             | `http://quinn:7870/a2a`            | `protoquinn[bot]` | `bug_triage`, `pr_review`, `qa_report`, `board_audit`                                             |
+| **Frank**      | Dev       | DevOps — infrastructure, deploys, monitoring                     | `http://frank:7880/a2a`            | `protofrank[bot]` (roadmap) | `infra_health`, `deploy`, `monitoring`                                                            |
+| **Jon**        | GTM       | Strategy — market positioning, ROI analysis, antagonistic review | internal (called by Ava)           | `protojon[bot]` (roadmap) | `market_review`, `positioning`, `antagonistic_review`                                             |
+| **Cindi**      | GTM       | Content — blog posts, technical docs, SEO                        | internal (called by Ava)           | `protocindi[bot]` (roadmap) | `blog`, `seo`, `content_review`                                                                   |
+| **Researcher** | Knowledge | Deep research — entity extraction, knowledge graph               | internal (called by Ava)           | — | `research`, `entity_extract`                                                                      |
+
+### Per-Agent Discord Bot Pool (Roadmap)
+
+Each agent will eventually have its own Discord bot identity. This makes it clear which agent is speaking in any channel. Currently `protoava[bot]` and `protoquinn[bot]` are active; all others share the Ava bot token. Full bot pool activation is a roadmap item tracked in `workspace/projects.yaml` under `discord-bot-pool`.
 
 ### Team Boundaries
 
 - **Dev team** (Ava, Quinn, Frank): A2A-addressable services with their own endpoints. Workstacean routes directly to them based on skill matching.
-- **GTM team** (Jon, Cindi): Called by Ava as sub-agents during planning and content pipelines. Not directly addressable via the bus (yet).
+- **GTM team** (Jon, Cindi): Called by Ava as sub-agents during planning and content pipelines. Not directly addressable via the bus yet — planned for the per-agent bot pool phase.
 - **Knowledge** (Researcher): Called by Ava or Quinn when deep research is needed before planning or triage.
 
-## Workstacean -- The Shared Spine
+## Workstacean — The Orchestration Backbone
 
-protoWorkstacean is the central message bus and registry service. It has three jobs:
+protoWorkstacean is the central orchestration backbone — not just a Discord bot. It connects every interface to every agent through a unified bus, serves the authoritative agent and project registries, and ensures every signal is traceable end-to-end.
+
+Three core responsibilities:
 
 1. **Route messages** from interface plugins to the correct agent based on skill matching
 2. **Serve the registry** so any service can discover agents and projects
 3. **Mint correlationIds** that flow through every downstream artifact
+
+The Discord plugin is one of many plugins connected to the bus. Workstacean is indifferent to which interface a signal came from — it routes based on skill, not surface.
 
 ### Registry Files
 
@@ -63,18 +73,46 @@ Any interface plugin can connect to the bus. The plugin contract has three respo
 
 ### Interface Plugins
 
-| Plugin  | Status  | Transport                            | Notes                                                               |
-| ------- | ------- | ------------------------------------ | ------------------------------------------------------------------- |
-| Discord | Active  | WebSocket (discord.js)               | Primary interface — embeds, threads, reactions, webhooks            |
-| GitHub  | Active  | Webhooks (POST /webhook/github)      | Issue/PR events, bot comments via protoava[bot] and protoquinn[bot] |
-| API     | Active  | HTTP (POST /publish)                 | Programmatic injection for scripts, cron, external services         |
-| Voice   | Planned | WebSocket (Whisper STT + Kokoro TTS) | Voice-in/voice-out via gateway audio models                         |
-| Plane   | Planned | Webhooks                             | Board-native interface for project management                       |
-| Slack   | Planned | Slack Events API                     | Workspace integration                                               |
+| Plugin             | Status   | Transport                            | Notes                                                               |
+| ------------------ | -------- | ------------------------------------ | ------------------------------------------------------------------- |
+| Discord            | Active   | WebSocket (discord.js)               | Primary interface — embeds, threads, reactions, webhooks            |
+| GitHub             | Active   | Webhooks (POST /webhook/github)      | Issue/PR events, bot comments via protoava[bot] and protoquinn[bot] |
+| A2A                | Active   | HTTP JSON-RPC 2.0                    | Inter-agent calls following the A2A spec                            |
+| API                | Active   | HTTP (POST /publish)                 | Programmatic injection for scripts, cron, external services         |
+| Onboarding         | Active   | Internal                             | Runs `/setuplab` 5-phase pipeline when `skillHint: "onboard_project"` arrives |
+| Voice              | Planned  | WebSocket (Whisper STT + Kokoro TTS) | Voice-in/voice-out via gateway audio models                         |
+| Plane              | Planned  | Webhooks                             | Board-native interface for project management                       |
+| Slack              | Planned  | Slack Events API                     | Workspace integration                                               |
+| Google Workspace   | Roadmap  | OAuth + Google APIs                  | Gmail intake, Calendar context, Docs read. Config: `workspace/plugins/google.yaml` |
+
+### OnboardingPlugin Pipeline
+
+When a signal arrives with `skillHint: "onboard_project"`, the OnboardingPlugin executes a 5-phase pipeline:
+
+```
+1. scan       — detect tech stack, dependencies, project structure
+2. analyze    — compare against quality standard (CI, types, testing, tooling)
+3. initialize — create .automaker/ context files, register in projects.yaml
+4. propose    — create alignment features on the protoMaker board
+5. execute    — launch auto-mode to implement alignment work
+```
+
+Output: the project is registered in `workspace/projects.yaml`, its features are on the board, and auto-mode begins executing alignment work. No manual scaffolding required.
+
+Config: `workspace/plugins/onboarding.yaml`
+
+### Google Workspace Plugin (Roadmap)
+
+Planned integration with Google Workspace to add two new signal sources:
+
+- **Gmail intake**: Emails tagged with a specific label are injected as signals onto the bus
+- **Calendar context**: Upcoming deadlines and events are surfaced as context when Ava is planning
+
+Config will live in `workspace/plugins/google.yaml`. OAuth credentials managed by Infisical.
 
 ### Key Principle
 
-**The bus is dumb.** Interface plugins own rendering. Ava owns plan state. `correlationId` is the spine. Adding a new interface (e.g., Slack) requires only implementing the three plugin responsibilities above -- no changes to Ava, the bus, or any other plugin.
+**The bus is dumb.** Interface plugins own rendering. Ava owns plan state. `correlationId` is the spine. Adding a new interface (e.g., Slack) requires only implementing the three plugin responsibilities above — no changes to Ava, the bus, or any other plugin.
 
 ## CorrelationId Lineage
 

--- a/docs/internal/protolabs/fleet-architecture.md
+++ b/docs/internal/protolabs/fleet-architecture.md
@@ -6,14 +6,14 @@ Cross-links: [Org Architecture](../org-architecture.md) | [Ava Operating Model](
 
 Six agents organized into three teams. All A2A agents expose `/.well-known/agent.json` and accept JSON-RPC 2.0 `message/send` calls.
 
-| Agent          | Team      | Role                                                             | A2A Endpoint                       | Discord Bot      | Key Skills                                                                                        |
-| -------------- | --------- | ---------------------------------------------------------------- | ---------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------- |
-| **Ava**        | Dev       | Portfolio orchestrator — planning, board management, cross-app authority | `http://automaker-server:3008/a2a` | `protoava[bot]` | `plan`, `plan_resume`, `sitrep`, `manage_feature`, `auto_mode`, `board_health`, `onboard_project` |
-| **Quinn**      | Dev       | QA Engineer — triage, review, audits                             | `http://quinn:7870/a2a`            | `protoquinn[bot]` | `bug_triage`, `pr_review`, `qa_report`, `board_audit`                                             |
-| **Frank**      | Dev       | DevOps — infrastructure, deploys, monitoring                     | `http://frank:7880/a2a`            | `protofrank[bot]` (roadmap) | `infra_health`, `deploy`, `monitoring`                                                            |
-| **Jon**        | GTM       | Strategy — market positioning, ROI analysis, antagonistic review | internal (called by Ava)           | `protojon[bot]` (roadmap) | `market_review`, `positioning`, `antagonistic_review`                                             |
-| **Cindi**      | GTM       | Content — blog posts, technical docs, SEO                        | internal (called by Ava)           | `protocindi[bot]` (roadmap) | `blog`, `seo`, `content_review`                                                                   |
-| **Researcher** | Knowledge | Deep research — entity extraction, knowledge graph               | internal (called by Ava)           | — | `research`, `entity_extract`                                                                      |
+| Agent          | Team      | Role                                                                     | A2A Endpoint                       | Discord Bot                 | Key Skills                                                                                        |
+| -------------- | --------- | ------------------------------------------------------------------------ | ---------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------- |
+| **Ava**        | Dev       | Portfolio orchestrator — planning, board management, cross-app authority | `http://automaker-server:3008/a2a` | `protoava[bot]`             | `plan`, `plan_resume`, `sitrep`, `manage_feature`, `auto_mode`, `board_health`, `onboard_project` |
+| **Quinn**      | Dev       | QA Engineer — triage, review, audits                                     | `http://quinn:7870/a2a`            | `protoquinn[bot]`           | `bug_triage`, `pr_review`, `qa_report`, `board_audit`                                             |
+| **Frank**      | Dev       | DevOps — infrastructure, deploys, monitoring                             | `http://frank:7880/a2a`            | `protofrank[bot]` (roadmap) | `infra_health`, `deploy`, `monitoring`                                                            |
+| **Jon**        | GTM       | Strategy — market positioning, ROI analysis, antagonistic review         | internal (called by Ava)           | `protojon[bot]` (roadmap)   | `market_review`, `positioning`, `antagonistic_review`                                             |
+| **Cindi**      | GTM       | Content — blog posts, technical docs, SEO                                | internal (called by Ava)           | `protocindi[bot]` (roadmap) | `blog`, `seo`, `content_review`                                                                   |
+| **Researcher** | Knowledge | Deep research — entity extraction, knowledge graph                       | internal (called by Ava)           | —                           | `research`, `entity_extract`                                                                      |
 
 ### Per-Agent Discord Bot Pool (Roadmap)
 
@@ -73,17 +73,17 @@ Any interface plugin can connect to the bus. The plugin contract has three respo
 
 ### Interface Plugins
 
-| Plugin             | Status   | Transport                            | Notes                                                               |
-| ------------------ | -------- | ------------------------------------ | ------------------------------------------------------------------- |
-| Discord            | Active   | WebSocket (discord.js)               | Primary interface — embeds, threads, reactions, webhooks            |
-| GitHub             | Active   | Webhooks (POST /webhook/github)      | Issue/PR events, bot comments via protoava[bot] and protoquinn[bot] |
-| A2A                | Active   | HTTP JSON-RPC 2.0                    | Inter-agent calls following the A2A spec                            |
-| API                | Active   | HTTP (POST /publish)                 | Programmatic injection for scripts, cron, external services         |
-| Onboarding         | Active   | Internal                             | Runs `/setuplab` 5-phase pipeline when `skillHint: "onboard_project"` arrives |
-| Voice              | Planned  | WebSocket (Whisper STT + Kokoro TTS) | Voice-in/voice-out via gateway audio models                         |
-| Plane              | Planned  | Webhooks                             | Board-native interface for project management                       |
-| Slack              | Planned  | Slack Events API                     | Workspace integration                                               |
-| Google Workspace   | Roadmap  | OAuth + Google APIs                  | Gmail intake, Calendar context, Docs read. Config: `workspace/plugins/google.yaml` |
+| Plugin           | Status  | Transport                            | Notes                                                                              |
+| ---------------- | ------- | ------------------------------------ | ---------------------------------------------------------------------------------- |
+| Discord          | Active  | WebSocket (discord.js)               | Primary interface — embeds, threads, reactions, webhooks                           |
+| GitHub           | Active  | Webhooks (POST /webhook/github)      | Issue/PR events, bot comments via protoava[bot] and protoquinn[bot]                |
+| A2A              | Active  | HTTP JSON-RPC 2.0                    | Inter-agent calls following the A2A spec                                           |
+| API              | Active  | HTTP (POST /publish)                 | Programmatic injection for scripts, cron, external services                        |
+| Onboarding       | Active  | Internal                             | Runs `/setuplab` 5-phase pipeline when `skillHint: "onboard_project"` arrives      |
+| Voice            | Planned | WebSocket (Whisper STT + Kokoro TTS) | Voice-in/voice-out via gateway audio models                                        |
+| Plane            | Planned | Webhooks                             | Board-native interface for project management                                      |
+| Slack            | Planned | Slack Events API                     | Workspace integration                                                              |
+| Google Workspace | Roadmap | OAuth + Google APIs                  | Gmail intake, Calendar context, Docs read. Config: `workspace/plugins/google.yaml` |
 
 ### OnboardingPlugin Pipeline
 


### PR DESCRIPTION
## Summary

Create and update the canonical architecture docs for the protoLabs org. These docs are the source of truth for any new team member, agent, or system trying to understand how the org is structured.

**1. NEW: `docs/internal/org-architecture.md`**
Full org stack diagram in both ASCII and Mermaid. Cover every layer:
- External surface: Discord, GitHub, Google Workspace (+ roadmap note)
- Cloudflare Tunnel: routing rules, hostnames → services mapping
- Gateway layer: LiteLLM (model routing, auth), ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive organization architecture reference documenting the complete tech stack, system layers, external interfaces, services, and infrastructure components.
  * Added portfolio philosophy documentation covering operating models, governance frameworks, and project coordination mechanisms.
  * Added Ava operating model documentation defining execution workflows and decision authorities.
  * Updated fleet architecture documentation with expanded agent and plugin information.
  * Enhanced internal documentation navigation with new architecture and operating model references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->