### PR TITLE
feat(auto-recovery): auto-fix prettier-drift failures on open PRs

### DIFF
--- a/apps/server/src/services/maintenance.module.ts
+++ b/apps/server/src/services/maintenance.module.ts
@@ -22,6 +22,7 @@ import { PostMergeReconcilerCheck } from './maintenance/checks/post-merge-reconc
 import { DoneWorktreeCleanupCheck } from './maintenance/checks/done-worktree-cleanup-check.js';
 import { EpicAdoptionSweepCheck } from './maintenance/checks/epic-adoption-sweep-check.js';
 import { BacklogTitleReconcilerCheck } from './maintenance/checks/backlog-title-reconciler-check.js';
+import { PrettierDriftAutofixCheck } from './maintenance/checks/prettier-drift-autofix.js';
 
 const logger = createLogger('Server:Wiring');
 
@@ -35,6 +36,7 @@ export function register(container: ServiceContainer): void {
     eventHistoryService,
     autoModeService,
     worktreeLifecycleService,
+    settingsService,
   } = container;
 
   // Board health check (full tier) — replaces built-in:board-health automation
@@ -192,6 +194,52 @@ export function register(container: ServiceContainer): void {
   // See protoLabsAI/protoMaker#3511.
   const backlogTitleReconcilerCheck = new BacklogTitleReconcilerCheck(featureLoader, events);
 
+  // Prettier drift autofix (full tier) — auto-fixes PRs whose 'checks' CI job fails solely on
+  // format:check by running prettier --write on the offending files and pushing a fix commit.
+  // Gated by featureFlags.autoPrettierFix (default: true). Idempotent.
+  const prettierDriftAutofixCheck = new PrettierDriftAutofixCheck(featureLoader, settingsService);
+  const prettierDriftCheck: MaintenanceCheck = {
+    id: 'prettier-drift-autofix',
+    name: 'Prettier Drift Auto-Fix',
+    tier: 'full',
+    async run(context: MaintenanceCheckContext): Promise<MaintenanceCheckResult> {
+      const t0 = Date.now();
+      let totalFixed = 0;
+      let totalFailed = 0;
+
+      for (const projectPath of context.projectPaths) {
+        try {
+          const issues = await prettierDriftAutofixCheck.run(projectPath);
+          for (const issue of issues) {
+            if (issue.severity === 'info') {
+              totalFixed++;
+            } else {
+              totalFailed++;
+              logger.warn(`[prettier-drift-autofix] ${issue.message}`);
+            }
+          }
+        } catch (err) {
+          logger.error(`Prettier drift autofix failed for ${projectPath}:`, err);
+        }
+      }
+
+      const summary =
+        totalFixed === 0 && totalFailed === 0
+          ? 'Prettier drift: no formatting drift detected'
+          : totalFailed > 0
+            ? `Prettier drift: ${totalFixed} fixed, ${totalFailed} failed (manual fix needed)`
+            : `Prettier drift: auto-fixed ${totalFixed} PR(s)`;
+
+      return {
+        checkId: 'prettier-drift-autofix',
+        passed: totalFailed === 0,
+        summary,
+        details: { totalFixed, totalFailed, projectCount: context.projectPaths.length },
+        durationMs: Date.now() - t0,
+      };
+    },
+  };
+
   maintenanceOrchestrator.register(boardHealthCheck);
   maintenanceOrchestrator.register(resourceUsageCheck);
   maintenanceOrchestrator.register(webhookHealthCheck);
@@ -199,6 +247,7 @@ export function register(container: ServiceContainer): void {
   maintenanceOrchestrator.register(doneWorktreeCleanupCheck);
   maintenanceOrchestrator.register(epicAdoptionSweepCheck);
   maintenanceOrchestrator.register(backlogTitleReconcilerCheck);
+  maintenanceOrchestrator.register(prettierDriftCheck);
 
   // Wire TopicBus for hierarchical event routing of sweep results
   if (container.topicBus) {
@@ -259,6 +308,6 @@ export function register(container: ServiceContainer): void {
   );
 
   logger.info(
-    'MaintenanceOrchestrator started with board-health, resource-usage, webhook-health, post-merge-reconciler, done-worktree-cleanup, epic-adoption-sweep, and backlog-title-reconciler checks'
+    'MaintenanceOrchestrator started with board-health, resource-usage, webhook-health, post-merge-reconciler, done-worktree-cleanup, epic-adoption-sweep, backlog-title-reconciler, and prettier-drift-autofix checks'
   );
 }

--- a/apps/server/src/services/maintenance/checks/prettier-drift-autofix.ts
+++ b/apps/server/src/services/maintenance/checks/prettier-drift-autofix.ts
@@ -214,10 +214,7 @@ export class PrettierDriftAutofixCheck implements MaintenanceCheck {
     }
   }
 
-  private async fetchCheckRuns(
-    projectPath: string,
-    headSha: string
-  ): Promise<CheckRunEntry[]> {
+  private async fetchCheckRuns(projectPath: string, headSha: string): Promise<CheckRunEntry[]> {
     try {
       const { stdout } = await execFileAsync(
         'gh',
@@ -262,25 +259,25 @@ export class PrettierDriftAutofixCheck implements MaintenanceCheck {
 
     try {
       // Fetch the branch from origin
-      await execFileAsync(
-        'git',
-        ['fetch', 'origin', branchName],
-        { cwd: projectPath, encoding: 'utf-8', timeout: 30_000 }
-      );
+      await execFileAsync('git', ['fetch', 'origin', branchName], {
+        cwd: projectPath,
+        encoding: 'utf-8',
+        timeout: 30_000,
+      });
 
       // Create temporary worktree tracking the branch
-      await execFileAsync(
-        'git',
-        ['worktree', 'add', tmpDir, `origin/${branchName}`],
-        { cwd: projectPath, encoding: 'utf-8', timeout: 15_000 }
-      );
+      await execFileAsync('git', ['worktree', 'add', tmpDir, `origin/${branchName}`], {
+        cwd: projectPath,
+        encoding: 'utf-8',
+        timeout: 15_000,
+      });
 
       // Set up branch tracking in the worktree
-      await execFileAsync(
-        'git',
-        ['checkout', '-B', branchName, `origin/${branchName}`],
-        { cwd: tmpDir, encoding: 'utf-8', timeout: 10_000 }
-      );
+      await execFileAsync('git', ['checkout', '-B', branchName, `origin/${branchName}`], {
+        cwd: tmpDir,
+        encoding: 'utf-8',
+        timeout: 10_000,
+      });
 
       // Run prettier on the offending files
       const prettierCmd = prettierVersion ? `prettier@${prettierVersion}` : 'prettier';
@@ -296,11 +293,11 @@ export class PrettierDriftAutofixCheck implements MaintenanceCheck {
       );
 
       // Check if prettier made any changes
-      const { stdout: diffOutput } = await execFileAsync(
-        'git',
-        ['diff', '--name-only'],
-        { cwd: tmpDir, encoding: 'utf-8', timeout: 10_000 }
-      );
+      const { stdout: diffOutput } = await execFileAsync('git', ['diff', '--name-only'], {
+        cwd: tmpDir,
+        encoding: 'utf-8',
+        timeout: 10_000,
+      });
 
       if (!diffOutput.trim()) {
         // No changes — already clean
@@ -323,23 +320,19 @@ export class PrettierDriftAutofixCheck implements MaintenanceCheck {
 
       // Commit the format changes
       const commitMessage = `style: apply prettier formatting\n\nAuto-formatted via ${prettierCmd} — prettier-drift recovery.`;
-      await execFileAsync(
-        'git',
-        ['commit', '-am', commitMessage],
-        {
-          cwd: tmpDir,
-          encoding: 'utf-8',
-          timeout: 15_000,
-          env: { ...process.env, HUSKY: '0' },
-        }
-      );
+      await execFileAsync('git', ['commit', '-am', commitMessage], {
+        cwd: tmpDir,
+        encoding: 'utf-8',
+        timeout: 15_000,
+        env: { ...process.env, HUSKY: '0' },
+      });
 
       // Push the branch
-      await execFileAsync(
-        'git',
-        ['push', 'origin', branchName],
-        { cwd: tmpDir, encoding: 'utf-8', timeout: 30_000 }
-      );
+      await execFileAsync('git', ['push', 'origin', branchName], {
+        cwd: tmpDir,
+        encoding: 'utf-8',
+        timeout: 30_000,
+      });
 
       // Post a PR comment
       await this.postPRComment(
@@ -356,11 +349,11 @@ export class PrettierDriftAutofixCheck implements MaintenanceCheck {
     } finally {
       // Always clean up the temporary worktree
       try {
-        await execFileAsync(
-          'git',
-          ['worktree', 'remove', '--force', tmpDir],
-          { cwd: projectPath, encoding: 'utf-8', timeout: 15_000 }
-        );
+        await execFileAsync('git', ['worktree', 'remove', '--force', tmpDir], {
+          cwd: projectPath,
+          encoding: 'utf-8',
+          timeout: 15_000,
+        });
       } catch (cleanupErr) {
         logger.warn(`PrettierDriftAutofix: failed to remove worktree ${tmpDir}: ${cleanupErr}`);
         // Best-effort cleanup via fs
@@ -380,8 +373,7 @@ export class PrettierDriftAutofixCheck implements MaintenanceCheck {
         devDependencies?: Record<string, string>;
         dependencies?: Record<string, string>;
       };
-      const version =
-        pkg.devDependencies?.prettier ?? pkg.dependencies?.prettier ?? null;
+      const version = pkg.devDependencies?.prettier ?? pkg.dependencies?.prettier ?? null;
       // Strip semver range prefixes (^, ~, >=, etc.)
       return version ? version.replace(/^[^0-9]*/, '') : null;
     } catch {
@@ -389,15 +381,11 @@ export class PrettierDriftAutofixCheck implements MaintenanceCheck {
     }
   }
 
-  private async postPRComment(
-    projectPath: string,
-    prNumber: number,
-    body: string
-  ): Promise<void> {
-    await execFileAsync(
-      'gh',
-      ['pr', 'comment', String(prNumber), '--body', body],
-      { cwd: projectPath, encoding: 'utf-8', timeout: 15_000 }
-    );
+  private async postPRComment(projectPath: string, prNumber: number, body: string): Promise<void> {
+    await execFileAsync('gh', ['pr', 'comment', String(prNumber), '--body', body], {
+      cwd: projectPath,
+      encoding: 'utf-8',
+      timeout: 15_000,
+    });
   }
 }

--- a/apps/server/src/services/maintenance/checks/prettier-drift-autofix.ts
+++ b/apps/server/src/services/maintenance/checks/prettier-drift-autofix.ts
@@ -1,0 +1,403 @@
+/**
+ * PrettierDriftAutofixCheck - Detects and auto-fixes PR CI failures caused by prettier drift.
+ *
+ * Triggers when:
+ * - Feature status is 'review' AND
+ * - A check run named 'checks' is failing AND
+ * - The job log contains [warn] file paths and "Code style issues found" (prettier output) AND
+ * - The 'checks' job is the only failing check run
+ *
+ * Fix: creates a temporary git worktree, runs npx prettier@<version> --write on the
+ * offending files, verifies changes are format-only, commits with HUSKY=0, and pushes.
+ * Posts a PR comment on success. Cleans up the worktree in a finally block.
+ *
+ * Idempotent: if prettier --write produces no changes (already clean), no commit is made.
+ *
+ * Gated by featureFlags.autoPrettierFix (default: true).
+ */
+
+import { execFile } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { promisify } from 'util';
+import { createLogger } from '@protolabsai/utils';
+import type { FeatureLoader } from '../../feature-loader.js';
+import type { MaintenanceCheck, MaintenanceIssue } from '../types.js';
+import type { SettingsService } from '../../settings-service.js';
+
+const execFileAsync = promisify(execFile);
+const logger = createLogger('PrettierDriftAutofix');
+
+/** Pattern for prettier [warn] file lines in CI output */
+const WARN_FILE_RE = /^\[warn\]\s+(.+\.[a-zA-Z0-9]+)\s*$/;
+/** Marker that confirms prettier found formatting violations */
+const FORMAT_ISSUE_MARKER = 'Code style issues found';
+/** The check workflow name that contains format:check */
+const CHECKS_WORKFLOW_JOB_NAME = 'checks';
+
+interface CheckRunEntry {
+  id: number;
+  name: string;
+  status: string;
+  conclusion: string | null;
+}
+
+export class PrettierDriftAutofixCheck implements MaintenanceCheck {
+  readonly id = 'prettier-drift-autofix';
+
+  constructor(
+    private readonly featureLoader: FeatureLoader,
+    private readonly settingsService?: SettingsService
+  ) {}
+
+  async run(projectPath: string): Promise<MaintenanceIssue[]> {
+    const settings = await this.settingsService?.getGlobalSettings().catch(() => null);
+    const enabled = settings?.featureFlags?.autoPrettierFix ?? true;
+    if (!enabled) return [];
+
+    const issues: MaintenanceIssue[] = [];
+
+    try {
+      const features = await this.featureLoader.getAll(projectPath);
+      const reviewFeatures = features.filter(
+        (f) => f.status === 'review' && f.prNumber != null && f.branchName
+      );
+
+      for (const feature of reviewFeatures) {
+        try {
+          const issue = await this.inspectAndFix(
+            projectPath,
+            feature.id,
+            feature.prNumber!,
+            feature.branchName!
+          );
+          if (issue) {
+            issues.push(issue);
+          }
+        } catch (err) {
+          logger.warn(`PrettierDriftAutofix: error processing feature ${feature.id}: ${err}`);
+        }
+      }
+    } catch (err) {
+      logger.error(`PrettierDriftAutofix failed for ${projectPath}: ${err}`);
+    }
+
+    return issues;
+  }
+
+  private async inspectAndFix(
+    projectPath: string,
+    featureId: string,
+    prNumber: number,
+    branchName: string
+  ): Promise<MaintenanceIssue | null> {
+    // Get PR head SHA
+    const prDetails = await this.fetchPRDetails(projectPath, prNumber);
+    if (!prDetails) return null;
+
+    const { headSha } = prDetails;
+
+    // Get all check runs for this commit
+    const checkRuns = await this.fetchCheckRuns(projectPath, headSha);
+    if (checkRuns.length === 0) return null;
+
+    // Find the failing 'checks' check run
+    const failingChecksRun = checkRuns.find(
+      (c) => c.name === CHECKS_WORKFLOW_JOB_NAME && c.conclusion === 'failure'
+    );
+    if (!failingChecksRun) return null;
+
+    // Ensure it's the ONLY failing required check (ignore non-completed runs)
+    const otherFailures = checkRuns.filter(
+      (c) => c.conclusion === 'failure' && c.id !== failingChecksRun.id
+    );
+    if (otherFailures.length > 0) {
+      logger.debug(
+        `PrettierDriftAutofix: PR #${prNumber} has other failures (${otherFailures.map((c) => c.name).join(', ')}), skipping`
+      );
+      return null;
+    }
+
+    // Fetch job logs to detect prettier output
+    const logs = await this.fetchJobLogs(projectPath, failingChecksRun.id);
+    if (!logs) return null;
+
+    const offendingFiles = this.parsePrettierFiles(logs);
+    if (offendingFiles.length === 0) {
+      logger.debug(`PrettierDriftAutofix: PR #${prNumber} checks failure is not a prettier issue`);
+      return null;
+    }
+
+    logger.info(
+      `PrettierDriftAutofix: PR #${prNumber} has prettier drift on ${offendingFiles.length} file(s): ${offendingFiles.join(', ')}`
+    );
+
+    // Apply the fix
+    const fixed = await this.applyFix(projectPath, prNumber, branchName, offendingFiles);
+
+    if (fixed === 'already_clean') {
+      logger.info(`PrettierDriftAutofix: PR #${prNumber} is already clean (idempotent no-op)`);
+      return null;
+    }
+
+    if (fixed === 'success') {
+      return {
+        checkId: this.id,
+        severity: 'info',
+        featureId,
+        message: `PR #${prNumber}: auto-applied prettier formatting to ${offendingFiles.length} file(s) to fix CI drift`,
+        autoFixable: false,
+        fixDescription: 'Prettier fix committed and pushed',
+        context: {
+          featureId,
+          prNumber,
+          branchName,
+          offendingFiles,
+          projectPath,
+        },
+      };
+    }
+
+    // fix === 'failed' — return an issue with autoFixable false so operator can see it
+    return {
+      checkId: this.id,
+      severity: 'warning',
+      featureId,
+      message: `PR #${prNumber}: prettier drift detected but auto-fix failed — manual intervention required`,
+      autoFixable: false,
+      context: {
+        featureId,
+        prNumber,
+        branchName,
+        offendingFiles,
+        projectPath,
+      },
+    };
+  }
+
+  /**
+   * Parse [warn] file lines from a GHA job log.
+   * Returns the list of file paths that prettier reported as needing formatting.
+   */
+  parsePrettierFiles(log: string): string[] {
+    // Only proceed if the "Code style issues found" marker is present
+    if (!log.includes(FORMAT_ISSUE_MARKER)) return [];
+
+    const files: string[] = [];
+    for (const line of log.split('\n')) {
+      // Strip GHA timestamp prefix if present
+      const content = line.replace(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s+/, '');
+      const match = WARN_FILE_RE.exec(content);
+      if (match) {
+        files.push(match[1].trim());
+      }
+    }
+    return files;
+  }
+
+  private async fetchPRDetails(
+    projectPath: string,
+    prNumber: number
+  ): Promise<{ headSha: string; headBranch: string } | null> {
+    try {
+      const { stdout } = await execFileAsync(
+        'gh',
+        ['pr', 'view', String(prNumber), '--json', 'headRefOid,headRefName'],
+        { cwd: projectPath, encoding: 'utf-8', timeout: 15_000 }
+      );
+      const data = JSON.parse(stdout) as { headRefOid: string; headRefName: string };
+      return { headSha: data.headRefOid, headBranch: data.headRefName };
+    } catch (err) {
+      logger.debug(`PrettierDriftAutofix: failed to fetch PR #${prNumber} details: ${err}`);
+      return null;
+    }
+  }
+
+  private async fetchCheckRuns(
+    projectPath: string,
+    headSha: string
+  ): Promise<CheckRunEntry[]> {
+    try {
+      const { stdout } = await execFileAsync(
+        'gh',
+        ['api', `repos/{owner}/{repo}/commits/${headSha}/check-runs`, '--jq', '.check_runs'],
+        { cwd: projectPath, encoding: 'utf-8', timeout: 15_000 }
+      );
+      return JSON.parse(stdout) as CheckRunEntry[];
+    } catch (err) {
+      logger.debug(`PrettierDriftAutofix: failed to fetch check runs for ${headSha}: ${err}`);
+      return [];
+    }
+  }
+
+  private async fetchJobLogs(projectPath: string, checkRunId: number): Promise<string | null> {
+    try {
+      const { stdout } = await execFileAsync(
+        'gh',
+        ['api', `repos/{owner}/{repo}/actions/jobs/${checkRunId}/logs`],
+        {
+          cwd: projectPath,
+          encoding: 'utf-8',
+          timeout: 30_000,
+          maxBuffer: 10 * 1024 * 1024,
+        }
+      );
+      return stdout;
+    } catch (err) {
+      logger.debug(`PrettierDriftAutofix: failed to fetch logs for job ${checkRunId}: ${err}`);
+      return null;
+    }
+  }
+
+  private async applyFix(
+    projectPath: string,
+    prNumber: number,
+    branchName: string,
+    offendingFiles: string[]
+  ): Promise<'success' | 'already_clean' | 'failed'> {
+    // Get prettier version from project root package.json
+    const prettierVersion = this.getPrettierVersion(projectPath);
+    const tmpDir = path.join(os.tmpdir(), `pr-${prNumber}-${Date.now()}`);
+
+    try {
+      // Fetch the branch from origin
+      await execFileAsync(
+        'git',
+        ['fetch', 'origin', branchName],
+        { cwd: projectPath, encoding: 'utf-8', timeout: 30_000 }
+      );
+
+      // Create temporary worktree tracking the branch
+      await execFileAsync(
+        'git',
+        ['worktree', 'add', tmpDir, `origin/${branchName}`],
+        { cwd: projectPath, encoding: 'utf-8', timeout: 15_000 }
+      );
+
+      // Set up branch tracking in the worktree
+      await execFileAsync(
+        'git',
+        ['checkout', '-B', branchName, `origin/${branchName}`],
+        { cwd: tmpDir, encoding: 'utf-8', timeout: 10_000 }
+      );
+
+      // Run prettier on the offending files
+      const prettierCmd = prettierVersion ? `prettier@${prettierVersion}` : 'prettier';
+      await execFileAsync(
+        'npx',
+        [prettierCmd, '--ignore-path', '/dev/null', '--write', ...offendingFiles],
+        {
+          cwd: tmpDir,
+          encoding: 'utf-8',
+          timeout: 60_000,
+          env: { ...process.env },
+        }
+      );
+
+      // Check if prettier made any changes
+      const { stdout: diffOutput } = await execFileAsync(
+        'git',
+        ['diff', '--name-only'],
+        { cwd: tmpDir, encoding: 'utf-8', timeout: 10_000 }
+      );
+
+      if (!diffOutput.trim()) {
+        // No changes — already clean
+        return 'already_clean';
+      }
+
+      // Safety check: ensure changes are format-only (no non-whitespace diffs)
+      const { stdout: substantiveDiff } = await execFileAsync(
+        'git',
+        ['diff', '--ignore-all-space', '--ignore-blank-lines'],
+        { cwd: tmpDir, encoding: 'utf-8', timeout: 10_000 }
+      );
+
+      if (substantiveDiff.trim()) {
+        logger.warn(
+          `PrettierDriftAutofix: PR #${prNumber} — prettier made non-whitespace changes, aborting auto-fix`
+        );
+        return 'failed';
+      }
+
+      // Commit the format changes
+      const commitMessage = `style: apply prettier formatting\n\nAuto-formatted via ${prettierCmd} — prettier-drift recovery.`;
+      await execFileAsync(
+        'git',
+        ['commit', '-am', commitMessage],
+        {
+          cwd: tmpDir,
+          encoding: 'utf-8',
+          timeout: 15_000,
+          env: { ...process.env, HUSKY: '0' },
+        }
+      );
+
+      // Push the branch
+      await execFileAsync(
+        'git',
+        ['push', 'origin', branchName],
+        { cwd: tmpDir, encoding: 'utf-8', timeout: 30_000 }
+      );
+
+      // Post a PR comment
+      await this.postPRComment(
+        projectPath,
+        prNumber,
+        `Auto-formatted via \`${prettierCmd}\` — prettier-drift recovery.`
+      ).catch((err) => logger.warn(`PrettierDriftAutofix: failed to post PR comment: ${err}`));
+
+      logger.info(`PrettierDriftAutofix: PR #${prNumber} prettier drift fixed and pushed`);
+      return 'success';
+    } catch (err) {
+      logger.error(`PrettierDriftAutofix: fix failed for PR #${prNumber}: ${err}`);
+      return 'failed';
+    } finally {
+      // Always clean up the temporary worktree
+      try {
+        await execFileAsync(
+          'git',
+          ['worktree', 'remove', '--force', tmpDir],
+          { cwd: projectPath, encoding: 'utf-8', timeout: 15_000 }
+        );
+      } catch (cleanupErr) {
+        logger.warn(`PrettierDriftAutofix: failed to remove worktree ${tmpDir}: ${cleanupErr}`);
+        // Best-effort cleanup via fs
+        try {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+          // Ignore
+        }
+      }
+    }
+  }
+
+  private getPrettierVersion(projectPath: string): string | null {
+    try {
+      const pkgPath = path.join(projectPath, 'package.json');
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as {
+        devDependencies?: Record<string, string>;
+        dependencies?: Record<string, string>;
+      };
+      const version =
+        pkg.devDependencies?.prettier ?? pkg.dependencies?.prettier ?? null;
+      // Strip semver range prefixes (^, ~, >=, etc.)
+      return version ? version.replace(/^[^0-9]*/, '') : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async postPRComment(
+    projectPath: string,
+    prNumber: number,
+    body: string
+  ): Promise<void> {
+    await execFileAsync(
+      'gh',
+      ['pr', 'comment', String(prNumber), '--body', body],
+      { cwd: projectPath, encoding: 'utf-8', timeout: 15_000 }
+    );
+  }
+}

--- a/apps/server/tests/unit/prettier-drift-autofix.test.ts
+++ b/apps/server/tests/unit/prettier-drift-autofix.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Unit tests for PrettierDriftAutofixCheck
+ *
+ * Coverage:
+ * - parsePrettierFiles: extracts file paths from GHA job log output
+ * - run: skips when autoPrettierFix flag is disabled
+ * - run: skips when no features are in review
+ * - run: skips when checks job is not failing
+ * - run: skips when other checks are also failing
+ * - run: returns info issue on successful fix
+ * - run: returns warning issue when fix fails
+ * - run: returns no issue when already clean (idempotent)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Feature } from '@protolabsai/types';
+
+// --- Module mocks (declared before imports) ---
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock('fs', () => ({
+  readFileSync: vi.fn(),
+  rmSync: vi.fn(),
+}));
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+// --- Imports after mocks ---
+
+import { PrettierDriftAutofixCheck } from '../../src/services/maintenance/checks/prettier-drift-autofix.js';
+import { execFile } from 'child_process';
+import * as fs from 'fs';
+
+// Helper to create a promisified-style mock for execFile
+const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+
+// Build a mock FeatureLoader
+function makeMockFeatureLoader(features: Partial<Feature>[] = []) {
+  return {
+    getAll: vi.fn().mockResolvedValue(features),
+  };
+}
+
+// Build a mock SettingsService
+function makeMockSettingsService(autoPrettierFix = true) {
+  return {
+    getGlobalSettings: vi.fn().mockResolvedValue({
+      featureFlags: { autoPrettierFix },
+    }),
+  };
+}
+
+// Sample GHA job log with prettier failures
+const PRETTIER_FAIL_LOG = `
+2026-01-01T00:00:01.000Z ##[group]Run npm run format:check
+2026-01-01T00:00:02.000Z Checking formatting...
+2026-01-01T00:00:03.000Z [warn] apps/server/src/services/foo.ts
+2026-01-01T00:00:04.000Z [warn] libs/types/src/bar.ts
+2026-01-01T00:00:05.000Z Code style issues found in 2 files. Run Prettier with --write to fix.
+2026-01-01T00:00:06.000Z ##[endgroup]
+2026-01-01T00:00:07.000Z ##[error]Process completed with exit code 1.
+`;
+
+// Sample GHA job log with NO prettier failures
+const NON_PRETTIER_FAIL_LOG = `
+2026-01-01T00:00:01.000Z ##[group]Run npm run build:packages
+2026-01-01T00:00:02.000Z error TS2345: Argument of type ...
+2026-01-01T00:00:03.000Z ##[error]Process completed with exit code 2.
+`;
+
+describe('PrettierDriftAutofixCheck', () => {
+  describe('parsePrettierFiles', () => {
+    it('extracts file paths from prettier warn output', () => {
+      const check = new PrettierDriftAutofixCheck(makeMockFeatureLoader() as any);
+      const files = check.parsePrettierFiles(PRETTIER_FAIL_LOG);
+      expect(files).toEqual([
+        'apps/server/src/services/foo.ts',
+        'libs/types/src/bar.ts',
+      ]);
+    });
+
+    it('returns empty array when no Code style issues marker', () => {
+      const check = new PrettierDriftAutofixCheck(makeMockFeatureLoader() as any);
+      const log = `[warn] some/file.ts\n[warn] other/file.ts\n`;
+      const files = check.parsePrettierFiles(log);
+      expect(files).toEqual([]);
+    });
+
+    it('returns empty array for non-prettier failure log', () => {
+      const check = new PrettierDriftAutofixCheck(makeMockFeatureLoader() as any);
+      const files = check.parsePrettierFiles(NON_PRETTIER_FAIL_LOG);
+      expect(files).toEqual([]);
+    });
+
+    it('ignores [warn] lines that are not file paths', () => {
+      const check = new PrettierDriftAutofixCheck(makeMockFeatureLoader() as any);
+      const log = `[warn] some/file.ts\n[warn] From the output above, no files found.\nCode style issues found in 1 file.`;
+      const files = check.parsePrettierFiles(log);
+      // "From the output above, no files found." doesn't match WARN_FILE_RE (it has spaces and no extension at the end)
+      expect(files).toEqual(['some/file.ts']);
+    });
+
+    it('handles logs without timestamps', () => {
+      const check = new PrettierDriftAutofixCheck(makeMockFeatureLoader() as any);
+      const log = `[warn] apps/ui/src/App.tsx\nCode style issues found in 1 file.`;
+      const files = check.parsePrettierFiles(log);
+      expect(files).toEqual(['apps/ui/src/App.tsx']);
+    });
+  });
+
+  describe('run', () => {
+    let featureLoader: ReturnType<typeof makeMockFeatureLoader>;
+    let settingsService: ReturnType<typeof makeMockSettingsService>;
+
+    const projectPath = '/test/project';
+
+    const reviewFeature: Partial<Feature> = {
+      id: 'feature-123',
+      status: 'review',
+      prNumber: 42,
+      branchName: 'feature/my-feature',
+      title: 'My Feature',
+    };
+
+    // Check runs response: only 'checks' failing
+    const checkRunsOnlyChecksFailing = JSON.stringify([
+      { id: 999, name: 'checks', status: 'completed', conclusion: 'failure' },
+      { id: 1000, name: 'test', status: 'completed', conclusion: 'success' },
+    ]);
+
+    // Check runs response: 'checks' passing
+    const checkRunsAllPassing = JSON.stringify([
+      { id: 999, name: 'checks', status: 'completed', conclusion: 'success' },
+    ]);
+
+    // Check runs response: multiple failures
+    const checkRunsMultipleFailing = JSON.stringify([
+      { id: 999, name: 'checks', status: 'completed', conclusion: 'failure' },
+      { id: 1001, name: 'test', status: 'completed', conclusion: 'failure' },
+    ]);
+
+    function setupExecFileMock(responses: Array<{ stdout: string } | Error>) {
+      let callIndex = 0;
+      mockExecFile.mockImplementation(
+        (
+          _file: string,
+          _args: string[],
+          _opts: unknown,
+          callback: (err: Error | null, result: { stdout: string } | null) => void
+        ) => {
+          const response = responses[callIndex++];
+          if (response instanceof Error) {
+            callback(response, null);
+          } else {
+            callback(null, response);
+          }
+        }
+      );
+    }
+
+    beforeEach(() => {
+      featureLoader = makeMockFeatureLoader([reviewFeature]);
+      settingsService = makeMockSettingsService(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ devDependencies: { prettier: '3.7.4' } })
+      );
+    });
+
+    it('returns empty when autoPrettierFix flag is disabled', async () => {
+      settingsService = makeMockSettingsService(false);
+      const check = new PrettierDriftAutofixCheck(featureLoader as any, settingsService as any);
+      const issues = await check.run(projectPath);
+      expect(issues).toEqual([]);
+      expect(featureLoader.getAll).not.toHaveBeenCalled();
+    });
+
+    it('returns empty when no features are in review', async () => {
+      featureLoader = makeMockFeatureLoader([]);
+      const check = new PrettierDriftAutofixCheck(featureLoader as any, settingsService as any);
+      setupExecFileMock([]);
+      const issues = await check.run(projectPath);
+      expect(issues).toEqual([]);
+    });
+
+    it('returns empty when no failing checks job', async () => {
+      const check = new PrettierDriftAutofixCheck(featureLoader as any, settingsService as any);
+      setupExecFileMock([
+        // gh pr view (headSha)
+        { stdout: JSON.stringify({ headRefOid: 'abc123', headRefName: 'feature/my-feature' }) },
+        // gh api check-runs (all passing)
+        { stdout: checkRunsAllPassing },
+      ]);
+      const issues = await check.run(projectPath);
+      expect(issues).toEqual([]);
+    });
+
+    it('returns empty when other checks are also failing', async () => {
+      const check = new PrettierDriftAutofixCheck(featureLoader as any, settingsService as any);
+      setupExecFileMock([
+        // gh pr view (headSha)
+        { stdout: JSON.stringify({ headRefOid: 'abc123', headRefName: 'feature/my-feature' }) },
+        // gh api check-runs (multiple failing)
+        { stdout: checkRunsMultipleFailing },
+      ]);
+      const issues = await check.run(projectPath);
+      expect(issues).toEqual([]);
+    });
+
+    it('returns empty when job logs have no prettier output', async () => {
+      const check = new PrettierDriftAutofixCheck(featureLoader as any, settingsService as any);
+      setupExecFileMock([
+        // gh pr view
+        { stdout: JSON.stringify({ headRefOid: 'abc123', headRefName: 'feature/my-feature' }) },
+        // gh api check-runs
+        { stdout: checkRunsOnlyChecksFailing },
+        // gh api job logs
+        { stdout: NON_PRETTIER_FAIL_LOG },
+      ]);
+      const issues = await check.run(projectPath);
+      expect(issues).toEqual([]);
+    });
+
+    it('returns info issue on successful fix', async () => {
+      const check = new PrettierDriftAutofixCheck(featureLoader as any, settingsService as any);
+      setupExecFileMock([
+        // gh pr view
+        { stdout: JSON.stringify({ headRefOid: 'abc123', headRefName: 'feature/my-feature' }) },
+        // gh api check-runs
+        { stdout: checkRunsOnlyChecksFailing },
+        // gh api job logs
+        { stdout: PRETTIER_FAIL_LOG },
+        // git fetch origin
+        { stdout: '' },
+        // git worktree add
+        { stdout: '' },
+        // git checkout -B
+        { stdout: '' },
+        // npx prettier@3.7.4 --write
+        { stdout: '' },
+        // git diff --name-only (has changes)
+        { stdout: 'apps/server/src/services/foo.ts\nlibs/types/src/bar.ts\n' },
+        // git diff --ignore-all-space (empty = format only)
+        { stdout: '' },
+        // git commit
+        { stdout: '' },
+        // git push
+        { stdout: '' },
+        // gh pr comment
+        { stdout: '' },
+        // git worktree remove (cleanup)
+        { stdout: '' },
+      ]);
+      const issues = await check.run(projectPath);
+      expect(issues).toHaveLength(1);
+      expect(issues[0].severity).toBe('info');
+      expect(issues[0].featureId).toBe('feature-123');
+      expect(issues[0].message).toContain('PR #42');
+      expect(issues[0].message).toContain('prettier formatting');
+    });
+
+    it('returns no issue when already clean (idempotent)', async () => {
+      const check = new PrettierDriftAutofixCheck(featureLoader as any, settingsService as any);
+      setupExecFileMock([
+        // gh pr view
+        { stdout: JSON.stringify({ headRefOid: 'abc123', headRefName: 'feature/my-feature' }) },
+        // gh api check-runs
+        { stdout: checkRunsOnlyChecksFailing },
+        // gh api job logs
+        { stdout: PRETTIER_FAIL_LOG },
+        // git fetch origin
+        { stdout: '' },
+        // git worktree add
+        { stdout: '' },
+        // git checkout -B
+        { stdout: '' },
+        // npx prettier@3.7.4 --write
+        { stdout: '' },
+        // git diff --name-only (empty = no changes)
+        { stdout: '' },
+        // git worktree remove (cleanup)
+        { stdout: '' },
+      ]);
+      const issues = await check.run(projectPath);
+      expect(issues).toEqual([]);
+    });
+
+    it('returns warning issue when non-whitespace changes detected', async () => {
+      const check = new PrettierDriftAutofixCheck(featureLoader as any, settingsService as any);
+      setupExecFileMock([
+        // gh pr view
+        { stdout: JSON.stringify({ headRefOid: 'abc123', headRefName: 'feature/my-feature' }) },
+        // gh api check-runs
+        { stdout: checkRunsOnlyChecksFailing },
+        // gh api job logs
+        { stdout: PRETTIER_FAIL_LOG },
+        // git fetch origin
+        { stdout: '' },
+        // git worktree add
+        { stdout: '' },
+        // git checkout -B
+        { stdout: '' },
+        // npx prettier@3.7.4 --write
+        { stdout: '' },
+        // git diff --name-only (has changes)
+        { stdout: 'apps/server/src/services/foo.ts\n' },
+        // git diff --ignore-all-space (non-empty = substantive change!)
+        { stdout: 'diff --git a/foo.ts b/foo.ts\n+const x = 1;\n' },
+        // git worktree remove (cleanup)
+        { stdout: '' },
+      ]);
+      const issues = await check.run(projectPath);
+      expect(issues).toHaveLength(1);
+      expect(issues[0].severity).toBe('warning');
+      expect(issues[0].message).toContain('manual intervention');
+    });
+  });
+});

--- a/apps/server/tests/unit/prettier-drift-autofix.test.ts
+++ b/apps/server/tests/unit/prettier-drift-autofix.test.ts
@@ -83,10 +83,7 @@ describe('PrettierDriftAutofixCheck', () => {
     it('extracts file paths from prettier warn output', () => {
       const check = new PrettierDriftAutofixCheck(makeMockFeatureLoader() as any);
       const files = check.parsePrettierFiles(PRETTIER_FAIL_LOG);
-      expect(files).toEqual([
-        'apps/server/src/services/foo.ts',
-        'libs/types/src/bar.ts',
-      ]);
+      expect(files).toEqual(['apps/server/src/services/foo.ts', 'libs/types/src/bar.ts']);
     });
 
     it('returns empty array when no Code style issues marker', () => {

--- a/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
+++ b/apps/ui/src/components/views/settings-view/developer/developer-section.tsx
@@ -41,6 +41,11 @@ const FEATURE_FLAG_LABELS: Record<keyof FeatureFlags, { label: string; descripti
     description:
       'Allow Ava Gateway to automatically act on board issues each heartbeat cycle (unblock features, retry agents, merge ready PRs). Budget: max 3 actions per cycle.',
   },
+  autoPrettierFix: {
+    label: 'Auto Prettier Fix',
+    description:
+      'Automatically fix prettier formatting drift on PRs whose "checks" CI job fails solely on format:check. Applies prettier --write, commits, and pushes. On by default.',
+  },
 };
 
 // Role badge colour mapping

--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -208,6 +208,14 @@ export interface FeatureFlags {
    * Off by default.
    */
   gatewayAutoRemediate: boolean;
+  /**
+   * Auto Prettier Fix — enables the prettier-drift-autofix maintenance check.
+   * When a PR's "checks" CI job fails solely on `npm run format:check`, this check
+   * automatically applies `prettier --write` to the offending files, commits, and pushes.
+   * Idempotent: re-running on an already-clean PR is a no-op.
+   * On by default.
+   */
+  autoPrettierFix: boolean;
 }
 
 /** Default feature flags — all off by default, opt-in per environment */
@@ -217,6 +225,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   reactorEnabled: false,
   hitlForms: false,
   gatewayAutoRemediate: false,
+  autoPrettierFix: true,
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary

When a PR's `checks` job fails solely on `npm run format:check` with "Code style issues found in N files", the remediation is mechanical and should be automated. Observed twice today (PRs #3534 and #3535) — both fixed by hand with the exact same procedure.

## The pattern

Symptom: PR's `checks` job fails at the "Check formatting" step. CI output lists specific files with `[warn] <file>` and closes with "Code style issues found in N files. Run Prettier with --write to fix." No other failures. Co...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-20T16:57:00.730Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic Prettier formatting fixes: when a PR's formatting check is the only failing CI check, offending files are auto-formatted, committed, pushed, and a PR comment reports the fix.
  * Feature flag added in Developer Settings to enable/disable automatic formatting fixes (enabled by default).
* **Tests**
  * Unit tests added to validate parsing, control flow, and success/failure outcomes of the autofix behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->