### PR TITLE
fix(pr-remediation): GitHubWebhookHandler is dead code — never wired + wrong check-name granularity

### DIFF
--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -40,6 +40,7 @@ import { ProjMAuthorityAgent } from '../services/authority-agents/projm-agent.js
 import { EMAuthorityAgent } from '../services/authority-agents/em-agent.js';
 import { AuditService } from '../services/audit-service.js';
 import { PRFeedbackService } from '../services/pr-feedback-service.js';
+import { GitHubWebhookHandler } from '../services/github-webhook-handler.js';
 import { WorktreeLifecycleService } from '../services/worktree-lifecycle-service.js';
 import { DiscordBotService } from '../services/discord-bot-service.js';
 import { SensorRegistryService } from '../services/sensor-registry-service.js';
@@ -243,6 +244,7 @@ export interface ServiceContainer {
 
   // PR & worktree lifecycle
   prFeedbackService: PRFeedbackService;
+  githubWebhookHandler: GitHubWebhookHandler;
   worktreeLifecycleService: WorktreeLifecycleService;
   githubStateChecker: GitHubStateChecker;
   reconciliationService: ReconciliationService;
@@ -638,6 +640,10 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   // PR Feedback Service (monitors open PRs for review comments)
   const prFeedbackService = new PRFeedbackService(events, featureLoader, dataDir);
 
+  // GitHub Webhook Handler (subscribes to pr:ci-failure, triggers format auto-remediation)
+  const githubWebhookHandler = new GitHubWebhookHandler(events, repoRoot);
+  githubWebhookHandler.start();
+
   // Worktree Lifecycle Service (auto-cleanup after merge + recovery)
   const worktreeLifecycleService = new WorktreeLifecycleService(events, featureLoader, async () => {
     const runningAgents = await autoModeService.getRunningAgents();
@@ -942,6 +948,7 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
     trajectoryQueryService,
     leadHandoffService,
     prFeedbackService,
+    githubWebhookHandler,
     worktreeLifecycleService,
     githubStateChecker,
     reconciliationService,

--- a/apps/server/src/server/shutdown.ts
+++ b/apps/server/src/server/shutdown.ts
@@ -36,6 +36,7 @@ async function gracefulShutdown(server: http.Server, services: ServiceContainer)
     agentDiscordRouter,
     agentService,
     crdtSyncService,
+    githubWebhookHandler,
     dataDir,
   } = services;
 
@@ -67,6 +68,7 @@ async function gracefulShutdown(server: http.Server, services: ServiceContainer)
   schedulerService.stop();
   terminalService.cleanup();
   worktreeLifecycleService.shutdown();
+  githubWebhookHandler.stop();
   issueCreationService.shutdown();
   hitlFormService.shutdown();
   actionableItemBridge.shutdown();

--- a/apps/server/src/services/github-webhook-handler.ts
+++ b/apps/server/src/services/github-webhook-handler.ts
@@ -33,8 +33,18 @@ const logger = createLogger('GitHubWebhookHandler');
 // Constants
 // ---------------------------------------------------------------------------
 
-/** The exact name of the GitHub Actions step we are watching. */
-const FORMAT_CHECK_NAME = 'Check formatting';
+/**
+ * The GitHub Actions job name that runs all CI checks, including formatting.
+ * The GitHub check_runs API returns job-level entries only — "Check formatting"
+ * is a step name (not a job name) and will never appear as a check run name.
+ */
+const CHECKS_JOB_NAME = 'checks';
+
+/**
+ * The string emitted by prettier to stdout when it finds formatting issues.
+ * Appears in the failed step log output fetched via `gh run view --log-failed`.
+ */
+const FORMAT_FAILURE_MARKER = 'Code style issues found';
 
 // ---------------------------------------------------------------------------
 // CI failure event payload (matches what routes/webhooks/routes/github.ts emits)
@@ -167,13 +177,23 @@ export class GitHubWebhookHandler {
   }
 
   /**
-   * Query the GitHub API to determine whether the "Check formatting" check run
-   * failed in the given check suite.
+   * Determine whether a format-check failure caused the `checks` CI job to fail.
    *
-   * Uses `checksUrl` (the check_suite.check_runs_url) when available;
+   * Background: `.github/workflows/checks.yml` defines a single job named `checks`
+   * (not `Check formatting`). The "Check formatting" label is a step name inside
+   * that job. The GitHub check_runs API only exposes job-level entries, so searching
+   * for `cr.name === 'Check formatting'` always returns undefined.
+   *
+   * This method:
+   *   1. Finds the `checks` job run and confirms it failed.
+   *   2. Extracts the workflow run ID from `details_url`.
+   *   3. Fetches the failed-step log via `gh run view --log-failed`.
+   *   4. Returns true only if the log contains the prettier failure marker.
+   *
+   * Uses `checksUrl` (check_suite.check_runs_url) when available;
    * falls back to querying by checkSuiteId.
    *
-   * Returns false on any API error (fail-safe: don't remediate if we can't confirm).
+   * Returns false on any API or parse error (fail-safe: don't remediate if uncertain).
    */
   private async isFormatCheckFailed(
     repository: string,
@@ -207,21 +227,48 @@ export class GitHubWebhookHandler {
         return false;
       }
 
-      const formatCheck = checkRuns.check_runs.find((cr) => cr.name === FORMAT_CHECK_NAME);
-      if (!formatCheck) {
-        logger.debug('[GitHubWebhookHandler] "Check formatting" check run not found in suite');
+      // The GitHub check_runs API returns job-level entries only.
+      // "Check formatting" is a step inside the "checks" job — not its own check run.
+      const checksJob = checkRuns.check_runs.find(
+        (cr) => cr.name === CHECKS_JOB_NAME && cr.conclusion === 'failure'
+      );
+
+      if (!checksJob) {
+        logger.debug(
+          '[GitHubWebhookHandler] "checks" job not found or did not fail — skipping format remediation'
+        );
         return false;
       }
 
-      const failed = formatCheck.conclusion === 'failure';
-      logger.debug('[GitHubWebhookHandler] Format check status', {
-        checkName: formatCheck.name,
-        conclusion: formatCheck.conclusion,
-        failed,
+      // Extract the workflow run ID from the job detail URL so we can fetch step-level logs.
+      // URL format: https://github.com/{org}/{repo}/actions/runs/{runId}/job/{jobId}
+      const detailsUrl = checksJob.details_url ?? '';
+      const runIdMatch = /\/actions\/runs\/(\d+)/.exec(detailsUrl);
+      if (!runIdMatch) {
+        logger.warn(
+          '[GitHubWebhookHandler] Could not extract run_id from details_url — cannot confirm format failure',
+          { detailsUrl }
+        );
+        // Fail-safe: without run_id we cannot inspect logs, so do not auto-remediate
+        return false;
+      }
+      const runId = runIdMatch[1];
+
+      // Fetch the output of all failed steps for this run.
+      // The prettier "Check formatting" step emits FORMAT_FAILURE_MARKER to stdout on failure.
+      const { stdout: logOutput } = await execAsync(
+        `gh run view ${runId} --log-failed --repo ${repository}`,
+        { timeout: 30000 }
+      );
+
+      const hasFormatFailure = logOutput.includes(FORMAT_FAILURE_MARKER);
+      logger.debug('[GitHubWebhookHandler] Format failure log check', {
+        runId,
+        hasFormatFailure,
       });
-      return failed;
+      return hasFormatFailure;
     } catch (err) {
-      logger.warn('[GitHubWebhookHandler] Failed to fetch check runs', {
+      logger.warn('[GitHubWebhookHandler] Failed to check format failure in CI logs', {
         error: err instanceof Error ? err.message : String(err),
       });
       // Fail-safe: if we can't confirm the format check failed, don't auto-remediate

--- a/apps/server/src/types/pr-remediation.ts
+++ b/apps/server/src/types/pr-remediation.ts
@@ -70,6 +70,8 @@ export interface GitHubCheckRunSummary {
   name: string;
   status: string;
   conclusion: string | null;
+  /** URL to the GitHub Actions job detail page (contains run_id in path). */
+  details_url?: string;
 }
 
 export interface GitHubCheckRunsListResponse {

--- a/apps/server/tests/integration/github-webhook-handler-wiring.test.ts
+++ b/apps/server/tests/integration/github-webhook-handler-wiring.test.ts
@@ -39,10 +39,7 @@ vi.mock('../../src/services/pr-remediation-service.js', () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 
-function setupExecStub(opts: {
-  checkRunsResponse: object;
-  runViewOutput: string;
-}): void {
+function setupExecStub(opts: { checkRunsResponse: object; runViewOutput: string }): void {
   mockExec.mockImplementation(
     (
       cmd: string,

--- a/apps/server/tests/integration/github-webhook-handler-wiring.test.ts
+++ b/apps/server/tests/integration/github-webhook-handler-wiring.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Integration test: GitHubWebhookHandler wiring
+ *
+ * Verifies that GitHubWebhookHandler correctly subscribes to the real
+ * EventEmitter (not a stub) and reacts to `pr:ci-failure` events.
+ *
+ * This test is distinct from the unit tests in tests/services/pr-remediation.test.ts,
+ * which use a mock EventEmitter. Here we use the actual `createEventEmitter()` to
+ * confirm the event subscription wiring works end-to-end — the bug that was fixed
+ * (service never instantiated in production) would have caused these tests to pass
+ * while the real server silently swallowed all `pr:ci-failure` events.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createEventEmitter } from '../../src/lib/events.js';
+import { GitHubWebhookHandler } from '../../src/services/github-webhook-handler.js';
+
+// ---------------------------------------------------------------------------
+// Mock child_process.exec (used by isFormatCheckFailed via execAsync)
+// ---------------------------------------------------------------------------
+
+const mockExec = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({
+  exec: mockExec,
+  execFile: vi.fn(),
+  spawn: vi.fn(),
+  fork: vi.fn(),
+  execSync: vi.fn(),
+  execFileSync: vi.fn(),
+}));
+
+// Mock pr-remediation-service so we can assert it was called without running git ops
+const mockRemediateFormatFailure = vi.hoisted(() => vi.fn());
+vi.mock('../../src/services/pr-remediation-service.js', () => ({
+  remediateFormatFailure: mockRemediateFormatFailure,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setupExecStub(opts: {
+  checkRunsResponse: object;
+  runViewOutput: string;
+}): void {
+  mockExec.mockImplementation(
+    (
+      cmd: string,
+      _opts: unknown,
+      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
+    ) => {
+      if (cmd.includes('gh api') && cmd.includes('check-runs')) {
+        cb(null, { stdout: JSON.stringify(opts.checkRunsResponse), stderr: '' });
+        return;
+      }
+      if (cmd.includes('gh run view') && cmd.includes('--log-failed')) {
+        cb(null, { stdout: opts.runViewOutput, stderr: '' });
+        return;
+      }
+      cb(null, { stdout: '', stderr: '' });
+    }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GitHubWebhookHandler — real EventEmitter wiring', () => {
+  let handler: GitHubWebhookHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRemediateFormatFailure.mockResolvedValue({ status: 'success', prNumber: 1, reason: 'ok' });
+  });
+
+  afterEach(() => {
+    handler?.stop();
+  });
+
+  it('subscribes to the real event bus and reacts to pr:ci-failure when checks job failed with format marker', async () => {
+    const events = createEventEmitter();
+    handler = new GitHubWebhookHandler(events, '/tmp/test-project');
+    handler.start();
+
+    setupExecStub({
+      checkRunsResponse: {
+        total_count: 1,
+        check_runs: [
+          {
+            id: 1,
+            name: 'checks',
+            status: 'completed',
+            conclusion: 'failure',
+            details_url: 'https://github.com/owner/repo/actions/runs/24676789130/job/68012345',
+          },
+        ],
+      },
+      runViewOutput: 'Code style issues found in 4 files',
+    });
+
+    events.emit('pr:ci-failure', {
+      projectPath: '/tmp/test-project',
+      prNumber: 42,
+      headBranch: 'feature/integration-test-abc',
+      headSha: 'deadbeef',
+      checkSuiteId: 99999,
+      repository: 'owner/repo',
+    });
+
+    // Allow async handlers to settle
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // The handler must have called remediateFormatFailure — this is the observable
+    // side effect that confirms the event subscription is live.
+    expect(mockRemediateFormatFailure).toHaveBeenCalledOnce();
+    expect(mockRemediateFormatFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prNumber: 42,
+        headBranch: 'feature/integration-test-abc',
+        repository: 'owner/repo',
+      }),
+      events
+    );
+  });
+
+  it('does NOT call remediateFormatFailure when checks job passed (real event bus)', async () => {
+    const events = createEventEmitter();
+    handler = new GitHubWebhookHandler(events, '/tmp/test-project');
+    handler.start();
+
+    setupExecStub({
+      checkRunsResponse: {
+        total_count: 1,
+        check_runs: [
+          {
+            id: 1,
+            name: 'checks',
+            status: 'completed',
+            conclusion: 'success',
+            details_url: 'https://github.com/owner/repo/actions/runs/24676789130/job/68012345',
+          },
+        ],
+      },
+      runViewOutput: '',
+    });
+
+    events.emit('pr:ci-failure', {
+      projectPath: '/tmp/test-project',
+      prNumber: 43,
+      headBranch: 'feature/no-format-issue',
+      headSha: 'cafecafe',
+      checkSuiteId: 99998,
+      repository: 'owner/repo',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(mockRemediateFormatFailure).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribes from the real event bus after stop()', async () => {
+    const events = createEventEmitter();
+    handler = new GitHubWebhookHandler(events, '/tmp/test-project');
+    handler.start();
+    handler.stop();
+
+    setupExecStub({
+      checkRunsResponse: {
+        total_count: 1,
+        check_runs: [
+          {
+            id: 1,
+            name: 'checks',
+            status: 'completed',
+            conclusion: 'failure',
+            details_url: 'https://github.com/owner/repo/actions/runs/24676789130/job/68012345',
+          },
+        ],
+      },
+      runViewOutput: 'Code style issues found in 2 files',
+    });
+
+    events.emit('pr:ci-failure', {
+      projectPath: '/tmp/test-project',
+      prNumber: 44,
+      headBranch: 'feature/after-stop',
+      headSha: 'aa',
+      checkSuiteId: 99997,
+      repository: 'owner/repo',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // After stop(), the subscription is gone — no remediation should be triggered
+    expect(mockRemediateFormatFailure).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/tests/services/pr-remediation.test.ts
+++ b/apps/server/tests/services/pr-remediation.test.ts
@@ -145,11 +145,22 @@ function setupExecMock(overrides: Record<string, string | Error> = {}): void {
           stdout: JSON.stringify({
             total_count: 1,
             check_runs: [
-              { id: 1, name: 'Check formatting', status: 'completed', conclusion: 'failure' },
+              {
+                id: 1,
+                name: 'checks',
+                status: 'completed',
+                conclusion: 'failure',
+                details_url:
+                  'https://github.com/owner/repo/actions/runs/24676789130/job/68012345',
+              },
             ],
           }),
           stderr: '',
         });
+        return;
+      }
+      if (cmd.includes('gh run view') && cmd.includes('--log-failed')) {
+        cb(null, { stdout: 'Code style issues found in 4 files', stderr: '' });
         return;
       }
 
@@ -629,9 +640,16 @@ describe('GitHubWebhookHandler event filtering', () => {
       'gh api': JSON.stringify({
         total_count: 1,
         check_runs: [
-          { id: 1, name: 'Check formatting', status: 'completed', conclusion: 'failure' },
+          {
+            id: 1,
+            name: 'checks',
+            status: 'completed',
+            conclusion: 'failure',
+            details_url: 'https://github.com/owner/repo/actions/runs/24676789130/job/68012345',
+          },
         ],
       }),
+      'gh run view': 'Code style issues found in 4 files',
       'gh pr view': JSON.stringify({ baseRefName: 'dev' }),
       'gh pr diff': 'src/index.ts',
     });
@@ -655,12 +673,18 @@ describe('GitHubWebhookHandler event filtering', () => {
     expect(PrRemediationWorker).toHaveBeenCalled();
   });
 
-  it('skips remediation when Check formatting check passed', async () => {
+  it('skips remediation when checks job passed (format check succeeded)', async () => {
     setupExecMock({
       'gh api': JSON.stringify({
         total_count: 2,
         check_runs: [
-          { id: 1, name: 'Check formatting', status: 'completed', conclusion: 'success' },
+          {
+            id: 1,
+            name: 'checks',
+            status: 'completed',
+            conclusion: 'success',
+            details_url: 'https://github.com/owner/repo/actions/runs/24676789130/job/68012345',
+          },
           { id: 2, name: 'Lint UI', status: 'completed', conclusion: 'failure' },
         ],
       }),
@@ -681,7 +705,7 @@ describe('GitHubWebhookHandler event filtering', () => {
     expect(mockWorker.runPrettier).not.toHaveBeenCalled();
   });
 
-  it('skips remediation when Check formatting check is not in the suite', async () => {
+  it('skips remediation when checks job is not in the suite (only other jobs failed)', async () => {
     setupExecMock({
       'gh api': JSON.stringify({
         total_count: 1,
@@ -700,6 +724,70 @@ describe('GitHubWebhookHandler event filtering', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 100));
 
+    expect(mockWorker.runPrettier).not.toHaveBeenCalled();
+  });
+
+  it('skips remediation when checks job failed but log contains no format failure marker', async () => {
+    setupExecMock({
+      'gh api': JSON.stringify({
+        total_count: 1,
+        check_runs: [
+          {
+            id: 1,
+            name: 'checks',
+            status: 'completed',
+            conclusion: 'failure',
+            details_url: 'https://github.com/owner/repo/actions/runs/24676789130/job/68012345',
+          },
+        ],
+      }),
+      // The "test" job failed, not the format check step
+      'gh run view': '  checks  test  ✗ Run tests\n  Tests failed: 42 expected 0',
+    });
+
+    events.emit('pr:ci-failure', {
+      projectPath: '',
+      prNumber: 54,
+      headBranch: 'feature/test-fail-not-format',
+      headSha: 'abc123',
+      checkSuiteId: 1002,
+      repository: 'owner/repo',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Log contains no "Code style issues found" → no format remediation
+    expect(mockWorker.runPrettier).not.toHaveBeenCalled();
+  });
+
+  it('skips remediation when checks job failed but details_url has no run_id', async () => {
+    setupExecMock({
+      'gh api': JSON.stringify({
+        total_count: 1,
+        check_runs: [
+          {
+            id: 1,
+            name: 'checks',
+            status: 'completed',
+            conclusion: 'failure',
+            // No details_url — cannot extract run_id
+          },
+        ],
+      }),
+    });
+
+    events.emit('pr:ci-failure', {
+      projectPath: '',
+      prNumber: 55,
+      headBranch: 'feature/no-details-url',
+      headSha: 'abc123',
+      checkSuiteId: 1003,
+      repository: 'owner/repo',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Cannot confirm format failure without run_id — safe to skip
     expect(mockWorker.runPrettier).not.toHaveBeenCalled();
   });
 

--- a/apps/server/tests/services/pr-remediation.test.ts
+++ b/apps/server/tests/services/pr-remediation.test.ts
@@ -150,8 +150,7 @@ function setupExecMock(overrides: Record<string, string | Error> = {}): void {
                 name: 'checks',
                 status: 'completed',
                 conclusion: 'failure',
-                details_url:
-                  'https://github.com/owner/repo/actions/runs/24676789130/job/68012345',
+                details_url: 'https://github.com/owner/repo/actions/runs/24676789130/job/68012345',
               },
             ],
           }),

--- a/apps/server/tests/unit/lib/goap/goap-feedback-loop-e2e.test.ts
+++ b/apps/server/tests/unit/lib/goap/goap-feedback-loop-e2e.test.ts
@@ -299,6 +299,11 @@ describe('GOAP Feedback Loop Prevention (E2E)', () => {
       for (let i = 0; i < 5; i++) {
         circuitBreaker.recordAgentFailure('lead-engineer-2');
       }
+      // Re-register lead-engineer-2 so its lastSeenAt is fresh at the current
+      // fake-timer position. Without this, the 900s total elapsed time exceeds
+      // the 30s registryGracePeriodMs and the registry blocks the dispatch
+      // before the circuit breaker gets a chance to run.
+      validator.registerAgent('lead-engineer-2');
       const circuited = tryDispatch({
         action: 'fleet_incident_response',
         agentId: 'lead-engineer-2',


### PR DESCRIPTION
## Summary

RCA of today's recurrence (2026-04-20) of the prettier-drift pattern on PRs #3534 and #3535. A prior feature (`f1o2c28zg`, PR #3463, merged 2026-04-15) was supposed to auto-remediate format failures but did nothing today. Investigation found two independent bugs:

## Bug 1 — Service never wired (primary)

`apps/server/src/services/github-webhook-handler.ts` exports `GitHubWebhookHandler` with a `.start()` method that subscribes to `pr:ci-failure` events. **Zero production instantiations of `new ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled a GitHub webhook handler to start and stop with the server, activating real-time PR CI event handling.

* **Bug Fixes**
  * Improved CI formatting-failure detection by inspecting CI job logs for formatter output markers and adding fail-safes when job details are unavailable.

* **Tests**
  * Added integration and updated unit tests covering webhook wiring, log-based detection, and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->