### PR TITLE
fix(scheduler): broaden synthetic-probe sentinel beyond [SMOKE-*] (RPC probe slipped through)

### DIFF
--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -1378,13 +1378,14 @@ export class FeatureScheduler {
             continue;
           }
 
-          // Sentinel filter: skip synthetic/probe features created by tooling (e.g. smoke-check).
-          // Features with titles starting "[SMOKE-" or category "smoke" must never be dispatched
+          // Sentinel filter: skip synthetic/probe features created by tooling (e.g. smoke-check, RPC probes).
+          // Features with titles matching the [PREFIX-hexhash] pattern or category "smoke" must never be dispatched
           // to an agent — they are test artifacts and self-complete via cleanup in the originating
           // tool. If cleanup fails, this guard prevents wasteful agent spawns.
-          if (feature.title?.startsWith('[SMOKE-') || feature.category === 'smoke') {
+          const SYNTHETIC_PROBE_RX = /^\[[A-Z]+-[a-f0-9]+\]/;
+          if (SYNTHETIC_PROBE_RX.test(feature.title ?? '') || feature.category === 'smoke') {
             logger.info(
-              `[loadPendingFeatures] Skipping smoke-check sentinel feature ${feature.id} — not eligible for agent dispatch`
+              `[loadPendingFeatures] Skipping synthetic probe ${feature.id} — not eligible for agent dispatch`
             );
             continue;
           }

--- a/apps/server/tests/unit/services/feature-scheduler-smoke-sentinel.test.ts
+++ b/apps/server/tests/unit/services/feature-scheduler-smoke-sentinel.test.ts
@@ -147,7 +147,7 @@ function mockFeatureJsonReads(features: Record<string, Partial<Feature> | null>)
   });
 }
 
-describe('feature-scheduler.ts — smoke-check sentinel filter', () => {
+describe('feature-scheduler.ts — synthetic probe sentinel filter', () => {
   let scheduler: FeatureScheduler;
   let mockFeatureLoader: ReturnType<typeof createMockFeatureLoader>;
 
@@ -204,6 +204,63 @@ describe('feature-scheduler.ts — smoke-check sentinel filter', () => {
 
     expect(result).toHaveLength(0);
     expect(mockFeatureLoader.update).not.toHaveBeenCalled();
+  });
+
+  it('skips a feature whose title starts with "[RPC-" (hex hash)', async () => {
+    const rpcFeature: Partial<Feature> = {
+      id: 'rpc-probe-1',
+      title: '[RPC-e58af9] Settings modal close button unresponsive on mobile Chrome',
+      description: 'Synthetic RPC probe.',
+      status: 'backlog',
+      category: 'bug',
+    };
+
+    mockFeatureDirectories(['rpc-probe-1']);
+    mockFeatureJsonReads({ 'rpc-probe-1': rpcFeature });
+
+    const result = await (scheduler as any).loadPendingFeatures('/test/project');
+
+    expect(result).toHaveLength(0);
+    expect(mockInfo).toHaveBeenCalledWith(expect.stringContaining('rpc-probe-1'));
+    expect(mockFeatureLoader.update).not.toHaveBeenCalled();
+  });
+
+  it('does NOT skip "[WIP]" title — no hex hash, not a probe pattern', async () => {
+    const wipFeature: Partial<Feature> = {
+      id: 'wip-feature-1',
+      title: '[WIP] Add dark mode toggle',
+      description: 'Work in progress.',
+      status: 'backlog',
+      category: 'feature',
+      createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    };
+
+    mockFeatureDirectories(['wip-feature-1']);
+    mockFeatureJsonReads({ 'wip-feature-1': wipFeature });
+
+    const result = await (scheduler as any).loadPendingFeatures('/test/project');
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0].id).toBe('wip-feature-1');
+  });
+
+  it('does NOT skip "[Arc 0.1]" title — not a probe pattern', async () => {
+    const arcFeature: Partial<Feature> = {
+      id: 'arc-feature-1',
+      title: '[Arc 0.1] Core infrastructure',
+      description: 'Architecture phase.',
+      status: 'backlog',
+      category: 'feature',
+      createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    };
+
+    mockFeatureDirectories(['arc-feature-1']);
+    mockFeatureJsonReads({ 'arc-feature-1': arcFeature });
+
+    const result = await (scheduler as any).loadPendingFeatures('/test/project');
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0].id).toBe('arc-feature-1');
   });
 
   it('does NOT skip a normal backlog feature that does not match the sentinel pattern', async () => {


### PR DESCRIPTION
## Summary

## Observation (2026-04-15 22:58 UTC)

The sentinel filter shipped in PR #3465 (`feature-scheduler.ts`, rmad8t6aj) only matches titles starting with `[SMOKE-` or category `smoke`. An RPC-probe synthetic feature with title `[RPC-e58af9] Settings modal close button unresponsive on mobile Chrome` slipped through the filter — auto-mode dispatched an agent on a non-existent bug until manually deflected.

## Proposed fix

Replace the startsWith check in feature-scheduler.ts `loadPendingFeatures()` wit...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced filtering of synthetic probe features to identify a broader range of probe patterns, ensuring they are properly excluded from dispatch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->