### PR TITLE
Bug: Quinn double-triage — idempotency guard on issues.opened webhook

### DIFF
--- a/apps/server/src/routes/github/routes/webhook.ts
+++ b/apps/server/src/routes/github/routes/webhook.ts
@@ -24,6 +24,7 @@ import { generateCorrelationId } from '../../../lib/events.js';
 import { getPRWatcherService } from '../../../services/pr-watcher-service.js';
 import { projectPathSchema } from '../../../lib/validation.js';
 import { verifySingleSecret } from '../../../lib/webhook-signature.js';
+import { getWebhookDeliveryService } from '../../../services/webhook-delivery-service.js';
 
 const logger = createLogger('GitHubWebhook');
 
@@ -66,13 +67,30 @@ async function handlePingEvent(payload: GitHubPingWebhookPayload): Promise<void>
 async function handleIssueEvent(
   payload: GitHubIssueWebhookPayload,
   projectPath: string,
-  events: EventEmitter
-): Promise<void> {
+  events: EventEmitter,
+  deliveryId?: string
+): Promise<boolean> {
   const { action, issue, repository } = payload;
 
   logger.info(
     `Received issue event: ${action} on ${repository.full_name}#${issue.number} - ${issue.title}`
   );
+
+  // Idempotency guard for issues.opened: reject duplicate X-GitHub-Delivery IDs before
+  // emitting any events. This prevents double-triage when both the global /github handler
+  // and this per-project /github/webhook handler receive the same webhook event (e.g., two
+  // GitHub webhook registrations for the same repo), or when GitHub retries a delivery.
+  if (action === 'opened' && deliveryId) {
+    const deliveryService = getWebhookDeliveryService();
+    const deduplicationKey = `issues:opened:${deliveryId}`;
+    if (deliveryService.isDuplicate('github', 'issues', deduplicationKey)) {
+      logger.info(
+        `[idempotency] Duplicate delivery ${deliveryId} for issue #${issue.number} — skipping`
+      );
+      return false; // signal: skip, already processed
+    }
+    deliveryService.trackDelivery('github', 'issues', undefined, { deduplicationKey });
+  }
 
   // Emit event for logging and potential auto-creation
   events.emit('webhook:github:issue', {
@@ -86,8 +104,7 @@ async function handleIssueEvent(
     labels: issue.labels?.map((l) => l.name) || [],
   });
 
-  // Future: Auto-create features from issues when webhookSettings.autoCreateFromIssues is enabled
-  // This would integrate with the feature creation logic
+  return true; // processed
 }
 
 /**
@@ -336,8 +353,9 @@ export function createWebhookHandler(
         return;
       }
 
-      // Get event type from header
+      // Get event type and delivery ID from headers
       const eventType = req.headers['x-github-event'] as string | undefined;
+      const deliveryId = req.headers['x-github-delivery'] as string | undefined;
 
       if (!eventType) {
         res.status(400).json({
@@ -375,9 +393,20 @@ export function createWebhookHandler(
           await handlePingEvent(payload as GitHubPingWebhookPayload);
           break;
 
-        case 'issues':
-          await handleIssueEvent(payload as GitHubIssueWebhookPayload, projectPath, events);
+        case 'issues': {
+          const processed = await handleIssueEvent(
+            payload as GitHubIssueWebhookPayload,
+            projectPath,
+            events,
+            deliveryId
+          );
+          if (!processed) {
+            events.clearCorrelationContext();
+            res.status(200).json({ message: 'Duplicate delivery ignored' });
+            return;
+          }
           break;
+        }
 
         case 'pull_request':
           await handlePullRequestEvent(

--- a/apps/server/src/routes/webhooks/routes/github.ts
+++ b/apps/server/src/routes/webhooks/routes/github.ts
@@ -19,6 +19,7 @@ import type { EventEmitter } from '../../../lib/events.js';
 import type { TopicBus } from '../../../lib/topic-bus.js';
 import type { SettingsService } from '../../../services/settings-service.js';
 import { FeatureLoader } from '../../../services/feature-loader.js';
+import { getWebhookDeliveryService } from '../../../services/webhook-delivery-service.js';
 import { StagingPromotionService } from '../../../services/staging-promotion-service.js';
 import { getPRWatcherService } from '../../../services/pr-watcher-service.js';
 import type {
@@ -366,6 +367,25 @@ export function createGitHubWebhookHandler(
         const issuePayload = req.body as GitHubIssuePayload;
 
         if (issuePayload.action === 'opened') {
+          // Idempotency guard: reject duplicate webhook deliveries before emitting any events.
+          // GitHub sends a unique X-GitHub-Delivery UUID per delivery attempt (shared across
+          // retries of the same event). Checking it here prevents duplicate features when
+          // multiple webhook registrations fire for the same issue (e.g., GitHub App +
+          // repository webhook), or when GitHub retries a delivery.
+          const deliveryId = req.headers['x-github-delivery'] as string | undefined;
+          if (deliveryId) {
+            const deliveryService = getWebhookDeliveryService();
+            const deduplicationKey = `issues:opened:${deliveryId}`;
+            if (deliveryService.isDuplicate('github', 'issues', deduplicationKey)) {
+              logger.info(
+                `[idempotency] Duplicate delivery ${deliveryId} for issue #${issuePayload.issue.number} — skipping`
+              );
+              res.json({ success: true, message: 'Duplicate delivery ignored' });
+              return;
+            }
+            deliveryService.trackDelivery('github', 'issues', undefined, { deduplicationKey });
+          }
+
           logger.info(
             `GitHub issue #${issuePayload.issue.number} created: ${issuePayload.issue.title}`
           );

--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -442,12 +442,27 @@ export class SignalIntakeService {
 
   private async handleSignal(signal: SignalPayload): Promise<void> {
     // Deduplicate by source + unique identifier.
-    // For integration sources (GitHub), use author.id which is the issue/event ID.
+    // For GitHub issues, key on repo+issueNumber (canonical issue identity, not author).
+    // Keying on author.id would allow the same issue to slip through if two webhook
+    // registrations fire simultaneously with different payloads (e.g., global /github
+    // handler vs. per-project /github/webhook handler produce author:undefined on the
+    // latter, resulting in a different dedup key and a second feature being created).
     // For UI/MCP sources, include timestamp to allow repeat submissions.
     const isUserSource = signal.source.startsWith('ui:') || signal.source.startsWith('mcp:');
-    const dedupeKey = isUserSource
-      ? `${signal.source}:${signal.timestamp}`
-      : `${signal.source}:${signal.author.id}`;
+    let dedupeKey: string;
+    if (
+      signal.source === 'github' &&
+      signal.channelContext?.issueNumber !== undefined &&
+      signal.channelContext?.repository !== undefined
+    ) {
+      // Canonical dedup key: repo + issue number. Stable across duplicate webhook
+      // deliveries regardless of which handler received the event or who the author is.
+      dedupeKey = `github:${signal.channelContext.repository as string}#${signal.channelContext.issueNumber as number}`;
+    } else if (isUserSource) {
+      dedupeKey = `${signal.source}:${signal.timestamp}`;
+    } else {
+      dedupeKey = `${signal.source}:${signal.author.id}`;
+    }
     if (this.processedSignals.has(dedupeKey)) {
       logger.debug(`Skipping duplicate signal: ${dedupeKey}`);
       return;

--- a/apps/server/tests/unit/services/signal-intake-service.test.ts
+++ b/apps/server/tests/unit/services/signal-intake-service.test.ts
@@ -368,23 +368,77 @@ describe('SignalIntakeService', () => {
   });
 
   describe('deduplication logic', () => {
-    it('should prevent duplicate GitHub signals by event ID', async () => {
+    it('should prevent duplicate GitHub issue signals by repo+issueNumber', async () => {
+      // Same repo + issue number → same dedup key, regardless of author
       const signal = createTestSignal({
         source: 'github',
         author: {
-          id: 'event-456',
-          name: 'GitHub Event',
+          id: 'mabry1985',
+          name: 'mabry1985',
         },
         content: 'Issue created',
+        channelContext: {
+          issueNumber: 3299,
+          repository: 'protoLabsAI/protoMaker',
+        },
       });
 
-      // Send same signal twice
+      // Send same signal twice (simulates two webhook registrations firing)
       mockEmitter.emit('signal:received', signal);
       mockEmitter.emit('signal:received', signal);
 
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       // Feature should only be created once
+      expect(mockFeatureLoader.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT deduplicate two different GitHub issues from the same author', async () => {
+      // Same author, different issue numbers → different dedup keys → both should create features
+      const signal1 = createTestSignal({
+        source: 'github',
+        author: { id: 'mabry1985', name: 'mabry1985' },
+        content: 'First issue',
+        channelContext: { issueNumber: 100, repository: 'protoLabsAI/protoMaker' },
+      });
+      const signal2 = createTestSignal({
+        source: 'github',
+        author: { id: 'mabry1985', name: 'mabry1985' },
+        content: 'Second issue',
+        channelContext: { issueNumber: 101, repository: 'protoLabsAI/protoMaker' },
+      });
+
+      mockEmitter.emit('signal:received', signal1);
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      mockEmitter.emit('signal:received', signal2);
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      // Both should create features
+      expect(mockFeatureLoader.create).toHaveBeenCalledTimes(2);
+    });
+
+    it('should deduplicate GitHub issue even when author fields differ between duplicate deliveries', async () => {
+      // Simulates global handler (with author) vs per-project handler (author=undefined)
+      // firing for the same issue — old bug: different author.id → different keys → 2 features
+      const signalWithAuthor = createTestSignal({
+        source: 'github',
+        author: { id: 'mabry1985', name: 'mabry1985' },
+        content: 'Bug report',
+        channelContext: { issueNumber: 3300, repository: 'protoLabsAI/protoMaker' },
+      });
+      const signalWithoutAuthor = createTestSignal({
+        source: 'github',
+        author: { id: undefined as unknown as string, name: '' },
+        content: 'Bug report',
+        channelContext: { issueNumber: 3300, repository: 'protoLabsAI/protoMaker' },
+      });
+
+      mockEmitter.emit('signal:received', signalWithAuthor);
+      mockEmitter.emit('signal:received', signalWithoutAuthor);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Only one feature should be created despite different author fields
       expect(mockFeatureLoader.create).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
## Summary

**Source:** GitHub Issue protoLabsAI/protoMaker#3300 — @mabry1985 (trust tier: 1)
**URL:** https://github.com/protoLabsAI/protoMaker/issues/3300

---

## Bug Summary

Quinn's `auto_triage` flow ran twice for the same GitHub issue (#3299), creating **4 duplicate features** on the board in ~7 seconds. All 4 competed for agent capacity, all hit the same merge conflict on `origin/dev`, and all ended up blocked simultaneously. Classic thundering herd from a missing idempotency gate.

## Root Cause (t...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented deduplication for GitHub webhook deliveries to prevent duplicate processing of the same issue events.
  * Improved signal deduplication logic to correctly identify duplicate GitHub events based on repository and issue identity rather than author information, ensuring duplicate webhooks don't trigger redundant actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->