### PR TITLE
Worktree creation fails when feature title contains brackets — branch name not sanitized

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -34,6 +34,7 @@ import {
   getFeatureBackupDir,
   getAppSpecPath,
   ensureAutomakerDir,
+  isValidBranchName,
 } from '@protolabsai/platform';
 import { addImplementedFeature, type ImplementedFeature } from '../lib/xml-extractor.js';
 import { debugLog } from '../lib/debug-log.js';
@@ -641,12 +642,16 @@ export class FeatureLoader implements FeatureStore {
       });
     }
 
-    // Read-only features don't need a branch — skip generation entirely
+    // Read-only features don't need a branch — skip generation entirely.
+    // If a branchName is provided by the caller, validate it before use — special characters
+    // like `[`, `]`, `(`, `)`, `:` are illegal in git refs and cause worktree creation to fail.
+    // Invalid branch names are discarded and regenerated from the title via generateBranchName.
     const branchName =
       featureData.executionMode === 'read-only'
         ? undefined
-        : featureData.branchName ||
-          this.generateBranchName(featureData.title, featureId, featureData.category);
+        : (featureData.branchName && isValidBranchName(featureData.branchName)
+            ? featureData.branchName
+            : null) ?? this.generateBranchName(featureData.title, featureId, featureData.category);
 
     // Auto-assign projectSlug if not already provided
     let resolvedProjectSlug = featureData.projectSlug;

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -649,9 +649,9 @@ export class FeatureLoader implements FeatureStore {
     const branchName =
       featureData.executionMode === 'read-only'
         ? undefined
-        : (featureData.branchName && isValidBranchName(featureData.branchName)
+        : ((featureData.branchName && isValidBranchName(featureData.branchName)
             ? featureData.branchName
-            : null) ?? this.generateBranchName(featureData.title, featureId, featureData.category);
+            : null) ?? this.generateBranchName(featureData.title, featureId, featureData.category));
 
     // Auto-assign projectSlug if not already provided
     let resolvedProjectSlug = featureData.projectSlug;

--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -28,6 +28,8 @@ vi.mock('@protolabsai/platform', () => ({
   getFeatureBackupDir: vi.fn((p: string, id: string) => `${p}/.automaker/backups/${id}`),
   getAppSpecPath: vi.fn((p: string) => `${p}/app_spec.txt`),
   ensureAutomakerDir: vi.fn(),
+  // Real implementation: only alphanumeric, hyphens, underscores, dots, forward slashes
+  isValidBranchName: vi.fn((name: string) => /^[a-zA-Z0-9._\-/]+$/.test(name)),
 }));
 
 vi.mock('@protolabsai/utils', () => ({
@@ -339,5 +341,58 @@ describe('FeatureLoader.generateBranchName with category', () => {
       'Uncategorized'
     );
     expect(branch).toMatch(/^refactor\//);
+  });
+});
+
+describe('FeatureLoader.generateBranchName — special character sanitization', () => {
+  const loader = new FeatureLoader();
+
+  it('strips brackets from feature-factory arc titles like [DD-1.0] Plugin WidgetDescriptor contract', () => {
+    // Reproduces the bug: feature-factory emits titles with bracket prefixes
+    // (e.g. [Arc 6.4], [DD-1.0], [TR-2.1]) that are illegal in git refs.
+    const branch = loader.generateBranchName(
+      '[DD-1.0] Plugin WidgetDescriptor contract',
+      'feature-123-abc1234'
+    );
+    // Must not contain [ or ] which are illegal in git refs
+    expect(branch).not.toMatch(/[\[\]]/);
+    // Must be a valid branch name format
+    expect(branch).toMatch(/^feature\//);
+    expect(branch).toMatch(/^[a-z0-9/._-]+-[a-z0-9]+$/);
+  });
+
+  it('strips parentheses from titles', () => {
+    const branch = loader.generateBranchName(
+      'Fix login (regression) from v2.1',
+      'feature-123-abc1234'
+    );
+    expect(branch).not.toMatch(/[()]/);
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('strips colon characters from titles', () => {
+    const branch = loader.generateBranchName(
+      'Arc 6.4: Widget contract implementation',
+      'feature-123-abc1234'
+    );
+    expect(branch).not.toMatch(/:/);
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('strips slash characters from slug portion of title', () => {
+    const branch = loader.generateBranchName(
+      'Add support for path/to/resource',
+      'feature-123-abc1234'
+    );
+    // Branch should have exactly one slash (the prefix separator feature/)
+    const slashCount = (branch.match(/\//g) || []).length;
+    expect(slashCount).toBe(1);
+  });
+
+  it('produces a non-empty slug for a pure-bracket title', () => {
+    const branch = loader.generateBranchName('[TR-2.1]', 'feature-123-jqr32ki');
+    // After stripping brackets and dots, slug may be empty — branch must still be valid
+    expect(branch).toMatch(/^feature\/(untitled|[a-z0-9])/);
+    expect(branch).not.toMatch(/[\[\]]/);
   });
 });


### PR DESCRIPTION
## Summary

Branch name derivation does not sanitize special characters from feature titles. Characters like `[`, `]`, `(`, `)`, `/`, `:` are illegal in git refs and cause worktree creation to fail, blocking the feature.

Repro: Create a feature with title containing brackets (e.g. `[DD-1.0] Plugin WidgetDescriptor contract`). Auto-mode derives branch `feature/[DD-1.0]-Plugin-WidgetDescriptor-contract`, which is an invalid git ref. Worktree spawn fails and the feature is blocked.

Impact: High. The `feature...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T07:32:52.136Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened branch-name handling when creating features: invalid or missing branch names are now rejected and replaced with a safe autogenerated name; read-only executions remain unchanged. Special characters that could produce illegal branch refs are sanitized.

* **Tests**
  * Added thorough tests covering branch-name validation and sanitization to ensure titles produce valid, predictable branch names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->