### PR TITLE
Add .mjs (and .cjs) to lint-staged glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "site:css": "npx --yes -p tailwindcss@4.1.18 -p @tailwindcss/cli@4.1.18 tailwindcss -i site/styles/input.css -o site/styles.css --minify"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,mts,cts,json,css,md,html,yml,yaml}": [
+    "*.{js,jsx,mjs,cjs,ts,tsx,mts,cts,json,css,md,html,yml,yaml}": [
       "prettier --ignore-path .prettierignore --write"
     ],
     "*.{ts,tsx}": [


### PR DESCRIPTION
## Summary

Closes #3609.

## Context

Lint-staged glob in `package.json` is currently `*.{js,jsx,ts,tsx,mts,cts,json,css,md,html,yml,yaml}` — `.mjs` is absent. This lets `.mjs` files commit cleanly through husky/lint-staged but then fail CI's `format:check`. Surfaced when `scripts/gen-mcp-tools-doc.mjs` failed CI on PR #3591.

## Acceptance criteria

- `package.json` lint-staged config glob includes `mjs` AND `cjs` extensions for the prettier task.
- ESLint task (currently `*.{ts,tsx}`) is unchanged — only...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=transient-293754f4 team= created=2026-05-22T00:03:29.815Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting tool configuration to include additional JavaScript module file extensions in automated formatting operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->