### PR TITLE
bug: auto-mode ignores gitWorkflow.prBaseBranch — agents target main instead of dev

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -2109,9 +2109,12 @@ Address the follow-up instructions above. Review the previous work and make the 
             }
           }
 
-          // Resolve per-project prBaseBranch override
-          const projectSettings = await this.settingsService.getProjectSettings(projectPath);
-          const projectPrBaseBranch = projectSettings.workflow?.gitWorkflow?.prBaseBranch;
+          // Resolve effective prBaseBranch: project settings → global settings → auto-detect → default
+          const projectPrBaseBranch = await getEffectivePrBaseBranch(
+            projectPath,
+            this.settingsService,
+            '[FollowUp]'
+          );
 
           gitWorkflowResult = await gitWorkflowService.runPostCompletionWorkflow(
             projectPath,

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -993,7 +993,7 @@ Output the branch name only.`,
           if (!lsOutput.trim()) {
             const missingBranchReason =
               `Pre-flight check failed: base branch "origin/${preFlightBaseBranch}" does not exist on remote. ` +
-              `Configure workflow.gitWorkflow.prBaseBranch in .automaker/settings.json to match the project's default branch.`;
+              `Configure gitWorkflow.prBaseBranch in global settings or workflow.gitWorkflow.prBaseBranch in .automaker/settings.json to match the project's default branch.`;
             logger.error(`[PreFlight] ${missingBranchReason}`);
             this.typedEventBus.emitAutoModeEvent('sync_warning', {
               featureId,
@@ -1323,7 +1323,7 @@ Output the branch name only.`,
             }
           }
 
-          // Resolve per-project prBaseBranch: project settings → auto-detect (never global)
+          // Resolve effective prBaseBranch: project settings → global settings → auto-detect → default
           const projectPrBaseBranch = await getEffectivePrBaseBranch(
             projectPath,
             this.settingsService,

--- a/apps/server/src/services/maintenance-tasks.ts
+++ b/apps/server/src/services/maintenance-tasks.ts
@@ -950,8 +950,12 @@ export async function scanWorktreesForCrashRecovery(
 
         try {
           const globalSettings = await settingsService.getGlobalSettings();
-          const projectSettings = await settingsService.getProjectSettings(projectPath);
-          const projectPrBaseBranch = projectSettings.workflow?.gitWorkflow?.prBaseBranch;
+          // Resolve effective prBaseBranch: project settings → global settings → auto-detect → default
+          const projectPrBaseBranch = await getEffectivePrBaseBranch(
+            projectPath,
+            settingsService,
+            '[MaintenanceRecovery]'
+          );
           const result = await gitWorkflowService.runPostCompletionWorkflow(
             projectPath,
             feature.id,


### PR DESCRIPTION
## Summary

## Observed
Setting `gitWorkflow.prBaseBranch: "dev"` in global settings has no effect. Auto-mode agents still create PRs targeting `main`.

## Reproduction
1. Set `gitWorkflow.prBaseBranch = "dev"` via update_settings MCP tool
2. Start auto-mode on a project with backlog features
3. Wait for an agent to complete a feature and create a PR
4. Observe: PR is created with `base: main` instead of `base: dev`

## Evidence
On protoWorkstacean this session, 6 auto-mode agents created PRs #70-77 all tar...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-10T05:21:56.544Z -->