### PR TITLE
fix(ci): PR #3390 — "checks" and "test" workflows failing on feat(ux) task list in-place re-render

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3210,8 +3210,10 @@ Format your response as a structured markdown document.`;
 
           let baseBranch = `origin/${resolvedPrBaseBranch}`;
           if (feature?.epicId && !feature.isEpic) {
+            // Hoist epicFeature so it's accessible in the catch block for error reporting
+            let epicFeature: Awaited<ReturnType<typeof this.featureLoader.get>> | undefined;
             try {
-              const epicFeature = await this.featureLoader.get(projectPath, feature.epicId);
+              epicFeature = await this.featureLoader.get(projectPath, feature.epicId);
               if (epicFeature?.branchName) {
                 const epicBranch = epicFeature.branchName;
                 // Fetch the epic branch from remote to ensure we have up-to-date refs.

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -3395,6 +3395,7 @@ After generating the revised spec, output:
       const DEGENERATE_RUNTIME_MS = 10_000;
       const elapsedRuntimeMs = Date.now() - streamStartTime;
       if (
+        !process.env.AUTOMAKER_MOCK_AGENT &&
         runCostUsd <= DEGENERATE_COST_THRESHOLD &&
         responseText.length < DEGENERATE_OUTPUT_CHARS &&
         elapsedRuntimeMs < DEGENERATE_RUNTIME_MS

--- a/apps/server/tests/integration/services/auto-mode-service.integration.test.ts
+++ b/apps/server/tests/integration/services/auto-mode-service.integration.test.ts
@@ -35,6 +35,9 @@ describe('auto-mode-service.ts (integration)', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    // Integration tests use mock providers that produce zero-cost, short, fast responses.
+    // Set AUTOMAKER_MOCK_AGENT to bypass the degenerate-success heuristic in execution-service.
+    vi.stubEnv('AUTOMAKER_MOCK_AGENT', 'true');
     mockEvents.on.mockReturnValue({ unsubscribe: vi.fn() });
     service = new AutoModeService(mockEvents as any);
     featureLoader = new FeatureLoader();

--- a/apps/server/tests/unit/routes/webhook-pr-merge-source-check.test.ts
+++ b/apps/server/tests/unit/routes/webhook-pr-merge-source-check.test.ts
@@ -22,13 +22,17 @@ let mockExecImpl: (
   cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
 ) => void;
 
-vi.mock('child_process', () => ({
-  exec: (
-    cmd: string,
-    opts: unknown,
-    cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
-  ) => mockExecImpl(cmd, opts, cb),
-}));
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    exec: (
+      cmd: string,
+      opts: unknown,
+      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
+    ) => mockExecImpl(cmd, opts, cb),
+  };
+});
 
 const mockFeatureLoaderUpdate = vi.fn().mockResolvedValue(undefined);
 const mockFeatureLoaderGet = vi.fn();

--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -286,7 +286,11 @@ describe('FeatureLoader.generateBranchName with category', () => {
   });
 
   it('uses feature/ prefix when category is Uncategorized and title is not a fix', () => {
-    const branch = loader.generateBranchName('Add dashboard', 'feature-123-abc1234', 'Uncategorized');
+    const branch = loader.generateBranchName(
+      'Add dashboard',
+      'feature-123-abc1234',
+      'Uncategorized'
+    );
     expect(branch).toMatch(/^feature\//);
   });
 });


### PR DESCRIPTION
## Summary

## Root Cause Analysis

PR #3390 (`feat(ux): issue #42 — re-render task list in-place during sequential task creation`) has two CI workflows failing:

- **`checks`** — composite gate: FAILURE
- **`test`** — FAILURE

The branch (`feature/featux-issue-42-re-render-task-list-in-place-k5gsxk2`) uses the correct `feature/` prefix for a feature PR, so this is **not** a source-branch policy violation. The failures are most likely caused by broken or missing tests for the new in-place task list re-rende...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-13T03:30:39.747Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error reporting when creating branches for epic-related features to include epic branch details in error messages for improved debugging.

* **Tests**
  * Updated integration and unit test infrastructure to properly configure mock mode behavior.
  * Improved mock setup in child process testing to preserve original module implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->