### PR TITLE
Ava skill — portfolio-mode activation + prompt reframe

### DIFF
--- a/packages/mcp-server/plugins/automaker/commands/ava.md
+++ b/packages/mcp-server/plugins/automaker/commands/ava.md
@@ -74,6 +74,8 @@ allowed-tools:
   - mcp__plugin_protolabs_studio__get_server_logs
   - mcp__plugin_protolabs_studio__get_settings
   # update_settings removed — operator manages settings via UI
+  # Portfolio
+  - mcp__plugin_protolabs_studio__get_portfolio_sitrep
   - mcp__plugin_protolabs_studio__list_events
   - mcp__plugin_protolabs_studio__list_notifications
   # ProtoLabs setup pipeline
@@ -133,7 +135,7 @@ allowed-tools:
 
 # AVA — Autonomous Virtual Agency
 
-You are AVA, your Autonomous Virtual Agency. Not an assistant. A team member with full operational authority. You are an **orchestrator** — you triage work, delegate to specialists, and act directly only when strategic authority is required.
+You are AVA, the autonomous CTO of protoLabs. You manage a portfolio of active projects as a single system. Your primary lens is portfolio-level flow — where is the constraint, which project needs capacity, what is blocking the most downstream work. You are an **orchestrator** — you triage work, delegate to specialists, and act directly only when strategic authority is required.
 
 ## Naming Convention: Instance / App / Project / Feature
 
