### PR TITLE
fix(ci): PR #3388 — fix branch uses feature/ prefix instead of fix/, triggering source-branch policy rejection and cascading checks/test gate failures

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -325,17 +325,22 @@ export class FeatureLoader implements FeatureStore {
     // Use the last 7 characters of the id — always alphanumeric, always unique.
     const shortId = featureId ? featureId.slice(-7) : Date.now().toString(36).slice(-7);
 
-    // Category takes priority. When absent, detect from conventional-commit title type.
+    // Category takes priority when it maps to a specific non-default prefix.
+    // When the category is unknown or maps to the default "feature" prefix (e.g.
+    // "Uncategorized"), fall through to title detection — this prevents the
+    // "Uncategorized" default from masking fix(ci): / fixci: titles and emitting
+    // a wrong feature/ prefix (root cause of recurring source-branch CI failures).
     let prefix: string;
-    if (category) {
-      prefix = this.branchPrefixForCategory(category);
+    const catPrefix = category ? this.branchPrefixForCategory(category) : null;
+    if (catPrefix && catPrefix !== 'feature') {
+      prefix = catPrefix;
     } else if (title && /^fix([a-z0-9-]{0,15}|\([^)]*\))?!?:/.test(title.trim())) {
       // Matches: fix:, fix(scope):, fix!:, fix(scope)!:
       // Also matches concatenated scope variants: fixci:, fix-ci:, fixup:
       // (agents sometimes omit parentheses when writing fix(scope): commit types)
       prefix = 'fix';
     } else {
-      prefix = 'feature';
+      prefix = catPrefix ?? 'feature';
     }
 
     if (!title || !title.trim()) {

--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -262,4 +262,31 @@ describe('FeatureLoader.generateBranchName with category', () => {
     const branch = loader.generateBranchName(undefined, 'feature-123-abc1234', 'bug');
     expect(branch).toMatch(/^fix\/untitled-/);
   });
+
+  it('uses fix/ prefix when category is Uncategorized but title starts with fix(ci):', () => {
+    // Regression: "Uncategorized" is the default category when agents omit category.
+    // branchPrefixForCategory("Uncategorized") returns "feature", which previously
+    // blocked title detection — causing fix(ci): titles to get feature/ prefix.
+    // Root cause of PR #3388 source-branch CI failure.
+    const branch = loader.generateBranchName(
+      'fix(ci): #3115 — post-merge webhook only watches protoMaker repo',
+      'feature-1775874851806-74z02ivk0',
+      'Uncategorized'
+    );
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses fix/ prefix when category is Uncategorized but title starts with fixci:', () => {
+    const branch = loader.generateBranchName(
+      'fixci: PR #3388 — branch prefix regression',
+      'feature-123-abc1234',
+      'Uncategorized'
+    );
+    expect(branch).toMatch(/^fix\//);
+  });
+
+  it('uses feature/ prefix when category is Uncategorized and title is not a fix', () => {
+    const branch = loader.generateBranchName('Add dashboard', 'feature-123-abc1234', 'Uncategorized');
+    expect(branch).toMatch(/^feature\//);
+  });
 });


### PR DESCRIPTION
## Summary

## RCA

PR #3388 (branch `feature/fixci-3115-post-merge-webhook-only-watches-z02ivk0`) is failing CI because the agent-generated branch uses the `feature/` prefix for a fix PR. The source-branch policy rejects this, causing the composite `checks` gate to fail and the `test` workflow to follow.

**Failing workflows:**
- `checks` — COMPLETED / FAILURE
- `test` — COMPLETED / FAILURE

**Root cause:** The branch naming logic still emits `feature/` prefix for fix-category work instead of `fix/`. This ...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-12T12:10:03.425Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch name generation to correctly prioritize conventional commit prefixes (e.g., `fix/`) over default category mappings, ensuring branch names accurately reflect commit intent when unconventional categories are provided.

* **Tests**
  * Added test coverage for branch name generation with uncategorized items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->