### PR TITLE
fix(ci): #3376 — auto-mode marks features done when merged PR contains no source code changes

### DIFF
--- a/apps/server/src/routes/webhooks/routes/github.ts
+++ b/apps/server/src/routes/webhooks/routes/github.ts
@@ -140,6 +140,33 @@ async function cascadeUpdateBranches(
 }
 
 /**
+ * Returns true if the file path is metadata (lock files, gitignore, .automaker/ dir, markdown)
+ * and therefore should NOT count as a source-code change for feature completion verification.
+ *
+ * Files listed in `filesToModify` are never considered metadata — they are explicitly expected.
+ */
+function isMetadataFile(filePath: string, filesToModify?: string[]): boolean {
+  if (filesToModify?.includes(filePath)) return false;
+
+  const basename = filePath.split('/').pop() ?? filePath;
+
+  // Standard lock files
+  if (['package-lock.json', 'yarn.lock', 'pnpm-lock.yaml'].includes(basename)) return true;
+
+  // Automaker metadata
+  if (basename === '.automaker-lock') return true;
+  if (filePath.startsWith('.automaker/')) return true;
+
+  // Git / editor metadata
+  if (basename === '.gitignore') return true;
+
+  // Markdown (unless explicitly listed in filesToModify above)
+  if (basename.endsWith('.md')) return true;
+
+  return false;
+}
+
+/**
  * Scan all configured projects to find the one whose features satisfy `matcher`.
  * Returns the project path on first match, or null if none match.
  */
