### PR TITLE
fix(reconciler): branch-fallback Phase 2 so features without prNumber reconcile

### DIFF
--- a/apps/server/src/services/maintenance/checks/post-merge-reconciler-check.ts
+++ b/apps/server/src/services/maintenance/checks/post-merge-reconciler-check.ts
@@ -39,6 +39,13 @@ interface PRViewResult {
   merged: boolean;
 }
 
+/** GitHub CLI `gh pr list --head <branch> --state merged --json number,url,mergedAt` response item */
+interface PRListItem {
+  number: number;
+  url: string;
+  mergedAt: string | null;
+}
+
 /** Statuses that indicate the feature is already done — skip reconciliation. */
 const TERMINAL_STATUSES = new Set(['done', 'completed', 'verified']);
 
@@ -87,11 +94,12 @@ export class PostMergeReconcilerCheck {
     try {
       const features = await this.featureLoader.getAll(projectPath);
 
-      const reviewFeatures = features.filter(
+      // Phase 1: features that already have prNumber + prUrl — direct `gh pr view` lookup.
+      const featuresWithPr = features.filter(
         (f) => RECONCILABLE_STATUSES.has(f.status ?? '') && f.prNumber != null && f.prUrl
       );
 
-      for (const feature of reviewFeatures) {
+      for (const feature of featuresWithPr) {
         // Idempotency guard — skip if already in a terminal status
         if (TERMINAL_STATUSES.has(feature.status ?? '')) continue;
 
@@ -124,7 +132,7 @@ export class PostMergeReconcilerCheck {
 
           // PR is merged but we never received the webhook — reconcile now
           logger.info(
-            `[reconciler] PR #${feature.prNumber} on ${repo} is merged — transitioning feature "${feature.title}" (${feature.id}) from review → done (missed webhook)`
+            `[reconciler] PR #${feature.prNumber} on ${repo} is merged — transitioning feature "${feature.title}" (${feature.id}) from ${feature.status} → done (missed webhook)`
           );
 
           await this.featureLoader.update(projectPath, feature.id, {
@@ -146,6 +154,81 @@ export class PostMergeReconcilerCheck {
           // Non-fatal: log and continue to next feature
           logger.debug(
             `[reconciler] Could not check PR #${feature.prNumber} for feature ${feature.id} on ${repo}: ${prCheckErr instanceof Error ? prCheckErr.message : String(prCheckErr)}`
+          );
+        }
+      }
+
+      // Phase 2: features that have a branchName but NO prNumber yet.
+      // The PR-creation write path can drop `prNumber`/`prUrl` from `feature.json`
+      // when the recovery PostAgentHook owns the PR creation instead of the normal
+      // REVIEW phase. Without this fallback, such features stay stuck in review
+      // forever because Phase 1's filter (`prNumber != null && prUrl`) excludes
+      // them. `gh pr list --head <branch>` finds the merged PR by branch name and
+      // we write the discovered metadata back so subsequent ticks short-circuit.
+      const featuresWithoutPr = features.filter(
+        (f) =>
+          RECONCILABLE_STATUSES.has(f.status ?? '') &&
+          f.branchName &&
+          (f.prNumber == null || !f.prUrl)
+      );
+
+      for (const feature of featuresWithoutPr) {
+        if (TERMINAL_STATUSES.has(feature.status ?? '')) continue;
+
+        checked++;
+
+        try {
+          const { stdout } = await this.execFileAsync(
+            'gh',
+            [
+              'pr',
+              'list',
+              '--head',
+              feature.branchName!,
+              '--state',
+              'merged',
+              '--json',
+              'number,url,mergedAt',
+              '--limit',
+              '1',
+            ],
+            { encoding: 'utf-8', timeout: 10_000 }
+          );
+
+          const matches = JSON.parse(stdout) as PRListItem[];
+          if (matches.length === 0) {
+            logger.debug(
+              `[reconciler] No merged PR found for branch "${feature.branchName}" (feature ${feature.id}) — skipping`
+            );
+            continue;
+          }
+
+          const merged = matches[0];
+          logger.info(
+            `[reconciler] Merged PR #${merged.number} (${merged.url}) found for branch "${feature.branchName}" — transitioning feature "${feature.title}" (${feature.id}) from ${feature.status} → done (branch-fallback path)`
+          );
+
+          await this.featureLoader.update(projectPath, feature.id, {
+            status: 'done',
+            prNumber: merged.number,
+            prUrl: merged.url,
+            prMergedAt: merged.mergedAt ?? new Date().toISOString(),
+            statusChangeReason: 'merged PR detected via branch-fallback reconciliation',
+          });
+
+          this.events.emit('feature:pr-merged', {
+            featureId: feature.id,
+            title: feature.title ?? feature.id,
+            prNumber: merged.number,
+            prTitle: '',
+            branchName: feature.branchName ?? '',
+            projectPath,
+          });
+
+          reconciled++;
+        } catch (branchCheckErr) {
+          logger.debug(
+            `[reconciler] Branch-fallback lookup failed for "${feature.branchName}" (feature ${feature.id}): ${branchCheckErr instanceof Error ? branchCheckErr.message : String(branchCheckErr)}`
           );
         }
       }

--- a/apps/server/tests/unit/services/post-merge-reconciler-check.test.ts
+++ b/apps/server/tests/unit/services/post-merge-reconciler-check.test.ts
@@ -137,8 +137,10 @@ describe('PostMergeReconcilerCheck', () => {
     expect(execFileAsync).not.toHaveBeenCalled();
   });
 
-  it('skips features without prNumber', async () => {
-    const feature = makeFeature({ prNumber: undefined });
+  it('skips features without prNumber AND without branchName', async () => {
+    // Phase 2 (branch-fallback) requires branchName. With neither, the feature
+    // can't be looked up at all and is skipped silently.
+    const feature = makeFeature({ prNumber: undefined, branchName: undefined });
     mockFeatureLoaderGetAll.mockResolvedValue([feature]);
 
     const execFileAsync = vi.fn();
@@ -150,17 +152,71 @@ describe('PostMergeReconcilerCheck', () => {
     expect(execFileAsync).not.toHaveBeenCalled();
   });
 
-  it('skips features without prUrl', async () => {
-    const feature = makeFeature({ prUrl: undefined });
+  it('falls back to branchName lookup when prNumber is missing (Phase 2)', async () => {
+    // Phase 2: feature has branchName but no prNumber → `gh pr list --head <branch> --state merged`
+    // discovers the merged PR and writes prNumber/prUrl back. This catches the
+    // case where the PR-creation write path dropped the metadata (#3613).
+    const feature = makeFeature({ prNumber: undefined, prUrl: undefined });
     mockFeatureLoaderGetAll.mockResolvedValue([feature]);
 
-    const execFileAsync = vi.fn();
-    const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync);
+    const execFileAsync = vi.fn(async (_file: string, args: string[]) => {
+      // Only `gh pr list ... --state merged ... --head <branch>` is expected.
+      if (args[0] === 'pr' && args[1] === 'list') {
+        return {
+          stdout: JSON.stringify([
+            {
+              number: 184,
+              url: 'https://github.com/protoLabsAI/mythxengine/pull/184',
+              mergedAt: '2026-05-22T12:00:00Z',
+            },
+          ]),
+          stderr: '',
+        };
+      }
+      throw new Error(`Unexpected gh invocation: ${args.join(' ')}`);
+    });
+    const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync as any);
 
     const result = await check.run('/project');
 
-    expect(result.checked).toBe(0);
-    expect(execFileAsync).not.toHaveBeenCalled();
+    expect(result.checked).toBe(1);
+    expect(result.reconciled).toBe(1);
+    expect(mockFeatureLoaderUpdate).toHaveBeenCalledWith(
+      '/project',
+      'feature-001',
+      expect.objectContaining({
+        status: 'done',
+        prNumber: 184,
+        prUrl: 'https://github.com/protoLabsAI/mythxengine/pull/184',
+      })
+    );
+  });
+
+  it('falls back to branchName lookup when prUrl is missing (Phase 2)', async () => {
+    const feature = makeFeature({ prUrl: undefined });
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+
+    const execFileAsync = vi.fn(async (_file: string, args: string[]) => {
+      if (args[0] === 'pr' && args[1] === 'list') {
+        return {
+          stdout: JSON.stringify([
+            {
+              number: 184,
+              url: 'https://github.com/protoLabsAI/mythxengine/pull/184',
+              mergedAt: '2026-05-22T12:00:00Z',
+            },
+          ]),
+          stderr: '',
+        };
+      }
+      throw new Error(`Unexpected gh invocation: ${args.join(' ')}`);
+    });
+    const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync as any);
+
+    const result = await check.run('/project');
+
+    expect(result.checked).toBe(1);
+    expect(result.reconciled).toBe(1);
   });
 
   it('does not transition a feature whose PR is still open', async () => {
@@ -266,9 +322,17 @@ describe('PostMergeReconcilerCheck', () => {
     );
   });
 
-  it('returns zero counts when no features are in review status', async () => {
+  it('returns zero counts when no features have any reconcilable identifier', async () => {
+    // Only features with prNumber+prUrl (Phase 1) OR a branchName (Phase 2) are
+    // checked. A backlog feature with neither prNumber nor branchName can't be
+    // looked up, and a done feature is filtered by the terminal-status guard.
     mockFeatureLoaderGetAll.mockResolvedValue([
-      makeFeature({ status: 'backlog', prNumber: undefined, prUrl: undefined }),
+      makeFeature({
+        status: 'backlog',
+        prNumber: undefined,
+        prUrl: undefined,
+        branchName: undefined,
+      }),
       makeFeature({ status: 'done' }),
     ]);
 


### PR DESCRIPTION
Closes #3613.

## Summary

Every PR in this session's dogfood loop (#3636, #3637, #3638, #3639) sat in \`[review]\` until manual re-dispatch — even though the 60-second \`PostMergeReconciler\` poll was firing on schedule (44+ executions, 2ms each, no failures).

Root cause: three of the original stuck features (#3593, #3611, #3612) had \`prNumber: null\` and \`prUrl: null\` on disk, because the PR-creation write path (PostAgentHook recovery or normal REVIEW phase) didn't always persist the metadata back to \`feature.json\`. The reconciler's filter required both fields, so those features were silently skipped every tick.

## Fix

\`PostMergeReconcilerCheck\` now runs in two phases:

**Phase 1 (existing):** features with \`prNumber\` + \`prUrl\` → \`gh pr view\` direct lookup. Transitions to \`done\` if merged.

**Phase 2 (new):** features with \`branchName\` but missing \`prNumber\` or \`prUrl\` → \`gh pr list --head <branch> --state merged --limit 1\`. When a merged PR is found, writes \`prNumber\`/\`prUrl\`/\`prMergedAt\` back to the feature so subsequent ticks short-circuit through Phase 1.

This is a safety-net fix — it doesn't remove the underlying need to plug the write-path gap that drops PR metadata, but it eliminates the permanent-stuck case where a feature has no way to be picked up by the reconciler.

## Verification

- \`npm run test:server -- tests/unit/services/post-merge-reconciler-check.test.ts\` — 15/15 pass.
- \`npm run test:server\` — 3386 passed, 23 skipped (no regressions; +1 net from the new Phase 2 tests).
- \`npm run typecheck\` — server clean.
- Prettier — clean on touched files.

## Test plan

- [ ] After this lands and the server restarts, any feature already stuck in \`[review]\` with a \`branchName\` (even without \`prNumber\`) should transition to \`done\` on the next poll tick (~60s).
- [ ] Dispatch a new feature through auto-mode; once its PR is merged via GitHub auto-merge, confirm the feature flips to \`done\` autonomously without manual re-dispatch.
- [ ] Inspect \`feature.json\` after the transition: it should now have \`prNumber\`, \`prUrl\`, \`prMergedAt\` populated (Phase 2 writes these back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)