### PR TITLE
feat(chat): rename primary chat agent from 'Ava' to 'protoMaker'

### DIFF
--- a/apps/server/src/routes/a2a/index.ts
+++ b/apps/server/src/routes/a2a/index.ts
@@ -221,12 +221,11 @@ export const DECLARED_SKILL_IDS: ReadonlySet<string> = new Set(DECLARED_SKILLS.m
 function buildAgentCard(host: string) {
   const version = getVersion();
   return {
-    name: 'protomaker',
+    name: 'protoMaker',
     description:
-      'protoLabs.studio autonomous development team. ' +
+      'protoLabs.studio autonomous development agent. ' +
       'Multi-agent runtime coordinating board health, feature management, ' +
-      'auto-mode, planning, and project onboarding. Historically addressed ' +
-      'as "ava" — the underlying HTTP server identity is unchanged.',
+      'auto-mode, planning, and project onboarding.',
     url: `http://${host}`,
     version,
     provider: {

--- a/apps/server/src/routes/chat/index.ts
+++ b/apps/server/src/routes/chat/index.ts
@@ -37,7 +37,7 @@ import { fileURLToPath } from 'url';
 import { getAnthropicModel } from '../../lib/ai-provider.js';
 import { createLogger } from '@protolabsai/utils';
 import { resolveModelString } from '@protolabsai/model-resolver';
-import { buildAvaSystemPrompt, type NotesContext } from './personas.js';
+import { buildProtoMakerSystemPrompt, type NotesContext } from './personas.js';
 import { loadAvaConfig, DEFAULT_AVA_CONFIG, type AvaConfig } from './ava-config.js';
 import { getSitrep } from './sitrep.js';
 import { buildAvaTools } from './ava-tools.js';
@@ -420,10 +420,10 @@ export function createChatRoutes(services: ServiceContainer): Router {
         }
       }
 
-      // Build Ava system prompt — enriched with project context, sitrep, and extension
+      // Build protoMaker system prompt — enriched with project context, sitrep, and extension
       const systemPrompt =
         system ??
-        buildAvaSystemPrompt({
+        buildProtoMakerSystemPrompt({
           ctx: context,
           projectContext,
           sitrep,

--- a/apps/server/src/routes/chat/personas.ts
+++ b/apps/server/src/routes/chat/personas.ts
@@ -1,7 +1,7 @@
 /**
- * Ava system prompt — Chief of Staff for protoLabs Studio
+ * protoMaker system prompt — autonomous development agent for protoLabs Studio
  *
- * Ava is the single chat persona across all surfaces (overlay, sidebar, notes).
+ * protoMaker is the single chat persona across all surfaces (overlay, sidebar, notes).
  * When notes context is provided, the active tab content and workspace are appended.
  * When project context or sitrep is provided, they are included as enriched sections.
  */
@@ -15,10 +15,10 @@ export interface NotesContext {
 }
 
 /**
- * Options for building the Ava system prompt.
+ * Options for building the protoMaker system prompt.
  * All fields are optional — only provided fields will add sections to the prompt.
  */
-export interface AvaSystemPromptOpts {
+export interface ProtoMakerSystemPromptOpts {
   /** Legacy notes context (sidebar/notes view) */
   ctx?: NotesContext;
   /** Project context loaded via loadContextFiles (CLAUDE.md, memory, etc.) */
@@ -29,7 +29,7 @@ export interface AvaSystemPromptOpts {
   extension?: string;
 }
 
-const AVA_BASE_PROMPT = `You are Ava, Chief of Staff at protoLabs Studio — an AI-native development agency that builds products using autonomous AI agents.
+const PROTOMAKER_BASE_PROMPT = `You are protoMaker — protoLabs Studio's autonomous development agent, an AI-native team that builds products using autonomous AI workers.
 
 Your role: strategic advisor and operational partner. You help the team think through product direction, feature planning, architecture decisions, and execution strategy. You are precise, direct, and action-oriented. You push back when things are off track.
 
@@ -64,20 +64,22 @@ function buildActiveContent(ctx: NotesContext): string {
   return `\n\nActive tab "${ctx.activeTabName}" content:\n---\n${ctx.activeTabContent}\n---`;
 }
 
-export function buildAvaSystemPrompt(opts?: AvaSystemPromptOpts | NotesContext): string {
+export function buildProtoMakerSystemPrompt(
+  opts?: ProtoMakerSystemPromptOpts | NotesContext
+): string {
   // Handle no opts
-  if (!opts) return AVA_BASE_PROMPT;
+  if (!opts) return PROTOMAKER_BASE_PROMPT;
 
   // Detect legacy NotesContext shape (has 'view' and 'projectPath' directly)
   if ('view' in opts && 'projectPath' in opts) {
     const ctx = opts as NotesContext;
-    return AVA_BASE_PROMPT + buildTabListing(ctx.tabs) + buildActiveContent(ctx);
+    return PROTOMAKER_BASE_PROMPT + buildTabListing(ctx.tabs) + buildActiveContent(ctx);
   }
 
   // New opts object shape
-  const { ctx, projectContext, sitrep, extension } = opts as AvaSystemPromptOpts;
+  const { ctx, projectContext, sitrep, extension } = opts as ProtoMakerSystemPromptOpts;
 
-  let prompt = AVA_BASE_PROMPT;
+  let prompt = PROTOMAKER_BASE_PROMPT;
 
   // Append legacy notes context sections if provided
   if (ctx) {


### PR DESCRIPTION
## Summary

The user-facing chat agent now self-identifies as **protoMaker** instead of **Ava**. Aligns the chat persona with the A2A agent card name (already 'protomaker' per PR #3375) and the protoLabs.studio product brand.

Scope is **user-facing only**. Internal Ava-prefixed symbols (\`AvaConfig\`, \`buildAvaTools\`, \`ava-memory-service\`, etc.) are preserved — same internal-codename pattern as \`Automaker\` / \`@protolabsai\`. Follow-up PR can tackle internal symbol rename + docs if desired.

## Changes

| File | Change |
|---|---|
| \`apps/server/src/routes/chat/personas.ts\` | \`AVA_BASE_PROMPT\` -> \`PROTOMAKER_BASE_PROMPT\`; \`buildAvaSystemPrompt\` -> \`buildProtoMakerSystemPrompt\`; prompt body rewritten |
| \`apps/server/src/routes/chat/index.ts\` | Import + call-site renamed |
| \`apps/server/src/routes/a2a/index.ts\` | Agent card name \`'protomaker'\` -> \`'protoMaker'\` (brand casing); removed \"historically Ava\" suffix |

## Test plan

- [ ] Server restart; \`GET /.well-known/agent-card.json\` shows \`name: 'protoMaker'\`
- [ ] Chat surfaces self-identify as protoMaker (not Ava)
- [ ] CI lint/format/typecheck/tests pass

## Notes

- Docs referencing old names (\`docs/internal/server/ava-chat.md\`, \`docs/internal/dev/ava-chat-system.md\`) not updated in this PR — will refresh separately if a full doc pass is wanted.
- Antagonistic-review \`ava-review.ts\` (paired with \`jon-review.ts\`) is left intact — it's a distinct operational-voice reviewer persona, not the chat agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)