### PR TITLE
fix(ci): PR #3397 — "test" and "checks" workflows failing; webhook source-check mock resilience patch introduces or fails to resolve test suite breakage

### DIFF
--- a/apps/server/tests/unit/routes/webhook-pr-merge-source-check.test.ts
+++ b/apps/server/tests/unit/routes/webhook-pr-merge-source-check.test.ts
@@ -39,37 +39,31 @@ const mockFeatureLoaderGet = vi.fn();
 const mockFeatureLoaderGetAll = vi.fn().mockResolvedValue([]);
 
 vi.mock('@/services/feature-loader.js', () => ({
-  FeatureLoader: vi.fn().mockImplementation(() => ({
-    getAll: mockFeatureLoaderGetAll,
-    get: mockFeatureLoaderGet,
-    update: mockFeatureLoaderUpdate,
-    findByBranch: vi.fn().mockResolvedValue(null),
-  })),
+  FeatureLoader: vi.fn(),
 }));
 
 vi.mock('@/services/staging-promotion-service.js', () => ({
-  StagingPromotionService: vi.fn().mockImplementation(() => ({
-    detectDevMerge: vi.fn().mockReturnValue(false),
-    createCandidate: vi.fn(),
-  })),
+  StagingPromotionService: vi.fn(),
 }));
 
 vi.mock('@/lib/webhook-signature.js', () => ({
-  verifyWebhookSignature: vi.fn().mockReturnValue({ valid: true }),
+  verifyWebhookSignature: vi.fn(),
 }));
 
 vi.mock('@/services/pr-watcher-service.js', () => ({
-  getPRWatcherService: vi.fn().mockReturnValue({
-    isWatching: vi.fn().mockReturnValue(false),
-    triggerCheck: vi.fn().mockResolvedValue(undefined),
-  }),
+  getPRWatcherService: vi.fn(),
 }));
 
 vi.mock('@/services/webhook-delivery-service.js', () => ({
-  getWebhookDeliveryService: vi.fn().mockReturnValue(null),
+  getWebhookDeliveryService: vi.fn(),
 }));
 
 import { createGitHubWebhookHandler } from '@/routes/webhooks/routes/github.js';
+import { FeatureLoader } from '@/services/feature-loader.js';
+import { StagingPromotionService } from '@/services/staging-promotion-service.js';
+import { verifyWebhookSignature } from '@/lib/webhook-signature.js';
+import { getPRWatcherService } from '@/services/pr-watcher-service.js';
+import { getWebhookDeliveryService } from '@/services/webhook-delivery-service.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -130,6 +124,29 @@ describe('PR merge source-code verification gate', () => {
     vi.clearAllMocks();
     events = new EventEmitter();
     settingsService = buildSettingsService();
+
+    // Re-apply mock implementations cleared by mockReset: true in vitest config.
+    vi.mocked(FeatureLoader).mockImplementation(() => ({
+      getAll: mockFeatureLoaderGetAll,
+      get: mockFeatureLoaderGet,
+      update: mockFeatureLoaderUpdate,
+      findByBranch: vi.fn().mockResolvedValue(null),
+      findByPRNumber: vi.fn().mockResolvedValue(null),
+    }));
+
+    vi.mocked(StagingPromotionService).mockImplementation(() => ({
+      detectDevMerge: vi.fn().mockReturnValue(false),
+      createCandidate: vi.fn(),
+    }));
+
+    vi.mocked(verifyWebhookSignature).mockReturnValue({ valid: true });
+
+    vi.mocked(getPRWatcherService).mockReturnValue({
+      isWatching: vi.fn().mockReturnValue(false),
+      triggerCheck: vi.fn().mockResolvedValue(undefined),
+    } as any);
+
+    vi.mocked(getWebhookDeliveryService).mockReturnValue(null as any);
 
     // Default exec: git diff returns empty, gh pr list returns []
     mockExecImpl = (_cmd, _opts, cb) => {


### PR DESCRIPTION
## Summary

## Root Cause Analysis

PR #3397 ("fix(test): make webhook source-check mocks resilient to mockReset") is intended to harden webhook source-check mocks against `mockReset` calls, but the `test` and `checks` CI workflows are both failing on head `a9d75fe`.

**Branch:** `fix/webhook-source-check-test-mock-reset` (correct `fix/` prefix — source-branch policy is NOT the issue here)
**Failing workflows:** `checks` (composite gate), `test`
**Pending:** 1 additional check still pending

The most likely...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-13T07:07:43.286Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test suite setup for improved test isolation and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->