### PR TITLE
fix(checkpoint): distinguish transient gh errors from PR-not-found

### DIFF
--- a/apps/server/src/services/pipeline-checkpoint-service.ts
+++ b/apps/server/src/services/pipeline-checkpoint-service.ts
@@ -69,6 +69,9 @@ export class PipelineCheckpointService {
         const prNumber = checkpoint.stateContext.prNumber as number | undefined;
         if ((state === 'REVIEW' || state === 'MERGE') && prNumber) {
           const prStatus = await this.validatePRForResume(projectPath, prNumber);
+          // Only invalidate on DEFINITIVE closed/not_found responses. 'unknown'
+          // (transient gh CLI error) leaves the checkpoint untouched so a brief
+          // GitHub outage can't wipe valid checkpoints across the portfolio.
           if (prStatus === 'closed' || prStatus === 'not_found') {
             logger.warn(
               `Checkpoint for ${featureId} at ${state} references PR #${prNumber} which is ${prStatus} — auto-invalidating checkpoint`
@@ -144,7 +147,7 @@ export class PipelineCheckpointService {
   async validatePRForResume(
     projectPath: string,
     prNumber: number
-  ): Promise<'open' | 'merged' | 'closed' | 'not_found'> {
+  ): Promise<'open' | 'merged' | 'closed' | 'not_found' | 'unknown'> {
     try {
       const { stdout } = await execAsync(
         `gh pr view ${prNumber} --json state,mergedAt --jq '{state: .state, mergedAt: .mergedAt}'`,
@@ -155,8 +158,16 @@ export class PipelineCheckpointService {
       if (data.state === 'CLOSED') return 'closed';
       if (data.state === 'OPEN') return 'open';
       return 'not_found';
-    } catch {
-      return 'not_found';
+    } catch (err) {
+      // Distinguish "PR genuinely doesn't exist" (gh CLI succeeds, state unmapped)
+      // from "transient error talking to GitHub" (network, rate limit, CLI failure).
+      // A transient error must NOT cause load() to delete a valid checkpoint — a
+      // brief outage should leave state untouched. Caller treats 'unknown' as
+      // "proceed with the checkpoint as-is."
+      logger.debug(
+        `validatePRForResume: gh CLI error for PR #${prNumber} — returning 'unknown' (transient, keep checkpoint): ${err instanceof Error ? err.message : String(err)}`
+      );
+      return 'unknown';
     }
   }
 

--- a/apps/server/tests/unit/services/pipeline-checkpoint-service.test.ts
+++ b/apps/server/tests/unit/services/pipeline-checkpoint-service.test.ts
@@ -79,14 +79,17 @@ describe('PipelineCheckpointService.validatePRForResume', () => {
     expect(result).toBe('closed');
   });
 
-  it('returns "not_found" when gh CLI errors (PR deleted, auth failure, network)', async () => {
+  it('returns "unknown" when gh CLI errors (transient: network, rate limit, auth)', async () => {
+    // Previously returned 'not_found', which caused load() to delete valid
+    // checkpoints during GitHub outages. Now 'unknown' so load() leaves the
+    // checkpoint intact until a definitive response is available.
     execMock.mockImplementationOnce((_cmd: string, _opts: unknown, cb: ExecCallback) => {
       const err: NodeJS.ErrnoException = new Error('gh: not found');
       err.code = 'ENOENT';
       cb(err, '', 'could not find pull request');
     });
     const result = await service.validatePRForResume('/tmp/proj', 99999);
-    expect(result).toBe('not_found');
+    expect(result).toBe('unknown');
   });
 
   it('returns "not_found" when state is an unexpected value (future GitHub API change)', async () => {
@@ -169,11 +172,26 @@ describe('PipelineCheckpointService.load — PR validation at load time', () => 
     await expect(fs.access(filePath)).rejects.toThrow();
   });
 
-  it('deletes checkpoint and returns null when PR is not_found (deleted)', async () => {
-    const filePath = await writeCheckpoint('feat-gone', 'MERGE', 404);
+  it('KEEPS checkpoint when gh CLI errors (transient "unknown" state)', async () => {
+    // Regression for feature-1776652853666: a brief GitHub outage must NOT
+    // cause load() to delete a valid checkpoint. The 'unknown' response from
+    // validatePRForResume leaves the checkpoint intact so the next load
+    // attempt can re-validate once the outage clears.
+    const filePath = await writeCheckpoint('feat-transient', 'MERGE', 404);
     execMock.mockImplementationOnce((_cmd: string, _opts: unknown, cb: ExecCallback) => {
-      cb(new Error('gh: not found'), '', 'could not find pull request');
+      cb(new Error('gh: network error'), '', 'rate limit exceeded');
     });
+
+    const result = await service.load(tmpProject, 'feat-transient');
+
+    expect(result).not.toBeNull();
+    expect(result?.currentState).toBe('MERGE');
+    await expect(fs.access(filePath)).resolves.toBeUndefined();
+  });
+
+  it('deletes checkpoint and returns null when gh reports explicit CLOSED state', async () => {
+    const filePath = await writeCheckpoint('feat-gone', 'MERGE', 404);
+    respondExec(JSON.stringify({ state: 'CLOSED', mergedAt: null }));
 
     const result = await service.load(tmpProject, 'feat-gone');
 


### PR DESCRIPTION
Resolves feature-1776652853666.

## Summary

\`validatePRForResume\` returned \`'not_found'\` on any gh CLI error, which caused \`load()\` to delete valid checkpoints during brief GitHub outages (rate limits, transient network failures, auth hiccups). A PR that exists but is momentarily unreachable was treated identically to a PR that was deleted — wiping legitimate state.

## Fix

Add an \`'unknown'\` return for the catch branch. \`load()\` treats \`'unknown'\` as \"keep the checkpoint as-is.\" Only definitive \`'closed'\` / \`'not_found'\` states (from successful gh calls that return a recognized non-open state) cause invalidation.

## Test plan

- [x] Updated test: \"KEEPS checkpoint when gh CLI errors (transient 'unknown' state)\" — exercise the regression
- [x] New test: \"deletes checkpoint when gh reports explicit CLOSED state\" — ensures the real invalidation path still works
- [x] 13/13 tests green
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of transient GitHub API errors during checkpoint validation. Checkpoints are now retained when temporary connection or authentication issues occur, instead of being incorrectly deleted. Definitive pull request state changes still trigger appropriate checkpoint cleanup as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->