### PR TITLE
[SMOKE-skills] Save-draft button fails silently in Firefox 130

### DIFF
--- a/apps/ui/src/components/shared/hitl-form/hitl-form-dialog.tsx
+++ b/apps/ui/src/components/shared/hitl-form/hitl-form-dialog.tsx
@@ -162,7 +162,10 @@ export function HITLFormDialog() {
   /** Close dialog without cancelling — form stays pending on server */
   const handleDefer = useCallback(() => {
     setAdditionalContext('');
-    deferForm();
+    const draftSaved = deferForm();
+    if (!draftSaved) {
+      toast.error('Draft could not be saved. Your progress may be lost.');
+    }
   }, [deferForm]);
 
   const handleOpenChange = useCallback(

--- a/apps/ui/src/store/hitl-form-store.ts
+++ b/apps/ui/src/store/hitl-form-store.ts
@@ -30,14 +30,14 @@ interface HITLFormActions {
   removePendingForm: (formId: string) => void;
   openForm: (form: HITLFormRequest) => void;
   closeDialog: () => void;
-  /** Close dialog without cancelling — form stays pending on server */
-  deferForm: () => void;
+  /** Close dialog without cancelling — form stays pending on server. Returns true if draft was saved. */
+  deferForm: () => boolean;
   nextStep: (data: Record<string, unknown>) => void;
   prevStep: () => void;
   setStepData: (stepIndex: number, data: Record<string, unknown>) => void;
   setSubmitting: (submitting: boolean) => void;
-  /** Save draft step data to localStorage for a form */
-  saveDraft: (formId: string, stepData: Record<string, unknown>[]) => void;
+  /** Save draft step data to localStorage for a form. Returns true if saved successfully. */
+  saveDraft: (formId: string, stepData: Record<string, unknown>[]) => boolean;
   /** Load draft step data from localStorage for a form */
   loadDraft: (formId: string) => Record<string, unknown>[] | null;
   /** Clear draft from localStorage */
@@ -94,9 +94,8 @@ export const useHITLFormStore = create<HITLFormState & HITLFormActions>((set, ge
 
   deferForm: () => {
     const { activeForm, stepData } = get();
-    if (activeForm) {
-      get().saveDraft(activeForm.id, stepData);
-    }
+    // When no active form, nothing to save — treat as success
+    const draftSaved = activeForm ? get().saveDraft(activeForm.id, stepData) : true;
     set({
       isDialogOpen: false,
       activeForm: null,
@@ -104,6 +103,7 @@ export const useHITLFormStore = create<HITLFormState & HITLFormActions>((set, ge
       stepData: [],
       isSubmitting: false,
     });
+    return draftSaved;
   },
 
   nextStep: (data) =>
@@ -133,8 +133,9 @@ export const useHITLFormStore = create<HITLFormState & HITLFormActions>((set, ge
   saveDraft: (formId, stepData) => {
     try {
       localStorage.setItem(`${DRAFT_STORAGE_PREFIX}${formId}`, JSON.stringify(stepData));
+      return true;
     } catch {
-      // localStorage full or unavailable — silently ignore
+      return false;
     }
   },
 


### PR DESCRIPTION
## Summary

**Reported behavior:** The save-draft button sometimes fails silently in Firefox 130. No console error is produced, making this difficult to diagnose from the user's perspective.

**Environment:** Firefox 130
**Reproducibility:** Intermittent ("sometimes")
**Console output:** None -- fails silently

**Triage notes:**
- No existing bug patterns match this issue in the QA knowledge base.
- No blocked features currently on the board related to save-draft.
- Silent failure with no console error sugg...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-16T00:14:24.104Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Draft save failures now display error notifications to alert users, preventing silent loss of form progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->