### PR TITLE
fix(auto-mode): handle AUTO_RECOVERED outcome in startup-recovery switch

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -4011,8 +4011,23 @@ You can use the Read tool to view these images at any time during implementation
               );
               break;
 
+            case 'AUTO_RECOVERED':
+              // Dirty worktree was auto-recovered: WIP committed to recovery/ branch
+              logger.info(
+                `[STARTUP-RECOVERY] Feature ${feature.id} auto-recovered: ${check.reason}`
+              );
+              this.emitAutoModeEvent('worktree_recovered', {
+                featureId: feature.id,
+                projectPath,
+                worktreePath: check.worktreePath,
+                recoveryBranch: check.recoveryBranch,
+                reason: check.reason,
+              });
+              safeToResume.push(feature);
+              break;
+
             case 'RESET_DIRTY':
-              // Dirty/conflicted worktree — block and require human intervention
+              // Unrecoverable dirty worktree — block and escalate to HITL
               logger.warn(`[STARTUP-RECOVERY] Blocking feature ${feature.id}: ${check.reason}`);
               await this.featureLoader.update(projectPath, feature.id, {
                 status: 'blocked',
@@ -4025,6 +4040,12 @@ You can use the Read tool to view these images at any time during implementation
                 reason: check.reason,
                 projectPath,
               });
+              this.emitAutoModeEvent('worktree_unrecoverable', {
+                featureId: feature.id,
+                projectPath,
+                worktreePath: check.worktreePath,
+                reason: check.reason,
+              });
               break;
 
             case 'SAFE_TO_RESUME':
@@ -4036,6 +4057,11 @@ You can use the Read tool to view these images at any time during implementation
               // No worktree or no commits ahead — safe to start fresh
               safeToResume.push(feature);
               break;
+
+            default: {
+              const _exhaustive: never = check.outcome;
+              throw new Error(`Unhandled RestartOutcome: ${_exhaustive as string}`);
+            }
           }
         } catch (checkError) {
           // Safety check failed — fall back to resuming (same as previous behaviour)


### PR DESCRIPTION
Follow-up to #3419. Closes #3421.

## Problem

PR #3419 extended \`RestartOutcome\` with \`AUTO_RECOVERED\` and returns it from \`checkFeatureRestartOutcome\` when a dirty worktree is successfully rescued to a \`recovery/*\` branch. The consumer switch in \`auto-mode-service.ts\` (startup-recovery loop) was not updated to handle the new case. Without a \`default\`/exhaustiveness guard, the build didn't catch it.

**Runtime impact on staging today:** features that successfully auto-recover fall through the switch silently — not pushed to \`safeToResume\`, no \`worktree_recovered\` event emitted. Net effect: auto-recovery drops the feature instead of resuming it, the opposite of #3419's intent.

## Fix

- Add \`case 'AUTO_RECOVERED'\` — emits \`worktree_recovered\` event (with \`recoveryBranch\` in payload) and pushes the feature into \`safeToResume\`
- Add matching \`worktree_unrecoverable\` event on \`case 'RESET_DIRTY'\` for symmetric observability on the HITL-escalation path
- Add a \`default\` arm with \`const _exhaustive: never = check.outcome\` so any future \`RestartOutcome\` variant breaks the build if its consumer isn't updated

No test changes — staging already carries adequate Scenario 3 coverage from #3419.

## Why target staging

Same pattern as #3419 — the bug ships on staging; dev doesn't yet have the \`AUTO_RECOVERED\` variant, so this fix belongs next to #3419's code. Hold \`staging → main\` promotion until this lands.

## Test plan

- [ ] CI green (vitest + typecheck)
- [ ] Manual: simulate dirty-but-recoverable worktree on startup, confirm feature resumes and \`worktree_recovered\` event fires (visible in auto-mode event stream)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved auto-recovery handling for worktrees, enabling automatic feature resumption after recovery.
  * Enhanced detection of unrecoverable worktree states that require manual intervention.

* **Improvements**
  * Strengthened error handling with exhaustive validation of restart outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->