### PR TITLE
feat(providers): make proto the primary driver for agent runs

### DIFF
--- a/apps/server/src/providers/proto-provider.ts
+++ b/apps/server/src/providers/proto-provider.ts
@@ -327,11 +327,23 @@ export class ProtoProvider extends BaseProvider {
 }
 
 /**
- * Match any model that should route through the proto SDK. For PR 1 this is
- * conservative — only models that explicitly start with `protolabs/` are
- * claimed. PR 2 will widen this to "anything not claimed by a more-specific
- * provider" once we've validated the path end-to-end.
+ * Match any model that should route through the proto SDK.
+ *
+ * Claims:
+ *   - `protolabs/*` — first-party gateway model ids (smart, fast, ...)
+ *   - `claude-*` — legacy ClaudeProvider model ids. ProtoProvider speaks the
+ *     gateway protocol and the gateway resolves Anthropic Claude models
+ *     transparently, so these dispatch through the gateway with no change to
+ *     stored model strings.
+ *   - bare `opus` / `sonnet` / `haiku` aliases — the same legacy ids
+ *     `auto-mode-service.ts` and `lead-engineer-processors.ts` return from
+ *     `DEFAULT_MODELS.claude`. The gateway maps these to their Claude SKUs.
+ *
+ * The factory's `priority: 100` ensures ProtoProvider wins over the older
+ * Claude provider registration whenever both could claim the same model.
  */
 export function isProtoModel(model: string): boolean {
-  return model.startsWith('protolabs/');
+  if (model.startsWith('protolabs/')) return true;
+  if (model.startsWith('claude-')) return true;
+  return ['opus', 'sonnet', 'haiku'].includes(model);
 }

--- a/apps/server/src/services/ava-gateway-service.ts
+++ b/apps/server/src/services/ava-gateway-service.ts
@@ -14,7 +14,7 @@ import { createLogger } from '@protolabsai/utils';
 import type { EventEmitter } from '../lib/events.js';
 import { FeatureLoader } from './feature-loader.js';
 import type { DiscordBotService } from './discord-bot-service.js';
-import { ClaudeProvider } from '../providers/claude-provider.js';
+import { ProtoProvider } from '../providers/proto-provider.js';
 import type { SettingsService } from './settings-service.js';
 import type { HealthMonitorService } from './health-monitor-service.js';
 import { withTimeout } from '../lib/timeout-enforcer.js';
@@ -194,7 +194,7 @@ interface BoardSummary {
 export class AvaGatewayService {
   private featureLoader: FeatureLoader;
   private discordBotService: DiscordBotService | null = null;
-  private provider: ClaudeProvider | null = null;
+  private provider: ProtoProvider | null = null;
   private events: EventEmitter | null = null;
   private settingsService: SettingsService | null = null;
   private healthMonitor: HealthMonitorService | null = null;
@@ -825,7 +825,7 @@ export class AvaGatewayService {
     }
 
     if (!this.provider) {
-      this.provider = new ClaudeProvider();
+      this.provider = new ProtoProvider();
     }
 
     try {

--- a/apps/server/tests/unit/lib/model-resolver.test.ts
+++ b/apps/server/tests/unit/lib/model-resolver.test.ts
@@ -155,7 +155,10 @@ describe('model-resolver.ts', () => {
     });
 
     it('should have valid default model', () => {
-      expect(DEFAULT_MODELS.claude).toContain('claude');
+      // DEFAULT_MODELS.claude resolves through the gateway via @protolabsai/sdk.
+      // The field name still says "claude" for callsite stability; PR 3 renames
+      // it to `proto` when ClaudeProvider is removed.
+      expect(DEFAULT_MODELS.claude).toBe('protolabs/smart');
     });
   });
 });

