### PR TITLE
Board flow: stale in_progress features with failureCount > 0 not escalated until 4h threshold

### DIFF
--- a/apps/server/src/services/lead-engineer-rules.ts
+++ b/apps/server/src/services/lead-engineer-rules.ts
@@ -14,10 +14,13 @@ import type {
 
 // ────────────────────────── Thresholds ──────────────────────────
 
-const ORPHANED_IN_PROGRESS_MS = 4 * 60 * 60 * 1000; // 4 hours
+const ORPHANED_IN_PROGRESS_MS = 4 * 60 * 60 * 1000; // 4 hours (backstop)
 const STUCK_AGENT_MS = 2 * 60 * 60 * 1000; // 2 hours
 const STALE_REVIEW_MS = 30 * 60 * 1000; // 30 minutes
 const REMEDIATION_STALL_MS = 60 * 60 * 1000; // 1 hour
+// Escalation thresholds for stale in_progress detection (faster than the 4h backstop)
+const FAILURE_STALE_MS = 30 * 60 * 1000; // 30 min: trigger when failureCount > 0 + no agent
+const UNPUSHED_BRANCH_STALE_MS = 45 * 60 * 1000; // 45 min: trigger when worktree created but branch never pushed
 
 // ────────────────────────── Helper ──────────────────────────
 
@@ -78,12 +81,55 @@ export const orphanedInProgress: LeadFastPathRule = {
       if (!f.startedAt) continue;
 
       const age = now - new Date(f.startedAt).getTime();
+      const failureCount = f.failureCount ?? 0;
+
+      // Trigger 2: failureCount >= 2 with no running agent → block immediately
+      // A feature that has already failed twice will not self-recover; escalate now.
+      if (failureCount >= 2) {
+        actions.push({
+          type: 'move_feature',
+          featureId: f.id,
+          toStatus: 'blocked',
+        });
+        actions.push({
+          type: 'log',
+          level: 'warn',
+          message: `orphanedInProgress: ${f.id} blocked immediately — orphaned with failureCount=${failureCount}`,
+        });
+        continue;
+      }
+
+      // Trigger 1: failureCount > 0 + no running agent + elapsed >= 30 min → reset
+      // Prior failure means the agent is unlikely to recover on its own; detect quickly.
+      if (failureCount > 0 && age >= FAILURE_STALE_MS) {
+        const elapsedMin = Math.round(age / 60_000);
+        actions.push({
+          type: 'reset_feature',
+          featureId: f.id,
+          reason: `Orphaned in-progress with ${failureCount} prior failure(s) for ${elapsedMin} min`,
+        });
+        continue;
+      }
+
+      // Trigger 3: worktree created (branchName set) but no PR yet + elapsed >= 45 min → reset
+      // Branch was never pushed to remote; the agent crashed before completing git workflow.
+      if (f.branchName && !f.prNumber && age >= UNPUSHED_BRANCH_STALE_MS) {
+        const elapsedMin = Math.round(age / 60_000);
+        actions.push({
+          type: 'reset_feature',
+          featureId: f.id,
+          reason: `Orphaned in-progress for ${elapsedMin} min — worktree created but branch never pushed`,
+        });
+        continue;
+      }
+
+      // Backstop: elapsed > 4h with no running agent → reset (or block if repeat failures)
       if (age > ORPHANED_IN_PROGRESS_MS) {
         const hours = Math.round(age / (60 * 60 * 1000));
 
         // Features with repeated failures get blocked instead of reset
         // to prevent infinite retry loops
-        if (f.failureCount && f.failureCount >= 3) {
+        if (failureCount >= 3) {
           actions.push({
             type: 'move_feature',
             featureId: f.id,
@@ -92,7 +138,7 @@ export const orphanedInProgress: LeadFastPathRule = {
           actions.push({
             type: 'log',
             level: 'warn',
-            message: `orphanedInProgress: ${f.id} blocked after ${f.failureCount} failures (orphaned ${hours}h)`,
+            message: `orphanedInProgress: ${f.id} blocked after ${failureCount} failures (orphaned ${hours}h)`,
           });
         } else {
           actions.push({

--- a/apps/server/tests/unit/services/lead-engineer-rules.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-rules.test.ts
@@ -112,11 +112,143 @@ describe('orphanedInProgress', () => {
     expect(actions).toHaveLength(0);
   });
 
-  it('no-ops when in-progress less than 4h', () => {
-    const oneHourAgo = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
-    const feature = createFeature({ id: 'f1', status: 'in_progress', startedAt: oneHourAgo });
+  it('no-ops when in-progress less than 45 min with no failures and no branch', () => {
+    const thirtyMinAgo = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    const feature = createFeature({ id: 'f1', status: 'in_progress', startedAt: thirtyMinAgo });
     const ws = createMockWorldState({ features: { f1: feature } });
     const actions = orphanedInProgress.evaluate(ws, 'feature:stopped', { featureId: 'f1' });
+    expect(actions).toHaveLength(0);
+  });
+
+  // ── Trigger 1: failureCount > 0 + no agent + >= 30 min ──
+
+  it('trigger 1: resets feature in-progress >= 30 min with failureCount 1 and no agent', () => {
+    const thirtyFiveMinAgo = new Date(Date.now() - 35 * 60 * 1000).toISOString();
+    const feature = createFeature({
+      id: 'f1',
+      status: 'in_progress',
+      startedAt: thirtyFiveMinAgo,
+      failureCount: 1,
+    });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = orphanedInProgress.evaluate(ws, 'feature:stopped', { featureId: 'f1' });
+    expect(actions).toHaveLength(1);
+    expect(actions[0].type).toBe('reset_feature');
+  });
+
+  it('trigger 1: no-ops when failureCount > 0 but elapsed < 30 min', () => {
+    const twentyMinAgo = new Date(Date.now() - 20 * 60 * 1000).toISOString();
+    const feature = createFeature({
+      id: 'f1',
+      status: 'in_progress',
+      startedAt: twentyMinAgo,
+      failureCount: 1,
+    });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = orphanedInProgress.evaluate(ws, 'feature:stopped', { featureId: 'f1' });
+    expect(actions).toHaveLength(0);
+  });
+
+  // ── Trigger 2: failureCount >= 2 → block immediately ──
+
+  it('trigger 2: blocks feature immediately when failureCount >= 2 and no agent', () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    const feature = createFeature({
+      id: 'f1',
+      status: 'in_progress',
+      startedAt: fiveMinAgo,
+      failureCount: 2,
+    });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = orphanedInProgress.evaluate(ws, 'feature:stopped', { featureId: 'f1' });
+    const moveAction = actions.find((a) => a.type === 'move_feature');
+    expect(moveAction).toBeDefined();
+    expect((moveAction as { type: string; toStatus: string }).toStatus).toBe('blocked');
+  });
+
+  it('trigger 2: blocks immediately with failureCount 3 even under 4h', () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const feature = createFeature({
+      id: 'f1',
+      status: 'in_progress',
+      startedAt: oneHourAgo,
+      failureCount: 3,
+    });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = orphanedInProgress.evaluate(ws, 'feature:stopped', { featureId: 'f1' });
+    const moveAction = actions.find((a) => a.type === 'move_feature');
+    expect(moveAction).toBeDefined();
+    expect((moveAction as { type: string; toStatus: string }).toStatus).toBe('blocked');
+  });
+
+  it('trigger 2: no-ops when failureCount >= 2 but agent is still running', () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    const feature = createFeature({
+      id: 'f1',
+      status: 'in_progress',
+      startedAt: fiveMinAgo,
+      failureCount: 2,
+    });
+    const agent: LeadAgentSnapshot = { featureId: 'f1', startTime: fiveMinAgo };
+    const ws = createMockWorldState({ features: { f1: feature }, agents: [agent] });
+    const actions = orphanedInProgress.evaluate(ws, 'feature:stopped', { featureId: 'f1' });
+    expect(actions).toHaveLength(0);
+  });
+
+  // ── Trigger 3: branchName set + no PR + >= 45 min ──
+
+  it('trigger 3: resets feature when worktree created but branch never pushed >= 45 min', () => {
+    const fiftyMinAgo = new Date(Date.now() - 50 * 60 * 1000).toISOString();
+    const feature = createFeature({
+      id: 'f1',
+      status: 'in_progress',
+      startedAt: fiftyMinAgo,
+      branchName: 'fix/some-bug',
+    });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = orphanedInProgress.evaluate(ws, 'feature:stopped', { featureId: 'f1' });
+    expect(actions).toHaveLength(1);
+    expect(actions[0].type).toBe('reset_feature');
+  });
+
+  it('trigger 3: no-ops when branchName set but elapsed < 45 min', () => {
+    const thirtyMinAgo = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    const feature = createFeature({
+      id: 'f1',
+      status: 'in_progress',
+      startedAt: thirtyMinAgo,
+      branchName: 'fix/some-bug',
+    });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = orphanedInProgress.evaluate(ws, 'feature:stopped', { featureId: 'f1' });
+    expect(actions).toHaveLength(0);
+  });
+
+  it('trigger 3: no-ops when branchName not set (worktree not yet created)', () => {
+    const sixtyMinAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const feature = createFeature({
+      id: 'f1',
+      status: 'in_progress',
+      startedAt: sixtyMinAgo,
+    });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = orphanedInProgress.evaluate(ws, 'feature:stopped', { featureId: 'f1' });
+    // Falls through to 4h backstop — 1h is not enough
+    expect(actions).toHaveLength(0);
+  });
+
+  it('trigger 3: no-ops when branch has been pushed (prNumber set)', () => {
+    const sixtyMinAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const feature = createFeature({
+      id: 'f1',
+      status: 'in_progress',
+      startedAt: sixtyMinAgo,
+      branchName: 'fix/some-bug',
+      prNumber: 42,
+    });
+    const ws = createMockWorldState({ features: { f1: feature } });
+    const actions = orphanedInProgress.evaluate(ws, 'feature:stopped', { featureId: 'f1' });
+    // prNumber set means branch was pushed; trigger 3 does not apply
     expect(actions).toHaveLength(0);
   });
 


### PR DESCRIPTION
## Summary

The board's stale-detection logic only fires at a 4-hour blanket threshold. When a feature has failureCount > 0 and no running agent, no branch push, and no PR activity, 4h is far too forgiving — the feature appears 'in progress' but will never complete.

Concrete incident: feature-1776392157265-yhc1c1gri (ava board, rabbit-hole.io A2A spec fix). Agent stopped at 02:17, failureCount: 1, branch never pushed. Discovered manually at 03:13 (~56 min later). Without manual intervention, would have sat...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of stuck features with multiple failures—features are now blocked more quickly.
  * Faster recovery from temporary failures with optimized timeout thresholds.
  * Better handling of unpushed branch scenarios.

* **Tests**
  * Expanded test coverage for failure and escalation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->