### PR TITLE
Task Rendering Improvements (protoCLI#42)

### DIFF
--- a/apps/ui/src/components/views/board-view/components/log-viewer.tsx
+++ b/apps/ui/src/components/views/board-view/components/log-viewer.tsx
@@ -415,9 +415,23 @@ export function LogViewer({ output, className }: LogViewerProps) {
   // Parse entries and compute initial expanded state together
   const { entries, initialExpandedIds } = useMemo(() => {
     const parsedEntries = parseLogOutput(output);
-    const toExpand: string[] = [];
 
-    parsedEntries.forEach((entry) => {
+    // Deduplicate TodoWrite entries: keep only the last one.
+    // Each TodoWrite call replaces the previous task list, so only the final
+    // state is meaningful. Showing every call produces a cascading redundant list.
+    const lastTodoWriteIdx = parsedEntries.reduce(
+      (lastIdx, entry, idx) => (entry.metadata?.toolName === 'TodoWrite' ? idx : lastIdx),
+      -1
+    );
+    const dedupedEntries =
+      lastTodoWriteIdx === -1
+        ? parsedEntries
+        : parsedEntries.filter(
+            (entry, idx) => entry.metadata?.toolName !== 'TodoWrite' || idx === lastTodoWriteIdx
+          );
+
+    const toExpand: string[] = [];
+    dedupedEntries.forEach((entry) => {
       // If entry should NOT collapse by default, mark it for expansion
       if (!shouldCollapseByDefault(entry)) {
         toExpand.push(entry.id);
@@ -425,7 +439,7 @@ export function LogViewer({ output, className }: LogViewerProps) {
     });
 
     return {
-      entries: parsedEntries,
+      entries: dedupedEntries,
       initialExpandedIds: new Set(toExpand),
     };
   }, [output]);


### PR DESCRIPTION
## Summary

When the agent adds multiple tasks in a row, it should re-render the same component instead of cascading down a huge repeating list. The current behavior produces long, redundant visual output rather than updating in place.

**Complexity:** Medium

**Ref:** https://github.com/protoLabsAI/protoCLI/issues/42

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed log viewer displaying duplicate entries for certain operations, now showing only the most recent occurrence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->