### PR TITLE
fix(agent): Arc features have over-broad file scope causing cross-PR collision clusters (issue #3418)

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -3635,6 +3635,18 @@ After generating the revised spec, output:
       builder.addSection('TRAJECTORY_CONTEXT', trajectoryContext);
     }
 
+    // FILE_SCOPE section — explicit file boundary when filesToModify is declared (EXECUTE phase only)
+    // Prevents agents from editing docs/tutorials, dashboard/, and adjacent test files that are
+    // outside the feature's declared scope, which causes PR collision clusters on parallel runs.
+    if (feature.filesToModify && feature.filesToModify.length > 0) {
+      const fileList = feature.filesToModify.map((f) => `- ${f}`).join('\n');
+      builder.addSection(
+        'FILE_SCOPE',
+        `\n## File Scope\n\nThis feature declares the following files as its intended scope:\n${fileList}\n\n**DO NOT edit any file outside this list.** Edits to undeclared files create merge conflicts with other concurrent agents and produce PR collision clusters.\n\nForbidden anti-patterns:\n- **improve-adjacent-docs**: Editing docs/tutorials/, dashboard/, or README files you encounter — unless they appear in the list above\n- **cross-file cleanup**: Formatting or style fixes in unrelated files you happen to read\n- **dashboard-version-bump**: Touching package.json or version files outside your declared scope\n\nIf you discover a file you genuinely need to edit that is NOT listed, limit the change to the minimum required and explain in your summary why it was necessary.\n`,
+        ['EXECUTE']
+      );
+    }
+
     // CODING_STANDARDS section — implementation instructions (EXECUTE phase only)
     builder.addSection('CODING_STANDARDS', `\n${taskExecutionPrompts.implementationInstructions}`, [
       'EXECUTE',

--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -71,6 +71,110 @@ function isMergeOnlyMetadata(filePath: string, filesToModify?: string[]): boolea
   return false;
 }
 
+// ────────────────────────── Scope Budget Enforcement ──────────────────────────
+
+/** Returns true if the file is a test file by name or path convention. */
+function isTestFile(filePath: string): boolean {
+  return (
+    /\.(test|spec)\.(ts|js|tsx|jsx)$/.test(filePath) ||
+    filePath.includes('/tests/') ||
+    filePath.includes('/test/') ||
+    filePath.includes('/__tests__/')
+  );
+}
+
+/**
+ * Returns true if filePath falls within the declared scope.
+ * Handles both exact matches and directory prefix matches.
+ */
+function isWithinDeclaredScope(filePath: string, filesToModify: string[]): boolean {
+  for (const declared of filesToModify) {
+    if (filePath === declared) return true;
+    if (filePath.startsWith(declared + '/')) return true;
+  }
+  return false;
+}
+
+/**
+ * Returns true if filePath is a test file whose directory matches or is under
+ * the directory of any declared file (adjacent test heuristic).
+ */
+function isAdjacentTestFile(filePath: string, filesToModify: string[]): boolean {
+  if (!isTestFile(filePath)) return false;
+  const fileDir = filePath.split('/').slice(0, -1).join('/');
+  return filesToModify.some((declared) => {
+    const declaredDir = declared.split('/').slice(0, -1).join('/');
+    return fileDir === declaredDir || fileDir.startsWith(declaredDir + '/');
+  });
+}
+
+export interface ScopeBudgetResult {
+  withinBudget: boolean;
+  outOfScopeFiles: string[];
+  toleratedFiles: string[];
+  outOfScopePercent: number;
+  totalSourceFiles: number;
+}
+
+const SCOPE_TEST_FILE_TOLERANCE = 2;
+const SCOPE_OUT_OF_BUDGET_PERCENT = 20;
+
+/**
+ * Analyzes whether a PR's changed files stay within the declared scope.
+ *
+ * Rules:
+ * - Metadata files (lock files, .automaker, .md, etc.) are excluded from analysis.
+ *   Files explicitly in filesToModify are never treated as metadata.
+ * - Up to SCOPE_TEST_FILE_TOLERANCE test files adjacent to declared files are tolerated
+ *   without counting against the budget.
+ * - If out-of-scope non-tolerated files exceed SCOPE_OUT_OF_BUDGET_PERCENT of total
+ *   source files, withinBudget is false.
+ */
+export function analyzeScopeBudget(
+  changedFiles: string[],
+  filesToModify: string[]
+): ScopeBudgetResult {
+  // Exclude metadata-only files (lock files, .automaker dir, .md) but preserve declared files.
+  const sourceFiles = changedFiles.filter((f) => !isMergeOnlyMetadata(f, filesToModify));
+
+  if (sourceFiles.length === 0 || filesToModify.length === 0) {
+    return {
+      withinBudget: true,
+      outOfScopeFiles: [],
+      toleratedFiles: [],
+      outOfScopePercent: 0,
+      totalSourceFiles: sourceFiles.length,
+    };
+  }
+
+  const outOfScope: string[] = [];
+  const tolerated: string[] = [];
+  let toleranceUsed = 0;
+
+  for (const file of sourceFiles) {
+    if (isWithinDeclaredScope(file, filesToModify)) continue;
+
+    // Adjacent test files are tolerated up to SCOPE_TEST_FILE_TOLERANCE
+    if (toleranceUsed < SCOPE_TEST_FILE_TOLERANCE && isAdjacentTestFile(file, filesToModify)) {
+      tolerated.push(file);
+      toleranceUsed++;
+    } else {
+      outOfScope.push(file);
+    }
+  }
+
+  const outOfScopePercent =
+    sourceFiles.length > 0 ? (outOfScope.length / sourceFiles.length) * 100 : 0;
+
+  return {
+    withinBudget: outOfScopePercent <= SCOPE_OUT_OF_BUDGET_PERCENT,
+    outOfScopeFiles: outOfScope,
+    toleratedFiles: tolerated,
+    outOfScopePercent,
+    totalSourceFiles: sourceFiles.length,
+  };
+}
+
 // ────────────────────────── ReviewProcessor ──────────────────────────
 
 /**
@@ -198,6 +302,10 @@ export class ReviewProcessor implements StateProcessor {
     });
 
     if (reviewState === 'approved') {
+      // Check scope budget: warn if PR contains files outside declared filesToModify.
+      // Non-blocking — warning only per deviation rule (auto-rollback risks losing legitimate changes).
+      await this.checkScopeBudget(ctx);
+
       // Run fresh-eyes review if enabled in workflow settings
       const freshEyesResult = await this.runFreshEyesReview(ctx);
       if (freshEyesResult === 'blocked') {
@@ -588,6 +696,85 @@ export class ReviewProcessor implements StateProcessor {
     } catch (err) {
       // Review failure must not block the pipeline — log and skip
       logger.warn('[REVIEW] Fresh-eyes review failed, proceeding without review', err);
+      return 'skipped';
+    }
+  }
+
+  /**
+   * Checks whether the PR's changed files stay within the feature's declared filesToModify.
+   *
+   * Warning mode: logs violations and posts a PR comment but never blocks the pipeline.
+   * Returns 'within_budget' | 'over_budget' | 'skipped'.
+   *
+   * Per deviation rule: auto-rollback at REVIEW phase can lose legitimate cross-cutting
+   * changes, so this check is intentionally non-blocking.
+   */
+  private async checkScopeBudget(
+    ctx: StateContext
+  ): Promise<'within_budget' | 'over_budget' | 'skipped'> {
+    const { filesToModify } = ctx.feature;
+    if (!filesToModify || filesToModify.length === 0) {
+      return 'skipped';
+    }
+
+    try {
+      const { stdout } = await execAsync(
+        `gh pr view ${ctx.prNumber} --json files --jq '[.files[].path]'`,
+        { cwd: ctx.projectPath, timeout: 15000 }
+      );
+
+      let changedFiles: string[] = [];
+      try {
+        changedFiles = JSON.parse(stdout.trim()) as string[];
+      } catch {
+        logger.warn('[REVIEW] Scope budget: failed to parse PR files JSON, skipping');
+        return 'skipped';
+      }
+
+      const result = analyzeScopeBudget(changedFiles, filesToModify);
+
+      if (!result.withinBudget) {
+        logger.warn('[REVIEW] Scope budget exceeded — PR contains out-of-scope files', {
+          featureId: ctx.feature.id,
+          prNumber: ctx.prNumber,
+          outOfScopeFiles: result.outOfScopeFiles,
+          outOfScopePercent: result.outOfScopePercent.toFixed(1),
+          toleratedFiles: result.toleratedFiles,
+          declaredScope: filesToModify,
+        });
+
+        const fileLines = result.outOfScopeFiles.map((f) => `- \`${f}\``).join('\n');
+        const scopeLines = filesToModify.map((f) => `- \`${f}\``).join('\n');
+        const commentBody =
+          `**Scope Budget Warning**\n\n` +
+          `This PR modifies ${result.outOfScopeFiles.length} file(s) outside the declared \`filesToModify\` scope ` +
+          `(${result.outOfScopePercent.toFixed(1)}% out-of-scope, threshold: 20%).\n\n` +
+          `Out-of-scope files:\n${fileLines}\n\n` +
+          `Declared scope:\n${scopeLines}\n\n` +
+          `This is a warning only — the PR will proceed to merge. ` +
+          `If these changes are intentional, update \`filesToModify\` in the feature spec.`;
+
+        try {
+          await execAsync(`gh pr comment ${ctx.prNumber} --body ${JSON.stringify(commentBody)}`, {
+            cwd: ctx.projectPath,
+            timeout: 15000,
+          });
+        } catch (commentErr) {
+          logger.warn('[REVIEW] Scope budget: failed to post warning comment', commentErr);
+        }
+
+        return 'over_budget';
+      }
+
+      logger.info('[REVIEW] Scope budget check passed', {
+        featureId: ctx.feature.id,
+        prNumber: ctx.prNumber,
+        totalSourceFiles: result.totalSourceFiles,
+        toleratedFiles: result.toleratedFiles,
+      });
+      return 'within_budget';
+    } catch (err) {
+      logger.warn('[REVIEW] Scope budget check failed, proceeding without enforcement', err);
       return 'skipped';
     }
   }

--- a/apps/server/tests/unit/services/scope-budget-enforcement.test.ts
+++ b/apps/server/tests/unit/services/scope-budget-enforcement.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeScopeBudget } from '@/services/lead-engineer-review-merge-processors.js';
+
+describe('analyzeScopeBudget', () => {
+  describe('empty inputs', () => {
+    it('returns within_budget when no changed files', () => {
+      const result = analyzeScopeBudget([], ['src/foo.ts']);
+      expect(result.withinBudget).toBe(true);
+      expect(result.outOfScopeFiles).toEqual([]);
+      expect(result.totalSourceFiles).toBe(0);
+    });
+
+    it('returns within_budget when filesToModify is empty (no declared scope)', () => {
+      const result = analyzeScopeBudget(['src/foo.ts', 'src/bar.ts'], []);
+      expect(result.withinBudget).toBe(true);
+      expect(result.outOfScopeFiles).toEqual([]);
+    });
+  });
+
+  describe('metadata file exclusion', () => {
+    it('excludes lock files from analysis', () => {
+      const result = analyzeScopeBudget(
+        ['src/foo.ts', 'package-lock.json', 'pnpm-lock.yaml'],
+        ['src/foo.ts']
+      );
+      expect(result.totalSourceFiles).toBe(1);
+      expect(result.withinBudget).toBe(true);
+    });
+
+    it('excludes .automaker files from analysis', () => {
+      const result = analyzeScopeBudget(
+        ['src/foo.ts', '.automaker/features/123/feature.json'],
+        ['src/foo.ts']
+      );
+      expect(result.totalSourceFiles).toBe(1);
+    });
+
+    it('excludes .md files from analysis', () => {
+      const result = analyzeScopeBudget(
+        ['src/foo.ts', 'docs/README.md', 'CHANGELOG.md'],
+        ['src/foo.ts']
+      );
+      expect(result.totalSourceFiles).toBe(1);
+    });
+
+    it('does NOT exclude a declared .md file', () => {
+      // Files explicitly in filesToModify are never treated as metadata
+      const result = analyzeScopeBudget(
+        ['docs/guide.md', 'src/foo.ts'],
+        ['docs/guide.md', 'src/foo.ts']
+      );
+      expect(result.totalSourceFiles).toBe(2);
+      expect(result.withinBudget).toBe(true);
+    });
+  });
+
+  describe('within-scope detection', () => {
+    it('treats exact match as in-scope', () => {
+      const result = analyzeScopeBudget(['src/foo.ts', 'src/bar.ts'], ['src/foo.ts', 'src/bar.ts']);
+      expect(result.outOfScopeFiles).toEqual([]);
+      expect(result.withinBudget).toBe(true);
+    });
+
+    it('treats subdirectory match as in-scope', () => {
+      const result = analyzeScopeBudget(
+        ['src/services/auth/auth.ts', 'src/services/auth/utils.ts'],
+        ['src/services/auth']
+      );
+      expect(result.outOfScopeFiles).toEqual([]);
+      expect(result.withinBudget).toBe(true);
+    });
+  });
+
+  describe('test file tolerance (±2)', () => {
+    it('tolerates up to 2 adjacent test files without counting them out-of-scope', () => {
+      const result = analyzeScopeBudget(
+        [
+          'src/services/auth.ts', // in scope
+          'src/services/auth.test.ts', // adjacent test - tolerated
+          'src/services/auth.spec.ts', // adjacent test - tolerated
+        ],
+        ['src/services/auth.ts']
+      );
+      expect(result.toleratedFiles).toHaveLength(2);
+      expect(result.outOfScopeFiles).toHaveLength(0);
+      expect(result.withinBudget).toBe(true);
+    });
+
+    it('counts 3rd out-of-scope test file against budget', () => {
+      const result = analyzeScopeBudget(
+        [
+          'src/services/auth.ts',
+          'src/services/auth.test.ts', // tolerated
+          'src/services/auth.spec.ts', // tolerated
+          'src/services/other.test.ts', // 3rd test - not adjacent, over tolerance
+        ],
+        ['src/services/auth.ts']
+      );
+      expect(result.toleratedFiles).toHaveLength(2);
+      expect(result.outOfScopeFiles).toHaveLength(1);
+      expect(result.outOfScopeFiles[0]).toBe('src/services/other.test.ts');
+    });
+
+    it('tolerates test files in tests/ subdirectory of declared directory', () => {
+      const result = analyzeScopeBudget(
+        ['src/auth/index.ts', 'src/auth/tests/auth.test.ts'],
+        ['src/auth/index.ts']
+      );
+      expect(result.toleratedFiles).toContain('src/auth/tests/auth.test.ts');
+      expect(result.outOfScopeFiles).toHaveLength(0);
+    });
+  });
+
+  describe('scope budget threshold (20%)', () => {
+    it('is within budget when out-of-scope is exactly 20%', () => {
+      // 1 out-of-scope / 5 total = 20%
+      const result = analyzeScopeBudget(
+        [
+          'src/a.ts',
+          'src/b.ts',
+          'src/c.ts',
+          'src/d.ts',
+          'dashboard/unrelated.ts', // out-of-scope
+        ],
+        ['src/a.ts', 'src/b.ts', 'src/c.ts', 'src/d.ts']
+      );
+      expect(result.outOfScopePercent).toBeCloseTo(20, 1);
+      expect(result.withinBudget).toBe(true);
+    });
+
+    it('is over budget when out-of-scope exceeds 20%', () => {
+      // 2 out-of-scope / 5 total = 40%
+      const result = analyzeScopeBudget(
+        [
+          'src/a.ts',
+          'src/b.ts',
+          'src/c.ts',
+          'dashboard/widget.ts', // out-of-scope
+          'docs/tutorials/guide.ts', // out-of-scope
+        ],
+        ['src/a.ts', 'src/b.ts', 'src/c.ts']
+      );
+      expect(result.withinBudget).toBe(false);
+      expect(result.outOfScopeFiles).toContain('dashboard/widget.ts');
+      expect(result.outOfScopeFiles).toContain('docs/tutorials/guide.ts');
+    });
+
+    it('flags improve-adjacent-docs anti-pattern (docs/ out of scope)', () => {
+      const result = analyzeScopeBudget(
+        [
+          'src/services/auth.ts',
+          'src/services/auth.test.ts',
+          'docs/tutorials/auth-guide.ts', // improve-adjacent-docs
+          'docs/tutorials/overview.ts', // improve-adjacent-docs
+          'docs/tutorials/advanced.ts', // improve-adjacent-docs
+        ],
+        ['src/services/auth.ts']
+      );
+      // 1 test file tolerated (within 2), remaining 2 docs files + 1 extra test = out of scope
+      expect(result.withinBudget).toBe(false);
+    });
+
+    it('flags dashboard-version-bump anti-pattern (dashboard/ out of scope)', () => {
+      // 1 out-of-scope dashboard file / 2 total = 50% over budget
+      const result = analyzeScopeBudget(
+        ['src/services/feature.ts', 'dashboard/package.json'],
+        ['src/services/feature.ts']
+      );
+      // dashboard/package.json would be excluded as metadata (.json lock pattern doesn't match)
+      // but package.json IS a real file that doesn't match lock file patterns
+      // Actually, isMergeOnlyMetadata only excludes: package-lock.json, yarn.lock, pnpm-lock.yaml
+      // So dashboard/package.json is a real source file = out of scope
+      expect(result.outOfScopeFiles).toContain('dashboard/package.json');
+      expect(result.withinBudget).toBe(false);
+    });
+  });
+});

