### PR TITLE
GOAP planner: no goal-satisfied pre-dispatch check — actions fire when goal already met

### DIFF
--- a/apps/server/src/lib/goap/goal-satisfied-guard.ts
+++ b/apps/server/src/lib/goap/goal-satisfied-guard.ts
@@ -1,0 +1,187 @@
+/**
+ * Goal Satisfied Guard — pre-dispatch goal predicate evaluation.
+ *
+ * Evaluates whether the target goal predicate for a GOAP action is already
+ * satisfied in the current world state snapshot before allowing dispatch.
+ *
+ * This is architecturally distinct from the existing protection mechanisms:
+ * - Cooldown: prevents repeated dispatches within a time window
+ * - Dedup: prevents duplicate in-flight incidents
+ * - Registry: blocks phantom agent targets
+ * - Circuit breaker: pauses routing after consecutive failures
+ *
+ * The goal-satisfied guard addresses a different failure mode: dispatching
+ * corrective actions when the condition they correct is already resolved.
+ * Confirmed instances: GitHub #147 (investigate_orphaned_skills dispatched
+ * with orphanedSkillCount=0) and #148 (fleet_incident_response re-dispatched
+ * after fleet.no_agent_stuck was already resolved).
+ */
+
+import { createLogger } from '@protolabsai/utils';
+
+const logger = createLogger('GoalSatisfiedGuard');
+
+/**
+ * A flat snapshot of the current world state.
+ * Keys are world state property names; values are primitive types only.
+ */
+export type WorldStateSnapshot = Record<string, boolean | number | string | undefined>;
+
+/**
+ * A function that evaluates whether a goal predicate is satisfied given
+ * the current world state snapshot.
+ *
+ * Returns true if the goal IS already satisfied (dispatch should be skipped).
+ */
+export type GoalPredicate = (state: WorldStateSnapshot) => boolean;
+
+export interface GoalSatisfiedResult {
+  /** Whether the goal is already satisfied (dispatch should be blocked). */
+  satisfied: boolean;
+  /** The skill ID that was evaluated. */
+  skillId: string;
+  /** Human-readable reason when satisfied=true. */
+  reason?: string;
+  /** The GOAP goal name (e.g. "fleet.no_skill_orphaned"). */
+  goalName?: string;
+}
+
+interface RegisteredGoal {
+  predicate: GoalPredicate;
+  goalName: string;
+  description: string;
+}
+
+/**
+ * GoalSatisfiedGuard — maps GOAP skill IDs to goal predicates and evaluates
+ * them against a live world state snapshot before dispatch proceeds.
+ *
+ * Usage:
+ *   const guard = createGoalSatisfiedGuard();
+ *   const result = guard.evaluate('investigate_orphaned_skills', worldState);
+ *   if (result.satisfied) { // skip dispatch }
+ */
+export class GoalSatisfiedGuard {
+  private goals = new Map<string, RegisteredGoal>();
+
+  /**
+   * Register a goal predicate for a skill.
+   *
+   * @param skillId    The GOAP skill / action identifier
+   * @param predicate  Function returning true when goal is already satisfied
+   * @param goalName   GOAP goal name (e.g. "fleet.no_skill_orphaned")
+   * @param description Human-readable description for log messages
+   */
+  register(
+    skillId: string,
+    predicate: GoalPredicate,
+    goalName: string,
+    description: string
+  ): void {
+    this.goals.set(skillId, { predicate, goalName, description });
+    logger.debug(`Registered goal predicate for skill "${skillId}": ${goalName}`);
+  }
+
+  /**
+   * Evaluate whether the goal for a skill is already satisfied.
+   *
+   * If no predicate is registered for the skill, returns satisfied=false
+   * (allow dispatch — unknown skill is not blocked).
+   */
+  evaluate(skillId: string, worldState: WorldStateSnapshot): GoalSatisfiedResult {
+    const goal = this.goals.get(skillId);
+    if (!goal) {
+      return { satisfied: false, skillId };
+    }
+
+    const satisfied = goal.predicate(worldState);
+    if (satisfied) {
+      logger.info(
+        `Goal "${goal.goalName}" for skill "${skillId}" already satisfied in world state — blocking dispatch. ${goal.description}`
+      );
+      return {
+        satisfied: true,
+        skillId,
+        goalName: goal.goalName,
+        reason: `Goal "${goal.goalName}" is already satisfied: ${goal.description}`,
+      };
+    }
+
+    return { satisfied: false, skillId, goalName: goal.goalName };
+  }
+
+  /**
+   * Returns the list of skill IDs that have registered goal predicates.
+   */
+  getRegisteredSkills(): string[] {
+    return Array.from(this.goals.keys());
+  }
+
+  /**
+   * Returns the goal name for a skill, or undefined if not registered.
+   */
+  getGoalName(skillId: string): string | undefined {
+    return this.goals.get(skillId)?.goalName;
+  }
+
+  /**
+   * Clear all registered predicates (admin/testing).
+   */
+  clear(): void {
+    this.goals.clear();
+  }
+}
+
+// ─── Built-in goal predicates ─────────────────────────────────────────────────
+//
+// These match the confirmed bug instances from GitHub #147 and #148.
+// The world state keys correspond to values the GOAP planner includes in
+// the worldState snapshot passed to POST /api/world/check-dispatch.
+
+export const BUILTIN_GOAL_PREDICATES: ReadonlyArray<{
+  skillId: string;
+  goalName: string;
+  description: string;
+  predicate: GoalPredicate;
+}> = [
+  {
+    // GitHub #147: investigate_orphaned_skills dispatched with orphanedSkillCount=0
+    skillId: 'investigate_orphaned_skills',
+    goalName: 'fleet.no_skill_orphaned',
+    description: 'orphaned_skill_count is 0 — fleet has no orphaned skills, no action needed',
+    predicate: (state) => {
+      const count = state['orphaned_skill_count'];
+      if (typeof count === 'number') return count === 0;
+      // Accept boolean shorthand: fleet_no_skill_orphaned=true
+      const noOrphaned = state['fleet_no_skill_orphaned'];
+      if (typeof noOrphaned === 'boolean') return noOrphaned;
+      return false;
+    },
+  },
+  {
+    // GitHub #148: fleet_incident_response re-dispatched after fleet.no_agent_stuck resolved
+    skillId: 'fleet_incident_response',
+    goalName: 'fleet.no_agent_stuck',
+    description: 'stuck_agent_count is 0 — no agents are stuck, fleet is healthy',
+    predicate: (state) => {
+      const count = state['stuck_agent_count'];
+      if (typeof count === 'number') return count === 0;
+      // Accept boolean shorthand: fleet_no_agent_stuck=true
+      const noStuck = state['fleet_no_agent_stuck'];
+      if (typeof noStuck === 'boolean') return noStuck;
+      return false;
+    },
+  },
+] as const;
+
+/**
+ * Create a GoalSatisfiedGuard pre-populated with built-in predicates
+ * for all known GOAP skills.
+ */
+export function createGoalSatisfiedGuard(): GoalSatisfiedGuard {
+  const guard = new GoalSatisfiedGuard();
+  for (const { skillId, goalName, description, predicate } of BUILTIN_GOAL_PREDICATES) {
+    guard.register(skillId, predicate, goalName, description);
+  }
+  return guard;
+}

