### PR TITLE
fix(ui): wire ava chat overlay settings and queue panels through store

### DIFF
--- a/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx
@@ -41,12 +41,15 @@ export function ChatOverlayContent({
   const historyOpen = useChatStore((s) => s.historyOpen);
   const toggleHistory = useChatStore((s) => s.toggleHistory);
   const setHistoryOpen = useChatStore((s) => s.setHistoryOpen);
+  // settingsOpen + queueOpen are read by ChatSessionSlot through the store
+  // (not as props), so the toggle buttons here must drive store state — local
+  // useState wouldn't propagate to the rendered panel.
+  const toggleSettings = useChatStore((s) => s.toggleSettings);
+  const toggleQueue = useChatStore((s) => s.toggleQueue);
   const createSession = useChatStore((s) => s.createSession);
   const activateSession = useChatStore((s) => s.activateSession);
 
-  const [settingsOpen, setSettingsOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
-  const [queueOpen, setQueueOpen] = useState(false);
 
   // Bootstrap: on mount, ensure currentSessionId is set and in activeSessions so
   // ChatSessionPool has a slot to render. activeSessions is runtime-only (not persisted).
@@ -139,7 +142,7 @@ export function ChatOverlayContent({
             variant="ghost"
             size="icon"
             className="size-7"
-            onClick={() => setQueueOpen((v) => !v)}
+            onClick={toggleQueue}
             title="Feature queue"
             aria-label="Toggle feature queue"
             data-testid="queue-panel-toggle"
@@ -172,7 +175,7 @@ export function ChatOverlayContent({
             variant="ghost"
             size="icon"
             className="size-7"
-            onClick={() => setSettingsOpen((v) => !v)}
+            onClick={toggleSettings}
             title="Settings"
             aria-label="Toggle settings"
           >

--- a/apps/ui/src/components/views/chat-overlay/chat-session-slot.tsx
+++ b/apps/ui/src/components/views/chat-overlay/chat-session-slot.tsx
@@ -39,6 +39,12 @@ export function ChatSessionSlot({
     setSessionStreaming,
     historyOpen,
     setHistoryOpen,
+    // settingsOpen + queueOpen are pure read state — the gear / queue
+    // buttons in chat-overlay-content's header are what toggle them.
+    settingsOpen,
+    queueOpen,
+    queuePaused,
+    toggleQueuePaused,
     switchSession,
     createSession,
     deleteSession,
@@ -207,10 +213,10 @@ export function ChatSessionSlot({
         tokenUsage={{ total: 0, input: 0, output: 0, estimated: true }}
         branchInfoMap={new Map()}
         pendingBranchOrigId={null}
-        settingsOpen={false}
+        settingsOpen={settingsOpen}
         historyOpen={historyOpen}
-        queueOpen={false}
-        queuePaused={false}
+        queueOpen={queueOpen}
+        queuePaused={queuePaused}
         stepCount={0}
         effortLevel={effortLevel}
         onSubmit={handleSubmit}
@@ -227,7 +233,7 @@ export function ChatSessionSlot({
         onNewChat={handleNewChat}
         onDeleteSession={handleDeleteSession}
         onCloseHistory={handleCloseHistory}
-        onToggleQueuePause={() => {}}
+        onToggleQueuePause={toggleQueuePaused}
         onModelChange={handleModelChange}
         onEffortChange={handleEffortChange}
         getToolProgressLabel={() => undefined}

--- a/apps/ui/src/store/chat-store.ts
+++ b/apps/ui/src/store/chat-store.ts
@@ -37,6 +37,13 @@ interface ChatStoreState {
   sessions: ChatSession[];
   currentSessionId: string | null;
   historyOpen: boolean;
+  // settingsOpen / queueOpen live in the store (not in chat-overlay-content
+  // local state) because ChatSessionSlot consumes them directly — see
+  // chat-session-slot.tsx. The header buttons in chat-overlay-content toggle
+  // these via setSettingsOpen / setQueueOpen.
+  settingsOpen: boolean;
+  queueOpen: boolean;
+  queuePaused: boolean;
   chatModalOpen: boolean;
   /** Session ID that is currently streaming — used for the background streaming indicator */
   activeStreamingSessionId: string | null;
@@ -56,6 +63,12 @@ interface ChatActions {
   updateEffort: (id: string, effortLevel: ChatEffortLevel) => void;
   setHistoryOpen: (open: boolean) => void;
   toggleHistory: () => void;
+  setSettingsOpen: (open: boolean) => void;
+  toggleSettings: () => void;
+  setQueueOpen: (open: boolean) => void;
+  toggleQueue: () => void;
+  setQueuePaused: (paused: boolean) => void;
+  toggleQueuePaused: () => void;
   setChatModalOpen: (open: boolean) => void;
   setActiveStreamingSession: (sessionId: string | null) => void;
   getCurrentSession: () => ChatSession | null;
@@ -104,6 +117,9 @@ export const useChatStore = create<ChatStoreState & ChatActions>()(
       sessions: [],
       currentSessionId: null,
       historyOpen: false,
+      settingsOpen: false,
+      queueOpen: false,
+      queuePaused: false,
       chatModalOpen: false,
       activeStreamingSessionId: null,
       activeSessions: [],
@@ -182,6 +198,12 @@ export const useChatStore = create<ChatStoreState & ChatActions>()(
 
       setHistoryOpen: (open) => set({ historyOpen: open }),
       toggleHistory: () => set({ historyOpen: !get().historyOpen }),
+      setSettingsOpen: (open) => set({ settingsOpen: open }),
+      toggleSettings: () => set({ settingsOpen: !get().settingsOpen }),
+      setQueueOpen: (open) => set({ queueOpen: open }),
+      toggleQueue: () => set({ queueOpen: !get().queueOpen }),
+      setQueuePaused: (paused) => set({ queuePaused: paused }),
+      toggleQueuePaused: () => set({ queuePaused: !get().queuePaused }),
       setChatModalOpen: (open) => set({ chatModalOpen: open }),
       setActiveStreamingSession: (sessionId) => set({ activeStreamingSessionId: sessionId }),
 


### PR DESCRIPTION
## Symptom

In the Ava chat overlay, clicking the **gear** (settings) or **queue** buttons in the header does nothing — no panel slides in. The history button works.

## Root cause

\`chat-overlay-content.tsx\` held \`settingsOpen\` and \`queueOpen\` as local \`useState\`:

\`\`\`tsx
const [settingsOpen, setSettingsOpen] = useState(false);
const [queueOpen, setQueueOpen] = useState(false);
\`\`\`

The header buttons toggled these correctly, but the rendered panels live in a sibling subtree: \`ChatSessionPool\` → \`ChatSessionSlot\` → \`AskAvaTab\`. The slot hardcoded:

\`\`\`tsx
settingsOpen={false}
queueOpen={false}
queuePaused={false}
onToggleQueuePause={() => {}}
\`\`\`

So the toggle button updated state that was never consumed.

\`historyOpen\` worked because it already lived in the Zustand \`useChatStore\` and the slot read it from there directly. This PR moves the other two onto the same path.

## Changes

**\`apps/ui/src/store/chat-store.ts\`**

- New state fields: \`settingsOpen\`, \`queueOpen\`, \`queuePaused\` (default \`false\`)
- New actions: \`setSettingsOpen\`, \`toggleSettings\`, \`setQueueOpen\`, \`toggleQueue\`, \`setQueuePaused\`, \`toggleQueuePaused\`

**\`apps/ui/src/components/views/chat-overlay/chat-overlay-content.tsx\`**

- Drop \`const [settingsOpen, setSettingsOpen] = useState(false)\` and the matching \`queueOpen\`
- Pull \`toggleSettings\` and \`toggleQueue\` from \`useChatStore\` instead
- Header gear and queue buttons now call the store actions directly

**\`apps/ui/src/components/views/chat-overlay/chat-session-slot.tsx\`**

- Destructure \`settingsOpen\`, \`queueOpen\`, \`queuePaused\`, \`toggleQueuePaused\` from \`useChatStore()\`
- Replace the hardcoded \`false\` / \`() => {}\` props passed to \`AskAvaTab\` with the live store values
- Comment explains that the panels close via the same header buttons (no \`onClose\` prop needed)

No changes to \`AskAvaTab\`, \`AvaSettingsPanel\`, or \`MessageQueuePanel\` — they already render correctly when their visibility prop is true.

## Validation

- \`npm run typecheck\` clean across all 21 workspaces
- UI production build succeeds
- Manual: gear button now slides the AvaSettingsPanel in from the right; queue button toggles the message queue panel from the left; clicking the button again closes the panel (same toggle as before)