### PR TITLE
fix(security): migrate worktree-recovery-service to safeGit/safeExec (#3597 part 2/3)

### DIFF
--- a/apps/server/src/lib/git-staging-utils.ts
+++ b/apps/server/src/lib/git-staging-utils.ts
@@ -67,3 +67,30 @@ export function buildGitAddCommand(workDir: string, _excludeFromStaging?: string
 
   return `git add -A -- ${pathspecArgs.join(' ')}`;
 }
+
+/**
+ * Argv-form of {@link buildGitAddCommand} — returns the args to pass after
+ * the `git` binary, so callers can use `safeGit(args, opts)` instead of
+ * interpolating a shell string. Same logic as the string form, minus the
+ * shell-quoting (argv doesn't need it).
+ *
+ * Use this in any new code path. The string-returning sibling is preserved
+ * for the existing 5 call sites pending their own migration.
+ */
+export function buildGitAddArgs(workDir: string): string[] {
+  const args: string[] = ['add', '-A'];
+  const pathspecs: string[] = [];
+
+  if (existsSync(join(workDir, '.automaker/memory'))) {
+    pathspecs.push('.automaker/memory/');
+  }
+  if (existsSync(join(workDir, '.automaker/skills'))) {
+    pathspecs.push('.automaker/skills/');
+  }
+
+  if (pathspecs.length === 0) {
+    return args;
+  }
+
+  return [...args, '--', ...pathspecs];
+}

--- a/apps/server/src/services/worktree-recovery-service.ts
+++ b/apps/server/src/services/worktree-recovery-service.ts
@@ -6,18 +6,17 @@
  * Returns structured results; callers are responsible for status updates and events.
  */
 
-import { exec, execFile } from 'child_process';
+import { execFile } from 'child_process';
 import fs from 'fs/promises';
 import path from 'path';
 import { promisify } from 'util';
 import { createLogger } from '@protolabsai/utils';
 import type { Feature } from '@protolabsai/types';
 import { DEFAULT_GIT_WORKFLOW_SETTINGS } from '@protolabsai/types';
-import { buildGitAddCommand } from '../lib/git-staging-utils.js';
-import { createGitExecEnv } from '@protolabsai/git-utils';
+import { buildGitAddArgs } from '../lib/git-staging-utils.js';
+import { createGitExecEnv, safeGit, safeExec, assertSafeRef } from '@protolabsai/git-utils';
 import { createPrWithFallback } from '../lib/gh-pr-create.js';
 
-const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 const logger = createLogger('WorktreeRecovery');
 
@@ -64,13 +63,14 @@ export async function checkAndRecoverUncommittedWork(
   skipGitHooks = true
 ): Promise<WorktreeRecoveryResult> {
   const rawBranch = prBaseBranch || DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch;
-  // Sanitize branch name to prevent shell injection — allow only valid git ref characters
+  // Sanitize branch name — strip everything outside the conservative git-ref
+  // allowlist. assertSafeRef below catches the empty-after-sanitization case.
   const baseBranch = rawBranch.replace(/[^a-zA-Z0-9_./-]/g, '');
   const result: WorktreeRecoveryResult = { detected: false, recovered: false };
 
   try {
     // Check for uncommitted changes
-    const { stdout: statusOutput } = await execAsync('git status --short', {
+    const { stdout: statusOutput } = await safeGit(['status', '--short'], {
       cwd: worktreePath,
       env: execEnv,
     });
@@ -88,6 +88,16 @@ export async function checkAndRecoverUncommittedWork(
       logger.warn(`[PostAgentHook] ${result.error}`);
       return result;
     }
+    // Refuse to proceed if the branch name has shell-unsafe characters. This
+    // catches the case where a feature title produced a slug containing chars
+    // like '+', '&', '#'. Hard-fail here is better than silently shell-quoting.
+    try {
+      assertSafeRef(branchName, 'feature.branchName');
+    } catch (err) {
+      result.error = err instanceof Error ? err.message : String(err);
+      logger.error(`[PostAgentHook] ${result.error}`);
+      return result;
+    }
 
     logger.warn(
       `[PostAgentHook] Uncommitted work detected in ${worktreePath} for feature ${feature.id} — attempting recovery`
@@ -95,16 +105,13 @@ export async function checkAndRecoverUncommittedWork(
     logger.debug(`[PostAgentHook] Uncommitted changes:\n${statusOutput}`);
 
     // Step 1: Stage changed files (exclude .automaker/ except memory/ and skills/ if they exist).
-    const addCommand = buildGitAddCommand(worktreePath);
-    logger.debug(`[PostAgentHook] Running: ${addCommand}`);
-    await execAsync(addCommand, {
-      cwd: worktreePath,
-      env: execEnv,
-    });
+    const addArgs = buildGitAddArgs(worktreePath);
+    logger.debug(`[PostAgentHook] Running: git ${addArgs.join(' ')}`);
+    await safeGit(addArgs, { cwd: worktreePath, env: execEnv });
 
     // Verify files were actually staged. If not, fall back to plain `git add .`
     // (worktrees are isolated, so staging everything is safe).
-    const { stdout: stagedCheck } = await execAsync('git diff --cached --name-only', {
+    const { stdout: stagedCheck } = await safeGit(['diff', '--cached', '--name-only'], {
       cwd: worktreePath,
       env: execEnv,
     });
@@ -112,10 +119,10 @@ export async function checkAndRecoverUncommittedWork(
       logger.warn(
         `[PostAgentHook] Pathspec-based git add staged nothing — falling back to 'git add .'`
       );
-      await execAsync('git add .', { cwd: worktreePath, env: execEnv });
+      await safeGit(['add', '.'], { cwd: worktreePath, env: execEnv });
 
       // Check again
-      const { stdout: retryCheck } = await execAsync('git diff --cached --name-only', {
+      const { stdout: retryCheck } = await safeGit(['diff', '--cached', '--name-only'], {
         cwd: worktreePath,
         env: execEnv,
       });
@@ -131,19 +138,32 @@ export async function checkAndRecoverUncommittedWork(
     // Run AFTER staging so new/untracked files are included via git diff --cached.
     // Using git diff --cached (not git diff HEAD) ensures newly-added files are covered.
     try {
-      const { stdout: stagedFiles } = await execAsync(
-        "git diff --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.json' '*.css' '*.md'",
+      const { stdout: stagedFiles } = await safeGit(
+        [
+          'diff',
+          '--cached',
+          '--name-only',
+          '--diff-filter=ACMR',
+          '--',
+          '*.ts',
+          '*.tsx',
+          '*.js',
+          '*.jsx',
+          '*.json',
+          '*.css',
+          '*.md',
+        ],
         { cwd: worktreePath, env: execEnv }
       );
       const files = stagedFiles.trim().split('\n').filter(Boolean);
       if (files.length > 0) {
         const prettierBin = path.join(projectPath, 'node_modules/.bin/prettier');
-        await execAsync(
-          `node "${prettierBin}" --ignore-path /dev/null --write ${files.map((f) => `"${f}"`).join(' ')}`,
-          { cwd: worktreePath, env: execEnv }
-        );
+        await safeExec('node', [prettierBin, '--ignore-path', '/dev/null', '--write', ...files], {
+          cwd: worktreePath,
+          env: execEnv,
+        });
         // Re-stage after formatting so prettier changes are included in the commit
-        await execAsync(addCommand, { cwd: worktreePath, env: execEnv });
+        await safeGit(addArgs, { cwd: worktreePath, env: execEnv });
         logger.debug(`[PostAgentHook] Auto-formatted ${files.length} staged files`);
       }
     } catch {
@@ -179,15 +199,18 @@ export async function checkAndRecoverUncommittedWork(
 
     logger.info(`[PostAgentHook] Committed uncommitted work for feature ${feature.id}`);
 
-    // Step 3.5: Rebase onto origin/dev before push to prevent CONFLICTING PRs
+    // Step 3.5: Rebase onto origin/dev before push to prevent CONFLICTING PRs.
+    // baseBranch is sanitized at function entry; assertSafeRef catches the
+    // post-sanitization empty case (e.g. caller passed only metacharacters).
+    assertSafeRef(baseBranch, 'baseBranch');
     let useForceWithLease = false;
     try {
-      await execAsync(`git fetch origin ${baseBranch}`, {
+      await safeGit(['fetch', 'origin', baseBranch], {
         cwd: worktreePath,
         env: execEnv,
         timeout: 30_000,
       });
-      await execAsync(`git rebase origin/${baseBranch}`, {
+      await safeGit(['rebase', `origin/${baseBranch}`], {
         cwd: worktreePath,
         env: execEnv,
         timeout: 60_000,
@@ -197,7 +220,7 @@ export async function checkAndRecoverUncommittedWork(
       const msg = rebaseError instanceof Error ? rebaseError.message : String(rebaseError);
       if (msg.includes('conflict') || msg.includes('CONFLICT')) {
         try {
-          await execAsync('git rebase --abort', { cwd: worktreePath, env: execEnv });
+          await safeGit(['rebase', '--abort'], { cwd: worktreePath, env: execEnv });
         } catch {
           // Best-effort abort
         }
@@ -205,7 +228,7 @@ export async function checkAndRecoverUncommittedWork(
       } else {
         logger.warn(`[PostAgentHook] Rebase failed for ${feature.id}: ${msg}`);
         try {
-          await execAsync('git rebase --abort', { cwd: worktreePath, env: execEnv });
+          await safeGit(['rebase', '--abort'], { cwd: worktreePath, env: execEnv });
         } catch {
           // Best-effort abort — may not be in rebase state
         }
@@ -215,11 +238,12 @@ export async function checkAndRecoverUncommittedWork(
     // Step 4: Push to remote with -u
     // --no-verify skips pre-push hooks (e.g. turbo build) that fail in worktrees
     // due to symlinked node_modules. CI is the verification layer for worktree pushes.
-    const forceFlag = useForceWithLease ? ' --force-with-lease' : '';
-    await execAsync(`git push --no-verify${forceFlag} -u origin "${branchName}"`, {
-      cwd: worktreePath,
-      env: execEnv,
-    });
+    // branchName was asserted safe earlier — passing as argv leaves no room for
+    // shell injection regardless of what's in the slug.
+    const pushArgs = ['push', '--no-verify'];
+    if (useForceWithLease) pushArgs.push('--force-with-lease');
+    pushArgs.push('-u', 'origin', branchName);
+    await safeGit(pushArgs, { cwd: worktreePath, env: execEnv });
 
     logger.info(`[PostAgentHook] Pushed branch ${branchName} for feature ${feature.id}`);
 
@@ -355,7 +379,7 @@ export async function recoverNestedWorktreeWork(
 
     for (const nestedWorktreePath of agentDirs) {
       try {
-        const { stdout: statusOutput } = await execAsync('git status --short', {
+        const { stdout: statusOutput } = await safeGit(['status', '--short'], {
           cwd: nestedWorktreePath,
           env: execEnv,
         });

--- a/apps/server/tests/unit/services/worktree-recovery-service.test.ts
+++ b/apps/server/tests/unit/services/worktree-recovery-service.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Feature } from '@protolabsai/types';
 
-// Mock exec/execFile before importing the service
+// Mock execFile before importing the service. After the shell-string →
+// argv migration (#3597 part 2), every external command in this service
+// goes through execFile via safeGit/safeExec; the bare `exec` symbol is
+// no longer used by production code.
 vi.mock('child_process', () => ({
   exec: vi.fn(),
   execFile: vi.fn(),
@@ -11,9 +14,8 @@ vi.mock('util', () => ({
 }));
 
 import { checkAndRecoverUncommittedWork } from '@/services/worktree-recovery-service.js';
-import { exec, execFile } from 'child_process';
+import { execFile } from 'child_process';
 
-const mockExec = exec as unknown as ReturnType<typeof vi.fn>;
 const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
 
 const baseFeature: Feature = {
@@ -35,7 +37,7 @@ describe('worktree-recovery-service', () => {
   describe('checkAndRecoverUncommittedWork', () => {
     it('returns detected=false when worktree is clean', async () => {
       // git status --short returns empty
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
       const result = await checkAndRecoverUncommittedWork(
         baseFeature,
@@ -50,7 +52,7 @@ describe('worktree-recovery-service', () => {
 
     it('returns detected=true, error when feature has no branchName', async () => {
       // git status --short returns uncommitted changes
-      mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
 
       const featureNoBranch: Feature = { ...baseFeature, branchName: undefined };
       const result = await checkAndRecoverUncommittedWork(
@@ -66,25 +68,25 @@ describe('worktree-recovery-service', () => {
 
     it('successfully recovers uncommitted work (commit + push + PR)', async () => {
       // git status --short: uncommitted files
-      mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
       // git add (step 1: stage)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git diff --cached --name-only (staging verification)
-      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
       // git diff --cached --name-only --diff-filter=ACMR (step 1.5: prettier file list)
-      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
       // node prettier --write
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git add (re-stage after prettier)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit (execFile)
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git fetch origin dev (rebase step)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git rebase origin/dev (rebase step)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git push --force-with-lease
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // gh pr create (execFileAsync)
       mockExecFile.mockResolvedValueOnce({
         stdout: 'https://github.com/owner/repo/pull/42\n',
@@ -107,25 +109,25 @@ describe('worktree-recovery-service', () => {
 
     it('invokes project-local prettier with --ignore-path /dev/null on staged files', async () => {
       // git status --short: uncommitted files
-      mockExec.mockResolvedValueOnce({ stdout: 'A  src/new-file.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'A  src/new-file.ts\n', stderr: '' });
       // git add (stage)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git diff --cached (verify staging)
-      mockExec.mockResolvedValueOnce({ stdout: 'src/new-file.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'src/new-file.ts\n', stderr: '' });
       // git diff --cached --diff-filter=ACMR (prettier file list)
-      mockExec.mockResolvedValueOnce({ stdout: 'src/new-file.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'src/new-file.ts\n', stderr: '' });
       // node prettier --write (captured for assertion)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git add (re-stage after prettier)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git fetch
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git rebase
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git push
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // gh pr create
       mockExecFile.mockResolvedValueOnce({
         stdout: 'https://github.com/owner/repo/pull/10\n',
@@ -134,25 +136,36 @@ describe('worktree-recovery-service', () => {
 
       await checkAndRecoverUncommittedWork(baseFeature, '/mock/worktree', '/fake/project');
 
-      // Find the prettier invocation among all exec calls
-      const allCalls = mockExec.mock.calls.map((call: unknown[]) => String(call[0]));
-      const prettierCall = allCalls.find((cmd) => cmd.includes('prettier'));
+      // Find the prettier invocation among the execFile calls. After the
+      // shell-string → argv migration, prettier is invoked as
+      //   execFile('node', [prettierBin, '--ignore-path', '/dev/null', '--write', ...files])
+      // so we look at the argv array (call[1]) instead of a joined command string.
+      const prettierCall = mockExecFile.mock.calls.find(
+        (call: unknown[]) =>
+          call[0] === 'node' &&
+          Array.isArray(call[1]) &&
+          (call[1] as string[]).some((arg) => arg.includes('prettier'))
+      );
       expect(prettierCall).toBeDefined();
-      expect(prettierCall).toContain('--ignore-path /dev/null');
-      expect(prettierCall).toContain('--write');
+      const argv = prettierCall![1] as string[];
+      expect(argv).toContain('--ignore-path');
+      expect(argv).toContain('/dev/null');
+      expect(argv).toContain('--write');
       // Uses the project-local binary path (node_modules/.bin/prettier)
-      expect(prettierCall).toContain('/fake/project/node_modules/.bin/prettier');
+      expect(argv.some((arg) => arg.includes('/fake/project/node_modules/.bin/prettier'))).toBe(
+        true
+      );
     });
 
     it('returns error when commit step fails', async () => {
       // git status --short: uncommitted files
-      mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
       // git add (stage)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git diff --cached --name-only (staging verification)
-      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
       // git diff --cached --diff-filter=ACMR (prettier list — empty, skip prettier)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit (execFile) fails
       mockExecFile.mockRejectedValueOnce(new Error('nothing to commit, working tree clean'));
 
@@ -169,21 +182,21 @@ describe('worktree-recovery-service', () => {
 
     it('returns error when push step fails', async () => {
       // git status --short
-      mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
       // git add (stage)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git diff --cached --name-only (staging verification)
-      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
       // git diff --cached --diff-filter=ACMR (prettier list — empty, skip prettier)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit succeeds
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git fetch origin dev (rebase step)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git rebase origin/dev (rebase step)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git push fails
-      mockExec.mockRejectedValueOnce(new Error('remote: Permission denied'));
+      mockExecFile.mockRejectedValueOnce(new Error('remote: Permission denied'));
 
       const result = await checkAndRecoverUncommittedWork(
         baseFeature,
@@ -198,23 +211,23 @@ describe('worktree-recovery-service', () => {
 
     it('continues recovery even if prettier formatting fails', async () => {
       // git status --short
-      mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
       // git add (stage)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git diff --cached --name-only (staging verification)
-      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
       // git diff --cached --diff-filter=ACMR (prettier list)
-      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
       // node prettier fails (non-fatal)
-      mockExec.mockRejectedValueOnce(new Error('prettier not found'));
+      mockExecFile.mockRejectedValueOnce(new Error('prettier not found'));
       // git commit succeeds
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git fetch origin dev (rebase step)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git rebase origin/dev (rebase step)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git push --force-with-lease succeeds
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // gh pr create (execFileAsync)
       mockExecFile.mockResolvedValueOnce({
         stdout: 'https://github.com/owner/repo/pull/99\n',
@@ -235,29 +248,29 @@ describe('worktree-recovery-service', () => {
 
     it('recovers when rebase conflicts — pushes without force-with-lease', async () => {
       // git status --short
-      mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
       // git add (stage)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git diff --cached --name-only (staging verification)
-      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
       // git diff --cached --diff-filter=ACMR (prettier list)
-      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
       // node prettier --write
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git add (re-stage after prettier)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit (execFile)
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git fetch origin dev (rebase step)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git rebase origin/dev FAILS with CONFLICT
-      mockExec.mockRejectedValueOnce(
+      mockExecFile.mockRejectedValueOnce(
         new Error('CONFLICT (content): Merge conflict in src/index.ts')
       );
       // git rebase --abort (best-effort)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git push (NO --force-with-lease since rebase was aborted)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // gh pr create (execFileAsync)
       mockExecFile.mockResolvedValueOnce({
         stdout: 'https://github.com/owner/repo/pull/55\n',
@@ -277,25 +290,25 @@ describe('worktree-recovery-service', () => {
 
     it('recovers when rebase fails for non-conflict reason — aborts and pushes normally', async () => {
       // git status --short
-      mockExec.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
       // git add (stage)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git diff --cached --name-only (staging verification)
-      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
       // git diff --cached --diff-filter=ACMR (prettier list)
-      mockExec.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: 'src/index.ts\n', stderr: '' });
       // node prettier --write
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git add (re-stage after prettier)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git commit (execFile)
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git fetch origin dev — fails (network error)
-      mockExec.mockRejectedValueOnce(new Error('fatal: unable to access remote'));
+      mockExecFile.mockRejectedValueOnce(new Error('fatal: unable to access remote'));
       // git rebase --abort (best-effort after non-conflict failure)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git push (NO --force-with-lease)
-      mockExec.mockResolvedValueOnce({ stdout: '', stderr: '' });
+      mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // gh pr create (execFileAsync)
       mockExecFile.mockResolvedValueOnce({
         stdout: 'https://github.com/owner/repo/pull/77\n',


### PR DESCRIPTION
**Part 2 of 3** — base = \`main\`. (PR #3654, which introduced \`safeExec\`/\`safeGit\`, has already merged.)

## Stack

| # | What | Status |
|---|---|---|
| #3654 | New \`safeExec\`/\`safeGit\` primitives | ✓ merged |
| **This PR** | Migrate \`worktree-recovery-service.ts\` shell calls | open |
| Next | Migrate \`worktree-lifecycle-service.ts\` shell calls | will stack on this |

## Migration

Every shell-string exec in \`worktree-recovery-service.ts\` → argv via \`safeGit\`/\`safeExec\`:

| Before (vulnerable) | After (argv) |
|---|---|
| \`execAsync('git status --short')\` | \`safeGit(['status', '--short'])\` |
| \`execAsync(buildGitAddCommand(...))\` | \`safeGit(buildGitAddArgs(...))\` |
| \`execAsync(\`node "${prettierBin}" --write ${files...}\`)\` | \`safeExec('node', [prettierBin, ..., ...files])\` |
| \`execAsync(\`git fetch origin ${baseBranch}\`)\` | \`safeGit(['fetch', 'origin', baseBranch])\` |
| \`execAsync(\`git push ... "${branchName}"\`)\` | \`safeGit(['push', ..., 'origin', branchName])\` |
| ...and 5 more static-command sites | ...same pattern |

Plus two extra hardening passes:

- \`assertSafeRef(feature.branchName)\` — refuses recovery if the slug has shell metas. The recovery service now hard-fails with a clear error instead of silently shell-quoting.
- \`assertSafeRef(baseBranch)\` — belt-and-suspenders against the empty-after-sanitization case in the existing regex strip.

## Also adds

\`buildGitAddArgs\` (sibling of \`buildGitAddCommand\`) in \`apps/server/src/lib/git-staging-utils.ts\` — returns argv instead of a shell string. The string-returning sibling is intentionally preserved for the 5 other call sites that haven't been migrated yet (out of scope for this stack).

## Verification

- \`npm run test:server\` — **3388 pass**, 23 skipped, no regressions.
- Targeted: \`worktree-recovery-service.test.ts\` 9/9 (bulk-migrated mock setup from \`mockExec\` → \`mockExecFile\` since every command now flows through \`execFile\`).
- \`npm run typecheck\` — 21/21 clean.
- Prettier — clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced safety and reliability of git staging and recovery operations with stricter validation and error handling for branch references.
  * Improved git command execution patterns to use safer, argument-based approaches with better failure detection and recovery mechanisms.

* **Tests**
  * Updated test suite to verify safer git execution paths and enhanced error handling scenarios during recovery workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->