### PR TITLE
feat(server): emit feature lifecycle events on the workstacean bus (#3549)

### DIFF
--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -62,6 +62,7 @@ import { gitWorkflowService } from '../services/git-workflow-service.js';
 import { TrustTierService } from '../services/trust-tier-service.js';
 import { LedgerService } from '../services/ledger-service.js';
 import { ArchivalService } from '../services/archival-service.js';
+import { FeatureLifecycleBusPublisher } from '../services/feature-lifecycle-bus-publisher.js';
 import { KnowledgeStoreService } from '../services/knowledge-store-service.js';
 import { DocsUpdateDetector } from '../services/docs-update-detector.js';
 import { AgentDiscordRouter } from '../services/agent-discord-router.js';
@@ -378,6 +379,12 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   // Metrics Ledger & Archival
   const ledgerService = new LedgerService(featureLoader, events);
   ledgerService.initialize();
+
+  // Forward terminal feature transitions to the protoWorkstacean bus so
+  // downstream consumers (e.g. the Linear bridge) can close the loop. Opt-in
+  // via WORKSTACEAN_URL. See protoLabsAI/protoMaker#3549.
+  const featureLifecycleBusPublisher = new FeatureLifecycleBusPublisher(events, featureLoader);
+  featureLifecycleBusPublisher.start();
   const archivalService = new ArchivalService(
     featureLoader,
     ledgerService,

--- a/apps/server/src/services/feature-lifecycle-bus-publisher.ts
+++ b/apps/server/src/services/feature-lifecycle-bus-publisher.ts
@@ -1,0 +1,111 @@
+/**
+ * FeatureLifecycleBusPublisher — forwards terminal board-feature transitions to
+ * the protoWorkstacean bus so downstream consumers can close the loop without
+ * polling protoMaker.
+ *
+ * Subscribes to the existing `feature:status-changed` event (emitted by
+ * FeatureLoader.update) and, when a feature transitions into a terminal state,
+ * publishes `protomaker.feature.completed` to protoWorkstacean's /publish
+ * endpoint. The payload echoes the originating signal metadata so a consumer
+ * (e.g. the Linear ↔ protoMaker bridge) can reconstruct lineage and post a
+ * "feature done" comment on the source issue. See protoLabsAI/protoMaker#3549
+ * and the downstream consumer protoLabsAI/protoWorkstacean#482.
+ *
+ * Opt-in: only active when WORKSTACEAN_URL is explicitly set, so installs
+ * without protoWorkstacean don't attempt (and log) a publish on every feature
+ * completion. The canonical board has a single terminal state (`done`); the
+ * TERMINAL_STATUSES set is the extension point if more are added later.
+ */
+
+import { createLogger } from '@protolabsai/utils';
+import type { EventEmitter } from '../lib/events.js';
+import type { FeatureLoader } from './feature-loader.js';
+import { publish as workstaceanPublish } from '../client/workstacean-api.client.js';
+
+const logger = createLogger('FeatureLifecycleBusPublisher');
+
+/** Board statuses treated as terminal for lifecycle-event purposes. */
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set(['done']);
+
+/** Subset of the `feature:status-changed` payload this publisher needs. */
+interface StatusChangedPayload {
+  featureId: string;
+  oldStatus?: string;
+  newStatus?: string;
+  projectPath?: string;
+}
+
+type PublishFn = (payload: {
+  event: string;
+  data: Record<string, unknown>;
+}) => Promise<{ ok: boolean; error?: string }>;
+
+export class FeatureLifecycleBusPublisher {
+  private readonly enabled: boolean;
+
+  constructor(
+    private readonly events: Pick<EventEmitter, 'on'>,
+    private readonly featureLoader: Pick<FeatureLoader, 'get'>,
+    private readonly publishFn: PublishFn = workstaceanPublish,
+    enabled: boolean = Boolean(process.env.WORKSTACEAN_URL)
+  ) {
+    this.enabled = enabled;
+  }
+
+  /** Wire up the subscription. No-op (with a debug log) when disabled. */
+  start(): void {
+    if (!this.enabled) {
+      logger.debug('Feature lifecycle bus publishing disabled — WORKSTACEAN_URL not set');
+      return;
+    }
+    this.events.on('feature:status-changed', (payload) => {
+      void this.handleStatusChange(payload);
+    });
+    logger.info('Feature lifecycle bus publishing enabled');
+  }
+
+  /**
+   * Publish `protomaker.feature.completed` when a feature reaches a terminal
+   * state. Loads the feature fresh to echo its source signal metadata. Never
+   * throws — a publish failure must not affect the board transition.
+   */
+  async handleStatusChange(payload: StatusChangedPayload): Promise<void> {
+    const { featureId, newStatus, oldStatus, projectPath } = payload ?? {};
+    if (!featureId || !projectPath || !newStatus || !TERMINAL_STATUSES.has(newStatus)) {
+      return;
+    }
+
+    let feature = null;
+    try {
+      feature = await this.featureLoader.get(projectPath, featureId);
+    } catch (err) {
+      logger.warn(`Could not load feature ${featureId} for lifecycle event:`, err);
+    }
+
+    const event = 'protomaker.feature.completed';
+    try {
+      const result = await this.publishFn({
+        event,
+        data: {
+          featureId,
+          projectPath,
+          projectSlug: feature?.projectSlug,
+          title: feature?.title,
+          completedAt: Date.now(),
+          previousStatus: oldStatus,
+          // Echo the originating signal so consumers reconstruct lineage (e.g.
+          // sourceLinearIssueId lives in signalMetadata) without a second query.
+          sourceMeta: {
+            sourceChannel: feature?.sourceChannel,
+            signalMetadata: feature?.signalMetadata,
+          },
+        },
+      });
+      if (!result.ok) {
+        logger.warn(`Failed to publish ${event} for ${featureId}: ${result.error}`);
+      }
+    } catch (err) {
+      logger.warn(`Error publishing ${event} for ${featureId}:`, err);
+    }
+  }
+}

--- a/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
+++ b/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { FeatureLifecycleBusPublisher } from '@/services/feature-lifecycle-bus-publisher.js';
+
+function makePublisher(opts?: { feature?: unknown; publishFn?: ReturnType<typeof vi.fn> }) {
+  const publishFn = opts?.publishFn ?? vi.fn().mockResolvedValue({ ok: true });
+  const featureLoader = { get: vi.fn().mockResolvedValue(opts?.feature ?? null) };
+  // enabled=true bypasses the WORKSTACEAN_URL env gate for these tests.
+  const pub = new FeatureLifecycleBusPublisher(
+    { on: vi.fn() } as never,
+    featureLoader as never,
+    publishFn,
+    true
+  );
+  return { pub, publishFn, featureLoader };
+}
+
+describe('FeatureLifecycleBusPublisher', () => {
+  it('publishes protomaker.feature.completed on transition to done', async () => {
+    const feature = {
+      id: 'f1',
+      title: 'Ship it',
+      projectSlug: 'proj',
+      sourceChannel: 'github',
+      signalMetadata: { sourceLinearIssueId: 'LIN-1' },
+    };
+    const { pub, publishFn } = makePublisher({ feature });
+
+    await pub.handleStatusChange({
+      featureId: 'f1',
+      projectPath: '/p',
+      oldStatus: 'review',
+      newStatus: 'done',
+    });
+
+    expect(publishFn).toHaveBeenCalledTimes(1);
+    const arg = publishFn.mock.calls[0][0];
+    expect(arg.event).toBe('protomaker.feature.completed');
+    expect(arg.data.featureId).toBe('f1');
+    expect(arg.data.title).toBe('Ship it');
+    expect(arg.data.projectSlug).toBe('proj');
+    expect(arg.data.previousStatus).toBe('review');
+    expect(arg.data.sourceMeta.signalMetadata).toEqual({ sourceLinearIssueId: 'LIN-1' });
+    expect(arg.data.sourceMeta.sourceChannel).toBe('github');
+  });
+
+  it('ignores non-terminal transitions', async () => {
+    const { pub, publishFn } = makePublisher();
+    await pub.handleStatusChange({
+      featureId: 'f1',
+      projectPath: '/p',
+      oldStatus: 'backlog',
+      newStatus: 'in_progress',
+    });
+    expect(publishFn).not.toHaveBeenCalled();
+  });
+
+  it('ignores transitions missing featureId or projectPath', async () => {
+    const { pub, publishFn } = makePublisher();
+    await pub.handleStatusChange({ featureId: '', projectPath: '/p', newStatus: 'done' });
+    await pub.handleStatusChange({ featureId: 'f1', newStatus: 'done' });
+    expect(publishFn).not.toHaveBeenCalled();
+  });
+
+  it('still publishes (with empty sourceMeta) when the feature cannot be loaded', async () => {
+    const featureLoader = { get: vi.fn().mockRejectedValue(new Error('gone')) };
+    const publishFn = vi.fn().mockResolvedValue({ ok: true });
+    const pub = new FeatureLifecycleBusPublisher(
+      { on: vi.fn() } as never,
+      featureLoader as never,
+      publishFn,
+      true
+    );
+
+    await pub.handleStatusChange({ featureId: 'f1', projectPath: '/p', newStatus: 'done' });
+
+    expect(publishFn).toHaveBeenCalledTimes(1);
+    expect(publishFn.mock.calls[0][0].data.title).toBeUndefined();
+    expect(publishFn.mock.calls[0][0].data.featureId).toBe('f1');
+  });
+
+  it('does not throw when the publish fails', async () => {
+    const publishFn = vi.fn().mockResolvedValue({ ok: false, error: 'unreachable' });
+    const { pub } = makePublisher({ publishFn });
+    await expect(
+      pub.handleStatusChange({ featureId: 'f1', projectPath: '/p', newStatus: 'done' })
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not subscribe when disabled (WORKSTACEAN_URL unset)', () => {
+    const onSpy = vi.fn();
+    const pub = new FeatureLifecycleBusPublisher(
+      { on: onSpy } as never,
+      { get: vi.fn() } as never,
+      vi.fn(),
+      false
+    );
+    pub.start();
+    expect(onSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

protoMaker now emits `protomaker.feature.completed` on protoWorkstacean's bus when a board feature reaches a terminal state, so downstream consumers can close the loop without polling. Implements #3549; unblocks the consumer protoLabsAI/protoWorkstacean#482.

## How

`FeatureLifecycleBusPublisher` subscribes to the existing `feature:status-changed` event (no change to FeatureLoader) and, on transition to `done`, fire-and-forget POSTs via the existing `workstacean-api.client.publish()`:

```jsonc
{
  "event": "protomaker.feature.completed",
  "data": {
    "featureId", "projectPath", "projectSlug", "title",
    "completedAt", "previousStatus",
    "sourceMeta": { "sourceChannel", "signalMetadata" }  // echoes the originating signal (e.g. sourceLinearIssueId)
  }
}
```

- **Opt-in:** only active when `WORKSTACEAN_URL` is set, so non-workstacean installs don't attempt (or error-log) a publish on every completion.
- **Decoupled + fail-quiet:** a publish failure or an unreachable bus never affects the board transition; the feature is loaded fresh to echo its source metadata.
- **Terminal states:** the canonical 5-status board has a single terminal state (`done`); `TERMINAL_STATUSES` is the extension point if `cancelled`/`archived` are added.

## Tests

`feature-lifecycle-bus-publisher.test.ts` (6 cases): publishes on `done` with echoed `sourceMeta`; ignores non-terminal transitions; ignores missing ids; publishes with empty sourceMeta when the feature can't be loaded; doesn't throw on publish failure; doesn't subscribe when disabled. `tsc --noEmit` clean.

## Wiring

Instantiated + `.start()`ed in `server/services.ts` next to the other `feature:status-changed` consumers.

## Follow-up

The downstream subscriber lands separately in protoWorkstacean (`linear-protomaker-bridge.ts`), per protoLabsAI/protoWorkstacean#482.

Closes #3549

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Features reaching completion status now automatically publish lifecycle events to configured external endpoints
  * Event payloads include feature metadata (ID, title, project information) to support downstream integrations
  * Publishing only activates when explicitly enabled via configuration

* **Tests**
  * Added comprehensive unit test coverage for feature lifecycle event publishing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3784?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->