### PR TITLE
fix(beads-ui): poll list/ready every 2s while panel is visible

### DIFF
--- a/apps/ui/src/hooks/queries/use-beads.ts
+++ b/apps/ui/src/hooks/queries/use-beads.ts
@@ -10,6 +10,12 @@ import { getHttpApiClient } from '@/lib/http-api-client';
 import { queryKeys } from '@/lib/query-keys';
 import type { BeadsIssue } from '@protolabsai/types';
 
+// Polls every 2s while the panel is visible. React Query auto-pauses polling
+// when the tab is hidden (refetchIntervalInBackground: false), so cost is
+// bounded to ~1 `br` subprocess every 2s while the user is actively looking
+// at the view. This gives near-live updates without a server-side watcher.
+const BEADS_LIVE_POLL_MS = 2_000;
+
 export function useBeadsList(projectPath: string | undefined) {
   return useQuery({
     queryKey: queryKeys.beads.list(projectPath ?? ''),
@@ -21,8 +27,10 @@ export function useBeadsList(projectPath: string | undefined) {
       return result.issues ?? [];
     },
     enabled: !!projectPath,
-    staleTime: 30_000,
-    refetchOnWindowFocus: false,
+    staleTime: 1_000,
+    refetchInterval: BEADS_LIVE_POLL_MS,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: true,
   });
 }
 
@@ -37,7 +45,9 @@ export function useBeadsReady(projectPath: string | undefined) {
       return result.issues ?? [];
     },
     enabled: !!projectPath,
-    staleTime: 30_000,
-    refetchOnWindowFocus: false,
+    staleTime: 1_000,
+    refetchInterval: BEADS_LIVE_POLL_MS,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: true,
   });
 }


### PR DESCRIPTION
## Summary

The Beads view was static (staleTime 30s, refetchOnWindowFocus false), so issues created via CLI (\`br create\`) or other clients didn't appear without a manual reload.

This switches both \`useBeadsList\` and \`useBeadsReady\` to a 2s \`refetchInterval\` with \`refetchIntervalInBackground: false\` — React Query auto-pauses polling when the tab is hidden. Cost is bounded to ~1 \`br\` subprocess every 2s while the user is actively looking at the panel.

## Notes

- Drop-in replacement for the static query; no API changes.
- Future improvement (separate PR): server-side watcher on \`.beads/issues.jsonl\` → WebSocket push, would eliminate polling entirely.

## Test plan

- [ ] Open the Beads view, run \`br create "live test" --type task\` in a terminal at the repo root.
- [ ] Confirm the row appears within ~2 seconds without reloading.
- [ ] Tab away, run another \`br create\`, tab back — confirm refetch on focus catches it immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)