### PR TITLE
fix(ci): prettier formatting + update stale worktree-creation test for PR #3381

### DIFF
--- a/apps/server/src/routes/features/routes/create.ts
+++ b/apps/server/src/routes/features/routes/create.ts
@@ -14,15 +14,10 @@ import type { QuarantineStage, SanitizationViolation } from '@protolabsai/types'
 
 export const CreateRequestSchema = z.object({
   projectPath: z.string().min(1, 'projectPath is required'),
-  feature: z
-    .custom<Partial<Feature>>(
-      (val): val is Partial<Feature> => val !== null && typeof val === 'object',
-      'feature must be an object'
-    )
-    .refine(
-      (val: Partial<Feature>) => !(val.isEpic && val.epicId),
-      'A feature cannot be both an epic (isEpic: true) and a member of another epic (epicId set). Set either isEpic or epicId, not both.'
-    ),
+  feature: z.custom<Partial<Feature>>(
+    (val): val is Partial<Feature> => val !== null && typeof val === 'object',
+    'feature must be an object'
+  ),
 });
 
 /**

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3238,7 +3238,8 @@ Format your response as a structured markdown document.`;
               // would branch from the wrong base — the agent would commit to the wrong
               // history and likely produce a lock-only PR that auto-merges without source
               // changes. Fail loudly so the feature is blocked rather than silently corrupted.
-              const epicBranchName = epicFeature?.branchName ?? `(unknown, epicId: ${feature.epicId})`;
+              const epicBranchName =
+                epicFeature?.branchName ?? `(unknown, epicId: ${feature.epicId})`;
               throw new Error(
                 `Epic base branch '${epicBranchName}' not found on remote for feature ` +
                   `${feature.id}. Push the epic branch before starting child features. ` +

--- a/apps/server/tests/unit/routes/webhook-pr-merge-source-check.test.ts
+++ b/apps/server/tests/unit/routes/webhook-pr-merge-source-check.test.ts
@@ -80,12 +80,14 @@ function buildSettingsService() {
   };
 }
 
-function makePrMergedPayload(overrides: {
-  branchName?: string;
-  baseBranch?: string;
-  mergeCommitSha?: string;
-  prNumber?: number;
-} = {}) {
+function makePrMergedPayload(
+  overrides: {
+    branchName?: string;
+    baseBranch?: string;
+    mergeCommitSha?: string;
+    prNumber?: number;
+  } = {}
+) {
   return {
     action: 'closed',
     pull_request: {

--- a/apps/server/tests/unit/services/worktree-creation-base-branch.test.ts
+++ b/apps/server/tests/unit/services/worktree-creation-base-branch.test.ts
@@ -342,7 +342,7 @@ describe('AutoModeService - createWorktreeForBranch base branch resolution', () 
     expect(worktreeAdd![1]).not.toContain('origin/dev');
   });
 
-  it('falls back to origin/dev when epic branch does not exist on remote', async () => {
+  it('returns null and logs an error when epic branch does not exist on remote', async () => {
     mockGetEffectivePrBaseBranch.mockResolvedValue('dev');
 
     mockExecFileAsync.mockImplementation(async (bin: string, args: string[]) => {
@@ -376,16 +376,25 @@ describe('AutoModeService - createWorktreeForBranch base branch resolution', () 
       branchName: 'feature/test-branch',
     });
 
-    await (svc as any).createWorktreeForBranch(PROJECT_PATH, BRANCH_NAME, childFeature);
+    // Missing epic branch on remote is a hard failure — the function returns null and logs an error
+    // rather than silently branching from the wrong base (which would produce a corrupt PR).
+    const result = await (svc as any).createWorktreeForBranch(
+      PROJECT_PATH,
+      BRANCH_NAME,
+      childFeature
+    );
 
+    expect(result).toBeNull();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining(`Failed to create worktree for branch "${BRANCH_NAME}"`),
+      expect.objectContaining({ message: expect.stringContaining('not found on remote') })
+    );
+
+    // No worktree add should have been attempted
     const calls = mockExecFileAsync.mock.calls as [string, string[]][];
-
-    // Should fall back to origin/dev when epic branch not found on remote
     const worktreeAdd = calls.find(
       ([bin, args]) => bin === 'git' && args.includes('worktree') && args.includes('-B')
     );
-    expect(worktreeAdd).toBeDefined();
-    expect(worktreeAdd![1]).toContain('origin/dev');
-    expect(worktreeAdd![1]).not.toContain('origin/epic/');
+    expect(worktreeAdd).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Removes redundant `.refine()` from `CreateRequestSchema` in `create.ts` — the handler already rejects `isEpic && epicId` at line 71, making the schema-level check duplicate and confusing
- Applies Prettier formatting to `auto-mode-service.ts` and `webhook-pr-merge-source-check.test.ts` to fix `format:check` CI failures
- Updates `worktree-creation-base-branch.test.ts`: the test expected the old silent fallback to `origin/dev` when an epic branch is missing on remote, but `auto-mode-service` now throws loudly in that case; updated to assert `null` return + `logger.error` call

## Root Cause

PR #3381 shipped the `FeatureScheduler` epic contradiction guard but CI failed because:
1. `format:check` — Prettier violations in `create.ts`, `auto-mode-service.ts`, `webhook-pr-merge-source-check.test.ts`
2. `test` — `worktree-creation-base-branch.test.ts` expected the old "silent fallback to dev" behavior, but a previous commit changed `auto-mode-service` to throw instead of silently falling back

## Test plan
- [ ] `format:check` passes on all modified files
- [ ] `worktree-creation-base-branch.test.ts` test "returns null and logs an error when epic branch does not exist on remote" passes
- [ ] All other existing scheduler tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed error handling when epic branch references are missing on remote—now properly reports the issue instead of attempting a fallback.

* **Refactor**
  * Streamlined validation logic by simplifying schema constraints while maintaining runtime safety checks.
  * Improved code formatting for readability in internal utilities and test helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->