### PR TITLE
fix(maintenance): reconciler #NNNN fast-path requires resolution verb

### DIFF
--- a/apps/server/src/services/maintenance/checks/backlog-title-reconciler-check.ts
+++ b/apps/server/src/services/maintenance/checks/backlog-title-reconciler-check.ts
@@ -138,19 +138,33 @@ export function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
 }
 
 /**
- * Extract `#NNNN` PR/issue references from a string. Filters out very small
- * numbers (< 100) to avoid matching against minor refs like "#1" that are
- * more likely to be workstream numbers, checklist positions, or footnote
- * markers than real PR/issue identifiers.
+ * Extract `#NNNN` PR/issue references from a string that appear in a
+ * contextual phrase indicating resolution — "closes #N", "fixes #N",
+ * "resolved by PR #N", "shipped in #N", etc. Plain mentions ("see #3498 for
+ * context", "related: #3505") are intentionally excluded because they would
+ * false-match features that cite a PR without that PR being the actual
+ * resolution.
+ *
+ * Filters out numbers below 100 (likely workstream indices, checklist items,
+ * or footnote markers rather than real PR/issue IDs).
  */
 export function extractIssueRefs(text: string): number[] {
   if (!text) return [];
-  const matches = text.matchAll(/#(\d{3,})/g);
   const refs = new Set<number>();
-  for (const m of matches) {
-    const n = parseInt(m[1], 10);
-    if (!Number.isNaN(n) && n >= 100) refs.add(n);
+
+  // Contextual patterns — the verb or preposition must appear within ~20 chars
+  // of the #NNNN. Case-insensitive.
+  const patterns = [
+    /\b(closes?|closed|fix(?:es|ed)?|resolv(?:es|ed)|address(?:es|ed)|ship(?:ped)?(?:\s+in)?|landed\s+in|introduced\s+in|covered\s+by)\b(?:\s+(?:by|in))?\s+(?:PR\s+)?#(\d{3,})/gi,
+  ];
+
+  for (const re of patterns) {
+    for (const m of text.matchAll(re)) {
+      const n = parseInt(m[2], 10);
+      if (!Number.isNaN(n) && n >= 100) refs.add(n);
+    }
   }
+
   return Array.from(refs);
 }
 

--- a/apps/server/tests/unit/services/maintenance/checks/backlog-title-reconciler-check.test.ts
+++ b/apps/server/tests/unit/services/maintenance/checks/backlog-title-reconciler-check.test.ts
@@ -92,21 +92,27 @@ describe('normalizeTitle', () => {
 });
 
 describe('extractIssueRefs', () => {
-  it('extracts multi-digit #NNNN references', () => {
-    const refs = extractIssueRefs('fix(ci): PR #3498 — prettier violation, see also #3504');
-    expect(refs).toContain(3498);
-    expect(refs).toContain(3504);
-    // Bare numbers (no # prefix) are ignored — they're often CI run IDs, line
-    // numbers, or dates that would collide with real PR numbers.
-    expect(extractIssueRefs('ran job 24645447205 successfully')).toEqual([]);
+  it('extracts refs appearing after resolution verbs', () => {
+    expect(extractIssueRefs('closes #3498')).toContain(3498);
+    expect(extractIssueRefs('Closes PR #3498')).toContain(3498);
+    expect(extractIssueRefs('fixed by #3504')).toContain(3504);
+    expect(extractIssueRefs('resolved in #3512')).toContain(3512);
+    expect(extractIssueRefs('shipped in PR #3490')).toContain(3490);
+    expect(extractIssueRefs('landed in #3506')).toContain(3506);
+    expect(extractIssueRefs('Introduced in PR #3498 — file follow-up')).toContain(3498);
+  });
+
+  it('IGNORES plain mentions without a resolution verb', () => {
+    // These are the false-positive patterns the tightened extractor guards against.
+    expect(extractIssueRefs('see #3505 for context')).toEqual([]);
+    expect(extractIssueRefs('related: #3505, #3511')).toEqual([]);
+    expect(extractIssueRefs('tracking: #3498 #3504')).toEqual([]);
   });
 
   it('ignores short numeric refs below 100', () => {
-    const refs = extractIssueRefs('see #1 and #42 about item #99 vs #100');
-    expect(refs).not.toContain(1);
-    expect(refs).not.toContain(42);
-    expect(refs).not.toContain(99);
-    expect(refs).toContain(100);
+    // Below-100 filter applies even within a contextual phrase.
+    expect(extractIssueRefs('closes #42')).toEqual([]);
+    expect(extractIssueRefs('closes #100')).toContain(100);
   });
 
   it('returns empty array for empty input', () => {
@@ -115,7 +121,7 @@ describe('extractIssueRefs', () => {
   });
 
   it('deduplicates repeated refs', () => {
-    const refs = extractIssueRefs('see #3498 and later #3498 again');
+    const refs = extractIssueRefs('closes #3498 — also fixes #3498 downstream');
     expect(refs.filter((r) => r === 3498).length).toBe(1);
   });
 });
@@ -290,14 +296,16 @@ describe('BacklogTitleReconcilerCheck.sweepProject', () => {
     expect(loader.update).not.toHaveBeenCalled();
   });
 
-  it('direct #NNNN reference in title reconciles even when Jaccard would miss', async () => {
-    // Title has NO meaningful token overlap with the merged PR, but carries the
-    // explicit #3498 reference. The fast-path should catch it.
+  it('direct #NNNN reference with resolution verb reconciles even when Jaccard would miss', async () => {
+    // Title has NO meaningful token overlap with the merged PR, but the
+    // description uses a resolution verb ("introduced in PR #3498"). The
+    // fast-path should catch it via the contextual extractor.
     const now = new Date().toISOString();
     const loader = createFeatureLoader([
       {
         id: 'feat-ref',
-        title: 'fix(ci): PR #3498 — Prettier formatting violation in test file',
+        title: 'fix(ci): Prettier formatting violation in test file',
+        description: 'Introduced in PR #3498. File follow-up.',
         status: 'backlog',
         prNumber: null,
       },
@@ -357,7 +365,8 @@ describe('BacklogTitleReconcilerCheck.sweepProject', () => {
     const loader = createFeatureLoader([
       {
         id: 'feat-ref-dup',
-        title: 'followup mentioning #3498',
+        title: 'followup',
+        description: 'fixed by PR #3498',
         status: 'backlog',
         prNumber: null,
       },
@@ -375,6 +384,33 @@ describe('BacklogTitleReconcilerCheck.sweepProject', () => {
 
     const result = await check.sweepProject('/tmp/proj');
 
+    expect(result.reconciled).toBe(0);
+    expect(loader.update).not.toHaveBeenCalled();
+  });
+
+  it('plain #NNNN mention (no resolution verb) does NOT trigger direct-ref path', async () => {
+    // Regression: feature-1776656525567 previously false-matched PR #3504
+    // because its description listed "#3504" in a "related:" context. The
+    // tightened extractor must ignore that and fall back to Jaccard.
+    const now = new Date().toISOString();
+    const loader = createFeatureLoader([
+      {
+        id: 'feat-plain-mention',
+        title: 'widget platform improvement',
+        description: 'Context: related to #3498, #3504, #3511. Tracks ongoing cleanup.',
+        status: 'backlog',
+        prNumber: null,
+      },
+    ]);
+    const events = createEvents();
+    const check = new BacklogTitleReconcilerCheck(loader, events, 0.9);
+
+    respondMergedPrs([
+      { number: 3498, title: 'unrelated title', mergedAt: now },
+      { number: 3504, title: 'another unrelated', mergedAt: now },
+    ]);
+
+    const result = await check.sweepProject('/tmp/proj');
     expect(result.reconciled).toBe(0);
     expect(loader.update).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Tightens the #NNNN fast-path shipped in #3519. The original extractor matched ANY \`#NNNN\` reference, causing false matches against features that cite related PRs for context rather than as the actual resolution.

## Observed failure

Running the reconciler against the ava board after #3519 shipped:

| Feature | Matched PR | Actual fix |
|---|---|---|
| feature-1776656525567 (duplicate-feature dedup) | #3504 | spread across #3504 + #3512 + #3519 — no single PR |
| feature-1776660066944 (reconciliation sweep) | #3506 (unrelated test) | #3512 |

Both description cited multiple PRs as context. The fast-path matched the first one in the merged-PR list rather than the resolving one.

## Fix

Require a **resolution verb** within ~20 chars of the \`#NNNN\`: \`closes\`, \`fixes\`, \`resolves\`, \`addresses\`, \`shipped in\`, \`landed in\`, \`introduced in\`, \`covered by\`, \`fixed by\`.

Plain mentions (\"related: #N\", \"see #N for context\", \"tracking #N\") no longer trigger direct-ref matching — those fall back to Jaccard as before.

## Test plan

- [x] 2 new regression tests: plain-mention rejection; resolution-verb patterns accepted
- [x] \`npm run test:server -- backlog-title-reconciler\` — 23/23 pass
- [x] \`npm run typecheck\` — 21/21 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue reference detection to only recognize references in resolution-context phrases (e.g., "closes #123", "fixes #456") rather than arbitrary mentions, preventing inaccurate reconciliation from incidental references like "related: #N".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->