### PR TITLE
Enforce package-lock sync in the git-workflow (all managed projects)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,20 +86,20 @@
         "@opentelemetry/exporter-trace-otlp-http": "^0.212.0",
         "@opentelemetry/sdk-node": "^0.212.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
-        "@protolabsai/context-engine": "^0.68.39",
-        "@protolabsai/dependency-resolver": "^0.107.1",
-        "@protolabsai/error-tracking": "^0.53.54",
-        "@protolabsai/flows": "^0.107.1",
-        "@protolabsai/git-utils": "^0.107.1",
-        "@protolabsai/model-resolver": "^0.107.1",
-        "@protolabsai/observability": "^0.107.1",
-        "@protolabsai/platform": "^0.107.1",
-        "@protolabsai/prompts": "^0.107.1",
+        "@protolabsai/context-engine": "^0.68.40",
+        "@protolabsai/dependency-resolver": "^0.108.0",
+        "@protolabsai/error-tracking": "^0.53.55",
+        "@protolabsai/flows": "^0.108.0",
+        "@protolabsai/git-utils": "^0.108.0",
+        "@protolabsai/model-resolver": "^0.108.0",
+        "@protolabsai/observability": "^0.108.0",
+        "@protolabsai/platform": "^0.108.0",
+        "@protolabsai/prompts": "^0.108.0",
         "@protolabsai/sdk": "^0.3.1",
         "@protolabsai/templates": "^0.56.0",
-        "@protolabsai/tools": "^0.107.1",
-        "@protolabsai/types": "^0.107.1",
-        "@protolabsai/utils": "^0.107.1",
+        "@protolabsai/tools": "^0.108.0",
+        "@protolabsai/types": "^0.108.0",
+        "@protolabsai/utils": "^0.108.0",
         "@twurple/api": "^8.0.3",
         "@twurple/auth": "^8.0.3",
         "@twurple/chat": "^8.0.3",
@@ -690,10 +690,10 @@
         "@fontsource/source-sans-3": "^5.2.9",
         "@fontsource/work-sans": "^5.2.8",
         "@lezer/highlight": "1.2.3",
-        "@protolabsai/dependency-resolver": "^0.107.1",
-        "@protolabsai/spec-parser": "^0.107.1",
-        "@protolabsai/types": "^0.107.1",
-        "@protolabsai/utils": "^0.107.1",
+        "@protolabsai/dependency-resolver": "^0.108.0",
+        "@protolabsai/spec-parser": "^0.108.0",
+        "@protolabsai/types": "^0.108.0",
+        "@protolabsai/utils": "^0.108.0",
         "@radix-ui/react-checkbox": "1.3.3",
         "@radix-ui/react-collapsible": "1.1.12",
         "@radix-ui/react-dialog": "1.1.15",
@@ -761,7 +761,7 @@
         "@chromatic-com/storybook": "^5.0.1",
         "@eslint/js": "9.0.0",
         "@playwright/test": "1.57.0",
-        "@protolabsai/ui": "^0.107.1",
+        "@protolabsai/ui": "^0.108.0",
         "@storybook/addon-a11y": "^10.2.8",
         "@storybook/addon-docs": "^10.2.8",
         "@storybook/react-vite": "^10.2.8",
@@ -829,10 +829,10 @@
     },
     "libs/context-engine": {
       "name": "@protolabsai/context-engine",
-      "version": "0.68.39",
+      "version": "0.68.40",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@protolabsai/utils": "^0.107.0",
+        "@protolabsai/utils": "^0.108.0",
         "better-sqlite3": "^11.7.0"
       },
       "devDependencies": {
@@ -848,10 +848,10 @@
     },
     "libs/dependency-resolver": {
       "name": "@protolabsai/dependency-resolver",
-      "version": "0.107.1",
+      "version": "0.108.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@protolabsai/types": "^0.107.1"
+        "@protolabsai/types": "^0.108.0"
       },
       "devDependencies": {
         "@types/node": "22.19.3",
@@ -865,11 +865,11 @@
     },
     "libs/error-tracking": {
       "name": "@protolabsai/error-tracking",
-      "version": "0.53.54",
+      "version": "0.53.55",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@protolabsai/types": "^0.107.0",
-        "@protolabsai/utils": "^0.107.0",
+        "@protolabsai/types": "^0.108.0",
+        "@protolabsai/utils": "^0.108.0",
         "@sentry/electron": "^5.6.0",
         "@sentry/node": "^8.47.0",
         "@sentry/types": "^8.47.0",
@@ -887,18 +887,18 @@
     },
     "libs/flows": {
       "name": "@protolabsai/flows",
-      "version": "0.107.1",
+      "version": "0.108.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@langchain/anthropic": "^0.3.10",
         "@langchain/core": "^0.3.33",
         "@langchain/langgraph": "^0.2.26",
         "@opentelemetry/api": "^1.9.0",
-        "@protolabsai/model-resolver": "^0.107.1",
-        "@protolabsai/observability": "^0.107.1",
-        "@protolabsai/prompts": "^0.107.1",
-        "@protolabsai/types": "^0.107.1",
-        "@protolabsai/utils": "^0.107.1"
+        "@protolabsai/model-resolver": "^0.108.0",
+        "@protolabsai/observability": "^0.108.0",
+        "@protolabsai/prompts": "^0.108.0",
+        "@protolabsai/types": "^0.108.0",
+        "@protolabsai/utils": "^0.108.0"
       },
       "devDependencies": {
         "@types/node": "22.19.3",
@@ -913,11 +913,11 @@
     },
     "libs/git-utils": {
       "name": "@protolabsai/git-utils",
-      "version": "0.107.1",
+      "version": "0.108.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@protolabsai/types": "^0.107.1",
-        "@protolabsai/utils": "^0.107.1"
+        "@protolabsai/types": "^0.108.0",
+        "@protolabsai/utils": "^0.108.0"
       },
       "devDependencies": {
         "@types/node": "22.19.3",
@@ -931,10 +931,10 @@
     },
     "libs/model-resolver": {
       "name": "@protolabsai/model-resolver",
-      "version": "0.107.1",
+      "version": "0.108.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@protolabsai/types": "^0.107.1"
+        "@protolabsai/types": "^0.108.0"
       },
       "devDependencies": {
         "@types/node": "22.19.3",
@@ -948,11 +948,11 @@
     },
     "libs/observability": {
       "name": "@protolabsai/observability",
-      "version": "0.107.1",
+      "version": "0.108.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@protolabsai/types": "^0.107.1",
-        "@protolabsai/utils": "^0.107.1",
+        "@protolabsai/types": "^0.108.0",
+        "@protolabsai/utils": "^0.108.0",
         "langfuse": "^3.32.0",
         "zod": "^4.3.6"
       },
