### PR TITLE
feat: HITL escalation pattern analysis — auto-file features for recurring stuck PRs

### DIFF
--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -84,6 +84,7 @@ import {
   FrictionTrackerService,
   type FailureContext,
 } from '../services/friction-tracker-service.js';
+import { HitlPatternAnalysisService } from '../services/hitl-pattern-analysis-service.js';
 import { FailureClassifierService } from '../services/failure-classifier-service.js';
 import {
   getReactiveSpawnerService,
@@ -291,6 +292,9 @@ export interface ServiceContainer {
 
   // Friction tracker (self-improvement loop — recurring failure pattern detection)
   frictionTrackerService: FrictionTrackerService;
+
+  // HITL pattern analysis (recurring stuck-PR pattern detection → auto-file)
+  hitlPatternAnalysisService: HitlPatternAnalysisService;
 
   // Reactive spawner (trigger-based agent spawning with rate limiting and circuit breaking)
   reactiveSpawnerService: ReactiveSpawnerService;
@@ -727,6 +731,13 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
     instanceId: crdtSyncService.getInstanceId(),
   });
 
+  // HITL Pattern Analysis Service — recurring stuck-PR pattern detection + auto-filing
+  const hitlPatternAnalysisService = new HitlPatternAnalysisService({
+    featureLoader,
+    projectPath: repoRoot,
+    events,
+  });
+
   // Wire friction tracker into the feature-status-change event pipeline.
   // On every blocked status change, classify the reason and record the pattern.
   const failureClassifierService = new FailureClassifierService();
@@ -950,6 +961,7 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
     metricsCollectionService,
     errorBudgetService,
     frictionTrackerService,
+    hitlPatternAnalysisService,
     reactiveSpawnerService,
     commandRegistryService,
     checkpointService,

--- a/apps/server/src/server/wiring.ts
+++ b/apps/server/src/server/wiring.ts
@@ -21,6 +21,7 @@ import { register as registerSignalDictionary } from '../services/signal-diction
 import { register as registerProjectHealth } from '../services/project-health.module.js';
 import { register as registerTrajectoryQuery } from '../services/trajectory-query.module.js';
 import { register as registerLiteLLMGateway } from '../services/litellm-gateway.module.js';
+import { register as registerHitlPatternAnalysis } from '../services/hitl-pattern-analysis.module.js';
 
 /**
  * Wire all cross-service dependencies by invoking each module's register() in order.
@@ -51,6 +52,7 @@ export async function wireServices(services: ServiceContainer): Promise<void> {
   registerProjectHealth(services);
   registerTrajectoryQuery(services);
   registerLiteLLMGateway(services);
+  await registerHitlPatternAnalysis(services);
 
   // Start built-in sensors (websocket-clients) after all wiring is complete.
   // This ensures the sensor registry is fully initialised before polling begins.

--- a/apps/server/src/services/hitl-pattern-analysis-service.ts
+++ b/apps/server/src/services/hitl-pattern-analysis-service.ts
@@ -163,17 +163,11 @@ export class HitlPatternAnalysisService {
    * Called by the TopicBus subscriber when a
    * 'hitl.request.pr.remediation_stuck.*' message arrives.
    */
