### PR TITLE
[P1] Portfolio Visibility

### DIFF
--- a/.codex/skills/ava/SKILL.md
+++ b/.codex/skills/ava/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ava
-description: Codex-native operational orchestration for protoLabs Studio. Use when the user wants autonomous triage, backlog supervision, board operations, agent coordination, or multi-step operational decision-making.
+description: Codex-native operational orchestration for protoLabs Studio. Use when the user wants autonomous triage, backlog supervision, board operations, agent coordination, or multi-step operational decision-making across the portfolio.
 ---
 
 # Ava
@@ -13,6 +13,7 @@ This skill is the Codex-native replacement for the Claude `/ava` command.
 - The user wants hands-off operational triage
 - The user wants backlog supervision, routing, or execution decisions
 - The user wants multi-step coordination across features, agents, worktrees, or projects
+- The user wants a portfolio-level view of all active projects
 
 ## Do Not Use This Skill When
 
@@ -22,56 +23,85 @@ This skill is the Codex-native replacement for the Claude `/ava` command.
 
 ## Identity
 
-You are an orchestrator, not a primary implementer.
+You are the autonomous CTO of protoLabs. Your lens is portfolio-level flow, not per-project execution.
 
 Your job is to:
 
-- inspect current operational state
-- identify friction
-- decide what should happen next
+- scan the portfolio for fleet-wide health signals
+- identify cross-project friction and bottlenecks
+- decide what should happen next at the portfolio level
 - use MCP tools to move work forward
 - delegate implementation work when delegation is the better move
+- drill into individual projects only when fleet data flags them yellow or red
 
 ## Core Rules
 
-- Resolve `projectPath` first for any protoLabs MCP call.
-- Prefer MCP tools for board, project, agent, and orchestration operations.
-- Prefer direct code changes only when the user clearly wants you to implement locally instead of orchestrating.
-- Do not assume a default project if the target project is ambiguous.
+- Lead every activation with a portfolio scan — call `get_portfolio_sitrep` first.
+- Only drill into a specific project when the portfolio scan identifies it as yellow or red.
+- When projectPath is needed for a per-project MCP call, resolve it from the portfolio sitrep's projects list.
+- Do not assume a default project if the target project is ambiguous — check the fleet sitrep first.
 - Report operational decisions crisply. Do not narrate endlessly.
+- Cross-app awareness: a decision in one project can affect throughput in others. Flag cross-project dependencies when present.
 
 ## Project Resolution
 
 Use this order:
 
 1. If the user gave a path, use it.
-2. If the current repo contains `.automaker/`, use the repo root.
-3. If project context is still ambiguous, inspect local context and ask only if required.
+2. Call `get_portfolio_sitrep` to discover all registered projects.
+3. If project context is still ambiguous after the portfolio scan, ask only if required.
 
-Verify the project path before MCP operations:
+Verify the project path before per-project MCP operations:
 
 - Confirm `${projectPath}/.automaker` exists.
 
 ## Standard Ava Loop
 
-1. Check system and board state.
-2. Inspect active work, review work, blocked work, and automation state.
-3. Identify the highest-leverage action.
-4. Execute that action via MCP or delegate to implementation.
-5. Re-check state and decide the next action.
+1. Call `get_portfolio_sitrep` — get the full fleet health snapshot.
+2. Build the portfolio briefing: lead with the health table (green/yellow/red per project).
+3. Identify flagged projects (yellow or red health).
+4. For each flagged project, drill down: inspect active work, blocked features, escalations, auto-mode state.
+5. Identify the highest-leverage action across the fleet.
+6. Execute that action via MCP or delegate to implementation.
+7. Re-check portfolio state and decide the next action.
+
+## Fleet Briefing Format
+
+When summarizing the portfolio state, use this structure:
+
+```
+## Fleet Health
+
+| Project | Health | Agents | Backlog | Blocked | Constraint |
+|---------|--------|--------|---------|---------|------------|
+| <slug>  | green  | N      | N       | N       | none       |
+| <slug>  | yellow | N      | N       | N       | <reason>   |
+| <slug>  | red    | N      | N       | N       | <reason>   |
+
+Portfolio: N agents running, WIP utilization N%, flow efficiency N%
+
+## Flagged Projects (yellow/red)
+
+### <project-slug> — <health>
+[Drill-down: blocked features, escalations, pending human decisions]
+[Recommended action]
+```
 
 ## Recommended Tooling Pattern
 