--- a/libs/prompts/src/defaults.ts
+++ b/libs/prompts/src/defaults.ts
@@ -939,9 +939,15 @@ Implement this feature by:
 
 **Scope Discipline**
 - Implement exactly what the feature description says — nothing more
+- If the feature declares \`filesToModify\`, treat that list as your hard file boundary. Do NOT edit any file outside it.
 - If the description says "create ServiceX", create only ServiceX. Do not create routes, modify index.ts, or wire it into the server unless the description explicitly asks
 - Other features in the backlog handle remaining integration work. Over-delivering causes merge conflicts and blocks other agents
 - When in doubt, do less, not more
+
+**Forbidden anti-patterns (scope creep that causes PR collision clusters):**
+- **improve-adjacent-docs**: Editing docs/tutorials/, dashboard/, or README files you encounter while working, unless they are explicitly in \`filesToModify\`. Reading them for reference is fine; editing is not.
+- **cross-file cleanup**: Fixing formatting, linting, or style issues in files you read but don't need to change.
+- **dashboard-version-bump**: Editing dashboard/package.json, root package.json, or other version/config files that are not in your declared scope. These create version-bump collisions when multiple agents run concurrently.
 
 **Turn Budget**
 - Spend no more than 20% of your turns reading/exploring code


### PR DESCRIPTION
## Summary

Tracks protoMaker issue #3418. Single-concept Arc features produce PRs touching dashboard/, docs/tutorials, multiple adjacent test files outside their stated scope. Observed: 2 DIRTY collision-clusters in one session (12 PRs total closed + reset), dashboard/package.json version-bump collisions on every parallel Arc feature.

## Proposed fix
Three layers:
1. **Agent prompt:** explicitly forbid edits outside the feature's stated scope. Add 'improve-adjacent-docs' as an anti-pattern in the system p...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced scope enforcement to restrict file modifications to declared boundaries, preventing unintended edits to adjacent documentation, dashboards, configurations, and unrelated code changes
  * Added scope budget validation for approved pull requests to monitor changes against declared scope and report violations

* **Tests**
  * Comprehensive test coverage added for scope budget analysis and validation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->