### PR TITLE
bug: epic foundation orchestration missing — dependent features don't branch from foundation

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3184,18 +3184,29 @@ Format your response as a structured markdown document.`;
             try {
               const epicFeature = await this.featureLoader.get(projectPath, feature.epicId);
               if (epicFeature?.branchName) {
-                // Verify the epic branch exists before using it as base
-                await execFileAsync('git', ['rev-parse', '--verify', epicFeature.branchName], {
+                const epicBranch = epicFeature.branchName;
+                // Fetch the epic branch from remote to ensure we have up-to-date refs.
+                // Epic branches are pushed to remote-only during project scaffold, so a
+                // local `git rev-parse` would fail without an explicit fetch first.
+                try {
+                  await execFileAsync('git', ['fetch', 'origin', epicBranch], {
+                    cwd: projectPath,
+                  });
+                } catch {
+                  // Non-fatal: cached remote refs may suffice if fetch fails transiently
+                }
+                // Verify the epic branch exists on the remote (origin/epic/...)
+                await execFileAsync('git', ['rev-parse', '--verify', `origin/${epicBranch}`], {
                   cwd: projectPath,
                 });
-                baseBranch = epicFeature.branchName;
+                baseBranch = `origin/${epicBranch}`;
                 logger.info(
                   `Feature ${feature.id} belongs to epic, branching from epic branch: ${baseBranch}`
                 );
               }
             } catch {
               logger.warn(
-                `Epic branch not found for feature ${feature.id} (epicId: ${feature.epicId}), falling back to HEAD`
+                `Epic branch not found for feature ${feature.id} (epicId: ${feature.epicId}), falling back to origin/${resolvedPrBaseBranch}`
               );
             }
           }

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -967,11 +967,31 @@ Output the branch name only.`,
       await this.featureLoader.update(projectPath, featureId, { model: modelResult.model });
 
       // Resolve the effective base branch for this project (project setting → auto-detect → 'dev')
-      const preFlightBaseBranch = await getEffectivePrBaseBranch(
+      let preFlightBaseBranch = await getEffectivePrBaseBranch(
         projectPath,
         this.settingsService,
         '[PreFlight]'
       );
+
+      // For features belonging to an epic, sync against the epic branch instead of dev.
+      // Epic child features are branched from origin/epic/... (not dev), so merging dev
+      // would pull in unrelated changes and cause conflicts against the epic branch.
+      if (feature.epicId && !feature.isEpic) {
+        try {
+          const epicFeature = await this.featureLoader.get(projectPath, feature.epicId);
+          if (epicFeature?.branchName) {
+            preFlightBaseBranch = epicFeature.branchName;
+            logger.info(
+              `[PreFlight] Feature ${featureId} belongs to epic, syncing against epic branch: ${preFlightBaseBranch}`
+            );
+          }
+        } catch (err) {
+          logger.warn(
+            `[PreFlight] Could not load epic feature ${feature.epicId} for branch resolution — using default: ${preFlightBaseBranch}`,
+            err
+          );
+        }
+      }
 
       // Merge branch with the project's base branch before agent execution
       // Uses merge instead of rebase to handle concurrent .automaker/ modifications gracefully

--- a/apps/server/tests/unit/services/worktree-creation-base-branch.test.ts
+++ b/apps/server/tests/unit/services/worktree-creation-base-branch.test.ts
@@ -281,4 +281,103 @@ describe('AutoModeService - createWorktreeForBranch base branch resolution', () 
     // getEffectivePrBaseBranch is only called in the new-branch path, so it should NOT be called here
     expect(mockGetEffectivePrBaseBranch).not.toHaveBeenCalled();
   });
