### PR TITLE
fix(ci): #3115 — post-merge webhook only watches protoMaker repo; external project PR merges never trigger feature→done sync

### DIFF
--- a/apps/server/src/services/maintenance.module.ts
+++ b/apps/server/src/services/maintenance.module.ts
@@ -5,6 +5,7 @@
  * - board-health (full tier, 6h): FeatureHealthService board audit with auto-fix
  * - resource-usage (critical tier, 5min): HealthMonitorService resource check
  * - webhook-health (full tier, 6h): Warns when PRs in review have no CI events after grace period
+ * - post-merge-reconciler (critical tier, 5min): Poll-based fallback for missed PR merge webhooks
  */
 
 import { createLogger } from '@protolabsai/utils';
@@ -15,6 +16,7 @@ import type {
 } from '@protolabsai/types';
 import type { ServiceContainer } from '../server/services.js';
 import { WebhookHealthCheck } from './maintenance/checks/webhook-health-check.js';
+import { PostMergeReconcilerCheck } from './maintenance/checks/post-merge-reconciler-check.js';
 
 const logger = createLogger('Server:Wiring');
 
@@ -98,6 +100,7 @@ export function register(container: ServiceContainer): void {
 
   // Webhook health check (full tier) — warns when PRs in review have no CI events
   const { featureLoader } = container;
+
   const webhookHealthCheckInstance = new WebhookHealthCheck(featureLoader);
   const webhookHealthCheck: MaintenanceCheck = {
     id: 'webhook-health',
@@ -133,9 +136,44 @@ export function register(container: ServiceContainer): void {
     },
   };
 
+  // Post-merge reconciler (critical tier) — poll fallback for missed PR merge webhooks.
+  // Runs every 5 minutes alongside resource-usage. Catches the case where a PR merges
+  // on a repo that has no GitHub webhook configured, preventing the feature from staying
+  // stuck in 'review' and triggering repeated failed agent spawns.
+  // See: protoLabsAI/protoMaker#3115
+  const postMergeReconcilerInstance = new PostMergeReconcilerCheck(featureLoader, events);
+  const postMergeReconcilerCheck: MaintenanceCheck = {
+    id: 'post-merge-reconciler',
+    name: 'Post-Merge PR Reconciler',
+    tier: 'critical',
+    async run(context: MaintenanceCheckContext): Promise<MaintenanceCheckResult> {
+      const t0 = Date.now();
+      let totalChecked = 0;
+      let totalReconciled = 0;
+
+      for (const projectPath of context.projectPaths) {
+        const result = await postMergeReconcilerInstance.run(projectPath);
+        totalChecked += result.checked;
+        totalReconciled += result.reconciled;
+      }
+
+      return {
+        checkId: 'post-merge-reconciler',
+        passed: true,
+        summary:
+          totalReconciled > 0
+            ? `Post-merge reconciler: reconciled ${totalReconciled} missed merge(s) out of ${totalChecked} checked`
+            : `Post-merge reconciler: ${totalChecked} review-state PR(s) checked, none missed`,
+        details: { totalChecked, totalReconciled, projectCount: context.projectPaths.length },
+        durationMs: Date.now() - t0,
+      };
+    },
+  };
+
   maintenanceOrchestrator.register(boardHealthCheck);
   maintenanceOrchestrator.register(resourceUsageCheck);
   maintenanceOrchestrator.register(webhookHealthCheck);
+  maintenanceOrchestrator.register(postMergeReconcilerCheck);
 
   // Wire TopicBus for hierarchical event routing of sweep results
   if (container.topicBus) {
@@ -151,6 +189,6 @@ export function register(container: ServiceContainer): void {
   });
 
   logger.info(
-    'MaintenanceOrchestrator started with board-health, resource-usage, and webhook-health checks'
+    'MaintenanceOrchestrator started with board-health, resource-usage, webhook-health, and post-merge-reconciler checks'
   );
 }

