### PR TITLE
bug: FeatureScheduler silently skips features with isEpic=true + epicId set (#3299)

### DIFF
--- a/apps/server/src/routes/features/routes/create.ts
+++ b/apps/server/src/routes/features/routes/create.ts
@@ -63,6 +63,16 @@ export function createCreateHandler(
         return;
       }
 
+      // Reject contradictory epic state: a feature cannot be both an epic container and a child
+      if (feature.isEpic && feature.epicId) {
+        res.status(400).json({
+          success: false,
+          error:
+            'A feature cannot be both an epic (isEpic: true) and a member of another epic (epicId set). Set either isEpic or epicId, not both.',
+        });
+        return;
+      }
+
       // Check for duplicate title if title is provided
       if (feature.title && feature.title.trim()) {
         const duplicate = await featureLoader.findDuplicateTitle(projectPath, feature.title);

--- a/apps/server/src/routes/features/routes/update.ts
+++ b/apps/server/src/routes/features/routes/update.ts
@@ -86,6 +86,20 @@ export function createUpdateHandler(
       const previousStatus = currentFeature?.status as FeatureStatus | undefined;
       const newStatus = updates.status as FeatureStatus | undefined;
 
+      // Reject contradictory epic state: check effective state after applying the update
+      const effectiveIsEpic =
+        updates.isEpic !== undefined ? updates.isEpic : currentFeature?.isEpic;
+      const effectiveEpicId =
+        updates.epicId !== undefined ? updates.epicId : currentFeature?.epicId;
+      if (effectiveIsEpic && effectiveEpicId) {
+        res.status(400).json({
+          success: false,
+          error:
+            'A feature cannot be both an epic (isEpic: true) and a member of another epic (epicId set). Set either isEpic or epicId, not both.',
+        });
+        return;
+      }
+
       // Authority system policy check: gate status changes when enabled
       if (newStatus && previousStatus !== newStatus && settingsService && authorityService) {
         try {

--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -1202,9 +1202,17 @@ export class FeatureScheduler {
 
         if (isEligibleStatus) {
           if (feature.isEpic) {
-            logger.info(
-              `[loadPendingFeatures] Skipping epic feature ${feature.id} - ${feature.title}`
-            );
+            if (feature.epicId) {
+              // Contradictory state: a feature cannot be both an epic container and a child of
+              // another epic. This was likely caused by a direct write bypassing API validation.
+              logger.warn(
+                `[loadPendingFeatures] Feature ${feature.id} ("${feature.title}") is marked as an epic but also has a parent epic assigned (epicId: ${feature.epicId}) — it will not be scheduled. Fix the feature configuration to proceed.`
+              );
+            } else {
+              logger.info(
+                `[loadPendingFeatures] Skipping epic feature ${feature.id} - ${feature.title}`
+              );
+            }
             continue;
           }
 

--- a/apps/server/tests/unit/routes/features-epic-validation.test.ts
+++ b/apps/server/tests/unit/routes/features-epic-validation.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Unit tests for feature create/update routes — epic invariant enforcement
+ *
+ * Covers:
+ * - POST /features/create returns 400 when isEpic: true and epicId both present
+ * - POST /features/update returns 400 when the resulting state would have isEpic: true and epicId
+ * - Valid payloads (epic without epicId, child with epicId but not isEpic) are not rejected
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response } from 'express';
+import { createMockExpressContext } from '../../utils/mocks.js';
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+// QuarantineService is instantiated inside createCreateHandler.
+// We mock it so the handler can proceed past the quarantine step.
+vi.mock('@/services/quarantine-service.js', () => ({
+  QuarantineService: vi.fn().mockImplementation(() => ({
+    process: vi.fn().mockResolvedValue({
+      approved: true,
+      sanitizedTitle: 'Test Title',
+      sanitizedDescription: 'Test Description',
+      entry: { id: 'q-1', result: 'approved', stage: 'passed', violations: [] },
+    }),
+  })),
+}));
+
+import { createCreateHandler } from '@/routes/features/routes/create.js';
+import { createUpdateHandler } from '@/routes/features/routes/update.js';
+
+function createMockFeatureLoader() {
+  return {
+    get: vi.fn(),
+    getAll: vi.fn(),
+    update: vi.fn().mockResolvedValue({ id: 'feat-1', title: 'Test', status: 'backlog' }),
+    create: vi.fn().mockResolvedValue({ id: 'feat-1', title: 'Test', status: 'backlog' }),
+    findDuplicateTitle: vi.fn().mockResolvedValue(null),
+  };
+}
+
+function createMockTrustTierService() {
+  return {
+    classifyTrust: vi.fn().mockReturnValue(1),
+  };
+}
+
+// Shared error message fragment for the epic invariant rejection
+const EPIC_INVARIANT_ERROR = 'cannot be both an epic';
+
+describe('POST /features/create — epic invariant', () => {
+  let mockFeatureLoader: ReturnType<typeof createMockFeatureLoader>;
+  let mockTrustTierService: ReturnType<typeof createMockTrustTierService>;
+  let req: Request;
+  let res: Response;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFeatureLoader = createMockFeatureLoader();
+    mockTrustTierService = createMockTrustTierService();
+    const ctx = createMockExpressContext();
+    req = ctx.req;
+    res = ctx.res;
+  });
+
+  it('returns 400 when feature has isEpic: true and epicId set (contradictory state)', async () => {
+    req.body = {
+      projectPath: '/test/project',
+      feature: {
+        description: 'A feature that is both an epic and a child',
+        isEpic: true,
+        epicId: 'parent-epic-123',
+      },
+    };
+
+    const handler = createCreateHandler(
+      mockFeatureLoader as any,
+      mockTrustTierService as any
+    );
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: expect.stringContaining(EPIC_INVARIANT_ERROR),
+      })
+    );
+
+    // Feature must not be created
+    expect(mockFeatureLoader.create).not.toHaveBeenCalled();
+  });
+
+  it('does NOT reject a valid epic container (isEpic: true, no epicId)', async () => {
+    req.body = {
+      projectPath: '/test/project',
+      feature: {
+        description: 'A proper epic container',
+        isEpic: true,
+        // epicId intentionally absent — valid state
+      },
+    };
+
+    const handler = createCreateHandler(
+      mockFeatureLoader as any,
+      mockTrustTierService as any
+    );
+    await handler(req, res);
+
+    // The epic invariant check must not fire
+    expect(res.json).not.toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining(EPIC_INVARIANT_ERROR) })
+    );
+    expect(res.status).not.toHaveBeenCalledWith(400);
+  });
+
+  it('does NOT reject a valid child feature (epicId set, isEpic absent/false)', async () => {
+    req.body = {
+      projectPath: '/test/project',
+      feature: {
+        description: 'A child feature in an epic',
+        isEpic: false,
+        epicId: 'parent-epic-123',
+      },
+    };
+
+    const handler = createCreateHandler(
+      mockFeatureLoader as any,
+      mockTrustTierService as any
+    );
+    await handler(req, res);
+
+    // The epic invariant check must not fire
+    expect(res.json).not.toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining(EPIC_INVARIANT_ERROR) })
+    );
+    expect(res.status).not.toHaveBeenCalledWith(400);
+  });
+});
+
+describe('POST /features/update — epic invariant', () => {
+  let mockFeatureLoader: ReturnType<typeof createMockFeatureLoader>;
+  let req: Request;
+  let res: Response;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFeatureLoader = createMockFeatureLoader();
+    const ctx = createMockExpressContext();
+    req = ctx.req;
+    res = ctx.res;
+  });
+
+  it('returns 400 when update adds epicId to an existing epic container', async () => {
+    // Existing feature is an epic container (isEpic: true)
+    mockFeatureLoader.get.mockResolvedValue({
+      id: 'feat-1',
+      title: 'Existing Epic',
+      status: 'backlog',
+      isEpic: true,
+    });
+
+    req.body = {
+      projectPath: '/test/project',
+      featureId: 'feat-1',
+      // Adding epicId to a feature that is already isEpic: true → contradiction
+      updates: { epicId: 'parent-epic-123' },
+    };
+
+    const handler = createUpdateHandler(mockFeatureLoader as any);
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: expect.stringContaining(EPIC_INVARIANT_ERROR),
+      })
+    );
+    expect(mockFeatureLoader.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when update sets isEpic: true on a feature that already has epicId', async () => {
+    // Existing feature is a child of an epic
+    mockFeatureLoader.get.mockResolvedValue({
+      id: 'feat-1',
+      title: 'Existing Child Feature',
+      status: 'backlog',
+      isEpic: false,
+      epicId: 'parent-epic-123',
+    });
+
+    req.body = {
+      projectPath: '/test/project',
+      featureId: 'feat-1',
+      // Trying to promote to epic while epicId is still set → contradiction
+      updates: { isEpic: true },
+    };
+
+    const handler = createUpdateHandler(mockFeatureLoader as any);
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: expect.stringContaining(EPIC_INVARIANT_ERROR),
+      })
+    );
+    expect(mockFeatureLoader.update).not.toHaveBeenCalled();
+  });
+
+  it('does NOT reject an update that adds epicId to a regular (non-epic) feature', async () => {
+    mockFeatureLoader.get.mockResolvedValue({
+      id: 'feat-1',
+      title: 'Regular Feature',
+      status: 'backlog',
+      isEpic: false,
+    });
+
+    req.body = {
+      projectPath: '/test/project',
+      featureId: 'feat-1',
+      updates: { epicId: 'parent-epic-123' },
+    };
+
+    const handler = createUpdateHandler(mockFeatureLoader as any);
+    await handler(req, res);
+
+    expect(res.json).not.toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining(EPIC_INVARIANT_ERROR) })
+    );
+    expect(res.status).not.toHaveBeenCalledWith(400);
+    expect(mockFeatureLoader.update).toHaveBeenCalled();
+  });
+
+  it('does NOT reject an update that resolves the contradiction by setting isEpic: false', async () => {
+    // Feature is in contradictory state (legacy migration gap)
+    mockFeatureLoader.get.mockResolvedValue({
+      id: 'feat-1',
+      title: 'Contradictory Feature',
+      status: 'backlog',
+      isEpic: true,
+      epicId: 'parent-epic-123',
+    });
+
+    req.body = {
+      projectPath: '/test/project',
+      featureId: 'feat-1',
+      // Setting isEpic: false resolves the contradiction — effective state: not epic, has epicId
+      updates: { isEpic: false },
+    };
+
+    const handler = createUpdateHandler(mockFeatureLoader as any);
+    await handler(req, res);
+
+    // effectiveIsEpic = false, effectiveEpicId = 'parent-epic-123' → valid (child feature)
+    expect(res.json).not.toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining(EPIC_INVARIANT_ERROR) })
+    );
+    expect(res.status).not.toHaveBeenCalledWith(400);
+    expect(mockFeatureLoader.update).toHaveBeenCalled();
+  });
+});

