### PR TITLE
fix(worktree): auto-recover dirty worktrees on server restart (issue #3413)

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -1650,8 +1650,7 @@ export class AutoModeService {
             // Dirty worktree was auto-recovered: WIP committed to recovery/ branch.
             // Feature is safe to resume from backlog — worktree is now clean.
             newStatus = 'backlog';
-            reconcileReason =
-              safetyResult.reason ?? 'Dirty worktree auto-recovered — resuming';
+            reconcileReason = safetyResult.reason ?? 'Dirty worktree auto-recovered — resuming';
             // Emit worktree:recovered on the event bus for observability
             this.events.emit('worktree:recovered', {
               featureId: feature.id,

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -1646,6 +1646,25 @@ export class AutoModeService {
             newStatus = 'blocked';
             reconcileReason = safetyResult.reason ?? 'Unsafe to resume after restart';
             break;
+          case 'recovered':
+            // Dirty worktree was auto-recovered: WIP committed to recovery/ branch.
+            // Feature is safe to resume from backlog — worktree is now clean.
+            newStatus = 'backlog';
+            reconcileReason =
+              safetyResult.reason ?? 'Dirty worktree auto-recovered — resuming';
+            // Emit worktree:recovered on the event bus for observability
+            this.events.emit('worktree:recovered', {
+              featureId: feature.id,
+              projectPath,
+              worktreePath: safetyResult.worktreePath ?? '',
+              recoveryBranch: safetyResult.recoveryBranch ?? '',
+              reason: reconcileReason,
+              timestamp: new Date().toISOString(),
+            });
+            logger.info(
+              `[RECONCILE] Auto-recovered dirty worktree for feature ${feature.id}: ${reconcileReason}`
+            );
+            break;
           case 'resume':
           default:
             newStatus = 'backlog';

--- a/apps/server/src/services/restart-safety-check-service.ts
+++ b/apps/server/src/services/restart-safety-check-service.ts
@@ -8,7 +8,9 @@
  * Possible outcomes per feature:
  * - `resume`    — No PR, clean (or absent) worktree. Safe to reset to backlog.
  * - `to_review` — Feature already has an open PR. Move to review status.
- * - `block`     — Worktree has uncommitted changes or merge conflicts.
+ * - `recovered` — Dirty worktree auto-recovered: WIP committed to recovery/ branch,
+ *                 worktree reset to clean state. Safe to resume from backlog.
+ * - `block`     — Worktree has merge conflicts or recovery failed.
  *                 Set to blocked with a human-readable reason.
  */
 
@@ -18,6 +20,7 @@ import path from 'path';
 import type { ExecFileOptions } from 'child_process';
 import type { Feature } from '@protolabsai/types';
 import { createLogger } from '@protolabsai/utils';
+import { recoverDirtyWorktree } from './startup-recovery-service.js';
 
 const logger = createLogger('RestartSafetyCheck');
 
@@ -39,11 +42,15 @@ function execFile(
   });
 }
 
-export type SafetyCheckAction = 'resume' | 'block' | 'to_review';
+export type SafetyCheckAction = 'resume' | 'block' | 'to_review' | 'recovered';
 
 export interface SafetyCheckResult {
   action: SafetyCheckAction;
   reason?: string;
+  /** Recovery branch created when action is 'recovered' */
+  recoveryBranch?: string;
+  /** Worktree path (populated for block/recovered outcomes) */
+  worktreePath?: string;
 }
 
 export class RestartSafetyCheckService {
@@ -69,13 +76,47 @@ export class RestartSafetyCheckService {
           return {
             action: 'block',
             reason: `Worktree has merge conflicts: ${worktreePath}`,
+            worktreePath,
           };
         }
         if (isDirty) {
-          return {
-            action: 'block',
-            reason: `Worktree has uncommitted changes: ${worktreePath}`,
-          };
+          // Attempt auto-recovery: commit WIP to a recovery/ branch
+          const branchName = feature.branchName;
+          if (!branchName) {
+            return {
+              action: 'block',
+              reason: `Worktree has uncommitted changes but no branch name — cannot auto-recover: ${worktreePath}`,
+              worktreePath,
+            };
+          }
+
+          try {
+            const recoveryBranch = await recoverDirtyWorktree(
+              worktreePath,
+              branchName,
+              feature.id
+            );
+            logger.info(
+              `[RestartSafetyCheck] Auto-recovered dirty worktree for feature ${feature.id}: WIP saved to ${recoveryBranch}`
+            );
+            return {
+              action: 'recovered',
+              reason: `Uncommitted WIP preserved to ${recoveryBranch} — resuming on original branch`,
+              recoveryBranch,
+              worktreePath,
+            };
+          } catch (recoveryErr) {
+            const msg =
+              recoveryErr instanceof Error ? recoveryErr.message : String(recoveryErr);
+            logger.warn(
+              `[RestartSafetyCheck] Auto-recovery failed for feature ${feature.id}: ${msg}`
+            );
+            return {
+              action: 'block',
+              reason: `Worktree has uncommitted changes and auto-recovery failed: ${msg}`,
+              worktreePath,
+            };
+          }
         }
       }
     }

--- a/apps/server/src/services/restart-safety-check-service.ts
+++ b/apps/server/src/services/restart-safety-check-service.ts
@@ -91,11 +91,7 @@ export class RestartSafetyCheckService {
           }
 
           try {
-            const recoveryBranch = await recoverDirtyWorktree(
-              worktreePath,
-              branchName,
-              feature.id
-            );
+            const recoveryBranch = await recoverDirtyWorktree(worktreePath, branchName, feature.id);
             logger.info(
               `[RestartSafetyCheck] Auto-recovered dirty worktree for feature ${feature.id}: WIP saved to ${recoveryBranch}`
             );
@@ -106,8 +102,7 @@ export class RestartSafetyCheckService {
               worktreePath,
             };
           } catch (recoveryErr) {
-            const msg =
-              recoveryErr instanceof Error ? recoveryErr.message : String(recoveryErr);
+            const msg = recoveryErr instanceof Error ? recoveryErr.message : String(recoveryErr);
             logger.warn(
               `[RestartSafetyCheck] Auto-recovery failed for feature ${feature.id}: ${msg}`
             );

--- a/apps/server/tests/unit/services/restart-safety-check-service.test.ts
+++ b/apps/server/tests/unit/services/restart-safety-check-service.test.ts
@@ -10,11 +10,17 @@ vi.mock('node:fs/promises', () => ({
 // Mock child_process execFileCb (the service wraps it in an explicit promise)
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
-  return { ...actual, execFile: vi.fn() };
+  return { ...actual, execFile: vi.fn(), exec: vi.fn() };
 });
+
+// Mock the startup-recovery-service's recoverDirtyWorktree function
+vi.mock('@/services/startup-recovery-service.js', () => ({
+  recoverDirtyWorktree: vi.fn(),
+}));
 
 import { access } from 'node:fs/promises';
 import { execFile } from 'child_process';
+import { recoverDirtyWorktree } from '@/services/startup-recovery-service.js';
 
 function mockExecFileWithOutput(stdout: string): void {
   vi.mocked(execFile).mockImplementation((...args: unknown[]) => {
@@ -103,16 +109,52 @@ describe('RestartSafetyCheckService', () => {
       });
     });
 
-    describe('when worktree exists and is dirty', () => {
-      it('returns block with uncommitted changes reason', async () => {
+    describe('when worktree exists and is dirty (auto-recovery)', () => {
+      it('returns recovered when auto-recovery succeeds', async () => {
         const feature = makeFeature({ branchName: 'feature/dirty-branch' });
         vi.mocked(access).mockResolvedValue(undefined);
         mockExecFileWithOutput(' M src/some-file.ts\n?? newfile.ts\n');
+        vi.mocked(recoverDirtyWorktree).mockResolvedValue(
+          'recovery/feature-abc-123-1713200000000'
+        );
+
+        const result = await service.check(feature, PROJECT_PATH);
+
+        expect(result.action).toBe('recovered');
+        expect(result.reason).toContain('Uncommitted WIP preserved to recovery/');
+        expect(result.recoveryBranch).toBe('recovery/feature-abc-123-1713200000000');
+        expect(result.worktreePath).toContain('.worktrees/feature-dirty-branch');
+        expect(recoverDirtyWorktree).toHaveBeenCalledWith(
+          expect.stringContaining('.worktrees/feature-dirty-branch'),
+          'feature/dirty-branch',
+          'feature-abc-123'
+        );
+      });
+
+      it('returns block when auto-recovery fails', async () => {
+        const feature = makeFeature({ branchName: 'feature/dirty-branch' });
+        vi.mocked(access).mockResolvedValue(undefined);
+        mockExecFileWithOutput(' M src/some-file.ts\n');
+        vi.mocked(recoverDirtyWorktree).mockRejectedValue(new Error('stash lock exists'));
 
         const result = await service.check(feature, PROJECT_PATH);
 
         expect(result.action).toBe('block');
-        expect(result.reason).toContain('uncommitted changes');
+        expect(result.reason).toContain('auto-recovery failed');
+        expect(result.reason).toContain('stash lock exists');
+        expect(result.worktreePath).toBeDefined();
+      });
+
+      it('returns block when dirty worktree has no branchName (cannot auto-recover)', async () => {
+        const feature = makeFeature({ branchName: undefined });
+        vi.mocked(access).mockResolvedValue(undefined);
+        mockExecFileWithOutput(' M src/some-file.ts\n');
+
+        const result = await service.check(feature, PROJECT_PATH);
+
+        expect(result.action).toBe('block');
+        expect(result.reason).toContain('no branch name');
+        expect(result.reason).toContain('cannot auto-recover');
       });
     });
 
@@ -126,6 +168,8 @@ describe('RestartSafetyCheckService', () => {
 
         expect(result.action).toBe('block');
         expect(result.reason).toContain('merge conflicts');
+        // Auto-recovery should NOT be attempted for conflicts
+        expect(recoverDirtyWorktree).not.toHaveBeenCalled();
       });
 
       it('returns block for AA (both added) conflict', async () => {

--- a/apps/server/tests/unit/services/restart-safety-check-service.test.ts
+++ b/apps/server/tests/unit/services/restart-safety-check-service.test.ts
@@ -114,9 +114,7 @@ describe('RestartSafetyCheckService', () => {
         const feature = makeFeature({ branchName: 'feature/dirty-branch' });
         vi.mocked(access).mockResolvedValue(undefined);
         mockExecFileWithOutput(' M src/some-file.ts\n?? newfile.ts\n');
-        vi.mocked(recoverDirtyWorktree).mockResolvedValue(
-          'recovery/feature-abc-123-1713200000000'
-        );
+        vi.mocked(recoverDirtyWorktree).mockResolvedValue('recovery/feature-abc-123-1713200000000');
 
         const result = await service.check(feature, PROJECT_PATH);
 

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -206,6 +206,7 @@ export type EventType =
   | 'worktree:drift-detected'
   | 'worktree:phantom-pruned'
   | 'worktree:cleanup'
+  | 'worktree:recovered'
   // World state monitor events
   | 'world-state:reconciliation'
   // Chief of Staff (CoS) events
@@ -648,6 +649,16 @@ export interface EventPayloadMap {
     removed: number;
     paths: string[];
     dryRun: boolean;
+  };
+
+  // Worktree auto-recovery event (dirty worktree salvaged on restart)
+  'worktree:recovered': {
+    featureId: string;
+    projectPath: string;
+    worktreePath: string;
+    recoveryBranch: string;
+    reason: string;
+    timestamp: string;
   };
 
   // Maintenance sweep events


### PR DESCRIPTION
## Summary

Tracks GitHub issue #3413.

## Problem

When automaker-server restarts while features have worktrees with uncommitted changes, those features get blocked with 'Dirty worktree detected on restart — manual intervention required'. Any mid-execution feature is trapped until a human cleans up. Hit twice in a single hour during 2026-04-14 observation.

## Proposed fix

On startup, `WorktreeLifecycleService` should inspect each active worktree and classify:

1. **clean** — matches HEAD, no action neede...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T20:14:57.364Z -->