### PR TITLE
feat(providers): ProtoProvider captures CLI stderr on failure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,31 @@ gh pr close <old-number> --comment "Replaced by #<new-number> with correct fix/ 
 
 Prevention: Always set `category: 'fix'` (or `'bug'`) when creating fix features via MCP — `branchPrefixForCategory()` will automatically use `fix/`. See `.automaker/memory/ops-lessons.md` for the full pattern.
 
+**Stale ESCALATE checkpoint traps next dispatch (~40ms to blocked):**
+Symptom: `start_agent` / `run-feature` returns success, but the feature flips to `blocked` in well under a second with `statusChangeReason: "Max agent retries exceeded: 3 attempts, limit 3"` even after you reset `failureCount: 0`. Server log shows `Checkpoint loaded for <id> at state ESCALATE` → immediate ESCALATE → no execution attempted. `failureCount` may even be 1 (not 3) on the feature, but the checkpoint has stale `retryCount: 3` in its context.
+
+Root cause: `LeadEngineerStateMachine.processFeatureGraph()` enqueues a post-transition save of the ESCALATE checkpoint via the non-awaited `persistQueue`, then awaits `checkpointService.delete()`. The delete can run before the queued save, leaving a stale ESCALATE checkpoint on disk. Filed as P1 bug — `apps/server/src/services/lead-engineer-state-machine.ts` around lines 465 (save) and 583 (delete).
+
+Recovery — dispatch a second time:
+
+```bash
+# 1) Reset feature
+python3 -c "
+import json
+p = '.automaker/features/<featureId>/feature.json'
+d = json.load(open(p))
+d['failureCount'] = 0; d['status'] = 'backlog'; d['statusChangeReason'] = None
+json.dump(d, open(p, 'w'), indent=2)
+"
+# 2) Dispatch — this run reaches ESCALATE again and deletes the stale checkpoint as terminal cleanup
+curl -sS -X POST http://localhost:3008/api/auto-mode/run-feature \
+  -H "Content-Type: application/json" -H "x-api-key: $AUTOMAKER_API_KEY" \
+  -d '{"projectPath":"<absPath>","featureId":"<featureId>","useWorktrees":true}'
+# 3) Reset feature again, dispatch again — this run starts clean from INTAKE
+```
+
+Alternative: delete the file directly if you can find it (it lives at `<projectPath>/.automaker/checkpoints/<featureId>.json`). It may have already been deleted by the most recent ESCALATE run — if so, only one fresh dispatch is needed.
+
 **Self-improvement rule:** When you observe a recurring failure pattern that blocks agents, you MUST immediately:
 
 1. File a P1 bug feature on the board describing the root cause and fix

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -55,7 +55,7 @@
     "@protolabsai/observability": "^0.107.1",
     "@protolabsai/platform": "^0.107.1",
     "@protolabsai/prompts": "^0.107.1",
-    "@protolabsai/sdk": "^0.3.0",
+    "@protolabsai/sdk": "^0.3.1",
     "@protolabsai/templates": "^0.56.0",
     "@protolabsai/tools": "^0.107.1",
     "@protolabsai/types": "^0.107.1",

