### PR TITLE
chore: conform protoMaker to workspace-config standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,9 @@ gource.mp4
 test/fixtures/**/.automaker/
 # Worktree directories (managed by protoLabs Studio)
 .claude/worktrees/
+
+# protoLabs workspace-config standard
+.beads/beads.db
+.automaker/features/
+.automaker/checkpoints/
+.automaker/trajectory/


### PR DESCRIPTION
Adds the workspace-config standard `.gitignore` lines (`.beads/beads.db` + `.automaker/features|checkpoints|trajectory`). protoMaker already commits `.beads/issues.jsonl` and `.automaker/settings.json`, so this clears the last `verify-workspace-config` error.

Generated by `release-tools init-workspace-config`. protoMaker now passes the standard clean (verified locally with the git-tracked fix from release-tools #15).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to exclude additional workspace configuration files and database files from source control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->