### PR TITLE
fix(ci): PR #3364 — fix branch carries feature/ prefix instead of fix/, re-triggering source-branch policy rejection and cascading checks gate failure

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -301,7 +301,10 @@ export class FeatureLoader implements FeatureStore {
    * Generate a branch name from a feature title and feature ID.
    * Appends a short fragment derived from the featureId to guarantee
    * uniqueness even when multiple features share a long common title prefix.
-   * Returns a feature/ prefixed branch name suitable for git.
+   *
+   * The branch prefix is derived from the conventional-commit type in the title:
+   * - "fix: ...", "fix(scope): ...", "fix!: ..." → fix/
+   * - all other titles → feature/
    */
   generateBranchName(title: string | undefined, featureId?: string): string {
     // Derive a short, deterministic uniqueness suffix from featureId.
@@ -312,9 +315,14 @@ export class FeatureLoader implements FeatureStore {
     if (!title || !title.trim()) {
       return `feature/untitled-${shortId}`;
     }
+
+    // Detect conventional-commit fix type: fix:, fix(scope):, fix!:
+    const isFixCommit = /^fix(\([^)]*\))?!?:/.test(title.trim());
+    const prefix = isFixCommit ? 'fix' : 'feature';
+
     // Keep slug portion to 50 chars so the full branch stays under ~60 chars.
     const slug = slugify(title, 50);
-    return `feature/${slug || `untitled`}-${shortId}`;
+    return `${prefix}/${slug || `untitled`}-${shortId}`;
   }
 
   /**

--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -130,4 +130,35 @@ describe('FeatureLoader.generateBranchName', () => {
     const branch = loader.generateBranchName('   ', 'feature-123-abc1234');
     expect(branch).toMatch(/^feature\/untitled-/);
   });
+
+  it('uses fix/ prefix for conventional-commit fix: titles', () => {
+    const branch = loader.generateBranchName('fix: correct login redirect', 'feature-123-abc1234');
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses fix/ prefix for scoped fix(scope): titles', () => {
+    const branch = loader.generateBranchName(
+      'fix(auth): handle token expiry',
+      'feature-123-abc1234',
+    );
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses fix/ prefix for breaking fix!: titles', () => {
+    const branch = loader.generateBranchName('fix!: remove deprecated API', 'feature-123-abc1234');
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses fix/ prefix for scoped breaking fix(scope)!: titles', () => {
+    const branch = loader.generateBranchName(
+      'fix(ci)!: enforce branch prefix policy',
+      'feature-123-abc1234',
+    );
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses feature/ prefix for feat: titles (not fix)', () => {
+    const branch = loader.generateBranchName('feat: add dark mode', 'feature-123-abc1234');
+    expect(branch).toMatch(/^feature\//);
+  });
 });


### PR DESCRIPTION
## Summary

## RCA

PR #3364 (`feature/fixci-pr-3362-fix-branch-carries-feature-prefix-qis9qbr`) is the agent-generated fix for PR #3362, but the branch was created with the `feature/` prefix instead of the required `fix/` prefix. This directly violates the source-branch naming policy enforced by the `source-branch` check, which in turn cascades into the composite `checks` gate failure.

This is a repeat of the same root-cause seen in PRs #3339, #3342, #3347, #3355, #3359, #3360, #3361, #3362 — the branch-n...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-11T00:23:53.161Z -->