### PR TITLE
fix(ui): phase model selector shows litellm model in closed trigger

### DIFF
--- a/apps/ui/src/components/views/settings-view/model-defaults/phase-model-selector.tsx
+++ b/apps/ui/src/components/views/settings-view/model-defaults/phase-model-selector.tsx
@@ -496,6 +496,20 @@ export function PhaseModelSelector({
       }
     }
 
+    // Check LiteLLM Gateway models. The gateway returns flat model IDs; we
+    // store the raw ID in PhaseModelEntry.model. Without this branch the
+    // closed-popover trigger falls through to "Select model" even when a
+    // gateway model is selected.
+    if (litellmGatewayModels.includes(selectedModel)) {
+      return {
+        id: selectedModel,
+        label: selectedModel,
+        description: 'LiteLLM Gateway',
+        provider: 'openai-compatible' as const,
+        icon: Server,
+      };
+    }
+
     return null;
   }, [
     selectedModel,
@@ -506,6 +520,7 @@ export function PhaseModelSelector({
     dynamicOpencodeModels,
     enabledProviders,
     enabledOpenAICompatibleProviders,
+    litellmGatewayModels,
   ]);
 
   // Compute grouped vs standalone Cursor models


### PR DESCRIPTION
## Regression from #3621

Selecting a LiteLLM Gateway model from the dropdown worked — the value persisted in \`PhaseModelEntry.model\` — but the closed-popover trigger displayed "Select model" instead of the selected model id.

## Root cause

The \`currentModel\` useMemo (\`phase-model-selector.tsx\` ~line 354) walks each provider type in order — Claude, Cursor (canonical + grouped), Codex, OpenCode (static + dynamic), ClaudeCompatible (with/without providerId), OpenAI-Compatible — and returns a label/icon/description. Anything not matched falls through to \`return null\`, which makes the trigger render its placeholder.

#3621 added a LiteLLM Gateway \`CommandGroup\` to the open dropdown but didn't extend \`currentModel\` to recognize the new selection source. Hence the mismatch: pick works, display doesn't.

## Fix

After the OpenAI-Compatible loop, check whether \`selectedModel\` is in \`litellmGatewayModels\` and return a matching \`currentModel\` record:

\`\`\`ts
if (litellmGatewayModels.includes(selectedModel)) {
  return {
    id: selectedModel,
    label: selectedModel,            // gateway model ids are already human-readable (protolabs/smart)
    description: 'LiteLLM Gateway',
    provider: 'openai-compatible' as const,
    icon: Server,
  };
}
\`\`\`

Also adds \`litellmGatewayModels\` to the useMemo deps so the trigger updates when the gateway model list refreshes (e.g., after first fetch).

## Validation

- \`tsc --noEmit\` clean
- UI production build succeeds
- Manual: closed trigger now shows the selected gateway model id (e.g. \`protolabs/smart\`) with the \`LiteLLM Gateway\` description and Server icon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LiteLLM Gateway models now display correctly when selected in the model selector. Previously, gateway selections would revert to showing a generic "Select model..." prompt, but now they properly display with the "LiteLLM Gateway" provider label and appropriate icons.
  * Model selector state now updates correctly whenever the gateway model list is fetched or modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->