### PR TITLE
fix(ci): PR #3355 — agent branch uses feature/ prefix instead of fix/, triggering source-branch policy rejection and cascading checks gate failure

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -313,9 +313,7 @@ export class FeatureLoader implements FeatureStore {
     const shortId = featureId ? featureId.slice(-7) : Date.now().toString(36).slice(-7);
 
     // Determine branch prefix from category or title convention.
-    const isFixWork =
-      category === 'bug' ||
-      (title != null && /^fix[:(]/i.test(title.trim()));
+    const isFixWork = category === 'bug' || (title != null && /^fix[:(]/i.test(title.trim()));
     const prefix = isFixWork ? 'fix' : 'feature';
 
     if (!title || !title.trim()) {

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -298,23 +298,32 @@ export class FeatureLoader implements FeatureStore {
   }
 
   /**
-   * Generate a branch name from a feature title and feature ID.
+   * Generate a branch name from a feature title, feature ID, and optional category.
    * Appends a short fragment derived from the featureId to guarantee
    * uniqueness even when multiple features share a long common title prefix.
-   * Returns a feature/ prefixed branch name suitable for git.
+   *
+   * Prefix mapping:
+   * - category === 'bug', or title starts with 'fix:' / 'fix(' → fix/
+   * - all other categories → feature/
    */
-  generateBranchName(title: string | undefined, featureId?: string): string {
+  generateBranchName(title: string | undefined, featureId?: string, category?: string): string {
     // Derive a short, deterministic uniqueness suffix from featureId.
     // featureId format: "feature-{timestamp}-{random9chars}"
     // Use the last 7 characters of the id — always alphanumeric, always unique.
     const shortId = featureId ? featureId.slice(-7) : Date.now().toString(36).slice(-7);
 
+    // Determine branch prefix from category or title convention.
+    const isFixWork =
+      category === 'bug' ||
+      (title != null && /^fix[:(]/i.test(title.trim()));
+    const prefix = isFixWork ? 'fix' : 'feature';
+
     if (!title || !title.trim()) {
-      return `feature/untitled-${shortId}`;
+      return `${prefix}/untitled-${shortId}`;
     }
     // Keep slug portion to 50 chars so the full branch stays under ~60 chars.
     const slug = slugify(title, 50);
-    return `feature/${slug || `untitled`}-${shortId}`;
+    return `${prefix}/${slug || `untitled`}-${shortId}`;
   }
 
   /**
@@ -589,7 +598,8 @@ export class FeatureLoader implements FeatureStore {
     const branchName =
       featureData.executionMode === 'read-only'
         ? undefined
-        : featureData.branchName || this.generateBranchName(featureData.title, featureId);
+        : featureData.branchName ||
+          this.generateBranchName(featureData.title, featureId, featureData.category);
 
     // Auto-assign projectSlug if not already provided
     let resolvedProjectSlug = featureData.projectSlug;

--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -106,9 +106,33 @@ describe('FeatureLoader.generateBranchName', () => {
   });
 
   it('branch name is human-readable and contains a slug of the title', () => {
-    const branch = loader.generateBranchName('Fix login button', 'feature-123-abc1234');
+    const branch = loader.generateBranchName('Add login button', 'feature-123-abc1234');
     expect(branch).toMatch(/^feature\//);
-    expect(branch).toContain('fix-login-button');
+    expect(branch).toContain('add-login-button');
+  });
+
+  it('uses fix/ prefix when category is bug', () => {
+    const branch = loader.generateBranchName('Fix login crash', 'feature-123-abc1234', 'bug');
+    expect(branch).toMatch(/^fix\//);
+    expect(branch).toContain('fix-login-crash');
+  });
+
+  it('uses fix/ prefix when title starts with fix:', () => {
+    const branch = loader.generateBranchName('fix: correct null check', 'feature-123-abc1234');
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses fix/ prefix when title starts with fix(ci):', () => {
+    const branch = loader.generateBranchName(
+      'fix(ci): PR #3351 source-branch failure',
+      'feature-123-abc1234'
+    );
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses feature/ prefix for non-fix categories', () => {
+    const branch = loader.generateBranchName('Add dark mode', 'feature-123-abc1234', 'feature');
+    expect(branch).toMatch(/^feature\//);
   });
 
   it('is deterministic: same title + same featureId always yields the same branch name', () => {


### PR DESCRIPTION
## Summary

## RCA

PR #3355 (branch: `feature/fixci-pr-3351-source-branch-policy-rejection-and-p7yz7y0`) was generated by the auto-mode agent to fix PR #3351, but the branch was created with the wrong prefix (`feature/` instead of `fix/`). The source-branch policy enforces that fix PRs must originate from a `fix/`-prefixed branch; using `feature/` causes immediate rejection.

**Failure chain:**
1. `source-branch` check → FAILURE (branch prefix `feature/` violates policy for fix PRs)
2. `checks` composite g...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved branch naming: branch prefixes now adapt to feature category and title conventions so bug-related work is auto-labeled with a fix/ prefix while standard work uses feature/, yielding clearer branch organization.

* **Tests**
  * Expanded test coverage to validate branch naming across categories and title patterns, including bug titles and various fix: prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->