--- a/apps/server/tests/unit/routes/features-epic-validation.test.ts
+++ b/apps/server/tests/unit/routes/features-epic-validation.test.ts
@@ -80,10 +80,7 @@ describe('POST /features/create — epic invariant', () => {
       },
     };
 
-    const handler = createCreateHandler(
-      mockFeatureLoader as any,
-      mockTrustTierService as any
-    );
+    const handler = createCreateHandler(mockFeatureLoader as any, mockTrustTierService as any);
     await handler(req, res);
 
     expect(res.status).toHaveBeenCalledWith(400);
@@ -108,10 +105,7 @@ describe('POST /features/create — epic invariant', () => {
       },
     };
 
-    const handler = createCreateHandler(
-      mockFeatureLoader as any,
-      mockTrustTierService as any
-    );
+    const handler = createCreateHandler(mockFeatureLoader as any, mockTrustTierService as any);
     await handler(req, res);
 
     // The epic invariant check must not fire
@@ -131,10 +125,7 @@ describe('POST /features/create — epic invariant', () => {
       },
     };
 
-    const handler = createCreateHandler(
-      mockFeatureLoader as any,
-      mockTrustTierService as any
-    );
+    const handler = createCreateHandler(mockFeatureLoader as any, mockTrustTierService as any);
     await handler(req, res);
 
     // The epic invariant check must not fire

