### PR TITLE
feat(features): create-time dedup via title-Jaccard + #NNNN parsing (#3505)

### DIFF
--- a/apps/server/src/lib/title-match.ts
+++ b/apps/server/src/lib/title-match.ts
@@ -1,0 +1,107 @@
+/**
+ * Title matching primitives shared between the backlog reconciler (post-hoc
+ * sweep against merged PRs) and FeatureLoader.create (at-create dedup against
+ * recently filed features).
+ *
+ * - normalizeTitle: lower-case, strip conventional-commit prefix and [tag]
+ *   prefix, split on non-alphanumeric, drop stopwords and short tokens.
+ * - jaccardSimilarity: standard intersection-over-union on token sets.
+ * - extractIssueRefs: find `#NNNN` references introduced by a resolution verb
+ *   (closes, fixes, introduced in, shipped in, resolved by, …). Plain
+ *   "related: #NNNN" mentions are intentionally ignored.
+ */
+
+const STOPWORDS = new Set([
+  'the',
+  'a',
+  'an',
+  'and',
+  'or',
+  'but',
+  'in',
+  'on',
+  'at',
+  'to',
+  'for',
+  'of',
+  'with',
+  'by',
+  'from',
+  'is',
+  'was',
+  'are',
+  'be',
+  'been',
+  'being',
+  'have',
+  'has',
+  'had',
+  'do',
+  'does',
+  'did',
+  'will',
+  'would',
+  'should',
+  'could',
+  'may',
+  'might',
+  'must',
+  'can',
+  'that',
+  'this',
+  'these',
+  'those',
+  'when',
+  'where',
+  'how',
+  'why',
+  'what',
+  'which',
+  'who',
+  'if',
+  'then',
+  'else',
+]);
+
+export function normalizeTitle(raw: string): Set<string> {
+  let s = raw.toLowerCase();
+  s = s.replace(/^(fix|feat|chore|docs|refactor|test|perf|style|ci|build|revert)\b[^:]*:\s*/, '');
+  s = s.replace(/^\[[^\]]+\]\s*/, '');
+  s = s.replace(/[^a-z0-9]+/g, ' ');
+  const tokens = s
+    .split(/\s+/)
+    .filter((t) => t.length >= 3 && !STOPWORDS.has(t) && !/^\d+$/.test(t));
+  return new Set(tokens);
+}
+
+export function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersect = 0;
+  for (const token of a) if (b.has(token)) intersect++;
+  const union = a.size + b.size - intersect;
+  return intersect / union;
+}
+
+/**
+ * Extract `#NNNN` refs that appear after a resolution verb (closes, fixes,
+ * resolves, shipped in, introduced in, …). Plain mentions (`related: #N`,
+ * `see #N for context`) are intentionally skipped because they describe
+ * context rather than resolution.
+ *
+ * Filters out numbers below 100 to avoid matching against workstream indices
+ * or checklist items.
+ */
+export function extractIssueRefs(text: string): number[] {
+  if (!text) return [];
+  const refs = new Set<number>();
+  const patterns = [
+    /\b(closes?|closed|fix(?:es|ed)?|resolv(?:es|ed)|address(?:es|ed)|ship(?:ped)?(?:\s+in)?|landed\s+in|introduced\s+in|covered\s+by)\b(?:\s+(?:by|in))?\s+(?:PR\s+)?#(\d{3,})/gi,
+  ];
+  for (const re of patterns) {
+    for (const m of text.matchAll(re)) {
+      const n = parseInt(m[2], 10);
+      if (!Number.isNaN(n) && n >= 100) refs.add(n);
+    }
+  }
+  return Array.from(refs);
+}

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -38,6 +38,7 @@ import {
 } from '@protolabsai/platform';
 import { addImplementedFeature, type ImplementedFeature } from '../lib/xml-extractor.js';
 import { debugLog } from '../lib/debug-log.js';
+import { normalizeTitle, jaccardSimilarity, extractIssueRefs } from '../lib/title-match.js';
 import type { DataIntegrityWatchdogService } from './data-integrity-watchdog-service.js';
 import type { ProjectSlugResolver } from './project-slug-resolver.js';
 import { featuresByStatus } from '../lib/prometheus.js';
