### PR TITLE
feat(maintenance): auto-dismiss stale CHANGES_REQUESTED bot reviews

### DIFF
--- a/apps/server/src/services/maintenance.module.ts
+++ b/apps/server/src/services/maintenance.module.ts
@@ -22,6 +22,7 @@ import { PostMergeReconcilerCheck } from './maintenance/checks/post-merge-reconc
 import { DoneWorktreeCleanupCheck } from './maintenance/checks/done-worktree-cleanup-check.js';
 import { EpicAdoptionSweepCheck } from './maintenance/checks/epic-adoption-sweep-check.js';
 import { BacklogTitleReconcilerCheck } from './maintenance/checks/backlog-title-reconciler-check.js';
+import { AutoDismissStaleBotReviewsCheck } from './maintenance/checks/auto-dismiss-stale-bot-reviews-check.js';
 
 const logger = createLogger('Server:Wiring');
 
@@ -193,6 +194,42 @@ export function register(container: ServiceContainer): void {
   // See protoLabsAI/protoMaker#3511.
   const backlogTitleReconcilerCheck = new BacklogTitleReconcilerCheck(featureLoader, events);
 
+  // Auto-dismiss stale bot CHANGES_REQUESTED reviews (full tier) — protoquinn /
+  // coderabbit re-review fix commits as COMMENTED rather than APPROVED, which
+  // leaves PRs permanently BLOCKED on the original CHANGES_REQUESTED. This
+  // check finds and dismisses those superseded reviews when the same bot has
+  // posted a later follow-up and CI is green.
+  // See protoLabsAI/protoMaker#3732.
+  const repoOwner = process.env.GITHUB_REPO_OWNER || 'protoLabsAI';
+  const repoName = process.env.GITHUB_REPO_NAME || 'protoMaker';
+  const autoDismissStaleBotReviewsInstance = new AutoDismissStaleBotReviewsCheck({
+    owner: repoOwner,
+    repo: repoName,
+  });
+  const autoDismissStaleBotReviewsCheck: MaintenanceCheck = {
+    id: 'auto-dismiss-stale-bot-reviews',
+    name: 'Auto-Dismiss Stale Bot Reviews',
+    tier: 'full',
+    async run(context: MaintenanceCheckContext): Promise<MaintenanceCheckResult> {
+      const t0 = Date.now();
+      let totalDismissed = 0;
+      for (const projectPath of context.projectPaths) {
+        const issues = await autoDismissStaleBotReviewsInstance.run(projectPath);
+        totalDismissed += issues.length;
+      }
+      return {
+        checkId: 'auto-dismiss-stale-bot-reviews',
+        passed: true,
+        summary:
+          totalDismissed > 0
+            ? `Auto-dismissed ${totalDismissed} stale CHANGES_REQUESTED bot review(s)`
+            : 'Auto-dismiss check: no stale bot reviews found',
+        details: { totalDismissed, projectCount: context.projectPaths.length },
+        durationMs: Date.now() - t0,
+      };
+    },
+  };
+
   maintenanceOrchestrator.register(boardHealthCheck);
   maintenanceOrchestrator.register(resourceUsageCheck);
   maintenanceOrchestrator.register(webhookHealthCheck);
@@ -200,6 +237,7 @@ export function register(container: ServiceContainer): void {
   maintenanceOrchestrator.register(doneWorktreeCleanupCheck);
   maintenanceOrchestrator.register(epicAdoptionSweepCheck);
   maintenanceOrchestrator.register(backlogTitleReconcilerCheck);
+  maintenanceOrchestrator.register(autoDismissStaleBotReviewsCheck);
 
   // Wire TopicBus for hierarchical event routing of sweep results
   if (container.topicBus) {

--- a/apps/server/src/services/maintenance/checks/auto-dismiss-stale-bot-reviews-check.ts
+++ b/apps/server/src/services/maintenance/checks/auto-dismiss-stale-bot-reviews-check.ts
@@ -1,0 +1,253 @@
+/**
+ * AutoDismissStaleBotReviewsCheck — clear blocking CHANGES_REQUESTED reviews
+ * left by bot reviewers (protoquinn, CodeRabbit) on stale commits.
+ *
+ * Problem: GitHub branch protection treats a `CHANGES_REQUESTED` review as
+ * blocking until the reviewer either dismisses it OR submits a fresh
+ * `APPROVED` review. Our review bots routinely re-review fix commits with
+ * `COMMENTED` (acknowledging the fix without escalating to APPROVED),
+ * which does NOT clear the blocking state. The result is PRs stuck at
+ * `mergeStateStatus: BLOCKED` even after all flagged concerns are
+ * resolved and CI is green — a maintainer has to manually dismiss.
+ *
+ * This check identifies the exact "stale" shape and dismisses the
+ * blocking review automatically:
+ *
+ *   1. PR is OPEN
+ *   2. Latest CHANGES_REQUESTED review is from a `[bot]` user
+ *   3. That review's commit is NOT the current head
+ *   4. The same bot has posted a later COMMENTED or APPROVED review
+ *      on a more recent commit (proves it's seen and acked the fix)
+ *   5. All required CI checks on the current head are SUCCESS
+ *
+ * When all 5 hold, the stale CHANGES_REQUESTED is dismissed with a
+ * message citing the follow-up review and the head SHA.
+ *
+ * See: protoLabsAI/protoMaker#3732
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { createLogger } from '@protolabsai/utils';
+import type { MaintenanceCheck, MaintenanceIssue } from '../types.js';
+
+const logger = createLogger('AutoDismissStaleBotReviewsCheck');
+
+type ExecFileAsync = (
+  file: string,
+  args: string[],
+  options: { cwd?: string; encoding: string; timeout: number }
+) => Promise<{ stdout: string; stderr: string }>;
+
+interface PROpen {
+  number: number;
+  headRefOid: string;
+  mergeStateStatus: string;
+  reviewDecision: string | null;
+  url: string;
+}
+
+interface PRReview {
+  id: number;
+  user: { login: string } | null;
+  state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED' | 'DISMISSED' | 'PENDING';
+  commit_id: string | null;
+  submitted_at: string | null;
+}
+
+interface PRCheck {
+  name: string;
+  status: 'COMPLETED' | 'IN_PROGRESS' | 'QUEUED' | 'PENDING' | string;
+  conclusion: 'SUCCESS' | 'FAILURE' | 'SKIPPED' | 'CANCELLED' | 'NEUTRAL' | null;
+}
+
+interface RepoCoords {
+  owner: string;
+  repo: string;
+}
+
+/** Identify a user that's a GitHub App / bot (login ends with `[bot]`). */
+function isBot(login: string): boolean {
+  return login.endsWith('[bot]');
+}
+
+export class AutoDismissStaleBotReviewsCheck implements MaintenanceCheck {
+  readonly id = 'auto-dismiss-stale-bot-reviews';
+
+  private readonly execFileAsync: ExecFileAsync;
+
+  constructor(
+    private readonly repoCoords: RepoCoords,
+    execFileAsyncOverride?: ExecFileAsync
+  ) {
+    this.execFileAsync = execFileAsyncOverride ?? (promisify(execFile) as ExecFileAsync);
+  }
+
+  async run(projectPath: string): Promise<MaintenanceIssue[]> {
+    const issues: MaintenanceIssue[] = [];
+
+    try {
+      const openPRs = await this.listOpenPRs(projectPath);
+      for (const pr of openPRs) {
+        // Fast-path: only act on PRs that GitHub thinks are blocked AND have a
+        // CHANGES_REQUESTED decision. Anything else means either the PR is
+        // happy, or it's blocked for a different reason (CI failure, conflicts).
+        if (pr.mergeStateStatus !== 'BLOCKED') continue;
+        if (pr.reviewDecision !== 'CHANGES_REQUESTED') continue;
+
+        const dismissed = await this.processPR(projectPath, pr);
+        for (const reviewId of dismissed) {
+          issues.push({
+            checkId: this.id,
+            severity: 'info',
+            message: `Dismissed stale CHANGES_REQUESTED on PR #${pr.number} (review id ${reviewId})`,
+            autoFixable: false,
+            context: {
+              prNumber: pr.number,
+              prUrl: pr.url,
+              reviewId,
+              headSha: pr.headRefOid,
+            },
+          });
+        }
+      }
+    } catch (error) {
+      logger.error(`AutoDismissStaleBotReviewsCheck failed for ${projectPath}:`, error);
+    }
+
+    return issues;
+  }
+
+  /**
+   * Inspect a single PR. Returns the list of review IDs that were dismissed.
+   */
+  private async processPR(projectPath: string, pr: PROpen): Promise<number[]> {
+    const reviews = await this.listReviews(projectPath, pr.number);
+
+    // Group reviews by author (login). For each bot author, find any
+    // CHANGES_REQUESTED that's been superseded by a later COMMENTED/APPROVED.
+    const byAuthor = new Map<string, PRReview[]>();
+    for (const r of reviews) {
+      if (!r.user) continue;
+      if (!isBot(r.user.login)) continue;
+      const arr = byAuthor.get(r.user.login) ?? [];
+      arr.push(r);
+      byAuthor.set(r.user.login, arr);
+    }
+
+    const dismissed: number[] = [];
+
+    for (const [_login, list] of byAuthor) {
+      // Sort ascending by submitted_at
+      list.sort((a, b) => (a.submitted_at ?? '').localeCompare(b.submitted_at ?? ''));
+      const stale = list.filter(
+        (r) => r.state === 'CHANGES_REQUESTED' && r.commit_id !== pr.headRefOid
+      );
+      if (stale.length === 0) continue;
+
+      const latestStale = stale[stale.length - 1];
+      const followUp = list.find(
+        (r) =>
+          (r.state === 'COMMENTED' || r.state === 'APPROVED') &&
+          (r.submitted_at ?? '').localeCompare(latestStale.submitted_at ?? '') > 0
+      );
+      if (!followUp) continue;
+
+      // Final guard — all required CI checks must be SUCCESS on head.
+      const checksClean = await this.allChecksGreen(projectPath, pr.number);
+      if (!checksClean) continue;
+
+      for (const sr of stale) {
+        const ok = await this.dismiss(
+          projectPath,
+          pr.number,
+          sr.id,
+          `Auto-dismissed: superseded by ${followUp.state} review from same bot on later commit ${(followUp.commit_id ?? '').slice(0, 7)}. CI green on head ${pr.headRefOid.slice(0, 7)}.`
+        );
+        if (ok) {
+          dismissed.push(sr.id);
+          logger.info(
+            `Dismissed stale CHANGES_REQUESTED review ${sr.id} on PR #${pr.number} (bot=${sr.user?.login})`
+          );
+        }
+      }
+    }
+
+    return dismissed;
+  }
+
+  private async listOpenPRs(projectPath: string): Promise<PROpen[]> {
+    const { stdout } = await this.execFileAsync(
+      'gh',
+      [
+        'pr',
+        'list',
+        '--state',
+        'open',
+        '--limit',
+        '50',
+        '--json',
+        'number,headRefOid,mergeStateStatus,reviewDecision,url',
+      ],
+      { cwd: projectPath, encoding: 'utf-8', timeout: 30_000 }
+    );
+    return JSON.parse(stdout) as PROpen[];
+  }
+
+  private async listReviews(projectPath: string, prNumber: number): Promise<PRReview[]> {
+    const { owner, repo } = this.repoCoords;
+    const { stdout } = await this.execFileAsync(
+      'gh',
+      ['api', `repos/${owner}/${repo}/pulls/${prNumber}/reviews`],
+      { cwd: projectPath, encoding: 'utf-8', timeout: 30_000 }
+    );
+    return JSON.parse(stdout) as PRReview[];
+  }
+
+  private async allChecksGreen(projectPath: string, prNumber: number): Promise<boolean> {
+    const { stdout } = await this.execFileAsync(
+      'gh',
+      ['pr', 'view', String(prNumber), '--json', 'statusCheckRollup'],
+      { cwd: projectPath, encoding: 'utf-8', timeout: 30_000 }
+    );
+    const parsed = JSON.parse(stdout) as { statusCheckRollup: PRCheck[] };
+    const checks = parsed.statusCheckRollup ?? [];
+    // Conservative: there must be at least one completed check, and zero
+    // failures. If anything is still IN_PROGRESS / QUEUED, we hold off — the
+    // dismissal will happen on a later sweep when CI settles.
+    const completed = checks.filter((c) => c.status === 'COMPLETED');
+    if (completed.length === 0) return false;
+    if (completed.length < checks.filter((c) => c.name).length) return false;
+    return completed.every(
+      (c) => c.conclusion === 'SUCCESS' || c.conclusion === 'SKIPPED' || c.conclusion === 'NEUTRAL'
+    );
+  }
+
+  private async dismiss(
+    projectPath: string,
+    prNumber: number,
+    reviewId: number,
+    message: string
+  ): Promise<boolean> {
+    const { owner, repo } = this.repoCoords;
+    try {
+      await this.execFileAsync(
+        'gh',
+        [
+          'api',
+          `repos/${owner}/${repo}/pulls/${prNumber}/reviews/${reviewId}/dismissals`,
+          '-X',
+          'PUT',
+          '-f',
+          `message=${message}`,
+        ],
+        { cwd: projectPath, encoding: 'utf-8', timeout: 30_000 }
+      );
+      return true;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn(`Failed to dismiss review ${reviewId} on PR #${prNumber}: ${msg}`);
+      return false;
+    }
+  }
+}

--- a/apps/server/tests/unit/services/maintenance/auto-dismiss-stale-bot-reviews-check.test.ts
+++ b/apps/server/tests/unit/services/maintenance/auto-dismiss-stale-bot-reviews-check.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Tests for AutoDismissStaleBotReviewsCheck — see #3732.
+ *
+ * The check looks for the exact "stale CHANGES_REQUESTED from a bot" shape
+ * and dismisses the review when:
+ *  1. PR is OPEN, BLOCKED, with reviewDecision: CHANGES_REQUESTED
+ *  2. The blocking review's author is a `[bot]` user
+ *  3. The blocking review's commit is NOT the current head
+ *  4. The same bot has a later COMMENTED or APPROVED review
+ *  5. CI on the head is all-green
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AutoDismissStaleBotReviewsCheck } from '@/services/maintenance/checks/auto-dismiss-stale-bot-reviews-check.js';
+
+interface MockCall {
+  args: string[];
+  result: { stdout: string; stderr: string };
+}
+
+function buildExec(responses: Map<string, string>): {
+  exec: (
+    file: string,
+    args: string[],
+    options: { cwd?: string; encoding: string; timeout: number }
+  ) => Promise<{ stdout: string; stderr: string }>;
+  calls: MockCall[];
+} {
+  const calls: MockCall[] = [];
+  const exec = vi
+    .fn()
+    .mockImplementation(
+      async (
+        _file: string,
+        args: string[],
+        _options: { cwd?: string; encoding: string; timeout: number }
+      ) => {
+        const key = args.join(' ');
+        for (const [pattern, stdout] of responses) {
+          if (key.includes(pattern)) {
+            const result = { stdout, stderr: '' };
+            calls.push({ args, result });
+            return result;
+          }
+        }
+        // Default: rejecting unmocked calls makes the test fail loud rather than
+        // pass on a missing response. Dismissal calls (the action under test)
+        // return empty stdout — match them via the 'dismissals' pattern below.
+        throw new Error(`unmocked gh call: ${key}`);
+      }
+    );
+  return { exec, calls };
+}
+
+const REPO_COORDS = { owner: 'protoLabsAI', repo: 'protoMaker' };
+const PROJECT_PATH = '/test/project';
+
+describe('AutoDismissStaleBotReviewsCheck (#3732)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('dismisses a CHANGES_REQUESTED that was superseded by a COMMENTED on a later commit', async () => {
+    const head = 'b59a3706c71af6c51bf667387d1209f4de28b952';
+    const oldCommit = '89d367384e1ca5d496b3655007a69666192b6bb3';
+
+    const responses = new Map<string, string>();
+    responses.set(
+      'pr list --state open',
+      JSON.stringify([
+        {
+          number: 3691,
+          headRefOid: head,
+          mergeStateStatus: 'BLOCKED',
+          reviewDecision: 'CHANGES_REQUESTED',
+          url: 'https://github.com/protoLabsAI/protoMaker/pull/3691',
+        },
+      ])
+    );
+    responses.set(
+      'repos/protoLabsAI/protoMaker/pulls/3691/reviews',
+      JSON.stringify([
+        {
+          id: 4352033760,
+          user: { login: 'protoquinn[bot]' },
+          state: 'CHANGES_REQUESTED',
+          commit_id: oldCommit,
+          submitted_at: '2026-05-24T08:36:54Z',
+        },
+        {
+          id: 4352052824,
+          user: { login: 'protoquinn[bot]' },
+          state: 'COMMENTED',
+          commit_id: head,
+          submitted_at: '2026-05-24T08:56:37Z',
+        },
+      ])
+    );
+    responses.set(
+      'pr view 3691 --json statusCheckRollup',
+      JSON.stringify({
+        statusCheckRollup: [
+          { name: 'checks', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { name: 'build', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { name: 'test', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { name: 'review', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { name: 'ci-complete', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          {
+            name: 'Close external code contributions',
+            status: 'COMPLETED',
+            conclusion: 'SKIPPED',
+          },
+        ],
+      })
+    );
+    responses.set('dismissals', JSON.stringify({ ok: true }));
+
+    const { exec, calls } = buildExec(responses);
+    const check = new AutoDismissStaleBotReviewsCheck(REPO_COORDS, exec);
+
+    const issues = await check.run(PROJECT_PATH);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      checkId: 'auto-dismiss-stale-bot-reviews',
+      severity: 'info',
+      context: { prNumber: 3691, reviewId: 4352033760, headSha: head },
+    });
+    // The dismissal call landed
+    expect(calls.some((c) => c.args.join(' ').includes('dismissals'))).toBe(true);
+  });
+
+  it('does NOT dismiss when the CHANGES_REQUESTED is on the current head', async () => {
+    const head = 'aaaaaaaa';
+    const responses = new Map<string, string>();
+    responses.set(
+      'pr list --state open',
+      JSON.stringify([
+        {
+          number: 100,
+          headRefOid: head,
+          mergeStateStatus: 'BLOCKED',
+          reviewDecision: 'CHANGES_REQUESTED',
+          url: 'u',
+        },
+      ])
+    );
+    responses.set(
+      'pulls/100/reviews',
+      JSON.stringify([
+        {
+          id: 1,
+          user: { login: 'protoquinn[bot]' },
+          state: 'CHANGES_REQUESTED',
+          commit_id: head, // current head — not stale
+          submitted_at: '2026-05-24T00:00:00Z',
+        },
+      ])
+    );
+    // No statusCheckRollup call expected; check should bail before that.
+
+    const { exec, calls } = buildExec(responses);
+    const check = new AutoDismissStaleBotReviewsCheck(REPO_COORDS, exec);
+
+    const issues = await check.run(PROJECT_PATH);
+
+    expect(issues).toEqual([]);
+    expect(calls.every((c) => !c.args.join(' ').includes('dismissals'))).toBe(true);
+  });
+
+  it('does NOT dismiss when there is no later COMMENTED/APPROVED from the same bot', async () => {
+    const responses = new Map<string, string>();
+    responses.set(
+      'pr list --state open',
+      JSON.stringify([
+        {
+          number: 200,
+          headRefOid: 'newhead',
+          mergeStateStatus: 'BLOCKED',
+          reviewDecision: 'CHANGES_REQUESTED',
+          url: 'u',
+        },
+      ])
+    );
+    responses.set(
+      'pulls/200/reviews',
+      JSON.stringify([
+        {
+          id: 1,
+          user: { login: 'protoquinn[bot]' },
+          state: 'CHANGES_REQUESTED',
+          commit_id: 'oldhead',
+          submitted_at: '2026-05-24T00:00:00Z',
+        },
+        // The follow-up is from a DIFFERENT bot — should not satisfy the guard.
+        {
+          id: 2,
+          user: { login: 'coderabbitai[bot]' },
+          state: 'COMMENTED',
+          commit_id: 'newhead',
+          submitted_at: '2026-05-24T01:00:00Z',
+        },
+      ])
+    );
+
+    const { exec, calls } = buildExec(responses);
+    const check = new AutoDismissStaleBotReviewsCheck(REPO_COORDS, exec);
+
+    const issues = await check.run(PROJECT_PATH);
+
+    expect(issues).toEqual([]);
+    expect(calls.every((c) => !c.args.join(' ').includes('dismissals'))).toBe(true);
+  });
+
+  it('does NOT dismiss when the blocking review is from a human, not a bot', async () => {
+    const responses = new Map<string, string>();
+    responses.set(
+      'pr list --state open',
+      JSON.stringify([
+        {
+          number: 300,
+          headRefOid: 'newhead',
+          mergeStateStatus: 'BLOCKED',
+          reviewDecision: 'CHANGES_REQUESTED',
+          url: 'u',
+        },
+      ])
+    );
+    responses.set(
+      'pulls/300/reviews',
+      JSON.stringify([
+        {
+          id: 1,
+          user: { login: 'mabry1985' }, // human, no [bot] suffix
+          state: 'CHANGES_REQUESTED',
+          commit_id: 'oldhead',
+          submitted_at: '2026-05-24T00:00:00Z',
+        },
+        {
+          id: 2,
+          user: { login: 'mabry1985' },
+          state: 'COMMENTED',
+          commit_id: 'newhead',
+          submitted_at: '2026-05-24T01:00:00Z',
+        },
+      ])
+    );
+
+    const { exec } = buildExec(responses);
+    const check = new AutoDismissStaleBotReviewsCheck(REPO_COORDS, exec);
+
+    const issues = await check.run(PROJECT_PATH);
+
+    expect(issues).toEqual([]);
+  });
+
+  it('does NOT dismiss when CI has a failure on the current head', async () => {
+    const head = 'newhead';
+    const responses = new Map<string, string>();
+    responses.set(
+      'pr list --state open',
+      JSON.stringify([
+        {
+          number: 400,
+          headRefOid: head,
+          mergeStateStatus: 'BLOCKED',
+          reviewDecision: 'CHANGES_REQUESTED',
+          url: 'u',
+        },
+      ])
+    );
+    responses.set(
+      'pulls/400/reviews',
+      JSON.stringify([
+        {
+          id: 1,
+          user: { login: 'protoquinn[bot]' },
+          state: 'CHANGES_REQUESTED',
+          commit_id: 'oldhead',
+          submitted_at: '2026-05-24T00:00:00Z',
+        },
+        {
+          id: 2,
+          user: { login: 'protoquinn[bot]' },
+          state: 'COMMENTED',
+          commit_id: head,
+          submitted_at: '2026-05-24T01:00:00Z',
+        },
+      ])
+    );
+    responses.set(
+      'pr view 400 --json statusCheckRollup',
+      JSON.stringify({
+        statusCheckRollup: [
+          { name: 'checks', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { name: 'test', status: 'COMPLETED', conclusion: 'FAILURE' }, // ← fails
+        ],
+      })
+    );
+
+    const { exec, calls } = buildExec(responses);
+    const check = new AutoDismissStaleBotReviewsCheck(REPO_COORDS, exec);
+
+    const issues = await check.run(PROJECT_PATH);
+
+    expect(issues).toEqual([]);
+    expect(calls.every((c) => !c.args.join(' ').includes('dismissals'))).toBe(true);
+  });
+
+  it('does NOT dismiss when CI is still IN_PROGRESS (waits for stable state)', async () => {
+    const responses = new Map<string, string>();
+    responses.set(
+      'pr list --state open',
+      JSON.stringify([
+        {
+          number: 500,
+          headRefOid: 'newhead',
+          mergeStateStatus: 'BLOCKED',
+          reviewDecision: 'CHANGES_REQUESTED',
+          url: 'u',
+        },
+      ])
+    );
+    responses.set(
+      'pulls/500/reviews',
+      JSON.stringify([
+        {
+          id: 1,
+          user: { login: 'protoquinn[bot]' },
+          state: 'CHANGES_REQUESTED',
+          commit_id: 'oldhead',
+          submitted_at: '2026-05-24T00:00:00Z',
+        },
+        {
+          id: 2,
+          user: { login: 'protoquinn[bot]' },
+          state: 'COMMENTED',
+          commit_id: 'newhead',
+          submitted_at: '2026-05-24T01:00:00Z',
+        },
+      ])
+    );
+    responses.set(
+      'pr view 500 --json statusCheckRollup',
+      JSON.stringify({
+        statusCheckRollup: [
+          { name: 'checks', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { name: 'test', status: 'IN_PROGRESS', conclusion: null },
+        ],
+      })
+    );
+
+    const { exec } = buildExec(responses);
+    const check = new AutoDismissStaleBotReviewsCheck(REPO_COORDS, exec);
+
+    const issues = await check.run(PROJECT_PATH);
+
+    expect(issues).toEqual([]);
+  });
+
+  it('skips PRs that are not BLOCKED or do not have CHANGES_REQUESTED', async () => {
+    const responses = new Map<string, string>();
+    responses.set(
+      'pr list --state open',
+      JSON.stringify([
+        // CLEAN — no action
+        {
+          number: 601,
+          headRefOid: 'h',
+          mergeStateStatus: 'CLEAN',
+          reviewDecision: '',
+          url: 'u',
+        },
+        // BLOCKED but for a different reason (no CHANGES_REQUESTED)
+        {
+          number: 602,
+          headRefOid: 'h',
+          mergeStateStatus: 'BLOCKED',
+          reviewDecision: '',
+          url: 'u',
+        },
+      ])
+    );
+
+    const { exec } = buildExec(responses);
+    const check = new AutoDismissStaleBotReviewsCheck(REPO_COORDS, exec);
+
+    const issues = await check.run(PROJECT_PATH);
+
+    expect(issues).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3732. Adds a maintenance check that detects and dismisses bot CHANGES_REQUESTED reviews that have been superseded by later COMMENTED/APPROVED reviews on subsequent commits, when CI is green on the current head.

## Why

GitHub branch protection only clears a CHANGES_REQUESTED review when the reviewer dismisses it explicitly OR submits a fresh APPROVED. Our review bots routinely re-review fix commits with COMMENTED (acknowledging the fix without escalating), which does NOT clear the blocking state.

Today (session), we hit this on three PRs (#3660, #3691, plus the crew dispatch flow) and had to manually dismiss each blocking review. This check eliminates that toil.

## Detection criteria — all must hold

1. PR is OPEN, `mergeStateStatus: BLOCKED`, `reviewDecision: CHANGES_REQUESTED`
2. The blocking review's author is a `[bot]` user
3. The blocking review's commit is NOT the current head
4. The same bot has posted a later COMMENTED or APPROVED review
5. All CI checks on head are COMPLETED + SUCCESS/SKIPPED/NEUTRAL (no FAILURE, no IN_PROGRESS)

When all five hold, dismiss with a message citing the follow-up review and head SHA.

## Test plan

7 new unit tests in `apps/server/tests/unit/services/maintenance/auto-dismiss-stale-bot-reviews-check.test.ts`:

- [x] Happy path: dismiss when superseded by COMMENTED on later commit
- [x] Skip when CHANGES_REQUESTED is on current head (not stale)
- [x] Skip when follow-up is from a different bot
- [x] Skip when blocking review is from a human
- [x] Skip when CI has a FAILURE on head
- [x] Skip when CI is still IN_PROGRESS (wait for stable state)
- [x] Skip when PR is not BLOCKED or has no CHANGES_REQUESTED decision

Full server suite: 3449/3449 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new maintenance check that automatically dismisses outdated blocking bot reviews on pull requests. The check runs when a blocking review from a bot has been superseded by a newer approval from the same bot and all required CI status checks pass (full tier).

* **Tests**
  * Added comprehensive unit test suite validating dismissal conditions and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3744?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->