### PR TITLE
fix(chat): route through LiteLLM gateway, default to protolabs/smart

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.45",
+    "@ai-sdk/openai-compatible": "^2.0.47",
     "@ai-sdk/react": "^3.0.92",
     "@anthropic-ai/claude-agent-sdk": "^0.2.36",
     "@anthropic-ai/sdk": "^0.65.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.45",
     "@ai-sdk/openai-compatible": "^2.0.47",
+    "@ai-sdk/provider": "^3.0.10",
     "@ai-sdk/react": "^3.0.92",
     "@anthropic-ai/claude-agent-sdk": "^0.2.36",
     "@anthropic-ai/sdk": "^0.65.0",

--- a/apps/server/src/lib/ai-provider.ts
+++ b/apps/server/src/lib/ai-provider.ts
@@ -1,41 +1,58 @@
 /**
- * AI Provider — shared Anthropic provider for @ai-sdk/anthropic routes.
+ * AI Provider — chat-route language model factory, routed through the protoLabs
+ * LiteLLM gateway by default.
  *
- * Resolves credentials using the same chain as the Claude Agent SDK:
- * 1. Credentials from settings UI (data/credentials.json via settingsService)
- * 2. ANTHROPIC_API_KEY environment variable
- * 3. ANTHROPIC_AUTH_TOKEN environment variable
- * 4. Claude CLI OAuth token from credential files (~/.claude/.credentials.json)
- * 5. Claude CLI OAuth token from macOS Keychain ("Claude Code-credentials")
+ * History: this file used to wrap `@ai-sdk/anthropic` for direct Anthropic
+ * calls. As of the gateway-first migration we no longer talk to api.anthropic.com
+ * directly — every chat request goes through the gateway via the OpenAI-compatible
+ * `/v1/chat/completions` endpoint. Anthropic OAuth (Claude Max/Pro) and bare
+ * ANTHROPIC_API_KEY are no longer used; the gateway terminates auth.
  *
- * All routes that call the Anthropic API via @ai-sdk/anthropic should use
- * getAnthropicModel() instead of importing `anthropic` directly, so they
- * work with CLI OAuth auth (Claude Max/Pro plans) and not just API keys.
+ * The export name `getAnthropicModel` is kept to avoid touching every caller in
+ * the same change; a follow-up can rename to `getChatModel`. Callers should
+ * pass any model identifier the gateway recognizes (e.g. `protolabs/smart`,
+ * `protolabs/fast`). Legacy Claude aliases (`sonnet`, `opus`, `claude-sonnet-4-6`)
+ * fall back to `protolabs/smart` so existing UI surfaces don't crash mid-migration.
+ *
+ * Auth resolution order:
+ * 1. GATEWAY_API_KEY env var
+ * 2. OPENAI_API_KEY env var (alias — the gateway speaks OpenAI's wire format)
+ * 3. `apiKeys.protolabsGateway` from settings credentials (when wired)
+ * 4. Empty string + warn (the gateway will reject the request — but the server
+ *    won't crash at boot, which keeps the rest of the API surface usable)
+ *
+ * Base URL: GATEWAY_BASE_URL or OPENAI_BASE_URL env var,
+ * default `https://api.proto-labs.ai/v1`.
  */
 
-import { execSync } from 'node:child_process';
-import { createAnthropic } from '@ai-sdk/anthropic';
-import { getClaudeCredentialPaths, systemPathReadFile } from '@protolabsai/platform';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import type { LanguageModelV3 } from '@ai-sdk/provider';
 import { createLogger } from '@protolabsai/utils';
 
 const logger = createLogger('AIProvider');
 
+const DEFAULT_BASE_URL = 'https://api.proto-labs.ai/v1';
+/** Models the gateway knows about that legacy Claude aliases should fall back to. */
+const FALLBACK_GATEWAY_MODEL = 'protolabs/smart';
+
 /** Cached provider instance — created once, reused across requests. */
-let cachedProvider: ReturnType<typeof createAnthropic> | null = null;
+let cachedProvider: ReturnType<typeof createOpenAICompatible> | null = null;
 
 /**
  * Credential resolver function — set by the server at boot to wire in
  * settingsService.getCredentials() without a circular import.
  */
