### PR TITLE
fix(infra): dev container auto-restart on new image push (ra8e74dcq)

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -1,8 +1,10 @@
 name: Build Dev Server Image
 
 # Builds and pushes the dev-branch server image to GHCR on every push to dev.
-# Watchtower on local machines polls GHCR every 5 minutes and auto-restarts
-# the automaker-dev-server container when a new image is available.
+# After pushing, optionally triggers Watchtower's HTTP API for an immediate restart
+# (requires WATCHTOWER_API_URL + WATCHTOWER_API_TOKEN repo secrets).
+# If those secrets are not set, Watchtower polls GHCR every 60 seconds and
+# auto-restarts the automaker-dev-server container when a new image is available.
 
 on:
   push:
@@ -49,3 +51,51 @@ jobs:
           # Use GitHub Actions cache to speed up subsequent builds
           cache-from: type=gha,scope=dev-server
           cache-to: type=gha,mode=max,scope=dev-server
+
+      # Trigger Watchtower to immediately check for the new image instead of waiting for the
+      # next poll cycle. Requires WATCHTOWER_API_URL and WATCHTOWER_API_TOKEN secrets to be set.
+      # Set WATCHTOWER_API_URL to http://<host-ip>:9091 (the host must be reachable from GH Actions).
+      # If the secrets are not set, Watchtower will pick up the new image on its next 60-second poll.
+      - name: Trigger Watchtower HTTP API update
+        if: success()
+        env:
+          WATCHTOWER_API_URL: ${{ secrets.WATCHTOWER_API_URL }}
+          WATCHTOWER_API_TOKEN: ${{ secrets.WATCHTOWER_API_TOKEN }}
+        run: |
+          if [ -n "$WATCHTOWER_API_URL" ] && [ -n "$WATCHTOWER_API_TOKEN" ]; then
+            echo "Triggering Watchtower at $WATCHTOWER_API_URL to pull new image..."
+            HTTP_CODE=$(curl -s -o /tmp/wt_response.txt -w "%{http_code}" \
+              --max-time 10 \
+              -X POST "$WATCHTOWER_API_URL/v1/update" \
+              -H "Authorization: Bearer $WATCHTOWER_API_TOKEN")
+            echo "Watchtower API response: HTTP $HTTP_CODE"
+            cat /tmp/wt_response.txt || true
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "Watchtower triggered — container restart underway."
+            else
+              echo "WARNING: Watchtower API returned HTTP $HTTP_CODE. Container will update on next 60s poll."
+            fi
+          else
+            echo "WATCHTOWER_API_URL / WATCHTOWER_API_TOKEN not configured."
+            echo "Container will pick up the new image on Watchtower's next 60-second poll."
+            echo "To enable direct trigger: set WATCHTOWER_API_URL and WATCHTOWER_API_TOKEN in repo secrets."
+          fi
+
+      # Post a notification to #infra Discord channel after a successful image push.
+      # Requires DISCORD_INFRA_WEBHOOK_URL secret to be set.
+      - name: Notify Discord infra channel
+        if: success()
+        env:
+          DISCORD_INFRA_WEBHOOK_URL: ${{ secrets.DISCORD_INFRA_WEBHOOK_URL }}
+        run: |
+          if [ -n "$DISCORD_INFRA_WEBHOOK_URL" ]; then
+            SHORT_SHA="${{ github.sha }}"
+            SHORT_SHA="${SHORT_SHA:0:7}"
+            COMMIT_MSG=$(echo '${{ github.event.head_commit.message }}' | head -c 80 | tr -d '"\\')
+            curl -s -X POST "$DISCORD_INFRA_WEBHOOK_URL" \
+              -H "Content-Type: application/json" \
+              -d "{\"content\": \"**[dev-image]** New server image pushed: \`${SHORT_SHA}\` — ${COMMIT_MSG}\\nWatchtower will restart the container within 60 seconds.\"}"
+            echo "Discord notification sent."
+          else
+            echo "DISCORD_INFRA_WEBHOOK_URL not set. Skipping Discord notification."
+          fi

