### PR TITLE
fix(ci): PR #3362 — fix branch carries feature/ prefix instead of fix/, re-triggering source-branch policy rejection and cascading checks gate failure

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -301,7 +301,10 @@ export class FeatureLoader implements FeatureStore {
    * Generate a branch name from a feature title and feature ID.
    * Appends a short fragment derived from the featureId to guarantee
    * uniqueness even when multiple features share a long common title prefix.
-   * Returns a feature/ prefixed branch name suitable for git.
+   *
+   * Branch prefix is determined by the conventional commit category in the title:
+   * - fix:, bug:, ci: → fix/
+   * - everything else → feature/
    */
   generateBranchName(title: string | undefined, featureId?: string): string {
     // Derive a short, deterministic uniqueness suffix from featureId.
@@ -312,9 +315,14 @@ export class FeatureLoader implements FeatureStore {
     if (!title || !title.trim()) {
       return `feature/untitled-${shortId}`;
     }
+
+    // Detect conventional commit category prefix and map to the correct branch prefix.
+    // fix:, bug:, ci: → fix/; everything else → feature/
+    const branchPrefix = /^(fix|bug|ci)\s*:/i.test(title.trim()) ? 'fix' : 'feature';
+
     // Keep slug portion to 50 chars so the full branch stays under ~60 chars.
     const slug = slugify(title, 50);
-    return `feature/${slug || `untitled`}-${shortId}`;
+    return `${branchPrefix}/${slug || 'untitled'}-${shortId}`;
   }
 
   /**

--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -131,3 +131,43 @@ describe('FeatureLoader.generateBranchName', () => {
     expect(branch).toMatch(/^feature\/untitled-/);
   });
 });
+
+describe('FeatureLoader.generateBranchName — branch prefix by conventional commit category', () => {
+  const loader = new FeatureLoader();
+
+  it('uses fix/ prefix for fix: category with a body', () => {
+    const branch = loader.generateBranchName('fix: broken login button', 'feature-123-abc1234');
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses fix/ prefix for fix: category with empty body (regression guard)', () => {
+    // Guards against regression back to feature/ prefix when title is just "fix:"
+    const branch = loader.generateBranchName('fix:', 'feature-123-abc1234');
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses fix/ prefix for bug: category', () => {
+    const branch = loader.generateBranchName('bug: null pointer in auth service', 'feature-123-abc1234');
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses fix/ prefix for ci: category', () => {
+    const branch = loader.generateBranchName('ci: add missing test coverage', 'feature-123-abc1234');
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses feature/ prefix for feat: category', () => {
+    const branch = loader.generateBranchName('feat: add dark mode', 'feature-123-abc1234');
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('uses feature/ prefix for chore: category', () => {
+    const branch = loader.generateBranchName('chore: update dependencies', 'feature-123-abc1234');
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('uses feature/ prefix for title without conventional commit prefix', () => {
+    const branch = loader.generateBranchName('Fix login button', 'feature-123-abc1234');
+    expect(branch).toMatch(/^feature\//);
+  });
+});


### PR DESCRIPTION
## Summary

## RCA

PR #3362 (`feature/fixci-pr-3360-source-branch-policy-rejects-4o8gt6y`) was generated to remediate #3360 but the agent again emitted a `feature/` prefix instead of the required `fix/` prefix. The repository source-branch policy rejects any branch targeting `main` that doesn't carry the correct prefix, causing the **source-branch** check to fail immediately and the composite **checks** gate to cascade-fail behind it.

**Failing workflows:**
- `source-branch` — FAILURE (branch prefix polic...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-11T00:16:35.649Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Branch names now automatically use `fix/` prefix for fix, bug, and ci-related changes; all other changes use `feature/` prefix.

* **Tests**
  * Added test suite validating branch prefix selection based on commit type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->