### PR TITLE
fix(ci): prevent script injection via commit message in deploy workflows

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -55,13 +55,18 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Pass the commit message through the environment, never interpolate it
+          # directly into the shell — a message containing backticks / $() / ;
+          # would otherwise break the script or allow command injection in a job
+          # that holds CLOUDFLARE_API_TOKEN.
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message || 'Deploy' }}
         run: |
           BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
           npx wrangler pages deploy docs/.vitepress/dist \
             --project-name=protolabs-docs \
             --branch="$BRANCH" \
             --commit-hash="${GITHUB_SHA}" \
-            --commit-message="${{ github.event.head_commit.message || 'Deploy' }}"
+            --commit-message="${COMMIT_MESSAGE:-Deploy}"
 
       - name: Comment PR preview URL
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -48,13 +48,18 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Pass the commit message through the environment, never interpolate it
+          # directly into the shell — a message containing backticks / $() / ;
+          # would otherwise break the script or allow command injection in a job
+          # that holds CLOUDFLARE_API_TOKEN.
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message || 'Deploy' }}
         run: |
           BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
           npx -y wrangler pages deploy site \
             --project-name=automaker \
             --branch="$BRANCH" \
             --commit-hash="${GITHUB_SHA}" \
-            --commit-message="${{ github.event.head_commit.message || 'Deploy' }}"
+            --commit-message="${COMMIT_MESSAGE:-Deploy}"
 
       - name: Comment PR preview URL
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Fixes #3811.

`deploy-docs.yml` and `deploy-site.yml` interpolated `${{ github.event.head_commit.message }}` directly into the wrangler `run:` block. GitHub substitutes `${{ }}` as raw text before bash runs, so a commit message with backticks / `$()` / `;` is executed (CWE-94 script injection) in a job holding `CLOUDFLARE_API_TOKEN`. This already broke docs deploy on main (an agent commit body contained backticks).

**Fix:** pass the message via an `env:` var (`COMMIT_MESSAGE`) so the shell treats it as literal data, then reference `"${COMMIT_MESSAGE:-Deploy}"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment workflow robustness by preventing special characters in commit messages from causing deployment failures. Commit messages are now safely passed through environment variables rather than direct shell interpolation, reducing the risk of injection-related issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3812?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->