### PR TITLE
fix(ci): PR #3342 — fix branch named feature/ instead of fix/, re-triggering source-branch and checks failures

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -554,6 +554,7 @@ export class ExecutionService {
             );
             const { model } = resolvePhaseModel(phaseModel);
             const titleForPrompt = feature.title ?? feature.description?.slice(0, 200) ?? featureId;
+            const branchPrefix = this.featureLoader.branchPrefixForCategory(feature.category);
             const result = await simpleQuery({
               model,
               cwd: projectPath,
@@ -562,31 +563,32 @@ export class ExecutionService {
               systemPrompt:
                 'You generate git branch names. Output ONLY the branch name, nothing else — no explanation, no punctuation, no quotes.',
               prompt: `Generate a concise git branch name for this feature. Rules:
-- Prefix: "feature/"
+- Prefix: "${branchPrefix}/"
 - Lowercase letters, numbers, hyphens only
 - Max 60 characters total (including prefix)
 - Must be URL-safe (no spaces, slashes beyond the prefix, special chars)
 - End with the last 7 chars of the feature ID: "${featureId.slice(-7)}"
 
 Feature title: ${titleForPrompt}
+Feature category: ${feature.category ?? 'feature'}
 Feature ID: ${featureId}
 
 Output the branch name only.`,
             });
             const raw = result.text?.trim().replace(/['"]/g, '') ?? '';
-            // Validate: must start with feature/, only safe chars, reasonable length
-            if (/^feature\/[a-z0-9][a-z0-9-]{1,58}$/.test(raw)) {
+            // Validate: must start with a known prefix/, only safe chars, reasonable length
+            if (/^[a-z]+\/[a-z0-9][a-z0-9-]{1,58}$/.test(raw)) {
               generatedBranchName = raw;
             } else {
               // Sanitize the raw output as a fallback
               const slug = raw
-                .replace(/^feature\//, '')
+                .replace(/^[a-z]+\//, '')
                 .toLowerCase()
                 .replace(/[^a-z0-9-]/g, '-')
                 .replace(/-+/g, '-')
                 .replace(/^-|-$/g, '')
                 .slice(0, 52);
-              generatedBranchName = `feature/${slug}-${featureId.slice(-7)}`;
+              generatedBranchName = `${branchPrefix}/${slug}-${featureId.slice(-7)}`;
             }
           }
         } catch (err) {
@@ -595,7 +597,8 @@ Output the branch name only.`,
 
         if (!generatedBranchName) {
           // Final fallback: derive from feature ID directly — always safe
-          generatedBranchName = `feature/${featureId.slice(0, 52)}`;
+          const branchPrefix = this.featureLoader.branchPrefixForCategory(feature.category);
+          generatedBranchName = `${branchPrefix}/${featureId.slice(0, 52)}`;
         }
 
         logger.info(`Generated branchName "${generatedBranchName}" for feature ${featureId}`);

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -298,23 +298,37 @@ export class FeatureLoader implements FeatureStore {
   }
 
   /**
-   * Generate a branch name from a feature title and feature ID.
+   * Derive the git branch prefix from a feature category.
+   * Maps semantic categories to conventional-commit-style prefixes.
+   */
+  branchPrefixForCategory(category: string | undefined): string {
+    if (!category) return 'feature';
+    const c = category.toLowerCase();
+    if (c === 'bug' || c === 'fix') return 'fix';
+    if (c === 'ops' || c === 'chore' || c === 'maintenance') return 'chore';
+    if (c === 'docs' || c === 'documentation') return 'docs';
+    return 'feature';
+  }
+
+  /**
+   * Generate a branch name from a feature title, feature ID, and optional category.
    * Appends a short fragment derived from the featureId to guarantee
    * uniqueness even when multiple features share a long common title prefix.
-   * Returns a feature/ prefixed branch name suitable for git.
+   * Uses the category to select the correct branch prefix (fix/, chore/, feature/, etc.).
    */
-  generateBranchName(title: string | undefined, featureId?: string): string {
+  generateBranchName(title: string | undefined, featureId?: string, category?: string): string {
     // Derive a short, deterministic uniqueness suffix from featureId.
     // featureId format: "feature-{timestamp}-{random9chars}"
     // Use the last 7 characters of the id — always alphanumeric, always unique.
     const shortId = featureId ? featureId.slice(-7) : Date.now().toString(36).slice(-7);
+    const prefix = this.branchPrefixForCategory(category);
 
     if (!title || !title.trim()) {
-      return `feature/untitled-${shortId}`;
+      return `${prefix}/untitled-${shortId}`;
     }
     // Keep slug portion to 50 chars so the full branch stays under ~60 chars.
     const slug = slugify(title, 50);
-    return `feature/${slug || `untitled`}-${shortId}`;
+    return `${prefix}/${slug || `untitled`}-${shortId}`;
   }
 
   /**
@@ -589,7 +603,7 @@ export class FeatureLoader implements FeatureStore {
     const branchName =
       featureData.executionMode === 'read-only'
         ? undefined
-        : featureData.branchName || this.generateBranchName(featureData.title, featureId);
+        : featureData.branchName || this.generateBranchName(featureData.title, featureId, featureData.category);
 
     // Auto-assign projectSlug if not already provided
     let resolvedProjectSlug = featureData.projectSlug;

--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -1,11 +1,12 @@
 /**
- * Unit tests for FeatureLoader.generateBranchName
+ * Unit tests for FeatureLoader.generateBranchName and branchPrefixForCategory
  *
  * Covers:
  * - Two features with a long common title prefix get distinct branch names
  * - Branch names are human-readable (contain slug of title)
  * - Untitled/empty features get unique branch names
  * - Determinism: same title + same featureId always yields the same branch
+ * - Category-based prefix selection (bug → fix/, ops → chore/, default → feature/)
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -129,5 +130,75 @@ describe('FeatureLoader.generateBranchName', () => {
   it('returns an untitled branch for blank title', () => {
     const branch = loader.generateBranchName('   ', 'feature-123-abc1234');
     expect(branch).toMatch(/^feature\/untitled-/);
+  });
+});
+
+describe('FeatureLoader.branchPrefixForCategory', () => {
+  const loader = new FeatureLoader();
+
+  it('returns fix for bug category', () => {
+    expect(loader.branchPrefixForCategory('bug')).toBe('fix');
+  });
+
+  it('returns fix for fix category', () => {
+    expect(loader.branchPrefixForCategory('fix')).toBe('fix');
+  });
+
+  it('returns chore for ops category', () => {
+    expect(loader.branchPrefixForCategory('ops')).toBe('chore');
+  });
+
+  it('returns chore for chore category', () => {
+    expect(loader.branchPrefixForCategory('chore')).toBe('chore');
+  });
+
+  it('returns chore for maintenance category', () => {
+    expect(loader.branchPrefixForCategory('maintenance')).toBe('chore');
+  });
+
+  it('returns docs for docs category', () => {
+    expect(loader.branchPrefixForCategory('docs')).toBe('docs');
+  });
+
+  it('returns feature for feature category', () => {
+    expect(loader.branchPrefixForCategory('feature')).toBe('feature');
+  });
+
+  it('returns feature for improvement category', () => {
+    expect(loader.branchPrefixForCategory('improvement')).toBe('feature');
+  });
+
+  it('returns feature for undefined category', () => {
+    expect(loader.branchPrefixForCategory(undefined)).toBe('feature');
+  });
+
+  it('is case-insensitive', () => {
+    expect(loader.branchPrefixForCategory('BUG')).toBe('fix');
+    expect(loader.branchPrefixForCategory('OPS')).toBe('chore');
+  });
+});
+
+describe('FeatureLoader.generateBranchName with category', () => {
+  const loader = new FeatureLoader();
+
+  it('uses fix/ prefix for bug category', () => {
+    const branch = loader.generateBranchName('Login crash on submit', 'feature-123-abc1234', 'bug');
+    expect(branch).toMatch(/^fix\//);
+    expect(branch).toContain('login-crash-on-submit');
+  });
+
+  it('uses chore/ prefix for ops category', () => {
+    const branch = loader.generateBranchName('Update CI config', 'feature-123-abc1234', 'ops');
+    expect(branch).toMatch(/^chore\//);
+  });
+
+  it('uses feature/ prefix when no category is given', () => {
+    const branch = loader.generateBranchName('Add dashboard', 'feature-123-abc1234');
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('untitled bug branches use fix/ prefix', () => {
+    const branch = loader.generateBranchName(undefined, 'feature-123-abc1234', 'bug');
+    expect(branch).toMatch(/^fix\/untitled-/);
   });
 });


### PR DESCRIPTION
## Summary

## RCA

PR #3342 (`feature/fixci-pr-3339-fix-branch-carries-wrong-prefix-f5tuq0n`) was opened to remediate the wrong-prefix problem from PR #3339, but the agent created the fix branch itself using the `feature/` prefix instead of `fix/`. This causes the `source-branch` workflow to reject the branch (it expects a `fix/` prefix for fix-type PRs), which in turn cascades into the composite `checks` gate failing.

The root bug is that whatever code or workflow template creates agent-generated fix bra...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-10T20:59:50.853Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-generated branch names now use category-specific prefixes for improved repository organization: `fix/` for bug-related features, `chore/` for maintenance and operational tasks, `docs/` for documentation updates, and `feature/` as the default prefix for other feature types and general improvements. This ensures consistent, semantically meaningful branch naming across projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->