### PR TITLE
chore: auto-cleanup worktrees for features in done state

### DIFF
--- a/apps/server/src/routes/ops/index.ts
+++ b/apps/server/src/routes/ops/index.ts
@@ -1,11 +1,12 @@
 /**
  * Ops routes - Operational management endpoints
  *
- * /api/ops/timers       - Timer registry (cron + interval listing, pause/resume)
- * /api/ops/deliveries   - Webhook delivery tracking (list, detail, retry)
- * /api/ops/audit        - Tool execution audit log (recent entries with filtering)
- * /api/ops/concurrency  - Concurrency resolution overview (precedence chain + active loops)
- * /api/ops/events       - Correlated event store (query, chain reconstruction)
+ * /api/ops/timers            - Timer registry (cron + interval listing, pause/resume)
+ * /api/ops/deliveries        - Webhook delivery tracking (list, detail, retry)
+ * /api/ops/audit             - Tool execution audit log (recent entries with filtering)
+ * /api/ops/concurrency       - Concurrency resolution overview (precedence chain + active loops)
+ * /api/ops/events            - Correlated event store (query, chain reconstruction)
+ * /api/ops/worktree-cleanup  - Manual trigger for done-worktree cleanup sweep
  */
 
 import { Router } from 'express';
@@ -17,11 +18,14 @@ import type { AuditService } from '../../services/audit-service.js';
 import type { AutoModeService } from '../../services/auto-mode-service.js';
 import type { SettingsService } from '../../services/settings-service.js';
 import type { EventStore } from '../../lib/event-store.js';
+import type { WorktreeLifecycleService } from '../../services/worktree-lifecycle-service.js';
+import type { FeatureLoader } from '../../services/feature-loader.js';
 import { createTimersRoutes } from './routes/timers.js';
 import { createDeliveriesRoutes } from './routes/deliveries.js';
 import { createAuditRoutes } from './routes/audit.js';
 import { createConcurrencyRoutes } from './routes/concurrency.js';
 import { createEventsRoutes } from './routes/events.js';
