### PR TITLE
fix(pipeline): harden PR creation, checkpoint reset, worktree safety

### DIFF
--- a/apps/server/src/lib/gh-pr-create.ts
+++ b/apps/server/src/lib/gh-pr-create.ts
@@ -1,0 +1,162 @@
+/**
+ * PR creation with automatic REST fallback for `gh pr create` secondary rate limits.
+ *
+ * `gh pr create` frequently trips GitHub's secondary rate limit during bursts of
+ * agent-driven PR creation. The `gh api POST /repos/{owner}/{repo}/pulls` path
+ * has different limits and routinely succeeds when the CLI is throttled, so we
+ * retry through the REST API before surfacing the error to the caller.
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { createLogger } from '@protolabsai/utils';
+
+const execFileAsync = promisify(execFile);
+const logger = createLogger('ghPrCreate');
+
+export interface CreatePrArgs {
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  base: string;
+  head: string;
+  title: string;
+  body: string;
+  draft?: boolean;
+  /** Required when the target repo differs from the current remote (forks, cross-repo). */
+  repo?: string;
+}
+
+export interface CreatePrResult {
+  url: string;
+  number?: number;
+  /** Which path returned the PR: 'cli' or 'rest'. Useful for diagnostics. */
+  via: 'cli' | 'rest';
+}
+
+/**
+ * Detect secondary rate limit / abuse signals in a `gh` CLI error message.
+ *
+ * The GitHub API returns these verbatim in stderr when `gh` hits a burst limit:
+ *   - "secondary rate limit"
+ *   - "abuse detection"
+ *   - "exceeded a secondary rate limit"
+ *   - HTTP 403 with "retry after"
+ */
+export function isSecondaryRateLimit(errorMessage: string): boolean {
+  const msg = errorMessage.toLowerCase();
+  return (
+    msg.includes('secondary rate limit') ||
+    msg.includes('abuse detection') ||
+    msg.includes('was submitted too quickly') ||
+    (msg.includes('http 403') && msg.includes('retry after'))
+  );
+}
+
+/**
+ * Parse `owner/repo` from a git remote URL. Accepts both SSH and HTTPS forms.
+ */
+function parseOwnerRepo(remoteUrl: string): { owner: string; repo: string } | null {
+  const match = remoteUrl.match(/[:/]([^/]+)\/([^/\s]+?)(?:\.git)?$/);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2] };
+}
+
+async function getOwnerRepo(
+  cwd: string,
+  env: NodeJS.ProcessEnv | undefined,
+  explicitRepo?: string
+): Promise<{ owner: string; repo: string } | null> {
+  if (explicitRepo) {
+    const [owner, repo] = explicitRepo.split('/');
+    if (owner && repo) return { owner, repo };
+  }
+  try {
+    const { stdout } = await execFileAsync('git', ['config', '--get', 'remote.origin.url'], {
+      cwd,
+      env,
+    });
+    return parseOwnerRepo(stdout.trim());
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create a PR via `gh pr create`, falling back to `gh api POST /repos/.../pulls`
+ * if the CLI hits a secondary rate limit.
+ *
+ * Throws the original error on non-rate-limit failures so callers can keep their
+ * existing "already exists" / etc. handling paths.
+ */
+export async function createPrWithFallback(args: CreatePrArgs): Promise<CreatePrResult> {
+  const { cwd, env, base, head, title, body, draft, repo } = args;
+
+  const cliArgs = [
+    'pr',
+    'create',
+    '--base',
+    base,
+    '--head',
+    head,
+    '--title',
+    title,
+    '--body',
+    body,
+  ];
+  if (repo) cliArgs.splice(2, 0, '--repo', repo);
+  if (draft) cliArgs.push('--draft');
+
+  try {
+    const { stdout } = await execFileAsync('gh', cliArgs, { cwd, env });
+    const url = stdout.trim();
+    const numberMatch = url.match(/\/pull\/(\d+)/);
+    return { url, number: numberMatch ? parseInt(numberMatch[1], 10) : undefined, via: 'cli' };
+  } catch (cliError) {
+    const err = cliError as { stderr?: string; message?: string };
+    const message = err.stderr || err.message || '';
+
+    if (!isSecondaryRateLimit(message)) {
+      throw cliError;
+    }
+
+    logger.warn(
+      `gh pr create hit secondary rate limit; falling back to REST API: ${message.slice(0, 200)}`
+    );
+
+    const target = await getOwnerRepo(cwd, env, repo);
+    if (!target) {
+      // Can't build a REST path without owner/repo — rethrow the original CLI error
+      throw cliError;
+    }
+
+    // `head` for cross-repo forks is "owner:branch". The REST API accepts that
+    // form directly, so no transformation is needed.
+    const restArgs = [
+      'api',
+      '-X',
+      'POST',
+      `/repos/${target.owner}/${target.repo}/pulls`,
+      '-f',
+      `title=${title}`,
+      '-f',
+      `head=${head}`,
+      '-f',
+      `base=${base}`,
+      '-f',
+      `body=${body}`,
+    ];
+    if (draft) restArgs.push('-F', 'draft=true');
+
+    const { stdout: restStdout } = await execFileAsync('gh', restArgs, { cwd, env });
+    const payload = JSON.parse(restStdout) as { html_url?: string; number?: number };
+    if (!payload.html_url) {
+      throw new Error(`REST fallback returned no html_url: ${restStdout.slice(0, 200)}`);
+    }
+
+    logger.info(
+      `PR created via REST fallback after CLI rate limit: #${payload.number} ${payload.html_url}`
+    );
+
+    return { url: payload.html_url, number: payload.number, via: 'rest' };
+  }
+}

--- a/apps/server/src/routes/worktree/routes/create-pr.ts
+++ b/apps/server/src/routes/worktree/routes/create-pr.ts
@@ -20,6 +20,7 @@ import { validatePRState } from '@protolabsai/types';
 import { buildPROwnershipWatermark } from '../../github/utils/pr-ownership.js';
 import type { SettingsService } from '../../../services/settings-service.js';
 import { getEffectivePrBaseBranch } from '../../../lib/settings-helpers.js';
+import { createPrWithFallback } from '../../../lib/gh-pr-create.js';
 
 const logger = createLogger('CreatePR');
 
@@ -405,34 +406,25 @@ export function createCreatePRHandler(settingsService?: SettingsService) {
           }
 
           try {
-            // Build gh pr create args - use array to avoid shell injection
-            // with backticks, $(), !, and other special chars in LLM-generated PR bodies
-            const prArgs = ['pr', 'create', '--base', base];
+            const head = upstreamRepo && originOwner ? `${originOwner}:${branchName}` : branchName;
 
-            // If this is a fork (has upstream remote), specify the repo and head
-            if (upstreamRepo && originOwner) {
-              // For forks: --repo specifies where to create PR, --head specifies source
-              prArgs.push('--repo', upstreamRepo, '--head', `${originOwner}:${branchName}`);
-            } else {
-              // Not a fork, just specify the head branch
-              prArgs.push('--head', branchName);
-            }
-
-            prArgs.push('--title', title, '--body', body);
-            if (draft) prArgs.push('--draft');
-
-            logger.debug(`Creating PR with args: gh ${prArgs.join(' ')}`);
-            const { stdout: prOutput } = await execFileAsync('gh', prArgs, {
+            logger.debug(`Creating PR: base=${base} head=${head} draft=${!!draft}`);
+            const prResult = await createPrWithFallback({
               cwd: worktreePath,
               env: execEnv,
+              base,
+              head,
+              title,
+              body,
+              draft,
+              repo: upstreamRepo || undefined,
             });
-            prUrl = prOutput.trim();
-            logger.info(`PR created: ${prUrl}`);
+            prUrl = prResult.url;
+            logger.info(`PR created via ${prResult.via}: ${prUrl}`);
 
             // Extract PR number and store metadata for newly created PR
             if (prUrl) {
-              const prMatch = prUrl.match(/\/pull\/(\d+)/);
-              prNumber = prMatch ? parseInt(prMatch[1], 10) : undefined;
+              prNumber = prResult.number;
 
               if (prNumber) {
                 try {

--- a/apps/server/src/services/maintenance/checks/done-worktree-cleanup-check.ts
+++ b/apps/server/src/services/maintenance/checks/done-worktree-cleanup-check.ts
@@ -208,12 +208,39 @@ export class DoneWorktreeCleanupCheck implements MaintenanceCheck {
   }
 
   private async isOrphanSafeToRemove(worktreePath: string): Promise<boolean> {
+    // Guard 1: uncommitted changes in the working tree
     try {
       const { stdout } = await execAsync('git status --porcelain', { cwd: worktreePath });
-      return !stdout.trim();
+      if (stdout.trim()) return false;
     } catch {
+      // git status failed — worktree is likely broken; let caller fall through
       return true;
     }
+
+    // Guard 2: committed but unpushed work. A worktree can have a clean
+    // working tree (status --porcelain empty) while still holding commits
+    // that exist on no remote. Destroying the worktree with --force would
+    // delete that work. Refuse removal if HEAD is not reachable from any
+    // remote ref.
+    try {
+      const { stdout: remoteContainers } = await execAsync('git branch -r --contains HEAD', {
+        cwd: worktreePath,
+      });
+      if (!remoteContainers.trim()) {
+        logger.warn(
+          `[SAFETY] Skipping orphan worktree removal: ${worktreePath} has commits not present on any remote ref`
+        );
+        return false;
+      }
+    } catch {
+      // git branch -r failed — assume unsafe to avoid silent data loss
+      logger.warn(
+        `[SAFETY] Skipping orphan worktree removal: ${worktreePath} unpushed-commit check failed`
+      );
+      return false;
+    }
+
+    return true;
   }
 
   private async removeWorktree(

--- a/apps/server/src/services/worktree-lifecycle-service.ts
+++ b/apps/server/src/services/worktree-lifecycle-service.ts
@@ -17,7 +17,7 @@ import fs from 'node:fs';
 import path from 'path';
 import { exec, execFile, execSync } from 'child_process';
 import { createLogger } from '@protolabsai/utils';
-import { getFeatureDir } from '@protolabsai/platform';
+import { getFeatureDir, getAutomakerDir } from '@protolabsai/platform';
 import * as secureFs from '../lib/secure-fs.js';
 import type { EventEmitter } from '../lib/events.js';
 import type { FeatureLoader } from './feature-loader.js';
@@ -406,7 +406,9 @@ export class WorktreeLifecycleService {
   /**
    * Rename stale agent context files so the next agent launch starts fresh.
    *
-   * Renames agent-output.md and handoff-*.json files to .stale variants.
+   * Renames agent-output.md and handoff-*.json files to .stale variants, and
+   * deletes the pipeline checkpoint file so the next run does not resume at a
+   * dead state (e.g. REVIEW with a closed PR number).
    */
   private async renameStaleContextFiles(projectPath: string, featureId: string): Promise<void> {
     const featureDir = getFeatureDir(projectPath, featureId);
@@ -433,6 +435,25 @@ export class WorktreeLifecycleService {
       }
     } catch {
       // Feature directory may not exist — nothing to rename
+    }
+
+    // Delete pipeline checkpoint. The HTTP update handler already calls
+    // PipelineCheckpointService.delete() on the status→backlog transition, but
+    // any other caller of cleanupForBacklogReset (direct mutation, maintenance
+    // job, future code path) would otherwise leave a stale checkpoint behind —
+    // and auto-mode resumes from REVIEW with a dead PR number, looping forever.
+    const checkpointPath = path.join(
+      getAutomakerDir(projectPath),
+      'checkpoints',
+      `${featureId}.json`
+    );
+    try {
+      await fs.promises.unlink(checkpointPath);
+      logger.info(`[BACKLOG-RESET] Deleted pipeline checkpoint for ${featureId}`);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        logger.warn(`[BACKLOG-RESET] Failed to delete checkpoint for ${featureId}: ${err}`);
+      }
     }
   }
 

--- a/apps/server/src/services/worktree-recovery-service.ts
+++ b/apps/server/src/services/worktree-recovery-service.ts
@@ -15,6 +15,7 @@ import type { Feature } from '@protolabsai/types';
 import { DEFAULT_GIT_WORKFLOW_SETTINGS } from '@protolabsai/types';
 import { buildGitAddCommand } from '../lib/git-staging-utils.js';
 import { createGitExecEnv } from '@protolabsai/git-utils';
+import { createPrWithFallback } from '../lib/gh-pr-create.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -228,27 +229,18 @@ export async function checkAndRecoverUncommittedWork(
         "'"
       );
 
-    const { stdout: prOutput } = await execFileAsync(
-      'gh',
-      [
-        'pr',
-        'create',
-        '--base',
-        baseBranch,
-        '--head',
-        branchName,
-        '--title',
-        prTitle,
-        '--body',
-        prBody,
-      ],
-      { cwd: worktreePath, env: execEnv }
-    );
+    const prResult = await createPrWithFallback({
+      cwd: worktreePath,
+      env: execEnv,
+      base: baseBranch,
+      head: branchName,
+      title: prTitle,
+      body: prBody,
+    });
 
-    // Parse PR URL and number from output (gh pr create prints the URL on stdout)
-    const prUrl = prOutput.trim();
-    const prNumberMatch = prUrl.match(/\/pull\/(\d+)/);
-    const prNumber = prNumberMatch ? parseInt(prNumberMatch[1], 10) : undefined;
+    const prUrl = prResult.url;
+    const prNumber = prResult.number;
+    logger.info(`[PostAgentHook] PR created via ${prResult.via}: ${prUrl}`);
 
     result.prUrl = prUrl;
     result.prNumber = prNumber;

--- a/apps/server/tests/unit/lib/gh-pr-create.test.ts
+++ b/apps/server/tests/unit/lib/gh-pr-create.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for createPrWithFallback — verifies REST fallback on gh CLI
+ * secondary rate limit, and that non-rate-limit errors propagate unchanged.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { promisify } from 'util';
+
+// The production code does `promisify(execFile)`, which uses the custom
+// promisify symbol on the real execFile to resolve with `{stdout, stderr}`.
+// Our mock must preserve that behavior or promisify collapses it to a single
+// positional result and the helper reads `undefined` as stdout.
+const execFileMock = vi.fn();
+(execFileMock as unknown as Record<symbol, unknown>)[promisify.custom] = (
+  file: string,
+  args: string[],
+  opts?: unknown
+) =>
+  new Promise((resolve, reject) => {
+    execFileMock(file, args, opts, (err: Error | null, stdout: string, stderr: string) =>
+      err ? reject(err) : resolve({ stdout, stderr })
+    );
+  });
+
+vi.mock('child_process', () => ({ execFile: execFileMock }));
+
+const { createPrWithFallback, isSecondaryRateLimit } = await import('@/lib/gh-pr-create.js');
+
+type ExecCallback = (err: Error | null, stdout: string, stderr: string) => void;
+
+function respond(stdout: string, stderr = '', err: Error | null = null) {
+  execFileMock.mockImplementationOnce(
+    (_file: string, _args: string[], _opts: unknown, cb: ExecCallback) => {
+      cb(err, stdout, stderr);
+    }
+  );
+}
+
+function respondError(stderr: string) {
+  const err = Object.assign(new Error('gh: error'), { stderr });
+  execFileMock.mockImplementationOnce(
+    (_file: string, _args: string[], _opts: unknown, cb: ExecCallback) => {
+      cb(err, '', stderr);
+    }
+  );
+}
+
+describe('createPrWithFallback', () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it('returns CLI result on success without touching REST', async () => {
+    respond('https://github.com/owner/repo/pull/42\n');
+
+    const result = await createPrWithFallback({
+      cwd: '/tmp/wt',
+      base: 'dev',
+      head: 'feature/x',
+      title: 't',
+      body: 'b',
+    });
+
+    expect(result).toEqual({
+      url: 'https://github.com/owner/repo/pull/42',
+      number: 42,
+      via: 'cli',
+    });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to REST API when CLI hits secondary rate limit', async () => {
+    respondError('You have exceeded a secondary rate limit. Please wait a few minutes.');
+    // REST needs owner/repo — it calls `git config remote.origin.url` first
+    respond('git@github.com:acme/tool.git\n');
+    respond(JSON.stringify({ html_url: 'https://github.com/acme/tool/pull/99', number: 99 }));
+
+    const result = await createPrWithFallback({
+      cwd: '/tmp/wt',
+      base: 'dev',
+      head: 'feature/x',
+      title: 't',
+      body: 'b',
+    });
+
+    expect(result).toEqual({
+      url: 'https://github.com/acme/tool/pull/99',
+      number: 99,
+      via: 'rest',
+    });
+    // 3 calls: cli create (fail), git config, gh api POST
+    expect(execFileMock).toHaveBeenCalledTimes(3);
+    expect(execFileMock.mock.calls[2][1][0]).toBe('api');
+  });
+
+  it('rethrows non-rate-limit CLI errors without attempting REST', async () => {
+    respondError('a PR for branch feature/x already exists');
+
+    await expect(
+      createPrWithFallback({
+        cwd: '/tmp/wt',
+        base: 'dev',
+        head: 'feature/x',
+        title: 't',
+        body: 'b',
+      })
+    ).rejects.toMatchObject({ stderr: expect.stringContaining('already exists') });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses explicit repo when provided (fork workflow)', async () => {
+    respondError('secondary rate limit');
+    respond(JSON.stringify({ html_url: 'https://github.com/upstream/tool/pull/7', number: 7 }));
+
+    const result = await createPrWithFallback({
+      cwd: '/tmp/wt',
+      base: 'main',
+      head: 'fork-owner:feature/y',
+      title: 't',
+      body: 'b',
+      repo: 'upstream/tool',
+    });
+
+    expect(result.via).toBe('rest');
+    expect(result.number).toBe(7);
+    // Only 2 calls: no git-config lookup because `repo` was explicit
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('isSecondaryRateLimit', () => {
+  it.each([
+    ['You have exceeded a secondary rate limit', true],
+    ['Secondary rate limit', true],
+    ['Abuse detection mechanism triggered', true],
+    ['was submitted too quickly', true],
+    ['HTTP 403: You have to wait. Retry After: 60', true],
+    ['a PR for branch x already exists', false],
+    ['Could not resolve host', false],
+    ['', false],
+  ])('returns %p for %p', (msg, expected) => {
+    expect(isSecondaryRateLimit(msg)).toBe(expected);
+  });
+});

--- a/apps/server/tests/unit/worktree-backlog-reset.test.ts
+++ b/apps/server/tests/unit/worktree-backlog-reset.test.ts
@@ -36,6 +36,7 @@ vi.mock('@/lib/worktree-lock.js', () => ({
 vi.mock('@protolabsai/platform', () => ({
   getFeatureDir: (projectPath: string, featureId: string) =>
     `${projectPath}/.automaker/features/${featureId}`,
+  getAutomakerDir: (projectPath: string) => `${projectPath}/.automaker`,
 }));
 
 function createMockEvents(): EventEmitter {


### PR DESCRIPTION
## Summary

Three cross-repo reliability fixes captured from a recent protoagent-repo session.

1. **REST fallback for `gh pr create` secondary rate limits.** New `lib/gh-pr-create.ts` wraps the CLI and falls back to `gh api POST /repos/.../pulls` when stderr matches a rate-limit or abuse-detection signal. Wired into both the `/create-pr` route and the post-agent `worktree-recovery-service`.
2. **Pipeline checkpoint cleanup on backlog reset.** `WorktreeLifecycleService.cleanupForBacklogReset()` now deletes `.automaker/checkpoints/<id>.json` as part of the stale-file sweep. The HTTP update path already did this; adding it here makes the invariant hold for any future caller.
3. **Unpushed-commit safety in orphan worktree cleanup.** `done-worktree-cleanup-check.isOrphanSafeToRemove` now refuses removal when `git branch -r --contains HEAD` is empty (commits on the worktree branch exist on no remote). Previous check only detected uncommitted working-tree state, so committed-but-unpushed agent work could be destroyed by `--force`.

## Test plan

- [x] `npm run typecheck` — 21/21 pass
- [x] `npm run test:server` — 3573 pass, 23 skipped, 0 fail
- [x] New dedicated unit tests for `createPrWithFallback` (CLI happy path, REST fallback on rate limit, non-rate-limit errors propagate, explicit repo for forks) and `isSecondaryRateLimit` (8 cases)
- [x] Existing `worktree-backlog-reset` and `worktree-recovery-service` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)