### PR TITLE
fix(ci): document prettier CI failure pattern + confirm 3-file formatting fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,24 @@ Then use `create_pr_from_worktree` targeting `dev`, move feature to `review`, en
 **Prettier check fails in CI (worktree path masking):**
 Fixed at the source — `worktree-recovery-service.ts` and `git-workflow-service.ts` now use `node "${projectPath}/node_modules/.bin/prettier" --ignore-path /dev/null` instead of `npx prettier`. If you still hit this manually, use: `npx prettier --write <file> --ignore-path /dev/null`.
 
+**Prettier check fails in CI (pre-existing formatting violations — passes locally but fails CI):**
+Symptom: `npm run format:check` returns `Code style issues found in N files` on specific files, but running the same command locally reports `All matched files use Prettier code style!`. Same version, same config, same SHA.
+
+Root cause: CI always runs a fresh `npm install` (exact version pins), while local `pnpm` may use a cached/prior prettier install or a globally installed prettier of a slightly different version. Files that were formatted by an older prettier and never re-checked can silently drift. CI catches this; local won't unless you explicitly re-run prettier write.
+
+Common violations found: multi-line `import { x, }` that should be inline when the name fits under `printWidth: 100`; inline object property values (`description: 'long...'`) that exceed 100 chars and should be on a new line; escaped single-quotes (`\'`) that should use outer double-quotes.
+
+Recovery:
+
+```bash
+# On the host machine (not in a worktree sandbox):
+./node_modules/.bin/prettier --write <file1> <file2> ...
+# Or from any environment with node:
+node /path/to/project/node_modules/.bin/prettier --ignore-path /dev/null --write <files>
+```
+
+Prevention: After any merge or back-merge, run `npm run format:check` before opening a PR. This check runs first in the `checks` CI workflow and blocks promotion.
+
 **Feature blocked with "merge_conflict" / "unmerged files" (stuck MERGE_HEAD):**
 A previous `git merge` failed with conflicts and left `.git/MERGE_HEAD` in the worktree. Every subsequent merge or stash attempt immediately fails with "Merging is not possible because you have unmerged files", creating an unrecoverable loop. The system now auto-clears this via `ensureCleanMergeState()` before each merge attempt (`libs/git-utils/src/rebase.ts`). If a feature is still stuck:
 


### PR DESCRIPTION
## Summary

- The `checks` CI workflow was failing on 3 files that passed local prettier checks, blocking PR #3343 (staging→main promotion)
- Those 3 files were fixed in prior commits via back-merges: `routes.ts` (15382bb61), `discord-tools.ts` (97747b032), `worktree-creation-base-branch.test.ts` (36d621f77)
- This PR documents the root cause and recovery pattern in CLAUDE.md so future agents recognize the symptom immediately

## Root Cause

CI uses a fresh `npm install` with exact version pinning (prettier 3.7.4). Local `pnpm` may cache a prior prettier install. Files formatted by an older version drift silently. CI catches this on the exact pinned version; local won't unless `prettier --write` is explicitly re-run.

Common violations found in these 3 files:
- Multi-line `import { x, }` that should be inline when the name fits under `printWidth: 100`
- Inline `description: 'long...'` values exceeding 100 chars that should be split to a new line
- Escaped single-quotes (`\'`) that should use outer double-quotes when the string contains apostrophes

## Test plan

- [ ] CI `checks` workflow passes on this PR (format:check, lint, typecheck)
- [ ] No code changes — only CLAUDE.md documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)