### PR TITLE
fix(server): gateway-key startup guard + A2A native-session skill routing

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -32,6 +32,7 @@ import { createLogger, registerLogTransport } from '@protolabsai/utils';
 import { MAX_SYSTEM_CONCURRENCY } from '@protolabsai/types';
 import { createFileLogTransport } from './lib/server-log.js';
 import { isTerminalEnabled, isTerminalPasswordRequired } from './routes/terminal/index.js';
+import { hasGatewayKey } from './lib/ai-provider.js';
 
 import {
   setupMiddleware,
@@ -153,6 +154,30 @@ server.listen(PORT, HOST, () => {
 ║                                                                     ║
 ╚═════════════════════════════════════════════════════════════════════╝
 `);
+
+  // Gateway key gate (#3771): a server with no gateway credential serves
+  // happily but 401s every model call — chat, sitrep, A2A, auto-mode. That
+  // failure mode ran undetected for ~18h once. Surface it loudly at boot so
+  // an operator notices immediately instead of grepping request logs.
+  void hasGatewayKey()
+    .then((present) => {
+      if (!present) {
+        logger.error(
+          '\n' +
+            '╔═════════════════════════════════════════════════════════════════════╗\n' +
+            '║  ⚠️  NO GATEWAY API KEY — every model call will 401                  ║\n' +
+            '║                                                                     ║\n' +
+            '║  chat, sitrep, A2A delegation, and auto-mode execution will all     ║\n' +
+            '║  fail. Set GATEWAY_API_KEY (or OPENAI_API_KEY) in the server env,   ║\n' +
+            '║  or configure a key in Settings. The provider re-resolves per       ║\n' +
+            '║  request, so adding the key recovers without a restart.             ║\n' +
+            '╚═════════════════════════════════════════════════════════════════════╝'
+        );
+      }
+    })
+    .catch(() => {
+      /* resolution failure is itself a keyless signal — already logged by resolveApiKey */
+    });
 });
 
 server.on('error', (error: NodeJS.ErrnoException) => {

--- a/apps/server/src/lib/ai-provider.ts
+++ b/apps/server/src/lib/ai-provider.ts
@@ -94,18 +94,32 @@ async function getOrCreateProvider(): Promise<ReturnType<typeof createOpenAIComp
   if (!key) {
     logger.warn(
       'No gateway API key found. Chat requests will fail. ' +
-        'Set GATEWAY_API_KEY in the server environment or enter a key in Settings.'
+        'Set GATEWAY_API_KEY in the server environment or enter a key in Settings. ' +
+        'Not caching the provider — it will re-resolve on the next request.'
     );
-  } else {
-    logger.info(`Gateway provider initialized: baseURL=${baseURL} keySource=${source}`);
+    // Transient provider — intentionally NOT cached so a later key addition
+    // (env or Settings) recovers without a full restart (#3771). Caching an
+    // empty-key provider previously wedged the whole process until restart.
+    return createOpenAICompatible({ name: 'protolabs-gateway', baseURL, apiKey: key });
   }
 
+  logger.info(`Gateway provider initialized: baseURL=${baseURL} keySource=${source}`);
   cachedProvider = createOpenAICompatible({
     name: 'protolabs-gateway',
     baseURL,
     apiKey: key,
   });
   return cachedProvider;
+}
+
+/**
+ * Whether a gateway key currently resolves. Used by the startup health gate
+ * to surface a keyless server loudly instead of letting every model call
+ * silently 401. See #3771.
+ */
+export async function hasGatewayKey(): Promise<boolean> {
+  const { key } = await resolveApiKey();
+  return key.length > 0;
 }
 
 /**

--- a/apps/server/src/routes/a2a/index.ts
+++ b/apps/server/src/routes/a2a/index.ts
@@ -33,7 +33,8 @@ import { ProviderFactory } from '../../providers/provider-factory.js';
 import { resolveModelString } from '@protolabsai/model-resolver';
 import type { PlanningService } from '../../services/planning-service.js';
 import type { SettingsService } from '../../services/settings-service.js';
-import { getWorkflowSettings } from '../../lib/settings-helpers.js';
+import { getWorkflowSettings, getMCPServersFromSettings } from '../../lib/settings-helpers.js';
+import type { McpServerConfig } from '@protolabsai/types';
 
 const logger = createLogger('A2ARoutes');
 
@@ -284,7 +285,16 @@ function extractText(parts: Array<{ kind?: string; type?: string; text?: string 
     .trim();
 }
 
-/** Collect SSE text-delta events from the chat endpoint into a single string */
+/**
+ * Collect SSE text-delta events from the chat endpoint into a single string.
+ *
+ * Throws if the stream emitted an `error` event and produced no text. A chat
+ * stream that errors (e.g. gateway 401) used to be swallowed here — the
+ * caller got an empty string and the A2A handler returned `state: completed`
+ * with an empty artifact, telling the fleet the skill succeeded when it
+ * didn't (#3771). Surfacing the error lets message/send return a JSON-RPC
+ * error so the caller can retry or route elsewhere.
+ */
 async function collectChatResponse(chatResponse: globalThis.Response): Promise<string> {
   const reader = chatResponse.body?.getReader();
   if (!reader) return '';
@@ -292,6 +302,7 @@ async function collectChatResponse(chatResponse: globalThis.Response): Promise<s
   const decoder = new TextDecoder();
   const chunks: string[] = [];
   const seenTypes = new Set<string>();
+  let streamErrorText: string | undefined;
 
   while (true) {
     const { done, value } = await reader.read();
@@ -306,6 +317,10 @@ async function collectChatResponse(chatResponse: globalThis.Response): Promise<s
         if (payload.type) seenTypes.add(String(payload.type));
         if (payload.type === 'text-delta' && typeof payload.delta === 'string') {
           chunks.push(payload.delta);
+        } else if (payload.type === 'error' && typeof payload.errorText === 'string') {
+          // Keep the first concrete error; later "No output generated" is a
+          // downstream symptom of the same failure.
+          if (!streamErrorText) streamErrorText = payload.errorText;
         }
       } catch {
         // non-JSON data line — skip
@@ -315,6 +330,10 @@ async function collectChatResponse(chatResponse: globalThis.Response): Promise<s
 
   const result = chunks.join('');
   if (result.length === 0) {
+    if (streamErrorText) {
+      logger.error(`collectChatResponse: stream error with no output — ${streamErrorText}`);
+      throw new Error(`chat stream error: ${streamErrorText}`);
+    }
     logger.warn(`collectChatResponse: 0 chars — event types seen: [${[...seenTypes].join(', ')}]`);
   }
   return result;
@@ -359,11 +378,21 @@ const CLAUDE_CODE_NATIVE_TOOLS = new Set([
 interface SkillMeta {
   body: string;
   allowedTools: string[];
+  /** True only if EVERY tool is a Claude Code native tool. */
   isNativeTool: boolean;
+  /**
+   * True if the skill lists ANY Claude Code native tool (Bash, Read, etc.).
+   * Such skills must run via executeQuery — the /api/chat (Vercel AI SDK) path
+   * has the Ava board tools but NOT Bash/Read/Write, so a mixed native+MCP
+   * skill like board_health silently degrades there (the model narrates a
+   * shell command it can't run). See #3772.
+   */
+  needsNativeSession: boolean;
 }
 
-/** Load a skill file and parse its frontmatter. Returns null if not found. */
-async function loadSkill(projectPath: string, skillName: string): Promise<SkillMeta | null> {
+/** Load a skill file and parse its frontmatter. Returns null if not found.
+ *  Exported for testing the native-session classification (#3772). */
+export async function loadSkill(projectPath: string, skillName: string): Promise<SkillMeta | null> {
   const skillPath = join(projectPath, '.claude', 'skills', `${skillName}.md`);
   let raw: string;
   try {
@@ -374,7 +403,8 @@ async function loadSkill(projectPath: string, skillName: string): Promise<SkillM
 
   // Parse YAML frontmatter between --- delimiters
   const fmMatch = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
-  if (!fmMatch) return { body: raw, allowedTools: [], isNativeTool: false };
+  if (!fmMatch)
+    return { body: raw, allowedTools: [], isNativeTool: false, needsNativeSession: false };
 
   const [, frontmatter, body] = fmMatch;
 
@@ -398,19 +428,26 @@ async function loadSkill(projectPath: string, skillName: string): Promise<SkillM
 
   const isNativeTool =
     toolLines.length > 0 && toolLines.every((t) => CLAUDE_CODE_NATIVE_TOOLS.has(t));
+  const needsNativeSession = toolLines.some((t) => CLAUDE_CODE_NATIVE_TOOLS.has(t));
 
-  return { body: body.trim(), allowedTools: toolLines, isNativeTool };
+  return { body: body.trim(), allowedTools: toolLines, isNativeTool, needsNativeSession };
 }
 
 /**
- * Execute a skill using the Claude Code SDK (ProviderFactory.executeQuery).
- * Used when the skill's allowed-tools are all native Claude Code tools
- * (Bash, Read, Write, etc.) which are not available in Ava's Vercel AI SDK path.
+ * Execute a skill via the Claude Code SDK (ProviderFactory.executeQuery).
+ * Used for any skill that needs Claude Code native tools (Bash, Read, Write,
+ * etc.) — these are unavailable in Ava's Vercel AI SDK chat path.
+ *
+ * Mixed skills (native + MCP tools, e.g. board_health which needs Bash AND
+ * mcp__plugin_protolabs_studio__*) get their MCP servers wired here via
+ * `mcpServers` so the mcp__ tools in `allowedTools` actually resolve. Without
+ * this the MCP tools would be allow-listed but have no backing server (#3772).
  */
 async function executeNativeSkill(
   projectPath: string,
   skill: SkillMeta,
-  userText: string
+  userText: string,
+  mcpServers?: Record<string, McpServerConfig>
 ): Promise<string> {
   if (!projectPath) {
     throw new Error(
@@ -427,6 +464,7 @@ async function executeNativeSkill(
     cwd: projectPath,
     maxTurns: 30,
     allowedTools: skill.allowedTools,
+    ...(mcpServers && Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
   });
 
   let responseText = '';
@@ -1132,16 +1170,29 @@ export function createA2AHandlerRoutes(projectPath: string, deps?: A2AHandlerDep
     try {
       let responseText: string;
 
-      // When a skill is requested, check if it needs Claude Code native tools (Bash,
-      // Read, Write, etc.). If so, bypass /api/chat and run via ProviderFactory.executeQuery
-      // which has the full Claude Code SDK tool set. Otherwise use /api/chat as before.
+      // When a skill is requested, check if it needs Claude Code native tools
+      // (Bash, Read, Write, etc.). If it lists ANY native tool, bypass /api/chat
+      // and run via ProviderFactory.executeQuery — the chat path has Ava's board
+      // tools but no Bash/Read/Write, so a skill that needs them silently
+      // degrades there (the model narrates a shell command it can't run, #3772).
+      // Mixed skills (native + MCP, e.g. board_health) also get their MCP
+      // servers wired so the mcp__ tools resolve in the SDK session.
       if (skillOverride) {
         const skill = await loadSkill(effectiveProjectPath, skillOverride);
-        if (skill?.isNativeTool) {
+        if (skill?.needsNativeSession) {
           logger.info(
-            `A2A skill "${skillOverride}" uses native tools [${skill.allowedTools.join(', ')}] — routing via executeQuery`
+            `A2A skill "${skillOverride}" needs a native session [${skill.allowedTools.join(', ')}] — routing via executeQuery`
           );
-          responseText = await executeNativeSkill(effectiveProjectPath, skill, userText);
+          const mcpServers = await getMCPServersFromSettings(deps?.settingsService, '[A2A]', {
+            context: 'agents',
+            projectPath: effectiveProjectPath,
+          });
+          responseText = await executeNativeSkill(
+            effectiveProjectPath,
+            skill,
+            userText,
+            mcpServers
+          );
         } else {
           // Skill not found, has no tool restrictions, or uses Ava board tools → /api/chat
           responseText = await callChatEndpointWithRetry(

--- a/apps/server/tests/unit/routes/a2a-skill-routing.test.ts
+++ b/apps/server/tests/unit/routes/a2a-skill-routing.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for A2A native-session skill routing (#3772).
+ *
+ * A skill that lists ANY Claude Code native tool (Bash, Read, Write, ...) must
+ * route through executeNativeSkill (the Claude Code SDK path), NOT /api/chat
+ * (the Vercel AI SDK path) which has no Bash. Mixed native+MCP skills like
+ * board_health were silently degrading on the chat path — the model narrated a
+ * shell command it couldn't run.
+ *
+ * `loadSkill` computes the two classification flags. These tests assert against
+ * the real skill files shipped in .claude/skills/ plus temp fixtures for the
+ * pure-MCP and pure-native cases.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadSkill } from '@/routes/a2a/index.js';
+
+// Repo root — .claude/skills/board_health.md lives here.
+const REPO_ROOT = join(__dirname, '..', '..', '..', '..', '..');
+
+describe('A2A loadSkill native-session classification (#3772)', () => {
+  it('board_health (Bash + Read + MCP tools) needs a native session but is not all-native', async () => {
+    const skill = await loadSkill(REPO_ROOT, 'board_health');
+    expect(skill).not.toBeNull();
+    // Mixed: lists Bash/Read (native) AND mcp__plugin_* (not native)
+    expect(skill!.needsNativeSession).toBe(true);
+    expect(skill!.isNativeTool).toBe(false);
+    expect(skill!.allowedTools).toContain('Bash');
+    expect(skill!.allowedTools.some((t) => t.startsWith('mcp__'))).toBe(true);
+  });
+
+  it('returns null for an unknown skill (falls through to chat path)', async () => {
+    const skill = await loadSkill(REPO_ROOT, 'does-not-exist-skill');
+    expect(skill).toBeNull();
+  });
+
+  describe('with temp fixtures', () => {
+    let dir: string;
+
+    beforeAll(() => {
+      dir = mkdtempSync(join(tmpdir(), 'a2a-skill-routing-'));
+      mkdirSync(join(dir, '.claude', 'skills'), { recursive: true });
+
+      // Pure-native skill — every tool is a Claude Code native tool.
+      writeFileSync(
+        join(dir, '.claude', 'skills', 'pure-native.md'),
+        `---
+name: pure-native
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+---
+Do native things.`
+      );
+
+      // Pure-MCP skill — no native tools, only MCP / board tools.
+      writeFileSync(
+        join(dir, '.claude', 'skills', 'pure-mcp.md'),
+        `---
+name: pure-mcp
+allowed-tools:
+  - mcp__plugin_protolabs_studio__list_features
+  - mcp__plugin_protolabs_studio__create_feature
+---
+Do board things.`
+      );
+
+      // No allowed-tools at all.
+      writeFileSync(
+        join(dir, '.claude', 'skills', 'no-tools.md'),
+        `---
+name: no-tools
+---
+Just talk.`
+      );
+    });
+
+    afterAll(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('pure-native → needsNativeSession AND isNativeTool', async () => {
+      const skill = await loadSkill(dir, 'pure-native');
+      expect(skill!.needsNativeSession).toBe(true);
+      expect(skill!.isNativeTool).toBe(true);
+    });
+
+    it('pure-mcp → neither (routes to chat path, which has board tools)', async () => {
+      const skill = await loadSkill(dir, 'pure-mcp');
+      expect(skill!.needsNativeSession).toBe(false);
+      expect(skill!.isNativeTool).toBe(false);
+    });
+
+    it('no allowed-tools → neither', async () => {
+      const skill = await loadSkill(dir, 'no-tools');
+      expect(skill!.needsNativeSession).toBe(false);
+      expect(skill!.isNativeTool).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Two fixes from today's A2A board test. Closes #3771 and #3772.

## #3771 — silent keyless server (high)

The server ran ~18h with no `GATEWAY_API_KEY`, 401ing **every** model call (chat, sitrep, A2A delegation, auto-mode execution) with nothing surfaced but a buried WARN.

- **`ai-provider.ts`** — no longer caches an empty-key provider. A keyless boot cached an empty provider for the whole process lifetime, so even after the key was added every request kept 401ing until a full restart. Empty resolution now returns a transient (uncached) provider; adding the key recovers on the next request. New `hasGatewayKey()` export.
- **`index.ts`** — loud `logger.error` banner at startup when no gateway key resolves.
- **`a2a/index.ts` `collectChatResponse`** — when the chat stream emits an `error` event and produces no text, throw instead of returning `''`. The handler's catch turns it into a JSON-RPC error, so callers stop getting `state: completed` + empty artifact (a completed task with no output falsely tells the fleet a delegation succeeded).

## #3772 — native-session skill routing (medium)

`board_health` via A2A returned a hallucinated `cat workspace/projects.yaml` instead of running, because it routed to the `/api/chat` (Vercel AI SDK) path which has no Bash.

- **`loadSkill`** now computes `needsNativeSession` (skill lists ANY Claude Code native tool) alongside `isNativeTool` (ALL native). Mixed native+MCP skills like `board_health` (`Bash` + `Read` + `mcp__plugin_*`) now route through `executeNativeSkill` (the SDK path with Bash) instead of degrading on chat.
- **`executeNativeSkill`** now wires `mcpServers` (from `getMCPServersFromSettings`) so a mixed skill's `mcp__` tools resolve in the SDK session.

**Verified live:** board_health now runs real `gh pr list` stale-PR detection across the fleet (found 4 stale in protoWorkstacean, 8 in rabbit-hole.io) instead of narrating a fake command. Its `mcp__plugin_protolabs_studio` tools require that MCP plugin to be configured in server settings (a per-deploy config matter — only `context7` ships as a default); the skill degrades gracefully when absent.

## Tests

- New `a2a-skill-routing.test.ts` (5 tests) — asserts `needsNativeSession`/`isNativeTool` classification against the real `board_health.md` + temp fixtures (pure-native, pure-MCP, no-tools).
- Full server suite: **3454/3454 pass**. Typecheck clean.

## Follow-up (not in this PR)

- The A2A streaming variant (`handleA2AMessageStream`) doesn't do native-session routing — only `message/send` does. The fleet uses non-streaming (`streaming: false` in agents.yaml), so low priority, but worth aligning.
- Configuring the `plugin_protolabs_studio` MCP server in deploy settings so board_health's create_feature / discord_send tools work end-to-end.

Closes #3771
Closes #3772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup validation for gateway API key configuration with clear error messaging.
  * Enhanced skill execution routing to support mixed native and MCP tool scenarios.

* **Bug Fixes**
  * Fixed issue where missing API key prevented reconfiguration without server restart.
  * Improved error handling to properly surface upstream chat failures instead of silent failures.

* **Tests**
  * Added unit test suite for skill routing and native session classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->