### PR TITLE
feat(ui): surface litellm gateway models as the first category in model defaults

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"5b7f052e-c94f-4e74-92cc-86ef286a8152","pid":60414,"procStart":"Fri May 22 04:41:20 2026","acquiredAt":1779432384250}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"5b7f052e-c94f-4e74-92cc-86ef286a8152","pid":60414,"procStart":"Fri May 22 04:41:20 2026","acquiredAt":1779432384250}

--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ libs/**/*.js.map
 docker-compose.override.yml
 .claude/docker-compose.override.yml
 .claude/hans/
+.claude/scheduled_tasks.lock
 
 pnpm-lock.yaml
 yarn.lock

--- a/apps/ui/src/components/views/settings-view/model-defaults/phase-model-selector.tsx
+++ b/apps/ui/src/components/views/settings-view/model-defaults/phase-model-selector.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { useAIModelsStore } from '@/store/ai-models-store';
+import { useGlobalSettings } from '@/hooks/queries/use-settings';
 import { useIsMobile } from '@/hooks/use-media-query';
 import type {
   ModelAlias,
@@ -181,7 +182,16 @@ export function PhaseModelSelector({
     disabledProviders,
     claudeCompatibleProviders,
     openaiCompatibleProviders,
+    litellmGatewayModels,
+    litellmGatewayModelsLoading,
+    fetchLitellmGatewayModels,
   } = useAIModelsStore();
+
+  // LiteLLM gateway is configured in global settings; read it here so we can
+  // (a) fetch the model list on mount when the gateway is enabled, and
+  // (b) decide whether to render the "LiteLLM Gateway" group at all.
+  const { data: globalSettings } = useGlobalSettings();
+  const litellmGateway = globalSettings?.litellmGateway;
 
   // Detect mobile devices to use inline expansion instead of nested popovers
   const isMobile = useIsMobile();
@@ -219,6 +229,18 @@ export function PhaseModelSelector({
       });
     }
   }, [dynamicOpencodeModels.length, opencodeModelsLoading, fetchOpencodeModels]);
