### PR TITLE
feat(pr-remediator): issue #149 — close-and-recut strategy for conflicting PRs

### DIFF
--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -160,6 +160,14 @@ export class ReviewProcessor implements StateProcessor {
       };
     }
 
+    // Detect merge conflicts before normalizing or evaluating review state.
+    // A CONFLICTING PR can never be auto-merged. Retrying fix_ci or update_branch
+    // wastes budget and fires false-positive HITL alerts. Instead, close and re-queue.
+    const mergeableState = await this.getMergeableState(ctx);
+    if (mergeableState === 'CONFLICTING') {
+      return this.handleConflictingPR(ctx);
+    }
+
     // Normalize PR: patch ownership watermark and enable auto-merge if missing
     await this.normalizePR(ctx);
 
@@ -566,6 +574,103 @@ export class ReviewProcessor implements StateProcessor {
       logger.warn('[REVIEW] Fresh-eyes review failed, proceeding without review', err);
       return 'skipped';
     }
+  }
+
+  /**
+   * Query GitHub for the PR's mergeable state.
+   * Returns 'CONFLICTING', 'MERGEABLE', 'UNKNOWN', or null on error.
+   */
+  private async getMergeableState(ctx: StateContext): Promise<string | null> {
+    if (!ctx.prNumber) return null;
+    try {
+      const { stdout } = await execAsync(
+        `gh pr view ${ctx.prNumber} --json mergeable --jq '.mergeable'`,
+        { cwd: ctx.projectPath, timeout: 10000 }
+      );
+      // GitHub returns a quoted JSON string — strip quotes and whitespace
+      return stdout.trim().replace(/^"|"$/g, '') || null;
+    } catch (err) {
+      logger.debug('[REVIEW] getMergeableState: gh CLI failed, skipping conflict check', err);
+      return null;
+    }
+  }
+
+  /**
+   * Handle a PR that has unresolvable merge conflicts (mergeable: CONFLICTING).
+   *
+   * 1. Post an explanatory comment on the PR.
+   * 2. Close the PR.
+   * 3. If the feature's branch already has a merged PR (race: both agents landed),
+   *    mark the feature done.
+   * 4. Otherwise, reset the feature to backlog so the next auto-mode cycle re-cuts
+   *    a fresh branch from the current base branch. No HITL escalation.
+   */
+  private async handleConflictingPR(ctx: StateContext): Promise<StateTransitionResult> {
+    logger.info('[REVIEW] PR has merge conflicts — closing and re-queuing to backlog', {
+      featureId: ctx.feature.id,
+      prNumber: ctx.prNumber,
+    });
+
+    const comment =
+      `This PR has merge conflicts with the base branch and cannot be auto-merged.\n\n` +
+      `Closing and re-queuing the feature to backlog so it will be re-cut from the ` +
+      `current base branch on the next auto-mode cycle.`;
+
+    try {
+      await execAsync(`gh pr comment ${ctx.prNumber} --body ${JSON.stringify(comment)}`, {
+        cwd: ctx.projectPath,
+        timeout: 15000,
+      });
+    } catch (err) {
+      logger.warn('[REVIEW] handleConflictingPR: failed to post conflict comment', err);
+    }
+
+    try {
+      await execAsync(`gh pr close ${ctx.prNumber}`, {
+        cwd: ctx.projectPath,
+        timeout: 15000,
+      });
+      logger.info(`[REVIEW] Closed conflicting PR #${ctx.prNumber}`);
+    } catch (err) {
+      logger.warn('[REVIEW] handleConflictingPR: failed to close PR', err);
+    }
+
+    // If the branch already has a merged PR (e.g. a parallel agent landed the same fix),
+    // mark the feature done instead of re-filing.
+    const alreadyMerged = await this.checkBranchMerged(ctx);
+    if (alreadyMerged) {
+      logger.info('[REVIEW] Branch already merged — marking feature done (superseded)', {
+        featureId: ctx.feature.id,
+      });
+      await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
+        status: 'done',
+      });
+      this.serviceContext.events.emit('feature:pr-merged' as EventType, {
+        featureId: ctx.feature.id,
+        prNumber: ctx.prNumber,
+        projectPath: ctx.projectPath,
+      });
+      return {
+        nextState: null,
+        shouldContinue: false,
+        reason: 'PR conflicting but branch already merged — marked done (superseded)',
+      };
+    }
+
+    // Reset to backlog for re-cut — no HITL escalation
+    await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
+      status: 'backlog',
+    });
+    logger.info('[REVIEW] Feature reset to backlog for re-cut from fresh base', {
+      featureId: ctx.feature.id,
+      prNumber: ctx.prNumber,
+    });
+
+    return {
+      nextState: null,
+      shouldContinue: false,
+      reason: 'PR closed due to merge conflicts — feature re-queued to backlog',
+    };
   }
 
   /**

--- a/apps/server/tests/unit/services/lead-engineer-review-processor.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-review-processor.test.ts
@@ -1,9 +1,12 @@
 /**
- * Unit tests for ReviewProcessor — external merge detection and early-exit paths
+ * Unit tests for ReviewProcessor — external merge detection, early-exit paths,
+ * and close_and_recut remediation for CONFLICTING PRs.
  *
  * Covers:
  * 1. Feature in REVIEW + PR merged externally → processor detects merge and returns DONE
  * 2. Feature already `done` → REVIEW process() is a no-op (returns immediately)
+ * 3. PR is CONFLICTING → closes PR, posts comment, resets feature to backlog (no HITL)
+ * 4. PR is CONFLICTING + branch already merged → marks feature done (superseded)
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -157,5 +160,126 @@ describe('ReviewProcessor — external merge detection', () => {
     );
     expect(nonReviewStartCalls).toHaveLength(0);
     expect(serviceCtx.events.emit).not.toHaveBeenCalled();
+  });
+});
+
+// ── close_and_recut tests ─────────────────────────────────────────────────────
+
+describe('ReviewProcessor — close_and_recut for CONFLICTING PRs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('CONFLICTING PR → closes PR with comment and resets feature to backlog (no HITL)', async () => {
+    const feature = makeFeature({ status: 'review', branchName: 'fix/test-fix' });
+    const serviceCtx = makeServiceContext({ status: 'review', branchName: 'fix/test-fix' });
+    (serviceCtx.featureLoader.get as ReturnType<typeof vi.fn>).mockResolvedValue(feature);
+
+    // Call sequence:
+    // 1. getMergeableState: returns CONFLICTING
+    // 2. gh pr comment: success
+    // 3. gh pr close: success
+    // 4. checkBranchMerged (gh pr list): returns '' (not merged)
+    mockExecAsync
+      .mockResolvedValueOnce({ stdout: '"CONFLICTING"', stderr: '' }) // getMergeableState
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh pr comment
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh pr close
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }); // checkBranchMerged
+
+    const processor = new ReviewProcessor(serviceCtx);
+    const ctx = makeCtx(feature, 42);
+    await processor.enter(ctx);
+    const result = await processor.process(ctx);
+
+    // Should terminate cleanly — no HITL escalation
+    expect(result.shouldContinue).toBe(false);
+    expect(result.nextState).toBeNull();
+    expect(result.reason).toMatch(/backlog/i);
+
+    // Should have closed the PR
+    const execCalls = mockExecAsync.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(execCalls.some((cmd) => cmd.includes('gh pr close 42'))).toBe(true);
+    expect(execCalls.some((cmd) => cmd.includes('gh pr comment 42'))).toBe(true);
+
+    // Feature should be reset to backlog, not blocked or escalated
+    expect(serviceCtx.featureLoader.update).toHaveBeenCalledWith(
+      '/test/project',
+      'feat-review-001',
+      { status: 'backlog' }
+    );
+
+    // Should NOT have emitted a merge event
+    expect(serviceCtx.events.emit).not.toHaveBeenCalledWith(
+      'feature:pr-merged',
+      expect.anything()
+    );
+  });
+
+  it('CONFLICTING PR + branch already merged → marks feature done (superseded)', async () => {
+    const feature = makeFeature({ status: 'review', branchName: 'fix/test-fix' });
+    const serviceCtx = makeServiceContext({ status: 'review', branchName: 'fix/test-fix' });
+    (serviceCtx.featureLoader.get as ReturnType<typeof vi.fn>).mockResolvedValue(feature);
+
+    // Call sequence:
+    // 1. getMergeableState: CONFLICTING
+    // 2. gh pr comment: success
+    // 3. gh pr close: success
+    // 4. checkBranchMerged (gh pr list): returns a mergedAt timestamp → merged
+    mockExecAsync
+      .mockResolvedValueOnce({ stdout: '"CONFLICTING"', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '2024-01-15T12:00:00Z\n', stderr: '' });
+
+    const processor = new ReviewProcessor(serviceCtx);
+    const ctx = makeCtx(feature, 42);
+    await processor.enter(ctx);
+    const result = await processor.process(ctx);
+
+    // Should terminate cleanly
+    expect(result.shouldContinue).toBe(false);
+    expect(result.nextState).toBeNull();
+    expect(result.reason).toMatch(/superseded|done/i);
+
+    // Feature should be marked done, not backlog
+    expect(serviceCtx.featureLoader.update).toHaveBeenCalledWith(
+      '/test/project',
+      'feat-review-001',
+      { status: 'done' }
+    );
+
+    // Should have emitted the merge event
+    expect(serviceCtx.events.emit).toHaveBeenCalledWith(
+      'feature:pr-merged',
+      expect.objectContaining({ featureId: 'feat-review-001' })
+    );
+  });
+
+  it('non-CONFLICTING PR (MERGEABLE) → continues normal REVIEW flow (no close)', async () => {
+    const feature = makeFeature({ status: 'review', branchName: 'fix/test-fix' });
+    const serviceCtx = makeServiceContext({ status: 'review', branchName: 'fix/test-fix' });
+    (serviceCtx.featureLoader.get as ReturnType<typeof vi.fn>).mockResolvedValue(feature);
+
+    // getMergeableState returns MERGEABLE — should NOT trigger close_and_recut
+    // subsequent calls handle normalizePR, getPRReviewState, etc.
+    mockExecAsync
+      .mockResolvedValueOnce({ stdout: '"MERGEABLE"', stderr: '' }) // getMergeableState
+      .mockResolvedValue({ stdout: '{"body":"","autoMerge":false}', stderr: '' }); // normalizePR etc.
+
+    const processor = new ReviewProcessor(serviceCtx);
+    const ctx = makeCtx(feature, 42);
+    await processor.enter(ctx);
+    await processor.process(ctx);
+
+    // Should NOT have called gh pr close
+    const execCalls = mockExecAsync.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(execCalls.some((cmd) => cmd.includes('gh pr close'))).toBe(false);
+
+    // Feature should NOT have been reset to backlog by close_and_recut
+    const updateCalls = (serviceCtx.featureLoader.update as ReturnType<typeof vi.fn>).mock.calls;
+    const backlogReset = updateCalls.filter(
+      (call: unknown[]) => (call[2] as Record<string, unknown>)?.status === 'backlog'
+    );
+    expect(backlogReset).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

## Source
Issue filed by @mabry1985 (trust tier 1): protoLabsAI/protoWorkstacean#149
https://github.com/protoLabsAI/protoWorkstacean/issues/149

## Root Cause
When a PR enters `CONFLICTING` state, pr-remediator retries `fix_ci` (3x) and `update_branch` (3x) before escalating to HITL. Neither action can resolve merge conflicts — `update_branch` is rejected by GitHub, and `fix_ci` dispatches to Ava who lacks force-push access. This produces 6 failed attempts + 3 HITL escalation messages for a know...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced merge conflict handling for pull requests. The system now detects when a PR has merge conflicts, automatically posts a notification comment, closes the conflicted PR, and resets the feature status to allow reprocessing in the next cycle. If a branch was already merged before conflict detection, the feature is appropriately marked complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->