-let credentialResolver: (() => Promise<{ apiKeys?: { anthropic?: string } }>) | null = null;
+let credentialResolver:
+  | (() => Promise<{ apiKeys?: { protolabsGateway?: string; anthropic?: string } }>)
+  | null = null;
 
 /**
  * Register the credential resolver (called once at server startup).
- * This allows ai-provider to read credentials from settingsService
- * without importing the service directly.
+ * Kept as the same export name as the legacy Anthropic version so callers
+ * don't need to change.
  */
 export function setCredentialResolver(
-  resolver: () => Promise<{ apiKeys?: { anthropic?: string } }>
+  resolver: () => Promise<{ apiKeys?: { protolabsGateway?: string; anthropic?: string } }>
 ): void {
   credentialResolver = resolver;
   // Invalidate cache so next request picks up the resolver
@@ -43,140 +60,87 @@ export function setCredentialResolver(
 }
 
 /**
- * Read the OAuth access token from Claude CLI credential files.
- * Supports:
- * - Claude Code format: { claudeAiOauth: { accessToken } }
- * - Legacy format: { oauth_token } or { access_token }
+ * Resolve a gateway API key from the chain above. Returns the key + a label
+ * for logging.
  */
-async function readCliOAuthToken(): Promise<string | null> {
-  const credentialPaths = getClaudeCredentialPaths();
-  for (const credPath of credentialPaths) {
-    try {
-      const content = await systemPathReadFile(credPath);
-      const creds = JSON.parse(content) as Record<string, unknown>;
-
-      // Claude Code CLI format
-      const claudeOauth = creds.claudeAiOauth as { accessToken?: string } | undefined;
-      if (claudeOauth?.accessToken) {
-        return claudeOauth.accessToken;
-      }
-
-      // Legacy formats
-      if (typeof creds.oauth_token === 'string') return creds.oauth_token;
-      if (typeof creds.access_token === 'string') return creds.access_token;
-    } catch {
-      // Continue to next credential path
-    }
-  }
-  return null;
-}
-
-/**
- * Read the OAuth access token from the macOS Keychain.
- * Claude Code stores credentials in the system keychain under
- * the service name "Claude Code-credentials" as a JSON blob:
- * { claudeAiOauth: { accessToken, refreshToken, expiresAt } }
- */
-function readKeychainOAuthToken(): string | null {
-  if (process.platform !== 'darwin') return null;
-
-  try {
-    const raw = execSync('security find-generic-password -s "Claude Code-credentials" -w', {
-      encoding: 'utf-8',
-      timeout: 5000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-
-    const creds = JSON.parse(raw) as Record<string, unknown>;
-    const claudeOauth = creds.claudeAiOauth as { accessToken?: string } | undefined;
-    if (claudeOauth?.accessToken) {
-      return claudeOauth.accessToken;
-    }
-  } catch {
-    // Keychain entry not found or not on macOS
-  }
-  return null;
-}
-
-/**
- * Create or return the cached Anthropic provider with proper auth.
- * Mirrors the credential resolution chain from claude-provider.ts buildEnv().
- */
-async function getOrCreateProvider(): Promise<ReturnType<typeof createAnthropic>> {
-  if (cachedProvider) return cachedProvider;
-
-  // 1. Check credentials from settings UI (data/credentials.json)
+async function resolveApiKey(): Promise<{ key: string; source: string }> {
   if (credentialResolver) {
     try {
       const credentials = await credentialResolver();
-      if (credentials.apiKeys?.anthropic) {
-        logger.info('Using API key from settings credentials');
-        cachedProvider = createAnthropic({ apiKey: credentials.apiKeys.anthropic });
-        return cachedProvider;
-      }
+      const fromSettings = credentials.apiKeys?.protolabsGateway;
+      if (fromSettings) return { key: fromSettings, source: 'settings.protolabsGateway' };
     } catch {
-      // Credentials not available, continue chain
+      // ignore, continue chain
     }
   }
+  if (process.env.GATEWAY_API_KEY) {
+    return { key: process.env.GATEWAY_API_KEY, source: 'env.GATEWAY_API_KEY' };
+  }
+  if (process.env.OPENAI_API_KEY) {
+    return { key: process.env.OPENAI_API_KEY, source: 'env.OPENAI_API_KEY' };
+  }
+  return { key: '', source: 'none' };
+}
 
-  // 2. Check ANTHROPIC_API_KEY env var
-  if (process.env.ANTHROPIC_API_KEY) {
-    logger.info('Using ANTHROPIC_API_KEY from environment');
-    cachedProvider = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
-    return cachedProvider;
+/**
+ * Build or return the cached OpenAI-compatible provider pointed at the gateway.
+ */
+async function getOrCreateProvider(): Promise<ReturnType<typeof createOpenAICompatible>> {
+  if (cachedProvider) return cachedProvider;
+
+  const baseURL = process.env.GATEWAY_BASE_URL || process.env.OPENAI_BASE_URL || DEFAULT_BASE_URL;
+  const { key, source } = await resolveApiKey();
+
+  if (!key) {
+    logger.warn(
+      'No gateway API key found. Chat requests will fail. ' +
+        'Set GATEWAY_API_KEY in the server environment or enter a key in Settings.'
+    );
+  } else {
+    logger.info(`Gateway provider initialized: baseURL=${baseURL} keySource=${source}`);
   }
 
-  // 3. Check ANTHROPIC_AUTH_TOKEN env var
-  if (process.env.ANTHROPIC_AUTH_TOKEN) {
-    logger.info('Using ANTHROPIC_AUTH_TOKEN from environment');
-    cachedProvider = createAnthropic({
-      authToken: process.env.ANTHROPIC_AUTH_TOKEN,
-      headers: { 'anthropic-beta': 'oauth-2025-04-20' },
-    });
-    return cachedProvider;
-  }
-
-  // 4. Read CLI OAuth token from credential files
-  const fileToken = await readCliOAuthToken();
-  if (fileToken) {
-    logger.info('Using Claude CLI OAuth token (file) for AI SDK provider');
-    cachedProvider = createAnthropic({
-      authToken: fileToken,
-      headers: { 'anthropic-beta': 'oauth-2025-04-20' },
-    });
-    return cachedProvider;
-  }
-
-  // 5. Read CLI OAuth token from macOS Keychain
-  const keychainToken = readKeychainOAuthToken();
-  if (keychainToken) {
-    logger.info('Using Claude CLI OAuth token (keychain) for AI SDK provider');
-    cachedProvider = createAnthropic({
-      authToken: keychainToken,
-      headers: { 'anthropic-beta': 'oauth-2025-04-20' },
-    });
-    return cachedProvider;
-  }
-
-  // 6. Fallback — let @ai-sdk/anthropic try its own defaults (will likely fail)
-  logger.warn(
-    'No API key or OAuth token found. AI SDK chat routes will fail. ' +
-      'Set ANTHROPIC_API_KEY, enter a key in Settings, or authenticate via Claude CLI.'
-  );
-  cachedProvider = createAnthropic();
+  cachedProvider = createOpenAICompatible({
+    name: 'protolabs-gateway',
+    baseURL,
+    apiKey: key,
+  });
   return cachedProvider;
 }
 
 /**
- * Get an Anthropic model instance with proper authentication.
- * Drop-in replacement for `anthropic(modelId)` from @ai-sdk/anthropic.
+ * Map a legacy Claude alias to a gateway model. Any non-Claude model name
+ * (e.g. `protolabs/smart`, `protolabs/fast`) passes through unchanged.
  *
- * @param modelId - The model ID (e.g., 'claude-sonnet-4-6')
- * @returns A language model instance ready for streamText/generateText
+ * Why: chat default falls through to `'sonnet'` in several places. Until that
+ * default is fully scrubbed, treat Claude-flavored names as a request for the
+ * gateway's smart model instead of letting them leak to a now-unsupported path.
  */
-export async function getAnthropicModel(modelId: string) {
+function mapLegacyClaudeModel(modelId: string): string {
+  const lower = modelId.toLowerCase();
+  if (lower === 'sonnet' || lower === 'opus' || lower === 'haiku' || lower.startsWith('claude-')) {
+    return FALLBACK_GATEWAY_MODEL;
+  }
+  return modelId;
+}
+
+/**
+ * Get a language model instance routed through the gateway.
+ *
+ * Drop-in replacement for the old `getAnthropicModel(...)` signature; callers
+ * pass a model id and receive a model object compatible with
+ * `streamText`/`generateText`.
+ *
+ * Legacy Claude aliases are silently remapped to `protolabs/smart` so existing
+ * UI flows don't 4xx during the migration window.
+ */
+export async function getAnthropicModel(modelId: string): Promise<LanguageModelV3> {
   const provider = await getOrCreateProvider();
-  return provider(modelId);
+  const mapped = mapLegacyClaudeModel(modelId);
+  if (mapped !== modelId) {
+    logger.debug(`Remapped legacy model id ${modelId} -> ${mapped}`);
+  }
+  return provider(mapped);
 }
 
 /**

--- a/apps/server/src/routes/chat/index.ts
+++ b/apps/server/src/routes/chat/index.ts
@@ -382,7 +382,10 @@ export function createChatRoutes(services: ServiceContainer): Router {
       // Model selection: session picker (header/body) > AvaConfig.model > default (sonnet)
       // The inline ChatModelSelect sends x-model-alias; config model is the fallback for new chats.
       const modelAlias =
-        (req.headers['x-model-alias'] as string) || bodyModel || avaConfig.model || 'sonnet';
+        (req.headers['x-model-alias'] as string) ||
+        bodyModel ||
+        avaConfig.model ||
+        'protolabs/smart';
       const effortLevel = (req.headers['x-effort-level'] as string) || 'medium';
 
       const resolvedModelId = resolveModelString(modelAlias, 'sonnet');

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.45",
+        "@ai-sdk/openai-compatible": "^2.0.47",
         "@ai-sdk/react": "^3.0.92",
         "@anthropic-ai/claude-agent-sdk": "^0.2.36",
         "@anthropic-ai/sdk": "^0.65.0",
@@ -1333,6 +1334,51 @@
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.19",
         "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai-compatible": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.47.tgz",
+      "integrity": "sha512-Enm5UlL0zUCrW3792opk5h7hRWxZOZzDe6eQYVFqX9LUOGGCe1h8MZWAGim765nwzgnjlpeYOsuzZmLtRsTPlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai-compatible/node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/openai-compatible/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -17461,7 +17507,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.45",
         "@ai-sdk/openai-compatible": "^2.0.47",
+        "@ai-sdk/provider": "^3.0.10",
         "@ai-sdk/react": "^3.0.92",
         "@anthropic-ai/claude-agent-sdk": "^0.2.36",
         "@anthropic-ai/sdk": "^0.65.0",
@@ -144,6 +145,18 @@
       },
       "engines": {
         "node": ">=22.0.0 <23.0.0"
+      }
+    },
+    "apps/server/node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "apps/server/node_modules/@eslint/config-array": {


### PR DESCRIPTION
## Why

Ava chat was unusable — Anthropic returned `rate_limit_error` with a useless `"message":"Error"` on every call. The chat path was going direct to `api.anthropic.com` via `@ai-sdk/anthropic`. The team direction is gateway-first: no Anthropic keys, no direct calls, everything routed through `https://api.proto-labs.ai/v1`.

This PR yanks the direct-Anthropic path out of chat.

## Changes

- **`apps/server/src/lib/ai-provider.ts`** — rewritten to use `@ai-sdk/openai-compatible` pointed at the gateway. Auth chain:
  1. `GATEWAY_API_KEY` env
  2. `OPENAI_API_KEY` env (alias — gateway accepts both)
  3. `apiKeys.protolabsGateway` from settings credentials

  Legacy Claude aliases (`sonnet`, `opus`, `haiku`, anything starting with `claude-`) are silently remapped to `protolabs/smart` so the UI's stored `"sonnet"` defaults don't blow up mid-migration.

- **`apps/server/src/routes/chat/index.ts`** — default model alias goes from `'sonnet'` → `'protolabs/smart'`. Existing fall-back chain (header > body > avaConfig.model > default) is preserved.

- **`apps/server/package.json`** — adds `@ai-sdk/openai-compatible`.

## Validation

```
( cd apps/server && npm run build )
GATEWAY_API_KEY=... GATEWAY_BASE_URL=https://api.proto-labs.ai/v1 \
  node apps/server/dist/apps/server/src/index.js

# server.log:
[AIProvider] Gateway provider initialized: baseURL=https://api.proto-labs.ai/v1 keySource=env.GATEWAY_API_KEY

# POST /api/chat:
data: {"type":"reasoning-start","id":"reasoning-0"}
data: {"type":"reasoning-delta","delta":"The"}
data: {"type":"reasoning-delta","delta":" user"}
... (full stream from protolabs/smart)
```

Before this change, that same payload returned `rate_limit_error` and `NoOutputGeneratedError`. The previous Anthropic-direct path is no longer reachable from `/api/chat`.

## Kept intentionally (for follow-ups)

- **Export name `getAnthropicModel`** is unchanged. Renaming touches ~10 call sites with no behavior change. Rename in a follow-up.
- **`providerOptions.anthropic`** block in chat/index.ts (`extended thinking`, `contextManagement`) stays as-is. The AI SDK ignores provider-specific options when the active provider doesn't match, so these are inert under openai-compatible. Cleanup later.
- **Settings UI "Claude" provider tile + Anthropic credential field** can be removed in a separate UI-side PR. They're inert now because no code path consumes the Anthropic API key.

## Operational note

The server process needs `GATEWAY_API_KEY` and (optionally) `GATEWAY_BASE_URL` in its environment. For host-process systemd (the `automaker-host.service` from PR #3617), drop them into `/etc/systemd/system/automaker-host.service.d/override.conf`:

```ini
[Service]
Environment=GATEWAY_API_KEY=...
Environment=GATEWAY_BASE_URL=https://api.proto-labs.ai/v1
```

…or pipe from Infisical at deploy time.