### PR TITLE
fix(auto-mode): don't mark features 'done' when zero source code lands (issue #3376)

### DIFF
--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -55,6 +55,22 @@ function sanitizePrNumber(prNumber: unknown): number {
   return parsed;
 }
 
+/**
+ * Returns true if the file path is metadata-only (lock files, .automaker dir, markdown)
+ * and therefore should NOT count as source-code for the lock-only PR gate.
+ * Files explicitly listed in `filesToModify` are never considered metadata.
+ */
+function isMergeOnlyMetadata(filePath: string, filesToModify?: string[]): boolean {
+  if (filesToModify?.includes(filePath)) return false;
+  const basename = filePath.split('/').pop() ?? filePath;
+  if (['package-lock.json', 'yarn.lock', 'pnpm-lock.yaml'].includes(basename)) return true;
+  if (basename === '.automaker-lock') return true;
+  if (filePath.startsWith('.automaker/')) return true;
+  if (basename === '.gitignore') return true;
+  if (basename.endsWith('.md')) return true;
+  return false;
+}
+
 // ────────────────────────── ReviewProcessor ──────────────────────────
 
 /**
@@ -1040,12 +1056,68 @@ export class MergeProcessor implements StateProcessor {
         };
       }
 
+      // Source-code gate: verify the PR contains non-metadata changes.
+      // A PR containing only .automaker-lock or lock files indicates the agent ran in
+      // the wrong context (e.g. base-branch failure). Block and escalate instead of
+      // marking done, so the failure is visible on the board.
+      let hasSourceChanges = true; // default true so failures are non-fatal
+      try {
+        const { stdout: filesJson } = await execAsync(
+          `gh pr view ${ctx.prNumber} --json files --jq '[.files[].path]'`,
+          { cwd: ctx.projectPath, timeout: 15000 }
+        );
+        const changedFiles: string[] = JSON.parse(filesJson.trim());
+        // An empty diff (no files) is unusual but allowed through — treat as source change
+        if (changedFiles.length > 0) {
+          const sourceFiles = changedFiles.filter(
+            (f) => !isMergeOnlyMetadata(f, ctx.feature.filesToModify)
+          );
+          hasSourceChanges = sourceFiles.length > 0;
+          if (!hasSourceChanges) {
+            logger.warn(
+              `[MERGE] PR #${ctx.prNumber} contains only metadata files ` +
+                `(${changedFiles.length} file(s): ${changedFiles.slice(0, 5).join(', ')}). ` +
+                `Escalating — no source code landed.`
+            );
+          }
+        }
+      } catch (diffErr) {
+        // Non-fatal: if diff inspection fails, proceed as normal done.
+        logger.warn(
+          `[MERGE] PR #${ctx.prNumber} diff inspection failed — proceeding as done:`,
+          diffErr
+        );
+      }
+
       // Update feature status with merge timestamps
       const now = new Date().toISOString();
       const prReviewDurationMs =
         ctx.feature.prCreatedAt != null
           ? Date.now() - new Date(ctx.feature.prCreatedAt).getTime()
           : undefined;
+
+      if (!hasSourceChanges) {
+        // Lock-only merge: block the feature and escalate for human review.
+        const reason = `PR merged with lock-only changes — no source code landed (PR #${ctx.prNumber})`;
+        await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
+          status: 'blocked',
+          statusChangeReason: reason,
+          prMergedAt: now,
+          ...(prReviewDurationMs !== undefined ? { prReviewDurationMs } : {}),
+        });
+        this.serviceContext.events.emit('feature:pr-merged' as EventType, {
+          featureId: ctx.feature.id,
+          prNumber: ctx.prNumber,
+          projectPath: ctx.projectPath,
+        });
+        logger.info(`[MERGE] PR #${ctx.prNumber} escalated — lock-only merge`);
+        ctx.escalationReason = reason;
+        return {
+          nextState: 'ESCALATE',
+          shouldContinue: true,
+          reason,
+        };
+      }
 
       await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
         status: 'done',

--- a/apps/server/tests/unit/services/lead-engineer-review-merge-processors.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-review-merge-processors.test.ts
@@ -123,9 +123,12 @@ function execFailure(err: Error) {
  * Sets up the exec mock to simulate:
  *   1st call (gh pr view --json baseRefName): returns 'dev' (non-promotion branch)
  *   2nd call (gh pr merge): succeeds
- *   3rd call (gh pr view --json merged): returns `mergeResult`
+ *   3rd call (gh pr view --json mergedAt): returns `mergeResult`
+ *   4th call (gh pr view --json files): returns JSON list of changed file paths
+ *
+ * `changedFiles` defaults to a source file so existing merge tests are unaffected.
  */
