### PR TITLE
fix(webhook): idempotency on issues.opened — prevent double-triage (issue #3300)

### DIFF
--- a/apps/server/src/services/webhook-delivery-service.ts
+++ b/apps/server/src/services/webhook-delivery-service.ts
@@ -36,8 +36,10 @@ const DEFAULT_MAX_ATTEMPTS = 3;
 /** Exponential backoff delays in milliseconds: 1s, 5s, 30s */
 const RETRY_DELAYS_MS = [1_000, 5_000, 30_000] as const;
 
-/** Window (ms) for deduplication lookups — only check deliveries from the last 5 minutes */
-const DEDUP_WINDOW_MS = 5 * 60 * 1000;
+/** Window (ms) for deduplication lookups — check deliveries from the last 24 hours.
+ *  GitHub can retry a failed delivery for up to 72h; 24h covers all practical retry scenarios
+ *  while keeping memory usage bounded (at most 500 entries regardless of window size). */
+const DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Callback invoked when a delivery is retried. The caller provides the actual

--- a/apps/server/tests/unit/services/webhook-delivery-service.test.ts
+++ b/apps/server/tests/unit/services/webhook-delivery-service.test.ts
@@ -268,6 +268,85 @@ describe('WebhookDeliveryService', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Regression: issues.opened delivery-id idempotency (GH #3300)
+  //
+  // Verifies that two arrivals of the same X-GitHub-Delivery ID for an
+  // issues.opened event are deduplicated, and that the dedup window is 24h
+  // (not 5 minutes) so GitHub retries arriving hours later are still caught.
+  // ---------------------------------------------------------------------------
+
+  describe('issues.opened delivery-id idempotency', () => {
+    it('downstream handler fires only once when same delivery-id arrives twice', () => {
+      const deliveryId = 'gh-delivery-uuid-999';
+      const deduplicationKey = `issues:opened:${deliveryId}`;
+      const handler = vi.fn();
+
+      function simulateWebhookArrival(): boolean {
+        if (service.isDuplicate('github', 'issues', deduplicationKey)) {
+          return false; // duplicate — skip, return 200 without re-processing
+        }
+        service.trackDelivery('github', 'issues', undefined, { deduplicationKey });
+        handler(); // downstream: Quinn bug_triage
+        return true;
+      }
+
+      const first = simulateWebhookArrival();
+      const second = simulateWebhookArrival(); // GitHub retry — same X-GitHub-Delivery
+
+      expect(first).toBe(true);
+      expect(second).toBe(false);
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('dedup window is 24h — retry arriving 23h later is still caught', () => {
+      const deduplicationKey = 'issues:opened:late-retry-uuid';
+      service.trackDelivery('github', 'issues', undefined, { deduplicationKey });
+
+      // Advance fake clock by 23h — still within 24h window
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now + 23 * 60 * 60 * 1000);
+
+      expect(service.isDuplicate('github', 'issues', deduplicationKey)).toBe(true);
+
+      vi.restoreAllMocks();
+    });
+
+    it('dedup window expires after 24h — a delivery older than 24h is not a duplicate', () => {
+      const deduplicationKey = 'issues:opened:expired-uuid';
+      service.trackDelivery('github', 'issues', undefined, { deduplicationKey });
+
+      // Advance fake clock beyond 24h window
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now + 25 * 60 * 60 * 1000);
+
+      expect(service.isDuplicate('github', 'issues', deduplicationKey)).toBe(false);
+
+      vi.restoreAllMocks();
+    });
+
+    it('two different issues (different delivery-ids) are both processed', () => {
+      const handler = vi.fn();
+
+      function simulateWebhookArrival(deliveryId: string): boolean {
+        const deduplicationKey = `issues:opened:${deliveryId}`;
+        if (service.isDuplicate('github', 'issues', deduplicationKey)) {
+          return false;
+        }
+        service.trackDelivery('github', 'issues', undefined, { deduplicationKey });
+        handler();
+        return true;
+      }
+
+      const first = simulateWebhookArrival('delivery-issue-3299');
+      const second = simulateWebhookArrival('delivery-issue-3300');
+
+      expect(first).toBe(true);
+      expect(second).toBe(true);
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Rolling window eviction at 500 entries
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Tracks GitHub issue #3300.

## Problem

Quinn's bug_triage flow ran twice on GH issue #3299, creating two board features for the same GitHub issue. The protoMaker webhook handler for `issues.opened` is being invoked twice per event (or accepting GitHub retries without dedup).

## Root cause hypotheses

1. Webhook endpoint registered twice (two subscriptions or two cloudflared routes hitting the same handler), OR
2. GitHub retries deliveries and no idempotency guard exists on `issues.opened` — ea...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T20:32:28.734Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended webhook deduplication window from 5 minutes to 24 hours, improving detection of duplicate webhook deliveries across a longer timeframe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->