### PR TITLE
fix(ci): ci-complete sentinel check for dev PRs — unblocks docs-only merges

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,11 +7,6 @@ on:
       - dev
       - staging
       - main
-    paths-ignore:
-      - 'docs/**'
-      - 'site/**'
-      - '**.md'
-      - '.automaker/**'
   push:
     branches:
       - main
@@ -31,17 +26,54 @@ jobs:
   build:
     runs-on: self-hosted
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    outputs:
+      docs_only: ${{ steps.changes.outputs.docs_only }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Detect code changes
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --depth=1 origin ${{ github.event.pull_request.base.ref }}
+            CHANGED=$(git diff --name-only FETCH_HEAD HEAD)
+            CODE=$(echo "$CHANGED" | grep -Ev '^(docs/|site/|\.automaker/)' | grep -Ev '\.md$' | head -1)
+            if [ -z "$CODE" ]; then
+              echo "docs_only=true" >> $GITHUB_OUTPUT
+              echo "Docs-only change detected — skipping build"
+            else
+              echo "docs_only=false" >> $GITHUB_OUTPUT
+              echo "Code changes detected — build required"
+            fi
+          else
+            echo "docs_only=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Setup project
+        if: steps.changes.outputs.docs_only != 'true'
         uses: ./.github/actions/setup-project
         with:
           check-lockfile: 'true'
 
       - name: Build web app
+        if: steps.changes.outputs.docs_only != 'true'
         run: npm run build
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
+
+  ci-complete:
+    runs-on: self-hosted
+    needs: [build]
+    if: always() && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request')
+    steps:
+      - name: Verify build passed
+        run: |
+          BUILD_RESULT="${{ needs.build.result }}"
+          echo "Build result: $BUILD_RESULT"
+          if [ "$BUILD_RESULT" = "failure" ]; then
+            echo "Build failed — blocking merge"
+            exit 1
+          fi
+          echo "CI complete"

--- a/scripts/infra/rulesets/dev.json
+++ b/scripts/infra/rulesets/dev.json
@@ -36,7 +36,7 @@
             "integration_id": 15368
           },
           {
-            "context": "build",
+            "context": "ci-complete",
             "integration_id": 15368
           },
           {


### PR DESCRIPTION
## Summary

Ships the work from board feature feature-1776276030933-gfeixra82 (agent-authored, mechanically pushed by operator because agent OAuth token lacks workflow scope for editing `.github/workflows/**`).

## Problem

Dev branch protection required `build` as a status check, but `pr-check.yml` had `paths-ignore` for docs/**/site/**/**.md/.automaker/**. Docs-only PRs to dev never emitted `build` and stayed permanently blocked. Observed on PR #3433 (Fleet Command PRD) — required manual ruleset edit to unblock.

## Fix (Approach A: sentinel check)

- Added `ci-complete` job to `pr-check.yml` that always runs on PRs and emits a status
  - Passes on docs-only diffs (build skipped by design)
  - Depends on `build` result for code PRs (fails if build fails)
- Removed `paths-ignore` from `pull_request` trigger (kept on `push` trigger — push events don't gate required checks)
- Added `detect-changes` step inside `build` job: fetches base ref, diffs to determine docs-only, short-circuits to success on docs-only
- Updated `scripts/infra/rulesets/dev.json`: replaced `build` with `ci-complete` in required_status_checks

## Post-merge action required

Run `scripts/infra/github-settings.sh` to apply the updated ruleset to GitHub. The JSON change doesn't self-apply.

## Test plan

- [ ] CI passes on this PR (the sentinel's first real run)
- [ ] Docs-only follow-up PR to dev merges without intervention
- [ ] Code PR to dev still requires build to succeed

🤖 Ships agent output that failed to auto-push due to OAuth workflow scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow to optimize build performance and streamline verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->