### PR TITLE
Guard EXECUTE -> REVIEW transition: require a PR or commits, not just absence of ESCALATE

### DIFF
--- a/apps/server/src/services/lead-engineer-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-execute-processor.ts
@@ -924,6 +924,39 @@ export class ExecuteProcessor implements StateProcessor {
       }
     }
 
+    // ── Guard: require a PR and commits before transitioning to REVIEW ────────
+    // Without this guard, an agent that hard-fails on turn 1 (e.g. 401 from the
+    // model gateway) can still reach REVIEW with no PR and no commits — leaving
+    // a human with "in review" but nothing to review.
+    const hasPr = ctx.prNumber != null || ctx.feature.prNumber != null;
+
+    // If no PR was created, check for commits as a secondary signal.
+    // If we have a PR, the commits check is advisory — a PR is strong enough evidence.
+    const hasCommits = hasPr || (await this.hasCommitsAheadOfBase(ctx));
+
+    if (!hasPr) {
+      const missingParts: string[] = [];
+      missingParts.push('no PR created');
+      if (!hasCommits) missingParts.push('no commits ahead of base');
+      const reason = `Agent exited without producing reviewable output — ${missingParts.join(', ')}. Check agent-output.md for model/auth errors.`;
+      logger.warn('[EXECUTE] Guard failed — blocking feature instead of transitioning to REVIEW', {
+        featureId: ctx.feature.id,
+        reason,
+        hasPr,
+        hasCommits,
+        prNumber: ctx.prNumber ?? ctx.feature.prNumber,
+      });
+      await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
+        status: 'blocked',
+        statusChangeReason: reason,
+      });
+      return {
+        nextState: null,
+        shouldContinue: false,
+        reason,
+      };
+    }
+
     // Post-agent formatting: unconditionally run prettier on all changed files
     // before transitioning to REVIEW, regardless of how the agent committed.
     await this.runPostAgentFormatting(ctx);
