### PR TITLE
feat(features): add reconcile_feature_with_pr MCP tool for out-of-band PR recovery

### DIFF
--- a/apps/server/src/routes/features/index.ts
+++ b/apps/server/src/routes/features/index.ts
@@ -27,6 +27,10 @@ import {
   createFlagExternalDepHandler,
   createResolveExternalDepHandler,
 } from './routes/external-deps.js';
+import {
+  createReconcileWithPrHandler,
+  ReconcileWithPrRequestSchema,
+} from './routes/reconcile-with-pr.js';
 import type { FeatureHealthService } from '../../services/feature-health-service.js';
 import type { TrustTierService } from '../../services/trust-tier-service.js';
 import type { PipelineCheckpointService } from '../../services/pipeline-checkpoint-service.js';
@@ -119,6 +123,14 @@ export function createFeaturesRoutes(
   // Cross-repo dependency management
   router.post('/external-deps/flag', createFlagExternalDepHandler(featureLoader));
   router.post('/external-deps/resolve', createResolveExternalDepHandler(featureLoader));
+
+  // Manual PR reconciliation — link a feature to an out-of-band merged PR
+  router.post(
+    '/reconcile-with-pr',
+    validatePathParams('projectPath'),
+    validateBody(ReconcileWithPrRequestSchema),
+    createReconcileWithPrHandler(featureLoader)
+  );
 
   return router;
 }

--- a/apps/server/src/routes/features/routes/reconcile-with-pr.ts
+++ b/apps/server/src/routes/features/routes/reconcile-with-pr.ts
@@ -1,0 +1,128 @@
+/**
+ * POST /features/reconcile-with-pr
+ *
+ * Manual reconciliation: link a feature to a specific PR and mark it done.
+ * Used when a feature shipped via an out-of-band PR (cherry-pick, re-cut branch,
+ * manual fix) that was never linked to the feature's prNumber/branchName fields.
+ *
+ * Verifies that the PR is actually merged before marking the feature done.
+ */
+
+import type { Request, Response } from 'express';
+import { z } from 'zod';
+import { promisify } from 'util';
+import { exec } from 'child_process';
+import { createLogger } from '@protolabsai/utils';
+import type { Feature } from '@protolabsai/types';
+import type { FeatureLoader } from '../../../services/feature-loader.js';
+import { getErrorMessage } from '../common.js';
+
+const execAsync = promisify(exec);
+const logger = createLogger('features/reconcile-with-pr');
+
+export const ReconcileWithPrRequestSchema = z.object({
+  projectPath: z.string().min(1, 'projectPath is required'),
+  featureId: z.string().min(1, 'featureId is required'),
+  prNumber: z.number().int().positive('prNumber must be a positive integer'),
+});
+
+export function createReconcileWithPrHandler(featureLoader: FeatureLoader) {
+  return async (req: Request, res: Response): Promise<void> => {
+    const parsed = ReconcileWithPrRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({
+        success: false,
+        error: 'Validation failed',
+        details: parsed.error.issues,
+      });
+      return;
+    }
+
+    const { projectPath, featureId, prNumber } = parsed.data;
+
+    try {
+      // Verify the feature exists
+      const feature = await featureLoader.get(projectPath, featureId);
+      if (!feature) {
+        res.status(404).json({
+          success: false,
+          error: `Feature ${featureId} not found in project ${projectPath}`,
+        });
+        return;
+      }
+
+      // Verify the PR is merged via gh
+      let prState: string;
+      let prMergedAt: string | undefined;
+      let prTitle: string | undefined;
+      let prHeadRef: string | undefined;
+
+      try {
+        const { stdout } = await execAsync(
+          `gh pr view ${prNumber} --json state,mergedAt,title,headRefName`,
+          { cwd: projectPath, timeout: 15000 }
+        );
+        const prData: {
+          state: string;
+          mergedAt?: string;
+          title?: string;
+          headRefName?: string;
+        } = JSON.parse(stdout);
+        prState = prData.state;
+        prMergedAt = prData.mergedAt;
+        prTitle = prData.title;
+        prHeadRef = prData.headRefName;
+      } catch (err) {
+        res.status(422).json({
+          success: false,
+          error: `Could not fetch PR #${prNumber} — is GITHUB_TOKEN set and does the PR exist? (${getErrorMessage(err)})`,
+        });
+        return;
+      }
+
+      if (prState !== 'MERGED') {
+        res.status(422).json({
+          success: false,
+          error: `PR #${prNumber} is not merged (current state: ${prState}). Only merged PRs can reconcile a feature to done.`,
+          prState,
+        });
+        return;
+      }
+
+      const mergedAt = prMergedAt ?? new Date().toISOString();
+      const reason = `Manually reconciled with merged PR #${prNumber}${prTitle ? ` — "${prTitle}"` : ''}`;
+
+      const updates: Partial<Feature> = {
+        status: 'done',
+        prNumber,
+        prMergedAt: mergedAt,
+        statusChangeReason: reason,
+      };
+
+      // If feature had no branch set and the PR has a head ref, backfill it
+      if (!feature.branchName && prHeadRef) {
+        updates.branchName = prHeadRef;
+      }
+
+      const updated = await featureLoader.update(projectPath, featureId, updates);
+
+      logger.info(
+        `[reconcile-with-pr] Feature ${featureId} ("${feature.title}") reconciled to done via PR #${prNumber} ("${prTitle}")`
+      );
+
+      res.json({
+        success: true,
+        feature: updated,
+        reconciled: {
+          prNumber,
+          prTitle,
+          prMergedAt: mergedAt,
+          previousStatus: feature.status,
+        },
+      });
+    } catch (error) {
+      logger.error('reconcile-with-pr failed:', error);
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -307,6 +307,13 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         featureId: args.featureId,
       });
 