-function setupExecMock(mergeResult: string) {
+function setupExecMock(mergeResult: string, changedFiles: string[] = ['src/index.ts']) {
   mockExec.mockReset();
   mockExec
     // First call: gh pr view --json baseRefName (promotion check)
@@ -148,7 +151,7 @@ function setupExecMock(mergeResult: string) {
         cb(null, { stdout: '', stderr: '' });
       }
     )
-    // Third call: gh pr view --json merged
+    // Third call: gh pr view --json mergedAt
     .mockImplementationOnce(
       (
         _cmd: string,
@@ -156,6 +159,16 @@ function setupExecMock(mergeResult: string) {
         cb: (err: null, result: { stdout: string; stderr: string }) => void
       ) => {
         cb(null, { stdout: mergeResult, stderr: '' });
+      }
+    )
+    // Fourth call: gh pr view --json files (source-code gate)
+    .mockImplementationOnce(
+      (
+        _cmd: string,
+        _opts: unknown,
+        cb: (err: null, result: { stdout: string; stderr: string }) => void
+      ) => {
+        cb(null, { stdout: JSON.stringify(changedFiles), stderr: '' });
       }
     );
 }
@@ -385,6 +398,94 @@ describe('MergeProcessor', () => {
 
       expect(result.nextState).toBe('DEPLOY');
       expect(result.shouldContinue).toBe(true);
+    });
+  });
+
+  describe('source-code gate (lock-only PR detection)', () => {
+    it('escalates to ESCALATE when PR contains only .automaker-lock', async () => {
+      setupExecMock('2026-01-01T00:00:00Z\n', ['.automaker-lock']);
+      const ctx = makeCtx();
+
+      const result = await processor.process(ctx);
+
+      expect(result.nextState).toBe('ESCALATE');
+      expect(result.reason).toMatch(/lock-only/);
+    });
+
+    it('sets feature status to blocked on lock-only merge', async () => {
+      setupExecMock('2026-01-01T00:00:00Z\n', ['.automaker-lock']);
+      const ctx = makeCtx();
+
+      await processor.process(ctx);
+
+      const updatePayload = (serviceContext.featureLoader.update as ReturnType<typeof vi.fn>).mock
+        .calls[0][2];
+      expect(updatePayload.status).toBe('blocked');
+      expect(updatePayload.statusChangeReason).toMatch(/lock-only/);
+    });
+
+    it('escalates when PR contains only lock files and markdown', async () => {
+      setupExecMock('2026-01-01T00:00:00Z\n', [
+        '.automaker-lock',
+        'pnpm-lock.yaml',
+        'README.md',
+      ]);
+      const ctx = makeCtx();
+
+      const result = await processor.process(ctx);
+
+      expect(result.nextState).toBe('ESCALATE');
+    });
+
+    it('proceeds to DEPLOY when PR contains source files alongside metadata', async () => {
+      setupExecMock('2026-01-01T00:00:00Z\n', [
+        '.automaker-lock',
+        'src/services/my-service.ts',
+      ]);
+      const ctx = makeCtx();
+
+      const result = await processor.process(ctx);
+
+      expect(result.nextState).toBe('DEPLOY');
+    });
+
+    it('treats files in filesToModify as source even if they are markdown', async () => {
+      setupExecMock('2026-01-01T00:00:00Z\n', ['docs/api.md']);
+      const ctx = makeCtx({
+        feature: makeFeature({ filesToModify: ['docs/api.md'] }) as any,
+      });
+
+      const result = await processor.process(ctx);
+
+      expect(result.nextState).toBe('DEPLOY');
+    });
+
+    it('proceeds to DEPLOY when diff inspection fails (non-fatal)', async () => {
+      mockExec.mockReset();
+      mockExec
+        // Call 1: baseRefName
+        .mockImplementationOnce(execSuccess({ stdout: 'dev\n', stderr: '' }))
+        // Call 2: gh pr merge
+        .mockImplementationOnce(execSuccess({ stdout: '', stderr: '' }))
+        // Call 3: gh pr view mergedAt
+        .mockImplementationOnce(execSuccess({ stdout: '2026-01-01T00:00:00Z\n', stderr: '' }))
+        // Call 4: gh pr view --json files — fails
+        .mockImplementationOnce(execFailure(new Error('gh CLI unavailable')));
+
+      const ctx = makeCtx();
+      const result = await processor.process(ctx);
+
+      // Diff failure is non-fatal — should proceed as done
+      expect(result.nextState).toBe('DEPLOY');
+    });
+
+    it('proceeds to DEPLOY when PR has empty file list (unusual case)', async () => {
+      setupExecMock('2026-01-01T00:00:00Z\n', []);
+      const ctx = makeCtx();
+
+      const result = await processor.process(ctx);
+
+      expect(result.nextState).toBe('DEPLOY');
     });
   });
 });


### PR DESCRIPTION
## Summary

Tracks protoMaker issue #3376. Auto-mode marks features done when the PR merges — even when the PR diff contains only .automaker-lock changes and no source files. Observed: Ava stand-alone agent project had 4 phases auto-complete with zero source code on main.

## Proposed fix
Before transitioning REVIEW→MERGE→DONE:
- Inspect the merged PR's diff via GitHub API.
- Require at least one non-automaker file changed, OR a configurable minimum-substance gate (lines added + files touched outside .autom...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T05:20:43.838Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added source code detection to distinguish actual code changes from metadata-only modifications (lock files, configuration files, documentation).
  * PRs containing only metadata changes are now escalated for review instead of being automatically deployed, improving deployment safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->