### PR TITLE
Output + flag conventions

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -88,9 +88,11 @@ program.addCommand(devCmd);
 // ---------------------------------------------------------------------------
 
 try {
-  // Show help if no command provided (exit code 2 = usage error)
+  // Show help if no command provided (exit code 2 = usage error).
+  // outputHelp() prints without exiting; help() would call process.exit(0)
+  // internally, making the intended exit(2) below unreachable.
   if (!process.argv.slice(2).length) {
-    program.help();
+    program.outputHelp();
     process.exit(2);
   }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,10 +8,21 @@
  * Usage:
  *   protomaker <command> [options]
  *   protomaker --help
+ *
+ * Global flags:
+ *   --json      Output results as JSON
+ *   --quiet     Suppress all non-error output
+ *   --project   Project path (defaults to cwd)
+ *
+ * Exit codes:
+ *   0 = success
+ *   1 = runtime error
+ *   2 = usage error
  */
 
 import { createRequire } from 'node:module';
 import { Command } from 'commander';
+import { type GlobalFlags, output, usageError, exitError } from './output.js';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json') as { version: string };
@@ -21,7 +32,14 @@ const program = new Command();
 program
   .name('protomaker')
   .description('CLI for protoLabs.studio — automate AI engineering workflows')
-  .version(version);
+  .version(version)
+  // -----------------------------------------------------------------------
+  // Global flags
+  // -----------------------------------------------------------------------
+  .option('--json', 'Output results as JSON', false)
+  .option('--quiet', 'Suppress all non-error output', false)
+  .option('--project <path>', 'Project path (defaults to cwd)', process.cwd())
+  .exitOverride(); // Prevent Commander from calling process.exit — we control exit codes
 
 // ---------------------------------------------------------------------------
 // Command groups
@@ -66,12 +84,48 @@ program.addCommand(agentCmd);
 program.addCommand(devCmd);
 
 // ---------------------------------------------------------------------------
-// Entry
+// Entry — exit-code discipline
 // ---------------------------------------------------------------------------
 
-program.parse(process.argv);
+try {
+  // Show help if no command provided (exit code 2 = usage error)
+  if (!process.argv.slice(2).length) {
+    program.help();
+    process.exit(2);
+  }
 
-// Show help if no command provided
-if (!process.argv.slice(2).length) {
-  program.help();
+  program.parse(process.argv);
+
+  // Extract global flags after parsing
+  const opts = program.opts();
+  const globalFlags: GlobalFlags = {
+    json: opts.json ?? false,
+    quiet: opts.quiet ?? false,
+    project: opts.project ?? process.cwd(),
+  };
+
+  // Success — exit code 0
+  process.exit(0);
+} catch (err: any) {
+  // Commander exitOverride throws CommanderError on failures
+  const commanderCode = err?.code;
+
+  // --help / --version are fine
+  if (commanderCode === 'COMMANDER_HELP' || commanderCode === 'COMMANDER_VERSION') {
+    process.exit(0);
+    return;
+  }
+
+  // Usage errors (unknown command, missing required arg, etc.) → exit 2
+  if (
+    commanderCode === 'COMMANDER_INCORRECTVALUE' ||
+    commanderCode === 'COMMANDER_ARGUMENT_MISSING' ||
+    commanderCode === 'COMMANDER_CREATE_OPTION_FAILED'
+  ) {
+    usageError(err.message || String(err));
+    return;
+  }
+
+  // Runtime error → exit 1
+  exitError(err.message || String(err));
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -22,7 +22,7 @@
 
 import { createRequire } from 'node:module';
 import { Command } from 'commander';
-import { type GlobalFlags, output, usageError, exitError } from './output.js';
+import { type GlobalFlags, usageError, exitError } from './output.js';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json') as { version: string };
@@ -113,7 +113,6 @@ try {
   // --help / --version are fine
   if (commanderCode === 'COMMANDER_HELP' || commanderCode === 'COMMANDER_VERSION') {
     process.exit(0);
-    return;
   }
 
   // Usage errors (unknown command, missing required arg, etc.) → exit 2
@@ -123,7 +122,6 @@ try {
     commanderCode === 'COMMANDER_CREATE_OPTION_FAILED'
   ) {
     usageError(err.message || String(err));
-    return;
   }
 
   // Runtime error → exit 1

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -53,9 +53,15 @@ function parseDotEnv(filePath: string): Record<string, string> {
 /**
  * Resolve API configuration.
  *
- * Checks process.env first, then falls back to .env in cwd.
+ * Checks process.env first, then falls back to .env in the project directory
+ * (defaults to cwd). The project path can be overridden via `--project` flag.
+ *
+ * @param projectPath - Project directory for .env lookup (defaults to cwd).
  */
-export function resolveApiConfig(): { apiUrl: string; apiKey?: string } {
+export function resolveApiConfig(projectPath: string = process.cwd()): {
+  apiUrl: string;
+  apiKey?: string;
+} {
   const envUrl = process.env.AUTOMAKER_API_URL;
   const envKey = process.env.AUTOMAKER_API_KEY;
 
@@ -64,8 +70,8 @@ export function resolveApiConfig(): { apiUrl: string; apiKey?: string } {
     return { apiUrl: envUrl, apiKey: envKey };
   }
 
-  // Try .env file
-  const dotenv = parseDotEnv(resolve(process.cwd(), '.env'));
+  // Try .env file in the project directory
+  const dotenv = parseDotEnv(resolve(projectPath, '.env'));
 
   const apiUrl = envUrl || dotenv.AUTOMAKER_API_URL || DEFAULT_API_URL;
   const apiKey = envKey || dotenv.AUTOMAKER_API_KEY;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,17 @@
 
 export { Command } from 'commander';
 
+// Output helper
+export {
+  output,
+  error,
+  usageError,
+  exitError,
+  getOutputMode,
+  type OutputMode,
+  type GlobalFlags,
+} from './output.js';
+
 // API client
 export {
   ApiClient,

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,0 +1,92 @@
+/**
+ * Output helper — standard --json vs human-readable output.
+ *
+ * Every command uses this module to produce consistent output:
+ *   --json  → structured JSON on stdout
+ *   --quiet → suppress all non-error output
+ *   default → human-readable text
+ *
+ * Exit codes:
+ *   0 = success
+ *   1 = runtime error
+ *   2 = usage error (bad args, missing required flag, etc.)
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Global CLI output mode. */
+export type OutputMode = 'text' | 'json' | 'quiet';
+
+/** Parsed global flags shared across all commands. */
+export interface GlobalFlags {
+  json: boolean;
+  quiet: boolean;
+  project: string;
+}
+
+/**
+ * Resolve output mode from global flags.
+ * --quiet takes precedence over --json.
+ */
+export function getOutputMode(flags: { json?: boolean; quiet?: boolean }): OutputMode {
+  if (flags.quiet) return 'quiet';
+  if (flags.json) return 'json';
+  return 'text';
+}
+
+// ---------------------------------------------------------------------------
+// Output functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Print output respecting the current output mode.
+ *
+ * - 'quiet'  → no output
+ * - 'json'   → JSON.stringify on stdout
+ * - 'text'   → raw string on stdout
+ */
+export function output(data: unknown, flags: { json?: boolean; quiet?: boolean }): void {
+  const mode = getOutputMode(flags);
+
+  if (mode === 'quiet') {
+    return;
+  }
+
+  if (mode === 'json') {
+    process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+    return;
+  }
+
+  // text mode
+  if (typeof data === 'string') {
+    process.stdout.write(data + '\n');
+  } else {
+    process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+  }
+}
+
+/**
+ * Print an error message to stderr.
+ * Always prints (ignores --quiet) so errors are visible.
+ */
+export function error(msg: string): void {
+  process.stderr.write('Error: ' + msg + '\n');
+}
+
+/**
+ * Print a usage error to stderr and exit with code 2.
+ */
+export function usageError(msg: string): never {
+  process.stderr.write('Usage error: ' + msg + '\n');
+  process.exit(2);
+}
+
+/**
+ * Exit with a runtime error (code 1).
+ */
+export function exitError(msg: string): never {
+  process.stderr.write('Error: ' + msg + '\n');
+  process.exit(1);
+}

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { resolveApiConfig } from '../src/config.js';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
@@ -99,5 +100,27 @@ describe('resolveApiConfig', () => {
 
     expect(result.apiUrl).toBe('http://localhost:3008');
     expect(result.apiKey).toBeUndefined();
+  });
+
+  it('reads .env from an explicit projectPath override (--project)', () => {
+    vi.mocked(readFileSync).mockReturnValue(
+      'AUTOMAKER_API_URL=http://project.example.com:7000\nAUTOMAKER_API_KEY=project-key\n'
+    );
+
+    const result = resolveApiConfig('/some/other/project');
+
+    expect(result.apiUrl).toBe('http://project.example.com:7000');
+    expect(result.apiKey).toBe('project-key');
+    // The .env must be looked up under the supplied projectPath, not cwd.
+    expect(readFileSync).toHaveBeenCalledWith(resolve('/some/other/project', '.env'), 'utf-8');
+  });
+
+  it('defaults projectPath to cwd when not supplied', () => {
+    vi.mocked(readFileSync).mockReturnValue('AUTOMAKER_API_KEY=cwd-key\n');
+
+    const result = resolveApiConfig();
+
+    expect(result.apiKey).toBe('cwd-key');
+    expect(readFileSync).toHaveBeenCalledWith(resolve(process.cwd(), '.env'), 'utf-8');
   });
 });

--- a/packages/cli/test/output.test.ts
+++ b/packages/cli/test/output.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getOutputMode, output, error } from '../src/output.js';
+
+describe('getOutputMode', () => {
+  it('returns "text" by default', () => {
+    expect(getOutputMode({})).toBe('text');
+  });
+
+  it('returns "json" when --json is set', () => {
+    expect(getOutputMode({ json: true })).toBe('json');
+  });
+
+  it('returns "quiet" when --quiet is set', () => {
+    expect(getOutputMode({ quiet: true })).toBe('quiet');
+  });
+
+  it('prefers --quiet over --json', () => {
+    expect(getOutputMode({ json: true, quiet: true })).toBe('quiet');
+  });
+});
+
+describe('output', () => {
+  let stdoutWrite: vi.SpyInstance;
+
+  beforeEach(() => {
+    stdoutWrite = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    stdoutWrite.mockRestore();
+  });
+
+  it('prints text mode output', () => {
+    output('hello world', {});
+    expect(stdoutWrite).toHaveBeenCalledWith('hello world\n');
+  });
+
+  it('prints JSON for objects in text mode', () => {
+    output({ key: 'value' }, {});
+    expect(stdoutWrite).toHaveBeenCalledWith(JSON.stringify({ key: 'value' }, null, 2) + '\n');
+  });
+
+  it('prints JSON mode output', () => {
+    output({ key: 'value' }, { json: true });
+    expect(stdoutWrite).toHaveBeenCalledWith(JSON.stringify({ key: 'value' }, null, 2) + '\n');
+  });
+
+  it('prints string as JSON in json mode', () => {
+    output('hello', { json: true });
+    expect(stdoutWrite).toHaveBeenCalledWith(JSON.stringify('hello', null, 2) + '\n');
+  });
+
+  it('suppresses output in quiet mode', () => {
+    output('should not appear', { quiet: true });
+    expect(stdoutWrite).not.toHaveBeenCalled();
+  });
+});
+
+describe('error', () => {
+  let stderrWrite: vi.SpyInstance;
+
+  beforeEach(() => {
+    stderrWrite = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    stderrWrite.mockRestore();
+  });
+
+  it('prints to stderr with "Error: " prefix', () => {
+    error('something failed');
+    expect(stderrWrite).toHaveBeenCalledWith('Error: something failed\n');
+  });
+});


### PR DESCRIPTION
## Summary

**Milestone:** CLI foundation & API client

Standard --json vs human output helper, global flags (--json, --quiet, --project <path> defaulting to cwd), and exit-code discipline (0 ok / 1 error / 2 usage). Used by every command.
**Acceptance Criteria:**
- [ ] every command supports --json
- [ ] non-zero exit codes on error vs usage
- [ ] projectPath defaults to cwd, overridable

**Complexity:** small

**Guardrails:** If this phase involves new or changed behavior, include tests that verify correc...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global CLI flags: --json, --quiet, and --project
  * Multiple output modes (text, json, quiet) with clear precedence

* **Bug Fixes**
  * Consistent exit codes and improved error/usage messaging across commands

* **Tests**
  * Added test coverage for output modes, output formatting, and error output behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->