### PR TITLE
fix(server): harden agent against HOME tmpfs fill corrupting .claude.json (#3564)

### DIFF
--- a/apps/server/src/providers/claude-provider.ts
+++ b/apps/server/src/providers/claude-provider.ts
@@ -20,6 +20,7 @@ import {
   type ClaudeCompatibleProvider,
   type Credentials,
 } from '@protolabsai/types';
+import { resolve as resolvePath } from 'node:path';
 import { BaseProvider } from './base-provider.js';
 import { classifyError, getUserFriendlyErrorMessage, createLogger } from '@protolabsai/utils';
 
@@ -82,6 +83,11 @@ const SYSTEM_ENV_VARS = [
   'USER',
   'LANG',
   'LC_ALL',
+  // npm cache location. Propagated so a deployment can point it off a small
+  // HOME tmpfs; defaulted below when unset. Without this on the allowlist the
+  // agent's npm falls back to $HOME/.npm, which on the staging container is a
+  // 64M tmpfs that fills and truncates .claude.json mid-write (protoMaker#3564).
+  'NPM_CONFIG_CACHE',
   // Self-service API access (skills that call back to the server via A2A)
   'AUTOMAKER_API_KEY',
   'PORT',
@@ -219,6 +225,18 @@ function buildEnv(
     if (process.env[key]) {
       env[key] = process.env[key];
     }
+  }
+
+  // Default the npm cache off the HOME tmpfs when a deployment hasn't set it.
+  // npm otherwise caches to $HOME/.npm; on the staging container $HOME is a
+  // 64M tmpfs that fills and then silently truncates sibling files like
+  // .claude.json mid-write, surfacing as bogus auth failures (protoMaker#3564).
+  // Point it at the server's persistent data dir instead — npm creates the
+  // directory on first use. An explicit NPM_CONFIG_CACHE (propagated above)
+  // always wins so infra can override.
+  if (!env['NPM_CONFIG_CACHE']) {
+    const dataDir = resolvePath(process.env.DATA_DIR ?? './data');
+    env['NPM_CONFIG_CACHE'] = `${dataDir}/npm-cache`;
   }
 
   // Pass OTel telemetry config to subprocess for per-turn trace visibility.

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -622,7 +622,11 @@ export class AutoModeService {
     if (
       errorInfo.type === 'quota_exhausted' ||
       errorInfo.type === 'rate_limit' ||
-      errorInfo.type === 'network'
+      errorInfo.type === 'network' ||
+      // A corrupted/truncated config is environmental (disk full); respawning
+      // agents only writes more garbage to the shared .claude.json and makes it
+      // worse. Pause immediately so an operator can free space (protoMaker#3564).
+      errorInfo.type === 'config_corrupted'
     ) {
       return true;
     }

--- a/apps/server/src/services/maintenance.module.ts
+++ b/apps/server/src/services/maintenance.module.ts
@@ -23,6 +23,7 @@ import { DoneWorktreeCleanupCheck } from './maintenance/checks/done-worktree-cle
 import { EpicAdoptionSweepCheck } from './maintenance/checks/epic-adoption-sweep-check.js';
 import { BacklogTitleReconcilerCheck } from './maintenance/checks/backlog-title-reconciler-check.js';
 import { AutoDismissStaleBotReviewsCheck } from './maintenance/checks/auto-dismiss-stale-bot-reviews-check.js';
+import { DiskPressureCheck } from './maintenance/checks/disk-pressure-check.js';
 
 const logger = createLogger('Server:Wiring');
 
@@ -144,6 +145,41 @@ export function register(container: ServiceContainer): void {
     },
   };
 
+  // Disk pressure (full tier) — warns before the agent HOME volume fills and
+  // truncates .claude.json (protoMaker#3564). Instance-global: the volume is
+  // shared across projects, so we run it once per cycle rather than per project.
+  const diskPressureCheckInstance = new DiskPressureCheck();
+  const diskPressureCheck: MaintenanceCheck = {
+    id: 'disk-pressure',
+    name: 'Agent HOME Disk Pressure',
+    tier: 'full',
+    async run(_context: MaintenanceCheckContext): Promise<MaintenanceCheckResult> {
+      const t0 = Date.now();
+      let issues: Awaited<ReturnType<DiskPressureCheck['run']>> = [];
+      try {
+        issues = await diskPressureCheckInstance.run('');
+        for (const issue of issues) {
+          logger.warn(`[disk-pressure] ${issue.message}`);
+        }
+      } catch (err) {
+        logger.error('Disk pressure check failed:', err);
+      }
+      return {
+        checkId: 'disk-pressure',
+        passed: issues.length === 0,
+        summary:
+          issues.length === 0
+            ? 'Disk pressure: agent HOME volume has healthy free space'
+            : (issues[0]?.message ?? 'Disk pressure detected'),
+        details: {
+          issueCount: issues.length,
+          critical: issues.some((i) => i.severity === 'critical'),
+        },
+        durationMs: Date.now() - t0,
+      };
+    },
+  };
+
   // Post-merge reconciler (critical tier) — poll fallback for missed PR merge webhooks.
   // Runs every 5 minutes alongside resource-usage. Catches the case where a PR merges
   // on a repo that has no GitHub webhook configured, preventing the feature from staying
@@ -238,6 +274,7 @@ export function register(container: ServiceContainer): void {
   maintenanceOrchestrator.register(epicAdoptionSweepCheck);
   maintenanceOrchestrator.register(backlogTitleReconcilerCheck);
   maintenanceOrchestrator.register(autoDismissStaleBotReviewsCheck);
+  maintenanceOrchestrator.register(diskPressureCheck);
 
   // Wire TopicBus for hierarchical event routing of sweep results
   if (container.topicBus) {

--- a/apps/server/src/services/maintenance/checks/disk-pressure-check.ts
+++ b/apps/server/src/services/maintenance/checks/disk-pressure-check.ts
@@ -1,0 +1,90 @@
+/**
+ * DiskPressureCheck — warns when the agent HOME volume is running low on space.
+ *
+ * The agent runs with HOME on a volume that, in some deployments, is a small
+ * tmpfs (64M on the staging container). When it fills, the kernel silently
+ * truncates writes to sibling files like .claude.json / .credentials.json, and
+ * the Claude CLI then reports the config as "corrupted" — which masquerades as
+ * an auth failure and sends operators down the wrong path (protoMaker#3564).
+ *
+ * This check is the early-warning signal that issue lacked: it surfaces disk
+ * pressure as a 'warning' (>= warnPct) or 'critical' (>= criticalPct) issue
+ * BEFORE the volume fills and corrupts config.
+ *
+ * No auto-fix — freeing space / enlarging the volume / moving the npm cache off
+ * it is an operator (or infra) action.
+ */
+
+import { statfs } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { createLogger } from '@protolabsai/utils';
+import type { MaintenanceCheck, MaintenanceIssue } from '../types.js';
+
+const logger = createLogger('DiskPressureCheck');
+
+/** Percent-full at which we emit a warning. Override via DISK_PRESSURE_WARN_PCT. */
+export const DISK_PRESSURE_WARN_PCT = Number(process.env.DISK_PRESSURE_WARN_PCT ?? 80);
+/** Percent-full at which the issue escalates to critical. Override via DISK_PRESSURE_CRITICAL_PCT. */
+export const DISK_PRESSURE_CRITICAL_PCT = Number(process.env.DISK_PRESSURE_CRITICAL_PCT ?? 95);
+
+/** Minimal shape of node:fs StatFs we depend on (subset, for testability). */
+interface StatfsLike {
+  blocks: number;
+  bavail: number;
+  bsize: number;
+}
+
+export class DiskPressureCheck implements MaintenanceCheck {
+  readonly id = 'disk-pressure';
+
+  constructor(
+    private readonly homePathFn: () => string = () => process.env.HOME || homedir(),
+    private readonly statfsFn: (path: string) => Promise<StatfsLike> = (path) =>
+      statfs(path) as Promise<StatfsLike>,
+    private readonly warnPct: number = DISK_PRESSURE_WARN_PCT,
+    private readonly criticalPct: number = DISK_PRESSURE_CRITICAL_PCT
+  ) {}
+
+  // The HOME volume is instance-global, so the result is independent of
+  // projectPath — single-project installs (the common case) see one issue.
+  async run(_projectPath: string): Promise<MaintenanceIssue[]> {
+    const home = this.homePathFn();
+
+    try {
+      const stat = await this.statfsFn(home);
+      if (!stat.blocks || stat.blocks <= 0) {
+        return [];
+      }
+
+      const usedPct = ((stat.blocks - stat.bavail) / stat.blocks) * 100;
+      if (usedPct < this.warnPct) {
+        return [];
+      }
+
+      const severity = usedPct >= this.criticalPct ? 'critical' : 'warning';
+      const freeMb = Math.round((stat.bavail * stat.bsize) / (1024 * 1024));
+      const usedRounded = Math.round(usedPct * 10) / 10;
+
+      logger.warn(`DiskPressureCheck: ${home} is ${usedRounded}% full (${freeMb}MB free)`);
+
+      return [
+        {
+          checkId: this.id,
+          severity,
+          message: `Agent HOME volume ${home} is ${usedRounded}% full (${freeMb}MB free). When it fills, writes to .claude.json are silently truncated and surface as bogus auth failures (protoMaker#3564). Free space, enlarge the volume, or move NPM_CONFIG_CACHE off it.`,
+          autoFixable: false,
+          context: {
+            path: home,
+            usedPct: usedRounded,
+            freeMb,
+            warnPct: this.warnPct,
+            criticalPct: this.criticalPct,
+          },
+        },
+      ];
+    } catch (error) {
+      logger.error(`DiskPressureCheck failed for ${home}:`, error);
+      return [];
+    }
+  }
+}

--- a/apps/server/tests/unit/services/maintenance/checks/disk-pressure-check.test.ts
+++ b/apps/server/tests/unit/services/maintenance/checks/disk-pressure-check.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { DiskPressureCheck } from '@/services/maintenance/checks/disk-pressure-check.js';
+
+/** Build a statfs result with the given used percentage. */
+function statfsAtUsedPct(usedPct: number) {
+  const blocks = 1000;
+  const bavail = Math.round(blocks * (1 - usedPct / 100));
+  return { blocks, bavail, bsize: 4096 };
+}
+
+function makeCheck(usedPct: number, home = '/home/automaker') {
+  return new DiskPressureCheck(
+    () => home,
+    async () => statfsAtUsedPct(usedPct)
+  );
+}
+
+describe('DiskPressureCheck', () => {
+  it('returns no issues below the warning threshold', async () => {
+    const issues = await makeCheck(50).run('/project');
+    expect(issues).toHaveLength(0);
+  });
+
+  it('returns no issues just under the warning threshold', async () => {
+    const issues = await makeCheck(79).run('/project');
+    expect(issues).toHaveLength(0);
+  });
+
+  it('emits a warning between warn and critical thresholds', async () => {
+    const issues = await makeCheck(85).run('/project');
+    expect(issues).toHaveLength(1);
+    expect(issues[0].severity).toBe('warning');
+    expect(issues[0].checkId).toBe('disk-pressure');
+    expect(issues[0].autoFixable).toBe(false);
+    expect(issues[0].context?.path).toBe('/home/automaker');
+  });
+
+  it('escalates to critical at/above the critical threshold', async () => {
+    const issues = await makeCheck(97).run('/project');
+    expect(issues).toHaveLength(1);
+    expect(issues[0].severity).toBe('critical');
+  });
+
+  it('reports the volume path it inspected', async () => {
+    const issues = await makeCheck(90, '/data/agent-home').run('/project');
+    expect(issues[0].message).toContain('/data/agent-home');
+    expect(issues[0].context?.path).toBe('/data/agent-home');
+  });
+
+  it('returns no issues (does not throw) when statfs fails', async () => {
+    const check = new DiskPressureCheck(
+      () => '/home/automaker',
+      async () => {
+        throw new Error('ENOENT');
+      }
+    );
+    await expect(check.run('/project')).resolves.toEqual([]);
+  });
+
+  it('returns no issues when the filesystem reports zero blocks', async () => {
+    const check = new DiskPressureCheck(
+      () => '/home/automaker',
+      async () => ({ blocks: 0, bavail: 0, bsize: 4096 })
+    );
+    expect(await check.run('/project')).toEqual([]);
+  });
+});

--- a/libs/types/src/error.ts
+++ b/libs/types/src/error.ts
@@ -3,6 +3,7 @@
  */
 export type ErrorType =
   | 'authentication'
+  | 'config_corrupted'
   | 'cancellation'
   | 'abort'
   | 'execution'
@@ -20,6 +21,7 @@ export interface ErrorInfo {
   message: string;
   isAbort: boolean;
   isAuth: boolean;
+  isConfigCorrupted: boolean; // Config/credentials file unreadable or truncated (often disk-full)
   isCancellation: boolean;
   isRateLimit: boolean;
   isQuotaExhausted: boolean; // Session/weekly usage limit reached

--- a/libs/utils/src/error-handler.ts
+++ b/libs/utils/src/error-handler.ts
@@ -53,6 +53,31 @@ export function isAuthenticationError(errorMessage: string): boolean {
 }
 
 /**
+ * Check if an error indicates a corrupted/truncated config or credentials file,
+ * usually caused by the agent HOME volume running out of space (a small tmpfs
+ * filling silently truncates writes to .claude.json / .credentials.json). The
+ * CLI then reports the file as "corrupted", which otherwise masquerades as an
+ * auth failure and sends operators down the wrong path (protoMaker#3564).
+ *
+ * @param errorMessage - The error message to check
+ * @returns True if the error indicates a corrupted/truncated config file
+ */
+export function isConfigCorruptedError(errorMessage: string): boolean {
+  const lower = errorMessage.toLowerCase();
+  // Root cause: a write to the (full) HOME volume is rejected by the kernel.
+  if (lower.includes('no space left on device') || lower.includes('enospc')) {
+    return true;
+  }
+  // Symptom: the CLI reads the truncated config/credentials file and reports it
+  // as corrupted. Require config context so a generic JSON error elsewhere
+  // doesn't get misclassified.
+  return (
+    (lower.includes('configuration file') && lower.includes('corrupt')) ||
+    (lower.includes('.claude.json') && (lower.includes('corrupt') || lower.includes('parse error')))
+  );
+}
+
+/**
  * Check if an error is a rate limit error (429 Too Many Requests)
  *
  * @param error - The error to check
@@ -172,6 +197,7 @@ export function classifyError(error: unknown): ErrorInfo {
   const message = error instanceof Error ? error.message : String(error || 'Unknown error');
   const isAbort = isAbortError(error);
   const isAuth = isAuthenticationError(message);
+  const isConfigCorrupted = isConfigCorruptedError(message);
   const isCancellation = isCancellationError(message);
   const isRateLimit = isRateLimitError(error);
   const isQuotaExhausted = isQuotaExhaustedError(error);
@@ -184,6 +210,10 @@ export function classifyError(error: unknown): ErrorInfo {
   let type: ErrorType;
   if (isMaxTurns) {
     type = 'max_turns';
+  } else if (isConfigCorrupted) {
+    // Priority over authentication: a truncated credentials file surfaces as an
+    // auth error too, but the real failure is disk/config, not the key (#3564).
+    type = 'config_corrupted';
   } else if (isAuth) {
     type = 'authentication';
   } else if (isQuotaExhausted) {
@@ -209,6 +239,7 @@ export function classifyError(error: unknown): ErrorInfo {
     message,
     isAbort,
     isAuth,
+    isConfigCorrupted,
     isCancellation,
     isRateLimit,
     isQuotaExhausted,
@@ -235,6 +266,9 @@ export function getUserFriendlyErrorMessage(error: unknown): string {
 
     case 'authentication':
       return 'Authentication failed. Please check your API key.';
+
+    case 'config_corrupted':
+      return 'Agent config/credentials file is unreadable or truncated — usually the agent HOME volume is full. Check disk space (e.g. `df -h $HOME`) and the npm cache location (NPM_CONFIG_CACHE); this is NOT an invalid API key.';
 
     case 'quota_exhausted':
       return 'Usage limit reached. Auto Mode has been paused. Please wait for your quota to reset or upgrade your plan.';

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -8,6 +8,7 @@ export {
   isAbortError,
   isCancellationError,
   isAuthenticationError,
+  isConfigCorruptedError,
   isRateLimitError,
   isQuotaExhaustedError,
   isFetchError,

--- a/libs/utils/tests/error-handler.test.ts
+++ b/libs/utils/tests/error-handler.test.ts
@@ -3,6 +3,7 @@ import {
   isAbortError,
   isCancellationError,
   isAuthenticationError,
+  isConfigCorruptedError,
   isRateLimitError,
   isQuotaExhaustedError,
   extractRetryAfter,
@@ -456,6 +457,66 @@ describe('error-handler.ts', () => {
       const message = getUserFriendlyErrorMessage(error);
 
       expect(message).toBe('');
+    });
+  });
+
+  describe('isConfigCorruptedError', () => {
+    it('detects disk-full write failures', () => {
+      expect(isConfigCorruptedError('Error: ENOSPC: no space left on device, write')).toBe(true);
+      expect(isConfigCorruptedError('cat: write error: No space left on device')).toBe(true);
+    });
+
+    it('detects a corrupted/truncated Claude config file', () => {
+      expect(
+        isConfigCorruptedError(
+          'Claude configuration file at /home/automaker/.claude.json is corrupted: JSON Parse error: Unterminated string'
+        )
+      ).toBe(true);
+    });
+
+    it('does not match unrelated JSON or auth errors', () => {
+      expect(isConfigCorruptedError('Authentication failed: Invalid or expired API key')).toBe(
+        false
+      );
+      expect(isConfigCorruptedError('SyntaxError: Unexpected token in JSON at position 5')).toBe(
+        false
+      );
+      expect(isConfigCorruptedError('Something went wrong')).toBe(false);
+    });
+  });
+
+  describe('classifyError — config_corrupted', () => {
+    it('classifies a corrupted config file as config_corrupted', () => {
+      const info = classifyError(
+        new Error(
+          'Claude configuration file at /home/automaker/.claude.json is corrupted: JSON Parse error'
+        )
+      );
+      expect(info.type).toBe('config_corrupted');
+      expect(info.isConfigCorrupted).toBe(true);
+    });
+
+    it('prioritizes config_corrupted over authentication when both signatures are present', () => {
+      // The SDK surfaces a truncated credentials file as an auth failure too;
+      // the disk/config signal must win so operators do not chase the API key.
+      const info = classifyError(
+        new Error('Authentication failed: Invalid API key — .claude.json is corrupted')
+      );
+      expect(info.type).toBe('config_corrupted');
+    });
+
+    it('still classifies a plain auth error as authentication', () => {
+      const info = classifyError(new Error('Authentication failed: Invalid API key'));
+      expect(info.type).toBe('authentication');
+      expect(info.isConfigCorrupted).toBe(false);
+    });
+  });
+
+  describe('getUserFriendlyErrorMessage — config_corrupted', () => {
+    it('returns an actionable disk/config message, not an API-key message', () => {
+      const message = getUserFriendlyErrorMessage(new Error('No space left on device'));
+      expect(message).toContain('truncated');
+      expect(message).not.toContain('check your API key');
     });
   });
 });


### PR DESCRIPTION
## Problem

When the agent HOME volume fills (a 64M tmpfs on the staging container), the kernel silently truncates writes to `.claude.json`. The Claude CLI reads the truncated file, reports it "corrupted", and the failure surfaces as `Invalid or expired API key` — sending operators after the wrong thing while auto-mode respawns agents that corrupt the file further. Full root-cause: #3564.

The **permanent** prevention is infra (bump the tmpfs / move the npm cache off it) — filed as protoLabsAI/homelab-iac#94. This PR is protoMaker's defensive slice.

## Changes

**1. Spawn env — stop the npm cache filling HOME** (`claude-provider.ts`)
- `NPM_CONFIG_CACHE` is now on the agent env allowlist, so an infra-set value actually reaches the agent (it was silently dropped before).
- When unset, it defaults off `$HOME` to `${DATA_DIR}/npm-cache` (persistent volume); npm creates it on first use.

**2. Distinct error classification** (`error.ts`, `error-handler.ts`)
- New `isConfigCorruptedError` + `'config_corrupted'` ErrorType, **prioritized over `authentication`** (a truncated credentials file also trips the auth signature).
- `getUserFriendlyErrorMessage` returns an actionable disk/config message, explicitly "this is NOT an invalid API key".

**3. Auto-mode pauses instead of respawning** (`auto-mode-service.ts`)
- `config_corrupted` is now a circuit-breaker-worthy error — respawning only writes more garbage to the shared `.claude.json`.

**4. Early warning** (`disk-pressure-check.ts` + registration)
- New maintenance check warns (≥80%) / critical (≥95%) on the agent HOME volume before it fills.

## Tests

- `error-handler.test.ts`: +new cases for detection, `config_corrupted` classification, auth-priority, and the user-facing message (71 pass).
- `disk-pressure-check.test.ts`: thresholds, critical escalation, path reporting, statfs-failure safety (7 pass).
- `tsc --noEmit` clean; prettier clean.

## Wiring

`disk-pressure-check.ts` is imported + registered in `maintenance.module.ts`; the new error type flows through `classifyError` → auto-mode pause gate.

Refs #3564 · infra follow-up protoLabsAI/homelab-iac#94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added disk pressure monitoring to detect and report filesystem usage issues.

* **Improvements**
  * Enhanced detection and error messaging for corrupted or truncated configuration files.
  * Auto-mode now pauses immediately when configuration is corrupted.
  * Improved npm cache management for better disk space handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3782?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->