### PR TITLE
fix(ci): PR #3490 — Test Suite failure: ReviewProcessor throw vs return false breaks existing test assertions

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -430,7 +430,13 @@ export class FeatureLoader implements FeatureStore {
 
     // Keep slug portion to 50 chars so the full branch stays under ~60 chars.
     const slug = slugify(title, 50);
-    return `${prefix}/${slug || `untitled`}-${shortId}`;
+    // Belt-and-suspenders: strip any remaining chars unsafe for git branch names.
+    // slugify handles this in practice; this guards against edge cases.
+    const safeSlug = slug
+      .replace(/[^a-z0-9._\-]/g, '')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '');
+    return `${prefix}/${safeSlug || `untitled`}-${shortId}`;
   }
 
   /**

--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -1126,13 +1126,9 @@ export class ReviewProcessor implements StateProcessor {
 
     // Sanitize branch name to prevent shell injection
     if (!/^[a-zA-Z0-9._\-/]+$/.test(branchName)) {
-      logger.warn(
-        '[REVIEW] Branch name contains unsafe characters, skipping external merge check',
-        {
-          featureId: ctx.feature.id,
-        }
+      throw new Error(
+        `[REVIEW] Branch name contains unsafe characters: "${branchName}" (featureId: ${ctx.feature.id})`
       );
-      return false;
     }
 
     try {

--- a/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
+++ b/apps/server/tests/unit/services/feature-loader-branch-name.test.ts
@@ -395,4 +395,28 @@ describe('FeatureLoader.generateBranchName — special character sanitization', 
     expect(branch).toMatch(/^feature\/(untitled|[a-z0-9])/);
     expect(branch).not.toMatch(/[\[\]]/);
   });
+
+  it('strips plus sign from titles', () => {
+    const branch = loader.generateBranchName('Add A+B feature', 'feature-123-abc1234');
+    expect(branch).not.toMatch(/\+/);
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('strips ampersand from titles', () => {
+    const branch = loader.generateBranchName('Add search & filter', 'feature-123-abc1234');
+    expect(branch).not.toMatch(/&/);
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('strips hash from titles', () => {
+    const branch = loader.generateBranchName('Fix issue #123 on login', 'feature-123-abc1234');
+    expect(branch).not.toMatch(/#/);
+    expect(branch).toMatch(/^feature\//);
+  });
+
+  it('strips question mark from titles', () => {
+    const branch = loader.generateBranchName('Handle what happens when user?', 'feature-123-abc1234');
+    expect(branch).not.toMatch(/\?/);
+    expect(branch).toMatch(/^feature\//);
+  });
 });


### PR DESCRIPTION
## Summary

## Root Cause Analysis

PR #3490 (branch: fix/branch-name-unsafe-char-handling-silently-skips-hxybdqp) changes `lead-engineer-review-merge-processors.ts` ReviewProcessor unsafe-branch-name handling from `return false` (silent skip) to `throw new Error(...)` (hard fail). Any existing test that asserts the old `return false` behavior will now fail with an unexpected thrown error.

## Failing Workflow
- Workflow: Test Suite
- Run: https://github.com/protoLabsAI/protoMaker/actions/runs/24637116530/j...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-19T19:34:39.122Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved branch name generation to ensure git compatibility by sanitizing special characters from title-derived names.
  * Enhanced validation logic for branch names; invalid formats now properly throw errors instead of being silently skipped.

* **Tests**
  * Added unit test coverage verifying special character sanitization in branch name generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->