### PR TITLE
chore(.claude/commands/rollcall.md:5): hardcoded absolute path breaks non-josh clones

### DIFF
--- a/.claude/commands/rollcall.md
+++ b/.claude/commands/rollcall.md
@@ -8,6 +8,6 @@ Run the agent roll call smoke test. Reports container status, A2A agent card, an
 
 ## Steps
 
-1. Run `bash /home/josh/dev/protoWorkstacean/scripts/agent-rollcall.sh`
+1. Run `bash "$(git rev-parse --show-toplevel)/scripts/agent-rollcall.sh"`
 2. Report the output to the user
 3. If any services are down, suggest remediation steps


### PR DESCRIPTION
## Summary

`.claude/commands/rollcall.md` line 5 contains a hardcoded absolute path `/home/josh/dev/protoWorkstacean/scripts/agent-rollcall.sh`. This breaks for any operator whose clone is not at that exact path.

Fix: use relative path `scripts/agent-rollcall.sh` and run from repo root, OR resolve the path dynamically from `$PWD`.

Source: CodeRabbit review on PR #466, tracked in GitHub issue #467 (finding #1).
Severity: Low — polish/portability, does not affect production runtime.

---
**Source:** GitHub...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the rollcall command to work reliably across different directories and user environments by using repository-relative path resolution instead of hard-coded paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->