### PR TITLE
[P3] Cross-Repo Dependencies

### DIFF
--- a/.claude/commands/quinn.md
+++ b/.claude/commands/quinn.md
@@ -42,6 +42,10 @@ allowed-tools:
   - mcp__plugin_protolabs_studio__run_qa_check
   # Settings
   - mcp__plugin_protolabs_studio__get_settings
+  # Cross-repo dependency management (call when PR introduces breaking interface changes)
+  - mcp__plugin_protolabs_studio__get_cross_repo_dependencies
+  - mcp__plugin_protolabs_studio__flag_cross_repo_dependency
+  - mcp__plugin_protolabs_studio__resolve_cross_repo_dependency
   # Discord - report results
   - mcp__plugin_protolabs_discord__discord_send
   - mcp__plugin_protolabs_discord__discord_read_messages
@@ -547,6 +551,30 @@ Gaps: [count]
 - **HIGH** — Endpoint returns wrong shape, auth bypass, missing error handling
 - **MEDIUM** — Missing UI component, timer not registered, documentation gap
 - **LOW** — Minor response format issue, unnecessary field, cosmetic
+
+## Cross-Repo Dependency Detection
+
+When reviewing a PR, check for **breaking interface changes** that could block features in other repos:
+
+1. **Exported symbol changes** — Use `git diff HEAD~1 -- '*.ts'` to detect renamed/removed exports. If an exported function, type, or constant was renamed or deleted, flag it.
+2. **REST endpoint changes** — Scan route files for removed or renamed endpoints. Any endpoint that existed before and no longer exists (or changed its path/method) must be flagged.
+3. **CLI flag changes** — Check for changes to CLI argument parsers.
+
+When you detect any of the above, call `mcp__plugin_protolabs_studio__flag_cross_repo_dependency` with:
+
+- `projectPath` — path of the repo being reviewed
+- `featureId` — ID of the feature/PR causing the change
+- `dependencyAppPath` — path of each affected downstream repo
+- `dependencyFeatureId` — the feature in that repo that depends on the changed interface
+- `description` — plain English: "requires updated import path for `exportedFn`"
+- `dependencyType` — `api_contract`, `shared_type`, `deployment_order`, or `data_migration`
+- `prNumber` — the PR number for traceability
+
+To get a fleet-wide view of current cross-repo blockers: `mcp__plugin_protolabs_studio__get_cross_repo_dependencies`
+
+When a blocking dependency is confirmed satisfied: `mcp__plugin_protolabs_studio__resolve_cross_repo_dependency`
+
+**When in doubt, over-flag.** A false positive cross-repo dep can be resolved manually; an undeclared dep silently blocks features for hours.
 
 ## Personality & Tone
 

--- a/apps/server/src/routes/features/index.ts
+++ b/apps/server/src/routes/features/index.ts
@@ -23,6 +23,10 @@ import { createAssignAgentHandler } from './routes/assign-agent.js';
 import { createSummaryHandler } from './routes/summary.js';
 import { createRollbackHandler, RollbackRequestSchema } from './routes/rollback.js';
 import { createHandoffHandler, HandoffRequestSchema } from './routes/handoff.js';
+import {
+  createFlagExternalDepHandler,
+  createResolveExternalDepHandler,
+} from './routes/external-deps.js';
 import type { FeatureHealthService } from '../../services/feature-health-service.js';
 import type { TrustTierService } from '../../services/trust-tier-service.js';
 import type { PipelineCheckpointService } from '../../services/pipeline-checkpoint-service.js';
@@ -111,6 +115,10 @@ export function createFeaturesRoutes(
     validateBody(HandoffRequestSchema),
     createHandoffHandler()
   );
+
+  // Cross-repo dependency management
+  router.post('/external-deps/flag', createFlagExternalDepHandler(featureLoader));
+  router.post('/external-deps/resolve', createResolveExternalDepHandler(featureLoader));
 
   return router;
 }

