### PR TITLE
chore(scripts): add reconcile-backlog-once.mjs one-shot runner

### DIFF
--- a/scripts/reconcile-backlog-once.mjs
+++ b/scripts/reconcile-backlog-once.mjs
@@ -37,6 +37,8 @@ const events = {
 const featureLoader = new FeatureLoader();
 const check = new BacklogTitleReconcilerCheck(featureLoader, events, threshold);
 
-console.log(`Running BacklogTitleReconcilerCheck against ${projectPath} (threshold=${threshold})...`);
+console.log(
+  `Running BacklogTitleReconcilerCheck against ${projectPath} (threshold=${threshold})...`
+);
 const result = await check.sweepProject(projectPath);
 console.log(JSON.stringify(result, null, 2));

--- a/scripts/reconcile-backlog-once.mjs
+++ b/scripts/reconcile-backlog-once.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * One-shot invocation of BacklogTitleReconcilerCheck against the current repo's
+ * .automaker/features directory. Clears zombie backlog features that match
+ * recently merged PRs by title. Safe to re-run — the check is idempotent
+ * (already-done features are skipped by filter, already-claimed PRs are skipped).
+ *
+ * This script exists so the initial backlog cleanup can run without waiting on
+ * the server's 6h full-tier maintenance sweep. After the reconciler ships, the
+ * scheduled sweep picks up any new zombies automatically.
+ *
+ * Run: node scripts/reconcile-backlog-once.mjs [threshold]  (default 0.4)
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectPath = path.resolve(__dirname, '..');
+const threshold = parseFloat(process.argv[2] ?? '0.4');
+
+const { BacklogTitleReconcilerCheck } = await import(
+  path.join(
+    projectPath,
+    'apps/server/dist/apps/server/src/services/maintenance/checks/backlog-title-reconciler-check.js'
+  )
+);
+const { FeatureLoader } = await import(
+  path.join(projectPath, 'apps/server/dist/apps/server/src/services/feature-loader.js')
+);
+
+// Minimal EventEmitter compat with the one the server uses.
+const events = {
+  emit: (type, payload) => console.log(`[event] ${type}: ${JSON.stringify(payload)}`),
+};
+
+const featureLoader = new FeatureLoader();
+const check = new BacklogTitleReconcilerCheck(featureLoader, events, threshold);
+
+console.log(`Running BacklogTitleReconcilerCheck against ${projectPath} (threshold=${threshold})...`);
+const result = await check.sweepProject(projectPath);
+console.log(JSON.stringify(result, null, 2));


### PR DESCRIPTION
Thin wrapper around \`BacklogTitleReconcilerCheck.sweepProject\` (shipped in #3512) for clearing zombie backlog features without waiting for the 6h full-tier maintenance sweep.

## Usage

\`\`\`bash
npm run build:server
node scripts/reconcile-backlog-once.mjs           # default threshold 0.4
node scripts/reconcile-backlog-once.mjs 0.6       # stricter
\`\`\`

## Threshold note

Default here is 0.4 — looser than the scheduled sweep's 0.6 default. A human running this script can eyeball the output and revert false positives; an unattended scheduled sweep should stay conservative to avoid mismatches.

Used this script just now to clear 4 zombie features against v0.103.1 merged PRs (#3490 → 2 branch-name zombies, #3498 → 1 checkpoint zombie, #3507 → 1 validatePRForResume zombie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a one‑shot executable utility that accepts an optional numeric threshold, prints startup info, logs events to stdout, runs a single sweep, and emits the results as formatted JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->