### PR TITLE
test(a2a): pin board_health native-session routing contract (#3773)

### DIFF
--- a/apps/server/src/routes/a2a/index.ts
+++ b/apps/server/src/routes/a2a/index.ts
@@ -390,6 +390,21 @@ interface SkillMeta {
   needsNativeSession: boolean;
 }
 
+/**
+ * The dispatch routing decision behind the #3772 fix: a skill that needs a
+ * Claude Code native session (lists Bash/Read/Write/etc.) MUST run via
+ * executeNativeSkill, never the /api/chat path — that path has Ava's board
+ * tools but no native tools, so a native-or-mixed skill like board_health
+ * silently degrades there (the model narrates a shell command it can't run).
+ *
+ * A null skill (unknown skill, or one with no tool restrictions) falls through
+ * to the chat path. Exported so the routing contract is pinned by tests
+ * independently of the dispatch handler that consumes it (#3773).
+ */
+export function shouldRouteToNativeSession(skill: SkillMeta | null): boolean {
+  return Boolean(skill?.needsNativeSession);
+}
+
 /** Load a skill file and parse its frontmatter. Returns null if not found.
  *  Exported for testing the native-session classification (#3772). */
 export async function loadSkill(projectPath: string, skillName: string): Promise<SkillMeta | null> {
@@ -1179,7 +1194,7 @@ export function createA2AHandlerRoutes(projectPath: string, deps?: A2AHandlerDep
       // servers wired so the mcp__ tools resolve in the SDK session.
       if (skillOverride) {
         const skill = await loadSkill(effectiveProjectPath, skillOverride);
-        if (skill?.needsNativeSession) {
+        if (skill && shouldRouteToNativeSession(skill)) {
           logger.info(
             `A2A skill "${skillOverride}" needs a native session [${skill.allowedTools.join(', ')}] — routing via executeQuery`
           );

--- a/apps/server/tests/unit/routes/a2a-skill-routing.test.ts
+++ b/apps/server/tests/unit/routes/a2a-skill-routing.test.ts
@@ -16,7 +16,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { loadSkill } from '@/routes/a2a/index.js';
+import { loadSkill, shouldRouteToNativeSession } from '@/routes/a2a/index.js';
 
 // Repo root — .claude/skills/board_health.md lives here.
 const REPO_ROOT = join(__dirname, '..', '..', '..', '..', '..');
@@ -35,6 +35,20 @@ describe('A2A loadSkill native-session classification (#3772)', () => {
   it('returns null for an unknown skill (falls through to chat path)', async () => {
     const skill = await loadSkill(REPO_ROOT, 'does-not-exist-skill');
     expect(skill).toBeNull();
+  });
+
+  // #3773: pin the dispatch routing contract, not just the classification flag.
+  // The handler routes on shouldRouteToNativeSession(skill); board_health MUST
+  // resolve to the native path or it regresses to the chat path that narrated a
+  // shell command instead of returning board data (#3772).
+  it('routes board_health to the native session (not the chat path)', async () => {
+    const skill = await loadSkill(REPO_ROOT, 'board_health');
+    expect(shouldRouteToNativeSession(skill)).toBe(true);
+  });
+
+  it('routes an unknown skill to the chat path', async () => {
+    const skill = await loadSkill(REPO_ROOT, 'does-not-exist-skill');
+    expect(shouldRouteToNativeSession(skill)).toBe(false);
   });
 
   describe('with temp fixtures', () => {
@@ -87,12 +101,14 @@ Just talk.`
       const skill = await loadSkill(dir, 'pure-native');
       expect(skill!.needsNativeSession).toBe(true);
       expect(skill!.isNativeTool).toBe(true);
+      expect(shouldRouteToNativeSession(skill)).toBe(true);
     });
 
     it('pure-mcp → neither (routes to chat path, which has board tools)', async () => {
       const skill = await loadSkill(dir, 'pure-mcp');
       expect(skill!.needsNativeSession).toBe(false);
       expect(skill!.isNativeTool).toBe(false);
+      expect(shouldRouteToNativeSession(skill)).toBe(false);
     });
 
     it('no allowed-tools → neither', async () => {


### PR DESCRIPTION
## What

Guards the #3772 regression at the dispatch level. #3772 fixed native-tool skills like `board_health` being misrouted to the `/api/chat` path (no native tools → the model narrated a shell command instead of returning board data). The existing tests covered `loadSkill`'s classification flags but **not the dispatch decision** that consumes them.

Closes #3773.

## How

- Extract the routing decision into an exported `shouldRouteToNativeSession(skill)` predicate, and wire the message/send handler to use it (`if (skill && shouldRouteToNativeSession(skill))`).
- Pin it with tests: `board_health` and pure-native skills → native session; unknown and pure-MCP skills → chat path. If the dispatch predicate ever drifts (e.g. to `isNativeTool`, which is `false` for the mixed `board_health`), `board_health` regresses to chat and these tests fail.

## Why not a literal output e2e

#3773 suggested asserting the artifact text isn't a fenced shell command. That's not deterministically testable — it depends on live LLM output, and the repo has no A2A HTTP test harness (existing A2A tests are pure unit tests against exported functions). So this guards the deterministic **root** (the routing contract) rather than a flaky symptom. Noted on the issue.

## Tests

`a2a-skill-routing.test.ts`: +board_health routes native, +unknown routes chat, + predicate assertions on the pure-native/pure-mcp fixtures (9 total in file, all pass). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized skill routing logic for improved code organization and maintainability.

* **Tests**
  * Enhanced routing behavior validation with additional test assertions for skill dispatch scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->