+
+  // Fetch LiteLLM Gateway models on mount when the gateway is enabled. The
+  // store dedupes/caches/cooldowns; calling it eagerly is safe. We don't gate
+  // on `litellmGatewayModels.length === 0` because the cache may legitimately
+  // return zero models from a fresh-but-empty gateway.
+  useEffect(() => {
+    if (!litellmGateway?.enabled || !litellmGateway.baseUrl) return;
+    fetchLitellmGatewayModels(litellmGateway).catch(() => {
+      // Silently fail — user will see no LiteLLM section, which is the correct
+      // visual signal that the gateway isn't reachable from the browser.
+    });
+  }, [litellmGateway, fetchLitellmGatewayModels]);
 
   // Close expanded group when trigger scrolls out of view
   useEffect(() => {
@@ -1126,6 +1148,62 @@ export function PhaseModelSelector({
   };
 
   // Render OpenAI-Compatible provider model item (simple selection, no thinking levels)
+  // Render a single LiteLLM Gateway model item. The gateway returns flat model
+  // IDs like `protolabs/smart` over OpenAI's `/v1/models` schema. We store the
+  // raw ID in the PhaseModelEntry (no UI prefix) so it round-trips correctly
+  // through the AI SDK / openai-compatible provider — the modelPrefix from
+  // settings is purely a label convention.
+  const renderLitellmModelItem = (modelId: string) => {
+    const isSelected = selectedModel === modelId;
+    const isFavorite = favoriteModels.includes(modelId);
+
+    return (
+      <CommandItem
+        key={`litellm-${modelId}`}
+        value={`LiteLLM Gateway ${modelId}`}
+        onSelect={() => {
+          onChange({ model: modelId });
+          setOpen(false);
+        }}
+        className="group flex items-center justify-between py-2"
+      >
+        <div className="flex items-center gap-3 overflow-hidden">
+          <Server
+            className={cn(
+              'h-4 w-4 shrink-0',
+              isSelected ? 'text-primary' : 'text-muted-foreground'
+            )}
+          />
+          <div className="flex flex-col truncate">
+            <span className={cn('truncate font-medium', isSelected && 'text-primary')}>
+              {modelId}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1 ml-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            className={cn(
+              'h-6 w-6 hover:bg-transparent hover:text-yellow-500 focus:ring-0',
+              isFavorite
+                ? 'text-yellow-500 opacity-100'
+                : 'opacity-0 group-hover:opacity-100 text-muted-foreground'
+            )}
+            onClick={(e) => {
+              e.stopPropagation();
+              toggleFavoriteModel(modelId);
+            }}
+          >
+            <Star className={cn('h-3.5 w-3.5', isFavorite && 'fill-current')} />
+          </Button>
+          {isSelected && <Check className="h-4 w-4 text-primary shrink-0" />}
+        </div>
+      </CommandItem>
+    );
+  };
+
   const renderOpenAICompatModelItem = (provider: OpenAICompatibleConfig, model: ProviderModel) => {
     const isSelected = selectedModel === model.id;
     const isFavorite = favoriteModels.includes(model.id);
@@ -2005,6 +2083,16 @@ export function PhaseModelSelector({
               </CommandGroup>
               <CommandSeparator />
             </>
+          )}
+
+          {/* LiteLLM Gateway models — first provider category. When the
+              gateway is enabled and returning models, surface them above all
+              other providers so the gateway-first defaults workflow is the
+              path of least resistance. Hidden entirely when disabled or empty. */}
+          {litellmGateway?.enabled && litellmGatewayModels.length > 0 && (
+            <CommandGroup heading="LiteLLM Gateway">
+              {litellmGatewayModels.map((modelId) => renderLitellmModelItem(modelId))}
+            </CommandGroup>
           )}
 
           {claude.length > 0 && (

--- a/apps/ui/src/store/ai-models-store.ts
+++ b/apps/ui/src/store/ai-models-store.ts
@@ -11,6 +11,7 @@ import type {
   ModelDefinition,
   ClaudeCompatibleProvider,
   OpenAICompatibleConfig,
+  LiteLLMGatewayConfig,
 } from '@protolabsai/types';
 import {
   getAllCursorModelIds,
@@ -91,6 +92,12 @@ interface AIModelsState {
   codexModelsError: string | null;
   codexModelsLastFetched: number | null;
   codexModelsLastFailedAt: number | null;
+  // LiteLLM Gateway Models (dynamically fetched from gateway /v1/models)
+  litellmGatewayModels: string[];
+  litellmGatewayModelsLoading: boolean;
+  litellmGatewayModelsError: string | null;
+  litellmGatewayModelsLastFetched: number | null;
+  litellmGatewayModelsLastFailedAt: number | null;
 }
 
 interface AIModelsActions {
@@ -176,6 +183,11 @@ interface AIModelsActions {
   ) => void;
   // OpenCode Models actions
   fetchOpencodeModels: (forceRefresh?: boolean) => Promise<void>;
+  // LiteLLM Gateway Models actions
+  fetchLitellmGatewayModels: (
+    config: LiteLLMGatewayConfig,
+    forceRefresh?: boolean
+  ) => Promise<void>;
 }
 
 const initialState: AIModelsState = {
@@ -216,6 +228,11 @@ const initialState: AIModelsState = {
   codexModelsError: null,
   codexModelsLastFetched: null,
   codexModelsLastFailedAt: null,
+  litellmGatewayModels: [],
+  litellmGatewayModelsLoading: false,
+  litellmGatewayModelsError: null,
+  litellmGatewayModelsLastFetched: null,
+  litellmGatewayModelsLastFailedAt: null,
 };
 
 export const useAIModelsStore = create<AIModelsState & AIModelsActions>()((set, get) => ({
@@ -587,6 +604,81 @@ export const useAIModelsStore = create<AIModelsState & AIModelsActions>()((set, 
         opencodeModelsError: errorMessage,
         opencodeModelsLoading: false,
         opencodeModelsLastFailedAt: Date.now(),
+      });
+    }
+  },
+
+  // LiteLLM Gateway Models — fetched directly from the gateway's /v1/models
+  // endpoint (browser → gateway). The gateway response is OpenAI-compatible
+  // (`{data: [{id}, ...]}`). Cached for 5 min on success; cooled-down for 30s
+  // on failure so a missing/wrong base URL doesn't hammer the network.
+  fetchLitellmGatewayModels: async (config, forceRefresh = false) => {
+    const FAILURE_COOLDOWN_MS = 30 * 1000;
+    const SUCCESS_CACHE_MS = 5 * 60 * 1000;
+
+    const {
+      litellmGatewayModelsLastFetched,
+      litellmGatewayModelsLoading,
+      litellmGatewayModelsLastFailedAt,
+    } = get();
+
+    if (litellmGatewayModelsLoading) return;
+    if (!config.enabled || !config.baseUrl?.trim()) return;
+
+    if (
+      !forceRefresh &&
+      litellmGatewayModelsLastFailedAt &&
+      Date.now() - litellmGatewayModelsLastFailedAt < FAILURE_COOLDOWN_MS
+    ) {
+      return;
+    }
+
+    if (
+      !forceRefresh &&
+      litellmGatewayModelsLastFetched &&
+      Date.now() - litellmGatewayModelsLastFetched < SUCCESS_CACHE_MS
+    ) {
+      return;
+    }
+
+    set({ litellmGatewayModelsLoading: true, litellmGatewayModelsError: null });
+
+    try {
+      const url = config.baseUrl.replace(/\/$/, '') + '/models';
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (config.apiKeySource === 'inline' && config.apiKey) {
+        headers['Authorization'] = `Bearer ${config.apiKey}`;
+      }
+
+      const response = await fetch(url, {
+        method: 'GET',
+        headers,
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Gateway returned HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const data = (await response.json()) as { data?: Array<{ id?: string }> };
+      const models = Array.isArray(data?.data)
+        ? data.data.map((m) => m.id ?? '').filter((id) => id.length > 0)
+        : [];
+
+      set({
+        litellmGatewayModels: models,
+        litellmGatewayModelsLastFetched: Date.now(),
+        litellmGatewayModelsLoading: false,
+        litellmGatewayModelsError: null,
+        litellmGatewayModelsLastFailedAt: null,
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      logger.warn(`LiteLLM gateway model fetch failed: ${errorMessage}`);
+      set({
+        litellmGatewayModelsError: errorMessage,
+        litellmGatewayModelsLoading: false,
+        litellmGatewayModelsLastFailedAt: Date.now(),
       });
     }
   },


### PR DESCRIPTION
## Why

Gateway-first is the project direction; chat already routes through LiteLLM. The model defaults selector (`phase-model-selector.tsx`) was missing any LiteLLM integration, so users could configure the gateway in the LiteLLM Gateway settings tab and see their available models there — but couldn't pick those models as phase defaults. This PR closes that loop.

Per the request: surface LiteLLM Gateway models in the dropdown, **as the first provider category** so the gateway-first defaults workflow is the path of least resistance.

## Changes

**`ai-models-store.ts`** — new state + fetch action

\`\`\`ts
litellmGatewayModels: string[];           // model IDs from the gateway
litellmGatewayModelsLoading: boolean;
litellmGatewayModelsError: string | null;
litellmGatewayModelsLastFetched: number | null;
litellmGatewayModelsLastFailedAt: number | null;

fetchLitellmGatewayModels(config: LiteLLMGatewayConfig, forceRefresh?: boolean): Promise<void>;
\`\`\`

Calls the gateway's \`/v1/models\` directly from the browser (no server proxy — gateway returns proper CORS headers). Follows the same 5-min success cache / 30-sec failure cooldown pattern as \`fetchCodexModels\` and \`fetchOpencodeModels\`.

**`phase-model-selector.tsx`** — wire it in

- Read the gateway config via \`useGlobalSettings()\`
- Fetch on mount when \`litellmGateway.enabled\` and a base URL is set
- New \`renderLitellmModelItem\` (favorites toggle, selected state, raw model ID label)
- New \`CommandGroup heading="LiteLLM Gateway"\` rendered **above Claude Models** — i.e. the first provider category in the list
- Hidden entirely when the gateway is disabled or returns zero models, so users without LiteLLM see no visual change

**`.gitignore`** — also untracks \`.claude/scheduled_tasks.lock\` (runtime claude session lock that was drifting into diffs)

## Storage convention

Raw model IDs (e.g. \`protolabs/smart\`) are stored in \`PhaseModelEntry.model\`. The \`modelPrefix\` config field on \`LiteLLMGatewayConfig\` is a UI label convention only — it shouldn't leak into round-trip values that get passed to the AI SDK / openai-compatible provider, which expects bare gateway model IDs.

## Validation

- \`tsc --noEmit\` clean across the UI workspace
- UI production build (\`apps/ui && npm run build\`) succeeds with no new warnings on the changed files
- Manual smoke (will validate locally after merge): gateway enabled + reachable → "LiteLLM Gateway" group appears at the top of the dropdown with all gateway-discovered models; selecting one updates the phase entry to that raw model ID