### PR TITLE
fix(rollcall): homelab-iac copy of agent-rollcall.sh diverged from in-repo copy

### DIFF
--- a/.claude/commands/rollcall.md
+++ b/.claude/commands/rollcall.md
@@ -1,0 +1,13 @@
+---
+name: rollcall
+description: Fleet smoke test. Reports status of all agents (local + remote), AI infrastructure, media stack, and monitoring services.
+model: haiku
+---
+
+Run the agent roll call smoke test. Reports container status, A2A agent card, and endpoint health for the entire homelab fleet.
+
+## Steps
+
+1. Run `bash /home/josh/dev/protoWorkstacean/scripts/agent-rollcall.sh`
+2. Report the output to the user
+3. If any services are down, suggest remediation steps


### PR DESCRIPTION
## Summary

PR #410 cleaned scripts/agent-rollcall.sh in protoWorkstacean to remove deprecated protoaudio and protovoice checks. A second copy of the script in the homelab-iac repo was not updated and still references stale services: ava-agent on port 7871 (Ava is now in-process since 2026-04-12), protovoice on port 7880, and protoaudio on port 8210.

The rollcall skill and cron jobs call the homelab-iac copy. This produces false-negative container-missing for ava-agent and false-positive health checks for ...

---
*Recovered automatically by Automaker post-agent hook*