+import { createWorktreeCleanupRoutes } from './routes/worktree-cleanup.js';
 
 export function createOpsRoutes(
   schedulerService: SchedulerService,
@@ -30,7 +34,9 @@ export function createOpsRoutes(
   auditService: AuditService,
   autoModeService: AutoModeService,
   settingsService: SettingsService,
-  eventStore: EventStore
+  eventStore: EventStore,
+  worktreeLifecycleService: WorktreeLifecycleService,
+  featureLoader: FeatureLoader
 ): Router {
   const router = Router();
 
@@ -39,6 +45,10 @@ export function createOpsRoutes(
   router.use('/audit', createAuditRoutes(auditService));
   router.use('/concurrency', createConcurrencyRoutes(autoModeService, settingsService));
   router.use('/events', createEventsRoutes(eventStore));
+  router.use(
+    '/worktree-cleanup',
+    createWorktreeCleanupRoutes(worktreeLifecycleService, featureLoader, events, autoModeService)
+  );
 
   return router;
 }

--- a/apps/server/src/routes/ops/routes/worktree-cleanup.ts
+++ b/apps/server/src/routes/ops/routes/worktree-cleanup.ts
@@ -1,0 +1,62 @@
+/**
+ * Worktree Cleanup API routes
+ *
+ * Manual trigger for the done-worktree-cleanup maintenance sweep.
+ *
+ * POST /           - Run a one-shot cleanup sweep across all active projects.
+ *                    Body: { dryRun?: boolean }
+ *                    Returns: { removed, paths, dryRun, projectCount, summary, durationMs }
+ */
+
+import { Router } from 'express';
+import { createLogger } from '@protolabsai/utils';
+import { DoneWorktreeCleanupCheck } from '../../../services/maintenance/checks/done-worktree-cleanup-check.js';
+import type { WorktreeLifecycleService } from '../../../services/worktree-lifecycle-service.js';
+import type { FeatureLoader } from '../../../services/feature-loader.js';
+import type { EventEmitter } from '../../../lib/events.js';
+import type { AutoModeService } from '../../../services/auto-mode-service.js';
+
+const logger = createLogger('Routes:WorktreeCleanup');
+
+export function createWorktreeCleanupRoutes(
+  worktreeLifecycleService: WorktreeLifecycleService,
+  featureLoader: FeatureLoader,
+  events: EventEmitter,
+  autoModeService: AutoModeService
+): Router {
+  const router = Router();
+
+  router.post('/', async (req, res) => {
+    const dryRun = req.body?.dryRun === true;
+
+    logger.info(`Manual worktree cleanup triggered (dryRun=${dryRun})`);
+
+    try {
+      const projectPaths = Array.from(new Set(autoModeService.getActiveAutoLoopProjects()));
+
+      const check = new DoneWorktreeCleanupCheck(
+        worktreeLifecycleService,
+        featureLoader,
+        events,
+        dryRun
+      );
+
+      const result = await check.run({ projectPaths });
+
+      res.json({
+        removed: (result.details?.totalRemoved as number) ?? 0,
+        paths: (result.details?.removedPaths as string[]) ?? [],
+        dryRun: (result.details?.dryRun as boolean) ?? dryRun,
+        projectCount: projectPaths.length,
+        summary: result.summary,
+        durationMs: result.durationMs,
+      });
+    } catch (err) {
+      logger.error('Manual worktree cleanup failed:', err);
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -484,7 +484,9 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
       auditService,
       autoModeService,
       settingsService,
-      eventStore
+      eventStore,
+      worktreeLifecycleService,
+      featureLoader
     )
   );
   logger.info('Ops routes mounted at /api/ops');

--- a/apps/server/src/services/maintenance.module.ts
+++ b/apps/server/src/services/maintenance.module.ts
@@ -6,6 +6,7 @@
  * - resource-usage (critical tier, 5min): HealthMonitorService resource check
  * - webhook-health (full tier, 6h): Warns when PRs in review have no CI events after grace period
  * - post-merge-reconciler (critical tier, 5min): Poll-based fallback for missed PR merge webhooks
+ * - done-worktree-cleanup (full tier, 6h): Removes worktrees for done features and orphaned worktrees
  */
 
 import { createLogger } from '@protolabsai/utils';
@@ -17,6 +18,7 @@ import type {
 import type { ServiceContainer } from '../server/services.js';
 import { WebhookHealthCheck } from './maintenance/checks/webhook-health-check.js';
 import { PostMergeReconcilerCheck } from './maintenance/checks/post-merge-reconciler-check.js';
+import { DoneWorktreeCleanupCheck } from './maintenance/checks/done-worktree-cleanup-check.js';
 
 const logger = createLogger('Server:Wiring');
 
@@ -29,6 +31,7 @@ export function register(container: ServiceContainer): void {
     events,
     eventHistoryService,
     autoModeService,
+    worktreeLifecycleService,
   } = container;
 
   // Board health check (full tier) — replaces built-in:board-health automation
@@ -170,10 +173,18 @@ export function register(container: ServiceContainer): void {
     },
   };
 
+  // Done worktree cleanup (full tier) — removes worktrees for done features and orphaned worktrees
+  const doneWorktreeCleanupCheck = new DoneWorktreeCleanupCheck(
+    worktreeLifecycleService,
+    featureLoader,
+    events
+  );
+
   maintenanceOrchestrator.register(boardHealthCheck);
   maintenanceOrchestrator.register(resourceUsageCheck);
   maintenanceOrchestrator.register(webhookHealthCheck);
   maintenanceOrchestrator.register(postMergeReconcilerCheck);
+  maintenanceOrchestrator.register(doneWorktreeCleanupCheck);
 
   // Wire TopicBus for hierarchical event routing of sweep results
   if (container.topicBus) {
@@ -189,6 +200,6 @@ export function register(container: ServiceContainer): void {
   });
 
   logger.info(
-    'MaintenanceOrchestrator started with board-health, resource-usage, webhook-health, and post-merge-reconciler checks'
+    'MaintenanceOrchestrator started with board-health, resource-usage, webhook-health, post-merge-reconciler, and done-worktree-cleanup checks'
   );
 }

--- a/apps/server/src/services/maintenance/checks/done-worktree-cleanup-check.ts
+++ b/apps/server/src/services/maintenance/checks/done-worktree-cleanup-check.ts
@@ -1,0 +1,246 @@
+/**
+ * DoneWorktreeCleanupCheck - Periodic sweep that removes worktrees for completed features.
+ *
+ * Runs as a full-tier (6h) maintenance check. For each project:
+ * 1. Removes worktrees for features in 'done' status via WorktreeLifecycleService.
+ * 2. Removes fully orphaned worktrees (directory on disk with no matching feature).
+ *
+ * Safety:
+ * - Worktrees with uncommitted changes are skipped (enforced by WorktreeLifecycleService).
+ * - Worktrees for in-flight features (not 'done') are never removed.
+ * - Dry-run mode: set WORKTREE_CLEANUP_DRY_RUN=true to list removals without acting.
+ *
+ * Events:
+ * - Emits 'worktree:cleanup' with { projectPath, removed, paths, dryRun } after each project sweep.
+ */
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import path from 'path';
+import type { Dirent } from 'fs';
+import { createLogger } from '@protolabsai/utils';
+import type {
+  MaintenanceCheck,
+  MaintenanceCheckContext,
+  MaintenanceCheckResult,
+} from '@protolabsai/types';
+import type { WorktreeLifecycleService } from '../../worktree-lifecycle-service.js';
+import type { FeatureLoader } from '../../feature-loader.js';
+import type { EventEmitter } from '../../../lib/events.js';
+import * as secureFs from '../../../lib/secure-fs.js';
+
+const logger = createLogger('DoneWorktreeCleanupCheck');
+
+const execAsync = promisify(exec) as (
+  command: string,
+  options?: { cwd?: string }
+) => Promise<{ stdout: string; stderr: string }>;
+
+export class DoneWorktreeCleanupCheck implements MaintenanceCheck {
+  readonly id = 'done-worktree-cleanup';
+  readonly name = 'Done Worktree Cleanup';
+  readonly tier = 'full' as const;
+
+  private readonly dryRun: boolean;
+
+  constructor(
+    private readonly worktreeLifecycleService: WorktreeLifecycleService,
+    private readonly featureLoader: FeatureLoader,
+    private readonly events: EventEmitter,
+    dryRun?: boolean
+  ) {
+    this.dryRun = dryRun ?? process.env.WORKTREE_CLEANUP_DRY_RUN === 'true';
+  }
+
+  async run(context: MaintenanceCheckContext): Promise<MaintenanceCheckResult> {
+    const t0 = Date.now();
+    let totalRemoved = 0;
+    const allRemovedPaths: string[] = [];
+
+    for (const projectPath of context.projectPaths) {
+      try {
+        const { removed, paths } = await this.sweepProject(projectPath);
+        totalRemoved += removed;
+        allRemovedPaths.push(...paths);
+
+        this.events.emit('worktree:cleanup', {
+          projectPath,
+          removed,
+          paths,
+          dryRun: this.dryRun,
+        });
+      } catch (err) {
+        logger.error(`Done worktree cleanup failed for ${projectPath}:`, err);
+      }
+    }
+
+    const dryRunNote = this.dryRun ? ' (dry-run)' : '';
+
+    return {
+      checkId: this.id,
+      passed: true,
+      summary:
+        totalRemoved > 0
+          ? `Worktree cleanup${dryRunNote}: ${totalRemoved} stale worktree(s) removed across ${context.projectPaths.length} projects`
+          : `Worktree cleanup${dryRunNote}: no stale worktrees found across ${context.projectPaths.length} projects`,
+      details: {
+        totalRemoved,
+        removedPaths: allRemovedPaths,
+        projectCount: context.projectPaths.length,
+        dryRun: this.dryRun,
+      },
+      durationMs: Date.now() - t0,
+    };
+  }
+
+  /**
+   * Sweep a single project: remove done-feature worktrees and orphaned worktrees.
+   */
+  private async sweepProject(projectPath: string): Promise<{ removed: number; paths: string[] }> {
+    const features = await this.featureLoader.getAll(projectPath);
+    const worktreesDir = path.join(projectPath, '.worktrees');
+
+    // Enumerate worktree directories on disk
+    let worktreeDirs: string[] = [];
+    try {
+      const entries = (await secureFs.readdir(worktreesDir, {
+        withFileTypes: true,
+      })) as unknown as Dirent[];
+      worktreeDirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+    } catch {
+      return { removed: 0, paths: [] };
+    }
+
+    // Index features by branch slug for O(1) lookup
+    const featureBySlug = new Map(
+      features
+        .filter((f) => f.branchName)
+        .map((f) => [this.branchSlug(f.branchName!), f])
+    );
+
+    // Classify each worktree directory
+    const doneWorktreePaths: string[] = [];
+    const orphanedWorktreeDirs: string[] = [];
+
+    for (const dir of worktreeDirs) {
+      if (dir === 'main' || dir === 'master') continue;
+
+      const feature = featureBySlug.get(dir);
+      if (feature) {
+        if (feature.status === 'done') {
+          doneWorktreePaths.push(path.join(worktreesDir, dir));
+        }
+        // Features not done are skipped (in-flight protection)
+      } else {
+        orphanedWorktreeDirs.push(dir);
+      }
+    }
+
+    if (this.dryRun) {
+      return this.dryRunSweep(worktreesDir, doneWorktreePaths, orphanedWorktreeDirs);
+    }
+
+    return this.livesweep(projectPath, worktreesDir, doneWorktreePaths, orphanedWorktreeDirs);
+  }
+
+  private async dryRunSweep(
+    worktreesDir: string,
+    doneWorktreePaths: string[],
+    orphanedDirs: string[]
+  ): Promise<{ removed: number; paths: string[] }> {
+    const paths: string[] = [];
+
+    for (const p of doneWorktreePaths) {
+      logger.info(`[dry-run] Would remove done-feature worktree: ${p}`);
+      paths.push(p);
+    }
+
+    for (const dir of orphanedDirs) {
+      const p = path.join(worktreesDir, dir);
+      if (await this.isOrphanSafeToRemove(p)) {
+        logger.info(`[dry-run] Would remove orphaned worktree: ${p}`);
+        paths.push(p);
+      }
+    }
+
+    return { removed: paths.length, paths };
+  }
+
+  private async livesweep(
+    projectPath: string,
+    worktreesDir: string,
+    doneWorktreePaths: string[],
+    orphanedDirs: string[]
+  ): Promise<{ removed: number; paths: string[] }> {
+    const removedPaths: string[] = [];
+
+    // Phase 1: remove done-feature worktrees via lifecycle service (handles locks)
+    if (doneWorktreePaths.length > 0) {
+      try {
+        const cleaned = await this.worktreeLifecycleService.cleanupAllDoneFeatures(projectPath);
+        logger.info(`cleanupAllDoneFeatures removed ${cleaned} worktree(s) for ${projectPath}`);
+
+        // Record which done worktrees are now gone
+        for (const p of doneWorktreePaths) {
+          const stillExists = await this.pathExists(p);
+          if (!stillExists) removedPaths.push(p);
+        }
+      } catch (err) {
+        logger.warn(`cleanupAllDoneFeatures failed for ${projectPath}: ${err}`);
+      }
+    }
+
+    // Phase 2: remove fully orphaned worktrees
+    for (const dir of orphanedDirs) {
+      const p = path.join(worktreesDir, dir);
+      if (!(await this.isOrphanSafeToRemove(p))) continue;
+      await this.removeWorktree(projectPath, p, dir, removedPaths);
+    }
+
+    return { removed: removedPaths.length, paths: removedPaths };
+  }
+
+  private async pathExists(p: string): Promise<boolean> {
+    try {
+      await secureFs.stat(p);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async isOrphanSafeToRemove(worktreePath: string): Promise<boolean> {
+    try {
+      const { stdout } = await execAsync('git status --porcelain', { cwd: worktreePath });
+      return !stdout.trim();
+    } catch {
+      return true;
+    }
+  }
+
+  private async removeWorktree(
+    projectPath: string,
+    worktreePath: string,
+    dir: string,
+    removedPaths: string[]
+  ): Promise<void> {
+    logger.info(`Removing orphaned worktree: ${worktreePath}`);
+    try {
+      await execAsync(`git worktree remove "${worktreePath}" --force`, { cwd: projectPath });
+      removedPaths.push(worktreePath);
+    } catch {
+      try {
+        await secureFs.rm(worktreePath, { recursive: true, force: true });
+        await execAsync('git worktree prune', { cwd: projectPath });
+        removedPaths.push(worktreePath);
+        logger.info(`Manually removed orphaned worktree: ${worktreePath} (dir: ${dir})`);
+      } catch (err2) {
+        logger.warn(`Failed to remove orphaned worktree ${worktreePath}: ${err2}`);
+      }
+    }
+  }
+
+  private branchSlug(branchName: string): string {
+    return branchName.split('/').pop() ?? branchName;
+  }
+}

--- a/apps/server/src/services/maintenance/checks/done-worktree-cleanup-check.ts
+++ b/apps/server/src/services/maintenance/checks/done-worktree-cleanup-check.ts
@@ -113,9 +113,7 @@ export class DoneWorktreeCleanupCheck implements MaintenanceCheck {
 
     // Index features by branch slug for O(1) lookup
     const featureBySlug = new Map(
-      features
-        .filter((f) => f.branchName)
-        .map((f) => [this.branchSlug(f.branchName!), f])
+      features.filter((f) => f.branchName).map((f) => [this.branchSlug(f.branchName!), f])
     );
 
     // Classify each worktree directory

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -205,6 +205,7 @@ export type EventType =
   // Worktree recovery events
   | 'worktree:drift-detected'
   | 'worktree:phantom-pruned'
+  | 'worktree:cleanup'
   // World state monitor events
   | 'world-state:reconciliation'
   // Chief of Staff (CoS) events
@@ -640,6 +641,14 @@ export interface EventPayloadMap {
   // Health events
   'health:issue-detected': { message?: string; severity?: string };
   'health:issue-remediated': { message?: string };
+
+  // Worktree cleanup event
+  'worktree:cleanup': {
+    projectPath: string;
+    removed: number;
+    paths: string[];
+    dryRun: boolean;
+  };
 
   // Maintenance sweep events
   'maintenance:sweep:started': { sweepId: string; tier: 'critical' | 'full'; startedAt: string };


### PR DESCRIPTION
## Summary

## Observation

`.worktrees/` has **90 directories** — most correspond to features long since completed. Each worktree holds a checked-out branch (many stale, some still mergeable). Accumulates disk usage and complicates debugging.

## Proposed fix

Periodic sweep (maintenance-task) that:
1. For each worktree, look up the matching feature by branch name.
2. If the feature is done AND its PR is merged, run `git worktree remove --force`.
3. If no matching feature exists (fully orphaned), remove it...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T18:14:04.884Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new maintenance operation for cleaning up worktrees associated with completed features and orphaned worktrees.
  * Includes dry-run mode to safely preview cleanup actions before implementation.
  * Provides detailed reporting with removal counts, affected paths, duration metrics, and project information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->