### PR TITLE
promote: back-merge main + prettier formatting fix

### DIFF
--- a/apps/server/src/routes/discord/index.ts
+++ b/apps/server/src/routes/discord/index.ts
@@ -1,44 +1,21 @@
 /**
- * Discord routes - HTTP API for Discord channel management and DMs
+ * Discord routes - HTTP API for Discord channel notifications via project webhooks.
+ *
+ * send-channel-message is project-scoped: routes to the project's dev or release
+ * webhook URL as configured in workspace/projects.yaml (source of truth).
+ *
+ * Other routes (read-channel-messages, add-reaction, DMs) require a live Discord
+ * bot connection and are served by workstacean's bot pool — not by protoMaker.
  */
 
 import { Router } from 'express';
-import type { DiscordBotService } from '../../services/discord-bot-service.js';
-import { createSendDMHandler } from './routes/send-dm.js';
-import { createReadDMsHandler } from './routes/read-dms.js';
+import type { ProjectRegistryService } from '../../services/project-registry-service.js';
 import { createSendChannelMessageHandler } from './routes/send-channel-message.js';
-import { createReadChannelMessagesHandler } from './routes/read-channel-messages.js';
-import { createAddReactionHandler } from './routes/add-reaction.js';
 
-export function createDiscordRoutes(discordBotService?: DiscordBotService): Router {
+export function createDiscordRoutes(projectRegistry: ProjectRegistryService): Router {
   const router = Router();
 
-  if (!discordBotService) {
-    // No bot service — all routes return a clear error
-    router.use((_req, res) => {
-      res.status(503).json({ success: false, error: 'Discord bot service not available' });
-    });
-    return router;
-  }
-
-  // Guard: reject requests when bot is not connected
-  router.use((_req, res, next) => {
-    if (!discordBotService.isConnected()) {
-      res.status(503).json({
-        success: false,
-        error:
-          'Discord bot not connected. Check DISCORD_BOT_TOKEN (or DISCORD_TOKEN) is set in the server environment.',
-      });
-      return;
-    }
-    next();
-  });
-
-  router.post('/send-dm', createSendDMHandler(discordBotService));
-  router.post('/read-dms', createReadDMsHandler(discordBotService));
-  router.post('/send-channel-message', createSendChannelMessageHandler(discordBotService));
-  router.post('/read-channel-messages', createReadChannelMessagesHandler(discordBotService));
-  router.post('/add-reaction', createAddReactionHandler(discordBotService));
+  router.post('/send-channel-message', createSendChannelMessageHandler(projectRegistry));
 
   return router;
 }

--- a/apps/server/src/routes/discord/routes/send-channel-message.ts
+++ b/apps/server/src/routes/discord/routes/send-channel-message.ts
@@ -43,7 +43,11 @@ export function createSendChannelMessageHandler(projectRegistry: ProjectRegistry
     try {
       let success: boolean;
       if (embed && typeof embed === 'object' && (embed as WebhookEmbed).title) {
-        success = await sendEmbedToProjectChannel(project, channelType as ProjectChannelType, embed as WebhookEmbed);
+        success = await sendEmbedToProjectChannel(
+          project,
+          channelType as ProjectChannelType,
+          embed as WebhookEmbed
+        );
       } else if (content && typeof content === 'string') {
         success = await sendToProjectChannel(project, channelType as ProjectChannelType, content);
       } else {

--- a/apps/server/src/routes/discord/routes/send-channel-message.ts
+++ b/apps/server/src/routes/discord/routes/send-channel-message.ts
@@ -1,12 +1,28 @@
 import type { Request, Response } from 'express';
-import type { DiscordBotService } from '../../../services/discord-bot-service.js';
+import type { ProjectRegistryService } from '../../../services/project-registry-service.js';
+import {
+  sendToProjectChannel,
+  sendEmbedToProjectChannel,
+  type WebhookEmbed,
+  type ProjectChannelType,
+} from '../../../services/discord-webhook.service.js';
 
-export function createSendChannelMessageHandler(discordBotService: DiscordBotService) {
+const VALID_CHANNEL_TYPES = new Set<ProjectChannelType>(['dev', 'release']);
+
+export function createSendChannelMessageHandler(projectRegistry: ProjectRegistryService) {
   return async (req: Request, res: Response) => {
-    const { channelId, content, embed } = req.body;
+    const { projectSlug, channelType, content, embed } = req.body;
 
-    if (!channelId || typeof channelId !== 'string') {
-      res.status(400).json({ success: false, error: 'channelId is required' });
+    if (!projectSlug || typeof projectSlug !== 'string') {
+      res.status(400).json({ success: false, error: 'projectSlug is required' });
+      return;
+    }
+
+    if (!channelType || !VALID_CHANNEL_TYPES.has(channelType as ProjectChannelType)) {
+      res.status(400).json({
+        success: false,
+        error: `channelType must be one of: ${[...VALID_CHANNEL_TYPES].join(', ')}`,
+      });
       return;
     }
 
@@ -15,12 +31,21 @@ export function createSendChannelMessageHandler(discordBotService: DiscordBotSer
       return;
     }
 
+    const project = projectRegistry.getProject(projectSlug);
+    if (!project) {
+      res.status(404).json({
+        success: false,
+        error: `Project "${projectSlug}" not found in registry`,
+      });
+      return;
+    }
+
     try {
       let success: boolean;
-      if (embed && typeof embed === 'object' && embed.title) {
-        success = await discordBotService.sendEmbed(channelId, embed);
+      if (embed && typeof embed === 'object' && (embed as WebhookEmbed).title) {
+        success = await sendEmbedToProjectChannel(project, channelType as ProjectChannelType, embed as WebhookEmbed);
       } else if (content && typeof content === 'string') {
-        success = await discordBotService.sendToChannel(channelId, content);
+        success = await sendToProjectChannel(project, channelType as ProjectChannelType, content);
       } else {
         res.status(400).json({ success: false, error: 'Invalid content or embed' });
         return;

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -378,7 +378,9 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api/automations', createAutomationsRoutes(automationService));
   app.use('/api/ava', createAvaRoutes(services));
   const projectRegistry = new ProjectRegistryService({ projectRoot: repoRoot });
-  projectRegistry.start().catch((err: unknown) => logger.warn('ProjectRegistry start failed:', err));
+  projectRegistry
+    .start()
+    .catch((err: unknown) => logger.warn('ProjectRegistry start failed:', err));
   app.use('/api/discord', createDiscordRoutes(projectRegistry));
   app.use(
     '/api/ceremonies',

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -61,6 +61,7 @@ import { createCosRoutes } from '../routes/cos/index.js';
 import { createCeremoniesRoutes } from '../routes/ceremonies/index.js';
 import { createWebhooksRoutes } from '../routes/webhooks/index.js';
 import { createDiscordRoutes } from '../routes/discord/index.js';
+import { ProjectRegistryService } from '../services/project-registry-service.js';
 import { createAvaRoutes } from '../routes/ava/index.js';
 import { createKnowledgeRoutes } from '../routes/knowledge/index.js';
 import { createPromotionsRoutes } from '../routes/promotions/index.js';
@@ -372,7 +373,9 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   );
   app.use('/api/automations', createAutomationsRoutes(automationService));
   app.use('/api/ava', createAvaRoutes(services));
-  app.use('/api/discord', createDiscordRoutes(discordBotService));
+  const projectRegistry = new ProjectRegistryService({ projectRoot: repoRoot });
+  projectRegistry.start().catch((err: unknown) => logger.warn('ProjectRegistry start failed:', err));
+  app.use('/api/discord', createDiscordRoutes(projectRegistry));
   app.use(
     '/api/ceremonies',
     createCeremoniesRoutes(events, featureLoader, projectService, ceremonyService, ceremonyAuditLog)

--- a/apps/server/src/services/discord-webhook.service.ts
+++ b/apps/server/src/services/discord-webhook.service.ts
@@ -168,7 +168,10 @@ export async function sendToChannelViaWebhook(
 /**
  * Send an embed to a fleet-wide Discord channel via webhook.
  */
-export async function sendEmbedViaWebhook(channelId: string, embed: WebhookEmbed): Promise<boolean> {
+export async function sendEmbedViaWebhook(
+  channelId: string,
+  embed: WebhookEmbed
+): Promise<boolean> {
   const webhookUrl = resolveFleetWebhookUrl(channelId);
   if (!webhookUrl) {
     logger.warn(`No webhook URL configured for channel ${channelId}`);

--- a/apps/server/src/services/discord-webhook.service.ts
+++ b/apps/server/src/services/discord-webhook.service.ts
@@ -2,22 +2,20 @@
  * Discord Webhook Service
  *
  * Sends outbound Discord notifications via webhook HTTP POSTs.
- * Replaces discord.js bot sends for channel notifications.
  *
- * Webhook URLs are configured per channel via environment variables:
- *   DISCORD_WEBHOOK_INFRA
- *   DISCORD_WEBHOOK_AGENT_LOGS
- *   DISCORD_WEBHOOK_CODE_REVIEW
- *   DISCORD_WEBHOOK_SUGGESTIONS
+ * Two resolution paths:
  *
- * Channels are matched by channel ID using a mapping from env vars:
- *   DISCORD_CHANNEL_INFRA → DISCORD_WEBHOOK_INFRA
- *   DISCORD_CHANNEL_AGENT_LOGS → DISCORD_WEBHOOK_AGENT_LOGS
- *   DISCORD_CHANNEL_CODE_REVIEW → DISCORD_WEBHOOK_CODE_REVIEW
- *   DISCORD_CHANNEL_SUGGESTIONS → DISCORD_WEBHOOK_SUGGESTIONS
+ * 1. Project-scoped (new): sendToProjectChannel(project, channelType, content)
+ *    Webhook URL sourced from project registry (projects.yaml → Workstacean API).
+ *    Each project has a Discord category with dev + release channels.
+ *
+ * 2. Fleet-wide (legacy): sendToChannelViaWebhook(channelId, content)
+ *    Webhook URL resolved from environment variables (DISCORD_WEBHOOK_INFRA, etc.)
+ *    Used for fleet channels: infra, alerts, ava, etc.
  */
 
 import { createLogger } from '@protolabsai/utils';
+import type { ProjectRegistryEntry } from './project-registry-service.js';
 
 const logger = createLogger('DiscordWebhookService');
 
@@ -38,38 +36,39 @@ interface WebhookPayload {
   username?: string;
 }
 
-/**
- * Resolves channel ID → webhook URL using environment variable mapping.
- * Priority: exact channel ID match in the webhook→channel mapping.
- */
-function resolveWebhookUrl(channelId: string): string | undefined {
-  // Map from channel ID env var → webhook URL env var
-  const channelToWebhookEnv: Array<[string | undefined, string | undefined]> = [
-    [process.env.DISCORD_CHANNEL_INFRA, process.env.DISCORD_WEBHOOK_INFRA],
-    [process.env.DISCORD_CHANNEL_AGENT_LOGS, process.env.DISCORD_WEBHOOK_AGENT_LOGS],
-    [process.env.DISCORD_CHANNEL_CODE_REVIEW, process.env.DISCORD_WEBHOOK_CODE_REVIEW],
-    [process.env.DISCORD_CHANNEL_SUGGESTIONS, process.env.DISCORD_WEBHOOK_SUGGESTIONS],
-  ];
+export type ProjectChannelType = 'dev' | 'release';
 
-  for (const [chanId, webhookUrl] of channelToWebhookEnv) {
+// ── Fleet-wide channel resolution (env vars) ─────────────────────────────────
+
+const CHANNEL_TO_WEBHOOK_ENV: Array<[string, string]> = [
+  ['DISCORD_CHANNEL_INFRA', 'DISCORD_WEBHOOK_INFRA'],
+  ['DISCORD_CHANNEL_AGENT_LOGS', 'DISCORD_WEBHOOK_AGENT_LOGS'],
+  ['DISCORD_CHANNEL_CODE_REVIEW', 'DISCORD_WEBHOOK_CODE_REVIEW'],
+  ['DISCORD_CHANNEL_SUGGESTIONS', 'DISCORD_WEBHOOK_SUGGESTIONS'],
+  ['DISCORD_CHANNEL_ALERTS', 'DISCORD_WEBHOOK_ALERTS'],
+  ['DISCORD_CHANNEL_AVA', 'DISCORD_WEBHOOK_AVA'],
+];
+
+function resolveFleetWebhookUrl(channelId: string): string | undefined {
+  for (const [chanEnv, webhookEnv] of CHANNEL_TO_WEBHOOK_ENV) {
+    const chanId = process.env[chanEnv];
+    const webhookUrl = process.env[webhookEnv];
     if (chanId && chanId === channelId && webhookUrl) {
       return webhookUrl;
     }
   }
-
   return undefined;
 }
 
-/**
- * Post a raw payload to a Discord webhook URL.
- * Returns true on success (2xx), false on failure.
- */
+// ── Core HTTP ─────────────────────────────────────────────────────────────────
+
 async function postToWebhook(webhookUrl: string, payload: WebhookPayload): Promise<boolean> {
   try {
     const response = await fetch(webhookUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(10_000),
     });
 
     if (!response.ok) {
@@ -85,46 +84,55 @@ async function postToWebhook(webhookUrl: string, payload: WebhookPayload): Promi
   }
 }
 
+// ── Project-scoped sends ──────────────────────────────────────────────────────
+
 /**
- * Send a plain-text message to a Discord channel via webhook.
- * Returns true if successful, false if no webhook configured or request failed.
+ * Resolve the webhook URL for a project channel from the registry entry.
  */
-export async function sendToChannelViaWebhook(
-  channelId: string,
+export function resolveProjectWebhookUrl(
+  project: ProjectRegistryEntry,
+  channelType: ProjectChannelType
+): string | undefined {
+  return project.discord?.[channelType]?.webhook || undefined;
+}
+
+/**
+ * Send a plain-text message to a project's Discord channel via webhook.
+ * Webhook URL sourced from workspace/projects.yaml via the project registry.
+ */
+export async function sendToProjectChannel(
+  project: ProjectRegistryEntry,
+  channelType: ProjectChannelType,
   content: string
 ): Promise<boolean> {
-  if (!content) {
-    logger.warn(`sendToChannelViaWebhook: empty content for channel ${channelId} — skipping`);
-    return false;
-  }
+  if (!content) return false;
 
-  const webhookUrl = resolveWebhookUrl(channelId);
+  const webhookUrl = resolveProjectWebhookUrl(project, channelType);
   if (!webhookUrl) {
     logger.warn(
-      `No webhook URL configured for channel ${channelId} — message not sent. ` +
-        `Set DISCORD_WEBHOOK_* env vars to enable webhook delivery.`
+      `No webhook URL for ${project.slug}#${channelType} — ` +
+        `populate discord.${channelType}.webhook in workspace/projects.yaml`
     );
     return false;
   }
 
-  // Discord webhook message limit is 2000 chars
   const truncated = content.length > 2000 ? content.slice(0, 1997) + '...' : content;
   return postToWebhook(webhookUrl, { content: truncated });
 }
 
 /**
- * Send an embed message to a Discord channel via webhook.
- * Returns true if successful, false if no webhook configured or request failed.
+ * Send an embed to a project's Discord channel via webhook.
  */
-export async function sendEmbedViaWebhook(
-  channelId: string,
+export async function sendEmbedToProjectChannel(
+  project: ProjectRegistryEntry,
+  channelType: ProjectChannelType,
   embed: WebhookEmbed
 ): Promise<boolean> {
-  const webhookUrl = resolveWebhookUrl(channelId);
+  const webhookUrl = resolveProjectWebhookUrl(project, channelType);
   if (!webhookUrl) {
     logger.warn(
-      `No webhook URL configured for channel ${channelId} — embed not sent. ` +
-        `Set DISCORD_WEBHOOK_* env vars to enable webhook delivery.`
+      `No webhook URL for ${project.slug}#${channelType} — ` +
+        `populate discord.${channelType}.webhook in workspace/projects.yaml`
     );
     return false;
   }
@@ -132,14 +140,47 @@ export async function sendEmbedViaWebhook(
   return postToWebhook(webhookUrl, { embeds: [embed] });
 }
 
+// ── Fleet-wide sends (legacy — infra, alerts, ava, etc.) ─────────────────────
+
 /**
- * Check whether any webhook URLs are configured.
+ * Send a plain-text message to a fleet-wide Discord channel via webhook.
+ * Channel ID is resolved to a webhook URL via DISCORD_WEBHOOK_* environment variables.
+ */
+export async function sendToChannelViaWebhook(
+  channelId: string,
+  content: string
+): Promise<boolean> {
+  if (!content) return false;
+
+  const webhookUrl = resolveFleetWebhookUrl(channelId);
+  if (!webhookUrl) {
+    logger.warn(
+      `No webhook URL configured for channel ${channelId} — ` +
+        `set DISCORD_WEBHOOK_* env vars to enable fleet channel delivery`
+    );
+    return false;
+  }
+
+  const truncated = content.length > 2000 ? content.slice(0, 1997) + '...' : content;
+  return postToWebhook(webhookUrl, { content: truncated });
+}
+
+/**
+ * Send an embed to a fleet-wide Discord channel via webhook.
+ */
+export async function sendEmbedViaWebhook(channelId: string, embed: WebhookEmbed): Promise<boolean> {
+  const webhookUrl = resolveFleetWebhookUrl(channelId);
+  if (!webhookUrl) {
+    logger.warn(`No webhook URL configured for channel ${channelId}`);
+    return false;
+  }
+
+  return postToWebhook(webhookUrl, { embeds: [embed] });
+}
+
+/**
+ * Check whether any fleet webhook URLs are configured.
  */
 export function hasWebhooksConfigured(): boolean {
-  return !!(
-    process.env.DISCORD_WEBHOOK_INFRA ||
-    process.env.DISCORD_WEBHOOK_AGENT_LOGS ||
-    process.env.DISCORD_WEBHOOK_CODE_REVIEW ||
-    process.env.DISCORD_WEBHOOK_SUGGESTIONS
-  );
+  return CHANNEL_TO_WEBHOOK_ENV.some(([, webhookEnv]) => !!process.env[webhookEnv]);
 }

--- a/apps/server/src/services/project-registry-service.ts
+++ b/apps/server/src/services/project-registry-service.ts
@@ -21,16 +21,28 @@ export interface RegistryProjectOperationalState {
   activeAgents: number;
 }
 
+export interface ProjectDiscordChannel {
+  channelId?: string;
+  webhook?: string;
+}
+
+export interface ProjectDiscordConfig {
+  dev?: ProjectDiscordChannel;
+  release?: ProjectDiscordChannel;
+}
+
 export interface ProjectRegistryEntry {
   slug: string;
   title?: string;
   team?: string;
   github?: string;
+  repoUrl?: string;
   defaultBranch?: string;
   status?: string;
   projectPath?: string;
   studioUrl?: string;
   agents?: string[];
+  discord?: ProjectDiscordConfig;
   operationalState?: RegistryProjectOperationalState | { state: 'unreachable' };
   [key: string]: unknown;
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -945,18 +945,9 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
 
     // Discord Channel Tools
     case 'send_channel_message': {
-      const resolvedChannelId = resolveDiscordChannelId(
-        args.channelId as string | undefined,
-        args.channelName as string | undefined
-      );
-      if (!resolvedChannelId) {
-        return {
-          success: false,
-          error: 'Either channelId or a recognized channelName is required',
-        };
-      }
       return apiCall('/discord/send-channel-message', {
-        channelId: resolvedChannelId,
+        projectSlug: args.projectSlug,
+        channelType: args.channelType,
         content: args.content,
       });
     }

--- a/packages/mcp-server/src/tools/discord-tools.ts
+++ b/packages/mcp-server/src/tools/discord-tools.ts
@@ -12,7 +12,7 @@ export const discordTools: Tool[] = [
   {
     name: 'send_channel_message',
     description:
-      'Send a message to a project\'s Discord channel via webhook. ' +
+      "Send a message to a project's Discord channel via webhook. " +
       'Requires a project slug (e.g. "protolabsai-protomaker") and a channel type ("dev" or "release"). ' +
       'Webhook URLs are configured in workspace/projects.yaml.',
     inputSchema: {
@@ -20,12 +20,14 @@ export const discordTools: Tool[] = [
       properties: {
         projectSlug: {
           type: 'string',
-          description: 'Project slug from the registry (e.g. "protolabsai-protomaker", "protolabsai-protoui")',
+          description:
+            'Project slug from the registry (e.g. "protolabsai-protomaker", "protolabsai-protoui")',
         },
         channelType: {
           type: 'string',
           enum: ['dev', 'release'],
-          description: 'Which project channel to send to: "dev" for development activity, "release" for deployment/release notifications',
+          description:
+            'Which project channel to send to: "dev" for development activity, "release" for deployment/release notifications',
         },
         content: {
           type: 'string',

--- a/packages/mcp-server/src/tools/discord-tools.ts
+++ b/packages/mcp-server/src/tools/discord-tools.ts
@@ -12,19 +12,20 @@ export const discordTools: Tool[] = [
   {
     name: 'send_channel_message',
     description:
-      'Send a message to a Discord channel. Accepts a channel name (e.g. "ava", "dev", "infra") or a raw channel ID. ' +
-      'Returns an error if the Discord bot is not connected.',
+      'Send a message to a project\'s Discord channel via webhook. ' +
+      'Requires a project slug (e.g. "protolabsai-protomaker") and a channel type ("dev" or "release"). ' +
+      'Webhook URLs are configured in workspace/projects.yaml.',
     inputSchema: {
       type: 'object',
       properties: {
-        channelId: {
+        projectSlug: {
           type: 'string',
-          description: 'Raw Discord channel ID (18-19 digit snowflake)',
+          description: 'Project slug from the registry (e.g. "protolabsai-protomaker", "protolabsai-protoui")',
         },
-        channelName: {
+        channelType: {
           type: 'string',
-          description:
-            'Human-readable channel name (e.g. "ava", "dev", "infra", "alerts", "deployments", "bug-reports", "vip-lounge"). Used when channelId is not provided.',
+          enum: ['dev', 'release'],
+          description: 'Which project channel to send to: "dev" for development activity, "release" for deployment/release notifications',
         },
         content: {
           type: 'string',
@@ -32,7 +33,7 @@ export const discordTools: Tool[] = [
           maxLength: 2000,
         },
       },
-      required: ['content'],
+      required: ['projectSlug', 'channelType', 'content'],
     },
   },
   {


### PR DESCRIPTION
## Summary
- Back-merges main into staging to bring in PR #3328 (project-scoped Discord webhooks)
- Applies `prettier --write` to 4 files that landed on main unformatted
- Unblocks PR #3343 (staging → main) which fails CI because the merge ref inherits main's dirty files

## Root cause
PR #3328 merged into main on 2026-04-08 **despite its Checks workflow failing** — branch protection didn't block it. Every staging → main promotion since fails CI because GitHub Actions tests the _merge_ ref, which inherits main's broken formatting.

## Files fixed
- `apps/server/src/server/routes.ts`
- `apps/server/src/routes/discord/routes/send-channel-message.ts`
- `apps/server/src/services/discord-webhook.service.ts`
- `packages/mcp-server/src/tools/discord-tools.ts`

## Test plan
- [x] `prettier --check` passes on all fixed files locally
- [ ] CI passes on this PR
- [ ] PR #3343 re-runs green after merge

## Follow-up
Branch protection on main should require Checks to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)