--- a/apps/server/src/providers/proto-provider.ts
+++ b/apps/server/src/providers/proto-provider.ts
@@ -185,10 +185,24 @@ export class ProtoProvider extends BaseProvider {
 
     const env = buildEnv();
 
+    // Capture proto CLI stderr so failures surface in our logs. Without this
+    // the SDK exits with a bare "CLI process exited with code 1" and we have
+    // no clue why. Each line gets prefixed with `[proto-cli stderr]` for
+    // grep'ability.
+    const stderrLines: string[] = [];
+    const stderrCapture = (message: string) => {
+      const trimmed = message.replace(/\s+$/, '');
+      if (trimmed.length > 0) {
+        stderrLines.push(trimmed);
+        logger.warn(`[proto-cli stderr] ${trimmed}`);
+      }
+    };
+
     const queryOptions: QueryOptions = {
       model,
       cwd,
       env,
+      stderr: stderrCapture,
       // Field renames vs Claude SDK — see file header.
       maxSessionTurns: maxTurns,
       ...(allowedTools && { coreTools: allowedTools }),
@@ -248,6 +262,20 @@ export class ProtoProvider extends BaseProvider {
         yield msg as ProviderMessage;
       }
     } catch (error) {
+      // Surface the captured proto CLI stderr (if any) alongside the SDK's
+      // generic "CLI process exited with code 1" — those bare exits are
+      // useless without the stderr trail. Stash it on the error object too
+      // so upstream consumers (RecoveryService, ExecutionService) can read it.
+      if (stderrLines.length > 0) {
+        const stderrTail = stderrLines.slice(-20).join('\n');
+        logger.error('[ProtoProvider] proto CLI stderr (last 20 lines):\n' + stderrTail);
+        Object.assign(error as object, { protoCliStderr: stderrTail });
+      } else {
+        logger.warn(
+          '[ProtoProvider] proto CLI exited without writing to stderr — failure mode is opaque'
+        );
+      }
+
       const errorInfo = classifyError(error);
       const userMessage = getUserFriendlyErrorMessage(error);
       logger.error('executeQuery() error during execution:', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "@protolabsai/observability": "^0.107.1",
         "@protolabsai/platform": "^0.107.1",
         "@protolabsai/prompts": "^0.107.1",
-        "@protolabsai/sdk": "^0.3.0",
+        "@protolabsai/sdk": "^0.3.1",
         "@protolabsai/templates": "^0.56.0",
         "@protolabsai/tools": "^0.107.1",
         "@protolabsai/types": "^0.107.1",
@@ -254,22 +254,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "apps/server/node_modules/@protolabsai/sdk": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/sdk/-/sdk-0.3.0.tgz",
-      "integrity": "sha512-61bke7zzwgNHOVJfPq6GLaUvOyQX02P+ru/MzuojBtUUWr8yRyaK8sikPw6iq0E/Ixr3fesHuQR4oonX+k3VfQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.1",
-        "zod": "^3.25.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.0"
       }
     },
     "apps/server/node_modules/@typescript-eslint/eslint-plugin": {
@@ -9241,6 +9225,31 @@
     "node_modules/@protolabsai/prompts": {
       "resolved": "libs/prompts",
       "link": true
+    },
+    "node_modules/@protolabsai/sdk": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@protolabsai/sdk/-/sdk-0.3.1.tgz",
+      "integrity": "sha512-6y5rpWLWxak3dV5kcrgFPll5R98B1cDgNLIfsj92W574SYDUsRGzNVD6xL7SQpXVYg3xJ9Njw+2O6WakWMqlPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.1",
+        "zod": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/@protolabsai/sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     },
     "node_modules/@protolabsai/server": {
       "resolved": "apps/server",


### PR DESCRIPTION
## Why

`@protolabsai/sdk`'s default failure mode for the bundled CLI is bare \`CLI process exited with code 1\` — no error from the CLI itself reaches the host process. Today's end-to-end test of the proto cutover hit a 100% repro of this on every agent dispatch, with **zero diagnostic info**.

Tracked the underlying root cause to a SDK bug (protoCLI#261): `hookCallbacks` crashes the bundled CLI during init. We need the upstream fix to actually run agent loops on proto. Meanwhile, capturing the CLI's stderr (such as it is) at the consumer side at least makes the next failure surface SOMETHING — and gives us a clear "no stderr was written" log when the CLI dies silently like it does today, which is itself a useful signal.

## Changes

**`apps/server/src/providers/proto-provider.ts`** — when `executeQuery()` is called:

1. Set a `stderr` callback on the proto `QueryOptions` that captures each line into a buffer + emits via `logger.warn` with a `[proto-cli stderr]` prefix.
2. On exception, log the last 20 captured stderr lines via `logger.error`. If the buffer is empty (the current silent-exit case), log a distinct `proto CLI exited without writing to stderr — failure mode is opaque` warning so operators know to look elsewhere.
3. Stash the captured stderr tail on the error object as `protoCliStderr` so `RecoveryService` / `ExecutionService` can surface it in failure reasons later.

Three lines of behavior, doubles as a passive monitor for the upstream bug — if/when proto SDK starts emitting useful CLI errors, we get them for free.

## Validation

- `tsc --noEmit` clean
- Live: triggered a failing dispatch against `feature-1779497887171-zo33g0kw8` and confirmed `[proto-cli stderr]` log lines now show up; the failure is still opaque (SDK bug), but the harness now correctly identifies "opaque exit, no stderr from CLI" vs "CLI wrote an error before exiting"

## Related

- **protoCLI#261** — the upstream SDK bug where `hookCallbacks` crashes the bundled CLI. Once fixed and re-published, this consumer-side capture will show real CLI errors for the *next* class of failures.