### PR TITLE
fix(test): repair 6 lead-engineer tests broken by API drift on resetToBacklog + execution gate

### DIFF
--- a/apps/server/tests/unit/services/lead-engineer-action-executor.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-action-executor.test.ts
@@ -50,6 +50,7 @@ function createMockFeatureLoader() {
   return {
     update: vi.fn().mockResolvedValue(undefined),
     get: vi.fn(),
+    resetToBacklog: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -469,9 +470,11 @@ describe('ActionExecutor — reset_feature merged PR guard', () => {
     });
 
     // Should reset to backlog as usual
-    expect(deps.featureLoader.update).toHaveBeenCalledWith('/test/project', 'feat-no-pr', {
-      status: 'backlog',
-    });
+    expect(deps.featureLoader.resetToBacklog).toHaveBeenCalledWith(
+      '/test/project',
+      'feat-no-pr',
+      'Auto-retry: flaky test'
+    );
     // Should emit feature_reset escalation signal
     const emitCalls = vi.mocked(deps.events.emit).mock.calls;
     const resetEmitted = emitCalls.some(
@@ -515,9 +518,11 @@ describe('ActionExecutor — reset_feature merged PR guard', () => {
     });
 
     expect(vi.mocked(exec)).not.toHaveBeenCalled();
-    expect(deps.featureLoader.update).toHaveBeenCalledWith('/test/project', 'feat-no-branch', {
-      status: 'backlog',
-    });
+    expect(deps.featureLoader.resetToBacklog).toHaveBeenCalledWith(
+      '/test/project',
+      'feat-no-branch',
+      'Auto-retry'
+    );
   });
 
   it('resets to backlog (fail-open) when GitHub check throws', async () => {
@@ -554,8 +559,10 @@ describe('ActionExecutor — reset_feature merged PR guard', () => {
     });
 
     // On gh check failure, fail-open: reset to backlog
-    expect(deps.featureLoader.update).toHaveBeenCalledWith('/test/project', 'feat-gh-fail', {
-      status: 'backlog',
-    });
+    expect(deps.featureLoader.resetToBacklog).toHaveBeenCalledWith(
+      '/test/project',
+      'feat-gh-fail',
+      'Auto-retry'
+    );
   });
 });

--- a/apps/server/tests/unit/services/lead-engineer-execute-processor.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-execute-processor.test.ts
@@ -403,9 +403,11 @@ describe('ExecuteProcessor — execution gate rejection tracking (Bug 3)', () =>
   });
 
   it('returns to backlog on first gate rejection (count < 3)', async () => {
-    // Gate enabled. featureLoader.getAll returns 6 features in 'review' (> default maxPendingReviews=5).
+    // Gate enabled. featureLoader.getAll returns 6 features in 'review' with prNumber
+    // (> default maxPendingReviews=5). The gate only counts review features that have
+    // an actual PR — features in 'review' without a prNumber are excluded.
     const reviewFeatures = Array.from({ length: 6 }, (_, i) =>
-      makeFeature({ id: `feat-review-${i}`, status: 'review' as const })
+      makeFeature({ id: `feat-review-${i}`, status: 'review' as const, prNumber: 100 + i })
     );
     const { ctx, featureLoader } = makeServiceContext({
       executionGate: true,
@@ -431,7 +433,7 @@ describe('ExecuteProcessor — execution gate rejection tracking (Bug 3)', () =>
 
   it('escalates after 3rd consecutive gate rejection', async () => {
     const reviewFeatures = Array.from({ length: 6 }, (_, i) =>
-      makeFeature({ id: `feat-review-${i}`, status: 'review' as const })
+      makeFeature({ id: `feat-review-${i}`, status: 'review' as const, prNumber: 200 + i })
     );
     const { ctx, featureLoader } = makeServiceContext({
       executionGate: true,
@@ -459,7 +461,7 @@ describe('ExecuteProcessor — execution gate rejection tracking (Bug 3)', () =>
 
   it('increments gateRejectionCount from undefined on first rejection', async () => {
     const reviewFeatures = Array.from({ length: 6 }, (_, i) =>
-      makeFeature({ id: `feat-review-${i}`, status: 'review' as const })
+      makeFeature({ id: `feat-review-${i}`, status: 'review' as const, prNumber: 300 + i })
     );
     const { ctx } = makeServiceContext({
       executionGate: true,


### PR DESCRIPTION
## Summary

Six unit tests in `apps/server/tests/unit/services/` have been failing on `dev` because their assertions no longer match the production code. This is the failing `test` job blocking PR #3492 and all future PRs from merging on `dev`. Resolves #3493.

Tests-only fix — no product code touched.

### File 1: `lead-engineer-action-executor.test.ts` (3 fails)

Production code in `lead-engineer-action-executor.ts` (line 127) now calls:

```ts
await this.deps.featureLoader.resetToBacklog(session.projectPath, action.featureId, action.reason);
```

The three tests in `describe("ActionExecutor — reset_feature merged PR guard")` still asserted against the old `featureLoader.update(..., { status: 'backlog' })` API.

Fix:

- Added `resetToBacklog: vi.fn().mockResolvedValue(undefined)` to the `createMockFeatureLoader` helper.
- Updated the three assertions to check `resetToBacklog` was called with `(projectPath, featureId, reason)`.

### File 2: `lead-engineer-execute-processor.test.ts` (3 fails)

The execution gate's review-queue depth check (`runExecutionGate` in `lead-engineer-execute-processor.ts` line 1020) was tightened to only count review features that have a real `prNumber`:

```ts
const reviewDepth = allFeatures.filter(
  (f) => f.status === 'review' && f.prNumber != null
).length;
```

This was an intentional fix to prevent silent data loss when a feature in `review` status (but mid-PR-creation, no `prNumber` yet) caused the gate to reject its own retry, decaying the work back to `backlog`.

The three tests in `describe("ExecuteProcessor — execution gate rejection tracking (Bug 3)")` synthesized six features with `status: 'review'` but no `prNumber`, so the gate never tripped and the tests asserted against a code path that was never reached.

Fix: Added `prNumber: 100 + i` (and 200/300 for the other two tests) when constructing the synthetic review features, so the gate counts them and fires as the tests expect.

## Test plan

- [x] `cd apps/server && npx vitest run tests/unit/services/lead-engineer-action-executor.test.ts tests/unit/services/lead-engineer-execute-processor.test.ts` — all 25 tests pass locally
- [x] `prettier --check` passes on both files
- [ ] CI `test` job goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures for execution gate rejection tracking validation to improve test data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->