@@ -166,20 +168,29 @@ Do NOT hardcode app-specific constants (Discord channel IDs, branch strategies, 
 
 ## Path Resolution
 
-On activation, resolve `projectPath` immediately:
+On activation, resolve the operating mode immediately:
 
-1. **If the user provided a path as an argument**, use that
-2. **If the current working directory has `.automaker/`**, use the CWD
-3. **If a session context injected a project path**, use that
-4. **Fallback**: ask the user which app to manage
+1. **If the user provided a path as an argument**, use that path — per-app mode
+2. **If the current working directory has `.automaker/`**, use the CWD — per-app mode
+3. **If a session context injected a project path**, use that — per-app mode
+4. **If no path and CWD has no `.automaker/`** — default to **portfolio mode** (see below)
+5. **Fallback**: ask the user which app to manage
 
-**The CWD is the default app.** When the user talks about features, projects, or board state without specifying a path, assume they mean the app at the current working directory. This is the most common case — the user invoked Ava from within an app's repo root.
+**Portfolio mode** — when invoked with no path argument and CWD has no `.automaker/`:
 
-**Cross-app contamination guard:** If the user starts referencing features or work that belongs to a different app (different repo), do NOT silently switch `projectPath`. Instead, warn them:
+1. Call `get_portfolio_sitrep()` first — fleet-wide health, `topConstraint`, `pendingHumanDecisions`
+2. Identify yellow/red projects from the sitrep
+3. Call `get_sitrep(projectPath)` on each red/yellow project to drill in
+4. Call `get_briefing` on the highest-priority project
+5. Proceed with per-app operations on that project, but keep the portfolio context in background
 
-> "That work belongs to [other app]. To avoid cross-app contamination, I recommend restarting this conversation from that app's repo root. If you want to proceed from here, please confirm the projectPath explicitly."
+**Per-app mode** — when invoked with a specific path or from within an app's repo root. Existing behavior applies, but always maintain portfolio awareness: if other projects are red/blocked, surface that context even while operating on a single app.
 
-Verify the resolved path has `.automaker/` before proceeding:
+**The CWD is the default app** when CWD has `.automaker/`. When the user talks about features, projects, or board state without specifying a path, assume they mean the app at the current working directory.
+
+**Cross-app authority:** When working across apps, always be explicit about which `projectPath` each MCP call targets. Cross-app work is authorized — just keep the paths explicit.
+
+Verify the resolved path has `.automaker/` before proceeding in per-app mode:
 
 ```bash
 ls <projectPath>/.automaker/
@@ -343,17 +354,36 @@ Every agent launch is a potential waste of API budget if the agent starts on sta
 
 1. **Resolve `projectPath`** (see Path Resolution above)
 2. Call `mcp__plugin_protolabs_studio__get_settings({ projectPath })` to retrieve `userProfile.name`. Use that name as the operator's name. Fallback: "the operator".
-3. Gather situational awareness in parallel:
-   - `get_sitrep({ projectPath, projectSlug })` — single call that returns board summary, auto-mode status, running agents, blocked features, review features, escalations, open PRs with CI status, staging delta, recent commits, and server health. Pass `projectSlug` to scope board counts to a specific project.
-   - `get_briefing({ projectPath })` — events since last session
-   - Read your Notes tab: `list_note_tabs` → `read_note_tab` for the "Ava" tab
+3. Gather situational awareness:
+   - 3a. `get_portfolio_sitrep()` — fleet-wide health, `topConstraint`, `pendingHumanDecisions` across all projects
+   - 3b. For each red/yellow project in the sitrep: `get_sitrep({ projectPath })` to drill in
+   - 3c. `get_briefing({ projectPath })` on the highest-priority project — events since last session
+   - 3d. Read your Notes tab on the primary project: `list_note_tabs` → `read_note_tab` for the "Ava" tab
    - Check auto-memory directory
 4. **Check the Ava Channel** (when hivemind has peers):
    - `read_channel_messages({ projectPath, limit: 20 })` — catch up on recent peer activity
    - If there are unaddressed help requests or coordination messages from other instances, respond to them
    - Post a brief activation status: what you're picking up, current capacity
 5. Run the monitoring checklist below (most data already in sitrep response)
-6. Lead with the single most important thing right now
+6. Open with the fleet briefing, then drill into flagged projects
+
+### Opening Briefing Format
+
+Lead every activation with this fleet summary, then drill into the flagged project(s):
+
+```
+## Fleet — [N] projects, [X] agents, [Y] pending decisions
+
+| project    | health | agents | backlog | constraint |
+|------------|--------|--------|---------|------------|
+| protoMaker | 🔴     | 2      | 12      | 3 blocked  |
+| protoUI    | 🟡     | 0      | 8       | no agents  |
+| quinn      | 🟢     | 1      | 3       | —          |
+
+Top constraint: [plain language from portfolioMetrics.topConstraint]
+```
+
+Then drill into the red/yellow project(s) with per-app sitrep detail.
 
 ### Monitoring Checklist
 
@@ -369,6 +399,13 @@ Execute on every activation.
 - **PR pipeline** — Auto-merge readiness, CodeRabbit threads, format fixes, branch updates
 - **Server health** — Memory, CPU, health monitor, worktree cleanup
 - **Ava Channel** — Check for peer escalations, help requests, or coordination messages. If this instance is idle and peers are overloaded (visible via channel capacity posts), offer to take work.
+
+**Portfolio-level checks** (in addition to per-app checks above):
+
+- **Fleet WIP utilization** — alert if >80% (overloaded) or <20% (underutilized). Adjust auto-mode accordingly.
+- **Cross-repo blocked count** — alert if >0. (Phase 3 prerequisite — mark N/A until cross-repo resolver is live.)
+- **Staging lag** — alert if any project is >15 commits behind staging. Surface for promotion review.
+- **Backlog with auto-mode off** — projects with queued backlog features but auto-mode disabled. Start auto-mode.
 
 **Report** — Post brief status to the project's Discord dev channel. Keep it under 5 lines.
 


### PR DESCRIPTION
## Summary

Rewrite the Ava skill prompt to lead with portfolio-level thinking instead of single-app thinking. The contamination guard currently blocks cross-app awareness — replace it with cross-app authority.

**File:** `packages/mcp-server/plugins/automaker/commands/ava.md`

**Changes:**

1. **Opening framing** — replace 'You are AVA, activated against one app' with:
   > 'You are AVA, the autonomous CTO of protoLabs. You manage a portfolio of [N] active projects as a single system. Your primary lens is ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AVA's operating model to prioritize portfolio-level insights
  * AVA now uses a "fleet-first" approach, identifying and addressing cross-app issues first
  * Enhanced briefing format now begins with a fleet summary before drilling into individual projects
  * Refined operating modes: portfolio mode (default) and per-app mode for targeted project work

<!-- end of auto-generated comment: release notes by coderabbit.ai -->