### PR TITLE
fix(tests): update jon-review test mocks to XML format

### DIFF
--- a/libs/flows/tests/unit/jon-review.test.ts
+++ b/libs/flows/tests/unit/jon-review.test.ts
@@ -58,34 +58,34 @@ describe('jon-review node', () => {
   describe('normal case', () => {
     it('should return approve verdict for high-value PRD', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'Solves major user pain point, high satisfaction expected',
-              concerns: [],
-            },
-            {
-              area: 'ROI',
-              assessment: 'Strong ROI, 200% expected return within 6 months',
-              concerns: [],
-            },
-            {
-              area: 'Market Positioning',
-              assessment: 'Differentiates us from competitors',
-              concerns: [],
-            },
-            {
-              area: 'Priority',
-              assessment: 'Aligns perfectly with Q1 strategic goals',
-              concerns: [],
-            },
-          ],
-          comments: 'Strong business case. Proceed with implementation.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>approve</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Solves major user pain point, high satisfaction expected</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>ROI</area>
+      <assessment>Strong ROI, 200% expected return within 6 months</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>Market Positioning</area>
+      <assessment>Differentiates us from competitors</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>Priority</area>
+      <assessment>Aligns perfectly with Q1 strategic goals</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>Strong business case. Proceed with implementation.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -105,40 +105,54 @@ describe('jon-review node', () => {
 
     it('should return approve-with-concerns verdict with recommendations', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve-with-concerns',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'Good customer value but scope may be too broad',
-              concerns: ['Feature creep risk', 'May confuse non-technical users'],
-              recommendations: ['Start with MVP, gather feedback'],
-            },
-            {
-              area: 'ROI',
-              assessment: 'Positive ROI but uncertain timeline',
-              concerns: [
-                'Development cost may exceed budget',
-                'Revenue impact depends on adoption rate',
-              ],
-              recommendations: ['Set clear success metrics', 'Plan phased rollout'],
-            },
-            {
-              area: 'Market Positioning',
-              assessment: 'Maintains competitive parity',
-              concerns: ['Not a differentiator, just keeps us competitive'],
-            },
-            {
-              area: 'Priority',
-              assessment: 'Important but not urgent',
-              concerns: ['Other features may provide more immediate value'],
-              recommendations: ['Consider prioritizing security features first'],
-            },
-          ],
-          comments: 'Good business case but monitor scope and ROI closely.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>approve-with-concerns</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Good customer value but scope may be too broad</assessment>
+      <concerns>
+        <item>Feature creep risk</item>
+        <item>May confuse non-technical users</item>
+      </concerns>
+      <recommendations>
+        <item>Start with MVP, gather feedback</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>ROI</area>
+      <assessment>Positive ROI but uncertain timeline</assessment>
+      <concerns>
+        <item>Development cost may exceed budget</item>
+        <item>Revenue impact depends on adoption rate</item>
+      </concerns>
+      <recommendations>
+        <item>Set clear success metrics</item>
+        <item>Plan phased rollout</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Market Positioning</area>
+      <assessment>Maintains competitive parity</assessment>
+      <concerns>
+        <item>Not a differentiator, just keeps us competitive</item>
+      </concerns>
+    </section>
+    <section>
+      <area>Priority</area>
+      <assessment>Important but not urgent</assessment>
+      <concerns>
+        <item>Other features may provide more immediate value</item>
+      </concerns>
+      <recommendations>
+        <item>Consider prioritizing security features first</item>
+      </recommendations>
+    </section>
+  </sections>
+  <comments>Good business case but monitor scope and ROI closely.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -160,51 +174,65 @@ describe('jon-review node', () => {
 
     it('should return revise verdict for unclear business case', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'revise',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'Unclear target audience and value proposition',
-              concerns: [
-                'No user research cited',
-                'Vague problem definition',
-                'No success criteria',
-              ],
-              recommendations: [
-                'Conduct user interviews',
-                'Define specific use cases',
-                'Set measurable goals',
-              ],
-            },
-            {
-              area: 'ROI',
-              assessment: 'Cannot assess ROI without clear metrics',
-              concerns: [
-                'No cost analysis',
-                'No revenue projections',
-                'No comparison to alternatives',
-              ],
-              recommendations: ['Create detailed cost/benefit analysis', 'Project revenue impact'],
-            },
-            {
-              area: 'Market Positioning',
-              assessment: 'Positioning strategy unclear',
-              concerns: ['How does this differentiate us?', 'Competitive analysis missing'],
-              recommendations: ['Research competitor offerings', 'Define unique value proposition'],
-            },
-            {
-              area: 'Priority',
-              assessment: 'Cannot prioritize without business case',
-              concerns: ['No urgency explained', 'Opportunity cost not considered'],
-              recommendations: ['Justify timing', 'Compare to other initiatives'],
-            },
-          ],
-          comments:
-            'PRD needs significant revision. Clarify business value, target audience, and success metrics before proceeding.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>revise</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Unclear target audience and value proposition</assessment>
+      <concerns>
+        <item>No user research cited</item>
+        <item>Vague problem definition</item>
+        <item>No success criteria</item>
+      </concerns>
+      <recommendations>
+        <item>Conduct user interviews</item>
+        <item>Define specific use cases</item>
+        <item>Set measurable goals</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>ROI</area>
+      <assessment>Cannot assess ROI without clear metrics</assessment>
+      <concerns>
+        <item>No cost analysis</item>
+        <item>No revenue projections</item>
+        <item>No comparison to alternatives</item>
+      </concerns>
+      <recommendations>
+        <item>Create detailed cost/benefit analysis</item>
+        <item>Project revenue impact</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Market Positioning</area>
+      <assessment>Positioning strategy unclear</assessment>
+      <concerns>
+        <item>How does this differentiate us?</item>
+        <item>Competitive analysis missing</item>
+      </concerns>
+      <recommendations>
+        <item>Research competitor offerings</item>
+        <item>Define unique value proposition</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Priority</area>
+      <assessment>Cannot prioritize without business case</assessment>
+      <concerns>
+        <item>No urgency explained</item>
+        <item>Opportunity cost not considered</item>
+      </concerns>
+      <recommendations>
+        <item>Justify timing</item>
+        <item>Compare to other initiatives</item>
+      </recommendations>
+    </section>
+  </sections>
+  <comments>PRD needs significant revision. Clarify business value, target audience, and success metrics before proceeding.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -221,46 +249,48 @@ describe('jon-review node', () => {
 
     it('should return reject verdict for poor business case', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'reject',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'Minimal customer value',
-              concerns: [
-                'Solves edge case for <1% of users',
-                'Customer feedback indicates low interest',
-              ],
-            },
-            {
-              area: 'ROI',
-              assessment: 'Negative ROI',
-              concerns: [
-                'High development cost',
-                'No revenue opportunity',
-                'Ongoing maintenance burden',
-              ],
-            },
-            {
-              area: 'Market Positioning',
-              assessment: 'No competitive advantage',
-              concerns: ['Feature already commoditized', 'Would not influence buying decisions'],
-            },
-            {
-              area: 'Priority',
-              assessment: 'Wrong priority for business goals',
-              concerns: [
-                'Misaligned with company strategy',
-                'Opportunity cost too high',
-                'Better alternatives exist',
-              ],
-            },
-          ],
-          comments:
-            'Cannot recommend this PRD. Poor business case, minimal customer value, and wrong strategic priority.',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>reject</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Minimal customer value</assessment>
+      <concerns>
+        <item>Solves edge case for &lt;1% of users</item>
+        <item>Customer feedback indicates low interest</item>
+      </concerns>
+    </section>
+    <section>
+      <area>ROI</area>
+      <assessment>Negative ROI</assessment>
+      <concerns>
+        <item>High development cost</item>
+        <item>No revenue opportunity</item>
+        <item>Ongoing maintenance burden</item>
+      </concerns>
+    </section>
+    <section>
+      <area>Market Positioning</area>
+      <assessment>No competitive advantage</assessment>
+      <concerns>
+        <item>Feature already commoditized</item>
+        <item>Would not influence buying decisions</item>
+      </concerns>
+    </section>
+    <section>
+      <area>Priority</area>
+      <assessment>Wrong priority for business goals</assessment>
+      <concerns>
+        <item>Misaligned with company strategy</item>
+        <item>Opportunity cost too high</item>
+        <item>Better alternatives exist</item>
+      </concerns>
+    </section>
+  </sections>
+  <comments>Cannot recommend this PRD. Poor business case, minimal customer value, and wrong strategic priority.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -274,23 +304,9 @@ describe('jon-review node', () => {
       expect(result.jonReview?.verdict).toBe('reject');
     });
 
-    it('should handle JSON in markdown code blocks', async () => {
+    it('should handle XML in markdown code blocks', async () => {
       const smartModel = new TestChatModel([
-        '```json\n' +
-          JSON.stringify({
-            reviewer: 'Jon',
-            verdict: 'approve',
-            sections: [
-              {
-                area: 'Customer Impact',
-                assessment: 'Good customer value',
-                concerns: [],
-              },
-            ],
-            comments: 'Looks good from business perspective',
-            timestamp: '2024-01-01T00:00:00.000Z',
-          }) +
-          '\n```',
+        '```xml\n<review>\n  <reviewer>Jon</reviewer>\n  <verdict>approve</verdict>\n  <sections>\n    <section>\n      <area>Customer Impact</area>\n      <assessment>Good customer value</assessment>\n      <concerns></concerns>\n    </section>\n  </sections>\n  <comments>Looks good from business perspective</comments>\n  <timestamp>2024-01-01T00:00:00.000Z</timestamp>\n</review>\n```',
       ]);
 
       const state: JonReviewState = {
@@ -328,36 +344,41 @@ describe('jon-review node', () => {
       };
 
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve-with-concerns',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'High customer value',
-              concerns: [],
-            },
-            {
-              area: 'ROI',
-              assessment: 'Good ROI if execution risks are managed',
-              concerns: ['Ava flagged timeline and technical risks that could impact cost'],
-              recommendations: ["Factor in Ava's recommended buffer when calculating ROI"],
-            },
-            {
-              area: 'Market Positioning',
-              assessment: 'Strong competitive advantage',
-              concerns: [],
-            },
-            {
-              area: 'Priority',
-              assessment: 'High priority with execution caveats',
-              concerns: ["Success depends on managing Ava's identified risks"],
-            },
-          ],
-          comments:
-            "Strong business case. Proceed but budget for Ava's recommended timeline buffer.",
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>approve-with-concerns</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>High customer value</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>ROI</area>
+      <assessment>Good ROI if execution risks are managed</assessment>
+      <concerns>
+        <item>Ava flagged timeline and technical risks that could impact cost</item>
+      </concerns>
+      <recommendations>
+        <item>Factor in Ava's recommended buffer when calculating ROI</item>
+      </recommendations>
+    </section>
+    <section>
+      <area>Market Positioning</area>
+      <assessment>Strong competitive advantage</assessment>
+      <concerns></concerns>
+    </section>
+    <section>
+      <area>Priority</area>
+      <assessment>High priority with execution caveats</assessment>
+      <concerns>
+        <item>Success depends on managing Ava's identified risks</item>
+      </concerns>
+    </section>
+  </sections>
+  <comments>Strong business case. Proceed but budget for Ava's recommended timeline buffer.</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -378,19 +399,19 @@ describe('jon-review node', () => {
 
     it('should work without Ava review context', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'Clear customer value',
-              concerns: [],
-            },
-          ],
-          comments: 'Good business case',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>approve</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Clear customer value</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>Good business case</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -407,24 +428,31 @@ describe('jon-review node', () => {
   });
 
   describe('malformed LLM output', () => {
-    it('should throw error on invalid JSON', async () => {
-      const smartModel = new TestChatModel(['This is not valid JSON']);
+    it('should throw error on missing review root element', async () => {
+      const smartModel = new TestChatModel(['This is not valid XML']);
 
       const state: JonReviewState = {
         prd: 'Some PRD',
         smartModel,
       };
 
-      await expect(jonReviewNode(state)).rejects.toThrow('Failed to parse JSON');
+      await expect(jonReviewNode(state)).rejects.toThrow('Failed to parse XML');
     });
 
-    it('should throw error on missing required fields', async () => {
+    it('should throw error on missing verdict field', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve',
-          // missing sections and comments
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Good</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>Test</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -437,13 +465,19 @@ describe('jon-review node', () => {
 
     it('should throw error on invalid verdict value', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'maybe', // invalid value
-          sections: [],
-          comments: 'Test',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>maybe</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Good</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>Test</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -454,28 +488,15 @@ describe('jon-review node', () => {
       await expect(jonReviewNode(state)).rejects.toThrow('Invalid review format');
     });
 
-    it('should throw error on invalid section structure', async () => {
-      const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve',
-          sections: [
-            {
-              // missing area and assessment
-              concerns: [],
-            },
-          ],
-          comments: 'Test',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
-      ]);
+    it('should throw error on empty review content', async () => {
+      const smartModel = new TestChatModel([`<review></review>`]);
 
       const state: JonReviewState = {
         prd: 'Some PRD',
         smartModel,
       };
 
-      await expect(jonReviewNode(state)).rejects.toThrow('Invalid review format');
+      await expect(jonReviewNode(state)).rejects.toThrow('Failed to parse XML');
     });
   });
 
@@ -486,19 +507,21 @@ describe('jon-review node', () => {
 
       // Fast model provides valid response
       const fastModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve-with-concerns',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'From fast model - good customer value',
-              concerns: ['Minor concern'],
-            },
-          ],
-          comments: 'Fallback review from fast model',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>approve-with-concerns</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>From fast model - good customer value</assessment>
+      <concerns>
+        <item>Minor concern</item>
+      </concerns>
+    </section>
+  </sections>
+  <comments>Fallback review from fast model</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {
@@ -530,19 +553,19 @@ describe('jon-review node', () => {
 
     it('should work with only smart model provided', async () => {
       const smartModel = new TestChatModel([
-        JSON.stringify({
-          reviewer: 'Jon',
-          verdict: 'approve',
-          sections: [
-            {
-              area: 'Customer Impact',
-              assessment: 'Looks good',
-              concerns: [],
-            },
-          ],
-          comments: 'All good',
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
+        `<review>
+  <reviewer>Jon</reviewer>
+  <verdict>approve</verdict>
+  <sections>
+    <section>
+      <area>Customer Impact</area>
+      <assessment>Looks good</assessment>
+      <concerns></concerns>
+    </section>
+  </sections>
+  <comments>All good</comments>
+  <timestamp>2024-01-01T00:00:00.000Z</timestamp>
+</review>`,
       ]);
 
       const state: JonReviewState = {


### PR DESCRIPTION
## Summary
- Updates `libs/flows/tests/unit/jon-review.test.ts` mock responses from JSON to XML format, matching the XML schema that `JonReviewNode` expects via `parseAndValidateReview()` / `parseReviewXml()`
- Fixes pre-existing trunk test failure that snuck into dev via merged PRs

## Root Cause
`JonReviewNode` calls `parseAndValidateReview()` which calls `parseReviewXml()` — expects `<review>...</review>` XML. The test mocks were returning JSON strings from before the node was changed to XML output.

This same fix was applied to `ava-review.test.ts` and `consolidate.test.ts` in PRs #3290/#3291. This PR completes the fix for `jon-review.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)