--- a/docker/dev-server/README.md
+++ b/docker/dev-server/README.md
@@ -3,7 +3,7 @@
 Always-on, production-mode container running the **dev branch** on `localhost:3008`.
 
 - Starts automatically on machine boot (Docker Desktop auto-start + `restart: unless-stopped`)
-- Auto-rebuilds within 5 minutes of a new commit landing on `dev` (via CI + Watchtower)
+- Auto-rebuilds within 1–2 minutes of a new commit landing on `dev` (CI + Watchtower + optional direct trigger)
 - State (features, data, credentials) persists across rebuilds via mounted volumes
 
 ## Architecture
@@ -15,12 +15,17 @@ Push to dev branch
 GitHub Actions (build-dev-image.yml)
   • Builds docker/dev-server/Dockerfile
   • Pushes ghcr.io/protolabsai/automaker-dev-server:latest to GHCR
+  • (optional) POST http://<host>:9091/v1/update  →  Watchtower HTTP API
+  • (optional) Discord #infra notification
       │
-      ▼ (within 5 minutes)
-Watchtower (running locally)
-  • Polls GHCR every 5 minutes
-  • Pulls new image when SHA changes
-  • Gracefully restarts automaker-dev-server container
+      ├── Watchtower HTTP API (fast path, if WATCHTOWER_API_URL secret is set)
+      │     • GH Actions POSTs to Watchtower immediately after push
+      │     • Watchtower pulls + restarts within seconds
+      │
+      └── Watchtower polling (fallback, always active)
+            • Polls GHCR every 60 seconds
+            • Pulls new image when SHA changes
+            • Gracefully restarts automaker-dev-server
       │
       ▼
 automaker-dev-server (localhost:3008)
@@ -111,11 +116,53 @@ The repo-root `.env` is **not** mounted directly (to avoid leaking dev secrets).
 1. A PR is merged into `dev`
 2. GitHub Actions runs `.github/workflows/build-dev-image.yml`
 3. The workflow builds the server image and pushes to GHCR with tag `latest` + the commit SHA
-4. Watchtower polls GHCR every **5 minutes**
-5. When it detects a new `latest` digest, it pulls the new image and restarts `automaker-dev-server`
-6. The health check confirms the new container is ready
+4. After pushing, GH Actions optionally POSTs to Watchtower's HTTP API for an immediate trigger (see [Faster restarts via Watchtower HTTP API](#faster-restarts-via-watchtower-http-api))
+5. If the API trigger is not configured, Watchtower polls GHCR every **60 seconds**
+6. When it detects a new `latest` digest, it pulls the new image and restarts `automaker-dev-server`
+7. The health check confirms the new container is ready
 
-Build time is typically **5–10 minutes** (layer caching keeps it fast after the first build). Total time from merged PR to running container: **≤ 15 minutes**.
+Build time is typically **5–10 minutes** (layer caching keeps it fast after the first build). Total time from merged PR to running container:
+
+| Scenario | Time |
+|---|---|
+| HTTP API trigger configured | **5–11 minutes** (build time + ~10s restart) |
+| Polling only (default) | **5–12 minutes** (build time + up to 60s poll) |
+
+## Faster Restarts via Watchtower HTTP API
+
+By default Watchtower polls every 60 seconds. For near-instant restarts after a push, configure
+the optional HTTP API trigger so GH Actions can tell Watchtower exactly when to check.
+
+### 1. Set the API token
+
+Choose a secret token and add it to your shell or `.env`:
+
+```bash
+export WATCHTOWER_API_TOKEN=my-secret-token
+```
+
+This value is interpolated by Docker Compose into `WATCHTOWER_HTTP_API_TOKEN`.
+
+### 2. Expose the host to GitHub Actions
+
+Watchtower's HTTP API listens on host port **9091**. GitHub Actions needs to reach it.
+
+Options:
+- **Cloud VM**: open port 9091 in your firewall/security group, set `WATCHTOWER_API_URL=http://<vm-ip>:9091`
+- **Cloudflare Tunnel**: tunnel port 9091 to a public URL
+- **Tailscale/WireGuard**: point GH Actions runner at the Tailscale IP
+
+### 3. Add GitHub repo secrets
+
+In your GitHub repo → Settings → Secrets → Actions, add:
+
+| Secret | Value |
+|---|---|
+| `WATCHTOWER_API_URL` | `http://<your-host>:9091` |
+| `WATCHTOWER_API_TOKEN` | same token you set in step 1 |
+| `DISCORD_INFRA_WEBHOOK_URL` | Discord webhook URL for #infra notifications (optional) |
+
+Once set, every push to `dev` will trigger an immediate container restart after the image is pushed.
 
 ## Troubleshooting
 
