### PR TITLE
Add per-key in-flight dedup to auto-filing services

### DIFF
--- a/apps/server/src/services/hitl-pattern-analysis-service.ts
+++ b/apps/server/src/services/hitl-pattern-analysis-service.ts
@@ -151,6 +151,12 @@ export class HitlPatternAnalysisService {
   /** Whether the store has been loaded from disk */
   private initialized = false;
 
+  /**
+   * Per-signature in-flight guard to prevent the race window between
+   * the dedup check and the storage write.  Keys are pattern signatures.
+   */
+  private filingInFlight = new Set<string>();
+
   constructor(deps: HitlPatternAnalysisDeps) {
     this.deps = deps;
   }
@@ -289,6 +295,27 @@ export class HitlPatternAnalysisService {
   }
 
   private async maybeFileFeature(
+    signature: string,
+    state: PatternState,
+    latestRecord: EscalationRecord
+  ): Promise<void> {
+    // Per-key in-flight guard: if another call for this signature is already
+    // running, skip — the durable findByTitle check below is the second line
+    // of defense, but this Set prevents the race window between check and create.
+    if (this.filingInFlight.has(signature)) {
+      logger.info(`Skipping auto-file for pattern="${signature}" — filing already in flight`);
+      return;
+    }
+    this.filingInFlight.add(signature);
+
+    try {
+      await this.doMaybeFileFeature(signature, state, latestRecord);
+    } finally {
+      this.filingInFlight.delete(signature);
+    }
+  }
+
+  private async doMaybeFileFeature(
     signature: string,
     state: PatternState,
     latestRecord: EscalationRecord

--- a/apps/server/src/services/issue-creation-service.ts
+++ b/apps/server/src/services/issue-creation-service.ts
@@ -89,6 +89,12 @@ export class IssueCreationService {
    */
   private issuedFeatures = new Set<string>();
 
+  /**
+   * Per-feature in-flight guard to prevent the race window between the
+   * issuedFeatures check and the actual bug creation.  Keys are feature IDs.
+   */
+  private bugFilingInFlight = new Set<string>();
+
   constructor(
     events: EventEmitter,
     featureLoader: FeatureLoader,
@@ -149,33 +155,46 @@ export class IssueCreationService {
       return;
     }
 
-    const feature = await this.featureLoader.get(projectPath, featureId);
-    if (!feature) {
-      logger.warn(`Feature ${featureId} not found, cannot create bug`);
+    // Per-key in-flight guard: skip if another handler for this featureId is
+    // already running — prevents race window between the issuedFeatures check
+    // and the durable storage write.
+    if (this.bugFilingInFlight.has(featureId)) {
+      logger.info(`Bug filing already in flight for feature ${featureId}, skipping`);
       return;
     }
+    this.bugFilingInFlight.add(featureId);
 
-    const triageInput: TriageInput = {
-      featureId,
-      projectPath,
-      failureCategory: isFailureCategory(failureCategory) ? failureCategory : undefined,
-      retryCount,
-      error: lastError,
-    };
+    try {
+      const feature = await this.featureLoader.get(projectPath, featureId);
+      if (!feature) {
+        logger.warn(`Feature ${featureId} not found, cannot create bug`);
+        return;
+      }
 
-    const triage = this.triageService.triage(triageInput);
+      const triageInput: TriageInput = {
+        featureId,
+        projectPath,
+        failureCategory: isFailureCategory(failureCategory) ? failureCategory : undefined,
+        retryCount,
+        error: lastError,
+      };
 
-    const result = await this.createBugFeature(projectPath, feature, {
-      retryCount,
-      lastError,
-      failureCategory,
-      triage,
-      trigger: 'max-retries',
-    });
+      const triage = this.triageService.triage(triageInput);
 
-    if (result.success) {
-      this.issuedFeatures.add(featureId);
-      await this.postDiscordNotification(feature, result, triage, projectPath);
+      const result = await this.createBugFeature(projectPath, feature, {
+        retryCount,
+        lastError,
+        failureCategory,
+        triage,
+        trigger: 'max-retries',
+      });
+
+      if (result.success) {
+        this.issuedFeatures.add(featureId);
+        await this.postDiscordNotification(feature, result, triage, projectPath);
+      }
+    } finally {
+      this.bugFilingInFlight.delete(featureId);
     }
   }
 
@@ -194,26 +213,36 @@ export class IssueCreationService {
       return;
     }
 
-    const feature = await this.featureLoader.get(projectPath, featureId);
-    if (!feature) return;
+    if (this.bugFilingInFlight.has(featureId)) {
+      logger.info(`Bug filing already in flight for feature ${featureId}, skipping`);
+      return;
+    }
+    this.bugFilingInFlight.add(featureId);
 
-    const triageInput: TriageInput = {
-      featureId,
-      projectPath,
-      error: reason,
-    };
+    try {
+      const feature = await this.featureLoader.get(projectPath, featureId);
+      if (!feature) return;
 
-    const triage = this.triageService.triage(triageInput);
+      const triageInput: TriageInput = {
+        featureId,
+        projectPath,
+        error: reason,
+      };
 
-    const result = await this.createBugFeature(projectPath, feature, {
-      lastError: reason,
-      triage,
-      trigger: 'recovery-escalated',
-    });
+      const triage = this.triageService.triage(triageInput);
 
-    if (result.success) {
-      this.issuedFeatures.add(featureId);
-      await this.postDiscordNotification(feature, result, triage, projectPath);
+      const result = await this.createBugFeature(projectPath, feature, {
+        lastError: reason,
+        triage,
+        trigger: 'recovery-escalated',
+      });
+
+      if (result.success) {
+        this.issuedFeatures.add(featureId);
+        await this.postDiscordNotification(feature, result, triage, projectPath);
+      }
+    } finally {
+      this.bugFilingInFlight.delete(featureId);
     }
   }
 
@@ -229,28 +258,38 @@ export class IssueCreationService {
       return;
     }
 
-    const feature = await this.featureLoader.get(projectPath, featureId);
-    if (!feature) return;
+    if (this.bugFilingInFlight.has(featureId)) {
+      logger.info(`Bug filing already in flight for feature ${featureId}, skipping`);
+      return;
+    }
+    this.bugFilingInFlight.add(featureId);
 
-    const triageInput: TriageInput = {
-      featureId,
-      projectPath,
-      isCIFailure: true,
-      error: failedChecks?.map((c) => `${c.name}: ${c.conclusion}`).join(', '),
-    };
+    try {
+      const feature = await this.featureLoader.get(projectPath, featureId);
+      if (!feature) return;
 
-    const triage = this.triageService.triage(triageInput);
+      const triageInput: TriageInput = {
+        featureId,
+        projectPath,
+        isCIFailure: true,
+        error: failedChecks?.map((c) => `${c.name}: ${c.conclusion}`).join(', '),
+      };
 
-    const result = await this.createBugFeature(projectPath, feature, {
-      prNumber,
-      failedChecks,
-      triage,
-      trigger: 'ci-failure',
-    });
+      const triage = this.triageService.triage(triageInput);
 
-    if (result.success) {
-      this.issuedFeatures.add(featureId);
-      await this.postDiscordNotification(feature, result, triage, projectPath);
+      const result = await this.createBugFeature(projectPath, feature, {
+        prNumber,
+        failedChecks,
+        triage,
+        trigger: 'ci-failure',
+      });
+
+      if (result.success) {
+        this.issuedFeatures.add(featureId);
+        await this.postDiscordNotification(feature, result, triage, projectPath);
+      }
+    } finally {
+      this.bugFilingInFlight.delete(featureId);
     }
   }
 

--- a/apps/server/tests/unit/services/hitl-pattern-analysis-service-dedup.test.ts
+++ b/apps/server/tests/unit/services/hitl-pattern-analysis-service-dedup.test.ts
@@ -1,0 +1,124 @@
+/**
+ * HitlPatternAnalysisService — per-key in-flight dedup regression tests
+ *
+ * Verifies that concurrent HITL escalations with identical signatures
+ * produce exactly ONE backlog feature (race window between dedup check
+ * and storage write is guarded by an in-flight Set).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HitlPatternAnalysisService } from '@/services/hitl-pattern-analysis-service.js';
+import type { FeatureLoader } from '@/services/feature-loader.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockEvents() {
+  return {
+    emit: vi.fn(),
+    subscribe: vi.fn(),
+  };
+}
+
+function makeDelayedMockFeatureLoader(delayMs = 50) {
+  const featureLoader = {
+    findByTitle: vi
+      .fn()
+      .mockImplementation(
+        (_projectPath: string, _title: string) =>
+          new Promise<null>((resolve) => setTimeout(() => resolve(null), delayMs))
+      ),
+    create: vi.fn().mockImplementation(
+      (_projectPath: string, data: unknown) =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              id: 'feature-created-1',
+              title: (data as { title?: string })?.title ?? '',
+              status: 'backlog',
+              category: 'infra',
+            });
+          }, delayMs);
+        })
+    ),
+  };
+  return featureLoader as unknown as FeatureLoader;
+}
+
+function makePayload(signature: string) {
+  const [kind, workflow, errorClass] = signature.split(':');
+  return {
+    repo: 'owner/repo',
+    prNumber: 100,
+    kind,
+    failingWorkflow: workflow,
+    ciStatus: 'failure',
+    attempts: 3,
+    timestamp: new Date().toISOString(),
+    errorMessage: errorClass,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HitlPatternAnalysisService — per-key in-flight dedup', () => {
+  let service: HitlPatternAnalysisService;
+  let featureLoader: ReturnType<typeof makeDelayedMockFeatureLoader>;
+  const projectPath = '/test/project';
+
+  beforeEach(() => {
+    featureLoader = makeDelayedMockFeatureLoader(50);
+    service = new HitlPatternAnalysisService({
+      featureLoader,
+      projectPath,
+      events: createMockEvents() as any,
+    });
+  });
+
+  it('two concurrent HITL escalations with identical signature produce ONE feature', async () => {
+    // Initialize service (no-op since there's no store on disk)
+    await service.initialize();
+
+    const signature = 'ci_failure:test:ts_error';
+
+    // Fire three escalations to reach threshold — the first two are concurrent,
+    // the third is sequential to guarantee we cross the threshold.
+    const p1 = service.handleEscalation(makePayload(signature));
+    const p2 = service.handleEscalation(makePayload(signature));
+    await Promise.all([p1, p2]);
+
+    // Third escalation to push count >= OCCURRENCE_THRESHOLD (3)
+    await service.handleEscalation(makePayload(signature));
+
+    // findByTitle is called once (by the winner), create is called once
+    expect(featureLoader.findByTitle).toHaveBeenCalledTimes(1);
+    expect(featureLoader.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('concurrent escalations with different signatures each produce their own feature', async () => {
+    await service.initialize();
+
+    const sigA = 'ci_failure:test:ts_error';
+    const sigB = 'merge_conflict:build:lint_failure';
+
+    // Fire enough for A
+    await Promise.all([
+      service.handleEscalation(makePayload(sigA)),
+      service.handleEscalation(makePayload(sigA)),
+      service.handleEscalation(makePayload(sigA)),
+    ]);
+
+    // Fire enough for B
+    await Promise.all([
+      service.handleEscalation(makePayload(sigB)),
+      service.handleEscalation(makePayload(sigB)),
+      service.handleEscalation(makePayload(sigB)),
+    ]);
+
+    // Each signature should trigger its own filing
+    expect(featureLoader.create).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/server/tests/unit/services/issue-creation-service-dedup.test.ts
+++ b/apps/server/tests/unit/services/issue-creation-service-dedup.test.ts
@@ -1,0 +1,221 @@
+/**
+ * IssueCreationService — per-key in-flight dedup regression tests
+ *
+ * Verifies that concurrent failure events for the same featureId produce
+ * exactly ONE bug feature (race window between issuedFeatures check and
+ * storage write is guarded by an in-flight Set).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { IssueCreationService } from '@/services/issue-creation-service.js';
+import type { FeatureLoader } from '@/services/feature-loader.js';
+import type { TriageService, TriageResult } from '@/services/triage-service.js';
+import type { SettingsService } from '@/services/settings-service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockEvents() {
+  return {
+    emit: vi.fn(),
+    subscribe: vi.fn(),
+  };
+}
+
+function makeDelayedMockFeatureLoader(delayMs = 50) {
+  const mock = {
+    get: vi.fn().mockImplementation(
+      (_projectPath: string, id: string) =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              id,
+              title: 'Test Feature',
+              status: 'in_progress',
+              description: 'A test feature',
+            });
+          }, delayMs);
+        })
+    ),
+    create: vi.fn().mockImplementation(
+      (_projectPath: string, data: unknown) =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              id: 'bug-feature-1',
+              title: (data as { title?: string })?.title ?? '',
+              status: 'backlog',
+              category: 'bug',
+            });
+          }, delayMs);
+        })
+    ),
+  };
+  return mock as unknown as FeatureLoader;
+}
+
+function makeMockTriageService(): TriageService {
+  return {
+    triage: vi.fn().mockReturnValue({
+      priority: 3,
+      priorityLabel: 'Medium',
+      team: 'backend',
+      reason: 'Auto-triage',
+    } as TriageResult),
+  };
+}
+
+function makeMockSettingsService(): SettingsService {
+  return {
+    getProjectSettings: vi.fn().mockResolvedValue({
+      integrations: { discord: { channels: { bugs: '' } } },
+    }),
+  } as unknown as SettingsService;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('IssueCreationService — per-key in-flight dedup', () => {
+  let service: IssueCreationService;
+  let featureLoader: ReturnType<typeof makeDelayedMockFeatureLoader>;
+  const projectPath = '/test/project';
+  const featureId = 'feature-123';
+
+  beforeEach(() => {
+    featureLoader = makeDelayedMockFeatureLoader(50);
+    const events = createMockEvents();
+    const triage = makeMockTriageService();
+    const settings = makeMockSettingsService();
+
+    service = new IssueCreationService(events as any, featureLoader, triage, settings);
+    service.initialize();
+  });
+
+  it('two concurrent permanently-blocked events for same featureId produce ONE bug', async () => {
+    const payload = {
+      projectPath,
+      featureId,
+      retryCount: 3,
+      lastError: 'Something broke',
+      failureCategory: 'unknown',
+    };
+
+    // Fire two events concurrently
+    // We need to trigger the internal handler — use events.subscribe callback
+    // Since initialize() sets up a subscriber, we can emit events
+    // However, the service subscribes via events.subscribe which is mocked.
+    // We need to call the handler directly.
+
+    // Access private method via any cast for testing
+    const handler = (service as any).handlePermanentlyBlocked.bind(service);
+
+    const p1 = handler(payload);
+    const p2 = handler(payload);
+    await Promise.all([p1, p2]);
+
+    // featureLoader.create should be called exactly once
+    expect(featureLoader.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('two concurrent recovery_escalated events for same featureId produce ONE bug', async () => {
+    const payload = {
+      featureId,
+      reason: 'Recovery failed',
+      timestamp: new Date().toISOString(),
+      projectPath,
+    };
+
+    const handler = (service as any).handleRecoveryEscalated.bind(service);
+
+    const p1 = handler(payload);
+    const p2 = handler(payload);
+    await Promise.all([p1, p2]);
+
+    expect(featureLoader.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('two concurrent pr:ci-failure events for same featureId produce ONE bug', async () => {
+    const payload = {
+      projectPath,
+      featureId,
+      prNumber: 42,
+      failedChecks: [{ name: 'ci', conclusion: 'failure' }],
+    };
+
+    const handler = (service as any).handleCIFailure.bind(service);
+
+    const p1 = handler(payload);
+    const p2 = handler(payload);
+    await Promise.all([p1, p2]);
+
+    expect(featureLoader.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('concurrent events for different featureIds each produce their own bug', async () => {
+    const payloadA = {
+      projectPath,
+      featureId: 'feature-a',
+      retryCount: 3,
+      lastError: 'Error A',
+    };
+    const payloadB = {
+      projectPath,
+      featureId: 'feature-b',
+      retryCount: 3,
+      lastError: 'Error B',
+    };
+
+    const handler = (service as any).handlePermanentlyBlocked.bind(service);
+
+    await Promise.all([handler(payloadA), handler(payloadB)]);
+
+    expect(featureLoader.create).toHaveBeenCalledTimes(2);
+  });
+
+  it('in-flight guard is cleared after failure so retries can succeed', async () => {
+    // Make featureLoader.get throw to simulate a failure
+    const getMock = vi
+      .fn()
+      .mockImplementation(() => Promise.reject(Object.assign(new Error(), { message: 'DB down' })));
+    const createMock = vi.fn();
+    const failingLoader = {
+      get: getMock,
+      create: createMock,
+    } as unknown as FeatureLoader;
+
+    const events = createMockEvents();
+    const triage = makeMockTriageService();
+    const settings = makeMockSettingsService();
+
+    const failingService = new IssueCreationService(events as any, failingLoader, triage, settings);
+    failingService.initialize();
+
+    const payload = {
+      projectPath,
+      featureId,
+      retryCount: 3,
+      lastError: 'Something broke',
+    };
+
+    const handler = (failingService as any).handlePermanentlyBlocked.bind(failingService);
+
+    // First call fails — error propagates, but guard is cleared in finally
+    await expect(handler(payload)).rejects.toThrow('DB down');
+    expect(getMock).toHaveBeenCalledTimes(1);
+
+    // Now make it succeed
+    getMock.mockResolvedValue({
+      id: featureId,
+      title: 'Test',
+      status: 'in_progress',
+    });
+    createMock.mockResolvedValue({ id: 'bug-1', title: 'Bug', status: 'backlog' });
+
+    // Second call should succeed — guard was cleared
+    await handler(payload);
+    expect(createMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fix #3600. Auto-filing paths in two services check their dedup state, then await storage work before reserving the key — concurrent events for the same signature can both pass the check and create duplicate features.

## Evidence

- apps/server/src/services/hitl-pattern-analysis-service.ts:296-310 (`maybeFileFeature`)
- apps/server/src/services/hitl-pattern-analysis-service.ts:329-337 (`maybeFileFeature`)
- apps/server/src/services/issue-creation-service.ts:146-177 (`handlePermanentlyBlocked`)

...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-05-24T08:36:20.549Z -->