### PR TITLE
feat(a2a): agent card identifies this runtime as 'protomaker'

### DIFF
--- a/apps/server/src/routes/a2a/index.ts
+++ b/apps/server/src/routes/a2a/index.ts
@@ -204,17 +204,27 @@ const DECLARED_SKILLS: readonly SkillDefinition[] = [
 export const DECLARED_SKILL_IDS: ReadonlySet<string> = new Set(DECLARED_SKILLS.map((s) => s.id));
 
 // ─── Agent Card ──────────────────────────────────────────────────────────────
-// Describes Ava's skills in the A2A standard format.
-// Agents read this to understand what they can delegate here.
+// Describes the protoMaker team's skills in the A2A standard format.
+// Other agents read this to understand what they can delegate here.
+//
+// Naming note: the returned card identifies this runtime as 'protomaker' —
+// the multi-agent team that runs board ops, planning, feature lifecycle,
+// and onboarding. This is distinct from the in-process 'ava' chat agent
+// that lives in protoWorkstacean's workspace/agents/ava.yaml. We used to
+// collapse both into a single "ava" slug; that caused confusion as the
+// fleet grew. The HTTP env vars (AVA_BASE_URL, AVA_API_KEY, AVA_APP_ID)
+// keep their historical names because they describe this server's HTTP
+// identity, not the logical agent slug.
 
 function buildAgentCard(host: string) {
   const version = getVersion();
   return {
-    name: 'ava',
+    name: 'protomaker',
     description:
-      'protoLabs.studio autonomous development orchestrator. ' +
-      'Monitors board health, manages features, coordinates the agent fleet, ' +
-      'runs auto-mode, and reports status via Discord.',
+      'protoLabs.studio autonomous development team. ' +
+      'Multi-agent runtime coordinating board health, feature management, ' +
+      'auto-mode, planning, and project onboarding. Historically addressed ' +
+      'as "ava" — the underlying HTTP server identity is unchanged.',
     url: `http://${host}`,
     version,
     provider: {

--- a/libs/types/src/project.ts
+++ b/libs/types/src/project.ts
@@ -729,7 +729,11 @@ export type TimelineEntryType =
   | 'milestone_complete';
 
 /**
- * Author role for a timeline entry
+ * Author role for a timeline entry. 'ava' here is a persona label
+ * (alongside 'pm', 'operator', 'lead-engineer') — the semantic author
+ * role that wrote the entry, not the routing slug of any particular
+ * A2A agent. Stays 'ava' even though the underlying protoMaker team
+ * runtime may produce the content.
  */
 export type TimelineEntryAuthor = 'pm' | 'ava' | 'operator' | 'lead-engineer';
 


### PR DESCRIPTION
## Summary

External A2A agents discover this service via \`GET /.well-known/agent.json\` and dispatch to the \`name\` field. That field was \`ava\`, which collapsed two separate concepts:

- **protoMaker team** — the multi-agent runtime at this HTTP endpoint (board ops, planning, feature lifecycle, onboarding)
- **Ava** (new) — in-process conversational chat agent in protoWorkstacean with no tools

Workstacean's A2A registry renamed the slug \`ava\` → \`protomaker\` in protoLabsAI/protoWorkstacean#131. This PR makes the server side match so the agent-card discovery response is consistent with how callers address it.

## What stays 'ava' (deliberately)

- \`TimelineEntryAuthor\` union (\`'pm' | 'ava' | 'operator' | 'lead-engineer'\`) — persona label for who semantically authored a ceremony timeline entry, not a routing slug. Doc comment added to make this explicit.
- \`reviewer: 'ava'\` in \`antagonistic-review-service.ts\` — distinct persona from \`'jon'\` in the Ava-vs-Jon antagonistic review pipeline.
- \`role: 'ava'\` in \`workflow-loader.ts\` strategic-review workflow — persona lens, not a routing target.
- Container hostname \`'ava'\`, MCP \`context: 'ava'\` — infrastructure identifiers.
- \`AVA_*\` env vars — historical HTTP server identity names.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run tests/unit/routes/a2a-allowlist.test.ts\` — 2 pass (allowlist guards still work; skill names unchanged)
- [ ] Post-deploy: \`curl http://ava:3008/.well-known/agent.json | jq '.name'\` returns \`"protomaker"\`
- [ ] Workstacean's \`[skill-broker] Registered N A2A agent(s)\` log matches the new name

Part of protoLabsAI/protoWorkstacean#86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated agent discovery naming to identify as 'protomaker' for improved clarity.
  * Refined internal documentation to distinguish between multi-agent runtime identities and semantic author roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->