@@ -796,9 +797,108 @@ export class FeatureLoader implements FeatureStore {
   }
 
   /**
+   * Scan recent features for a near-duplicate title match. Used by `create()`
+   * to short-circuit duplicate filings. Configurable window (default 7 days)
+   * and threshold (default 0.85 Jaccard) — tight threshold because at create
+   * time we prefer false negatives (let the new feature through) over false
+   * positives (swallow legitimate new work).
+   *
+   * Only considers non-terminal features (backlog, in_progress, review,
+   * blocked) — a title that matches a long-done feature is likely describing
+   * a follow-up, not a duplicate.
+   */
+  private async findRecentDuplicateByTitle(
+    projectPath: string,
+    title: string,
+    options: { windowMs?: number; threshold?: number; minTokens?: number } = {}
+  ): Promise<{ feature: Feature; score: number } | null> {
+    const windowMs = options.windowMs ?? 7 * 24 * 60 * 60 * 1000;
+    const threshold = options.threshold ?? 0.85;
+    // Minimum meaningful-token count. Short titles like "MS1 Phase 1"
+    // normalize to 2-3 tokens; at that density, any collision dominates the
+    // Jaccard score and produces spurious matches (e.g. "MS1 Phase 1" and
+    // "MS1 Phase 2" both normalize to {ms1, phase}, score=1.0). Require
+    // more signal before we're willing to swallow a new feature as dup.
+    const minTokens = options.minTokens ?? 4;
+    const cutoff = Date.now() - windowMs;
+    const newTokens = normalizeTitle(title);
+    if (newTokens.size < minTokens) return null;
+
+    let all: Feature[];
+    try {
+      all = await this.getAll(projectPath);
+    } catch {
+      return null;
+    }
+
+    let best: { feature: Feature; score: number } | null = null;
+    for (const f of all) {
+      if (!f.title) continue;
+      if (f.status === 'done') continue;
+      if (f.createdAt) {
+        const createdMs = Date.parse(f.createdAt);
+        if (!Number.isNaN(createdMs) && createdMs < cutoff) continue;
+      }
+      const existingTokens = normalizeTitle(f.title);
+      if (existingTokens.size < minTokens) continue;
+      const score = jaccardSimilarity(newTokens, existingTokens);
+      if (score >= threshold && (!best || score > best.score)) {
+        best = { feature: f, score };
+      }
+    }
+    return best;
+  }
+
+  /**
    * Create a new feature
    */
   async create(projectPath: string, featureData: Partial<Feature>): Promise<Feature> {
+    // Dedup pass — resolves protoLabsAI/protoMaker#3505. Runs BEFORE id/dir
+    // generation so we don't allocate resources for a duplicate. Two signals:
+    //
+    //   1. #NNNN resolution-verb references in title/description. If the
+    //      caller didn't explicitly pass `githubIssueNumber` but the title or
+    //      description says "closes #3498" / "fixed by #3504" / "introduced
+    //      in PR #3498", auto-populate githubIssueNumber from the first ref.
+    //      This lets the downstream idempotency guard in SignalIntakeService
+    //      dedup even when the agent filed the feature without metadata.
+    //
+    //   2. Title-Jaccard against last 7 days of backlog/review features.
+    //      If a near-duplicate is found (≥ 0.85 similarity), return the
+    //      existing feature instead of creating a new one. Catches the
+    //      "two dispatches before the first feature is visible" race and
+    //      the "same bug filed from two channels" pattern.
+    //
+    // Dedup can be disabled via `__skipDedup` flag on featureData (not on the
+    // Feature type — internal escape hatch for test fixtures and migrations).
+    const skipDedup = (featureData as { __skipDedup?: boolean }).__skipDedup === true;
+    if (!skipDedup) {
+      const title = featureData.title?.trim() ?? '';
+      const description = featureData.description ?? '';
+
+      // Signal 1: auto-populate githubIssueNumber from title/description refs
+      if (featureData.githubIssueNumber == null && title) {
+        const refs = [...extractIssueRefs(title), ...extractIssueRefs(description)];
+        if (refs.length > 0) {
+          featureData = { ...featureData, githubIssueNumber: refs[0] };
+          logger.info(
+            `[dedup] Auto-populated githubIssueNumber=${refs[0]} from #NNNN ref in "${title.slice(0, 60)}"`
+          );
+        }
+      }
+
+      // Signal 2: title-Jaccard against recent features (7-day window)
+      if (title) {
+        const existing = await this.findRecentDuplicateByTitle(projectPath, title);
+        if (existing) {
+          logger.warn(
+            `[dedup] Title-similarity duplicate detected — new="${title.slice(0, 60)}" matches existing feature ${existing.feature.id} ("${(existing.feature.title ?? '').slice(0, 60)}") at score ${(existing.score * 100).toFixed(0)}% — returning existing feature`
+          );
+          return existing.feature;
+        }
+      }
+    }
+
     const featureId = featureData.id || this.generateFeatureId();
     const featureDir = this.getFeatureDir(projectPath, featureId);
     const featureJsonPath = this.getFeatureJsonPath(projectPath, featureId);

--- a/apps/server/tests/unit/services/feature-loader.test.ts
+++ b/apps/server/tests/unit/services/feature-loader.test.ts
@@ -416,6 +416,110 @@ describe('feature-loader.ts', () => {
     });
   });
 
