### PR TITLE
bug: docs not visible in protomaker app docs view

### DIFF
--- a/apps/ui/src/components/views/docs-view.tsx
+++ b/apps/ui/src/components/views/docs-view.tsx
@@ -5,6 +5,14 @@ import { useAppStore } from '@/store/app-store';
 import { PanelHeader } from '@/components/shared/panel-header';
 import { DocsFileTree } from './docs-view/docs-file-tree';
 import { DocsContentPanel } from './docs-view/docs-content-panel';
+import { getApiKey, getSessionToken } from '@/lib/http-api-client';
+
+function getAuthHeaders(): Record<string, string> {
+  const apiKey = getApiKey();
+  if (apiKey) return { 'X-API-Key': apiKey };
+  const sessionToken = getSessionToken();
+  return sessionToken ? { 'X-Session-Token': sessionToken } : {};
+}
 
 interface DocsConfig {
   docsPath?: string;
@@ -27,7 +35,10 @@ function useDocsConfig(projectPath: string | undefined) {
     let cancelled = false;
     setIsLoading(true);
 
-    fetch(`/api/docs/config?projectPath=${encodeURIComponent(projectPath)}`)
+    fetch(`/api/docs/config?projectPath=${encodeURIComponent(projectPath)}`, {
+      headers: getAuthHeaders(),
+      credentials: 'include',
+    })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error('Failed'))))
       .then((data) => {
         if (!cancelled) setConfig(data);

--- a/apps/ui/src/components/views/docs-view/docs-content-panel.tsx
+++ b/apps/ui/src/components/views/docs-view/docs-content-panel.tsx
@@ -8,6 +8,14 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@proto
 import { cn } from '@/lib/utils';
 import { DocsEditor } from './docs-editor';
 import { DocsToolbar } from './docs-toolbar';
+import { getApiKey, getSessionToken } from '@/lib/http-api-client';
+
+function getAuthHeaders(): Record<string, string> {
+  const apiKey = getApiKey();
+  if (apiKey) return { 'X-API-Key': apiKey };
+  const sessionToken = getSessionToken();
+  return sessionToken ? { 'X-Session-Token': sessionToken } : {};
+}
 
 interface DocsContentPanelProps {
   projectPath: string;
@@ -38,7 +46,8 @@ export function DocsContentPanel({ projectPath, selectedPath }: DocsContentPanel
     try {
       const response = await fetch('/api/docs/file', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+        credentials: 'include',
         body: JSON.stringify({ projectPath, path: pathToSave, content: toSave }),
       });
       if (!response.ok) throw new Error('Save failed');
@@ -89,7 +98,10 @@ export function DocsContentPanel({ projectPath, selectedPath }: DocsContentPanel
       setIsEditing(false);
       try {
         const params = new URLSearchParams({ projectPath, path: selectedPath! });
-        const response = await fetch(`/api/docs/file?${params}`);
+        const response = await fetch(`/api/docs/file?${params}`, {
+          headers: getAuthHeaders(),
+          credentials: 'include',
+        });
         if (!response.ok) throw new Error(`Failed to fetch doc: ${response.status}`);
         const data = await response.json();
         if (!cancelled) {

--- a/apps/ui/src/components/views/docs-view/docs-file-tree.tsx
+++ b/apps/ui/src/components/views/docs-view/docs-file-tree.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useState } from 'react';
 import { FileText, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { getApiKey, getSessionToken } from '@/lib/http-api-client';
+
+function getAuthHeaders(): Record<string, string> {
+  const apiKey = getApiKey();
+  if (apiKey) return { 'X-API-Key': apiKey };
+  const sessionToken = getSessionToken();
+  return sessionToken ? { 'X-Session-Token': sessionToken } : {};
+}
 
 interface DocFile {
   path: string;
@@ -28,7 +36,8 @@ export function DocsFileTree({ projectPath, selectedPath, onSelect }: DocsFileTr
       setError(null);
       try {
         const response = await fetch(
-          `/api/docs/list?projectPath=${encodeURIComponent(projectPath)}`
+          `/api/docs/list?projectPath=${encodeURIComponent(projectPath)}`,
+          { headers: getAuthHeaders(), credentials: 'include' }
         );
         if (!response.ok) {
           throw new Error(`Failed to fetch docs list: ${response.status}`);


### PR DESCRIPTION
## Summary

The docs directory at `docs/` in protoWorkstacean (Diátaxis structure with `reference/`, `how-to/`, `explanation/`, `tutorials/`) is not rendering or visible in the protomaker app's docs view.

**Root cause (from browser logs):**
```
api/docs/config?projectPath=%2Fhome%2Fjosh%2Fdev%2FprotoWorkstacean:1
Failed to load resource: the server responded with a status of 401 (Unauthorized)
```
The docs config endpoint returns 401 even though the session is authenticated via cookies (session verified su...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-08T06:14:16.799Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced docs API requests with API key and session token authentication support
  * Enabled secure cookie-based requests across docs file operations and configuration fetching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->