### PR TITLE
fix(smoke-check): auto-cleanup synthetic features after probe completes

### DIFF
--- a/.claude/commands/smoke-check.md
+++ b/.claude/commands/smoke-check.md
@@ -27,18 +27,18 @@ Run a fast connectivity check across all MCP tool categories. No retries, no ana
 
 1. Run ALL of the following tool calls **in parallel** (use a single message with multiple tool calls):
 
-| #   | Category      | Tool Call              | Args                                                                                                                                |
-| --- | ------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | Health        | `health_check`         | `{}`                                                                                                                                |
-| 2   | Features      | `list_features`        | `{projectPath: "$CWD"}`                                                                                                             |
-| 3   | Agents        | `list_running_agents`  | `{projectPath: "$CWD"}`                                                                                                             |
-| 4   | Worktrees     | `list_worktrees`       | `{projectPath: "$CWD"}`                                                                                                             |
-| 5   | Context       | `list_context_files`   | `{projectPath: "$CWD"}`                                                                                                             |
-| 6   | Auto-Mode     | `get_auto_mode_status` | `{projectPath: "$CWD"}`                                                                                                             |
-| 7   | Notes         | `list_note_tabs`       | `{}`                                                                                                                                |
-| 8   | Settings      | `get_settings`         | `{}`                                                                                                                                |
-| 9   | Events        | `list_events`          | `{limit: 1}`                                                                                                                        |
-| 10  | Discord       | `read_discord_dms`     | `{userId: "test", limit: 1}`                                                                                                        |
+| #   | Category      | Tool Call              | Args                                                                                                                                                   |
+| --- | ------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | Health        | `health_check`         | `{}`                                                                                                                                                   |
+| 2   | Features      | `list_features`        | `{projectPath: "$CWD"}`                                                                                                                                |
+| 3   | Agents        | `list_running_agents`  | `{projectPath: "$CWD"}`                                                                                                                                |
+| 4   | Worktrees     | `list_worktrees`       | `{projectPath: "$CWD"}`                                                                                                                                |
+| 5   | Context       | `list_context_files`   | `{projectPath: "$CWD"}`                                                                                                                                |
+| 6   | Auto-Mode     | `get_auto_mode_status` | `{projectPath: "$CWD"}`                                                                                                                                |
+| 7   | Notes         | `list_note_tabs`       | `{}`                                                                                                                                                   |
+| 8   | Settings      | `get_settings`         | `{}`                                                                                                                                                   |
+| 9   | Events        | `list_events`          | `{limit: 1}`                                                                                                                                           |
+| 10  | Discord       | `read_discord_dms`     | `{userId: "test", limit: 1}`                                                                                                                           |
 | 11  | Feature Write | `create_feature`       | `{projectPath: "$CWD", title: "[SMOKE-probe] connectivity test", description: "Synthetic probe — auto-deleted after smoke check.", category: "smoke"}` |
 
 Replace `$CWD` with the actual current working directory path.

--- a/.claude/commands/smoke-check.md
+++ b/.claude/commands/smoke-check.md
@@ -14,6 +14,9 @@ allowed-tools:
   - mcp__plugin_protolabs_studio__list_events
   - mcp__plugin_protolabs_studio__send_discord_dm
   - mcp__plugin_protolabs_studio__read_discord_dms
+  - mcp__plugin_protolabs_studio__create_feature
+  - mcp__plugin_protolabs_studio__delete_feature
+  - mcp__plugin_protolabs_studio__update_feature
 ---
 
 # Smoke Check
@@ -24,18 +27,19 @@ Run a fast connectivity check across all MCP tool categories. No retries, no ana
 
 1. Run ALL of the following tool calls **in parallel** (use a single message with multiple tool calls):
 
