### PR TITLE
feat(pr-remediation): auto-fix Check formatting failures on open PRs

### DIFF
--- a/apps/server/src/services/github-webhook-handler.ts
+++ b/apps/server/src/services/github-webhook-handler.ts
@@ -113,10 +113,13 @@ export class GitHubWebhookHandler {
     );
 
     if (!formatCheckFailed) {
-      logger.debug('[GitHubWebhookHandler] Format check did not fail — skipping format remediation', {
-        prNumber,
-        headBranch,
-      });
+      logger.debug(
+        '[GitHubWebhookHandler] Format check did not fail — skipping format remediation',
+        {
+          prNumber,
+          headBranch,
+        }
+      );
       return;
     }
 
@@ -193,7 +196,9 @@ export class GitHubWebhookHandler {
         );
         checkRuns = JSON.parse(stdout) as GitHubCheckRunsListResponse;
       } else {
-        logger.debug('[GitHubWebhookHandler] No checksUrl or checkSuiteId — cannot verify check name');
+        logger.debug(
+          '[GitHubWebhookHandler] No checksUrl or checkSuiteId — cannot verify check name'
+        );
         return false;
       }
 

--- a/apps/server/src/services/github-webhook-handler.ts
+++ b/apps/server/src/services/github-webhook-handler.ts
@@ -1,0 +1,226 @@
+/**
+ * GitHubWebhookHandler Service
+ *
+ * Listens for CI failure events emitted by the global webhook route and
+ * triggers format-failure auto-remediation when the "Check formatting" check fails.
+ *
+ * Flow:
+ *   pr:ci-failure event received
+ *     → fetch check runs for the failed suite (via GitHub API)
+ *     → filter for a failed "Check formatting" check run
+ *     → call remediateFormatFailure() from pr-remediation-service
+ *     → emit pr:remediation-completed on success
+ *
+ * Safety gates (enforced inside remediateFormatFailure):
+ *   - Protected branch guard (never touch main/staging/dev)
+ *   - Agent-author guard (branch prefix)
+ *   - One-remediation-per-PR cap
+ *   - Scope check (only PR-diff files modified by prettier)
+ */
+
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createLogger } from '@protolabsai/utils';
+import type { EventEmitter } from '../lib/events.js';
+import type { EventType } from '@protolabsai/types';
+import { remediateFormatFailure } from './pr-remediation-service.js';
+import type { GitHubCheckRunsListResponse } from '../types/pr-remediation.js';
+
+const execAsync = promisify(exec);
+const logger = createLogger('GitHubWebhookHandler');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** The exact name of the GitHub Actions step we are watching. */
+const FORMAT_CHECK_NAME = 'Check formatting';
+
+// ---------------------------------------------------------------------------
+// CI failure event payload (matches what routes/webhooks/routes/github.ts emits)
+// ---------------------------------------------------------------------------
+
+interface CIFailurePayload {
+  projectPath: string;
+  prNumber: number;
+  headBranch: string;
+  headSha: string;
+  checkSuiteId?: number;
+  checkSuiteUrl?: string | null;
+  repository: string;
+  checksUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class GitHubWebhookHandler {
+  private readonly events: EventEmitter;
+  /** Resolved project path used for git operations / worktree lookups. */
+  private readonly projectPath: string;
+  private unsubscribe?: () => void;
+
+  /**
+   * @param events      Shared event bus (subscribe + emit).
+   * @param projectPath Root project directory — used to locate worktrees and
+   *                    prettier when remediating format failures.
+   */
+  constructor(events: EventEmitter, projectPath: string) {
+    this.events = events;
+    this.projectPath = projectPath;
+  }
+
+  /**
+   * Start listening for CI failure events. Call once during server startup.
+   */
+  start(): void {
+    this.unsubscribe = this.events.subscribe((type: EventType, payload: unknown) => {
+      if (type === 'pr:ci-failure') {
+        // Fire-and-forget: errors are caught and logged inside the handler.
+        void this.handleCIFailure(payload as CIFailurePayload);
+      }
+    });
+    logger.info('[GitHubWebhookHandler] Listening for CI failure events');
+  }
+
+  /**
+   * Stop listening. Call during graceful shutdown.
+   */
+  stop(): void {
+    this.unsubscribe?.();
+    logger.info('[GitHubWebhookHandler] Stopped listening for CI failure events');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal handlers
+  // ---------------------------------------------------------------------------
+
+  private async handleCIFailure(payload: CIFailurePayload): Promise<void> {
+    const { prNumber, headBranch, headSha, repository, checksUrl } = payload;
+
+    logger.info('[GitHubWebhookHandler] Received CI failure', {
+      prNumber,
+      headBranch,
+      repository,
+    });
+
+    // Check if the "Check formatting" step specifically failed
+    const formatCheckFailed = await this.isFormatCheckFailed(
+      repository,
+      payload.checkSuiteId,
+      checksUrl
+    );
+
+    if (!formatCheckFailed) {
+      logger.debug('[GitHubWebhookHandler] Format check did not fail — skipping format remediation', {
+        prNumber,
+        headBranch,
+      });
+      return;
+    }
+
+    logger.info('[GitHubWebhookHandler] Format check failure confirmed — triggering remediation', {
+      prNumber,
+      headBranch,
+    });
+
+    // Resolve project path: use the provided projectPath if non-empty, else fall back to
+    // process.cwd() (the server's working directory where the repo lives).
+    const projectPath = this.projectPath || process.cwd();
+
+    try {
+      const result = await remediateFormatFailure(
+        {
+          projectPath,
+          prNumber,
+          headBranch,
+          headSha,
+          repository,
+          checksUrl,
+        },
+        this.events
+      );
+
+      logger.info('[GitHubWebhookHandler] Remediation complete', {
+        prNumber,
+        status: result.status,
+        reason: result.reason.slice(0, 120),
+      });
+
+      if (result.status === 'escalated') {
+        logger.warn('[GitHubWebhookHandler] Escalating to HITL', {
+          prNumber,
+          reason: result.reason,
+          details: result.details,
+        });
+      }
+    } catch (err) {
+      logger.error('[GitHubWebhookHandler] Unhandled error during format remediation', {
+        prNumber,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Query the GitHub API to determine whether the "Check formatting" check run
+   * failed in the given check suite.
+   *
+   * Uses `checksUrl` (the check_suite.check_runs_url) when available;
+   * falls back to querying by checkSuiteId.
+   *
+   * Returns false on any API error (fail-safe: don't remediate if we can't confirm).
+   */
+  private async isFormatCheckFailed(
+    repository: string,
+    checkSuiteId: number | undefined,
+    checksUrl: string | undefined
+  ): Promise<boolean> {
+    try {
+      let checkRuns: GitHubCheckRunsListResponse | null = null;
+
+      if (checksUrl) {
+        // Use the URL directly — gh api accepts full GitHub API URLs
+        const { stdout } = await execAsync(`gh api ${JSON.stringify(checksUrl)}`, {
+          timeout: 15000,
+        });
+        checkRuns = JSON.parse(stdout) as GitHubCheckRunsListResponse;
+      } else if (checkSuiteId) {
+        const { stdout } = await execAsync(
+          `gh api repos/${repository}/check-suites/${checkSuiteId}/check-runs`,
+          { timeout: 15000 }
+        );
+        checkRuns = JSON.parse(stdout) as GitHubCheckRunsListResponse;
+      } else {
+        logger.debug('[GitHubWebhookHandler] No checksUrl or checkSuiteId — cannot verify check name');
+        return false;
+      }
+
+      if (!checkRuns || !Array.isArray(checkRuns.check_runs)) {
+        logger.debug('[GitHubWebhookHandler] Unexpected check_runs response shape');
+        return false;
+      }
+
+      const formatCheck = checkRuns.check_runs.find((cr) => cr.name === FORMAT_CHECK_NAME);
+      if (!formatCheck) {
+        logger.debug('[GitHubWebhookHandler] "Check formatting" check run not found in suite');
+        return false;
+      }
+
+      const failed = formatCheck.conclusion === 'failure';
+      logger.debug('[GitHubWebhookHandler] Format check status', {
+        checkName: formatCheck.name,
+        conclusion: formatCheck.conclusion,
+        failed,
+      });
+      return failed;
+    } catch (err) {
+      logger.warn('[GitHubWebhookHandler] Failed to fetch check runs', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // Fail-safe: if we can't confirm the format check failed, don't auto-remediate
+      return false;
+    }
+  }
+}

--- a/apps/server/src/services/pr-remediation-service.ts
+++ b/apps/server/src/services/pr-remediation-service.ts
@@ -703,10 +703,10 @@ export async function remediateFormatFailure(
       scratchDir = await worker.createScratchDir();
       workDir = scratchDir;
 
-      await execAsync(
-        `gh pr checkout ${prNumber} --repo ${repository} --force`,
-        { cwd: scratchDir, timeout: 60000 }
-      );
+      await execAsync(`gh pr checkout ${prNumber} --repo ${repository} --force`, {
+        cwd: scratchDir,
+        timeout: 60000,
+      });
     } catch (checkoutErr) {
       if (scratchDir) await worker.cleanup(scratchDir);
       return {
@@ -722,7 +722,10 @@ export async function remediateFormatFailure(
     // ------------------------------------------------------------------
     // Run prettier on changed files
     // ------------------------------------------------------------------
-    logger.info('[FormatRemediation] Running prettier', { prNumber, fileCount: prChangedFiles.length });
+    logger.info('[FormatRemediation] Running prettier', {
+      prNumber,
+      fileCount: prChangedFiles.length,
+    });
 
     let filesFixed: string[];
     try {

--- a/apps/server/src/services/pr-remediation-service.ts
+++ b/apps/server/src/services/pr-remediation-service.ts
@@ -10,9 +10,14 @@
  *   rebasable     → attempt git merge -X ours (keep PR semantics, accept base formatting)
  *   decomposable  → propose PR split to user via HITL comment
  *   genuine       → escalate to HITL exactly once with specific hunks
+ *
+ * Format remediation:
+ *   When CI's "Check formatting" step fails on an agent-authored PR, remediateFormatFailure()
+ *   runs prettier on the PR's changed files, verifies scope, and pushes an auto-fix commit.
  */
 
 import { exec } from 'node:child_process';
+import path from 'node:path';
 import { promisify } from 'node:util';
 import { createLogger } from '@protolabsai/utils';
 import Anthropic from '@anthropic-ai/sdk';
@@ -21,6 +26,13 @@ import {
   type ConflictClassification,
   type ConflictVerdict,
 } from './pr-conflict-classifier.js';
+import { PrRemediationWorker } from './pr-remediation-worker.js';
+import type {
+  FormatRemediationInput,
+  FormatRemediationResult,
+  PRFormatRemediatedPayload,
+} from '../types/pr-remediation.js';
+import type { EventEmitter } from '../lib/events.js';
 
 const execAsync = promisify(exec);
 const logger = createLogger('PRRemediationService');
@@ -490,4 +502,352 @@ export function logRemediationOutcome(result: RemediationResult, featureId?: str
 /** Get the current remediation count for a PR (for observability/metrics). */
 export function getRemediationCountForPR(projectPath: string, prNumber: number): number {
   return getRemediationCount(projectPath, prNumber);
+}
+
+// ---------------------------------------------------------------------------
+// Format failure remediation
+// ---------------------------------------------------------------------------
+
+/**
+ * Protected branches that should never be touched by auto-remediation.
+ * Only feature branches (feature/, fix/, chore/, etc.) are eligible.
+ */
+const PROTECTED_BRANCHES = new Set(['main', 'staging', 'dev']);
+
+/**
+ * Branch prefixes that identify agent-authored branches.
+ * Human PRs typically don't follow these naming conventions.
+ */
+const AGENT_BRANCH_PREFIXES = [
+  'feature/',
+  'fix/',
+  'chore/',
+  'refactor/',
+  'feat/',
+  'style/',
+  'docs/',
+  'test/',
+  'ci/',
+  'perf/',
+  'build/',
+];
+
+function isProtectedBranch(branch: string): boolean {
+  return PROTECTED_BRANCHES.has(branch);
+}
+
+function isAgentBranch(branch: string): boolean {
+  return AGENT_BRANCH_PREFIXES.some((prefix) => branch.startsWith(prefix));
+}
+
+/**
+ * Auto-remediate a "Check formatting" CI failure on an agent-authored PR.
+ *
+ * Safety gates (any failure skips or escalates):
+ * 1. Protected branch guard — never touch main/staging/dev
+ * 2. Agent-author guard — only act on agent-authored branches (prefix check)
+ * 3. One-remediation cap — check git log for existing auto-remediation commit
+ * 4. Scope check — after prettier runs, verify only PR-diff files were modified
+ *
+ * On success: commits "style: prettier fix (auto-remediation)" and pushes.
+ * On scope drift: escalates to HITL (does not push).
+ */
+export async function remediateFormatFailure(
+  input: FormatRemediationInput,
+  events?: EventEmitter
+): Promise<FormatRemediationResult> {
+  const { prNumber, headBranch, headSha, projectPath, repository } = input;
+
+  logger.info('[FormatRemediation] Triggered', {
+    prNumber,
+    headBranch,
+    repository,
+  });
+
+  // ------------------------------------------------------------------
+  // Guard 1: Protected branch check
+  // ------------------------------------------------------------------
+  if (isProtectedBranch(headBranch)) {
+    logger.warn('[FormatRemediation] Refusing to remediate protected branch', {
+      prNumber,
+      headBranch,
+    });
+    logger.info('[FormatRemediation:security] Skipped — protected branch target', {
+      prNumber,
+      headBranch,
+    });
+    return {
+      status: 'skipped',
+      prNumber,
+      reason: `Skipped: branch '${headBranch}' is protected. Auto-remediation only applies to feature branches.`,
+      details: { headBranch, guard: 'protected-branch' },
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Guard 2: Agent-author check (branch prefix)
+  // ------------------------------------------------------------------
+  if (!isAgentBranch(headBranch)) {
+    logger.info('[FormatRemediation] Skipping non-agent branch', { prNumber, headBranch });
+    return {
+      status: 'skipped',
+      prNumber,
+      reason: `Skipped: branch '${headBranch}' does not match agent naming convention (expected prefix: ${AGENT_BRANCH_PREFIXES.slice(0, 3).join(', ')}...).`,
+      details: { headBranch, guard: 'agent-author' },
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Find the worktree path for this branch (reuse existing checkout)
+  // ------------------------------------------------------------------
+  const worktreePath = path.join(projectPath, '.worktrees', headBranch);
+
+  const worker = new PrRemediationWorker();
+
+  // ------------------------------------------------------------------
+  // Guard 3: One-remediation-per-PR cap
+  // ------------------------------------------------------------------
+  let baseBranch = 'dev'; // default; we'll try to detect from gh
+  try {
+    const { stdout: prJson } = await execAsync(
+      `gh pr view ${prNumber} --repo ${repository} --json baseRefName`,
+      { timeout: 15000 }
+    );
+    const parsed = JSON.parse(prJson) as { baseRefName?: string };
+    if (parsed.baseRefName) baseBranch = parsed.baseRefName;
+  } catch {
+    logger.debug('[FormatRemediation] Could not detect base branch from gh, using default', {
+      prNumber,
+      defaultBaseBranch: baseBranch,
+    });
+  }
+
+  try {
+    const hasExisting = await worker.hasExistingRemediationCommit(
+      worktreePath,
+      baseBranch,
+      headBranch
+    );
+    if (hasExisting) {
+      logger.warn('[FormatRemediation] One-remediation cap reached — skipping', {
+        prNumber,
+        headBranch,
+      });
+      logger.warn('[FormatRemediation:security] Possible infinite-loop scenario detected', {
+        prNumber,
+      });
+      return {
+        status: 'skipped',
+        prNumber,
+        reason: 'Skipped: a remediation commit already exists on this PR. One-per-PR cap enforced.',
+        details: { headBranch, guard: 'one-per-pr-cap' },
+      };
+    }
+  } catch (capErr) {
+    // If we can't check the worktree (branch not checked out yet), proceed cautiously
+    logger.debug('[FormatRemediation] Could not check remediation cap — worktree may not exist', {
+      prNumber,
+      error: capErr instanceof Error ? capErr.message : String(capErr),
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // Get changed files in the PR diff
+  // ------------------------------------------------------------------
+  let prChangedFiles: string[] = [];
+  try {
+    const { stdout: diffOut } = await execAsync(
+      `gh pr diff ${prNumber} --repo ${repository} --name-only`,
+      { timeout: 30000 }
+    );
+    prChangedFiles = diffOut.trim().split('\n').filter(Boolean);
+  } catch (diffErr) {
+    logger.warn('[FormatRemediation] Could not get PR diff files', {
+      prNumber,
+      error: diffErr instanceof Error ? diffErr.message : String(diffErr),
+    });
+    return {
+      status: 'error',
+      prNumber,
+      reason: `Could not determine PR changed files: ${diffErr instanceof Error ? diffErr.message : String(diffErr)}`,
+      details: { guard: 'pr-diff-fetch' },
+    };
+  }
+
+  if (prChangedFiles.length === 0) {
+    return {
+      status: 'skipped',
+      prNumber,
+      reason: 'Skipped: PR has no changed files.',
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Find the prettier binary
+  // ------------------------------------------------------------------
+  const prettierBin = path.join(projectPath, 'node_modules', '.bin', 'prettier');
+
+  // ------------------------------------------------------------------
+  // Determine working directory (prefer existing worktree, else checkout)
+  // ------------------------------------------------------------------
+  let workDir = worktreePath;
+  let scratchDir: string | null = null;
+
+  try {
+    await execAsync(`test -d ${JSON.stringify(worktreePath)}`, { timeout: 3000 });
+    logger.debug('[FormatRemediation] Using existing worktree', { worktreePath });
+  } catch {
+    // Worktree doesn't exist — checkout the PR branch to a scratch dir
+    logger.info('[FormatRemediation] Worktree not found, checking out PR branch', { prNumber });
+    try {
+      scratchDir = await worker.createScratchDir();
+      workDir = scratchDir;
+
+      await execAsync(
+        `gh pr checkout ${prNumber} --repo ${repository} --force`,
+        { cwd: scratchDir, timeout: 60000 }
+      );
+    } catch (checkoutErr) {
+      if (scratchDir) await worker.cleanup(scratchDir);
+      return {
+        status: 'error',
+        prNumber,
+        reason: `Could not checkout PR branch: ${checkoutErr instanceof Error ? checkoutErr.message : String(checkoutErr)}`,
+        details: { guard: 'branch-checkout' },
+      };
+    }
+  }
+
+  try {
+    // ------------------------------------------------------------------
+    // Run prettier on changed files
+    // ------------------------------------------------------------------
+    logger.info('[FormatRemediation] Running prettier', { prNumber, fileCount: prChangedFiles.length });
+
+    let filesFixed: string[];
+    try {
+      filesFixed = await worker.runPrettier(prettierBin, prChangedFiles, workDir);
+    } catch (prettierErr) {
+      const msg = prettierErr instanceof Error ? prettierErr.message : String(prettierErr);
+      logger.error('[FormatRemediation] Prettier execution failed — escalating to HITL', {
+        prNumber,
+        error: msg,
+      });
+      return {
+        status: 'escalated',
+        prNumber,
+        reason: `Prettier execution failed: ${msg}. Manual intervention required.`,
+        details: { error: msg, guard: 'prettier-execution' },
+      };
+    }
+
+    if (filesFixed.length === 0) {
+      logger.info('[FormatRemediation] Prettier made no changes — nothing to commit', { prNumber });
+      return {
+        status: 'skipped',
+        prNumber,
+        reason: 'Prettier ran but made no changes. The formatting issue may have resolved itself.',
+        details: { prChangedFiles },
+      };
+    }
+
+    // ------------------------------------------------------------------
+    // Scope check: verify prettier only touched files within the PR diff
+    // ------------------------------------------------------------------
+    const allModified = await worker.getModifiedFiles(workDir);
+    const outOfScope = allModified.filter((f) => !prChangedFiles.includes(f));
+
+    if (outOfScope.length > 0) {
+      logger.warn('[FormatRemediation] Scope drift detected — escalating to HITL', {
+        prNumber,
+        outOfScope,
+        prChangedFiles: prChangedFiles.length,
+      });
+      return {
+        status: 'escalated',
+        prNumber,
+        reason:
+          `Scope drift: prettier modified ${outOfScope.length} file(s) outside the PR diff. ` +
+          `Escalating for operator review instead of auto-pushing. ` +
+          `Out-of-scope files: ${outOfScope.slice(0, 5).join(', ')}`,
+        details: {
+          outOfScope,
+          filesFixed,
+          prChangedFiles,
+          guard: 'scope-check',
+        },
+      };
+    }
+
+    // ------------------------------------------------------------------
+    // Commit and push
+    // ------------------------------------------------------------------
+    let commitSha: string;
+    try {
+      commitSha = await worker.commitRemediationFix(workDir, prNumber, filesFixed);
+    } catch (commitErr) {
+      const msg = commitErr instanceof Error ? commitErr.message : String(commitErr);
+      logger.error('[FormatRemediation] Commit failed — escalating to HITL', {
+        prNumber,
+        error: msg,
+      });
+      return {
+        status: 'escalated',
+        prNumber,
+        reason: `Commit failed: ${msg}. Manual intervention required.`,
+        details: { error: msg, filesFixed },
+      };
+    }
+
+    try {
+      await worker.pushBranch(workDir, headBranch);
+    } catch (pushErr) {
+      const msg = pushErr instanceof Error ? pushErr.message : String(pushErr);
+      logger.error('[FormatRemediation] Push failed — escalating to HITL', {
+        prNumber,
+        headSha,
+        error: msg,
+      });
+      return {
+        status: 'escalated',
+        prNumber,
+        reason: `Push failed: ${msg}. The format fix was committed locally but not pushed.`,
+        details: { error: msg, commitSha, filesFixed },
+      };
+    }
+
+    // ------------------------------------------------------------------
+    // Emit observability event
+    // ------------------------------------------------------------------
+    const eventPayload: PRFormatRemediatedPayload = {
+      prNumber,
+      filesFixed,
+      commitSha,
+      timestamp: new Date().toISOString(),
+      remediationType: 'format',
+    };
+
+    if (events) {
+      events.emit('pr:remediation-completed', eventPayload);
+    }
+
+    logger.info('[FormatRemediation:outcome] Success', {
+      prNumber,
+      filesFixed: filesFixed.length,
+      commitSha,
+    });
+
+    return {
+      status: 'success',
+      prNumber,
+      filesFixed,
+      commitSha,
+      reason: `Auto-remediation successful: formatted ${filesFixed.length} file(s) and pushed commit ${commitSha}.`,
+      details: { filesFixed, baseBranch, headBranch },
+    };
+  } finally {
+    if (scratchDir) {
+      await worker.cleanup(scratchDir);
+    }
+  }
 }

--- a/apps/server/src/services/pr-remediation-worker.ts
+++ b/apps/server/src/services/pr-remediation-worker.ts
@@ -1,0 +1,236 @@
+/**
+ * PrRemediationWorker — shared base for PR branch checkout and safe git operations.
+ *
+ * Provides reusable infrastructure for services that need to:
+ * - Fetch and inspect PR branches
+ * - Run git operations with proper timeouts
+ * - Execute prettier for format remediation
+ * - Clean up temporary resources
+ *
+ * Both format-failure remediation and conflict classification use this base.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createLogger } from '@protolabsai/utils';
+
+const execAsync = promisify(exec);
+const logger = createLogger('PrRemediationWorker');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GitRunOptions {
+  cwd: string;
+  timeout?: number;
+}
+
+export interface GitRunResult {
+  stdout: string;
+  stderr: string;
+}
+
+export interface ScratchWorktree {
+  /** Absolute path to the temporary directory */
+  dir: string;
+  /** Branch that was checked out */
+  branch: string;
+}
+
+// ---------------------------------------------------------------------------
+// Worker class
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared base class for PR remediation operations.
+ *
+ * Callers are responsible for calling cleanup() in a finally block.
+ */
+export class PrRemediationWorker {
+  /**
+   * Create a temporary directory for PR branch operations.
+   * The prefix `pr-remediation-` identifies these dirs in /tmp.
+   */
+  async createScratchDir(): Promise<string> {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'pr-remediation-'));
+    logger.debug(`[Worker] Created scratch dir: ${dir}`);
+    return dir;
+  }
+
+  /**
+   * Run a git command in a directory and return trimmed stdout.
+   * Throws on non-zero exit code.
+   */
+  async runGit(args: string, options: GitRunOptions): Promise<string> {
+    const { cwd, timeout = 30000 } = options;
+    try {
+      const { stdout } = await execAsync(`git ${args}`, { cwd, timeout });
+      return stdout.trim();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.debug(`[Worker] git ${args.slice(0, 60)} failed: ${msg}`);
+      throw err;
+    }
+  }
+
+  /**
+   * Run a git command and return both stdout and stderr (without throwing).
+   * Useful for commands where stderr output is informational.
+   */
+  async runGitSafe(args: string, options: GitRunOptions): Promise<GitRunResult> {
+    const { cwd, timeout = 30000 } = options;
+    try {
+      const { stdout, stderr } = await execAsync(`git ${args}`, { cwd, timeout });
+      return { stdout: stdout.trim(), stderr: stderr.trim() };
+    } catch (err: unknown) {
+      const exitError = err as { stdout?: string; stderr?: string };
+      return {
+        stdout: (exitError.stdout ?? '').trim(),
+        stderr: (exitError.stderr ?? '').trim(),
+      };
+    }
+  }
+
+  /**
+   * Get the list of files changed in a PR relative to its base branch.
+   *
+   * Requires both the PR branch and the base branch to be accessible in cwd.
+   * Uses triple-dot diff to show only commits unique to headBranch since it
+   * diverged from baseBranch.
+   */
+  async getChangedFiles(
+    cwd: string,
+    baseBranch: string,
+    headBranch: string
+  ): Promise<string[]> {
+    // Ensure base is available
+    await this.runGitSafe(`fetch origin ${baseBranch} --depth=1`, { cwd, timeout: 30000 });
+
+    const output = await this.runGit(
+      `diff --name-only origin/${baseBranch}...origin/${headBranch}`,
+      { cwd, timeout: 15000 }
+    );
+    return output.split('\n').filter(Boolean);
+  }
+
+  /**
+   * Run prettier --write on the given file paths.
+   *
+   * Uses the project's own prettier installation at `prettierBin`.
+   * Runs from `cwd` so .prettierrc / .prettierignore are resolved correctly.
+   *
+   * Returns the list of files that were actually modified.
+   */
+  async runPrettier(
+    prettierBin: string,
+    files: string[],
+    cwd: string
+  ): Promise<string[]> {
+    if (files.length === 0) return [];
+
+    // Quote each file path for safety
+    const quotedFiles = files.map((f) => JSON.stringify(f)).join(' ');
+    const cmd = `node ${JSON.stringify(prettierBin)} --ignore-path /dev/null --write ${quotedFiles}`;
+
+    logger.debug(`[Worker] Running prettier on ${files.length} file(s) in ${cwd}`);
+
+    await execAsync(cmd, { cwd, timeout: 60000 });
+
+    // Determine which files were actually modified
+    const modifiedFiles: string[] = [];
+    for (const file of files) {
+      const result = await this.runGitSafe(`diff --name-only -- ${JSON.stringify(file)}`, {
+        cwd,
+        timeout: 5000,
+      });
+      if (result.stdout) {
+        modifiedFiles.push(file);
+      }
+    }
+    return modifiedFiles;
+  }
+
+  /**
+   * Get the list of files modified in the working tree (unstaged and staged).
+   * Used for scope checking after prettier runs.
+   */
+  async getModifiedFiles(cwd: string): Promise<string[]> {
+    const result = await this.runGitSafe('diff --name-only HEAD', { cwd, timeout: 10000 });
+    return result.stdout.split('\n').filter(Boolean);
+  }
+
+  /**
+   * Commit modified files with an auto-remediation message and machine-parseable audit trailer.
+   *
+   * Returns the new commit SHA.
+   */
+  async commitRemediationFix(
+    cwd: string,
+    prNumber: number,
+    filesFixed: string[]
+  ): Promise<string> {
+    // Stage only the files that were modified
+    const quotedFiles = filesFixed.map((f) => JSON.stringify(f)).join(' ');
+    await execAsync(`git add -- ${quotedFiles}`, { cwd, timeout: 10000 });
+
+    const timestamp = new Date().toISOString();
+    const trailers = [
+      `Auto-Remediation: format-fix`,
+      `PR-Number: ${prNumber}`,
+      `Files-Fixed: ${filesFixed.length}`,
+      `Remediation-Timestamp: ${timestamp}`,
+    ].join('\n');
+
+    const commitMsg = `style: prettier fix (auto-remediation)\n\n${trailers}`;
+
+    await execAsync(`git commit -m ${JSON.stringify(commitMsg)}`, { cwd, timeout: 15000 });
+
+    const sha = await this.runGit('rev-parse HEAD', { cwd, timeout: 5000 });
+    logger.info(`[Worker] Committed format fix for PR #${prNumber} → ${sha}`);
+    return sha;
+  }
+
+  /**
+   * Push the current branch to origin.
+   */
+  async pushBranch(cwd: string, branchName: string): Promise<void> {
+    await execAsync(`git push origin ${JSON.stringify(branchName)}`, { cwd, timeout: 30000 });
+    logger.info(`[Worker] Pushed branch ${branchName}`);
+  }
+
+  /**
+   * Check if a commit matching the auto-remediation pattern already exists
+   * on the PR branch relative to the base. Returns true if a cap-triggering
+   * commit is found (prevents infinite remediation loops).
+   */
+  async hasExistingRemediationCommit(
+    cwd: string,
+    baseBranch: string,
+    headBranch: string
+  ): Promise<boolean> {
+    await this.runGitSafe(`fetch origin ${baseBranch} --depth=1`, { cwd, timeout: 30000 });
+    await this.runGitSafe(`fetch origin ${headBranch} --depth=10`, { cwd, timeout: 30000 });
+
+    const result = await this.runGitSafe(
+      `log --oneline origin/${baseBranch}..origin/${headBranch} --grep=auto-remediation`,
+      { cwd, timeout: 10000 }
+    );
+    return result.stdout.length > 0;
+  }
+
+  /**
+   * Remove the scratch directory. Must be called in a finally block.
+   */
+  async cleanup(scratchDir: string): Promise<void> {
+    try {
+      await rm(scratchDir, { recursive: true, force: true });
+      logger.debug(`[Worker] Cleaned up scratch dir: ${scratchDir}`);
+    } catch (err) {
+      logger.warn(`[Worker] Failed to clean up scratch dir ${scratchDir}:`, err);
+    }
+  }
+}

--- a/apps/server/src/services/pr-remediation-worker.ts
+++ b/apps/server/src/services/pr-remediation-worker.ts
@@ -102,11 +102,7 @@ export class PrRemediationWorker {
    * Uses triple-dot diff to show only commits unique to headBranch since it
    * diverged from baseBranch.
    */
-  async getChangedFiles(
-    cwd: string,
-    baseBranch: string,
-    headBranch: string
-  ): Promise<string[]> {
+  async getChangedFiles(cwd: string, baseBranch: string, headBranch: string): Promise<string[]> {
     // Ensure base is available
     await this.runGitSafe(`fetch origin ${baseBranch} --depth=1`, { cwd, timeout: 30000 });
 
@@ -125,11 +121,7 @@ export class PrRemediationWorker {
    *
    * Returns the list of files that were actually modified.
    */
-  async runPrettier(
-    prettierBin: string,
-    files: string[],
-    cwd: string
-  ): Promise<string[]> {
+  async runPrettier(prettierBin: string, files: string[], cwd: string): Promise<string[]> {
     if (files.length === 0) return [];
 
     // Quote each file path for safety
@@ -168,11 +160,7 @@ export class PrRemediationWorker {
    *
    * Returns the new commit SHA.
    */
-  async commitRemediationFix(
-    cwd: string,
-    prNumber: number,
-    filesFixed: string[]
-  ): Promise<string> {
+  async commitRemediationFix(cwd: string, prNumber: number, filesFixed: string[]): Promise<string> {
     // Stage only the files that were modified
     const quotedFiles = filesFixed.map((f) => JSON.stringify(f)).join(' ');
     await execAsync(`git add -- ${quotedFiles}`, { cwd, timeout: 10000 });

--- a/apps/server/src/types/pr-remediation.ts
+++ b/apps/server/src/types/pr-remediation.ts
@@ -1,0 +1,78 @@
+/**
+ * Types for PR format-failure auto-remediation.
+ *
+ * These types are server-internal. They are not part of the shared
+ * @protolabsai/types package because they relate to server-specific
+ * remediation operations.
+ */
+
+// ---------------------------------------------------------------------------
+// Format remediation
+// ---------------------------------------------------------------------------
+
+/** What happened during a format remediation attempt */
+export type FormatRemediationStatus =
+  /** Prettier ran, files formatted, commit pushed */
+  | 'success'
+  /** Guard condition prevented remediation (protected branch, non-agent PR, cap reached) */
+  | 'skipped'
+  /** Prettier ran but scope drift detected, or execution error — HITL needed */
+  | 'escalated'
+  /** Unexpected error during remediation */
+  | 'error';
+
+/** Input to the format remediation process */
+export interface FormatRemediationInput {
+  /** Path to the project root (where .automaker/ lives, used for worktree lookup) */
+  projectPath: string;
+  /** GitHub PR number */
+  prNumber: number;
+  /** PR head branch name (e.g. feature/feat-auth) */
+  headBranch: string;
+  /** PR head commit SHA */
+  headSha: string;
+  /** GitHub repository full name (owner/repo) */
+  repository: string;
+  /** URL to check runs list (from check_suite.check_runs_url) */
+  checksUrl?: string;
+}
+
+/** Result from a format remediation attempt */
+export interface FormatRemediationResult {
+  status: FormatRemediationStatus;
+  prNumber: number;
+  /** Files that were reformatted and committed */
+  filesFixed?: string[];
+  /** Git commit SHA of the remediation commit */
+  commitSha?: string;
+  /** Human-readable reason for the result */
+  reason: string;
+  /** Additional metadata for observability */
+  details?: Record<string, unknown>;
+}
+
+/** Payload of the pr:remediation-completed event emitted after successful format remediation */
+export interface PRFormatRemediatedPayload {
+  prNumber: number;
+  filesFixed: string[];
+  commitSha: string;
+  timestamp: string;
+  /** Discriminator: identifies this as a format remediation (not a conflict remediation) */
+  remediationType: 'format';
+}
+
+// ---------------------------------------------------------------------------
+// CI check run shape (subset of GitHub check_runs API response)
+// ---------------------------------------------------------------------------
+
+export interface GitHubCheckRunSummary {
+  id: number;
+  name: string;
+  status: string;
+  conclusion: string | null;
+}
+
+export interface GitHubCheckRunsListResponse {
+  total_count: number;
+  check_runs: GitHubCheckRunSummary[];
+}

--- a/apps/server/tests/services/pr-remediation.test.ts
+++ b/apps/server/tests/services/pr-remediation.test.ts
@@ -1,0 +1,771 @@
+/**
+ * PR Format Remediation — Comprehensive Test Suite
+ *
+ * Coverage:
+ * - Successful remediation (single file, multiple files)
+ * - Scope-check validation (out-of-scope drift detected → escalated)
+ * - Loop prevention (one-per-PR cap → skipped)
+ * - Agent-author verification (non-agent branch → skipped)
+ * - Protected branch rejection (main/staging/dev → skipped)
+ * - HITL escalation paths (prettier error, push error, scope drift)
+ * - pr:remediation-completed event emission on success
+ * - Synthesized unformatted PR scenario (regression)
+ * - GitHubWebhookHandler: filters non-format CI failures correctly
+ * - GitHubWebhookHandler: triggers remediation on format failure confirmation
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Module mocks (hoisted — declared before any imports)
+// ---------------------------------------------------------------------------
+
+// Mock the PrRemediationWorker class so we can control each method in isolation
+const mockWorker = {
+  createScratchDir: vi.fn(),
+  runGit: vi.fn(),
+  runGitSafe: vi.fn(),
+  getChangedFiles: vi.fn(),
+  runPrettier: vi.fn(),
+  getModifiedFiles: vi.fn(),
+  commitRemediationFix: vi.fn(),
+  pushBranch: vi.fn(),
+  hasExistingRemediationCommit: vi.fn(),
+  cleanup: vi.fn(),
+};
+
+vi.mock('../../src/services/pr-remediation-worker.js', () => ({
+  PrRemediationWorker: vi.fn().mockImplementation(() => mockWorker),
+}));
+
+// Mock child_process.exec — used by promisify() inside remediateFormatFailure
+const mockExec = vi.fn();
+vi.mock('node:child_process', () => ({
+  exec: mockExec,
+}));
+
+// Mock fs/promises for PrRemediationWorker base class tests
+vi.mock('node:fs/promises', () => ({
+  mkdtemp: vi.fn().mockResolvedValue('/tmp/pr-remediation-test123'),
+  rm: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { remediateFormatFailure } from '../../src/services/pr-remediation-service.js';
+import { GitHubWebhookHandler } from '../../src/services/github-webhook-handler.js';
+import { PrRemediationWorker } from '../../src/services/pr-remediation-worker.js';
+import type { EventEmitter } from '../../src/lib/events.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal EventEmitter stub for testing event emission.
+ */
+function makeEventEmitter() {
+  const handlers: Array<(type: string, payload: unknown) => void> = [];
+  const emitted: Array<{ type: string; payload: unknown }> = [];
+
+  return {
+    subscribe: vi.fn((cb: (type: string, payload: unknown) => void) => {
+      handlers.push(cb);
+      const unsub = () => {
+        const idx = handlers.indexOf(cb);
+        if (idx !== -1) handlers.splice(idx, 1);
+      };
+      return Object.assign(unsub, { unsubscribe: unsub });
+    }),
+    emit: vi.fn((type: string, payload: unknown) => {
+      emitted.push({ type, payload });
+      handlers.forEach((h) => h(type, payload));
+    }),
+    on: vi.fn(),
+    getEmitted: () => emitted,
+  };
+}
+
+/**
+ * Configure the exec mock to respond like a working environment.
+ *
+ * The promisify() wrapper calls exec with a callback:
+ *   exec(cmd, opts, callback)
+ * The callback receives (error, { stdout, stderr }).
+ *
+ * `overrides` maps substrings to either a stdout string or an Error to throw.
+ */
+function setupExecMock(
+  overrides: Record<string, string | Error> = {}
+): void {
+  mockExec.mockImplementation(
+    (cmd: string, _opts: unknown, cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
+      // Check each override key as a substring of cmd
+      for (const [pattern, response] of Object.entries(overrides)) {
+        if (cmd.includes(pattern)) {
+          if (response instanceof Error) {
+            cb(response, { stdout: '', stderr: response.message });
+          } else {
+            cb(null, { stdout: response, stderr: '' });
+          }
+          return;
+        }
+      }
+
+      // Default responses
+      if (cmd.includes('test -d')) {
+        // Worktree exists
+        cb(null, { stdout: '', stderr: '' });
+        return;
+      }
+      if (cmd.includes('gh pr view') && cmd.includes('baseRefName')) {
+        cb(null, { stdout: JSON.stringify({ baseRefName: 'dev' }), stderr: '' });
+        return;
+      }
+      if (cmd.includes('gh pr diff') && cmd.includes('--name-only')) {
+        cb(null, { stdout: 'src/index.ts\nsrc/utils.ts', stderr: '' });
+        return;
+      }
+      if (cmd.includes('gh api') && cmd.includes('check-runs')) {
+        cb(null, {
+          stdout: JSON.stringify({
+            total_count: 1,
+            check_runs: [
+              { id: 1, name: 'Check formatting', status: 'completed', conclusion: 'failure' },
+            ],
+          }),
+          stderr: '',
+        });
+        return;
+      }
+
+      cb(null, { stdout: '', stderr: '' });
+    }
+  );
+}
+
+/**
+ * Standard happy-path worker mock setup.
+ * Override individual methods in tests as needed.
+ */
+function setupHappyPathWorker(): void {
+  mockWorker.hasExistingRemediationCommit.mockResolvedValue(false);
+  mockWorker.runPrettier.mockResolvedValue(['src/index.ts']);
+  mockWorker.getModifiedFiles.mockResolvedValue(['src/index.ts']);
+  mockWorker.commitRemediationFix.mockResolvedValue('abc123sha');
+  mockWorker.pushBranch.mockResolvedValue(undefined);
+  mockWorker.cleanup.mockResolvedValue(undefined);
+  mockWorker.createScratchDir.mockResolvedValue('/tmp/pr-remediation-scratch');
+}
+
+// ---------------------------------------------------------------------------
+// Test suite: safety guards
+// ---------------------------------------------------------------------------
+
+describe('safety guards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupExecMock();
+    setupHappyPathWorker();
+  });
+
+  it('protected branch — main — returns skipped', async () => {
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 1,
+      headBranch: 'main',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toMatch(/protected/i);
+    expect(result.details?.guard).toBe('protected-branch');
+    // Should never proceed to git operations for protected branches
+    expect(mockWorker.runPrettier).not.toHaveBeenCalled();
+  });
+
+  it('protected branch — staging — returns skipped', async () => {
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 2,
+      headBranch: 'staging',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('skipped');
+    expect(result.details?.guard).toBe('protected-branch');
+  });
+
+  it('protected branch — dev — returns skipped', async () => {
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 3,
+      headBranch: 'dev',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('skipped');
+    expect(result.details?.guard).toBe('protected-branch');
+  });
+
+  it('non-agent branch — no recognized prefix — returns skipped', async () => {
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 4,
+      headBranch: 'johns-random-branch',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('skipped');
+    expect(result.details?.guard).toBe('agent-author');
+    expect(mockWorker.runPrettier).not.toHaveBeenCalled();
+  });
+
+  it('agent branch — feature/ prefix — passes agent guard', async () => {
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 5,
+      headBranch: 'feature/my-feature-abc123',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    // Should NOT be skipped due to agent-author guard
+    expect(result.details?.guard).not.toBe('agent-author');
+  });
+
+  it('agent branch — fix/ prefix — passes agent guard', async () => {
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 6,
+      headBranch: 'fix/bug-fix-xyz',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    expect(result.details?.guard).not.toBe('agent-author');
+  });
+
+  it('one-remediation cap — existing commit found — returns skipped', async () => {
+    mockWorker.hasExistingRemediationCommit.mockResolvedValue(true);
+
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 7,
+      headBranch: 'feature/auth-abc',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('skipped');
+    expect(result.details?.guard).toBe('one-per-pr-cap');
+    expect(result.reason).toMatch(/cap/i);
+    expect(mockWorker.runPrettier).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test suite: successful remediation
+// ---------------------------------------------------------------------------
+
+describe('successful remediation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupExecMock();
+    setupHappyPathWorker();
+  });
+
+  it('single file — returns success with filesFixed and commitSha', async () => {
+    mockWorker.runPrettier.mockResolvedValue(['src/index.ts']);
+    mockWorker.getModifiedFiles.mockResolvedValue(['src/index.ts']);
+    mockWorker.commitRemediationFix.mockResolvedValue('deadbeef1234');
+
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 10,
+      headBranch: 'feature/auth-login-abc',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('success');
+    expect(result.filesFixed).toEqual(['src/index.ts']);
+    expect(result.commitSha).toBe('deadbeef1234');
+    expect(result.reason).toMatch(/deadbeef1234/);
+  });
+
+  it('multiple files — returns all fixed files', async () => {
+    setupExecMock({
+      'gh pr diff': 'src/index.ts\nsrc/utils.ts\nsrc/helpers.ts',
+    });
+    mockWorker.runPrettier.mockResolvedValue(['src/index.ts', 'src/utils.ts', 'src/helpers.ts']);
+    mockWorker.getModifiedFiles.mockResolvedValue(['src/index.ts', 'src/utils.ts', 'src/helpers.ts']);
+    mockWorker.commitRemediationFix.mockResolvedValue('sha-multi');
+
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 11,
+      headBranch: 'feature/multi-file-xyz',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('success');
+    expect(result.filesFixed).toHaveLength(3);
+    expect(result.filesFixed).toContain('src/utils.ts');
+  });
+
+  it('emits pr:remediation-completed event on success', async () => {
+    mockWorker.runPrettier.mockResolvedValue(['src/index.ts']);
+    mockWorker.commitRemediationFix.mockResolvedValue('event-test-sha');
+
+    const events = makeEventEmitter();
+
+    await remediateFormatFailure(
+      {
+        projectPath: '/project',
+        prNumber: 12,
+        headBranch: 'feature/event-test-abc',
+        headSha: 'abc',
+        repository: 'owner/repo',
+      },
+      events as unknown as EventEmitter
+    );
+
+    const emitted = events.getEmitted();
+    const remediationEvent = emitted.find((e) => e.type === 'pr:remediation-completed');
+    expect(remediationEvent).toBeDefined();
+    const p = remediationEvent?.payload as { prNumber: number; remediationType: string };
+    expect(p.prNumber).toBe(12);
+    expect(p.remediationType).toBe('format');
+  });
+
+  it('prettier makes no changes — returns skipped (not an error)', async () => {
+    mockWorker.runPrettier.mockResolvedValue([]); // no files modified
+
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 13,
+      headBranch: 'feature/already-formatted-abc',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toMatch(/no changes/i);
+    expect(mockWorker.commitRemediationFix).not.toHaveBeenCalled();
+    expect(mockWorker.pushBranch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test suite: scope checker and drift detection
+// ---------------------------------------------------------------------------
+
+describe('scope checker and drift detection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupHappyPathWorker();
+  });
+
+  it('out-of-scope file detected — returns escalated without pushing', async () => {
+    // PR only changed src/index.ts, but prettier also touched src/unrelated.ts
+    setupExecMock({
+      'gh pr diff': 'src/index.ts',
+    });
+    // Worker reports both files modified
+    mockWorker.runPrettier.mockResolvedValue(['src/index.ts', 'src/unrelated.ts']);
+    mockWorker.getModifiedFiles.mockResolvedValue(['src/index.ts', 'src/unrelated.ts']);
+
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 20,
+      headBranch: 'feature/scope-drift-abc',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('escalated');
+    expect(result.reason).toMatch(/scope drift/i);
+    expect(result.details?.guard).toBe('scope-check');
+    expect((result.details?.outOfScope as string[])?.includes('src/unrelated.ts')).toBe(true);
+    // Must NOT push when scope drift detected
+    expect(mockWorker.pushBranch).not.toHaveBeenCalled();
+    expect(mockWorker.commitRemediationFix).not.toHaveBeenCalled();
+  });
+
+  it('all modified files within PR diff — no escalation, pushes successfully', async () => {
+    setupExecMock({
+      'gh pr diff': 'src/index.ts\nsrc/unrelated.ts',
+    });
+    // Both files are in the PR diff AND were modified by prettier
+    mockWorker.runPrettier.mockResolvedValue(['src/index.ts', 'src/unrelated.ts']);
+    mockWorker.getModifiedFiles.mockResolvedValue(['src/index.ts', 'src/unrelated.ts']);
+    mockWorker.commitRemediationFix.mockResolvedValue('no-drift-sha');
+
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 21,
+      headBranch: 'feature/no-drift-abc',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('success');
+    expect(mockWorker.pushBranch).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test suite: HITL escalation paths
+// ---------------------------------------------------------------------------
+
+describe('hitl escalation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupExecMock();
+    setupHappyPathWorker();
+  });
+
+  it('prettier execution error — returns escalated without pushing', async () => {
+    mockWorker.runPrettier.mockRejectedValue(new Error('Prettier binary not found'));
+
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 30,
+      headBranch: 'feature/prettier-fail-abc',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('escalated');
+    expect(result.reason).toMatch(/prettier execution failed/i);
+    expect(mockWorker.pushBranch).not.toHaveBeenCalled();
+  });
+
+  it('push failure — returns escalated with commitSha in details', async () => {
+    mockWorker.runPrettier.mockResolvedValue(['src/index.ts']);
+    mockWorker.commitRemediationFix.mockResolvedValue('sha789-committed');
+    mockWorker.pushBranch.mockRejectedValue(new Error('Permission denied'));
+
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 31,
+      headBranch: 'feature/push-fail-abc',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('escalated');
+    expect(result.details?.commitSha).toBe('sha789-committed');
+    expect(result.reason).toMatch(/push failed/i);
+  });
+
+  it('commit failure — returns escalated', async () => {
+    mockWorker.runPrettier.mockResolvedValue(['src/index.ts']);
+    mockWorker.commitRemediationFix.mockRejectedValue(new Error('nothing to commit'));
+
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 32,
+      headBranch: 'feature/commit-fail-abc',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('escalated');
+    expect(result.reason).toMatch(/commit failed/i);
+  });
+
+  it('PR diff fetch failure — returns error', async () => {
+    setupExecMock({
+      'gh pr diff': new Error('gh: authentication failed'),
+    });
+
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 33,
+      headBranch: 'feature/diff-fail-abc',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.details?.guard).toBe('pr-diff-fetch');
+    expect(mockWorker.runPrettier).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test suite: regression — synthesized unformatted PR scenario
+// ---------------------------------------------------------------------------
+
+describe('regression: synthesized unformatted PR', () => {
+  it('formats known bad file and produces the correct remediation commit', async () => {
+    vi.clearAllMocks();
+    setupExecMock({
+      'gh pr diff': 'src/badly-formatted.ts',
+    });
+
+    mockWorker.hasExistingRemediationCommit.mockResolvedValue(false);
+    mockWorker.runPrettier.mockResolvedValue(['src/badly-formatted.ts']);
+    mockWorker.getModifiedFiles.mockResolvedValue(['src/badly-formatted.ts']);
+    mockWorker.commitRemediationFix.mockResolvedValue('format-fix-sha-001');
+    mockWorker.pushBranch.mockResolvedValue(undefined);
+    mockWorker.cleanup.mockResolvedValue(undefined);
+
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 100,
+      headBranch: 'feature/unformatted-regression-abc',
+      headSha: 'badsha',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('success');
+    expect(result.filesFixed).toEqual(['src/badly-formatted.ts']);
+    expect(result.commitSha).toBe('format-fix-sha-001');
+    // Verify commitRemediationFix was called with the expected arguments
+    expect(mockWorker.commitRemediationFix).toHaveBeenCalledWith(
+      expect.any(String), // workDir (worktree path)
+      100,                // prNumber
+      ['src/badly-formatted.ts']
+    );
+    // Verify push was called
+    expect(mockWorker.pushBranch).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test suite: one remediation per PR cap
+// ---------------------------------------------------------------------------
+
+describe('one remediation per PR cap', () => {
+  it('skips if an existing auto-remediation commit is found', async () => {
+    vi.clearAllMocks();
+    setupExecMock();
+    mockWorker.hasExistingRemediationCommit.mockResolvedValue(true);
+    mockWorker.cleanup.mockResolvedValue(undefined);
+
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 60,
+      headBranch: 'feature/repeat-remediation-abc',
+      headSha: 'sha',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('skipped');
+    expect(result.details?.guard).toBe('one-per-pr-cap');
+    expect(mockWorker.runPrettier).not.toHaveBeenCalled();
+    expect(mockWorker.pushBranch).not.toHaveBeenCalled();
+  });
+
+  it('allows remediation when no existing auto-remediation commit', async () => {
+    vi.clearAllMocks();
+    setupExecMock();
+    setupHappyPathWorker();
+    mockWorker.commitRemediationFix.mockResolvedValue('fresh-sha');
+
+    const result = await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 61,
+      headBranch: 'feature/first-remediation-abc',
+      headSha: 'sha',
+      repository: 'owner/repo',
+    });
+
+    expect(result.status).toBe('success');
+    expect(mockWorker.runPrettier).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test suite: GitHubWebhookHandler event filtering
+// ---------------------------------------------------------------------------
+
+describe('GitHubWebhookHandler event filtering', () => {
+  let events: ReturnType<typeof makeEventEmitter>;
+  let handler: GitHubWebhookHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    events = makeEventEmitter();
+    handler = new GitHubWebhookHandler(
+      events as unknown as EventEmitter,
+      '/project'
+    );
+    handler.start();
+  });
+
+  it('ignores non-pr:ci-failure events — no remediation triggered', () => {
+    events.emit('feature:status-changed', { featureId: 'abc' });
+    events.emit('pr:approved', { prNumber: 1 });
+
+    expect(mockWorker.runPrettier).not.toHaveBeenCalled();
+  });
+
+  it('processes pr:ci-failure events and attempts format check lookup', async () => {
+    setupExecMock({
+      'gh api': JSON.stringify({
+        total_count: 1,
+        check_runs: [
+          { id: 1, name: 'Check formatting', status: 'completed', conclusion: 'failure' },
+        ],
+      }),
+      'gh pr view': JSON.stringify({ baseRefName: 'dev' }),
+      'gh pr diff': 'src/index.ts',
+    });
+    setupHappyPathWorker();
+    mockWorker.commitRemediationFix.mockResolvedValue('triggered-sha');
+
+    events.emit('pr:ci-failure', {
+      projectPath: '',
+      prNumber: 50,
+      headBranch: 'feature/ci-fail-test',
+      headSha: 'abc123',
+      checkSuiteId: 999,
+      repository: 'owner/repo',
+      checksUrl: 'https://api.github.com/repos/owner/repo/check-suites/999/check-runs',
+    });
+
+    // Allow async handlers to settle
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Remediation should have been attempted (PrRemediationWorker was instantiated)
+    expect(PrRemediationWorker).toHaveBeenCalled();
+  });
+
+  it('skips remediation when Check formatting check passed', async () => {
+    setupExecMock({
+      'gh api': JSON.stringify({
+        total_count: 2,
+        check_runs: [
+          { id: 1, name: 'Check formatting', status: 'completed', conclusion: 'success' },
+          { id: 2, name: 'Lint UI', status: 'completed', conclusion: 'failure' },
+        ],
+      }),
+    });
+
+    events.emit('pr:ci-failure', {
+      projectPath: '',
+      prNumber: 51,
+      headBranch: 'feature/lint-fail-not-format',
+      headSha: 'abc123',
+      checkSuiteId: 1000,
+      repository: 'owner/repo',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Format check passed, so prettier should NOT have been invoked
+    expect(mockWorker.runPrettier).not.toHaveBeenCalled();
+  });
+
+  it('skips remediation when Check formatting check is not in the suite', async () => {
+    setupExecMock({
+      'gh api': JSON.stringify({
+        total_count: 1,
+        check_runs: [
+          { id: 1, name: 'Lint UI', status: 'completed', conclusion: 'failure' },
+        ],
+      }),
+    });
+
+    events.emit('pr:ci-failure', {
+      projectPath: '',
+      prNumber: 52,
+      headBranch: 'feature/other-check-fail',
+      headSha: 'abc123',
+      checkSuiteId: 1001,
+      repository: 'owner/repo',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(mockWorker.runPrettier).not.toHaveBeenCalled();
+  });
+
+  it('stops listening after stop() is called', () => {
+    handler.stop();
+
+    // After stop(), new events should not trigger handlers
+    events.emit('pr:ci-failure', {
+      projectPath: '',
+      prNumber: 53,
+      headBranch: 'feature/after-stop',
+      headSha: 'abc',
+      repository: 'owner/repo',
+    });
+
+    // The event will still be emitted but the handler's internal subscription is gone
+    // Verify by checking that the subscribe was called once (on start()) and the
+    // handler did not instantiate a new PrRemediationWorker (unsubscribed before emit)
+    expect(PrRemediationWorker).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test suite: PrRemediationWorker base class (via mock contract)
+// ---------------------------------------------------------------------------
+
+describe('PrRemediationWorker base class', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupExecMock();
+    setupHappyPathWorker();
+    // Restore default mock implementations for worker methods
+    mockWorker.createScratchDir.mockResolvedValue('/tmp/pr-remediation-xyz');
+    mockWorker.cleanup.mockResolvedValue(undefined);
+  });
+
+  it('createScratchDir is called with no arguments and returns a string path', async () => {
+    // createScratchDir should return a temp path
+    const dir = await mockWorker.createScratchDir();
+    expect(typeof dir).toBe('string');
+    expect(dir).toContain('pr-remediation');
+  });
+
+  it('cleanup is called during format remediation (finally block)', async () => {
+    // When worktree doesn't exist, a scratch dir is created and must be cleaned up
+    setupExecMock({
+      'test -d': new Error('ENOENT'), // Worktree doesn't exist
+      'gh pr checkout': '', // Checkout succeeds
+      'gh pr diff': 'src/index.ts',
+      'gh pr view': JSON.stringify({ baseRefName: 'dev' }),
+    });
+    mockWorker.createScratchDir.mockResolvedValue('/tmp/pr-remediation-scratch');
+    mockWorker.runPrettier.mockResolvedValue(['src/index.ts']);
+    mockWorker.getModifiedFiles.mockResolvedValue(['src/index.ts']);
+    mockWorker.commitRemediationFix.mockResolvedValue('sha-cleanup-test');
+
+    await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 70,
+      headBranch: 'feature/cleanup-test-abc',
+      headSha: 'sha',
+      repository: 'owner/repo',
+    });
+
+    // Scratch dir should have been cleaned up in the finally block
+    expect(mockWorker.cleanup).toHaveBeenCalledWith('/tmp/pr-remediation-scratch');
+  });
+
+  it('PrRemediationWorker is instantiated during remediateFormatFailure', async () => {
+    await remediateFormatFailure({
+      projectPath: '/project',
+      prNumber: 71,
+      headBranch: 'feature/worker-instantiation-test',
+      headSha: 'sha',
+      repository: 'owner/repo',
+    });
+
+    expect(PrRemediationWorker).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/server/tests/services/pr-remediation.test.ts
+++ b/apps/server/tests/services/pr-remediation.test.ts
@@ -97,11 +97,13 @@ function makeEventEmitter() {
  *
  * `overrides` maps substrings to either a stdout string or an Error to throw.
  */
-function setupExecMock(
-  overrides: Record<string, string | Error> = {}
-): void {
+function setupExecMock(overrides: Record<string, string | Error> = {}): void {
   mockExec.mockImplementation(
-    (cmd: string, _opts: unknown, cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
+    (
+      cmd: string,
+      _opts: unknown,
+      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
+    ) => {
       // Check each override key as a substring of cmd
       for (const [pattern, response] of Object.entries(overrides)) {
         if (cmd.includes(pattern)) {
@@ -305,7 +307,11 @@ describe('successful remediation', () => {
       'gh pr diff': 'src/index.ts\nsrc/utils.ts\nsrc/helpers.ts',
     });
     mockWorker.runPrettier.mockResolvedValue(['src/index.ts', 'src/utils.ts', 'src/helpers.ts']);
-    mockWorker.getModifiedFiles.mockResolvedValue(['src/index.ts', 'src/utils.ts', 'src/helpers.ts']);
+    mockWorker.getModifiedFiles.mockResolvedValue([
+      'src/index.ts',
+      'src/utils.ts',
+      'src/helpers.ts',
+    ]);
     mockWorker.commitRemediationFix.mockResolvedValue('sha-multi');
 
     const result = await remediateFormatFailure({
@@ -534,7 +540,7 @@ describe('regression: synthesized unformatted PR', () => {
     // Verify commitRemediationFix was called with the expected arguments
     expect(mockWorker.commitRemediationFix).toHaveBeenCalledWith(
       expect.any(String), // workDir (worktree path)
-      100,                // prNumber
+      100, // prNumber
       ['src/badly-formatted.ts']
     );
     // Verify push was called
@@ -597,10 +603,7 @@ describe('GitHubWebhookHandler event filtering', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     events = makeEventEmitter();
-    handler = new GitHubWebhookHandler(
-      events as unknown as EventEmitter,
-      '/project'
-    );
+    handler = new GitHubWebhookHandler(events as unknown as EventEmitter, '/project');
     handler.start();
   });
 
@@ -672,9 +675,7 @@ describe('GitHubWebhookHandler event filtering', () => {
     setupExecMock({
       'gh api': JSON.stringify({
         total_count: 1,
-        check_runs: [
-          { id: 1, name: 'Lint UI', status: 'completed', conclusion: 'failure' },
-        ],
+        check_runs: [{ id: 1, name: 'Lint UI', status: 'completed', conclusion: 'failure' }],
       }),
     });
 


### PR DESCRIPTION
## Summary

## Problem

Agent-authored PRs frequently land with unformatted files, causing the `Check formatting` step in CI to fail, blocking auto-merge. Observed pattern this session:

- Every single one of the 4+ agent PRs in the afternoon batch needed a manual prettier push to unblock
- Pattern has recurred throughout the stabilization sprint (10+ occurrences)
- PR #3451 addresses the root cause (agent workflow runs prettier pre-commit) but the fix only activates after a server restart; PRs opened by ag...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T21:49:27.304Z -->