-  async handleEscalation(
-    payload: HitlPrRemediationStuckPayload,
-  ): Promise<void> {
+  async handleEscalation(payload: HitlPrRemediationStuckPayload): Promise<void> {
     if (!this.initialized) await this.initialize();
 
     const errorClass = extractErrorClass(payload);
-    const signature = buildSignature(
-      payload.kind,
-      payload.failingWorkflow,
-      errorClass,
-    );
+    const signature = buildSignature(payload.kind, payload.failingWorkflow, errorClass);
 
     const record: EscalationRecord = {
       id: randomUUID(),
@@ -203,7 +197,7 @@ export class HitlPatternAnalysisService {
     });
 
     logger.info(
-      `Ingested escalation for ${record.repo}#${record.prNumber} kind=${record.kind} signature="${signature}"`,
+      `Ingested escalation for ${record.repo}#${record.prNumber} kind=${record.kind} signature="${signature}"`
     );
 
     await this.updatePatternCounter(signature, record);
@@ -238,10 +232,7 @@ export class HitlPatternAnalysisService {
   // Internal helpers
   // ---------------------------------------------------------------------------
 
-  private async updatePatternCounter(
-    signature: string,
-    record: EscalationRecord,
-  ): Promise<void> {
+  private async updatePatternCounter(signature: string, record: EscalationRecord): Promise<void> {
     const now = Date.now();
     const existing = this.patterns.get(signature);
 
@@ -264,9 +255,7 @@ export class HitlPatternAnalysisService {
 
     this.patterns.set(signature, state);
 
-    logger.debug(
-      `Pattern counter updated: signature="${signature}" count=${state.count}`,
-    );
+    logger.debug(`Pattern counter updated: signature="${signature}" count=${state.count}`);
 
     if (state.count >= OCCURRENCE_THRESHOLD) {
       await this.maybeFileFeature(signature, state, record);
@@ -276,14 +265,14 @@ export class HitlPatternAnalysisService {
   private async maybeFileFeature(
     signature: string,
     state: PatternState,
-    latestRecord: EscalationRecord,
+    latestRecord: EscalationRecord
   ): Promise<void> {
     // Dedup: skip if a feature was filed recently
     if (state.filedAt) {
       const filedAt = new Date(state.filedAt).getTime();
       if (!isNaN(filedAt) && Date.now() - filedAt < FILING_DEDUP_WINDOW_MS) {
         logger.info(
-          `Skipping auto-file for pattern="${signature}" — filed recently (${state.filedAt})`,
+          `Skipping auto-file for pattern="${signature}" — filed recently (${state.filedAt})`
         );
         return;
       }
@@ -292,15 +281,8 @@ export class HitlPatternAnalysisService {
     // Durable dedup: check feature store for an open feature with the same title
     const title = buildFeatureTitle(signature);
     try {
-      const existing = await this.deps.featureLoader.findByTitle(
-        this.deps.projectPath,
-        title,
-      );
-      if (
-        existing &&
-        existing.status !== 'done' &&
-        existing.status !== 'interrupted'
-      ) {
+      const existing = await this.deps.featureLoader.findByTitle(this.deps.projectPath, title);
+      if (existing && existing.status !== 'done' && existing.status !== 'interrupted') {
         // Re-populate local dedup guard
         this.patterns.set(signature, {
           ...state,
@@ -308,13 +290,13 @@ export class HitlPatternAnalysisService {
           filedAt: new Date().toISOString(),
         });
         logger.info(
-          `Skipping auto-file for pattern="${signature}" — open feature ${existing.id} already exists (status=${existing.status})`,
+          `Skipping auto-file for pattern="${signature}" — open feature ${existing.id} already exists (status=${existing.status})`
         );
         return;
       }
     } catch (err) {
       logger.warn(
-        `Failed to check for existing feature for pattern="${signature}", proceeding with filing: ${err}`,
+        `Failed to check for existing feature for pattern="${signature}", proceeding with filing: ${err}`
       );
     }
 
@@ -326,25 +308,22 @@ export class HitlPatternAnalysisService {
 
     try {
       const description = this.buildFeatureDescription(signature, latestRecord);
-      const feature = await this.deps.featureLoader.create(
-        this.deps.projectPath,
-        {
-          title,
-          description,
-          complexity: 'medium',
-          status: 'backlog',
-          priority: 3,
-          category: 'infra',
-          tags: ['auto-remediation', 'hitl-pattern', 'self-improvement'],
-        } as Parameters<FeatureLoader['create']>[1],
-      );
+      const feature = await this.deps.featureLoader.create(this.deps.projectPath, {
+        title,
+        description,
+        complexity: 'medium',
+        status: 'backlog',
+        priority: 3,
+        category: 'infra',
+        tags: ['auto-remediation', 'hitl-pattern', 'self-improvement'],
+      } as Parameters<FeatureLoader['create']>[1]);
 
       // Update pattern state with filed feature ID
       const updated = this.patterns.get(signature)!;
       this.patterns.set(signature, { ...updated, filedFeatureId: feature.id });
 
       logger.info(
-        `Auto-filed feature ${feature.id} for recurring pattern="${signature}" (${state.count} occurrences)`,
+        `Auto-filed feature ${feature.id} for recurring pattern="${signature}" (${state.count} occurrences)`
       );
 
       this.deps.events.emit('hitl:pattern-analysis:feature-filed', {
@@ -364,18 +343,13 @@ export class HitlPatternAnalysisService {
     }
   }
 
-  private buildFeatureDescription(
-    signature: string,
-    latest: EscalationRecord,
-  ): string {
-    const occurrences = this.escalations
-      .filter((e) => e.patternSignature === signature)
-      .slice(-5); // Last 5 for evidence
+  private buildFeatureDescription(signature: string, latest: EscalationRecord): string {
+    const occurrences = this.escalations.filter((e) => e.patternSignature === signature).slice(-5); // Last 5 for evidence
 
     const evidenceLines = occurrences
       .map(
         (e) =>
-          `- ${e.timestamp}: ${e.repo}#${e.prNumber} kind=${e.kind} workflow=${e.failingWorkflow} ci=${e.ciStatus} attempts=${e.attempts}`,
+          `- ${e.timestamp}: ${e.repo}#${e.prNumber} kind=${e.kind} workflow=${e.failingWorkflow} ci=${e.ciStatus} attempts=${e.attempts}`
       )
       .join('\n');
 
@@ -413,12 +387,7 @@ export class HitlPatternAnalysisService {
   // ---------------------------------------------------------------------------
 
   private getStorePath(): string {
-    return join(
-      this.deps.projectPath,
-      '.automaker',
-      'ava-memory',
-      'hitl-patterns.json',
-    );
+    return join(this.deps.projectPath, '.automaker', 'ava-memory', 'hitl-patterns.json');
   }
 
   private async loadStore(): Promise<void> {
@@ -426,23 +395,19 @@ export class HitlPatternAnalysisService {
     try {
       const raw = await fs.readFile(storePath, 'utf-8');
       const store = JSON.parse(raw) as HitlPatternStore;
-      this.escalations = Array.isArray(store.escalations)
-        ? store.escalations
-        : [];
+      this.escalations = Array.isArray(store.escalations) ? store.escalations : [];
       if (store.patterns && typeof store.patterns === 'object') {
         for (const [key, value] of Object.entries(store.patterns)) {
           this.patterns.set(key, value as PatternState);
         }
       }
       logger.debug(
-        `Loaded HITL pattern store: ${this.escalations.length} escalations, ${this.patterns.size} patterns`,
+        `Loaded HITL pattern store: ${this.escalations.length} escalations, ${this.patterns.size} patterns`
       );
     } catch (err: unknown) {
       // ENOENT is expected on first start — any other error is logged as a warning
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-        logger.warn(
-          `Failed to load HITL pattern store (starting fresh): ${err}`,
-        );
+        logger.warn(`Failed to load HITL pattern store (starting fresh): ${err}`);
       }
     }
   }
@@ -473,9 +438,7 @@ export class HitlPatternAnalysisService {
  * Returns 'unknown' when no class can be determined.
  */
 function extractErrorClass(payload: HitlPrRemediationStuckPayload): string {
-  const text = [payload.failingWorkflow ?? '', payload.errorMessage ?? '']
-    .join(' ')
-    .toLowerCase();
+  const text = [payload.failingWorkflow ?? '', payload.errorMessage ?? ''].join(' ').toLowerCase();
 
   if (/type.?error|typescript|\.ts\b|tsc\b/.test(text)) return 'ts_error';
   if (/test.fail|jest|vitest|spec\b|\.spec\./.test(text)) return 'test_failure';
@@ -491,14 +454,8 @@ function extractErrorClass(payload: HitlPrRemediationStuckPayload): string {
  * Build a canonical pattern signature from its three components.
  * Format: `{kind}:{failingWorkflow}:{errorClass}`
  */
-function buildSignature(
-  kind: string,
-  failingWorkflow: string,
-  errorClass: string,
-): string {
-  return [kind ?? 'unknown', failingWorkflow ?? 'unknown', errorClass].join(
-    ':',
-  );
+function buildSignature(kind: string, failingWorkflow: string, errorClass: string): string {
+  return [kind ?? 'unknown', failingWorkflow ?? 'unknown', errorClass].join(':');
 }
 
 /**

--- a/apps/server/src/services/hitl-pattern-analysis-service.ts
+++ b/apps/server/src/services/hitl-pattern-analysis-service.ts
@@ -20,14 +20,14 @@
  * until FILING_DEDUP_WINDOW_MS has elapsed or the filed feature reaches 'done'.
  */
 
-import { randomUUID } from "node:crypto";
-import fs from "fs/promises";
-import { join } from "node:path";
-import { atomicWriteJson, createLogger } from "@protolabsai/utils";
-import type { FeatureLoader } from "./feature-loader.js";
-import type { EventEmitter } from "../lib/events.js";
+import { randomUUID } from 'node:crypto';
+import fs from 'fs/promises';
+import { join } from 'node:path';
+import { atomicWriteJson, createLogger } from '@protolabsai/utils';
+import type { FeatureLoader } from './feature-loader.js';
+import type { EventEmitter } from '../lib/events.js';
 
-const logger = createLogger("HitlPatternAnalysisService");
+const logger = createLogger('HitlPatternAnalysisService');
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -177,11 +177,11 @@ export class HitlPatternAnalysisService {
 
     const record: EscalationRecord = {
       id: randomUUID(),
-      repo: payload.repo ?? "",
+      repo: payload.repo ?? '',
       prNumber: payload.prNumber ?? 0,
-      kind: payload.kind ?? "",
-      failingWorkflow: payload.failingWorkflow ?? "",
-      ciStatus: payload.ciStatus ?? "",
+      kind: payload.kind ?? '',
+      failingWorkflow: payload.failingWorkflow ?? '',
+      ciStatus: payload.ciStatus ?? '',
       attempts: payload.attempts ?? 0,
       timestamp: payload.timestamp ?? new Date().toISOString(),
       errorClass,
@@ -195,7 +195,7 @@ export class HitlPatternAnalysisService {
       this.escalations = this.escalations.slice(-MAX_ESCALATION_RECORDS);
     }
 
-    this.deps.events.emit("hitl:pattern-analysis:escalation-ingested", {
+    this.deps.events.emit('hitl:pattern-analysis:escalation-ingested', {
       id: record.id,
       repo: record.repo,
       prNumber: record.prNumber,
@@ -298,8 +298,8 @@ export class HitlPatternAnalysisService {
       );
       if (
         existing &&
-        existing.status !== "done" &&
-        existing.status !== "interrupted"
+        existing.status !== 'done' &&
+        existing.status !== 'interrupted'
       ) {
         // Re-populate local dedup guard
         this.patterns.set(signature, {
@@ -331,12 +331,12 @@ export class HitlPatternAnalysisService {
         {
           title,
           description,
-          complexity: "medium",
-          status: "backlog",
+          complexity: 'medium',
+          status: 'backlog',
           priority: 3,
-          category: "infra",
-          tags: ["auto-remediation", "hitl-pattern", "self-improvement"],
-        } as Parameters<FeatureLoader["create"]>[1],
+          category: 'infra',
+          tags: ['auto-remediation', 'hitl-pattern', 'self-improvement'],
+        } as Parameters<FeatureLoader['create']>[1],
       );
 
       // Update pattern state with filed feature ID
@@ -347,7 +347,7 @@ export class HitlPatternAnalysisService {
         `Auto-filed feature ${feature.id} for recurring pattern="${signature}" (${state.count} occurrences)`,
       );
 
-      this.deps.events.emit("hitl:pattern-analysis:feature-filed", {
+      this.deps.events.emit('hitl:pattern-analysis:feature-filed', {
         featureId: feature.id,
         patternSignature: signature,
         occurrenceCount: state.count,
@@ -377,9 +377,9 @@ export class HitlPatternAnalysisService {
         (e) =>
           `- ${e.timestamp}: ${e.repo}#${e.prNumber} kind=${e.kind} workflow=${e.failingWorkflow} ci=${e.ciStatus} attempts=${e.attempts}`,
       )
-      .join("\n");
+      .join('\n');
 
-    const [kind, failingWorkflow, errorClass] = signature.split(":");
+    const [kind, failingWorkflow, errorClass] = signature.split(':');
 
     return [
       `This feature was automatically filed by the HITL pattern analysis pipeline.`,
@@ -405,7 +405,7 @@ export class HitlPatternAnalysisService {
       `4. Add a regression test covering the pattern`,
       ``,
       `**Latest escalation:** ${latest.repo}#${latest.prNumber} at ${latest.timestamp}`,
-    ].join("\n");
+    ].join('\n');
   }
 
   // ---------------------------------------------------------------------------
@@ -415,21 +415,21 @@ export class HitlPatternAnalysisService {
   private getStorePath(): string {
     return join(
       this.deps.projectPath,
-      ".automaker",
-      "ava-memory",
-      "hitl-patterns.json",
+      '.automaker',
+      'ava-memory',
+      'hitl-patterns.json',
     );
   }
 
   private async loadStore(): Promise<void> {
     const storePath = this.getStorePath();
     try {
-      const raw = await fs.readFile(storePath, "utf-8");
+      const raw = await fs.readFile(storePath, 'utf-8');
       const store = JSON.parse(raw) as HitlPatternStore;
       this.escalations = Array.isArray(store.escalations)
         ? store.escalations
         : [];
-      if (store.patterns && typeof store.patterns === "object") {
+      if (store.patterns && typeof store.patterns === 'object') {
         for (const [key, value] of Object.entries(store.patterns)) {
           this.patterns.set(key, value as PatternState);
         }
@@ -439,7 +439,7 @@ export class HitlPatternAnalysisService {
       );
     } catch (err: unknown) {
       // ENOENT is expected on first start — any other error is logged as a warning
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
         logger.warn(
           `Failed to load HITL pattern store (starting fresh): ${err}`,
         );
@@ -473,18 +473,18 @@ export class HitlPatternAnalysisService {
  * Returns 'unknown' when no class can be determined.
  */
 function extractErrorClass(payload: HitlPrRemediationStuckPayload): string {
-  const text = [payload.failingWorkflow ?? "", payload.errorMessage ?? ""]
-    .join(" ")
+  const text = [payload.failingWorkflow ?? '', payload.errorMessage ?? '']
+    .join(' ')
     .toLowerCase();
 
-  if (/type.?error|typescript|\.ts\b|tsc\b/.test(text)) return "ts_error";
-  if (/test.fail|jest|vitest|spec\b|\.spec\./.test(text)) return "test_failure";
-  if (/\blint\b|eslint|prettier/.test(text)) return "lint_failure";
+  if (/type.?error|typescript|\.ts\b|tsc\b/.test(text)) return 'ts_error';
+  if (/test.fail|jest|vitest|spec\b|\.spec\./.test(text)) return 'test_failure';
+  if (/\blint\b|eslint|prettier/.test(text)) return 'lint_failure';
   if (/source.branch|wrong.branch|promotion.check|source-branch/.test(text))
-    return "source_branch_guard";
-  if (/build.fail|webpack|vite\b|compile/.test(text)) return "build_failure";
+    return 'source_branch_guard';
+  if (/build.fail|webpack|vite\b|compile/.test(text)) return 'build_failure';
 
-  return "unknown";
+  return 'unknown';
 }
 
 /**
@@ -496,8 +496,8 @@ function buildSignature(
   failingWorkflow: string,
   errorClass: string,
 ): string {
-  return [kind ?? "unknown", failingWorkflow ?? "unknown", errorClass].join(
-    ":",
+  return [kind ?? 'unknown', failingWorkflow ?? 'unknown', errorClass].join(
+    ':',
   );
 }
 
@@ -505,9 +505,9 @@ function buildSignature(
  * Build the feature title for a given pattern signature.
  */
 function buildFeatureTitle(signature: string): string {
-  const [kind, failingWorkflow, errorClass] = signature.split(":");
+  const [kind, failingWorkflow, errorClass] = signature.split(':');
   const humanReadable = [kind, failingWorkflow, errorClass]
-    .map((s) => s?.replace(/_/g, " "))
-    .join(" / ");
+    .map((s) => s?.replace(/_/g, ' '))
+    .join(' / ');
   return `auto-remediate: stuck on ${humanReadable}`;
 }

--- a/apps/server/src/services/hitl-pattern-analysis-service.ts
+++ b/apps/server/src/services/hitl-pattern-analysis-service.ts
@@ -1,0 +1,474 @@
+/**
+ * HitlPatternAnalysisService
+ *
+ * Ingests HITL escalation events emitted by Workstacean's pr-remediator
+ * (hitl.request.pr.remediation_stuck.{id}) and performs recurring pattern
+ * analysis. When the same failure pattern occurs >= OCCURRENCE_THRESHOLD times
+ * within a rolling COUNTER_WINDOW_MS window, automatically files a backlog
+ * feature on the project board and emits 'hitl:pattern-analysis:feature-filed'.
+ *
+ * Transport: The service subscribes via TopicBus to
+ * 'hitl.request.pr.remediation_stuck.#'. Workstacean events must be published
+ * to the TopicBus by the inbound transport layer before this service processes
+ * them.
+ *
+ * Persistence: Escalation records and pattern counters are persisted to
+ * {projectPath}/.automaker/ava-memory/hitl-patterns.json using atomic writes.
+ * In-memory state is rebuilt from disk on startup (via initialize()).
+ *
+ * Deduplication: Once a feature is filed for a pattern, filing is suppressed
+ * until FILING_DEDUP_WINDOW_MS has elapsed or the filed feature reaches 'done'.
+ */
+
+import { randomUUID } from 'node:crypto';
+import fs from 'fs/promises';
+import { join } from 'node:path';
+import { atomicWriteJson, createLogger } from '@protolabsai/utils';
+import type { FeatureLoader } from './feature-loader.js';
+import type { EventEmitter } from '../lib/events.js';
+
+const logger = createLogger('HitlPatternAnalysisService');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Number of occurrences before a backlog feature is auto-filed */
+const OCCURRENCE_THRESHOLD = 3;
+
+/** Sliding window for pattern counters (7 days) */
+const COUNTER_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** How long to suppress duplicate filings for the same pattern (24 hours) */
+const FILING_DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/** Maximum escalation records to retain in persistent store */
+const MAX_ESCALATION_RECORDS = 500;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Payload emitted by Workstacean's pr-remediator on
+ * hitl.request.pr.remediation_stuck.{id}.
+ */
+export interface HitlPrRemediationStuckPayload {
+  /** GitHub repo (owner/repo) */
+  repo: string;
+  /** Pull request number */
+  prNumber: number;
+  /**
+   * Remediation kind attempted — e.g. 'merge_conflict', 'ci_failure',
+   * 'source_branch_guard', 'test_failure'.
+   */
+  kind: string;
+  /** CI workflow name that failed (e.g. 'checks', 'test', 'build') */
+  failingWorkflow: string;
+  /** CI status string (e.g. 'failure', 'error', 'timed_out') */
+  ciStatus: string;
+  /** Number of remediation attempts exhausted */
+  attempts: number;
+  /** ISO 8601 timestamp when the escalation was emitted */
+  timestamp: string;
+  /** Snapshot of the last known PR state */
+  prState?: Record<string, unknown>;
+  /** Log excerpt or error message used to derive error_class */
+  errorMessage?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal persistence types
+// ---------------------------------------------------------------------------
+
+interface EscalationRecord {
+  id: string;
+  repo: string;
+  prNumber: number;
+  kind: string;
+  failingWorkflow: string;
+  ciStatus: string;
+  attempts: number;
+  timestamp: string;
+  errorClass: string;
+  patternSignature: string;
+  prState: Record<string, unknown>;
+}
+
+interface PatternState {
+  signature: string;
+  count: number;
+  /** ISO 8601 timestamp of the first occurrence in the current window */
+  windowStart: string;
+  /** Feature ID filed for this pattern, if any */
+  filedFeatureId?: string;
+  /** ISO 8601 timestamp when the feature was filed */
+  filedAt?: string;
+}
+
+interface HitlPatternStore {
+  escalations: EscalationRecord[];
+  patterns: Record<string, PatternState>;
+  lastUpdated: string;
+}
+
+// ---------------------------------------------------------------------------
+// Dependencies
+// ---------------------------------------------------------------------------
+
+export interface HitlPatternAnalysisDeps {
+  featureLoader: FeatureLoader;
+  /** Project path where backlog features will be filed */
+  projectPath: string;
+  events: EventEmitter;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class HitlPatternAnalysisService {
+  private readonly deps: HitlPatternAnalysisDeps;
+
+  /** In-memory escalation list (bounded by MAX_ESCALATION_RECORDS) */
+  private escalations: EscalationRecord[] = [];
+
+  /** In-memory pattern state map */
+  private patterns = new Map<string, PatternState>();
+
+  /** Whether the store has been loaded from disk */
+  private initialized = false;
+
+  constructor(deps: HitlPatternAnalysisDeps) {
+    this.deps = deps;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Initialize the service by loading persisted state from disk.
+   * Safe to call multiple times — subsequent calls are no-ops.
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+    await this.loadStore();
+  }
+
+  /**
+   * Handle an inbound HITL escalation payload.
+   *
+   * Called by the TopicBus subscriber when a
+   * 'hitl.request.pr.remediation_stuck.*' message arrives.
+   */
+  async handleEscalation(payload: HitlPrRemediationStuckPayload): Promise<void> {
+    if (!this.initialized) await this.initialize();
+
+    const errorClass = extractErrorClass(payload);
+    const signature = buildSignature(payload.kind, payload.failingWorkflow, errorClass);
+
+    const record: EscalationRecord = {
+      id: randomUUID(),
+      repo: payload.repo ?? '',
+      prNumber: payload.prNumber ?? 0,
+      kind: payload.kind ?? '',
+      failingWorkflow: payload.failingWorkflow ?? '',
+      ciStatus: payload.ciStatus ?? '',
+      attempts: payload.attempts ?? 0,
+      timestamp: payload.timestamp ?? new Date().toISOString(),
+      errorClass,
+      patternSignature: signature,
+      prState: payload.prState ?? {},
+    };
+
+    this.escalations.push(record);
+    // Bound growth
+    if (this.escalations.length > MAX_ESCALATION_RECORDS) {
+      this.escalations = this.escalations.slice(-MAX_ESCALATION_RECORDS);
+    }
+
+    this.deps.events.emit('hitl:pattern-analysis:escalation-ingested', {
+      id: record.id,
+      repo: record.repo,
+      prNumber: record.prNumber,
+      patternSignature: signature,
+    });
+
+    logger.info(
+      `Ingested escalation for ${record.repo}#${record.prNumber} kind=${record.kind} signature="${signature}"`
+    );
+
+    await this.updatePatternCounter(signature, record);
+    await this.persistStore();
+  }
+
+  /**
+   * Return active (non-expired) pattern states, sorted by occurrence count descending.
+   * Useful for observability / dashboard widgets.
+   */
+  getPatterns(): PatternState[] {
+    const now = Date.now();
+    const results: PatternState[] = [];
+    for (const state of this.patterns.values()) {
+      const windowStart = new Date(state.windowStart).getTime();
+      if (!isNaN(windowStart) && now - windowStart <= COUNTER_WINDOW_MS) {
+        results.push(state);
+      }
+    }
+    results.sort((a, b) => b.count - a.count);
+    return results;
+  }
+
+  /**
+   * Return recent escalation records (newest-first, bounded to last N).
+   */
+  getEscalations(limit = 50): EscalationRecord[] {
+    return [...this.escalations].reverse().slice(0, limit);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  private async updatePatternCounter(
+    signature: string,
+    record: EscalationRecord
+  ): Promise<void> {
+    const now = Date.now();
+    const existing = this.patterns.get(signature);
+
+    let state: PatternState;
+    if (!existing) {
+      state = { signature, count: 1, windowStart: new Date(now).toISOString() };
+    } else {
+      const windowStart = new Date(existing.windowStart).getTime();
+      if (isNaN(windowStart) || now - windowStart > COUNTER_WINDOW_MS) {
+        // Window expired — start fresh
+        state = { signature, count: 1, windowStart: new Date(now).toISOString() };
+      } else {
+        state = { ...existing, count: existing.count + 1 };
+      }
+    }
+
+    this.patterns.set(signature, state);
+
+    logger.debug(
+      `Pattern counter updated: signature="${signature}" count=${state.count}`
+    );
+
+    if (state.count >= OCCURRENCE_THRESHOLD) {
+      await this.maybeFileFeature(signature, state, record);
+    }
+  }
+
+  private async maybeFileFeature(
+    signature: string,
+    state: PatternState,
+    latestRecord: EscalationRecord
+  ): Promise<void> {
+    // Dedup: skip if a feature was filed recently
+    if (state.filedAt) {
+      const filedAt = new Date(state.filedAt).getTime();
+      if (!isNaN(filedAt) && Date.now() - filedAt < FILING_DEDUP_WINDOW_MS) {
+        logger.info(
+          `Skipping auto-file for pattern="${signature}" — filed recently (${state.filedAt})`
+        );
+        return;
+      }
+    }
+
+    // Durable dedup: check feature store for an open feature with the same title
+    const title = buildFeatureTitle(signature);
+    try {
+      const existing = await this.deps.featureLoader.findByTitle(
+        this.deps.projectPath,
+        title
+      );
+      if (existing && existing.status !== 'done' && existing.status !== 'interrupted') {
+        // Re-populate local dedup guard
+        this.patterns.set(signature, { ...state, filedFeatureId: existing.id, filedAt: new Date().toISOString() });
+        logger.info(
+          `Skipping auto-file for pattern="${signature}" — open feature ${existing.id} already exists (status=${existing.status})`
+        );
+        return;
+      }
+    } catch (err) {
+      logger.warn(
+        `Failed to check for existing feature for pattern="${signature}", proceeding with filing: ${err}`
+      );
+    }
+
+    // Mark as filed immediately to prevent concurrent duplicates
+    this.patterns.set(signature, {
+      ...state,
+      filedAt: new Date().toISOString(),
+    });
+
+    try {
+      const description = this.buildFeatureDescription(signature, latestRecord);
+      const feature = await this.deps.featureLoader.create(this.deps.projectPath, {
+        title,
+        description,
+        complexity: 'medium',
+        status: 'backlog',
+        priority: 3,
+        category: 'infra',
+        tags: ['auto-remediation', 'hitl-pattern', 'self-improvement'],
+      } as Parameters<FeatureLoader['create']>[1]);
+
+      // Update pattern state with filed feature ID
+      const updated = this.patterns.get(signature)!;
+      this.patterns.set(signature, { ...updated, filedFeatureId: feature.id });
+
+      logger.info(
+        `Auto-filed feature ${feature.id} for recurring pattern="${signature}" (${state.count} occurrences)`
+      );
+
+      this.deps.events.emit('hitl:pattern-analysis:feature-filed', {
+        featureId: feature.id,
+        patternSignature: signature,
+        occurrenceCount: state.count,
+        latestRepo: latestRecord.repo,
+        latestPrNumber: latestRecord.prNumber,
+      });
+    } catch (err) {
+      // Roll back filing timestamp so a future run can retry
+      const rollback = this.patterns.get(signature);
+      if (rollback) {
+        this.patterns.set(signature, { ...rollback, filedAt: undefined });
+      }
+      logger.error(`Failed to file feature for pattern="${signature}": ${err}`);
+    }
+  }
+
+  private buildFeatureDescription(signature: string, latest: EscalationRecord): string {
+    const occurrences = this.escalations
+      .filter((e) => e.patternSignature === signature)
+      .slice(-5); // Last 5 for evidence
+
+    const evidenceLines = occurrences
+      .map(
+        (e) =>
+          `- ${e.timestamp}: ${e.repo}#${e.prNumber} kind=${e.kind} workflow=${e.failingWorkflow} ci=${e.ciStatus} attempts=${e.attempts}`
+      )
+      .join('\n');
+
+    const [kind, failingWorkflow, errorClass] = signature.split(':');
+
+    return [
+      `This feature was automatically filed by the HITL pattern analysis pipeline.`,
+      ``,
+      `## Pattern`,
+      `- **Signature:** \`${signature}\``,
+      `- **Kind:** ${kind}`,
+      `- **Failing workflow:** ${failingWorkflow}`,
+      `- **Error class:** ${errorClass}`,
+      ``,
+      `## Root Cause Template`,
+      `PRs matching this pattern exhaust the automated remediation retry budget and require manual unblocking.`,
+      `Investigate why \`${failingWorkflow}\` fails with error class \`${errorClass}\` for \`${kind}\` remediations`,
+      `and implement a durable automated fix so this case never stalls again.`,
+      ``,
+      `## Recent Evidence (last ${occurrences.length} occurrences)`,
+      evidenceLines,
+      ``,
+      `## Suggested Approach`,
+      `1. Review the failing workflow logs for the PRs listed above`,
+      `2. Identify the common root cause`,
+      `3. Implement an automated handler in the pr-remediator for this case`,
+      `4. Add a regression test covering the pattern`,
+      ``,
+      `**Latest escalation:** ${latest.repo}#${latest.prNumber} at ${latest.timestamp}`,
+    ].join('\n');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Persistence
+  // ---------------------------------------------------------------------------
+
+  private getStorePath(): string {
+    return join(this.deps.projectPath, '.automaker', 'ava-memory', 'hitl-patterns.json');
+  }
+
+  private async loadStore(): Promise<void> {
+    const storePath = this.getStorePath();
+    try {
+      const raw = await fs.readFile(storePath, 'utf-8');
+      const store = JSON.parse(raw) as HitlPatternStore;
+      this.escalations = Array.isArray(store.escalations) ? store.escalations : [];
+      if (store.patterns && typeof store.patterns === 'object') {
+        for (const [key, value] of Object.entries(store.patterns)) {
+          this.patterns.set(key, value as PatternState);
+        }
+      }
+      logger.debug(
+        `Loaded HITL pattern store: ${this.escalations.length} escalations, ${this.patterns.size} patterns`
+      );
+    } catch (err: unknown) {
+      // ENOENT is expected on first start — any other error is logged as a warning
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        logger.warn(`Failed to load HITL pattern store (starting fresh): ${err}`);
+      }
+    }
+  }
+
+  private async persistStore(): Promise<void> {
+    const storePath = this.getStorePath();
+    const store: HitlPatternStore = {
+      escalations: this.escalations,
+      patterns: Object.fromEntries(this.patterns),
+      lastUpdated: new Date().toISOString(),
+    };
+    try {
+      await atomicWriteJson(storePath, store, { createDirs: true });
+    } catch (err) {
+      logger.warn(`Failed to persist HITL pattern store: ${err}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a coarse error class from the escalation payload.
+ *
+ * Checks the failingWorkflow name and optional errorMessage for known patterns.
+ * Returns 'unknown' when no class can be determined.
+ */
+function extractErrorClass(payload: HitlPrRemediationStuckPayload): string {
+  const text = [payload.failingWorkflow ?? '', payload.errorMessage ?? '']
+    .join(' ')
+    .toLowerCase();
+
+  if (/type.?error|typescript|\.ts\b|tsc\b/.test(text)) return 'ts_error';
+  if (/test.fail|jest|vitest|spec\b|\.spec\./.test(text)) return 'test_failure';
+  if (/\blint\b|eslint|prettier/.test(text)) return 'lint_failure';
+  if (/source.branch|wrong.branch|promotion.check|source-branch/.test(text))
+    return 'source_branch_guard';
+  if (/build.fail|webpack|vite\b|compile/.test(text)) return 'build_failure';
+
+  return 'unknown';
+}
+
+/**
+ * Build a canonical pattern signature from its three components.
+ * Format: `{kind}:{failingWorkflow}:{errorClass}`
+ */
+function buildSignature(kind: string, failingWorkflow: string, errorClass: string): string {
+  return [kind ?? 'unknown', failingWorkflow ?? 'unknown', errorClass].join(':');
+}
+
+/**
+ * Build the feature title for a given pattern signature.
+ */
+function buildFeatureTitle(signature: string): string {
+  const [kind, failingWorkflow, errorClass] = signature.split(':');
+  const humanReadable = [kind, failingWorkflow, errorClass]
+    .map((s) => s?.replace(/_/g, ' '))
+    .join(' / ');
+  return `auto-remediate: stuck on ${humanReadable}`;
+}

--- a/apps/server/src/services/hitl-pattern-analysis-service.ts
+++ b/apps/server/src/services/hitl-pattern-analysis-service.ts
@@ -20,14 +20,14 @@
  * until FILING_DEDUP_WINDOW_MS has elapsed or the filed feature reaches 'done'.
  */
 
-import { randomUUID } from 'node:crypto';
-import fs from 'fs/promises';
-import { join } from 'node:path';
-import { atomicWriteJson, createLogger } from '@protolabsai/utils';
-import type { FeatureLoader } from './feature-loader.js';
-import type { EventEmitter } from '../lib/events.js';
+import { randomUUID } from "node:crypto";
+import fs from "fs/promises";
+import { join } from "node:path";
+import { atomicWriteJson, createLogger } from "@protolabsai/utils";
+import type { FeatureLoader } from "./feature-loader.js";
+import type { EventEmitter } from "../lib/events.js";
 
-const logger = createLogger('HitlPatternAnalysisService');
+const logger = createLogger("HitlPatternAnalysisService");
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -163,19 +163,25 @@ export class HitlPatternAnalysisService {
    * Called by the TopicBus subscriber when a
    * 'hitl.request.pr.remediation_stuck.*' message arrives.
    */
-  async handleEscalation(payload: HitlPrRemediationStuckPayload): Promise<void> {
+  async handleEscalation(
+    payload: HitlPrRemediationStuckPayload,
+  ): Promise<void> {
     if (!this.initialized) await this.initialize();
 
     const errorClass = extractErrorClass(payload);
-    const signature = buildSignature(payload.kind, payload.failingWorkflow, errorClass);
+    const signature = buildSignature(
+      payload.kind,
+      payload.failingWorkflow,
+      errorClass,
+    );
 
     const record: EscalationRecord = {
       id: randomUUID(),
-      repo: payload.repo ?? '',
+      repo: payload.repo ?? "",
       prNumber: payload.prNumber ?? 0,
-      kind: payload.kind ?? '',
-      failingWorkflow: payload.failingWorkflow ?? '',
-      ciStatus: payload.ciStatus ?? '',
+      kind: payload.kind ?? "",
+      failingWorkflow: payload.failingWorkflow ?? "",
+      ciStatus: payload.ciStatus ?? "",
       attempts: payload.attempts ?? 0,
       timestamp: payload.timestamp ?? new Date().toISOString(),
       errorClass,
@@ -189,7 +195,7 @@ export class HitlPatternAnalysisService {
       this.escalations = this.escalations.slice(-MAX_ESCALATION_RECORDS);
     }
 
-    this.deps.events.emit('hitl:pattern-analysis:escalation-ingested', {
+    this.deps.events.emit("hitl:pattern-analysis:escalation-ingested", {
       id: record.id,
       repo: record.repo,
       prNumber: record.prNumber,
@@ -197,7 +203,7 @@ export class HitlPatternAnalysisService {
     });
 
     logger.info(
-      `Ingested escalation for ${record.repo}#${record.prNumber} kind=${record.kind} signature="${signature}"`
+      `Ingested escalation for ${record.repo}#${record.prNumber} kind=${record.kind} signature="${signature}"`,
     );
 
     await this.updatePatternCounter(signature, record);
@@ -234,7 +240,7 @@ export class HitlPatternAnalysisService {
 
   private async updatePatternCounter(
     signature: string,
-    record: EscalationRecord
+    record: EscalationRecord,
   ): Promise<void> {
     const now = Date.now();
     const existing = this.patterns.get(signature);
@@ -246,7 +252,11 @@ export class HitlPatternAnalysisService {
       const windowStart = new Date(existing.windowStart).getTime();
       if (isNaN(windowStart) || now - windowStart > COUNTER_WINDOW_MS) {
         // Window expired — start fresh
-        state = { signature, count: 1, windowStart: new Date(now).toISOString() };
+        state = {
+          signature,
+          count: 1,
+          windowStart: new Date(now).toISOString(),
+        };
       } else {
         state = { ...existing, count: existing.count + 1 };
       }
@@ -255,7 +265,7 @@ export class HitlPatternAnalysisService {
     this.patterns.set(signature, state);
 
     logger.debug(
-      `Pattern counter updated: signature="${signature}" count=${state.count}`
+      `Pattern counter updated: signature="${signature}" count=${state.count}`,
     );
 
     if (state.count >= OCCURRENCE_THRESHOLD) {
@@ -266,14 +276,14 @@ export class HitlPatternAnalysisService {
   private async maybeFileFeature(
     signature: string,
     state: PatternState,
-    latestRecord: EscalationRecord
+    latestRecord: EscalationRecord,
   ): Promise<void> {
     // Dedup: skip if a feature was filed recently
     if (state.filedAt) {
       const filedAt = new Date(state.filedAt).getTime();
       if (!isNaN(filedAt) && Date.now() - filedAt < FILING_DEDUP_WINDOW_MS) {
         logger.info(
-          `Skipping auto-file for pattern="${signature}" — filed recently (${state.filedAt})`
+          `Skipping auto-file for pattern="${signature}" — filed recently (${state.filedAt})`,
         );
         return;
       }
@@ -284,19 +294,27 @@ export class HitlPatternAnalysisService {
     try {
       const existing = await this.deps.featureLoader.findByTitle(
         this.deps.projectPath,
-        title
+        title,
       );
-      if (existing && existing.status !== 'done' && existing.status !== 'interrupted') {
+      if (
+        existing &&
+        existing.status !== "done" &&
+        existing.status !== "interrupted"
+      ) {
         // Re-populate local dedup guard
-        this.patterns.set(signature, { ...state, filedFeatureId: existing.id, filedAt: new Date().toISOString() });
+        this.patterns.set(signature, {
+          ...state,
+          filedFeatureId: existing.id,
+          filedAt: new Date().toISOString(),
+        });
         logger.info(
-          `Skipping auto-file for pattern="${signature}" — open feature ${existing.id} already exists (status=${existing.status})`
+          `Skipping auto-file for pattern="${signature}" — open feature ${existing.id} already exists (status=${existing.status})`,
         );
         return;
       }
     } catch (err) {
       logger.warn(
-        `Failed to check for existing feature for pattern="${signature}", proceeding with filing: ${err}`
+        `Failed to check for existing feature for pattern="${signature}", proceeding with filing: ${err}`,
       );
     }
 
@@ -308,25 +326,28 @@ export class HitlPatternAnalysisService {
 
     try {
       const description = this.buildFeatureDescription(signature, latestRecord);
-      const feature = await this.deps.featureLoader.create(this.deps.projectPath, {
-        title,
-        description,
-        complexity: 'medium',
-        status: 'backlog',
-        priority: 3,
-        category: 'infra',
-        tags: ['auto-remediation', 'hitl-pattern', 'self-improvement'],
-      } as Parameters<FeatureLoader['create']>[1]);
+      const feature = await this.deps.featureLoader.create(
+        this.deps.projectPath,
+        {
+          title,
+          description,
+          complexity: "medium",
+          status: "backlog",
+          priority: 3,
+          category: "infra",
+          tags: ["auto-remediation", "hitl-pattern", "self-improvement"],
+        } as Parameters<FeatureLoader["create"]>[1],
+      );
 
       // Update pattern state with filed feature ID
       const updated = this.patterns.get(signature)!;
       this.patterns.set(signature, { ...updated, filedFeatureId: feature.id });
 
       logger.info(
-        `Auto-filed feature ${feature.id} for recurring pattern="${signature}" (${state.count} occurrences)`
+        `Auto-filed feature ${feature.id} for recurring pattern="${signature}" (${state.count} occurrences)`,
       );
 
-      this.deps.events.emit('hitl:pattern-analysis:feature-filed', {
+      this.deps.events.emit("hitl:pattern-analysis:feature-filed", {
         featureId: feature.id,
         patternSignature: signature,
         occurrenceCount: state.count,
@@ -343,7 +364,10 @@ export class HitlPatternAnalysisService {
     }
   }
 
-  private buildFeatureDescription(signature: string, latest: EscalationRecord): string {
+  private buildFeatureDescription(
+    signature: string,
+    latest: EscalationRecord,
+  ): string {
     const occurrences = this.escalations
       .filter((e) => e.patternSignature === signature)
       .slice(-5); // Last 5 for evidence
@@ -351,11 +375,11 @@ export class HitlPatternAnalysisService {
     const evidenceLines = occurrences
       .map(
         (e) =>
-          `- ${e.timestamp}: ${e.repo}#${e.prNumber} kind=${e.kind} workflow=${e.failingWorkflow} ci=${e.ciStatus} attempts=${e.attempts}`
+          `- ${e.timestamp}: ${e.repo}#${e.prNumber} kind=${e.kind} workflow=${e.failingWorkflow} ci=${e.ciStatus} attempts=${e.attempts}`,
       )
-      .join('\n');
+      .join("\n");
 
-    const [kind, failingWorkflow, errorClass] = signature.split(':');
+    const [kind, failingWorkflow, errorClass] = signature.split(":");
 
     return [
       `This feature was automatically filed by the HITL pattern analysis pipeline.`,
@@ -381,7 +405,7 @@ export class HitlPatternAnalysisService {
       `4. Add a regression test covering the pattern`,
       ``,
       `**Latest escalation:** ${latest.repo}#${latest.prNumber} at ${latest.timestamp}`,
-    ].join('\n');
+    ].join("\n");
   }
 
   // ---------------------------------------------------------------------------
@@ -389,27 +413,36 @@ export class HitlPatternAnalysisService {
   // ---------------------------------------------------------------------------
 
   private getStorePath(): string {
-    return join(this.deps.projectPath, '.automaker', 'ava-memory', 'hitl-patterns.json');
+    return join(
+      this.deps.projectPath,
+      ".automaker",
+      "ava-memory",
+      "hitl-patterns.json",
+    );
   }
 
   private async loadStore(): Promise<void> {
     const storePath = this.getStorePath();
     try {
-      const raw = await fs.readFile(storePath, 'utf-8');
+      const raw = await fs.readFile(storePath, "utf-8");
       const store = JSON.parse(raw) as HitlPatternStore;
-      this.escalations = Array.isArray(store.escalations) ? store.escalations : [];
-      if (store.patterns && typeof store.patterns === 'object') {
+      this.escalations = Array.isArray(store.escalations)
+        ? store.escalations
+        : [];
+      if (store.patterns && typeof store.patterns === "object") {
         for (const [key, value] of Object.entries(store.patterns)) {
           this.patterns.set(key, value as PatternState);
         }
       }
       logger.debug(
-        `Loaded HITL pattern store: ${this.escalations.length} escalations, ${this.patterns.size} patterns`
+        `Loaded HITL pattern store: ${this.escalations.length} escalations, ${this.patterns.size} patterns`,
       );
     } catch (err: unknown) {
       // ENOENT is expected on first start — any other error is logged as a warning
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-        logger.warn(`Failed to load HITL pattern store (starting fresh): ${err}`);
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        logger.warn(
+          `Failed to load HITL pattern store (starting fresh): ${err}`,
+        );
       }
     }
   }
@@ -440,35 +473,41 @@ export class HitlPatternAnalysisService {
  * Returns 'unknown' when no class can be determined.
  */
 function extractErrorClass(payload: HitlPrRemediationStuckPayload): string {
-  const text = [payload.failingWorkflow ?? '', payload.errorMessage ?? '']
-    .join(' ')
+  const text = [payload.failingWorkflow ?? "", payload.errorMessage ?? ""]
+    .join(" ")
     .toLowerCase();
 
-  if (/type.?error|typescript|\.ts\b|tsc\b/.test(text)) return 'ts_error';
-  if (/test.fail|jest|vitest|spec\b|\.spec\./.test(text)) return 'test_failure';
-  if (/\blint\b|eslint|prettier/.test(text)) return 'lint_failure';
+  if (/type.?error|typescript|\.ts\b|tsc\b/.test(text)) return "ts_error";
+  if (/test.fail|jest|vitest|spec\b|\.spec\./.test(text)) return "test_failure";
+  if (/\blint\b|eslint|prettier/.test(text)) return "lint_failure";
   if (/source.branch|wrong.branch|promotion.check|source-branch/.test(text))
-    return 'source_branch_guard';
-  if (/build.fail|webpack|vite\b|compile/.test(text)) return 'build_failure';
+    return "source_branch_guard";
+  if (/build.fail|webpack|vite\b|compile/.test(text)) return "build_failure";
 
-  return 'unknown';
+  return "unknown";
 }
 
 /**
  * Build a canonical pattern signature from its three components.
  * Format: `{kind}:{failingWorkflow}:{errorClass}`
  */
-function buildSignature(kind: string, failingWorkflow: string, errorClass: string): string {
-  return [kind ?? 'unknown', failingWorkflow ?? 'unknown', errorClass].join(':');
+function buildSignature(
+  kind: string,
+  failingWorkflow: string,
+  errorClass: string,
+): string {
+  return [kind ?? "unknown", failingWorkflow ?? "unknown", errorClass].join(
+    ":",
+  );
 }
 
 /**
  * Build the feature title for a given pattern signature.
  */
 function buildFeatureTitle(signature: string): string {
-  const [kind, failingWorkflow, errorClass] = signature.split(':');
+  const [kind, failingWorkflow, errorClass] = signature.split(":");
   const humanReadable = [kind, failingWorkflow, errorClass]
-    .map((s) => s?.replace(/_/g, ' '))
-    .join(' / ');
+    .map((s) => s?.replace(/_/g, " "))
+    .join(" / ");
   return `auto-remediate: stuck on ${humanReadable}`;
 }

--- a/apps/server/src/services/hitl-pattern-analysis.module.ts
+++ b/apps/server/src/services/hitl-pattern-analysis.module.ts
@@ -1,9 +1,9 @@
-import { createLogger } from "@protolabsai/utils";
-import type { ServiceContainer } from "../server/services.js";
-import type { TopicMessage } from "@protolabsai/types";
-import type { HitlPrRemediationStuckPayload } from "./hitl-pattern-analysis-service.js";
+import { createLogger } from '@protolabsai/utils';
+import type { ServiceContainer } from '../server/services.js';
+import type { TopicMessage } from '@protolabsai/types';
+import type { HitlPrRemediationStuckPayload } from './hitl-pattern-analysis-service.js';
 
-const logger = createLogger("Server:Wiring");
+const logger = createLogger('Server:Wiring');
 
 /**
  * Wires HitlPatternAnalysisService to the TopicBus.
@@ -26,14 +26,14 @@ export async function register(container: ServiceContainer): Promise<void> {
 
   // Subscribe to all pr-remediator stuck escalations from Workstacean
   topicBus.subscribe(
-    "hitl.request.pr.remediation_stuck.#",
+    'hitl.request.pr.remediation_stuck.#',
     (msg: TopicMessage<unknown>) => {
       const payload = msg.payload as HitlPrRemediationStuckPayload;
       void hitlPatternAnalysisService
         .handleEscalation(payload)
         .catch((err: unknown) => {
           logger.warn(
-            "[HitlPatternAnalysis] Failed to handle escalation:",
+            '[HitlPatternAnalysis] Failed to handle escalation:',
             err,
           );
         });
@@ -41,6 +41,6 @@ export async function register(container: ServiceContainer): Promise<void> {
   );
 
   logger.info(
-    "[HitlPatternAnalysis] Subscribed to hitl.request.pr.remediation_stuck.#",
+    '[HitlPatternAnalysis] Subscribed to hitl.request.pr.remediation_stuck.#',
   );
 }

--- a/apps/server/src/services/hitl-pattern-analysis.module.ts
+++ b/apps/server/src/services/hitl-pattern-analysis.module.ts
@@ -25,22 +25,12 @@ export async function register(container: ServiceContainer): Promise<void> {
   await hitlPatternAnalysisService.initialize();
 
   // Subscribe to all pr-remediator stuck escalations from Workstacean
-  topicBus.subscribe(
-    'hitl.request.pr.remediation_stuck.#',
-    (msg: TopicMessage<unknown>) => {
-      const payload = msg.payload as HitlPrRemediationStuckPayload;
-      void hitlPatternAnalysisService
-        .handleEscalation(payload)
-        .catch((err: unknown) => {
-          logger.warn(
-            '[HitlPatternAnalysis] Failed to handle escalation:',
-            err,
-          );
-        });
-    },
-  );
+  topicBus.subscribe('hitl.request.pr.remediation_stuck.#', (msg: TopicMessage<unknown>) => {
+    const payload = msg.payload as HitlPrRemediationStuckPayload;
+    void hitlPatternAnalysisService.handleEscalation(payload).catch((err: unknown) => {
+      logger.warn('[HitlPatternAnalysis] Failed to handle escalation:', err);
+    });
+  });
 
-  logger.info(
-    '[HitlPatternAnalysis] Subscribed to hitl.request.pr.remediation_stuck.#',
-  );
+  logger.info('[HitlPatternAnalysis] Subscribed to hitl.request.pr.remediation_stuck.#');
 }

--- a/apps/server/src/services/hitl-pattern-analysis.module.ts
+++ b/apps/server/src/services/hitl-pattern-analysis.module.ts
@@ -1,0 +1,39 @@
+import { createLogger } from '@protolabsai/utils';
+import type { ServiceContainer } from '../server/services.js';
+import type { TopicMessage } from '@protolabsai/types';
+import type { HitlPrRemediationStuckPayload } from './hitl-pattern-analysis-service.js';
+
+const logger = createLogger('Server:Wiring');
+
+/**
+ * Wires HitlPatternAnalysisService to the TopicBus.
+ *
+ * Subscribes to 'hitl.request.pr.remediation_stuck.#' — the pattern emitted
+ * by Workstacean's pr-remediator when a (PR, kind) tuple exhausts its retry
+ * budget. Each matching message is forwarded to the service for persistent
+ * storage and pattern analysis.
+ *
+ * Transport note: for events to arrive here, the inbound transport layer must
+ * publish them to the TopicBus using the topic
+ * 'hitl.request.pr.remediation_stuck.{id}'. The Workstacean inbound route
+ * (POST /api/hitl/events) is the recommended transport.
+ */
+export async function register(container: ServiceContainer): Promise<void> {
+  const { topicBus, hitlPatternAnalysisService } = container;
+
+  // Initialize persistent store on startup (loads disk state into memory)
+  await hitlPatternAnalysisService.initialize();
+
+  // Subscribe to all pr-remediator stuck escalations from Workstacean
+  topicBus.subscribe(
+    'hitl.request.pr.remediation_stuck.#',
+    (msg: TopicMessage<unknown>) => {
+      const payload = msg.payload as HitlPrRemediationStuckPayload;
+      void hitlPatternAnalysisService.handleEscalation(payload).catch((err: unknown) => {
+        logger.warn('[HitlPatternAnalysis] Failed to handle escalation:', err);
+      });
+    }
+  );
+
+  logger.info('[HitlPatternAnalysis] Subscribed to hitl.request.pr.remediation_stuck.#');
+}

--- a/apps/server/src/services/hitl-pattern-analysis.module.ts
+++ b/apps/server/src/services/hitl-pattern-analysis.module.ts
@@ -1,9 +1,9 @@
-import { createLogger } from '@protolabsai/utils';
-import type { ServiceContainer } from '../server/services.js';
-import type { TopicMessage } from '@protolabsai/types';
-import type { HitlPrRemediationStuckPayload } from './hitl-pattern-analysis-service.js';
+import { createLogger } from "@protolabsai/utils";
+import type { ServiceContainer } from "../server/services.js";
+import type { TopicMessage } from "@protolabsai/types";
+import type { HitlPrRemediationStuckPayload } from "./hitl-pattern-analysis-service.js";
 
-const logger = createLogger('Server:Wiring');
+const logger = createLogger("Server:Wiring");
 
 /**
  * Wires HitlPatternAnalysisService to the TopicBus.
@@ -26,14 +26,21 @@ export async function register(container: ServiceContainer): Promise<void> {
 
   // Subscribe to all pr-remediator stuck escalations from Workstacean
   topicBus.subscribe(
-    'hitl.request.pr.remediation_stuck.#',
+    "hitl.request.pr.remediation_stuck.#",
     (msg: TopicMessage<unknown>) => {
       const payload = msg.payload as HitlPrRemediationStuckPayload;
-      void hitlPatternAnalysisService.handleEscalation(payload).catch((err: unknown) => {
-        logger.warn('[HitlPatternAnalysis] Failed to handle escalation:', err);
-      });
-    }
+      void hitlPatternAnalysisService
+        .handleEscalation(payload)
+        .catch((err: unknown) => {
+          logger.warn(
+            "[HitlPatternAnalysis] Failed to handle escalation:",
+            err,
+          );
+        });
+    },
   );
 
-  logger.info('[HitlPatternAnalysis] Subscribed to hitl.request.pr.remediation_stuck.#');
+  logger.info(
+    "[HitlPatternAnalysis] Subscribed to hitl.request.pr.remediation_stuck.#",
+  );
 }

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -372,7 +372,10 @@ export type EventType =
   // Planning pipeline events (A2A plan + plan_resume skills)
   | 'plan:hitl-requested'
   | 'plan:created'
-  | 'plan:rejected';
+  | 'plan:rejected'
+  // HITL pattern analysis events (recurring stuck-PR pattern detection → auto-file)
+  | 'hitl:pattern-analysis:escalation-ingested'
+  | 'hitl:pattern-analysis:feature-filed';
 
 export type EventCallback = (type: EventType, payload: unknown) => void;
 


### PR DESCRIPTION
## Summary

## Context

Workstacean's pr-remediator now emits a HITL escalation to `hitl.request.pr.remediation_stuck.{id}` when a (PR, kind) tuple exhausts its retry budget (workstacean PR #97). This unblocks the immediate case: a human sees the notification, investigates, and manually resolves the stuck PR.

## The gap

Every stuck PR is TWO signals:

1. **Unblock signal** — a human needs to investigate right now (already handled by the HITL emission)
2. **Feature-request signal** — what would have auto-f...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection and ranking of recurring escalation patterns by frequency.
  * Auto-creates backlog remediation features when a pattern meets a threshold, with deduplication safeguards to avoid duplicates.
  * Persists recent escalation history and exposes APIs to view active patterns and recent escalations for prioritization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->