-| #   | Category  | Tool Call              | Args                         |
-| --- | --------- | ---------------------- | ---------------------------- |
-| 1   | Health    | `health_check`         | `{}`                         |
-| 2   | Features  | `list_features`        | `{projectPath: "$CWD"}`      |
-| 3   | Agents    | `list_running_agents`  | `{projectPath: "$CWD"}`      |
-| 4   | Worktrees | `list_worktrees`       | `{projectPath: "$CWD"}`      |
-| 5   | Context   | `list_context_files`   | `{projectPath: "$CWD"}`      |
-| 6   | Auto-Mode | `get_auto_mode_status` | `{projectPath: "$CWD"}`      |
-| 7   | Notes     | `list_note_tabs`       | `{}`                         |
-| 8   | Settings  | `get_settings`         | `{}`                         |
-| 9   | Events    | `list_events`          | `{limit: 1}`                 |
-| 10  | Discord   | `read_discord_dms`     | `{userId: "test", limit: 1}` |
+| #   | Category      | Tool Call              | Args                                                                                                                                |
+| --- | ------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Health        | `health_check`         | `{}`                                                                                                                                |
+| 2   | Features      | `list_features`        | `{projectPath: "$CWD"}`                                                                                                             |
+| 3   | Agents        | `list_running_agents`  | `{projectPath: "$CWD"}`                                                                                                             |
+| 4   | Worktrees     | `list_worktrees`       | `{projectPath: "$CWD"}`                                                                                                             |
+| 5   | Context       | `list_context_files`   | `{projectPath: "$CWD"}`                                                                                                             |
+| 6   | Auto-Mode     | `get_auto_mode_status` | `{projectPath: "$CWD"}`                                                                                                             |
+| 7   | Notes         | `list_note_tabs`       | `{}`                                                                                                                                |
+| 8   | Settings      | `get_settings`         | `{}`                                                                                                                                |
+| 9   | Events        | `list_events`          | `{limit: 1}`                                                                                                                        |
+| 10  | Discord       | `read_discord_dms`     | `{userId: "test", limit: 1}`                                                                                                        |
+| 11  | Feature Write | `create_feature`       | `{projectPath: "$CWD", title: "[SMOKE-probe] connectivity test", description: "Synthetic probe — auto-deleted after smoke check.", category: "smoke"}` |
 
 Replace `$CWD` with the actual current working directory path.
 
@@ -43,7 +47,12 @@ Replace `$CWD` with the actual current working directory path.
    - **PASS** if the tool returned a response (even an empty list or expected error like "no messages")
    - **FAIL** if the tool threw a connection error, timeout, or was not found
 
-3. Output a single markdown table:
+3. **After step 1 completes**, clean up the synthetic probe feature from step 11:
+   - If `create_feature` returned a feature ID, call `delete_feature({projectPath: "$CWD", featureId: "<returned-id>"})`.
+   - If `delete_feature` fails, call `update_feature({projectPath: "$CWD", featureId: "<returned-id>", status: "done", statusChangeReason: "smoke-check artifact"})` as a fallback.
+   - Record the cleanup result in the Notes column for row 11 (e.g., "created + deleted" or "created + marked done").
+
+4. Output a single markdown table:
 
 ```
 ## Smoke Check Results
@@ -53,13 +62,14 @@ Replace `$CWD` with the actual current working directory path.
 | 1 | Health | PASS | Server v1.2.3 |
 | 2 | Features | PASS | 12 features |
 | ... | ... | ... | ... |
+| 11 | Feature Write | PASS | created + deleted |
 
-**Result: 9/10 PASS** | 1 failure: Discord (bot token not configured)
+**Result: 9/11 PASS** | 2 failures: Discord (bot token not configured), ...
 ```
 
-4. Keep the Notes column to 5 words or fewer per row. Use counts where available (e.g., "3 agents running", "0 worktrees").
+5. Keep the Notes column to 5 words or fewer per row. Use counts where available (e.g., "3 agents running", "0 worktrees").
 
-5. Do NOT:
+6. Do NOT:
    - Retry failed tools
    - Analyze root causes
    - Suggest fixes

--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -1378,6 +1378,17 @@ export class FeatureScheduler {
             continue;
           }
 
