### PR TITLE
Document start-automaker.mjs entry point

### DIFF
--- a/start-automaker.mjs
+++ b/start-automaker.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Cross-platform launcher for Automaker
- * Works on Windows (CMD, PowerShell, Git Bash) and Unix (macOS, Linux)
+ * Cross-platform launcher for Automaker — dispatches to `start-automaker.sh`
+ * and orchestrates dev/prod mode selection. Works on Windows and Unix systems.
  */
 
 import { spawn, spawnSync } from 'child_process';


### PR DESCRIPTION
## Summary

Add a one-line JSDoc comment at the top of `start-automaker.mjs` explaining what the file does. The file is the cross-platform launcher that dispatches to `start-automaker.sh` and orchestrates dev/prod mode selection (see PR #3617 history for context). The comment should be a single short JSDoc that summarizes those responsibilities in plain language. No other changes.

Acceptance:
- `start-automaker.mjs` has a top-of-file JSDoc block (3-5 lines) describing the launcher purpose
- No behavior cha...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-05-23T05:00:04.756Z -->