### PR TITLE
P1: ESCALATE checkpoint never invalidated, traps next dispatch

### DIFF
--- a/apps/server/src/services/lead-engineer-state-machine.ts
+++ b/apps/server/src/services/lead-engineer-state-machine.ts
@@ -402,7 +402,10 @@ export class FeatureStateMachine {
 
         // Pre-transition checkpoint: persist currentState before processing begins.
         // Ensures crash during processing is recoverable — resume starts at current state.
-        if (this.checkpointService) {
+        // Skip terminal states — they delete the checkpoint on exit, so saving
+        // a checkpoint for them would race with delete() and leave a stale file.
+        const terminalStates = new Set<FeatureProcessingState>(['ESCALATE', 'DONE', 'DEPLOY']);
+        if (this.checkpointService && !terminalStates.has(currentState)) {
           const cs = this.checkpointService;
           this.persistQueue.enqueue(() =>
             cs.save(projectPath, feature.id, currentState, ctx, completedStates, goalGateResults)
@@ -463,7 +466,10 @@ export class FeatureStateMachine {
         });
 
         // Post-transition checkpoint: update to nextState after successful transition.
-        if (this.checkpointService && result.nextState) {
+        // Skip terminal states — they delete the checkpoint immediately, so saving
+        // a checkpoint for them would race with delete() and leave a stale file.
+        const TERMINAL_STATES = new Set<FeatureProcessingState>(['ESCALATE', 'DONE', 'DEPLOY']);
+        if (this.checkpointService && result.nextState && !TERMINAL_STATES.has(result.nextState)) {
           const cs = this.checkpointService;
           const nextStateSnapshot = result.nextState;
           this.persistQueue.enqueue(() =>

--- a/apps/server/tests/unit/services/lead-engineer-service.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-service.test.ts
@@ -873,6 +873,62 @@ describe('FeatureStateMachine — pipeline state transitions', () => {
       })
     );
   });
+
+  it('ESCALATE does not leave a stale checkpoint (race with persistQueue)', async () => {
+    // Regression: post-transition save was enqueued (non-awaited) for ESCALATE,
+    // then delete() ran before the queued save, leaving a stale checkpoint on disk.
+    const mockCheckpointService = {
+      save: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn().mockResolvedValue(null),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const feature = makeFeature({ failureCount: 0 });
+    mockFeatureLoader.update.mockResolvedValue(undefined);
+
+    const stateMachine = new FeatureStateMachine(serviceContext, {
+      goalGatesEnabled: false,
+      checkpointService: mockCheckpointService as any,
+    });
+
+    // INTAKE → ESCALATE
+    stateMachine.registerProcessor('INTAKE', {
+      enter: vi.fn().mockResolvedValue(undefined),
+      process: vi.fn().mockImplementation(async (ctx: StateContext) => {
+        ctx.escalationReason = 'Test escalation';
+        return { nextState: 'ESCALATE', shouldContinue: true, reason: 'Test' };
+      }),
+      exit: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const { finalState } = await stateMachine.processFeature(
+      feature,
+      '/test/project',
+      makeOptions()
+    );
+
+    expect(finalState).toBe('ESCALATE');
+
+    // The checkpoint service's save() must NOT be called for terminal states.
+    // Previously, save() was enqueued for ESCALATE and delete() was awaited — the
+    // async save could run after delete(), leaving a stale checkpoint.
+    const terminalCalls = (mockCheckpointService.save.mock.calls as any[]).filter(
+      ([, , state]) => state === 'ESCALATE' || state === 'DONE' || state === 'DEPLOY'
+    );
+    expect(terminalCalls).toHaveLength(0);
+
+    // delete() should be called for terminal cleanup
+    expect(mockCheckpointService.delete).toHaveBeenCalledWith('/test/project', 'feat-1');
+
+    // Give the persist queue time to drain (in case anything slipped through)
+    await new Promise((r) => setTimeout(r, 200));
+
+    // No terminal-state saves should have appeared even after drain
+    const terminalCallsAfter = (mockCheckpointService.save.mock.calls as any[]).filter(
+      ([, , state]) => state === 'ESCALATE' || state === 'DONE' || state === 'DEPLOY'
+    );
+    expect(terminalCallsAfter).toHaveLength(0);
+  });
 });
 
 // ────────────────────────── Two-Tier Rule Routing Tests ──────────────────────────


### PR DESCRIPTION
## Summary

When LeadEngineerStateMachine.processFeatureGraph() finishes with currentState=ESCALATE, it enqueues a post-transition save of an ESCALATE checkpoint via persistQueue (non-awaited), then awaits checkpointService.delete(). The delete can run before the queued save, leaving a stale ESCALATE checkpoint on disk. The next dispatch loads it, jumps straight to ESCALATE with old retryCount, and re-blocks the feature in ~40ms — no execution attempted, statusChangeReason set to the old retry-exhausted mes...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-05-23T05:32:37.792Z -->