### PR TITLE
fix(worktree-lifecycle): skip npm ci when node_modules is symlinked

### DIFF
--- a/apps/server/src/services/init-script-service.ts
+++ b/apps/server/src/services/init-script-service.ts
@@ -6,6 +6,7 @@
  */
 
 import { spawn } from 'child_process';
+import fs from 'node:fs';
 import path from 'path';
 import { createLogger } from '@protolabsai/utils';
 import { systemPathExists, getShellPaths, findGitBashPath } from '@protolabsai/platform';
@@ -139,6 +140,22 @@ export class InitScriptService {
     if (await this.hasInitScriptRun(projectPath, branch)) {
       logger.info(`Init script already ran for branch "${branch}", skipping`);
       return;
+    }
+
+    // If symlinkBuildArtifacts() linked the host's node_modules into the worktree,
+    // any package-manager install inside the init script would rewrite that shared
+    // directory and kill the running dev server. The symlinked deps are already
+    // sufficient for the agent to operate — skip the init script entirely.
+    try {
+      const stat = await fs.promises.lstat(path.join(worktreePath, 'node_modules'));
+      if (stat.isSymbolicLink()) {
+        logger.info(
+          `Worktree ${path.basename(worktreePath)} node_modules is symlinked — skipping init script to avoid disturbing the host install`
+        );
+        return;
+      }
+    } catch {
+      // node_modules doesn't exist — proceed with init script
     }
 
     // Get shell command

--- a/apps/server/src/services/worktree-lifecycle-service.ts
+++ b/apps/server/src/services/worktree-lifecycle-service.ts
@@ -964,6 +964,23 @@ export async function installWorktreeDependencies(
     return false;
   }
 
+  // If symlinkBuildArtifacts() symlinked the host's node_modules into the worktree,
+  // a fresh `npm ci` here would rewrite that shared directory and kill the running
+  // dev server (which depends on the same node_modules). The symlinked deps are
+  // already sufficient — skip the install.
+  const worktreeNodeModules = path.join(worktreePath, 'node_modules');
+  try {
+    const stat = await fs.promises.lstat(worktreeNodeModules);
+    if (stat.isSymbolicLink()) {
+      logger.info(
+        `Worktree ${path.basename(worktreePath)} node_modules is symlinked — skipping ${detected.command} ${detected.args.join(' ')} to avoid disturbing the host install`
+      );
+      return true;
+    }
+  } catch {
+    // node_modules doesn't exist yet — proceed with install
+  }
+
   const { command, args } = detected;
   const fullCommand = [command, ...args].join(' ');
 


### PR DESCRIPTION
## Summary

Local dev: any feature dispatch with `useWorktrees:true` killed the dev server ~1.7s after worktree creation, before the agent could write a single byte to `agent-output.md`. 100% reproducible.

## Root cause

`symlinkBuildArtifacts()` symlinks the host's `node_modules` into the new worktree. `installWorktreeDependencies()` then runs `npm ci` in that worktree. Because the worktree's `node_modules` is a symlink back to the host's, the `npm ci` rewrites the *same* directory the running `tsx watch` dev server depends on. tsx watch sees changes (or the running tsx binary is yanked out from under it), sends SIGTERM, the server shuts down gracefully, and the restart never recovers because the install is still rewriting `node_modules`.

## Smoking gun from `apps/server/data/server.log`

```
Created worktree at .worktrees/<branch>
Symlinked node_modules into worktree
Installing dependencies in worktree via: npm ci
[1.67s later] Server:Shutdown — Shutting down gracefully...
```

## Fix

In `installWorktreeDependencies()`, lstat `<worktreePath>/node_modules` before invoking the package manager. If it's a symbolic link, the symlinked deps from `symlinkBuildArtifacts()` are already sufficient — return `true` and skip the install entirely.

Behavior in production / non-symlinked setups is unchanged: `lstat` throws ENOENT (or the entry is a real directory rather than a symlink), and we fall through to the existing `npm ci` path.

## Test plan

- [x] Manual: confirmed crash repros without the fix (worktree creation → SIGTERM 1.67s later)
- [ ] Manual after fix: re-dispatch the same feature, confirm worktree creation completes without server shutdown and agent-output.md gets written
- [x] Compile check (added imports already present: `fs`, `path`)
- [ ] No behavior change for non-symlinked setups (lstat ENOENT → fall through)

## Why no unit test

`installWorktreeDependencies` uses `execFile` directly (not promisified) and there's no existing test file for this function. Adding one requires the same `child_process` mock plumbing as `worktree-creation-base-branch.test.ts` — worth doing as a follow-up but out of scope for this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved dependency installation handling to prevent potential issues in shared environment configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->