### PR TITLE
Implement workflow match-rule scoring in WorkflowLoader.resolveForFeature

### DIFF
--- a/apps/server/src/services/workflow-loader.ts
+++ b/apps/server/src/services/workflow-loader.ts
@@ -402,16 +402,19 @@ export class WorkflowLoader {
    *   1. feature.workflow (explicit assignment)
    *   2. feature.featureType mapping ('content' → content, 'signal' → signal workflow)
    *   3. feature.executionMode mapping ('read-only' → read-only workflow)
-   *   4. Default: 'standard'
+   *   4. Match-rule scoring pass (category + keyword scoring)
+   *   5. Default: 'standard'
    */
   async resolveForFeature(projectPath: string, feature: Feature): Promise<WorkflowDefinition> {
-    // Explicit workflow assignment
+    // Explicit workflow assignment — if specified but not found, fall back to standard
+    // without proceeding to scoring (explicit choice takes precedence over auto-matching)
     if (feature.workflow) {
       const workflow = await this.resolve(projectPath, feature.workflow);
       if (workflow) return workflow;
       logger.warn(
         `Workflow "${feature.workflow}" not found for feature ${feature.id}, falling back to standard`
       );
+      return STANDARD_WORKFLOW;
     }
 
     // featureType mapping
@@ -429,6 +432,66 @@ export class WorkflowLoader {
     if (feature.executionMode === 'read-only') {
       const workflow = await this.resolve(projectPath, 'read-only');
       if (workflow) return workflow;
+    }
+
+    // Match-rule scoring pass: iterate all workflows that declare match rules,
+    // score each against the feature's category and title/description keywords,
+    // return the highest-scoring workflow with score > 0.
+    const projectWorkflows = await this.loadProjectWorkflows(projectPath);
+    const allWorkflows = new Map<string, WorkflowDefinition>([
+      ...BUILT_IN_WORKFLOWS,
+      ...projectWorkflows,
+    ]);
+
+    let bestWorkflow: WorkflowDefinition | null = null;
+    let bestScore = 0;
+
+    for (const workflow of allWorkflows.values()) {
+      const match = workflow.match;
+      if (!match) continue;
+
+      let score = 0;
+      const category = (feature.category ?? '').toLowerCase();
+      const title = (feature.title ?? '').toLowerCase();
+      const description = (feature.description ?? '').toLowerCase();
+      const textToSearch = `${title} ${description}`;
+
+      // Category match — exact match on feature.category
+      if (match.categories) {
+        for (const cat of match.categories) {
+          if (category === cat.toLowerCase()) {
+            score += 10;
+            break;
+          }
+        }
+      }
+
+      // Keyword matches in title/description
+      if (match.keywords) {
+        for (const keyword of match.keywords) {
+          if (textToSearch.includes(keyword.toLowerCase())) {
+            score += 1;
+          }
+        }
+      }
+
+      // Legacy executionMode match
+      if (match.executionMode && feature.executionMode === match.executionMode) {
+        score += 10;
+      }
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestWorkflow = workflow;
+      }
+    }
+
+    if (bestWorkflow && bestScore > 0) {
+      logger.debug(
+        `Auto-matched feature ${feature.id} to workflow "${bestWorkflow.name}" ` +
+          `(score: ${bestScore}, category: ${feature.category})`
+      );
+      return bestWorkflow;
     }
 
     // Default

--- a/apps/server/tests/unit/services/workflow-loader.test.ts
+++ b/apps/server/tests/unit/services/workflow-loader.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { WorkflowLoader } from '@/services/workflow-loader.js';
+import type { Feature } from '@protolabsai/types';
+import * as fs from 'node:fs';
+import path from 'path';
+
+vi.mock('node:fs');
+vi.mock('yaml', () => ({
+  parse: vi.fn((content: string) => {
+    // Minimal YAML parser for test fixtures
+    const result: Record<string, unknown> = {};
+    const lines = content.split('\n');
+    for (const line of lines) {
+      const match = line.match(/^(\w+):\s*(.+)$/);
+      if (match) {
+        result[match[1]] = match[2].trim();
+      }
+    }
+    return result;
+  }),
+}));
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+describe('WorkflowLoader', () => {
+  let loader: WorkflowLoader;
+  const testProjectPath = '/test/project';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loader = new WorkflowLoader();
+    // Ensure workflow directory doesn't exist (no project overrides)
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+  });
+
+  const createFeature = (overrides: Partial<Feature> = {}): Feature => ({
+    id: 'feature-test-123',
+    category: 'code',
+    description: 'Implement a new feature',
+    ...overrides,
+  });
+
+  describe('resolveForFeature', () => {
+    it('should resolve category "audit" to the audit workflow', async () => {
+      const feature = createFeature({
+        category: 'audit',
+        title: 'Audit codebase for security issues',
+        description: 'Review and analyze the codebase',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('audit');
+      expect(result.execution.useWorktrees).toBe(false);
+    });
+
+    it('should resolve title containing "research" to the research workflow', async () => {
+      const feature = createFeature({
+        category: 'code',
+        title: 'Research authentication options',
+        description: 'Explore different auth libraries',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('research');
+      expect(result.execution.useWorktrees).toBe(false);
+    });
+
+    it('explicit feature.workflow "standard" should override keyword match', async () => {
+      const feature = createFeature({
+        category: 'audit',
+        title: 'Audit codebase',
+        description: 'Review and analyze',
+        workflow: 'standard',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('standard');
+      expect(result.execution.useWorktrees).toBe(true);
+    });
+
+    it('explicit feature.workflow for unknown name should fall back to standard', async () => {
+      const feature = createFeature({
+        category: 'audit',
+        title: 'Audit codebase',
+        description: 'Review and analyze',
+        workflow: 'nonexistent-workflow',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('standard');
+    });
+
+    it('no category and no keyword should fall back to standard', async () => {
+      const feature = createFeature({
+        category: 'code',
+        title: 'Fix button alignment',
+        description: 'Adjust padding for the login button',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('standard');
+      expect(result.execution.useWorktrees).toBe(true);
+    });
+
+    it('should resolve category "research" to the research workflow', async () => {
+      const feature = createFeature({
+        category: 'research',
+        title: 'Explore state management options',
+        description: 'Compare Redux, Zustand, and Jotai',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('research');
+    });
+
+    it('should resolve category "dependencies" to dependency-health workflow', async () => {
+      const feature = createFeature({
+        category: 'dependencies',
+        title: 'Check dependency vulnerabilities',
+        description: 'Scan for CVEs and outdated packages',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('dependency-health');
+    });
+
+    it('should prefer category match over keyword match when both apply', async () => {
+      // "audit" category matches audit workflow (score: 10)
+      // keyword "audit" also appears in dependency-health keywords (score: 1)
+      // Category match should win
+      const feature = createFeature({
+        category: 'audit',
+        title: 'Dependency audit',
+        description: 'Run audit on dependencies',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('audit');
+    });
+
+    it('should resolve featureType "content" to content workflow', async () => {
+      const feature = createFeature({
+        category: 'code',
+        featureType: 'content',
+        title: 'Write blog post',
+        description: 'Create content for the blog',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('content');
+    });
+
+    it('should resolve featureType "signal" to signal workflow', async () => {
+      const feature = createFeature({
+        category: 'code',
+        featureType: 'signal',
+        title: 'CI failing on main',
+        description: 'Investigate CI failures',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('signal');
+    });
+
+    it('should resolve executionMode "read-only" to read-only workflow', async () => {
+      const feature = createFeature({
+        category: 'code',
+        executionMode: 'read-only',
+        title: 'Analyze codebase',
+        description: 'Read-only analysis',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('read-only');
+    });
+
+    it('should resolve category "cost" to cost-analysis workflow', async () => {
+      const feature = createFeature({
+        category: 'cost',
+        title: 'Analyze API costs',
+        description: 'Review spending on API usage',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('cost-analysis');
+    });
+
+    it('should resolve category "postmortem" to postmortem workflow', async () => {
+      const feature = createFeature({
+        category: 'postmortem',
+        title: 'Incident postmortem',
+        description: 'Analyze the outage on May 1st',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('postmortem');
+    });
+
+    it('should resolve category "changelog" to changelog-digest workflow', async () => {
+      const feature = createFeature({
+        category: 'changelog',
+        title: 'Generate changelog',
+        description: 'Create release notes for v2.0',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('changelog-digest');
+    });
+
+    it('should resolve category "benchmark" to swebench workflow', async () => {
+      const feature = createFeature({
+        category: 'benchmark',
+        title: 'Run SWE-bench evaluation',
+        description: 'Evaluate agent performance',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('swebench');
+    });
+
+    it('should resolve category "strategy" to strategic-review workflow', async () => {
+      const feature = createFeature({
+        category: 'strategy',
+        title: 'Q3 strategic review',
+        description: 'Review goals and roadmap',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('strategic-review');
+    });
+
+    it('should resolve category "tech-debt" to tech-debt-scan workflow', async () => {
+      const feature = createFeature({
+        category: 'tech-debt',
+        title: 'Scan for tech debt',
+        description: 'Find TODOs and deprecated patterns',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('tech-debt-scan');
+    });
+  });
+
+  describe('getBuiltIn', () => {
+    it('should return built-in workflow by name', () => {
+      const result = loader.getBuiltIn('standard');
+      expect(result).toBeDefined();
+      expect(result!.name).toBe('standard');
+    });
+
+    it('should return undefined for unknown name', () => {
+      const result = loader.getBuiltIn('nonexistent');
+      expect(result).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fix #3605. `WorkflowLoader.resolveForFeature` advertises auto-matching workflows by category/keyword, and built-in workflows (`AUDIT_WORKFLOW`, `RESEARCH_WORKFLOW`, etc.) carry match rules — but the resolver only checks explicit `workflow`, `featureType`, `executionMode`, then falls through to `standard`. Features that should auto-route to `audit`/`research`/`dependency-health`/etc. end up running the standard code pipeline (including worktree/PR phases the target workflow intentionally disables...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-05-24T08:33:43.329Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented intelligent workflow matching with automatic selection based on category, keyword detection, and execution mode compatibility.
  * Workflows are now scored and the highest-scoring match is automatically selected when relevant.

* **Tests**
  * Added comprehensive unit tests for workflow resolution across multiple scenarios and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->