--- a/apps/server/tests/unit/services/feature-scheduler-epic-contradiction.test.ts
+++ b/apps/server/tests/unit/services/feature-scheduler-epic-contradiction.test.ts
@@ -190,12 +190,8 @@ describe('feature-scheduler.ts — loadPendingFeatures epic contradiction', () =
     expect(mockWarn).toHaveBeenCalledWith(
       expect.stringContaining('Fix the feature configuration to proceed')
     );
-    expect(mockWarn).toHaveBeenCalledWith(
-      expect.stringContaining('feat-contradiction-1')
-    );
-    expect(mockWarn).toHaveBeenCalledWith(
-      expect.stringContaining('parent-epic-123')
-    );
+    expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining('feat-contradiction-1'));
+    expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining('parent-epic-123'));
   });
 
   it('emits info-level log (not warn) for a normal epic container without epicId', async () => {

--- a/apps/server/tests/unit/services/feature-scheduler-epic-contradiction.test.ts
+++ b/apps/server/tests/unit/services/feature-scheduler-epic-contradiction.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Unit tests for FeatureScheduler — contradictory epic state handling
+ *
+ * Covers:
+ * - loadPendingFeatures emits warn for features with isEpic: true AND epicId set
+ * - Normal epic features (isEpic: true, no epicId) emit info, not warn
+ * - Contradictory features are skipped (not scheduled)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Feature } from '@protolabsai/types';
+
+// vi.mock() is hoisted to the top of the file before variable declarations.
+// Use vi.hoisted() to define stable references that are available inside the factory.
+const { mockWarn, mockInfo, mockDebug, mockError } = vi.hoisted(() => ({
+  mockWarn: vi.fn(),
+  mockInfo: vi.fn(),
+  mockDebug: vi.fn(),
+  mockError: vi.fn(),
+}));
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: vi.fn(() => ({
+    info: mockInfo,
+    debug: mockDebug,
+    warn: mockWarn,
+    error: mockError,
+  })),
+  readJsonWithRecovery: vi.fn(),
+  logRecoveryWarning: vi.fn(),
+  DEFAULT_BACKUP_COUNT: 3,
+  classifyError: vi.fn((err: unknown) => ({
+    type: 'unknown',
+    message: String(err),
+    isRateLimit: false,
+    isCancellation: false,
+  })),
+}));
+
+vi.mock('@/lib/secure-fs.js', () => ({
+  readdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  stat: vi.fn(),
+}));
+
+vi.mock('@protolabsai/platform', () => ({
+  getFeaturesDir: vi.fn((projectPath: string) => `${projectPath}/.automaker/features`),
+}));
+
+vi.mock('@protolabsai/dependency-resolver', () => ({
+  resolveDependencies: vi.fn(),
+  areDependenciesSatisfied: vi.fn(),
+}));
+
+vi.mock('@protolabsai/types', async () => {
+  const actual = await vi.importActual('@protolabsai/types');
+  return {
+    ...actual,
+    DEFAULT_MAX_CONCURRENCY: 1,
+    MAX_SYSTEM_CONCURRENCY: 10,
+    normalizeFeatureStatus: vi.fn((s: string) => s),
+  };
+});
+
+vi.mock('@/lib/worktree-lock.js', () => ({
+  isWorktreeLocked: vi.fn(),
+}));
+
+vi.mock('@/lib/settings-helpers.js', () => ({
+  getEffectivePrBaseBranch: vi.fn().mockResolvedValue('dev'),
+}));
+
+vi.mock('@/config/timeouts.js', () => ({
+  SLEEP_INTERVAL_CAPACITY_MS: 5000,
+  SLEEP_INTERVAL_IDLE_MS: 30000,
+  SLEEP_INTERVAL_NORMAL_MS: 2000,
+  SLEEP_INTERVAL_ERROR_MS: 10000,
+}));
+
+import { FeatureScheduler } from '@/services/feature-scheduler.js';
+import * as secureFs from '@/lib/secure-fs.js';
+import { readJsonWithRecovery } from '@protolabsai/utils';
+import type { SchedulerCallbacks, PipelineRunner } from '@/services/feature-scheduler.js';
+
+function createMockFeatureLoader() {
+  return {
+    get: vi.fn(),
+    getAll: vi.fn(),
+    update: vi.fn().mockResolvedValue({}),
+    create: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function createMockSettingsService() {
+  return {
+    getGlobalSettings: vi.fn().mockResolvedValue({}),
+    getProjectSettings: vi.fn().mockResolvedValue({
+      workflow: { maxPendingReviews: 5, autoDecayTimeoutMinutes: 30 },
+    }),
+  };
+}
+
+function createMockCallbacks(): SchedulerCallbacks {
+  return {
+    getRunningCountForWorktree: vi.fn().mockResolvedValue(0),
+    getGlobalRunningCount: vi.fn().mockReturnValue(0),
+    canProjectAcquireGlobalSlot: vi.fn().mockResolvedValue(true),
+    hasInProgressFeatures: vi.fn().mockResolvedValue(false),
+    isFeatureRunning: vi.fn().mockReturnValue(false),
+    getRunningFeatureIds: vi.fn().mockReturnValue([]),
+    isFeatureActiveInPipeline: vi.fn().mockReturnValue(false),
+    isFeatureFinished: vi.fn().mockReturnValue(false),
+    emitAutoModeEvent: vi.fn(),
+    getHeapUsagePercent: vi.fn().mockReturnValue(0.5),
+    getMostRecentRunningFeature: vi.fn().mockReturnValue(null),
+    recordSuccessForProject: vi.fn(),
+    trackFailureAndCheckPauseForProject: vi.fn().mockReturnValue(false),
+    signalShouldPauseForProject: vi.fn(),
+    sleep: vi.fn().mockResolvedValue(undefined),
+    HEAP_USAGE_STOP_NEW_AGENTS_THRESHOLD: 0.8,
+    HEAP_USAGE_ABORT_AGENTS_THRESHOLD: 0.9,
+  };
+}
+
+function createMockRunner(): PipelineRunner {
+  return {
+    run: vi.fn().mockResolvedValue({ outcome: 'completed' }),
+  };
+}
+
+function mockFeatureDirectories(featureIds: string[]) {
+  (secureFs.readdir as ReturnType<typeof vi.fn>).mockResolvedValue(
+    featureIds.map((id) => ({
+      name: id,
+      isDirectory: () => true,
+    }))
+  );
+}
+
+function mockFeatureJsonReads(features: Record<string, Partial<Feature> | null>) {
+  (readJsonWithRecovery as ReturnType<typeof vi.fn>).mockImplementation((filePath: string) => {
+    const parts = filePath.split('/');
+    const featureIdx = parts.indexOf('features');
+    const featureId = featureIdx >= 0 ? parts[featureIdx + 1] : undefined;
+    const data = featureId ? (features[featureId] ?? null) : null;
+    return Promise.resolve({ data, recovered: false, source: 'primary' });
+  });
+}
+
+describe('feature-scheduler.ts — loadPendingFeatures epic contradiction', () => {
+  let scheduler: FeatureScheduler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    scheduler = new FeatureScheduler({
+      featureLoader: createMockFeatureLoader() as any,
+      settingsService: createMockSettingsService() as any,
+      events: {
+        emit: vi.fn(),
+        on: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+        subscribe: vi.fn(),
+      } as any,
+      runner: createMockRunner(),
+      callbacks: createMockCallbacks(),
+    });
+  });
+
+  it('emits warn-level log when feature has both isEpic and epicId set (contradictory state)', async () => {
+    const contradictoryFeature: Partial<Feature> = {
+      id: 'feat-contradiction-1',
+      title: 'Contradictory Epic Feature',
+      description: 'A feature that is incorrectly both an epic and a child of another epic',
+      status: 'backlog',
+      isEpic: true,
+      epicId: 'parent-epic-123',
+    };
+
+    mockFeatureDirectories(['feat-contradiction-1']);
+    mockFeatureJsonReads({ 'feat-contradiction-1': contradictoryFeature });
+
+    const result = await (scheduler as any).loadPendingFeatures('/test/project');
+
+    // The contradictory feature must not be scheduled
+    expect(result).toHaveLength(0);
+
+    // Warn should be emitted with an actionable message
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Fix the feature configuration to proceed')
+    );
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringContaining('feat-contradiction-1')
+    );
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringContaining('parent-epic-123')
+    );
+  });
+
+  it('emits info-level log (not warn) for a normal epic container without epicId', async () => {
+    const epicFeature: Partial<Feature> = {
+      id: 'feat-normal-epic-1',
+      title: 'Normal Epic Container',
+      description: 'A proper epic container with no parent',
+      status: 'backlog',
+      isEpic: true,
+      // epicId intentionally absent
+    };
+
+    mockFeatureDirectories(['feat-normal-epic-1']);
+    mockFeatureJsonReads({ 'feat-normal-epic-1': epicFeature });
+
+    const result = await (scheduler as any).loadPendingFeatures('/test/project');
+
+    // Normal epics are also skipped
+    expect(result).toHaveLength(0);
+
+    // Warn must NOT be called for a normal epic
+    expect(mockWarn).not.toHaveBeenCalledWith(
+      expect.stringContaining('Fix the feature configuration to proceed')
+    );
+
+    // Info should be called instead
+    expect(mockInfo).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping epic feature feat-normal-epic-1')
+    );
+  });
+});


### PR DESCRIPTION
## Summary

**Source:** protoLabsAI/protoMaker#3299 — @mabry1985 (trust tier: 1)

## Bug Summary

`FeatureScheduler.loadPendingFeatures` silently skips any feature where `isEpic: true` AND `epicId` is set. This is a contradictory state (a feature cannot simultaneously be an epic header and a child of another epic), but the API currently accepts it without complaint, leaving features permanently stuck in backlog with no user-facing signal.

**Logged output (actual):** `[loadPendingFeatures] Skipping epic fea...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Features can no longer be configured as both an epic container and simultaneously assigned to a parent epic. Validation now prevents this contradictory state during feature creation, updates, and scheduling operations, ensuring data integrity.

* **Tests**
  * Added comprehensive unit tests validating epic state invariants and error handling across feature creation and update workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->