### PR TITLE
fix(reconciler): use mergedAt, not merged, in gh pr view --json

### DIFF
--- a/apps/server/src/services/maintenance/checks/post-merge-reconciler-check.ts
+++ b/apps/server/src/services/maintenance/checks/post-merge-reconciler-check.ts
@@ -33,10 +33,10 @@ type ExecFileAsync = (
   options: { encoding: string; timeout: number }
 ) => Promise<{ stdout: string; stderr: string }>;
 
-/** GitHub CLI `gh pr view --json state,merged` response */
+/** GitHub CLI `gh pr view --json state,mergedAt` response */
 interface PRViewResult {
   state: 'OPEN' | 'CLOSED' | 'MERGED' | string;
-  merged: boolean;
+  mergedAt: string | null;
 }
 
 /** GitHub CLI `gh pr list --head <branch> --state merged --json number,url,mergedAt` response item */
@@ -116,12 +116,18 @@ export class PostMergeReconcilerCheck {
         try {
           const { stdout } = await this.execFileAsync(
             'gh',
-            ['pr', 'view', String(feature.prNumber), '--repo', repo, '--json', 'state,merged'],
+            ['pr', 'view', String(feature.prNumber), '--repo', repo, '--json', 'state,mergedAt'],
             { encoding: 'utf-8', timeout: 10_000 }
           );
 
           const prData = JSON.parse(stdout) as PRViewResult;
-          const isMerged = prData.state === 'MERGED' || prData.merged === true;
+          // `state` is MERGED when the PR has been merged. `mergedAt` is a
+          // belt-and-suspenders check — gh has historically returned both.
+          // The previous code asked for a `merged` boolean field that does
+          // not exist on `gh pr view`, so the call exited non-zero and was
+          // swallowed by the catch handler at debug level — silently failing
+          // every tick. See protoMaker (post-#3613 / #3642 follow-up).
+          const isMerged = prData.state === 'MERGED' || prData.mergedAt != null;
 
           if (!isMerged) {
             logger.debug(
@@ -151,8 +157,12 @@ export class PostMergeReconcilerCheck {
 
           reconciled++;
         } catch (prCheckErr) {
-          // Non-fatal: log and continue to next feature
-          logger.debug(
+          // Non-fatal: continue to next feature. Log at warn level —
+          // previously this was debug, which hid an entire class of "the
+          // reconciler is broken" bugs (e.g. invalid --json field names).
+          // The reconciler firing 1000+ times with 0 reconciled while
+          // every call silently errored is exactly what we want to surface.
+          logger.warn(
             `[reconciler] Could not check PR #${feature.prNumber} for feature ${feature.id} on ${repo}: ${prCheckErr instanceof Error ? prCheckErr.message : String(prCheckErr)}`
           );
         }

--- a/apps/server/tests/unit/services/post-merge-reconciler-check.test.ts
+++ b/apps/server/tests/unit/services/post-merge-reconciler-check.test.ts
@@ -100,7 +100,7 @@ describe('PostMergeReconcilerCheck', () => {
 
     const execFileAsync = makeExecFileAsync({
       'protoLabsAI/mythxengine#184': {
-        stdout: JSON.stringify({ state: 'MERGED', merged: true }),
+        stdout: JSON.stringify({ state: 'MERGED', mergedAt: '2026-05-22T12:00:00Z' }),
       },
     });
 
@@ -225,7 +225,7 @@ describe('PostMergeReconcilerCheck', () => {
 
     const execFileAsync = makeExecFileAsync({
       'protoLabsAI/mythxengine#184': {
-        stdout: JSON.stringify({ state: 'OPEN', merged: false }),
+        stdout: JSON.stringify({ state: 'OPEN', mergedAt: null }),
       },
     });
 
@@ -252,7 +252,7 @@ describe('PostMergeReconcilerCheck', () => {
     const execFileAsync = makeExecFileAsync({
       'protoLabsAI/mythxengine#184': new Error('gh: API rate limit exceeded'),
       'protoLabsAI/mythxengine#185': {
-        stdout: JSON.stringify({ state: 'MERGED', merged: true }),
+        stdout: JSON.stringify({ state: 'MERGED', mergedAt: '2026-05-22T12:00:00Z' }),
       },
     });
 
@@ -281,7 +281,7 @@ describe('PostMergeReconcilerCheck', () => {
 
     const execFileAsync = makeExecFileAsync({
       'protoLabsAI/mythxengine#184': {
-        stdout: JSON.stringify({ state: 'MERGED', merged: true }),
+        stdout: JSON.stringify({ state: 'MERGED', mergedAt: '2026-05-22T12:00:00Z' }),
       },
     });
 
@@ -307,7 +307,7 @@ describe('PostMergeReconcilerCheck', () => {
 
     const execFileAsync = makeExecFileAsync({
       'protoLabsAI/mythxengine#184': {
-        stdout: JSON.stringify({ state: 'MERGED', merged: true }),
+        stdout: JSON.stringify({ state: 'MERGED', mergedAt: '2026-05-22T12:00:00Z' }),
       },
     });
 
@@ -360,7 +360,7 @@ describe('PostMergeReconcilerCheck', () => {
       _opts: unknown
     ): Promise<{ stdout: string; stderr: string }> => {
       calls.push(args);
-      return { stdout: JSON.stringify({ state: 'OPEN', merged: false }), stderr: '' };
+      return { stdout: JSON.stringify({ state: 'OPEN', mergedAt: null }), stderr: '' };
     };
 
     const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync);


### PR DESCRIPTION
## Root cause

The Post-Merge reconciler check called \`gh pr view --json state,merged\` but \`merged\` is **not a valid field** on \`gh pr view\` (the available boolean-ish field is \`mergedAt\` — null when unmerged, ISO string when merged). Every call exited non-zero with \`Unknown JSON field: "merged"\`, the catch handler logged at \`debug\` level (effectively /dev/null), and the feature was silently skipped every tick.

## Observed

The 60-second reconciler timer fired **1168 times with 0 failures** (because the catch swallows them) and **0 reconciliations** across two PRs that had been merged for hours. \`WebhookHealthCheck\` flagged \`"PR has been in review for 1023 min with no CI events"\` but nothing tied it back to the reconciler itself being broken.

Manual repro:

\`\`\`
$ gh pr view 3645 --repo protoLabsAI/protoMaker --json state,merged
Unknown JSON field: "merged"
\`\`\`

## Fix

- \`gh\` args: \`--json state,mergedAt\` instead of \`state,merged\`
- \`isMerged\` predicate: \`state === 'MERGED' || mergedAt != null\` (belt-and-suspenders, since gh has historically returned both)
- catch handler: **bumped from \`debug\` to \`warn\`** so this class of bug surfaces immediately if it happens again
- updated 4 test mocks + the \`PRViewResult\` interface

## Note on #3642

The Phase 2 (branch-fallback) path I shipped in #3642 was correct on its own merits — but Phase 1 silently failing is what made Phase 2 appear necessary in the first place. Both paths now work as intended.

## Verification

- \`npm run test:server -- tests/unit/services/post-merge-reconciler-check.test.ts\` — 15/15 pass.
- \`npm run typecheck\` — server clean.
- Prettier — clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed pull request merge state detection to properly identify merged pull requests.

* **Improvements**
  * Enhanced error logging visibility for GitHub PR polling operations by displaying failures at warning level for better troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->