### PR TITLE
fix(escalations): break re-entry loop in lead-engineer reasoning path

### DIFF
--- a/apps/server/src/services/lead-engineer-service.ts
+++ b/apps/server/src/services/lead-engineer-service.ts
@@ -741,7 +741,10 @@ export class LeadEngineerService {
         projectPath: session.projectPath,
         reason: details,
       },
-      deduplicationKey: `reasoning_${reason}_${featureId ?? session.projectPath}_${Date.now()}`,
+      // Stable key so repeated identical missing-context escalations dedupe.
+      // Including Date.now() made every escalation unique and defeated dedup
+      // (see #3568 spam loop). The bus owns the time window.
+      deduplicationKey: `reasoning_${reason}_${featureId ?? session.projectPath}`,
       timestamp: new Date().toISOString(),
     });
   }
@@ -765,6 +768,22 @@ export class LeadEngineerService {
   ): Promise<void> {
     const p = payload as Record<string, unknown> | null;
     const featureId = p?.featureId as string | undefined;
+
+    // Re-entry guard: drop signals our own reasoning subsystem emitted.
+    // Without this, a missing-featureId signal escalates as
+    // `context_incomplete`, that escalation re-enters here, fails the same
+    // featureId guard, and emits another `context_incomplete` — looping until
+    // something else interrupts the bus. See #3568.
+    const source = p?.source as string | undefined;
+    const escType = p?.type as string | undefined;
+    if (source === 'lead_engineer_reasoning' || escType === 'context_incomplete') {
+      logger.debug('[Reasoning] Dropping self-emitted escalation to break re-entry loop', {
+        eventType,
+        source,
+        escType,
+      });
+      return;
+    }
 
     // Guard: escalate immediately if signal context is missing required fields
     if (!featureId) {


### PR DESCRIPTION
Closes #3568.

## Root cause

\`invokeReasoningPath\` (\`lead-engineer-service.ts\`) was self-triggering. When a signal arrived without a featureId, it emitted an \`escalation:signal-received\` event with type \`context_incomplete\`. That same event matched \`classifiedRecovery\`'s trigger list (\`['escalation:signal-received']\`), which re-entered \`invokeReasoningPath\`, which again found no featureId, and emitted another \`context_incomplete\`. Result: 8+ identical escalations within ~1 minute every time the original signal hit, drowning the notification feed.

Compounding bug: \`emitReasoningEscalation\` set \`deduplicationKey: \`reasoning_<reason>_<featureId|projectPath>_<Date.now()>\`\` — including \`Date.now()\` made every escalation unique, defeating the bus-level dedup window entirely.

## Fix

1. **Re-entry guard** at the top of \`invokeReasoningPath\`: drop signals whose \`source === 'lead_engineer_reasoning'\` or whose \`type === 'context_incomplete'\`. These are escalations our own subsystem emitted; re-processing them just walks the loop.

2. **Stable \`deduplicationKey\`** in \`emitReasoningEscalation\`: drop the \`Date.now()\` component. The key is now \`reasoning_<reason>_<featureId|projectPath>\` so identical missing-context escalations collapse into one.

## Verification

- \`npm run typecheck\` — server clean.
- \`npm run test:server -- tests/unit/services/lead-engineer\` — 209/209 pass.
- Prettier — clean.

## Test plan

- [ ] After this lands, trigger a missing-context signal (e.g. an event payload without featureId routed through lead-engineer). Confirm only ONE \`context_incomplete\` escalation appears in the notification feed (not 8+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)