### PR TITLE
feat: world-state HTTP endpoints for workstacean polling + A2A trace propagation

### DIFF
--- a/apps/server/src/routes/a2a/index.ts
+++ b/apps/server/src/routes/a2a/index.ts
@@ -372,16 +372,24 @@ async function callChatEndpoint(
   apiKey: string,
   projectPath: string,
   userText: string,
-  skillOverride?: string
+  skillOverride?: string,
+  correlationId?: string
 ): Promise<string> {
   const baseUrl = `http://localhost:${process.env['PORT'] ?? 3008}`;
   const chatRes = await fetch(`${baseUrl}/api/chat`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey },
+    headers: {
+      'Content-Type': 'application/json',
+      'X-API-Key': apiKey,
+      // Propagate the trace context so ava's internal spans are linked to the
+      // originating workstacean correlationId.
+      ...(correlationId ? { 'X-Correlation-Id': correlationId } : {}),
+    },
     body: JSON.stringify({
       messages: [{ id: randomUUID(), role: 'user', parts: [{ type: 'text', text: userText }] }],
       projectPath,
       ...(skillOverride ? { skillOverride } : {}),
+      ...(correlationId ? { correlationId } : {}),
     }),
   });
 
@@ -455,7 +463,9 @@ export function createA2AHandlerRoutes(projectPath: string, deps?: A2AHandlerDep
     const parts = body.params?.message?.parts ?? [];
     const userText = extractText(parts);
     const skillOverride = body.params?.metadata?.skillHint as string | undefined;
-    const contextId = body.params?.contextId;
+    // Prefer params.contextId, then X-Correlation-Id header (set by workstacean A2AExecutor)
+    const contextId =
+      body.params?.contextId ?? (req.headers['x-correlation-id'] as string | undefined);
     const metadata = body.params?.metadata ?? {};
 
     if (!userText && skillOverride !== 'plan_resume') {
@@ -652,14 +662,22 @@ export function createA2AHandlerRoutes(projectPath: string, deps?: A2AHandlerDep
           responseText = await executeNativeSkill(projectPath, skill, userText);
         } else {
           // Skill not found, has no tool restrictions, or uses Ava board tools → /api/chat
-          responseText = await callChatEndpoint(key, projectPath, userText, skillOverride);
+          responseText = await callChatEndpoint(
+            key,
+            projectPath,
+            userText,
+            skillOverride,
+            contextId
+          );
         }
       } else {
-        responseText = await callChatEndpoint(key, projectPath, userText, undefined);
+        responseText = await callChatEndpoint(key, projectPath, userText, undefined, contextId);
       }
 
       const taskId = randomUUID();
-      const responseContextId = randomUUID();
+      // Propagate incoming contextId to preserve the distributed trace chain.
+      // Only generate a new one if no contextId arrived (e.g. direct curl calls).
+      const responseContextId = contextId ?? randomUUID();
 
       res.status(200).json({
         jsonrpc: '2.0',

--- a/apps/server/src/routes/world/index.ts
+++ b/apps/server/src/routes/world/index.ts
@@ -1,0 +1,160 @@
+/**
+ * World-state endpoints — lightweight GET snapshots for workstacean polling.
+ *
+ * GET /api/world/board        — aggregate feature counts across all projects
+ * GET /api/world/agent-health — running agents + count
+ *
+ * These are designed to be polled by workstacean's WorldStateEngine via HTTP
+ * domain collectors registered in workspace/domains.yaml.  Responses are
+ * intentionally minimal — just the facts the GOAP planner needs.
+ *
+ * Auth: X-API-Key header (same credential as /a2a and /webhooks).
+ * Mounted before authMiddleware so the API key check is done manually here.
+ */
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import type { FeatureLoader } from '../../services/feature-loader.js';
+import type { AutoModeService } from '../../services/auto-mode-service.js';
+import { validateApiKey } from '../../lib/auth.js';
+import { getBacklogPlanStatus, getRunningDetails } from '../backlog-plan/common.js';
+import { getAllRunningGenerations } from '../app-spec/common.js';
+
+function requireApiKey(req: Request, res: Response): boolean {
+  const key = req.headers['x-api-key'] as string | undefined;
+  if (!key || !validateApiKey(key)) {
+    res.status(401).json({ success: false, error: 'Unauthorized: X-API-Key required' });
+    return false;
+  }
+  return true;
+}
+
+export function createWorldRoutes(
+  featureLoader: FeatureLoader,
+  autoModeService: AutoModeService,
+  repoRoot: string
+): Router {
+  const router = Router();
+
+  /**
+   * GET /api/world/board
+   *
+   * Returns aggregate feature counts across all projects in this ava instance.
+   * Shape is intentionally flat so the GOAP planner can access counts via
+   * JSON-path queries like `board.inProgress`.
+   */
+  router.get('/board', async (req: Request, res: Response): Promise<void> => {
+    if (!requireApiKey(req, res)) return;
+
+    try {
+      const features = await featureLoader.getAll(repoRoot);
+
+      const counts = {
+        total: features.length,
+        backlog: 0,
+        inProgress: 0,
+        review: 0,
+        blocked: 0,
+        done: 0,
+        verified: 0,
+      };
+
+      for (const f of features) {
+        switch (f.status) {
+          case 'backlog':
+            counts.backlog++;
+            break;
+          case 'in_progress':
+            counts.inProgress++;
+            break;
+          case 'review':
+            counts.review++;
+            break;
+          case 'blocked':
+            counts.blocked++;
+            break;
+          case 'done':
+            counts.done++;
+            break;
+          case 'verified':
+            counts.verified++;
+            break;
+        }
+      }
+
+      res.json({ success: true, data: counts, collectedAt: Date.now() });
+    } catch (err) {
+      res.status(500).json({ success: false, error: String(err) });
+    }
+  });
+
+  /**
+   * GET /api/world/agent-health
+   *
+   * Returns running agents and a simple health summary.
+   * Matches the same agent enumeration logic as GET /api/running-agents
+   * (includes backlog-plan and spec-generation pseudo-agents).
+   * projectPath is omitted to avoid leaking internal filesystem topology.
+   */
+  router.get('/agent-health', async (req: Request, res: Response): Promise<void> => {
+    if (!requireApiKey(req, res)) return;
+
+    try {
+      const runningAgents = [...(await autoModeService.getRunningAgents())];
+
+      // Backlog-plan pseudo-agent (same logic as /api/running-agents)
+      const backlogStatus = getBacklogPlanStatus();
+      const backlogDetails = getRunningDetails();
+      if (backlogStatus.isRunning && backlogDetails) {
+        runningAgents.push({
+          featureId: `backlog-plan:${backlogDetails.projectPath}`,
+          projectPath: backlogDetails.projectPath,
+          isAutoMode: false,
+          startTime: backlogDetails.startedAt
+            ? new Date(backlogDetails.startedAt).getTime()
+            : Date.now(),
+          title: 'Backlog plan',
+          description: backlogDetails.prompt,
+          projectName: '',
+        });
+      }
+
+      // Spec-generation pseudo-agents
+      for (const gen of getAllRunningGenerations()) {
+        const title =
+          gen.type === 'feature_generation'
+            ? 'Generating features from spec'
+            : gen.type === 'sync'
+              ? 'Syncing spec with code'
+              : 'Regenerating spec';
+        runningAgents.push({
+          featureId: `spec-generation:${gen.projectPath}`,
+          projectPath: gen.projectPath,
+          isAutoMode: false,
+          startTime: gen.startedAt ? new Date(gen.startedAt).getTime() : Date.now(),
+          title,
+          description: '',
+          projectName: '',
+        });
+      }
+
+      res.json({
+        success: true,
+        data: {
+          runningCount: runningAgents.length,
+          // projectPath intentionally omitted — avoids leaking internal fs paths
+          agents: runningAgents.map((a) => ({
+            featureId: a.featureId,
+            startTime: a.startTime,
+            title: a.title,
+          })),
+        },
+        collectedAt: Date.now(),
+      });
+    } catch (err) {
+      res.status(500).json({ success: false, error: String(err) });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -96,6 +96,7 @@ import { createOpsRoutes } from '../routes/ops/index.js';
 import { createQaRoutes } from '../routes/qa/index.js';
 import { createContextEngineRoutes } from '../routes/context-engine.js';
 import { createA2ARoutes, createA2AHandlerRoutes } from '../routes/a2a/index.js';
+import { createWorldRoutes } from '../routes/world/index.js';
 import { PlanningService } from '../services/planning-service.js';
 
 const logger = createLogger('Server:Routes');
@@ -230,6 +231,9 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
 
   // A2A message handler — manual X-API-Key check inside (same pattern as /webhooks)
   app.use('/a2a', createA2AHandlerRoutes(repoRoot, { planningService }));
+
+  // World-state polling endpoints — unauthenticated, intended for workstacean HTTP collectors
+  app.use('/api/world', createWorldRoutes(featureLoader, autoModeService, repoRoot));
 
   // --- AUTHENTICATION MIDDLEWARE ---
   // Apply authentication to all /api/* routes

--- a/workspace/domains.yaml
+++ b/workspace/domains.yaml
@@ -1,0 +1,27 @@
+# Domain registrations for workstacean's WorldStateEngine.
+# Each entry defines an HTTP endpoint to poll and the interval.
+# workstacean registers these via domain-discovery on startup.
+#
+# URLs support ${ENV_VAR} interpolation.
+# Set AVA_BASE_URL in workstacean's environment to match your deployment:
+#   Local dev:  AVA_BASE_URL=http://localhost:3008
+#   Docker:     AVA_BASE_URL=http://ava:3008
+#   Remote:     AVA_BASE_URL=https://ava.internal
+#
+# Also set AVA_API_KEY to the same value as ava's API_KEY so workstacean
+# can authenticate against the X-API-Key-protected /api/world/* endpoints.
+
+domains:
+  - name: board
+    url: ${AVA_BASE_URL}/api/world/board
+    tickMs: 30000 # poll every 30s
+    timeoutMs: 5000
+    headers:
+      X-API-Key: ${AVA_API_KEY}
+
+  - name: agent-health
+    url: ${AVA_BASE_URL}/api/world/agent-health
+    tickMs: 15000 # poll every 15s — agents change faster
+    timeoutMs: 5000
+    headers:
+      X-API-Key: ${AVA_API_KEY}

--- a/workspace/projects.yaml
+++ b/workspace/projects.yaml
@@ -274,18 +274,3 @@ projects:
       priorityWeight: 1.0
       minConcurrency: 1
       maxConcurrency: 3
-
-  - slug: protolabsai-protomaker
-    title: protoMaker
-    github: protoLabsAI/protoMaker
-    defaultBranch: main
-    status: active
-    onboardedAt: '2026-04-07T00:00:00.000Z'
-    discord:
-      channels:
-        general: '1490957797406408746'
-        updates: '1490957799151239368'
-        dev: '1490957800711393333'
-    plane:
-      projectId: not provisioned
-      identifier: not provisioned


### PR DESCRIPTION
## Summary

- Add `GET /api/world/board` and `GET /api/world/agent-health` endpoints for workstacean's `WorldStateEngine` to poll ava's operational state as generic HTTP domains
- Fix A2A distributed trace propagation so `correlationId` flows into ava's internal chat processing
- Add `workspace/domains.yaml` for workstacean domain registration
- Remove duplicate `protolabsai-protomaker` entry from `workspace/projects.yaml`

## Changes

**`routes/world/index.ts`** (new)
- `GET /api/world/board` — aggregate feature counts (backlog/inProgress/review/blocked/done/verified) across all projects via `featureLoader.getAll(repoRoot)`
- `GET /api/world/agent-health` — running agents with same enumeration logic as `GET /api/running-agents` (includes backlog-plan and spec-generation pseudo-agents); `projectPath` omitted from response to avoid leaking internal fs paths
- Both endpoints require `X-API-Key` header auth (same credential as `/a2a`)

**`routes/a2a/index.ts`**
- `callChatEndpoint()` now accepts and forwards `correlationId` as both `X-Correlation-Id` header and in the request body — ava's internal chat spans are now linked to the originating workstacean trace ID rather than being orphaned

**`workspace/domains.yaml`** (new)
- Registers `board` (30s tick) and `agent-health` (15s tick) domains
- Uses `${AVA_BASE_URL}` and `${AVA_API_KEY}` env var interpolation — no hardcoded hostnames

## Test plan

- [ ] `GET /api/world/board` with valid X-API-Key returns `{ success: true, data: { total, backlog, inProgress, ... } }`
- [ ] `GET /api/world/board` without key returns 401
- [ ] `GET /api/world/agent-health` response does not include `projectPath` field on any agent
- [ ] `GET /api/world/agent-health` when a backlog plan is running shows it in the agents list
- [ ] A2A skill invocation from workstacean — confirm `X-Correlation-Id` header appears on the `/api/chat` request in server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced world-state monitoring endpoints providing real-time visibility into board status and running agent health metrics
  * Enhanced request tracking across operations to improve system observability and identify related activities
  * Configured automated polling with adjustable refresh intervals for continuous monitoring data collection

* **Chores**
  * Removed duplicate project configuration entry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->