### PR TITLE
PipelineCheckpointService resumes features on deleted PRs — auto-mode loops on ghost PRs

### DIFF
--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -590,8 +590,35 @@ export class LeadEngineerService {
           if (restoredContext.ciStatus === 'pending') {
             restoredContext.ciStatus = undefined;
           }
+
+          // Ghost PR guard: when resuming at REVIEW or MERGE, validate the PR still exists and
+          // is in a resumable state. A closed/deleted PR causes the review processor to loop
+          // indefinitely. If the PR is gone, invalidate the checkpoint and reset to backlog.
+          const resumeState = checkpoint.currentState as FeatureProcessingState;
+          const prNumber = restoredContext.prNumber;
+          if ((resumeState === 'REVIEW' || resumeState === 'MERGE') && prNumber) {
+            const prStatus = await this.checkpointService.validatePRForResume(
+              projectPath,
+              prNumber
+            );
+            if (prStatus === 'closed' || prStatus === 'not_found') {
+              logger.warn(
+                `[LeadEngineer] Checkpoint at ${resumeState} references PR #${prNumber} which is ${prStatus} — invalidating checkpoint and resetting ${featureId} to backlog`
+              );
+              await this.checkpointService.delete(projectPath, featureId);
+              await this.featureLoader.update(projectPath, featureId, {
+                status: 'backlog',
+                prNumber: undefined,
+                statusChangeReason: `Checkpoint invalidated: PR #${prNumber} was ${prStatus}. Re-queued for execution.`,
+              });
+              this.activeFeatures.delete(featureId);
+              return { outcome: 'completed', finalState: FeatureState.INTAKE, failureCount: 0 };
+            }
+            // 'merged' or 'open' — safe to resume; REVIEW processor will handle merged state.
+          }
+
           resumeFromCheckpoint = {
-            state: checkpoint.currentState as FeatureProcessingState,
+            state: resumeState,
             restoredContext,
           };
         }

--- a/apps/server/src/services/pipeline-checkpoint-service.ts
+++ b/apps/server/src/services/pipeline-checkpoint-service.ts
@@ -6,14 +6,17 @@
  * features to resume from their last known-good state after a server restart.
  */
 
+import { exec } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs/promises';
+import { promisify } from 'node:util';
 import { createLogger, atomicWriteJson, readJsonWithRecovery } from '@protolabsai/utils';
 import { getAutomakerDir } from '@protolabsai/platform';
 import type { PipelineCheckpoint, GoalGateResult } from '@protolabsai/types';
 import { FeatureState } from '@protolabsai/types';
 import type { StateContext, FeatureProcessingState } from './lead-engineer-service.js';
 
+const execAsync = promisify(exec);
 const logger = createLogger('PipelineCheckpointService');
 
 const CHECKPOINTS_DIR = 'checkpoints';
@@ -111,6 +114,34 @@ export class PipelineCheckpointService {
         logger.error(`Failed to list checkpoints for ${projectPath}:`, err);
       }
       return [];
+    }
+  }
+
+  /**
+   * Validate that a PR referenced in a REVIEW/MERGE checkpoint still exists and is resumable.
+   *
+   * Returns:
+   *   'open'      — PR is open; safe to resume
+   *   'merged'    — PR already merged; let the REVIEW processor detect and advance
+   *   'closed'    — PR was closed without merging; invalidate the checkpoint
+   *   'not_found' — gh CLI error or PR does not exist; invalidate the checkpoint
+   */
+  async validatePRForResume(
+    projectPath: string,
+    prNumber: number
+  ): Promise<'open' | 'merged' | 'closed' | 'not_found'> {
+    try {
+      const { stdout } = await execAsync(
+        `gh pr view ${prNumber} --json state,mergedAt --jq '{state: .state, mergedAt: .mergedAt}'`,
+        { cwd: projectPath, timeout: 10000 }
+      );
+      const data = JSON.parse(stdout.trim()) as { state: string; mergedAt: string | null };
+      if (data.state === 'MERGED' || data.mergedAt) return 'merged';
+      if (data.state === 'CLOSED') return 'closed';
+      if (data.state === 'OPEN') return 'open';
+      return 'not_found';
+    } catch {
+      return 'not_found';
     }
   }
 


### PR DESCRIPTION
## Summary

## Summary
PipelineCheckpointService resume logic does not validate that the PR referenced in a checkpoint still exists on GitHub before resuming at REVIEW. When a PR is deleted or closed out-of-band (operator cleanup, force-deleted branch, revoked merge), the resume points at nothing and the review-phase processor retries indefinitely.

## Observed
In protoagent app, 2026-04-19. Feature `sklindex2` stuck in `review`. Every auto-mode sweep re-tried reviewing a ghost PR. Recovery required manuall...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-19T18:58:38.277Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for pull requests when resuming interrupted features to detect closed or deleted PRs
  * Automatically cleans up stale checkpoint data and resets features to backlog status when invalid PRs are detected, enabling proper recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->