--- a/apps/server/src/lib/goap/goal-satisfied-guard.ts
+++ b/apps/server/src/lib/goap/goal-satisfied-guard.ts
@@ -72,12 +72,7 @@ export class GoalSatisfiedGuard {
    * @param goalName   GOAP goal name (e.g. "fleet.no_skill_orphaned")
    * @param description Human-readable description for log messages
    */
-  register(
-    skillId: string,
-    predicate: GoalPredicate,
-    goalName: string,
-    description: string
-  ): void {
+  register(skillId: string, predicate: GoalPredicate, goalName: string, description: string): void {
     this.goals.set(skillId, { predicate, goalName, description });
     logger.debug(`Registered goal predicate for skill "${skillId}": ${goalName}`);
   }

--- a/apps/server/src/lib/goap/index.ts
+++ b/apps/server/src/lib/goap/index.ts
@@ -1,7 +1,9 @@
 /**
  * GOAP Feedback Loop Protection
  *
- * Prevents incident feedback loops in the GOAP engine through four mechanisms:
+ * Prevents incident feedback loops in the GOAP engine through five mechanisms:
+ * 0. Goal satisfied guard — skips dispatch when the target goal predicate is
+ *    already satisfied in the current world state snapshot (pre-dispatch check)
  * 1. Dispatch cooldown — 5-min window prevents tick-rate storms
  * 2. Incident deduplication — agent+skill composite key prevents duplicate INC filing
  * 3. Pre-dispatch registry validation — blocks phantom agent routing
@@ -32,3 +34,11 @@ export {
   type CircuitState,
 } from './agent-circuit-breaker.js';
 export { DEFAULT_GOAP_CONFIG, type GoapFeedbackLoopConfig } from './goap-config.js';
+export {
+  GoalSatisfiedGuard,
+  createGoalSatisfiedGuard,
+  BUILTIN_GOAL_PREDICATES,
+  type GoalPredicate,
+  type GoalSatisfiedResult,
+  type WorldStateSnapshot,
+} from './goal-satisfied-guard.js';

--- a/apps/server/src/routes/world/index.ts
+++ b/apps/server/src/routes/world/index.ts
@@ -38,7 +38,13 @@ const dispatchValidator = new DispatchValidator();
 const agentCircuitBreaker = new AgentCircuitBreakerManager();
 const goalSatisfiedGuard: GoalSatisfiedGuard = createGoalSatisfiedGuard();
 
-export { dispatchCooldown, incidentDedup, dispatchValidator, agentCircuitBreaker, goalSatisfiedGuard };
+export {
+  dispatchCooldown,
+  incidentDedup,
+  dispatchValidator,
+  agentCircuitBreaker,
+  goalSatisfiedGuard,
+};
 
 function requireApiKey(req: Request, res: Response): boolean {
   const key = req.headers['x-api-key'] as string | undefined;

--- a/apps/server/src/routes/world/index.ts
+++ b/apps/server/src/routes/world/index.ts
@@ -25,7 +25,10 @@ import {
   IncidentDedup,
   DispatchValidator,
   AgentCircuitBreakerManager,
+  GoalSatisfiedGuard,
+  createGoalSatisfiedGuard,
   DEFAULT_GOAP_CONFIG,
+  type WorldStateSnapshot,
 } from '../../lib/goap/index.js';
 
 // Singleton instances for GOAP feedback loop protection
@@ -33,8 +36,9 @@ const dispatchCooldown = new DispatchCooldown();
 const incidentDedup = new IncidentDedup();
 const dispatchValidator = new DispatchValidator();
 const agentCircuitBreaker = new AgentCircuitBreakerManager();
+const goalSatisfiedGuard: GoalSatisfiedGuard = createGoalSatisfiedGuard();
 
-export { dispatchCooldown, incidentDedup, dispatchValidator, agentCircuitBreaker };
+export { dispatchCooldown, incidentDedup, dispatchValidator, agentCircuitBreaker, goalSatisfiedGuard };
 
 function requireApiKey(req: Request, res: Response): boolean {
   const key = req.headers['x-api-key'] as string | undefined;
@@ -256,11 +260,69 @@ export function createWorldRoutes(
   });
 
   /**
+   * POST /api/world/check-dispatch
+   *
+   * Pre-dispatch goal-satisfaction check. The GOAP planner calls this before
+   * dispatching a corrective action to verify the target goal is not already
+   * satisfied in the current world state snapshot.
+   *
+   * If the goal predicate evaluates true against the provided worldState,
+   * the endpoint returns allowed=false with blockedBy="goal_satisfied".
+   * This prevents dispatching corrective actions when the condition they
+   * address has already resolved (GitHub #147, #148).
+   *
+   * Request body: { skillId: string, worldState: Record<string, boolean | number | string> }
+   * Response: { allowed: boolean, blockedBy?: "goal_satisfied", reason?: string, skillId: string }
+   */
+  router.post('/check-dispatch', (req: Request, res: Response): void => {
+    if (!requireApiKey(req, res)) return;
+
+    const body = req.body as { skillId?: unknown; worldState?: unknown };
+    const { skillId, worldState } = body;
+
+    if (!skillId || typeof skillId !== 'string') {
+      res.status(400).json({ success: false, error: 'skillId (string) is required' });
+      return;
+    }
+
+    if (!worldState || typeof worldState !== 'object' || Array.isArray(worldState)) {
+      res.status(400).json({ success: false, error: 'worldState (object) is required' });
+      return;
+    }
+
+    // Extract only primitive values — predicates operate on flat primitive snapshots
+    const snapshot: WorldStateSnapshot = {};
+    for (const [key, value] of Object.entries(worldState as Record<string, unknown>)) {
+      if (typeof value === 'boolean' || typeof value === 'number' || typeof value === 'string') {
+        snapshot[key] = value;
+      }
+    }
+
+    const result = goalSatisfiedGuard.evaluate(skillId, snapshot);
+
+    if (result.satisfied) {
+      res.json({
+        allowed: false,
+        blockedBy: 'goal_satisfied',
+        reason: result.reason,
+        skillId,
+        goalName: result.goalName,
+      });
+    } else {
+      res.json({
+        allowed: true,
+        skillId,
+        goalName: result.goalName ?? null,
+      });
+    }
+  });
+
+  /**
    * GET /api/world/dispatch-health
    *
    * Returns GOAP feedback loop protection status.
    * Exposes cooldown entries, open incidents, circuit breaker states,
-   * and registry size for the GOAP planner to factor into decisions.
+   * registry size, and goal predicate registrations for the GOAP planner.
    */
   router.get('/dispatch-health', (req: Request, res: Response): void => {
     if (!requireApiKey(req, res)) return;
@@ -299,6 +361,10 @@ export function createWorldRoutes(
       registry: {
         registered_count: dispatchValidator.getRegisteredCount(),
         phantom_patterns: DEFAULT_GOAP_CONFIG.phantomAgentPatterns,
+      },
+      goal_satisfied_guard: {
+        registered_skill_count: goalSatisfiedGuard.getRegisteredSkills().length,
+        registered_skills: goalSatisfiedGuard.getRegisteredSkills(),
       },
     });
   });

--- a/apps/server/tests/unit/lib/goap/goal-satisfied-guard.test.ts
+++ b/apps/server/tests/unit/lib/goap/goal-satisfied-guard.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit tests for GoalSatisfiedGuard
+ *
+ * Covers the pre-dispatch goal predicate evaluation that prevents
+ * corrective GOAP actions from firing when the target goal is already met.
+ *
+ * Regression cases: GitHub #147 (investigate_orphaned_skills with orphanedSkillCount=0)
+ * and #148 (fleet_incident_response after fleet.no_agent_stuck resolved).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  GoalSatisfiedGuard,
+  createGoalSatisfiedGuard,
+  BUILTIN_GOAL_PREDICATES,
+} from '@/lib/goap/goal-satisfied-guard.js';
+
+describe('GoalSatisfiedGuard', () => {
+  let guard: GoalSatisfiedGuard;
+
+  beforeEach(() => {
+    guard = new GoalSatisfiedGuard();
+  });
+
+  describe('register / getRegisteredSkills', () => {
+    it('should start empty', () => {
+      expect(guard.getRegisteredSkills()).toHaveLength(0);
+    });
+
+    it('should register a predicate and return skill ID', () => {
+      guard.register('my_skill', () => false, 'my.goal', 'test description');
+      expect(guard.getRegisteredSkills()).toContain('my_skill');
+    });
+
+    it('should return goal name for registered skill', () => {
+      guard.register('my_skill', () => false, 'my.goal', 'test description');
+      expect(guard.getGoalName('my_skill')).toBe('my.goal');
+    });
+
+    it('should return undefined goal name for unknown skill', () => {
+      expect(guard.getGoalName('unknown_skill')).toBeUndefined();
+    });
+  });
+
+  describe('evaluate — unknown skill', () => {
+    it('should allow dispatch when no predicate registered for skill', () => {
+      const result = guard.evaluate('unknown_skill', { some_key: 0 });
+      expect(result.satisfied).toBe(false);
+      expect(result.skillId).toBe('unknown_skill');
+    });
+  });
+
+  describe('evaluate — goal satisfied', () => {
+    it('should block dispatch when predicate returns true', () => {
+      guard.register(
+        'check_health',
+        (state) => state['health_issues'] === 0,
+        'system.healthy',
+        'no health issues detected'
+      );
+
+      const result = guard.evaluate('check_health', { health_issues: 0 });
+      expect(result.satisfied).toBe(true);
+      expect(result.skillId).toBe('check_health');
+      expect(result.goalName).toBe('system.healthy');
+      expect(result.reason).toContain('system.healthy');
+    });
+  });
+
+  describe('evaluate — goal not satisfied', () => {
+    it('should allow dispatch when predicate returns false', () => {
+      guard.register(
+        'check_health',
+        (state) => state['health_issues'] === 0,
+        'system.healthy',
+        'no health issues detected'
+      );
+
+      const result = guard.evaluate('check_health', { health_issues: 3 });
+      expect(result.satisfied).toBe(false);
+      expect(result.goalName).toBe('system.healthy');
+    });
+  });
+
+  describe('evaluate — empty world state', () => {
+    it('should not satisfy goal when world state has no matching key', () => {
+      guard.register(
+        'my_skill',
+        (state) => typeof state['count'] === 'number' && state['count'] === 0,
+        'my.goal',
+        'count is zero'
+      );
+
+      // World state missing the key entirely — predicate returns false
+      const result = guard.evaluate('my_skill', {});
+      expect(result.satisfied).toBe(false);
+    });
+  });
+
+  describe('clear', () => {
+    it('should remove all registered predicates', () => {
+      guard.register('skill_a', () => true, 'goal.a', 'desc a');
+      guard.register('skill_b', () => false, 'goal.b', 'desc b');
+      guard.clear();
+      expect(guard.getRegisteredSkills()).toHaveLength(0);
+    });
+  });
+});
+
+// ─── Built-in predicates ──────────────────────────────────────────────────────
+
+describe('createGoalSatisfiedGuard (built-in predicates)', () => {
+  let guard: GoalSatisfiedGuard;
+
+  beforeEach(() => {
+    guard = createGoalSatisfiedGuard();
+  });
+
+  it('should register all built-in skills', () => {
+    const skills = guard.getRegisteredSkills();
+    for (const { skillId } of BUILTIN_GOAL_PREDICATES) {
+      expect(skills).toContain(skillId);
+    }
+  });
+
+  describe('investigate_orphaned_skills (GitHub #147)', () => {
+    it('should block dispatch when orphaned_skill_count is 0', () => {
+      const result = guard.evaluate('investigate_orphaned_skills', { orphaned_skill_count: 0 });
+      expect(result.satisfied).toBe(true);
+      expect(result.goalName).toBe('fleet.no_skill_orphaned');
+    });
+
+    it('should allow dispatch when orphaned_skill_count > 0', () => {
+      const result = guard.evaluate('investigate_orphaned_skills', { orphaned_skill_count: 3 });
+      expect(result.satisfied).toBe(false);
+    });
+
+    it('should block dispatch when fleet_no_skill_orphaned boolean is true', () => {
+      const result = guard.evaluate('investigate_orphaned_skills', {
+        fleet_no_skill_orphaned: true,
+      });
+      expect(result.satisfied).toBe(true);
+    });
+
+    it('should allow dispatch when fleet_no_skill_orphaned boolean is false', () => {
+      const result = guard.evaluate('investigate_orphaned_skills', {
+        fleet_no_skill_orphaned: false,
+      });
+      expect(result.satisfied).toBe(false);
+    });
+
+    it('should allow dispatch when world state has no relevant key', () => {
+      const result = guard.evaluate('investigate_orphaned_skills', { other_key: 0 });
+      expect(result.satisfied).toBe(false);
+    });
+  });
+
+  describe('fleet_incident_response (GitHub #148)', () => {
+    it('should block dispatch when stuck_agent_count is 0', () => {
+      const result = guard.evaluate('fleet_incident_response', { stuck_agent_count: 0 });
+      expect(result.satisfied).toBe(true);
+      expect(result.goalName).toBe('fleet.no_agent_stuck');
+    });
+
+    it('should allow dispatch when stuck_agent_count > 0', () => {
+      const result = guard.evaluate('fleet_incident_response', { stuck_agent_count: 2 });
+      expect(result.satisfied).toBe(false);
+    });
+
+    it('should block dispatch when fleet_no_agent_stuck boolean is true', () => {
+      const result = guard.evaluate('fleet_incident_response', { fleet_no_agent_stuck: true });
+      expect(result.satisfied).toBe(true);
+    });
+
+    it('should allow dispatch when fleet_no_agent_stuck boolean is false', () => {
+      const result = guard.evaluate('fleet_incident_response', { fleet_no_agent_stuck: false });
+      expect(result.satisfied).toBe(false);
+    });
+
+    it('should allow dispatch when world state has no relevant key', () => {
+      const result = guard.evaluate('fleet_incident_response', { other_key: 'value' });
+      expect(result.satisfied).toBe(false);
+    });
+  });
+
+  describe('does not block non-goal-related skills', () => {
+    it('should allow dispatch for skills with no registered predicate', () => {
+      const result = guard.evaluate('deploy_feature', { stuck_agent_count: 0 });
+      expect(result.satisfied).toBe(false);
+    });
+  });
+});

