### PR TITLE
fix(ci): PR #3359 — fix branch carries feature/ prefix instead of fix/, re-triggering source-branch policy rejection and cascading checks gate failure

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -298,23 +298,31 @@ export class FeatureLoader implements FeatureStore {
   }
 
   /**
-   * Generate a branch name from a feature title and feature ID.
+   * Generate a branch name from a feature title, feature ID, and optional category.
    * Appends a short fragment derived from the featureId to guarantee
    * uniqueness even when multiple features share a long common title prefix.
-   * Returns a feature/ prefixed branch name suitable for git.
+   * Returns a branch name prefixed with fix/ for bug/fix/ci categories,
+   * or feature/ for all other categories.
    */
-  generateBranchName(title: string | undefined, featureId?: string): string {
+  generateBranchName(title: string | undefined, featureId?: string, category?: string): string {
     // Derive a short, deterministic uniqueness suffix from featureId.
     // featureId format: "feature-{timestamp}-{random9chars}"
     // Use the last 7 characters of the id — always alphanumeric, always unique.
     const shortId = featureId ? featureId.slice(-7) : Date.now().toString(36).slice(-7);
 
+    // Use fix/ prefix for bug/fix/ci categories to satisfy source-branch policy.
+    const normalizedCategory = category?.toLowerCase().trim();
+    const prefix =
+      normalizedCategory === 'bug' || normalizedCategory === 'fix' || normalizedCategory === 'ci'
+        ? 'fix'
+        : 'feature';
+
     if (!title || !title.trim()) {
-      return `feature/untitled-${shortId}`;
+      return `${prefix}/untitled-${shortId}`;
     }
     // Keep slug portion to 50 chars so the full branch stays under ~60 chars.
     const slug = slugify(title, 50);
-    return `feature/${slug || `untitled`}-${shortId}`;
+    return `${prefix}/${slug || `untitled`}-${shortId}`;
   }
 
   /**
@@ -589,7 +597,8 @@ export class FeatureLoader implements FeatureStore {
     const branchName =
       featureData.executionMode === 'read-only'
         ? undefined
-        : featureData.branchName || this.generateBranchName(featureData.title, featureId);
+        : featureData.branchName ||
+          this.generateBranchName(featureData.title, featureId, featureData.category);
 
     // Auto-assign projectSlug if not already provided
     let resolvedProjectSlug = featureData.projectSlug;

--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -130,4 +130,39 @@ describe('FeatureLoader.generateBranchName', () => {
     const branch = loader.generateBranchName('   ', 'feature-123-abc1234');
     expect(branch).toMatch(/^feature\/untitled-/);
   });
+
+  it('uses fix/ prefix for category=bug', () => {
+    const branch = loader.generateBranchName('Fix login bug', 'feature-123-abc1234', 'bug');
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses fix/ prefix for category=fix', () => {
+    const branch = loader.generateBranchName('Fix login bug', 'feature-123-abc1234', 'fix');
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses fix/ prefix for category=ci', () => {
+    const branch = loader.generateBranchName('Fix CI pipeline', 'feature-123-abc1234', 'ci');
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses fix/ prefix for category=CI (case-insensitive)', () => {
+    const branch = loader.generateBranchName('Fix CI pipeline', 'feature-123-abc1234', 'CI');
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses feature/ prefix for category=feature', () => {
+    const branch = loader.generateBranchName('Add new feature', 'feature-123-abc1234', 'feature');
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('uses feature/ prefix when category is undefined', () => {
+    const branch = loader.generateBranchName('Add new feature', 'feature-123-abc1234', undefined);
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('returns fix/untitled for blank title with bug category', () => {
+    const branch = loader.generateBranchName('   ', 'feature-123-abc1234', 'bug');
+    expect(branch).toMatch(/^fix\/untitled-/);
+  });
 });


### PR DESCRIPTION
## Summary

## RCA

PR #3359 (`feature/fixci-pr-3355-agent-branch-uses-feature-prefix-knm7hyy`) was generated by the auto-mode agent to resolve #3355, but the agent again emitted a `feature/` prefix for the branch name instead of the required `fix/` prefix. The repository's source-branch policy rejects any PR targeting `main` whose head branch does not match the `fix/**` pattern for fix-type work, causing the `source-branch` check to fail immediately. The composite `checks` gate then fails in turn because i...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Category-aware branch naming: Branches are now created with prefixes reflecting their purpose. Bug-related items automatically receive `fix/` prefixes for streamlined organization, while feature items use `feature/` prefixes. This enhancement improves repository navigation and makes it easier to identify the nature of work in each branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->