### PR TITLE
fix(agent commit): run prettier --write before git add in worktree commit path

### DIFF
--- a/apps/server/src/services/worktree-recovery-service.ts
+++ b/apps/server/src/services/worktree-recovery-service.ts
@@ -42,11 +42,11 @@ export interface WorktreeRecoveryResult {
  * Check for uncommitted work in a worktree after agent exit and recover if found.
  *
  * Steps when uncommitted work is detected:
- * 1. Format changed files with prettier (non-fatal)
- * 2. Stage changed files (excluding .automaker/ except memory/)
- * 3. Commit with HUSKY=0 / --no-verify to bypass hooks
- * 4. Push to remote with -u
- * 5. Create PR via gh CLI targeting prBaseBranch
+ * 1. Stage changed files (excluding .automaker/ except memory/)
+ * 1.5. Format staged files with prettier (non-fatal) and re-stage
+ * 2. Commit with HUSKY=0 / --no-verify to bypass hooks
+ * 3. Push to remote with -u
+ * 4. Create PR via gh CLI targeting prBaseBranch
  *
  * Returns a structured result. The caller is responsible for updating feature
  * status, emitting events, and deciding how to proceed.
@@ -94,26 +94,7 @@ export async function checkAndRecoverUncommittedWork(
     );
     logger.debug(`[PostAgentHook] Uncommitted changes:\n${statusOutput}`);
 
-    // Step 1: Format changed files with prettier (non-fatal)
-    // Use the main repo's prettier binary — worktrees have no node_modules/
-    try {
-      const { stdout: diffOutput } = await execAsync(
-        "git diff HEAD --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.json' '*.css' '*.md'",
-        { cwd: worktreePath, env: execEnv }
-      );
-      const files = diffOutput.trim().split('\n').filter(Boolean);
-      if (files.length > 0) {
-        const prettierBin = path.join(projectPath, 'node_modules/.bin/prettier');
-        await execAsync(
-          `node "${prettierBin}" --ignore-path /dev/null --write ${files.map((f) => `"${f}"`).join(' ')}`,
-          { cwd: worktreePath, env: execEnv }
-        );
-      }
-    } catch {
-      // Non-fatal: formatting failure should not block recovery
-    }
-
-    // Step 2: Stage changed files (exclude .automaker/ except memory/ and skills/ if they exist).
+    // Step 1: Stage changed files (exclude .automaker/ except memory/ and skills/ if they exist).
     const addCommand = buildGitAddCommand(worktreePath);
     logger.debug(`[PostAgentHook] Running: ${addCommand}`);
     await execAsync(addCommand, {
@@ -146,7 +127,30 @@ export async function checkAndRecoverUncommittedWork(
       logger.info(`[PostAgentHook] Fallback 'git add .' staged files successfully`);
     }
 
-    // Step 3: Commit — skip hooks by default unless skipGitHooks is false
+    // Step 1.5: Format staged files with prettier before commit (prevents CI prettier drift).
+    // Run AFTER staging so new/untracked files are included via git diff --cached.
+    // Using git diff --cached (not git diff HEAD) ensures newly-added files are covered.
+    try {
+      const { stdout: stagedFiles } = await execAsync(
+        "git diff --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.json' '*.css' '*.md'",
+        { cwd: worktreePath, env: execEnv }
+      );
+      const files = stagedFiles.trim().split('\n').filter(Boolean);
+      if (files.length > 0) {
+        const prettierBin = path.join(projectPath, 'node_modules/.bin/prettier');
+        await execAsync(
+          `node "${prettierBin}" --ignore-path /dev/null --write ${files.map((f) => `"${f}"`).join(' ')}`,
+          { cwd: worktreePath, env: execEnv }
+        );
+        // Re-stage after formatting so prettier changes are included in the commit
+        await execAsync(addCommand, { cwd: worktreePath, env: execEnv });
+        logger.debug(`[PostAgentHook] Auto-formatted ${files.length} staged files`);
+      }
+    } catch {
+      // Non-fatal: formatting failure should not block recovery
+    }
+
+    // Step 2: Commit — skip hooks by default unless skipGitHooks is false
     const commitTitle = (feature.title || 'feature implementation')
       .replace(/"/g, "'")
       .substring(0, 72);

--- a/apps/server/tests/unit/services/worktree-recovery-service.test.ts
+++ b/apps/server/tests/unit/services/worktree-recovery-service.test.ts
@@ -67,14 +67,16 @@ describe('worktree-recovery-service', () => {
     it('successfully recovers uncommitted work (commit + push + PR)', async () => {
       // git status --short: uncommitted files
       mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
-      // git diff HEAD (for prettier formatting)
-      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
-      // npx prettier
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // git add -A -- ':!.automaker/' '.automaker/memory/' '.automaker/skills/'
+      // git add (step 1: stage)
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git diff --cached --name-only (staging verification)
       mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      // git diff --cached --name-only --diff-filter=ACMR (step 1.5: prettier file list)
+      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      // node prettier --write
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git add (re-stage after prettier)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit (execFile)
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git fetch origin dev (rebase step)
@@ -103,15 +105,54 @@ describe('worktree-recovery-service', () => {
       expect(result.error).toBeUndefined();
     });
 
+    it('invokes project-local prettier with --ignore-path /dev/null on staged files', async () => {
+      // git status --short: uncommitted files
+      mockExec.mockResolvedValueOnce({ stdout: 'A  src/new-file.ts\n', stderr: '' });
+      // git add (stage)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git diff --cached (verify staging)
+      mockExec.mockResolvedValueOnce({ stdout: 'src/new-file.ts\n', stderr: '' });
+      // git diff --cached --diff-filter=ACMR (prettier file list)
+      mockExec.mockResolvedValueOnce({ stdout: 'src/new-file.ts\n', stderr: '' });
+      // node prettier --write (captured for assertion)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git add (re-stage after prettier)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git commit
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git fetch
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git rebase
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git push
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // gh pr create
+      mockExecFile.mockResolvedValueOnce({
+        stdout: 'https://github.com/owner/repo/pull/10\n',
+        stderr: '',
+      });
+
+      await checkAndRecoverUncommittedWork(baseFeature, '/mock/worktree', '/fake/project');
+
+      // Find the prettier invocation among all exec calls
+      const allCalls = mockExec.mock.calls.map((call: unknown[]) => String(call[0]));
+      const prettierCall = allCalls.find((cmd) => cmd.includes('prettier'));
+      expect(prettierCall).toBeDefined();
+      expect(prettierCall).toContain('--ignore-path /dev/null');
+      expect(prettierCall).toContain('--write');
+      // Uses the project-local binary path (node_modules/.bin/prettier)
+      expect(prettierCall).toContain('/fake/project/node_modules/.bin/prettier');
+    });
+
     it('returns error when commit step fails', async () => {
       // git status --short: uncommitted files
       mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
-      // git diff HEAD (for prettier formatting)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // git add -A -- ':!.automaker/' '.automaker/memory/' '.automaker/skills/'
+      // git add (stage)
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git diff --cached --name-only (staging verification)
       mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      // git diff --cached --diff-filter=ACMR (prettier list — empty, skip prettier)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit (execFile) fails
       mockExecFile.mockRejectedValueOnce(new Error('nothing to commit, working tree clean'));
 
@@ -129,12 +170,12 @@ describe('worktree-recovery-service', () => {
     it('returns error when push step fails', async () => {
       // git status --short
       mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
-      // git diff HEAD
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // git add -A -- ':!.automaker/' '.automaker/memory/' '.automaker/skills/'
+      // git add (stage)
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git diff --cached --name-only (staging verification)
       mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      // git diff --cached --diff-filter=ACMR (prettier list — empty, skip prettier)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit succeeds
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git fetch origin dev (rebase step)
@@ -158,14 +199,14 @@ describe('worktree-recovery-service', () => {
     it('continues recovery even if prettier formatting fails', async () => {
       // git status --short
       mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
-      // git diff HEAD
-      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
-      // npx prettier fails (non-fatal)
-      mockExec.mockRejectedValueOnce(new Error('prettier not found'));
-      // git add -A -- ':!.automaker/' '.automaker/memory/' '.automaker/skills/'
+      // git add (stage)
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git diff --cached --name-only (staging verification)
       mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      // git diff --cached --diff-filter=ACMR (prettier list)
+      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      // node prettier fails (non-fatal)
+      mockExec.mockRejectedValueOnce(new Error('prettier not found'));
       // git commit succeeds
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git fetch origin dev (rebase step)
@@ -195,14 +236,16 @@ describe('worktree-recovery-service', () => {
     it('recovers when rebase conflicts — pushes without force-with-lease', async () => {
       // git status --short
       mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
-      // git diff HEAD (for prettier formatting)
-      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
-      // npx prettier
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // git add
+      // git add (stage)
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git diff --cached --name-only (staging verification)
       mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      // git diff --cached --diff-filter=ACMR (prettier list)
+      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      // node prettier --write
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git add (re-stage after prettier)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit (execFile)
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git fetch origin dev (rebase step)
@@ -235,14 +278,16 @@ describe('worktree-recovery-service', () => {
     it('recovers when rebase fails for non-conflict reason — aborts and pushes normally', async () => {
       // git status --short
       mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
-      // git diff HEAD
-      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
-      // npx prettier
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // git add
+      // git add (stage)
       mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git diff --cached --name-only (staging verification)
       mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      // git diff --cached --diff-filter=ACMR (prettier list)
+      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      // node prettier --write
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      // git add (re-stage after prettier)
+      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit (execFile)
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git fetch origin dev — fails (network error)


### PR DESCRIPTION
## Summary

Three fresh agent PRs (#3537, #3540, #3541) all landed with prettier-drift violations on their OWN newly-authored files, causing the `checks` job to fail and blocking auto-merge.

**Pattern observed (all three PRs):**
- #3541: `apps/server/tests/unit/lib/goap/incident-dedup.test.ts` unformatted
- #3540: `apps/server/src/lib/goap/goal-satisfied-guard.ts`, `apps/server/src/routes/world/index.ts` unformatted
- #3537: `apps/server/src/services/maintenance/checks/prettier-drift-autofix.ts`, `apps/ser...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=098ecc9b-63b7-49bd-88d6-f7cbed6f8019 team= created=2026-04-21T10:20:53.095Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the recovery workflow step ordering to format files after staging changes, rather than before, for improved efficiency.

* **Tests**
  * Updated recovery workflow tests to reflect revised step sequence and formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->