### PR TITLE
fix(automation): purge any stale built-in automation, not just maintenance:*

### DIFF
--- a/apps/server/src/services/automation-service.ts
+++ b/apps/server/src/services/automation-service.ts
@@ -603,16 +603,14 @@ export class AutomationService {
   }
 
   /**
-   * Remove any persisted `maintenance:*` automation records whose flowId is not registered
+   * Remove any persisted built-in automation records whose flowId is not registered
    * in the flow registry, and unregister their corresponding scheduler tasks.
    * Called at the end of seedBuiltInAutomations() to clean up stale records left behind
    * when built-in flows are removed from code.
    */
   private async purgeStaleBuiltIns(): Promise<void> {
     const automations = await this.readAutomations();
-    const stale = automations.filter(
-      (a) => a.id.startsWith('maintenance:') && !flowRegistry.has(a.flowId)
-    );
+    const stale = automations.filter((a) => a.isBuiltIn && !flowRegistry.has(a.flowId));
 
     if (stale.length === 0) return;
 


### PR DESCRIPTION
## Summary

`purgeStaleBuiltIns()` was filtering on `id.startsWith("maintenance:")`. That meant when the ceremony stack got deleted in #3572, the three ceremony built-ins (`ceremony:standup`, `ceremony:retro`, `ceremony:project-retro`) stayed in `automations.json` and kept appearing in the Workflow Settings UI pointing at flow ids that no longer exist.

The filter now keys on `isBuiltIn === true` AND `flowId not in flowRegistry`. Any built-in whose flow code is removed gets purged on next server startup, regardless of id prefix.

User-created automations are never touched (they have `isBuiltIn: false`).

## Verification

- Verified by clearing the stale ceremony entries from local `data/automations.json` and `apps/server/data/automations.json` — Workflow Settings UI now shows only the 3 active maintenance automations.
- typecheck clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved built-in automation cleanup to use more reliable detection of stale automations, preventing orphaned records and scheduler tasks from accumulating in the system.

## Documentation
* Updated documentation for automation cleanup procedures to reflect current implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->