### PR TITLE
fix(ci): issue #3299 — FeatureScheduler silently skips features with contradictory isEpic=true + epicId state

### DIFF
--- a/apps/server/src/routes/features/routes/create.ts
+++ b/apps/server/src/routes/features/routes/create.ts
@@ -14,10 +14,15 @@ import type { QuarantineStage, SanitizationViolation } from '@protolabsai/types'
 
 export const CreateRequestSchema = z.object({
   projectPath: z.string().min(1, 'projectPath is required'),
-  feature: z.custom<Partial<Feature>>(
-    (val): val is Partial<Feature> => val !== null && typeof val === 'object',
-    'feature must be an object'
-  ),
+  feature: z
+    .custom<Partial<Feature>>(
+      (val): val is Partial<Feature> => val !== null && typeof val === 'object',
+      'feature must be an object'
+    )
+    .refine(
+      (val: Partial<Feature>) => !(val.isEpic && val.epicId),
+      'A feature cannot be both an epic (isEpic: true) and a member of another epic (epicId set). Set either isEpic or epicId, not both.'
+    ),
 });
 
 /**

--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -1213,6 +1213,17 @@ export class FeatureScheduler {
               logger.warn(
                 `[loadPendingFeatures] Feature ${feature.id} ("${feature.title}") is marked as an epic but also has a parent epic assigned (epicId: ${feature.epicId}) — it will not be scheduled. Fix the feature configuration to proceed.`
               );
+              // Surface the conflict in the feature data so the UI and agents can observe it.
+              try {
+                await this.featureLoader.update(projectPath, feature.id, {
+                  statusChangeReason: `Contradictory epic state: feature is marked as an epic container (isEpic: true) but also has a parent epic assigned (epicId: ${feature.epicId}). Set either isEpic or epicId, not both.`,
+                });
+              } catch (updateErr) {
+                logger.error(
+                  `[loadPendingFeatures] Failed to surface contradictory state for feature ${feature.id}:`,
+                  updateErr
+                );
+              }
             } else {
               logger.info(
                 `[loadPendingFeatures] Skipping epic feature ${feature.id} - ${feature.title}`

--- a/apps/server/tests/unit/services/feature-scheduler-epic-contradiction.test.ts
+++ b/apps/server/tests/unit/services/feature-scheduler-epic-contradiction.test.ts
@@ -151,12 +151,14 @@ function mockFeatureJsonReads(features: Record<string, Partial<Feature> | null>)
 
 describe('feature-scheduler.ts — loadPendingFeatures epic contradiction', () => {
   let scheduler: FeatureScheduler;
+  let mockFeatureLoader: ReturnType<typeof createMockFeatureLoader>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFeatureLoader = createMockFeatureLoader();
 
     scheduler = new FeatureScheduler({
-      featureLoader: createMockFeatureLoader() as any,
+      featureLoader: mockFeatureLoader as any,
       settingsService: createMockSettingsService() as any,
       events: {
         emit: vi.fn(),
@@ -192,6 +194,15 @@ describe('feature-scheduler.ts — loadPendingFeatures epic contradiction', () =
     );
     expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining('feat-contradiction-1'));
     expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining('parent-epic-123'));
+
+    // The contradictory state must be surfaced in the feature data so the UI and agents observe it
+    expect(mockFeatureLoader.update).toHaveBeenCalledWith(
+      '/test/project',
+      'feat-contradiction-1',
+      expect.objectContaining({
+        statusChangeReason: expect.stringContaining('Contradictory epic state'),
+      })
+    );
   });
 
   it('emits info-level log (not warn) for a normal epic container without epicId', async () => {
@@ -221,5 +232,8 @@ describe('feature-scheduler.ts — loadPendingFeatures epic contradiction', () =
     expect(mockInfo).toHaveBeenCalledWith(
       expect.stringContaining('Skipping epic feature feat-normal-epic-1')
     );
+
+    // No update should be emitted for a normal epic — only contradictory state triggers an update
+    expect(mockFeatureLoader.update).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

## RCA

`FeatureScheduler.loadPendingFeatures` checks `isEpic` first and short-circuits with 'Skipping epic feature' log line — it never inspects `epicId` or surfaces the conflict to the caller. Upstream, the API layer accepts the contradictory payload (`isEpic: true` + `epicId` both set) without validation, so invalid state enters the store silently.

A feature cannot simultaneously be an epic and a child of another epic. When both fields are set the feature lands in a zombie state: it appears ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation to prevent features from being configured as both an epic container and a member of another epic simultaneously. Invalid contradictory states are now detected and recorded for visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->