+
+  it('branches from origin/epic/<name> when feature belongs to an epic with a remote branch', async () => {
+    mockGetEffectivePrBaseBranch.mockResolvedValue('dev');
+
+    // Feature branch doesn't exist locally (first call is for feature branch check)
+    // Epic branch doesn't exist locally either (second rev-parse is for origin/epic/...)
+    // Both git fetch and git rev-parse --verify origin/... succeed
+    mockExecFileAsync.mockImplementation(async (bin: string, args: string[]) => {
+      // Feature branch rev-parse → not found (forces new-branch path)
+      if (args.includes('rev-parse') && args.includes('feature/test-branch')) {
+        throw new Error('unknown revision');
+      }
+      // All other calls succeed (fetch, epic branch verify, worktree add)
+      return { stdout: '', stderr: '' };
+    });
+
+    const svc = makeService();
+    const epicFeature = makeFeature({ id: 'epic-123', isEpic: true, branchName: 'epic/my-feature' });
+    // Inject a mock featureLoader that returns the epic feature for the epicId lookup
+    (svc as any).featureLoader = {
+      get: vi.fn().mockResolvedValue(epicFeature),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const childFeature = makeFeature({
+      id: 'feat-child-456',
+      epicId: 'epic-123',
+      isEpic: false,
+      branchName: 'feature/test-branch',
+    });
+
+    await (svc as any).createWorktreeForBranch(PROJECT_PATH, BRANCH_NAME, childFeature);
+
+    const calls = mockExecFileAsync.mock.calls as [string, string[]][];
+
+    // Verify git fetch origin epic/my-feature was called
+    const fetchCall = calls.find(
+      ([bin, args]) => bin === 'git' && args.includes('fetch') && args.includes('epic/my-feature')
+    );
+    expect(fetchCall).toBeDefined();
+
+    // Verify rev-parse checks origin/epic/my-feature (remote), not local epic/my-feature
+    const verifyCall = calls.find(
+      ([bin, args]) =>
+        bin === 'git' && args.includes('rev-parse') && args.includes('origin/epic/my-feature')
+    );
+    expect(verifyCall).toBeDefined();
+
+    // Verify worktree add uses origin/epic/my-feature as base
+    const worktreeAdd = calls.find(
+      ([bin, args]) => bin === 'git' && args.includes('worktree') && args.includes('-B')
+    );
+    expect(worktreeAdd).toBeDefined();
+    expect(worktreeAdd![1]).toContain('origin/epic/my-feature');
+    expect(worktreeAdd![1]).not.toContain('origin/dev');
+  });
+
+  it('falls back to origin/dev when epic branch does not exist on remote', async () => {
+    mockGetEffectivePrBaseBranch.mockResolvedValue('dev');
+
+    mockExecFileAsync.mockImplementation(async (bin: string, args: string[]) => {
+      // Feature branch rev-parse → not found
+      if (args.includes('rev-parse') && args.includes('feature/test-branch')) {
+        throw new Error('unknown revision');
+      }
+      // Epic branch rev-parse on remote → not found (simulates missing remote branch)
+      if (args.includes('rev-parse') && args.some((a) => a.startsWith('origin/epic/'))) {
+        throw new Error('unknown revision');
+      }
+      // fetch and worktree add succeed
+      return { stdout: '', stderr: '' };
+    });
+
+    const svc = makeService();
+    const epicFeature = makeFeature({ id: 'epic-123', isEpic: true, branchName: 'epic/my-feature' });
+    (svc as any).featureLoader = {
+      get: vi.fn().mockResolvedValue(epicFeature),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const childFeature = makeFeature({
+      id: 'feat-child-456',
+      epicId: 'epic-123',
+      isEpic: false,
+      branchName: 'feature/test-branch',
+    });
+
+    await (svc as any).createWorktreeForBranch(PROJECT_PATH, BRANCH_NAME, childFeature);
+
+    const calls = mockExecFileAsync.mock.calls as [string, string[]][];
+
+    // Should fall back to origin/dev when epic branch not found on remote
+    const worktreeAdd = calls.find(
+      ([bin, args]) => bin === 'git' && args.includes('worktree') && args.includes('-B')
+    );
+    expect(worktreeAdd).toBeDefined();
+    expect(worktreeAdd![1]).toContain('origin/dev');
+    expect(worktreeAdd![1]).not.toContain('origin/epic/');
+  });
 });


### PR DESCRIPTION
## Summary

## Observed
When a project has an epic with a foundation feature (`isFoundation: true`) and dependent features (`epicId: <epic>`, `dependencies: [<foundation>]`), the auto-mode pipeline runs all features in parallel from `main`/`dev` branches — NOT from the epic branch AFTER the foundation merges.

Result: every sub-feature rebuilds the foundation scaffold, creating massive merge conflicts.

## Reproduction
1. Create an epic feature with `isEpic: true`
2. Create a foundation feature under the ep...

---
*Recovered automatically by Automaker post-agent hook*