### PR TITLE
Serialize TrustTierService writes to avoid lost records

### DIFF
--- a/apps/server/src/services/trust-tier-service.ts
+++ b/apps/server/src/services/trust-tier-service.ts
@@ -19,6 +19,32 @@ import path from 'path';
 const logger = createLogger('TrustTierService');
 
 /**
+ * In-memory per-file locks to serialize read-modify-write operations.
+ * Prevents lost updates when two concurrent calls read the same stale storage.
+ */
+const fileLocks = new Map<string, Promise<void>>();
+
+async function withFileLock<T>(filePath: string, operation: () => Promise<T>): Promise<T> {
+  const existingLock = fileLocks.get(filePath);
+  if (existingLock) {
+    await existingLock;
+  }
+
+  let releaseLock: () => void;
+  const lockPromise = new Promise<void>((resolve) => {
+    releaseLock = resolve;
+  });
+  fileLocks.set(filePath, lockPromise);
+
+  try {
+    return await operation();
+  } finally {
+    releaseLock!();
+    fileLocks.delete(filePath);
+  }
+}
+
+/**
  * Storage format for trust tiers
  * Maps GitHub username -> TrustTierRecord
  */
@@ -61,6 +87,17 @@ export class TrustTierService {
     grantedBy: string,
     reason?: string
   ): Promise<TrustTierRecord> {
+    return withFileLock(this.filePath, () =>
+      this.setTierLocked(githubUsername, tier, grantedBy, reason)
+    );
+  }
+
+  private async setTierLocked(
+    githubUsername: string,
+    tier: TrustTier,
+    grantedBy: string,
+    reason?: string
+  ): Promise<TrustTierRecord> {
     const record: TrustTierRecord = {
       githubUsername,
       tier,
@@ -81,6 +118,10 @@ export class TrustTierService {
    * Revoke a user's trust tier (removes entry from storage)
    */
   async revokeTier(githubUsername: string): Promise<void> {
+    return withFileLock(this.filePath, () => this.revokeTierLocked(githubUsername));
+  }
+
+  private async revokeTierLocked(githubUsername: string): Promise<void> {
     const storage = await this.loadStorage();
 
     if (!storage[githubUsername]) {

--- a/apps/server/src/services/trust-tier-service.ts
+++ b/apps/server/src/services/trust-tier-service.ts
@@ -20,27 +20,42 @@ const logger = createLogger('TrustTierService');
 
 /**
  * In-memory per-file locks to serialize read-modify-write operations.
- * Prevents lost updates when two concurrent calls read the same stale storage.
+ * Prevents lost updates when concurrent calls would otherwise read the same
+ * stale storage. Each caller chains its work onto the tail of any in-flight
+ * lock for the same path, so N concurrent callers execute strictly in arrival
+ * order — no thundering-herd, even with 3+ waiters.
  */
 const fileLocks = new Map<string, Promise<void>>();
 
 async function withFileLock<T>(filePath: string, operation: () => Promise<T>): Promise<T> {
-  const existingLock = fileLocks.get(filePath);
-  if (existingLock) {
-    await existingLock;
-  }
+  // Capture the current tail of the chain (or a resolved promise if no one's
+  // queued). We must do this BEFORE the await so the next caller chains on us,
+  // not on the same predecessor.
+  const previousTail = fileLocks.get(filePath) ?? Promise.resolve();
 
-  let releaseLock: () => void;
-  const lockPromise = new Promise<void>((resolve) => {
-    releaseLock = resolve;
+  let releaseTurn!: () => void;
+  const myTurn = new Promise<void>((resolve) => {
+    releaseTurn = resolve;
   });
-  fileLocks.set(filePath, lockPromise);
+
+  // Install our work as the new tail. Subsequent callers will await
+  // `previousTail.then(() => myTurn)` — i.e. the previous queue plus our own
+  // operation. This is the strict-ordering bit the thundering-herd version
+  // missed.
+  const myTail = previousTail.then(() => myTurn);
+  fileLocks.set(filePath, myTail);
+
+  await previousTail;
 
   try {
     return await operation();
   } finally {
-    releaseLock!();
-    fileLocks.delete(filePath);
+    releaseTurn();
+    // Only clear the map entry if no one queued behind us. If a later caller
+    // already replaced the tail, leave their chain intact.
+    if (fileLocks.get(filePath) === myTail) {
+      fileLocks.delete(filePath);
+    }
   }
 }
 

--- a/apps/server/tests/unit/services/trust-tier-service.test.ts
+++ b/apps/server/tests/unit/services/trust-tier-service.test.ts
@@ -187,4 +187,44 @@ describe('TrustTierService', () => {
       expect(records.find((r) => r.githubUsername === 'user3')?.tier).toBe(3);
     });
   });
+
+  describe('concurrent writes', () => {
+    it('should preserve both records when setTier is called concurrently', async () => {
+      // Fire two setTier calls concurrently — both should survive the mutex serialization
+      const [recordAlice, recordBob] = await Promise.all([
+        trustTierService.setTier('alice', 2, 'admin', 'Alice'),
+        trustTierService.setTier('bob', 3, 'admin', 'Bob'),
+      ]);
+
+      expect(recordAlice.githubUsername).toBe('alice');
+      expect(recordAlice.tier).toBe(2);
+      expect(recordBob.githubUsername).toBe('bob');
+      expect(recordBob.tier).toBe(3);
+
+      // Both users must be retrievable
+      expect(await trustTierService.getTierForUser('alice')).toBe(2);
+      expect(await trustTierService.getTierForUser('bob')).toBe(3);
+
+      const all = await trustTierService.getAll();
+      expect(all).toHaveLength(2);
+    });
+
+    it('should preserve both records when setTier and revokeTier run concurrently', async () => {
+      // Pre-populate so revokeTier has something to delete
+      await trustTierService.setTier('charlie', 1, 'admin');
+
+      const [recordAlice] = await Promise.all([
+        trustTierService.setTier('alice', 2, 'admin', 'Alice'),
+        trustTierService.revokeTier('charlie'),
+      ]);
+
+      expect(recordAlice.githubUsername).toBe('alice');
+      expect(await trustTierService.getTierForUser('alice')).toBe(2);
+      expect(await trustTierService.getTierForUser('charlie')).toBe(0);
+
+      const all = await trustTierService.getAll();
+      expect(all).toHaveLength(1);
+      expect(all[0].githubUsername).toBe('alice');
+    });
+  });
 });

--- a/apps/server/tests/unit/services/trust-tier-service.test.ts
+++ b/apps/server/tests/unit/services/trust-tier-service.test.ts
@@ -234,7 +234,9 @@ describe('TrustTierService', () => {
       // where multiple waiters all unblock on the first release and then race.
       const usernames = ['u1', 'u2', 'u3', 'u4', 'u5', 'u6', 'u7', 'u8'];
       await Promise.all(
-        usernames.map((u, i) => trustTierService.setTier(u, ((i % 4) + 1) as 1 | 2 | 3 | 4, 'admin'))
+        usernames.map((u, i) =>
+          trustTierService.setTier(u, ((i % 4) + 1) as 1 | 2 | 3 | 4, 'admin')
+        )
       );
 
       const all = await trustTierService.getAll();

--- a/apps/server/tests/unit/services/trust-tier-service.test.ts
+++ b/apps/server/tests/unit/services/trust-tier-service.test.ts
@@ -226,5 +226,43 @@ describe('TrustTierService', () => {
       expect(all).toHaveLength(1);
       expect(all[0].githubUsername).toBe('alice');
     });
+
+    it('preserves all records when N=8 setTier calls fire concurrently (thundering-herd check)', async () => {
+      // The 2-caller test passes a naive mutex (`if (existing) await existing`)
+      // even when it has the thundering-herd bug — only 1 waiter exists, so it
+      // gets the lock cleanly. The bug surfaces with 3+ concurrent callers,
+      // where multiple waiters all unblock on the first release and then race.
+      const usernames = ['u1', 'u2', 'u3', 'u4', 'u5', 'u6', 'u7', 'u8'];
+      await Promise.all(
+        usernames.map((u, i) => trustTierService.setTier(u, ((i % 4) + 1) as 1 | 2 | 3 | 4, 'admin'))
+      );
+
+      const all = await trustTierService.getAll();
+      expect(all).toHaveLength(8);
+      const got = new Set(all.map((r) => r.githubUsername));
+      for (const u of usernames) {
+        expect(got.has(u)).toBe(true);
+      }
+    });
+
+    it('handles a setTier-then-revoke chain on the same user without losing the final state', async () => {
+      // Race two operations against the SAME user. With a broken mutex, the
+      // revoke could land before the set persists, leaving 'dave' with a tier
+      // that should have been revoked, or vice versa. With proper ordering,
+      // whichever call queued last wins.
+      await trustTierService.setTier('dave', 1, 'admin');
+
+      // Fire 4 concurrent ops in a deterministic Promise.all order
+      const ops = [
+        trustTierService.setTier('dave', 2, 'admin'),
+        trustTierService.setTier('dave', 3, 'admin'),
+        trustTierService.setTier('dave', 4, 'admin'),
+        trustTierService.revokeTier('dave'),
+      ];
+      await Promise.all(ops);
+
+      // Last queued op was the revoke — final state must reflect that.
+      expect(await trustTierService.getTierForUser('dave')).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fix #3601. `setTier` and `revokeTier` in `apps/server/src/services/trust-tier-service.ts` do a read-modify-write against `trust-tiers.json` without serialization. Two concurrent updates that both read the old storage will lose whichever change finishes first when the second write completes.

## Fix

Add a per-file async mutex around the load→mutate→save critical section in `setTier` and `revokeTier`. Keep `getAll`/`getTier` read-only. The existing atomic-write helper still protects against parti...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-05-24T08:36:21.090Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Trust tier updates now correctly handle concurrent operations, ensuring data remains consistent when multiple simultaneous changes occur.

## Tests
* Added comprehensive test coverage for concurrent trust tier scenarios, including simultaneous tier assignments, revocations, and mixed operations targeting single and multiple users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->