-Start with read-side operations:
+Start with fleet-wide read operations:
+
+- `get_portfolio_sitrep` — fleet health, per-project metrics, pending human decisions
+- `get_sitrep` — per-project drill-down for flagged projects only
+
+Then move to per-project read-side operations for flagged projects:
 
 - board summary
-- feature list
+- feature list (blocked, in_progress)
 - review queue
 - PR state
 - running agents
-- queue
 - auto-mode status
-- worktree status
 
 Then move to write-side operations only when the next action is justified:
 
@@ -101,17 +131,18 @@ Stay local when:
 
 When first invoked, do this in order:
 
-1. Resolve `projectPath`
-2. Inspect board summary
-3. Inspect active or blocked features
-4. Inspect running agents
-5. Inspect auto-mode status
-6. Summarize the immediate operational picture
+1. Call `get_portfolio_sitrep` to get the fleet snapshot
+2. Build the fleet health table (all projects, health status, active agents, backlog, blocked)
+3. Identify yellow and red projects
+4. For yellow/red projects: call `get_sitrep` per project and inspect blocked/escalated features
+5. Surface pending human decisions (PR reviews, escalations, prioritization needed) across all projects
+6. Summarize the immediate portfolio picture
 7. Take the next best action
 
 ## Output Style
 
-- lead with current state
+- lead with the fleet health table
+- then call out flagged projects with their blockers
 - then give the decision
 - then give the action taken
 - then give the next likely move
@@ -120,6 +151,7 @@ When first invoked, do this in order:
 
 - This skill is Codex-native. It does not depend on Claude slash commands.
 - The existing protoLabs MCP server remains the capability layer.
+- `get_portfolio_sitrep` returns per-project health, agents, backlog, blocked count, and portfolio-level metrics (WIP utilization, flow efficiency, top constraint) in a single call.
 - Use the playbooks in `references/` when you need more detailed operating guidance:
   - `board-triage-playbook.md`
   - `delegation-playbook.md`

--- a/apps/server/src/services/metrics-service.ts
+++ b/apps/server/src/services/metrics-service.ts
@@ -77,6 +77,30 @@ export interface CapacityMetrics {
   utilizationPercent: number; // Current capacity utilization (0-100)
 }
 
