### PR TITLE
fix(test): 3 test suites broken by today's agent PRs (epic-auto-adoption, pr-remediation, smoke-sentinel)

### DIFF
--- a/apps/server/tests/services/pr-remediation.test.ts
+++ b/apps/server/tests/services/pr-remediation.test.ts
@@ -21,27 +21,37 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // ---------------------------------------------------------------------------
 
 // Mock the PrRemediationWorker class so we can control each method in isolation
-const mockWorker = {
-  createScratchDir: vi.fn(),
-  runGit: vi.fn(),
-  runGitSafe: vi.fn(),
-  getChangedFiles: vi.fn(),
-  runPrettier: vi.fn(),
-  getModifiedFiles: vi.fn(),
-  commitRemediationFix: vi.fn(),
-  pushBranch: vi.fn(),
-  hasExistingRemediationCommit: vi.fn(),
-  cleanup: vi.fn(),
-};
-
+const { mockWorker, MockPrRemediationWorker } = vi.hoisted(() => {
+  const _mockWorker = {
+    createScratchDir: vi.fn(),
+    runGit: vi.fn(),
+    runGitSafe: vi.fn(),
+    getChangedFiles: vi.fn(),
+    runPrettier: vi.fn(),
+    getModifiedFiles: vi.fn(),
+    commitRemediationFix: vi.fn(),
+    pushBranch: vi.fn(),
+    hasExistingRemediationCommit: vi.fn(),
+    cleanup: vi.fn(),
+  };
+  const _MockClass = vi.fn(function (this: any) {
+    return _mockWorker;
+  });
+  return { mockWorker: _mockWorker, MockPrRemediationWorker: _MockClass };
+});
 vi.mock('../../src/services/pr-remediation-worker.js', () => ({
-  PrRemediationWorker: vi.fn().mockImplementation(() => mockWorker),
+  PrRemediationWorker: MockPrRemediationWorker,
 }));
 
 // Mock child_process.exec — used by promisify() inside remediateFormatFailure
-const mockExec = vi.fn();
+const mockExec = vi.hoisted(() => vi.fn());
 vi.mock('node:child_process', () => ({
   exec: mockExec,
+  execFile: vi.fn(),
+  spawn: vi.fn(),
+  fork: vi.fn(),
+  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
 // Mock fs/promises for PrRemediationWorker base class tests

--- a/apps/server/tests/unit/services/epic-auto-adoption.test.ts
+++ b/apps/server/tests/unit/services/epic-auto-adoption.test.ts
@@ -64,14 +64,16 @@ vi.mock('@/lib/prometheus.js', () => ({
 }));
 
 vi.mock('@/services/quarantine-service.js', () => ({
-  QuarantineService: vi.fn().mockImplementation(() => ({
-    process: vi.fn().mockResolvedValue({
-      approved: true,
-      sanitizedTitle: 'sanitized-title',
-      sanitizedDescription: 'sanitized-description',
-      entry: { id: 'q-1', result: 'approved', stage: 'passed', violations: [] },
-    }),
-  })),
+  QuarantineService: class MockQuarantineService {
+    process(input: { title: string; description: string }) {
+      return Promise.resolve({
+        approved: true,
+        sanitizedTitle: input.title,
+        sanitizedDescription: input.description,
+        entry: { id: 'q-1', result: 'approved', stage: 'passed', violations: [] },
+      });
+    }
+  },
 }));
 
 // --- Imports ---
@@ -158,7 +160,7 @@ describe('findCandidateEpic', () => {
 
   it('returns null when no epic title matches the keyword', () => {
     const features = [arcEpic];
-    expect(findCandidateEpic('[TR-1.2] Unrelated task', features)).toBeNull();
+    expect(findCandidateEpic('[QZ-1.2] Unrelated task', features)).toBeNull();
   });
 
   it('returns null when multiple epics match the keyword (ambiguous)', () => {
@@ -264,7 +266,7 @@ describe('POST /features/create — epic auto-adoption', () => {
     req.body = {
       projectPath: '/test/project',
       feature: {
-        title: '[TR-1.0] Unrelated task',
+        title: '[QZ-1.0] Unrelated task',
         description: 'Something unrelated',
       },
     };

--- a/apps/server/tests/unit/services/feature-scheduler-smoke-sentinel.test.ts
+++ b/apps/server/tests/unit/services/feature-scheduler-smoke-sentinel.test.ts
@@ -47,8 +47,14 @@ vi.mock('@protolabsai/platform', () => ({
 }));
 
 vi.mock('@protolabsai/dependency-resolver', () => ({
-  resolveDependencies: vi.fn(),
-  areDependenciesSatisfied: vi.fn(),
+  resolveDependencies: vi.fn((features: any[]) => ({
+    orderedFeatures: features,
+    missingDependencies: new Map(),
+    downstreamImpact: new Map(),
+  })),
+  areDependenciesSatisfied: vi.fn(() => true),
+  checkExternalDependencies: vi.fn(() => Promise.resolve({ satisfied: true, results: [] })),
+  buildLocalForeignFeatureFetcher: vi.fn(() => vi.fn()),
 }));
 
 vi.mock('@protolabsai/types', async () => {
@@ -60,6 +66,12 @@ vi.mock('@protolabsai/types', async () => {
     normalizeFeatureStatus: vi.fn((s: string) => s),
   };
 });
+
+vi.mock('child_process', () => ({
+  exec: vi.fn((_cmd: string, _opts: unknown, cb?: Function) => {
+    if (cb) cb(new Error('mock'), { stdout: '', stderr: '' });
+  }),
+}));
 
 vi.mock('@/lib/worktree-lock.js', () => ({
   isWorktreeLocked: vi.fn(),


### PR DESCRIPTION
## Summary

## Observation

Dev HEAD has 3 broken test suites introduced by today's stabilization-queue PRs:

- `apps/server/tests/unit/services/epic-auto-adoption.test.ts` (from PR #3462, epic auto-adoption)
  - `findCandidateEpic > returns null when no epic title matches the keyword`
  - `POST /features/create — epic auto-adoption > auto-adopts a feature with [Arc 0.1] title into the matching epic`
  - `POST /features/create — epic auto-adoption > creates an orphan when no epic matches the title pattern`
...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-15T23:21:19.762Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test mock infrastructure to improve maintainability and consistency across test suites. Updated mock implementations for better structure and coverage of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->