### PR TITLE
fix(ci): prettier violations blocking staging→main PR #3343 + concurrency fix note

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,7 @@ on:
 permissions: read-all
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,7 @@ on:
 permissions: read-all
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -23,7 +23,9 @@ import {
 } from '../routes/health/index.js';
 import { createSessionsRoutes } from '../routes/sessions/index.js';
 import { createFeaturesRoutes } from '../routes/features/index.js';
-import { createBackfillProjectSlugHandler } from '../routes/features/routes/backfill-project-slug.js';
+import {
+  createBackfillProjectSlugHandler,
+} from '../routes/features/routes/backfill-project-slug.js';
 import { createProjectsRoutes } from '../routes/projects/index.js';
 import { createAutoModeRoutes } from '../routes/auto-mode/index.js';
 import { createEnhancePromptRoutes } from '../routes/enhance-prompt/index.js';
@@ -374,7 +376,9 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api/automations', createAutomationsRoutes(automationService));
   app.use('/api/ava', createAvaRoutes(services));
   const projectRegistry = new ProjectRegistryService({ projectRoot: repoRoot });
-  projectRegistry.start().catch((err: unknown) => logger.warn('ProjectRegistry start failed:', err));
+  projectRegistry
+    .start()
+    .catch((err: unknown) => logger.warn('ProjectRegistry start failed:', err));
   app.use('/api/discord', createDiscordRoutes(projectRegistry));
   app.use(
     '/api/ceremonies',

--- a/packages/mcp-server/src/tools/discord-tools.ts
+++ b/packages/mcp-server/src/tools/discord-tools.ts
@@ -12,7 +12,7 @@ export const discordTools: Tool[] = [
   {
     name: 'send_channel_message',
     description:
-      'Send a message to a project\'s Discord channel via webhook. ' +
+      "Send a message to a project's Discord channel via webhook. " +
       'Requires a project slug (e.g. "protolabsai-protomaker") and a channel type ("dev" or "release"). ' +
       'Webhook URLs are configured in workspace/projects.yaml.',
     inputSchema: {


### PR DESCRIPTION
## Summary

PR #3343 (staging → main promote) is blocked by a failing `checks` CI run. Investigation revealed two root causes:

### Root Cause 1: Prettier violations in staging

Three files have formatting violations that cause `npm run format:check` to fail:

- **`packages/mcp-server/src/tools/discord-tools.ts`**: Uses escaped single quote (`\'`) in a string containing an apostrophe. Prettier with `singleQuote: true` requires double quotes here.
- **`apps/server/src/server/routes.ts`** (import line): 101-char `createBackfillProjectSlugHandler` import exceeds `printWidth: 100`.
- **`apps/server/src/server/routes.ts`** (method chain): 103-char `projectRegistry.start().catch(...)` chain exceeds `printWidth: 100`.

These match fixes already on `origin/dev` (commit `38b565a36`). Once this PR is merged to dev and promoted to staging, PR #3343's `checks` will pass.

### Root Cause 2: Cross-PR status poisoning (requires manual fix)

`checks.yml` has concurrency group keyed on `head_ref` (branch name). Both PR #3343 (staging→main) and PR #3345 (staging→dev) share `Checks-staging` as their concurrency group. When PR #3345's run fired and failed, it replaced PR #3343's passing status.

**Recommended fix** (requires `workflow` OAuth scope — apply manually):

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}
  cancel-in-progress: true
```

This isolates each PR's checks run so one PR can't poison another's status.

## Fix plan

1. Merge this PR → dev (formatting fixes land in dev)
2. Promote dev → staging (staging gets the formatting fixes)
3. PR #3343 checks rerun → pass
4. Apply the `checks.yml` concurrency group fix (manual, requires workflow scope)

## Test plan

- [ ] Verify `npm run format:check` passes on this branch
- [ ] Verify PR #3343 `checks` passes after staging is updated with these fixes
- [ ] Optionally apply the `checks.yml` concurrency fix to prevent future cross-PR poisoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting and consistency across the codebase through updated import declarations, error-handling formatting, and string literal formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->