### PR TITLE
fix(security): migrate worktree-lifecycle-service to safeGit (#3597 part 3/3)

### DIFF
--- a/apps/server/src/services/worktree-lifecycle-service.ts
+++ b/apps/server/src/services/worktree-lifecycle-service.ts
@@ -15,9 +15,10 @@
 
 import fs from 'node:fs';
 import path from 'path';
-import { exec, execFile, execSync } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { createLogger } from '@protolabsai/utils';
 import { getFeatureDir, getAutomakerDir } from '@protolabsai/platform';
+import { safeGit, assertSafeRef } from '@protolabsai/git-utils';
 import * as secureFs from '../lib/secure-fs.js';
 import type { EventEmitter } from '../lib/events.js';
 import type { FeatureLoader } from './feature-loader.js';
@@ -237,9 +238,8 @@ export class WorktreeLifecycleService {
 
       // Check if worktree exists
       try {
-        execSync(`git worktree list --porcelain`, {
+        await safeGit(['worktree', 'list', '--porcelain'], {
           cwd: projectPath,
-          encoding: 'utf-8',
           timeout: 10_000,
         });
       } catch {
@@ -257,12 +257,24 @@ export class WorktreeLifecycleService {
         return; // Do NOT prune — work is at risk
       }
 
-      // Remove worktree
+      // Validate branchName before interpolating into any further git command.
+      // A slug that escapes the allowlist gets logged and skipped instead of
+      // silently shell-quoted (#3597).
       try {
-        execSync(`git worktree remove "${worktreePath}" --force`, {
+        assertSafeRef(branchName, 'branchName');
+      } catch (err) {
+        logger.error(
+          `[SAFETY] Refusing to clean up worktree ${worktreeName} — ${err instanceof Error ? err.message : String(err)}`
+        );
+        return;
+      }
+
+      // Remove worktree — worktreePath is constructed by this service from the
+      // sanitized branchName, so it's safe to pass as a single argv element.
+      try {
+        await safeGit(['worktree', 'remove', worktreePath, '--force'], {
           cwd: projectPath,
           timeout: 30_000,
-          encoding: 'utf-8',
         });
         logger.info(`Removed worktree: ${worktreeName}`);
       } catch (error) {
@@ -272,17 +284,15 @@ export class WorktreeLifecycleService {
 
       // Check if branch is merged and can be deleted
       try {
-        const merged = execSync(`git branch --merged main`, {
+        const { stdout: merged } = await safeGit(['branch', '--merged', 'main'], {
           cwd: projectPath,
-          encoding: 'utf-8',
           timeout: 10_000,
         });
 
         if (merged.includes(branchName)) {
-          execSync(`git branch -d "${branchName}"`, {
+          await safeGit(['branch', '-d', branchName], {
             cwd: projectPath,
             timeout: 10_000,
-            encoding: 'utf-8',
           });
           logger.info(`Deleted merged branch: ${branchName}`);
         }
@@ -349,12 +359,22 @@ export class WorktreeLifecycleService {
     const worktreeName = branchName.replace(/\//g, '-');
     const worktreePath = path.join(projectPath, '.worktrees', worktreeName);
 
+    // Validate before any git interpolation. Backlog-reset is destructive, so
+    // refusing fast is safer than shell-quoting an attacker-controlled slug.
+    try {
+      assertSafeRef(branchName, 'branchName');
+    } catch (err) {
+      logger.error(
+        `[BACKLOG-RESET] Refusing reset for ${worktreeName} — ${err instanceof Error ? err.message : String(err)}`
+      );
+      return;
+    }
+
     // 1. Remove worktree (force — we are intentionally discarding this work)
     try {
-      execSync(`git worktree remove "${worktreePath}" --force`, {
+      await safeGit(['worktree', 'remove', worktreePath, '--force'], {
         cwd: projectPath,
         timeout: 30_000,
-        encoding: 'utf-8',
       });
       logger.info(`[BACKLOG-RESET] Removed worktree: ${worktreeName}`);
     } catch (error) {
@@ -365,10 +385,9 @@ export class WorktreeLifecycleService {
 
     // 2. Force-delete the local branch so the next agent creates a fresh one
     try {
-      execSync(`git branch -D "${branchName}"`, {
+      await safeGit(['branch', '-D', branchName], {
         cwd: projectPath,
         timeout: 10_000,
-        encoding: 'utf-8',
       });
       logger.info(`[BACKLOG-RESET] Deleted local branch: ${branchName}`);
     } catch (error) {
@@ -377,11 +396,7 @@ export class WorktreeLifecycleService {
 
     // 3. Prune stale worktree metadata
     try {
-      execSync('git worktree prune', {
-        cwd: projectPath,
-        timeout: 10_000,
-        encoding: 'utf-8',
-      });
+      await safeGit(['worktree', 'prune'], { cwd: projectPath, timeout: 10_000 });
     } catch {
       // Non-critical
     }
@@ -493,9 +508,8 @@ export class WorktreeLifecycleService {
     try {
       // Check if git is available and this is a repo
       try {
-        execSync('git worktree list --porcelain', {
+        await safeGit(['worktree', 'list', '--porcelain'], {
           cwd: projectPath,
-          encoding: 'utf-8',
           timeout: 10_000,
         });
       } catch {
@@ -505,9 +519,8 @@ export class WorktreeLifecycleService {
 
       // Run git worktree prune (removes stale metadata)
       const startTime = Date.now();
-      execSync('git worktree prune --verbose', {
+      await safeGit(['worktree', 'prune', '--verbose'], {
         cwd: projectPath,
-        encoding: 'utf-8',
         timeout: 30_000,
       });
       const elapsed = Date.now() - startTime;

--- a/apps/server/tests/unit/worktree-backlog-reset.test.ts
+++ b/apps/server/tests/unit/worktree-backlog-reset.test.ts
@@ -1,14 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import fs from 'node:fs';
-import { execSync } from 'child_process';
+import { execFile } from 'child_process';
 import { WorktreeLifecycleService } from '@/services/worktree-lifecycle-service.js';
 import type { FeatureLoader } from '@/services/feature-loader.js';
 import type { EventEmitter } from '@/lib/events.js';
 
+// After #3597 part 3: cleanupForBacklogReset + cleanupWorktree now route
+// every git invocation through safeGit (which uses execFile under the hood),
+// not execSync. Mock execFile and assert on argv arrays.
 vi.mock('child_process', () => ({
   exec: vi.fn(),
   execFile: vi.fn(),
   execSync: vi.fn(),
+}));
+vi.mock('util', () => ({
+  promisify: (fn: unknown) => fn,
 }));
 
 vi.mock('node:fs', () => ({
@@ -83,25 +89,28 @@ describe('WorktreeLifecycleService.cleanupForBacklogReset', () => {
       'handoff-PLAN.json',
       'feature.json',
     ] as unknown as fs.Dirent[]);
-    vi.mocked(execSync).mockReturnValue('');
+    vi.mocked(execFile).mockResolvedValue({ stdout: '', stderr: '' } as never);
 
     await service.cleanupForBacklogReset(projectPath, featureId);
 
-    // Should remove worktree
-    expect(execSync).toHaveBeenCalledWith(
-      `git worktree remove "${projectPath}/.worktrees/${worktreeName}" --force`,
+    // Should remove worktree (argv form — no shell string)
+    expect(execFile).toHaveBeenCalledWith(
+      'git',
+      ['worktree', 'remove', `${projectPath}/.worktrees/${worktreeName}`, '--force'],
       expect.objectContaining({ cwd: projectPath })
     );
 
-    // Should force-delete branch
-    expect(execSync).toHaveBeenCalledWith(
-      `git branch -D "${branchName}"`,
+    // Should force-delete branch (argv form)
+    expect(execFile).toHaveBeenCalledWith(
+      'git',
+      ['branch', '-D', branchName],
       expect.objectContaining({ cwd: projectPath })
     );
 
-    // Should prune worktree metadata
-    expect(execSync).toHaveBeenCalledWith(
-      'git worktree prune',
+    // Should prune worktree metadata (argv form)
+    expect(execFile).toHaveBeenCalledWith(
+      'git',
+      ['worktree', 'prune'],
       expect.objectContaining({ cwd: projectPath })
     );
 
@@ -148,39 +157,49 @@ describe('WorktreeLifecycleService.cleanupForBacklogReset', () => {
     await service.cleanupForBacklogReset(projectPath, featureId);
 
     // Should NOT call git commands
-    expect(execSync).not.toHaveBeenCalled();
+    expect(execFile).not.toHaveBeenCalled();
 
     // Should NOT emit cleanup event (no branch to report)
     expect(events.emit).not.toHaveBeenCalled();
   });
 
   it('does not throw when worktree removal fails', async () => {
-    vi.mocked(execSync).mockImplementation((cmd: string) => {
-      if (typeof cmd === 'string' && cmd.includes('worktree remove')) {
-        throw new Error('worktree not found');
-      }
-      return '';
-    });
+    vi.mocked(execFile).mockImplementation(
+      // safeGit passes ['worktree', 'remove', ...] as args[1]; throw on that
+      // path only so the subsequent branch-delete call still gets exercised.
+      ((cmd: unknown, args: unknown) => {
+        if (
+          cmd === 'git' &&
+          Array.isArray(args) &&
+          args[0] === 'worktree' &&
+          args[1] === 'remove'
+        ) {
+          return Promise.reject(new Error('worktree not found'));
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      }) as never
+    );
     vi.mocked(fs.promises.access).mockRejectedValue(new Error('ENOENT'));
     vi.mocked(fs.promises.readdir).mockRejectedValue(new Error('ENOENT'));
 
     // Should not throw
     await expect(service.cleanupForBacklogReset(projectPath, featureId)).resolves.toBeUndefined();
 
-    // Branch deletion should still be attempted
-    expect(execSync).toHaveBeenCalledWith(
-      `git branch -D "${branchName}"`,
+    // Branch deletion should still be attempted (argv form)
+    expect(execFile).toHaveBeenCalledWith(
+      'git',
+      ['branch', '-D', branchName],
       expect.objectContaining({ cwd: projectPath })
     );
   });
 
   it('does not throw when branch deletion fails', async () => {
-    vi.mocked(execSync).mockImplementation((cmd: string) => {
-      if (typeof cmd === 'string' && cmd.includes('branch -D')) {
-        throw new Error('branch not found');
+    vi.mocked(execFile).mockImplementation(((cmd: unknown, args: unknown) => {
+      if (cmd === 'git' && Array.isArray(args) && args[0] === 'branch' && args[1] === '-D') {
+        return Promise.reject(new Error('branch not found'));
       }
-      return '';
-    });
+      return Promise.resolve({ stdout: '', stderr: '' });
+    }) as never);
     vi.mocked(fs.promises.access).mockRejectedValue(new Error('ENOENT'));
     vi.mocked(fs.promises.readdir).mockRejectedValue(new Error('ENOENT'));
 
@@ -199,7 +218,7 @@ describe('WorktreeLifecycleService.cleanupForBacklogReset', () => {
   });
 
   it('handles missing agent-output.md gracefully', async () => {
-    vi.mocked(execSync).mockReturnValue('');
+    vi.mocked(execFile).mockResolvedValue({ stdout: '', stderr: '' } as never);
     vi.mocked(fs.promises.access).mockRejectedValue(new Error('ENOENT'));
     vi.mocked(fs.promises.readdir).mockResolvedValue([] as unknown as fs.Dirent[]);
 


### PR DESCRIPTION
**Part 3 of 3 — base = \`main\`.** Closes #3597.

PRs #3654 and #3655 have both merged; this PR cleans up the last call sites.

## Stack

| # | What | Status |
|---|---|---|
| #3654 | New \`safeExec\`/\`safeGit\` primitives | ✓ merged |
| #3655 | Migrate \`worktree-recovery-service.ts\` | ✓ merged |
| **This PR** | Migrate \`worktree-lifecycle-service.ts\` | open |

## Migration

Every shell-string \`execSync\` in \`worktree-lifecycle-service.ts\` → argv via \`safeGit\`:

| Before (sync, vulnerable) | After (async, argv) |
|---|---|
| \`execSync(\`git worktree remove "${worktreePath}" --force\`)\` | \`await safeGit(['worktree', 'remove', worktreePath, '--force'])\` |
| \`execSync(\`git branch -d "${branchName}"\`)\` | \`await safeGit(['branch', '-d', branchName])\` |
| \`execSync(\`git branch -D "${branchName}"\`)\` | \`await safeGit(['branch', '-D', branchName])\` |
| + 4 static-command sites | + same pattern |

Hardening:
- \`assertSafeRef(branchName)\` at the top of both \`cleanupWorktree\` and \`cleanupForBacklogReset\` — slug with shell metas hard-fails with a clear log instead of being silently shell-quoted.
- All sync → async (enclosing methods already \`async\`).
- \`execSync\` symbol dropped from the import.

## Verification

- \`npm run test:server\` — **3388 pass**, 23 skipped, no regressions.
- Targeted: \`worktree-backlog-reset.test.ts\` 6/6 (mock setup migrated from \`execSync\` → \`execFile\`; assertions rewritten from shell-string equality to argv-array equality).
- \`npm run typecheck\` — 21/21 clean.
- Prettier — clean on touched files.

## Closes

#3597 — all five call sites flagged by the original clawpatch audit (3 in worktree-recovery-service, 2 in worktree-lifecycle-service) are now argv-safe across the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced reliability of worktree cleanup and reset operations through refined command execution
  * Added input validation for branch-related operations in destructive scenarios
  * Improved error handling and stability in worktree removal and branch management processes

* **Tests**
  * Updated test coverage to reflect new command execution patterns

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->