### PR TITLE
fix(ci): issue #3140 — missing circuit breaker lets zombie features retry infinitely after Claude Code exit code 1

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -3470,15 +3470,24 @@ After generating the revised spec, output:
         responseText.length < DEGENERATE_OUTPUT_CHARS &&
         elapsedRuntimeMs < DEGENERATE_RUNTIME_MS
       ) {
+        const truncatedOutput =
+          responseText.length > 0
+            ? responseText.slice(0, 500) + (responseText.length > 500 ? `… [${responseText.length} chars total]` : '')
+            : '(empty)';
         logger.warn(
           `[DegenerateSuccess] Feature ${featureId}: SDK reported success but made 0 API calls ` +
             `(${responseText.length} chars, ${Math.round(elapsedRuntimeMs / 1000)}s). ` +
-            `Likely CLI init crash. Treating as failure.`
+            `Likely CLI init crash. Treating as failure.\nRaw output: ${truncatedOutput}`
         );
+        const rawOutputSuffix =
+          responseText.length > 0
+            ? `\nRaw output (${responseText.length} chars): ${responseText.slice(0, 200)}${responseText.length > 200 ? '…' : ''}`
+            : '';
         throw new Error(
           `SDK init failure: process exited cleanly but made 0 API calls ` +
             `(${responseText.length} chars output, ${Math.round(elapsedRuntimeMs / 1000)}s runtime). ` +
-            `Possible cause: invalid content in feature description caused CLI crash before any API call.`
+            `Possible cause: invalid content in feature description caused CLI crash before any API call.` +
+            rawOutputSuffix
         );
       }
 
@@ -3577,7 +3586,20 @@ After generating the revised spec, output:
     // an argument-parsing or stdin-sanitization fault in the Claude Code CLI during its
     // initialization phase, producing a process exit-code-1 crash with $0 cost and ~225 chars
     // of output — the "degenerate success" bug (issue #3140).
-    const sanitizedDescription = (feature.description ?? '').replace(/<[^>]*>/g, '');
+    const rawDescription = feature.description ?? '';
+    const sanitizedDescription = rawDescription.replace(/<[^>]*>/g, '');
+    // Log a warning when HTML was present — this is the known trigger for the exit-code-1
+    // degenerate-success crash. Logging here gives operators a diagnostic breadcrumb before
+    // the agent run, even though the tags will be stripped before reaching the SDK.
+    if (sanitizedDescription !== rawDescription) {
+      const strippedChars = rawDescription.length - sanitizedDescription.length;
+      logger.warn(
+        `[HTMLSanitization] Feature ${feature.id}: description contained HTML that was stripped ` +
+          `(${strippedChars} chars removed, ${rawDescription.length} → ${sanitizedDescription.length}). ` +
+          `Raw HTML in descriptions triggers Claude Code CLI init crash (exit-code-1 / degenerate-success). ` +
+          `Sanitization applied before SDK handoff.`
+      );
+    }
     builder.addSection(
       'FEATURE_HEADER',
       `## Feature Implementation Task\n\n**Feature ID:** ${feature.id}\n**Title:** ${title}\n**Description:** ${sanitizedDescription}\n`


### PR DESCRIPTION
## Summary

## Bounce-back — antagonistic review (re-dispatch from issues.opened #3140)

### Original RCA (from issue #3140)
Two root causes:
1. **Circuit breaker missing**: Features reaching `failureCount >= maxRetries` return to `backlog` instead of being permanently marked failed, causing infinite scheduler retry loops (~3 s cadence).
2. **Claude Code exit-code 1 + `result success` contradiction**: Process exits non-zero after emitting success signal during SDK init (no API call made, $0 cost, ~4 s, 225 ...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T02:29:34.230Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error diagnostics and logging for failure detection, providing more detailed information in error messages.
  * Improved logging for HTML content detection in feature descriptions, tracking sanitization details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->