### PR TITLE
fix(platform): honor protocol option + fix callback-url.test os mock

### DIFF
--- a/apps/server/tests/unit/callback-url.test.ts
+++ b/apps/server/tests/unit/callback-url.test.ts
@@ -10,12 +10,21 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // Mock 'os' so we can control hostname() and networkInterfaces() per test.
+// NOTE: Vitest surfaces CJS modules with both a namespace AND a `default` export.
+// `import os from 'os'` resolves to `default`, so we must override both.
 vi.mock('os', async () => {
   const actual = await vi.importActual<typeof import('os')>('os');
+  const hostname = vi.fn();
+  const networkInterfaces = vi.fn();
   return {
     ...actual,
-    hostname: vi.fn(),
-    networkInterfaces: vi.fn(),
+    hostname,
+    networkInterfaces,
+    default: {
+      ...actual,
+      hostname,
+      networkInterfaces,
+    },
   };
 });
 

--- a/libs/platform/src/callback-url.ts
+++ b/libs/platform/src/callback-url.ts
@@ -196,7 +196,9 @@ export function resolveCallbackUrl(options: ResolveCallbackUrlOptions = {}): str
 
     const detection = detectTailscale(hostname);
     if (detection.isTailscale && detection.tailscaleUrl) {
-      const base = detection.tailscaleUrl.replace(/\/$/, '');
+      const base = detection.tailscaleUrl
+        .replace(/\/$/, '')
+        .replace(/^http:\/\//, `${protocol}://`);
       return port != null ? `${base}${portSuffix}` : base;
     }
   }


### PR DESCRIPTION
## Summary

- Fix `resolveCallbackUrl` Tailscale branch ignoring the `protocol` option — it returned the `http://`-prefixed URL from `detectTailscale()` without rewriting the scheme, forcing https callers back to http.
- Fix the `vi.mock('os', ...)` factory in `apps/server/tests/unit/callback-url.test.ts` — it spread `...actual` and overrode `hostname`/`networkInterfaces`, but not `actual.default`. `import os from 'os'` resolves to `module.default`, so `os.hostname` stayed un-mocked, and every test errored at setup with `mockReturnValue is not a function`.

## Context

`test` has been red on every dev PR since PR #3535 landed, blocking auto-merge on PRs #3537, #3540, #3541 (auto-merge waits for all rollup checks even when not required by the branch ruleset). This PR unblocks them.

The product-bug fix was surfaced only after fixing the mock — with the mock broken, every test errored at setup and the protocol-ignored case never got a chance to assert.

## Test plan

- [x] `npx vitest run tests/unit/callback-url.test.ts` in `apps/server` — 19/19 pass locally
- [x] Prettier check green on both edited files
- [ ] CI `checks` + `test` green
- [ ] Confirm queued PRs #3537, #3540, #3541 go to mergeable after this lands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed callback URL scheme normalization when using Tailscale detection to ensure the protocol matches the configured protocol setting.

* **Tests**
  * Updated test mocks to support multiple module import patterns for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->