### PR TITLE
fix(review): treat unresolved CodeRabbit threads as changes_requested

### DIFF
--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -383,19 +383,32 @@ export class ReviewProcessor implements StateProcessor {
         };
       }
 
-      // Fetch review comments so the agent knows what to fix
+      // Fetch review comments so the agent knows what to fix.
+      // Two sources: (a) human/bot reviews with state CHANGES_REQUESTED, and
+      // (b) unresolved CodeRabbit review threads (CR doesn't submit reviews —
+      // it posts thread comments). Bodies are concatenated; either may be empty.
+      const feedbackParts: string[] = [];
       try {
         const { stdout } = await execAsync(
           `gh pr view ${ctx.prNumber} --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED") | .body] | join("\\n---\\n")'`,
           { cwd: ctx.projectPath, timeout: 15000 }
         );
-        const feedback = stdout.trim();
-        if (feedback) {
-          ctx.reviewFeedback = feedback;
-          logger.info(`[REVIEW] Captured review feedback (${feedback.length} chars)`);
-        }
+        const reviewFeedback = stdout.trim();
+        if (reviewFeedback) feedbackParts.push(`## Human review feedback\n\n${reviewFeedback}`);
       } catch (err) {
-        logger.warn('[REVIEW] Failed to fetch review comments:', err);
+        logger.warn('[REVIEW] Failed to fetch CHANGES_REQUESTED review bodies:', err);
+      }
+      const crThreads = await this.getUnresolvedCodeRabbitThreads(ctx);
+      if (crThreads.bodies.length > 0) {
+        feedbackParts.push(
+          `## Unresolved CodeRabbit threads (${crThreads.count})\n\n${crThreads.bodies.join('\n\n---\n\n')}`
+        );
+      }
+      if (feedbackParts.length > 0) {
+        ctx.reviewFeedback = feedbackParts.join('\n\n');
+        logger.info(
+          `[REVIEW] Captured review feedback (${ctx.reviewFeedback.length} chars, ${feedbackParts.length} source(s))`
+        );
       }
 
       ctx.remediationAttempts++;
@@ -1016,6 +1029,18 @@ export class ReviewProcessor implements StateProcessor {
       if (data.decision === 'APPROVED') return 'approved';
       if (data.decision === 'CHANGES_REQUESTED') return 'changes_requested';
 
+      // CodeRabbit posts review THREADS, not CHANGES_REQUESTED reviews, by default.
+      // Its findings sit in `reviewThreads` and never affect `reviewDecision`. If we
+      // wait for `CHANGES_REQUESTED` alone we time out at 45m while CR feedback rots
+      // unaddressed. Treat any unresolved CR-authored thread as a remediation signal.
+      const crThreads = await this.getUnresolvedCodeRabbitThreads(ctx);
+      if (crThreads.count > 0) {
+        logger.info(
+          `[REVIEW] PR #${ctx.prNumber} has ${crThreads.count} unresolved CodeRabbit thread(s) — treating as changes_requested`
+        );
+        return 'changes_requested';
+      }
+
       // Read soft checks from settings (failures logged but don't block approval)
       let softChecks: string[] = [];
       if (this.serviceContext.settingsService) {
@@ -1099,6 +1124,88 @@ export class ReviewProcessor implements StateProcessor {
     } catch (err) {
       logger.error(`[REVIEW] gh CLI fallback failed for PR #${ctx.prNumber}:`, err);
       return 'error';
+    }
+  }
+
+  /**
+   * Query GitHub for review threads on the PR and return the count plus bodies
+   * of any threads where (a) CodeRabbit is among the authors and (b) the thread
+   * isn't yet resolved.
+   *
+   * Used to drive remediation when CR posts comments but doesn't submit a
+   * CHANGES_REQUESTED review (its default behavior). Returns `{ count: 0, bodies: [] }`
+   * on any GraphQL or shell failure so a transient gh outage doesn't mistakenly
+   * unblock merge.
+   */
+  private async getUnresolvedCodeRabbitThreads(
+    ctx: StateContext
+  ): Promise<{ count: number; bodies: string[] }> {
+    if (!ctx.prNumber) return { count: 0, bodies: [] };
+
+    try {
+      const { stdout: repoOut } = await execAsync(
+        "gh repo view --json owner,name --jq '{owner: .owner.login, name: .name}'",
+        { cwd: ctx.projectPath, timeout: 10000 }
+      );
+      const repoInfo = JSON.parse(repoOut.trim()) as { owner?: string; name?: string };
+      if (!repoInfo.owner || !repoInfo.name) return { count: 0, bodies: [] };
+
+      const query = `
+        query {
+          repository(owner: "${repoInfo.owner}", name: "${repoInfo.name}") {
+            pullRequest(number: ${ctx.prNumber}) {
+              reviewThreads(first: 100) {
+                nodes {
+                  isResolved
+                  path
+                  line
+                  comments(first: 5) {
+                    nodes {
+                      author { login }
+                      body
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `;
+      const { stdout } = await execAsync(`gh api graphql -f query='${query}'`, {
+        cwd: ctx.projectPath,
+        timeout: 15000,
+      });
+      const data = JSON.parse(stdout);
+      const threads = (data?.data?.repository?.pullRequest?.reviewThreads?.nodes ?? []) as Array<{
+        isResolved?: boolean;
+        path?: string;
+        line?: number;
+        comments?: { nodes?: Array<{ author?: { login?: string }; body?: string }> };
+      }>;
+
+      const bodies: string[] = [];
+      for (const thread of threads) {
+        if (thread.isResolved) continue;
+        const comments = thread.comments?.nodes ?? [];
+        const crComments = comments.filter((c) =>
+          (c.author?.login ?? '').toLowerCase().includes('coderabbit')
+        );
+        if (crComments.length === 0) continue;
+        for (const c of crComments) {
+          bodies.push(`### ${thread.path ?? '?'}:${thread.line ?? '?'}\n${c.body ?? ''}`);
+        }
+      }
+      // Count unique threads, not comments — one thread may have several CR replies.
+      const unresolvedThreadCount = threads.filter((t) => {
+        if (t.isResolved) return false;
+        const comments = t.comments?.nodes ?? [];
+        return comments.some((c) => (c.author?.login ?? '').toLowerCase().includes('coderabbit'));
+      }).length;
+
+      return { count: unresolvedThreadCount, bodies };
+    } catch (err) {
+      logger.debug(`[REVIEW] Failed to query CodeRabbit threads for PR #${ctx.prNumber}: ${err}`);
+      return { count: 0, bodies: [] };
     }
   }
 

--- a/apps/server/tests/unit/services/lead-engineer-review-merge-processors.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-review-merge-processors.test.ts
@@ -219,8 +219,20 @@ describe('ReviewProcessor', () => {
             stderr: '',
           })
         )
