### PR TITLE
feat(pr-remediation): diagnose conflict type before update_branch retry (issue #3411)

### DIFF
--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -46,7 +46,10 @@ import { getBriefingCursorService } from '../../services/briefing-cursor-service
 import { queryPm } from '../project-pm/pm-agent.js';
 import { simpleQuery } from '../../providers/simple-query-service.js';
 import Anthropic from '@anthropic-ai/sdk';
-import { classifyAndRemediate, logRemediationOutcome } from '../../services/pr-remediation-service.js';
+import {
+  classifyAndRemediate,
+  logRemediationOutcome,
+} from '../../services/pr-remediation-service.js';
 
 // ---------------------------------------------------------------------------
 // Plan types

--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -45,6 +45,8 @@ import { getEventHistoryService } from '../../services/event-history-service.js'
 import { getBriefingCursorService } from '../../services/briefing-cursor-service.js';
 import { queryPm } from '../project-pm/pm-agent.js';
 import { simpleQuery } from '../../providers/simple-query-service.js';
+import Anthropic from '@anthropic-ai/sdk';
+import { classifyAndRemediate, logRemediationOutcome } from '../../services/pr-remediation-service.js';
 
 // ---------------------------------------------------------------------------
 // Plan types
@@ -1211,6 +1213,52 @@ export function buildAvaTools(
         } catch (err) {
           return {
             error: `Failed to resolve PR threads: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      },
+    });
+
+    tools['diagnose_pr_conflict'] = makeTool({
+      description:
+        'Classify the conflict type for a pull request and take the appropriate remediation action. ' +
+        'Returns one of four verdicts: redundant (auto-closes with comment), rebasable (attempts LLM-assisted merge), ' +
+        'decomposable (proposes splitting the PR), or genuine (escalates to HITL with specific conflict details). ' +
+        'Use this before retrying update_branch to avoid burning retry budget on unresolvable conflicts.',
+      inputSchema: z.object({
+        prNumber: z.number().int().describe('PR number to diagnose and remediate'),
+        retryAttempt: z
+          .number()
+          .int()
+          .optional()
+          .describe('Current retry attempt number (default: 2 — triggers classification)'),
+        maxRetries: z
+          .number()
+          .int()
+          .optional()
+          .describe('Maximum remediation attempts before budget exhaustion (default: 3)'),
+      }),
+      execute: async ({ prNumber, retryAttempt, maxRetries }) => {
+        try {
+          const anthropic = new Anthropic();
+          const result = await classifyAndRemediate({
+            projectPath,
+            prNumber,
+            retryAttempt: retryAttempt ?? 2,
+            anthropic,
+            maxRetries: maxRetries ?? 3,
+          });
+          logRemediationOutcome(result);
+          return {
+            prNumber: result.prNumber,
+            verdict: result.verdict,
+            actionType: result.actionType,
+            remediationCount: result.remediationCount,
+            reasoning: result.reasoning,
+            details: result.details,
+          };
+        } catch (err) {
+          return {
+            error: `Failed to diagnose PR conflict: ${err instanceof Error ? err.message : String(err)}`,
           };
         }
       },

--- a/apps/server/src/services/pr-conflict-classifier.ts
+++ b/apps/server/src/services/pr-conflict-classifier.ts
@@ -80,7 +80,8 @@ function sanitizePrNumber(prNumber: unknown): number {
 // ---------------------------------------------------------------------------
 
 function buildClassifierPrompt(evidence: ConflictEvidence): string {
-  const conflictingFileList = evidence.conflictingFiles.map((f) => `- ${f}`).join('\n') || '(none detected)';
+  const conflictingFileList =
+    evidence.conflictingFiles.map((f) => `- ${f}`).join('\n') || '(none detected)';
   const commitList = evidence.recentBaseCommits.slice(0, 20).join('\n') || '(none)';
 
   return `You are a Git merge conflict classifier. Analyze this pull request's conflict situation and return a JSON verdict.
@@ -157,9 +158,7 @@ export class PRConflictClassifier {
       return classification;
     } catch (error) {
       logger.error('[PRConflictClassifier] Classification failed, defaulting to genuine', error);
-      return this.fallbackClassification(
-        error instanceof Error ? error.message : String(error)
-      );
+      return this.fallbackClassification(error instanceof Error ? error.message : String(error));
     }
   }
 
@@ -195,7 +194,13 @@ export class PRConflictClassifier {
   private async fetchPRMetadata(
     prNumber: number,
     projectPath: string
-  ): Promise<{ prTitle: string; prBody: string; prBranch: string; baseBranch: string; prCreatedAt: string }> {
+  ): Promise<{
+    prTitle: string;
+    prBody: string;
+    prBranch: string;
+    baseBranch: string;
+    prCreatedAt: string;
+  }> {
     try {
       const { stdout } = await execAsync(
         `gh pr view ${prNumber} --json title,body,headRefName,baseRefName,createdAt`,
@@ -313,18 +318,18 @@ export class PRConflictClassifier {
     } catch {
       // Merge had conflicts — collect conflicting file list and sample
       try {
-        const { stdout: conflictList } = await execAsync(
-          'git diff --name-only --diff-filter=U',
-          { cwd, timeout: 10000 }
-        );
+        const { stdout: conflictList } = await execAsync('git diff --name-only --diff-filter=U', {
+          cwd,
+          timeout: 10000,
+        });
         conflictingFiles = conflictList.trim().split('\n').filter(Boolean);
 
         if (conflictingFiles.length > 0 && conflictingFiles[0]) {
           try {
-            const { stdout: sampleDiff } = await execAsync(
-              `git diff -- "${conflictingFiles[0]}"`,
-              { cwd, timeout: 10000 }
-            );
+            const { stdout: sampleDiff } = await execAsync(`git diff -- "${conflictingFiles[0]}"`, {
+              cwd,
+              timeout: 10000,
+            });
             conflictingSample = sampleDiff.slice(0, 3000);
           } catch {
             // ignore — sample is optional
@@ -391,7 +396,10 @@ export class PRConflictClassifier {
     }
 
     // Strip markdown code fences if present
-    const raw = content.text.trim().replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+    const raw = content.text
+      .trim()
+      .replace(/^```(?:json)?\n?/, '')
+      .replace(/\n?```$/, '');
     const result = JSON.parse(raw) as {
       verdict: ConflictVerdict;
       confidence: number;
@@ -431,7 +439,9 @@ export class PRConflictClassifier {
         recentBaseCommits: [],
         conflictingSample: '',
       },
-      conflictingHunks: ['Classification error — treating as genuine conflict requiring human review'],
+      conflictingHunks: [
+        'Classification error — treating as genuine conflict requiring human review',
+      ],
     };
   }
 }

--- a/apps/server/src/services/pr-conflict-classifier.ts
+++ b/apps/server/src/services/pr-conflict-classifier.ts
@@ -1,0 +1,444 @@
+/**
+ * PR Conflict Classifier
+ *
+ * Analyzes merge conflicts in a pull request and classifies them into
+ * one of four verdicts: redundant, rebasable, decomposable, or genuine.
+ *
+ * Verdicts guide the remediation action taken before retry attempts,
+ * preventing wasteful update_branch retries on conflicts that cannot
+ * be resolved automatically.
+ */
+
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createLogger } from '@protolabsai/utils';
+import { resolveModelString } from '@protolabsai/model-resolver';
+import Anthropic from '@anthropic-ai/sdk';
+
+const execAsync = promisify(exec);
+const logger = createLogger('PRConflictClassifier');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The four possible conflict verdicts. */
+export type ConflictVerdict = 'redundant' | 'rebasable' | 'decomposable' | 'genuine';
+
+/** Evidence gathered from git and GitHub about the conflicting PR. */
+export interface ConflictEvidence {
+  prTitle: string;
+  prBody: string;
+  prBranch: string;
+  baseBranch: string;
+  /** Files with merge conflict markers after dry-run merge attempt. */
+  conflictingFiles: string[];
+  /** Total number of files changed in the PR. */
+  totalPRFiles: number;
+  /** Recent commits on base branch since PR was created (oneline format). */
+  recentBaseCommits: string[];
+  /** Sample conflict diff content (truncated to avoid token limits). */
+  conflictingSample: string;
+}
+
+/** Classification result returned by the classifier. */
+export interface ConflictClassification {
+  verdict: ConflictVerdict;
+  /** Confidence score 0–1. */
+  confidence: number;
+  reasoning: string;
+  evidence: ConflictEvidence;
+  /** For 'redundant': SHAs or one-line descriptions of superseding commits. */
+  supersedingCommits?: string[];
+  /** For 'decomposable': which files should be extracted into a smaller PR. */
+  decompositionFiles?: string[];
+  /** For 'genuine': descriptions of the specific semantic conflicts. */
+  conflictingHunks?: string[];
+}
+
+/** Input required to run the classifier. */
+export interface PRConflictClassifierInput {
+  projectPath: string;
+  prNumber: number;
+  anthropic: Anthropic;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+function sanitizePrNumber(prNumber: unknown): number {
+  const parsed = parseInt(String(prNumber), 10);
+  if (isNaN(parsed) || parsed <= 0) {
+    throw new Error(`Invalid PR number: ${String(prNumber)}`);
+  }
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt
+// ---------------------------------------------------------------------------
+
+function buildClassifierPrompt(evidence: ConflictEvidence): string {
+  const conflictingFileList = evidence.conflictingFiles.map((f) => `- ${f}`).join('\n') || '(none detected)';
+  const commitList = evidence.recentBaseCommits.slice(0, 20).join('\n') || '(none)';
+
+  return `You are a Git merge conflict classifier. Analyze this pull request's conflict situation and return a JSON verdict.
+
+## Pull Request
+Title: ${evidence.prTitle}
+Description: ${evidence.prBody.slice(0, 800)}
+Branch: ${evidence.prBranch}
+Base: ${evidence.baseBranch}
+
+## Conflict Summary
+Total files changed in PR: ${evidence.totalPRFiles}
+Files with merge conflicts (${evidence.conflictingFiles.length}):
+${conflictingFileList}
+
+## Recent commits on base branch since PR was created:
+${commitList}
+
+## Sample conflict markers (first conflicting file):
+${evidence.conflictingSample.slice(0, 2500)}
+
+## Verdict Definitions
+
+**redundant**: The PR's stated intent has ALREADY been achieved by commits on the base branch. If merged, it would add no new value or would revert base changes. Look for base commits with descriptions that match this PR's title/goal.
+
+**rebasable**: Conflicts are purely textual and non-semantic — whitespace, import order, doc/comment changes, lock file version bumps, or duplicate-but-identical parallel edits. The conflict resolution is unambiguous: one side's changes are correct and the other should be discarded or they are identical.
+
+**decomposable**: The conflict affects only K files out of N total PR files where K < N. The remaining (N-K) non-conflicting files could be merged cleanly as a smaller PR, delivering partial value immediately.
+
+**genuine**: Both the PR and base made semantically different decisions in the same code (different logic, different API contracts, different type shapes). No automatic resolution is safe — human judgment is required.
+
+Respond with ONLY a JSON object (no markdown fencing):
+{
+  "verdict": "redundant|rebasable|decomposable|genuine",
+  "confidence": 0.0,
+  "reasoning": "One paragraph explaining the verdict",
+  "supersedingCommits": ["sha or description"],
+  "decompositionFiles": ["path/to/file"],
+  "conflictingHunks": ["description of semantic conflict"]
+}
+
+Include only the arrays relevant to your verdict. Omit the others.`;
+}
+
+// ---------------------------------------------------------------------------
+// Classifier class
+// ---------------------------------------------------------------------------
+
+export class PRConflictClassifier {
+  private readonly input: PRConflictClassifierInput;
+
+  constructor(input: PRConflictClassifierInput) {
+    this.input = input;
+  }
+
+  /**
+   * Classify the conflict type for this PR.
+   * Falls back to 'genuine' on any error (conservative default).
+   */
+  async classify(): Promise<ConflictClassification> {
+    const prNumber = sanitizePrNumber(this.input.prNumber);
+    const { projectPath, anthropic } = this.input;
+
+    logger.info(`[PRConflictClassifier] Classifying PR #${prNumber}`, { projectPath });
+
+    try {
+      const evidence = await this.gatherEvidence(prNumber, projectPath);
+      const classification = await this.llmClassify(evidence, anthropic);
+      logger.info('[PRConflictClassifier] Classification complete', {
+        prNumber,
+        verdict: classification.verdict,
+        confidence: classification.confidence,
+      });
+      return classification;
+    } catch (error) {
+      logger.error('[PRConflictClassifier] Classification failed, defaulting to genuine', error);
+      return this.fallbackClassification(
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Evidence gathering
+  // -------------------------------------------------------------------------
+
+  private async gatherEvidence(prNumber: number, projectPath: string): Promise<ConflictEvidence> {
+    const [prMeta, totalPRFiles] = await Promise.all([
+      this.fetchPRMetadata(prNumber, projectPath),
+      this.fetchPRFileCount(prNumber, projectPath),
+    ]);
+
+    const { prTitle, prBody, prBranch, baseBranch, prCreatedAt } = prMeta;
+
+    const [conflictInfo, recentBaseCommits] = await Promise.all([
+      this.detectConflicts(prNumber, prBranch, baseBranch, projectPath),
+      this.fetchRecentBaseCommits(baseBranch, prCreatedAt, projectPath),
+    ]);
+
+    return {
+      prTitle,
+      prBody,
+      prBranch,
+      baseBranch,
+      conflictingFiles: conflictInfo.conflictingFiles,
+      totalPRFiles,
+      recentBaseCommits,
+      conflictingSample: conflictInfo.conflictingSample,
+    };
+  }
+
+  private async fetchPRMetadata(
+    prNumber: number,
+    projectPath: string
+  ): Promise<{ prTitle: string; prBody: string; prBranch: string; baseBranch: string; prCreatedAt: string }> {
+    try {
+      const { stdout } = await execAsync(
+        `gh pr view ${prNumber} --json title,body,headRefName,baseRefName,createdAt`,
+        { cwd: projectPath, timeout: 15000 }
+      );
+      const data = JSON.parse(stdout.trim()) as {
+        title: string;
+        body: string;
+        headRefName: string;
+        baseRefName: string;
+        createdAt: string;
+      };
+      return {
+        prTitle: data.title ?? '',
+        prBody: data.body ?? '',
+        prBranch: data.headRefName ?? '',
+        baseBranch: data.baseRefName ?? '',
+        prCreatedAt: data.createdAt ?? '',
+      };
+    } catch (err) {
+      logger.warn('[PRConflictClassifier] Failed to fetch PR metadata', err);
+      return { prTitle: '', prBody: '', prBranch: '', baseBranch: '', prCreatedAt: '' };
+    }
+  }
+
+  private async fetchPRFileCount(prNumber: number, projectPath: string): Promise<number> {
+    try {
+      const { stdout } = await execAsync(
+        `gh pr view ${prNumber} --json files --jq '.files | length'`,
+        { cwd: projectPath, timeout: 15000 }
+      );
+      return parseInt(stdout.trim(), 10) || 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  private async detectConflicts(
+    prNumber: number,
+    prBranch: string,
+    baseBranch: string,
+    projectPath: string
+  ): Promise<{ conflictingFiles: string[]; conflictingSample: string }> {
+    if (!prBranch || !baseBranch) {
+      return { conflictingFiles: [], conflictingSample: '' };
+    }
+
+    try {
+      await execAsync(`git fetch origin ${baseBranch}`, { cwd: projectPath, timeout: 30000 });
+    } catch (err) {
+      logger.warn('[PRConflictClassifier] Failed to fetch base branch', err);
+    }
+
+    // Check if we are currently on the PR branch in this worktree
+    let currentBranch = '';
+    try {
+      const { stdout } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+        cwd: projectPath,
+        timeout: 5000,
+      });
+      currentBranch = stdout.trim();
+    } catch {
+      // ignore
+    }
+
+    if (currentBranch === prBranch) {
+      return this.detectConflictsOnBranch(baseBranch, projectPath);
+    }
+
+    // Not on the PR branch — use the feature worktree if it exists
+    const worktreePath = `${projectPath}/.worktrees/${prBranch}`;
+    try {
+      const { stdout: wt } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+        cwd: worktreePath,
+        timeout: 5000,
+      });
+      if (wt.trim() === prBranch) {
+        return this.detectConflictsOnBranch(baseBranch, worktreePath);
+      }
+    } catch {
+      // Worktree doesn't exist or is on a different branch
+    }
+
+    // Fall back: list PR files as potential conflict candidates
+    try {
+      const { stdout } = await execAsync(
+        `gh pr view ${prNumber} --json files --jq '[.files[].path] | join("\\n")'`,
+        { cwd: projectPath, timeout: 15000 }
+      );
+      const files = stdout.trim().split('\n').filter(Boolean);
+      return {
+        conflictingFiles: files,
+        conflictingSample: '(conflict markers not available — worktree not on PR branch)',
+      };
+    } catch {
+      return { conflictingFiles: [], conflictingSample: '' };
+    }
+  }
+
+  /** Attempt a dry-run merge to identify conflicting files. Aborts cleanly. */
+  private async detectConflictsOnBranch(
+    baseBranch: string,
+    cwd: string
+  ): Promise<{ conflictingFiles: string[]; conflictingSample: string }> {
+    let conflictingFiles: string[] = [];
+    let conflictingSample = '';
+
+    try {
+      await execAsync(`git merge --no-commit --no-ff origin/${baseBranch}`, {
+        cwd,
+        timeout: 30000,
+      });
+      // Merge succeeded cleanly — abort to leave working tree unchanged
+      await execAsync('git merge --abort', { cwd, timeout: 10000 });
+    } catch {
+      // Merge had conflicts — collect conflicting file list and sample
+      try {
+        const { stdout: conflictList } = await execAsync(
+          'git diff --name-only --diff-filter=U',
+          { cwd, timeout: 10000 }
+        );
+        conflictingFiles = conflictList.trim().split('\n').filter(Boolean);
+
+        if (conflictingFiles.length > 0 && conflictingFiles[0]) {
+          try {
+            const { stdout: sampleDiff } = await execAsync(
+              `git diff -- "${conflictingFiles[0]}"`,
+              { cwd, timeout: 10000 }
+            );
+            conflictingSample = sampleDiff.slice(0, 3000);
+          } catch {
+            // ignore — sample is optional
+          }
+        }
+      } catch (listErr) {
+        logger.warn('[PRConflictClassifier] Failed to list conflicting files', listErr);
+      } finally {
+        // Always abort the in-progress merge
+        try {
+          await execAsync('git merge --abort', { cwd, timeout: 10000 });
+        } catch {
+          try {
+            await execAsync('git reset --merge', { cwd, timeout: 10000 });
+          } catch {
+            logger.warn('[PRConflictClassifier] Failed to abort merge — worktree may be dirty');
+          }
+        }
+      }
+    }
+
+    return { conflictingFiles, conflictingSample };
+  }
+
+  private async fetchRecentBaseCommits(
+    baseBranch: string,
+    since: string,
+    projectPath: string
+  ): Promise<string[]> {
+    if (!baseBranch) return [];
+    try {
+      const sinceArg = since ? `--since="${since}"` : '--since="1 week ago"';
+      const { stdout } = await execAsync(
+        `git log origin/${baseBranch} --oneline --no-merges ${sinceArg}`,
+        { cwd: projectPath, timeout: 15000 }
+      );
+      return stdout.trim().split('\n').filter(Boolean);
+    } catch (err) {
+      logger.warn('[PRConflictClassifier] Failed to fetch recent base commits', err);
+      return [];
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // LLM classification
+  // -------------------------------------------------------------------------
+
+  private async llmClassify(
+    evidence: ConflictEvidence,
+    anthropic: Anthropic
+  ): Promise<ConflictClassification> {
+    const prompt = buildClassifierPrompt(evidence);
+    const model = resolveModelString('haiku');
+
+    const response = await anthropic.messages.create({
+      model,
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const content = response.content[0];
+    if (content.type !== 'text') {
+      throw new Error('Expected text response from classifier LLM');
+    }
+
+    // Strip markdown code fences if present
+    const raw = content.text.trim().replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+    const result = JSON.parse(raw) as {
+      verdict: ConflictVerdict;
+      confidence: number;
+      reasoning: string;
+      supersedingCommits?: string[];
+      decompositionFiles?: string[];
+      conflictingHunks?: string[];
+    };
+
+    return {
+      verdict: result.verdict,
+      confidence: result.confidence ?? 0.5,
+      reasoning: result.reasoning ?? '',
+      evidence,
+      supersedingCommits: result.supersedingCommits,
+      decompositionFiles: result.decompositionFiles,
+      conflictingHunks: result.conflictingHunks,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Fallback
+  // -------------------------------------------------------------------------
+
+  private fallbackClassification(errorMessage: string): ConflictClassification {
+    return {
+      verdict: 'genuine',
+      confidence: 0,
+      reasoning: `Classifier failed: ${errorMessage}. Defaulting to genuine to trigger HITL escalation.`,
+      evidence: {
+        prTitle: '',
+        prBody: '',
+        prBranch: '',
+        baseBranch: '',
+        conflictingFiles: [],
+        totalPRFiles: 0,
+        recentBaseCommits: [],
+        conflictingSample: '',
+      },
+      conflictingHunks: ['Classification error — treating as genuine conflict requiring human review'],
+    };
+  }
+}
+
+/**
+ * Factory function for creating a PRConflictClassifier.
+ */
+export function createPRConflictClassifier(input: PRConflictClassifierInput): PRConflictClassifier {
+  return new PRConflictClassifier(input);
+}

--- a/apps/server/src/services/pr-remediation-service.ts
+++ b/apps/server/src/services/pr-remediation-service.ts
@@ -303,7 +303,9 @@ async function handleRebasable(
     await execAsync(`gh pr comment ${prNumber} --body ${JSON.stringify(successComment)}`, {
       cwd: projectPath,
       timeout: 15000,
-    }).catch(() => {/* comment is informational only */});
+    }).catch(() => {
+      /* comment is informational only */
+    });
   } catch (err) {
     mergeError = err instanceof Error ? err.message : String(err);
     logger.warn('[PRRemediation] Rebasable merge failed', { prNumber, error: mergeError });
@@ -427,8 +429,7 @@ async function handleGenuine(
         '(no specific hunks identified)';
 
   const sampleSection =
-    classification.evidence.conflictingSample.slice(0, 1500) ||
-    '(conflict sample not available)';
+    classification.evidence.conflictingSample.slice(0, 1500) || '(conflict sample not available)';
 
   const comment =
     `**Conflict classifier verdict: genuine — human review required**\n\n` +
@@ -437,7 +438,8 @@ async function handleGenuine(
     `**Conflict sample:**\n\`\`\`diff\n${sampleSection}\n\`\`\`\n\n` +
     `**Classifier reasoning:** ${classification.reasoning}\n\n` +
     `**Files with conflicts (${conflictingFiles.length}):**\n` +
-    conflictingFiles.map((f) => `- \`${f}\``).join('\n') + '\n\n' +
+    conflictingFiles.map((f) => `- \`${f}\``).join('\n') +
+    '\n\n' +
     `No further automatic retries will be made. Please resolve the conflicts manually, ` +
     `push the resolved branch, and reopen this PR if needed.`;
 

--- a/apps/server/src/services/pr-remediation-service.ts
+++ b/apps/server/src/services/pr-remediation-service.ts
@@ -1,0 +1,491 @@
+/**
+ * PR Remediation Service
+ *
+ * Integrates conflict-type classification into the update_branch retry loop.
+ * Before the 2nd retry, classifies the conflict nature and dispatches to an
+ * appropriate remediation path instead of blindly retrying.
+ *
+ * Verdict → Action mapping:
+ *   redundant     → auto-close PR with comment linking superseding commits
+ *   rebasable     → attempt git merge -X ours (keep PR semantics, accept base formatting)
+ *   decomposable  → propose PR split to user via HITL comment
+ *   genuine       → escalate to HITL exactly once with specific hunks
+ */
+
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createLogger } from '@protolabsai/utils';
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  PRConflictClassifier,
+  type ConflictClassification,
+  type ConflictVerdict,
+} from './pr-conflict-classifier.js';
+
+const execAsync = promisify(exec);
+const logger = createLogger('PRRemediationService');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RemediationActionType =
+  | 'auto-closed'
+  | 'merged'
+  | 'decompose-proposed'
+  | 'hitl-escalated'
+  | 'budget-exhausted'
+  | 'classification-failed'
+  | 'retry-allowed';
+
+export interface RemediationResult {
+  verdict: ConflictVerdict | null;
+  actionType: RemediationActionType;
+  prNumber: number;
+  remediationCount: number;
+  reasoning: string;
+  details: Record<string, unknown>;
+}
+
+export interface PRRemediationInput {
+  projectPath: string;
+  prNumber: number;
+  /** Current retry attempt number (1-based). Classification triggers on attempt >= 2. */
+  retryAttempt: number;
+  anthropic: Anthropic;
+  /** Maximum total remediation attempts before budget exhaustion (default: 3). */
+  maxRetries?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Per-PR budget tracking (in-memory)
+// ---------------------------------------------------------------------------
+
+/** Map of `${projectPath}:${prNumber}` → remediation attempt count. */
+const remediationCounts = new Map<string, number>();
+
+function getBudgetKey(projectPath: string, prNumber: number): string {
+  return `${projectPath}:${prNumber}`;
+}
+
+function getRemediationCount(projectPath: string, prNumber: number): number {
+  return remediationCounts.get(getBudgetKey(projectPath, prNumber)) ?? 0;
+}
+
+function incrementRemediationCount(projectPath: string, prNumber: number): number {
+  const key = getBudgetKey(projectPath, prNumber);
+  const next = (remediationCounts.get(key) ?? 0) + 1;
+  remediationCounts.set(key, next);
+  return next;
+}
+
+/** Reset the budget counter for a PR (e.g., after a successful merge). */
+export function resetRemediationCount(projectPath: string, prNumber: number): void {
+  remediationCounts.delete(getBudgetKey(projectPath, prNumber));
+}
+
+// ---------------------------------------------------------------------------
+// PR shell injection guard
+// ---------------------------------------------------------------------------
+
+function sanitizePrNumber(prNumber: unknown): number {
+  const parsed = parseInt(String(prNumber), 10);
+  if (isNaN(parsed) || parsed <= 0) {
+    throw new Error(`Invalid PR number: ${String(prNumber)}`);
+  }
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Diagnose a PR conflict and take the appropriate remediation action.
+ *
+ * On the 1st retry (retryAttempt === 1) this is a no-op — the caller
+ * should just attempt update_branch normally.
+ *
+ * On retryAttempt >= 2 this classifies the conflict type and dispatches
+ * to the correct remediation path, logging the verdict and outcome for
+ * observability.
+ */
+export async function classifyAndRemediate(input: PRRemediationInput): Promise<RemediationResult> {
+  const { projectPath, anthropic, maxRetries = 3 } = input;
+  const prNumber = sanitizePrNumber(input.prNumber);
+  const retryAttempt = input.retryAttempt;
+
+  const remediationCount = incrementRemediationCount(projectPath, prNumber);
+
+  logger.info('[PRRemediation] Remediation invoked', {
+    prNumber,
+    retryAttempt,
+    remediationCount,
+    maxRetries,
+  });
+
+  // Budget exhaustion check
+  if (remediationCount > maxRetries) {
+    logger.warn('[PRRemediation] Budget exhausted', { prNumber, remediationCount, maxRetries });
+    return {
+      verdict: null,
+      actionType: 'budget-exhausted',
+      prNumber,
+      remediationCount,
+      reasoning: `Remediation budget exhausted after ${remediationCount - 1} attempts (max: ${maxRetries}).`,
+      details: { remediationCount, maxRetries },
+    };
+  }
+
+  // On the first retry, allow normal update_branch to proceed
+  if (retryAttempt <= 1) {
+    logger.info('[PRRemediation] First retry — deferring to normal update_branch', { prNumber });
+    return {
+      verdict: null,
+      actionType: 'retry-allowed',
+      prNumber,
+      remediationCount,
+      reasoning: 'First retry — classifier not invoked yet.',
+      details: { retryAttempt },
+    };
+  }
+
+  // Classify the conflict
+  let classification: ConflictClassification;
+  try {
+    const classifier = new PRConflictClassifier({ projectPath, prNumber, anthropic });
+    classification = await classifier.classify();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error('[PRRemediation] Classifier threw unexpectedly', { prNumber, error: msg });
+    return {
+      verdict: null,
+      actionType: 'classification-failed',
+      prNumber,
+      remediationCount,
+      reasoning: `Classifier failed: ${msg}`,
+      details: { error: msg },
+    };
+  }
+
+  logger.info('[PRRemediation] Conflict classified', {
+    prNumber,
+    verdict: classification.verdict,
+    confidence: classification.confidence,
+    remediationCount,
+  });
+
+  // Dispatch to verdict-specific handler
+  switch (classification.verdict) {
+    case 'redundant':
+      return handleRedundant(projectPath, prNumber, classification, remediationCount);
+
+    case 'rebasable':
+      return handleRebasable(projectPath, prNumber, classification, remediationCount);
+
+    case 'decomposable':
+      return handleDecomposable(projectPath, prNumber, classification, remediationCount);
+
+    case 'genuine':
+      return handleGenuine(projectPath, prNumber, classification, remediationCount);
+
+    default:
+      // Should not happen — type system enforces this, but be safe
+      return handleGenuine(projectPath, prNumber, classification, remediationCount);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Verdict handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * redundant: Auto-close the PR with a comment linking the superseding commits.
+ * No further retries.
+ */
+async function handleRedundant(
+  projectPath: string,
+  prNumber: number,
+  classification: ConflictClassification,
+  remediationCount: number
+): Promise<RemediationResult> {
+  const superseding = classification.supersedingCommits ?? [];
+  const commitLinks =
+    superseding.length > 0
+      ? superseding.map((c) => `- ${c}`).join('\n')
+      : '(see recent commits on base branch)';
+
+  const comment =
+    `**Conflict classifier verdict: redundant**\n\n` +
+    `This PR's intent has already been satisfied by commits on the base branch.\n\n` +
+    `**Superseding commits:**\n${commitLinks}\n\n` +
+    `**Reasoning:** ${classification.reasoning}\n\n` +
+    `Closing this PR automatically — no further retries needed. ` +
+    `If you believe this is incorrect, reopen the PR and reassign it for manual review.`;
+
+  try {
+    await execAsync(`gh pr comment ${prNumber} --body ${JSON.stringify(comment)}`, {
+      cwd: projectPath,
+      timeout: 15000,
+    });
+    await execAsync(`gh pr close ${prNumber}`, {
+      cwd: projectPath,
+      timeout: 15000,
+    });
+    logger.info('[PRRemediation] Auto-closed redundant PR', { prNumber, superseding });
+  } catch (err) {
+    logger.warn('[PRRemediation] Failed to auto-close redundant PR', { prNumber, err });
+  }
+
+  resetRemediationCount(projectPath, prNumber);
+
+  return {
+    verdict: 'redundant',
+    actionType: 'auto-closed',
+    prNumber,
+    remediationCount,
+    reasoning: classification.reasoning,
+    details: {
+      supersedingCommits: superseding,
+      comment,
+    },
+  };
+}
+
+/**
+ * rebasable: Attempt git merge -X ours to keep the PR's semantic content while
+ * accepting base branch changes in the non-conflicting regions. Pushes if successful.
+ */
+async function handleRebasable(
+  projectPath: string,
+  prNumber: number,
+  classification: ConflictClassification,
+  remediationCount: number
+): Promise<RemediationResult> {
+  const prBranch = classification.evidence.prBranch;
+  const baseBranch = classification.evidence.baseBranch;
+
+  if (!prBranch || !baseBranch) {
+    logger.warn('[PRRemediation] Missing branch info for rebasable merge', { prNumber });
+    return handleGenuine(projectPath, prNumber, classification, remediationCount);
+  }
+
+  // Determine the worktree path to operate in
+  const worktreePath = `${projectPath}/.worktrees/${prBranch}`;
+
+  let mergeSucceeded = false;
+  let mergeError = '';
+
+  try {
+    // Fetch latest base
+    await execAsync(`git fetch origin ${baseBranch}`, { cwd: worktreePath, timeout: 30000 });
+
+    // Attempt the merge preferring our (PR branch) changes for conflicts
+    await execAsync(`git merge -X ours origin/${baseBranch} --no-edit`, {
+      cwd: worktreePath,
+      timeout: 60000,
+    });
+    mergeSucceeded = true;
+
+    logger.info('[PRRemediation] Rebasable merge succeeded', { prNumber, prBranch });
+
+    // Push the resolved branch
+    await execAsync(`git push origin ${prBranch}`, { cwd: worktreePath, timeout: 30000 });
+
+    logger.info('[PRRemediation] Pushed resolved branch', { prNumber, prBranch });
+
+    const successComment =
+      `**Conflict classifier verdict: rebasable**\n\n` +
+      `Textual conflicts were resolved automatically using the PR branch's content as the source of truth.\n\n` +
+      `**Reasoning:** ${classification.reasoning}\n\n` +
+      `The branch has been updated. CI checks are re-running.`;
+
+    await execAsync(`gh pr comment ${prNumber} --body ${JSON.stringify(successComment)}`, {
+      cwd: projectPath,
+      timeout: 15000,
+    }).catch(() => {/* comment is informational only */});
+  } catch (err) {
+    mergeError = err instanceof Error ? err.message : String(err);
+    logger.warn('[PRRemediation] Rebasable merge failed', { prNumber, error: mergeError });
+
+    // Abort any in-progress merge
+    try {
+      await execAsync('git merge --abort', { cwd: worktreePath, timeout: 10000 });
+    } catch {
+      try {
+        await execAsync('git reset --merge', { cwd: worktreePath, timeout: 10000 });
+      } catch {
+        logger.warn('[PRRemediation] Could not abort failed merge in worktree', { worktreePath });
+      }
+    }
+  }
+
+  if (mergeSucceeded) {
+    return {
+      verdict: 'rebasable',
+      actionType: 'merged',
+      prNumber,
+      remediationCount,
+      reasoning: classification.reasoning,
+      details: {
+        prBranch,
+        baseBranch,
+        mergeStrategy: 'ours',
+        resolvedFiles: classification.evidence.conflictingFiles,
+      },
+    };
+  }
+
+  // Merge failed — escalate as genuine
+  logger.info('[PRRemediation] Rebasable merge failed, escalating to genuine HITL', { prNumber });
+  const degradedClassification = {
+    ...classification,
+    verdict: 'genuine' as const,
+    reasoning: `${classification.reasoning}\n\nNote: A rebasable merge was attempted but failed: ${mergeError}`,
+    conflictingHunks: classification.evidence.conflictingFiles.map(
+      (f) => `Conflict in ${f} (rebasable merge failed)`
+    ),
+  };
+  return handleGenuine(projectPath, prNumber, degradedClassification, remediationCount);
+}
+
+/**
+ * decomposable: Post a proposal to split the PR into smaller pieces.
+ * Does not close — presents recommendation to user.
+ */
+async function handleDecomposable(
+  projectPath: string,
+  prNumber: number,
+  classification: ConflictClassification,
+  remediationCount: number
+): Promise<RemediationResult> {
+  const decompositionFiles = classification.decompositionFiles ?? [];
+  const conflictingFiles = classification.evidence.conflictingFiles;
+  const allPRFiles = classification.evidence.totalPRFiles;
+
+  const fileList =
+    decompositionFiles.length > 0
+      ? decompositionFiles.map((f) => `- ${f}`).join('\n')
+      : conflictingFiles.map((f) => `- ${f}`).join('\n') || '(see conflicting files above)';
+
+  const comment =
+    `**Conflict classifier verdict: decomposable**\n\n` +
+    `This PR changes ${allPRFiles} files but conflicts are limited to ${conflictingFiles.length} of them. ` +
+    `The remaining ${allPRFiles - conflictingFiles.length} files could be merged cleanly as a smaller PR.\n\n` +
+    `**Suggested split:**\n` +
+    `1. Extract the following conflicting files into a separate PR to resolve manually:\n${fileList}\n` +
+    `2. Create a new PR with the remaining (non-conflicting) files and merge it first.\n\n` +
+    `**Reasoning:** ${classification.reasoning}\n\n` +
+    `This PR has been left open for manual review. Use the suggestion above to unblock incremental progress.`;
+
+  try {
+    await execAsync(`gh pr comment ${prNumber} --body ${JSON.stringify(comment)}`, {
+      cwd: projectPath,
+      timeout: 15000,
+    });
+    logger.info('[PRRemediation] Posted decomposition proposal', {
+      prNumber,
+      conflictingFiles: conflictingFiles.length,
+      totalFiles: allPRFiles,
+    });
+  } catch (err) {
+    logger.warn('[PRRemediation] Failed to post decomposition comment', { prNumber, err });
+  }
+
+  return {
+    verdict: 'decomposable',
+    actionType: 'decompose-proposed',
+    prNumber,
+    remediationCount,
+    reasoning: classification.reasoning,
+    details: {
+      conflictingFiles,
+      decompositionFiles,
+      totalPRFiles: allPRFiles,
+      comment,
+    },
+  };
+}
+
+/**
+ * genuine: Escalate to HITL exactly once with specific conflicting hunks and context.
+ * Posts a detailed diagnostic comment on the PR and does not retry.
+ */
+async function handleGenuine(
+  projectPath: string,
+  prNumber: number,
+  classification: ConflictClassification,
+  remediationCount: number
+): Promise<RemediationResult> {
+  const conflictingHunks = classification.conflictingHunks ?? [];
+  const conflictingFiles = classification.evidence.conflictingFiles;
+
+  const hunkSection =
+    conflictingHunks.length > 0
+      ? conflictingHunks.map((h) => `- ${h}`).join('\n')
+      : conflictingFiles.map((f) => `- Conflict in \`${f}\``).join('\n') ||
+        '(no specific hunks identified)';
+
+  const sampleSection =
+    classification.evidence.conflictingSample.slice(0, 1500) ||
+    '(conflict sample not available)';
+
+  const comment =
+    `**Conflict classifier verdict: genuine — human review required**\n\n` +
+    `This PR has semantic conflicts with the base branch that cannot be resolved automatically.\n\n` +
+    `**Conflicting areas:**\n${hunkSection}\n\n` +
+    `**Conflict sample:**\n\`\`\`diff\n${sampleSection}\n\`\`\`\n\n` +
+    `**Classifier reasoning:** ${classification.reasoning}\n\n` +
+    `**Files with conflicts (${conflictingFiles.length}):**\n` +
+    conflictingFiles.map((f) => `- \`${f}\``).join('\n') + '\n\n' +
+    `No further automatic retries will be made. Please resolve the conflicts manually, ` +
+    `push the resolved branch, and reopen this PR if needed.`;
+
+  try {
+    await execAsync(`gh pr comment ${prNumber} --body ${JSON.stringify(comment)}`, {
+      cwd: projectPath,
+      timeout: 15000,
+    });
+    logger.info('[PRRemediation] Posted genuine conflict HITL escalation', {
+      prNumber,
+      conflictingFiles: conflictingFiles.length,
+    });
+  } catch (err) {
+    logger.warn('[PRRemediation] Failed to post HITL escalation comment', { prNumber, err });
+  }
+
+  return {
+    verdict: 'genuine',
+    actionType: 'hitl-escalated',
+    prNumber,
+    remediationCount,
+    reasoning: classification.reasoning,
+    details: {
+      conflictingFiles,
+      conflictingHunks,
+      confidence: classification.confidence,
+      comment,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Observability helpers
+// ---------------------------------------------------------------------------
+
+/** Log a structured remediation outcome for monitoring dashboards. */
+export function logRemediationOutcome(result: RemediationResult, featureId?: string): void {
+  logger.info('[PRRemediation:outcome]', {
+    featureId,
+    prNumber: result.prNumber,
+    verdict: result.verdict,
+    actionType: result.actionType,
+    remediationCount: result.remediationCount,
+    reasoning: result.reasoning.slice(0, 200),
+  });
+}
+
+/** Get the current remediation count for a PR (for observability/metrics). */
+export function getRemediationCountForPR(projectPath: string, prNumber: number): number {
+  return getRemediationCount(projectPath, prNumber);
+}


### PR DESCRIPTION
## Summary

Tracks GitHub issue #3411.

## Problem

The PR remediation `update_branch` skill retries on the same conflicting content 3 times without inspecting what changed. Each attempt fails identically, burns the retry budget, escalates HITL.

Observed 2026-04-14 on protoWorkstacean PR #176: 3 update_branch attempts in ~15 min, all failed. Root cause: the PR was already superseded by Arc 0.1/0.2 commits on base — no amount of rebase would help. The remediation loop had no way to know.

## Proposed fix

B...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced intelligent PR conflict detection that automatically classifies and analyzes pull request conflicts
* Applies targeted remediation based on classification: auto-closes redundant pull requests, merges rebasable conflicts, recommends decomposition strategies, or escalates complex cases for manual review

<!-- end of auto-generated comment: release notes by coderabbit.ai -->