### PR TITLE
fix(scheduler): issue #3140 — circuit breaker unreachable on SDK-level crash + zombie features on create-helix-app never remediated

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -396,6 +396,11 @@ export class ExecutionService {
     const executionStartedAt = new Date().toISOString();
     let startingCostUsd = 0;
 
+    // Pre-execution failureCount write (Concern 3 — issue #3140).
+    // Declared outside try so the catch block can reference it.
+    // Set to the pre-incremented value when the write succeeds, null otherwise.
+    let preIncrementedFailureCount: number | null = null;
+
     try {
       // Validate that project path is allowed using centralized validation
       validateWorkingDirectory(projectPath);
@@ -1120,6 +1125,38 @@ Output the branch name only.`,
         }
       }
 
+      // Write-before-run: pre-increment failureCount on disk BEFORE starting the agent.
+      // If the server crashes during SDK initialization (before the agent produces any
+      // output and before the catch block can increment), the failure is still counted on
+      // restart. Without this, a repeated SDK-init crash keeps failureCount at 0 and
+      // permanently bypasses the circuit breaker (issue #3140, Concern 3).
+      //
+      // Only applied to the initial dispatch (retryCount === 0). Recovery retries within
+      // the same scheduling cycle share the same "attempt" — the outer pre-increment already
+      // covers them, and a second pre-increment per retry would double-count failures.
+      //
+      // Success path: resets failureCount to 0 (existing logic at line ~1253).
+      // Failure path: catch block uses preIncrementedFailureCount to skip the re-write.
+      if ((options?.retryCount ?? 0) === 0) {
+        try {
+          preIncrementedFailureCount = (feature.failureCount ?? 0) + 1;
+          await this.featureLoader.update(projectPath, featureId, {
+            failureCount: preIncrementedFailureCount,
+          });
+          logger.debug(
+            `[PreExecution] Pre-wrote failureCount=${preIncrementedFailureCount} for ${featureId}`
+          );
+        } catch (preWriteError) {
+          // Non-fatal: the post-execution catch block handles the normal increment.
+          // This is a durability guard for crash scenarios only.
+          logger.warn(
+            `[PreExecution] Failed to pre-write failureCount for ${featureId}:`,
+            preWriteError
+          );
+          preIncrementedFailureCount = null;
+        }
+      }
+
       // Run the agent with the feature's model and images
       // Context files are passed as system prompt for higher priority
       // On retries, try to resume from the previous session if available
@@ -1721,10 +1758,17 @@ Output the branch name only.`,
         // Increment failure count for model escalation on retry
         let newFailureCount = 0;
         if (feature) {
-          newFailureCount = (feature.failureCount ?? 0) + 1;
-          await this.featureLoader.update(projectPath, featureId, {
-            failureCount: newFailureCount,
-          });
+          if (preIncrementedFailureCount !== null) {
+            // Write-before-run already wrote the incremented value to disk (issue #3140).
+            // Re-use that value for the circuit breaker check without a redundant write.
+            newFailureCount = preIncrementedFailureCount;
+          } else {
+            // No pre-increment (recovery retry path or pre-write failed): compute and persist now.
+            newFailureCount = (feature.failureCount ?? 0) + 1;
+            await this.featureLoader.update(projectPath, featureId, {
+              failureCount: newFailureCount,
+            });
+          }
           logger.info(`Feature ${featureId} failure count: ${newFailureCount}`);
 
           // Trigger self-healing when a feature has failed twice

--- a/apps/server/tests/unit/services/execution-service.test.ts
+++ b/apps/server/tests/unit/services/execution-service.test.ts
@@ -1254,3 +1254,102 @@ describe('ExecutionService - concurrency and runningFeatures', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Exit-code-1 degenerate-success fingerprint regression (issue #3140)
+// ---------------------------------------------------------------------------
+// Reproduces the zombie-loop failure mode:
+//   ~4 s runtime, $0 cost, 225-char output, 0 API calls.
+// The SDK emits result:success even though the underlying Claude Code process
+// exited with code 1. The degenerate-success guard (inside runAgent) detects
+// this and throws an error, which must route through the circuit-breaker path
+// and eventually mark the feature "interrupted" — never returning it to "backlog".
+// ---------------------------------------------------------------------------
+
+describe('ExecutionService — exit-code-1 degenerate-success fingerprint (issue #3140)', () => {
+  const PROJECT_PATH = '/tmp/test-project';
+  const FEATURE_ID = 'feature-zombie-regression-1';
+
+  beforeEach(() => {
+    // Do NOT stub AUTOMAKER_MOCK_AGENT here — these tests verify the real failure path
+    // by spying on runAgent directly, bypassing the env var gate.
+    vi.clearAllMocks();
+  });
+
+  it('circuit breaker trips when runAgent throws degenerate-success error at failureCount=2 → feature reaches interrupted', async () => {
+    // Feature at failureCount=2 (one below MAX_AUTO_RETRIES=3)
+    const feature = makeFeature({
+      id: FEATURE_ID,
+      status: 'backlog',
+      failureCount: 2,
+    });
+    const callbacks = makeCallbacks(feature);
+    // featureLoader.get always returns the same feature (failureCount=2).
+    // update() is a spy that records calls but returns the merged object.
+    const featureLoader = makeFeatureLoader(feature);
+    // Recovery service reports this error as non-retryable (SDK init crash is deterministic)
+    const recoveryService = makeRecoveryService();
+    const svc = makeService(callbacks, featureLoader, recoveryService);
+
+    // Simulate the exact degenerate-success error thrown by the runAgent guard:
+    // SDK emitted result:success but 0 API calls were made (exit-code-1 crash).
+    const degenerateError = new Error(
+      'SDK init failure: process exited cleanly but made 0 API calls ' +
+        '(225 chars output, 4s runtime). ' +
+        'Possible cause: invalid content in feature description caused CLI crash before any API call.'
+    );
+    vi.spyOn(svc as any, 'runAgent').mockRejectedValue(degenerateError);
+
+    await svc.executeFeature(PROJECT_PATH, FEATURE_ID);
+
+    // Circuit breaker must trip: feature should be marked interrupted
+    const updateCalls: Array<[string, string, Record<string, unknown>]> =
+      (featureLoader.update as ReturnType<typeof vi.fn>).mock.calls;
+
+    const interruptedUpdate = updateCalls.find(([, , updates]) => updates.status === 'interrupted');
+    expect(interruptedUpdate).toBeDefined();
+
+    // After the circuit breaker trips, the feature must never be re-queued to backlog
+    if (interruptedUpdate) {
+      const interruptedIdx = updateCalls.indexOf(interruptedUpdate);
+      const backlogAfterInterrupted = updateCalls
+        .slice(interruptedIdx + 1)
+        .some(([, , updates]) => updates.status === 'backlog');
+      expect(backlogAfterInterrupted).toBe(false);
+    }
+  });
+
+  it('pre-execution failureCount write: write-before-run increments count before runAgent is called', async () => {
+    // Verifies that failureCount is written to disk BEFORE runAgent starts.
+    // If the server crashes during SDK initialization, the failure is already counted.
+    const feature = makeFeature({
+      id: FEATURE_ID,
+      status: 'backlog',
+      failureCount: 1,
+    });
+    const callbacks = makeCallbacks(feature);
+    const featureLoader = makeFeatureLoader(feature);
+    const recoveryService = makeRecoveryService();
+    const svc = makeService(callbacks, featureLoader, recoveryService);
+
+    let failureCountAtRunAgentTime: number | undefined;
+
+    // Capture the failureCount that was written before runAgent executes
+    vi.spyOn(svc as any, 'runAgent').mockImplementation(async () => {
+      // Check what failureCount value was written before this call
+      const updateCalls: Array<[string, string, Record<string, unknown>]> =
+        (featureLoader.update as ReturnType<typeof vi.fn>).mock.calls;
+      const preWriteCall = updateCalls.find(
+        ([, , updates]) => typeof updates.failureCount === 'number'
+      );
+      failureCountAtRunAgentTime = preWriteCall?.[2]?.failureCount as number | undefined;
+      // Succeed normally so we can isolate the pre-write assertion
+      return Promise.resolve();
+    });
+
+    await svc.executeFeature(PROJECT_PATH, FEATURE_ID);
+
+    // failureCount must have been written to 2 (feature.failureCount=1 + 1) BEFORE runAgent ran
+    expect(failureCountAtRunAgentTime).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

## Antagonistic review bounce-back — issue #3140

Two prior fix features (feature-1775874598693-w4f3o8jwg, feature-1776018547623-dzvlgk2nb) are marked done but leave four gaps:

### Concern 1 — Zombie features on create-helix-app never remediated (original issue item 3)
`feature-1774530152717-dvtmrhfi6` and `feature-1774530209850-2frh7otyf` on project `create-helix-app` were listed as needing immediate manual `failed` status. Neither fix feature addressed this. Verify both are no longer looping;...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-13T23:34:44.990Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where auto-mode execution failures were not being properly tracked and persisted, particularly in edge cases where execution appeared to succeed at a higher level.
  * Enhanced failure state management to ensure failure counts are accurately recorded before execution attempts, improving overall reliability in auto mode operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->