### PR TITLE
Branch name generated from prompt content — agent's instructions leak into git history

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -358,6 +358,38 @@ export class FeatureLoader implements FeatureStore {
   }
 
   /**
+   * Detect LLM prompt-completion artifacts in a candidate branch name.
+   *
+   * When a Haiku-tier agent is asked to generate a branch name, it sometimes
+   * completes its own internal reasoning ("the user wants me to generate a git
+   * branch name based on: ...") rather than emitting the computed slug. These
+   * strings pass isValidBranchName (they are syntactically valid git refs) but
+   * are not legitimate branch names.
+   *
+   * Returns true when the slug portion of the branch looks like an LLM artifact
+   * so the caller can fall back to deterministic generation from the title.
+   */
+  isLlmArtifactBranchName(name: string): boolean {
+    // Extract the slug portion (everything after the first /)
+    const slashIdx = name.indexOf('/');
+    const slug = slashIdx >= 0 ? name.slice(slashIdx + 1) : name;
+
+    // LLM artifact phrases that appear when the model completes its own prompt
+    const artifactPhrases = [
+      'the-user-wants',
+      'i-will-generate',
+      'based-on-the',
+      'generate-a-git',
+      'generate-a-branch',
+      'git-branch-name',
+      'branch-name-based',
+    ];
+
+    const lower = slug.toLowerCase();
+    return artifactPhrases.some((phrase) => lower.includes(phrase));
+  }
+
+  /**
    * Derive the git branch prefix from a feature category.
    * Maps semantic categories to conventional-commit-style prefixes.
    */
@@ -791,10 +823,15 @@ export class FeatureLoader implements FeatureStore {
     // If a branchName is provided by the caller, validate it before use — special characters
     // like `[`, `]`, `(`, `)`, `:` are illegal in git refs and cause worktree creation to fail.
     // Invalid branch names are discarded and regenerated from the title via generateBranchName.
+    // LLM artifact branch names (e.g. "fix/the-user-wants-me-to-generate-a-git-branch-name-...")
+    // are also discarded — they pass syntactic validation but are the agent completing its own
+    // reasoning prompt rather than emitting a real slug.
     const branchName =
       featureData.executionMode === 'read-only'
         ? undefined
-        : ((featureData.branchName && isValidBranchName(featureData.branchName)
+        : ((featureData.branchName &&
+              isValidBranchName(featureData.branchName) &&
+              !this.isLlmArtifactBranchName(featureData.branchName)
             ? featureData.branchName
             : null) ?? this.generateBranchName(featureData.title, featureId, featureData.category));
 

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -830,8 +830,8 @@ export class FeatureLoader implements FeatureStore {
       featureData.executionMode === 'read-only'
         ? undefined
         : ((featureData.branchName &&
-              isValidBranchName(featureData.branchName) &&
-              !this.isLlmArtifactBranchName(featureData.branchName)
+          isValidBranchName(featureData.branchName) &&
+          !this.isLlmArtifactBranchName(featureData.branchName)
             ? featureData.branchName
             : null) ?? this.generateBranchName(featureData.title, featureId, featureData.category));
 

--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -396,3 +396,43 @@ describe('FeatureLoader.generateBranchName — special character sanitization', 
     expect(branch).not.toMatch(/[\[\]]/);
   });
 });
+
+describe('FeatureLoader.isLlmArtifactBranchName', () => {
+  const loader = new FeatureLoader();
+
+  it('detects the canonical LLM artifact phrase', () => {
+    expect(
+      loader.isLlmArtifactBranchName(
+        'fix/the-user-wants-me-to-generate-a-git-branch-name-base-pmw00hh'
+      )
+    ).toBe(true);
+  });
+
+  it('detects feature-prefixed LLM artifact', () => {
+    expect(
+      loader.isLlmArtifactBranchName(
+        'feature/the-user-wants-me-to-generate-a-git-branch-name-base-z02ivk0'
+      )
+    ).toBe(true);
+  });
+
+  it('detects "with" variant of LLM artifact', () => {
+    expect(
+      loader.isLlmArtifactBranchName(
+        'feature/the-user-wants-me-to-generate-a-git-branch-name-with-ogj7dzt'
+      )
+    ).toBe(true);
+  });
+
+  it('does not flag a legitimate branch name', () => {
+    expect(loader.isLlmArtifactBranchName('fix/completion-detector-missing-7b3f1c2')).toBe(false);
+  });
+
+  it('does not flag epic branch names', () => {
+    expect(loader.isLlmArtifactBranchName('epic/foundation-abc1234')).toBe(false);
+  });
+
+  it('does not flag feature-factory style branch names', () => {
+    expect(loader.isLlmArtifactBranchName('feature/milestone-one-phase-two-abc1234')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

**Observed:** Feature `feature-1776614270410-b4pmw00hh` was assigned the branch name `fix/the-user-wants-me-to-generate-a-git-branch-name-base-pmw00hh`. The phrase "the-user-wants-me-to-generate-a-git-branch-name-base" is clearly a fragment of an LLM prompt asking the agent to generate a branch name — the agent treated the prompt itself as the input rather than the feature's title or slug.

**Recurring pattern:** `git branch -a` shows two more origin branches with the same defect:
- `feature/the...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-19T18:42:07.481Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch-name handling to detect and reject AI-generated artifact-like branch names, falling back to a generated, properly formatted branch name when necessary; read-only mode behavior unchanged.

* **Tests**
  * Added unit tests covering detection of artifact-like branch names and confirmation that legitimate branch names remain accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->