### PR TITLE
fix(ci): issue #3300 — Quinn double-triage on issues.opened; missing idempotency guard + suspected duplicate webhook registration

### DIFF
--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -656,6 +656,32 @@ export class SignalIntakeService {
         return;
       }
 
+      // Persistent idempotency guard: verify no existing feature already tracks this
+      // GitHub issue number. The in-memory processedSignals set (above) handles same-session
+      // duplicates; this guard catches retried deliveries after a server restart or deliveries
+      // from a second webhook registration with a different X-GitHub-Delivery ID.
+      if (signal.source === 'github' && signal.channelContext?.issueNumber !== undefined) {
+        const issueNumber = signal.channelContext.issueNumber as number;
+        try {
+          const existingFeatures = await this.featureLoader.getAll(projectPath as string);
+          const alreadyTriaged = existingFeatures.find((f) => f.githubIssueNumber === issueNumber);
+          if (alreadyTriaged) {
+            logger.info(
+              `[idempotency] GitHub issue #${issueNumber} already triaged as feature ` +
+                `${alreadyTriaged.id} ("${alreadyTriaged.title}") — skipping duplicate creation`
+            );
+            this.updateRingBufferEntry(bufferEntry.id, 'dismissed');
+            return;
+          }
+        } catch (err) {
+          // Non-fatal: if lookup fails, proceed to avoid silently dropping the signal
+          logger.warn(
+            `[idempotency] Feature lookup failed for GitHub issue #${issueNumber} (proceeding with creation):`,
+            err
+          );
+        }
+      }
+
       // Ops signals: route to Lead Engineer state machine
 
       // Create feature with idea state

--- a/apps/server/tests/unit/services/signal-intake-service.test.ts
+++ b/apps/server/tests/unit/services/signal-intake-service.test.ts
@@ -442,6 +442,64 @@ describe('SignalIntakeService', () => {
       expect(mockFeatureLoader.create).toHaveBeenCalledTimes(1);
     });
 
+    it('should skip creation when GitHub issue is already tracked by an existing feature (persistent guard)', async () => {
+      // Simulate a feature already created for this issue in a previous server session.
+      // The in-memory processedSignals set is empty (fresh instance), but featureLoader.getAll
+      // returns a feature with a matching githubIssueNumber — the persistent guard must catch it.
+      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue([
+        {
+          id: 'feature-already-triaged',
+          title: '[github] Bug: quinn double triage on #3299',
+          status: 'backlog',
+          githubIssueNumber: 3299,
+        } as any,
+      ]);
+
+      const signal = createTestSignal({
+        source: 'github',
+        author: { id: 'mabry1985', name: 'mabry1985' },
+        content: 'Bug: quinn double triage',
+        channelContext: {
+          issueNumber: 3299,
+          repository: 'protoLabsAI/protoMaker',
+        },
+      });
+
+      mockEmitter.emit('signal:received', signal);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Feature must NOT be created — already triaged
+      expect(mockFeatureLoader.create).not.toHaveBeenCalled();
+    });
+
+    it('should allow creation when existing features have a different githubIssueNumber', async () => {
+      // A different issue is already triaged — the new issue should still be created
+      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue([
+        {
+          id: 'feature-other-issue',
+          title: '[github] Some other bug',
+          status: 'done',
+          githubIssueNumber: 9999,
+        } as any,
+      ]);
+
+      const signal = createTestSignal({
+        source: 'github',
+        author: { id: 'mabry1985', name: 'mabry1985' },
+        content: 'New bug report',
+        channelContext: {
+          issueNumber: 3300,
+          repository: 'protoLabsAI/protoMaker',
+        },
+      });
+
+      mockEmitter.emit('signal:received', signal);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Feature SHOULD be created (different issue number)
+      expect(mockFeatureLoader.create).toHaveBeenCalledTimes(1);
+    });
+
     it('should prevent duplicate Discord signals by author ID', async () => {
       const signal = createTestSignal({
         source: 'discord',


### PR DESCRIPTION
## Summary

## RCA

Quinn's `bug_triage` flow executes twice per `issues.opened` event, producing two board features and two triage comments for the same GitHub issue (observed on #3299: `feature-1775584119974-6z2280rlp` P3 and `feature-1775584123696-rzf3w88tt` P2 created seconds apart).

Two likely causes, both must be addressed:

1. **No idempotency guard** — the `issues.opened` handler does not check whether a board feature already references the incoming issue URL/number before running the triage + crea...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-12T09:43:23.303Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added persistent idempotency check for GitHub signals to prevent duplicate feature creation when the same GitHub issue is processed multiple times, improving data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->