### PR TITLE
fix(maintenance): many-to-one direct #ref matches OK

### DIFF
--- a/apps/server/src/services/maintenance/checks/backlog-title-reconciler-check.ts
+++ b/apps/server/src/services/maintenance/checks/backlog-title-reconciler-check.ts
@@ -269,8 +269,10 @@ export class BacklogTitleReconcilerCheck implements MaintenanceCheck {
       for (const ref of refs) {
         const pr = mergedPrsByNumber.get(ref);
         if (!pr) continue;
-        const claimed = features.some((f) => f.prNumber === pr.number);
-        if (claimed) continue;
+        // Direct contextual refs (closes/fixes/introduced-in #N) are legitimate
+        // many-to-one: several zombies can all be sub-concerns of the same
+        // shipping PR. No claim-uniqueness guard here — the contextual-verb
+        // requirement in extractIssueRefs is what prevents false matches.
         best = { pr, score: 1.0 };
         logger.debug(
           `[backlog-title-reconciler] Direct #${ref} reference in feature ${feature.id} matches merged PR — skipping Jaccard`

--- a/apps/server/tests/unit/services/maintenance/checks/backlog-title-reconciler-check.test.ts
+++ b/apps/server/tests/unit/services/maintenance/checks/backlog-title-reconciler-check.test.ts
@@ -360,7 +360,11 @@ describe('BacklogTitleReconcilerCheck.sweepProject', () => {
     expect(result.reconciled).toBe(1);
   });
 
-  it('direct #NNNN ref to a PR already claimed by another feature is skipped', async () => {
+  it('direct #NNNN ref can claim a PR that another feature already claims (many-to-one OK)', async () => {
+    // Multiple zombies filed as sub-concerns of the same shipping PR are a
+    // legitimate many-to-one match. The contextual-verb requirement in
+    // extractIssueRefs keeps false positives out; unique-claim enforcement is
+    // only needed on the fuzzy-Jaccard path.
     const now = new Date().toISOString();
     const loader = createFeatureLoader([
       {
@@ -384,8 +388,12 @@ describe('BacklogTitleReconcilerCheck.sweepProject', () => {
 
     const result = await check.sweepProject('/tmp/proj');
 
-    expect(result.reconciled).toBe(0);
-    expect(loader.update).not.toHaveBeenCalled();
+    expect(result.reconciled).toBe(1);
+    expect(loader.update).toHaveBeenCalledWith(
+      '/tmp/proj',
+      'feat-ref-dup',
+      expect.objectContaining({ status: 'done', prNumber: 3498 })
+    );
   });
 
   it('plain #NNNN mention (no resolution verb) does NOT trigger direct-ref path', async () => {


### PR DESCRIPTION
## Summary

The unique-claim guard shipped in #3519 + #3520 was over-restrictive for the direct-ref path. Multiple zombie features filed as sub-concerns of the same shipping PR (e.g. three zombies each citing \"introduced in PR #3498\") are a legitimate many-to-one match.

The contextual-verb requirement in \`extractIssueRefs\` shipped in #3520 is what prevents false positives. Unique-claim enforcement on the direct-ref path was redundant and harmful.

Fuzzy-Jaccard path still enforces unique claims (two randomly-similar titles shouldn't both claim one PR).

## Test plan

- [x] Updated test now expects many-to-one claim success
- [x] 23/23 tests green
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified the PR reconciliation logic in the maintenance system to remove a constraint that previously prevented multiple features from being matched to the same pull request when directly referenced. This change allows the maintenance system to properly consolidate and process abandoned features that reference the same pull request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->