--- a/apps/server/tests/unit/lib/goap/goap-feedback-loop-e2e.test.ts
+++ b/apps/server/tests/unit/lib/goap/goap-feedback-loop-e2e.test.ts
@@ -2,10 +2,11 @@
  * End-to-end test for GOAP feedback loop prevention.
  *
  * Replays the original incident cascade (14+ waves) and verifies:
- * - Cooldown suppresses repeated incidents
- * - Dedup prevents duplicate filing
- * - Registry validation blocks phantom agents
- * - Circuit breaker pauses after threshold
+ * - Goal satisfied guard blocks dispatch when goal is already met (layer 0)
+ * - Cooldown suppresses repeated incidents (layer 1)
+ * - Dedup prevents duplicate filing (layer 2)
+ * - Registry validation blocks phantom agents (layer 3)
+ * - Circuit breaker pauses after threshold (layer 4)
  * - Blast radius is contained
  */
 
@@ -14,12 +15,18 @@ import { DispatchCooldown } from '@/lib/goap/dispatch-cooldown.js';
 import { IncidentDedup } from '@/lib/goap/incident-dedup.js';
 import { DispatchValidator, InvalidAgentError } from '@/lib/goap/dispatch-validator.js';
 import { AgentCircuitBreakerManager } from '@/lib/goap/agent-circuit-breaker.js';
