### PR TITLE
Workstacean GET /api/projects — operational state + ProjectRegistryService in Studio

### DIFF
--- a/apps/server/src/routes/portfolio/sync-registry.ts
+++ b/apps/server/src/routes/portfolio/sync-registry.ts
@@ -1,0 +1,171 @@
+/**
+ * Portfolio Sync-Registry Route — Compare Studio settings.projects[] against
+ * the Workstacean project registry and optionally apply the sync.
+ *
+ * POST /api/portfolio/sync-registry
+ *
+ * Body: { dryRun?: boolean }  (default: dryRun = true)
+ *
+ * Returns a diff report:
+ *   - missing: registry projects not present in settings (by projectPath)
+ *   - orphaned: settings projects with no matching registry entry
+ *   - mismatches: projects in both but with differing name/title
+ *
+ * When dryRun is false, missing projects are added to settings.projects[].
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { randomUUID } from 'node:crypto';
+import { createLogger } from '@protolabsai/utils';
+import type { SettingsService } from '../../services/settings-service.js';
+import type { ProjectRef } from '@protolabsai/types';
+import type { ProjectRegistryEntry } from '../../services/project-registry-service.js';
+
+const logger = createLogger('PortfolioSyncRegistryRoute');
+
+const DEFAULT_WORKSTACEAN_URL = 'http://workstacean:8082';
+
+interface WorkstaceanResponse {
+  success: boolean;
+  data: ProjectRegistryEntry[];
+}
+
+interface SyncMissing {
+  slug: string;
+  title: string;
+  projectPath: string;
+}
+
+interface SyncOrphaned {
+  id: string;
+  name: string;
+  path: string;
+}
+
+interface SyncMismatch {
+  slug: string;
+  registryTitle: string;
+  settingsName: string;
+  projectPath: string;
+}
+
+interface SyncReport {
+  dryRun: boolean;
+  missing: SyncMissing[];
+  orphaned: SyncOrphaned[];
+  mismatches: SyncMismatch[];
+  applied?: boolean;
+  addedCount?: number;
+}
+
+interface SyncRegistryOptions {
+  settingsService: SettingsService;
+}
+
+export function createPortfolioSyncRegistryRoutes({
+  settingsService,
+}: SyncRegistryOptions): Router {
+  const router = Router();
+
+  router.post('/', async (req: Request, res: Response) => {
+    const dryRun = req.body.dryRun !== false;
+
+    try {
+      // Fetch registry from Workstacean
+      const workstaceanUrl = process.env.WORKSTACEAN_URL ?? DEFAULT_WORKSTACEAN_URL;
+      let registryEntries: ProjectRegistryEntry[] = [];
+      try {
+        const wRes = await fetch(`${workstaceanUrl}/api/projects`, {
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (wRes.ok) {
+          const body = (await wRes.json()) as WorkstaceanResponse;
+          if (body.success) registryEntries = body.data;
+        }
+      } catch (err) {
+        logger.warn(
+          'Workstacean unreachable during sync:',
+          err instanceof Error ? err.message : String(err)
+        );
+      }
+
+      // Get current settings projects
+      const settings = await settingsService.getGlobalSettings();
+      const settingsProjects: ProjectRef[] = settings.projects ?? [];
+
+      // Build lookup maps
+      const settingsByPath = new Map<string, ProjectRef>();
+      for (const sp of settingsProjects) {
+        if (sp.path) settingsByPath.set(sp.path, sp);
+      }
+
+      const registryByPath = new Map<string, ProjectRegistryEntry>();
+      for (const rp of registryEntries) {
+        if (rp.projectPath) registryByPath.set(rp.projectPath, rp);
+      }
+
+      // Missing from settings (in registry but not in settings)
+      const missing: SyncMissing[] = [];
+      for (const rp of registryEntries) {
+        if (!rp.projectPath) continue;
+        if (!settingsByPath.has(rp.projectPath)) {
+          missing.push({
+            slug: rp.slug,
+            title: rp.title ?? rp.slug,
+            projectPath: rp.projectPath,
+          });
+        }
+      }
+
+      // Orphaned in settings (in settings but not in registry)
+      const orphaned: SyncOrphaned[] = [];
+      for (const sp of settingsProjects) {
+        if (!sp.path) continue;
+        if (!registryByPath.has(sp.path)) {
+          orphaned.push({ id: sp.id, name: sp.name, path: sp.path });
+        }
+      }
+
+      // Metadata mismatches (in both but with differing name/title)
+      const mismatches: SyncMismatch[] = [];
+      for (const rp of registryEntries) {
+        if (!rp.projectPath) continue;
+        const sp = settingsByPath.get(rp.projectPath);
+        if (!sp) continue;
+        const registryTitle = rp.title ?? rp.slug;
+        if (registryTitle && sp.name && registryTitle !== sp.name) {
+          mismatches.push({
+            slug: rp.slug,
+            registryTitle,
+            settingsName: sp.name,
+            projectPath: rp.projectPath,
+          });
+        }
+      }
+
+      const report: SyncReport = { dryRun, missing, orphaned, mismatches };
+
+      if (!dryRun && missing.length > 0) {
+        const newRefs: ProjectRef[] = missing.map((m) => ({
+          id: randomUUID(),
+          name: m.title,
+          path: m.projectPath,
+        }));
+
+        const updatedProjects = [...settingsProjects, ...newRefs];
+        await settingsService.updateGlobalSettings({ projects: updatedProjects });
+
+        report.applied = true;
+        report.addedCount = newRefs.length;
+        logger.info(`Sync applied: added ${newRefs.length} projects to settings`);
+      }
+
+      res.json(report);
+    } catch (err) {
+      logger.error('Sync registry failed:', err);
+      res.status(500).json({ error: 'Failed to sync registry' });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -81,6 +81,7 @@ import { createTodoRoutes } from '../routes/todo/index.js';
 import { createSitrepRoutes } from '../routes/sitrep/index.js';
 import { createPortfolioSitrepRoutes } from '../routes/portfolio/sitrep.js';
 import { createCrossRepoDepsRoutes } from '../routes/portfolio/cross-repo-deps.js';
+import { createPortfolioSyncRegistryRoutes } from '../routes/portfolio/sync-registry.js';
 import { createLeadEngineerRoutes } from '../routes/lead-engineer/index.js';
 import { createPrometheusRoute } from '../routes/metrics/prometheus.js';
 import { createAutomationsRoutes } from '../routes/automations/index.js';
@@ -418,6 +419,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
     '/api/portfolio/cross-repo-deps',
     createCrossRepoDepsRoutes({ settingsService, featureLoader })
   );
+  app.use('/api/portfolio/sync-registry', createPortfolioSyncRegistryRoutes({ settingsService }));
   // Knowledge store routes (chunked retrieval)
   if (knowledgeStoreService) {
     app.use('/api/knowledge', createKnowledgeRoutes(knowledgeStoreService));

--- a/apps/server/src/services/project-registry-service.ts
+++ b/apps/server/src/services/project-registry-service.ts
@@ -1,0 +1,140 @@
+/**
+ * ProjectRegistryService — Fleet-wide project registry sourced from Workstacean.
+ *
+ * Fetches from Workstacean's GET /api/projects?includeState=true on startup and
+ * every 60 seconds. Falls back to the local workspace/projects.yaml snapshot when
+ * Workstacean is unreachable. After each successful remote fetch, writes a JSON
+ * cache to .automaker/cache/projects-registry.json so the fallback is always fresh.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import { createLogger } from '@protolabsai/utils';
+
+const logger = createLogger('ProjectRegistryService');
+
+export interface RegistryProjectOperationalState {
+  board: { backlog: number; inProgress: number; blocked: number };
+  autoMode: { running: boolean };
+  activeAgents: number;
+}
+
+export interface ProjectRegistryEntry {
+  slug: string;
+  title?: string;
+  team?: string;
+  github?: string;
+  defaultBranch?: string;
+  status?: string;
+  projectPath?: string;
+  studioUrl?: string;
+  agents?: string[];
+  operationalState?: RegistryProjectOperationalState | { state: 'unreachable' };
+  [key: string]: unknown;
+}
+
+interface WorkstaceanProjectsResponse {
+  success: boolean;
+  data: ProjectRegistryEntry[];
+}
+
+const POLL_INTERVAL_MS = 60_000;
+const DEFAULT_WORKSTACEAN_URL = 'http://workstacean:8082';
+
+export class ProjectRegistryService {
+  private projects: ProjectRegistryEntry[] = [];
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly workstaceanUrl: string;
+  private readonly localSnapshotPath: string;
+  private readonly cachePath: string;
+
+  constructor({ projectRoot }: { projectRoot: string }) {
+    this.workstaceanUrl = process.env.WORKSTACEAN_URL ?? DEFAULT_WORKSTACEAN_URL;
+    this.localSnapshotPath = join(projectRoot, 'workspace', 'projects.yaml');
+    this.cachePath = join(projectRoot, '.automaker', 'cache', 'projects-registry.json');
+  }
+
+  async start(): Promise<void> {
+    await this.refresh();
+    this.timer = setInterval(() => {
+      this.refresh().catch((err) => {
+        logger.error('Registry refresh failed:', err instanceof Error ? err.message : String(err));
+      });
+    }, POLL_INTERVAL_MS);
+  }
+
+  stop(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  getProjects(): ProjectRegistryEntry[] {
+    return this.projects;
+  }
+
+  getProject(slug: string): ProjectRegistryEntry | null {
+    return this.projects.find((p) => p.slug === slug) ?? null;
+  }
+
+  private async refresh(): Promise<void> {
+    try {
+      const entries = await this.fetchFromWorkstacean();
+      this.projects = entries;
+      await this.writeCache(entries);
+      logger.info(`Registry refreshed: ${entries.length} projects`);
+    } catch (err) {
+      logger.warn(
+        'Workstacean unreachable, falling back to local snapshot:',
+        err instanceof Error ? err.message : String(err)
+      );
+      this.projects = this.loadFromLocalSnapshot();
+    }
+  }
+
+  private async fetchFromWorkstacean(): Promise<ProjectRegistryEntry[]> {
+    const res = await fetch(`${this.workstaceanUrl}/api/projects?includeState=true`, {
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      throw new Error(`Workstacean returned HTTP ${res.status}`);
+    }
+    const body = (await res.json()) as WorkstaceanProjectsResponse;
+    if (!body.success) {
+      throw new Error('Workstacean returned success: false');
+    }
+    return body.data;
+  }
+
+  private loadFromLocalSnapshot(): ProjectRegistryEntry[] {
+    // Prefer the JSON cache (most recently fetched data)
+    if (existsSync(this.cachePath)) {
+      try {
+        const raw = readFileSync(this.cachePath, 'utf8');
+        return JSON.parse(raw) as ProjectRegistryEntry[];
+      } catch {
+        // Fall through to YAML snapshot
+      }
+    }
+    // Fall back to workspace/projects.yaml
+    if (existsSync(this.localSnapshotPath)) {
+      try {
+        const raw = readFileSync(this.localSnapshotPath, 'utf8');
+        const parsed = parseYaml(raw) as Record<string, unknown>;
+        return (parsed['projects'] ?? []) as ProjectRegistryEntry[];
+      } catch {
+        // Nothing to load
+      }
+    }
+    return [];
+  }
+
+  private async writeCache(entries: ProjectRegistryEntry[]): Promise<void> {
+    const dir = dirname(this.cachePath);
+    await mkdir(dir, { recursive: true });
+    await writeFile(this.cachePath, JSON.stringify(entries, null, 2), 'utf8');
+  }
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -781,6 +781,11 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         projectSlug: args.projectSlug,
       });
 
+    case 'sync_registry':
+      return apiCall('/portfolio/sync-registry', {
+        dryRun: args.dryRun !== false,
+      });
+
     case 'get_portfolio_sitrep':
       return apiCall(
         '/portfolio/sitrep',

--- a/packages/mcp-server/src/tools/portfolio-tools.ts
+++ b/packages/mcp-server/src/tools/portfolio-tools.ts
@@ -6,6 +6,22 @@ import { Tool } from '@modelcontextprotocol/sdk/types.js';
 
 export const portfolioTools: Tool[] = [
   {
+    name: 'sync_registry',
+    description:
+      'Compare Studio settings.projects[] against the Workstacean project registry. Reports missing projects (in Workstacean but not in settings), orphaned projects (in settings but not in Workstacean), and metadata mismatches. Runs as a dry run by default — set dryRun: false to apply the sync and add missing projects to settings.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        dryRun: {
+          type: 'boolean',
+          description:
+            'When true (default), only reports the diff without making any changes. Set to false to apply the sync: adds missing projects to settings and flags orphaned ones.',
+          default: true,
+        },
+      },
+    },
+  },
+  {
     name: 'get_portfolio_sitrep',
     description:
       'Get a fleet-wide portfolio status report aggregating all active projects in one call. Returns per-project health (green/yellow/red), active agents, backlog depth, blocked count, and staging lag. Also includes portfolio-level metrics (total active agents, WIP utilization, top constraint) and pending human decisions (PR reviews, escalations, prioritization needs) across all projects. Use this instead of calling get_sitrep for each project individually.',


### PR DESCRIPTION
## Summary

Two-part: extend Workstacean's projects API to include live operational state, then wire Studio to consume it as the authoritative registry.

**Part 1 — Workstacean (`/home/josh/dev/protoWorkstacean/src/index.ts` + routes)**

Extend `GET /api/projects` to optionally include operational state per project:
- Query param `?includeState=true`
- For each project with a `projectPath`, query its automaker server (`GET http://localhost:PORT/api/sitrep`) 
- PORT resolved from a `automakerPort` field in a...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added project registry synchronization between Workstacean and Portfolio Studio
  * Compare and align project registries with detailed reports showing missing, orphaned, and mismatched entries
  * Dry-run mode enabled by default to safely preview changes before applying them
  * Manual sync endpoint with option to apply identified updates to project settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->