--- a/apps/server/src/services/maintenance/checks/post-merge-reconciler-check.ts
+++ b/apps/server/src/services/maintenance/checks/post-merge-reconciler-check.ts
@@ -1,0 +1,145 @@
+/**
+ * PostMergeReconcilerCheck — Poll-based fallback for missed PR merge webhooks.
+ *
+ * The primary PR merge flow relies on GitHub webhook events at /github.
+ * However, webhooks are only delivered for repos where the hook is registered.
+ * When a feature's PR merges on a repo that has no hook configured (e.g., a
+ * secondary tracked repo like mythxengine), no event fires and the feature
+ * stays stuck in 'review' indefinitely — causing auto-mode to retry the
+ * already-merged branch until it hits max retries.
+ *
+ * This check runs on the 'critical' maintenance tier (every 5 minutes) and
+ * queries GitHub directly for every feature currently in 'review' status
+ * that has a prNumber and prUrl. If the PR is merged, it transitions the
+ * feature to 'done' and emits the standard feature:pr-merged event so
+ * downstream listeners (TopicBus, UI) react identically to the webhook path.
+ *
+ * Idempotency: features already in a terminal status are skipped silently.
+ *
+ * See: protoLabsAI/protoMaker#3115
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { createLogger } from '@protolabsai/utils';
+import type { FeatureLoader } from '../../feature-loader.js';
+import type { EventEmitter } from '../../../lib/events.js';
+
+const logger = createLogger('PostMergeReconcilerCheck');
+
+type ExecFileAsync = (
+  file: string,
+  args: string[],
+  options: { encoding: string; timeout: number }
+) => Promise<{ stdout: string; stderr: string }>;
+
+/** GitHub CLI `gh pr view --json state,merged` response */
+interface PRViewResult {
+  state: 'OPEN' | 'CLOSED' | 'MERGED' | string;
+  merged: boolean;
+}
+
+/** Statuses that indicate the feature is already done — skip reconciliation. */
+const TERMINAL_STATUSES = new Set(['done', 'completed', 'verified']);
+
+/**
+ * Extract `owner/repo` from a GitHub PR URL.
+ *
+ * @example
+ * extractRepoFromPrUrl('https://github.com/protoLabsAI/mythxengine/pull/184')
+ * // → 'protoLabsAI/mythxengine'
+ */
+export function extractRepoFromPrUrl(prUrl: string): string | null {
+  const match = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull\//);
+  return match ? match[1] : null;
+}
+
+export class PostMergeReconcilerCheck {
+  private readonly execFileAsync: ExecFileAsync;
+
+  constructor(
+    private readonly featureLoader: FeatureLoader,
+    private readonly events: EventEmitter,
+    execFileAsyncOverride?: ExecFileAsync
+  ) {
+    this.execFileAsync = execFileAsyncOverride ?? (promisify(execFile) as ExecFileAsync);
+  }
+
+  /**
+   * Reconcile PR merge status for all 'review' features in the given project.
+   *
+   * @returns Counts of features checked and transitioned to done.
+   */
+  async run(projectPath: string): Promise<{ checked: number; reconciled: number }> {
+    let checked = 0;
+    let reconciled = 0;
+
+    try {
+      const features = await this.featureLoader.getAll(projectPath);
+
+      const reviewFeatures = features.filter(
+        (f) => f.status === 'review' && f.prNumber != null && f.prUrl
+      );
+
+      for (const feature of reviewFeatures) {
+        // Idempotency guard — skip if already in a terminal status
+        if (TERMINAL_STATUSES.has(feature.status ?? '')) continue;
+
+        const repo = extractRepoFromPrUrl(feature.prUrl!);
+        if (!repo) {
+          logger.debug(
+            `[reconciler] Could not extract repo from prUrl "${feature.prUrl}" for feature ${feature.id} — skipping`
+          );
+          continue;
+        }
+
+        checked++;
+
+        try {
+          const { stdout } = await this.execFileAsync(
+            'gh',
+            ['pr', 'view', String(feature.prNumber), '--repo', repo, '--json', 'state,merged'],
+            { encoding: 'utf-8', timeout: 10_000 }
+          );
+
+          const prData = JSON.parse(stdout) as PRViewResult;
+          const isMerged = prData.state === 'MERGED' || prData.merged === true;
+
+          if (!isMerged) {
+            logger.debug(
+              `[reconciler] PR #${feature.prNumber} on ${repo} is not merged (state=${prData.state}) — skipping`
+            );
+            continue;
+          }
+
+          // PR is merged but we never received the webhook — reconcile now
+          logger.info(
+            `[reconciler] PR #${feature.prNumber} on ${repo} is merged — transitioning feature "${feature.title}" (${feature.id}) from review → done (missed webhook)`
+          );
+
+          await this.featureLoader.update(projectPath, feature.id, { status: 'done' });
+
+          this.events.emit('feature:pr-merged', {
+            featureId: feature.id,
+            title: feature.title ?? feature.id,
+            prNumber: feature.prNumber,
+            prTitle: '',
+            branchName: feature.branchName ?? '',
+            projectPath,
+          });
+
+          reconciled++;
+        } catch (prCheckErr) {
+          // Non-fatal: log and continue to next feature
+          logger.debug(
+            `[reconciler] Could not check PR #${feature.prNumber} for feature ${feature.id} on ${repo}: ${prCheckErr instanceof Error ? prCheckErr.message : String(prCheckErr)}`
+          );
+        }
+      }
+    } catch (err) {
+      logger.error(`[reconciler] Failed to reconcile project ${projectPath}:`, err);
+    }
+
+    return { checked, reconciled };
+  }
+}

