### PR TITLE
Fix: deleting current project causes 403-logout loop

### DIFF
--- a/apps/ui/src/components/views/project-settings-view/project-settings-view.tsx
+++ b/apps/ui/src/components/views/project-settings-view/project-settings-view.tsx
@@ -155,7 +155,10 @@ export function ProjectSettingsView() {
         open={showDeleteDialog}
         onOpenChange={setShowDeleteDialog}
         project={currentProject}
-        onConfirm={moveProjectToTrash}
+        onConfirm={(projectId) => {
+          moveProjectToTrash(projectId);
+          void navigate({ to: '/dashboard' });
+        }}
       />
     </div>
   );

--- a/apps/ui/src/lib/clients/base-http-client.ts
+++ b/apps/ui/src/lib/clients/base-http-client.ts
@@ -108,7 +108,7 @@ export class BaseHttpClient {
         credentials: 'include',
         cache: NO_STORE_CACHE_MODE,
       });
-      if (response.status === 401 || response.status === 403) {
+      if (response.status === 401) {
         handleUnauthorized();
         return null;
       }
@@ -321,7 +321,7 @@ export class BaseHttpClient {
       credentials: 'include',
       body: body ? JSON.stringify(body) : undefined,
     });
-    if (response.status === 401 || response.status === 403) {
+    if (response.status === 401) {
       handleUnauthorized();
       throw new Error('Unauthorized');
     }
@@ -345,7 +345,7 @@ export class BaseHttpClient {
       credentials: 'include',
       cache: NO_STORE_CACHE_MODE,
     });
-    if (response.status === 401 || response.status === 403) {
+    if (response.status === 401) {
       handleUnauthorized();
       throw new Error('Unauthorized');
     }
@@ -370,7 +370,7 @@ export class BaseHttpClient {
       credentials: 'include',
       body: body ? JSON.stringify(body) : undefined,
     });
-    if (response.status === 401 || response.status === 403) {
+    if (response.status === 401) {
       handleUnauthorized();
       throw new Error('Unauthorized');
     }
@@ -395,7 +395,7 @@ export class BaseHttpClient {
       credentials: 'include',
       body: body ? JSON.stringify(body) : undefined,
     });
-    if (response.status === 401 || response.status === 403) {
+    if (response.status === 401) {
       handleUnauthorized();
       throw new Error('Unauthorized');
     }
@@ -428,7 +428,7 @@ export class BaseHttpClient {
       credentials: 'include',
       body: data,
     });
-    if (response.status === 401 || response.status === 403) {
+    if (response.status === 401) {
       handleUnauthorized();
       throw new Error('Unauthorized');
     }


### PR DESCRIPTION
## Summary

## Bug

When a user deletes a project while currently viewing it, subsequent API calls return 403 (PathNotAllowed — the project path no longer exists or is inaccessible). The HttpClient treats any 403 response as an authentication failure and fires the `automaker:logged-out` event, kicking the user to `/logged-out` in an infinite loop.

## Root Cause

`HttpClient` does not distinguish between:
- **401 Unauthorized** — session expired/invalid → should trigger logout
- **403 Forbidden** — authenti...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-07T20:04:10.766Z -->