### PR TITLE
[RPC-e58af9] Settings modal close button unresponsive on mobile Chrome

### DIFF
--- a/apps/ui/src/components/shared/settings/settings-nav-container.tsx
+++ b/apps/ui/src/components/shared/settings/settings-nav-container.tsx
@@ -47,7 +47,7 @@ export function SettingsNavContainer({
             variant="ghost"
             size="sm"
             onClick={onClose}
-            className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground"
+            className="h-11 w-11 p-0 text-muted-foreground hover:text-foreground touch-manipulation"
             aria-label="Close navigation menu"
           >
             <X className="w-4 h-4" />

--- a/apps/ui/src/components/views/settings-view/components/settings-header.tsx
+++ b/apps/ui/src/components/views/settings-view/components/settings-header.tsx
@@ -29,7 +29,7 @@ export function SettingsHeader({
           {onToggleNavigation && (
             <button
               onClick={onToggleNavigation}
-              className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground lg:hidden"
+              className="rounded-md p-1.5 min-h-[44px] min-w-[44px] flex items-center justify-center text-muted-foreground transition-colors hover:bg-accent hover:text-foreground lg:hidden touch-manipulation"
               aria-label={showNavigation ? 'Close navigation menu' : 'Open navigation menu'}
             >
               {showNavigation ? <X className="size-4" /> : <Menu className="size-4" />}


### PR DESCRIPTION
## Summary

**Environment:** Mobile Chrome (exact version TBD)

**Steps to reproduce:**
1. Open the settings modal
2. Tap the close button

**Expected:** Modal closes.
**Actual:** Nothing happens. Modal remains open.

**Analysis:** Likely a touch event handling issue. Common causes:
- Close button hit target too small for mobile tap (< 44x44px)
- Click handler used instead of pointer/touch event
- Overlay or z-index conflict swallowing the tap
- CSS `pointer-events` issue on mobile viewport

**Ref:** RPC-e5...

---
*Recovered automatically by Automaker post-agent hook*