### PR TITLE
fix(auto-mode): propagate run failure to feature.statusChangeReason

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3336,12 +3336,18 @@ Format your response as a structured markdown document.`;
   private async updateFeatureStatus(
     projectPath: string,
     featureId: string,
-    status: string
+    status: string,
+    statusChangeReason?: string
   ): Promise<void> {
     // Delegate to FeatureStateManager which guarantees persist-before-emit ordering:
     // writes to disk first, then emits events (prevents stale reads on client refresh
     // after server restart triggered by status-change events).
-    await this.featureStateManager.updateFeatureStatus(projectPath, featureId, status);
+    await this.featureStateManager.updateFeatureStatus(
+      projectPath,
+      featureId,
+      status,
+      statusChangeReason
+    );
   }
 
   private isFeatureFinished(feature: Feature): boolean {

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -1921,7 +1921,13 @@ Output the branch name only.`,
               failureCategory: failureAnalysis.category,
             });
           } else {
-            await this.callbacks.updateFeatureStatus(projectPath, featureId, 'backlog');
+            // Propagate the provider error so the board surfaces it (#3635).
+            // Without this, the operator sees `statusChangeReason: null` and
+            // has to grep server logs to find out why the run failed.
+            const reason =
+              `Run failed (${failureAnalysis.category}, attempt ${newFailureCount}): ` +
+              errorInfo.message;
+            await this.callbacks.updateFeatureStatus(projectPath, featureId, 'backlog', reason);
             this.typedEventBus.emitAutoModeEvent('auto_mode_error', {
               featureId,
               featureName: feature?.title,
@@ -1970,7 +1976,8 @@ Output the branch name only.`,
         getRecoveryBaseBranch: async () => {
           return getEffectivePrBaseBranch(projectPath, this.settingsService, '[PostExecution]');
         },
-        updateFeatureStatus: (p, id, status) => this.callbacks.updateFeatureStatus(p, id, status),
+        updateFeatureStatus: (p, id, status, reason) =>
+          this.callbacks.updateFeatureStatus(p, id, status, reason),
         emitEvent: (eventType, data) => this.typedEventBus.emitAutoModeEvent(eventType, data),
       });
     }

--- a/apps/server/src/services/auto-mode/execution-types.ts
+++ b/apps/server/src/services/auto-mode/execution-types.ts
@@ -97,7 +97,12 @@ export interface IAutoModeCallbacks {
   getAutoLoopRunning(): boolean;
 
   // Status updates
-  updateFeatureStatus(projectPath: string, featureId: string, status: string): Promise<void>;
+  updateFeatureStatus(
+    projectPath: string,
+    featureId: string,
+    status: string,
+    statusChangeReason?: string
+  ): Promise<void>;
   updateFeaturePlanSpec(
     projectPath: string,
     featureId: string,

--- a/apps/server/src/services/auto-mode/feature-state-manager.ts
+++ b/apps/server/src/services/auto-mode/feature-state-manager.ts
@@ -30,7 +30,12 @@ export class FeatureStateManager {
    * feature:status-changed. This prevents clients from reading stale status data
    * on refresh after a server restart triggered by status-change events.
    */
-  async updateFeatureStatus(projectPath: string, featureId: string, status: string): Promise<void> {
+  async updateFeatureStatus(
+    projectPath: string,
+    featureId: string,
+    status: string,
+    statusChangeReason?: string
+  ): Promise<void> {
     try {
       // Read the current feature to get its state for derived field computation
       const feature = await this.featureLoader.get(projectPath, featureId);
@@ -46,6 +51,13 @@ export class FeatureStateManager {
         status,
         updatedAt: timestamp,
       };
+
+      // Persist the reason for the transition so it surfaces on the board.
+      // Without this, recovery-failed transitions to backlog/blocked leave
+      // statusChangeReason null and the operator has no signal (#3635).
+      if (statusChangeReason !== undefined) {
+        updates.statusChangeReason = statusChangeReason;
+      }
 
       // Clear stale pipeline gate metadata when reaching terminal states.
       // Without this, completed features keep awaitingGate=true forever and the

--- a/apps/server/src/services/auto-mode/post-execution-middleware.ts
+++ b/apps/server/src/services/auto-mode/post-execution-middleware.ts
@@ -58,7 +58,12 @@ export interface PostExecutionContext {
    * Optional: updates the feature status after successful recovery.
    * Called with status='review' after a recovery PR is created.
    */
-  updateFeatureStatus?: (projectPath: string, featureId: string, status: string) => Promise<void>;
+  updateFeatureStatus?: (
+    projectPath: string,
+    featureId: string,
+    status: string,
+    statusChangeReason?: string
+  ) => Promise<void>;
   /**
    * Optional: emits a structured event after recovery completes.
    * Called with recovery details when uncommitted work is recovered into a PR.


### PR DESCRIPTION
Closes #3635.

## Summary

When a feature's agent run failed and the recovery service classified it as non-retryable (or beyond max retries), \`ExecutionService\` bounced the feature back to \`backlog\` via \`updateFeatureStatus(p, id, 'backlog')\` — which had no \`reason\` parameter at all. Result: \`feature.json\` ended up with \`statusChangeReason: null\` and the operator had to grep server logs to find out why the run failed.

We've been observing this all session for ProtoProvider failures (e.g. the proto SDK hookCallbacks bug from earlier today). PR #3634 added consumer-side stderr capture so the actual error reaches the harness, but the board still showed a blank reason.

## Fix

- Extend \`IAutoModeCallbacks.updateFeatureStatus\` with an optional \`statusChangeReason\`.
- Extend \`FeatureStateManager.updateFeatureStatus\`, \`AutoModeService.updateFeatureStatus\`, and \`PostExecutionMiddleware\` context to forward it. When provided, it lands as \`updates.statusChangeReason\` in the same \`FeatureLoader.update\` write that flips \`status\`, preserving persist-before-emit ordering.
- At the backlog-bounce site in \`ExecutionService.executeFeature\`, build a reason of the form \`Run failed (<category>, attempt N): <error message>\` from the data the recovery service already computed (\`failureAnalysis.category\`, \`newFailureCount\`, \`errorInfo.message\`).

All other call sites stay backward-compatible (they omit the new param and \`statusChangeReason\` is left untouched).

## Verification

- \`npm run typecheck\` — 21/21 packages clean.
- \`npm run test:server -- tests/unit/services/auto-mode\` — 71/71 pass.
- Prettier — clean on touched files.

## Test plan

- [ ] Dispatch a feature that's known to fail (e.g. a malformed prompt or one routed through a flaky provider).
- [ ] Wait for the failure to bounce to \`backlog\`.
- [ ] Inspect \`feature.json\` — \`statusChangeReason\` should now be \`Run failed (<category>, attempt N): <message>\` instead of \`null\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature status transitions now include contextual reasons, providing clearer visibility into why features change states during execution and failure recovery processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->