### PR TITLE
feat(ux): issue #42 — re-render task list in-place during sequential task creation

### DIFF
--- a/apps/ui/src/lib/log-parser.ts
+++ b/apps/ui/src/lib/log-parser.ts
@@ -1158,7 +1158,50 @@ export function parseLogOutput(rawOutput: string): LogEntry[] {
   // Merge consecutive entries of the same type if they're both debug or info
   const mergedEntries = mergeConsecutiveEntries(entries);
 
-  return mergedEntries;
+  // Coalesce all TodoWrite entries into a single live-updating task list.
+  // When an agent calls TodoWrite sequentially (adding tasks one by one), each
+  // call replaces the full list — without coalescing, each call produces a
+  // separate rendered task list, creating a waterfall of repeated growing lists.
+  return coalesceTodoWriteEntries(mergedEntries);
+}
+
+/**
+ * Coalesces multiple TodoWrite entries into a single entry showing the latest state.
+ *
+ * When an agent calls TodoWrite sequentially (e.g. adding one task at a time),
+ * each call replaces the entire list. Without coalescing, the log viewer renders
+ * a separate growing task list per call — a "waterfall" of duplicate lists.
+ *
+ * This function:
+ * - Finds all TodoWrite entries in the log
+ * - Keeps the first occurrence's position (and stable ID) in the rendered output
+ * - Updates its content to reflect the latest TodoWrite state
+ * - Removes all subsequent TodoWrite entries
+ */
+function coalesceTodoWriteEntries(entries: LogEntry[]): LogEntry[] {
+  const todoWriteIndices: number[] = [];
+  entries.forEach((entry, i) => {
+    if (entry.metadata?.toolName === 'TodoWrite') {
+      todoWriteIndices.push(i);
+    }
+  });
+
+  if (todoWriteIndices.length <= 1) {
+    return entries;
+  }
+
+  const lastTodoEntry = entries[todoWriteIndices[todoWriteIndices.length - 1]];
+  const indicesToRemove = new Set(todoWriteIndices.slice(1));
+
+  return entries
+    .filter((_, i) => !indicesToRemove.has(i))
+    .map((entry) => {
+      if (entry.metadata?.toolName === 'TodoWrite') {
+        // Keep the first entry's stable ID, update content to the latest state
+        return { ...lastTodoEntry, id: entry.id };
+      }
+      return entry;
+    });
 }
 
 /**


### PR DESCRIPTION
## Summary

**RCA:** When the agent creates multiple tasks in sequence, the TaskList component is mounted as a fresh instance after each `TaskCreate` completion event rather than updating the existing mounted component. This produces a waterfall of repeated, growing task lists — one full re-render appended below the previous — instead of a single component that updates in place.

**Repro (from issue):** Have the agent create 6+ tasks in a single plan. Each `TaskCreate` tool call produces its own standalone ...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-13T03:08:05.775Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log consolidation to merge multiple TodoWrite entries into a single unified entry. The consolidated entry preserves its original position while reflecting the latest state information, eliminating redundant entries and improving log readability when reviewing activity records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->