### PR TITLE
PipelineCheckpointService resumes at REVIEW on deleted/ghost PRs — auto-mode loops indefinitely

### DIFF
--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -504,6 +504,24 @@ export class ReviewProcessor implements StateProcessor {
       };
     }
 
+    // PR was closed without merging (out-of-band operator cleanup, force-delete, etc.).
+    // Reset to backlog so the feature can be re-executed with a fresh PR instead of looping.
+    if (reviewState === 'pr_closed') {
+      logger.warn(`[REVIEW] PR #${ctx.prNumber} closed without merging — resetting to backlog`, {
+        featureId: ctx.feature.id,
+      });
+      await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
+        status: 'backlog',
+        prNumber: undefined,
+        statusChangeReason: `PR #${ctx.prNumber} was closed without merging. Re-queued for execution.`,
+      });
+      return {
+        nextState: null,
+        shouldContinue: false,
+        reason: `PR #${ctx.prNumber} closed without merging — feature reset to backlog`,
+      };
+    }
+
     // CLI/API error — check if PR is already merged before escalating.
     // Merged PRs can return 'error' review state when the GitHub API returns
     // unclear status on closed PRs. The merged check in getPRReviewState handles
@@ -1006,6 +1024,11 @@ export class ReviewProcessor implements StateProcessor {
           `[REVIEW] PR #${ctx.prNumber} already merged at ${mergeData.mergedAt}, fast-pathing to approved`
         );
         return 'approved';
+      }
+      // Closed-without-merge: reset to backlog instead of waiting until timeout.
+      if (mergeData.state === 'CLOSED') {
+        logger.warn(`[REVIEW] PR #${ctx.prNumber} is closed (not merged) — signalling pr_closed`);
+        return 'pr_closed';
       }
     } catch (mergeErr) {
       logger.debug(

--- a/apps/server/src/services/pipeline-checkpoint-service.ts
+++ b/apps/server/src/services/pipeline-checkpoint-service.ts
@@ -62,8 +62,23 @@ export class PipelineCheckpointService {
     try {
       const result = await readJsonWithRecovery<PipelineCheckpoint | null>(filePath, null);
       if (result.data && result.data.version === 1) {
-        logger.info(`Checkpoint loaded for ${featureId} at state ${result.data.currentState}`);
-        return result.data;
+        const checkpoint = result.data;
+        // Validate the PR on every load so stale checkpoints never surface
+        // regardless of which code path calls load().
+        const state = checkpoint.currentState as string;
+        const prNumber = checkpoint.stateContext.prNumber as number | undefined;
+        if ((state === 'REVIEW' || state === 'MERGE') && prNumber) {
+          const prStatus = await this.validatePRForResume(projectPath, prNumber);
+          if (prStatus === 'closed' || prStatus === 'not_found') {
+            logger.warn(
+              `Checkpoint for ${featureId} at ${state} references PR #${prNumber} which is ${prStatus} — auto-invalidating checkpoint`
+            );
+            await this.delete(projectPath, featureId);
+            return null;
+          }
+        }
+        logger.info(`Checkpoint loaded for ${featureId} at state ${checkpoint.currentState}`);
+        return checkpoint;
       }
       return null;
     } catch {

--- a/apps/server/tests/unit/services/lead-engineer-review-processor.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-review-processor.test.ts
@@ -284,3 +284,54 @@ describe('ReviewProcessor — close_and_recut for CONFLICTING PRs', () => {
     expect(backlogReset).toHaveLength(0);
   });
 });
+
+// ── pr_closed handling ────────────────────────────────────────────────────────
+
+describe('ReviewProcessor — closed PR detected during polling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('CLOSED PR (not merged) → resets feature to backlog without escalating', async () => {
+    const feature = makeFeature({ status: 'review', branchName: 'fix/test-fix' });
+    const serviceCtx = makeServiceContext({ status: 'review', branchName: 'fix/test-fix' });
+    (serviceCtx.featureLoader.get as ReturnType<typeof vi.fn>).mockResolvedValue(feature);
+
+    // Call sequence:
+    // 1. checkBranchMerged (gh pr list): returns '' (not externally merged)
+    // 2. getMergeableState (gh pr view --json mergeable): returns '' → null (not CONFLICTING)
+    // 3. normalizePR (gh pr view --json body,autoMergeRequest): throws → early return
+    // 4. getPRReviewState merge-check (gh pr view --json state,mergedAt): state=CLOSED → pr_closed
+    mockExecAsync
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // checkBranchMerged → not merged
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // getMergeableState → null (not CONFLICTING)
+      .mockRejectedValueOnce(new Error('PR not found')) // normalizePR → early return
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ state: 'CLOSED', mergedAt: null }),
+        stderr: '',
+      }); // getPRReviewState merge-check → CLOSED → pr_closed
+
+    const processor = new ReviewProcessor(serviceCtx);
+    const ctx = makeCtx(feature, 42);
+    await processor.enter(ctx);
+    const result = await processor.process(ctx);
+
+    // Should terminate cleanly without HITL escalation
+    expect(result.shouldContinue).toBe(false);
+    expect(result.nextState).toBeNull();
+    expect(result.reason).toMatch(/closed without merging/i);
+
+    // Feature should be reset to backlog with prNumber cleared
+    expect(serviceCtx.featureLoader.update).toHaveBeenCalledWith(
+      '/test/project',
+      'feat-review-001',
+      expect.objectContaining({ status: 'backlog', prNumber: undefined })
+    );
+
+    // Should NOT have escalated
+    expect(serviceCtx.events.emit).not.toHaveBeenCalledWith(
+      'feature:escalated',
+      expect.anything()
+    );
+  });
+});

--- a/apps/server/tests/unit/services/lead-engineer-review-processor.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-review-processor.test.ts
@@ -329,9 +329,6 @@ describe('ReviewProcessor — closed PR detected during polling', () => {
     );
 
     // Should NOT have escalated
-    expect(serviceCtx.events.emit).not.toHaveBeenCalledWith(
-      'feature:escalated',
-      expect.anything()
-    );
+    expect(serviceCtx.events.emit).not.toHaveBeenCalledWith('feature:escalated', expect.anything());
   });
 });


### PR DESCRIPTION
## Summary

PipelineCheckpointService resume logic does not validate that the PR referenced in a checkpoint still exists on GitHub before resuming at REVIEW stage. When a PR is deleted or closed out-of-band (operator cleanup, force-deleted branch, revoked merge), the resume points at a ghost PR and the review-phase processor retries indefinitely.

Recovery requires manual deletion of: .automaker/checkpoints/feature-*.json, tmp/ files, and handoff-*.json files, then re-dispatching.

Fix scope:
- apps/server/...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-20T02:21:27.583Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Closed pull requests are now detected during review and resume checks: affected features are returned to the backlog and detached from the PR to prevent stuck states.
  * Resuming work now validates PR status and removes checkpoints for closed or not-found PRs.

* **Tests**
  * Added unit tests covering closed-PR detection during polling and ensuring no unnecessary escalation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->