### PR TITLE
fix(protopen): push-callback URL heuristic breaks for Tailscale-external agents

### DIFF
--- a/apps/server/src/routes/a2a/index.ts
+++ b/apps/server/src/routes/a2a/index.ts
@@ -26,6 +26,7 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { Router, type Request, type Response } from 'express';
 import { createLogger } from '@protolabsai/utils';
+import { resolveCallbackUrl } from '@protolabsai/platform';
 import { validateApiKey } from '../../lib/auth.js';
 import { getVersion } from '../../lib/version.js';
 import { ProviderFactory } from '../../providers/provider-factory.js';
@@ -220,13 +221,18 @@ export const DECLARED_SKILL_IDS: ReadonlySet<string> = new Set(DECLARED_SKILLS.m
 
 function buildAgentCard(host: string) {
   const version = getVersion();
+  const port = process.env['PORT'] ? parseInt(process.env['PORT'], 10) : undefined;
+  // Resolve the publicly-routable callback URL for this agent.
+  // Resolution order: PUBLIC_CALLBACK_URL env var → Tailscale detection →
+  // HOSTNAME env var → HTTP Host header (local / development fallback).
+  const callbackBase = resolveCallbackUrl({ port, hostname: host.split(':')[0] });
   return {
     name: 'protoMaker',
     description:
       'protoLabs.studio autonomous development agent. ' +
       'Multi-agent runtime coordinating board health, feature management, ' +
       'auto-mode, planning, and project onboarding.',
-    url: `http://${host}`,
+    url: callbackBase,
     version,
     provider: {
       organization: 'protoLabsAI',

--- a/apps/server/tests/unit/callback-url.test.ts
+++ b/apps/server/tests/unit/callback-url.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Unit tests for the push-callback URL resolver.
+ *
+ * Covers the three key scenarios:
+ *   (a) Tailscale agent  → Tailscale URL
+ *   (b) External agent with PUBLIC_CALLBACK_URL configured → fallback URL
+ *   (c) External agent without any fallback and strict mode → clear error
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock 'os' so we can control hostname() and networkInterfaces() per test.
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return {
+    ...actual,
+    hostname: vi.fn(),
+    networkInterfaces: vi.fn(),
+  };
+});
+
+import os from 'os';
+import {
+  resolveCallbackUrl,
+  detectTailscale,
+  CallbackUrlNotConfiguredError,
+} from '@protolabsai/platform';
+
+const mockHostname = vi.mocked(os.hostname);
+const mockNetworkInterfaces = vi.mocked(os.networkInterfaces);
+
+// Helpers
+function setHostname(h: string) {
+  mockHostname.mockReturnValue(h);
+}
+function setNetworkInterfaces(ifaces: ReturnType<typeof os.networkInterfaces>) {
+  mockNetworkInterfaces.mockReturnValue(ifaces);
+}
+function clearEnv() {
+  delete process.env['PUBLIC_CALLBACK_URL'];
+  delete process.env['HOSTNAME'];
+}
+
+describe('detectTailscale', () => {
+  beforeEach(() => {
+    setNetworkInterfaces({});
+  });
+
+  afterEach(() => {
+    clearEnv();
+    vi.restoreAllMocks();
+  });
+
+  it('detects a .ts.net hostname as Tailscale', () => {
+    setHostname('myhost.tailnet.ts.net');
+    const result = detectTailscale();
+    expect(result.isTailscale).toBe(true);
+    expect(result.tailscaleUrl).toBe('http://myhost.tailnet.ts.net');
+  });
+
+  it('detects a .tailnet.ts.net hostname as Tailscale', () => {
+    setHostname('runner.my-corp.tailnet.ts.net');
+    const result = detectTailscale();
+    expect(result.isTailscale).toBe(true);
+    expect(result.tailscaleUrl).toBe('http://runner.my-corp.tailnet.ts.net');
+  });
+
+  it('detects a Tailscale IP in the 100.64/10 range', () => {
+    setHostname('worker-node');
+    setNetworkInterfaces({
+      eth0: [
+        { address: '192.168.1.1', family: 'IPv4', internal: false, netmask: '255.255.255.0', mac: '' },
+      ],
+      tailscale0: [
+        { address: '100.100.5.12', family: 'IPv4', internal: false, netmask: '255.192.0.0', mac: '' },
+      ],
+    } as ReturnType<typeof os.networkInterfaces>);
+    const result = detectTailscale();
+    expect(result.isTailscale).toBe(true);
+    expect(result.tailscaleUrl).toBe('http://100.100.5.12');
+  });
+
+  it('does NOT detect a regular hostname as Tailscale', () => {
+    setHostname('runner-123');
+    setNetworkInterfaces({
+      eth0: [
+        { address: '192.168.1.5', family: 'IPv4', internal: false, netmask: '255.255.255.0', mac: '' },
+      ],
+    } as ReturnType<typeof os.networkInterfaces>);
+    const result = detectTailscale();
+    expect(result.isTailscale).toBe(false);
+    expect(result.tailscaleUrl).toBeUndefined();
+  });
+
+  it('does NOT mistake 100.128.x.x (outside CGNAT range) as Tailscale IP', () => {
+    setHostname('runner-456');
+    setNetworkInterfaces({
+      eth0: [
+        { address: '100.128.0.1', family: 'IPv4', internal: false, netmask: '255.0.0.0', mac: '' },
+      ],
+    } as ReturnType<typeof os.networkInterfaces>);
+    const result = detectTailscale();
+    expect(result.isTailscale).toBe(false);
+  });
+
+  it('accepts an explicit hostname override instead of os.hostname()', () => {
+    setHostname('real-hostname');
+    const result = detectTailscale('agent.mynet.ts.net');
+    expect(result.isTailscale).toBe(true);
+    expect(result.tailscaleUrl).toBe('http://agent.mynet.ts.net');
+  });
+});
+
+describe('resolveCallbackUrl', () => {
+  beforeEach(() => {
+    setNetworkInterfaces({});
+    clearEnv();
+  });
+
+  afterEach(() => {
+    clearEnv();
+    vi.restoreAllMocks();
+  });
+
+  // ── (a) Tailscale agent ───────────────────────────────────────────────────
+
+  it('(a) Tailscale agent via .ts.net hostname → returns Tailscale URL', () => {
+    setHostname('ava.tailnet.ts.net');
+    const url = resolveCallbackUrl({ port: 3008 });
+    expect(url).toBe('http://ava.tailnet.ts.net:3008');
+  });
+
+  it('(a) Tailscale agent via 100.x.x.x IP → returns Tailscale URL', () => {
+    setHostname('runner');
+    setNetworkInterfaces({
+      ts0: [
+        { address: '100.80.1.42', family: 'IPv4', internal: false, netmask: '255.192.0.0', mac: '' },
+      ],
+    } as ReturnType<typeof os.networkInterfaces>);
+    const url = resolveCallbackUrl({ port: 3008 });
+    expect(url).toBe('http://100.80.1.42:3008');
+  });
+
+  it('(a) tailscaleDetection:"force-on" treats any host as Tailscale', () => {
+    setHostname('plain-ci-runner');
+    const url = resolveCallbackUrl({ port: 3008, tailscaleDetection: 'force-on' });
+    expect(url).toBe('http://plain-ci-runner:3008');
+  });
+
+  // ── (b) External agent with PUBLIC_CALLBACK_URL configured ───────────────
+
+  it('(b) PUBLIC_CALLBACK_URL env var takes highest priority over Tailscale', () => {
+    // Even though the host looks like Tailscale, the explicit env var wins.
+    setHostname('ava.tailnet.ts.net');
+    process.env['PUBLIC_CALLBACK_URL'] = 'https://ava.example.com';
+    const url = resolveCallbackUrl({ port: 3008 });
+    // The explicit URL does not have a port, so our port should be appended.
+    expect(url).toBe('https://ava.example.com:3008');
+  });
+
+  it('(b) explicit publicCallbackUrl option takes highest priority', () => {
+    setHostname('ava.tailnet.ts.net');
+    const url = resolveCallbackUrl({
+      port: 3008,
+      publicCallbackUrl: 'https://ci.example.org',
+    });
+    expect(url).toBe('https://ci.example.org:3008');
+  });
+
+  it('(b) PUBLIC_CALLBACK_URL with existing port does not double-append', () => {
+    process.env['PUBLIC_CALLBACK_URL'] = 'https://ava.example.com:9000';
+    setHostname('plain-runner');
+    const url = resolveCallbackUrl({ port: 3008 });
+    // Port already present — should be kept as-is.
+    expect(url).toBe('https://ava.example.com:9000');
+  });
+
+  it('(b) HOSTNAME env var (non-localhost) used when no Tailscale and no PUBLIC_CALLBACK_URL', () => {
+    setHostname('regular-hostname');
+    process.env['HOSTNAME'] = 'reachable.internal';
+    setNetworkInterfaces({});
+    const url = resolveCallbackUrl({ port: 3008 });
+    expect(url).toBe('http://reachable.internal:3008');
+  });
+
+  it('(b) tailscaleDetection:"force-off" skips Tailscale and falls through to HOSTNAME', () => {
+    setHostname('ava.tailnet.ts.net');
+    process.env['HOSTNAME'] = 'public-host.example.com';
+    const url = resolveCallbackUrl({ port: 3008, tailscaleDetection: 'force-off' });
+    expect(url).toBe('http://public-host.example.com:3008');
+  });
+
+  // ── (c) External agent without fallback → clear error (strict mode) ───────
+
+  it('(c) strict mode throws CallbackUrlNotConfiguredError when only localhost is available', () => {
+    setHostname('localhost');
+    setNetworkInterfaces({
+      lo: [
+        { address: '127.0.0.1', family: 'IPv4', internal: true, netmask: '255.0.0.0', mac: '' },
+      ],
+    } as ReturnType<typeof os.networkInterfaces>);
+
+    expect(() =>
+      resolveCallbackUrl({ port: 3008, strict: true, tailscaleDetection: 'force-off' })
+    ).toThrow(CallbackUrlNotConfiguredError);
+  });
+
+  it('(c) error message includes actionable hints for operators', () => {
+    setHostname('localhost');
+    setNetworkInterfaces({});
+
+    let errorMessage = '';
+    try {
+      resolveCallbackUrl({ port: 3008, strict: true, tailscaleDetection: 'force-off' });
+    } catch (err) {
+      if (err instanceof CallbackUrlNotConfiguredError) {
+        errorMessage = err.message;
+      }
+    }
+
+    expect(errorMessage).toContain('PUBLIC_CALLBACK_URL');
+    expect(errorMessage).toContain('HOSTNAME');
+  });
+
+  it('(c) non-strict mode (default) returns localhost fallback instead of throwing', () => {
+    setHostname('localhost');
+    setNetworkInterfaces({});
+
+    const url = resolveCallbackUrl({ port: 3008, tailscaleDetection: 'force-off' });
+    expect(url).toBe('http://localhost:3008');
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────────────
+
+  it('omits port suffix when port is not provided', () => {
+    setHostname('ava.ts.net');
+    const url = resolveCallbackUrl();
+    expect(url).toBe('http://ava.ts.net');
+  });
+
+  it('uses https protocol when specified', () => {
+    setHostname('ava.ts.net');
+    const url = resolveCallbackUrl({ port: 443, protocol: 'https' });
+    expect(url).toBe('https://ava.ts.net:443');
+  });
+});

--- a/apps/server/tests/unit/callback-url.test.ts
+++ b/apps/server/tests/unit/callback-url.test.ts
@@ -69,10 +69,22 @@ describe('detectTailscale', () => {
     setHostname('worker-node');
     setNetworkInterfaces({
       eth0: [
-        { address: '192.168.1.1', family: 'IPv4', internal: false, netmask: '255.255.255.0', mac: '' },
+        {
+          address: '192.168.1.1',
+          family: 'IPv4',
+          internal: false,
+          netmask: '255.255.255.0',
+          mac: '',
+        },
       ],
       tailscale0: [
-        { address: '100.100.5.12', family: 'IPv4', internal: false, netmask: '255.192.0.0', mac: '' },
+        {
+          address: '100.100.5.12',
+          family: 'IPv4',
+          internal: false,
+          netmask: '255.192.0.0',
+          mac: '',
+        },
       ],
     } as ReturnType<typeof os.networkInterfaces>);
     const result = detectTailscale();
@@ -84,7 +96,13 @@ describe('detectTailscale', () => {
     setHostname('runner-123');
     setNetworkInterfaces({
       eth0: [
-        { address: '192.168.1.5', family: 'IPv4', internal: false, netmask: '255.255.255.0', mac: '' },
+        {
+          address: '192.168.1.5',
+          family: 'IPv4',
+          internal: false,
+          netmask: '255.255.255.0',
+          mac: '',
+        },
       ],
     } as ReturnType<typeof os.networkInterfaces>);
     const result = detectTailscale();
@@ -134,7 +152,13 @@ describe('resolveCallbackUrl', () => {
     setHostname('runner');
     setNetworkInterfaces({
       ts0: [
-        { address: '100.80.1.42', family: 'IPv4', internal: false, netmask: '255.192.0.0', mac: '' },
+        {
+          address: '100.80.1.42',
+          family: 'IPv4',
+          internal: false,
+          netmask: '255.192.0.0',
+          mac: '',
+        },
       ],
     } as ReturnType<typeof os.networkInterfaces>);
     const url = resolveCallbackUrl({ port: 3008 });
@@ -195,9 +219,7 @@ describe('resolveCallbackUrl', () => {
   it('(c) strict mode throws CallbackUrlNotConfiguredError when only localhost is available', () => {
     setHostname('localhost');
     setNetworkInterfaces({
-      lo: [
-        { address: '127.0.0.1', family: 'IPv4', internal: true, netmask: '255.0.0.0', mac: '' },
-      ],
+      lo: [{ address: '127.0.0.1', family: 'IPv4', internal: true, netmask: '255.0.0.0', mac: '' }],
     } as ReturnType<typeof os.networkInterfaces>);
 
     expect(() =>

--- a/libs/platform/src/callback-url.ts
+++ b/libs/platform/src/callback-url.ts
@@ -1,0 +1,242 @@
+/**
+ * Push-callback URL resolution for agent-to-agent and webhook callbacks.
+ *
+ * Agents that need to advertise a reachable callback URL face an ambiguity:
+ *   - Agents running inside a Tailscale network can reach each other via
+ *     Tailscale magic-DNS (hostname.tailnet.ts.net) or 100.x.x.x addresses.
+ *   - Agents running outside Tailscale (public CI runners, external peers)
+ *     cannot reach those addresses. They need a publicly routable URL.
+ *
+ * This module provides `resolveCallbackUrl()` — a single function that
+ * resolves the correct callback base URL given the agent's environment.
+ *
+ * Resolution order:
+ *   1. Explicit `PUBLIC_CALLBACK_URL` env var (always wins when set).
+ *   2. Tailscale agent detected → use the Tailscale-derived URL.
+ *   3. HOSTNAME env var present and plausible (non-localhost) → use it.
+ *   4. No usable URL: throw CallbackUrlNotConfiguredError with a clear message.
+ *
+ * "Tailscale agent" detection is intentionally heuristic-based and exposed
+ * as a configurable option (`tailscaleDetection`) so operators can override it
+ * in environments where the heuristic gives false positives or false negatives.
+ *
+ * Settings-first: all detection thresholds are configurable via options.
+ * Never hardcode environment-specific assumptions in callers.
+ */
+
+import os from 'os';
+
+// ─── Error ────────────────────────────────────────────────────────────────────
+
+/**
+ * Thrown when no routable callback URL can be determined from the environment.
+ *
+ * Callers may catch this to emit a clear operator-facing error rather than
+ * silently advertising a non-routable address.
+ */
+export class CallbackUrlNotConfiguredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CallbackUrlNotConfiguredError';
+  }
+}
+
+// ─── Tailscale detection ─────────────────────────────────────────────────────
+
+/**
+ * Heuristic result from Tailscale detection.
+ */
+export interface TailscaleDetectionResult {
+  /** Whether this agent appears to be running inside a Tailscale network. */
+  isTailscale: boolean;
+  /** The derived Tailscale base URL if detected, e.g. `http://hostname.tailnet.ts.net`. */
+  tailscaleUrl?: string;
+}
+
+/**
+ * Detect whether the current host is a Tailscale node by inspecting its hostname.
+ *
+ * Heuristics applied (in order):
+ *   1. Hostname ends in `.ts.net` — official Tailscale magic-DNS TLD.
+ *   2. Hostname ends in `.tailnet.ts.net` — common magic-DNS variant.
+ *   3. A Tailscale IP address (100.64.0.0/10 range) is found among the host's
+ *      network interfaces.
+ *
+ * @param hostname - Override the hostname to test (default: `os.hostname()`).
+ */
+export function detectTailscale(hostname?: string): TailscaleDetectionResult {
+  const host = hostname ?? os.hostname();
+
+  // Heuristic 1 & 2: DNS-name based detection
+  if (host.endsWith('.ts.net') || host.endsWith('.tailnet.ts.net')) {
+    return { isTailscale: true, tailscaleUrl: `http://${host}` };
+  }
+
+  // Heuristic 3: Look for a Tailscale IP on a network interface.
+  // Tailscale addresses live in the RFC 6598 CGNAT range: 100.64.0.0/10
+  // (100.64.0.0 – 100.127.255.255).
+  const ifaces = os.networkInterfaces();
+  for (const addresses of Object.values(ifaces)) {
+    if (!addresses) continue;
+    for (const addr of addresses) {
+      if (addr.family !== 'IPv4') continue;
+      const tsIp = isTailscaleIpv4(addr.address);
+      if (tsIp) {
+        return { isTailscale: true, tailscaleUrl: `http://${addr.address}` };
+      }
+    }
+  }
+
+  return { isTailscale: false };
+}
+
+/**
+ * Return true if the IPv4 address is in the Tailscale CGNAT range (100.64.0.0/10).
+ */
+function isTailscaleIpv4(ip: string): boolean {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return false;
+  const first = parseInt(parts[0], 10);
+  const second = parseInt(parts[1], 10);
+  // 100.64.0.0/10 covers 100.64.0.0 – 100.127.255.255
+  return first === 100 && second >= 64 && second <= 127;
+}
+
+// ─── Resolution options ───────────────────────────────────────────────────────
+
+/**
+ * Options for `resolveCallbackUrl()`.
+ */
+export interface ResolveCallbackUrlOptions {
+  /**
+   * Port to include in the resolved URL.
+   * Omitted from the URL when not provided (allows callers to handle ports separately).
+   */
+  port?: number;
+
+  /**
+   * Explicit public callback URL override — takes highest priority.
+   * Falls back to the `PUBLIC_CALLBACK_URL` environment variable when omitted.
+   */
+  publicCallbackUrl?: string;
+
+  /**
+   * Control Tailscale detection behaviour.
+   *   - `'auto'` (default): run the hostname + network-interface heuristic.
+   *   - `'force-on'`:  treat this host as a Tailscale node regardless of heuristics.
+   *   - `'force-off'`: skip Tailscale detection entirely.
+   */
+  tailscaleDetection?: 'auto' | 'force-on' | 'force-off';
+
+  /**
+   * Override the hostname used for Tailscale detection and URL construction.
+   * Defaults to `os.hostname()`.
+   */
+  hostname?: string;
+
+  /**
+   * Protocol to use when building the URL. Defaults to `'http'`.
+   */
+  protocol?: 'http' | 'https';
+
+  /**
+   * When `true`, throw `CallbackUrlNotConfiguredError` if no routable URL
+   * can be determined (e.g. only localhost/127.0.0.1 is available).
+   * When `false` (default), return the best-effort URL even if it may not be
+   * externally routable.
+   */
+  strict?: boolean;
+}
+
+// ─── Core resolver ────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the base callback URL for this agent.
+ *
+ * See module-level docs for the full resolution order.
+ *
+ * @returns The resolved base URL (e.g. `http://my-host:3008`).
+ * @throws CallbackUrlNotConfiguredError when `strict: true` and no routable URL found.
+ */
+export function resolveCallbackUrl(options: ResolveCallbackUrlOptions = {}): string {
+  const {
+    port,
+    publicCallbackUrl,
+    tailscaleDetection = 'auto',
+    hostname,
+    protocol = 'http',
+    strict = false,
+  } = options;
+
+  const portSuffix = port != null ? `:${port}` : '';
+
+  // ── 1. Explicit PUBLIC_CALLBACK_URL always wins ───────────────────────────
+  const explicitPublicUrl = publicCallbackUrl ?? process.env['PUBLIC_CALLBACK_URL'];
+  if (explicitPublicUrl) {
+    // Strip trailing slash and append port if provided and not already present.
+    const base = explicitPublicUrl.replace(/\/$/, '');
+    // If the explicit URL already contains a port, honour it as-is.
+    try {
+      const parsed = new URL(base);
+      if (port != null && !parsed.port) {
+        return `${base}${portSuffix}`;
+      }
+    } catch {
+      // Not a valid URL — fall through to return as-is with port suffix.
+    }
+    return port != null && !base.match(/:\d+$/) ? `${base}${portSuffix}` : base;
+  }
+
+  // ── 2. Tailscale detection ────────────────────────────────────────────────
+  if (tailscaleDetection !== 'force-off') {
+    if (tailscaleDetection === 'force-on') {
+      const host = hostname ?? os.hostname();
+      return `${protocol}://${host}${portSuffix}`;
+    }
+
+    const detection = detectTailscale(hostname);
+    if (detection.isTailscale && detection.tailscaleUrl) {
+      const base = detection.tailscaleUrl.replace(/\/$/, '');
+      return port != null ? `${base}${portSuffix}` : base;
+    }
+  }
+
+  // ── 3. HOSTNAME env var / passed hostname (non-localhost) ─────────────────
+  const envHostname = hostname ?? process.env['HOSTNAME'];
+  if (envHostname && !isLocalhost(envHostname)) {
+    return `${protocol}://${envHostname}${portSuffix}`;
+  }
+
+  // ── 4. Strict mode: no routable URL found ────────────────────────────────
+  if (strict) {
+    throw new CallbackUrlNotConfiguredError(
+      'No routable callback URL could be determined for this agent.\n' +
+        'This agent does not appear to be on a Tailscale network, and neither\n' +
+        'PUBLIC_CALLBACK_URL nor a non-localhost HOSTNAME is configured.\n\n' +
+        'To fix:\n' +
+        '  • Set PUBLIC_CALLBACK_URL=https://your-public-host in the environment, or\n' +
+        '  • Set HOSTNAME=your-reachable-hostname, or\n' +
+        '  • Configure tailscaleDetection:"force-on" if the agent is on Tailscale\n' +
+        '    but the hostname heuristic is not detecting it.'
+    );
+  }
+
+  // ── Soft fallback: localhost (development / non-strict mode) ──────────────
+  const localHost = envHostname ?? 'localhost';
+  return `${protocol}://${localHost}${portSuffix}`;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Return true if the hostname looks like a loopback / local address.
+ */
+function isLocalhost(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1' ||
+    hostname === '0.0.0.0' ||
+    hostname.startsWith('127.')
+  );
+}

--- a/libs/platform/src/index.ts
+++ b/libs/platform/src/index.ts
@@ -265,6 +265,15 @@ export {
 // Network security (SSRF prevention)
 export { UrlNotAllowedError, isIpBlocked, validateUrlTarget } from './network-security.js';
 
+// Push-callback URL resolution (Tailscale-aware)
+export {
+  CallbackUrlNotConfiguredError,
+  detectTailscale,
+  resolveCallbackUrl,
+  type TailscaleDetectionResult,
+  type ResolveCallbackUrlOptions,
+} from './callback-url.js';
+
 // Safe environment builder for subprocess execution
 export { buildSafeEnv, type SafeEnvOptions } from './safe-env.js';
 


### PR DESCRIPTION
## Summary

Escalated 2026-04-20T09:38:13Z by lead_engineer_escalation. Original feature: feature-1776365794934-rq3io46gl.

The push-callback URL heuristic used by protoPen does not resolve correctly for agents running outside the Tailscale network (e.g., public/external runners). The heuristic presumably assumes the Tailscale magic-DNS / 100.x address space and falls through when the agent has no Tailscale identity.

Acceptance criteria:
- Identify the heuristic in protoPen that picks push-callback URLs (l...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-20T16:16:33.226Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent callback URL resolution with automatic Tailscale network detection
  * New utility to compute a public callback URL with protocol and port options
  * Flexible configuration via environment variables and explicit options

* **Bug Fixes / Reliability**
  * Smarter fallback order to produce a routable callback URL and avoid double-port appends

* **Tests**
  * Added comprehensive tests covering Tailscale detection and resolution scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->