### PR TITLE
fix(a2a): route message/send to Ava instead of protoBot (#471)

### DIFF
--- a/agents.yaml
+++ b/agents.yaml
@@ -19,7 +19,59 @@
 agents:
   ava:
     description: Autonomous orchestrator. Owns high-level operational skills.
+    # apiKeyEnv: AVA_API_KEY — set in calling agent (e.g. Workstacean) to authenticate
+    # url is read from the live agent card at /.well-known/agent.json; set
+    # PUBLIC_CALLBACK_URL on the ava server so the card advertises a routable URL.
     skills:
+      - name: chat
+        description: >
+          Free-form multi-turn dialogue. Default DM fallback when no keyword match.
+          Ava picks up context, asks clarifying questions, and routes to a specific
+          skill internally if the conversation lands on something actionable.
+        triggers:
+          - type: discord_dm
+          - type: a2a_message
+            action: chat
+
+      - name: sitrep
+        description: >
+          Returns current board state: feature counts by status, running agents,
+          auto-mode status, and recent escalations.
+        triggers:
+          - type: discord_dm
+          - type: a2a_message
+            action: sitrep
+
+      - name: manage_feature
+        description: >
+          Create, update, unblock, reassign, or change the status of a feature
+          on the board.
+        triggers:
+          - type: a2a_message
+            action: manage_feature
+
+      - name: auto_mode
+        description: Start or stop the autonomous feature execution loop.
+        triggers:
+          - type: a2a_message
+            action: auto_mode
+
+      - name: board_health
+        description: >
+          Analyse board health: blocked features, stalled agents, CI failures,
+          dependency issues.
+        triggers:
+          - type: a2a_message
+            action: board_health
+
+      - name: bug_triage
+        description: >
+          Triage an incoming bug report from GitHub. Classifies severity and
+          category, applies labels, and creates a board feature.
+        triggers:
+          - type: a2a_message
+            action: bug_triage
+
       - name: onboard_project
         description: >
           Onboard a GitHub repository into protoLabs Studio.
@@ -34,6 +86,32 @@ agents:
             example: /onboard_project protoLabsAI/protoWorkstacean
           - type: a2a_message
             action: onboard_project
+
+      - name: provision_discord
+        description: >
+          Provision Discord channels for a new project via ava's A2A endpoint.
+          Ava delegates internally to Quinn. Returns channel IDs for writing back
+          to project settings.
+        triggers:
+          - type: a2a_message
+            action: provision_discord
+
+      - name: plan
+        description: >
+          Draft a SPARC PRD from a raw idea, run antagonistic review (Ava vs Jon),
+          and publish a HITL gate for human approval. Returns immediately with
+          status "pending_approval" and a correlationId.
+        triggers:
+          - type: a2a_message
+            action: plan
+
+      - name: plan_resume
+        description: >
+          Resume a pending plan after human approval. Pass the correlationId and
+          a decision (approve / reject / modify).
+        triggers:
+          - type: a2a_message
+            action: plan_resume
 
   quinn:
     description: QA Engineer. Validates releases, tests endpoints, runs regression checks.

--- a/apps/server/src/routes/a2a/index.ts
+++ b/apps/server/src/routes/a2a/index.ts
@@ -228,7 +228,20 @@ function buildAgentCard() {
   // Do NOT derive from the HTTP Host header — the Host header reflects the
   // proxy/ingress address (e.g. ava:8081 for the Astro dashboard) which may
   // differ from the actual A2A server endpoint.
-  const callbackBase = resolveCallbackUrl({ port });
+  //
+  // Use HTTPS in production so external A2A peers (e.g. Workstacean) can
+  // reach the agent card at a publicly-routable URL. In development, http is
+  // fine. When PUBLIC_CALLBACK_URL is set it is used as-is (already has the
+  // correct scheme); otherwise we default to https in production.
+  const isProduction = process.env['NODE_ENV'] === 'production';
+  const protocol = isProduction ? 'https' : 'http';
+  const callbackBase = resolveCallbackUrl({ port, protocol });
+  if (callbackBase.includes('localhost') || callbackBase.includes('127.0.0.1')) {
+    logger.warn(
+      'A2A agent card URL resolved to localhost — external peers cannot reach this agent. ' +
+        'Set PUBLIC_CALLBACK_URL to an externally-routable URL (e.g. https://ava.proto-labs.ai).'
+    );
+  }
   return {
     name: 'protoMaker',
     description:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -103,6 +103,11 @@ services:
       - ALLOWED_ROOT_DIRECTORY=${ALLOWED_ROOT_DIRECTORY:-/home/josh/dev}
       - AUTOMAKER_PROJECT_PATH=${AUTOMAKER_PROJECT_PATH:-/home/josh/dev/ava}
 
+      # Public callback URL advertised in the A2A agent card (/.well-known/agent.json).
+      # Must be externally routable so peers (e.g. Workstacean) can POST to /a2a.
+      # Example: PUBLIC_CALLBACK_URL=https://ava.proto-labs.ai
+      - PUBLIC_CALLBACK_URL=${PUBLIC_CALLBACK_URL:-}
+
       # CORS
       - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:3007}
 


### PR DESCRIPTION
## Summary

- **Root cause**: `buildAgentCard()` advertised `http://automaker-server:3008/a2a` (Docker internal hostname) — unreachable by Workstacean externally. Workstacean fell back to `agents.yaml`, where Ava only had one skill (`onboard_project`), so bare `message/send` requests fell through to protoBot.
- **agents.yaml**: Added all 10 `DECLARED_SKILLS` to Ava's fallback entry (`chat`, `sitrep`, `manage_feature`, `auto_mode`, `board_health`, `bug_triage`, `onboard_project`, `provision_discord`, `plan`, `plan_resume`) so the fallback table matches the live agent card.
- **buildAgentCard()**: Default `protocol` is now `'https'` in production so Tailscale/HOSTNAME-derived URLs are externally routable. Added `logger.warn` when the resolved URL is localhost.
- **docker-compose.staging.yml**: Exposed `PUBLIC_CALLBACK_URL` env var so operators can set `https://ava.proto-labs.ai` without rebuilding the image.

## Deployment note

After deploying, set `PUBLIC_CALLBACK_URL=https://ava.proto-labs.ai` in the staging `.env` (or Docker env). This overrides any Tailscale/hostname heuristic and ensures the agent card always advertises the correct public URL. The localhost warning in logs will confirm if this is missing.

## Test plan

- [ ] Deploy staging with `PUBLIC_CALLBACK_URL=https://ava.proto-labs.ai`
- [ ] `curl https://ava.proto-labs.ai/.well-known/agent.json` — verify `url` field is `https://ava.proto-labs.ai/a2a`
- [ ] Repro curl from issue #471: `curl -X POST https://ava.proto-labs.ai/a2a -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"message/send","params":{"message":{"parts":[{"text":"ping"}]}}}'` — verify response identifies as Ava, not protoBot
- [ ] Verify no localhost warning appears in server logs after deployment with `PUBLIC_CALLBACK_URL` set

Closes #471. Unblocks protoVoice F7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registered 9 new skills: `chat`, `sitrep`, `manage_feature`, `auto_mode`, `board_health`, `bug_triage`, `provision_discord`, `plan`, and `plan_resume` with A2A and Discord DM triggering support.

* **Improvements**
  * Enhanced callback URL handling with automatic HTTPS/HTTP protocol selection based on environment.
  * Added diagnostic logging to identify configuration issues affecting external peer connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->