--- a/apps/server/tests/unit/providers/provider-factory.test.ts
+++ b/apps/server/tests/unit/providers/provider-factory.test.ts
@@ -9,6 +9,7 @@ vi.mock('@/lib/langfuse-singleton.js', () => ({
 
 import { ProviderFactory } from '@/providers/provider-factory.js';
 import { ClaudeProvider } from '@/providers/claude-provider.js';
+import { ProtoProvider } from '@/providers/proto-provider.js';
 import { CursorProvider } from '@/providers/cursor-provider.js';
 import { CodexProvider } from '@/providers/codex-provider.js';
 import { OpencodeProvider } from '@/providers/opencode-provider.js';
@@ -55,52 +56,57 @@ describe('provider-factory.ts', () => {
   });
 
   describe('getProviderForModel', () => {
-    describe('Claude models (claude-* prefix)', () => {
-      it('should return ClaudeProvider for claude-opus-4-5-20251101', () => {
+    // Claude-shaped model ids now route through ProtoProvider via the
+    // gateway. The ClaudeProvider class still exists as a registered fallback
+    // but no claude-* / haiku / sonnet / opus id reaches it because Proto's
+    // higher-priority matcher claims them first. PR 3 deletes ClaudeProvider
+    // entirely along with sdk-options.ts's Anthropic SDK dependency.
+    describe('Claude-shaped model ids (now Proto-routed)', () => {
+      it('should return ProtoProvider for claude-opus-4-5-20251101', () => {
         const provider = ProviderFactory.getProviderForModel('claude-opus-4-5-20251101');
-        expect(provider).toBeInstanceOf(ClaudeProvider);
+        expect(provider).toBeInstanceOf(ProtoProvider);
       });
 
-      it('should return ClaudeProvider for claude-sonnet-4-20250514', () => {
+      it('should return ProtoProvider for claude-sonnet-4-20250514', () => {
         const provider = ProviderFactory.getProviderForModel('claude-sonnet-4-20250514');
-        expect(provider).toBeInstanceOf(ClaudeProvider);
+        expect(provider).toBeInstanceOf(ProtoProvider);
       });
 
-      it('should return ClaudeProvider for claude-haiku-4-5', () => {
+      it('should return ProtoProvider for claude-haiku-4-5', () => {
         const provider = ProviderFactory.getProviderForModel('claude-haiku-4-5');
-        expect(provider).toBeInstanceOf(ClaudeProvider);
+        expect(provider).toBeInstanceOf(ProtoProvider);
       });
 
-      it('should be case-insensitive for claude models', () => {
+      it('should be case-insensitive for claude-* ids', () => {
         const provider = ProviderFactory.getProviderForModel('CLAUDE-OPUS-4-5-20251101');
-        expect(provider).toBeInstanceOf(ClaudeProvider);
+        expect(provider).toBeInstanceOf(ProtoProvider);
       });
     });
 
-    describe('Claude aliases', () => {
-      it("should return ClaudeProvider for 'haiku'", () => {
+    describe('Bare claude aliases (now Proto-routed)', () => {
+      it("should return ProtoProvider for 'haiku'", () => {
         const provider = ProviderFactory.getProviderForModel('haiku');
-        expect(provider).toBeInstanceOf(ClaudeProvider);
+        expect(provider).toBeInstanceOf(ProtoProvider);
       });
 
-      it("should return ClaudeProvider for 'sonnet'", () => {
+      it("should return ProtoProvider for 'sonnet'", () => {
         const provider = ProviderFactory.getProviderForModel('sonnet');
-        expect(provider).toBeInstanceOf(ClaudeProvider);
+        expect(provider).toBeInstanceOf(ProtoProvider);
       });
 
-      it("should return ClaudeProvider for 'opus'", () => {
+      it("should return ProtoProvider for 'opus'", () => {
         const provider = ProviderFactory.getProviderForModel('opus');
-        expect(provider).toBeInstanceOf(ClaudeProvider);
+        expect(provider).toBeInstanceOf(ProtoProvider);
       });
 
-      it('should be case-insensitive for aliases', () => {
+      it('should be case-insensitive for bare aliases', () => {
         const provider1 = ProviderFactory.getProviderForModel('HAIKU');
         const provider2 = ProviderFactory.getProviderForModel('Sonnet');
         const provider3 = ProviderFactory.getProviderForModel('Opus');
 
-        expect(provider1).toBeInstanceOf(ClaudeProvider);
-        expect(provider2).toBeInstanceOf(ClaudeProvider);
-        expect(provider3).toBeInstanceOf(ClaudeProvider);
+        expect(provider1).toBeInstanceOf(ProtoProvider);
+        expect(provider2).toBeInstanceOf(ProtoProvider);
+        expect(provider3).toBeInstanceOf(ProtoProvider);
       });
     });
 

--- a/libs/model-resolver/tests/resolver.test.ts
+++ b/libs/model-resolver/tests/resolver.test.ts
@@ -322,9 +322,13 @@ describe('model-resolver', () => {
     it('should use DEFAULT_MODELS.claude as fallback', () => {
       const result = resolveModelString(undefined);
 
+      // DEFAULT_MODELS.claude now points at the gateway-routed `protolabs/smart`
+      // model since the Anthropic SDK is being phased out in favor of
+      // @protolabsai/sdk. The field name still says "claude" through this PR
+      // to keep the diff focused; PR 3 of the cutover will rename it to `proto`.
       expect(result).toBe(DEFAULT_MODELS.claude);
       expect(DEFAULT_MODELS.claude).toBeDefined();
-      expect(DEFAULT_MODELS.claude).toContain('claude-');
+      expect(DEFAULT_MODELS.claude).toBe('protolabs/smart');
     });
   });
 

--- a/libs/types/src/model.ts
+++ b/libs/types/src/model.ts
@@ -98,8 +98,15 @@ export function getAllCodexModelIds(): CodexModelId[] {
  * - haiku: Trivial tasks, quick operations
  */
 export const DEFAULT_MODELS = {
-  /** Default for general Claude usage - opus for orchestration/planning */
-  claude: 'claude-opus-4-6',
+  /**
+   * Default for agent orchestration / planning.
+   * Historically pointed at `claude-opus-4-6`; now routed through the protoLabs
+   * gateway via the proto SDK. Existing callers that key off
+   * `DEFAULT_MODELS.claude` continue to compile — only the resolved model id
+   * changes. The field name is intentionally NOT renamed in this PR to keep
+   * the diff focused; PR 3 (final SDK rip-out) will rename it to `proto`.
+   */
+  claude: 'protolabs/smart',
   /** Default for auto-mode feature implementation - sonnet for ticket work */
   autoMode: 'claude-sonnet-4-6',
   /** Default for trivial/quick tasks - haiku */


### PR DESCRIPTION
## Why

PR 2 of the namesake SDK cutover. PR 1 (#3625) added \`ProtoProvider\` alongside \`ClaudeProvider\`. This PR flips the defaults so every active model dispatch — Claude-shaped ids included — routes through \`@protolabsai/sdk\` instead of \`@anthropic-ai/claude-agent-sdk\`. The Anthropic SDK dependency stays installed for one more PR while \`sdk-options.ts\` (1000+ lines of Claude-shaped option builders + hook matchers) is migrated; once that lands the dep is removed and \`claude-provider.ts\` is deleted.

## Changes

**\`apps/server/src/providers/proto-provider.ts\`** — widened \`isProtoModel\` to also claim \`claude-*\` ids and the bare aliases \`opus\` / \`sonnet\` / \`haiku\`. The gateway already resolves Claude SKUs transparently, so callers that store \`claude-opus-4-5-...\` keep working with no migration on persisted state.

**\`libs/types/src/model.ts\`** — \`DEFAULT_MODELS.claude\` flipped from \`claude-opus-4-6\` to \`protolabs/smart\`. Field name preserved through this PR (rename to \`proto\` lands in PR 3) so the ~6 call sites in \`auto-mode-service.ts\` and \`lead-engineer-processors.ts\` compile without touching their lines.

**\`apps/server/src/services/ava-gateway-service.ts\`** — instantiates \`ProtoProvider\` instead of \`ClaudeProvider\`. The two are interface-compatible (both extend \`BaseProvider\` and implement \`executeQuery\`), so this is a one-line file-import change plus a class rename.

**\`apps/server/tests/unit/providers/provider-factory.test.ts\`** — bumps Claude-routed expectations to ProtoProvider for the cases the new matcher claims. Tests for "unknown model fallback" and "empty string fallback" still resolve to ClaudeProvider since ProtoProvider's matcher is explicit (no catch-all).

**\`apps/server/tests/unit/lib/model-resolver.test.ts\`** — asserts the new \`DEFAULT_MODELS.claude\` value.

## Routing matrix (verified programmatically)

\`\`\`
  protolabs/smart                → proto    ← new primary
  protolabs/fast                 → proto    ← new primary
  claude-opus-4-5-20251101       → proto    ← legacy id, gateway-routed
  claude-sonnet-4-20250514       → proto    ← legacy id, gateway-routed
  opus                           → proto    ← bare alias, gateway-routed
  sonnet                         → proto    ← bare alias, gateway-routed
  haiku                          → proto    ← bare alias, gateway-routed
  cursor-auto                    → cursor   ← unchanged
  codex-gpt-5.5                  → codex    ← unchanged
  unknown-xyz                    → claude   ← unchanged fallback (PR 3 cleans up)
\`\`\`

## What this PR explicitly does NOT change

- \`apps/server/src/lib/sdk-options.ts\` is untouched. The 1005 lines of \`Options\` / \`HookCallback\` / \`PostToolUseHookInput\` consumers stay until PR 3. The hook callback shape difference (Claude's structured input vs proto's \`unknown + toolUseId\`) is the bulk of PR 3's diff.
- \`apps/server/src/providers/claude-provider.ts\` stays registered as the unknown-model fallback. Once \`isProtoModel\` widens to a catch-all in PR 3, this becomes unreachable and gets deleted along with the dep.
- \`apps/server/src/routes/setup/routes/verify-claude-auth.ts\` and the four UI call sites that hit it stay until PR 3 — they're not reachable from any active runtime path (gateway-routed chat in #3619 made it inert) but deleting them requires UI surgery.
- \`@anthropic-ai/claude-agent-sdk\` stays in \`package.json\` for one more PR.

## Validation

- \`npm run typecheck\` clean across all 21 workspaces
- \`vitest run\` in apps/server: **3431 passed**, 23 skipped, 0 failed
- Programmatic burn-in (from #3625) still passes for both bare query and tool-using paths through the gateway

## After this lands

PR 3 closes the loop:
1. Migrate \`sdk-options.ts\` to proto SDK types (hook callbacks rewritten for proto's signature)
2. Widen \`isProtoModel\` to a catch-all for non-cursor/codex/opencode/groq/openai-compatible models
3. Delete \`claude-provider.ts\` + \`verify-claude-auth.ts\` + the 4 UI setup steps that target verify-claude-auth
4. Rename \`DEFAULT_MODELS.claude\` → \`DEFAULT_MODELS.proto\` everywhere
5. Remove \`@anthropic-ai/claude-agent-sdk\` from \`apps/server/package.json\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Optimized default Claude model routing through an improved gateway provider system for enhanced performance
  * Enhanced support for Claude model aliases (opus, sonnet, haiku) with consistent provider routing
  * Updated legacy Claude model IDs to work seamlessly with the new routing infrastructure
  * Improved overall model provider resolution consistency and reliability across the platform

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->