### PR TITLE
fix(auto-mode): fetch origin/<base> before creating feature worktree

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3182,6 +3182,32 @@ Format your response as a structured markdown document.`;
             this.settingsService,
             '[createWorktreeForBranch]'
           );
+
+          // Refresh the remote tracking ref for the base branch before we
+          // branch off it. Without this fetch, worktrees inherit whatever
+          // commit origin/<base> pointed at the last time someone fetched
+          // — often stale by hours on long-running servers — and the new
+          // feature PR opens already behind origin, guaranteeing avoidable
+          // rebase conflicts downstream. One targeted fetch per worktree
+          // creation is cheap and closes the loop.
+          try {
+            await execFileAsync('git', ['fetch', 'origin', resolvedPrBaseBranch], {
+              cwd: projectPath,
+              env: gitEnv,
+            });
+            logger.debug(
+              `Fetched origin/${resolvedPrBaseBranch} before worktree creation for ${branchName}`
+            );
+          } catch (fetchErr) {
+            // Non-fatal: cached refs may be fresh enough, and a hard-failing
+            // fetch shouldn't block feature execution. Log so it surfaces if
+            // the loop starts shipping stale PRs again.
+            logger.warn(
+              `Failed to fetch origin/${resolvedPrBaseBranch} before worktree creation — proceeding with cached ref:`,
+              fetchErr
+            );
+          }
+
           let baseBranch = `origin/${resolvedPrBaseBranch}`;
           if (feature?.epicId && !feature.isEpic) {
             try {


### PR DESCRIPTION
## Summary

Auto-mode creates new feature worktrees from \`origin/<prBaseBranch>\`, but the main repo's fetch is only refreshed ambiently — long-running servers end up with hours-stale \`origin/dev\`, so every new feature PR opens already behind origin and guarantees avoidable rebase conflicts.

Adds one targeted \`git fetch origin <base>\` right before \`git worktree add -B\`, wrapped in try/catch so transient network failures fall through to the cached ref rather than blocking feature execution.

Closes protoLabsAI/protoWorkstacean#79

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run tests/unit/services/auto-mode-service.test.ts\` — 26/26 pass
- [ ] Post-deploy: tail server logs for \`Fetched origin/<base> before worktree creation\` debug line when auto-mode picks up the next feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of branch worktree creation by fetching the latest remote branch information before setting up new worktrees, ensuring operations use current branch data while gracefully handling fetch failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->