### PR TITLE
fix(webhook): post-merge reconciliation doesn't transition review→done reliably

### DIFF
--- a/apps/server/src/services/maintenance.module.ts
+++ b/apps/server/src/services/maintenance.module.ts
@@ -191,13 +191,39 @@ export function register(container: ServiceContainer): void {
     maintenanceOrchestrator.setTopicBus(container.topicBus);
   }
 
+  const { repoRoot } = container;
+
+  // Always include repoRoot so the reconciler runs even when auto-mode is off.
+  // Auto-mode active projects are added on top for multi-project setups.
   maintenanceOrchestrator.start(schedulerService, events, eventHistoryService, () => {
     const paths = new Set<string>();
+    paths.add(repoRoot);
     for (const p of autoModeService.getActiveAutoLoopProjects()) {
       paths.add(p);
     }
     return Array.from(paths);
   });
+
+  // Dedicated 60-second poll interval for the post-merge reconciler so that
+  // features in 'review' with merged PRs transition to 'done' within 90 seconds
+  // on local dev servers where webhooks never arrive (the maintenance critical
+  // tier runs every 5 minutes which is too slow for this SLA).
+  schedulerService.registerInterval(
+    'post-merge-reconciler:poll',
+    'Post-Merge Reconciler Poll (60s)',
+    60_000,
+    async () => {
+      const paths = new Set<string>();
+      paths.add(repoRoot);
+      for (const p of autoModeService.getActiveAutoLoopProjects()) {
+        paths.add(p);
+      }
+      for (const projectPath of paths) {
+        await postMergeReconcilerInstance.run(projectPath);
+      }
+    },
+    { category: 'sync' }
+  );
 
   logger.info(
     'MaintenanceOrchestrator started with board-health, resource-usage, webhook-health, post-merge-reconciler, and done-worktree-cleanup checks'

--- a/apps/server/src/services/maintenance/checks/post-merge-reconciler-check.ts
+++ b/apps/server/src/services/maintenance/checks/post-merge-reconciler-check.ts
@@ -117,7 +117,10 @@ export class PostMergeReconcilerCheck {
             `[reconciler] PR #${feature.prNumber} on ${repo} is merged — transitioning feature "${feature.title}" (${feature.id}) from review → done (missed webhook)`
           );
 
-          await this.featureLoader.update(projectPath, feature.id, { status: 'done' });
+          await this.featureLoader.update(projectPath, feature.id, {
+            status: 'done',
+            statusChangeReason: 'merged PR detected via poll reconciliation',
+          });
 
           this.events.emit('feature:pr-merged', {
             featureId: feature.id,

--- a/apps/server/tests/unit/services/post-merge-reconciler-check.test.ts
+++ b/apps/server/tests/unit/services/post-merge-reconciler-check.test.ts
@@ -115,7 +115,7 @@ describe('PostMergeReconcilerCheck', () => {
     expect(mockFeatureLoaderUpdate).toHaveBeenCalledWith(
       '/home/josh/dev/labs/mythxengine',
       'feature-001',
-      { status: 'done' }
+      { status: 'done', statusChangeReason: 'merged PR detected via poll reconciliation' }
     );
     expect(emittedEvents).toHaveLength(1);
     expect(emittedEvents[0]).toMatchObject({ featureId: 'feature-001', prNumber: 184 });
@@ -210,6 +210,7 @@ describe('PostMergeReconcilerCheck', () => {
     expect(mockFeatureLoaderUpdate).toHaveBeenCalledTimes(1);
     expect(mockFeatureLoaderUpdate).toHaveBeenCalledWith(expect.any(String), 'f-002', {
       status: 'done',
+      statusChangeReason: 'merged PR detected via poll reconciliation',
     });
   });
 


### PR DESCRIPTION
## Summary

## Observation

On localhost dev servers (port 3008), features in `review` with merged PRs do NOT auto-transition to `done`. Observed on gfeixra82 (PR #3446).

## Root cause (diagnosed this session)

The GitHub webhook for protoLabsAI/protoMaker is configured to deliver to **`https://hooks.proto-labs.ai/webhook/github`** — a cloud gateway — not the local dev server. So merge events never reach localhost:3008 listeners.

Proof: `GET /api/ops/deliveries` on localhost returns `count: 0`. `gh api /r...

---
*Recovered automatically by Automaker post-agent hook*