### PR TITLE
fix(ui): litellm gateway test connection probes /models, not /health

### DIFF
--- a/apps/ui/src/components/views/settings-view/providers/litellm-gateway-tab/index.tsx
+++ b/apps/ui/src/components/views/settings-view/providers/litellm-gateway-tab/index.tsx
@@ -82,7 +82,13 @@ export function LiteLLMGatewayTab() {
     setTestResult(null);
 
     try {
-      const url = config.baseUrl.replace(/\/$/, '') + '/health';
+      // Use /models, not /health: LiteLLM exposes /health at the deployment
+      // root (not under /v1), so a baseUrl of "https://host/v1" produced a
+      // /v1/health URL that 404s. /models is reachable under the /v1 base
+      // and exercises the same auth path the rest of the integration uses —
+      // it's also what `handleRefreshModels` below and the server-side
+      // LiteLLMGatewayService.testConnection both probe.
+      const url = config.baseUrl.replace(/\/$/, '') + '/models';
       const headers: Record<string, string> = { 'Content-Type': 'application/json' };
       if (config.apiKeySource === 'inline' && config.apiKey) {
         headers['Authorization'] = `Bearer ${config.apiKey}`;
@@ -94,8 +100,13 @@ export function LiteLLMGatewayTab() {
         signal: AbortSignal.timeout(5000),
       });
       if (response.ok) {
+        const data = (await response.json()) as { data?: Array<{ id?: string }> };
+        const modelCount = Array.isArray(data?.data) ? data.data.length : 0;
         setConnectionStatus('connected');
-        setTestResult({ success: true, message: 'Connected successfully to LiteLLM Gateway.' });
+        setTestResult({
+          success: true,
+          message: `Connected to LiteLLM Gateway (${modelCount} model${modelCount === 1 ? '' : 's'} available).`,
+        });
       } else {
         setConnectionStatus('error');
         setTestResult({


### PR DESCRIPTION
## Symptom

On the **LiteLLM Gateway** settings tab, clicking **Test Connection** hangs for 5 seconds then reports a timeout. The **Refresh Models** dropdown right next to it loads fine.

## Root cause

The button appended `/health` to the configured base URL:

\`\`\`ts
const url = config.baseUrl.replace(/\/$/, '') + '/health';
\`\`\`

With the canonical base URL \`https://api.proto-labs.ai/v1\`, that becomes \`https://api.proto-labs.ai/v1/health\` — which 404s. LiteLLM exposes \`/health\` at the deployment root, not under \`/v1\`.

Confirmed live:

\`\`\`
HTTP 404  https://api.proto-labs.ai/v1/health
HTTP 401  https://api.proto-labs.ai/health        # exists, requires auth
HTTP 401  https://api.proto-labs.ai/v1/models     # exists, requires auth
\`\`\`

Why a 404 looks like a timeout: with an \`Authorization\` header attached, the browser preflight (OPTIONS) interacts badly with the 404, and the fetch hangs until \`AbortSignal.timeout(5000)\` aborts it.

## Fix

Probe \`/models\` instead:

- Reachable under \`/v1\`, so the same \`baseUrl + path\` construction works for every deployment shape
- Exercises the same auth path the rest of the integration uses
- Same endpoint that \`handleRefreshModels\` (immediately below in the same file) already hits successfully
- Same endpoint that the server-side \`LiteLLMGatewayService.testConnection\` uses

Also surface the model count in the success message so a single click answers both "gateway reachable" and "auth working".

## Validation

- \`tsc --noEmit\` clean
- Manual probe: gateway responds to \`/v1/models\` with the model list, success banner reads "Connected to LiteLLM Gateway (N models available)"