### PR TITLE
fix(agent-health): bug_triage skill has 0% success rate (23/23 failures)

### DIFF
--- a/apps/server/src/lib/settings-helpers.ts
+++ b/apps/server/src/lib/settings-helpers.ts
@@ -832,6 +832,7 @@ export async function getWorkflowSettings(
         },
         ciClassification: projectSettings.workflow.ciClassification,
         heartbeat: projectSettings.workflow.heartbeat,
+        a2aSkillExecution: projectSettings.workflow.a2aSkillExecution,
       };
     }
     return DEFAULT_WORKFLOW_SETTINGS;

--- a/apps/server/src/routes/a2a/index.ts
+++ b/apps/server/src/routes/a2a/index.ts
@@ -31,6 +31,8 @@ import { getVersion } from '../../lib/version.js';
 import { ProviderFactory } from '../../providers/provider-factory.js';
 import { resolveModelString } from '@protolabsai/model-resolver';
 import type { PlanningService } from '../../services/planning-service.js';
+import type { SettingsService } from '../../services/settings-service.js';
+import { getWorkflowSettings } from '../../lib/settings-helpers.js';
 
 const logger = createLogger('A2ARoutes');
 
@@ -423,17 +425,36 @@ async function executeNativeSkill(
   return responseText;
 }
 
