### PR TITLE
fix(ci): PR #3395 — feature/ prefix on chore(infra) branch triggers source-branch policy rejection and cascading checks/test gate failures

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -328,17 +328,36 @@ export class FeatureLoader implements FeatureStore {
     // Category takes priority when it maps to a specific non-default prefix.
     // When the category is unknown or maps to the default "feature" prefix (e.g.
     // "Uncategorized"), fall through to title detection — this prevents the
-    // "Uncategorized" default from masking fix(ci): / fixci: titles and emitting
-    // a wrong feature/ prefix (root cause of recurring source-branch CI failures).
+    // "Uncategorized" default from masking fix(ci): / fixci: / chore(infra): titles and
+    // emitting a wrong feature/ prefix (root cause of recurring source-branch CI failures).
     let prefix: string;
     const catPrefix = category ? this.branchPrefixForCategory(category) : null;
     if (catPrefix && catPrefix !== 'feature') {
       prefix = catPrefix;
-    } else if (title && /^fix([a-z0-9-]{0,15}|\([^)]*\))?!?:/.test(title.trim())) {
-      // Matches: fix:, fix(scope):, fix!:, fix(scope)!:
-      // Also matches concatenated scope variants: fixci:, fix-ci:, fixup:
-      // (agents sometimes omit parentheses when writing fix(scope): commit types)
-      prefix = 'fix';
+    } else if (title) {
+      // Detect conventional-commit type from title when category doesn't give a specific prefix.
+      // Pattern matches: type:, type(scope):, type!:, type(scope)!:
+      // Also matches concatenated scope variants: fixci:, choreinfra: (agents sometimes omit parens)
+      const ccMatch = title
+        .trim()
+        .match(/^(fix|chore|docs|refactor|test|perf|style|ci|build|revert)([a-z0-9-]{0,15}|\([^)]*\))?!?:/);
+      if (ccMatch) {
+        const type = ccMatch[1];
+        if (type === 'fix' || type === 'revert') {
+          prefix = 'fix';
+        } else if (type === 'chore' || type === 'ci' || type === 'build') {
+          prefix = 'chore';
+        } else if (type === 'docs') {
+          prefix = 'docs';
+        } else if (type === 'refactor') {
+          prefix = 'refactor';
+        } else {
+          // test, perf, style → fall back to category default
+          prefix = catPrefix ?? 'feature';
+        }
+      } else {
+        prefix = catPrefix ?? 'feature';
+      }
     } else {
       prefix = catPrefix ?? 'feature';
     }

--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -293,4 +293,51 @@ describe('FeatureLoader.generateBranchName with category', () => {
     );
     expect(branch).toMatch(/^feature\//);
   });
+
+  it('uses chore/ prefix when category is Uncategorized but title starts with chore(infra):', () => {
+    // Regression: chore(infra): titles were getting feature/ prefix because title detection
+    // only handled fix: variants. Root cause of PR #3395 source-branch CI failure.
+    const branch = loader.generateBranchName(
+      'chore(infra): issue #11 — add branch protection ruleset to ava/main',
+      'feature-1776060855702-pxszngw6b',
+      'Uncategorized'
+    );
+    expect(branch).toMatch(/^chore\//);
+  });
+
+  it('uses chore/ prefix when category is Uncategorized but title starts with chore:', () => {
+    const branch = loader.generateBranchName(
+      'chore: update CI config',
+      'feature-123-abc1234',
+      'Uncategorized'
+    );
+    expect(branch).toMatch(/^chore\//);
+  });
+
+  it('uses chore/ prefix when category is Uncategorized but title starts with choreinfra: (concatenated scope)', () => {
+    const branch = loader.generateBranchName(
+      'choreinfra: add branch protection',
+      'feature-123-abc1234',
+      'Uncategorized'
+    );
+    expect(branch).toMatch(/^chore\//);
+  });
+
+  it('uses docs/ prefix when category is Uncategorized but title starts with docs:', () => {
+    const branch = loader.generateBranchName(
+      'docs: update contributing guide',
+      'feature-123-abc1234',
+      'Uncategorized'
+    );
+    expect(branch).toMatch(/^docs\//);
+  });
+
+  it('uses refactor/ prefix when category is Uncategorized but title starts with refactor:', () => {
+    const branch = loader.generateBranchName(
+      'refactor: extract auth service',
+      'feature-123-abc1234',
+      'Uncategorized'
+    );
+    expect(branch).toMatch(/^refactor\//);
+  });
 });


### PR DESCRIPTION
## Summary

## RCA

PR #3395 ("chore(infra): issue #11 — add branch protection ruleset to ava/main") is failing CI because the branch is named `feature/choreinfra-issue-11-add-branch-protection-ruleset-xekdmyn`, which uses the `feature/` prefix. The source-branch policy enforces that `chore` / `infra` PRs must not use the `feature/` prefix; this rejection causes the `checks` composite gate to fail, which in turn causes the `test` workflow to fail.

## Failing workflows
- `checks` — FAILURE (source-branch po...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-13T06:18:57.636Z -->