### PR TITLE
chore(ci): migrate remaining workflows to namespace runner

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -21,7 +21,7 @@ permissions: read-all
 
 jobs:
   release:
-    runs-on: self-hosted
+    runs-on: namespace-profile-protolabs-linux
     if: github.repository == 'protoLabsAI/protoMaker'
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/close-external-prs.yml
+++ b/.github/workflows/close-external-prs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   close-external-pr:
     name: Close external code contributions
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-protolabs-linux
     # Only run for PRs from forks (external contributors)
     if: github.event.pull_request.head.repo.fork == true
     permissions:

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   review:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-protolabs-linux
     if: github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 30
 

--- a/.github/workflows/create-protolab-test.yml
+++ b/.github/workflows/create-protolab-test.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   test:
     name: Test with Node ${{ matrix.node }} and ${{ matrix.package-manager }}
-    runs-on: self-hosted
+    runs-on: namespace-profile-protolabs-linux
 
     strategy:
       fail-fast: false
@@ -194,7 +194,7 @@ jobs:
 
   summary:
     name: Test Summary
-    runs-on: self-hosted
+    runs-on: namespace-profile-protolabs-linux
     needs: test
     if: always()
     steps:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-protolabs-linux
     if: github.repository == 'protoLabsAI/protoMaker'
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: self-hosted
+    runs-on: namespace-profile-protolabs-linux
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     timeout-minutes: 20
 

--- a/.github/workflows/idea-accepted.yml
+++ b/.github/workflows/idea-accepted.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   notify-acceptance:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-protolabs-linux
     if: "github.event.label.name == 'status: accepted'"
     steps:
       - name: Post acceptance comment

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: namespace-profile-protolabs-linux
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     outputs:
       docs_only: ${{ steps.changes.outputs.docs_only }}
@@ -62,7 +62,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
 
   ci-complete:
-    runs-on: self-hosted
+    runs-on: namespace-profile-protolabs-linux
     needs: [build]
     if: always() && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request')
     steps:

--- a/.github/workflows/regenerate-site.yml
+++ b/.github/workflows/regenerate-site.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   regenerate:
-    runs-on: self-hosted
+    runs-on: namespace-profile-protolabs-linux
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-protolabs-linux
     steps:
       - name: Mark stale issues and close inactive ones
         uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-protolabs-linux
     steps:
       - name: Add needs-triage label
         run: |


### PR DESCRIPTION
Pulls 11 workflows off GitHub-hosted (\`ubuntu-latest\`) and ad-hoc \`self-hosted\` onto \`namespace-profile-protolabs-linux\` — the same runner already used by \`checks.yml\`, \`test.yml\`, and \`langfuse-prompt-sync.yml\`. This stops consuming GitHub Actions minutes for the migrated workflows.

## ubuntu-latest → namespace (6)
- \`code-review.yml\`
- \`idea-accepted.yml\`
- \`deploy-docs.yml\`
- \`close-external-prs.yml\`
- \`stale.yml\`
- \`triage.yml\`

## self-hosted → namespace (5)
- \`auto-release.yml\`
- \`create-protolab-test.yml\`
- \`e2e-tests.yml\`
- \`regenerate-site.yml\`
- \`pr-check.yml\`

## Untouched
- \`deploy-main.yml\` — being removed in #3648 (was the only workflow targeting the offline \`protolabs-main\` runner).
- \`checks.yml\`, \`test.yml\`, \`langfuse-prompt-sync.yml\` — already on namespace.

## Verification

After this and #3648 land:
- All 14 active workflows route to \`namespace-profile-protolabs-linux\`.
- The 10 self-hosted automaker-runners (\`automaker-runner-1..8\`, \`ava-staging\`) become unused by CI and can be retired or repurposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration across multiple automated workflows to use a standardized runner environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->