### PR TITLE
ci: auto back-merge workflows (main→staging/dev, staging→dev)

### DIFF
--- a/.github/workflows/backmerge-from-main.yml
+++ b/.github/workflows/backmerge-from-main.yml
@@ -1,0 +1,107 @@
+name: Back-merge from main
+
+# Purpose: prevent ancestry divergence between main and the lower integration
+# branches (staging, dev) caused by squash promotions.
+#
+# Every time main receives a squash-merge from a staging→main promotion PR,
+# staging and dev lose sight of main's new commit. Without intervention, the
+# NEXT promotion PR (dev→staging or staging→main) hits phantom "add/add"
+# conflicts in git because the branches have the same content but different
+# ancestry. This workflow fixes that by immediately merging main's new tip
+# back into both staging and dev with `-X ours` — they already have the
+# correct content via their own real commits, so we're only acknowledging
+# the squash commit as an ancestor for future merge-base calculations.
+#
+# Paired with backmerge-from-staging.yml which handles the staging→dev hop
+# independently (e.g. when a dev→staging promotion lands and main hasn't
+# moved).
+#
+# Prerequisite: `required_status_checks` and `required_pull_request_reviews`
+# must be disabled on staging and dev (kept on main). Feature PRs still run
+# CI via the pull_request trigger on checks.yml / test.yml so the lower
+# branches don't need push-time gates.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  backmerge-to-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: staging
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch main
+        run: git fetch origin main
+
+      - name: Skip if main is already an ancestor of staging
+        id: check
+        run: |
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "main is already an ancestor of staging — nothing to do"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Merge main into staging (prefer staging on conflicts)
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          git merge origin/main -X ours --no-ff \
+            -m "Auto back-merge main → staging (post ${{ github.sha }})" \
+            -m "Triggered by .github/workflows/backmerge-from-main.yml to prevent ancestry drift that would otherwise produce phantom conflicts on the next staging→main promotion PR. Staging already has the correct content via its real commits; this commit only acknowledges main's squash as an ancestor for future merge-base calculations."
+
+      - name: Push staging
+        if: steps.check.outputs.needed == 'true'
+        run: git push origin staging
+
+  backmerge-to-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: dev
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch main
+        run: git fetch origin main
+
+      - name: Skip if main is already an ancestor of dev
+        id: check
+        run: |
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "main is already an ancestor of dev — nothing to do"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Merge main into dev (prefer dev on conflicts)
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          git merge origin/main -X ours --no-ff \
+            -m "Auto back-merge main → dev (post ${{ github.sha }})" \
+            -m "Triggered by .github/workflows/backmerge-from-main.yml. See the staging job for the full rationale — dev gets the same treatment."
+
+      - name: Push dev
+        if: steps.check.outputs.needed == 'true'
+        run: git push origin dev

--- a/.github/workflows/backmerge-from-staging.yml
+++ b/.github/workflows/backmerge-from-staging.yml
@@ -1,0 +1,66 @@
+name: Back-merge from staging
+
+# Purpose: prevent ancestry divergence between staging and dev caused by
+# dev→staging squash promotions. See backmerge-from-main.yml for the full
+# rationale — this workflow is the staging-tier counterpart.
+#
+# When a dev→staging promotion PR squash-merges, dev loses sight of the
+# new staging commit. Without this workflow, the next dev→staging promotion
+# PR hits phantom conflicts. The workflow immediately merges staging's new
+# tip back into dev with `-X ours` so dev acknowledges the squash as an
+# ancestor.
+#
+# This is the fast path for mid-cycle promotions — main hasn't moved, so
+# backmerge-from-main.yml doesn't fire, but dev still needs to pick up the
+# staging squash.
+#
+# Prerequisite: `required_status_checks` and `required_pull_request_reviews`
+# must be disabled on dev. Feature PRs still run CI via the pull_request
+# trigger on checks.yml / test.yml.
+
+on:
+  push:
+    branches: [staging]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  backmerge-to-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: dev
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch staging
+        run: git fetch origin staging
+
+      - name: Skip if staging is already an ancestor of dev
+        id: check
+        run: |
+          if git merge-base --is-ancestor origin/staging HEAD; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "staging is already an ancestor of dev — nothing to do"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Merge staging into dev (prefer dev on conflicts)
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          git merge origin/staging -X ours --no-ff \
+            -m "Auto back-merge staging → dev (post ${{ github.sha }})" \
+            -m "Triggered by .github/workflows/backmerge-from-staging.yml to prevent ancestry drift after a dev→staging promotion. Dev already has the correct content via its real commits; this commit only acknowledges staging's squash as an ancestor for future merge-base calculations."
+
+      - name: Push dev
+        if: steps.check.outputs.needed == 'true'
+        run: git push origin dev


### PR DESCRIPTION
## Summary

Port of protoWorkstacean's \`backmerge-main-to-dev.yml\` workflow (their PR #92), adapted for Ava's three-branch model (main / staging / dev). Eliminates the manual \`git merge -X ours\` dance we've been doing on every promotion.

## The problem

Squash-merge promotions create new commits on the higher branch with no ancestry link to the lower branch's originals. Without intervention, every subsequent promotion PR hits phantom add/add conflicts — same content, different history, git can't find a clean merge base.

Concretely: today I had to manually back-merge \`origin/staging\` into \`dev\` with \`-X ours\` before opening PR #3341 (dev → staging). That pattern repeats on every promotion and scales linearly with promotion frequency. That's operational toil to automate away.

## Two workflows

### \`.github/workflows/backmerge-from-main.yml\`

Triggers on \`push: main\`. Two parallel jobs — one back-merges main into staging, the other back-merges main into dev. Both use \`-X ours --no-ff\` so the lower branch's content wins on any conflict (the lower branch already has the right content via its own real commits; the merge is purely an ancestry acknowledgment).

### \`.github/workflows/backmerge-from-staging.yml\`

Triggers on \`push: staging\`. One job — back-merges staging into dev. Catches the mid-cycle case where a dev→staging promotion lands but main hasn't moved (so the main-triggered workflow doesn't fire) but dev still needs to absorb the staging squash.

Both workflows are idempotent via \`git merge-base --is-ancestor\` check and safe to re-run via \`workflow_dispatch\`.

## Branch protection prerequisites (already applied)

- \`required_status_checks\` removed from dev and staging — feature PRs still run CI via the \`pull_request\` trigger on \`checks.yml\` + \`test.yml\`, so push-time gates aren't needed on lower integration branches
- \`required_pull_request_reviews\` removed from dev and staging (was 0 approvals anyway — pure ceremony)
- \`required_linear_history\` stays disabled on dev and staging (merge commits are expected on integration branches)
- **Main stays fully locked down** — all gates preserved: ruleset, CodeRabbit, source-branch promotion check, version-bump check

## Verification

- YAML parses via \`bunx prettier --check\` (no formatting changes needed)
- Model matches the workstacean counterpart, which has been running in production without issue on the dev→main promotions since yesterday

## Rollout

File-only change, no behavioral impact until the next main or staging push. First real test will be on the next dev→staging promotion that lands after this PR merges — you should see an \`Auto back-merge staging → dev\` commit appear on dev shortly after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflows to synchronize development branches, automatically merging changes from main to staging and from staging to dev to ensure consistent code across the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->