### PR TITLE
fix(agent): ensure prettier runs in agent worktree before commit

### DIFF
--- a/apps/server/src/routes/worktree/routes/create-pr.ts
+++ b/apps/server/src/routes/worktree/routes/create-pr.ts
@@ -2,6 +2,7 @@
  * POST /create-pr endpoint - Commit changes and create a pull request from a worktree
  */
 
+import path from 'path';
 import type { Request, Response } from 'express';
 import {
   getErrorMessage,
@@ -86,6 +87,29 @@ export function createCreatePRHandler(settingsService?: SettingsService) {
           // Stage all changes
           logger.debug(`Running: git add -A (with staging exclusions)`);
           await execAsync(buildGitAddCommand(worktreePath), { cwd: worktreePath, env: execEnv });
+
+          // Auto-format staged files before committing (matches CI prettier behavior)
+          // Use the main repo's prettier binary — worktrees have no node_modules/
+          try {
+            const { stdout: stagedFiles } = await execAsync(
+              "git diff --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.json' '*.css' '*.md'",
+              { cwd: worktreePath, env: execEnv }
+            );
+            const files = stagedFiles.trim().split('\n').filter(Boolean);
+            if (files.length > 0) {
+              const prettierBin = path.join(effectiveProjectPath, 'node_modules/.bin/prettier');
+              await execAsync(
+                `node "${prettierBin}" --ignore-path /dev/null --write ${files.map((f) => `"${f}"`).join(' ')}`,
+                { cwd: worktreePath, env: execEnv }
+              );
+              // Re-stage after formatting
+              await execAsync(buildGitAddCommand(worktreePath), { cwd: worktreePath, env: execEnv });
+              logger.debug(`Auto-formatted ${files.length} staged files`);
+            }
+          } catch (fmtError: unknown) {
+            const err = fmtError as { message?: string };
+            logger.warn(`Auto-format failed (non-fatal): ${err.message ?? String(fmtError)}`);
+          }
 
           // Create commit
           logger.debug(`Running: git commit`);

--- a/apps/server/src/routes/worktree/routes/create-pr.ts
+++ b/apps/server/src/routes/worktree/routes/create-pr.ts
@@ -103,7 +103,10 @@ export function createCreatePRHandler(settingsService?: SettingsService) {
                 { cwd: worktreePath, env: execEnv }
               );
               // Re-stage after formatting
-              await execAsync(buildGitAddCommand(worktreePath), { cwd: worktreePath, env: execEnv });
+              await execAsync(buildGitAddCommand(worktreePath), {
+                cwd: worktreePath,
+                env: execEnv,
+              });
               logger.debug(`Auto-formatted ${files.length} staged files`);
             }
           } catch (fmtError: unknown) {


### PR DESCRIPTION
## Summary

## Pattern observed

Every agent-shipped PR in this session has required a manual prettier follow-up commit:
- PR #3441 — 8 files unformatted (fix session)
- PR #3442, #3443 — similar
- PR #3446 — new files unformatted
- PR #3447 — `done-worktree-cleanup-check.ts` unformatted
- PR #3448 — `sanitize.test.ts` unformatted

Agents create new files and commit without running prettier. The format check then fails in CI, blocking auto-merge. The operator (or another sweep) has to push a format-only com...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T18:35:40.569Z -->