### PR TITLE
chore(projects): register protoAgent in projects.yaml

### DIFF
--- a/workspace/projects.yaml
+++ b/workspace/projects.yaml
@@ -274,3 +274,31 @@ projects:
       priorityWeight: 1.0
       minConcurrency: 1
       maxConcurrency: 3
+
+  - slug: protolabsai-protoAgent
+    title: protoAgent
+    team: dev
+    github: protoLabsAI/protoAgent
+    defaultBranch: main
+    status: active
+    onboardedAt: '2026-04-17T20:15:40.845Z'
+    planeProjectId: ''
+    planeIdentifier: ''
+    projectPath: /home/josh/dev/labs/protoAgent
+    agents: [ava, quinn]
+    discord:
+      dev: ''
+      release: ''
+    webhooks:
+      release: ''
+    infisical:
+      projectId: ''
+    observability:
+      langfuseProjectId: ''
+    googleWorkspace:
+      driveFolderId: ''
+      sharedDocId: ''
+    capacity:
+      priorityWeight: 1.0
+      minConcurrency: 1
+      maxConcurrency: 3


### PR DESCRIPTION
## Summary

- Mirrors the entry added upstream in [protoLabsAI/protoWorkstacean#414](https://github.com/protoLabsAI/protoWorkstacean/pull/414)
- protoAgent is the new GitHub Template that replaces per-agent A2A bootstrapping
- Local clone at \`/home/josh/dev/labs/protoAgent\`

## Why now

This file's header notes it'll eventually be read from the Workstacean API directly, but for now it's still the manual-sync mirror. Keeping the two in sync so Ava/the dev server can route agent traffic to the new project without a restart.

## What's empty

\`planeProjectId\`, \`planeIdentifier\`, all Discord IDs/webhooks, and \`infisical.projectId\` stay as empty placeholders — the Workstacean onboard pipeline skipped those steps because the related integrations aren't configured in this deployment. They can be populated on a follow-up when Ava's \`provision_discord\` / Plane setup runs.

## Test plan

- [x] YAML parses cleanly (matches the shape of all other entries)
- [ ] Confirm dev server hot-reloads the new entry without restart
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Registered new project configuration for protoAgent with assigned agents and workspace capacity settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->