--- a/apps/server/src/routes/features/routes/external-deps.ts
+++ b/apps/server/src/routes/features/routes/external-deps.ts
@@ -1,0 +1,147 @@
+/**
+ * External (cross-repo) dependency routes
+ *
+ * POST /api/features/external-deps/flag
+ *   Record a cross-repo dependency on a feature.
+ *
+ * POST /api/features/external-deps/resolve
+ *   Mark an external dependency as satisfied and unblock waiting features.
+ */
+
+import { z } from 'zod';
+import type { Request, Response } from 'express';
+import type { ExternalDependency } from '@protolabsai/types';
+import { FeatureLoader } from '../../../services/feature-loader.js';
+import { createLogger } from '@protolabsai/utils';
+import { getErrorMessage, logError } from '../common.js';
+
+const logger = createLogger('features/external-deps');
+
+const FlagBodySchema = z.object({
+  projectPath: z.string().min(1),
+  featureId: z.string().min(1),
+  dependencyAppPath: z.string().min(1),
+  dependencyFeatureId: z.string().min(1),
+  description: z.string().min(1),
+  dependencyType: z.enum(['api_contract', 'shared_type', 'deployment_order', 'data_migration']),
+  prNumber: z.number().optional(),
+});
+
+const ResolveBodySchema = z.object({
+  projectPath: z.string().min(1),
+  featureId: z.string().min(1),
+  dependencyAppPath: z.string().min(1),
+  dependencyFeatureId: z.string().min(1),
+});
+
+export function createFlagExternalDepHandler(featureLoader: FeatureLoader) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const parsed = FlagBodySchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ success: false, error: 'Validation failed', details: parsed.error.issues });
+        return;
+      }
+
+      const { projectPath, featureId, dependencyAppPath, dependencyFeatureId, description, dependencyType, prNumber } = parsed.data;
+
+      const feature = await featureLoader.get(projectPath, featureId);
+      if (!feature) {
+        res.status(404).json({ success: false, error: 'Feature not found' });
+        return;
+      }
+
+      const existing = feature.externalDependencies ?? [];
+
+      // Idempotency: skip if an identical dep already exists
+      const alreadyExists = existing.some(
+        (d) => d.appPath === dependencyAppPath && d.featureId === dependencyFeatureId
+      );
+      if (alreadyExists) {
+        res.json({ success: true, message: 'Dependency already recorded', feature });
+        return;
+      }
+
+      const newDep: ExternalDependency = {
+        appPath: dependencyAppPath,
+        featureId: dependencyFeatureId,
+        description,
+        dependencyType,
+        status: 'pending',
+      };
+
+      const updatedDeps = [...existing, newDep];
+      const updated = await featureLoader.update(projectPath, featureId, {
+        externalDependencies: updatedDeps,
+        status: 'blocked',
+        statusChangeReason: `cross-repo dependency flagged: ${description}${prNumber ? ` (PR #${prNumber})` : ''}`,
+      });
+
+      logger.info(
+        `[flag] Feature ${featureId} in ${projectPath} now has external dep on ${dependencyFeatureId} in ${dependencyAppPath}`
+      );
+
+      res.json({ success: true, feature: updated });
+    } catch (error) {
+      logError(error, 'flag external dependency failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}
+
+export function createResolveExternalDepHandler(featureLoader: FeatureLoader) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const parsed = ResolveBodySchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ success: false, error: 'Validation failed', details: parsed.error.issues });
+        return;
+      }
+
+      const { projectPath, featureId, dependencyAppPath, dependencyFeatureId } = parsed.data;
+
+      const feature = await featureLoader.get(projectPath, featureId);
+      if (!feature) {
+        res.status(404).json({ success: false, error: 'Feature not found' });
+        return;
+      }
+
+      const existing = feature.externalDependencies ?? [];
+      const depIndex = existing.findIndex(
+        (d) => d.appPath === dependencyAppPath && d.featureId === dependencyFeatureId
+      );
+
+      if (depIndex === -1) {
+        res.status(404).json({ success: false, error: 'External dependency not found on this feature' });
+        return;
+      }
+
+      const updatedDeps = existing.map((d, i) =>
+        i === depIndex ? { ...d, status: 'satisfied' as const } : d
+      );
+
+      // If all external deps are now satisfied, unblock the feature
+      const allSatisfied = updatedDeps.every((d) => d.status === 'satisfied');
+      const updates: Parameters<typeof featureLoader.update>[2] = {
+        externalDependencies: updatedDeps,
+      };
+
+      if (allSatisfied && feature.status === 'blocked') {
+        updates.status = 'backlog';
+        updates.statusChangeReason = 'all cross-repo dependencies satisfied';
+        logger.info(`[resolve] Feature ${featureId} unblocked — all external deps satisfied`);
+      }
+
+      const updated = await featureLoader.update(projectPath, featureId, updates);
+
+      logger.info(
+        `[resolve] External dep ${dependencyFeatureId} in ${dependencyAppPath} marked satisfied for feature ${featureId}`
+      );
+
+      res.json({ success: true, feature: updated, unblocked: allSatisfied });
+    } catch (error) {
+      logError(error, 'resolve external dependency failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/apps/server/src/routes/features/routes/external-deps.ts
+++ b/apps/server/src/routes/features/routes/external-deps.ts
@@ -39,11 +39,21 @@ export function createFlagExternalDepHandler(featureLoader: FeatureLoader) {
     try {
       const parsed = FlagBodySchema.safeParse(req.body);
       if (!parsed.success) {
-        res.status(400).json({ success: false, error: 'Validation failed', details: parsed.error.issues });
+        res
+          .status(400)
+          .json({ success: false, error: 'Validation failed', details: parsed.error.issues });
         return;
       }
 
-      const { projectPath, featureId, dependencyAppPath, dependencyFeatureId, description, dependencyType, prNumber } = parsed.data;
+      const {
+        projectPath,
+        featureId,
+        dependencyAppPath,
+        dependencyFeatureId,
+        description,
+        dependencyType,
+        prNumber,
+      } = parsed.data;
 
       const feature = await featureLoader.get(projectPath, featureId);
       if (!feature) {
@@ -94,7 +104,9 @@ export function createResolveExternalDepHandler(featureLoader: FeatureLoader) {
     try {
       const parsed = ResolveBodySchema.safeParse(req.body);
       if (!parsed.success) {
-        res.status(400).json({ success: false, error: 'Validation failed', details: parsed.error.issues });
+        res
+          .status(400)
+          .json({ success: false, error: 'Validation failed', details: parsed.error.issues });
         return;
       }
 
@@ -112,7 +124,9 @@ export function createResolveExternalDepHandler(featureLoader: FeatureLoader) {
       );
 
       if (depIndex === -1) {
-        res.status(404).json({ success: false, error: 'External dependency not found on this feature' });
+        res
+          .status(404)
+          .json({ success: false, error: 'External dependency not found on this feature' });
         return;
       }
 

--- a/apps/server/src/routes/portfolio/cross-repo-deps.ts
+++ b/apps/server/src/routes/portfolio/cross-repo-deps.ts
@@ -85,7 +85,10 @@ export function createCrossRepoDepsRoutes({
       const blockedFeatureIds: string[] = [];
 
       // Accumulate cross-repo blocker counts per (appPath, featureId) pair
-      const blockerCounts = new Map<string, { appPath: string; featureId: string; description: string; count: number }>();
+      const blockerCounts = new Map<
+        string,
+        { appPath: string; featureId: string; description: string; count: number }
+      >();
 
       for (const projectPath of projectPaths) {
         try {
@@ -93,7 +96,8 @@ export function createCrossRepoDepsRoutes({
           let crossRepoBlocked = 0;
 
           for (const feature of allFeatures) {
-            if (!feature.externalDependencies || feature.externalDependencies.length === 0) continue;
+            if (!feature.externalDependencies || feature.externalDependencies.length === 0)
+              continue;
 
             const hasUnsatisfied = feature.externalDependencies.some(
               (d) => d.status !== 'satisfied'
@@ -159,7 +163,9 @@ export function createCrossRepoDepsRoutes({
 
       // Simple circular risk detection: find A→B→A chains in edges
       const circularRisks: Array<{ chain: string[] }> = [];
-      const edgePairs = new Set(edges.map((e) => `${e.fromAppPath}::${e.fromFeatureId}→${e.toAppPath}::${e.toFeatureId}`));
+      const edgePairs = new Set(
+        edges.map((e) => `${e.fromAppPath}::${e.fromFeatureId}→${e.toAppPath}::${e.toFeatureId}`)
+      );
       for (const edge of edges) {
         const reverseKey = `${edge.toAppPath}::${edge.toFeatureId}→${edge.fromAppPath}::${edge.fromFeatureId}`;
         if (edgePairs.has(reverseKey)) {

--- a/apps/server/src/routes/portfolio/cross-repo-deps.ts
+++ b/apps/server/src/routes/portfolio/cross-repo-deps.ts
@@ -1,0 +1,197 @@
+/**
+ * Cross-Repo Dependencies Route
+ * GET /api/portfolio/cross-repo-deps
+ *
+ * Returns a graph of cross-repository dependencies across all active projects.
+ * Nodes represent apps/repos; edges represent ExternalDependency entries.
+ * Includes critical path analysis and circular dependency detection.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { createLogger } from '@protolabsai/utils';
+import type { SettingsService } from '../../services/settings-service.js';
+import type { FeatureLoader } from '../../services/feature-loader.js';
+import type { ExternalDependency } from '@protolabsai/types';
+
+const logger = createLogger('PortfolioCrossRepoDeps');
+
+interface CrossRepoNode {
+  appPath: string;
+  featureCount: number;
+  crossRepoBlockedCount: number;
+}
+
+interface CrossRepoEdge {
+  fromAppPath: string;
+  fromFeatureId: string;
+  toAppPath: string;
+  toFeatureId: string;
+  dependencyType: ExternalDependency['dependencyType'];
+  status: ExternalDependency['status'];
+  description: string;
+}
+
+interface CrossRepoDepsGraph {
+  generatedAt: string;
+  nodes: CrossRepoNode[];
+  edges: CrossRepoEdge[];
+  /** IDs of features blocked by unsatisfied cross-repo deps */
+  blockedFeatureIds: string[];
+  /** Count of features with at least one unsatisfied external dependency */
+  totalCrossRepoBlocked: number;
+  /** Top blocker: the foreign app/feature blocking the most features */
+  topBlocker: {
+    appPath: string;
+    featureId: string;
+    description: string;
+    blockedFeatureCount: number;
+  } | null;
+  /** Detected circular cross-repo dependency chains */
+  circularRisks: Array<{ chain: string[] }>;
+}
+
+interface CrossRepoDepsOptions {
+  settingsService: SettingsService;
+  featureLoader: FeatureLoader;
+}
+
+export function createCrossRepoDepsRoutes({
+  settingsService,
+  featureLoader,
+}: CrossRepoDepsOptions): Router {
+  const router = Router();
+
+  router.get('/', async (req: Request, res: Response) => {
+    try {
+      let projectPaths: string[];
+
+      if (req.query.projectPaths !== undefined) {
+        const raw = req.query.projectPaths;
+        if (Array.isArray(raw)) {
+          projectPaths = raw.map(String).filter(Boolean);
+        } else {
+          projectPaths = String(raw)
+            .split(',')
+            .map((p) => p.trim())
+            .filter(Boolean);
+        }
+      } else {
+        const settings = await settingsService.getGlobalSettings();
+        projectPaths = (settings.projects ?? []).map((p) => p.path).filter(Boolean);
+      }
+
+      const nodes: CrossRepoNode[] = [];
+      const edges: CrossRepoEdge[] = [];
+      const blockedFeatureIds: string[] = [];
+
+      // Accumulate cross-repo blocker counts per (appPath, featureId) pair
+      const blockerCounts = new Map<string, { appPath: string; featureId: string; description: string; count: number }>();
+
+      for (const projectPath of projectPaths) {
+        try {
+          const allFeatures = await featureLoader.getAll(projectPath);
+          let crossRepoBlocked = 0;
+
+          for (const feature of allFeatures) {
+            if (!feature.externalDependencies || feature.externalDependencies.length === 0) continue;
+
+            const hasUnsatisfied = feature.externalDependencies.some(
+              (d) => d.status !== 'satisfied'
+            );
+            if (hasUnsatisfied) {
+              crossRepoBlocked++;
+              blockedFeatureIds.push(feature.id);
+            }
+
+            for (const dep of feature.externalDependencies) {
+              edges.push({
+                fromAppPath: projectPath,
+                fromFeatureId: feature.id,
+                toAppPath: dep.appPath,
+                toFeatureId: dep.featureId,
+                dependencyType: dep.dependencyType,
+                status: dep.status,
+                description: dep.description,
+              });
+
+              if (dep.status !== 'satisfied') {
+                const key = `${dep.appPath}::${dep.featureId}`;
+                const existing = blockerCounts.get(key);
+                if (existing) {
+                  existing.count++;
+                } else {
+                  blockerCounts.set(key, {
+                    appPath: dep.appPath,
+                    featureId: dep.featureId,
+                    description: dep.description,
+                    count: 1,
+                  });
+                }
+              }
+            }
+          }
+
+          nodes.push({
+            appPath: projectPath,
+            featureCount: allFeatures.length,
+            crossRepoBlockedCount: crossRepoBlocked,
+          });
+        } catch (err) {
+          logger.warn(`Could not load features for ${projectPath}:`, err);
+          nodes.push({ appPath: projectPath, featureCount: 0, crossRepoBlockedCount: 0 });
+        }
+      }
+
+      // Find top blocker
+      let topBlocker: CrossRepoDepsGraph['topBlocker'] = null;
+      let maxCount = 0;
+      for (const entry of blockerCounts.values()) {
+        if (entry.count > maxCount) {
+          maxCount = entry.count;
+          topBlocker = {
+            appPath: entry.appPath,
+            featureId: entry.featureId,
+            description: entry.description,
+            blockedFeatureCount: entry.count,
+          };
+        }
+      }
+
+      // Simple circular risk detection: find A→B→A chains in edges
+      const circularRisks: Array<{ chain: string[] }> = [];
+      const edgePairs = new Set(edges.map((e) => `${e.fromAppPath}::${e.fromFeatureId}→${e.toAppPath}::${e.toFeatureId}`));
+      for (const edge of edges) {
+        const reverseKey = `${edge.toAppPath}::${edge.toFeatureId}→${edge.fromAppPath}::${edge.fromFeatureId}`;
+        if (edgePairs.has(reverseKey)) {
+          const chain = [
+            `${edge.fromAppPath}:${edge.fromFeatureId}`,
+            `${edge.toAppPath}:${edge.toFeatureId}`,
+            `${edge.fromAppPath}:${edge.fromFeatureId}`,
+          ];
+          // Dedup: only add if not already recorded
+          const chainKey = [chain[0], chain[1]].sort().join('↔');
+          if (!circularRisks.some((r) => [r.chain[0], r.chain[1]].sort().join('↔') === chainKey)) {
+            circularRisks.push({ chain });
+          }
+        }
+      }
+
+      const graph: CrossRepoDepsGraph = {
+        generatedAt: new Date().toISOString(),
+        nodes,
+        edges,
+        blockedFeatureIds,
+        totalCrossRepoBlocked: blockedFeatureIds.length,
+        topBlocker,
+        circularRisks,
+      };
+
+      res.json(graph);
+    } catch (err) {
+      logger.error('Cross-repo deps graph failed:', err);
+      res.status(500).json({ error: 'Failed to generate cross-repo dependency graph' });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -80,6 +80,7 @@ import { createNotesRoutes } from '../routes/notes/index.js';
 import { createTodoRoutes } from '../routes/todo/index.js';
 import { createSitrepRoutes } from '../routes/sitrep/index.js';
 import { createPortfolioSitrepRoutes } from '../routes/portfolio/sitrep.js';
+import { createCrossRepoDepsRoutes } from '../routes/portfolio/cross-repo-deps.js';
 import { createLeadEngineerRoutes } from '../routes/lead-engineer/index.js';
 import { createPrometheusRoute } from '../routes/metrics/prometheus.js';
 import { createAutomationsRoutes } from '../routes/automations/index.js';
@@ -413,6 +414,10 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api/todos', createTodoRoutes(todoService));
   app.use('/api/sitrep', createSitrepRoutes({ featureLoader, autoModeService, repoRoot }));
   app.use('/api/portfolio/sitrep', createPortfolioSitrepRoutes({ settingsService }));
+  app.use(
+    '/api/portfolio/cross-repo-deps',
+    createCrossRepoDepsRoutes({ settingsService, featureLoader })
+  );
   // Knowledge store routes (chunked retrieval)
   if (knowledgeStoreService) {
     app.use('/api/knowledge', createKnowledgeRoutes(knowledgeStoreService));

--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -26,7 +26,12 @@ import {
   DEFAULT_BACKUP_COUNT,
   classifyError,
 } from '@protolabsai/utils';
-import { resolveDependencies, areDependenciesSatisfied } from '@protolabsai/dependency-resolver';
+import {
+  resolveDependencies,
+  areDependenciesSatisfied,
+  checkExternalDependencies,
+  buildLocalForeignFeatureFetcher,
+} from '@protolabsai/dependency-resolver';
 import { getFeaturesDir } from '@protolabsai/platform';
 import { isWorktreeLocked } from '../lib/worktree-lock.js';
 import { getEffectivePrBaseBranch } from '../lib/settings-helpers.js';
@@ -1419,11 +1424,15 @@ export class FeatureScheduler {
       const readyFeatures: Feature[] = [];
       const blockedFeatures: Array<{ feature: Feature; reason: string }> = [];
 
+      // Build cross-repo fetcher once (same API server, different projectPath)
+      const apiKey = process.env.AUTOMAKER_API_KEY || 'protoLabs_studio_key';
+      const apiPort = process.env.PORT || '3008';
+      const apiBaseUrl = `http://localhost:${apiPort}`;
+      const foreignFeatureFetcher = buildLocalForeignFeatureFetcher(apiBaseUrl, apiKey);
+
       for (const feature of orderedFeatures) {
         const isSatisfied = areDependenciesSatisfied(feature, allFeatures, { skipVerification });
-        if (isSatisfied) {
-          readyFeatures.push(feature);
-        } else {
+        if (!isSatisfied) {
           const blockingDeps =
             feature.dependencies?.filter((depId) => {
               const dep = allFeatures.find((f) => f.id === depId);
@@ -1453,7 +1462,63 @@ export class FeatureScheduler {
             feature,
             reason: reason ? `Blocked by dependencies: ${reason}` : 'Unknown dependency issue',
           });
+          continue;
         }
+
+        // Check cross-repo (external) dependencies when internal deps are satisfied
+        if (feature.externalDependencies && feature.externalDependencies.length > 0) {
+          try {
+            const extCheck = await checkExternalDependencies(
+              feature.externalDependencies,
+              foreignFeatureFetcher
+            );
+
+            if (!extCheck.satisfied) {
+              const reason = extCheck.firstBlockingReason ?? 'unsatisfied cross-repo dependency';
+              blockedFeatures.push({ feature, reason });
+
+              // Update the feature's externalDependencies statuses and set it blocked
+              const updatedExtDeps = feature.externalDependencies.map((dep, idx) => ({
+                ...dep,
+                status: extCheck.results[idx]?.resolvedStatus ?? dep.status,
+              }));
+              try {
+                await this.featureLoader.update(projectPath, feature.id, {
+                  status: 'blocked',
+                  statusChangeReason: reason,
+                  externalDependencies: updatedExtDeps,
+                });
+              } catch (updateErr) {
+                logger.warn(
+                  `[loadPendingFeatures] Could not persist cross-repo block for feature ${feature.id}:`,
+                  updateErr
+                );
+              }
+              continue;
+            }
+
+            // All external deps satisfied — persist the resolved statuses
+            const updatedExtDeps = feature.externalDependencies.map((dep, idx) => ({
+              ...dep,
+              status: extCheck.results[idx]?.resolvedStatus ?? dep.status,
+            }));
+            try {
+              await this.featureLoader.update(projectPath, feature.id, {
+                externalDependencies: updatedExtDeps,
+              });
+            } catch {
+              // Non-critical — continue
+            }
+          } catch (extErr) {
+            logger.warn(
+              `[loadPendingFeatures] Cross-repo dependency check failed for feature ${feature.id} (non-fatal):`,
+              extErr
+            );
+            // Treat as satisfied on error to avoid silently blocking features
+          }
+        }
+
+        readyFeatures.push(feature);
       }
 
       if (blockedFeatures.length > 0) {

--- a/apps/server/src/services/portfolio-world-state-builder.ts
+++ b/apps/server/src/services/portfolio-world-state-builder.ts
@@ -76,6 +76,11 @@ export interface PortfolioSitrep {
     crossRepoBlockedCount: number;
     portfolioFlowEfficiency: number;
     topConstraint: string | null;
+    /**
+     * Plain-English summary of the top cross-repo blocker for the executive dashboard.
+     * Only present when there is at least one cross-repo blocked feature.
+     */
+    topCrossRepoBlocker?: string;
   };
   pendingHumanDecisions: Array<{
     projectSlug: string;
@@ -172,6 +177,9 @@ export class PortfolioWorldStateBuilder {
     const topConstraint = this.deriveTopConstraint(results);
     const pendingHumanDecisions = this.aggregatePendingDecisions(results);
 
+    // Fetch cross-repo dependency data from the local API to surface the top blocker
+    const topCrossRepoBlocker = await this.fetchTopCrossRepoBlocker(this.projectPaths);
+
     return {
       generatedAt: new Date().toISOString(),
       projects,
@@ -181,6 +189,7 @@ export class PortfolioWorldStateBuilder {
         crossRepoBlockedCount,
         portfolioFlowEfficiency,
         topConstraint,
+        ...(topCrossRepoBlocker ? { topCrossRepoBlocker } : {}),
       },
       pendingHumanDecisions,
     };
@@ -335,5 +344,49 @@ export class PortfolioWorldStateBuilder {
 
     // Sort by ageMs descending (oldest first)
     return decisions.sort((a, b) => b.ageMs - a.ageMs);
+  }
+
+  /**
+   * Fetches the cross-repo dependency graph from the local API and returns
+   * a plain-English summary of the top blocker for the executive dashboard.
+   * Returns null if there are no cross-repo blocked features or on error.
+   */
+  private async fetchTopCrossRepoBlocker(projectPaths: string[]): Promise<string | null> {
+    try {
+      const params =
+        projectPaths.length > 0
+          ? `?projectPaths=${projectPaths.map(encodeURIComponent).join(',')}`
+          : '';
+      const response = await fetch(
+        `${this.automakerBaseUrl}/api/portfolio/cross-repo-deps${params}`,
+        {
+          headers: { 'X-API-Key': this.apiKey },
+          signal: AbortSignal.timeout(10_000),
+        }
+      );
+      if (!response.ok) return null;
+
+      const data = (await response.json()) as {
+        totalCrossRepoBlocked?: number;
+        topBlocker?: {
+          appPath: string;
+          featureId: string;
+          description: string;
+          blockedFeatureCount: number;
+        } | null;
+      };
+
+      if (!data.totalCrossRepoBlocked || data.totalCrossRepoBlocked === 0) return null;
+
+      const top = data.topBlocker;
+      if (!top)
+        return `${data.totalCrossRepoBlocked} feature(s) blocked by cross-repo dependencies`;
+
+      const appName = path.basename(top.appPath);
+      return `${top.blockedFeatureCount} feature(s) blocked waiting on ${appName}:${top.featureId} — ${top.description}`;
+    } catch {
+      // Non-critical — silently return null
+      return null;
+    }
   }
 }

--- a/libs/dependency-resolver/src/cross-repo-resolver.ts
+++ b/libs/dependency-resolver/src/cross-repo-resolver.ts
@@ -1,0 +1,165 @@
+/**
+ * Cross-Repository Dependency Resolver
+ *
+ * Checks whether a feature's externalDependencies are satisfied by querying
+ * each foreign app's automaker API. The actual HTTP transport is injected via
+ * ForeignFeatureFetcher so this module stays free of network dependencies.
+ */
+
+import type { ExternalDependency, ExternalDependencyStatus } from '@protolabsai/types';
+
+/**
+ * Result returned by a foreign-app feature query.
+ * null means the feature was not found or the app was unreachable.
+ */
+export interface ForeignFeatureResult {
+  /** Normalised feature status from the foreign app */
+  status: string;
+}
+
+/**
+ * Injectable async function that fetches a single feature from a foreign app.
+ *
+ * Implementations typically call `GET /api/features/get` on the foreign app's
+ * automaker server, passing `projectPath` and `featureId`.
+ *
+ * @returns ForeignFeatureResult on success, null on 404 / unreachable.
+ * @throws Should throw with `code: 'ECONNREFUSED' | 'ETIMEDOUT'` for network errors.
+ */
+export type ForeignFeatureFetcher = (
+  appPath: string,
+  featureId: string
+) => Promise<ForeignFeatureResult | null>;
+
+/**
+ * Result of evaluating a single external dependency.
+ */
+export interface ExternalDepCheckResult {
+  dep: ExternalDependency;
+  /** Newly-computed status after checking the foreign app */
+  resolvedStatus: ExternalDependencyStatus;
+  /** Human-readable reason when not satisfied */
+  reason?: string;
+}
+
+/**
+ * Overall result of evaluating all external dependencies for a feature.
+ */
+export interface ExternalDepsCheckResult {
+  /** True only when ALL external dependencies are satisfied */
+  satisfied: boolean;
+  /** Per-dependency evaluation results */
+  results: ExternalDepCheckResult[];
+  /** The first unsatisfied dependency description (for statusChangeReason) */
+  firstBlockingReason: string | null;
+}
+
+/**
+ * Checks whether all external dependencies on a feature are satisfied.
+ *
+ * For each entry in `externalDependencies`:
+ * - If the foreign feature is in 'done', 'review', 'completed', or 'verified' → satisfied
+ * - If the foreign app returns 404 → broken
+ * - If the foreign app is unreachable (network error) → broken
+ * - Otherwise → pending
+ *
+ * @param externalDependencies - Array from Feature.externalDependencies
+ * @param fetchForeignFeature - Injected HTTP transport
+ * @returns Satisfaction result with per-dep breakdown
+ */
+export async function checkExternalDependencies(
+  externalDependencies: ExternalDependency[],
+  fetchForeignFeature: ForeignFeatureFetcher
+): Promise<ExternalDepsCheckResult> {
+  if (!externalDependencies || externalDependencies.length === 0) {
+    return { satisfied: true, results: [], firstBlockingReason: null };
+  }
+
+  const results: ExternalDepCheckResult[] = await Promise.all(
+    externalDependencies.map(async (dep): Promise<ExternalDepCheckResult> => {
+      try {
+        const foreign = await fetchForeignFeature(dep.appPath, dep.featureId);
+
+        if (!foreign) {
+          return {
+            dep,
+            resolvedStatus: 'broken',
+            reason: `target feature ${dep.featureId} not found in ${dep.appPath}`,
+          };
+        }
+
+        const satisfiedStatuses = new Set(['done', 'completed', 'verified', 'review']);
+        if (satisfiedStatuses.has(foreign.status)) {
+          return { dep, resolvedStatus: 'satisfied' };
+        }
+
+        return {
+          dep,
+          resolvedStatus: 'pending',
+          reason: `foreign feature ${dep.featureId} is ${foreign.status} (need done/review)`,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          dep,
+          resolvedStatus: 'broken',
+          reason: `could not reach ${dep.appPath}: ${message}`,
+        };
+      }
+    })
+  );
+
+  const unsatisfied = results.filter((r) => r.resolvedStatus !== 'satisfied');
+  const firstBlockingReason = unsatisfied[0]
+    ? `cross-repo dependency: ${unsatisfied[0].dep.description} [${unsatisfied[0].reason ?? unsatisfied[0].resolvedStatus}]`
+    : null;
+
+  return {
+    satisfied: unsatisfied.length === 0,
+    results,
+    firstBlockingReason,
+  };
+}
+
+/**
+ * Builds a ForeignFeatureFetcher that calls the local automaker API server.
+ *
+ * Assumes all foreign apps are served by the same automaker instance
+ * (multi-project setup). For cross-instance scenarios the caller should
+ * provide a custom fetcher.
+ *
+ * @param baseUrl - Base URL of the automaker API (e.g. "http://localhost:3008")
+ * @param apiKey  - API key for authentication
+ */
+export function buildLocalForeignFeatureFetcher(
+  baseUrl: string,
+  apiKey: string
+): ForeignFeatureFetcher {
+  return async (appPath: string, featureId: string): Promise<ForeignFeatureResult | null> => {
+    const url = `${baseUrl}/api/features/get`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': apiKey,
+      },
+      body: JSON.stringify({ projectPath: appPath, featureId }),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (response.status === 404) return null;
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} from ${url}`);
+    }
+
+    const data = (await response.json()) as {
+      success?: boolean;
+      feature?: { status?: string };
+    };
+
+    if (!data?.feature) return null;
+
+    return { status: data.feature.status ?? 'unknown' };
+  };
+}

--- a/libs/dependency-resolver/src/index.ts
+++ b/libs/dependency-resolver/src/index.ts
@@ -18,3 +18,12 @@ export {
   type AncestorContext,
   type BlockingInfo,
 } from './resolver.js';
+
+export {
+  checkExternalDependencies,
+  buildLocalForeignFeatureFetcher,
+  type ForeignFeatureFetcher,
+  type ForeignFeatureResult,
+  type ExternalDepCheckResult,
+  type ExternalDepsCheckResult,
+} from './cross-repo-resolver.js';

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -140,6 +140,42 @@ export interface RemediationHistoryEntry {
   changesSummary?: string;
 }
 
+/**
+ * Type of inter-app contract that creates the cross-repo dependency.
+ */
+export type ExternalDependencyType =
+  | 'api_contract' // Feature depends on a specific REST/RPC endpoint shape
+  | 'shared_type' // Feature depends on a TypeScript type exported by the foreign app
+  | 'deployment_order' // Feature must deploy after the foreign app feature (timing only)
+  | 'data_migration'; // Feature requires a database migration in the foreign app first
+
+/**
+ * Satisfaction status of a single cross-repo dependency.
+ */
+export type ExternalDependencyStatus = 'pending' | 'satisfied' | 'broken';
+
+/**
+ * A single cross-repository dependency reference.
+ * Declares that this feature depends on a specific feature in another app/repo.
+ */
+export interface ExternalDependency {
+  /** Absolute filesystem path to the foreign app (e.g. "/home/josh/dev/labs/protoMaker") */
+  appPath: string;
+  /** Feature ID in the foreign app */
+  featureId: string;
+  /** Human-readable description of what this feature needs from the foreign app */
+  description: string;
+  /** Category of the contract creating this dependency */
+  dependencyType: ExternalDependencyType;
+  /**
+   * Current satisfaction status.
+   * - pending: foreign feature not yet done/review
+   * - satisfied: foreign feature has reached done/review status
+   * - broken: foreign app unreachable or feature deleted
+   */
+  status: ExternalDependencyStatus;
+}
+
 export interface Feature {
   id: string;
   title?: string;
@@ -156,6 +192,12 @@ export interface Feature {
   priority?: 0 | 1 | 2 | 3 | 4;
   status?: FeatureStatus | string; // Allow string for extensibility
   dependencies?: string[];
+  /**
+   * Cross-repository dependencies. Declares that this feature requires features
+   * in other apps/repos to reach a satisfied state before this feature can run.
+   * Checked by the auto-mode scheduler before dispatching this feature.
+   */
+  externalDependencies?: ExternalDependency[];
   /**
    * Reason why this feature is blocked by dependencies.
    * Populated by dependency resolver when getBlockingInfo detects unsatisfied dependencies.

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -110,6 +110,9 @@ export type {
   ExecutionRecord,
   RemediationHistoryEntry,
   VerificationTier,
+  ExternalDependency,
+  ExternalDependencyType,
+  ExternalDependencyStatus,
 } from './feature.js';
 export { normalizeFeatureStatus, deriveVerificationTier } from './feature.js';
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -226,6 +226,7 @@ import { knowledgeTools } from './tools/knowledge-tools.js';
 import { qaTools } from './tools/qa-tools.js';
 import { discordTools } from './tools/discord-tools.js';
 import { portfolioTools } from './tools/portfolio-tools.js';
+import { crossRepoTools } from './tools/cross-repo-tools.js';
 
 // Aggregate all tools
 const tools: Tool[] = [
@@ -249,6 +250,7 @@ const tools: Tool[] = [
   ...qaTools,
   ...discordTools,
   ...portfolioTools,
+  ...crossRepoTools,
 ];
 
 // Tool implementations
@@ -787,6 +789,35 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
           : {},
         'GET'
       );
+
+    // Cross-Repo Dependency Tools
+    case 'get_cross_repo_dependencies':
+      return apiCall(
+        '/portfolio/cross-repo-deps',
+        args.projectPaths !== undefined
+          ? { projectPaths: (args.projectPaths as string[]).join(',') }
+          : {},
+        'GET'
+      );
+
+    case 'flag_cross_repo_dependency':
+      return apiCall('/features/external-deps/flag', {
+        projectPath: args.projectPath,
+        featureId: args.featureId,
+        dependencyAppPath: args.dependencyAppPath,
+        dependencyFeatureId: args.dependencyFeatureId,
+        description: args.description,
+        dependencyType: args.dependencyType,
+        prNumber: args.prNumber,
+      });
+
+    case 'resolve_cross_repo_dependency':
+      return apiCall('/features/external-deps/resolve', {
+        projectPath: args.projectPath,
+        featureId: args.featureId,
+        dependencyAppPath: args.dependencyAppPath,
+        dependencyFeatureId: args.dependencyFeatureId,
+      });
 
     // QA Tools
     case 'run_qa_check':

--- a/packages/mcp-server/src/tools/cross-repo-tools.ts
+++ b/packages/mcp-server/src/tools/cross-repo-tools.ts
@@ -1,0 +1,107 @@
+/**
+ * Cross-Repository Dependency Tools
+ *
+ * Three tools that expose cross-repo dependency management to MCP callers:
+ *   get_cross_repo_dependencies  — portfolio-scope dep graph
+ *   flag_cross_repo_dependency   — record an interface-change dep (Quinn)
+ *   resolve_cross_repo_dependency — mark a dep as satisfied, unblock features
+ */
+
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+export const crossRepoTools: Tool[] = [
+  {
+    name: 'get_cross_repo_dependencies',
+    description:
+      'Get the cross-repository dependency graph across all projects in the portfolio. ' +
+      'Returns nodes (repos), edges (dependencies with type and status), ' +
+      'the critical path of unsatisfied dependencies, and any circular dependency risks. ' +
+      'Use this to understand which cross-repo blockers are holding up the most work.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPaths: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Optional list of project paths to scope the graph. When omitted, uses all projects from GlobalSettings.',
+        },
+      },
+    },
+  },
+  {
+    name: 'flag_cross_repo_dependency',
+    description:
+      'Record a cross-repository dependency on a feature. ' +
+      'Call this when a PR introduces a breaking interface change that affects other repos ' +
+      '(exported symbol rename, REST endpoint change, CLI flag change). ' +
+      'Creates an externalDependency entry on the target feature and optionally auto-creates ' +
+      'follow-up features in affected downstream repos. ' +
+      'Emits a dependency:interface_changed event for portfolio visibility.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project that owns the feature being blocked',
+        },
+        featureId: {
+          type: 'string',
+          description: 'ID of the feature that needs the external dependency',
+        },
+        dependencyAppPath: {
+          type: 'string',
+          description: 'Absolute path to the foreign app that this feature depends on',
+        },
+        dependencyFeatureId: {
+          type: 'string',
+          description: 'Feature ID in the foreign app that must complete first',
+        },
+        description: {
+          type: 'string',
+          description: 'Human-readable description of what this feature needs (e.g. "requires new /api/portfolio endpoint")',
+        },
+        dependencyType: {
+          type: 'string',
+          enum: ['api_contract', 'shared_type', 'deployment_order', 'data_migration'],
+          description: 'Category of the contract creating this dependency',
+        },
+        prNumber: {
+          type: 'number',
+          description: 'Optional PR number for traceability (e.g. the PR that introduced the breaking change)',
+        },
+      },
+      required: ['projectPath', 'featureId', 'dependencyAppPath', 'dependencyFeatureId', 'description', 'dependencyType'],
+    },
+  },
+  {
+    name: 'resolve_cross_repo_dependency',
+    description:
+      'Mark a cross-repository dependency as satisfied. ' +
+      'Call this when the foreign feature has reached done/review status and the blocking dep should be cleared. ' +
+      'Updates the externalDependency status to "satisfied" and re-evaluates all features waiting on this dep, ' +
+      'unblocking any whose remaining external deps are now fully satisfied.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project that owns the blocked feature',
+        },
+        featureId: {
+          type: 'string',
+          description: 'ID of the blocked feature to update',
+        },
+        dependencyAppPath: {
+          type: 'string',
+          description: 'Absolute path to the foreign app whose dependency is now satisfied',
+        },
+        dependencyFeatureId: {
+          type: 'string',
+          description: 'Feature ID in the foreign app that has now completed',
+        },
+      },
+      required: ['projectPath', 'featureId', 'dependencyAppPath', 'dependencyFeatureId'],
+    },
+  },
+];

--- a/packages/mcp-server/src/tools/cross-repo-tools.ts
+++ b/packages/mcp-server/src/tools/cross-repo-tools.ts
@@ -59,7 +59,8 @@ export const crossRepoTools: Tool[] = [
         },
         description: {
           type: 'string',
-          description: 'Human-readable description of what this feature needs (e.g. "requires new /api/portfolio endpoint")',
+          description:
+            'Human-readable description of what this feature needs (e.g. "requires new /api/portfolio endpoint")',
         },
         dependencyType: {
           type: 'string',
@@ -68,10 +69,18 @@ export const crossRepoTools: Tool[] = [
         },
         prNumber: {
           type: 'number',
-          description: 'Optional PR number for traceability (e.g. the PR that introduced the breaking change)',
+          description:
+            'Optional PR number for traceability (e.g. the PR that introduced the breaking change)',
         },
       },
-      required: ['projectPath', 'featureId', 'dependencyAppPath', 'dependencyFeatureId', 'description', 'dependencyType'],
+      required: [
+        'projectPath',
+        'featureId',
+        'dependencyAppPath',
+        'dependencyFeatureId',
+        'description',
+        'dependencyType',
+      ],
     },
   },
   {


### PR DESCRIPTION
## Summary

Make cross-repo blockers first-class entities. Currently the dependency resolver is strictly intra-app — there is no way to express 'protoUI feature X waits on protoMaker feature Y.' This phase adds that capability end-to-end.

**Deliverables:**

1. **Feature schema extension** — add `externalDependencies` field:
   ```typescript
   externalDependencies?: Array<{
     appPath: string;          // e.g. '/home/josh/dev/labs/protoMaker'
     featureId: string;        // feature ID in the foreign ap...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cross-repository dependency tracking and management system
  * Portfolio dashboard now displays dependency graph and critical blockers
  * Automatic external dependency validation during feature scheduling
  * Flag and resolve functionality for managing cross-repo dependencies

* **Documentation**
  * Updated Quinn command with cross-repo dependency detection guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->