### PR TITLE
fix(ci): issue #3299 — FeatureScheduler silently skips features with contradictory isEpic=true + epicId state

### DIFF
--- a/apps/server/src/routes/features/routes/bulk-update.ts
+++ b/apps/server/src/routes/features/routes/bulk-update.ts
@@ -8,15 +8,27 @@ import { FeatureLoader } from '../../../services/feature-loader.js';
 import type { Feature } from '@protolabsai/types';
 import { getErrorMessage, logError } from '../common.js';
 
-export const BulkUpdateRequestSchema = z.object({
-  projectPath: z.string().min(1, 'projectPath is required'),
-  featureIds: z.array(z.string()).min(1, 'featureIds must be a non-empty array'),
-  updates: z.custom<Partial<Feature>>(
-    (val): val is Partial<Feature> =>
-      val !== null && typeof val === 'object' && Object.keys(val as object).length > 0,
-    'updates must be a non-empty object'
-  ),
-});
+export const BulkUpdateRequestSchema = z
+  .object({
+    projectPath: z.string().min(1, 'projectPath is required'),
+    featureIds: z.array(z.string()).min(1, 'featureIds must be a non-empty array'),
+    updates: z.custom<Partial<Feature>>(
+      (val): val is Partial<Feature> =>
+        val !== null && typeof val === 'object' && Object.keys(val as object).length > 0,
+      'updates must be a non-empty object'
+    ),
+  })
+  .refine(
+    (data) => {
+      const updates = data.updates as Partial<Feature>;
+      return !(updates.isEpic === true && updates.epicId);
+    },
+    {
+      message:
+        'A feature cannot be both an epic (isEpic: true) and a member of another epic (epicId set). Set either isEpic or epicId, not both.',
+      path: ['updates'],
+    }
+  );
 
 interface BulkUpdateResult {
   featureId: string;

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -728,6 +728,19 @@ export class FeatureLoader implements FeatureStore {
       throw new Error(`Feature ${featureId} not found`);
     }
 
+    // Reject contradictory epic state when isEpic or epicId fields are being modified.
+    // Only checked when the update touches these fields to allow other updates (e.g. status)
+    // to proceed even on features already in contradictory state (handled by the scheduler).
+    if (updates.isEpic !== undefined || updates.epicId !== undefined) {
+      const effectiveIsEpic = updates.isEpic !== undefined ? updates.isEpic : feature.isEpic;
+      const effectiveEpicId = updates.epicId !== undefined ? updates.epicId : feature.epicId;
+      if (effectiveIsEpic && effectiveEpicId) {
+        throw new Error(
+          'A feature cannot be both an epic (isEpic: true) and a member of another epic (epicId set). Set either isEpic or epicId, not both.'
+        );
+      }
+    }
+
     // Handle image path changes
     let updatedImagePaths = updates.imagePaths;
     if (updates.imagePaths !== undefined) {

--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -1212,17 +1212,20 @@ export class FeatureScheduler {
             if (feature.epicId) {
               // Contradictory state: a feature cannot be both an epic container and a child of
               // another epic. This was likely caused by a direct write bypassing API validation.
-              logger.warn(
-                `[loadPendingFeatures] Feature ${feature.id} ("${feature.title}") is marked as an epic but also has a parent epic assigned (epicId: ${feature.epicId}) — it will not be scheduled. Fix the feature configuration to proceed.`
+              logger.error(
+                `[loadPendingFeatures] Feature ${feature.id} has both isEpic=true and epicId set — skipping; manual intervention required.`
               );
-              // Surface the conflict in the feature data so the UI and agents can observe it.
+              // Move to blocked so the contradictory state is visible in the UI and not silently
+              // swallowed every scheduler cycle. The update only touches status/statusChangeReason
+              // so it bypasses the isEpic+epicId validation guard in FeatureLoader.update.
               try {
                 await this.featureLoader.update(projectPath, feature.id, {
+                  status: 'blocked',
                   statusChangeReason: `Contradictory epic state: feature is marked as an epic container (isEpic: true) but also has a parent epic assigned (epicId: ${feature.epicId}). Set either isEpic or epicId, not both.`,
                 });
               } catch (updateErr) {
                 logger.error(
-                  `[loadPendingFeatures] Failed to surface contradictory state for feature ${feature.id}:`,
+                  `[loadPendingFeatures] Failed to block contradictory-state feature ${feature.id}:`,
                   updateErr
                 );
               }


### PR DESCRIPTION
## Summary

## RCA
FeatureScheduler.loadPendingFeatures silently skips features with isEpic=true + epicId set. No validation error, no warning, feature sits in backlog forever.

Original fix PR: protoLabsAI/protoMaker#3381 (MERGED — incomplete, CI failed at merge)
Issue: protoLabsAI/protoMaker#3299

---

## ⚠️ Bounce-back #4 — 4 concerns (antagonistic review, re-dispatched via issues.opened sweep)

### 0. [REPEAT — UNRESOLVED] No follow-up PR was ever created after bounce #3
Bounce #3 explicitly found 'feat...

---
*Recovered automatically by Automaker post-agent hook*