### PR TITLE
Apply deletes and renames during nested worktree D/R recovery

### DIFF
--- a/apps/server/src/services/worktree-recovery-service.ts
+++ b/apps/server/src/services/worktree-recovery-service.ts
@@ -397,51 +397,110 @@ export async function recoverNestedWorktreeWork(
         logger.debug(`[WorktreeRecovery] Uncommitted changes:\n${statusOutput}`);
         result.worktreesWithChanges.push(nestedWorktreePath);
 
-        // Parse file paths from `git status --short` output.
+        // Parse git status lines with explicit status-code handling.
         // Format: "XY filename" or "XY old -> new" for renames.
-        // Status codes: M=modified, A=added, D=deleted, R=renamed, ??=untracked.
-        const changedFiles = statusOutput
-          .trim()
-          .split('\n')
-          .map((line) => {
-            const rest = line.slice(3).trim(); // strip 2-char status code + space
-            // Handle rename: "old-path -> new-path" — use the new path
-            if (rest.includes(' -> ')) {
-              return rest.split(' -> ').pop()!.trim();
-            }
-            return rest;
-          })
-          .filter(Boolean);
+        // X = index status, Y = worktree status.
+        // D = deleted, R = renamed, M = modified, A = added, ?? = untracked.
+        const statusLines = statusOutput.trim().split('\n').filter(Boolean);
 
-        for (const relPath of changedFiles) {
+        for (const line of statusLines) {
+          const statusCode = line.slice(0, 2).trim();
+          const rest = line.slice(3).trim(); // strip 2-char status code + space
+
+          // Determine operation type and path(s) from the status code
+          const isDeleted = statusCode.includes('D');
+          const isRenamed = statusCode.includes('R');
+
+          let relPath: string;
+          let oldRelPath: string | undefined;
+
+          if (isRenamed && rest.includes(' -> ')) {
+            const parts = rest.split(' -> ');
+            oldRelPath = parts[0].trim();
+            relPath = parts[parts.length - 1].trim();
+          } else {
+            relPath = rest;
+          }
+
           const srcPath = path.join(nestedWorktreePath, relPath);
           const destPath = path.join(mainWorktreePath, relPath);
 
           try {
-            // Skip files that no longer exist in the nested worktree (e.g. deletions)
-            let srcStat;
-            try {
-              srcStat = await fs.stat(srcPath);
-            } catch {
-              logger.debug(`[WorktreeRecovery] Skipping absent file (likely deleted): ${relPath}`);
-              continue;
-            }
+            if (isDeleted) {
+              // File was deleted in the nested worktree — remove from main worktree too
+              const deletedDestPath = path.join(mainWorktreePath, relPath);
+              try {
+                await fs.rm(deletedDestPath, { recursive: true, force: true });
+                result.copiedFiles.push(relPath);
+                logger.info(
+                  `[WorktreeRecovery] Deleted ${relPath} from main worktree (was deleted in nested)`
+                );
+              } catch (rmError) {
+                // File may not exist in main worktree — non-fatal
+                const msg = rmError instanceof Error ? rmError.message : String(rmError);
+                logger.debug(
+                  `[WorktreeRecovery] Could not delete ${relPath} from main worktree (may not exist): ${msg}`
+                );
+              }
+            } else if (isRenamed && oldRelPath) {
+              // Rename: remove old path from main worktree, copy new path
+              const oldDestPath = path.join(mainWorktreePath, oldRelPath);
+              try {
+                await fs.rm(oldDestPath, { recursive: true, force: true });
+                logger.info(
+                  `[WorktreeRecovery] Removed old path ${oldRelPath} from main worktree (renamed)`
+                );
+              } catch (rmError) {
+                const msg = rmError instanceof Error ? rmError.message : String(rmError);
+                logger.debug(`[WorktreeRecovery] Could not remove old path ${oldRelPath}: ${msg}`);
+              }
 
-            if (srcStat.isDirectory()) {
-              // git status shows untracked directories as "?? dir/" — copy recursively
-              await fs.cp(srcPath, destPath, { recursive: true });
+              // Copy the new path from nested to main
+              let srcStat;
+              try {
+                srcStat = await fs.stat(srcPath);
+              } catch {
+                const msg = `Renamed file not found at ${srcPath}`;
+                logger.error(`[WorktreeRecovery] ${msg}`);
+                result.errors.push(`copy ${relPath}: ${msg}`);
+                continue;
+              }
+
+              if (srcStat.isDirectory()) {
+                await fs.cp(srcPath, destPath, { recursive: true });
+              } else {
+                await fs.mkdir(path.dirname(destPath), { recursive: true });
+                await fs.copyFile(srcPath, destPath);
+              }
               result.copiedFiles.push(relPath);
-              logger.info(`[WorktreeRecovery] Copied directory ${relPath} -> main worktree`);
+              logger.info(
+                `[WorktreeRecovery] Copied rename ${oldRelPath} -> ${relPath} to main worktree`
+              );
             } else {
-              await fs.mkdir(path.dirname(destPath), { recursive: true });
-              await fs.copyFile(srcPath, destPath);
-              result.copiedFiles.push(relPath);
-              logger.info(`[WorktreeRecovery] Copied ${relPath} -> main worktree`);
+              // M / A / ?? — copy from nested to main
+              let srcStat;
+              try {
+                srcStat = await fs.stat(srcPath);
+              } catch {
+                logger.debug(`[WorktreeRecovery] Skipping absent file: ${relPath}`);
+                continue;
+              }
+
+              if (srcStat.isDirectory()) {
+                await fs.cp(srcPath, destPath, { recursive: true });
+                result.copiedFiles.push(relPath);
+                logger.info(`[WorktreeRecovery] Copied directory ${relPath} -> main worktree`);
+              } else {
+                await fs.mkdir(path.dirname(destPath), { recursive: true });
+                await fs.copyFile(srcPath, destPath);
+                result.copiedFiles.push(relPath);
+                logger.info(`[WorktreeRecovery] Copied ${relPath} -> main worktree`);
+              }
             }
           } catch (copyError) {
             const msg = copyError instanceof Error ? copyError.message : String(copyError);
-            logger.error(`[WorktreeRecovery] Failed to copy ${relPath}: ${msg}`);
-            result.errors.push(`copy ${relPath}: ${msg}`);
+            logger.error(`[WorktreeRecovery] Failed to process ${relPath}: ${msg}`);
+            result.errors.push(`process ${relPath}: ${msg}`);
           }
         }
 

--- a/apps/server/tests/unit/services/worktree-recovery-service.test.ts
+++ b/apps/server/tests/unit/services/worktree-recovery-service.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
 import type { Feature } from '@protolabsai/types';
 
 // Mock execFile before importing the service. After the shell-string →
@@ -13,7 +16,10 @@ vi.mock('util', () => ({
   promisify: (fn: unknown) => fn,
 }));
 
-import { checkAndRecoverUncommittedWork } from '@/services/worktree-recovery-service.js';
+import {
+  checkAndRecoverUncommittedWork,
+  recoverNestedWorktreeWork,
+} from '@/services/worktree-recovery-service.js';
 import { execFile } from 'child_process';
 
 const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
@@ -324,6 +330,85 @@ describe('worktree-recovery-service', () => {
       expect(result.detected).toBe(true);
       expect(result.recovered).toBe(true);
       expect(result.prNumber).toBe(77);
+    });
+  });
+
+  describe('recoverNestedWorktreeWork', () => {
+    let tempMainWorktree: string;
+    let tempNestedWorktree: string;
+
+    afterEach(async () => {
+      try {
+        await fs.rm(tempMainWorktree, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup
+      }
+    });
+
+    it('applies deletes, renames, and modified files from nested worktree', async () => {
+      // Create main worktree with initial files
+      tempMainWorktree = await fs.mkdtemp(path.join(os.tmpdir(), 'main-wt-'));
+      tempNestedWorktree = path.join(tempMainWorktree, '.claude', 'worktrees', 'agent-test');
+      await fs.mkdir(tempNestedWorktree, { recursive: true });
+
+      // a.ts — will be deleted in nested (D status)
+      await fs.writeFile(path.join(tempMainWorktree, 'a.ts'), 'deleted content');
+      await fs.writeFile(path.join(tempNestedWorktree, 'a.ts'), 'deleted content');
+
+      // b.ts → c.ts — will be renamed in nested (R status)
+      await fs.writeFile(path.join(tempMainWorktree, 'b.ts'), 'old name');
+      await fs.writeFile(path.join(tempNestedWorktree, 'c.ts'), 'renamed content');
+
+      // d.ts — modified in nested (M status)
+      await fs.writeFile(path.join(tempMainWorktree, 'd.ts'), 'original');
+      await fs.writeFile(path.join(tempNestedWorktree, 'd.ts'), 'modified');
+
+      // Mock git status --short for the nested worktree
+      // D = deleted, R = renamed, M = modified
+      const statusOutput = 'D  a.ts\nR100 b.ts -> c.ts\nM  d.ts\n';
+
+      mockExecFile
+        // git status --short (nested worktree)
+        .mockResolvedValueOnce({ stdout: statusOutput, stderr: '' });
+
+      const result = await recoverNestedWorktreeWork(tempMainWorktree);
+
+      expect(result.found).toBe(true);
+      expect(result.worktreesWithChanges).toContain(tempNestedWorktree);
+
+      // a.ts should be removed from main worktree (was deleted in nested)
+      try {
+        await fs.access(path.join(tempMainWorktree, 'a.ts'));
+        expect(false).toBe(true); // Should not reach here
+      } catch {
+        // Expected — file was deleted
+      }
+
+      // b.ts should be removed from main worktree (was renamed in nested)
+      try {
+        await fs.access(path.join(tempMainWorktree, 'b.ts'));
+        expect(false).toBe(true); // Should not reach here
+      } catch {
+        // Expected — old path was removed
+      }
+
+      // c.ts should exist in main worktree (rename target)
+      const cContent = await fs.readFile(path.join(tempMainWorktree, 'c.ts'), 'utf-8');
+      expect(cContent).toBe('renamed content');
+
+      // d.ts should have modified content in main worktree
+      const dContent = await fs.readFile(path.join(tempMainWorktree, 'd.ts'), 'utf-8');
+      expect(dContent).toBe('modified');
+
+      // Nested worktree should be cleaned up
+      try {
+        await fs.access(tempNestedWorktree);
+        expect(false).toBe(true); // Should not reach here
+      } catch {
+        // Expected — nested worktree was removed
+      }
+
+      expect(result.errors).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fix #3602. `recoverNestedWorktreeWork` in `apps/server/src/services/worktree-recovery-service.ts` parses git status lines, but only copies paths that STILL EXIST in the nested worktree. Deleted files are skipped as absent. Rename handling copies the new path without removing the old path from the main worktree. Then the function removes the nested worktree — so those deletion / rename semantics are permanently lost.

## Evidence

- apps/server/src/services/worktree-recovery-service.ts:376-390 (`...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-05-24T09:03:05.889Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced worktree recovery mechanism to correctly handle file deletions, renames, and content modifications when recovering uncommitted changes in nested worktrees.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->