### PR TITLE
[P2] Registry Unification

### DIFF
--- a/apps/server/src/routes/registry/index.ts
+++ b/apps/server/src/routes/registry/index.ts
@@ -8,7 +8,10 @@
 import { Router, type Request, type Response } from 'express';
 import { randomUUID } from 'node:crypto';
 import { createLogger } from '@protolabsai/utils';
-import { getProjectRegistryService, type RegistryProject } from '../../services/project-registry-service.js';
+import {
+  getProjectRegistryService,
+  type RegistryProject,
+} from '../../services/project-registry-service.js';
 import { SettingsService } from '../../services/settings-service.js';
 import type { ProjectRef } from '../../types/settings.js';
 

--- a/apps/server/src/routes/registry/index.ts
+++ b/apps/server/src/routes/registry/index.ts
@@ -1,0 +1,147 @@
+/**
+ * Registry routes — fleet-wide project registry via Workstacean
+ *
+ * GET  /api/registry/projects — return the authoritative project registry
+ * POST /api/registry/sync     — reconcile settings.projects[] with registry
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { randomUUID } from 'node:crypto';
+import { createLogger } from '@protolabsai/utils';
+import { getProjectRegistryService, type RegistryProject } from '../../services/project-registry-service.js';
+import { SettingsService } from '../../services/settings-service.js';
+import type { ProjectRef } from '../../types/settings.js';
+
+const logger = createLogger('Registry:Routes');
+
+export function createRegistryRoutes(settingsService: SettingsService): Router {
+  const router = Router();
+
+  /**
+   * GET /api/registry/projects
+   *
+   * Returns the project registry from Workstacean (with local fallback).
+   * Query params:
+   *   projectPath (required) — used to locate the local snapshot for fallback
+   */
+  router.get('/projects', async (req: Request, res: Response) => {
+    const { projectPath } = req.query as Record<string, string>;
+    if (!projectPath) {
+      res.status(400).json({ success: false, error: 'projectPath query param is required' });
+      return;
+    }
+
+    try {
+      const registryService = getProjectRegistryService();
+      const result = await registryService.getProjects(projectPath);
+      res.json({
+        success: true,
+        source: result.source,
+        count: result.projects.length,
+        projects: result.projects,
+      });
+    } catch (err) {
+      logger.error('Failed to fetch registry projects', err);
+      res.status(500).json({
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+
+  /**
+   * POST /api/registry/sync
+   *
+   * Reconcile settings.projects[] with the Workstacean registry.
+   *
+   * Body:
+   *   projectPath (required) — used to locate the local snapshot for fallback
+   *   dryRun (optional, default true) — when false, applies changes to settings
+   *
+   * Returns:
+   *   added     — registry projects added to settings.projects[]
+   *   orphaned  — settings.projects[] entries not found in registry
+   *   unchanged — projects already in sync
+   *   source    — where the registry data came from
+   */
+  router.post('/sync', async (req: Request, res: Response) => {
+    const { projectPath, dryRun = true } = req.body as {
+      projectPath?: string;
+      dryRun?: boolean;
+    };
+
+    if (!projectPath) {
+      res.status(400).json({ success: false, error: 'projectPath is required' });
+      return;
+    }
+
+    try {
+      const registryService = getProjectRegistryService();
+      const { projects: registryProjects, source } = await registryService.getProjects(projectPath);
+
+      const settings = await settingsService.getGlobalSettings();
+      const currentRefs: ProjectRef[] = settings.projects ?? [];
+
+      // Build lookup maps
+      const refsByPath = new Map<string, ProjectRef>(currentRefs.map((r) => [r.path, r]));
+      const registryByPath = new Map<string, RegistryProject>(
+        registryProjects.map((p) => [p.projectPath, p])
+      );
+
+      // Find registry projects missing from settings
+      const added: Array<{ slug: string; title: string; path: string }> = [];
+      const refsToAdd: ProjectRef[] = [];
+
+      for (const project of registryProjects) {
+        if (!project.projectPath) continue;
+        if (refsByPath.has(project.projectPath)) continue;
+
+        const newRef: ProjectRef = {
+          id: randomUUID(),
+          name: project.title,
+          path: project.projectPath,
+        };
+        added.push({ slug: project.slug, title: project.title, path: project.projectPath });
+        refsToAdd.push(newRef);
+      }
+
+      // Find settings entries not in registry (orphaned)
+      const orphaned: Array<{ id: string; name: string; path: string }> = [];
+      for (const ref of currentRefs) {
+        if (!registryByPath.has(ref.path)) {
+          orphaned.push({ id: ref.id, name: ref.name, path: ref.path });
+        }
+      }
+
+      const unchanged = currentRefs.length - orphaned.length;
+
+      // Apply changes unless dry run
+      if (!dryRun && refsToAdd.length > 0) {
+        const updatedProjects = [...currentRefs, ...refsToAdd];
+        await settingsService.updateGlobalSettings({ projects: updatedProjects });
+        logger.info(`sync_registry: added ${refsToAdd.length} project(s) to settings.projects[]`);
+      }
+
+      res.json({
+        success: true,
+        dryRun,
+        source,
+        summary: {
+          added: added.length,
+          orphaned: orphaned.length,
+          unchanged,
+        },
+        added,
+        orphaned,
+      });
+    } catch (err) {
+      logger.error('Failed to sync registry', err);
+      res.status(500).json({
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -94,6 +94,7 @@ import { createOpsRoutes } from '../routes/ops/index.js';
 import { createQaRoutes } from '../routes/qa/index.js';
 import { createContextEngineRoutes } from '../routes/context-engine.js';
 import { createA2ARoutes, createA2AHandlerRoutes } from '../routes/a2a/index.js';
+import { createRegistryRoutes } from '../routes/registry/index.js';
 import { PlanningService } from '../services/planning-service.js';
 
 const logger = createLogger('Server:Routes');
@@ -413,6 +414,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api/todos', createTodoRoutes(todoService));
   app.use('/api/sitrep', createSitrepRoutes({ featureLoader, autoModeService, repoRoot }));
   app.use('/api/portfolio/sitrep', createPortfolioSitrepRoutes({ settingsService }));
+  app.use('/api/registry', createRegistryRoutes(settingsService));
   // Knowledge store routes (chunked retrieval)
   if (knowledgeStoreService) {
     app.use('/api/knowledge', createKnowledgeRoutes(knowledgeStoreService));

--- a/apps/server/src/services/project-registry-service.ts
+++ b/apps/server/src/services/project-registry-service.ts
@@ -145,7 +145,9 @@ export class ProjectRegistryService {
 
     const body = (await res.json()) as WorkstaceanProjectsResponse;
     if (!body.success || !Array.isArray(body.data)) {
-      throw new Error(`Unexpected Workstacean response shape: ${JSON.stringify(body).slice(0, 200)}`);
+      throw new Error(
+        `Unexpected Workstacean response shape: ${JSON.stringify(body).slice(0, 200)}`
+      );
     }
 
     logger.info(`Loaded ${body.data.length} projects from Workstacean`);

--- a/apps/server/src/services/project-registry-service.ts
+++ b/apps/server/src/services/project-registry-service.ts
@@ -1,0 +1,209 @@
+/**
+ * ProjectRegistryService
+ *
+ * Single source of truth for the org-wide project registry.
+ * Reads from Workstacean GET /api/projects (authoritative), with fallback
+ * to a locally cached workspace/projects.yaml snapshot when Workstacean is
+ * unreachable.
+ *
+ * Used by:
+ * - /api/registry/sync (reconcile settings.projects[] with registry)
+ * - ava-cron-tasks stale PR check (replaces direct YAML parsing)
+ * - Future: any service that needs fleet-wide project metadata
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import { createLogger } from '@protolabsai/utils';
+
+const logger = createLogger('ProjectRegistryService');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RegistryProjectDiscord {
+  [channel: string]: string | undefined;
+}
+
+export interface RegistryProjectWebhooks {
+  [name: string]: string | undefined;
+}
+
+export interface RegistryProjectCapacity {
+  priorityWeight: number;
+  minConcurrency: number;
+  maxConcurrency: number;
+}
+
+/** Full project entry as defined in projects.yaml / Workstacean registry */
+export interface RegistryProject {
+  slug: string;
+  title: string;
+  team?: string;
+  github?: string;
+  defaultBranch?: string;
+  status: 'active' | 'archived' | 'suspended';
+  onboardedAt?: string;
+  planeProjectId?: string;
+  planeIdentifier?: string;
+  projectPath: string;
+  /** URL of the Studio (automaker) server managing this project, e.g. http://localhost:3008 */
+  studioUrl?: string;
+  agents?: string[];
+  discord?: RegistryProjectDiscord;
+  webhooks?: RegistryProjectWebhooks;
+  infisical?: {
+    projectId: string;
+  };
+  observability?: {
+    langfuseProjectId: string;
+  };
+  googleWorkspace?: {
+    driveFolderId: string;
+    sharedDocId: string;
+  };
+  capacity?: RegistryProjectCapacity;
+}
+
+interface WorkstaceanProjectsResponse {
+  success: boolean;
+  data: RegistryProject[];
+}
+
+interface LocalProjectsYaml {
+  projects?: RegistryProject[];
+}
+
+// ---------------------------------------------------------------------------
+// ProjectRegistryService
+// ---------------------------------------------------------------------------
+
+export class ProjectRegistryService {
+  private readonly workstaceanUrl: string;
+  private readonly workstaceanApiKey: string;
+
+  constructor() {
+    this.workstaceanUrl = process.env['WORKSTACEAN_URL'] ?? 'http://workstacean:3000';
+    this.workstaceanApiKey = process.env['WORKSTACEAN_API_KEY'] ?? '';
+  }
+
+  /**
+   * Fetch the project registry, preferring Workstacean with local YAML fallback.
+   *
+   * @param projectPath - The current Studio projectPath, used to locate
+   *                      workspace/projects.yaml for fallback.
+   * @param useLocalFallback - When true (default), falls back to local YAML if
+   *                           Workstacean is unreachable.
+   */
+  async getProjects(
+    projectPath: string,
+    useLocalFallback = true
+  ): Promise<{ projects: RegistryProject[]; source: 'workstacean' | 'local-cache' }> {
+    // Try Workstacean first
+    try {
+      const projects = await this.fetchFromWorkstacean();
+      // Persist snapshot for future fallback
+      if (useLocalFallback) {
+        await this.saveLocalSnapshot(projectPath, projects).catch((err) => {
+          logger.warn('Failed to persist registry snapshot:', err);
+        });
+      }
+      return { projects, source: 'workstacean' };
+    } catch (err) {
+      logger.warn('Workstacean unreachable, falling back to local snapshot:', err);
+    }
+
+    if (!useLocalFallback) {
+      throw new Error('Workstacean unreachable and local fallback disabled');
+    }
+
+    // Fall back to local cache
+    const localProjects = await this.loadLocalSnapshot(projectPath);
+    return { projects: localProjects, source: 'local-cache' };
+  }
+
+  /**
+   * Fetch projects from Workstacean HTTP API.
+   * Throws on network error or non-OK response.
+   */
+  private async fetchFromWorkstacean(): Promise<RegistryProject[]> {
+    const url = `${this.workstaceanUrl}/api/projects`;
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+    };
+    if (this.workstaceanApiKey) {
+      headers['X-API-Key'] = this.workstaceanApiKey;
+    }
+
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(5_000) });
+    if (!res.ok) {
+      throw new Error(`Workstacean /api/projects returned ${res.status}: ${await res.text()}`);
+    }
+
+    const body = (await res.json()) as WorkstaceanProjectsResponse;
+    if (!body.success || !Array.isArray(body.data)) {
+      throw new Error(`Unexpected Workstacean response shape: ${JSON.stringify(body).slice(0, 200)}`);
+    }
+
+    logger.info(`Loaded ${body.data.length} projects from Workstacean`);
+    return body.data;
+  }
+
+  /**
+   * Read local workspace/projects.yaml as a fallback snapshot.
+   */
+  private async loadLocalSnapshot(projectPath: string): Promise<RegistryProject[]> {
+    const yamlPath = join(projectPath, 'workspace', 'projects.yaml');
+    if (!existsSync(yamlPath)) {
+      logger.warn('No local workspace/projects.yaml found');
+      return [];
+    }
+
+    const raw = await readFile(yamlPath, 'utf-8');
+    const parsed = parseYaml(raw) as LocalProjectsYaml;
+    const projects = parsed.projects ?? [];
+    logger.info(`Loaded ${projects.length} projects from local workspace/projects.yaml`);
+    return projects;
+  }
+
+  /**
+   * Persist a snapshot of the registry to workspace/projects.yaml.
+   * Called after each successful Workstacean fetch to keep the cache fresh.
+   */
+  private async saveLocalSnapshot(projectPath: string, projects: RegistryProject[]): Promise<void> {
+    const yamlPath = join(projectPath, 'workspace', 'projects.yaml');
+    const yamlDir = dirname(yamlPath);
+    if (!existsSync(yamlDir)) {
+      await mkdir(yamlDir, { recursive: true });
+    }
+
+    const header = [
+      '# workspace/projects.yaml — protoLabs Studio Project Routing Index',
+      '#',
+      '# AUTO-GENERATED SNAPSHOT — Do not edit manually.',
+      '# This file is refreshed from the Workstacean registry (GET /api/projects).',
+      '# Edit the authoritative source: protoWorkstacean/workspace/projects.yaml',
+      '#',
+    ].join('\n');
+
+    const content = `${header}\n${stringifyYaml({ projects })}`;
+    await writeFile(yamlPath, content, 'utf-8');
+    logger.debug(`Saved registry snapshot (${projects.length} projects) to ${yamlPath}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton export
+// ---------------------------------------------------------------------------
+
+let _instance: ProjectRegistryService | null = null;
+
+export function getProjectRegistryService(): ProjectRegistryService {
+  if (!_instance) {
+    _instance = new ProjectRegistryService();
+  }
+  return _instance;
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -779,6 +779,12 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         projectSlug: args.projectSlug,
       });
 
+    case 'sync_registry':
+      return apiCall('/registry/sync', {
+        projectPath: args.projectPath,
+        dryRun: args.dryRun !== false, // default true
+      });
+
     case 'get_portfolio_sitrep':
       return apiCall(
         '/portfolio/sitrep',

--- a/packages/mcp-server/src/tools/portfolio-tools.ts
+++ b/packages/mcp-server/src/tools/portfolio-tools.ts
@@ -6,6 +6,32 @@ import { Tool } from '@modelcontextprotocol/sdk/types.js';
 
 export const portfolioTools: Tool[] = [
   {
+    name: 'sync_registry',
+    description:
+      'Reconcile settings.projects[] with the Workstacean project registry. ' +
+      'Identifies registry projects missing from the UI project list (added), ' +
+      'and settings entries no longer in the registry (orphaned). ' +
+      'Set dryRun=false to apply changes automatically.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description:
+            'Absolute path to the Studio project directory. Used to locate the local ' +
+            'registry snapshot (workspace/projects.yaml) when Workstacean is unreachable.',
+        },
+        dryRun: {
+          type: 'boolean',
+          description:
+            'When true (default), reports what would change without applying it. ' +
+            'Set to false to automatically add missing projects to settings.projects[].',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+  {
     name: 'get_portfolio_sitrep',
     description:
       'Get a fleet-wide portfolio status report aggregating all active projects in one call. Returns per-project health (green/yellow/red), active agents, backlog depth, blocked count, and staging lag. Also includes portfolio-level metrics (total active agents, WIP utilization, top constraint) and pending human decisions (PR reviews, escalations, prioritization needs) across all projects. Use this instead of calling get_sitrep for each project individually.',

--- a/workspace/projects.yaml
+++ b/workspace/projects.yaml
@@ -256,4 +256,3 @@ projects:
       priorityWeight: 1.0
       minConcurrency: 1
       maxConcurrency: 3
-

--- a/workspace/projects.yaml
+++ b/workspace/projects.yaml
@@ -1,29 +1,11 @@
 # workspace/projects.yaml — protoLabs Studio Project Routing Index
 #
-# Each entry represents a GitHub repository onboarded into this Studio instance.
-# This file is updated by the onboard_project skill when a new repo is added.
-# Workstacean's A2APlugin reads this file at startup and rebuilds the index
-# every 5 seconds when the file changes — no restart required.
+# AUTO-GENERATED SNAPSHOT — Do not edit manually.
+# This file is refreshed from the Workstacean registry (GET /api/projects).
+# Edit the authoritative source: protoWorkstacean/workspace/projects.yaml
 #
-# NOTE: This file is synced from the authoritative Workstacean registry
-# (protoWorkstacean/workspace/projects.yaml). After P2 this will be read
-# from the Workstacean API directly — no more manual updates.
-#
-# Fields:
-#   slug          — kebab-case identifier derived from <owner>-<repo>
-#   title         — human-readable project name
-#   github        — <owner>/<repo> slug (used as the lookup key)
-#   defaultBranch — default branch at time of onboarding
-#   status        — active | archived | suspended
-#   onboardedAt   — ISO 8601 timestamp
-#   planeProjectId — Plane project ID (empty = pending OnboardingPlugin)
-#   planeIdentifier — Plane project identifier
-#   projectPath   — absolute path on this host
-#   discord       — Discord channel IDs for routing GitHub events
-#   infisical     — Infisical integration config
-#   observability — Observability config (Langfuse)
-#   googleWorkspace — Google Drive integration config
-#   capacity      — Scheduler capacity settings
+# Consumed by: Workstacean (routing), Quinn (portfolio monitoring), protoMaker (project registration)
+# After P2 this file is used as a local cache / offline fallback only.
 
 projects:
   - slug: protolabsai-protomaker
@@ -36,6 +18,7 @@ projects:
     planeProjectId: 'fe0a95b6-63a9-4a78-a0eb-36bad44228f2'
     planeIdentifier: PRMKR
     projectPath: /home/josh/dev/ava
+    studioUrl: 'http://localhost:3008'
     agents: [ava, quinn, frank]
     discord:
       dev: '1469080556720623699'
@@ -121,10 +104,9 @@ projects:
     projectPath: /home/josh/dev/labs/protoUI
     agents: [ava, quinn]
     discord:
-      channels:
-        general: '1490601617567912050'
-        updates: '1490601619300286525'
-        dev: '1490601620927418428'
+      general: '1490601617567912050'
+      updates: '1490601619300286525'
+      dev: '1490601620927418428'
     infisical:
       projectId: ''
     observability:
@@ -275,17 +257,3 @@ projects:
       minConcurrency: 1
       maxConcurrency: 3
 
-  - slug: protolabsai-protomaker
-    title: protoMaker
-    github: protoLabsAI/protoMaker
-    defaultBranch: main
-    status: active
-    onboardedAt: '2026-04-07T00:00:00.000Z'
-    discord:
-      channels:
-        general: '1490957797406408746'
-        updates: '1490957799151239368'
-        dev: '1490957800711393333'
-    plane:
-      projectId: not provisioned
-      identifier: not provisioned


### PR DESCRIPTION
## Summary

Make Workstacean `projects.yaml` the single authoritative org registry. Kill the three-way divergence (Workstacean 8 projects, Studio workspace 4 projects, settings.projects[] UI-only). Every layer reads from one source.

**Current state:**
- Workstacean `workspace/projects.yaml` — 8 projects, richest metadata (authoritative) ✅
- protoMaker `workspace/projects.yaml` — 4 projects, stale subset ❌
- `settings.projects[]` — 8 paths, no metadata, UI-only ❌

**Deliverables:**
1. **projects.yaml schema...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added registry endpoints to fetch fleet-wide projects and synchronize local project settings against the registry, with dry-run capability to preview changes before applying.
  * Introduced a new MCP tool for syncing the project registry with automatic fallback to local cache when the external service is unavailable.

* **Chores**
  * Updated project registry snapshot with the latest project metadata and standardized schema formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->