### PR TITLE
fix(review): protoCLI issue #42 — task list re-renders full snapshot on each TaskCreate instead of updating in-place

### DIFF
--- a/libs/templates/starters/ai-agent-app/packages/ui/src/components/chat-message.tsx
+++ b/libs/templates/starters/ai-agent-app/packages/ui/src/components/chat-message.tsx
@@ -274,6 +274,79 @@ function groupByStep(segments: PartSegment[]): PartSegment[][] {
   return groups.filter((g) => g.length > 0);
 }
 
+// ---------------------------------------------------------------------------
+// Sequential tool-call collapsing (prevents O(n²) task-list re-renders)
+// ---------------------------------------------------------------------------
+
+/**
+ * Tools whose sequential step-calls should be collapsed into a single render.
+ *
+ * When an agent calls one of these tools N times in consecutive steps (each step
+ * containing only that tool call with no other meaningful content), only the final
+ * call's output is displayed. This prevents the O(n²) stacking of full-list
+ * snapshots that occurs when tools like TodoWrite return the complete current state
+ * on every invocation — see protoLabsAI/protoCLI#42.
+ */
+const SEQUENTIAL_COLLAPSE_TOOLS = new Set(['TodoWrite']);
+
+/**
+ * Returns true when a step group contains exactly one segment that is a single
+ * tool-group call from SEQUENTIAL_COLLAPSE_TOOLS, with no other meaningful content.
+ */
+function isSingleCollapsibleToolGroup(group: PartSegment[]): boolean {
+  if (group.length !== 1) return false;
+  const seg = group[0];
+  if (seg.kind !== 'tool-group') return false;
+  if (seg.tools.length !== 1) return false;
+  return SEQUENTIAL_COLLAPSE_TOOLS.has(seg.tools[0].toolName);
+}
+
+/**
+ * Collapse consecutive step groups that each contain only a single call to a
+ * collapsible tool (e.g. TodoWrite).
+ *
+ * Keeps the final group's tool data (latest / complete state) but preserves the
+ * first group's segKey so React reuses the existing component instance rather than
+ * unmounting and remounting it on every new task — equivalent to Ink's rerender().
+ */
+function collapseSequentialToolGroups(groups: PartSegment[][]): PartSegment[][] {
+  const result: PartSegment[][] = [];
+  let i = 0;
+
+  while (i < groups.length) {
+    // Collect a consecutive run of collapsible single-tool groups
+    const runStart = i;
+    while (i < groups.length && isSingleCollapsibleToolGroup(groups[i])) {
+      i++;
+    }
+
+    const runLength = i - runStart;
+
+    if (runLength > 1) {
+      // Multiple consecutive collapsible groups — show only the final state,
+      // but preserve the first group's segKey and toolCallId so React reuses
+      // the existing component instance rather than unmounting it.
+      const firstSeg = groups[runStart][0];
+      const lastSeg = groups[i - 1][0];
+      if (firstSeg.kind === 'tool-group' && lastSeg.kind === 'tool-group') {
+        const lastTool = lastSeg.tools[0];
+        const mergedTool = { ...lastTool, toolCallId: firstSeg.tools[0].toolCallId };
+        result.push([{ kind: 'tool-group', tools: [mergedTool], segKey: firstSeg.segKey }]);
+      }
+    } else if (runLength === 1) {
+      result.push(groups[runStart]);
+    }
+
+    // Add the non-collapsible group that broke the run (if any)
+    if (i < groups.length) {
+      result.push(groups[i]);
+      i++;
+    }
+  }
+
+  return result;
+}
+
 export function ChatMessage({
   message,
   className,
@@ -350,7 +423,8 @@ export function ChatMessage({
 
   const citations = extractCitations(rawParts);
   const segments = buildSegments(rawParts);
-  const stepGroups = groupByStep(segments);
+  // Collapse consecutive single-TodoWrite groups to prevent O(n²) re-renders (protoCLI#42).
+  const stepGroups = collapseSequentialToolGroups(groupByStep(segments));
 
   const lastGroupIdx = stepGroups.length - 1;
   let lastTextSegIdxInLastGroup = -1;

--- a/libs/ui/src/ai/chat-message.tsx
+++ b/libs/ui/src/ai/chat-message.tsx
@@ -366,6 +366,79 @@ function groupByStep(segments: PartSegment[]): PartSegment[][] {
   return groups.filter((g) => g.length > 0);
 }
 
+// ---------------------------------------------------------------------------
+// Sequential tool-call collapsing (prevents O(n²) task-list re-renders)
+// ---------------------------------------------------------------------------
+
+/**
+ * Tools whose sequential step-calls should be collapsed into a single render.
+ *
+ * When an agent calls one of these tools N times in consecutive steps (each step
+ * containing only that tool call with no other meaningful content), only the final
+ * call's output is displayed. This prevents the O(n²) stacking of full-list
+ * snapshots that occurs when tools like TodoWrite return the complete current state
+ * on every invocation — see protoLabsAI/protoCLI#42.
+ */
+const SEQUENTIAL_COLLAPSE_TOOLS = new Set(['TodoWrite']);
+
+/**
+ * Returns true when a step group contains exactly one segment that is a single
+ * tool-group call from SEQUENTIAL_COLLAPSE_TOOLS, with no other meaningful content.
+ */
+function isSingleCollapsibleToolGroup(group: PartSegment[]): boolean {
+  if (group.length !== 1) return false;
+  const seg = group[0];
+  if (seg.kind !== 'tool-group') return false;
+  if (seg.tools.length !== 1) return false;
+  return SEQUENTIAL_COLLAPSE_TOOLS.has(seg.tools[0].toolName);
+}
+
+/**
+ * Collapse consecutive step groups that each contain only a single call to a
+ * collapsible tool (e.g. TodoWrite).
+ *
+ * Keeps the final group's tool data (latest / complete state) but preserves the
+ * first group's segKey so React reuses the existing component instance rather than
+ * unmounting and remounting it on every new task — equivalent to Ink's rerender().
+ */
+function collapseSequentialToolGroups(groups: PartSegment[][]): PartSegment[][] {
+  const result: PartSegment[][] = [];
+  let i = 0;
+
+  while (i < groups.length) {
+    // Collect a consecutive run of collapsible single-tool groups
+    const runStart = i;
+    while (i < groups.length && isSingleCollapsibleToolGroup(groups[i])) {
+      i++;
+    }
+
+    const runLength = i - runStart;
+
+    if (runLength > 1) {
+      // Multiple consecutive collapsible groups — show only the final state,
+      // but preserve the first group's segKey and toolCallId so React reuses
+      // the existing component instance rather than unmounting it.
+      const firstSeg = groups[runStart][0];
+      const lastSeg = groups[i - 1][0];
+      if (firstSeg.kind === 'tool-group' && lastSeg.kind === 'tool-group') {
+        const lastTool = lastSeg.tools[0];
+        const mergedTool = { ...lastTool, toolCallId: firstSeg.tools[0].toolCallId };
+        result.push([{ kind: 'tool-group', tools: [mergedTool], segKey: firstSeg.segKey }]);
+      }
+    } else if (runLength === 1) {
+      result.push(groups[runStart]);
+    }
+
+    // Add the non-collapsible group that broke the run (if any)
+    if (i < groups.length) {
+      result.push(groups[i]);
+      i++;
+    }
+  }
+
+  return result;
+}
+
 export function ChatMessage({
   message,
   className,
@@ -443,9 +516,10 @@ export function ChatMessage({
   // Extract server-resolved citations from data-citations parts
   const citations = extractCitations(rawParts);
 
-  // Build grouped segments and split at step boundaries into separate bubbles
+  // Build grouped segments, split at step boundaries, then collapse consecutive
+  // single-TodoWrite groups to prevent O(n²) task-list re-renders (protoCLI#42).
   const segments = buildSegments(rawParts);
-  const stepGroups = groupByStep(segments);
+  const stepGroups = collapseSequentialToolGroups(groupByStep(segments));
 
   // Find the index of the last 'other' text segment in the last group,
   // used to place the streaming cursor only on the final text part.


### PR DESCRIPTION
## Summary

## RCA

When the agent creates multiple tasks sequentially, the task list UI component mounts a fresh full-list snapshot after every `TaskCreate` tool call rather than mutating the existing rendered component. This causes the terminal output to cascade: each new task appended to the plan produces a complete re-render of all prior tasks stacked below the previous render, growing O(n²) in output lines.

## Root cause hypothesis

The task list component is not being reused across sequential renders...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-13T03:13:08.326Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat messages now collapse consecutive identical tool operations into a single display for improved readability and cleaner message rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->