### PR TITLE
Register rabbit-hole researcher as A2A fleet agent

### DIFF
--- a/agents.yaml
+++ b/agents.yaml
@@ -48,3 +48,42 @@ agents:
         triggers:
           - type: a2a_message
             action: provision_discord
+
+  researcher:
+    description: >
+      Deep research agent backed by rabbit-hole.io. Provides web search,
+      knowledge graph queries, URL ingestion, and multi-source deep research
+      with entity extraction and relationship mapping.
+    url: http://rabbit-hole-agent:7870/a2a
+    apiKeyEnv: RESEARCHER_API_KEY
+    skills:
+      - name: search
+        description: >
+          Quick hybrid search across web (SearXNG), knowledge graph (Neo4j),
+          and Wikipedia. Returns a consolidated markdown summary with source attribution.
+        triggers:
+          - type: a2a_message
+            action: search
+      - name: deep_research
+        description: >
+          Multi-source deep research with entity extraction, relationship mapping,
+          iterative gap-filling, and structured output. Runs the full rabbit-hole.io
+          research pipeline (scope -> plan -> research -> evaluate -> synthesis).
+        triggers:
+          - type: a2a_message
+            action: deep_research
+      - name: ingest_url
+        description: >
+          Fetch a URL (HTML page, PDF, audio, video, YouTube) and extract entities
+          into the knowledge graph via the rabbit-hole media processing pipeline.
+        triggers:
+          - type: a2a_message
+            action: ingest_url
+      - name: kg_facts
+        description: >
+          Query the rabbit-hole knowledge graph for entities and relationships.
+          Returns entity details, relationship counts, and connected entities.
+          Use to retrieve structured knowledge without triggering new research.
+        triggers:
+          - type: a2a_message
+            action: kg_facts


### PR DESCRIPTION
## Summary

rabbit-hole.io has a fully-wired A2A agent on port 7870 with 4 skills: search, deep_research, ingest_url, kg_facts. Phase 2 adds Graphiti episode tracking with a 7-day freshness gate. PRs #255 and #256 are merged into dev in rabbit-hole.io.

Work required across two repos:

protoWorkstacean:
- Add researcher entry to workspace/agents.yaml (url: http://rabbit-hole-agent:7870/a2a, apiKeyEnv: RESEARCHER_API_KEY, skills: search, deep_research, ingest_url, kg_facts)
- Add RESEARCHER_API_KEY to .env (...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-19T16:13:49.822Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- A new researcher agent has been successfully integrated, providing an expanded range of research-oriented capabilities and skills
- Supported operations include semantic search for discovering information, advanced in-depth research analysis, URL content ingestion for building knowledge repositories, and knowledge graph fact retrieval for accessing structured information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->