### PR TITLE
test(ci): document fixci: title prefix gap — category: fix required for fix/ branch

### DIFF
--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -162,6 +162,20 @@ describe('FeatureLoader.generateBranchName', () => {
     const branch = loader.generateBranchName('feat: add dark mode', 'feature-123-abc1234');
     expect(branch).toMatch(/^feature\//);
   });
+
+  it(
+    'uses feature/ prefix for fixci: titles — category: fix required to get fix/ prefix',
+    () => {
+      // "fixci:" does NOT match the conventional-commit regex /^fix(\([^)]*\))?!?:/
+      // Agents creating fix branches with non-standard prefixes MUST set category: 'fix'
+      // explicitly — title-based detection only works for "fix:", "fix(scope):", "fix!:", etc.
+      const branch = loader.generateBranchName(
+        'fixci: PR #3383 — checks and test workflows failing',
+        'feature-123-abc1234'
+      );
+      expect(branch).toMatch(/^feature\//);
+    }
+  );
 });
 
 describe('FeatureLoader.branchPrefixForCategory', () => {


### PR DESCRIPTION
## Summary

- Adds test case to `feature-loader-branch-name.test.ts` documenting that non-standard title prefixes like `fixci:` do NOT trigger the `fix/` branch prefix detection
- The regex `/^fix(\([^)]*\))?!?:/` only matches conventional-commit format (`fix:`, `fix(scope):`, `fix!:`)
- Agents creating fix branches must set `category: 'fix'` explicitly — this is the recurring root cause of source-branch CI failures

## RCA

PR #3383 (already merged) had CI failures because the agent-generated branch used `feature/` prefix instead of `fix/`. The feature title `fixci: PR #3381...` does not match the conventional-commit regex, and no `category: 'fix'` was set.

This test documents the expected behavior (gap) so future developers understand why `category` must be set explicitly when using non-standard title prefixes.

## Test plan
- [ ] `npm run test:server -- tests/unit/services/feature-loader-branch-name.test.ts` passes
- [ ] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for branch naming functionality. New tests verify proper classification and handling of commit message format patterns to ensure consistent application of branch naming conventions across various input scenarios, improving overall system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->