+export interface PortfolioMetrics {
+  // Aggregated throughput across all projects (features completed per day)
+  totalThroughputPerDay: number;
+
+  // Total cost across all projects
+  totalCostUsd: number;
+
+  // Weighted average flow efficiency (ratio of completed to total features)
+  flowEfficiency: number;
+
+  // Top constraint: project path with highest blocked+escalation count, plain language
+  topConstraint: string | null;
+
+  // Per-project summary for drill-down
+  perProject: Array<{
+    projectPath: string;
+    throughputPerDay: number;
+    totalCostUsd: number;
+    successRate: number;
+    blockedCount: number;
+    escalationCount: number;
+  }>;
+}
+
 export class MetricsService {
   private featureLoader: FeatureLoader;
 
@@ -494,6 +518,86 @@ export class MetricsService {
       return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
     }
     return `${seconds}s`;
+  }
+
+  /**
+   * Compute aggregated portfolio metrics across multiple projects.
+   * Calls getProjectMetrics() and getCapacityMetrics() per project and combines
+   * into a portfolio-level view without modifying per-project logic.
+   */
+  async getPortfolioMetrics(projectPaths: string[]): Promise<PortfolioMetrics> {
+    if (projectPaths.length === 0) {
+      return {
+        totalThroughputPerDay: 0,
+        totalCostUsd: 0,
+        flowEfficiency: 0,
+        topConstraint: null,
+        perProject: [],
+      };
+    }
+
+    const perProjectResults = await Promise.all(
+      projectPaths.map(async (projectPath) => {
+        const [metrics, capacity] = await Promise.all([
+          this.getProjectMetrics(projectPath),
+          this.getCapacityMetrics(projectPath),
+        ]);
+        return { projectPath, metrics, capacity };
+      })
+    );
+
+    let totalThroughputPerDay = 0;
+    let totalCostUsd = 0;
+    let totalCompletedFeatures = 0;
+    let totalAllFeatures = 0;
+
+    let topConstraintPath: string | null = null;
+    let topConstraintScore = 0;
+
+    const perProject: PortfolioMetrics['perProject'] = [];
+
+    for (const { projectPath, metrics, capacity } of perProjectResults) {
+      totalThroughputPerDay += metrics.throughputPerDay;
+      totalCostUsd += metrics.totalCostUsd;
+      totalCompletedFeatures += metrics.completedFeatures;
+      totalAllFeatures += metrics.totalFeatures;
+
+      // Constraint score = blocked + escalations (higher = worse bottleneck)
+      const constraintScore = capacity.blockedCount + metrics.escalationCount;
+      if (constraintScore > topConstraintScore) {
+        topConstraintScore = constraintScore;
+        topConstraintPath = projectPath;
+      }
+
+      perProject.push({
+        projectPath,
+        throughputPerDay: metrics.throughputPerDay,
+        totalCostUsd: metrics.totalCostUsd,
+        successRate: metrics.successRate,
+        blockedCount: capacity.blockedCount,
+        escalationCount: metrics.escalationCount,
+      });
+    }
+
+    const flowEfficiency = totalAllFeatures > 0 ? totalCompletedFeatures / totalAllFeatures : 0;
+
+    let topConstraint: string | null = null;
+    if (topConstraintPath && topConstraintScore > 0) {
+      const slug = topConstraintPath.split('/').at(-1) ?? topConstraintPath;
+      const entry = perProject.find((p) => p.projectPath === topConstraintPath);
+      const detail = entry
+        ? `${entry.blockedCount} blocked, ${entry.escalationCount} escalations`
+        : `${topConstraintScore} issues`;
+      topConstraint = `${slug}: ${detail}`;
+    }
+
+    return {
+      totalThroughputPerDay,
+      totalCostUsd,
+      flowEfficiency,
+      topConstraint,
+      perProject,
+    };
   }
 
   /**

--- a/apps/server/src/services/portfolio-world-state-builder.ts
+++ b/apps/server/src/services/portfolio-world-state-builder.ts
@@ -73,6 +73,7 @@ export interface PortfolioSitrep {
   portfolioMetrics: {
     totalActiveAgents: number;
     globalWipUtilization: number;
+    crossRepoBlockedCount: number;
     portfolioFlowEfficiency: number;
     topConstraint: string | null;
   };
@@ -115,6 +116,7 @@ export class PortfolioWorldStateBuilder {
         portfolioMetrics: {
           totalActiveAgents: 0,
           globalWipUtilization: 0,
+          crossRepoBlockedCount: 0,
           portfolioFlowEfficiency: 0,
           topConstraint: null,
         },
@@ -161,10 +163,12 @@ export class PortfolioWorldStateBuilder {
     });
 
     const totalActiveAgents = projects.reduce((sum, p) => sum + p.activeAgents, 0);
+    const crossRepoBlockedCount = projects.reduce((sum, p) => sum + p.blockedCount, 0);
     const systemMaxConcurrency = this.deriveSystemMaxConcurrency(results);
     const globalWipUtilization =
       systemMaxConcurrency > 0 ? totalActiveAgents / systemMaxConcurrency : 0;
 
+    const portfolioFlowEfficiency = this.computeFlowEfficiency(results);
     const topConstraint = this.deriveTopConstraint(results);
     const pendingHumanDecisions = this.aggregatePendingDecisions(results);
 
@@ -174,7 +178,8 @@ export class PortfolioWorldStateBuilder {
       portfolioMetrics: {
         totalActiveAgents,
         globalWipUtilization,
-        portfolioFlowEfficiency: 0,
+        crossRepoBlockedCount,
+        portfolioFlowEfficiency,
         topConstraint,
       },
       pendingHumanDecisions,
@@ -262,6 +267,24 @@ export class PortfolioWorldStateBuilder {
     const firstBlockedReason = topSitrep.blockedFeatures[0]?.reason;
     const reasonSuffix = firstBlockedReason ? ` — ${firstBlockedReason}` : '';
     return `${maxBlocked} feature${maxBlocked !== 1 ? 's' : ''} blocked in ${slug}${reasonSuffix}`;
+  }
+
+  /**
+   * Flow efficiency = done / total across all projects.
+   * Represents the fraction of work that has been completed (throughput / total work visible).
+   * Returns 0 when no sitrep data is available.
+   */
+  private computeFlowEfficiency(results: FetchResult[]): number {
+    let totalDone = 0;
+    let totalFeatures = 0;
+
+    for (const { sitrep } of results) {
+      if (!sitrep) continue;
+      totalDone += sitrep.board.done;
+      totalFeatures += sitrep.board.total;
+    }
+
+    return totalFeatures > 0 ? totalDone / totalFeatures : 0;
   }
 
   private aggregatePendingDecisions(

--- a/apps/server/tests/unit/services/portfolio-metrics.test.ts
+++ b/apps/server/tests/unit/services/portfolio-metrics.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for MetricsService.getPortfolioMetrics()
+ *
+ * Covers:
+ * - Empty project list returns zero-value metrics
+ * - Single project aggregation
+ * - Multi-project aggregation (throughput sum, cost sum)
+ * - Flow efficiency calculation across projects
+ * - Top constraint identification (project with most blocked + escalations)
+ * - Per-project summary in output
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+import { MetricsService } from '@/services/metrics-service.js';
+import type { Feature } from '@protolabsai/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFeature(overrides: Partial<Feature> = {}): Feature {
+  return {
+    id: `f-${Math.random().toString(36).slice(2, 8)}`,
+    title: 'Test Feature',
+    status: 'backlog',
+    description: '',
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  } as Feature;
+}
+
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MetricsService.getPortfolioMetrics()', () => {
+  let service: MetricsService;
+  const projectPaths = ['/projects/alpha', '/projects/beta'];
+
+  const makeLoader = (featuresByPath: Record<string, Feature[]>) => ({
+    getAll: vi.fn().mockImplementation((path: string) => {
+      return Promise.resolve(featuresByPath[path] ?? []);
+    }),
+  });
+
+  it('returns zero metrics for empty projectPaths[]', async () => {
+    const loader = makeLoader({});
+    service = new MetricsService(loader as never);
+
+    const result = await service.getPortfolioMetrics([]);
+
+    expect(result.totalThroughputPerDay).toBe(0);
+    expect(result.totalCostUsd).toBe(0);
+    expect(result.flowEfficiency).toBe(0);
+    expect(result.topConstraint).toBeNull();
+    expect(result.perProject).toHaveLength(0);
+  });
+
+  it('returns single project metrics when one path provided', async () => {
+    const features = [
+      makeFeature({
+        status: 'done',
+        costUsd: 2.5,
+        createdAt: daysAgo(10),
+        completedAt: daysAgo(1),
+      }),
+      makeFeature({ status: 'backlog' }),
+    ];
+
+    const loader = makeLoader({ '/projects/alpha': features });
+    service = new MetricsService(loader as never);
+
+    const result = await service.getPortfolioMetrics(['/projects/alpha']);
+
+    expect(result.perProject).toHaveLength(1);
+    expect(result.perProject[0].projectPath).toBe('/projects/alpha');
+    expect(result.totalCostUsd).toBeCloseTo(2.5, 1);
+    expect(result.flowEfficiency).toBeGreaterThan(0); // 1 done / 2 total = 0.5
+    expect(result.flowEfficiency).toBeLessThanOrEqual(1);
+  });
+
+  it('sums throughput and cost across multiple projects', async () => {
+    const alpha = [
+      makeFeature({
+        status: 'done',
+        costUsd: 1.0,
+        createdAt: daysAgo(7),
+        completedAt: daysAgo(1),
+      }),
+    ];
+    const beta = [
+      makeFeature({
+        status: 'done',
+        costUsd: 3.0,
+        createdAt: daysAgo(14),
+        completedAt: daysAgo(2),
+      }),
+    ];
+
+    const loader = makeLoader({ '/projects/alpha': alpha, '/projects/beta': beta });
+    service = new MetricsService(loader as never);
+
+    const result = await service.getPortfolioMetrics(projectPaths);
+
+    expect(result.totalCostUsd).toBeCloseTo(4.0, 1);
+    expect(result.perProject).toHaveLength(2);
+  });
+
+  it('calculates flow efficiency as completed / total features across all projects', async () => {
+    const alpha = [
+      makeFeature({ status: 'done', createdAt: daysAgo(5), completedAt: daysAgo(1) }),
+      makeFeature({ status: 'done', createdAt: daysAgo(5), completedAt: daysAgo(1) }),
+      makeFeature({ status: 'backlog' }),
+      makeFeature({ status: 'backlog' }),
+    ];
+    // 2 done / 4 total = 0.5
+
+    const loader = makeLoader({ '/projects/alpha': alpha });
+    service = new MetricsService(loader as never);
+
+    const result = await service.getPortfolioMetrics(['/projects/alpha']);
+
+    // flowEfficiency is based on completedFeatures/totalFeatures
+    expect(result.flowEfficiency).toBeCloseTo(0.5, 1);
+  });
+
+  it('identifies top constraint as project with most blocked + escalated features', async () => {
+    const alpha = [
+      makeFeature({ status: 'blocked', failureCount: 1 }),
+      makeFeature({ status: 'blocked', failureCount: 1 }),
+    ];
+    const beta = [
+      makeFeature({ status: 'blocked', failureCount: 1 }),
+      makeFeature({ status: 'backlog' }),
+    ];
+
+    const loader = makeLoader({ '/projects/alpha': alpha, '/projects/beta': beta });
+    service = new MetricsService(loader as never);
+
+    const result = await service.getPortfolioMetrics(projectPaths);
+
+    // alpha has 2 blocked + 2 escalations = score 4
+    // beta has 1 blocked + 1 escalation = score 2
+    expect(result.topConstraint).toContain('alpha');
+  });
+
+  it('returns null topConstraint when no blocked or escalated features exist', async () => {
+    const features = [makeFeature({ status: 'backlog' }), makeFeature({ status: 'in_progress' })];
+
+    const loader = makeLoader({ '/projects/alpha': features, '/projects/beta': [] });
+    service = new MetricsService(loader as never);
+
+    const result = await service.getPortfolioMetrics(projectPaths);
+
+    expect(result.topConstraint).toBeNull();
+  });
+
+  it('includes per-project blockedCount and escalationCount in perProject summary', async () => {
+    const features = [
+      makeFeature({ status: 'blocked' }),
+      makeFeature({ status: 'blocked', failureCount: 2 }),
+      makeFeature({ status: 'done', createdAt: daysAgo(3), completedAt: daysAgo(1) }),
+    ];
+
+    const loader = makeLoader({ '/projects/alpha': features });
+    service = new MetricsService(loader as never);
+
+    const result = await service.getPortfolioMetrics(['/projects/alpha']);
+
+    const entry = result.perProject.find((p) => p.projectPath === '/projects/alpha');
+    expect(entry).toBeDefined();
+    expect(entry!.blockedCount).toBe(2);
+    expect(entry!.escalationCount).toBeGreaterThan(0); // features with failureCount > 0
+  });
+});

