### PR TITLE
fix(test): lead-engineer review/merge processor tests failing on dev

### DIFF
--- a/apps/server/tests/unit/services/lead-engineer-review-merge-processors.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-review-merge-processors.test.ts
@@ -200,13 +200,15 @@ describe('ReviewProcessor', () => {
     function setupCiFailureExecMock(ciCheckName = 'CI / test') {
       mockExec.mockReset();
       mockExec
-        // Call 1: normalizePR fails → caught, returns early
+        // Call 1: getMergeableState → MERGEABLE (no conflict)
+        .mockImplementationOnce(execSuccess({ stdout: '"MERGEABLE"', stderr: '' }))
+        // Call 2: normalizePR fails → caught, returns early
         .mockImplementationOnce(execFailure(new Error('normalizePR network error')))
-        // Call 2: merge check — PR is OPEN
+        // Call 3: merge check — PR is OPEN
         .mockImplementationOnce(
           execSuccess({ stdout: JSON.stringify({ state: 'OPEN', mergedAt: null }), stderr: '' })
         )
-        // Call 3: main review state check — CI failure
+        // Call 4: main review state check — CI failure
         .mockImplementationOnce(
           execSuccess({
             stdout: JSON.stringify({
@@ -217,7 +219,7 @@ describe('ReviewProcessor', () => {
             stderr: '',
           })
         )
-        // Call 4: fetch CI failure names
+        // Call 5: fetch CI failure names
         .mockImplementationOnce(execSuccess({ stdout: ciCheckName, stderr: '' }));
     }
 

--- a/apps/server/tests/unit/services/lead-engineer-review-processor.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-review-processor.test.ts
@@ -176,15 +176,17 @@ describe('ReviewProcessor — close_and_recut for CONFLICTING PRs', () => {
     (serviceCtx.featureLoader.get as ReturnType<typeof vi.fn>).mockResolvedValue(feature);
 
     // Call sequence:
-    // 1. getMergeableState: returns CONFLICTING
-    // 2. gh pr comment: success
-    // 3. gh pr close: success
-    // 4. checkBranchMerged (gh pr list): returns '' (not merged)
+    // 1. checkBranchMerged (gh pr list): returns '' (not merged yet)
+    // 2. getMergeableState: returns CONFLICTING
+    // 3. gh pr comment: success
+    // 4. gh pr close: success
+    // 5. checkBranchMerged inside handleConflictingPR (gh pr list): returns '' (not merged)
     mockExecAsync
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // checkBranchMerged → not merged
       .mockResolvedValueOnce({ stdout: '"CONFLICTING"', stderr: '' }) // getMergeableState
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh pr comment
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh pr close
-      .mockResolvedValueOnce({ stdout: '', stderr: '' }); // checkBranchMerged
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }); // checkBranchMerged (handleConflictingPR)
 
     const processor = new ReviewProcessor(serviceCtx);
     const ctx = makeCtx(feature, 42);
@@ -218,15 +220,17 @@ describe('ReviewProcessor — close_and_recut for CONFLICTING PRs', () => {
     (serviceCtx.featureLoader.get as ReturnType<typeof vi.fn>).mockResolvedValue(feature);
 
     // Call sequence:
-    // 1. getMergeableState: CONFLICTING
-    // 2. gh pr comment: success
-    // 3. gh pr close: success
-    // 4. checkBranchMerged (gh pr list): returns a mergedAt timestamp → merged
+    // 1. checkBranchMerged (gh pr list): returns '' (not merged yet)
+    // 2. getMergeableState: CONFLICTING
+    // 3. gh pr comment: success
+    // 4. gh pr close: success
+    // 5. checkBranchMerged inside handleConflictingPR: returns a mergedAt timestamp → merged
     mockExecAsync
-      .mockResolvedValueOnce({ stdout: '"CONFLICTING"', stderr: '' })
-      .mockResolvedValueOnce({ stdout: '', stderr: '' })
-      .mockResolvedValueOnce({ stdout: '', stderr: '' })
-      .mockResolvedValueOnce({ stdout: '2024-01-15T12:00:00Z\n', stderr: '' });
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // checkBranchMerged → not merged
+      .mockResolvedValueOnce({ stdout: '"CONFLICTING"', stderr: '' }) // getMergeableState
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh pr comment
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh pr close
+      .mockResolvedValueOnce({ stdout: '2024-01-15T12:00:00Z\n', stderr: '' }); // checkBranchMerged (handleConflictingPR)
 
     const processor = new ReviewProcessor(serviceCtx);
     const ctx = makeCtx(feature, 42);

--- a/apps/server/tests/unit/services/lead-engineer/fresh-eyes-review.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer/fresh-eyes-review.test.ts
@@ -127,6 +127,7 @@ function workflowSettingsWithFreshEyes(enabled = true, model = 'haiku') {
 function setupApprovedExecMocks(extraCalls: { stdout: string; stderr: string }[] = []) {
   mockExecAsync
     .mockResolvedValueOnce({ stdout: '', stderr: '' }) // checkBranchMerged → not merged
+    .mockResolvedValueOnce({ stdout: '"MERGEABLE"', stderr: '' }) // getMergeableState → no conflict
     .mockResolvedValueOnce({ stdout: NORMALIZE_RESPONSE, stderr: '' }) // normalizePR body/autoMerge
     .mockResolvedValueOnce({
       stdout: JSON.stringify({ state: 'OPEN', mergedAt: null }),
@@ -147,6 +148,7 @@ function setupApprovedExecMocks(extraCalls: { stdout: string; stderr: string }[]
 function setupApprovedExecMocksDisabled() {
   mockExecAsync
     .mockResolvedValueOnce({ stdout: '', stderr: '' }) // checkBranchMerged
+    .mockResolvedValueOnce({ stdout: '"MERGEABLE"', stderr: '' }) // getMergeableState → no conflict
     .mockResolvedValueOnce({ stdout: NORMALIZE_RESPONSE, stderr: '' }) // normalizePR
     .mockResolvedValueOnce({
       stdout: JSON.stringify({ state: 'OPEN', mergedAt: null }),


### PR DESCRIPTION
## Summary

## Observation (2026-04-15)

The `test` workflow is failing on dev HEAD. Multiple failures concentrated in Lead Engineer review/merge processors:

**File: `apps/server/tests/unit/services/lead-engineer-review-merge-processors.test.ts`**
- CI failure handling > transitions to EXECUTE when CI checks fail
- CI failure handling > includes failing check names in the transition reason
- CI failure handling > includes ciFailures in the transition context
- CI failure handling > increments remediationAt...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T18:32:46.508Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated internal test mocks and call sequences to align with system behavior changes.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->