### PR TITLE
fix(ci): add protoMaker dev branch ruleset as code

### DIFF
--- a/scripts/infra/github-settings.sh
+++ b/scripts/infra/github-settings.sh
@@ -76,23 +76,23 @@ apply_repo_settings() {
     log_info "Repository settings updated successfully"
 }
 
-# Get or create ruleset for main branch
-apply_main_branch_ruleset() {
-    log_info "Applying main branch ruleset..."
-
-    local RULESET_FILE="scripts/infra/rulesets/main.json"
+# Apply a branch-protection ruleset (idempotent — updates if exists, else creates)
+apply_ruleset() {
+    local RULESET_NAME="$1"
+    local RULESET_FILE="$2"
+    log_info "Applying '${RULESET_NAME}' ruleset..."
 
     if [[ ! -f "$RULESET_FILE" ]]; then
         log_error "Ruleset file not found: $RULESET_FILE"
         exit 1
     fi
 
-    # Check if ruleset exists (ID: 12467930 mentioned in requirements)
-    local EXISTING_RULESET_ID=$(gh api \
+    local EXISTING_RULESET_ID
+    EXISTING_RULESET_ID=$(gh api \
         -H "Accept: application/vnd.github+json" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
         "/repos/${REPO_OWNER}/${REPO_NAME}/rulesets" \
-        --jq '.[] | select(.name == "Protect main") | .id' 2>/dev/null || echo "")
+        --jq ".[] | select(.name == \"${RULESET_NAME}\") | .id" 2>/dev/null || echo "")
 
     if [[ -n "$EXISTING_RULESET_ID" ]]; then
         log_info "Updating existing ruleset (ID: ${EXISTING_RULESET_ID})..."
@@ -103,9 +103,9 @@ apply_main_branch_ruleset() {
             "/repos/${REPO_OWNER}/${REPO_NAME}/rulesets/${EXISTING_RULESET_ID}" \
             --input "$RULESET_FILE" \
             > /dev/null
-        log_info "Ruleset updated successfully"
+        log_info "Ruleset '${RULESET_NAME}' updated successfully"
     else
-        log_info "Creating new ruleset..."
+        log_info "Creating new ruleset '${RULESET_NAME}'..."
         gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
@@ -113,8 +113,16 @@ apply_main_branch_ruleset() {
             "/repos/${REPO_OWNER}/${REPO_NAME}/rulesets" \
             --input "$RULESET_FILE" \
             > /dev/null
-        log_info "Ruleset created successfully"
+        log_info "Ruleset '${RULESET_NAME}' created successfully"
     fi
+}
+
+apply_main_branch_ruleset() {
+    apply_ruleset "Protect main" "scripts/infra/rulesets/main.json"
+}
+
+apply_dev_branch_ruleset() {
+    apply_ruleset "Protect dev" "scripts/infra/rulesets/dev.json"
 }
 
 # Verify settings
@@ -163,6 +171,9 @@ main() {
     apply_main_branch_ruleset
     echo ""
 
+    apply_dev_branch_ruleset
+    echo ""
+
     verify_settings
     echo ""
 
@@ -170,8 +181,9 @@ main() {
     log_info ""
     log_info "Next steps:"
     log_info "  1. Create a test PR to verify all required status checks pass"
-    log_info "  2. The ruleset enforces: build, test, format, audit, CodeRabbit"
-    log_info "  3. Admin bypass is available for emergency merges"
+    log_info "  2. main ruleset enforces: build, test, format, audit, CodeRabbit"
+    log_info "  3. dev ruleset enforces: checks, build, source-branch, CodeRabbit"
+    log_info "  4. Admin bypass is available for emergency merges"
 }
 
 main "$@"

--- a/scripts/infra/rulesets/dev.json
+++ b/scripts/infra/rulesets/dev.json
@@ -1,0 +1,61 @@
+{
+  "name": "Protect dev",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/dev"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          {
+            "context": "checks",
+            "integration_id": 15368
+          },
+          {
+            "context": "build",
+            "integration_id": 15368
+          },
+          {
+            "context": "source-branch",
+            "integration_id": 15368
+          },
+          {
+            "context": "CodeRabbit",
+            "integration_id": 347564
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `scripts/infra/rulesets/dev.json` for protoMaker's dev branch protection and refactors `github-settings.sh` to apply both main and dev rulesets idempotently. Follow-up to PR #3443 which shipped an `ava`-repo version at the wrong path.

## Why this is separate from #3443

PR #3443 landed a `dev.json` at `scripts/infra/ava/rulesets/` which targets the separate protoLabsAI/ava repo. This PR places a parallel ruleset at `scripts/infra/rulesets/` (protoMaker's canonical location, alongside `main.json`) and wires it into the top-level `scripts/infra/github-settings.sh`.

## Changes

- `scripts/infra/rulesets/dev.json` — new. Requires `checks`, `build`, `source-branch`, `CodeRabbit`. Blocks deletion + non-fast-forward.
- `scripts/infra/github-settings.sh` — refactored:
  - Extracted `apply_ruleset()` as a reusable function (name + file args)
  - `apply_main_branch_ruleset()` and `apply_dev_branch_ruleset()` now wrap the generic
  - `main()` applies both

## Apply after merge

Run `./scripts/infra/github-settings.sh` once to push the dev ruleset live on GitHub. This actually hardens dev protection — the file landing alone is necessary but not sufficient.

## Test plan

- [ ] CI `checks` / `build` / `source-branch` pass on this PR
- [ ] After merge, `bash ./scripts/infra/github-settings.sh` creates the "Protect dev" ruleset idempotently
- [ ] Next dev PR with a deliberately-broken `checks` cannot merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)