### PR TITLE
fix(ci): PR #3361 — fix branch carries feature/ prefix instead of fix/, re-triggering source-branch policy rejection and cascading checks gate failure

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -298,23 +298,29 @@ export class FeatureLoader implements FeatureStore {
   }
 
   /**
-   * Generate a branch name from a feature title and feature ID.
+   * Generate a branch name from a feature title, feature ID, and optional category.
    * Appends a short fragment derived from the featureId to guarantee
    * uniqueness even when multiple features share a long common title prefix.
-   * Returns a feature/ prefixed branch name suitable for git.
+   * Returns a branch name prefixed with:
+   *   - "fix/"     when category (trimmed, lowercased) is "ci" or "bug"
+   *   - "feature/" otherwise
    */
-  generateBranchName(title: string | undefined, featureId?: string): string {
+  generateBranchName(title: string | undefined, featureId?: string, category?: string): string {
     // Derive a short, deterministic uniqueness suffix from featureId.
     // featureId format: "feature-{timestamp}-{random9chars}"
     // Use the last 7 characters of the id — always alphanumeric, always unique.
     const shortId = featureId ? featureId.slice(-7) : Date.now().toString(36).slice(-7);
 
+    // Determine the branch prefix from the feature category.
+    const normalizedCategory = (category ?? '').trim().toLowerCase();
+    const prefix = normalizedCategory === 'ci' || normalizedCategory === 'bug' ? 'fix' : 'feature';
+
     if (!title || !title.trim()) {
-      return `feature/untitled-${shortId}`;
+      return `${prefix}/untitled-${shortId}`;
     }
     // Keep slug portion to 50 chars so the full branch stays under ~60 chars.
     const slug = slugify(title, 50);
-    return `feature/${slug || `untitled`}-${shortId}`;
+    return `${prefix}/${slug || `untitled`}-${shortId}`;
   }
 
   /**
@@ -589,7 +595,8 @@ export class FeatureLoader implements FeatureStore {
     const branchName =
       featureData.executionMode === 'read-only'
         ? undefined
-        : featureData.branchName || this.generateBranchName(featureData.title, featureId);
+        : featureData.branchName ||
+          this.generateBranchName(featureData.title, featureId, featureData.category);
 
     // Auto-assign projectSlug if not already provided
     let resolvedProjectSlug = featureData.projectSlug;

--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -130,4 +130,41 @@ describe('FeatureLoader.generateBranchName', () => {
     const branch = loader.generateBranchName('   ', 'feature-123-abc1234');
     expect(branch).toMatch(/^feature\/untitled-/);
   });
+
+  it('uses fix/ prefix when category is "ci"', () => {
+    const branch = loader.generateBranchName('fix ci pipeline', 'feature-123-abc1234', 'ci');
+    expect(branch).toMatch(/^fix\//);
+    expect(branch).toContain('fix-ci-pipeline');
+  });
+
+  it('uses fix/ prefix when category is "bug"', () => {
+    const branch = loader.generateBranchName('fix login error', 'feature-123-bbb5678', 'bug');
+    expect(branch).toMatch(/^fix\//);
+    expect(branch).toContain('fix-login-error');
+  });
+
+  it('uses fix/ prefix when category has surrounding whitespace ("  ci  ")', () => {
+    const branch = loader.generateBranchName('fix flaky test', 'feature-123-ccc9012', '  ci  ');
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses fix/ prefix when category is uppercase ("CI")', () => {
+    const branch = loader.generateBranchName('fix build', 'feature-123-ddd3456', 'CI');
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses feature/ prefix for non-fix categories ("feat")', () => {
+    const branch = loader.generateBranchName('add dark mode', 'feature-123-eee7890', 'feat');
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('uses feature/ prefix when category is undefined', () => {
+    const branch = loader.generateBranchName('add dark mode', 'feature-123-fff2345', undefined);
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('fix/ untitled branch for ci category with blank title', () => {
+    const branch = loader.generateBranchName('   ', 'feature-123-ggg6789', 'ci');
+    expect(branch).toMatch(/^fix\/untitled-/);
+  });
 });


### PR DESCRIPTION
## Summary

## RCA

PR #3361 (`feature/fixci-pr-3359-fix-branch-carries-feature-prefix-mvgrbsw`) was opened to remediate PR #3359 but was itself created with a `feature/` prefix instead of the required `fix/` prefix. The source-branch policy check (`source-branch`) rejects any branch targeting `dev` that does not conform to the `fix/` naming convention for bug-fix PRs, causing an immediate FAILURE on that check and leaving the composite `checks` gate incomplete.

This is a recursive manifestation of the sam...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-11T00:12:23.633Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-generated branch names now vary based on feature category, using `fix/` prefix for bug and CI features, and `feature/` prefix for other types.

* **Tests**
  * Added unit tests validating branch name generation with different feature categories and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->