@@ -568,14 +595,71 @@ export function createGitHubWebhookHandler(
           `Feature "${feature.title}" already in terminal status '${currentFeature.status}' — skipping merge update for PR #${prNumber}`
         );
       } else {
-        // Update feature status to done
-        await featureLoader.update(projectPath, feature.featureId, {
-          status: 'done',
-        });
+        // Post-merge source-code verification gate.
+        // Inspect the merge diff to ensure the PR contains actual source changes.
+        // A PR containing only metadata files (.automaker-lock, lock files, markdown)
+        // indicates a worktree/base-branch failure — the agent ran in the wrong context.
+        // In that case, block the feature instead of marking it done.
+        let hasSourceChanges = true; // default to true so failures are non-fatal
+        let changedSourceFiles: string[] = [];
+        if (mergeCommitSha) {
+          try {
+            const { stdout: diffOutput } = await execAsync(
+              `git diff --name-only ${mergeCommitSha}^1 ${mergeCommitSha}`,
+              { cwd: projectPath }
+            );
+            const changedFiles = diffOutput.trim().split('\n').filter(Boolean);
+            changedSourceFiles = changedFiles.filter(
+              (f) => !isMetadataFile(f, currentFeature.filesToModify)
+            );
+            hasSourceChanges = changedSourceFiles.length > 0;
 
-        logger.info(
-          `Feature "${feature.title}" moved from "${currentFeature.status}" to "done" after PR #${prNumber} was merged`
-        );
+            if (!hasSourceChanges) {
+              logger.warn(
+                `Feature "${feature.title}" PR #${prNumber} contains no source code changes ` +
+                  `(${changedFiles.length} metadata-only file(s): ${changedFiles.slice(0, 5).join(', ')}). ` +
+                  `Blocking feature instead of marking done.`
+              );
+            } else if (currentFeature.filesToModify?.length) {
+              const missing = currentFeature.filesToModify.filter(
+                (f) => !changedSourceFiles.includes(f)
+              );
+              if (missing.length > 0) {
+                logger.warn(
+                  `Feature "${feature.title}" PR #${prNumber}: expected files absent from diff: ${missing.join(', ')}`
+                );
+              }
+            }
+          } catch (diffErr) {
+            // Non-fatal: if git diff fails (e.g. shallow clone, detached HEAD), proceed normally.
+            logger.warn(
+              `Merge diff inspection failed for PR #${prNumber} (proceeding as done):`,
+              diffErr
+            );
+          }
+        }
+
+        if (!hasSourceChanges) {
+          // Lock-only merge — block, do not mark done
+          await featureLoader.update(projectPath, feature.featureId, {
+            status: 'blocked',
+            statusChangeReason:
+              'PR merged but no source code changes detected — likely worktree/base-branch failure',
+          });
+          logger.info(
+            `Feature "${feature.title}" moved from "${currentFeature.status}" to "blocked" ` +
+              `(lock-only merge, PR #${prNumber})`
+          );
+        } else {
+          // Update feature status to done
+          await featureLoader.update(projectPath, feature.featureId, {
+            status: 'done',
+          });
+
+          logger.info(
+            `Feature "${feature.title}" moved from "${currentFeature.status}" to "done" after PR #${prNumber} was merged`
+          );
+        }
 
         // Epic completion is handled by CompletionDetectorService which reacts to
         // the feature:status-changed event emitted by featureLoader.update() above.
@@ -684,7 +768,7 @@ export function createGitHubWebhookHandler(
         success: true,
         message: wasAlreadyTerminal
           ? `Feature already in terminal status '${currentFeature.status}'`
-          : `Feature "${feature.title}" moved to done`,
+          : `Feature "${feature.title}" processed after PR #${prNumber} merged`,
         featureId: feature.featureId,
       });
     } catch (error) {

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3233,9 +3233,16 @@ Format your response as a structured markdown document.`;
                   `Feature ${feature.id} belongs to epic, branching from epic branch: ${baseBranch}`
                 );
               }
-            } catch {
-              logger.warn(
-                `Epic branch not found for feature ${feature.id} (epicId: ${feature.epicId}), falling back to origin/${resolvedPrBaseBranch}`
+            } catch (epicBranchErr) {
+              // Epic branch is missing on remote. Falling back to origin/<prBaseBranch>
+              // would branch from the wrong base — the agent would commit to the wrong
+              // history and likely produce a lock-only PR that auto-merges without source
+              // changes. Fail loudly so the feature is blocked rather than silently corrupted.
+              const epicBranchName = epicFeature?.branchName ?? `(unknown, epicId: ${feature.epicId})`;
+              throw new Error(
+                `Epic base branch '${epicBranchName}' not found on remote for feature ` +
+                  `${feature.id}. Push the epic branch before starting child features. ` +
+                  `Original error: ${epicBranchErr instanceof Error ? epicBranchErr.message : String(epicBranchErr)}`
               );
             }
           }

--- a/apps/server/tests/unit/routes/webhook-pr-merge-source-check.test.ts
+++ b/apps/server/tests/unit/routes/webhook-pr-merge-source-check.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Regression tests for the post-merge source-code verification gate.
+ *
+ * When a PR merges but contains only metadata files (.automaker-lock, lock files,
+ * markdown), the feature should transition to `blocked` — not `done`. This prevents
+ * the silent failure mode where an agent committed to the wrong base (e.g., missing
+ * epic branch fallback) and the board incorrectly showed 100% completion.
+ *
+ * See: protoLabsAI/protoMaker#3376
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response } from 'express';
+import { EventEmitter } from 'events';
+import { createMockExpressContext } from '../../utils/mocks.js';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+let mockExecImpl: (
+  cmd: string,
+  opts: unknown,
+  cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
+) => void;
+
+vi.mock('child_process', () => ({
+  exec: (
+    cmd: string,
+    opts: unknown,
+    cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
+  ) => mockExecImpl(cmd, opts, cb),
+}));
+
+const mockFeatureLoaderUpdate = vi.fn().mockResolvedValue(undefined);
+const mockFeatureLoaderGet = vi.fn();
+const mockFeatureLoaderGetAll = vi.fn().mockResolvedValue([]);
+
+vi.mock('@/services/feature-loader.js', () => ({
+  FeatureLoader: vi.fn().mockImplementation(() => ({
+    getAll: mockFeatureLoaderGetAll,
+    get: mockFeatureLoaderGet,
+    update: mockFeatureLoaderUpdate,
+    findByBranch: vi.fn().mockResolvedValue(null),
+  })),
+}));
+
+vi.mock('@/services/staging-promotion-service.js', () => ({
+  StagingPromotionService: vi.fn().mockImplementation(() => ({
+    detectDevMerge: vi.fn().mockReturnValue(false),
+    createCandidate: vi.fn(),
+  })),
+}));
+
+vi.mock('@/lib/webhook-signature.js', () => ({
+  verifyWebhookSignature: vi.fn().mockReturnValue({ valid: true }),
+}));
+
+vi.mock('@/services/pr-watcher-service.js', () => ({
+  getPRWatcherService: vi.fn().mockReturnValue({
+    isWatching: vi.fn().mockReturnValue(false),
+    triggerCheck: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/services/webhook-delivery-service.js', () => ({
+  getWebhookDeliveryService: vi.fn().mockReturnValue(null),
+}));
+
+import { createGitHubWebhookHandler } from '@/routes/webhooks/routes/github.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function buildSettingsService() {
+  return {
+    getGlobalSettings: vi.fn().mockResolvedValue({
+      githubWebhook: { enabled: true },
+      projects: [{ path: '/project' }],
+      promotion: {},
+    }),
+    getCredentials: vi.fn().mockResolvedValue({ webhookSecrets: {} }),
+  };
+}
+
+function makePrMergedPayload(overrides: {
+  branchName?: string;
+  baseBranch?: string;
+  mergeCommitSha?: string;
+  prNumber?: number;
+} = {}) {
+  return {
+    action: 'closed',
+    pull_request: {
+      number: overrides.prNumber ?? 42,
+      title: 'test: feature PR',
+      state: 'closed',
+      merged: true,
+      merged_at: '2026-01-01T00:00:00Z',
+      merge_commit_sha: overrides.mergeCommitSha ?? 'abc123def456',
+      head: { ref: overrides.branchName ?? 'feature/test-feature' },
+      base: { ref: overrides.baseBranch ?? 'dev' },
+    },
+    repository: { full_name: 'org/repo' },
+  };
+}
+
+function makeFeature(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'feature-001',
+    featureId: 'feature-001',
+    title: 'Test Feature',
+    status: 'review',
+    branchName: 'feature/test-feature',
+    filesToModify: undefined,
+    ...overrides,
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('PR merge source-code verification gate', () => {
+  let events: EventEmitter;
+  let settingsService: ReturnType<typeof buildSettingsService>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    events = new EventEmitter();
+    settingsService = buildSettingsService();
+
+    // Default exec: git diff returns empty, gh pr list returns []
+    mockExecImpl = (_cmd, _opts, cb) => {
+      cb(null, { stdout: '', stderr: '' });
+    };
+  });
+
+  it('sets feature to blocked when PR contains only .automaker-lock', async () => {
+    const feature = makeFeature();
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+    mockFeatureLoaderGet.mockResolvedValue(feature);
+
+    // git diff returns only .automaker-lock
+    mockExecImpl = (cmd, _opts, cb) => {
+      if (cmd.includes('git diff')) {
+        cb(null, { stdout: '.automaker-lock\n', stderr: '' });
+      } else {
+        cb(null, { stdout: '[]', stderr: '' });
+      }
+    };
+
+    const handler = createGitHubWebhookHandler(events as any, settingsService as any);
+    const { req, res } = createMockExpressContext();
+    req.headers = { 'x-github-event': 'pull_request' };
+    req.body = makePrMergedPayload();
+
+    await handler(req as Request, res as Response);
+
+    expect(mockFeatureLoaderUpdate).toHaveBeenCalledWith(
+      expect.any(String),
+      feature.featureId,
+      expect.objectContaining({ status: 'blocked' })
+    );
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+  });
+
+  it('sets feature to blocked when PR contains only lock files and markdown', async () => {
+    const feature = makeFeature();
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+    mockFeatureLoaderGet.mockResolvedValue(feature);
+
+    mockExecImpl = (cmd, _opts, cb) => {
+      if (cmd.includes('git diff')) {
+        cb(null, { stdout: 'pnpm-lock.yaml\nREADME.md\n.automaker-lock\n', stderr: '' });
+      } else {
+        cb(null, { stdout: '[]', stderr: '' });
+      }
+    };
+
+    const handler = createGitHubWebhookHandler(events as any, settingsService as any);
+    const { req, res } = createMockExpressContext();
+    req.headers = { 'x-github-event': 'pull_request' };
+    req.body = makePrMergedPayload();
+
+    await handler(req as Request, res as Response);
+
+    expect(mockFeatureLoaderUpdate).toHaveBeenCalledWith(
+      expect.any(String),
+      feature.featureId,
+      expect.objectContaining({
+        status: 'blocked',
+        statusChangeReason: expect.stringContaining('no source code changes'),
+      })
+    );
+  });
+
+  it('sets feature to done when PR contains source files', async () => {
+    const feature = makeFeature();
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+    mockFeatureLoaderGet.mockResolvedValue(feature);
+
+    mockExecImpl = (cmd, _opts, cb) => {
+      if (cmd.includes('git diff')) {
+        cb(null, { stdout: 'src/services/my-service.ts\npnpm-lock.yaml\n', stderr: '' });
+      } else {
+        cb(null, { stdout: '[]', stderr: '' });
+      }
+    };
+
+    const handler = createGitHubWebhookHandler(events as any, settingsService as any);
+    const { req, res } = createMockExpressContext();
+    req.headers = { 'x-github-event': 'pull_request' };
+    req.body = makePrMergedPayload();
+
+    await handler(req as Request, res as Response);
+
+    expect(mockFeatureLoaderUpdate).toHaveBeenCalledWith(
+      expect.any(String),
+      feature.featureId,
+      expect.objectContaining({ status: 'done' })
+    );
+  });
+
+  it('treats files in filesToModify as source files even if they are markdown', async () => {
+    const feature = makeFeature({ filesToModify: ['docs/api.md'] });
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+    mockFeatureLoaderGet.mockResolvedValue(feature);
+
+    // PR only contains docs/api.md — normally metadata, but it's in filesToModify
+    mockExecImpl = (cmd, _opts, cb) => {
+      if (cmd.includes('git diff')) {
+        cb(null, { stdout: 'docs/api.md\n', stderr: '' });
+      } else {
+        cb(null, { stdout: '[]', stderr: '' });
+      }
+    };
+
+    const handler = createGitHubWebhookHandler(events as any, settingsService as any);
+    const { req, res } = createMockExpressContext();
+    req.headers = { 'x-github-event': 'pull_request' };
+    req.body = makePrMergedPayload();
+
+    await handler(req as Request, res as Response);
+
+    expect(mockFeatureLoaderUpdate).toHaveBeenCalledWith(
+      expect.any(String),
+      feature.featureId,
+      expect.objectContaining({ status: 'done' })
+    );
+  });
+
+  it('defaults to done when git diff fails (non-fatal failure mode)', async () => {
+    const feature = makeFeature();
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+    mockFeatureLoaderGet.mockResolvedValue(feature);
+
+    mockExecImpl = (cmd, _opts, cb) => {
+      if (cmd.includes('git diff')) {
+        cb(new Error('git not available'), { stdout: '', stderr: '' });
+      } else {
+        cb(null, { stdout: '[]', stderr: '' });
+      }
+    };
+
+    const handler = createGitHubWebhookHandler(events as any, settingsService as any);
+    const { req, res } = createMockExpressContext();
+    req.headers = { 'x-github-event': 'pull_request' };
+    req.body = makePrMergedPayload();
+
+    await handler(req as Request, res as Response);
+
+    // Should not block on diff failure — fail open to done
+    expect(mockFeatureLoaderUpdate).toHaveBeenCalledWith(
+      expect.any(String),
+      feature.featureId,
+      expect.objectContaining({ status: 'done' })
+    );
+  });
+
+  it('skips diff check and marks done when mergeCommitSha is empty', async () => {
+    const feature = makeFeature();
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+    mockFeatureLoaderGet.mockResolvedValue(feature);
+
+    const gitDiffCalled = vi.fn();
+    mockExecImpl = (cmd, _opts, cb) => {
+      if (cmd.includes('git diff')) {
+        gitDiffCalled();
+      }
+      cb(null, { stdout: '[]', stderr: '' });
+    };
+
+    const handler = createGitHubWebhookHandler(events as any, settingsService as any);
+    const { req, res } = createMockExpressContext();
+    req.headers = { 'x-github-event': 'pull_request' };
+    req.body = makePrMergedPayload({ mergeCommitSha: '' });
+
+    await handler(req as Request, res as Response);
+
+    expect(gitDiffCalled).not.toHaveBeenCalled();
+    expect(mockFeatureLoaderUpdate).toHaveBeenCalledWith(
+      expect.any(String),
+      feature.featureId,
+      expect.objectContaining({ status: 'done' })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

## RCA

Issue filed by @mabry1985 (trust tier 1): protoLabsAI/protoMaker#3376

The feature-completion pathway transitions a feature to `done` as soon as the associated PR merges, with no inspection of the merge diff. When the epic base branch does not exist on remote, worktree creation silently falls back and agents commit only `.automaker-lock` metadata changes. CodeRabbit passes on lock-only diffs. The PR auto-merges. The feature is marked `done`. Net result: board shows 100% completion with 0...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-12T05:19:56.793Z -->