### PR TITLE
fix(security): add path containment to KnowledgeIngestion + LabsService

### DIFF
--- a/apps/server/src/services/knowledge-ingestion-service.ts
+++ b/apps/server/src/services/knowledge-ingestion-service.ts
@@ -58,8 +58,18 @@ export class KnowledgeIngestionService {
     categoryFile: string,
     compactionThreshold: number = 50000
   ): Promise<void> {
-    const memoryDir = path.join(projectPath, '.automaker', 'memory');
-    const categoryPath = path.join(memoryDir, categoryFile);
+    const memoryDir = path.resolve(projectPath, '.automaker', 'memory');
+    const categoryPath = path.resolve(memoryDir, categoryFile);
+
+    // Containment guard (#3594): refuse paths that escape memoryDir.
+    // Without this, `categoryFile: '../../etc/passwd'` would resolve outside
+    // the project's memory directory and could read/write arbitrary files.
+    if (categoryPath !== memoryDir && !categoryPath.startsWith(memoryDir + path.sep)) {
+      logger.warn(
+        `Category file "${categoryFile}" resolves outside memory dir (${categoryPath}) — refusing`
+      );
+      return;
+    }
 
     if (!fs.existsSync(categoryPath)) {
       logger.debug(`Category file ${categoryFile} does not exist, skipping compaction`);

--- a/apps/server/src/services/labs-service.ts
+++ b/apps/server/src/services/labs-service.ts
@@ -363,7 +363,20 @@ export class LabsService {
    * Cleanup a specific repository (delete it)
    */
   async cleanupRepo(repoName: string, labsDir: string = this.defaultLabsDir): Promise<boolean> {
-    const repoPath = path.join(labsDir, repoName);
+    const labsDirResolved = path.resolve(labsDir);
+    const repoPath = path.resolve(labsDirResolved, repoName);
+
+    // Containment guard (#3596): refuse paths that escape labsDir.
+    // `cloneRepo` validates `directoryName` before joining, but `cleanupRepo`
+    // had no equivalent check. Passing `repoName: '../victim'` would resolve
+    // outside `labsDir`; if that target had a `.git` directory, `repoExists`
+    // returned true and `fs.rm` deleted it.
+    if (repoPath !== labsDirResolved && !repoPath.startsWith(labsDirResolved + path.sep)) {
+      logger.warn(`Refusing to clean up "${repoName}" — resolves outside labsDir (${repoPath})`, {
+        labsDir: labsDirResolved,
+      });
+      return false;
+    }
 
     try {
       // Check if repository exists


### PR DESCRIPTION
Closes #3594, #3596.

## Summary

Two parallel path-traversal bugs flagged by the same clawpatch audit run on 2026-05-21.

### #3594 — KnowledgeIngestionService.compactCategory

\`path.join(memoryDir, categoryFile)\` with no containment check. A value like \`'../../etc/passwd'\` resolved outside the project's \`.automaker/memory/\` dir and the function would happily read/overwrite it. Fix: resolve both paths and refuse anything not contained in \`memoryDir\`.

### #3596 — LabsService.cleanupRepo

Same shape: \`path.join(labsDir, repoName)\` with no validation. \`cloneRepo\` already blocked traversal in \`directoryName\`, but \`cleanupRepo\` didn't — so passing \`repoName: '../victim'\` would resolve outside \`labsDir\`; if that target had a \`.git\` directory, \`repoExists\` returned true and \`fs.rm\` deleted it. Fix: resolve both paths and refuse anything not contained in \`labsDir\`. Returns \`false\` (matching the existing "does not exist" path) rather than throwing.

Both fixes follow the same shape — \`path.resolve\` both, compare against the parent's resolved path, refuse if outside. No new dependencies, no API changes.

## Verification

- \`npm run typecheck\` — server clean.
- \`npm run test:server\` — 3385 passed, 23 skipped. No regressions.
- Prettier — clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)