+// Default A2A skill execution settings — sized for multi-step skills like bug_triage
+// which involve sequential LLM + tool calls and routinely take 3–5 minutes.
+const A2A_DEFAULT_TIMEOUT_MS = 600_000; // 10 minutes
+const A2A_DEFAULT_MAX_RETRIES = 2;
+const A2A_DEFAULT_RETRY_BASE_DELAY_MS = 5_000;
+
+/** Simple promise-based sleep for retry backoff */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /** Call /api/chat and collect the SSE text-delta response. */
 async function callChatEndpoint(
   apiKey: string,
   projectPath: string,
   userText: string,
   skillOverride?: string,
-  correlationId?: string
+  correlationId?: string,
+  timeoutMs: number = A2A_DEFAULT_TIMEOUT_MS
 ): Promise<string> {
   const baseUrl = `http://localhost:${process.env['PORT'] ?? 3008}`;
+
+  // AbortSignal.timeout() is built-in since Node 18 — creates a signal that
+  // automatically aborts after the given delay. A fresh signal is created per
+  // attempt so retries each get their own full timeout window.
+  const signal = AbortSignal.timeout(timeoutMs);
+
   const chatRes = await fetch(`${baseUrl}/api/chat`, {
     method: 'POST',
+    signal,
     headers: {
       'Content-Type': 'application/json',
       'X-API-Key': apiKey,
@@ -458,9 +479,64 @@ async function callChatEndpoint(
   return collectChatResponse(chatRes);
 }
 
+/**
+ * Call the chat endpoint with exponential-backoff retry.
+ * Retries on timeout (TimeoutError) and 5xx server errors — both are transient.
+ * Each retry gets a fresh AbortSignal so the full timeout window is available.
+ */
+async function callChatEndpointWithRetry(
+  apiKey: string,
+  projectPath: string,
+  userText: string,
+  skillOverride: string | undefined,
+  correlationId: string | undefined,
+  timeoutMs: number,
+  maxRetries: number,
+  retryBaseDelayMs: number
+): Promise<string> {
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (attempt > 0) {
+      const delay = retryBaseDelayMs * Math.pow(2, attempt - 1);
+      logger.info(
+        `A2A callChatEndpoint retry ${attempt}/${maxRetries} for skill="${skillOverride ?? 'none'}" after ${delay}ms (last error: ${lastError?.message ?? 'unknown'})`
+      );
+      await sleep(delay);
+    }
+    try {
+      return await callChatEndpoint(
+        apiKey,
+        projectPath,
+        userText,
+        skillOverride,
+        correlationId,
+        timeoutMs
+      );
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      // Retry only on timeout (TimeoutError name, set by AbortSignal.timeout) or 5xx
+      const isTransient =
+        lastError.name === 'TimeoutError' || lastError.message.startsWith('chat endpoint returned 5');
+      if (!isTransient || attempt === maxRetries) {
+        if (attempt < maxRetries) {
+          logger.warn(
+            `A2A callChatEndpoint non-transient error for skill="${skillOverride ?? 'none'}", not retrying: ${lastError.message}`
+          );
+        }
+        throw lastError;
+      }
+      logger.warn(
+        `A2A callChatEndpoint attempt ${attempt + 1} failed (transient: ${lastError.message}), will retry`
+      );
+    }
+  }
+  throw lastError ?? new Error('callChatEndpointWithRetry: unreachable');
+}
+
 /** Optional services for planning pipeline skills */
 export interface A2AHandlerDeps {
   planningService?: PlanningService;
+  settingsService?: SettingsService;
 }
 
 export function createA2AHandlerRoutes(projectPath: string, deps?: A2AHandlerDeps): Router {
@@ -751,6 +827,18 @@ export function createA2AHandlerRoutes(projectPath: string, deps?: A2AHandlerDep
       }
     }
 
+    // Load A2A execution settings for this project — controls timeout and retry behavior.
+    // Defaults are generous (10 min timeout, 2 retries) to handle multi-step skills.
+    const workflowSettings = await getWorkflowSettings(
+      effectiveProjectPath,
+      deps?.settingsService,
+      '[A2AHandler]'
+    );
+    const a2aExec = workflowSettings.a2aSkillExecution ?? {};
+    const timeoutMs = a2aExec.timeoutMs ?? A2A_DEFAULT_TIMEOUT_MS;
+    const maxRetries = a2aExec.maxRetries ?? A2A_DEFAULT_MAX_RETRIES;
+    const retryBaseDelayMs = a2aExec.retryBaseDelayMs ?? A2A_DEFAULT_RETRY_BASE_DELAY_MS;
+
     try {
       let responseText: string;
 
@@ -766,21 +854,27 @@ export function createA2AHandlerRoutes(projectPath: string, deps?: A2AHandlerDep
           responseText = await executeNativeSkill(effectiveProjectPath, skill, userText);
         } else {
           // Skill not found, has no tool restrictions, or uses Ava board tools → /api/chat
-          responseText = await callChatEndpoint(
+          responseText = await callChatEndpointWithRetry(
             key,
             effectiveProjectPath,
             userText,
             skillOverride,
-            contextId
+            contextId,
+            timeoutMs,
+            maxRetries,
+            retryBaseDelayMs
           );
         }
       } else {
-        responseText = await callChatEndpoint(
+        responseText = await callChatEndpointWithRetry(
           key,
           effectiveProjectPath,
           userText,
           undefined,
-          contextId
+          contextId,
+          timeoutMs,
+          maxRetries,
+          retryBaseDelayMs
         );
       }
 

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -239,7 +239,7 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   });
 
   // A2A message handler — manual X-API-Key check inside (same pattern as /webhooks)
-  app.use('/a2a', createA2AHandlerRoutes(repoRoot, { planningService }));
+  app.use('/a2a', createA2AHandlerRoutes(repoRoot, { planningService, settingsService }));
 
   // World-state polling endpoints — unauthenticated, intended for workstacean HTTP collectors
   app.use('/api/world', createWorldRoutes(featureLoader, autoModeService, repoRoot));

--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -600,6 +600,21 @@ export interface WorkflowSettings {
    * @default true
    */
   copyEnvFiles?: boolean;
+  /**
+   * A2A skill execution configuration.
+   * Controls timeout and retry behavior for inbound A2A skill dispatches.
+   * Multi-step skills like bug_triage involve several sequential LLM + tool calls
+   * and routinely take 3–5 minutes. The default 10-minute timeout is sized for
+   * the p99 case. Retries with exponential backoff handle transient gateway drops.
+   */
+  a2aSkillExecution?: {
+    /** Maximum milliseconds to wait for a skill response before aborting. @default 600000 (10 min) */
+    timeoutMs?: number;
+    /** Number of retry attempts on transient failure (timeout or 5xx). @default 2 */
+    maxRetries?: number;
+    /** Base delay in milliseconds before the first retry. Doubles on each subsequent attempt. @default 5000 */
+    retryBaseDelayMs?: number;
+  };
 }
 
 /** Default workflow settings */


### PR DESCRIPTION
## Summary

Tracks protoMaker issue #3428. The bug_triage skill dispatched via auto-triage-sweep has a 0% success rate over 23 attempts — every triage batch fails, leaving issues stuck in needs-triage. This is why 26 open issues were all unsorted.

## Diagnosis checklist
1. Pull Langfuse traces for the sample correlation IDs in the issue.
2. Reproduce with a single manual bug_triage call using a known-good payload.
3. Check A2A gateway timeout vs Quinn's p50 latency (~264s) — likely gateway cutoff.
4. Inspe...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A2A skill execution is now configurable with customizable timeout (default 10 minutes), retry attempts (default 2), and retry delay settings (default 5 seconds).
  * Automatic retry mechanism for transient failures including timeouts and server errors with exponential backoff strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->