### PR TITLE
feat(tooling): add list / read action to manage_board tool

### DIFF
--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -411,7 +411,8 @@ export function buildAvaTools(
           const q = input.query.toLowerCase();
           features = features.filter(
             (f) =>
-              f.title.toLowerCase().includes(q) || (f.description ?? '').toLowerCase().includes(q)
+              (f.title ?? '').toLowerCase().includes(q) ||
+              (f.description ?? '').toLowerCase().includes(q)
           );
         }
 

--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -341,6 +341,114 @@ export function buildAvaTools(
       },
     });
 
+    tools['manage_board'] = makeTool({
+      description:
+        'Read features from the project board. Supports three actions:\n' +
+        '  • list   — enumerate features with optional status/priority filters and pagination\n' +
+        '  • get    — retrieve full metadata for a single feature by ID\n' +
+        '  • search — search feature titles and descriptions by keyword',
+      inputSchema: z.discriminatedUnion('action', [
+        z.object({
+          action: z.literal('list').describe('List features with optional filters'),
+          status: z
+            .enum(FEATURE_STATUS_ENUM)
+            .optional()
+            .describe('Filter by status'),
+          priority: z
+            .number()
+            .int()
+            .min(0)
+            .max(4)
+            .optional()
+            .describe('Filter by priority (0-4)'),
+          limit: z
+            .number()
+            .int()
+            .min(1)
+            .max(200)
+            .optional()
+            .describe('Max results to return (default 50)'),
+          offset: z
+            .number()
+            .int()
+            .min(0)
+            .optional()
+            .describe('Results to skip for pagination (default 0)'),
+        }),
+        z.object({
+          action: z.literal('get').describe('Get full metadata for a single feature'),
+          featureId: z.string().describe('The feature ID to retrieve'),
+        }),
+        z.object({
+          action: z.literal('search').describe('Search features by title or description'),
+          query: z.string().describe('Text to search in feature title and description'),
+          limit: z
+            .number()
+            .int()
+            .min(1)
+            .max(200)
+            .optional()
+            .describe('Max results to return (default 50)'),
+          offset: z
+            .number()
+            .int()
+            .min(0)
+            .optional()
+            .describe('Results to skip for pagination (default 0)'),
+        }),
+      ]),
+      execute: async (input) => {
+        if (input.action === 'get') {
+          const feature = await services.featureLoader.get(projectPath, input.featureId);
+          if (!feature) {
+            return { error: `Feature '${input.featureId}' not found` };
+          }
+          return feature;
+        }
+
+        let features = await services.featureLoader.getAll(projectPath);
+
+        if (input.action === 'list') {
+          if (input.status) {
+            features = features.filter((f) => f.status === input.status);
+          }
+          if (input.priority !== undefined) {
+            features = features.filter((f) => f.priority === input.priority);
+          }
+        } else {
+          // search
+          const q = input.query.toLowerCase();
+          features = features.filter(
+            (f) =>
+              f.title.toLowerCase().includes(q) ||
+              (f.description ?? '').toLowerCase().includes(q)
+          );
+        }
+
+        const total = features.length;
+        const offset = input.offset ?? 0;
+        const limit = input.limit ?? 50;
+        const page = features.slice(offset, offset + limit);
+
+        return {
+          features: page.map((f) => ({
+            id: f.id,
+            title: f.title,
+            status: f.status,
+            priority: f.priority,
+            complexity: f.complexity,
+            statusChangeReason: f.statusChangeReason,
+            dependencies: f.dependencies ?? [],
+            updatedAt: f.updatedAt,
+          })),
+          total,
+          offset,
+          limit,
+          hasMore: offset + limit < total,
+        };
+      },
+    });
+
     tools['create_plan'] = makeTool({
       description:
         'Create a structured plan card with titled steps. Use this to present a multi-step execution plan to the user as a visual card rather than plain text.',

--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -350,17 +350,8 @@ export function buildAvaTools(
       inputSchema: z.discriminatedUnion('action', [
         z.object({
           action: z.literal('list').describe('List features with optional filters'),
-          status: z
-            .enum(FEATURE_STATUS_ENUM)
-            .optional()
-            .describe('Filter by status'),
-          priority: z
-            .number()
-            .int()
-            .min(0)
-            .max(4)
-            .optional()
-            .describe('Filter by priority (0-4)'),
+          status: z.enum(FEATURE_STATUS_ENUM).optional().describe('Filter by status'),
+          priority: z.number().int().min(0).max(4).optional().describe('Filter by priority (0-4)'),
           limit: z
             .number()
             .int()
@@ -420,8 +411,7 @@ export function buildAvaTools(
           const q = input.query.toLowerCase();
           features = features.filter(
             (f) =>
-              f.title.toLowerCase().includes(q) ||
-              (f.description ?? '').toLowerCase().includes(q)
+              f.title.toLowerCase().includes(q) || (f.description ?? '').toLowerCase().includes(q)
           );
         }
 

--- a/libs/tools/src/board-tools.ts
+++ b/libs/tools/src/board-tools.ts
@@ -246,7 +246,8 @@ export function createManageBoardTool(deps: BoardDeps): SharedTool {
           const q = input.query.toLowerCase();
           features = features.filter(
             (f) =>
-              f.title.toLowerCase().includes(q) || (f.description ?? '').toLowerCase().includes(q)
+              (f.title ?? '').toLowerCase().includes(q) ||
+              (f.description ?? '').toLowerCase().includes(q)
           );
         }
 

--- a/libs/tools/src/board-tools.ts
+++ b/libs/tools/src/board-tools.ts
@@ -246,8 +246,7 @@ export function createManageBoardTool(deps: BoardDeps): SharedTool {
           const q = input.query.toLowerCase();
           features = features.filter(
             (f) =>
-              f.title.toLowerCase().includes(q) ||
-              (f.description ?? '').toLowerCase().includes(q)
+              f.title.toLowerCase().includes(q) || (f.description ?? '').toLowerCase().includes(q)
           );
         }
 

--- a/libs/tools/src/board-tools.ts
+++ b/libs/tools/src/board-tools.ts
@@ -172,3 +172,119 @@ export function createBoardTools(deps: BoardDeps): SharedTool[] {
 
   return [listFeaturesTool, updateFeatureTool, createFeatureTool];
 }
+
+// ---------------------------------------------------------------------------
+// manage_board — unified read/write action tool
+// ---------------------------------------------------------------------------
+
+const ManageBoardInputSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('list').describe('List features with optional filters'),
+    projectPath: z.string().describe('Absolute path to the project directory'),
+    status: z
+      .enum(['backlog', 'in_progress', 'review', 'blocked', 'done'])
+      .optional()
+      .describe('Filter by status'),
+    priority: z.number().int().min(0).max(4).optional().describe('Filter by priority (0-4)'),
+    limit: z.number().int().min(1).max(200).optional().describe('Max results to return'),
+    offset: z.number().int().min(0).optional().describe('Number of results to skip (pagination)'),
+  }),
+  z.object({
+    action: z.literal('get').describe('Get full metadata for a single feature'),
+    projectPath: z.string().describe('Absolute path to the project directory'),
+    featureId: z.string().describe('The feature ID to retrieve'),
+  }),
+  z.object({
+    action: z.literal('search').describe('Search features by title or description'),
+    projectPath: z.string().describe('Absolute path to the project directory'),
+    query: z.string().describe('Text to search for in feature title and description'),
+    limit: z.number().int().min(1).max(200).optional().describe('Max results to return'),
+    offset: z.number().int().min(0).optional().describe('Number of results to skip (pagination)'),
+  }),
+]);
+
+/**
+ * Creates a manage_board tool that supports list, get, and search actions.
+ *
+ * @param deps - Board dependencies (featureLoader)
+ * @returns A SharedTool instance for the manage_board tool
+ */
+export function createManageBoardTool(deps: BoardDeps): SharedTool {
+  return defineSharedTool({
+    name: 'manage_board',
+    description:
+      'Read features from the Automaker board. Supports three actions:\n' +
+      '  • list — enumerate features with optional status/priority filters and pagination\n' +
+      '  • get  — retrieve full metadata for a single feature by ID\n' +
+      '  • search — search feature titles and descriptions by keyword',
+    inputSchema: ManageBoardInputSchema,
+    outputSchema: z.object({ result: z.unknown() }),
+    metadata: { category: 'board', tags: ['board', 'features', 'read'] },
+    execute: async (rawInput) => {
+      const input = rawInput as z.infer<typeof ManageBoardInputSchema>;
+      try {
+        if (input.action === 'get') {
+          const feature = await deps.featureLoader.get(input.projectPath, input.featureId);
+          if (!feature) {
+            return { success: false, error: `Feature '${input.featureId}' not found` };
+          }
+          return { success: true, data: { result: feature } };
+        }
+
+        // list and search both start from getAll
+        let features = await deps.featureLoader.getAll(input.projectPath);
+
+        if (input.action === 'list') {
+          if (input.status) {
+            features = features.filter((f) => f.status === input.status);
+          }
+          if (input.priority !== undefined) {
+            features = features.filter((f) => f.priority === input.priority);
+          }
+        } else {
+          // search
+          const q = input.query.toLowerCase();
+          features = features.filter(
+            (f) =>
+              f.title.toLowerCase().includes(q) ||
+              (f.description ?? '').toLowerCase().includes(q)
+          );
+        }
+
+        const total = features.length;
+        const offset = (input as { offset?: number }).offset ?? 0;
+        const limit = (input as { limit?: number }).limit ?? 50;
+        const page = features.slice(offset, offset + limit);
+
+        const summaries = page.map((f) => ({
+          id: f.id,
+          title: f.title,
+          status: f.status,
+          priority: f.priority,
+          complexity: f.complexity,
+          statusChangeReason: f.statusChangeReason,
+          dependencies: f.dependencies ?? [],
+          updatedAt: f.updatedAt,
+        }));
+
+        return {
+          success: true,
+          data: {
+            result: {
+              features: summaries,
+              total,
+              offset,
+              limit,
+              hasMore: offset + limit < total,
+            },
+          },
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'manage_board failed',
+        };
+      }
+    },
+  });
+}

--- a/libs/tools/src/index.ts
+++ b/libs/tools/src/index.ts
@@ -17,7 +17,7 @@ export * from './domains/features/index.js';
 export * from './domains/hitl/index.js';
 
 // DynamicStructuredTool factory families
-export { createBoardTools } from './board-tools.js';
+export { createBoardTools, createManageBoardTool } from './board-tools.js';
 export type { BoardDeps } from './board-tools.js';
 export { createDiscordTools } from './discord-tools.js';
 export type { DiscordDeps, DiscordMessage } from './discord-tools.js';


### PR DESCRIPTION
## Summary

Tracks GitHub issue #3414 (and duplicates #3415/#3416/#3417 closed).

## Problem

Ava's `manage_board` tool currently only supports create and update actions. No way to enumerate features programmatically through the tool interface. When Quinn and protoMaker agents are offline, there is zero path to pull per-feature metadata (ID, title, status, description, priority, complexity, blockers).

Operational impact: Ava cannot generate board health reports at the feature level or surface blocking reas...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T18:46:59.450Z -->