### PR TITLE
fix(pre-flight): missing epic branch should self-heal, not cluster-block children (issue #3410)

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3236,17 +3236,60 @@ Format your response as a structured markdown document.`;
                 );
               }
             } catch (epicBranchErr) {
-              // Epic branch is missing on remote. Falling back to origin/<prBaseBranch>
-              // would branch from the wrong base — the agent would commit to the wrong
-              // history and likely produce a lock-only PR that auto-merges without source
-              // changes. Fail loudly so the feature is blocked rather than silently corrupted.
-              const epicBranchName =
-                epicFeature?.branchName ?? `(unknown, epicId: ${feature.epicId})`;
-              throw new Error(
-                `Epic base branch '${epicBranchName}' not found on remote for feature ` +
-                  `${feature.id}. Push the epic branch before starting child features. ` +
-                  `Original error: ${epicBranchErr instanceof Error ? epicBranchErr.message : String(epicBranchErr)}`
+              // Epic branch is missing on remote. Auto-create and push it so child features
+              // can branch from the correct base without manual intervention.
+              if (!epicFeature?.branchName) {
+                throw new Error(
+                  `Epic '${feature.epicId}' has no branch name for feature ${feature.id}. ` +
+                    `Cannot auto-push epic branch. ` +
+                    `Original error: ${epicBranchErr instanceof Error ? epicBranchErr.message : String(epicBranchErr)}`
+                );
+              }
+              const epicBranch = epicFeature.branchName;
+              logger.info(
+                `[createWorktreeForBranch] Epic branch '${epicBranch}' not found on remote — attempting auto-push`,
+                { featureId: feature.id }
               );
+              // Check if the epic branch exists locally (from a prior checkout or creation)
+              let epicBranchExistsLocally = false;
+              try {
+                await execFileAsync('git', ['rev-parse', '--verify', epicBranch], {
+                  cwd: projectPath,
+                });
+                epicBranchExistsLocally = true;
+              } catch {
+                // Branch doesn't exist locally either
+              }
+              if (epicBranchExistsLocally) {
+                // Push the existing local branch to remote
+                await execFileAsync('git', ['push', 'origin', epicBranch], {
+                  cwd: projectPath,
+                  env: gitEnv,
+                });
+                logger.info(
+                  `[createWorktreeForBranch] Auto-pushed local epic branch '${epicBranch}' to remote`
+                );
+              } else {
+                // Create the epic branch on remote from origin/<prBaseBranch> without a local checkout
+                await execFileAsync(
+                  'git',
+                  [
+                    'push',
+                    'origin',
+                    `origin/${resolvedPrBaseBranch}:refs/heads/${epicBranch}`,
+                  ],
+                  { cwd: projectPath, env: gitEnv }
+                );
+                logger.info(
+                  `[createWorktreeForBranch] Auto-created epic branch '${epicBranch}' on remote from origin/${resolvedPrBaseBranch}`
+                );
+              }
+              // Fetch the newly pushed branch to update local tracking refs
+              await execFileAsync('git', ['fetch', 'origin', epicBranch], {
+                cwd: projectPath,
+                env: gitEnv,
+              });
+              baseBranch = `origin/${epicBranch}`;
             }
           }
 

--- a/apps/server/tests/unit/services/worktree-creation-base-branch.test.ts
+++ b/apps/server/tests/unit/services/worktree-creation-base-branch.test.ts
@@ -342,19 +342,83 @@ describe('AutoModeService - createWorktreeForBranch base branch resolution', () 
     expect(worktreeAdd![1]).not.toContain('origin/dev');
   });
 
-  it('returns null and logs an error when epic branch does not exist on remote', async () => {
+  it('auto-pushes local epic branch to remote when remote tracking ref is missing', async () => {
     mockGetEffectivePrBaseBranch.mockResolvedValue('dev');
 
     mockExecFileAsync.mockImplementation(async (bin: string, args: string[]) => {
-      // Feature branch rev-parse → not found
+      // Feature branch rev-parse → not found (forces new-branch path)
       if (args.includes('rev-parse') && args.includes('feature/test-branch')) {
         throw new Error('unknown revision');
       }
-      // Epic branch rev-parse on remote → not found (simulates missing remote branch)
+      // Epic branch remote tracking ref → not found (simulates missing remote branch)
       if (args.includes('rev-parse') && args.some((a) => a.startsWith('origin/epic/'))) {
         throw new Error('unknown revision');
       }
-      // fetch and worktree add succeed
+      // Local epic branch check (epic/my-feature without origin/ prefix) → found
+      // All other calls (fetch, push, worktree add) succeed
+      return { stdout: 'abc123', stderr: '' };
+    });
+
+    const svc = makeService();
+    const epicFeature = makeFeature({
+      id: 'epic-123',
+      isEpic: true,
+      branchName: 'epic/my-feature',
+    });
+    (svc as any).featureLoader = {
+      get: vi.fn().mockResolvedValue(epicFeature),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const childFeature = makeFeature({
+      id: 'feat-child-456',
+      epicId: 'epic-123',
+      isEpic: false,
+      branchName: 'feature/test-branch',
+    });
+
+    const result = await (svc as any).createWorktreeForBranch(
+      PROJECT_PATH,
+      BRANCH_NAME,
+      childFeature
+    );
+
+    // Auto-push of local branch should allow worktree creation to succeed
+    expect(result).not.toBeNull();
+
+    const calls = mockExecFileAsync.mock.calls as [string, string[]][];
+
+    // Verify the local branch was pushed to remote
+    const pushCall = calls.find(
+      ([bin, args]) => bin === 'git' && args.includes('push') && args.includes('epic/my-feature')
+    );
+    expect(pushCall).toBeDefined();
+
+    // Verify worktree was created from origin/epic/my-feature
+    const worktreeAdd = calls.find(
+      ([bin, args]) => bin === 'git' && args.includes('worktree') && args.includes('-B')
+    );
+    expect(worktreeAdd).toBeDefined();
+    expect(worktreeAdd![1]).toContain('origin/epic/my-feature');
+  });
+
+  it('auto-creates epic branch from prBaseBranch when branch is missing locally and remotely', async () => {
+    mockGetEffectivePrBaseBranch.mockResolvedValue('dev');
+
+    mockExecFileAsync.mockImplementation(async (bin: string, args: string[]) => {
+      // Feature branch rev-parse → not found (forces new-branch path)
+      if (args.includes('rev-parse') && args.includes('feature/test-branch')) {
+        throw new Error('unknown revision');
+      }
+      // Epic branch remote tracking ref → not found
+      if (args.includes('rev-parse') && args.some((a) => a.startsWith('origin/epic/'))) {
+        throw new Error('unknown revision');
+      }
+      // Local epic branch check → not found either
+      if (args.includes('rev-parse') && args.includes('epic/my-feature')) {
+        throw new Error('unknown revision');
+      }
+      // All other calls (fetch, push with refspec, worktree add) succeed
       return { stdout: '', stderr: '' };
     });
 
@@ -376,25 +440,86 @@ describe('AutoModeService - createWorktreeForBranch base branch resolution', () 
       branchName: 'feature/test-branch',
     });
 
-    // Missing epic branch on remote is a hard failure — the function returns null and logs an error
-    // rather than silently branching from the wrong base (which would produce a corrupt PR).
     const result = await (svc as any).createWorktreeForBranch(
       PROJECT_PATH,
       BRANCH_NAME,
       childFeature
     );
 
-    expect(result).toBeNull();
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining(`Failed to create worktree for branch "${BRANCH_NAME}"`),
-      expect.objectContaining({ message: expect.stringContaining('not found on remote') })
-    );
+    // Auto-create from prBaseBranch should allow worktree creation to succeed
+    expect(result).not.toBeNull();
 
-    // No worktree add should have been attempted
     const calls = mockExecFileAsync.mock.calls as [string, string[]][];
+
+    // Verify push with refspec was called to create the remote branch from origin/dev
+    const pushCall = calls.find(
+      ([bin, args]) =>
+        bin === 'git' &&
+        args.includes('push') &&
+        args.some((a) => a.includes('refs/heads/epic/my-feature'))
+    );
+    expect(pushCall).toBeDefined();
+
+    // Verify worktree was created from origin/epic/my-feature
     const worktreeAdd = calls.find(
       ([bin, args]) => bin === 'git' && args.includes('worktree') && args.includes('-B')
     );
-    expect(worktreeAdd).toBeUndefined();
+    expect(worktreeAdd).toBeDefined();
+    expect(worktreeAdd![1]).toContain('origin/epic/my-feature');
+  });
+
+  it('returns null when epic branch is missing on remote and auto-push fails', async () => {
+    mockGetEffectivePrBaseBranch.mockResolvedValue('dev');
+
+    mockExecFileAsync.mockImplementation(async (bin: string, args: string[]) => {
+      // Feature branch rev-parse → not found (forces new-branch path)
+      if (args.includes('rev-parse') && args.includes('feature/test-branch')) {
+        throw new Error('unknown revision');
+      }
+      // Epic branch remote tracking ref → not found
+      if (args.includes('rev-parse') && args.some((a) => a.startsWith('origin/epic/'))) {
+        throw new Error('unknown revision');
+      }
+      // Local epic branch check → not found
+      if (args.includes('rev-parse') && args.includes('epic/my-feature')) {
+        throw new Error('unknown revision');
+      }
+      // Push fails (e.g. permission denied)
+      if (args.includes('push')) {
+        throw new Error('push rejected: permission denied to refs/heads/epic/my-feature');
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const svc = makeService();
+    const epicFeature = makeFeature({
+      id: 'epic-123',
+      isEpic: true,
+      branchName: 'epic/my-feature',
+    });
+    (svc as any).featureLoader = {
+      get: vi.fn().mockResolvedValue(epicFeature),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const childFeature = makeFeature({
+      id: 'feat-child-456',
+      epicId: 'epic-123',
+      isEpic: false,
+      branchName: 'feature/test-branch',
+    });
+
+    const result = await (svc as any).createWorktreeForBranch(
+      PROJECT_PATH,
+      BRANCH_NAME,
+      childFeature
+    );
+
+    // Auto-push failed → worktree creation should return null (escalates to blocked)
+    expect(result).toBeNull();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining(`Failed to create worktree for branch "${BRANCH_NAME}"`),
+      expect.any(Error)
+    );
   });
 });


### PR DESCRIPTION
## Summary

Tracks protoMaker issue #3410. KEYSTONE for the Tier 2 epic state-machine cluster — fixes the root cause that also produces issues #3427, #3299, and feeds #3408/#3412.

## Symptom
Pre-flight 'base branch origin/feature/<epic-slug> does not exist on remote' fires on every child feature of an epic whose branch was never pushed. Observed: 43 features in protoWorkstacean all blocked with the same root cause, each needing manual reset.

## Proposed fix
In pre-flight check on worktree creation:
1. If ...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T05:44:14.547Z -->