### PR TITLE
docs(integrations): cross-link to protoCLI repo for quickstart

### DIFF
--- a/docs/integrations/ai-providers.md
+++ b/docs/integrations/ai-providers.md
@@ -1,8 +1,16 @@
 # AI Providers
 
-Connect protoLabs Studio to AI models from any provider. Three provider systems are available, each serving a different integration pattern. All provider models appear in every model dropdown once configured.
+Connect protoLabs Studio to AI models from any provider. The default runtime is [**protoCLI**](./proto-cli) — the namesake SDK — which routes through the protoLabs gateway. The alternative provider systems below remain available for users who want to point at a different endpoint or run a local CLI directly.
 
-## Provider Types
+## Default: protoCLI
+
+protoCLI is the default agent runtime. The app embeds `@protolabsai/sdk` so no install is required for in-app agent runs; install the standalone `proto` binary if you also want it in your terminal.
+
+- **Setup status** — Settings → AI Providers → protoCLI (status card backed by `GET /api/setup/proto-status`)
+- **Quickstart + reference** — [github.com/protoLabsAI/protoCLI](https://github.com/protoLabsAI/protoCLI)
+- **Detailed integration notes** — see [protoCLI integration page](./proto-cli)
+
+## Alternative provider systems
 
 | Type                                              | Use Case                                                              | Format                  |
 | ------------------------------------------------- | --------------------------------------------------------------------- | ----------------------- |

--- a/docs/integrations/proto-cli.md
+++ b/docs/integrations/proto-cli.md
@@ -1,0 +1,45 @@
+---
+title: protoCLI
+description: The namesake SDK and default agent runtime. Quickstart + reference live in the protoCLI repo.
+---
+
+# protoCLI
+
+protoCLI is the namesake SDK and the default agent runtime for protoLabs Studio. Every new agent run routes through it; the Claude / Cursor / Codex / OpenCode CLI integrations remain available for users who prefer those tools but are no longer the primary path.
+
+The agent in this app uses the **bundled SDK** (`@protolabsai/sdk`) so a standalone CLI install isn't required. Installing the standalone `proto` binary just lets you run protoCLI in any terminal outside the app.
+
+## Quickstart
+
+The protoCLI quickstart, command reference, skill catalog, and configuration docs live in the upstream repo. Start there:
+
+- **Repo**: [github.com/protoLabsAI/protoCLI](https://github.com/protoLabsAI/protoCLI)
+- **README** (quickstart + install + auth): [github.com/protoLabsAI/protoCLI#readme](https://github.com/protoLabsAI/protoCLI#readme)
+- **TypeScript SDK** (`@protolabsai/sdk` — what this app embeds): [packages/sdk-typescript](https://github.com/protoLabsAI/protoCLI/tree/dev/packages/sdk-typescript)
+
+## How protoLabs Studio uses it
+
+|               |                                                                                                                                                      |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime path  | `@protolabsai/sdk` `query()` calls from the server's `ProtoProvider` (and from `ClaudeProvider` via the `@protolabsai/sdk/anthropic-compat` subpath) |
+| Gateway       | All requests route through `https://api.proto-labs.ai/v1` by default. Override via `GATEWAY_BASE_URL` env.                                           |
+| Auth          | `GATEWAY_API_KEY` env (preferred) or `OPENAI_API_KEY` env. Org-issued; no per-user login.                                                            |
+| Default model | `protolabs/smart`                                                                                                                                    |
+
+## In-app status
+
+The app autodetects protoCLI install + gateway connectivity:
+
+- **Settings → AI Providers → protoCLI** — connection status card with CLI version, env-var source, and gateway reachability
+- **Setup wizard → Providers step** — protoCLI is the default-active first tab and runs the same status check on open
+
+Both surfaces read from `GET /api/setup/proto-status` on the server.
+
+## Where the rest of the docs live
+
+This page intentionally avoids duplicating what's already in the protoCLI repo. For:
+
+- **Install + login** — see the [protoCLI README](https://github.com/protoLabsAI/protoCLI#readme)
+- **Available skills** (test-driven-development, systematic-debugging, sprint-contract, etc.) — see the [skills catalog in the repo](https://github.com/protoLabsAI/protoCLI/tree/dev/packages/cli/src/skills)
+- **CLI commands** (`/help`, `/auth`, `/model`, `/skills`, `/memory`, `/voice`, `/team`, etc.) — `proto --help` after install
+- **SDK API** (programmatic `query()`, `tool()`, MCP servers, hooks) — see [packages/sdk-typescript README](https://github.com/protoLabsAI/protoCLI/tree/dev/packages/sdk-typescript)


### PR DESCRIPTION
## Why

Today's session added protoCLI as the namesake first-class provider in protoLabs Studio (PRs #3625–#3632). Documentation lagged — the integrations docs still positioned Claude as the default and didn't reference protoCLI at all.

Per direction: don't duplicate the quickstart in protomaker's docs — link to the protoCLI repo where it actually lives. This keeps a single source of truth and avoids the maintenance drift problem.

## Changes

**`docs/integrations/proto-cli.md`** — new short page. Says protoCLI is the default runtime, names the SDK + gateway + auth env vars, points at where the autodetect status lives in the app (Settings + Setup wizard), and routes the reader to the upstream repo for everything substantive (install, commands, skills, SDK API).

Intentionally short — anything that would duplicate `github.com/protoLabsAI/protoCLI`'s README belongs there, not here.

**`docs/integrations/ai-providers.md`** — adds a "Default: protoCLI" section at the top, repositions the existing Claude / OpenAI / LiteLLM provider tables as "Alternative provider systems". Page intro is rewritten to reflect protoCLI as the default rather than positioning all three legacy systems equally.

## Validation

- `npm run docs:build` — clean, 7.75s, no broken links
- `prettier --check` — passes on both touched files

## Out of scope

- The protoCLI quickstart in the protoCLI repo itself (separate repo, not touched here)
- Retiring the Claude / Cursor / Codex / OpenCode integration pages — they still describe valid alternative provider paths. They get a refresh when each surface gets retired in the app.