--- a/apps/server/tests/unit/services/portfolio-world-state-builder.test.ts
+++ b/apps/server/tests/unit/services/portfolio-world-state-builder.test.ts
@@ -97,7 +97,10 @@ describe('PortfolioWorldStateBuilder', () => {
   });
 
   it('returns empty portfolio sitrep for zero project paths', async () => {
-    const builder = new PortfolioWorldStateBuilder({ projectPaths: [], automakerBaseUrl: BASE_URL });
+    const builder = new PortfolioWorldStateBuilder({
+      projectPaths: [],
+      automakerBaseUrl: BASE_URL,
+    });
     const result = await builder.aggregate();
 
     expect(result.projects).toHaveLength(0);
@@ -113,11 +116,21 @@ describe('PortfolioWorldStateBuilder', () => {
     fetchMock
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(makeSitrep({ board: { blocked: 3, total: 5, backlog: 0, inProgress: 1, review: 0, done: 1 } })),
+        json: () =>
+          Promise.resolve(
+            makeSitrep({
+              board: { blocked: 3, total: 5, backlog: 0, inProgress: 1, review: 0, done: 1 },
+            })
+          ),
       } as Response)
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(makeSitrep({ board: { blocked: 2, total: 5, backlog: 1, inProgress: 1, review: 0, done: 1 } })),
+        json: () =>
+          Promise.resolve(
+            makeSitrep({
+              board: { blocked: 2, total: 5, backlog: 1, inProgress: 1, review: 0, done: 1 },
+            })
+          ),
       } as Response);
 
     const builder = new PortfolioWorldStateBuilder({
@@ -135,12 +148,22 @@ describe('PortfolioWorldStateBuilder', () => {
     fetchMock
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(makeSitrep({ board: { done: 2, total: 4, backlog: 2, inProgress: 0, review: 0, blocked: 0 } })),
+        json: () =>
+          Promise.resolve(
+            makeSitrep({
+              board: { done: 2, total: 4, backlog: 2, inProgress: 0, review: 0, blocked: 0 },
+            })
+          ),
       } as Response)
       // beta: 2 done / 4 total
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(makeSitrep({ board: { done: 2, total: 4, backlog: 2, inProgress: 0, review: 0, blocked: 0 } })),
+        json: () =>
+          Promise.resolve(
+            makeSitrep({
+              board: { done: 2, total: 4, backlog: 2, inProgress: 0, review: 0, blocked: 0 },
+            })
+          ),
       } as Response);
 
     const builder = new PortfolioWorldStateBuilder({

--- a/apps/server/tests/unit/services/portfolio-world-state-builder.test.ts
+++ b/apps/server/tests/unit/services/portfolio-world-state-builder.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Unit tests for PortfolioWorldStateBuilder
+ *
+ * Covers:
+ * - Empty project list returns zero metrics
+ * - crossRepoBlockedCount is sum of per-project blocked counts
+ * - portfolioFlowEfficiency = done / total across all projects
+ * - Unreachable project marked as red with exhausted error budget
+ * - Health status calculation (green/yellow/red)
+ * - topConstraint identifies project with most blocked features
+ * - pendingHumanDecisions aggregates PR reviews, escalations, and backlog warnings
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+import { PortfolioWorldStateBuilder } from '@/services/portfolio-world-state-builder.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type BoardCounts = {
+  total: number;
+  backlog: number;
+  inProgress: number;
+  review: number;
+  blocked: number;
+  done: number;
+};
+
+function makeSitrep(overrides: {
+  board?: Partial<BoardCounts>;
+  runningCount?: number;
+  maxConcurrency?: number;
+  humanBlockedCount?: number;
+  blocked?: Array<{ id: string; title: string; reason: string; failureCount: number }>;
+  review?: Array<{ id: string; title: string; prNumber?: number; prUrl?: string }>;
+  escalations?: Array<{
+    id: string;
+    title: string;
+    status: string;
+    failureCount: number;
+    reason: string;
+  }>;
+  commitsAhead?: number;
+}) {
+  const board: BoardCounts = {
+    total: 5,
+    backlog: 3,
+    inProgress: 1,
+    review: 0,
+    blocked: 0,
+    done: 1,
+    ...overrides.board,
+  };
+  return {
+    board,
+    autoMode: {
+      running: true,
+      loopRunning: true,
+      runningCount: overrides.runningCount ?? 1,
+      maxConcurrency: overrides.maxConcurrency ?? 5,
+      humanBlockedCount: overrides.humanBlockedCount ?? 0,
+    },
+    blockedFeatures: overrides.blocked ?? [],
+    reviewFeatures: overrides.review ?? [],
+    escalations: overrides.escalations ?? [],
+    stagingDelta: {
+      commitsAhead: overrides.commitsAhead ?? 0,
+      commits: [],
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PortfolioWorldStateBuilder', () => {
+  const BASE_URL = 'http://localhost:3008';
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns empty portfolio sitrep for zero project paths', async () => {
+    const builder = new PortfolioWorldStateBuilder({ projectPaths: [], automakerBaseUrl: BASE_URL });
+    const result = await builder.aggregate();
+
+    expect(result.projects).toHaveLength(0);
+    expect(result.portfolioMetrics.totalActiveAgents).toBe(0);
+    expect(result.portfolioMetrics.crossRepoBlockedCount).toBe(0);
+    expect(result.portfolioMetrics.portfolioFlowEfficiency).toBe(0);
+    expect(result.portfolioMetrics.topConstraint).toBeNull();
+    expect(result.pendingHumanDecisions).toHaveLength(0);
+  });
+
+  it('computes crossRepoBlockedCount as sum of blocked across all projects', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(makeSitrep({ board: { blocked: 3, total: 5, backlog: 0, inProgress: 1, review: 0, done: 1 } })),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(makeSitrep({ board: { blocked: 2, total: 5, backlog: 1, inProgress: 1, review: 0, done: 1 } })),
+      } as Response);
+
+    const builder = new PortfolioWorldStateBuilder({
+      projectPaths: ['/projects/alpha', '/projects/beta'],
+      automakerBaseUrl: BASE_URL,
+    });
+    const result = await builder.aggregate();
+
+    expect(result.portfolioMetrics.crossRepoBlockedCount).toBe(5);
+  });
+
+  it('computes portfolioFlowEfficiency as done / total across all projects', async () => {
+    const fetchMock = vi.mocked(fetch);
+    // alpha: 2 done / 4 total
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(makeSitrep({ board: { done: 2, total: 4, backlog: 2, inProgress: 0, review: 0, blocked: 0 } })),
+      } as Response)
+      // beta: 2 done / 4 total
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(makeSitrep({ board: { done: 2, total: 4, backlog: 2, inProgress: 0, review: 0, blocked: 0 } })),
+      } as Response);
+
+    const builder = new PortfolioWorldStateBuilder({
+      projectPaths: ['/projects/alpha', '/projects/beta'],
+      automakerBaseUrl: BASE_URL,
+    });
+    const result = await builder.aggregate();
+
+    // 4 done / 8 total = 0.5
+    expect(result.portfolioMetrics.portfolioFlowEfficiency).toBeCloseTo(0.5, 2);
+  });
+
+  it('marks unreachable projects as red with exhausted error budget', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('Connection refused'));
+
+    const builder = new PortfolioWorldStateBuilder({
+      projectPaths: ['/projects/alpha'],
+      automakerBaseUrl: BASE_URL,
+    });
+    const result = await builder.aggregate();
+
+    expect(result.projects).toHaveLength(1);
+    expect(result.projects[0].health).toBe('red');
+    expect(result.projects[0].errorBudgetStatus).toBe('exhausted');
+    expect(result.projects[0].activeAgents).toBe(0);
+  });
+
+  it('marks unreachable project as escalation in pendingHumanDecisions', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    const builder = new PortfolioWorldStateBuilder({
+      projectPaths: ['/projects/alpha'],
+      automakerBaseUrl: BASE_URL,
+    });
+    const result = await builder.aggregate();
+
+    const escalation = result.pendingHumanDecisions.find(
+      (d) => d.projectSlug === 'alpha' && d.type === 'escalation'
+    );
+    expect(escalation).toBeDefined();
+    expect(escalation!.description).toContain('Sitrep fetch failed');
+  });
+
+  it('calculates green health for healthy project with active agents', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve(
+          makeSitrep({
+            board: { total: 5, backlog: 2, inProgress: 1, review: 0, blocked: 0, done: 2 },
+            runningCount: 2,
+          })
+        ),
+    } as Response);
+
+    const builder = new PortfolioWorldStateBuilder({
+      projectPaths: ['/projects/alpha'],
+      automakerBaseUrl: BASE_URL,
+    });
+    const result = await builder.aggregate();
+
+    expect(result.projects[0].health).toBe('green');
+  });
+
+  it('calculates red health for project with blocked features', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve(
+          makeSitrep({
+            board: { total: 5, backlog: 2, inProgress: 1, review: 0, blocked: 2, done: 0 },
+            blocked: [
+              { id: 'f1', title: 'Feature 1', reason: 'CI failure', failureCount: 3 },
+              { id: 'f2', title: 'Feature 2', reason: 'Merge conflict', failureCount: 1 },
+            ],
+          })
+        ),
+    } as Response);
+
+    const builder = new PortfolioWorldStateBuilder({
+      projectPaths: ['/projects/alpha'],
+      automakerBaseUrl: BASE_URL,
+    });
+    const result = await builder.aggregate();
+
+    expect(result.projects[0].health).toBe('red');
+    expect(result.projects[0].blockedCount).toBe(2);
+  });
+
+  it('aggregates PR review decisions from all projects', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve(
+          makeSitrep({
+            review: [
+              { id: 'f1', title: 'Add login flow', prNumber: 42 },
+              { id: 'f2', title: 'Fix auth bug', prNumber: 43 },
+            ],
+          })
+        ),
+    } as Response);
+
+    const builder = new PortfolioWorldStateBuilder({
+      projectPaths: ['/projects/alpha'],
+      automakerBaseUrl: BASE_URL,
+    });
+    const result = await builder.aggregate();
+
+    const prDecisions = result.pendingHumanDecisions.filter((d) => d.type === 'pr_review');
+    expect(prDecisions).toHaveLength(2);
+    expect(prDecisions[0].description).toContain('Add login flow');
+    expect(prDecisions[0].description).toContain('#42');
+  });
+
+  it('sums total active agents across all projects', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(makeSitrep({ runningCount: 3 })),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(makeSitrep({ runningCount: 2 })),
+      } as Response);
+
+    const builder = new PortfolioWorldStateBuilder({
+      projectPaths: ['/projects/alpha', '/projects/beta'],
+      automakerBaseUrl: BASE_URL,
+    });
+    const result = await builder.aggregate();
+
+    expect(result.portfolioMetrics.totalActiveAgents).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

Give Ava a single-call view of the entire portfolio and rewire her activation sequence for fleet-first thinking. No changes to per-project execution logic — pure aggregation layer on top of existing machinery.

**Deliverables:**
1. `get_portfolio_sitrep` MCP tool — aggregates get_sitrep across all registered apps, returns unified fleet health
2. `PortfolioWorldStateBuilder` — aggregates per-project PMWorldStateBuilder instances
3. `MetricsService.getPortfolioMetrics(projectPaths[])` — cross-app ...

---
*Recovered automatically by Automaker post-agent hook*