### PR TITLE
test(feature-loader): pin clear-prNumber-via-undefined behavior

### DIFF
--- a/apps/server/tests/unit/services/feature-loader.test.ts
+++ b/apps/server/tests/unit/services/feature-loader.test.ts
@@ -377,6 +377,43 @@ describe('feature-loader.ts', () => {
 
       await expect(loader.update(testProjectPath, 'feature-123', {})).rejects.toThrow('not found');
     });
+
+    it('should clear prNumber when passed undefined (feature-1776652657290)', async () => {
+      // Regression coverage for the speculative concern that `{prNumber: undefined}`
+      // would not clear the field through the spread + JSON.stringify path used by
+      // atomicWriteJson. JSON.stringify correctly drops keys with undefined values,
+      // so on read-back prNumber is absent → equivalent to cleared. This test pins
+      // the behavior so future refactors (e.g. switching to a replacer, moving to
+      // a different serializer) cannot silently break the PR-cleanup path called
+      // from the pr_closed handler in lead-engineer-review-merge-processors.
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          id: 'feature-123',
+          status: 'review',
+          prNumber: 9999,
+        })
+      );
+      const writtenContents: string[] = [];
+      vi.mocked(fs.writeFile).mockImplementation(async (_path, data) => {
+        writtenContents.push(typeof data === 'string' ? data : data.toString());
+      });
+
+      const result = await loader.update(testProjectPath, 'feature-123', {
+        prNumber: undefined,
+        status: 'backlog',
+      });
+
+      // In-memory: key is present but value is undefined (spread + explicit undefined)
+      expect(result.prNumber).toBeUndefined();
+
+      // On disk: JSON.stringify drops undefined keys, so the serialized form has
+      // no `prNumber` key — the stale number is NOT persisted.
+      expect(writtenContents.length).toBeGreaterThan(0);
+      const serialized = writtenContents[writtenContents.length - 1];
+      const parsed = JSON.parse(serialized);
+      expect('prNumber' in parsed).toBe(false);
+      expect(parsed.prNumber).toBeUndefined();
+    });
   });
 
   describe('delete', () => {


### PR DESCRIPTION
## Summary

Resolves feature-1776652657290 — a speculative bug flagged during Quinn's adversarial review of PR #3498.

### What was claimed

> featureLoader.update: \`prNumber: undefined\` may not clear field due to JSON serialization

### What's actually true

Empirical test proves the field IS cleared correctly. The spread (\`{...feature, ...updates}\`) produces an in-memory object where \`prNumber\` is present with value \`undefined\`. \`JSON.stringify\` drops keys with \`undefined\` values from the output. On disk the stale number is absent; on read-back \`feature.prNumber\` is \`undefined\` — equivalent to cleared.

\`\`\`
Node test:
  merged.prNumber:     undefined
  serialized to disk:  { \"id\": \"f1\", \"status\": \"in_progress\" }   ← no prNumber key
  readBack.prNumber:   undefined
  'prNumber' in readBack: false
\`\`\`

### Why the test still has value

The pr_closed handler in \`lead-engineer-review-merge-processors.ts\` relies on this exact behavior. Without regression coverage, a future refactor (custom replacer, schema-aware serializer, \`exactOptionalPropertyTypes: true\`) could silently break the PR-cleanup path and resurrect the fear that motivated this feature. The test pins the behavior so that class of refactor fails loudly.

## Test plan

- [x] \`npm run test:server -- tests/unit/services/feature-loader.test.ts\` — 55/55 pass
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for feature loader functionality to ensure proper handling of configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->