### PR TITLE
fix(ci): extend branch-prefix detection to catch fixci: titles and hotfix/bugfix categories

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -304,7 +304,8 @@ export class FeatureLoader implements FeatureStore {
   branchPrefixForCategory(category: string | undefined): string {
     if (!category) return 'feature';
     const c = category.toLowerCase();
-    if (c === 'bug' || c === 'fix') return 'fix';
+    if (c === 'bug' || c === 'fix' || c === 'bugfix' || c === 'bug-fix' || c === 'hotfix')
+      return 'fix';
     if (c === 'ops' || c === 'chore' || c === 'maintenance') return 'chore';
     if (c === 'docs' || c === 'documentation') return 'docs';
     return 'feature';
@@ -328,7 +329,10 @@ export class FeatureLoader implements FeatureStore {
     let prefix: string;
     if (category) {
       prefix = this.branchPrefixForCategory(category);
-    } else if (title && /^fix(\([^)]*\))?!?:/.test(title.trim())) {
+    } else if (title && /^fix([a-z0-9-]{0,15}|\([^)]*\))?!?:/.test(title.trim())) {
+      // Matches: fix:, fix(scope):, fix!:, fix(scope)!:
+      // Also matches concatenated scope variants: fixci:, fix-ci:, fixup:
+      // (agents sometimes omit parentheses when writing fix(scope): commit types)
       prefix = 'fix';
     } else {
       prefix = 'feature';

--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -163,19 +163,23 @@ describe('FeatureLoader.generateBranchName', () => {
     expect(branch).toMatch(/^feature\//);
   });
 
-  it(
-    'uses feature/ prefix for fixci: titles — category: fix required to get fix/ prefix',
-    () => {
-      // "fixci:" does NOT match the conventional-commit regex /^fix(\([^)]*\))?!?:/
-      // Agents creating fix branches with non-standard prefixes MUST set category: 'fix'
-      // explicitly — title-based detection only works for "fix:", "fix(scope):", "fix!:", etc.
-      const branch = loader.generateBranchName(
-        'fixci: PR #3383 — checks and test workflows failing',
-        'feature-123-abc1234'
-      );
-      expect(branch).toMatch(/^feature\//);
-    }
-  );
+  it('uses fix/ prefix for fixci: titles (concatenated scope without parentheses)', () => {
+    // "fixci:" matches the extended regex /^fix([a-z0-9-]{0,15}|\([^)]*\))?!?:/
+    // Agents sometimes write fix(ci): as fixci: (omitting parentheses) — both get fix/ prefix.
+    const branch = loader.generateBranchName(
+      'fixci: PR #3383 — checks and test workflows failing',
+      'feature-123-abc1234'
+    );
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses fix/ prefix for fix-ci: titles (hyphenated concatenated scope)', () => {
+    const branch = loader.generateBranchName(
+      'fix-ci: source-branch policy failure on feature branches',
+      'feature-123-abc1234'
+    );
+    expect(branch).toMatch(/^fix\//);
+  });
 });
 
 describe('FeatureLoader.branchPrefixForCategory', () => {
@@ -220,6 +224,18 @@ describe('FeatureLoader.branchPrefixForCategory', () => {
   it('is case-insensitive', () => {
     expect(loader.branchPrefixForCategory('BUG')).toBe('fix');
     expect(loader.branchPrefixForCategory('OPS')).toBe('chore');
+  });
+
+  it('returns fix for bugfix category', () => {
+    expect(loader.branchPrefixForCategory('bugfix')).toBe('fix');
+  });
+
+  it('returns fix for bug-fix category', () => {
+    expect(loader.branchPrefixForCategory('bug-fix')).toBe('fix');
+  });
+
+  it('returns fix for hotfix category', () => {
+    expect(loader.branchPrefixForCategory('hotfix')).toBe('fix');
   });
 });
 


### PR DESCRIPTION
## Summary

RCA for the recurring `feature/` prefix on fix branches (PR #3384, #3377, #3365).

Two root causes identified and fixed:

**1. Title regex too narrow** — Agents sometimes write `fix(ci):` as `fixci:` (omitting parentheses). The previous regex `/^fix(\([^)]*\))?!?:/` only matched the parenthetical form, so `fixci:` titles fell through to the `feature/` default.

**2. Missing category aliases** — `branchPrefixForCategory()` didn't recognize `hotfix`, `bugfix`, or `bug-fix` as fix-type categories. The MCP `create_feature` schema shows `bug-fix` as an example category value, but it wasn't mapped to `fix/` prefix.

## Changes

- `feature-loader.ts` `generateBranchName()`: regex extended from `/^fix(\([^)]*\))?!?:/` to `/^fix([a-z0-9-]{0,15}|\([^)]*\))?!?:/` — catches `fixci:`, `fix-ci:`, `fixup:` etc.
- `feature-loader.ts` `branchPrefixForCategory()`: added `hotfix`, `bugfix`, `bug-fix` → `fix` mapping
- `feature-loader-branch-name.test.ts`: updated `fixci:` test expectation from `feature/` to `fix/`, added `fix-ci:` test, added category alias tests

## Test plan

- [ ] `fixci: ...` title now produces `fix/` branch prefix
- [ ] `fix-ci: ...` title now produces `fix/` branch prefix  
- [ ] `category: 'hotfix'` now produces `fix/` branch prefix
- [ ] `category: 'bugfix'` now produces `fix/` branch prefix
- [ ] `category: 'bug-fix'` now produces `fix/` branch prefix
- [ ] Existing tests still pass (fix:, fix(scope):, fix!: all still get fix/ prefix)
- [ ] CI checks workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced branch categorization to recognize additional fix-related category aliases (`bugfix`, `bug-fix`, `hotfix`) alongside existing patterns.
  * Improved fix prefix detection to support more flexible commit title formats, including variable-length scopes and concatenated variations, enabling more consistent branch naming across different development practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->