+  describe('create dedup (protoMaker#3505)', () => {
+    it('returns the existing feature when title matches at ≥0.85 Jaccard', async () => {
+      const existing = {
+        id: 'feature-existing',
+        title: 'fix(intake): dedup issue-triage across A2A re-dispatches',
+        status: 'backlog',
+        createdAt: new Date().toISOString(),
+      };
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readdir).mockResolvedValue([
+        { name: 'feature-existing', isDirectory: () => true } as any,
+      ]);
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(existing));
+      const writeSpy = vi.mocked(fs.writeFile);
+
+      // Near-identical titles — only surface-level punctuation differs.
+      // Jaccard ≈ 1.0 because the normalizer strips prefix/punctuation.
+      const result = await loader.create(testProjectPath, {
+        title: 'fix(intake): dedup issue-triage across A2A re-dispatches',
+        description: 'duplicate filing',
+      });
+
+      expect(result.id).toBe('feature-existing');
+      expect(writeSpy).not.toHaveBeenCalled();
+    });
+
+    it('skips terminal-status features — matching a done feature does NOT dedup', async () => {
+      const doneFeature = {
+        id: 'feature-done-123',
+        title: 'fix(ci): old completed work with matching tokens',
+        status: 'done',
+        createdAt: new Date().toISOString(),
+      };
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readdir).mockResolvedValue([
+        { name: 'feature-done-123', isDirectory: () => true } as any,
+      ]);
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(doneFeature));
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined as any);
+
+      const result = await loader.create(testProjectPath, {
+        title: 'fix(ci): old completed work with matching tokens',
+        description: 'new filing for follow-up',
+      });
+
+      expect(result.id).not.toBe('feature-done-123');
+      expect(fs.writeFile).toHaveBeenCalled();
+    });
+
+    it('auto-populates githubIssueNumber from contextual #NNNN ref in title', async () => {
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readdir).mockResolvedValue([]);
+      vi.mocked(fs.readFile).mockResolvedValue('{}');
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined as any);
+
+      const result = await loader.create(testProjectPath, {
+        title: 'follow-up concerns — introduced in PR #3498',
+        description: 'see upstream',
+      });
+
+      expect(result.githubIssueNumber).toBe(3498);
+    });
+
+    it('does NOT auto-populate githubIssueNumber from plain mentions', async () => {
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readdir).mockResolvedValue([]);
+      vi.mocked(fs.readFile).mockResolvedValue('{}');
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined as any);
+
+      const result = await loader.create(testProjectPath, {
+        title: 'some bug',
+        description: 'related: #3498, #3504, #3511',
+      });
+
+      expect(result.githubIssueNumber).toBeUndefined();
+    });
+
+    it('respects __skipDedup escape hatch (for fixtures/migrations)', async () => {
+      const existing = {
+        id: 'feature-exists',
+        title: 'same exact title',
+        status: 'backlog',
+        createdAt: new Date().toISOString(),
+      };
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readdir).mockResolvedValue([
+        { name: 'feature-exists', isDirectory: () => true } as any,
+      ]);
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(existing));
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined as any);
+
+      const result = await loader.create(testProjectPath, {
+        title: 'same exact title',
+        __skipDedup: true,
+      } as any);
+
+      expect(result.id).not.toBe('feature-exists');
+    });
+  });
+
   describe('delete', () => {
     it('should delete feature directory', async () => {
       vi.mocked(fs.rm).mockResolvedValue(undefined);


### PR DESCRIPTION
Closes #3505. Resolves board feature \`feature-1776656525567-4m2cdvn4e\`.

## Summary

Prevention-side complement to the reconciler (shipped in #3512/#3519/#3520/#3521). Where the reconciler runs post-hoc against the board to mark already-shipped zombies done, this PR stops most zombies from being created in the first place.

## Two dedup signals at \`FeatureLoader.create()\`

**1. #NNNN ref auto-population.** If the title or description contains a resolution-verb reference (\`closes #3498\`, \`introduced in PR #3504\`, \`fixed by #3512\`, …) and the caller did NOT pass \`githubIssueNumber\`, parse the first ref and populate it. This makes the SignalIntakeService idempotency guard (shipped in #3504) effective for agent-filed features, not just webhook-sourced ones.

**2. Title-Jaccard dedup.** Scan non-terminal features created in the last 7 days. If any has title similarity ≥ 0.85 via token-set Jaccard, return the existing feature instead of creating a duplicate. Uses a minimum-token-count guard (≥4 meaningful tokens) so short titles like "MS1 Phase 1" / "MS1 Phase 2" don't produce spurious matches.

## Escape hatch

Internal \`__skipDedup\` flag on \`featureData\` is supported for test fixtures and data migrations that intentionally need identical-title features.

## Shared primitives

Extracted \`normalizeTitle\`, \`jaccardSimilarity\`, \`extractIssueRefs\` to \`apps/server/src/lib/title-match.ts\` so the reconciler and future callers can share them. Reconciler itself continues to carry its own inline copy in this PR — a follow-up can deduplicate when tests are happy.

## Test plan

- [x] 5 new tests: positive match, terminal-status skip, #NNNN auto-populate, plain-mention rejection, __skipDedup escape hatch
- [x] \`npm run test:server\` — 3618 pass, 23 skipped, 0 fail
- [x] \`npm run typecheck\` — 21/21 pass
- [x] Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Automatic feature deduplication**: When creating a new feature, the system checks for existing features with similar titles. If a match is found, the existing feature is reused, preventing duplicates. Completed features are excluded from this check.
* **GitHub issue auto-linking**: GitHub issue references detected in feature titles are automatically linked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->