### PR TITLE
fix(chat): manage_board tool schema rejected by Anthropic — flatten discriminatedUnion

### DIFF
--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -346,49 +346,49 @@ export function buildAvaTools(
         '  • list   — enumerate features with optional status/priority filters and pagination\n' +
         '  • get    — retrieve full metadata for a single feature by ID\n' +
         '  • search — search feature titles and descriptions by keyword',
-      inputSchema: z.discriminatedUnion('action', [
-        z.object({
-          action: z.literal('list').describe('List features with optional filters'),
-          status: z.enum(FEATURE_STATUS_ENUM).optional().describe('Filter by status'),
-          priority: z.number().int().min(0).max(4).optional().describe('Filter by priority (0-4)'),
-          limit: z
-            .number()
-            .int()
-            .min(1)
-            .max(200)
-            .optional()
-            .describe('Max results to return (default 50)'),
-          offset: z
-            .number()
-            .int()
-            .min(0)
-            .optional()
-            .describe('Results to skip for pagination (default 0)'),
-        }),
-        z.object({
-          action: z.literal('get').describe('Get full metadata for a single feature'),
-          featureId: z.string().describe('The feature ID to retrieve'),
-        }),
-        z.object({
-          action: z.literal('search').describe('Search features by title or description'),
-          query: z.string().describe('Text to search in feature title and description'),
-          limit: z
-            .number()
-            .int()
-            .min(1)
-            .max(200)
-            .optional()
-            .describe('Max results to return (default 50)'),
-          offset: z
-            .number()
-            .int()
-            .min(0)
-            .optional()
-            .describe('Results to skip for pagination (default 0)'),
-        }),
-      ]),
+      // Flat schema (NOT discriminatedUnion): Anthropic's tool-use API requires
+      // input_schema.type === 'object' at the root, which discriminatedUnion
+      // doesn't emit (it produces anyOf instead). Branch by `action` at runtime
+      // and guard required-but-conditional fields with explicit error returns.
+      inputSchema: z.object({
+        action: z
+          .enum(['list', 'get', 'search'])
+          .describe('Which board action to run: list, get, or search'),
+        featureId: z.string().optional().describe('Feature ID (required when action=get)'),
+        query: z
+          .string()
+          .optional()
+          .describe('Search text — required when action=search; ignored otherwise'),
+        status: z
+          .enum(FEATURE_STATUS_ENUM)
+          .optional()
+          .describe('Filter by status (action=list only)'),
+        priority: z
+          .number()
+          .int()
+          .min(0)
+          .max(4)
+          .optional()
+          .describe('Filter by priority 0-4 (action=list only)'),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(200)
+          .optional()
+          .describe('Max results to return (default 50; action=list or action=search)'),
+        offset: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe('Results to skip for pagination (default 0; action=list or action=search)'),
+      }),
       execute: async (input) => {
         if (input.action === 'get') {
+          if (!input.featureId) {
+            return { error: 'featureId is required when action=get' };
+          }
           const feature = await services.featureLoader.get(projectPath, input.featureId);
           if (!feature) {
             return { error: `Feature '${input.featureId}' not found` };
@@ -407,6 +407,9 @@ export function buildAvaTools(
           }
         } else {
           // search
+          if (!input.query) {
+            return { error: 'query is required when action=search' };
+          }
           const q = input.query.toLowerCase();
           features = features.filter(
             (f) =>


### PR DESCRIPTION
## Symptom

Ava chat returns no response. Streaming endpoint emits:

```
data: {"type":"error","errorText":"tools.3.custom.input_schema.type: Field required"}
data: {"type":"error","errorText":"No output generated. Check the stream for errors."}
```

User-visible: the chat panel hangs forever. No tokens, no error in the UI.

## Root cause

`manage_board` is the only tool in `apps/server/src/routes/chat/ava-tools.ts` whose `inputSchema` is a `z.discriminatedUnion` (introduced in #3453, "feat(tooling): add list / read action to manage_board tool"). When zod's discriminated union is converted to JSON Schema, the root is:

```json
{ "anyOf": [...] }
```

…with **no top-level `type: 'object'`**. Anthropic's tool-use API now requires `input_schema.type === 'object'` at the root. The whole tool list fails validation before the model sees the prompt, the stream returns the error artifact and a "No output generated" follow-up, and the UI gets nothing.

Not introduced today — pre-existing since #3453. Anthropic tightened tool-schema validation since.

## Fix

Flatten the schema to a single `z.object({...})` with `action` as a required enum and the action-specific fields optional. Runtime branching on `input.action` was already there; added explicit guards for the conditionally-required fields (`featureId` for `get`, `query` for `search`) that return `{ error: '...' }` when the model omits them.

Lose the compile-time type narrowing that `discriminatedUnion` gave inside `if (input.action === 'get') { ... }` — `featureId` is now `string | undefined` always. That's fine; the runtime guard handles malformed calls.

## Validation

- [x] `tsc --noEmit` clean
- [x] Manual repro before fix: chat request returns `tools.3.custom.input_schema.type: Field required`
- [x] Grep confirms no other tools in `ava-tools.ts` use `discriminatedUnion` / `union` / `tuple` at the `inputSchema` root — `manage_board` is the only one
- [ ] After rebuild + restart on local prod: chat streams a real response

## After merge

Rebuild + restart the server:

```bash
( cd apps/server && npm run build )
# then restart whatever process runs the server (systemd unit, npm start, etc.)
```