### PR TITLE
Cross-repo monitoring features clog the review lane — no terminal state without a local PR

### DIFF
--- a/apps/server/src/services/workflow-loader.ts
+++ b/apps/server/src/services/workflow-loader.ts
@@ -310,6 +310,45 @@ const SWEBENCH_WORKFLOW: WorkflowDefinition = {
   },
 };
 
+// ─── Signal Workflow ──────────────────────────────────────────────────────────
+//
+// Cross-repo triage signals: informational features that describe problems in
+// external repos (e.g. "CI failing on rabbit-hole.io main branch"). These are
+// NOT code work units — they produce no local commits, branches, or PRs.
+//
+// Lifecycle: backlog → execute (agent investigates / documents) → done
+// Use featureType: 'signal' to assign this workflow automatically.
+
+const SIGNAL_WORKFLOW: WorkflowDefinition = {
+  name: 'signal',
+  description:
+    'Cross-repo triage signal — read-only investigation of an external repo issue, auto-resolves to done without a PR',
+  phases: [
+    { state: 'INTAKE', enabled: true },
+    { state: 'PLAN', enabled: false },
+    { state: 'EXECUTE', enabled: true },
+    { state: 'REVIEW', enabled: false },
+    { state: 'MERGE', enabled: false },
+    { state: 'DEPLOY', enabled: false },
+  ],
+  agent: {
+    model: 'sonnet',
+  },
+  execution: {
+    useWorktrees: false,
+    gitWorkflow: {
+      autoCommit: false,
+      autoPush: false,
+      autoCreatePR: false,
+    },
+    terminalStatus: 'done',
+  },
+  match: {
+    categories: ['signal', 'triage', 'cross-repo'],
+    keywords: ['signal', 'triage', 'cross-repo', 'external-repo', 'monitoring'],
+  },
+};
+
 /** All built-in workflows, keyed by name */
 const BUILT_IN_WORKFLOWS = new Map<string, WorkflowDefinition>([
   // Core pipelines
@@ -328,6 +367,8 @@ const BUILT_IN_WORKFLOWS = new Map<string, WorkflowDefinition>([
   ['strategic-review', STRATEGIC_REVIEW_WORKFLOW],
   // Benchmark
   ['swebench', SWEBENCH_WORKFLOW],
+  // Signals
+  ['signal', SIGNAL_WORKFLOW],
 ]);
 
 // ─── Service ──────────────────────────────────────────────────────────────
@@ -359,7 +400,7 @@ export class WorkflowLoader {
    *
    * Priority:
    *   1. feature.workflow (explicit assignment)
-   *   2. feature.featureType mapping ('content' → content workflow)
+   *   2. feature.featureType mapping ('content' → content, 'signal' → signal workflow)
    *   3. feature.executionMode mapping ('read-only' → read-only workflow)
    *   4. Default: 'standard'
    */
@@ -373,9 +414,14 @@ export class WorkflowLoader {
       );
     }
 
-    // Legacy featureType mapping
+    // featureType mapping
     if (feature.featureType === 'content') {
       const workflow = await this.resolve(projectPath, 'content');
+      if (workflow) return workflow;
+    }
+
+    if (feature.featureType === 'signal') {
+      const workflow = await this.resolve(projectPath, 'signal');
       if (workflow) return workflow;
     }
 

--- a/docs/internal/server/maintenance-checks.md
+++ b/docs/internal/server/maintenance-checks.md
@@ -5,6 +5,7 @@
 When a health-check ceremony creates features that describe problems in **external repos** (e.g. "CI failing on rabbit-hole.io main branch", "PR #72 in protoCLI has no reviewer"), those features must be filed as **signal** features, not `code` features.
 
 Signal features:
+
 - Do not create local branches, worktrees, or PRs.
 - Route to the `signal` workflow automatically via `featureType: 'signal'`.
 - Run a read-only investigation agent and auto-resolve to `done` when execution completes.
@@ -32,12 +33,10 @@ mcp__protolabs__update_feature({
   projectPath: '/path/to/project',
   featureId: 'feature-...',
   featureType: 'signal',
-  status: 'done',  // If the external issue is already resolved
+  status: 'done', // If the external issue is already resolved
   // OR: status: 'backlog' to re-run the investigation agent
 });
 ```
-
-
 
 This page shows you how to add a new maintenance check module to the MaintenanceOrchestrator. After reading it, you will know how to implement the check interface, register it, and assign it to the correct tier.
 

--- a/docs/internal/server/maintenance-checks.md
+++ b/docs/internal/server/maintenance-checks.md
@@ -1,5 +1,44 @@
 # Create a New Maintenance Check
 
+## Cross-Repo Triage Signals
+
+When a health-check ceremony creates features that describe problems in **external repos** (e.g. "CI failing on rabbit-hole.io main branch", "PR #72 in protoCLI has no reviewer"), those features must be filed as **signal** features, not `code` features.
+
+Signal features:
+- Do not create local branches, worktrees, or PRs.
+- Route to the `signal` workflow automatically via `featureType: 'signal'`.
+- Run a read-only investigation agent and auto-resolve to `done` when execution completes.
+- Never enter the PR-gated review cycle, so they cannot get stuck in `review` indefinitely.
+
+**How to create a signal feature via MCP:**
+
+```typescript
+mcp__protolabs__create_feature({
+  projectPath: '/path/to/project',
+  title: 'Signal: rabbit-hole.io CI failing on main',
+  description: 'CI checks on rabbit-hole.io main are red. Investigate and document root cause.',
+  category: 'signal',
+  featureType: 'signal',
+  // No branchName, no prNumber — signal workflow handles git-free execution
+});
+```
+
+**Why this matters:** Mixing signal features with code features inflates the review queue and makes board metrics misleading. Signal features that land in `review` with no `prNumber` will never transition to `done` automatically — the review→done gate requires a merged PR.
+
+**Immediate recovery for stuck signal features:** If you find existing features stuck in `review` with no `prNumber` that describe external-repo issues, update them in place:
+
+```typescript
+mcp__protolabs__update_feature({
+  projectPath: '/path/to/project',
+  featureId: 'feature-...',
+  featureType: 'signal',
+  status: 'done',  // If the external issue is already resolved
+  // OR: status: 'backlog' to re-run the investigation agent
+});
+```
+
+
+
 This page shows you how to add a new maintenance check module to the MaintenanceOrchestrator. After reading it, you will know how to implement the check interface, register it, and assign it to the correct tier.
 
 ## Prerequisites

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -592,10 +592,15 @@ export interface Feature {
 
   // GTM Content Track fields
   /**
-   * Type of feature: 'code' for engineering work, 'content' for GTM/marketing content.
-   * Defaults to 'code' for all existing features.
+   * Type of feature:
+   * - 'code': Engineering work — standard or read-only pipeline (default)
+   * - 'content': GTM/marketing content — content workflow, no git ops
+   * - 'signal': Cross-repo triage signal — no git ops, no worktrees, auto-resolves to done.
+   *   Use for health-check features that describe problems in external repos (e.g.
+   *   "rabbit-hole.io CI is failing"). These are informational signals, not code work units.
+   *   They do not create local PRs and must not enter the PR-gated review cycle.
    */
-  featureType?: 'code' | 'content';
+  featureType?: 'code' | 'content' | 'signal';
   /**
    * Execution mode for this feature.
    * - 'standard' (default): Full pipeline — worktree, branch, commit, push, PR.


### PR DESCRIPTION
## Summary

**Observed:** Three features currently in `review` describe problems in *other* repos (rabbit-hole.io, protoCLI, protoWorkstacean):
- `feature-1776556926949-ayqzv6tsf` — rabbit-hole.io: CI failing on main branch
- `feature-1776556938569-sfq37f8o6` — protoCLI PR #72: no CI, no reviewer
- `feature-1776556938573-3cqee3wni` — protoWorkstacean: 12-commit dev→main drift

None has a `prNumber` (no local PR exists — the work happens in other repos). The standard review→done transition is gated on PR mer...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-19T17:51:21.624Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "signal" feature type for automated cross-repo triage signals
  * Signal features run read-only (no local branches/PRs) and auto-resolve to done

* **Documentation**
  * Added guidance for creating and managing signal features in maintenance docs, including examples for creation and state transitions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->