### PR TITLE
fix(ci): replace invalid 'typeof this.x' type annotation (TS2304)

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3211,7 +3211,7 @@ Format your response as a structured markdown document.`;
           let baseBranch = `origin/${resolvedPrBaseBranch}`;
           if (feature?.epicId && !feature.isEpic) {
             // Hoist epicFeature so it's accessible in the catch block for error reporting
-            let epicFeature: Awaited<ReturnType<typeof this.featureLoader.get>> | undefined;
+            let epicFeature: Awaited<ReturnType<FeatureLoader['get']>> | undefined;
             try {
               epicFeature = await this.featureLoader.get(projectPath, feature.epicId);
               if (epicFeature?.branchName) {


### PR DESCRIPTION
## Summary

The dev `checks` workflow was failing on the **Typecheck** step (not the format step that PR #3441 fixed). Once format:check started passing, typecheck ran and exposed a pre-existing bug that came into dev via the main back-merge.

\`\`\`
apps/server/src/services/auto-mode-service.ts(3214,56): error TS2304: Cannot find name 'this'.
\`\`\`

\`typeof this.featureLoader.get\` is not valid TypeScript in this context — \`this\` in a \`typeof\` type position only works inside instance method bodies with strict conditions this file doesn't satisfy. Introduced by commit \`ab86cb864\` ("fix(ci): resolve 4 CI failures for PR #3390").

## Fix

Replace with idiomatic class-type lookup that produces the same narrowing:

\`\`\`diff
-let epicFeature: Awaited<ReturnType<typeof this.featureLoader.get>> | undefined;
+let epicFeature: Awaited<ReturnType<FeatureLoader['get']>> | undefined;
\`\`\`

\`FeatureLoader['get']\` is the same method type without needing \`this\` to resolve. \`FeatureLoader\` is already imported at line 109.

## Test plan

- [ ] CI \`checks\` workflow Typecheck step passes on this PR
- [ ] Dev merge commit finally shows \`checks: SUCCESS\` (first time since the back-merge)

## Remaining red workflows

- \`test\` — separate failure, tracked in feature-1776234779049-zgrzez2p2
- \`Build & push dev server image\` — separate failure, same feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code quality improvement with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->