### PR TITLE
fix(lifecycle): auto-decay review→backlog must preserve prNumber for later reconciliation

### DIFF
--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -989,6 +989,27 @@ export class FeatureScheduler {
                 error
               );
             }
+          } else if (prView.state === 'CLOSED') {
+            // PR was closed without merging (e.g. abandoned after auto-decay).
+            // Clear the stale PR linkage so the next agent run starts fresh.
+            logger.info(
+              `[loadPendingFeatures] Feature ${feature.id} ("${feature.title}") PR #${feature.prNumber} is CLOSED (not merged) — clearing stale prNumber so agent can start fresh`
+            );
+            try {
+              await this.featureLoader.update(projectPath, feature.id, {
+                prNumber: undefined,
+                prUrl: undefined,
+                prCreatedAt: undefined,
+                prTrackedSince: undefined,
+              });
+              feature.prNumber = undefined;
+              feature.prUrl = undefined;
+            } catch (error) {
+              logger.error(
+                `[loadPendingFeatures] Failed to clear stale prNumber for feature ${feature.id}:`,
+                error
+              );
+            }
           }
         } catch {
           logger.debug(
@@ -1920,7 +1941,10 @@ export class FeatureScheduler {
 
         if (!hasCiFailureIndicator) continue;
 
-        // Decay the feature back to backlog
+        // Decay the feature back to backlog.
+        // Preserve prNumber/prUrl so the post-merge reconciler and loadPendingFeatures
+        // can detect if the PR merges while the feature is in backlog, and transition
+        // it to done without re-running the agent.
         const prevFailureCount = feature.failureCount ?? 0;
         const elapsedMinutes = Math.round(elapsedMs / 60000);
         try {
@@ -1928,12 +1952,7 @@ export class FeatureScheduler {
             status: 'backlog',
             failureCount: prevFailureCount + 1,
             statusChangeReason: `Auto-decayed: stalled in review for ${elapsedMinutes}min with failing CI`,
-            // Clear PR linkage so the feature doesn't bounce back to review via open-PR sync
-            prNumber: undefined,
-            prUrl: undefined,
-            prCreatedAt: undefined,
             reviewStartedAt: undefined,
-            prTrackedSince: undefined,
           });
           decayedCount++;
           logger.warn(

--- a/apps/server/src/services/maintenance/checks/post-merge-reconciler-check.ts
+++ b/apps/server/src/services/maintenance/checks/post-merge-reconciler-check.ts
@@ -43,6 +43,13 @@ interface PRViewResult {
 const TERMINAL_STATUSES = new Set(['done', 'completed', 'verified']);
 
 /**
+ * Statuses that the reconciler should check for a merged PR.
+ * Includes 'backlog' because auto-decay may have moved a feature out of 'review'
+ * while its PR was still pending — the PR may merge while the feature is in backlog.
+ */
+const RECONCILABLE_STATUSES = new Set(['review', 'backlog', 'blocked']);
+
+/**
  * Extract `owner/repo` from a GitHub PR URL.
  *
  * @example
@@ -66,7 +73,10 @@ export class PostMergeReconcilerCheck {
   }
 
   /**
-   * Reconcile PR merge status for all 'review' features in the given project.
+   * Reconcile PR merge status for all features in 'review', 'backlog', or 'blocked'
+   * status that have a prNumber set.  Backlog and blocked are included because auto-decay
+   * can move a feature out of 'review' while its PR is still pending — the PR may merge
+   * while the feature sits in backlog, and the webhook path will miss it.
    *
    * @returns Counts of features checked and transitioned to done.
    */
@@ -78,7 +88,7 @@ export class PostMergeReconcilerCheck {
       const features = await this.featureLoader.getAll(projectPath);
 
       const reviewFeatures = features.filter(
-        (f) => f.status === 'review' && f.prNumber != null && f.prUrl
+        (f) => RECONCILABLE_STATUSES.has(f.status ?? '') && f.prNumber != null && f.prUrl
       );
 
       for (const feature of reviewFeatures) {

--- a/apps/server/tests/integration/services/feature-scheduler-decay.integration.test.ts
+++ b/apps/server/tests/integration/services/feature-scheduler-decay.integration.test.ts
@@ -230,6 +230,39 @@ describe('FeatureScheduler auto-decay (integration)', () => {
     expect(recentFeature.status).toBe('review');
   });
 
+  it('preserves prNumber and prUrl after decay so post-merge reconciler can detect a merge (issue #3467)', async () => {
+    const stalledTime = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const prCreatedAt = new Date(Date.now() - 65 * 60 * 1000).toISOString();
+
+    await createTestFeature(testRepo.path, 'pr-stalled', {
+      id: 'pr-stalled',
+      title: 'PR Stalled Feature',
+      category: 'feature',
+      description: 'Feature with a PR that stalled in CI',
+      status: 'review',
+      reviewStartedAt: stalledTime,
+      failureCount: 0,
+      ciRemediationCount: 2,
+      prNumber: 3459,
+      prUrl: 'https://github.com/protoLabsAI/protoMaker/pull/3459',
+      prCreatedAt,
+    });
+
+    const decayed = await scheduler.checkAndDecayStalled(testRepo.path);
+
+    expect(decayed).toBe(1);
+
+    const featuresDir = path.join(testRepo.path, '.automaker', 'features');
+    const raw = await fs.readFile(path.join(featuresDir, 'pr-stalled', 'feature.json'), 'utf-8');
+    const feature = JSON.parse(raw);
+
+    expect(feature.status).toBe('backlog');
+    // PR linkage must be preserved so reconciler can detect a merge
+    expect(feature.prNumber).toBe(3459);
+    expect(feature.prUrl).toBe('https://github.com/protoLabsAI/protoMaker/pull/3459');
+    expect(feature.prCreatedAt).toBe(prCreatedAt);
+  });
+
   it('emits auto-decayed events for each decayed feature', async () => {
     const stalledTime = new Date(Date.now() - 60 * 60 * 1000).toISOString();
 

--- a/apps/server/tests/unit/services/feature-scheduler.test.ts
+++ b/apps/server/tests/unit/services/feature-scheduler.test.ts
@@ -241,6 +241,35 @@ describe('feature-scheduler.ts', () => {
       );
     });
 
+    it('preserves prNumber and prUrl when decaying a review feature (issue #3467)', async () => {
+      const feature = makeReviewFeature('pr-feature-1', {
+        reviewStartedAt: new Date(Date.now() - 45 * 60 * 1000).toISOString(),
+        ciRemediationCount: 2,
+        failureCount: 0,
+        prNumber: 3459,
+        prUrl: 'https://github.com/protoLabsAI/protoMaker/pull/3459',
+        prCreatedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      });
+
+      mockFeatureDirectories(['pr-feature-1']);
+      mockFeatureJsonReads({ 'pr-feature-1': feature });
+
+      await scheduler.checkAndDecayStalled('/test/project');
+
+      expect(mockFeatureLoader.update).toHaveBeenCalledWith(
+        '/test/project',
+        'pr-feature-1',
+        expect.objectContaining({
+          status: 'backlog',
+        })
+      );
+      // prNumber and prUrl must NOT be cleared — the PR may still be valid and merge later
+      const updateCall = (mockFeatureLoader.update as ReturnType<typeof vi.fn>).mock.calls[0][2];
+      expect(updateCall).not.toHaveProperty('prNumber');
+      expect(updateCall).not.toHaveProperty('prUrl');
+      expect(updateCall).not.toHaveProperty('prCreatedAt');
+    });
+
     it('does NOT decay features without failing CI indicators', async () => {
       const healthyFeature = makeReviewFeature('healthy-1', {
         reviewStartedAt: new Date(Date.now() - 45 * 60 * 1000).toISOString(),

--- a/apps/server/tests/unit/services/post-merge-reconciler-check.test.ts
+++ b/apps/server/tests/unit/services/post-merge-reconciler-check.test.ts
@@ -214,6 +214,58 @@ describe('PostMergeReconcilerCheck', () => {
     });
   });
 
+  it('reconciles a backlog feature whose PR merged after auto-decay (issue #3467)', async () => {
+    // Feature was auto-decayed from review → backlog while PR was pending.
+    // The PR then merged. The reconciler must catch this even though status is backlog.
+    const feature = makeFeature({
+      status: 'backlog',
+      statusChangeReason: 'Auto-decayed: stalled in review for 58min with failing CI',
+    });
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+
+    const execFileAsync = makeExecFileAsync({
+      'protoLabsAI/mythxengine#184': {
+        stdout: JSON.stringify({ state: 'MERGED', merged: true }),
+      },
+    });
+
+    const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync);
+    const emittedEvents: unknown[] = [];
+    events.on('feature:pr-merged', (e) => emittedEvents.push(e));
+
+    const result = await check.run('/home/josh/dev/labs/mythxengine');
+
+    expect(result.checked).toBe(1);
+    expect(result.reconciled).toBe(1);
+    expect(mockFeatureLoaderUpdate).toHaveBeenCalledWith(
+      '/home/josh/dev/labs/mythxengine',
+      'feature-001',
+      { status: 'done', statusChangeReason: 'merged PR detected via poll reconciliation' }
+    );
+    expect(emittedEvents).toHaveLength(1);
+  });
+
+  it('reconciles a blocked feature whose PR merged after being blocked (issue #3467)', async () => {
+    const feature = makeFeature({ status: 'blocked' });
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+
+    const execFileAsync = makeExecFileAsync({
+      'protoLabsAI/mythxengine#184': {
+        stdout: JSON.stringify({ state: 'MERGED', merged: true }),
+      },
+    });
+
+    const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync);
+    const result = await check.run('/home/josh/dev/labs/mythxengine');
+
+    expect(result.reconciled).toBe(1);
+    expect(mockFeatureLoaderUpdate).toHaveBeenCalledWith(
+      expect.any(String),
+      'feature-001',
+      expect.objectContaining({ status: 'done' })
+    );
+  });
+
   it('returns zero counts when no features are in review status', async () => {
     mockFeatureLoaderGetAll.mockResolvedValue([
       makeFeature({ status: 'backlog', prNumber: undefined, prUrl: undefined }),


### PR DESCRIPTION
## Summary

## Observation

This afternoon, two features auto-decayed from review → backlog after sitting 49-58min with failing CI. Minutes later, the corresponding PRs were manually fixed (prettier push) and auto-merged — but the features remained stuck in backlog with `prNumber: undefined`, because the decay had cleared the prNumber field.

### Timeline (oi4fyy4b3 / PR #3459):
1. 20:42:40 — agent submits PR, status → review
2. 21:11:54 — first CI-failure recovery by agent
3. 21:26:04 — auto-decay: review ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request state management to clear stale PR linkage when pull requests are closed without merging
  * Enhanced merged pull request reconciliation to work correctly for features in multiple status states, not just review

* **Tests**
  * Added test coverage for pull request information preservation during automatic feature state transitions
  * Added test coverage for merged pull request reconciliation across different feature statuses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->