-        // Call 5: fetch CI failure names
-        .mockImplementationOnce(execSuccess({ stdout: ciCheckName, stderr: '' }));
+        // Call 5: gh repo view (from getUnresolvedCodeRabbitThreads) — fails fast
+        .mockImplementationOnce(execFailure(new Error('test: gh repo view stub')))
+        // Call 6: fetch CI failure names
+        .mockImplementationOnce(execSuccess({ stdout: ciCheckName, stderr: '' }))
+        // Safety tail: any further unexpected exec calls fail fast so tests don't hang
+        .mockImplementation(
+          (
+            _cmd: string,
+            _opts: unknown,
+            cb: (err: Error, result: { stdout: string; stderr: string }) => void
+          ) => {
+            cb(new Error('test: unmocked exec'), { stdout: '', stderr: '' });
+          }
+        );
     }
 
     it('transitions to EXECUTE when CI checks fail', async () => {


### PR DESCRIPTION
## Summary

**Closes the loop you kept hitting.** When CodeRabbit posted comments on a PR, the REVIEW poll never noticed and the feature sat in `pending` until the 45-min timeout escalated it.

## Root cause

CR's default behavior is to post review **thread comments**, not reviews with state `CHANGES_REQUESTED`. GitHub's `reviewDecision` field only reflects submitted reviews, so it stayed `null`/`REVIEW_REQUIRED` regardless of how many CR threads were open.

The REVIEW poll's `getPRReviewState` only looked at `reviewDecision` and `reviews[]`:

```ts
if (data.decision === 'APPROVED') return 'approved';
if (data.decision === 'CHANGES_REQUESTED') return 'changes_requested';
// ... falls through to CI / pending — CR threads are invisible
```

CR comments → no signal → no remediation → 45-min timeout → escalate. Confirmed empirically on PR #3593 right after the smoke test: `reviewDecision: ""`, `reviews: []`, but a CR summary comment in `.comments[]`.

## Fix

Add a third decision path in `getPRReviewState`: after the existing `CHANGES_REQUESTED` check, query `reviewThreads` via GraphQL. If any thread is `isResolved: false` AND has a comment from a `coderabbit*` author, return `changes_requested` — which fires the existing remediation loop with all its budget enforcement (`reviewRemediationCount`, `prIterationCount`, escalation on cap).

The `changes_requested` branch's feedback fetcher now also concatenates CR thread bodies with file paths and line numbers, so the agent's next EXECUTE pass has concrete context to fix. Human reviews remain a separate labelled section in the prompt.

## Failure modes are non-blocking

Any failure of `gh repo view` or `gh api graphql` returns `{ count: 0, bodies: [] }` and the poll proceeds to its existing CI / pending checks. A transient gh outage never mistakenly unblocks merge.

## Test plan

- [x] `tsc --noEmit` clean on the full server package
- [x] `npm run test:server -- tests/unit/services/lead-engineer-review-merge-processors.test.ts` — 19/19 pass
- [x] `npm run test:server -- tests/unit/services/lead-engineer-review-processor.test.ts` — 6/6 pass
- [x] Test fixture updated: `setupCiFailureExecMock` now mocks the new `gh repo view` call AND adds a fail-fast safety tail so future unmocked exec calls error immediately instead of hanging on `promisify(exec)` waiting for a callback the mock never invokes
- [ ] **Live verification**: after merge, open a no-op PR, wait for CR to post threads, observe the REVIEW poll detect them and transition to EXECUTE with `ctx.reviewFeedback` populated

## Architecture notes

This pairs with PR #3598 (async-parallel ClawPatch). After both land:

- **Pre-PR**: agent executes in worktree (current)
- **Post-push, parallel**: CodeRabbit + ClawPatch both review (#3598)
- **Loop closes**: REVIEW poll now sees CR threads via this PR, fires remediation
- **Budget enforced**: `reviewRemediationCount` caps how many times the loop can fire before escalating

The existing orphan endpoints (`process-coderabbit-feedback`, `resolve-pr-threads`, `get-pr-feedback`) remain available for manual operator use; this PR doesn't touch them. A future PR could wire the agent's EXECUTE step to call `resolve-pr-threads` after addressing feedback, but that's not required for the loop to function — CR will re-review on the new commits and either approve or post fresh threads.