### PR TITLE
A2A agent card omits /a2a path — protoMaker fleet RPC dispatches 404

### DIFF
--- a/apps/server/src/routes/a2a/index.ts
+++ b/apps/server/src/routes/a2a/index.ts
@@ -232,7 +232,7 @@ function buildAgentCard(host: string) {
       'protoLabs.studio autonomous development agent. ' +
       'Multi-agent runtime coordinating board health, feature management, ' +
       'auto-mode, planning, and project onboarding.',
-    url: callbackBase,
+    url: `${callbackBase}/a2a`,
     version,
     provider: {
       organization: 'protoLabsAI',


### PR DESCRIPTION
## Summary

protoMaker's /.well-known/agent-card.json emits url: "http://automaker-server:3008" (no /a2a path). Fleet clients using @a2a-js/sdk read card.url as the JSON-RPC transport endpoint and POST to root, receiving "Cannot POST /". Working agents (quinn, researcher) correctly emit url: "http://{host}:{port}/a2a". Fix: wherever the card builder constructs the url field (apps/server, likely driven by A2A_ADVERTISE_URL or PUBLIC_BASE_URL env var), append /a2a before emitting. Also consider populating add...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-20T17:00:28.074Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Agent Card's advertised endpoint URL to the proper path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->