### PR TITLE
fix(features): duplicate-feature detection on create + fix soft-delete title reservation

### DIFF
--- a/apps/server/src/routes/features/routes/create.ts
+++ b/apps/server/src/routes/features/routes/create.ts
@@ -73,15 +73,20 @@ export function createCreateHandler(
         return;
       }
 
-      // Check for duplicate title if title is provided
+      // Check for duplicate title if title is provided.
+      // Pass epicId so the check is scoped to the same epic — features in different epics
+      // may share a name. Archived features are excluded from the check automatically.
       if (feature.title && feature.title.trim()) {
-        const duplicate = await featureLoader.findDuplicateTitle(projectPath, feature.title);
+        const duplicate = await featureLoader.findDuplicateTitle(
+          projectPath,
+          feature.title,
+          undefined,
+          feature.epicId ?? null
+        );
         if (duplicate) {
-          res.status(409).json({
-            success: false,
-            error: `A feature with title "${feature.title}" already exists`,
-            duplicateFeatureId: duplicate.id,
-          });
+          // Idempotent: return the existing active feature rather than creating a phantom.
+          // The caller gets back the canonical record; no data is duplicated.
+          res.json({ success: true, feature: duplicate });
           return;
         }
       }

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -558,16 +558,22 @@ export class FeatureLoader implements FeatureStore {
   }
 
   /**
-   * Check if a title already exists on another feature (for duplicate detection)
+   * Check if a title already exists on another active feature (for duplicate detection).
+   * Archived features are excluded — delete-then-recreate and archive-then-recreate must work.
+   *
    * @param projectPath - Path to the project
    * @param title - Title to check
    * @param excludeFeatureId - Optional feature ID to exclude from the check (for updates)
-   * @returns The duplicate feature if found, null otherwise
+   * @param epicId - Optional epic ID; when provided only features within the same epic are
+   *   considered duplicates. Pass `null` explicitly to restrict matching to top-level features.
+   *   When omitted (`undefined`), the epicId dimension is ignored (legacy behaviour).
+   * @returns The duplicate active feature if found, null otherwise
    */
   async findDuplicateTitle(
     projectPath: string,
     title: string,
-    excludeFeatureId?: string
+    excludeFeatureId?: string,
+    epicId?: string | null | undefined
   ): Promise<Feature | null> {
     if (!title || !title.trim()) {
       return null;
@@ -582,12 +588,76 @@ export class FeatureLoader implements FeatureStore {
         continue;
       }
 
+      // Skip archived features — they are out of the active uniqueness pool.
+      // This allows delete-then-recreate and archive-then-recreate workflows.
+      if (feature.archived) {
+        continue;
+      }
+
       if (feature.title && this.normalizeTitle(feature.title) === normalizedTitle) {
+        // When epicId is explicitly supplied (including null), scope the duplicate check
+        // to features that share the same epicId. This prevents false positives when two
+        // epics contain child features with the same name.
+        if (epicId !== undefined) {
+          const featureEpicId = feature.epicId ?? null;
+          const searchEpicId = epicId ?? null;
+          if (featureEpicId !== searchEpicId) {
+            continue;
+          }
+        }
         return feature;
       }
     }
 
     return null;
+  }
+
+  /**
+   * One-shot sweep to detect existing duplicate titles in legacy data and log them for
+   * manual review. Duplicates are identified by (normalizedTitle, epicId) tuples across
+   * all active (non-archived) features.
+   *
+   * Call this once at startup or on demand to surface pre-existing duplicates that were
+   * created before the idempotent-create guard was in place.
+   *
+   * @param projectPath - Path to the project
+   * @returns Array of duplicate groups found (each group has title + array of feature IDs)
+   */
+  async detectLegacyDuplicates(
+    projectPath: string
+  ): Promise<Array<{ title: string; epicId: string | null; featureIds: string[] }>> {
+    const features = await this.getAll(projectPath);
+    const activeFeatures = features.filter((f) => !f.archived);
+
+    // Group by (normalizedTitle, epicId)
+    const groups = new Map<string, { title: string; epicId: string | null; featureIds: string[] }>();
+
+    for (const feature of activeFeatures) {
+      if (!feature.title || !feature.id) continue;
+      const epicId = feature.epicId ?? null;
+      const key = `${this.normalizeTitle(feature.title)}::${epicId ?? ''}`;
+
+      const existing = groups.get(key);
+      if (existing) {
+        existing.featureIds.push(feature.id);
+      } else {
+        groups.set(key, { title: feature.title, epicId, featureIds: [feature.id] });
+      }
+    }
+
+    const duplicates = Array.from(groups.values()).filter((g) => g.featureIds.length > 1);
+
+    if (duplicates.length > 0) {
+      logger.warn(`Legacy duplicate features detected (${duplicates.length} groups):`, {
+        duplicates: duplicates.map((d) => ({
+          title: d.title,
+          epicId: d.epicId,
+          ids: d.featureIds,
+        })),
+      });
+    }
+
+    return duplicates;
   }
 
   /**

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -630,7 +630,10 @@ export class FeatureLoader implements FeatureStore {
     const activeFeatures = features.filter((f) => !f.archived);
 
     // Group by (normalizedTitle, epicId)
-    const groups = new Map<string, { title: string; epicId: string | null; featureIds: string[] }>();
+    const groups = new Map<
+      string,
+      { title: string; epicId: string | null; featureIds: string[] }
+    >();
 
     for (const feature of activeFeatures) {
       if (!feature.title || !feature.id) continue;

--- a/apps/server/tests/unit/services/feature-loader.test.ts
+++ b/apps/server/tests/unit/services/feature-loader.test.ts
@@ -695,6 +695,88 @@ describe('feature-loader.ts', () => {
       expect(result).not.toBeNull();
       expect(result?.id).toBe('feature-1000-abc');
     });
+
+    it('should not return archived features as duplicates', async () => {
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readdir).mockResolvedValue([
+        { name: 'feature-1', isDirectory: () => true } as any,
+      ]);
+
+      vi.mocked(fs.readFile).mockResolvedValueOnce(
+        JSON.stringify({
+          id: 'feature-1000-abc',
+          title: 'My Feature',
+          archived: true,
+          status: 'done',
+          category: 'ui',
+          description: 'Archived feature',
+        })
+      );
+
+      const result = await loader.findDuplicateTitle(testProjectPath, 'My Feature');
+
+      // Archived feature must not block re-creation with the same title
+      expect(result).toBeNull();
+    });
+
+    it('should scope duplicate check by epicId when epicId is provided', async () => {
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readdir).mockResolvedValue([
+        { name: 'feature-1', isDirectory: () => true } as any,
+        { name: 'feature-2', isDirectory: () => true } as any,
+      ]);
+
+      vi.mocked(fs.readFile)
+        .mockResolvedValueOnce(
+          JSON.stringify({
+            id: 'feature-1000-abc',
+            title: 'My Feature',
+            epicId: 'epic-A',
+            category: 'ui',
+            description: 'In epic A',
+          })
+        )
+        .mockResolvedValueOnce(
+          JSON.stringify({
+            id: 'feature-2000-def',
+            title: 'My Feature',
+            epicId: 'epic-B',
+            category: 'ui',
+            description: 'In epic B',
+          })
+        );
+
+      // Searching within epic-A — only feature-1000-abc should match
+      const resultA = await loader.findDuplicateTitle(testProjectPath, 'My Feature', undefined, 'epic-A');
+      expect(resultA?.id).toBe('feature-1000-abc');
+
+      // Searching within a different epic — no match
+      vi.mocked(fs.readdir).mockResolvedValue([
+        { name: 'feature-1', isDirectory: () => true } as any,
+        { name: 'feature-2', isDirectory: () => true } as any,
+      ]);
+      vi.mocked(fs.readFile)
+        .mockResolvedValueOnce(
+          JSON.stringify({
+            id: 'feature-1000-abc',
+            title: 'My Feature',
+            epicId: 'epic-A',
+            category: 'ui',
+            description: 'In epic A',
+          })
+        )
+        .mockResolvedValueOnce(
+          JSON.stringify({
+            id: 'feature-2000-def',
+            title: 'My Feature',
+            epicId: 'epic-B',
+            category: 'ui',
+            description: 'In epic B',
+          })
+        );
+      const resultC = await loader.findDuplicateTitle(testProjectPath, 'My Feature', undefined, 'epic-C');
+      expect(resultC).toBeNull();
+    });
   });
 
   describe('syncFeatureToAppSpec', () => {

--- a/apps/server/tests/unit/services/feature-loader.test.ts
+++ b/apps/server/tests/unit/services/feature-loader.test.ts
@@ -747,7 +747,12 @@ describe('feature-loader.ts', () => {
         );
 
       // Searching within epic-A — only feature-1000-abc should match
-      const resultA = await loader.findDuplicateTitle(testProjectPath, 'My Feature', undefined, 'epic-A');
+      const resultA = await loader.findDuplicateTitle(
+        testProjectPath,
+        'My Feature',
+        undefined,
+        'epic-A'
+      );
       expect(resultA?.id).toBe('feature-1000-abc');
 
       // Searching within a different epic — no match
@@ -774,7 +779,12 @@ describe('feature-loader.ts', () => {
             description: 'In epic B',
           })
         );
-      const resultC = await loader.findDuplicateTitle(testProjectPath, 'My Feature', undefined, 'epic-C');
+      const resultC = await loader.findDuplicateTitle(
+        testProjectPath,
+        'My Feature',
+        undefined,
+        'epic-C'
+      );
       expect(resultC).toBeNull();
     });
   });


### PR DESCRIPTION
## Summary

Tackles GitHub issues #3407 and #3406 together — they share a root cause in the FeatureLoader's create/delete lifecycle.

## Problem 1 (#3407): silent duplicate coexistence

Two feature records with the same title, branch-name root, and epicId can coexist. Only divergence: ID suffix. Auto-mode picks whichever it saw first, dep-chain wiring targets the wrong record.

## Problem 2 (#3406): delete soft-archives but reserves title

`delete` returns success, but recreating with the same title returns...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T18:39:46.629Z -->