### PR TITLE
feat: implement Cindi's missing MCP tools for content pipeline

### DIFF
--- a/apps/server/src/routes/content/index.ts
+++ b/apps/server/src/routes/content/index.ts
@@ -148,6 +148,33 @@ export function createContentRoutes(settingsService: SettingsService): Router {
   });
 
   /**
+   * POST /api/content/antagonistic-review
+   * Run a standalone antagonistic review on content text.
+   * Returns dimension scores, pass/fail verdict, and per-dimension feedback.
+   */
+  router.post('/antagonistic-review', async (req: Request, res: Response) => {
+    try {
+      const { projectPath, content, topic, format, audience } = req.body;
+
+      if (!projectPath || !content) {
+        res.status(400).json({ error: 'projectPath and content are required' });
+        return;
+      }
+
+      const result = await contentFlowService.executeAntagonisticReview(
+        projectPath,
+        content,
+        { topic, format, audience }
+      );
+
+      res.json(result);
+    } catch (error: unknown) {
+      logger.error('Antagonistic review error:', error);
+      res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
+  /**
    * POST /api/content/export
    * Export content in specific format
    */

--- a/apps/server/src/services/content-flow-service.ts
+++ b/apps/server/src/services/content-flow-service.ts
@@ -886,5 +886,183 @@ ${content}`;
   }
 }
 
+  /**
+   * Run a standalone antagonistic review on content text.
+   *
+   * Scores across 6 dimensions on a 1-10 scale:
+   *   Accuracy, Usefulness, Clarity, Engagement, Depth, Actionability
+   *
+   * Passes if overall average >= 7.5 and no dimension < 5.
+   * Used by Cindi as a quality gate before publishing content.
+   */
+  async executeAntagonisticReview(
+    projectPath: string,
+    content: string,
+    options?: { topic?: string; format?: string; audience?: string }
+  ): Promise<{
+    success: boolean;
+    scores: {
+      accuracy: number;
+      usefulness: number;
+      clarity: number;
+      engagement: number;
+      depth: number;
+      actionability: number;
+    };
+    overallScore: number;
+    passed: boolean;
+    feedback: {
+      accuracy: string;
+      usefulness: string;
+      clarity: string;
+      engagement: string;
+      depth: string;
+      actionability: string;
+    };
+    verdict: string;
+    error?: string;
+  }> {
+    const topic = options?.topic || 'unspecified';
+    const format = options?.format || 'guide';
+    const audience = options?.audience || 'intermediate';
+
+    logger.info(
+      `Running antagonistic review for topic "${topic}" (format: ${format}, audience: ${audience})`
+    );
+
+    try {
+      const { smartModel } = await this.createModels(projectPath);
+
+      const prompt = `You are an antagonistic content reviewer. Your job is to critically evaluate content quality. Be harsh — assume content is mediocre until proven excellent.
+
+## Content to Review
+Topic: ${topic}
+Format: ${format}
+Audience: ${audience}
+
+<content>
+${content.slice(0, 8000)}
+</content>
+
+## Scoring Instructions
+
+Score this content across 6 dimensions on a 1-10 scale. Be critical and precise.
+
+Dimensions:
+1. **Accuracy** (1-10): Factual correctness, claims substantiated, no misinformation
+2. **Usefulness** (1-10): Reader value, actionable insights, practical application
+3. **Clarity** (1-10): Readability, logical structure, clear explanations, flow
+4. **Engagement** (1-10): Hook quality, pacing, storytelling, reader retention
+5. **Depth** (1-10): Detail level, nuance, complexity handling for target audience
+6. **Actionability** (1-10): Clear next steps, implementation guidance, CTA strength
+
+## Response Format
+
+Respond with ONLY valid JSON in this exact format:
+{
+  "scores": {
+    "accuracy": <1-10>,
+    "usefulness": <1-10>,
+    "clarity": <1-10>,
+    "engagement": <1-10>,
+    "depth": <1-10>,
+    "actionability": <1-10>
+  },
+  "feedback": {
+    "accuracy": "<specific critique for accuracy>",
+    "usefulness": "<specific critique for usefulness>",
+    "clarity": "<specific critique for clarity>",
+    "engagement": "<specific critique for engagement>",
+    "depth": "<specific critique for depth>",
+    "actionability": "<specific critique for actionability>"
+  },
+  "verdict": "<one sentence overall assessment>"
+}`;
+
+      const response = await smartModel.invoke([{ role: 'user', content: prompt }]);
+      const responseText =
+        typeof response.content === 'string' ? response.content : String(response.content);
+
+      // Extract JSON from response (handle markdown code blocks)
+      const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        throw new Error('Model returned non-JSON response');
+      }
+
+      const parsed = JSON.parse(jsonMatch[0]) as {
+        scores: Record<string, number>;
+        feedback: Record<string, string>;
+        verdict: string;
+      };
+
+      const scores = {
+        accuracy: Number(parsed.scores.accuracy) || 5,
+        usefulness: Number(parsed.scores.usefulness) || 5,
+        clarity: Number(parsed.scores.clarity) || 5,
+        engagement: Number(parsed.scores.engagement) || 5,
+        depth: Number(parsed.scores.depth) || 5,
+        actionability: Number(parsed.scores.actionability) || 5,
+      };
+
+      const values = Object.values(scores);
+      const overallScore = values.reduce((sum, v) => sum + v, 0) / values.length;
+      // Passing criteria (from Cindi's quality standards):
+      //   1. Overall average >= 7.5 (75%)
+      //   2. No dimension < 5 (no critical failures)
+      //   3. At least 3 dimensions >= 8 (80%)
+      const strongDimensions = values.filter((v) => v >= 8).length;
+      const passed = overallScore >= 7.5 && Math.min(...values) >= 5 && strongDimensions >= 3;
+
+      const feedback = {
+        accuracy: parsed.feedback.accuracy || '',
+        usefulness: parsed.feedback.usefulness || '',
+        clarity: parsed.feedback.clarity || '',
+        engagement: parsed.feedback.engagement || '',
+        depth: parsed.feedback.depth || '',
+        actionability: parsed.feedback.actionability || '',
+      };
+
+      logger.info(
+        `Antagonistic review complete: overall ${overallScore.toFixed(1)}/10, passed=${passed}`
+      );
+
+      return {
+        success: true,
+        scores,
+        overallScore: Math.round(overallScore * 10) / 10,
+        passed,
+        feedback,
+        verdict: parsed.verdict || '',
+      };
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error('Antagonistic review failed:', error);
+      return {
+        success: false,
+        scores: {
+          accuracy: 0,
+          usefulness: 0,
+          clarity: 0,
+          engagement: 0,
+          depth: 0,
+          actionability: 0,
+        },
+        overallScore: 0,
+        passed: false,
+        feedback: {
+          accuracy: '',
+          usefulness: '',
+          clarity: '',
+          engagement: '',
+          depth: '',
+          actionability: '',
+        },
+        verdict: '',
+        error: message,
+      };
+    }
+  }
+}
+
 // Singleton instance
 export const contentFlowService = new ContentFlowService();

--- a/libs/flows/tests/unit/jon-review.test.ts
+++ b/libs/flows/tests/unit/jon-review.test.ts
@@ -58,34 +58,34 @@ describe('jon-review node', () => {
   describe('normal case', () => {
     it('should return approve verdict for high-value PRD', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'Solves major user pain point, high satisfaction expected',
-              concerns: [],
-            },
-            {
-              area: 'ROI',
-              assessment: 'Strong ROI, 200% expected return within 6 months',
-              concerns: [],
-            },
-            {
-              area: 'Market Positioning',
-              assessment: 'Differentiates us from competitors',
-              concerns: [],
-            },
-            {
-              area: 'Priority',
-              assessment: 'Aligns perfectly with Q1 strategic goals',
-              concerns: [],
-            },
-          ],
-          comments: 'Strong business case. Proceed with implementation.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>approve</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Solves major user pain point, high satisfaction expected</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>ROI</area>
+      <assessment>Strong ROI, 200% expected return within 6 months</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>Market Positioning</area>
+      <assessment>Differentiates us from competitors</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>Priority</area>
+      <assessment>Aligns perfectly with Q1 strategic goals</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>Strong business case. Proceed with implementation.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -105,40 +105,54 @@ describe('jon-review node', () => {
 
     it('should return approve-with-concerns verdict with recommendations', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve-with-concerns',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'Good customer value but scope may be too broad',
-              concerns: ['Feature creep risk', 'May confuse non-technical users'],
-              recommendations: ['Start with MVP, gather feedback'],
-            },
-            {
-              area: 'ROI',
-              assessment: 'Positive ROI but uncertain timeline',
-              concerns: [
-                'Development cost may exceed budget',
-                'Revenue impact depends on adoption rate',
-              ],
-              recommendations: ['Set clear success metrics', 'Plan phased rollout'],
-            },
-            {
-              area: 'Market Positioning',
-              assessment: 'Maintains competitive parity',
-              concerns: ['Not a differentiator, just keeps us competitive'],
-            },
-            {
-              area: 'Priority',
-              assessment: 'Important but not urgent',
-              concerns: ['Other features may provide more immediate value'],
-              recommendations: ['Consider prioritizing security features first'],
-            },
-          ],
-          comments: 'Good business case but monitor scope and ROI closely.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>approve-with-concerns</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Good customer value but scope may be too broad</assessment>
+      <concerns>
+        <item>Feature creep risk</item>
+        <item>May confuse non-technical users</item>
+      </concerns>
+      <recommendations>
+        <item>Start with MVP, gather feedback</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>ROI</area>
+      <assessment>Positive ROI but uncertain timeline</assessment>
+      <concerns>
+        <item>Development cost may exceed budget</item>
+        <item>Revenue impact depends on adoption rate</item>
+      </concerns>
+      <recommendations>
+        <item>Set clear success metrics</item>
+        <item>Plan phased rollout</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Market Positioning</area>
+      <assessment>Maintains competitive parity</assessment>
+      <concerns>
+        <item>Not a differentiator, just keeps us competitive</item>
+      </concerns>
+    </section>
+    <section>
+      <area>Priority</area>
+      <assessment>Important but not urgent</assessment>
+      <concerns>
+        <item>Other features may provide more immediate value</item>
+      </concerns>
+      <recommendations>
+        <item>Consider prioritizing security features first</item>
+      </recommendations>
+    </section>
+  </sections>
+  <comments>Good business case but monitor scope and ROI closely.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -160,51 +174,65 @@ describe('jon-review node', () => {
 
     it('should return revise verdict for unclear business case', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'revise',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'Unclear target audience and value proposition',
-              concerns: [
-                'No user research cited',
-                'Vague problem definition',
-                'No success criteria',
-              ],
-              recommendations: [
-                'Conduct user interviews',
-                'Define specific use cases',
-                'Set measurable goals',
-              ],
-            },
-            {
-              area: 'ROI',
-              assessment: 'Cannot assess ROI without clear metrics',
-              concerns: [
-                'No cost analysis',
-                'No revenue projections',
-                'No comparison to alternatives',
-              ],
-              recommendations: ['Create detailed cost/benefit analysis', 'Project revenue impact'],
-            },
-            {
-              area: 'Market Positioning',
-              assessment: 'Positioning strategy unclear',
-              concerns: ['How does this differentiate us?', 'Competitive analysis missing'],
-              recommendations: ['Research competitor offerings', 'Define unique value proposition'],
-            },
-            {
-              area: 'Priority',
-              assessment: 'Cannot prioritize without business case',
-              concerns: ['No urgency explained', 'Opportunity cost not considered'],
-              recommendations: ['Justify timing', 'Compare to other initiatives'],
-            },
-          ],
-          comments:
-            'PRD needs significant revision. Clarify business value, target audience, and success metrics before proceeding.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>revise</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Unclear target audience and value proposition</assessment>
+      <concerns>
+        <item>No user research cited</item>
+        <item>Vague problem definition</item>
+        <item>No success criteria</item>
+      </concerns>
+      <recommendations>
+        <item>Conduct user interviews</item>
+        <item>Define specific use cases</item>
+        <item>Set measurable goals</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>ROI</area>
+      <assessment>Cannot assess ROI without clear metrics</assessment>
+      <concerns>
+        <item>No cost analysis</item>
+        <item>No revenue projections</item>
+        <item>No comparison to alternatives</item>
+      </concerns>
+      <recommendations>
+        <item>Create detailed cost/benefit analysis</item>
+        <item>Project revenue impact</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Market Positioning</area>
+      <assessment>Positioning strategy unclear</assessment>
+      <concerns>
+        <item>How does this differentiate us?</item>
+        <item>Competitive analysis missing</item>
+      </concerns>
+      <recommendations>
+        <item>Research competitor offerings</item>
+        <item>Define unique value proposition</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Priority</area>
+      <assessment>Cannot prioritize without business case</assessment>
+      <concerns>
+        <item>No urgency explained</item>
+        <item>Opportunity cost not considered</item>
+      </concerns>
+      <recommendations>
+        <item>Justify timing</item>
+        <item>Compare to other initiatives</item>
+      </recommendations>
+    </section>
+  </sections>
+  <comments>PRD needs significant revision. Clarify business value, target audience, and success metrics before proceeding.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -221,46 +249,48 @@ describe('jon-review node', () => {
 
     it('should return reject verdict for poor business case', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'reject',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'Minimal customer value',
-              concerns: [
-                'Solves edge case for <1% of users',
-                'Customer feedback indicates low interest',
-              ],
-            },
-            {
-              area: 'ROI',
-              assessment: 'Negative ROI',
-              concerns: [
-                'High development cost',
-                'No revenue opportunity',
-                'Ongoing maintenance burden',
-              ],
-            },
-            {
-              area: 'Market Positioning',
-              assessment: 'No competitive advantage',
-              concerns: ['Feature already commoditized', 'Would not influence buying decisions'],
-            },
-            {
-              area: 'Priority',
-              assessment: 'Wrong priority for business goals',
-              concerns: [
-                'Misaligned with company strategy',
-                'Opportunity cost too high',
-                'Better alternatives exist',
-              ],
-            },
-          ],
-          comments:
-            'Cannot recommend this PRD. Poor business case, minimal customer value, and wrong strategic priority.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>reject</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Minimal customer value</assessment>
+      <concerns>
+        <item>Solves edge case for &lt;1% of users</item>
+        <item>Customer feedback indicates low interest</item>
+      </concerns>
+    </section>
+    <section>
+      <area>ROI</area>
+      <assessment>Negative ROI</assessment>
+      <concerns>
+        <item>High development cost</item>
+        <item>No revenue opportunity</item>
+        <item>Ongoing maintenance burden</item>
+      </concerns>
+    </section>
+    <section>
+      <area>Market Positioning</area>
+      <assessment>No competitive advantage</assessment>
+      <concerns>
+        <item>Feature already commoditized</item>
+        <item>Would not influence buying decisions</item>
+      </concerns>
+    </section>
+    <section>
+      <area>Priority</area>
+      <assessment>Wrong priority for business goals</assessment>
+      <concerns>
+        <item>Misaligned with company strategy</item>
+        <item>Opportunity cost too high</item>
+        <item>Better alternatives exist</item>
+      </concerns>
+    </section>
+  </sections>
+  <comments>Cannot recommend this PRD. Poor business case, minimal customer value, and wrong strategic priority.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -274,23 +304,9 @@ describe('jon-review node', () => {
       expect(result.jonReview?.verdict).toBe('reject');
     });
 
-    it('should handle JSON in markdown code blocks', async () => {
+    it('should handle XML in markdown code blocks', async () => {
       const smartModel = new TestChatModel([
-        '```json\n' +
-          JSON.stringify({
-            reviewer: 'Jon',
-            verdict: 'approve',
-            sections: [
-              {
-                area: 'Customer Impact',
-                assessment: 'Good customer value',
-                concerns: [],
-              },
-            ],
-            comments: 'Looks good from business perspective',
-            timestamp: '2024-01-01T00:00:00.000Z',
-          }) +
-          '\n```',
+        '```xml\n<review>\n  <reviewer>Jon</reviewer>\n  <verdict>approve</verdict>\n  <sections>\n    <section>\n      <area>Customer Impact</area>\n      <assessment>Good customer value</assessment>\n      <concerns></concerns>\n    </section>\n  </sections>\n  <comments>Looks good from business perspective</comments>\n  <timestamp>2024-01-01T00:00:00.000Z</timestamp>\n</review>\n```',
       ]);
 
       const state: JonReviewState = {
@@ -328,36 +344,41 @@ describe('jon-review node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve-with-concerns',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'High customer value',
-              concerns: [],
-            },
-            {
-              area: 'ROI',
-              assessment: 'Good ROI if execution risks are managed',
-              concerns: ['Ava flagged timeline and technical risks that could impact cost'],
-              recommendations: ["Factor in Ava's recommended buffer when calculating ROI"],
-            },
-            {
-              area: 'Market Positioning',
-              assessment: 'Strong competitive advantage',
-              concerns: [],
-            },
-            {
-              area: 'Priority',
-              assessment: 'High priority with execution caveats',
-              concerns: ["Success depends on managing Ava's identified risks"],
-            },
-          ],
-          comments:
-            "Strong business case. Proceed but budget for Ava's recommended timeline buffer.",
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>approve-with-concerns</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>High customer value</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>ROI</area>
+      <assessment>Good ROI if execution risks are managed</assessment>
+      <concerns>
+        <item>Ava flagged timeline and technical risks that could impact cost</item>
+      </concerns>
+      <recommendations>
+        <item>Factor in Ava's recommended buffer when calculating ROI</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Market Positioning</area>
+      <assessment>Strong competitive advantage</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>Priority</area>
+      <assessment>High priority with execution caveats</assessment>
+      <concerns>
+        <item>Success depends on managing Ava's identified risks</item>
+      </concerns>
+    </section>
+  </sections>
+  <comments>Strong business case. Proceed but budget for Ava's recommended timeline buffer.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -378,19 +399,19 @@ describe('jon-review node', () => {
 
     it('should work without Ava review context', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'Clear customer value',
-              concerns: [],
-            },
-          ],
-          comments: 'Good business case',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>approve</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Clear customer value</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>Good business case</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -407,24 +428,31 @@ describe('jon-review node', () => {
   });
 
   describe('malformed LLM output', () => {
-    it('should throw error on invalid JSON', async () => {
-      const smartModel = new TestChatModel(['This is not valid JSON']);
+    it('should throw error on missing review root element', async () => {
+      const smartModel = new TestChatModel(['This is not valid XML']);
 
       const state: JonReviewState = {
         prd: 'Some PRD',
         smartModel,
       };
 
-      await expect(jonReviewNode(state)).rejects.toThrow('Failed to parse JSON');
+      await expect(jonReviewNode(state)).rejects.toThrow('Failed to parse XML');
     });
 
-    it('should throw error on missing required fields', async () => {
+    it('should throw error on missing verdict field', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve',
-          // missing sections and comments
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Good</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>Test</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -437,13 +465,19 @@ describe('jon-review node', () => {
 
     it('should throw error on invalid verdict value', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'maybe', // invalid value
-          sections: [],
-          comments: 'Test',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>maybe</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Test</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>Test</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -454,28 +488,15 @@ describe('jon-review node', () => {
       await expect(jonReviewNode(state)).rejects.toThrow('Invalid review format');
     });
 
-    it('should throw error on invalid section structure', async () => {
-      const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve',
-          sections: [
-            {
-              // missing area and assessment
-              concerns: [],
-            },
-          ],
-          comments: 'Test',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
-      ]);
+    it('should throw error on empty review content', async () => {
+      const smartModel = new TestChatModel([`<review></review>`]);
 
       const state: JonReviewState = {
         prd: 'Some PRD',
         smartModel,
       };
 
-      await expect(jonReviewNode(state)).rejects.toThrow('Invalid review format');
+      await expect(jonReviewNode(state)).rejects.toThrow('Failed to parse XML');
     });
   });
 
@@ -486,19 +507,21 @@ describe('jon-review node', () => {
 
       // Fast model provides valid response
       const fastModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve-with-concerns',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'From fast model - good customer value',
-              concerns: ['Minor concern'],
-            },
-          ],
-          comments: 'Fallback review from fast model',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>approve-with-concerns</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>From fast model - good customer value</assessment>
+      <concerns>
+        <item>Minor concern</item>
+      </concerns>
+    </section>
+  </sections>
+  <comments>Fallback review from fast model</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -530,19 +553,19 @@ describe('jon-review node', () => {
 
     it('should work with only smart model provided', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'Looks good',
-              concerns: [],
-            },
-          ],
-          comments: 'All good',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>approve</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Looks good</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>All good</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -226,6 +226,7 @@ import { knowledgeTools } from './tools/knowledge-tools.js';
 import { qaTools } from './tools/qa-tools.js';
 import { discordTools } from './tools/discord-tools.js';
 import { portfolioTools } from './tools/portfolio-tools.js';
+import { contentTools } from './tools/content-tools.js';
 
 // Aggregate all tools
 const tools: Tool[] = [
@@ -249,6 +250,7 @@ const tools: Tool[] = [
   ...qaTools,
   ...discordTools,
   ...portfolioTools,
+  ...contentTools,
 ];
 
 // Tool implementations
@@ -1390,6 +1392,60 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
     case 'knowledge_stats':
       return apiCall('/knowledge/stats', {
         projectPath: args.projectPath,
+      });
+
+    // Content Pipeline (Cindi)
+    case 'create_content':
+      return apiCall('/content/create', {
+        projectPath: args.projectPath,
+        topic: args.topic,
+        contentConfig: {
+          ...(args.format && { format: args.format }),
+          ...(args.tone && { tone: args.tone }),
+          ...(args.audience && { audience: args.audience }),
+          ...(args.outputFormats && { outputFormats: args.outputFormats }),
+          ...(args.enableHITL !== undefined && { enableHITL: args.enableHITL }),
+          ...(args.maxRetries !== undefined && { maxRetries: args.maxRetries }),
+        },
+      });
+
+    case 'get_content_status':
+      return apiCall('/content/status', {
+        runId: args.runId,
+      });
+
+    case 'list_content':
+      return apiCall('/content/list', {
+        projectPath: args.projectPath,
+        filters: {
+          ...(args.status && { status: args.status }),
+          ...(args.contentType && { contentType: args.contentType }),
+        },
+      });
+
+    case 'review_content':
+      return apiCall('/content/review', {
+        projectPath: args.projectPath,
+        runId: args.runId,
+        gate: args.gate,
+        decision: args.decision,
+        ...(args.feedback && { feedback: args.feedback }),
+      });
+
+    case 'export_content':
+      return apiCall('/content/export', {
+        projectPath: args.projectPath,
+        runId: args.runId,
+        format: args.format,
+      });
+
+    case 'execute_antagonistic_review':
+      return apiCall('/content/antagonistic-review', {
+        projectPath: args.projectPath,
+        content: args.content,
+        ...(args.topic && { topic: args.topic }),
+        ...(args.format && { format: args.format }),
+        ...(args.audience && { audience: args.audience }),
       });
 
     default:

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1400,12 +1400,12 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         projectPath: args.projectPath,
         topic: args.topic,
         contentConfig: {
-          ...(args.format && { format: args.format }),
-          ...(args.tone && { tone: args.tone }),
-          ...(args.audience && { audience: args.audience }),
-          ...(args.outputFormats && { outputFormats: args.outputFormats }),
-          ...(args.enableHITL !== undefined && { enableHITL: args.enableHITL }),
-          ...(args.maxRetries !== undefined && { maxRetries: args.maxRetries }),
+          ...(args.format ? { format: args.format } : {}),
+          ...(args.tone ? { tone: args.tone } : {}),
+          ...(args.audience ? { audience: args.audience } : {}),
+          ...(args.outputFormats ? { outputFormats: args.outputFormats } : {}),
+          ...(args.enableHITL !== undefined ? { enableHITL: args.enableHITL } : {}),
+          ...(args.maxRetries !== undefined ? { maxRetries: args.maxRetries } : {}),
         },
       });
 
@@ -1418,8 +1418,8 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
       return apiCall('/content/list', {
         projectPath: args.projectPath,
         filters: {
-          ...(args.status && { status: args.status }),
-          ...(args.contentType && { contentType: args.contentType }),
+          ...(args.status ? { status: args.status } : {}),
+          ...(args.contentType ? { contentType: args.contentType } : {}),
         },
       });
 
@@ -1429,7 +1429,7 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         runId: args.runId,
         gate: args.gate,
         decision: args.decision,
-        ...(args.feedback && { feedback: args.feedback }),
+        ...(args.feedback ? { feedback: args.feedback } : {}),
       });
 
     case 'export_content':
@@ -1443,9 +1443,9 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
       return apiCall('/content/antagonistic-review', {
         projectPath: args.projectPath,
         content: args.content,
-        ...(args.topic && { topic: args.topic }),
-        ...(args.format && { format: args.format }),
-        ...(args.audience && { audience: args.audience }),
+        ...(args.topic ? { topic: args.topic } : {}),
+        ...(args.format ? { format: args.format } : {}),
+        ...(args.audience ? { audience: args.audience } : {}),
       });
 
     default:

--- a/packages/mcp-server/src/tools/content-tools.ts
+++ b/packages/mcp-server/src/tools/content-tools.ts
@@ -1,0 +1,204 @@
+/**
+ * Content Pipeline Tools
+ *
+ * Tools for Cindi's content creation and review pipeline:
+ * - create_content: Start a new content creation flow
+ * - get_content_status: Check flow progress and pending HITL gates
+ * - list_content: List all generated content pieces
+ * - review_content: Submit HITL decisions at interrupt gates
+ * - export_content: Export final content to various formats
+ * - execute_antagonistic_review: Run standalone antagonistic quality review
+ */
+
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+export const contentTools: Tool[] = [
+  {
+    name: 'create_content',
+    description:
+      'Start a new content creation pipeline flow. Runs research → outline → writing → antagonistic review → export phases via LangGraph. Runs autonomously by default (no HITL). Output saved to .automaker/content/{runId}/. Returns runId for status tracking.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        topic: {
+          type: 'string',
+          description:
+            'Topic or title for the content (e.g., "Building RAG Pipelines with LangGraph")',
+        },
+        format: {
+          type: 'string',
+          enum: ['tutorial', 'reference', 'guide'],
+          description: 'Content format (default: guide)',
+        },
+        tone: {
+          type: 'string',
+          enum: ['technical', 'conversational', 'formal'],
+          description: 'Writing tone (default: conversational)',
+        },
+        audience: {
+          type: 'string',
+          enum: ['beginner', 'intermediate', 'expert'],
+          description: 'Target audience level (default: intermediate)',
+        },
+        outputFormats: {
+          type: 'array',
+          items: { type: 'string', enum: ['markdown', 'html', 'pdf'] },
+          description: 'Output formats to generate (default: ["markdown"])',
+        },
+        enableHITL: {
+          type: 'boolean',
+          description:
+            'Enable human-in-the-loop interrupt gates at review checkpoints (default: false). When enabled, flow pauses at research_hitl, outline_hitl, and final_review_hitl for approval via review_content.',
+        },
+        maxRetries: {
+          type: 'number',
+          description: 'Max retries per review phase if quality gates fail (default: 2)',
+        },
+      },
+      required: ['projectPath', 'topic'],
+    },
+  },
+  {
+    name: 'get_content_status',
+    description:
+      'Get the current status of a content creation flow run. Returns progress (0-100), current node, review scores for each phase (research/outline/content), and any pending HITL gates.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        runId: {
+          type: 'string',
+          description:
+            'Content run ID returned by create_content (e.g., "content-1708123456789-abc123")',
+        },
+      },
+      required: ['projectPath', 'runId'],
+    },
+  },
+  {
+    name: 'list_content',
+    description:
+      'List all content items for a project. Returns metadata about generated content including topic, format, status, review scores, and output paths.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        status: {
+          type: 'string',
+          description: 'Filter by status (e.g., "completed", "failed")',
+        },
+        contentType: {
+          type: 'string',
+          description: 'Filter by content type/format (e.g., "guide", "tutorial")',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+  {
+    name: 'review_content',
+    description:
+      'Submit a HITL review decision at a content flow interrupt gate. Only applicable when the flow was started with enableHITL=true and is currently in "interrupted" status. Check get_content_status for hitlGatesPending to know which gate to review.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        runId: {
+          type: 'string',
+          description: 'Content run ID to resume',
+        },
+        gate: {
+          type: 'string',
+          enum: ['research_hitl', 'outline_hitl', 'final_review_hitl'],
+          description:
+            'The HITL gate to review (must match hitlGatesPending from get_content_status)',
+        },
+        decision: {
+          type: 'string',
+          enum: ['approve', 'revise', 'reject'],
+          description:
+            'Review decision: approve continues the flow, revise triggers regeneration with feedback, reject stops the flow',
+        },
+        feedback: {
+          type: 'string',
+          description: 'Optional feedback to guide revision (used when decision is "revise")',
+        },
+      },
+      required: ['projectPath', 'runId', 'gate', 'decision'],
+    },
+  },
+  {
+    name: 'export_content',
+    description:
+      'Export completed content to a specific format. The run must be in "completed" status. Formats: markdown (raw .md), frontmatter-md (YAML front matter for CMS), jsonl (instruction-response pairs for training data), hf-dataset (HuggingFace dataset entry).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        runId: {
+          type: 'string',
+          description: 'Content run ID to export',
+        },
+        format: {
+          type: 'string',
+          enum: ['markdown', 'frontmatter-md', 'jsonl', 'hf-dataset'],
+          description:
+            'Export format: markdown (raw .md), frontmatter-md (CMS-ready with YAML front matter), jsonl (instruction-response training data), hf-dataset (HuggingFace dataset entry)',
+        },
+      },
+      required: ['projectPath', 'runId', 'format'],
+    },
+  },
+  {
+    name: 'execute_antagonistic_review',
+    description:
+      "Run an antagonistic quality review on content text. Scores across 6 dimensions on a 1-10 scale: Accuracy (factual correctness), Usefulness (reader value), Clarity (readability/structure), Engagement (hook quality), Depth (detail/nuance), Actionability (clear next steps). Passes if overall average >= 7.5 and no dimension < 5. Use this before publishing or after creating content to validate quality.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        content: {
+          type: 'string',
+          description: 'The content text to review',
+        },
+        topic: {
+          type: 'string',
+          description:
+            'The intended topic of the content (helps evaluate accuracy and relevance)',
+        },
+        format: {
+          type: 'string',
+          enum: ['tutorial', 'reference', 'guide', 'blog-post', 'documentation'],
+          description:
+            'Content format type for context-appropriate evaluation (default: guide)',
+        },
+        audience: {
+          type: 'string',
+          enum: ['beginner', 'intermediate', 'expert'],
+          description:
+            'Intended audience for calibrating depth and clarity scores (default: intermediate)',
+        },
+      },
+      required: ['projectPath', 'content'],
+    },
+  },
+];


### PR DESCRIPTION
## Summary

Cindi's activation skill (`/home/josh/staging-deploy/automaker/.claude/skills/cindi.md`) references 6 MCP tools that do not exist in the server:

- `create_content` — create a new content item (blog post, social post, etc.) in the pipeline
- `get_content_status` — check pipeline status of an in-progress content item
- `list_content` — list all content items (filterable by status/type)
- `review_content` — trigger an antagonistic review pass on a content item
- `export_content` — export a finishe...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standalone antagonistic review endpoint to evaluate content across six quality dimensions with pass/fail verdicts
  * Expanded content pipeline tools for create, status, list, review decisions, export, and antagonistic review; supports multiple export formats (markdown, frontmatter-markdown, JSONL, HuggingFace dataset)

* **Tests**
  * Updated review fixtures and parsing tests to use XML-formatted review payloads and XML-specific assertions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->