### PR TITLE
fix(ci): #3376 — add post-merge source diff verification before done transition

### DIFF
--- a/apps/server/src/routes/webhooks/routes/github.ts
+++ b/apps/server/src/routes/webhooks/routes/github.ts
@@ -26,8 +26,32 @@ import type {
   GitHubCheckSuiteWebhookPayload,
   GitHubCheckRunWebhookPayload,
 } from '@protolabsai/types';
+import { getFilesChangedInPR } from '@protolabsai/git-utils';
 
 const logger = createLogger('webhooks/github');
+
+/**
+ * Returns true for files that are pure metadata / tooling artifacts.
+ * Used in post-merge source diff verification to detect PRs that merged
+ * without any real source code changes (e.g. worktree base-branch failures).
+ *
+ * Matches: .automaker-lock, .gitignore, lockfiles (pnpm-lock.yaml, package-lock.json,
+ * yarn.lock), and anything under .automaker/.
+ */
+function isMetadataFile(filePath: string): boolean {
+  const parts = filePath.split('/');
+  const basename = parts[parts.length - 1] ?? '';
+  if (basename === '.automaker-lock') return true;
+  if (basename === '.gitignore') return true;
+  if (
+    basename === 'pnpm-lock.yaml' ||
+    basename === 'package-lock.json' ||
+    basename === 'yarn.lock'
+  )
+    return true;
+  if (parts[0] === '.automaker') return true;
+  return false;
+}
 
 interface GitHubPullRequestPayload {
   action: string;
@@ -568,40 +592,83 @@ export function createGitHubWebhookHandler(
           `Feature "${feature.title}" already in terminal status '${currentFeature.status}' — skipping merge update for PR #${prNumber}`
         );
       } else {
-        // Update feature status to done
-        await featureLoader.update(projectPath, feature.featureId, {
-          status: 'done',
-        });
+        // Post-merge source diff verification: ensure the PR contains real source
+        // changes, not just metadata (e.g. .automaker-lock). A metadata-only PR
+        // indicates a silent worktree/base-branch failure — the board should NOT
+        // auto-advance to 'done' in that case.
+        const repoFullName = payload.repository.full_name;
+        const changedFiles = await getFilesChangedInPR(repoFullName, prNumber);
+        const sourceFiles = changedFiles.filter((f) => !isMetadataFile(f));
 
-        logger.info(
-          `Feature "${feature.title}" moved from "${currentFeature.status}" to "done" after PR #${prNumber} was merged`
-        );
+        if (changedFiles.length > 0 && sourceFiles.length === 0) {
+          // PR merged but only metadata/lockfiles — block the feature instead of
+          // marking it done so the board accurately reflects the missing work.
+          const blockReason =
+            `POST-MERGE BLOCK: PR #${prNumber} merged but diff contains no source code changes. ` +
+            `Possible worktree/base-branch failure. Changed files: ${changedFiles.join(', ')}`;
 
-        // Epic completion is handled by CompletionDetectorService which reacts to
-        // the feature:status-changed event emitted by featureLoader.update() above.
-        // It creates an epic-to-dev PR instead of marking the epic done prematurely.
+          await featureLoader.update(projectPath, feature.featureId, {
+            status: 'blocked',
+            statusChangeReason: blockReason,
+            description: (currentFeature.description ?? '') + '\n\n⚠️ ' + blockReason,
+          });
 
-        // Emit event for UI notification
-        events.emit('feature:pr-merged', {
-          featureId: feature.featureId,
-          title: feature.title,
-          prNumber,
-          prTitle,
-          branchName,
-          projectPath,
-        });
+          logger.warn(
+            `[post-merge] Feature "${feature.title}" blocked after PR #${prNumber} — ` +
+              `no source code in merge diff (files: ${changedFiles.join(', ')})`
+          );
+        } else {
+          // Source changes present (or diff unavailable — err on side of caution) → mark done.
+          if (changedFiles.length === 0) {
+            logger.warn(
+              `[post-merge] Could not retrieve file list for PR #${prNumber} — proceeding to mark done`
+            );
+          } else if (currentFeature.filesToModify?.length) {
+            const missing = currentFeature.filesToModify.filter(
+              (f) => !sourceFiles.includes(f)
+            );
+            if (missing.length > 0) {
+              logger.warn(
+                `[post-merge] PR #${prNumber} missing expected files from diff:`,
+                missing
+              );
+            }
+          }
 
-        // Publish to TopicBus (hierarchical routing)
-        if (topicBus) {
-          topicBus.publish(`pr.merged.${prNumber}`, {
+          await featureLoader.update(projectPath, feature.featureId, {
+            status: 'done',
+          });
+
+          logger.info(
+            `Feature "${feature.title}" moved from "${currentFeature.status}" to "done" after PR #${prNumber} was merged`
+          );
+
+          // Epic completion is handled by CompletionDetectorService which reacts to
+          // the feature:status-changed event emitted by featureLoader.update() above.
+          // It creates an epic-to-dev PR instead of marking the epic done prematurely.
+
+          // Emit event for UI notification
+          events.emit('feature:pr-merged', {
             featureId: feature.featureId,
             title: feature.title,
             prNumber,
             prTitle,
             branchName,
-            baseBranch,
             projectPath,
           });
+
+          // Publish to TopicBus (hierarchical routing)
+          if (topicBus) {
+            topicBus.publish(`pr.merged.${prNumber}`, {
+              featureId: feature.featureId,
+              title: feature.title,
+              prNumber,
+              prTitle,
+              branchName,
+              baseBranch,
+              projectPath,
+            });
+          }
         }
       }
 

--- a/libs/git-utils/src/diff.ts
+++ b/libs/git-utils/src/diff.ts
@@ -281,3 +281,29 @@ export async function getGitRepositoryDiffs(
     hasChanges: files.length > 0,
   };
 }
+
+/**
+ * Get the list of file paths changed in a GitHub Pull Request.
+ * Uses the GitHub CLI (`gh`) to query the GitHub API — no local git fetch required.
+ *
+ * Returns an empty array if the gh CLI is unavailable or the request fails.
+ */
+export async function getFilesChangedInPR(
+  repoFullName: string,
+  prNumber: number
+): Promise<string[]> {
+  try {
+    const { stdout } = await execAsync(
+      `gh api "repos/${repoFullName}/pulls/${prNumber}/files" --jq '.[].filename'`
+    );
+    return stdout
+      .split('\n')
+      .map((f) => f.trim())
+      .filter(Boolean);
+  } catch (err) {
+    logger.warn(
+      `[getFilesChangedInPR] Failed to retrieve file list for PR #${prNumber} in ${repoFullName}: ${(err as Error).message}`
+    );
+    return [];
+  }
+}

--- a/libs/git-utils/src/index.ts
+++ b/libs/git-utils/src/index.ts
@@ -16,6 +16,7 @@ export {
   listAllFilesInDirectory,
   generateDiffsForNonGitDirectory,
   getGitRepositoryDiffs,
+  getFilesChangedInPR,
 } from './diff.js';
 
 // Export merge detection utilities


### PR DESCRIPTION
## Summary

## RCA

Auto-mode marks features `done` the moment a PR merges, with no inspection of the merge diff. When the epic base branch is absent from remote, worktree creation silently falls back to committing only `.automaker-lock` metadata changes. CodeRabbit passes on lock-only PRs; the reconciler sees a merged PR and immediately flips the feature to `done`. Result: board shows 100% completion, zero source code shipped.

Root failure chain:
1. Epic branch `origin/epic/text-chat-a2a-foundation` was n...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-12T05:17:58.808Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PR merge validation for features: PRs containing only metadata or tooling file changes now correctly mark features as "blocked" with explanatory warnings instead of prematurely marking them as complete.
  * Added validation checks to warn when expected files are missing from PR diffs or when file lists cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->