### PR TITLE
board + query commands

### DIFF
--- a/apps/server/src/routes/features/index.ts
+++ b/apps/server/src/routes/features/index.ts
@@ -21,6 +21,7 @@ import { createGenerateTitleHandler } from './routes/generate-title.js';
 import { createHealthHandler } from './routes/health.js';
 import { createAssignAgentHandler } from './routes/assign-agent.js';
 import { createSummaryHandler } from './routes/summary.js';
+import { createQueryHandler } from './routes/query.js';
 import { createRollbackHandler, RollbackRequestSchema } from './routes/rollback.js';
 import { createHandoffHandler, HandoffRequestSchema } from './routes/handoff.js';
 import {
@@ -93,6 +94,7 @@ export function createFeaturesRoutes(
     validatePathParams('projectPath'),
     createSummaryHandler(featureLoader, settingsService)
   );
+  router.post('/query', validatePathParams('projectPath'), createQueryHandler(featureLoader));
   router.post('/agent-output', createAgentOutputHandler(featureLoader));
   router.post('/raw-output', createRawOutputHandler(featureLoader));
   router.post('/generate-title', createGenerateTitleHandler(settingsService));

--- a/apps/server/src/routes/features/routes/query.ts
+++ b/apps/server/src/routes/features/routes/query.ts
@@ -1,0 +1,90 @@
+/**
+ * POST /query endpoint — compound filters over features
+ *
+ * Supports filtering by: status, category, assignee
+ * All filters are AND-combined.  Omitted filters are ignored.
+ */
+
+import { z } from 'zod';
+import type { Request, Response } from 'express';
+import type { Feature } from '@protolabsai/types';
+import { FeatureLoader } from '../../../services/feature-loader.js';
+import { getErrorMessage, logError } from '../common.js';
+import { projectPathSchema } from '../../../lib/validation.js';
+
+const queryFeaturesBodySchema = z.object({
+  projectPath: projectPathSchema,
+  status: z.string().optional(),
+  category: z.string().optional(),
+  assignee: z.string().optional(),
+  projectSlug: z.string().optional(),
+});
+
+interface QueryRequest {
+  projectPath: string;
+  status?: string;
+  category?: string;
+  assignee?: string;
+  projectSlug?: string;
+}
+
+interface QueryResponse {
+  success: boolean;
+  features?: Feature[];
+  count?: number;
+  error?: string;
+}
+
+/**
+ * Apply compound filters to a feature array.
+ */
+function applyFilters(features: Feature[], filter: QueryRequest): Feature[] {
+  let result = features;
+
+  if (filter.status) {
+    result = result.filter((f) => f.status === filter.status);
+  }
+
+  if (filter.category) {
+    result = result.filter((f) => f.category === filter.category);
+  }
+
+  if (filter.assignee !== undefined && filter.assignee !== '') {
+    result = result.filter((f) => f.assignee === filter.assignee);
+  }
+
+  if (filter.projectSlug) {
+    result = result.filter((f) => f.projectSlug === filter.projectSlug);
+  }
+
+  return result;
+}
+
+export function createQueryHandler(featureLoader: FeatureLoader) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const parsed = queryFeaturesBodySchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({
+          success: false,
+          error: 'Validation failed',
+          details: parsed.error.issues,
+        });
+        return;
+      }
+
+      const filter = parsed.data as QueryRequest;
+      const { projectPath } = filter;
+
+      let features = await featureLoader.getAll(projectPath);
+
+      // Apply compound filters
+      features = applyFilters(features, filter);
+
+      res.json({ success: true, features, count: features.length });
+    } catch (error) {
+      logError(error, 'Query features failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/packages/cli/src/board.ts
+++ b/packages/cli/src/board.ts
@@ -1,0 +1,231 @@
+/**
+ * protomaker board
+ *
+ * Print a per-status summary of the feature board.
+ *
+ * Usage:
+ *   protomaker board [options]
+ *   protomaker board --json
+ */
+
+import { Command } from 'commander';
+import { ApiClient } from './api-client.js';
+import { output, error, type GlobalFlags, getOutputMode } from './output.js';
+import { resolveApiConfig } from './config.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface WipLaneSaturation {
+  count: number;
+  limit: number;
+  ratio: number;
+  overLimit: boolean;
+}
+
+interface WipSaturation {
+  in_progress: WipLaneSaturation;
+  review: WipLaneSaturation;
+  overallSaturation: number;
+}
+
+interface BoardSummaryData {
+  total: number;
+  backlog: number;
+  inProgress: number;
+  review: number;
+  blocked: number;
+  done: number;
+  verified: number;
+  wipSaturation: WipSaturation;
+}
+
+interface SummaryResponse {
+  success: boolean;
+  summary?: BoardSummaryData;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getGlobalFlags(opts: Record<string, unknown>): GlobalFlags {
+  return {
+    json: opts.json === true,
+    quiet: opts.quiet === true,
+    project: (opts.project as string) ?? process.cwd(),
+  };
+}
+
+function createClient(flags: GlobalFlags): ApiClient {
+  const config = resolveApiConfig(flags.project);
+  return new ApiClient(config);
+}
+
+/**
+ * Render a text summary table from board summary data.
+ */
+function renderSummary(summary: BoardSummaryData): string {
+  const wip = summary.wipSaturation;
+
+  const rows: string[][] = [
+    ['Status', 'Count', 'WIP Limit'],
+    ['─'.repeat(12), '─'.repeat(5), '─'.repeat(9)],
+    ['backlog', String(summary.backlog), ''],
+    ['in_progress', String(summary.inProgress), String(wip.in_progress.limit)],
+    ['review', String(summary.review), String(wip.review.limit)],
+    ['blocked', String(summary.blocked), ''],
+    ['done', String(summary.done), ''],
+  ];
+
+  if (summary.verified > 0) {
+    rows.push(['verified', String(summary.verified), '']);
+  }
+
+  rows.push(['', '', '']);
+  rows.push(['TOTAL', String(summary.total), '']);
+
+  // Pad columns
+  const col0 = Math.max(...rows.map((r) => r[0].length));
+  const col1 = Math.max(...rows.map((r) => r[1].length));
+  const col2 = Math.max(...rows.map((r) => r[2].length));
+
+  const lines = rows.map(([a, b, c]) => `${a.padEnd(col0)}  ${b.padEnd(col1)}  ${c.padEnd(col2)}`);
+
+  const result = ['', `Board Summary (${summary.total} total)`, '─'.repeat(40), ...lines, ''];
+
+  // WIP saturation warnings
+  if (wip.in_progress.overLimit) {
+    result.push(`⚠ in_progress WIP exceeded: ${wip.in_progress.count}/${wip.in_progress.limit}`);
+  }
+  if (wip.review.overLimit) {
+    result.push(`⚠ review WIP exceeded: ${wip.review.count}/${wip.review.limit}`);
+  }
+
+  if (wip.in_progress.overLimit || wip.review.overLimit) {
+    result.push('');
+  }
+
+  return result.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+/**
+ * protomaker board
+ *
+ * Print a per-status summary.  With --json, output raw JSON.
+ */
+export function boardCommand(parent: Command): void {
+  const cmd = new Command('board');
+  cmd.description('Print a per-status summary of the feature board');
+
+  cmd.action(async (opts) => {
+    const flags = getGlobalFlags(opts);
+    const client = createClient(flags);
+
+    const result = await client.post<SummaryResponse>('/features/summary', {
+      projectPath: flags.project,
+    });
+
+    if (!result.ok) {
+      error(result.error || 'Failed to fetch board summary');
+      process.exit(1);
+      return;
+    }
+
+    const summary = result.data?.summary;
+    if (!summary) {
+      error('No summary data returned from server');
+      process.exit(1);
+      return;
+    }
+
+    if (getOutputMode(flags) === 'json') {
+      output(summary, flags);
+    } else {
+      output(renderSummary(summary), flags);
+    }
+  });
+
+  parent.addCommand(cmd);
+}
+
+/**
+ * protomaker query
+ *
+ * Query features with compound filters: status, category, assignee.
+ *
+ * Usage:
+ *   protomaker query [options]
+ *   protomaker query --status backlog --category feature
+ *   protomaker query --assignee agent --json
+ */
+export function queryCommand(parent: Command): void {
+  const cmd = new Command('query');
+  cmd.description('Query features with compound filters');
+  cmd.option('--status <status>', 'Filter by status (backlog, in_progress, review, blocked, done)');
+  cmd.option('--category <category>', 'Filter by category');
+  cmd.option('--assignee <assignee>', 'Filter by assignee');
+
+  cmd.action(async (opts) => {
+    const flags = getGlobalFlags(opts);
+    const client = createClient(flags);
+
+    const body: Record<string, unknown> = {
+      projectPath: flags.project,
+    };
+    if (opts.status) body.status = opts.status;
+    if (opts.category) body.category = opts.category;
+    if (opts.assignee !== undefined) body.assignee = opts.assignee;
+
+    const result = await client.post<{
+      success: boolean;
+      features?: any[];
+      count?: number;
+      error?: string;
+    }>('/features/query', body);
+
+    if (!result.ok) {
+      error(result.error || 'Failed to query features');
+      process.exit(1);
+      return;
+    }
+
+    const features = result.data?.features ?? [];
+    const count = result.data?.count ?? features.length;
+
+    if (getOutputMode(flags) === 'json') {
+      output({ features, count }, flags);
+    } else {
+      // Human-readable output
+      const filterParts: string[] = [];
+      if (opts.status) filterParts.push(`status=${opts.status}`);
+      if (opts.category) filterParts.push(`category=${opts.category}`);
+      if (opts.assignee !== undefined) filterParts.push(`assignee=${opts.assignee}`);
+
+      const filterLine = filterParts.length
+        ? `Filters: ${filterParts.join(', ')}`
+        : 'Filters: (none)';
+
+      const lines = ['', `Query Results (${count} found)`, filterLine, '─'.repeat(40)];
+
+      for (const f of features) {
+        const status = f.status || 'backlog';
+        const title = f.title || f.id;
+        const cat = f.category || '';
+        const assigneeLabel = f.assignee ? ` → ${f.assignee}` : '';
+        lines.push(`  ${f.id}  [${status}]  ${title}${cat ? ` (${cat})` : ''}${assigneeLabel}`);
+      }
+
+      lines.push('');
+      output(lines.join('\n'), flags);
+    }
+  });
+
+  parent.addCommand(cmd);
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,6 +24,7 @@ import { createRequire } from 'node:module';
 import { Command } from 'commander';
 import { type GlobalFlags, usageError, exitError } from './output.js';
 import { listCommand, getCommand, createCommand, updateCommand, moveCommand } from './feature.js';
+import { boardCommand, queryCommand } from './board.js';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json') as { version: string };
@@ -87,6 +88,11 @@ featureCmd
     `\nCommands:\n  list      List features grouped by status\n  get       Show full feature details\n  create    Create a new feature\n  update    Update a feature\n  move      Transition feature status`
   );
 
+// Register feature subcommands
+listCommand(featureCmd);
+getCommand(featureCmd);
+createCommand(featureCmd);
+
 // ---------------------------------------------------------------------------
 // Register command groups
 // ---------------------------------------------------------------------------
@@ -95,6 +101,10 @@ program.addCommand(projectCmd);
 program.addCommand(agentCmd);
 program.addCommand(devCmd);
 program.addCommand(featureCmd);
+
+// Top-level board and query commands
+boardCommand(program);
+queryCommand(program);
 
 // ---------------------------------------------------------------------------
 // Entry — exit-code discipline


### PR DESCRIPTION
## Summary

**Milestone:** Core board commands

`protomaker board` (summary) and `protomaker query` (compound filters: status/category/assignee) over the board/query endpoints.
**Acceptance Criteria:**
- [ ] board prints a per-status summary
- [ ] query supports at least status+category filters
- [ ] --json

**Complexity:** small

**Guardrails:** If this phase involves new or changed behavior, include tests that verify correctness. If this phase adds, removes, or changes a user-facing feature, API endpoint,...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=transient-b08e30be team= created=2026-05-26T09:23:59.613Z -->