### PR TITLE
fix(ci): PR #3401 — "test" and "checks" workflows failing on auto-mode-service integration test patch (status transitions + model name + loop continuation)

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -340,7 +340,9 @@ export class FeatureLoader implements FeatureStore {
       // Also matches concatenated scope variants: fixci:, choreinfra: (agents sometimes omit parens)
       const ccMatch = title
         .trim()
-        .match(/^(fix|chore|docs|refactor|test|perf|style|ci|build|revert)([a-z0-9-]{0,15}|\([^)]*\))?!?:/);
+        .match(
+          /^(fix|chore|docs|refactor|test|perf|style|ci|build|revert)([a-z0-9-]{0,15}|\([^)]*\))?!?:/
+        );
       if (ccMatch) {
         const type = ccMatch[1];
         if (type === 'fix' || type === 'revert') {

--- a/apps/server/tests/unit/routes/webhook-pr-merge-source-check.test.ts
+++ b/apps/server/tests/unit/routes/webhook-pr-merge-source-check.test.ts
@@ -126,18 +126,23 @@ describe('PR merge source-code verification gate', () => {
     settingsService = buildSettingsService();
 
     // Re-apply mock implementations cleared by mockReset: true in vitest config.
-    vi.mocked(FeatureLoader).mockImplementation(() => ({
-      getAll: mockFeatureLoaderGetAll,
-      get: mockFeatureLoaderGet,
-      update: mockFeatureLoaderUpdate,
-      findByBranch: vi.fn().mockResolvedValue(null),
-      findByPRNumber: vi.fn().mockResolvedValue(null),
-    }));
+    // Must use function() syntax — arrow functions lack [[Construct]] and cannot be called with `new`.
+    vi.mocked(FeatureLoader).mockImplementation(function () {
+      return {
+        getAll: mockFeatureLoaderGetAll,
+        get: mockFeatureLoaderGet,
+        update: mockFeatureLoaderUpdate,
+        findByBranch: vi.fn().mockResolvedValue(null),
+        findByPRNumber: vi.fn().mockResolvedValue(null),
+      };
+    });
 
-    vi.mocked(StagingPromotionService).mockImplementation(() => ({
-      detectDevMerge: vi.fn().mockReturnValue(false),
-      createCandidate: vi.fn(),
-    }));
+    vi.mocked(StagingPromotionService).mockImplementation(function () {
+      return {
+        detectDevMerge: vi.fn().mockReturnValue(false),
+        createCandidate: vi.fn(),
+      };
+    });
 
     vi.mocked(verifyWebhookSignature).mockReturnValue({ valid: true });
 

--- a/libs/platform/tests/subprocess.test.ts
+++ b/libs/platform/tests/subprocess.test.ts
@@ -207,36 +207,39 @@ describe('subprocess.ts', () => {
       });
     });
 
-    it('should yield error when process exits 1 after emitting result:success (regression #3140)', async () => {
-      // Regression test for issue #3140: Claude Code SDK emits result:success in JSONL but the
-      // underlying process exits with code 1 (CLI init crash). The subprocess layer must yield an
-      // error event AFTER the result:success event so callers can detect the contradiction and
-      // treat the run as failed. Stderr must also be captured and logged at warn level.
-      const stderrMessage = 'Claude Code CLI crashed: ENOENT /usr/local/bin/claude';
-      const mockProcess = createMockProcess({
-        stdoutLines: ['{"type":"result","subtype":"success","total_cost_usd":0,"session_id":"abc"}'],
-        stderrLines: [stderrMessage],
-        exitCode: 1,
-      });
+    it(
+      'should yield error when process exits 1 after emitting result:success (regression #3140)',
+      async () => {
+        // Regression test for issue #3140: Claude Code SDK emits result:success in JSONL but the
+        // underlying process exits with code 1 (CLI init crash). The subprocess layer must yield an
+        // error event AFTER the result:success event so callers can detect the contradiction and
+        // treat the run as failed. Stderr must also be captured and logged at warn level.
+        const stderrMessage = 'Claude Code CLI crashed: ENOENT /usr/local/bin/claude';
+        const mockProcess = createMockProcess({
+          stdoutLines: [
+            '{"type":"result","subtype":"success","total_cost_usd":0,"session_id":"abc"}',
+          ],
+          stderrLines: [stderrMessage],
+          exitCode: 1,
+        });
 
-      vi.mocked(cp.spawn).mockReturnValue(mockProcess);
+        vi.mocked(cp.spawn).mockReturnValue(mockProcess);
 
-      const generator = spawnJSONLProcess(baseOptions);
-      const results = await collectAsyncGenerator(generator);
+        const generator = spawnJSONLProcess(baseOptions);
+        const results = await collectAsyncGenerator(generator);
 
-      // Should yield both the result:success JSONL event AND a follow-up error event
-      expect(results).toHaveLength(2);
-      expect(results[0]).toMatchObject({ type: 'result', subtype: 'success' });
-      expect(results[1]).toMatchObject({
-        type: 'error',
-        error: expect.stringContaining(stderrMessage),
-      });
+        // Should yield both the result:success JSONL event AND a follow-up error event
+        expect(results).toHaveLength(2);
+        expect(results[0]).toMatchObject({ type: 'result', subtype: 'success' });
+        expect(results[1]).toMatchObject({
+          type: 'error',
+          error: expect.stringContaining(stderrMessage),
+        });
 
-      // Stderr must be logged at warn level so it appears in logs for diagnosis
-      expect(consoleSpy.warn).toHaveBeenCalledWith(
-        expect.stringContaining(stderrMessage)
-      );
-    });
+        // Stderr must be logged at warn level so it appears in logs for diagnosis
+        expect(consoleSpy.warn).toHaveBeenCalledWith(expect.stringContaining(stderrMessage));
+      }
+    );
 
     it('should yield error with exit code when stderr is empty', async () => {
       const mockProcess = createMockProcess({


### PR DESCRIPTION
## Summary

## RCA

PR #3401 (`fix(test): #3399 — auto-mode-service integration tests failing`) is failing CI on both the `test` and `checks` composite gate workflows (2 failed checks, 1 pending). The branch `feature/fixtest-3399-auto-mode-service-integration-tests-2kd6bos` targets `dev` at head `24752e4`.

The patch was intended to fix integration tests covering three areas of `auto-mode-service`:
1. **Status transitions** — incorrect state machine assertions or missing state guards
2. **Model name resolut...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-13T09:14:01.971Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code formatting and structure in internal service modules.

* **Tests**
  * Updated test mock implementations and refactored regression test formatting for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->