+          // Sentinel filter: skip synthetic/probe features created by tooling (e.g. smoke-check).
+          // Features with titles starting "[SMOKE-" or category "smoke" must never be dispatched
+          // to an agent — they are test artifacts and self-complete via cleanup in the originating
+          // tool. If cleanup fails, this guard prevents wasteful agent spawns.
+          if (feature.title?.startsWith('[SMOKE-') || feature.category === 'smoke') {
+            logger.info(
+              `[loadPendingFeatures] Skipping smoke-check sentinel feature ${feature.id} — not eligible for agent dispatch`
+            );
+            continue;
+          }
+
           // Creation cooldown: skip features created too recently to allow the creator time
           // to set dependencies, adjust properties, or batch-create related features.
           if (feature.createdAt) {

--- a/apps/server/tests/unit/services/feature-scheduler-smoke-sentinel.test.ts
+++ b/apps/server/tests/unit/services/feature-scheduler-smoke-sentinel.test.ts
@@ -183,9 +183,7 @@ describe('feature-scheduler.ts — smoke-check sentinel filter', () => {
     const result = await (scheduler as any).loadPendingFeatures('/test/project');
 
     expect(result).toHaveLength(0);
-    expect(mockInfo).toHaveBeenCalledWith(
-      expect.stringContaining('smoke-probe-1')
-    );
+    expect(mockInfo).toHaveBeenCalledWith(expect.stringContaining('smoke-probe-1'));
     // Must NOT attempt to update/block the feature — it is simply skipped silently
     expect(mockFeatureLoader.update).not.toHaveBeenCalled();
   });

--- a/apps/server/tests/unit/services/feature-scheduler-smoke-sentinel.test.ts
+++ b/apps/server/tests/unit/services/feature-scheduler-smoke-sentinel.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Unit tests for FeatureScheduler — smoke-check sentinel filter
+ *
+ * Covers:
+ * - loadPendingFeatures skips features whose title starts with "[SMOKE-"
+ * - loadPendingFeatures skips features with category === "smoke"
+ * - Normal features with similar-but-non-matching titles ARE dispatched
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Feature } from '@protolabsai/types';
+
+const { mockWarn, mockInfo, mockDebug, mockError } = vi.hoisted(() => ({
+  mockWarn: vi.fn(),
+  mockInfo: vi.fn(),
+  mockDebug: vi.fn(),
+  mockError: vi.fn(),
+}));
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: vi.fn(() => ({
+    info: mockInfo,
+    debug: mockDebug,
+    warn: mockWarn,
+    error: mockError,
+  })),
+  readJsonWithRecovery: vi.fn(),
+  logRecoveryWarning: vi.fn(),
+  DEFAULT_BACKUP_COUNT: 3,
+  classifyError: vi.fn((err: unknown) => ({
+    type: 'unknown',
+    message: String(err),
+    isRateLimit: false,
+    isCancellation: false,
+  })),
+}));
+
+vi.mock('@/lib/secure-fs.js', () => ({
+  readdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  stat: vi.fn(),
+}));
+
+vi.mock('@protolabsai/platform', () => ({
+  getFeaturesDir: vi.fn((projectPath: string) => `${projectPath}/.automaker/features`),
+}));
+
+vi.mock('@protolabsai/dependency-resolver', () => ({
+  resolveDependencies: vi.fn(),
+  areDependenciesSatisfied: vi.fn(),
+}));
+
+vi.mock('@protolabsai/types', async () => {
+  const actual = await vi.importActual('@protolabsai/types');
+  return {
+    ...actual,
+    DEFAULT_MAX_CONCURRENCY: 1,
+    MAX_SYSTEM_CONCURRENCY: 10,
+    normalizeFeatureStatus: vi.fn((s: string) => s),
+  };
+});
+
+vi.mock('@/lib/worktree-lock.js', () => ({
+  isWorktreeLocked: vi.fn(),
+}));
+
+vi.mock('@/lib/settings-helpers.js', () => ({
+  getEffectivePrBaseBranch: vi.fn().mockResolvedValue('dev'),
+}));
+
+vi.mock('@/config/timeouts.js', () => ({
+  SLEEP_INTERVAL_CAPACITY_MS: 5000,
+  SLEEP_INTERVAL_IDLE_MS: 30000,
+  SLEEP_INTERVAL_NORMAL_MS: 2000,
+  SLEEP_INTERVAL_ERROR_MS: 10000,
+}));
+
+import { FeatureScheduler } from '@/services/feature-scheduler.js';
+import * as secureFs from '@/lib/secure-fs.js';
+import { readJsonWithRecovery } from '@protolabsai/utils';
+import type { SchedulerCallbacks, PipelineRunner } from '@/services/feature-scheduler.js';
+
+function createMockFeatureLoader() {
+  return {
+    get: vi.fn(),
+    getAll: vi.fn(),
+    update: vi.fn().mockResolvedValue({}),
+    create: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function createMockSettingsService() {
+  return {
+    getGlobalSettings: vi.fn().mockResolvedValue({}),
+    getProjectSettings: vi.fn().mockResolvedValue({
+      workflow: { maxPendingReviews: 5, autoDecayTimeoutMinutes: 30 },
+    }),
+  };
+}
+
+function createMockCallbacks(): SchedulerCallbacks {
+  return {
+    getRunningCountForWorktree: vi.fn().mockResolvedValue(0),
+    getGlobalRunningCount: vi.fn().mockReturnValue(0),
+    canProjectAcquireGlobalSlot: vi.fn().mockResolvedValue(true),
+    hasInProgressFeatures: vi.fn().mockResolvedValue(false),
+    isFeatureRunning: vi.fn().mockReturnValue(false),
+    getRunningFeatureIds: vi.fn().mockReturnValue([]),
+    isFeatureActiveInPipeline: vi.fn().mockReturnValue(false),
+    isFeatureFinished: vi.fn().mockReturnValue(false),
+    emitAutoModeEvent: vi.fn(),
+    getHeapUsagePercent: vi.fn().mockReturnValue(0.5),
+    getMostRecentRunningFeature: vi.fn().mockReturnValue(null),
+    recordSuccessForProject: vi.fn(),
+    trackFailureAndCheckPauseForProject: vi.fn().mockReturnValue(false),
+    signalShouldPauseForProject: vi.fn(),
+    sleep: vi.fn().mockResolvedValue(undefined),
+    HEAP_USAGE_STOP_NEW_AGENTS_THRESHOLD: 0.8,
+    HEAP_USAGE_ABORT_AGENTS_THRESHOLD: 0.9,
+  };
+}
+
+function createMockRunner(): PipelineRunner {
+  return {
+    run: vi.fn().mockResolvedValue({ outcome: 'completed' }),
+  };
+}
+
+function mockFeatureDirectories(featureIds: string[]) {
+  (secureFs.readdir as ReturnType<typeof vi.fn>).mockResolvedValue(
+    featureIds.map((id) => ({
+      name: id,
+      isDirectory: () => true,
+    }))
+  );
+}
+
+function mockFeatureJsonReads(features: Record<string, Partial<Feature> | null>) {
+  (readJsonWithRecovery as ReturnType<typeof vi.fn>).mockImplementation((filePath: string) => {
+    const parts = filePath.split('/');
+    const featureIdx = parts.indexOf('features');
+    const featureId = featureIdx >= 0 ? parts[featureIdx + 1] : undefined;
+    const data = featureId ? (features[featureId] ?? null) : null;
+    return Promise.resolve({ data, recovered: false, source: 'primary' });
+  });
+}
+
+describe('feature-scheduler.ts — smoke-check sentinel filter', () => {
+  let scheduler: FeatureScheduler;
+  let mockFeatureLoader: ReturnType<typeof createMockFeatureLoader>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFeatureLoader = createMockFeatureLoader();
+
+    scheduler = new FeatureScheduler({
+      featureLoader: mockFeatureLoader as any,
+      settingsService: createMockSettingsService() as any,
+      events: {
+        emit: vi.fn(),
+        on: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+        subscribe: vi.fn(),
+      } as any,
+      runner: createMockRunner(),
+      callbacks: createMockCallbacks(),
+    });
+  });
+
+  it('skips a feature whose title starts with "[SMOKE-"', async () => {
+    const smokeFeature: Partial<Feature> = {
+      id: 'smoke-probe-1',
+      title: '[SMOKE-abc123] connectivity test',
+      description: 'Synthetic probe — auto-deleted after smoke check.',
+      status: 'backlog',
+      category: 'smoke',
+    };
+
+    mockFeatureDirectories(['smoke-probe-1']);
+    mockFeatureJsonReads({ 'smoke-probe-1': smokeFeature });
+
+    const result = await (scheduler as any).loadPendingFeatures('/test/project');
+
+    expect(result).toHaveLength(0);
+    expect(mockInfo).toHaveBeenCalledWith(
+      expect.stringContaining('smoke-probe-1')
+    );
+    // Must NOT attempt to update/block the feature — it is simply skipped silently
+    expect(mockFeatureLoader.update).not.toHaveBeenCalled();
+  });
+
+  it('skips a feature with category "smoke" regardless of title', async () => {
+    const smokeFeature: Partial<Feature> = {
+      id: 'smoke-probe-2',
+      title: 'Some probe feature',
+      description: 'A probe with smoke category.',
+      status: 'backlog',
+      category: 'smoke',
+    };
+
+    mockFeatureDirectories(['smoke-probe-2']);
+    mockFeatureJsonReads({ 'smoke-probe-2': smokeFeature });
+
+    const result = await (scheduler as any).loadPendingFeatures('/test/project');
+
+    expect(result).toHaveLength(0);
+    expect(mockFeatureLoader.update).not.toHaveBeenCalled();
+  });
+
+  it('does NOT skip a normal backlog feature that does not match the sentinel pattern', async () => {
+    const normalFeature: Partial<Feature> = {
+      id: 'normal-feature-1',
+      title: 'Fix Safari 17 save button crash',
+      description: 'Legitimate bug fix.',
+      status: 'backlog',
+      category: 'bug',
+      createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(), // 10 min ago (past cooldown)
+    };
+
+    mockFeatureDirectories(['normal-feature-1']);
+    mockFeatureJsonReads({ 'normal-feature-1': normalFeature });
+
+    const result = await (scheduler as any).loadPendingFeatures('/test/project');
+
+    // Normal features must still be scheduled
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0].id).toBe('normal-feature-1');
+  });
+});


### PR DESCRIPTION
## Summary

## Observation (2026-04-15 22:18 UTC)

The `smoke-check` skill (which verifies MCP tool connectivity by exercising 10 tools across protoLabs Studio and external integrations) creates a synthetic feature to test the `create_feature` tool:

```
[SMOKE-e371a4d2] Save button throws uncaught TypeError in Safari 17
```

But the skill doesn't clean up after itself. The synthetic feature lands in backlog, auto-mode picks it up within seconds, an agent spawns to 'fix' a non-existent Safari bug. Pure wast...

---
*Recovered automatically by Automaker post-agent hook*