### PR TITLE
fix(test): correct mock call order for close-and-recut tests (PR #3400 CI fix)

### DIFF
--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -160,6 +160,14 @@ export class ReviewProcessor implements StateProcessor {
       };
     }
 
+    // Detect merge conflicts before normalizing or evaluating review state.
+    // A CONFLICTING PR can never be auto-merged. Retrying fix_ci or update_branch
+    // wastes budget and fires false-positive HITL alerts. Instead, close and re-queue.
+    const mergeableState = await this.getMergeableState(ctx);
+    if (mergeableState === 'CONFLICTING') {
+      return this.handleConflictingPR(ctx);
+    }
+
     // Normalize PR: patch ownership watermark and enable auto-merge if missing
     await this.normalizePR(ctx);
 
@@ -566,6 +574,103 @@ export class ReviewProcessor implements StateProcessor {
       logger.warn('[REVIEW] Fresh-eyes review failed, proceeding without review', err);
       return 'skipped';
     }
+  }
+
+  /**
+   * Query GitHub for the PR's mergeable state.
+   * Returns 'CONFLICTING', 'MERGEABLE', 'UNKNOWN', or null on error.
+   */
+  private async getMergeableState(ctx: StateContext): Promise<string | null> {
+    if (!ctx.prNumber) return null;
+    try {
+      const { stdout } = await execAsync(
+        `gh pr view ${ctx.prNumber} --json mergeable --jq '.mergeable'`,
+        { cwd: ctx.projectPath, timeout: 10000 }
+      );
+      // GitHub returns a quoted JSON string — strip quotes and whitespace
+      return stdout.trim().replace(/^"|"$/g, '') || null;
+    } catch (err) {
+      logger.debug('[REVIEW] getMergeableState: gh CLI failed, skipping conflict check', err);
+      return null;
+    }
+  }
+
+  /**
+   * Handle a PR that has unresolvable merge conflicts (mergeable: CONFLICTING).
+   *
+   * 1. Post an explanatory comment on the PR.
+   * 2. Close the PR.
+   * 3. If the feature's branch already has a merged PR (race: both agents landed),
+   *    mark the feature done.
+   * 4. Otherwise, reset the feature to backlog so the next auto-mode cycle re-cuts
+   *    a fresh branch from the current base branch. No HITL escalation.
+   */
+  private async handleConflictingPR(ctx: StateContext): Promise<StateTransitionResult> {
+    logger.info('[REVIEW] PR has merge conflicts — closing and re-queuing to backlog', {
+      featureId: ctx.feature.id,
+      prNumber: ctx.prNumber,
+    });
+
+    const comment =
+      `This PR has merge conflicts with the base branch and cannot be auto-merged.\n\n` +
+      `Closing and re-queuing the feature to backlog so it will be re-cut from the ` +
+      `current base branch on the next auto-mode cycle.`;
+
+    try {
+      await execAsync(`gh pr comment ${ctx.prNumber} --body ${JSON.stringify(comment)}`, {
+        cwd: ctx.projectPath,
+        timeout: 15000,
+      });
+    } catch (err) {
+      logger.warn('[REVIEW] handleConflictingPR: failed to post conflict comment', err);
+    }
+
+    try {
+      await execAsync(`gh pr close ${ctx.prNumber}`, {
+        cwd: ctx.projectPath,
+        timeout: 15000,
+      });
+      logger.info(`[REVIEW] Closed conflicting PR #${ctx.prNumber}`);
+    } catch (err) {
+      logger.warn('[REVIEW] handleConflictingPR: failed to close PR', err);
+    }
+
+    // If the branch already has a merged PR (e.g. a parallel agent landed the same fix),
+    // mark the feature done instead of re-filing.
+    const alreadyMerged = await this.checkBranchMerged(ctx);
+    if (alreadyMerged) {
+      logger.info('[REVIEW] Branch already merged — marking feature done (superseded)', {
+        featureId: ctx.feature.id,
+      });
+      await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
+        status: 'done',
+      });
+      this.serviceContext.events.emit('feature:pr-merged' as EventType, {
+        featureId: ctx.feature.id,
+        prNumber: ctx.prNumber,
+        projectPath: ctx.projectPath,
+      });
+      return {
+        nextState: null,
+        shouldContinue: false,
+        reason: 'PR conflicting but branch already merged — marked done (superseded)',
+      };
+    }
+
+    // Reset to backlog for re-cut — no HITL escalation
+    await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
+      status: 'backlog',
+    });
+    logger.info('[REVIEW] Feature reset to backlog for re-cut from fresh base', {
+      featureId: ctx.feature.id,
+      prNumber: ctx.prNumber,
+    });
+
+    return {
+      nextState: null,
+      shouldContinue: false,
+      reason: 'PR closed due to merge conflicts — feature re-queued to backlog',
+    };
   }
 
   /**

--- a/apps/server/tests/unit/services/lead-engineer-review-merge-processors.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-review-merge-processors.test.ts
@@ -187,13 +187,15 @@ describe('ReviewProcessor', () => {
     function setupCiFailureExecMock(ciCheckName = 'CI / test') {
       mockExec.mockReset();
       mockExec
-        // Call 1: normalizePR fails → caught, returns early
+        // Call 1: getMergeableState → not conflicting (no branchName so checkBranchMerged is skipped)
+        .mockImplementationOnce(execSuccess({ stdout: '"MERGEABLE"', stderr: '' }))
+        // Call 2: normalizePR fails → caught, returns early
         .mockImplementationOnce(execFailure(new Error('normalizePR network error')))
-        // Call 2: merge check — PR is OPEN
+        // Call 3: merge check — PR is OPEN
         .mockImplementationOnce(
           execSuccess({ stdout: JSON.stringify({ state: 'OPEN', mergedAt: null }), stderr: '' })
         )
-        // Call 3: main review state check — CI failure
+        // Call 4: main review state check — CI failure
         .mockImplementationOnce(
           execSuccess({
             stdout: JSON.stringify({
@@ -204,7 +206,7 @@ describe('ReviewProcessor', () => {
             stderr: '',
           })
         )
-        // Call 4: fetch CI failure names
+        // Call 5: fetch CI failure names
         .mockImplementationOnce(execSuccess({ stdout: ciCheckName, stderr: '' }));
     }
 
@@ -263,13 +265,15 @@ describe('ReviewProcessor', () => {
       vi.useFakeTimers();
       mockExec.mockReset();
       mockExec
-        // Call 1: normalizePR fails
+        // Call 1: getMergeableState → not conflicting (no branchName so checkBranchMerged is skipped)
+        .mockImplementationOnce(execSuccess({ stdout: '"MERGEABLE"', stderr: '' }))
+        // Call 2: normalizePR fails
         .mockImplementationOnce(execFailure(new Error('network')))
-        // Call 2: merge check
+        // Call 3: merge check
         .mockImplementationOnce(
           execSuccess({ stdout: JSON.stringify({ state: 'OPEN', mergedAt: null }), stderr: '' })
         )
-        // Call 3: CodeRabbit fails, no human approval yet
+        // Call 4: CodeRabbit fails, no human approval yet
         .mockImplementationOnce(
           execSuccess({
             stdout: JSON.stringify({

--- a/apps/server/tests/unit/services/lead-engineer-review-processor.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-review-processor.test.ts
@@ -1,9 +1,12 @@
 /**
- * Unit tests for ReviewProcessor — external merge detection and early-exit paths
+ * Unit tests for ReviewProcessor — external merge detection, early-exit paths,
+ * and close_and_recut remediation for CONFLICTING PRs.
  *
  * Covers:
  * 1. Feature in REVIEW + PR merged externally → processor detects merge and returns DONE
  * 2. Feature already `done` → REVIEW process() is a no-op (returns immediately)
+ * 3. PR is CONFLICTING → closes PR, posts comment, resets feature to backlog (no HITL)
+ * 4. PR is CONFLICTING + branch already merged → marks feature done (superseded)
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -157,5 +160,131 @@ describe('ReviewProcessor — external merge detection', () => {
     );
     expect(nonReviewStartCalls).toHaveLength(0);
     expect(serviceCtx.events.emit).not.toHaveBeenCalled();
+  });
+});
+
+// ── close_and_recut tests ─────────────────────────────────────────────────────
+
+describe('ReviewProcessor — close_and_recut for CONFLICTING PRs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('CONFLICTING PR → closes PR with comment and resets feature to backlog (no HITL)', async () => {
+    const feature = makeFeature({ status: 'review', branchName: 'fix/test-fix' });
+    const serviceCtx = makeServiceContext({ status: 'review', branchName: 'fix/test-fix' });
+    (serviceCtx.featureLoader.get as ReturnType<typeof vi.fn>).mockResolvedValue(feature);
+
+    // Call sequence:
+    // 1. checkBranchMerged (gh pr list): returns '' (not merged)
+    // 2. getMergeableState: returns CONFLICTING
+    // 3. gh pr comment: success
+    // 4. gh pr close: success
+    // 5. checkBranchMerged (inside handleConflictingPR): returns '' (not merged)
+    mockExecAsync
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // checkBranchMerged → not merged
+      .mockResolvedValueOnce({ stdout: '"CONFLICTING"', stderr: '' }) // getMergeableState
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh pr comment
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh pr close
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }); // checkBranchMerged (inside handleConflictingPR)
+
+    const processor = new ReviewProcessor(serviceCtx);
+    const ctx = makeCtx(feature, 42);
+    await processor.enter(ctx);
+    const result = await processor.process(ctx);
+
+    // Should terminate cleanly — no HITL escalation
+    expect(result.shouldContinue).toBe(false);
+    expect(result.nextState).toBeNull();
+    expect(result.reason).toMatch(/backlog/i);
+
+    // Should have closed the PR
+    const execCalls = mockExecAsync.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(execCalls.some((cmd) => cmd.includes('gh pr close 42'))).toBe(true);
+    expect(execCalls.some((cmd) => cmd.includes('gh pr comment 42'))).toBe(true);
+
+    // Feature should be reset to backlog, not blocked or escalated
+    expect(serviceCtx.featureLoader.update).toHaveBeenCalledWith(
+      '/test/project',
+      'feat-review-001',
+      { status: 'backlog' }
+    );
+
+    // Should NOT have emitted a merge event
+    expect(serviceCtx.events.emit).not.toHaveBeenCalledWith(
+      'feature:pr-merged',
+      expect.anything()
+    );
+  });
+
+  it('CONFLICTING PR + branch already merged → marks feature done (superseded)', async () => {
+    const feature = makeFeature({ status: 'review', branchName: 'fix/test-fix' });
+    const serviceCtx = makeServiceContext({ status: 'review', branchName: 'fix/test-fix' });
+    (serviceCtx.featureLoader.get as ReturnType<typeof vi.fn>).mockResolvedValue(feature);
+
+    // Call sequence:
+    // 1. checkBranchMerged (gh pr list): returns '' (not merged)
+    // 2. getMergeableState: CONFLICTING
+    // 3. gh pr comment: success
+    // 4. gh pr close: success
+    // 5. checkBranchMerged (inside handleConflictingPR): returns a mergedAt timestamp → merged
+    mockExecAsync
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // checkBranchMerged → not merged
+      .mockResolvedValueOnce({ stdout: '"CONFLICTING"', stderr: '' }) // getMergeableState
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh pr comment
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh pr close
+      .mockResolvedValueOnce({ stdout: '2024-01-15T12:00:00Z\n', stderr: '' }); // checkBranchMerged (already merged)
+
+    const processor = new ReviewProcessor(serviceCtx);
+    const ctx = makeCtx(feature, 42);
+    await processor.enter(ctx);
+    const result = await processor.process(ctx);
+
+    // Should terminate cleanly
+    expect(result.shouldContinue).toBe(false);
+    expect(result.nextState).toBeNull();
+    expect(result.reason).toMatch(/superseded|done/i);
+
+    // Feature should be marked done, not backlog
+    expect(serviceCtx.featureLoader.update).toHaveBeenCalledWith(
+      '/test/project',
+      'feat-review-001',
+      { status: 'done' }
+    );
+
+    // Should have emitted the merge event
+    expect(serviceCtx.events.emit).toHaveBeenCalledWith(
+      'feature:pr-merged',
+      expect.objectContaining({ featureId: 'feat-review-001' })
+    );
+  });
+
+  it('non-CONFLICTING PR (MERGEABLE) → continues normal REVIEW flow (no close)', async () => {
+    const feature = makeFeature({ status: 'review', branchName: 'fix/test-fix' });
+    const serviceCtx = makeServiceContext({ status: 'review', branchName: 'fix/test-fix' });
+    (serviceCtx.featureLoader.get as ReturnType<typeof vi.fn>).mockResolvedValue(feature);
+
+    // checkBranchMerged runs first (branchName is set), then getMergeableState.
+    // MERGEABLE should NOT trigger close_and_recut — subsequent calls handle normalizePR etc.
+    mockExecAsync
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // checkBranchMerged → not merged
+      .mockResolvedValueOnce({ stdout: '"MERGEABLE"', stderr: '' }) // getMergeableState
+      .mockResolvedValue({ stdout: '{"body":"","autoMerge":false}', stderr: '' }); // normalizePR etc.
+
+    const processor = new ReviewProcessor(serviceCtx);
+    const ctx = makeCtx(feature, 42);
+    await processor.enter(ctx);
+    await processor.process(ctx);
+
+    // Should NOT have called gh pr close
+    const execCalls = mockExecAsync.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(execCalls.some((cmd) => cmd.includes('gh pr close'))).toBe(false);
+
+    // Feature should NOT have been reset to backlog by close_and_recut
+    const updateCalls = (serviceCtx.featureLoader.update as ReturnType<typeof vi.fn>).mock.calls;
+    const backlogReset = updateCalls.filter(
+      (call: unknown[]) => (call[2] as Record<string, unknown>)?.status === 'backlog'
+    );
+    expect(backlogReset).toHaveLength(0);
   });
 });

--- a/apps/server/tests/unit/services/lead-engineer/fresh-eyes-review.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer/fresh-eyes-review.test.ts
@@ -4,12 +4,13 @@
  * Covers PASS, CONCERN, and BLOCK verdict paths.
  *
  * Mock call order in ReviewProcessor.process() when reviewState === 'approved':
- * 1. gh pr list --head ... --state merged   (checkBranchMerged)
- * 2. gh pr view --json body,autoMergeRequest (normalizePR)
- * 3. gh pr view --json state,mergedAt        (getPRReviewState merged fast-path)
- * 4. gh pr view --json reviewDecision,...    (getPRReviewState review decision)
- * 5. gh pr diff                              (runFreshEyesReview)
- * 6. gh pr comment                          (runFreshEyesReview — CONCERN/BLOCK only)
+ * 1. gh pr list --head ... --state merged    (checkBranchMerged)
+ * 2. gh pr view --json mergeStateStatus      (getMergeableState)
+ * 3. gh pr view --json body,autoMergeRequest (normalizePR)
+ * 4. gh pr view --json state,mergedAt        (getPRReviewState merged fast-path)
+ * 5. gh pr view --json reviewDecision,...    (getPRReviewState review decision)
+ * 6. gh pr diff                              (runFreshEyesReview)
+ * 7. gh pr comment                          (runFreshEyesReview — CONCERN/BLOCK only)
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -127,6 +128,7 @@ function workflowSettingsWithFreshEyes(enabled = true, model = 'haiku') {
 function setupApprovedExecMocks(extraCalls: { stdout: string; stderr: string }[] = []) {
   mockExecAsync
     .mockResolvedValueOnce({ stdout: '', stderr: '' }) // checkBranchMerged → not merged
+    .mockResolvedValueOnce({ stdout: '"MERGEABLE"', stderr: '' }) // getMergeableState → not conflicting
     .mockResolvedValueOnce({ stdout: NORMALIZE_RESPONSE, stderr: '' }) // normalizePR body/autoMerge
     .mockResolvedValueOnce({
       stdout: JSON.stringify({ state: 'OPEN', mergedAt: null }),
@@ -147,6 +149,7 @@ function setupApprovedExecMocks(extraCalls: { stdout: string; stderr: string }[]
 function setupApprovedExecMocksDisabled() {
   mockExecAsync
     .mockResolvedValueOnce({ stdout: '', stderr: '' }) // checkBranchMerged
+    .mockResolvedValueOnce({ stdout: '"MERGEABLE"', stderr: '' }) // getMergeableState → not conflicting
     .mockResolvedValueOnce({ stdout: NORMALIZE_RESPONSE, stderr: '' }) // normalizePR
     .mockResolvedValueOnce({
       stdout: JSON.stringify({ state: 'OPEN', mergedAt: null }),


### PR DESCRIPTION
## Summary

- Fixes the `test` and `checks` CI failures for PR #3400 (`feat(pr-remediator): close-and-recut strategy for conflicting PRs`)
- The close-and-recut strategy inserts `getMergeableState()` before `normalizePR()` in `ReviewProcessor.process()`, but three test files had mock sequences that didn't account for this new exec call
- Corrects mock call order in 3 test files without changing any implementation

## Root Cause

`ReviewProcessor.process()` now calls execs in this order:
1. `checkBranchMerged` (if `branchName` set)
2. `getMergeableState` (if `prNumber` set) — **new call added by PR #3400**
3. `normalizePR`
4. `getPRReviewState` (×2)
5. `gh pr diff` (fresh-eyes only)

Tests had stale mock sequences missing step 2, causing downstream mocks to be consumed by the wrong calls and all assertions to fail.

## Files Fixed

- `apps/server/tests/unit/services/lead-engineer-review-processor.test.ts` — Added `checkBranchMerged` mock as first call in all 3 close_and_recut tests
- `apps/server/tests/unit/services/lead-engineer-review-merge-processors.test.ts` — Added `getMergeableState` mock to `setupCiFailureExecMock()` and CodeRabbit test
- `apps/server/tests/unit/services/lead-engineer/fresh-eyes-review.test.ts` — Added `getMergeableState` mock to both `setupApprovedExecMocks()` and `setupApprovedExecMocksDisabled()`

## Test plan

- [ ] `test` CI workflow passes (was failing due to wrong mock ordering)
- [ ] `checks` composite gate passes once `test` is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic handling of pull requests with merge conflicts—conflicting PRs are now automatically closed with an explanatory comment.
  * Features with conflicting pull requests are automatically moved back to backlog for re-cutting, eliminating manual escalation for this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->