### PR TITLE
Branch-name unsafe-char handling silently skips merge checks (e.g. '+' in title)

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -429,7 +429,14 @@ export class FeatureLoader implements FeatureStore {
     }
 
     // Keep slug portion to 50 chars so the full branch stays under ~60 chars.
-    const slug = slugify(title, 50);
+    const rawSlug = slugify(title, 50);
+    // Belt-and-suspenders: strip any characters outside [a-z0-9-] that may have slipped
+    // through slugify (e.g. '+', '&', '#', '?', ':' from titles with special syntax).
+    // This guarantees the slug portion contains only safe git ref characters.
+    const slug = rawSlug
+      .replace(/[^a-z0-9-]/g, '')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '');
     return `${prefix}/${slug || `untitled`}-${shortId}`;
   }
 

--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -1124,15 +1124,14 @@ export class ReviewProcessor implements StateProcessor {
     const branchName = ctx.feature.branchName;
     if (!branchName) return false;
 
-    // Sanitize branch name to prevent shell injection
+    // Refuse to proceed with an unsafe branch name — shell injection risk and indicative
+    // of a generation bug. Hard-fail so the state machine escalates and the operator is
+    // notified rather than silently skipping the merge gate.
     if (!/^[a-zA-Z0-9._\-/]+$/.test(branchName)) {
-      logger.warn(
-        '[REVIEW] Branch name contains unsafe characters, skipping external merge check',
-        {
-          featureId: ctx.feature.id,
-        }
+      throw new Error(
+        `[REVIEW] Branch name "${branchName}" contains unsafe characters — merge gate aborted. ` +
+          `Rename the branch to use only [a-zA-Z0-9._-/] characters before retrying.`
       );
-      return false;
     }
 
     try {

--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -395,4 +395,45 @@ describe('FeatureLoader.generateBranchName — special character sanitization', 
     expect(branch).toMatch(/^feature\/(untitled|[a-z0-9])/);
     expect(branch).not.toMatch(/[\[\]]/);
   });
+
+  it('strips + from titles — reproduction of skill index + retrieval injection bug', () => {
+    // Reproduces GitHub issue #3483: seed script title with '+' produced
+    // 'feature/skill-index-+-retrieval-injection' with '+' leaking into the branch name.
+    const branch = loader.generateBranchName(
+      'skill index + retrieval injection',
+      'feature-1776623241072-suhxybdqp'
+    );
+    expect(branch).not.toContain('+');
+    expect(branch).toMatch(/^feature\//);
+    expect(branch).toMatch(/^[a-z0-9/._-]+-[a-z0-9]+$/);
+  });
+
+  it('strips & from titles', () => {
+    const branch = loader.generateBranchName('Search & filter panel', 'feature-123-abc1234');
+    expect(branch).not.toContain('&');
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('strips # from titles', () => {
+    const branch = loader.generateBranchName('Fix issue #42 in auth', 'feature-123-abc1234');
+    expect(branch).not.toContain('#');
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('strips ? from titles', () => {
+    const branch = loader.generateBranchName('Why does auth fail?', 'feature-123-abc1234');
+    expect(branch).not.toContain('?');
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('branch slug contains only [a-z0-9-] characters', () => {
+    // Belt-and-suspenders: verify the full character set contract regardless of input
+    const branch = loader.generateBranchName(
+      'feature: use +async/await &co. #1 for real?',
+      'feature-123-abc1234'
+    );
+    // Strip the prefix (e.g. "feature/") and trailing short-id suffix
+    const slugPart = branch.replace(/^[a-z]+\//, '');
+    expect(slugPart).toMatch(/^[a-z0-9-]+$/);
+  });
 });


### PR DESCRIPTION
## Summary

Two compounding defects in the branch-name pipeline:

1. SLUGIFICATION GAP (HIGH): generateBranchName() (or equivalent in libs/git-utils/src/) does not strip unsafe characters — '+', '&', '#', '?', ':', etc. — at generation time. A feature title like "skill index + retrieval injection" produces branch name "feature/skill-index-+-retrieval-injection". Only [a-z0-9./-] should be allowed through.

2. SILENT MERGE-GATE BYPASS (CRITICAL): When the unsafe-char detection path fires downstream, it emits...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-19T19:21:46.174Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved branch name sanitization to properly handle special characters, collapse consecutive hyphens, and remove leading/trailing hyphens
  * Merge validation now throws errors for invalid branch names instead of silently skipping validation checks

* **Tests**
  * Added unit tests for branch name sanitization and special character handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->