### PR TITLE
feat(epics): auto-adopt children matching [Arc N.M] / [Epic X.Y] title pattern (issue #3408)

### DIFF
--- a/apps/server/src/routes/features/routes/create.ts
+++ b/apps/server/src/routes/features/routes/create.ts
@@ -11,6 +11,9 @@ import { getErrorMessage, logError } from '../common.js';
 import { TrustTierService } from '../../../services/trust-tier-service.js';
 import { QuarantineService } from '../../../services/quarantine-service.js';
 import type { QuarantineStage, SanitizationViolation } from '@protolabsai/types';
+import { createLogger } from '@protolabsai/utils';
+
+const logger = createLogger('CreateFeature');
 
 export const CreateRequestSchema = z.object({
   projectPath: z.string().min(1, 'projectPath is required'),
@@ -129,6 +132,30 @@ export function createCreateHandler(
         quarantineStatus: outcome.entry.result,
         quarantineId: outcome.entry.id,
       };
+
+      // Auto-adopt into a matching epic based on bracket pattern in the title.
+      // Opt-out: if the caller explicitly passed epicId: null, skip auto-adoption.
+      // Already-parented: if epicId is already set (non-null string), skip.
+      // Epics themselves are skipped (isEpic: true cannot have epicId).
+      const rawEpicId = (feature as Record<string, unknown>).epicId;
+      const epicIdExplicitlyNull = rawEpicId === null;
+      if (
+        !epicIdExplicitlyNull &&
+        !sanitizedFeature.epicId &&
+        !sanitizedFeature.isEpic &&
+        sanitizedFeature.title?.trim()
+      ) {
+        const candidateEpic = await featureLoader.findCandidateEpicForTitle(
+          projectPath,
+          sanitizedFeature.title
+        );
+        if (candidateEpic) {
+          sanitizedFeature.epicId = candidateEpic.id;
+          logger.debug(
+            `Auto-adopted feature "${sanitizedFeature.title}" into epic "${candidateEpic.title}" (${candidateEpic.id})`
+          );
+        }
+      }
 
       const created = await featureLoader.create(projectPath, sanitizedFeature);
 

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -48,6 +48,65 @@ const logger = createLogger('FeatureLoader');
 // Re-export Feature type for convenience
 export type { Feature };
 
+/**
+ * Extract the bracket keyword from a feature title used for epic auto-adoption matching.
+ *
+ * Recognized patterns (keyword is the alphabetic prefix before the version number):
+ *   [Arc 1.2]        → "Arc"
+ *   [TR-1.2]         → "TR"
+ *   [DD-1.2]         → "DD"
+ *   [Epic-Name 1.2]  → "Epic-Name"
+ *
+ * Returns null when the title does not start with a recognized bracket pattern.
+ */
+export function extractEpicKeyword(title: string): string | null {
+  // Match [PREFIX SEPARATOR VERSION] at the start of the title
+  // PREFIX: one or more words joined by hyphens (letters/digits only within each word)
+  // SEPARATOR: a single space or dash between the prefix and the version number
+  // VERSION: one or more dot-separated digit groups (e.g. 1, 0.1, 2.3.4)
+  const match = title
+    .trim()
+    .match(/^\[([A-Za-z][A-Za-z0-9]*(?:-[A-Za-z0-9]+)*)[\s\-](\d+(?:\.\d+)+)\]/);
+  if (!match) return null;
+  return match[1];
+}
+
+/**
+ * Find the best candidate parent epic for auto-adoption given a child feature title.
+ *
+ * Matching rules:
+ * - Extracts the keyword from the bracket prefix (e.g., "Arc" from "[Arc 1.2] xyz")
+ * - Searches active (non-archived) epics for a title that contains the keyword (case-insensitive)
+ *   or whose slugified title contains the slugified keyword
+ * - Returns the candidate only when exactly ONE epic matches — ambiguous matches are skipped
+ *   to avoid mis-assignment
+ *
+ * @param title - Title of the child feature being created
+ * @param features - All features in the project (pre-loaded)
+ * @returns The matching epic Feature, or null if no unique match found
+ */
+export function findCandidateEpic(title: string, features: Feature[]): Feature | null {
+  if (!title) return null;
+
+  const keyword = extractEpicKeyword(title);
+  if (!keyword || keyword.length < 2) return null;
+
+  const keywordLower = keyword.toLowerCase();
+  const keywordSlug = slugify(keyword);
+
+  const epics = features.filter((f) => f.isEpic && !f.archived);
+
+  const candidates = epics.filter((epic) => {
+    if (!epic.title) return false;
+    const epicTitleLower = epic.title.toLowerCase();
+    const epicSlug = slugify(epic.title);
+    return epicTitleLower.includes(keywordLower) || epicSlug.includes(keywordSlug);
+  });
+
+  // Only auto-adopt when exactly one epic matches — avoid wrong assignment on ambiguous results
+  return candidates.length === 1 ? candidates[0] : null;
+}
+
 export class FeatureLoader implements FeatureStore {
   private integrityWatchdog: DataIntegrityWatchdogService | null = null;
   private events: EventEmitter | null = null;
@@ -661,6 +720,19 @@ export class FeatureLoader implements FeatureStore {
     }
 
     return duplicates;
+  }
+
+  /**
+   * Find a candidate parent epic for auto-adoption based on the feature title's bracket pattern.
+   * Loads all features for the project and delegates to the standalone findCandidateEpic function.
+   *
+   * @param projectPath - Path to the project
+   * @param title - Title of the child feature being created
+   * @returns The matching epic Feature, or null if no unique match found
+   */
+  async findCandidateEpicForTitle(projectPath: string, title: string): Promise<Feature | null> {
+    const features = await this.getAll(projectPath);
+    return findCandidateEpic(title, features);
   }
 
   /**

--- a/apps/server/src/services/maintenance.module.ts
+++ b/apps/server/src/services/maintenance.module.ts
@@ -7,6 +7,7 @@
  * - webhook-health (full tier, 6h): Warns when PRs in review have no CI events after grace period
  * - post-merge-reconciler (critical tier, 5min): Poll-based fallback for missed PR merge webhooks
  * - done-worktree-cleanup (full tier, 6h): Removes worktrees for done features and orphaned worktrees
+ * - epic-adoption-sweep (full tier + 1h poll): Links orphaned features to parent epics via bracket-prefix matching
  */
 
 import { createLogger } from '@protolabsai/utils';
@@ -19,6 +20,7 @@ import type { ServiceContainer } from '../server/services.js';
 import { WebhookHealthCheck } from './maintenance/checks/webhook-health-check.js';
 import { PostMergeReconcilerCheck } from './maintenance/checks/post-merge-reconciler-check.js';
 import { DoneWorktreeCleanupCheck } from './maintenance/checks/done-worktree-cleanup-check.js';
+import { EpicAdoptionSweepCheck } from './maintenance/checks/epic-adoption-sweep-check.js';
 
 const logger = createLogger('Server:Wiring');
 
@@ -180,11 +182,15 @@ export function register(container: ServiceContainer): void {
     events
   );
 
+  // Epic adoption sweep (full tier + dedicated 1h poll) — links orphaned features to parent epics
+  const epicAdoptionSweepCheck = new EpicAdoptionSweepCheck(featureLoader);
+
   maintenanceOrchestrator.register(boardHealthCheck);
   maintenanceOrchestrator.register(resourceUsageCheck);
   maintenanceOrchestrator.register(webhookHealthCheck);
   maintenanceOrchestrator.register(postMergeReconcilerCheck);
   maintenanceOrchestrator.register(doneWorktreeCleanupCheck);
+  maintenanceOrchestrator.register(epicAdoptionSweepCheck);
 
   // Wire TopicBus for hierarchical event routing of sweep results
   if (container.topicBus) {
@@ -225,7 +231,26 @@ export function register(container: ServiceContainer): void {
     { category: 'sync' }
   );
 
+  // Dedicated 1-hour poll interval for the epic adoption sweep so that orphaned features
+  // created before the auto-adopt guard landed get linked to their parent epics within
+  // a reasonable window (the full maintenance tier runs every 6 hours which is too slow
+  // for active auto-mode sessions generating many child features in quick succession).
+  schedulerService.registerInterval(
+    'epic-adoption-sweep:poll',
+    'Epic Adoption Sweep Poll (1h)',
+    60 * 60_000,
+    async () => {
+      const paths = new Set<string>();
+      paths.add(repoRoot);
+      for (const p of autoModeService.getActiveAutoLoopProjects()) {
+        paths.add(p);
+      }
+      await epicAdoptionSweepCheck.run({ projectPaths: Array.from(paths) });
+    },
+    { category: 'maintenance' }
+  );
+
   logger.info(
-    'MaintenanceOrchestrator started with board-health, resource-usage, webhook-health, post-merge-reconciler, and done-worktree-cleanup checks'
+    'MaintenanceOrchestrator started with board-health, resource-usage, webhook-health, post-merge-reconciler, done-worktree-cleanup, and epic-adoption-sweep checks'
   );
 }

--- a/apps/server/src/services/maintenance/checks/epic-adoption-sweep-check.ts
+++ b/apps/server/src/services/maintenance/checks/epic-adoption-sweep-check.ts
@@ -1,0 +1,74 @@
+/**
+ * EpicAdoptionSweepCheck - Periodic sweep that links orphaned features to their parent epics.
+ *
+ * Features created before the auto-adopt-on-create guard landed (or created via paths
+ * that bypass the create route) may have epicId: undefined even when the title clearly
+ * belongs to an epic (e.g. "[Arc 0.1] Implement GOAP planner").
+ *
+ * This check runs on the 'full' maintenance tier (every 6 hours) and also on a dedicated
+ * 1-hour scheduler interval. It finds candidate orphans — active, non-epic features with
+ * no epicId and a bracket-prefixed title — and adopts them into the matching epic.
+ *
+ * Adoption is skipped when:
+ * - No bracket pattern is found in the title
+ * - Zero or multiple epics match the keyword (ambiguous)
+ * - The feature is an epic itself (isEpic: true)
+ * - The feature is archived
+ */
+
+import { createLogger } from '@protolabsai/utils';
+import type {
+  MaintenanceCheck,
+  MaintenanceCheckContext,
+  MaintenanceCheckResult,
+} from '@protolabsai/types';
+import type { FeatureLoader } from '../../feature-loader.js';
+import { findCandidateEpic } from '../../feature-loader.js';
+
+const logger = createLogger('EpicAdoptionSweepCheck');
+
+export class EpicAdoptionSweepCheck implements MaintenanceCheck {
+  readonly id = 'epic-adoption-sweep';
+  readonly name = 'Epic Adoption Sweep';
+  readonly tier = 'full' as const;
+
+  constructor(private readonly featureLoader: FeatureLoader) {}
+
+  async run(context: MaintenanceCheckContext): Promise<MaintenanceCheckResult> {
+    const t0 = Date.now();
+    let totalAdopted = 0;
+
+    for (const projectPath of context.projectPaths) {
+      try {
+        const features = await this.featureLoader.getAll(projectPath);
+
+        // Candidates: active non-epic features with no epicId and a non-empty title
+        const orphans = features.filter((f) => !f.isEpic && !f.epicId && !f.archived && f.title);
+
+        for (const orphan of orphans) {
+          const candidate = findCandidateEpic(orphan.title!, features);
+          if (!candidate) continue;
+
+          logger.info(
+            `Adopting feature "${orphan.title}" (${orphan.id}) into epic "${candidate.title}" (${candidate.id})`
+          );
+          await this.featureLoader.update(projectPath, orphan.id, { epicId: candidate.id });
+          totalAdopted++;
+        }
+      } catch (err) {
+        logger.error(`EpicAdoptionSweepCheck failed for ${projectPath}:`, err);
+      }
+    }
+
+    return {
+      checkId: this.id,
+      passed: true,
+      summary:
+        totalAdopted > 0
+          ? `Epic adoption sweep: adopted ${totalAdopted} orphan(s) into matching epics`
+          : `Epic adoption sweep: no orphaned features with matching epics found`,
+      details: { totalAdopted, projectCount: context.projectPaths.length },
+      durationMs: Date.now() - t0,
+    };
+  }
+}

--- a/apps/server/tests/unit/services/epic-auto-adoption.test.ts
+++ b/apps/server/tests/unit/services/epic-auto-adoption.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Unit tests for epic auto-adoption logic
+ *
+ * Covers:
+ * - extractEpicKeyword: bracket pattern parsing
+ * - findCandidateEpic: pure matching logic against a feature list
+ * - POST /features/create: adoption on create, no-match orphan, explicit null opt-out
+ * - EpicAdoptionSweepCheck: periodic sweep adopts orphans
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Feature } from '@protolabsai/types';
+import type { Request, Response } from 'express';
+
+// --- Module mocks (before imports) ---
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+  atomicWriteJson: vi.fn().mockResolvedValue(undefined),
+  readJsonWithRecovery: vi.fn(),
+  logRecoveryWarning: vi.fn(),
+  DEFAULT_BACKUP_COUNT: 3,
+  slugify: vi.fn((s: string) => s.toLowerCase().replace(/[\s\-]+/g, '-')),
+}));
+
+vi.mock('@protolabsai/platform', () => ({
+  validatePath: vi.fn(),
+  PathNotAllowedError: class PathNotAllowedError extends Error {},
+  getAutomakerDir: vi.fn((p: string) => `${p}/.automaker`),
+  getFeaturesDir: vi.fn((p: string) => `${p}/.automaker/features`),
+  getFeatureDir: vi.fn((p: string, id: string) => `${p}/.automaker/features/${id}`),
+  getFeatureImagesDir: vi.fn((p: string, id: string) => `${p}/.automaker/features/${id}/images`),
+  getFeatureBackupDir: vi.fn((p: string, id: string) => `${p}/.automaker/backups/${id}`),
+  getAppSpecPath: vi.fn((p: string) => `${p}/app_spec.txt`),
+  ensureAutomakerDir: vi.fn(),
+  isValidBranchName: vi.fn(() => true),
+}));
+
+vi.mock('@/lib/secure-fs.js', () => ({
+  access: vi.fn(),
+  readdir: vi.fn(),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn(),
+  unlink: vi.fn().mockResolvedValue(undefined),
+  stat: vi.fn(),
+}));
+
+vi.mock('@/lib/xml-extractor.js', () => ({
+  addImplementedFeature: vi.fn(),
+}));
+
+vi.mock('@/lib/debug-log.js', () => ({
+  debugLog: vi.fn(),
+}));
+
+vi.mock('@/lib/prometheus.js', () => ({
+  featuresByStatus: { inc: vi.fn(), dec: vi.fn(), set: vi.fn() },
+}));
+
+vi.mock('@/services/quarantine-service.js', () => ({
+  QuarantineService: vi.fn().mockImplementation(() => ({
+    process: vi.fn().mockResolvedValue({
+      approved: true,
+      sanitizedTitle: 'sanitized-title',
+      sanitizedDescription: 'sanitized-description',
+      entry: { id: 'q-1', result: 'approved', stage: 'passed', violations: [] },
+    }),
+  })),
+}));
+
+// --- Imports ---
+
+import { extractEpicKeyword, findCandidateEpic } from '@/services/feature-loader.js';
+import { createCreateHandler } from '@/routes/features/routes/create.js';
+import { EpicAdoptionSweepCheck } from '@/services/maintenance/checks/epic-adoption-sweep-check.js';
+import { createMockExpressContext } from '../../utils/mocks.js';
+
+// Helper to build a minimal Feature object
+function makeFeature(overrides: Partial<Feature> & { id: string; title: string }): Feature {
+  return {
+    status: 'backlog',
+    description: '',
+    category: 'test',
+    ...overrides,
+  } as Feature;
+}
+
+// ---------------------------------------------------------------------------
+// extractEpicKeyword
+// ---------------------------------------------------------------------------
+
+describe('extractEpicKeyword', () => {
+  it('extracts keyword from [Arc 1.2] prefix', () => {
+    expect(extractEpicKeyword('[Arc 1.2] Implement GOAP planner')).toBe('Arc');
+  });
+
+  it('extracts keyword from [Arc 0.1] prefix', () => {
+    expect(extractEpicKeyword('[Arc 0.1] Scaffold types')).toBe('Arc');
+  });
+
+  it('extracts keyword from dash-separated [TR-1.2]', () => {
+    expect(extractEpicKeyword('[TR-1.2] Some task')).toBe('TR');
+  });
+
+  it('extracts keyword from [DD-2.3] prefix', () => {
+    expect(extractEpicKeyword('[DD-2.3] Deep dive analysis')).toBe('DD');
+  });
+
+  it('extracts hyphenated keyword from [Epic-Name 1.0]', () => {
+    expect(extractEpicKeyword('[Epic-Name 1.0] Build the thing')).toBe('Epic-Name');
+  });
+
+  it('returns null when title has no bracket pattern', () => {
+    expect(extractEpicKeyword('Implement auth flow')).toBeNull();
+  });
+
+  it('returns null when bracket content has no version number', () => {
+    expect(extractEpicKeyword('[WIP] some task')).toBeNull();
+  });
+
+  it('returns null for empty title', () => {
+    expect(extractEpicKeyword('')).toBeNull();
+  });
+
+  it('returns null when bracket is mid-title (not at start)', () => {
+    expect(extractEpicKeyword('Some [Arc 1.2] task')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findCandidateEpic
+// ---------------------------------------------------------------------------
+
+describe('findCandidateEpic', () => {
+  const arcEpic = makeFeature({
+    id: 'epic-arc',
+    title: 'Arc — Living Agent Orchestrator',
+    isEpic: true,
+  });
+
+  it('returns the matching epic when exactly one epic contains the keyword', () => {
+    const features = [arcEpic];
+    const result = findCandidateEpic('[Arc 0.1] Scaffold types', features);
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('epic-arc');
+  });
+
+  it('returns null when title has no bracket pattern', () => {
+    const features = [arcEpic];
+    expect(findCandidateEpic('Implement GOAP planner', features)).toBeNull();
+  });
+
+  it('returns null when no epic title matches the keyword', () => {
+    const features = [arcEpic];
+    expect(findCandidateEpic('[TR-1.2] Unrelated task', features)).toBeNull();
+  });
+
+  it('returns null when multiple epics match the keyword (ambiguous)', () => {
+    const arcEpic2 = makeFeature({ id: 'epic-arc-2', title: 'Arc Phase 2', isEpic: true });
+    const features = [arcEpic, arcEpic2];
+    expect(findCandidateEpic('[Arc 0.1] Some child', features)).toBeNull();
+  });
+
+  it('skips archived epics when matching', () => {
+    const archivedArcEpic = makeFeature({
+      id: 'epic-arc-archived',
+      title: 'Arc — Old Orchestrator',
+      isEpic: true,
+      archived: true,
+    });
+    const features = [archivedArcEpic];
+    expect(findCandidateEpic('[Arc 0.1] Child task', features)).toBeNull();
+  });
+
+  it('matches via slug when epic title uses different casing', () => {
+    const upperEpic = makeFeature({ id: 'epic-dd', title: 'DD Deep Dive Analysis', isEpic: true });
+    const features = [upperEpic];
+    const result = findCandidateEpic('[DD-1.1] subtask', features);
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('epic-dd');
+  });
+
+  it('returns null for empty title', () => {
+    const features = [arcEpic];
+    expect(findCandidateEpic('', features)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /features/create — auto-adoption
+// ---------------------------------------------------------------------------
+
+function createMockFeatureLoader(epicFeatures: Feature[] = [], createdFeature?: Partial<Feature>) {
+  const defaultCreated = { id: 'feat-new', title: 'sanitized-title', status: 'backlog' };
+  return {
+    get: vi.fn(),
+    getAll: vi.fn().mockResolvedValue(epicFeatures),
+    update: vi.fn().mockResolvedValue({ ...defaultCreated }),
+    create: vi.fn().mockResolvedValue({ ...defaultCreated, ...createdFeature }),
+    findDuplicateTitle: vi.fn().mockResolvedValue(null),
+    findCandidateEpicForTitle: vi.fn().mockImplementation((_path: string, title: string) => {
+      return Promise.resolve(findCandidateEpic(title, epicFeatures));
+    }),
+  };
+}
+
+function createMockTrustTierService() {
+  return { classifyTrust: vi.fn().mockReturnValue(1) };
+}
+
+const arcEpicFeature = makeFeature({
+  id: 'epic-arc',
+  title: 'Arc — Living Agent Orchestrator',
+  isEpic: true,
+});
+
+describe('POST /features/create — epic auto-adoption', () => {
+  let req: Request;
+  let res: Response;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const ctx = createMockExpressContext();
+    req = ctx.req;
+    res = ctx.res;
+  });
+
+  it('auto-adopts a feature with [Arc 0.1] title into the matching epic', async () => {
+    const mockLoader = createMockFeatureLoader([arcEpicFeature]);
+    req.body = {
+      projectPath: '/test/project',
+      feature: {
+        title: '[Arc 0.1] Scaffold types',
+        description: 'Build the foundation types',
+      },
+    };
+
+    const handler = createCreateHandler(mockLoader as any, createMockTrustTierService() as any);
+    await handler(req, res);
+
+    // Verify findCandidateEpicForTitle was called
+    expect(mockLoader.findCandidateEpicForTitle).toHaveBeenCalledWith(
+      '/test/project',
+      expect.any(String)
+    );
+
+    // Verify create was called with epicId set to the arc epic
+    expect(mockLoader.create).toHaveBeenCalledWith(
+      '/test/project',
+      expect.objectContaining({ epicId: 'epic-arc' })
+    );
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+  });
+
+  it('creates an orphan when no epic matches the title pattern', async () => {
+    const mockLoader = createMockFeatureLoader([arcEpicFeature]);
+    req.body = {
+      projectPath: '/test/project',
+      feature: {
+        title: '[TR-1.0] Unrelated task',
+        description: 'Something unrelated',
+      },
+    };
+
+    const handler = createCreateHandler(mockLoader as any, createMockTrustTierService() as any);
+    await handler(req, res);
+
+    // create called WITHOUT epicId set from auto-adoption
+    const createCall = mockLoader.create.mock.calls[0];
+    expect(createCall).toBeDefined();
+    expect(createCall[1].epicId).toBeUndefined();
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+  });
+
+  it('skips auto-adoption when epicId: null is explicitly provided (opt-out)', async () => {
+    const mockLoader = createMockFeatureLoader([arcEpicFeature]);
+    req.body = {
+      projectPath: '/test/project',
+      feature: {
+        title: '[Arc 0.1] Scaffold types',
+        description: 'Build the foundation types',
+        epicId: null,
+      },
+    };
+
+    const handler = createCreateHandler(mockLoader as any, createMockTrustTierService() as any);
+    await handler(req, res);
+
+    // findCandidateEpicForTitle must NOT be called
+    expect(mockLoader.findCandidateEpicForTitle).not.toHaveBeenCalled();
+
+    // create called without epicId override
+    const createCall = mockLoader.create.mock.calls[0];
+    expect(createCall).toBeDefined();
+    expect(createCall[1].epicId == null).toBe(true);
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+  });
+
+  it('skips auto-adoption when epicId is already explicitly provided (non-null)', async () => {
+    const mockLoader = createMockFeatureLoader([arcEpicFeature]);
+    req.body = {
+      projectPath: '/test/project',
+      feature: {
+        title: '[Arc 0.1] Scaffold types',
+        description: 'Build the foundation types',
+        epicId: 'explicit-epic-id',
+      },
+    };
+
+    const handler = createCreateHandler(mockLoader as any, createMockTrustTierService() as any);
+    await handler(req, res);
+
+    // findCandidateEpicForTitle must NOT be called (already parented)
+    expect(mockLoader.findCandidateEpicForTitle).not.toHaveBeenCalled();
+
+    // epicId preserved as originally specified
+    expect(mockLoader.create).toHaveBeenCalledWith(
+      '/test/project',
+      expect.objectContaining({ epicId: 'explicit-epic-id' })
+    );
+  });
+
+  it('skips auto-adoption for epic containers (isEpic: true)', async () => {
+    const mockLoader = createMockFeatureLoader([arcEpicFeature]);
+    req.body = {
+      projectPath: '/test/project',
+      feature: {
+        title: '[Arc 0.1] Some epic',
+        description: 'Epic container',
+        isEpic: true,
+      },
+    };
+
+    // NOTE: isEpic + epicId is rejected (400). This test sends isEpic without epicId.
+    const handler = createCreateHandler(mockLoader as any, createMockTrustTierService() as any);
+    await handler(req, res);
+
+    // findCandidateEpicForTitle must NOT be called for epics
+    expect(mockLoader.findCandidateEpicForTitle).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EpicAdoptionSweepCheck — periodic sweep
+// ---------------------------------------------------------------------------
+
+describe('EpicAdoptionSweepCheck', () => {
+  it('adopts orphaned features with matching bracket patterns into their epics', async () => {
+    const orphan = makeFeature({ id: 'feat-orphan', title: '[Arc 0.1] Orphaned task' });
+    const epicArc = makeFeature({
+      id: 'epic-arc',
+      title: 'Arc — Living Agent Orchestrator',
+      isEpic: true,
+    });
+    const mockLoader = {
+      getAll: vi.fn().mockResolvedValue([orphan, epicArc]),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const check = new EpicAdoptionSweepCheck(mockLoader as any);
+    const result = await check.run({ projectPaths: ['/test/project'] });
+
+    expect(result.passed).toBe(true);
+    expect(mockLoader.update).toHaveBeenCalledWith('/test/project', 'feat-orphan', {
+      epicId: 'epic-arc',
+    });
+    expect(result.details?.totalAdopted).toBe(1);
+  });
+
+  it('does not adopt features with no matching epic pattern', async () => {
+    const nonMatch = makeFeature({ id: 'feat-1', title: 'Regular feature without bracket' });
+    const epicArc = makeFeature({
+      id: 'epic-arc',
+      title: 'Arc — Living Agent Orchestrator',
+      isEpic: true,
+    });
+    const mockLoader = {
+      getAll: vi.fn().mockResolvedValue([nonMatch, epicArc]),
+      update: vi.fn(),
+    };
+
+    const check = new EpicAdoptionSweepCheck(mockLoader as any);
+    const result = await check.run({ projectPaths: ['/test/project'] });
+
+    expect(mockLoader.update).not.toHaveBeenCalled();
+    expect(result.details?.totalAdopted).toBe(0);
+  });
+
+  it('does not re-adopt features that already have an epicId', async () => {
+    const alreadyParented = makeFeature({
+      id: 'feat-1',
+      title: '[Arc 0.1] Already parented',
+      epicId: 'epic-arc',
+    });
+    const epicArc = makeFeature({
+      id: 'epic-arc',
+      title: 'Arc — Living Agent Orchestrator',
+      isEpic: true,
+    });
+    const mockLoader = {
+      getAll: vi.fn().mockResolvedValue([alreadyParented, epicArc]),
+      update: vi.fn(),
+    };
+
+    const check = new EpicAdoptionSweepCheck(mockLoader as any);
+    await check.run({ projectPaths: ['/test/project'] });
+
+    expect(mockLoader.update).not.toHaveBeenCalled();
+  });
+
+  it('sweeps across multiple project paths', async () => {
+    const orphan1 = makeFeature({ id: 'feat-a', title: '[Arc 0.1] Task A' });
+    const orphan2 = makeFeature({ id: 'feat-b', title: '[Arc 0.2] Task B' });
+    const epicArc = makeFeature({
+      id: 'epic-arc',
+      title: 'Arc — Living Agent Orchestrator',
+      isEpic: true,
+    });
+
+    const mockLoader = {
+      getAll: vi
+        .fn()
+        .mockResolvedValueOnce([orphan1, epicArc])
+        .mockResolvedValueOnce([orphan2, epicArc]),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const check = new EpicAdoptionSweepCheck(mockLoader as any);
+    const result = await check.run({
+      projectPaths: ['/project/one', '/project/two'],
+    });
+
+    expect(mockLoader.update).toHaveBeenCalledTimes(2);
+    expect(result.details?.totalAdopted).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Tracks GitHub issue #3408.

## Problem

Children shipped via auto-mode (as new feature records, not via epic creation flow) are not linked back to their parent epic. They show up as orphans even when the title pattern makes the parent obvious.

Observed 2026-04-14: Epic 'Unified A2A + GOAP — Living Agent Orchestrator' had children titled [Arc 0.1] and [Arc 0.2] with epicId: null. Epic rollup (epicProgressPercent) read 0% complete even though 2/43 children were done. Operator had to manually repa...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T20:50:43.282Z -->