### PR TITLE
fix(server): silence reasoning-path escalation spam

### DIFF
--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -1061,7 +1061,7 @@ export class LeadEngineerService {
         projectPath: session.projectPath,
         reason: details,
       },
-      deduplicationKey: `reasoning_${reason}_${featureId ?? session.projectPath}_${Date.now()}`,
+      deduplicationKey: `reasoning_${reason}_${featureId ?? session.projectPath}_${eventType}`,
       timestamp: new Date().toISOString(),
     });
   }
@@ -1073,7 +1073,8 @@ export class LeadEngineerService {
    * statusChangeReason history) and invokes LLM to decide next action.
    *
    * Guards:
-   * - Context validation: escalates immediately if featureId is absent
+   * - Context validation: skips silently if featureId is absent (project-scoped
+   *   signals legitimately lack one and aren't actionable here)
    * - Cost cap: aborts if estimated prompt cost exceeds $0.50
    * - Timeout: aborts if LLM call exceeds 60 seconds
    * - Retry: retries once on malformed LLM response; escalates if still failing
@@ -1086,18 +1087,13 @@ export class LeadEngineerService {
     const p = payload as Record<string, unknown> | null;
     const featureId = p?.featureId as string | undefined;
 
-    // Guard: escalate immediately if signal context is missing required fields
+    // Project-scoped signals (no featureId) match some REASONING_RULES triggers
+    // but the reasoning path is per-feature, so there's nothing to do. Drop them
+    // silently; this is not a contract violation worth escalating to a human.
     if (!featureId) {
-      logger.warn('[Reasoning] Signal context incomplete: missing featureId — escalating', {
+      logger.debug('[Reasoning] Skipping reasoning path: signal lacks featureId', {
         eventType,
       });
-      this.emitReasoningEscalation(
-        session,
-        eventType,
-        undefined,
-        'context_incomplete',
-        'Signal context missing featureId — cannot invoke reasoning path'
-      );
       return;
     }
 


### PR DESCRIPTION
## Summary

Stops the dozens-per-burst flood of \`Escalation: context_incomplete — Signal context missing featureId\` notifications in the UI. Two related bugs in \`LeadEngineerService\`:

### Bug 1: guard escalates instead of skipping (the spam source)

\`apps/server/src/services/lead-engineer-service.ts:1090\` — \`invokeReasoningPath\`'s \"missing featureId\" guard emitted a \`medium\` severity escalation signal *every time it fired*. But that guard fires whenever a project-scoped event matches a \`REASONING_RULES\` trigger and the payload doesn't carry a featureId — which is normal and expected for project-level signals.

A guard that says \"this signal isn't actionable here, skip it\" should silently return, not page the operator. Demoted to a debug log.

### Bug 2: dedup key includes \`Date.now()\` (defeats dedup entirely)

\`apps/server/src/services/lead-engineer-service.ts:1064\` — the \`deduplicationKey\` for reasoning escalations was:

\`\`\`ts
deduplicationKey: \`reasoning_\${reason}_\${featureId ?? session.projectPath}_\${Date.now()}\`
\`\`\`

\`Date.now()\` makes every emission unique — the EscalationRouter's dedup logic can never suppress duplicates. Even if Bug 1 didn't exist, any legitimate reasoning failure that recurred (LLM timeout retry, cost-cap retry) would still flood the UI.

Replaced the timestamp suffix with \`eventType\` so the key is content-based: same (reason × scope × trigger) collapses to one notification within the dedup window.

## Why this matters

- The first bug was producing 14+ duplicate notifications per minute under normal operation.
- The second bug protects the *legitimate* remaining \`emitReasoningEscalation\` callers (LLM errors, timeouts, cost-cap aborts at lines 1150, 1215, 1226) from similar spam if they recur in tight succession.

## Test plan

- [x] \`npm run typecheck\` — 21/21 pass
- [x] No tests reference \`context_incomplete\` (verified via grep)
- [x] Other \`emitReasoningEscalation\` callers (LLM errors, timeouts, cost cap) unchanged and remain valid
- [ ] Smoke test on staging — confirm no more \`context_incomplete\` notifications appear in the UI escalations panel during normal operation

## Not in this PR

Option (b) from the discussion — stripping the \`recovery_escalated\` / \`feature:permanently-blocked\` path from the UI escalation channel — is a separate decision about whether to surface stuck-feature notifications at all. Punted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)