### PR TITLE
prompt(crew): require N>=5 + same-target race in concurrency tests (#3741)

### DIFF
--- a/libs/prompts/src/defaults.ts
+++ b/libs/prompts/src/defaults.ts
@@ -979,6 +979,25 @@ After completing your implementation, review your own work before running verifi
 4. Ask: "Did I change any files NOT mentioned in the feature description?" If yes, revert unless essential
 5. Only move to verification gates when self-review passes
 
+**Concurrency & Lock Testing**
+If your change involves a lock, mutex, queue, cache, or any "get-or-create" path that multiple concurrent callers can hit (file locks, in-memory maps written by parallel requests, etc.), 2-caller tests are NOT enough — a broken implementation often passes with 2 callers (one holder, one waiter) and only fails the thundering-herd case at 3+ waiters that wake together. Default to:
+- **N >= 5 concurrent operations** fired via \`Promise.all(...)\`, asserting all N results survive (no lost or interleaved writes).
+- **At least one same-target race** (multiple ops against the SAME key/path) to prove ordering, not just non-interleaving.
+- Keep any existing 2-caller tests — augment, don't replace them.
+
+\`\`\`ts
+it('preserves all N records under concurrent writes (thundering-herd guard)', async () => {
+  const n = 8;
+  await Promise.all(Array.from({ length: n }, (_, i) => service.write(\`u\${i}\`, i)));
+  expect(await service.getAll()).toHaveLength(n);
+});
+
+it('resolves a same-target race deterministically', async () => {
+  await Promise.all([service.write('x', 1), service.write('x', 2), service.revoke('x')]);
+  expect(await service.get('x')).toBeUndefined();
+});
+\`\`\`
+
 **Skill Creation:**
 If you discover a reusable pattern during implementation, consider creating a skill file at \`.automaker/skills/{name}.md\`. Good candidates: project-specific build patterns, common error fixes, integration techniques. See the skill format in the system prompt.
 


### PR DESCRIPTION
## Why

When the crew implemented #3601 (TrustTierService concurrent writes) it wrote concurrency tests with only **2 callers** — which pass against a broken lock (one holder, one waiter, no race). The thundering-herd bug only surfaces at 3+ waiters that wake together. protoquinn caught it in review; the fix shipped with an N=8 test. This is a **prompt/training gap**, not a code bug.

Closes #3741.

## Change

Adds a **Concurrency & Lock Testing** block to `DEFAULT_IMPLEMENTATION_INSTRUCTIONS` (the execution-phase prompt every feature implementer sees). When a change touches a lock/mutex/queue/cache or any get-or-create path, the agent now defaults to:
- **N ≥ 5 concurrent ops** via `Promise.all(...)`, asserting all N survive (no lost writes);
- **at least one same-target race** (multiple ops on the same key/path) to prove ordering;
- keeping existing 2-caller tests (augment, not replace).

Embeds the thundering-herd + same-target scaffold from the issue.

## Verification

- `@protolabsai/prompts` builds clean (template-literal escaping of the embedded code verified — renders with literal backticks/`${...}`).
- All 142 prompt-package tests pass (incl. snapshot suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal implementation guidance with expanded testing recommendations for concurrent operations, including example patterns for handling edge cases like race conditions and resource contention scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3787?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->