--- a/apps/server/tests/unit/services/post-merge-reconciler-check.test.ts
+++ b/apps/server/tests/unit/services/post-merge-reconciler-check.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Tests for PostMergeReconcilerCheck — poll-based fallback for missed PR merge webhooks.
+ *
+ * Verifies that features stuck in 'review' on ANY tracked repo (not just protoMaker)
+ * are correctly transitioned to 'done' when the reconciler detects a merged PR.
+ *
+ * See: protoLabsAI/protoMaker#3115
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import {
+  PostMergeReconcilerCheck,
+  extractRepoFromPrUrl,
+} from '@/services/maintenance/checks/post-merge-reconciler-check.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeFeature(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'feature-001',
+    title: 'PC Speech Bubbles in Chat',
+    status: 'review',
+    branchName: 'feature/pc-speech-bubbles-in-chat',
+    prNumber: 184,
+    prUrl: 'https://github.com/protoLabsAI/mythxengine/pull/184',
+    ...overrides,
+  };
+}
+
+function makeExecFileAsync(responses: Record<string, { stdout: string } | Error>) {
+  return async (
+    _file: string,
+    args: string[],
+    _opts: { encoding: string; timeout: number }
+  ): Promise<{ stdout: string; stderr: string }> => {
+    // Find the --repo arg to build the key
+    const repoIdx = args.indexOf('--repo');
+    const prIdx = args.indexOf('view') + 1;
+    const prNum = args[prIdx];
+    const repo = repoIdx >= 0 ? args[repoIdx + 1] : 'unknown';
+    const key = `${repo}#${prNum}`;
+
+    const response = responses[key] ?? responses['*'];
+    if (!response) throw new Error(`No mock response for ${key}`);
+    if (response instanceof Error) throw response;
+    return { stdout: response.stdout, stderr: '' };
+  };
+}
+
+// ── extractRepoFromPrUrl unit tests ───────────────────────────────────────
+
+describe('extractRepoFromPrUrl', () => {
+  it('extracts owner/repo from a standard GitHub PR URL', () => {
+    expect(extractRepoFromPrUrl('https://github.com/protoLabsAI/mythxengine/pull/184')).toBe(
+      'protoLabsAI/mythxengine'
+    );
+  });
+
+  it('extracts owner/repo from protoMaker PR URL', () => {
+    expect(extractRepoFromPrUrl('https://github.com/protoLabsAI/protoMaker/pull/42')).toBe(
+      'protoLabsAI/protoMaker'
+    );
+  });
+
+  it('returns null for non-GitHub URLs', () => {
+    expect(extractRepoFromPrUrl('https://gitlab.com/owner/repo/merge_requests/1')).toBeNull();
+  });
+
+  it('returns null for malformed URLs', () => {
+    expect(extractRepoFromPrUrl('not-a-url')).toBeNull();
+  });
+});
+
+// ── PostMergeReconcilerCheck integration tests ────────────────────────────
+
+describe('PostMergeReconcilerCheck', () => {
+  let events: EventEmitter;
+  let mockFeatureLoaderGetAll: ReturnType<typeof vi.fn>;
+  let mockFeatureLoaderUpdate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    events = new EventEmitter();
+    mockFeatureLoaderGetAll = vi.fn().mockResolvedValue([]);
+    mockFeatureLoaderUpdate = vi.fn().mockResolvedValue(undefined);
+  });
+
+  function makeLoader() {
+    return {
+      getAll: mockFeatureLoaderGetAll,
+      update: mockFeatureLoaderUpdate,
+    } as unknown as Parameters<typeof PostMergeReconcilerCheck>[0];
+  }
+
+  // ── Core scenario: non-protoMaker repo (the original bug) ───────────────
+
+  it('transitions a mythxengine feature to done when the PR is merged — missed webhook scenario', async () => {
+    const feature = makeFeature();
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+
+    const execFileAsync = makeExecFileAsync({
+      'protoLabsAI/mythxengine#184': {
+        stdout: JSON.stringify({ state: 'MERGED', merged: true }),
+      },
+    });
+
+    const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync);
+    const emittedEvents: unknown[] = [];
+    events.on('feature:pr-merged', (e) => emittedEvents.push(e));
+
+    const result = await check.run('/home/josh/dev/labs/mythxengine');
+
+    expect(result.checked).toBe(1);
+    expect(result.reconciled).toBe(1);
+    expect(mockFeatureLoaderUpdate).toHaveBeenCalledWith(
+      '/home/josh/dev/labs/mythxengine',
+      'feature-001',
+      { status: 'done' }
+    );
+    expect(emittedEvents).toHaveLength(1);
+    expect(emittedEvents[0]).toMatchObject({ featureId: 'feature-001', prNumber: 184 });
+  });
+
+  it('does NOT re-transition a feature already in done status (idempotency guard)', async () => {
+    const feature = makeFeature({ status: 'done' });
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+
+    const execFileAsync = vi.fn();
+    const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync);
+
+    const result = await check.run('/home/josh/dev/labs/mythxengine');
+
+    expect(result.checked).toBe(0);
+    expect(result.reconciled).toBe(0);
+    expect(mockFeatureLoaderUpdate).not.toHaveBeenCalled();
+    // execFile should never be called — feature is filtered out before checking GitHub
+    expect(execFileAsync).not.toHaveBeenCalled();
+  });
+
+  it('skips features without prNumber', async () => {
+    const feature = makeFeature({ prNumber: undefined });
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+
+    const execFileAsync = vi.fn();
+    const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync);
+
+    const result = await check.run('/project');
+
+    expect(result.checked).toBe(0);
+    expect(execFileAsync).not.toHaveBeenCalled();
+  });
+
+  it('skips features without prUrl', async () => {
+    const feature = makeFeature({ prUrl: undefined });
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+
+    const execFileAsync = vi.fn();
+    const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync);
+
+    const result = await check.run('/project');
+
+    expect(result.checked).toBe(0);
+    expect(execFileAsync).not.toHaveBeenCalled();
+  });
+
+  it('does not transition a feature whose PR is still open', async () => {
+    const feature = makeFeature();
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+
+    const execFileAsync = makeExecFileAsync({
+      'protoLabsAI/mythxengine#184': {
+        stdout: JSON.stringify({ state: 'OPEN', merged: false }),
+      },
+    });
+
+    const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync);
+
+    const result = await check.run('/home/josh/dev/labs/mythxengine');
+
+    expect(result.checked).toBe(1);
+    expect(result.reconciled).toBe(0);
+    expect(mockFeatureLoaderUpdate).not.toHaveBeenCalled();
+  });
+
+  it('handles GitHub CLI errors gracefully (non-fatal, continues to next feature)', async () => {
+    const features = [
+      makeFeature({ id: 'f-001', prNumber: 184 }),
+      makeFeature({
+        id: 'f-002',
+        prNumber: 185,
+        prUrl: 'https://github.com/protoLabsAI/mythxengine/pull/185',
+      }),
+    ];
+    mockFeatureLoaderGetAll.mockResolvedValue(features);
+
+    const execFileAsync = makeExecFileAsync({
+      'protoLabsAI/mythxengine#184': new Error('gh: API rate limit exceeded'),
+      'protoLabsAI/mythxengine#185': {
+        stdout: JSON.stringify({ state: 'MERGED', merged: true }),
+      },
+    });
+
+    const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync);
+
+    const result = await check.run('/home/josh/dev/labs/mythxengine');
+
+    // First feature errored (not reconciled), second was successfully reconciled
+    expect(result.checked).toBe(2);
+    expect(result.reconciled).toBe(1);
+    expect(mockFeatureLoaderUpdate).toHaveBeenCalledTimes(1);
+    expect(mockFeatureLoaderUpdate).toHaveBeenCalledWith(expect.any(String), 'f-002', {
+      status: 'done',
+    });
+  });
+
+  it('returns zero counts when no features are in review status', async () => {
+    mockFeatureLoaderGetAll.mockResolvedValue([
+      makeFeature({ status: 'backlog', prNumber: undefined, prUrl: undefined }),
+      makeFeature({ status: 'done' }),
+    ]);
+
+    const execFileAsync = vi.fn();
+    const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync);
+
+    const result = await check.run('/project');
+
+    expect(result.checked).toBe(0);
+    expect(result.reconciled).toBe(0);
+    expect(execFileAsync).not.toHaveBeenCalled();
+  });
+
+  it('passes the correct --repo flag derived from prUrl to gh CLI', async () => {
+    const feature = makeFeature({
+      prUrl: 'https://github.com/some-org/some-other-repo/pull/99',
+      prNumber: 99,
+    });
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+
+    const calls: string[][] = [];
+    const execFileAsync = async (
+      _file: string,
+      args: string[],
+      _opts: unknown
+    ): Promise<{ stdout: string; stderr: string }> => {
+      calls.push(args);
+      return { stdout: JSON.stringify({ state: 'OPEN', merged: false }), stderr: '' };
+    };
+
+    const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync);
+    await check.run('/project');
+
+    expect(calls).toHaveLength(1);
+    const repoIdx = calls[0].indexOf('--repo');
+    expect(calls[0][repoIdx + 1]).toBe('some-org/some-other-repo');
+    expect(calls[0]).toContain('99');
+  });
+});


### PR DESCRIPTION
## Summary

## RCA

The post-merge PR sync listener is scoped exclusively to the `protoLabsAI/protoMaker` repository webhook. When a feature's implementation PR is merged on a *different* tracked repo (e.g., `mythxengine`), no `pull_request.closed+merged` event is processed by the sync handler, so the feature's status is never transitioned to `done`. Auto-mode treats the feature as still actionable and keeps spawning agents — each of which instantly crashes (Claude Code exit code 1, $0 cost) because the bra...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-12T10:34:07.496Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new periodic maintenance check that monitors pull request states and automatically updates feature status when merges are detected. This ensures data consistency when GitHub webhook notifications may be missed or delayed, helping keep your project information synchronized at regular intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->