@@ -127,7 +174,39 @@ Build time is typically **5–10 minutes** (layer caching keeps it fast after th
 **Watchtower not pulling new images:**
 
 - Check `docker logs automaker-dev-watchtower` for auth errors
-- Re-run `docker login ghcr.io` if credentials expired
+- Re-run `docker login ghcr.io` if credentials expired (token needs `read:packages` scope)
+- Verify the GHCR package visibility is Internal or Private (not Public, which behaves differently with Watchtower auth)
+- Force a manual pull: `docker compose -f docker/dev-server/docker-compose.yml pull && docker compose -f docker/dev-server/docker-compose.yml up -d`
+
+**Diagnose the full chain after a dev push:**
+
+```bash
+# 1. Confirm CI built and pushed
+#    Open: https://github.com/protolabsai/protoMaker/actions/workflows/build-dev-image.yml
+#    Look for a green run on the commit you expect.
+
+# 2. Confirm Watchtower is running
+docker ps | grep watchtower
+
+# 3. Watch Watchtower logs for a pull
+docker logs automaker-dev-watchtower --since 15m -f
+
+# 4. Check the running image SHA
+docker inspect automaker-dev-server --format '{{.Image}}' | cut -c1-20
+```
+
+**Container running old code after CI shows green:**
+
+1. Check Watchtower logs: `docker logs automaker-dev-watchtower --tail 50`
+2. If Watchtower shows no recent activity, it may have stopped. Restart it:
+   ```bash
+   docker restart automaker-dev-watchtower
+   ```
+3. If still stale, force pull manually:
+   ```bash
+   docker compose -f docker/dev-server/docker-compose.yml pull server
+   docker compose -f docker/dev-server/docker-compose.yml up -d server
+   ```
 
 **Server crashes on start:**
 

--- a/docker/dev-server/README.md
+++ b/docker/dev-server/README.md
@@ -123,10 +123,10 @@ The repo-root `.env` is **not** mounted directly (to avoid leaking dev secrets).
 
 Build time is typically **5–10 minutes** (layer caching keeps it fast after the first build). Total time from merged PR to running container:
 
-| Scenario | Time |
-|---|---|
-| HTTP API trigger configured | **5–11 minutes** (build time + ~10s restart) |
-| Polling only (default) | **5–12 minutes** (build time + up to 60s poll) |
+| Scenario                    | Time                                           |
+| --------------------------- | ---------------------------------------------- |
+| HTTP API trigger configured | **5–11 minutes** (build time + ~10s restart)   |
+| Polling only (default)      | **5–12 minutes** (build time + up to 60s poll) |
 
 ## Faster Restarts via Watchtower HTTP API
 
@@ -148,6 +148,7 @@ This value is interpolated by Docker Compose into `WATCHTOWER_HTTP_API_TOKEN`.
 Watchtower's HTTP API listens on host port **9091**. GitHub Actions needs to reach it.
 
 Options:
+
 - **Cloud VM**: open port 9091 in your firewall/security group, set `WATCHTOWER_API_URL=http://<vm-ip>:9091`
 - **Cloudflare Tunnel**: tunnel port 9091 to a public URL
 - **Tailscale/WireGuard**: point GH Actions runner at the Tailscale IP
@@ -156,10 +157,10 @@ Options:
 
 In your GitHub repo → Settings → Secrets → Actions, add:
 
-| Secret | Value |
-|---|---|
-| `WATCHTOWER_API_URL` | `http://<your-host>:9091` |
-| `WATCHTOWER_API_TOKEN` | same token you set in step 1 |
+| Secret                      | Value                                                   |
+| --------------------------- | ------------------------------------------------------- |
+| `WATCHTOWER_API_URL`        | `http://<your-host>:9091`                               |
+| `WATCHTOWER_API_TOKEN`      | same token you set in step 1                            |
 | `DISCORD_INFRA_WEBHOOK_URL` | Discord webhook URL for #infra notifications (optional) |
 
 Once set, every push to `dev` will trigger an immediate container restart after the image is pushed.

--- a/docker/dev-server/docker-compose.yml
+++ b/docker/dev-server/docker-compose.yml
@@ -82,9 +82,17 @@ services:
       # Run `docker login ghcr.io` once to populate this file
       - ${HOME}/.docker/config.json:/config.json:ro
 
+    ports:
+      # Expose Watchtower HTTP API on host port 9091.
+      # Used by GitHub Actions to trigger an immediate update after a new image is pushed,
+      # instead of waiting for the next poll cycle.
+      # Requires WATCHTOWER_HTTP_API_UPDATE=true and a matching token (see below).
+      - '9091:8080'
+
     environment:
-      # Poll GHCR every 5 minutes for new images
-      - WATCHTOWER_POLL_INTERVAL=300
+      # Poll GHCR every 60 seconds for new images (reduced from 300s to shrink the
+      # worst-case activation window from 5 min to 1 min).
+      - WATCHTOWER_POLL_INTERVAL=60
 
       # Remove old images after pulling new ones
       - WATCHTOWER_CLEANUP=true
@@ -94,6 +102,17 @@ services:
 
       # Use the mounted Docker config for GHCR auth
       - DOCKER_CONFIG=/
+
+      # Enable HTTP API so GitHub Actions can trigger an immediate update.
+      # POST http://<host>:9091/v1/update  with  Authorization: Bearer <token>
+      - WATCHTOWER_HTTP_API_UPDATE=true
+
+      # Secret token for the HTTP API. Set WATCHTOWER_API_TOKEN in your shell or .env,
+      # or override here. Must match the WATCHTOWER_API_TOKEN repo secret in GitHub.
+      - WATCHTOWER_HTTP_API_TOKEN=${WATCHTOWER_API_TOKEN:-changeme}
+
+      # Continue polling even when the HTTP API is enabled (belt-and-suspenders).
+      - WATCHTOWER_HTTP_API_PERIODIC_POLLS=true
 
 volumes:
   automaker-dev-claude-config:


### PR DESCRIPTION
Ships agent output from feature ra8e74dcq that failed to auto-push because agent OAuth token lacks workflow scope for .github/workflows/** edits.

## Summary

Addresses the recurring 'fix lands but doesn't activate' issue — every PR merged to dev today had a 5-15min activation lag because the running container didn't restart.

See feature description for full context: fix-fixinfra-dev-container-auto-restart-on-new-image-8e74dcq branch commit.

## Post-merge

Per agent's summary: operator should add `WATCHTOWER_API_URL`, `WATCHTOWER_API_TOKEN`, `DISCORD_INFRA_WEBHOOK_URL` as GitHub repo secrets to activate the fast-path trigger. Also diagnose why Watchtower wasn't working — check `docker logs automaker-dev-watchtower` for auth errors (likely expired GHCR creds).

🤖 Mechanically shipped — agent SSH push blocked by workflow scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded dev-server docs with a new fast-path via Watchtower HTTP API, timing scenarios, troubleshooting, and setup guidance for immediate restarts.

* **Chores**
  * Reduced Watchtower polling from 5 minutes to 60 seconds for faster updates.
  * Added optional immediate update trigger after pushes and conditional infra notifications to Discord.
  * Enabled HTTP-update endpoint and periodic polling for faster, reliable restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->