### PR TITLE
Fix XSS in setup-cli report-generator (HTML escape interpolated fields)

### DIFF
--- a/packages/setup-cli/src/services/report-generator.test.ts
+++ b/packages/setup-cli/src/services/report-generator.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import { buildHtmlReport } from './report-generator.js';
+import type { GapAnalysisReport } from 'create-protolab';
+
+type GapItem = GapAnalysisReport['gaps'][number];
+type ComplianceItem = GapAnalysisReport['compliant'][number];
+
+function makeGap(overrides: Partial<GapItem> = {}): GapItem {
+  return {
+    id: 'gap-1',
+    category: 'ci',
+    severity: 'critical',
+    title: 'Missing CI config',
+    current: 'No CI',
+    target: 'GitHub Actions',
+    effort: 'small',
+    featureDescription: 'Add GitHub Actions workflow',
+    ...overrides,
+  };
+}
+
+function makeCompliant(overrides: Partial<ComplianceItem> = {}): ComplianceItem {
+  return {
+    category: 'quality',
+    title: 'Has README',
+    detail: 'README.md present',
+    ...overrides,
+  };
+}
+
+function makeReport(overrides: Partial<GapAnalysisReport> = {}): GapAnalysisReport {
+  return {
+    projectPath: '/home/user/my-project',
+    analyzedAt: '2024-01-01T00:00:00.000Z',
+    overallScore: 75,
+    summary: { critical: 1, recommended: 1, optional: 0, compliant: 1 },
+    gaps: [
+      makeGap({ severity: 'critical' }),
+      makeGap({
+        id: 'gap-2',
+        title: 'Add linting',
+        severity: 'recommended',
+        current: 'None',
+        target: 'ESLint',
+        effort: 'medium',
+      }),
+    ],
+    compliant: [makeCompliant()],
+    ...overrides,
+  };
+}
+
+describe('buildHtmlReport', () => {
+  it('renders normal report without modification', () => {
+    const html = buildHtmlReport(makeReport());
+    expect(html).toContain('Missing CI config');
+    expect(html).toContain('No CI');
+    expect(html).toContain('GitHub Actions');
+    expect(html).toContain('Has README');
+    expect(html).toContain('README.md present');
+    expect(html).toContain('/home/user/my-project');
+  });
+
+  it('escapes XSS payload in projectPath', () => {
+    const xss = '/repos/<script>alert(1)</script>';
+    const html = buildHtmlReport(makeReport({ projectPath: xss }));
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('escapes XSS payload in gap title', () => {
+    const payload = '<img src=x onerror=alert(1)>';
+    const html = buildHtmlReport(
+      makeReport({
+        gaps: [makeGap({ title: payload })],
+        summary: { critical: 1, recommended: 0, optional: 0, compliant: 0 },
+        compliant: [],
+      })
+    );
+    expect(html).not.toContain('<img src=x onerror=alert(1)>');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+  });
+
+  it('escapes XSS payload in gap current field', () => {
+    const payload = '"><script>evil()</script>';
+    const html = buildHtmlReport(
+      makeReport({
+        gaps: [makeGap({ current: payload })],
+        summary: { critical: 1, recommended: 0, optional: 0, compliant: 0 },
+        compliant: [],
+      })
+    );
+    expect(html).not.toContain('<script>evil()</script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&quot;');
+  });
+
+  it('escapes XSS payload in gap target field', () => {
+    const payload = '<b onmouseover=alert(2)>hover</b>';
+    const html = buildHtmlReport(
+      makeReport({
+        gaps: [makeGap({ severity: 'optional', target: payload, effort: 'large' })],
+        summary: { critical: 0, recommended: 0, optional: 1, compliant: 0 },
+        compliant: [],
+      })
+    );
+    expect(html).not.toContain('<b onmouseover=alert(2)>');
+    expect(html).toContain('&lt;b onmouseover=alert(2)&gt;');
+  });
+
+  it('escapes XSS payload in effort field', () => {
+    const payload = 'small<script>x()</script>' as GapItem['effort'];
+    const html = buildHtmlReport(
+      makeReport({
+        gaps: [makeGap({ effort: payload })],
+        summary: { critical: 1, recommended: 0, optional: 0, compliant: 0 },
+        compliant: [],
+      })
+    );
+    expect(html).not.toContain('<script>x()</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('escapes XSS payload in compliant title', () => {
+    const payload = '<script>document.cookie</script>';
+    const html = buildHtmlReport(
+      makeReport({
+        compliant: [makeCompliant({ title: payload })],
+        gaps: [],
+        summary: { critical: 0, recommended: 0, optional: 0, compliant: 1 },
+      })
+    );
+    expect(html).not.toContain('<script>document.cookie</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('escapes XSS payload in compliant detail', () => {
+    const payload = '<img src=x onerror=fetch("//evil.com")>';
+    const html = buildHtmlReport(
+      makeReport({
+        compliant: [makeCompliant({ detail: payload })],
+        gaps: [],
+        summary: { critical: 0, recommended: 0, optional: 0, compliant: 1 },
+      })
+    );
+    expect(html).not.toContain('<img src=x');
+    expect(html).toContain('&lt;img src=x');
+  });
+
+  it('escapes ampersands and quotes in text fields', () => {
+    const html = buildHtmlReport(
+      makeReport({
+        gaps: [
+          makeGap({
+            title: 'A & B',
+            severity: 'recommended',
+            current: 'value with "quotes"',
+            target: "value with 'apostrophe'",
+            effort: 'small',
+          }),
+        ],
+        summary: { critical: 0, recommended: 1, optional: 0, compliant: 0 },
+        compliant: [],
+      })
+    );
+    expect(html).toContain('A &amp; B');
+    expect(html).toContain('value with &quot;quotes&quot;');
+    expect(html).toContain('value with &#39;apostrophe&#39;');
+  });
+});

--- a/packages/setup-cli/src/services/report-generator.ts
+++ b/packages/setup-cli/src/services/report-generator.ts
@@ -11,6 +11,16 @@ import type { GapAnalysisReport } from 'create-protolab';
 
 type GapItem = GapAnalysisReport['gaps'][number];
 
+/** Escape special HTML characters to prevent XSS injection. */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export interface HtmlReportOptions {
   /** Output directory for the report (defaults to projectPath/.automaker/) */
   outputDir?: string;
@@ -24,11 +34,11 @@ function severityBadge(severity: GapItem['severity']): string {
     recommended: 'badge-recommended',
     optional: 'badge-optional',
   };
-  return `<span class="badge ${map[severity] ?? 'badge-optional'}">${severity}</span>`;
+  return `<span class="badge ${map[severity] ?? 'badge-optional'}">${escapeHtml(severity)}</span>`;
 }
 
 function effortBadge(effort: GapItem['effort']): string {
-  return `<span class="badge badge-effort">${effort} effort</span>`;
+  return `<span class="badge badge-effort">${escapeHtml(effort)} effort</span>`;
 }
 
 function scoreColor(score: number): string {
@@ -51,10 +61,10 @@ function renderGapRows(gaps: GapItem[]): string {
     .map(
       (g) => `
     <tr>
-      <td>${g.title}</td>
+      <td>${escapeHtml(g.title)}</td>
       <td>${severityBadge(g.severity)}</td>
-      <td class="dim">${g.current}</td>
-      <td class="dim">${g.target}</td>
+      <td class="dim">${escapeHtml(g.current)}</td>
+      <td class="dim">${escapeHtml(g.target)}</td>
       <td>${effortBadge(g.effort)}</td>
     </tr>`
     )
@@ -67,8 +77,8 @@ function renderCompliantRows(items: GapAnalysisReport['compliant']): string {
     .map(
       (c) => `
     <tr>
-      <td><span class="check">&#10003;</span> ${c.title}</td>
-      <td class="dim">${c.detail}</td>
+      <td><span class="check">&#10003;</span> ${escapeHtml(c.title)}</td>
+      <td class="dim">${escapeHtml(c.detail)}</td>
     </tr>`
     )
     .join('');
@@ -86,7 +96,7 @@ export function buildHtmlReport(report: GapAnalysisReport): string {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ProtoLabs Gap Report — ${report.projectPath}</title>
+  <title>ProtoLabs Gap Report — ${escapeHtml(report.projectPath)}</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f0f11; color: #e2e8f0; line-height: 1.6; }
@@ -131,8 +141,8 @@ export function buildHtmlReport(report: GapAnalysisReport): string {
   <header>
     <div>
       <div class="brand">proto<span>Labs</span> / Gap Report</div>
-      <h1>${path.basename(report.projectPath)}</h1>
-      <div class="meta">${report.projectPath} &nbsp;·&nbsp; ${new Date(report.analyzedAt).toLocaleString()}</div>
+      <h1>${escapeHtml(path.basename(report.projectPath))}</h1>
+      <div class="meta">${escapeHtml(report.projectPath)} &nbsp;·&nbsp; ${new Date(report.analyzedAt).toLocaleString()}</div>
     </div>
     <div class="score-ring">
       <div class="score-value" style="color:${color}">${report.overallScore}%</div>

--- a/packages/setup-cli/vitest.config.ts
+++ b/packages/setup-cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

Closes #3608.

## Context

Clawpatch found that `packages/setup-cli/src/services/report-generator.ts` interpolates `GapAnalysisReport` fields and `projectPath` directly into HTML without escaping. Values come from scanning user-selected repos, so a malicious repo can inject ``, renders the HTML, and asserts the output contains escaped entities (`&lt;img`) not the raw payload.
- Place the test next to existing setup-cli tests; match the existing test framework (vitest).
- Do NOT change the HTML s...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=transient-afb051e5 team= created=2026-05-22T00:07:08.948Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of special characters in generated reports, including project paths, gap titles, effort values, and compliance item details.

* **Tests**
  * Comprehensive test suite added for HTML report generation to verify correct rendering of all report fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->