### PR TITLE
fix(ci): Issue #3158 — add exponential backoff to agent execution retry logic

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -1521,6 +1521,7 @@ Output the branch name only.`,
       const errorInfo = classifyError(error);
 
       // Capture execution record on failure (skip aborts — not real executions)
+      let failureExecutionCostUsd = 0;
       if (!errorInfo.isAbort && tempRunningFeature.startTime) {
         try {
           const completedAt = new Date().toISOString();
@@ -1528,6 +1529,7 @@ Output the branch name only.`,
           const currentFeature = await this.featureLoader.get(projectPath, featureId);
           // Calculate execution-specific cost delta (not cumulative cost)
           const executionCostUsd = Math.max(0, (currentFeature?.costUsd ?? 0) - startingCostUsd);
+          failureExecutionCostUsd = executionCostUsd;
           const record: ExecutionRecord = {
             id: executionId,
             startedAt: executionStartedAt,
@@ -1649,6 +1651,7 @@ Output the branch name only.`,
           retryCount: tempRunningFeature?.retryCount ?? 0,
           previousErrors: tempRunningFeature?.previousErrors ?? [],
           runningTime: tempRunningFeature ? Date.now() - tempRunningFeature.startTime : 0,
+          costUsd: failureExecutionCostUsd,
         };
 
         // Analyze failure and determine recovery strategy

--- a/apps/server/src/services/recovery-service.ts
+++ b/apps/server/src/services/recovery-service.ts
@@ -61,7 +61,7 @@ export class RecoveryService {
     const category = this.categorizeFailure(errorInfo, error);
     const strategy = this.determineStrategy(category, context);
     const maxRetries = this.getMaxRetries(category);
-    const delay = this.calculateDelay(category, context.retryCount);
+    const delay = this.calculateDelay(category, context.retryCount, context);
 
     const analysis: FailureAnalysis = {
       category,
@@ -480,13 +480,13 @@ ${this.generateCategoryGuidance(category, successRate, strategies)}
       case 'transient':
         return {
           type: 'retry',
-          delay: this.calculateDelay(category, context.retryCount),
+          delay: this.calculateDelay(category, context.retryCount, context),
         };
 
       case 'rate_limit':
         return {
           type: 'pause_and_wait',
-          duration: this.calculateDelay(category, context.retryCount),
+          duration: this.calculateDelay(category, context.retryCount, context),
           reason: 'API rate limit reached. Waiting before retry.',
         };
 
@@ -549,7 +549,7 @@ ${this.generateCategoryGuidance(category, successRate, strategies)}
           return {
             type: 'retry_with_context',
             context: `Unknown error occurred: ${context.previousErrors.slice(-1).join('')}. Please try a different approach.`,
-            delay: this.calculateDelay('unknown', context.retryCount),
+            delay: this.calculateDelay('unknown', context.retryCount, context),
           };
         }
         return {
@@ -606,13 +606,33 @@ ${this.generateCategoryGuidance(category, successRate, strategies)}
   /**
    * Calculate delay before retry with exponential backoff and jitter.
    * Formula: min(base * 2^retryCount + jitter (up to 25% of exponential delay), maxDelay)
+   *
+   * SDK init failures (exit code 1, $0 cost, <10s runtime) get a longer base delay (10s)
+   * because they indicate transient resource contention that takes longer to clear.
    */
-  private calculateDelay(category: FailureCategory, retryCount: number): number {
+  private calculateDelay(
+    category: FailureCategory,
+    retryCount: number,
+    context?: ExecutionContext
+  ): number {
     let baseDelay = this.config.baseDelayMs;
 
     // Rate limits need longer delays
     if (category === 'rate_limit') {
-      baseDelay = 5000; // 5 seconds base for rate limits
+      baseDelay = 10000; // 10 seconds base for rate limits
+    }
+
+    // SDK init failures: zero cost + very short runtime = Claude Agent SDK never initialised.
+    // These are caused by transient resource contention and need a longer base to avoid
+    // exhausting the retry budget before contention clears.
+    const SDK_INIT_MAX_RUNTIME_MS = 10_000;
+    const isSdkInitFailure =
+      context !== undefined &&
+      (context.costUsd ?? 0) === 0 &&
+      context.runningTime < SDK_INIT_MAX_RUNTIME_MS;
+
+    if (isSdkInitFailure) {
+      baseDelay = 10000; // 10 seconds base for SDK init failures
     }
 
     // Exponential backoff: base * 2^retryCount

--- a/libs/types/src/failure.ts
+++ b/libs/types/src/failure.ts
@@ -91,6 +91,8 @@ export interface ExecutionContext {
   agentOutput?: string;
   /** Time feature has been running in ms */
   runningTime: number;
+  /** Execution cost in USD (0 for SDK init failures) */
+  costUsd?: number;
 }
 
 /**
@@ -118,7 +120,7 @@ export const DEFAULT_RECOVERY_CONFIG: RecoveryConfig = {
   enabled: true,
   maxTransientRetries: 3,
   maxTestFailureRetries: 2,
-  baseDelayMs: 1000,
+  baseDelayMs: 5000,
   maxDelayMs: 60000,
   preserveContext: true,
 };


### PR DESCRIPTION
## Summary

## Root Cause Analysis

Agent execution retries fire too aggressively on Claude Agent SDK initialisation failures (exit code 1, <10s duration, $0 cost). `recoveryService.executeRecovery()` returns `shouldRetry: true` with minimal `suggestedDelay`, causing 3-4 retries within ~30 seconds. When the underlying cause is transient resource contention from concurrent agent spawns, all retries exhaust before contention clears.

**Observed evidence:** `feature-1774570597277-dg6wvovml` (helix project) fai...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-12T07:26:32.811Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced failure recovery logic to track execution costs and intelligently adjust retry delays based on failure context.
  * Added specialized handling for SDK initialization failures with more appropriate delay timing.
  * Increased default retry delays for improved reliability in rate-limited and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->