### PR TITLE
feat(setup): add proto-status endpoint for protoCLI autodetect

### DIFF
--- a/apps/server/src/routes/setup/index.ts
+++ b/apps/server/src/routes/setup/index.ts
@@ -14,6 +14,7 @@ import { createVerifyCodexAuthHandler } from './routes/verify-codex-auth.js';
 import { createGhStatusHandler } from './routes/gh-status.js';
 import { createCursorStatusHandler } from './routes/cursor-status.js';
 import { createCodexStatusHandler } from './routes/codex-status.js';
+import { createProtoStatusHandler } from './routes/proto-status.js';
 import { createInstallCodexHandler } from './routes/install-codex.js';
 import { createAuthCodexHandler } from './routes/auth-codex.js';
 import { createAuthCursorHandler } from './routes/auth-cursor.js';
@@ -80,6 +81,11 @@ export function createSetupRoutes(
   router.get('/cursor-status', createCursorStatusHandler());
   router.post('/auth-cursor', createAuthCursorHandler());
   router.post('/deauth-cursor', createDeauthCursorHandler());
+
+  // protoCLI / protoLabs gateway status. Reports binary install, version,
+  // gateway auth presence, and reachability of /v1/models. Used by the
+  // protoCLI onboarding step and settings tab.
+  router.get('/proto-status', createProtoStatusHandler());
 
   // Codex CLI routes
   router.get('/codex-status', createCodexStatusHandler());

--- a/apps/server/src/routes/setup/routes/proto-status.ts
+++ b/apps/server/src/routes/setup/routes/proto-status.ts
@@ -1,0 +1,239 @@
+/**
+ * GET /proto-status endpoint — Detect protoCLI installation + gateway auth.
+ *
+ * Surfaces:
+ *   - whether `proto` is on PATH (standalone install via `npm i -g @protolabsai/proto`)
+ *   - the proto CLI version
+ *   - whether gateway env is wired (GATEWAY_API_KEY / OPENAI_API_KEY)
+ *   - whether the configured gateway base URL responds to /v1/models
+ *
+ * Used by the protoCLI setup step in the onboarding wizard and the protoCLI
+ * settings tab to render install/auth status. Mirrors the shape of
+ * codex-status / cursor-status so the UI's existing status-card pattern
+ * works without new component code.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Request, Response } from 'express';
+import { getErrorMessage, logError } from '../common.js';
+
+const execFileAsync = promisify(execFile);
+
+const DISCONNECTED_MARKER_FILE = '.proto-disconnected';
+
+const INSTALL_COMMAND = 'npm install -g @protolabsai/proto';
+const LOGIN_COMMAND = '# proto reads GATEWAY_API_KEY / OPENAI_API_KEY from env';
+const DEFAULT_GATEWAY_BASE_URL = 'https://api.proto-labs.ai/v1';
+/**
+ * Cap the `proto --version` probe so a misbehaving install can't hang the
+ * health check. The CLI normally returns in <100ms; 4s is well beyond that.
+ */
+const PROTO_VERSION_TIMEOUT_MS = 4000;
+/**
+ * Cap the gateway reachability check. Same logic as `proto --version` — fast
+ * happy path, hard cap on the misbehaving case.
+ */
+const GATEWAY_REACHABILITY_TIMEOUT_MS = 5000;
+
+function isProtoDisconnectedFromApp(): boolean {
+  try {
+    const projectRoot = process.cwd();
+    const markerPath = path.join(projectRoot, '.automaker', DISCONNECTED_MARKER_FILE);
+    return fs.existsSync(markerPath);
+  } catch {
+    return false;
+  }
+}
+
+interface ProtoBinaryInfo {
+  installed: boolean;
+  version: string | null;
+  path: string | null;
+}
+
+/**
+ * Probe the `proto` CLI on PATH. Returns null version when the binary isn't
+ * available or doesn't respond to `--version` within the timeout.
+ */
+async function detectProtoBinary(): Promise<ProtoBinaryInfo> {
+  try {
+    const { stdout } = await execFileAsync('proto', ['--version'], {
+      timeout: PROTO_VERSION_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    const version = stdout.trim() || null;
+
+    // Resolve the resolved path so settings UI can show where it lives — does
+    // not fail the detection if `which` is unavailable (e.g. Windows).
+    let resolvedPath: string | null = null;
+    try {
+      const { stdout: whichOut } = await execFileAsync(
+        process.platform === 'win32' ? 'where' : 'which',
+        ['proto'],
+        { timeout: 1500, windowsHide: true }
+      );
+      resolvedPath = whichOut.split('\n')[0]?.trim() || null;
+    } catch {
+      // which/where unavailable; carry on without the path
+    }
+
+    return { installed: true, version, path: resolvedPath };
+  } catch {
+    return { installed: false, version: null, path: null };
+  }
+}
+
+interface GatewayAuthInfo {
+  hasApiKey: boolean;
+  apiKeySource: 'GATEWAY_API_KEY' | 'OPENAI_API_KEY' | 'none';
+  baseUrl: string;
+}
+
+function detectGatewayAuth(): GatewayAuthInfo {
+  if (process.env.GATEWAY_API_KEY) {
+    return {
+      hasApiKey: true,
+      apiKeySource: 'GATEWAY_API_KEY',
+      baseUrl:
+        process.env.GATEWAY_BASE_URL || process.env.OPENAI_BASE_URL || DEFAULT_GATEWAY_BASE_URL,
+    };
+  }
+  if (process.env.OPENAI_API_KEY) {
+    return {
+      hasApiKey: true,
+      apiKeySource: 'OPENAI_API_KEY',
+      baseUrl:
+        process.env.OPENAI_BASE_URL || process.env.GATEWAY_BASE_URL || DEFAULT_GATEWAY_BASE_URL,
+    };
+  }
+  return {
+    hasApiKey: false,
+    apiKeySource: 'none',
+    baseUrl:
+      process.env.GATEWAY_BASE_URL || process.env.OPENAI_BASE_URL || DEFAULT_GATEWAY_BASE_URL,
+  };
+}
+
+interface GatewayReachability {
+  reachable: boolean;
+  status: number | null;
+  modelCount: number | null;
+  error: string | null;
+}
+
+/**
+ * Probe `${baseUrl}/models` with the resolved API key to confirm the gateway
+ * is reachable AND the key is authorized. A 200 with a `data` array means
+ * proto can actually do work; anything else is a configuration problem the
+ * UI should surface.
+ */
+async function checkGatewayReachable(
+  baseUrl: string,
+  apiKey: string | null
+): Promise<GatewayReachability> {
+  if (!apiKey) {
+    return { reachable: false, status: null, modelCount: null, error: 'no api key' };
+  }
+  const url = `${baseUrl.replace(/\/$/, '')}/models`;
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(GATEWAY_REACHABILITY_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      return {
+        reachable: false,
+        status: response.status,
+        modelCount: null,
+        error: `gateway HTTP ${response.status}`,
+      };
+    }
+    const data = (await response.json()) as { data?: unknown[] };
+    return {
+      reachable: true,
+      status: response.status,
+      modelCount: Array.isArray(data?.data) ? data.data.length : null,
+      error: null,
+    };
+  } catch (err) {
+    return {
+      reachable: false,
+      status: null,
+      modelCount: null,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Creates handler for GET /api/setup/proto-status.
+ *
+ * Returns the union of:
+ *   - proto CLI installation status (binary on PATH + version + path)
+ *   - gateway auth status (api key presence + source env var + base URL)
+ *   - gateway reachability (HTTP status from /models + model count)
+ *   - install/login command hints for the UI's "fix it" CTA
+ */
+export function createProtoStatusHandler() {
+  return async (_req: Request, res: Response): Promise<void> => {
+    try {
+      if (isProtoDisconnectedFromApp()) {
+        res.json({
+          success: true,
+          installed: false,
+          version: null,
+          path: null,
+          gateway: {
+            hasApiKey: false,
+            apiKeySource: 'none',
+            baseUrl: DEFAULT_GATEWAY_BASE_URL,
+            reachable: false,
+            modelCount: null,
+            error: 'disconnected',
+          },
+          installCommand: INSTALL_COMMAND,
+          loginCommand: LOGIN_COMMAND,
+        });
+        return;
+      }
+
+      const binary = await detectProtoBinary();
+      const auth = detectGatewayAuth();
+      const apiKey =
+        auth.apiKeySource === 'GATEWAY_API_KEY'
+          ? (process.env.GATEWAY_API_KEY ?? null)
+          : auth.apiKeySource === 'OPENAI_API_KEY'
+            ? (process.env.OPENAI_API_KEY ?? null)
+            : null;
+      const reachability = await checkGatewayReachable(auth.baseUrl, apiKey);
+
+      res.json({
+        success: true,
+        installed: binary.installed,
+        version: binary.version,
+        path: binary.path,
+        gateway: {
+          hasApiKey: auth.hasApiKey,
+          apiKeySource: auth.apiKeySource,
+          baseUrl: auth.baseUrl,
+          reachable: reachability.reachable,
+          status: reachability.status,
+          modelCount: reachability.modelCount,
+          error: reachability.error,
+        },
+        installCommand: INSTALL_COMMAND,
+        loginCommand: LOGIN_COMMAND,
+      });
+    } catch (error) {
+      logError(error, 'Get proto status failed');
+      res.status(500).json({
+        success: false,
+        error: getErrorMessage(error),
+      });
+    }
+  };
+}

--- a/apps/ui/src/lib/clients/setup-client.ts
+++ b/apps/ui/src/lib/clients/setup-client.ts
@@ -326,6 +326,30 @@ export const withSetupClient = <TBase extends Constructor<BaseHttpClient>>(Base:
         error?: string;
       }> => this.get('/api/setup/codex-status'),
 
+      /**
+       * Detect protoCLI installation + gateway connectivity. Returns the union
+       * of binary install state and gateway reachability so onboarding can
+       * render a single status card with actionable CTAs.
+       */
+      protoStatus: (): Promise<{
+        success: boolean;
+        installed: boolean;
+        version: string | null;
+        path: string | null;
+        gateway: {
+          hasApiKey: boolean;
+          apiKeySource: 'GATEWAY_API_KEY' | 'OPENAI_API_KEY' | 'none';
+          baseUrl: string;
+          reachable: boolean;
+          status?: number | null;
+          modelCount: number | null;
+          error: string | null;
+        };
+        installCommand: string;
+        loginCommand: string;
+        error?: string;
+      }> => this.get('/api/setup/proto-status'),
+
       installCodex: (): Promise<{
         success: boolean;
         message?: string;


### PR DESCRIPTION
## Why

PR A of the protoCLI first-class provider work — adds the server-side autodetect endpoint that the upcoming settings tab (PR B) and onboarding step (PR C) will read from. Reports protoCLI install state + gateway auth + gateway reachability in a single status card the UI can render with the existing setup-card pattern.

## Changes

**`apps/server/src/routes/setup/routes/proto-status.ts`** — new handler. Detects:

- **Binary install** — runs `proto --version` (with `where` / `which` for the resolved path). Capped at 4s so a misbehaving install can't hang health checks.
- **Gateway auth** — checks `GATEWAY_API_KEY` first, falls back to `OPENAI_API_KEY`. Reports which env var supplied it (`apiKeySource`) so the UI can show "configured via $ENV".
- **Gateway reachability** — probes `${baseUrl}/v1/models` with the resolved key. A 200 + `data` array means proto can actually do work; anything else surfaces as an `error` string the UI can render.
- **Disconnect marker** — honors `.automaker/.proto-disconnected` like the other status endpoints, so users can opt out of the autodetect without uninstalling.

Mirrors the response shape of `codex-status` so the UI's existing status-card components work without bespoke code.

**`apps/server/src/routes/setup/index.ts`** — registers `GET /api/setup/proto-status` next to the other CLI status routes.

**`apps/ui/src/lib/clients/setup-client.ts`** — adds the `setup.protoStatus()` client method with full response typing. PRs B + C call this.

## Response shape

\`\`\`json
{
  "success": true,
  "installed": true,
  "version": "0.39.0",
  "path": "/Users/.../node_modules/.bin/proto",
  "gateway": {
    "hasApiKey": true,
    "apiKeySource": "GATEWAY_API_KEY",
    "baseUrl": "https://api.proto-labs.ai/v1",
    "reachable": true,
    "status": 200,
    "modelCount": 12,
    "error": null
  },
  "installCommand": "npm install -g @protolabsai/proto",
  "loginCommand": "# proto reads GATEWAY_API_KEY / OPENAI_API_KEY from env"
}
\`\`\`

## Validation

- `npm run typecheck` clean across all 21 workspaces
- `vitest run` in apps/server: **3431 passed**, 23 skipped, 0 failed
- Endpoint added next to existing status routes, follows the same shape contract — no new test fixtures needed (PRs B + C will land UI-level tests as they bind to this)

## Next

- **PR B**: settings tab — adds a "protoCLI" entry in the AI Providers sidebar with a status card backed by this endpoint
- **PR C**: onboarding step — new "Set up protoCLI" wizard step + retires the Claude-specific setup surfaces that called the now-deleted `verify-claude-auth` endpoint