@@ -1528,6 +1561,45 @@ export class ExecuteProcessor implements StateProcessor {
   /**
    * Resolve the worktree directory for the given branch, or null if not found.
    * Uses `git worktree list --porcelain` in the project root.
+   */
+  /**
+   * Check whether the worktree (or projectPath) has commits ahead of the base branch.
+   * Returns false if no worktree can be resolved or the check fails (conservative:
+   * treat errors as "no commits" to avoid false positives reaching REVIEW).
+   */
+  private async hasCommitsAheadOfBase(ctx: StateContext): Promise<boolean> {
+    const { feature, projectPath } = ctx;
+    const baseBranch = feature.gitWorkflow?.prBaseBranch || 'main';
+    const worktreeDir = await this.resolveWorktreeDir(projectPath, feature.branchName);
+    const workDir = worktreeDir ?? projectPath;
+
+    try {
+      // Fetch to ensure origin/<baseBranch> is up-to-date
+      await execAsync(`git fetch origin ${baseBranch}`, {
+        cwd: workDir,
+        timeout: 15_000,
+      }).catch(() => {
+        // Non-fatal: worktree may not have origin configured
+      });
+
+      const { stdout } = await execAsync(`git rev-list --count origin/${baseBranch}..HEAD`, {
+        cwd: workDir,
+        timeout: 10_000,
+      });
+      const count = parseInt(stdout.trim(), 10);
+      return !isNaN(count) && count > 0;
+    } catch {
+      // If we can't check, be conservative — assume no commits
+      logger.debug('[EXECUTE] Could not check commits ahead of base (non-fatal)', {
+        featureId: feature.id,
+        baseBranch,
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Resolve the worktree directory for a given branch.
    */
   private async resolveWorktreeDir(
     projectPath: string,

--- a/apps/server/tests/unit/services/concurrency-slot-fixes.test.ts
+++ b/apps/server/tests/unit/services/concurrency-slot-fixes.test.ts
@@ -47,6 +47,9 @@ function makeFeature(overrides: Partial<Feature> = {}): Feature {
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     order: 0,
+    // Default to having a PR so REVIEW-transition tests pass the new guard
+    // added in #3742. Tests exercising "no PR" should override.
+    prNumber: 999,
     ...overrides,
   };
 }

--- a/apps/server/tests/unit/services/lead-engineer-execute-processor.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-execute-processor.test.ts
@@ -476,3 +476,108 @@ describe('ExecuteProcessor — execution gate rejection tracking (Bug 3)', () =>
     expect(stateCtx.gateRejectionCount).toBe(1);
   });
 });
+
+describe('ExecuteProcessor — EXECUTE→REVIEW guard (no PR or no commits)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('blocks feature when agent exits with no PR and no commits', async () => {
+    // Simulate: agent hard-fails on turn 1 (e.g. 401 from model gateway).
+    // waitForCompletion resolves successfully (feature:completed event fires),
+    // but no PR was created and no commits exist.
+    const { ctx, featureLoader } = makeServiceContext({
+      maxCostUsdPerFeature: 100, // well above any cost
+    });
+
+    // featureLoader.get returns a feature without prNumber
+    const noPrFeature = makeFeature({ costUsd: 1, prNumber: undefined });
+    (featureLoader.get as ReturnType<typeof vi.fn>).mockResolvedValue(noPrFeature);
+
+    const processor = new ExecuteProcessor(ctx);
+    const stateCtx = makeCtx({ feature: noPrFeature, prNumber: undefined });
+    const result = await processor.process(stateCtx);
+
+    // Should NOT transition to REVIEW
+    expect(result.nextState).toBeNull();
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reason).toMatch(/no PR created/i);
+    expect(result.reason).toMatch(/no commits ahead of base/i);
+
+    // Feature should be blocked with a descriptive reason
+    expect(featureLoader.update).toHaveBeenCalledWith(
+      '/test/project',
+      'feat-001',
+      expect.objectContaining({
+        status: 'blocked',
+        statusChangeReason: expect.stringMatching(
+          /Agent exited without producing reviewable output/i
+        ),
+      })
+    );
+  });
+
+  it('transitions to REVIEW when PR exists (commits check is advisory)', async () => {
+    // Having a PR is strong enough evidence — commits check is advisory
+    // and may fail in environments without git access.
+    const { ctx, featureLoader } = makeServiceContext({
+      maxCostUsdPerFeature: 100,
+    });
+
+    const prFeature = makeFeature({ costUsd: 1, prNumber: 42 });
+    (featureLoader.get as ReturnType<typeof vi.fn>).mockResolvedValue(prFeature);
+
+    const processor = new ExecuteProcessor(ctx);
+    const stateCtx = makeCtx({ feature: prFeature, prNumber: 42 });
+    const result = await processor.process(stateCtx);
+
+    expect(result.nextState).toBe('REVIEW');
+    expect(result.shouldContinue).toBe(true);
+    expect(result.reason).toMatch(/Execution completed, moving to review/i);
+  });
+
+  it('blocks feature when no PR and feature.prNumber is also missing', async () => {
+    // Both ctx.prNumber and feature.prNumber are missing.
+    const { ctx, featureLoader } = makeServiceContext({
+      maxCostUsdPerFeature: 100,
+    });
+
+    const noPrFeature = makeFeature({ costUsd: 1, prNumber: undefined });
+    (featureLoader.get as ReturnType<typeof vi.fn>).mockResolvedValue(noPrFeature);
+
+    const processor = new ExecuteProcessor(ctx);
+    const stateCtx = makeCtx({ feature: noPrFeature, prNumber: undefined });
+    const result = await processor.process(stateCtx);
+
+    expect(result.nextState).toBeNull();
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reason).toMatch(/no PR created/i);
+
+    expect(featureLoader.update).toHaveBeenCalledWith(
+      '/test/project',
+      'feat-001',
+      expect.objectContaining({
+        status: 'blocked',
+        statusChangeReason: expect.stringMatching(/no PR created/i),
+      })
+    );
+  });
+
+  it('transitions to REVIEW when feature.prNumber is set (even without ctx.prNumber)', async () => {
+    // Happy path: feature has prNumber from reload.
+    const { ctx, featureLoader } = makeServiceContext({
+      maxCostUsdPerFeature: 100,
+    });
+
+    const happyFeature = makeFeature({ costUsd: 1, prNumber: 42 });
+    (featureLoader.get as ReturnType<typeof vi.fn>).mockResolvedValue(happyFeature);
+
+    const processor = new ExecuteProcessor(ctx);
+    const stateCtx = makeCtx({ feature: happyFeature });
+    const result = await processor.process(stateCtx);
+
+    expect(result.nextState).toBe('REVIEW');
+    expect(result.shouldContinue).toBe(true);
+    expect(result.reason).toMatch(/Execution completed, moving to review/i);
+  });
+});

--- a/apps/server/tests/unit/services/lead-engineer-execute-processor.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-execute-processor.test.ts
@@ -70,6 +70,11 @@ function makeFeature(overrides: Partial<Feature> = {}): Feature {
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     order: 0,
+    // Default to having a PR so the cost-cap / runtime-cap tests can reach
+    // REVIEW. The guard added in #3742 blocks EXECUTE -> REVIEW when there
+    // is no PR; tests that intentionally exercise "no PR" should override
+    // with prNumber: undefined.
+    prNumber: 999,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Fix #3662. LeadEngineerStateMachine ticks features from in_progress -> review even when the agent hard-fails on turn 1 with no commits and no PR. A human reads it as in review; nothing to review. Add guards so a feature can only reach REVIEW when there is actually something to review.

---

## Symptom

When the agent hits a hard error on its very first turn (e.g. 401 from the model gateway), the LeadEngineerStateMachine still transitions the feature from `in_progress` to `review` after ~18 secon...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=e2cc7f6b-ab7e-4d34-99e3-f7658183e52e team= created=2026-05-24T10:33:30.498Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation to prevent advancing to review stage when neither a pull request nor new commits are detected. Features missing both are now blocked with a clear status reason.

* **Tests**
  * Added comprehensive test coverage for the review stage validation guard.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->