### PR TITLE
fix(ci): PR #3363 — fix branch carries feature/ prefix instead of fix/, re-triggering source-branch policy rejection and cascading checks gate failure

### DIFF
--- a/apps/server/src/services/health-monitor-service.ts
+++ b/apps/server/src/services/health-monitor-service.ts
@@ -456,7 +456,9 @@ export class HealthMonitorService {
 
       // Get branch names from features
       const featureBranches = new Set(
-        features.filter((f) => f.branchName).map((f) => f.branchName!.replace(/^feature\//, ''))
+        features
+          .filter((f) => f.branchName)
+          .map((f) => f.branchName!.replace(/^(feature|fix|chore|docs)\//, ''))
       );
 
       // Check for orphaned worktrees (worktrees without corresponding features)


### PR DESCRIPTION
## Summary

## RCA

PR #3363 is a fix-on-fix for PR #3361, but the agent-generated branch was named `feature/fixci-pr-3361-fix-branch-carries-feature-prefix-6ki536p` instead of `fix/...`. The repo's source-branch policy rejects any PR whose head branch does not start with `fix/` (or another allowed prefix) when targeting `dev`, so the `source-branch` check hard-fails, which in turn causes the composite `checks` gate to remain stuck/pending.

### CodeRabbit signal (addtional risk)
CodeRabbit flagged that `ge...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-12T05:23:08.682Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch name recognition in the health monitoring service to accurately identify feature branches using multiple naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->