### PR TITLE
docs(claude.md): add Prime Directive — file follow-ups immediately

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,23 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Prime Directive: File Follow-Ups Immediately
+
+**If something is worth following, file it — in the same turn you noticed it. Don't leave it in the conversation.**
+
+Conversations get compacted at the context limit. Issues, board features, CLAUDE.md entries, and memory files survive. Anything that lives only in chat will eventually be lost.
+
+When you say "worth filing later," "we should track this," "follow-up needed," or notice a bug / missing feature / recurring pattern — open the tool call to file it right then. Acceptable durable surfaces, in priority order:
+
+1. **GitHub issue** — for bugs, missing features, follow-ups that need work later
+2. **Board feature** (via `/api/features/create` or `mcp__protolabs__create_feature`) — for things the crew can pick up now
+3. **CLAUDE.md update** — for durable rules, recovery procedures, project conventions
+4. **`.automaker/memory/ops-lessons.md`** — for recurring failure patterns and their fixes
+
+Default to GitHub issue if unsure. Include enough context that a fresh session can act without reading the original conversation: symptom, evidence (file paths, PR numbers, commit SHAs), recommended fix, acceptance. Stub issues are fine — one paragraph beats no record.
+
+This is a stronger form of the existing self-improvement rule under "Blocked Feature Recovery" (which is about recurring failures specifically). This rule is broader: **any** follow-up at all, not just recurring failures.
+
 ## Philosophy: Greenfield-First
 
 This is a greenfield codebase. We are building the future, not maintaining the past.


### PR DESCRIPTION
## Summary

Adds a Prime Directive at the very top of CLAUDE.md telling future Claude sessions (and the crew) to file follow-ups the moment they notice them, instead of leaving them in conversation context where they'll be lost on compaction.

## Why

Today's session nearly lost the \"auto-dismiss-stale-bot-reviews\" follow-up — it lived only in chat, and the user had to explicitly ask me to file it before context refresh. The directive prevents that failure mode by codifying \"file immediately\" as a project rule.

The four durable surfaces in priority order: GitHub issue → board feature → CLAUDE.md → ops-lessons.md.

## Mirror

Same instruction is in user-level auto-memory at
\`~/.claude/projects/-Users-kj-dev-protomaker/memory/file-followups-immediately.md\`
so it survives at both the project and user level.

## Followup

The reason this came up is #3732 — protoquinn bot leaves \`CHANGES_REQUESTED\` reviews and never escalates to \`APPROVED\`, blocking PRs indefinitely. That issue is now properly filed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced development documentation with new guidelines for managing follow-up items, including prioritization procedures, context expectations for issue submissions (symptoms, evidence, recommendations), and clarified escalation paths to standardize team workflows and improve operational consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->