### PR TITLE
Quinn bug_triage skill crashes with NoneType path error (93% failure rate)

### DIFF
--- a/apps/server/src/routes/a2a/index.ts
+++ b/apps/server/src/routes/a2a/index.ts
@@ -390,6 +390,12 @@ async function executeNativeSkill(
   skill: SkillMeta,
   userText: string
 ): Promise<string> {
+  if (!projectPath) {
+    throw new Error(
+      'executeNativeSkill requires a valid projectPath but received a falsy value. ' +
+        'Cross-project dispatches must include metadata.projectPath.'
+    );
+  }
   const resolvedModel = resolveModelString('claude-sonnet');
   const provider = ProviderFactory.getProviderForModel(resolvedModel);
   const stream = provider.executeQuery({
@@ -431,6 +437,12 @@ async function callChatEndpoint(
   skillOverride?: string,
   correlationId?: string
 ): Promise<string> {
+  if (!projectPath) {
+    throw new Error(
+      `callChatEndpoint requires a valid projectPath but received "${String(projectPath)}". ` +
+        `Skill: ${skillOverride ?? 'none'}.`
+    );
+  }
   const baseUrl = `http://localhost:${process.env['PORT'] ?? 3008}`;
   const chatRes = await fetch(`${baseUrl}/api/chat`, {
     method: 'POST',
@@ -749,6 +761,37 @@ export function createA2AHandlerRoutes(projectPath: string, deps?: A2AHandlerDep
           `A2A projectPath override rejected: "${metaProjectPath}" has no .automaker/ — falling back to ${projectPath}`
         );
       }
+    }
+
+    // Guard: effectiveProjectPath must be a non-empty string. If the route-level
+    // projectPath was somehow undefined (e.g. misconfigured ServiceContainer) or
+    // the metadata override resolved to a falsy value, reject early with a clear
+    // error rather than passing undefined to downstream services (which causes
+    // Python NoneType crashes in the Claude Agent SDK).
+    if (!effectiveProjectPath) {
+      logger.error(
+        `A2A skill dispatch failed: effectiveProjectPath is falsy (route=${projectPath}, meta=${String(metaProjectPath)})`
+      );
+      res.status(200).json({
+        jsonrpc: '2.0',
+        id: rpcId,
+        result: {
+          id: randomUUID(),
+          contextId: contextId ?? randomUUID(),
+          status: { state: 'completed' },
+          artifacts: [
+            {
+              parts: [
+                {
+                  type: 'text',
+                  text: `ERROR: projectPath is missing — cannot execute skill "${skillOverride ?? 'chat'}". Ensure metadata.projectPath is set for cross-project dispatches.`,
+                },
+              ],
+            },
+          ],
+        },
+      });
+      return;
     }
 
     try {


### PR DESCRIPTION
## Summary

Quinn's bug_triage skill fails on every invocation with: "expected str, bytes or os.PathLike object, not NoneType". 25 of 27 attempts failed (7% success rate). Root cause: a None value passed where a file path is expected -- likely a missing/unset repo clone path or workspace directory config. Impact: 25 work items stuck in error state, WIP limit exceeded (30 vs limit of 2), auto-triage-sweep agent at 0% success. Ref: GitHub issue protoLabsAI/protoWorkstacean#331.

---
**Source:** GitHub issue #...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T04:53:43.254Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling and validation for project configurations. The system now detects invalid paths earlier and returns clearer error messages instead of failing silently or producing cryptic downstream errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->