+import {
+  GoalSatisfiedGuard,
+  createGoalSatisfiedGuard,
+  type WorldStateSnapshot,
+} from '@/lib/goap/goal-satisfied-guard.js';
 
 describe('GOAP Feedback Loop Prevention (E2E)', () => {
   let cooldown: DispatchCooldown;
   let dedup: IncidentDedup;
   let validator: DispatchValidator;
   let circuitBreaker: AgentCircuitBreakerManager;
+  let goalGuard: GoalSatisfiedGuard;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -34,6 +41,7 @@ describe('GOAP Feedback Loop Prevention (E2E)', () => {
       circuitBreakerThreshold: 5,
       circuitBreakerCooldownMs: 300_000,
     });
+    goalGuard = createGoalSatisfiedGuard();
 
     // Register legitimate agents
     validator.registerAgent('lead-engineer-1');
@@ -47,6 +55,7 @@ describe('GOAP Feedback Loop Prevention (E2E)', () => {
 
   /**
    * Simulate the full dispatch pipeline:
+   * 0. Check goal satisfaction (pre-dispatch short-circuit)
    * 1. Check cooldown
    * 2. Check incident dedup
    * 3. Validate dispatch target
@@ -58,7 +67,16 @@ describe('GOAP Feedback Loop Prevention (E2E)', () => {
     agentId: string;
     skillId: string;
     incidentId: string;
+    worldState?: WorldStateSnapshot;
   }): { allowed: boolean; blockedBy?: string; reason?: string } {
+    // Step 0: Goal satisfied guard — skip dispatch if goal already met
+    if (opts.worldState !== undefined) {
+      const goalResult = goalGuard.evaluate(opts.skillId, opts.worldState);
+      if (goalResult.satisfied) {
+        return { allowed: false, blockedBy: 'goal_satisfied', reason: goalResult.reason };
+      }
+    }
+
     // Step 1: Cooldown check
     const cooldownKey = DispatchCooldown.buildKey(opts.action, opts.agentId, opts.skillId);
     const cooldownResult = cooldown.checkAndRecord(cooldownKey);
@@ -241,6 +259,94 @@ describe('GOAP Feedback Loop Prevention (E2E)', () => {
       });
 
       expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe('goal satisfied guard — layer 0 (GitHub #147, #148)', () => {
+    it('should block investigate_orphaned_skills when orphaned_skill_count is 0 (#147)', () => {
+      const result = tryDispatch({
+        action: 'investigate_orphaned_skills',
+        agentId: 'lead-engineer-1',
+        skillId: 'investigate_orphaned_skills',
+        incidentId: 'INC-147',
+        worldState: { orphaned_skill_count: 0 },
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.blockedBy).toBe('goal_satisfied');
+      expect(result.reason).toContain('fleet.no_skill_orphaned');
+    });
+
+    it('should allow investigate_orphaned_skills when orphaned_skill_count > 0', () => {
+      const result = tryDispatch({
+        action: 'investigate_orphaned_skills',
+        agentId: 'lead-engineer-1',
+        skillId: 'investigate_orphaned_skills',
+        incidentId: 'INC-147b',
+        worldState: { orphaned_skill_count: 2 },
+      });
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should block fleet_incident_response when stuck_agent_count is 0 (#148)', () => {
+      const result = tryDispatch({
+        action: 'fleet_incident_response',
+        agentId: 'lead-engineer-2',
+        skillId: 'fleet_incident_response',
+        incidentId: 'INC-148',
+        worldState: { stuck_agent_count: 0 },
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.blockedBy).toBe('goal_satisfied');
+      expect(result.reason).toContain('fleet.no_agent_stuck');
+    });
+
+    it('should allow fleet_incident_response when agents are still stuck', () => {
+      const result = tryDispatch({
+        action: 'fleet_incident_response',
+        agentId: 'lead-engineer-2',
+        skillId: 'fleet_incident_response',
+        incidentId: 'INC-148b',
+        worldState: { stuck_agent_count: 1 },
+      });
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should allow dispatch when no worldState provided (backward compat — planner did not pass snapshot)', () => {
+      // When no worldState is provided, the goal guard is skipped entirely.
+      // This preserves backward compatibility for callers that do not yet
+      // send a worldState snapshot with their dispatch.
+      const result = tryDispatch({
+        action: 'investigate_orphaned_skills',
+        agentId: 'lead-engineer-1',
+        skillId: 'investigate_orphaned_skills',
+        incidentId: 'INC-149',
+        // worldState intentionally omitted
+      });
+      // Goal guard skipped; should pass all other layers
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should catch goal_satisfied before cooldown (earliest possible layer)', () => {
+      // First, dispatch once to prime the cooldown
+      tryDispatch({
+        action: 'fleet_incident_response',
+        agentId: 'lead-engineer-1',
+        skillId: 'fleet_incident_response',
+        incidentId: 'INC-150a',
+        worldState: { stuck_agent_count: 1 },
+      });
+
+      // Second dispatch: goal now satisfied AND cooldown active
+      // Goal guard should fire before cooldown check
+      const result = tryDispatch({
+        action: 'fleet_incident_response',
+        agentId: 'lead-engineer-1',
+        skillId: 'fleet_incident_response',
+        incidentId: 'INC-150b',
+        worldState: { stuck_agent_count: 0 },
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.blockedBy).toBe('goal_satisfied');
     });
   });
 


### PR DESCRIPTION
## Summary

The GOAP planner dispatches corrective actions even when the target goal predicate is already satisfied in the current world state. Confirmed instances: (1) investigate_orphaned_skills dispatched with orphanedSkillCount=0 (fleet.no_skill_orphaned already satisfied, GitHub #147); (2) fleet_incident_response re-dispatched after fleet.no_agent_stuck condition resolved (GitHub #148). Root cause: planner has no pre-dispatch step that evaluates the goal predicate against the live world state snapshot....

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-20T20:36:19.989Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-dispatch goal satisfaction check to avoid redundant skill dispatch.
  * New POST /api/world/check-dispatch to verify if dispatch would be blocked by goal satisfaction.
  * Dispatch health now reports goal-satisfied guard status and registered predicates.
  * Built-in detection for resolved conditions (orphaned skills, stuck agents).

* **Tests**
  * Added unit and end-to-end tests covering the guard and built-in predicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->