### PR TITLE
P0: Review-lane decay back to backlog discards verified work — never opens the PR

### DIFF
--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -1941,6 +1941,14 @@ export class FeatureScheduler {
         const elapsedMs = Date.now() - reviewStartMs;
         if (elapsedMs < timeoutMs) continue;
 
+        // Never decay a feature whose last execution succeeded.
+        // A successful execution means the code is committed and the branch is pushed —
+        // the only remaining step is PR creation. Decaying such a feature to backlog
+        // causes silent data loss: the pushed branch becomes invisible, the next dispatch
+        // re-does the work on a new branch, and the first commit is abandoned.
+        const lastExecution = (feature.executionHistory ?? []).slice(-1)[0];
+        if (lastExecution?.success === true) continue;
+
         // Check for failing CI indicators:
         // - ciRemediationCount > 0 indicates CI failures have been detected
         // - remediationHistory with ci_failure entries

--- a/apps/server/src/services/lead-engineer-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-execute-processor.ts
@@ -1013,7 +1013,13 @@ export class ExecuteProcessor implements StateProcessor {
     // ── (a) Review queue depth ────────────────────────────────────────────────
     try {
       const allFeatures = await this.serviceContext.featureLoader.getAll(projectPath);
-      const reviewDepth = allFeatures.filter((f) => f.status === 'review').length;
+      // Only count features with an actual PR — features in 'review' without a prNumber
+      // completed execution but haven't materialized a PR yet. They should not consume a
+      // review slot: counting them causes the gate to block their own PR-creation retry,
+      // resulting in silent data loss (branch pushed, work done, feature decayed to backlog).
+      const reviewDepth = allFeatures.filter(
+        (f) => f.status === 'review' && f.prNumber != null
+      ).length;
       if (reviewDepth >= maxPendingReviews) {
         return {
           passed: false,


### PR DESCRIPTION
## Summary

**Severity: P0 — silent data loss.**

**Observed:** Feature `feature-1776614270410-b4pmw00hh` ("add reconcile_feature_with_pr MCP tool") was picked up by an agent at 16:26, completed work successfully (1 commit, 4 files, +171 lines, pushed to origin as branch `fix/the-user-wants-…-pmw00hh`), transitioned to `review` at 16:35 with a clean `summary` payload — then at 16:56 was decayed back to `backlog` with `statusChangeReason: "Execution gate: review queue saturated (5/5 features in review)"`.

*...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-19T18:34:07.979Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stalled feature decay logic to prevent successful reviews from being unnecessarily reset to backlog.
  * Improved review queue depth calculation to accurately count only features with active pull requests, ensuring more reliable queue saturation signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->