### PR TITLE
fix(infra): persist .claude.json off /home/automaker tmpfs (closes #3564)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -158,10 +158,16 @@ services:
       - 'com.automaker.service=server'
       - 'com.automaker.environment=production'
     # Security hardening
+    # /home/automaker tmpfs is required because the parent fs is read-only;
+    # without it, any write to ~/.claude.json or other transient dotfiles would
+    # fail with EROFS. The entrypoint symlinks ~/.claude.json into the
+    # persistent .claude/ named volume so credential state survives restarts
+    # and disk pressure. See GitHub #3564.
     read_only: true
     tmpfs:
       - /tmp:size=512m,mode=1777
       - /npm-cache:size=512m
+      - /home/automaker:size=256m,uid=${UID:-1001},gid=${GID:-1001},mode=0750
     cap_drop:
       - ALL
     cap_add:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -142,14 +142,18 @@ services:
     user: '${UID:-1001}:${GID:-1001}'
 
     # Read-only root filesystem — writes go to named volumes or tmpfs mounts.
-    # /home/automaker tmpfs provides writable space for ~/.claude.json and other
-    # dotfiles; named volume mounts at subdirectories (.claude/, .cursor/, etc.)
-    # take precedence and remain persistent across restarts.
+    # /home/automaker tmpfs provides writable space for transient dotfiles from
+    # CLI tools we don't fully control (cursor, opencode subprocesses, etc.).
+    # Persistent state (.claude/, .cursor/, .config/, .cache/) lives on named
+    # volumes that mount over this tmpfs. ~/.claude.json is symlinked into the
+    # .claude/ named volume by the entrypoint — see GitHub #3564.
+    # 256M leaves headroom for misbehaving subprocesses; 64M was too tight and
+    # filled with npm cache, silently truncating .claude.json.
     read_only: true
     tmpfs:
       - /tmp:size=512m,mode=1777
       - /npm-cache:size=512m
-      - /home/automaker:size=64m,uid=${UID:-1001},gid=${GID:-1001},mode=0750
+      - /home/automaker:size=256m,uid=${UID:-1001},gid=${GID:-1001},mode=0750
 
     cap_drop:
       - ALL

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,12 +31,26 @@ if [ "$(id -u)" != "0" ]; then
         # Only the OAuth-injection block above creates it, and that runs
         # conditionally on $CLAUDE_OAUTH_CREDENTIALS being set.
         mkdir -p /home/automaker/.claude 2>/dev/null || true
-        if [ -f /home/automaker/.claude.json ] && [ ! -f "$PERSISTENT_CLAUDE_JSON" ]; then
-            cp /home/automaker/.claude.json "$PERSISTENT_CLAUDE_JSON" 2>/dev/null || true
+
+        # Ensure persistent file exists. Migrate from tmpfs if possible; init if neither
+        # source nor destination exists. Critically: never delete the original tmpfs
+        # file unless the persistent destination is in place — a failed cp followed
+        # by `rm + echo {}` would silently replace a valid config with an empty one,
+        # recreating the same misleading auth failures this PR is meant to remove.
+        if [ ! -f "$PERSISTENT_CLAUDE_JSON" ]; then
+            if [ -f /home/automaker/.claude.json ]; then
+                cp /home/automaker/.claude.json "$PERSISTENT_CLAUDE_JSON" 2>/dev/null \
+                    || echo "WARN: failed to migrate ~/.claude.json to persistent volume; leaving original in place" >&2
+            else
+                echo '{}' > "$PERSISTENT_CLAUDE_JSON"
+            fi
         fi
-        [ ! -f "$PERSISTENT_CLAUDE_JSON" ] && echo '{}' > "$PERSISTENT_CLAUDE_JSON"
-        rm -f /home/automaker/.claude.json 2>/dev/null || true
-        ln -sf "$PERSISTENT_CLAUDE_JSON" /home/automaker/.claude.json
+
+        # Symlink only when the persistent file is actually present.
+        if [ -f "$PERSISTENT_CLAUDE_JSON" ]; then
+            rm -f /home/automaker/.claude.json 2>/dev/null || true
+            ln -sf "$PERSISTENT_CLAUDE_JSON" /home/automaker/.claude.json
+        fi
     fi
 
     # Warn if /home/automaker tmpfs is under pressure — surfaces the underlying
@@ -121,14 +135,22 @@ chown -R automaker:automaker "$NPM_CACHE_DIR"
 # matching block in the non-root branch above for the full rationale.
 PERSISTENT_CLAUDE_JSON="/home/automaker/.claude/claude.json"
 if [ ! -L /home/automaker/.claude.json ]; then
-    if [ -f /home/automaker/.claude.json ] && [ ! -f "$PERSISTENT_CLAUDE_JSON" ]; then
-        cp /home/automaker/.claude.json "$PERSISTENT_CLAUDE_JSON" 2>/dev/null || true
+    # Ensure persistent file exists; never destroy a valid original if cp fails.
+    if [ ! -f "$PERSISTENT_CLAUDE_JSON" ]; then
+        if [ -f /home/automaker/.claude.json ]; then
+            cp /home/automaker/.claude.json "$PERSISTENT_CLAUDE_JSON" 2>/dev/null \
+                || echo "WARN: failed to migrate ~/.claude.json to persistent volume; leaving original in place" >&2
+        else
+            echo '{}' > "$PERSISTENT_CLAUDE_JSON"
+        fi
     fi
-    [ ! -f "$PERSISTENT_CLAUDE_JSON" ] && echo '{}' > "$PERSISTENT_CLAUDE_JSON"
-    rm -f /home/automaker/.claude.json 2>/dev/null || true
-    ln -sf "$PERSISTENT_CLAUDE_JSON" /home/automaker/.claude.json
-    chown -h automaker:automaker /home/automaker/.claude.json 2>/dev/null || true
-    chown automaker:automaker "$PERSISTENT_CLAUDE_JSON" 2>/dev/null || true
+
+    if [ -f "$PERSISTENT_CLAUDE_JSON" ]; then
+        rm -f /home/automaker/.claude.json 2>/dev/null || true
+        ln -sf "$PERSISTENT_CLAUDE_JSON" /home/automaker/.claude.json
+        chown -h automaker:automaker /home/automaker/.claude.json 2>/dev/null || true
+        chown automaker:automaker "$PERSISTENT_CLAUDE_JSON" 2>/dev/null || true
+    fi
 fi
 
 # Warn if /home/automaker tmpfs is under pressure

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,6 +27,10 @@ if [ "$(id -u)" != "0" ]; then
     # errors. See GitHub #3564.
     PERSISTENT_CLAUDE_JSON="/home/automaker/.claude/claude.json"
     if [ ! -L /home/automaker/.claude.json ]; then
+        # Ensure the parent .claude/ volume mountpoint exists before any cp/echo/ln.
+        # Only the OAuth-injection block above creates it, and that runs
+        # conditionally on $CLAUDE_OAUTH_CREDENTIALS being set.
+        mkdir -p /home/automaker/.claude 2>/dev/null || true
         if [ -f /home/automaker/.claude.json ] && [ ! -f "$PERSISTENT_CLAUDE_JSON" ]; then
             cp /home/automaker/.claude.json "$PERSISTENT_CLAUDE_JSON" 2>/dev/null || true
         fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,8 +4,11 @@ set -e
 # If already running as non-root (e.g. staging with user: directive and reduced caps),
 # skip chown/gosu but still handle credential injection and npm cache setup.
 if [ "$(id -u)" != "0" ]; then
-    # Ensure npm cache directory exists at the configured path
-    NPM_CACHE_DIR="${NPM_CONFIG_CACHE:-/home/automaker/.npm}"
+    # Ensure npm cache directory exists at the configured path.
+    # Default to /npm-cache (matching the tmpfs mount in compose) — never default
+    # to /home/automaker/.npm, which lives on a small tmpfs and triggered the
+    # claude.json corruption issue (see GitHub #3564).
+    NPM_CACHE_DIR="${NPM_CONFIG_CACHE:-/npm-cache}"
     if [ ! -d "$NPM_CACHE_DIR" ]; then
         mkdir -p "$NPM_CACHE_DIR" 2>/dev/null || true
     fi
@@ -15,6 +18,28 @@ if [ "$(id -u)" != "0" ]; then
         mkdir -p /home/automaker/.claude 2>/dev/null || true
         echo "$CLAUDE_OAUTH_CREDENTIALS" > /home/automaker/.claude/.credentials.json
         chmod 600 /home/automaker/.claude/.credentials.json
+    fi
+
+    # Persist ~/.claude.json on the named volume so it survives disk pressure
+    # on the parent /home/automaker tmpfs. Without this, npm cache or other
+    # transient writes can fill the home tmpfs and silently truncate
+    # .claude.json mid-write, masquerading as "Invalid or expired API key"
+    # errors. See GitHub #3564.
+    PERSISTENT_CLAUDE_JSON="/home/automaker/.claude/claude.json"
+    if [ ! -L /home/automaker/.claude.json ]; then
+        if [ -f /home/automaker/.claude.json ] && [ ! -f "$PERSISTENT_CLAUDE_JSON" ]; then
+            cp /home/automaker/.claude.json "$PERSISTENT_CLAUDE_JSON" 2>/dev/null || true
+        fi
+        [ ! -f "$PERSISTENT_CLAUDE_JSON" ] && echo '{}' > "$PERSISTENT_CLAUDE_JSON"
+        rm -f /home/automaker/.claude.json 2>/dev/null || true
+        ln -sf "$PERSISTENT_CLAUDE_JSON" /home/automaker/.claude.json
+    fi
+
+    # Warn if /home/automaker tmpfs is under pressure — surfaces the underlying
+    # condition that caused #3564 before agents start failing.
+    HOME_USED_PCT=$(df -P /home/automaker 2>/dev/null | awk 'NR==2 {gsub("%",""); print $5}')
+    if [ -n "$HOME_USED_PCT" ] && [ "$HOME_USED_PCT" -ge 80 ]; then
+        echo "WARN: /home/automaker is ${HOME_USED_PCT}% full — tmpfs pressure may corrupt CLI configs" >&2
     fi
 
     # Write Cursor auth token if provided
@@ -78,14 +103,35 @@ fi
 chown -R automaker:automaker /home/automaker/.cache/opencode
 chmod -R 700 /home/automaker/.cache/opencode
 
-# Ensure npm cache directory exists with correct permissions
-# NPM_CONFIG_CACHE may redirect to a tmpfs mount (e.g. /npm-cache) for read-only root fs
-# This is needed for using npx to run MCP servers
-NPM_CACHE_DIR="${NPM_CONFIG_CACHE:-/home/automaker/.npm}"
+# Ensure npm cache directory exists with correct permissions.
+# NPM_CONFIG_CACHE may redirect to a tmpfs mount (e.g. /npm-cache) for read-only root fs.
+# Default to /npm-cache, NOT /home/automaker/.npm — the latter shares a small tmpfs
+# with .claude.json and caused GitHub #3564 (silent credential-file truncation).
+NPM_CACHE_DIR="${NPM_CONFIG_CACHE:-/npm-cache}"
 if [ ! -d "$NPM_CACHE_DIR" ]; then
     mkdir -p "$NPM_CACHE_DIR"
 fi
 chown -R automaker:automaker "$NPM_CACHE_DIR"
+
+# Persist ~/.claude.json on the named volume — see GitHub #3564 and the
+# matching block in the non-root branch above for the full rationale.
+PERSISTENT_CLAUDE_JSON="/home/automaker/.claude/claude.json"
+if [ ! -L /home/automaker/.claude.json ]; then
+    if [ -f /home/automaker/.claude.json ] && [ ! -f "$PERSISTENT_CLAUDE_JSON" ]; then
+        cp /home/automaker/.claude.json "$PERSISTENT_CLAUDE_JSON" 2>/dev/null || true
+    fi
+    [ ! -f "$PERSISTENT_CLAUDE_JSON" ] && echo '{}' > "$PERSISTENT_CLAUDE_JSON"
+    rm -f /home/automaker/.claude.json 2>/dev/null || true
+    ln -sf "$PERSISTENT_CLAUDE_JSON" /home/automaker/.claude.json
+    chown -h automaker:automaker /home/automaker/.claude.json 2>/dev/null || true
+    chown automaker:automaker "$PERSISTENT_CLAUDE_JSON" 2>/dev/null || true
+fi
+
+# Warn if /home/automaker tmpfs is under pressure
+HOME_USED_PCT=$(df -P /home/automaker 2>/dev/null | awk 'NR==2 {gsub("%",""); print $5}')
+if [ -n "$HOME_USED_PCT" ] && [ "$HOME_USED_PCT" -ge 80 ]; then
+    echo "WARN: /home/automaker is ${HOME_USED_PCT}% full — tmpfs pressure may corrupt CLI configs" >&2
+fi
 
 # If CURSOR_AUTH_TOKEN is set, write it to the cursor auth file
 # On Linux, cursor-agent uses ~/.config/cursor/auth.json for file-based credential storage


### PR DESCRIPTION
## Summary

Closes #3564 — agents were failing with `Authentication failed: Invalid or expired API key` because the 64M `/home/automaker` tmpfs in the staging compose was filling with npm cache content, silently truncating `~/.claude.json` mid-write. The Claude CLI then read the truncated file and reported it as corrupted.

This PR makes the credentials file immune to home-dir disk pressure and closes the latent prod bug where `~/.claude.json` writes would have failed with `EROFS`.

- **`docker-entrypoint.sh`** — On startup, symlink `~/.claude.json` to `~/.claude/claude.json` so the file physically lives inside the persistent `automaker-claude-config` named volume (which mounts at `~/.claude/`). Migrates any existing on-tmpfs file on first boot. Also fixes the `NPM_CACHE_DIR` fallback to default to `/npm-cache` (matching the compose env) instead of `/home/automaker/.npm`, removing the misconfig pathway that originally caused this. Adds a startup warning when `/home/automaker` is >=80% full.
- **`docker-compose.staging.yml`** — Bumps `/home/automaker` tmpfs from `64M` to `256M`. Defense in depth: `.claude.json` doesn't live there anymore, but other CLI subprocesses (cursor, opencode, npm wrappers) may still write transient dotfiles to home, and 64M was genuinely tight.
- **`docker-compose.prod.yml`** — Adds the missing `/home/automaker` tmpfs entry (`256M`). Prod previously had `read_only: true` with no writable surface for `/home/automaker`, meaning any direct `~/.claude.json` write would have failed with `EROFS`. The symlink fix catches the credential path, but the tmpfs entry fixes the underlying writability gap.

## Test plan

- [ ] `docker compose -f docker-compose.staging.yml config --quiet` validates
- [ ] `docker compose -f docker-compose.prod.yml config --quiet` validates
- [ ] `sh -n docker-entrypoint.sh` validates
- [ ] Build the staging image, deploy to staging, observe `~/.claude.json` is a symlink to `~/.claude/claude.json` (`ls -la /home/automaker/.claude.json` inside container)
- [ ] Verify `df /home/automaker` reports the new 256M cap
- [ ] Run a few agent dispatches and confirm OAuth credentials persist across container restarts
- [ ] Confirm npm cache writes go to `/npm-cache` (`du -sh /npm-cache /home/automaker/.npm 2>/dev/null`) rather than filling home

## Follow-up (separate issue, not in this PR)

Suggested fix #5 from #3564 — making agent dispatch errors distinguish "credentials invalid" from "credentials file unreadable / truncated" — is a code-side change in the agent dispatch path. Worth filing so the next class of credential I/O failure surfaces with an accurate error instead of a misleading auth message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended container temporary storage to include an additional writable tmpfs path in production and increased tmpfs allocation in staging.
  * Improved startup initialization to persist CLI/config data into volume-backed storage and ensure the npm cache directory exists with correct ownership.
  * Added runtime tmpfs usage checks that emit warnings when usage reaches critical levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->