### PR TITLE
bug: closed PR reconciliation — features stay in review when their PR is closed (not merged)

### DIFF
--- a/apps/server/src/services/github-state-checker.ts
+++ b/apps/server/src/services/github-state-checker.ts
@@ -270,6 +270,25 @@ export class GitHubStateChecker {
             });
           }
 
+          // Check if closed without merging — only flag features currently in 'review'
+          // (features in backlog/in_progress/blocked don't have an active PR to close)
+          if (pr.state === 'closed' && !pr.merged && feature.status === 'review') {
+            logger.info(
+              `Feature "${feature.title}" (${feature.id}) has closed (unmerged) PR #${pr.number} — queuing reconciliation`
+            );
+            drifts.push({
+              type: 'pr-closed-not-merged',
+              severity: 'high',
+              projectPath,
+              featureId: feature.id,
+              prNumber: pr.number,
+              details: {
+                branchName: feature.branchName,
+                previousStatus: feature.status,
+              },
+            });
+          }
+
           // Check for drifts on open PRs
           if (pr.state === 'open') {
             if (ciStatus.state === 'failure') {

--- a/apps/server/src/services/reconciliation-service.ts
+++ b/apps/server/src/services/reconciliation-service.ts
@@ -38,6 +38,7 @@ export type DriftType =
   | 'pr-has-feedback'
   | 'pr-approved-not-merged'
   | 'pr-stale'
+  | 'pr-closed-not-merged'
   // Git
   | 'branch-merged-status-stale'
   | 'branch-deleted-feature-exists'
@@ -130,6 +131,10 @@ export class ReconciliationService {
 
         case 'pr-stale':
           action = await this.reconcilePRStale(drift);
+          break;
+
+        case 'pr-closed-not-merged':
+          action = await this.reconcilePRClosedNotMerged(drift);
           break;
 
         // Git drifts
@@ -684,6 +689,29 @@ export class ReconciliationService {
     }
 
     return 'stale-pr-pinged';
+  }
+
+  /**
+   * PR was closed without merging — move feature back to backlog
+   */
+  private async reconcilePRClosedNotMerged(drift: Drift): Promise<string> {
+    if (!drift.featureId) {
+      throw new Error('featureId required for pr-closed-not-merged');
+    }
+
+    const prNumber = drift.prNumber ?? '?';
+    logger.info(
+      `Moving feature ${drift.featureId} back to 'backlog' — PR #${prNumber} closed without merging`
+    );
+
+    await this.featureLoader.update(drift.projectPath, drift.featureId, {
+      status: 'backlog',
+      statusChangeReason: `PR #${prNumber} closed without merging`,
+      prNumber: undefined,
+      prUrl: undefined,
+    });
+
+    return 'feature-returned-to-backlog';
   }
 
   /**


### PR DESCRIPTION
## Summary

## Observed

When a PR is **closed without merging** (e.g. because a superseding PR made it obsolete), the feature it was tracking stays in 'review' status forever. The board has no way to distinguish 'PR merged → done' from 'PR closed → ???'.

## Evidence
protoWorkstacean project currently has 5 features stuck in 'review' for PRs #63, #72, #74, #76, #77 — all closed during the dashboard salvage operation. Their status never updated.

```
reviewFeatures: [
  { id: '...ci-health-domain', prNumber...

---
*Recovered automatically by Automaker post-agent hook*