### PR TITLE
fix(ci): resolve prettier violations breaking dev 'checks' workflow

### DIFF
--- a/apps/server/src/routes/webhooks/routes/github.ts
+++ b/apps/server/src/routes/webhooks/routes/github.ts
@@ -555,7 +555,9 @@ export function createGitHubWebhookHandler(
       const prTitle = payload.pull_request.title;
       const repoFullName = payload.repository.full_name;
 
-      logger.info(`PR #${prNumber} merged: ${prTitle} (branch: ${branchName} → ${baseBranch}, repo: ${repoFullName})`);
+      logger.info(
+        `PR #${prNumber} merged: ${prTitle} (branch: ${branchName} → ${baseBranch}, repo: ${repoFullName})`
+      );
 
       // Resolve the projectPath for the merged PR.
       // 1. First, look up the repo in the workspace registry (workspace/projects.yaml).

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3273,11 +3273,7 @@ Format your response as a structured markdown document.`;
                 // Create the epic branch on remote from origin/<prBaseBranch> without a local checkout
                 await execFileAsync(
                   'git',
-                  [
-                    'push',
-                    'origin',
-                    `origin/${resolvedPrBaseBranch}:refs/heads/${epicBranch}`,
-                  ],
+                  ['push', 'origin', `origin/${resolvedPrBaseBranch}:refs/heads/${epicBranch}`],
                   { cwd: projectPath, env: gitEnv }
                 );
                 logger.info(

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -3472,7 +3472,8 @@ After generating the revised spec, output:
       ) {
         const truncatedOutput =
           responseText.length > 0
-            ? responseText.slice(0, 500) + (responseText.length > 500 ? `… [${responseText.length} chars total]` : '')
+            ? responseText.slice(0, 500) +
+              (responseText.length > 500 ? `… [${responseText.length} chars total]` : '')
             : '(empty)';
         logger.warn(
           `[DegenerateSuccess] Feature ${featureId}: SDK reported success but made 0 API calls ` +

--- a/apps/server/tests/unit/services/execution-service.test.ts
+++ b/apps/server/tests/unit/services/execution-service.test.ts
@@ -1303,8 +1303,9 @@ describe('ExecutionService — exit-code-1 degenerate-success fingerprint (issue
     await svc.executeFeature(PROJECT_PATH, FEATURE_ID);
 
     // Circuit breaker must trip: feature should be marked interrupted
-    const updateCalls: Array<[string, string, Record<string, unknown>]> =
-      (featureLoader.update as ReturnType<typeof vi.fn>).mock.calls;
+    const updateCalls: Array<[string, string, Record<string, unknown>]> = (
+      featureLoader.update as ReturnType<typeof vi.fn>
+    ).mock.calls;
 
     const interruptedUpdate = updateCalls.find(([, , updates]) => updates.status === 'interrupted');
     expect(interruptedUpdate).toBeDefined();
@@ -1319,40 +1320,38 @@ describe('ExecutionService — exit-code-1 degenerate-success fingerprint (issue
     }
   });
 
-  it(
-    'pre-execution failureCount write: write-before-run increments count before runAgent is called',
-    async () => {
-      // Verifies that failureCount is written to disk BEFORE runAgent starts.
-      // If the server crashes during SDK initialization, the failure is already counted.
-      const feature = makeFeature({
-        id: FEATURE_ID,
-        status: 'backlog',
-        failureCount: 1,
-      });
-      const callbacks = makeCallbacks(feature);
-      const featureLoader = makeFeatureLoader(feature);
-      const recoveryService = makeRecoveryService();
-      const svc = makeService(callbacks, featureLoader, recoveryService);
+  it('pre-execution failureCount write: write-before-run increments count before runAgent is called', async () => {
+    // Verifies that failureCount is written to disk BEFORE runAgent starts.
+    // If the server crashes during SDK initialization, the failure is already counted.
+    const feature = makeFeature({
+      id: FEATURE_ID,
+      status: 'backlog',
+      failureCount: 1,
+    });
+    const callbacks = makeCallbacks(feature);
+    const featureLoader = makeFeatureLoader(feature);
+    const recoveryService = makeRecoveryService();
+    const svc = makeService(callbacks, featureLoader, recoveryService);
 
-      let failureCountAtRunAgentTime: number | undefined;
+    let failureCountAtRunAgentTime: number | undefined;
 
-      // Capture the failureCount that was written before runAgent executes
-      vi.spyOn(svc as any, 'runAgent').mockImplementation(async () => {
-        // Check what failureCount value was written before this call
-        const updateCalls: Array<[string, string, Record<string, unknown>]> =
-          (featureLoader.update as ReturnType<typeof vi.fn>).mock.calls;
-        const preWriteCall = updateCalls.find(
-          ([, , updates]) => typeof updates.failureCount === 'number'
-        );
-        failureCountAtRunAgentTime = preWriteCall?.[2]?.failureCount as number | undefined;
-        // Succeed normally so we can isolate the pre-write assertion
-        return Promise.resolve();
-      });
+    // Capture the failureCount that was written before runAgent executes
+    vi.spyOn(svc as any, 'runAgent').mockImplementation(async () => {
+      // Check what failureCount value was written before this call
+      const updateCalls: Array<[string, string, Record<string, unknown>]> = (
+        featureLoader.update as ReturnType<typeof vi.fn>
+      ).mock.calls;
+      const preWriteCall = updateCalls.find(
+        ([, , updates]) => typeof updates.failureCount === 'number'
+      );
+      failureCountAtRunAgentTime = preWriteCall?.[2]?.failureCount as number | undefined;
+      // Succeed normally so we can isolate the pre-write assertion
+      return Promise.resolve();
+    });
 
-      await svc.executeFeature(PROJECT_PATH, FEATURE_ID);
+    await svc.executeFeature(PROJECT_PATH, FEATURE_ID);
 
-      // failureCount must have been written to 2 (feature.failureCount=1 + 1) BEFORE runAgent ran
-      expect(failureCountAtRunAgentTime).toBe(2);
-    }
-  );
+    // failureCount must have been written to 2 (feature.failureCount=1 + 1) BEFORE runAgent ran
+    expect(failureCountAtRunAgentTime).toBe(2);
+  });
 });

--- a/apps/server/tests/unit/services/feature-scheduler-done-lock.test.ts
+++ b/apps/server/tests/unit/services/feature-scheduler-done-lock.test.ts
@@ -360,14 +360,17 @@ describe('FeatureScheduler — title-match on recent merged PRs (re-cut branch d
       status: 'backlog',
     });
 
-    setupExecMocks([], [
-      {
-        number: 42,
-        headRefName: 'fix/auth-recut-branch', // different branch name
-        mergedAt: new Date().toISOString(),
-        title: 'Implement user authentication flow', // same title
-      },
-    ]);
+    setupExecMocks(
+      [],
+      [
+        {
+          number: 42,
+          headRefName: 'fix/auth-recut-branch', // different branch name
+          mergedAt: new Date().toISOString(),
+          title: 'Implement user authentication flow', // same title
+        },
+      ]
+    );
     setupFeaturesOnDisk([feature]);
 
     const result = await scheduler.loadPendingFeatures('/fake/project');
@@ -394,14 +397,17 @@ describe('FeatureScheduler — title-match on recent merged PRs (re-cut branch d
       failureCount: 2,
     });
 
-    setupExecMocks([], [
-      {
-        number: 99,
-        headRefName: 'fix/oauth-recut',
-        mergedAt: new Date().toISOString(),
-        title: 'Add OAuth2 login support (re-cut from blocked branch)', // PR title contains feature title
-      },
-    ]);
+    setupExecMocks(
+      [],
+      [
+        {
+          number: 99,
+          headRefName: 'fix/oauth-recut',
+          mergedAt: new Date().toISOString(),
+          title: 'Add OAuth2 login support (re-cut from blocked branch)', // PR title contains feature title
+        },
+      ]
+    );
     setupFeaturesOnDisk([feature]);
 
     const result = await scheduler.loadPendingFeatures('/fake/project');
@@ -425,14 +431,17 @@ describe('FeatureScheduler — title-match on recent merged PRs (re-cut branch d
       status: 'backlog',
     });
 
-    setupExecMocks([], [
-      {
-        number: 7,
-        headRefName: 'fix/unrelated',
-        mergedAt: new Date().toISOString(),
-        title: 'Fix payment gateway timeout bug', // completely different title
-      },
-    ]);
+    setupExecMocks(
+      [],
+      [
+        {
+          number: 7,
+          headRefName: 'fix/unrelated',
+          mergedAt: new Date().toISOString(),
+          title: 'Fix payment gateway timeout bug', // completely different title
+        },
+      ]
+    );
     setupFeaturesOnDisk([feature]);
 
     const result = await scheduler.loadPendingFeatures('/fake/project');
@@ -457,14 +466,17 @@ describe('FeatureScheduler — title-match on recent merged PRs (re-cut branch d
       status: 'backlog',
     });
 
-    setupExecMocks([], [
-      {
-        number: 5,
-        headRefName: 'fix/misc',
-        mergedAt: new Date().toISOString(),
-        title: 'Fix bug', // exact match but title too short
-      },
-    ]);
+    setupExecMocks(
+      [],
+      [
+        {
+          number: 5,
+          headRefName: 'fix/misc',
+          mergedAt: new Date().toISOString(),
+          title: 'Fix bug', // exact match but title too short
+        },
+      ]
+    );
     setupFeaturesOnDisk([feature]);
 
     const result = await scheduler.loadPendingFeatures('/fake/project');

--- a/apps/server/tests/unit/services/lead-engineer-review-merge-processors.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-review-merge-processors.test.ts
@@ -425,11 +425,7 @@ describe('MergeProcessor', () => {
     });
 
     it('escalates when PR contains only lock files and markdown', async () => {
-      setupExecMock('2026-01-01T00:00:00Z\n', [
-        '.automaker-lock',
-        'pnpm-lock.yaml',
-        'README.md',
-      ]);
+      setupExecMock('2026-01-01T00:00:00Z\n', ['.automaker-lock', 'pnpm-lock.yaml', 'README.md']);
       const ctx = makeCtx();
 
       const result = await processor.process(ctx);
@@ -438,10 +434,7 @@ describe('MergeProcessor', () => {
     });
 
     it('proceeds to DEPLOY when PR contains source files alongside metadata', async () => {
-      setupExecMock('2026-01-01T00:00:00Z\n', [
-        '.automaker-lock',
-        'src/services/my-service.ts',
-      ]);
+      setupExecMock('2026-01-01T00:00:00Z\n', ['.automaker-lock', 'src/services/my-service.ts']);
       const ctx = makeCtx();
 
       const result = await processor.process(ctx);

--- a/apps/server/tests/unit/services/lead-engineer-review-processor.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-review-processor.test.ts
@@ -209,10 +209,7 @@ describe('ReviewProcessor — close_and_recut for CONFLICTING PRs', () => {
     );
 
     // Should NOT have emitted a merge event
-    expect(serviceCtx.events.emit).not.toHaveBeenCalledWith(
-      'feature:pr-merged',
-      expect.anything()
-    );
+    expect(serviceCtx.events.emit).not.toHaveBeenCalledWith('feature:pr-merged', expect.anything());
   });
 
   it('CONFLICTING PR + branch already merged → marks feature done (superseded)', async () => {

--- a/libs/platform/tests/subprocess.test.ts
+++ b/libs/platform/tests/subprocess.test.ts
@@ -207,39 +207,36 @@ describe('subprocess.ts', () => {
       });
     });
 
-    it(
-      'should yield error when process exits 1 after emitting result:success (regression #3140)',
-      async () => {
-        // Regression test for issue #3140: Claude Code SDK emits result:success in JSONL but the
-        // underlying process exits with code 1 (CLI init crash). The subprocess layer must yield an
-        // error event AFTER the result:success event so callers can detect the contradiction and
-        // treat the run as failed. Stderr must also be captured and logged at warn level.
-        const stderrMessage = 'Claude Code CLI crashed: ENOENT /usr/local/bin/claude';
-        const mockProcess = createMockProcess({
-          stdoutLines: [
-            '{"type":"result","subtype":"success","total_cost_usd":0,"session_id":"abc"}',
-          ],
-          stderrLines: [stderrMessage],
-          exitCode: 1,
-        });
+    it('should yield error when process exits 1 after emitting result:success (regression #3140)', async () => {
+      // Regression test for issue #3140: Claude Code SDK emits result:success in JSONL but the
+      // underlying process exits with code 1 (CLI init crash). The subprocess layer must yield an
+      // error event AFTER the result:success event so callers can detect the contradiction and
+      // treat the run as failed. Stderr must also be captured and logged at warn level.
+      const stderrMessage = 'Claude Code CLI crashed: ENOENT /usr/local/bin/claude';
+      const mockProcess = createMockProcess({
+        stdoutLines: [
+          '{"type":"result","subtype":"success","total_cost_usd":0,"session_id":"abc"}',
+        ],
+        stderrLines: [stderrMessage],
+        exitCode: 1,
+      });
 
-        vi.mocked(cp.spawn).mockReturnValue(mockProcess);
+      vi.mocked(cp.spawn).mockReturnValue(mockProcess);
 
-        const generator = spawnJSONLProcess(baseOptions);
-        const results = await collectAsyncGenerator(generator);
+      const generator = spawnJSONLProcess(baseOptions);
+      const results = await collectAsyncGenerator(generator);
 
-        // Should yield both the result:success JSONL event AND a follow-up error event
-        expect(results).toHaveLength(2);
-        expect(results[0]).toMatchObject({ type: 'result', subtype: 'success' });
-        expect(results[1]).toMatchObject({
-          type: 'error',
-          error: expect.stringContaining(stderrMessage),
-        });
+      // Should yield both the result:success JSONL event AND a follow-up error event
+      expect(results).toHaveLength(2);
+      expect(results[0]).toMatchObject({ type: 'result', subtype: 'success' });
+      expect(results[1]).toMatchObject({
+        type: 'error',
+        error: expect.stringContaining(stderrMessage),
+      });
 
-        // Stderr must be logged at warn level so it appears in logs for diagnosis
-        expect(consoleSpy.warn).toHaveBeenCalledWith(expect.stringContaining(stderrMessage));
-      }
-    );
+      // Stderr must be logged at warn level so it appears in logs for diagnosis
+      expect(consoleSpy.warn).toHaveBeenCalledWith(expect.stringContaining(stderrMessage));
+    });
 
     it('should yield error with exit code when stderr is empty', async () => {
       const mockProcess = createMockProcess({


### PR DESCRIPTION
## Summary

Dev CI's `checks` workflow has been **failing since the main->dev back-merge** (commit 170f58c3e onward) on the "Check formatting" step. Reformats 8 files that carried prettier violations into dev. No semantic changes.

## Evidence

- Every dev commit since ~PR #3429 has `checks` RED. Pre-break commit e00665554 (PR #3375) was green.
- CI log (run 24439007986, step "Check formatting"): `Process completed with exit code 1`
- Reproduced locally: `npx prettier --ignore-path .prettierignore --check` flagged exactly these 8 files. `--write` produces clean tree.
- Only files reformatted:
  - `apps/server/src/routes/webhooks/routes/github.ts`
  - `apps/server/src/services/auto-mode-service.ts`
  - `apps/server/src/services/auto-mode/execution-service.ts`
  - `apps/server/tests/unit/services/execution-service.test.ts`
  - `apps/server/tests/unit/services/feature-scheduler-done-lock.test.ts`
  - `apps/server/tests/unit/services/lead-engineer-review-merge-processors.test.ts`
  - `apps/server/tests/unit/services/lead-engineer-review-processor.test.ts`
  - `libs/platform/tests/subprocess.test.ts`

## Test plan

- [x] Local `prettier --check` passes on the 8 fixed files
- [ ] CI `checks` workflow passes on this PR
- [ ] Dev merge commit shows `checks: SUCCESS`

## Scope

- Unblocks `checks` only. Separate failures in `test` and `Build & push dev server image` are tracked in board feature feature-1776234779049-zgrzez2p2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)