### PR TITLE
fix(ci): replace broken CF Pages git-integration with wrangler deploy

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,91 @@
+# Deploy the marketing site (site/) to the existing Cloudflare Pages project
+# `automaker` via the wrangler CLI.
+#
+# Replaces the broken CF-Pages-git-integration path. The git-integration kept
+# trying to run a non-existent build command at the repo root, which failed on
+# every push to main and froze the live site at protolabs.studio (#3563).
+# site/ is plain HTML — no build step needed; just upload the directory.
+#
+# Required secrets: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID
+# Both are already configured at the repo level.
+
+name: Deploy Site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/deploy-site.yml'
+  pull_request:
+    paths:
+      - 'site/**'
+      - '.github/workflows/deploy-site.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+  pull-requests: write
+
+jobs:
+  deploy:
+    runs-on: namespace-profile-protolabs-linux
+    if: github.repository == 'protoLabsAI/protoMaker'
+    timeout-minutes: 10
+    concurrency:
+      group: site-deploy-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          npx -y wrangler pages deploy site \
+            --project-name=automaker \
+            --branch="$BRANCH" \
+            --commit-hash="${GITHUB_SHA}" \
+            --commit-message="${{ github.event.head_commit.message || 'Deploy' }}"
+
+      - name: Comment PR preview URL
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const slug = branch.replace(/[^a-z0-9-]/gi, '-').substring(0, 28);
+            const url = `https://${slug}.automaker.pages.dev`;
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Site preview: ${url}`
+            });
+
+      - name: Notify Discord
+        if: always() && github.event_name == 'push'
+        run: |
+          STATUS="${{ job.status }}"
+          COMMIT="${GITHUB_SHA:0:8}"
+          BRANCH="${GITHUB_REF_NAME}"
+          if [ "$STATUS" = "success" ]; then
+            MSG="Site deployed (${BRANCH}): \`${COMMIT}\` — https://protolabs.studio"
+          else
+            MSG="Site deploy FAILED (${BRANCH}): \`${COMMIT}\` — ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          fi
+          if [ -n "${DISCORD_DEPLOY_WEBHOOK:-}" ]; then
+            curl -sf -H "Content-Type: application/json" \
+              -d "{\"content\": \"${MSG}\"}" \
+              "$DISCORD_DEPLOY_WEBHOOK" || true
+          fi
+        env:
+          DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}


### PR DESCRIPTION
Closes #3563.

## Problem

The CF Pages project \`automaker\` (custom domain: protolabs.studio) has had **Failure status on every Production deployment for 3+ weeks**. The git-integration tries to run a non-existent build command at the repo root and fails before it touches \`site/\`. Live site is frozen on the last successful build from early May — \`v0.107.1\`'s site updates never shipped.

## Fix

\`site/\` is plain HTML — no build step needed. This workflow uploads it directly via \`wrangler pages deploy site --project-name=automaker\`, mirroring the pattern \`deploy-docs.yml\` already uses for the docs project.

| Trigger | What runs |
|---|---|
| \`push\` to \`main\` with \`site/**\` changes | Production deploy |
| \`pull_request\` with \`site/**\` changes | Preview deploy + PR comment with URL |
| \`workflow_dispatch\` | Manual deploy |

Secrets reused (already configured at the repo level):
- \`CLOUDFLARE_API_TOKEN\`
- \`CLOUDFLARE_ACCOUNT_ID\`

## Required admin follow-up

After this PR merges and produces a successful production deploy (verify at protolabs.studio), one admin step is needed in the Cloudflare dashboard:

1. Cloudflare Pages → \`automaker\` project → **Settings → Builds & deployments**
2. **Disable** the GitHub git-integration so the broken auto-deploy stops firing on every push.

If we don't disable the git-integration, every push to main will continue triggering a failed dashboard build alongside the successful Actions deploy — noisy but not blocking.

## Verification path

- [ ] Merge this PR
- [ ] Confirm Actions \`Deploy Site\` run on the merge commit succeeds
- [ ] Confirm protolabs.studio reflects current \`site/index.html\`
- [ ] Admin: disable git-integration on the CF Pages \`automaker\` project

## Out of scope

- The orphaned \`protolabs.studio\` Astro repo also mentioned in the issue — that's a separate decision (keep + add secrets vs delete). Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated site deployment to Cloudflare Pages on code changes
  * Pull request previews now generated and linked automatically
  * Deployment status notifications sent to Discord for visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->