### PR TITLE
fix(ci): PR #3360 — source-branch policy rejects feature/ prefix on fix branch, cascading checks gate failure

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -301,7 +301,12 @@ export class FeatureLoader implements FeatureStore {
    * Generate a branch name from a feature title and feature ID.
    * Appends a short fragment derived from the featureId to guarantee
    * uniqueness even when multiple features share a long common title prefix.
-   * Returns a feature/ prefixed branch name suitable for git.
+   *
+   * Branch prefix is derived from the conventional commit type in the title:
+   *   fix: ... / fix(scope): ...  → fix/
+   *   chore: ...                  → chore/
+   *   feat: ... / feature: ...   → feature/
+   *   (all other titles)          → feature/
    */
   generateBranchName(title: string | undefined, featureId?: string): string {
     // Derive a short, deterministic uniqueness suffix from featureId.
@@ -312,9 +317,30 @@ export class FeatureLoader implements FeatureStore {
     if (!title || !title.trim()) {
       return `feature/untitled-${shortId}`;
     }
+
+    // Detect conventional commit type prefix: "type: body" or "type(scope): body"
+    const conventionalMatch = title.match(/^([a-zA-Z]+)(?:\([^)]*\))?:\s*(.+)/s);
+    let branchPrefix = 'feature/';
+    let slugTitle = title;
+    if (conventionalMatch) {
+      const type = conventionalMatch[1].toLowerCase();
+      const body = conventionalMatch[2].trim();
+      if (type === 'fix') {
+        branchPrefix = 'fix/';
+        slugTitle = body;
+      } else if (type === 'chore') {
+        branchPrefix = 'chore/';
+        slugTitle = body;
+      } else if (type === 'feat' || type === 'feature') {
+        branchPrefix = 'feature/';
+        slugTitle = body;
+      }
+      // Other types (docs, refactor, test, etc.) fall through to default feature/ prefix
+    }
+
     // Keep slug portion to 50 chars so the full branch stays under ~60 chars.
-    const slug = slugify(title, 50);
-    return `feature/${slug || `untitled`}-${shortId}`;
+    const slug = slugify(slugTitle, 50);
+    return `${branchPrefix}${slug || `untitled`}-${shortId}`;
   }
 
   /**

--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -130,4 +130,42 @@ describe('FeatureLoader.generateBranchName', () => {
     const branch = loader.generateBranchName('   ', 'feature-123-abc1234');
     expect(branch).toMatch(/^feature\/untitled-/);
   });
+
+  it('uses fix/ prefix for titles with conventional fix: type', () => {
+    const branch = loader.generateBranchName('fix: login button broken', 'feature-123-abc1234');
+    expect(branch).toMatch(/^fix\//);
+    expect(branch).not.toMatch(/^feature\//);
+  });
+
+  it('uses fix/ prefix for titles with scoped fix(ci): type', () => {
+    const branch = loader.generateBranchName(
+      'fix(ci): PR #3357 — checks gate failure on f8una36',
+      'feature-1775864254653-vd4o8gt6y',
+    );
+    expect(branch).toMatch(/^fix\//);
+    expect(branch).not.toContain('fix-ci');
+  });
+
+  it('uses chore/ prefix for titles with conventional chore: type', () => {
+    const branch = loader.generateBranchName('chore: update dependencies', 'feature-123-abc1234');
+    expect(branch).toMatch(/^chore\//);
+  });
+
+  it('uses feature/ prefix for titles with conventional feat: type', () => {
+    const branch = loader.generateBranchName('feat: add dark mode', 'feature-123-abc1234');
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('slugifies only the body (after the type prefix) for conventional commit titles', () => {
+    const branch = loader.generateBranchName('fix: login button broken', 'feature-123-abc1234');
+    expect(branch).toContain('login-button-broken');
+    // "fix" should not appear twice in the slug portion
+    expect(branch).toBe('fix/login-button-broken-abc1234');
+  });
+
+  it('non-conventional titles without colon always use feature/ prefix', () => {
+    const branch = loader.generateBranchName('Fix login button', 'feature-123-abc1234');
+    expect(branch).toMatch(/^feature\//);
+    expect(branch).toContain('fix-login-button');
+  });
 });


### PR DESCRIPTION
## Summary

## Root Cause Analysis

PR #3360 (`feature/fixci-pr-3357-checks-composite-gate-failure-on-f8una36`) is failing CI because the agent-generated branch carries a `feature/` prefix instead of the required `fix/` prefix. The `source-branch` policy check rejects the branch, which cascades into the `checks` composite gate failing twice.

**Failed checks:**
- `source-branch` — FAILURE (branch prefix policy violation: `feature/` used on a fix/remediation PR)
- `checks` (x2) — FAILURE (composite gate, agg...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-11T00:06:10.024Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved branch name generation to intelligently extract and apply conventional commit type prefixes (fix, chore, feat) as branch name prefixes
  * Enhanced slug generation to process only the title body text

* **Tests**
  * Extended test coverage for updated branch naming behavior with various commit-style title formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->