@@ -986,10 +986,10 @@
     },
     "libs/platform": {
       "name": "@protolabsai/platform",
-      "version": "0.107.1",
+      "version": "0.108.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@protolabsai/types": "^0.107.1",
+        "@protolabsai/types": "^0.108.0",
         "p-limit": "6.2.0",
         "tree-kill": "1.2.2",
         "yaml": "^2.8.1"
@@ -1029,11 +1029,11 @@
     },
     "libs/prompts": {
       "name": "@protolabsai/prompts",
-      "version": "0.107.1",
+      "version": "0.108.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@protolabsai/types": "^0.107.1",
-        "@protolabsai/utils": "^0.107.1"
+        "@protolabsai/types": "^0.108.0",
+        "@protolabsai/utils": "^0.108.0"
       },
       "devDependencies": {
         "@types/node": "22.19.3",
@@ -1047,10 +1047,10 @@
     },
     "libs/spec-parser": {
       "name": "@protolabsai/spec-parser",
-      "version": "0.107.1",
+      "version": "0.108.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@protolabsai/types": "^0.107.1",
+        "@protolabsai/types": "^0.108.0",
         "fast-xml-parser": "^5.3.7"
       },
       "devDependencies": {
@@ -1108,10 +1108,10 @@
     },
     "libs/tools": {
       "name": "@protolabsai/tools",
-      "version": "0.107.1",
+      "version": "0.108.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@protolabsai/types": "^0.107.1",
+        "@protolabsai/types": "^0.108.0",
         "zod": "^4.3.6",
         "zod-to-json-schema": "^3.24.1"
       },
@@ -1138,7 +1138,7 @@
     },
     "libs/types": {
       "name": "@protolabsai/types",
-      "version": "0.107.1",
+      "version": "0.108.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "zod": "^4.3.6"
@@ -1154,11 +1154,11 @@
     },
     "libs/ui": {
       "name": "@protolabsai/ui",
-      "version": "0.107.1",
+      "version": "0.108.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@protolabsai/types": "^0.107.1",
-        "@protolabsai/utils": "^0.107.1",
+        "@protolabsai/types": "^0.108.0",
+        "@protolabsai/utils": "^0.108.0",
         "@radix-ui/react-checkbox": "^1.1.2",
         "@radix-ui/react-collapsible": "1.1.12",
         "@radix-ui/react-dialog": "^1.1.4",
@@ -1305,11 +1305,11 @@
     },
     "libs/utils": {
       "name": "@protolabsai/utils",
-      "version": "0.107.1",
+      "version": "0.108.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@protolabsai/platform": "^0.107.1",
-        "@protolabsai/types": "^0.107.1"
+        "@protolabsai/platform": "^0.108.0",
+        "@protolabsai/types": "^0.108.0"
       },
       "devDependencies": {
         "@types/node": "22.19.3",
@@ -9180,6 +9180,10 @@
     },
     "node_modules/@protolabsai/app": {
       "resolved": "apps/ui",
+      "link": true
+    },
+    "node_modules/@protolabsai/cli": {
+      "resolved": "packages/cli",
       "link": true
     },
     "node_modules/@protolabsai/context-engine": {
@@ -27167,6 +27171,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "packages/cli": {
+      "name": "@protolabsai/cli",
+      "version": "0.1.0",
+      "dependencies": {
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "protomaker": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.3"
+      }
+    },
     "packages/create-protolab": {
       "version": "0.6.0",
       "dependencies": {
@@ -27186,10 +27204,10 @@
     },
     "packages/mcp-server": {
       "name": "@protolabsai/mcp-server",
-      "version": "0.107.1",
+      "version": "0.108.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@protolabsai/tools": "^0.107.1"
+        "@protolabsai/tools": "^0.108.0"
       },
       "bin": {
         "automaker-mcp": "dist/index.js"


### PR DESCRIPTION
## Summary

## Why

When a protoMaker agent adds/removes a workspace package or dependency, package.json changes but package-lock.json is not regenerated. Root `npm ci` (CI, docs/deploy) then fails: 'Missing: <pkg> from lock file'. This hit the CLI scaffold (#3795 -> #3807, fixed for this repo by #3808) and WILL hit every onboarded project. Per-project CI guards are not enough — enforcement must live at the pipeline chokepoint so it works regardless of each project's CI.

## What (primary — universal)

In `...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=transient-516aa930 team= created=2026-05-26T08:42:24.526Z -->