+    case 'reconcile_feature_with_pr':
+      return apiCall('/features/reconcile-with-pr', {
+        projectPath: args.projectPath,
+        featureId: args.featureId,
+        prNumber: args.prNumber,
+      });
+
     case 'update_feature_git_settings': {
       const gitWorkflow: Record<string, unknown> = {};
       if (args.autoCommit !== undefined) gitWorkflow.autoCommit = args.autoCommit;

--- a/packages/mcp-server/src/tools/feature-tools.ts
+++ b/packages/mcp-server/src/tools/feature-tools.ts
@@ -8,6 +8,7 @@
  * - update_feature: Update feature properties (including status changes)
  * - delete_feature: Delete feature
  * - update_feature_git_settings: Update git workflow settings
+ * - reconcile_feature_with_pr: Manually link a feature to an out-of-band merged PR
  */
 
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
@@ -332,6 +333,29 @@ export const featureTools: Tool[] = [
         },
       },
       required: ['projectPath'],
+    },
+  },
+  {
+    name: 'reconcile_feature_with_pr',
+    description:
+      'Manually reconcile a feature with a merged GitHub PR. Use this when a feature shipped via an out-of-band PR (cherry-pick, re-cut branch, manual fix) that was never automatically linked to the feature. Verifies the PR is actually merged before marking the feature done. Sets prNumber, prMergedAt, and statusChangeReason on the feature.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        featureId: {
+          type: 'string',
+          description: 'The feature ID to reconcile',
+        },
+        prNumber: {
+          type: 'number',
+          description: 'The GitHub PR number that contains the merged work for this feature',
+        },
+      },
+      required: ['projectPath', 'featureId', 'prNumber'],
     },
   },
 ];


### PR DESCRIPTION
## Summary

Adds a manual reconciliation tool for the case where the agent never set `prNumber` on a feature, but a PR for that work eventually merges via an out-of-band path. Implements feature `b4pmw00hh`.

### What it does
- New route `POST /api/features/reconcile-with-pr` — verifies the PR is merged via `gh pr view`, then sets `status: done`, `prNumber`, `prMergedAt`, descriptive `statusChangeReason`. Backfills `branchName` from PR head ref if missing.
- New MCP tool `reconcile_feature_with_pr(projectPath, featureId, prNumber)` — operator escape hatch.

### Files
- apps/server/src/routes/features/routes/reconcile-with-pr.ts (new, 128 lines)
- apps/server/src/routes/features/index.ts (register route)
- packages/mcp-server/src/tools/feature-tools.ts
- packages/mcp-server/src/index.ts

## Test plan
- [ ] CI build passes (agent's sandbox hit ENOSPC, build skipped locally)
- [ ] After merge: invoke reconcile_feature_with_pr for feature-1776496574377-y2yyx9z33 / PR 3472, verify it transitions to done

## Notes
This PR was rescued — feature finished, went to review, then auto-decayed back to backlog because the review lane was saturated. PR was never opened by the agent. Branch name `fix/the-user-wants-…` is a separate prompt-injection bug (tracked in feature \`4buhlnzsp\`). Decay-loses-work is a separate P0 (\`aikev23t9\`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now reconcile features with merged GitHub PRs. The system validates that the PR is merged and automatically updates the feature status to done, capturing PR metadata including merge date and title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->