### PR TITLE
ci: publish UI + server images to GHCR on main (#3783)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,69 @@
+name: Build & publish images
+
+# Publishes the protoMaker UI + server container images to GHCR on every main
+# commit (and on v* release tags), so the homelab-iac stacks/protomaker/ stack
+# can run `image: ghcr.io/protolabsai/protomaker-{ui,server}` with Watchtower
+# auto-roll instead of building from a local checkout. See protoMaker#3783.
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    # workspace-config: allow-hosted-runner docker buildx build + registry push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: server
+            image: protomaker-server
+          - target: ui
+            image: protomaker-ui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # metadata-action lowercases the owner, so protoLabsAI -> protolabsai.
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-
+            type=semver,pattern=v{{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build & push ${{ matrix.image }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: ${{ matrix.target }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Scope the GHA cache per target so the ui/server builds don't evict
+          # each other's layers.
+          cache-from: type=gha,scope=${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target }}


### PR DESCRIPTION
## What

Adds `.github/workflows/publish-image.yml` — protoMaker's first image-publish workflow. On push to `main` (and `v*` tags, plus `workflow_dispatch`), it builds the Dockerfile `ui` and `server` targets and pushes to `ghcr.io/protolabsai/protomaker-ui` + `-server`. This is the **spin-up-on-upload** vehicle: the homelab-iac `stacks/protomaker/` stack can flip from a local `build:` to `image:` + Watchtower auto-roll, so every merge to main rolls the production/internal env.

Closes #3783.

## Shape (mirrors studio-brand/payload-image.yml)

- **Matrix** over `{ target: server → protomaker-server, target: ui → protomaker-ui }` — protoMaker ships two images.
- **Tags** via `docker/metadata-action@v5`: `type=ref,event=branch`, `type=sha,prefix=sha-`, `type=semver,pattern=v{{version}}`, and `:latest` on the default branch.
- **Build/push** via `docker/build-push-action@v6` with `target:` set per matrix leg; GHA cache **scoped per target** so ui/server don't evict each other.
- **GHCR login** with the built-in `GITHUB_TOKEN` (`packages: write`).

## Conformance

- Docker buildx job is annotated `# workspace-config: allow-hosted-runner docker buildx build + registry push` and runs on `ubuntu-latest`, matching the fleet standard (verified: `verify-workspace-config` reports protoMaker conformant with this as a sanctioned exception).
- YAML validated; `ui`/`server` targets confirmed present in the root `Dockerfile`.

## Out of scope

No compose/Dockerfile/runtime changes — per #3783, the homelab side flips to image-based in a follow-up PR there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Docker image publishing workflow for server and UI components to container registry on pushes to `main`, version releases, and manual dispatch triggers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->