### PR TITLE
queue + auto-mode commands

### DIFF
--- a/packages/cli/src/auto-mode.ts
+++ b/packages/cli/src/auto-mode.ts
@@ -1,0 +1,237 @@
+/**
+ * protomaker auto-mode
+ *
+ * Auto-mode control commands — start, stop, status.
+ *
+ * Usage:
+ *   protomaker auto-mode start [options]
+ *   protomaker auto-mode stop [options]
+ *   protomaker auto-mode status [options]
+ */
+
+import { Command } from 'commander';
+import { ApiClient } from './api-client.js';
+import { output, error, type GlobalFlags, getOutputMode } from './output.js';
+import { resolveApiConfig } from './config.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface RunningAgent {
+  featureId: string;
+  title?: string;
+  status?: string;
+  branchName?: string;
+  projectPath?: string;
+  startTime?: string;
+  [key: string]: unknown;
+}
+
+interface AutoModeStartResponse {
+  success: boolean;
+  alreadyRunning?: boolean;
+  message?: string;
+  error?: string;
+}
+
+interface AutoModeStopResponse {
+  success: boolean;
+  wasRunning?: boolean;
+  message?: string;
+  error?: string;
+}
+
+interface AutoModeStatusResponse {
+  success: boolean;
+  isRunning?: boolean;
+  isAutoLoopRunning?: boolean;
+  runningFeatures?: RunningAgent[];
+  runningCount?: number;
+  maxConcurrency?: number;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getGlobalFlags(opts: Record<string, unknown>): GlobalFlags {
+  return {
+    json: opts.json === true,
+    quiet: opts.quiet === true,
+    project: (opts.project as string) ?? process.cwd(),
+  };
+}
+
+function createClient(flags: GlobalFlags): ApiClient {
+  const config = resolveApiConfig(flags.project);
+  return new ApiClient(config);
+}
+
+function renderStatus(status: AutoModeStatusResponse): string {
+  const lines: string[] = [];
+  lines.push('');
+
+  const running = status.isAutoLoopRunning ?? status.isRunning ?? false;
+  lines.push(`Status:        ${running ? '▶️ running' : '⏹️ stopped'}`);
+
+  if (status.runningCount !== undefined) {
+    lines.push(`Running:       ${status.runningCount}`);
+  }
+  if (status.maxConcurrency !== undefined) {
+    lines.push(`Concurrency:   ${status.maxConcurrency}`);
+  }
+
+  if (status.runningFeatures && status.runningFeatures.length > 0) {
+    lines.push('');
+    lines.push('Active features:');
+    for (const f of status.runningFeatures) {
+      const title = f.title || f.featureId;
+      const branch = f.branchName ? ` (branch: ${f.branchName})` : '';
+      lines.push(`  • ${f.featureId} — ${title}${branch}`);
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+/**
+ * protomaker auto-mode start
+ *
+ * Start the auto-mode loop for a project.
+ *
+ * Options: --branch, --max-concurrency
+ */
+export function startCommand(parent: Command): void {
+  const cmd = new Command('start');
+  cmd.description('Start the auto-mode loop');
+  cmd.option('--branch <name>', 'Branch name for worktree isolation');
+  cmd.option('--max-concurrency <n>', 'Max concurrent features');
+
+  cmd.action(async (opts) => {
+    const flags = getGlobalFlags(opts);
+    const client = createClient(flags);
+
+    const body: Record<string, unknown> = { projectPath: flags.project };
+    if (opts.branch) {
+      body.branchName = opts.branch;
+    }
+    if (opts.maxConcurrency) {
+      const n = parseInt(opts.maxConcurrency, 10);
+      if (isNaN(n) || n < 1 || n > 20) {
+        error('max-concurrency must be between 1 and 20');
+        process.exit(1);
+        return;
+      }
+      body.maxConcurrency = n;
+    }
+
+    const result = await client.post<AutoModeStartResponse>('/auto-mode/start', body);
+
+    if (!result.ok) {
+      error(result.error || 'Failed to start auto-mode');
+      process.exit(1);
+      return;
+    }
+
+    if (getOutputMode(flags) === 'json') {
+      output(result.data, flags);
+    } else {
+      if (result.data?.alreadyRunning) {
+        output('Auto-mode is already running', flags);
+      } else {
+        output('Auto-mode started', flags);
+      }
+    }
+  });
+
+  parent.addCommand(cmd);
+}
+
+/**
+ * protomaker auto-mode stop
+ *
+ * Stop the auto-mode loop for a project.
+ *
+ * Options: --branch
+ */
+export function stopCommand(parent: Command): void {
+  const cmd = new Command('stop');
+  cmd.description('Stop the auto-mode loop');
+  cmd.option('--branch <name>', 'Branch name for worktree isolation');
+
+  cmd.action(async (opts) => {
+    const flags = getGlobalFlags(opts);
+    const client = createClient(flags);
+
+    const body: Record<string, unknown> = { projectPath: flags.project };
+    if (opts.branch) {
+      body.branchName = opts.branch;
+    }
+
+    const result = await client.post<AutoModeStopResponse>('/auto-mode/stop', body);
+
+    if (!result.ok) {
+      error(result.error || 'Failed to stop auto-mode');
+      process.exit(1);
+      return;
+    }
+
+    if (getOutputMode(flags) === 'json') {
+      output(result.data, flags);
+    } else {
+      if (result.data?.wasRunning === false) {
+        output('Auto-mode was not running', flags);
+      } else {
+        output('Auto-mode stopped', flags);
+      }
+    }
+  });
+
+  parent.addCommand(cmd);
+}
+
+/**
+ * protomaker auto-mode status
+ *
+ * Show the current auto-mode status for a project.
+ *
+ * Options: --branch
+ */
+export function statusCommand(parent: Command): void {
+  const cmd = new Command('status');
+  cmd.description('Show auto-mode status');
+  cmd.option('--branch <name>', 'Branch name for worktree isolation');
+
+  cmd.action(async (opts) => {
+    const flags = getGlobalFlags(opts);
+    const client = createClient(flags);
+
+    const body: Record<string, unknown> = { projectPath: flags.project };
+    if (opts.branch) {
+      body.branchName = opts.branch;
+    }
+
+    const result = await client.post<AutoModeStatusResponse>('/auto-mode/status', body);
+
+    if (!result.ok) {
+      error(result.error || 'Failed to get auto-mode status');
+      process.exit(1);
+      return;
+    }
+
+    if (getOutputMode(flags) === 'json') {
+      output(result.data, flags);
+    } else {
+      output(renderStatus(result.data ?? { success: true }), flags);
+    }
+  });
+
+  parent.addCommand(cmd);
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -31,6 +31,16 @@ import {
   outputCommand,
   messageCommand,
 } from './agent.js';
+import {
+  addCommand as queueAddCommand,
+  listCommand as queueListCommand,
+  clearCommand as queueClearCommand,
+} from './queue.js';
+import {
+  startCommand as autoModeStartCommand,
+  stopCommand as autoModeStopCommand,
+  statusCommand as autoModeStatusCommand,
+} from './auto-mode.js';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json') as { version: string };
@@ -100,6 +110,36 @@ featureCmd
     `\nCommands:\n  list      List features grouped by status\n  get       Show full feature details\n  create    Create a new feature\n  update    Update a feature\n  move      Transition feature status`
   );
 
+/**
+ * Queue commands — manage the execution queue.
+ */
+const queueCmd = new Command('queue');
+queueCmd
+  .description('Manage the feature execution queue')
+  .addHelpText(
+    'afterAll',
+    `\nCommands:\n  add     Add a feature to the queue\n  list    List features in the queue\n  clear   Clear all features from the queue`
+  );
+
+queueAddCommand(queueCmd);
+queueListCommand(queueCmd);
+queueClearCommand(queueCmd);
+
+/**
+ * Auto-mode commands — control the auto-mode loop.
+ */
+const autoModeCmd = new Command('auto-mode');
+autoModeCmd
+  .description('Control the auto-mode loop')
+  .addHelpText(
+    'afterAll',
+    `\nCommands:\n  start   Start the auto-mode loop\n  stop    Stop the auto-mode loop\n  status  Show auto-mode status`
+  );
+
+autoModeStartCommand(autoModeCmd);
+autoModeStopCommand(autoModeCmd);
+autoModeStatusCommand(autoModeCmd);
+
 // ---------------------------------------------------------------------------
 // Register command groups
 // ---------------------------------------------------------------------------
@@ -108,6 +148,8 @@ program.addCommand(projectCmd);
 program.addCommand(agentCmd);
 program.addCommand(devCmd);
 program.addCommand(featureCmd);
+program.addCommand(queueCmd);
+program.addCommand(autoModeCmd);
 
 // ---------------------------------------------------------------------------
 // Entry — exit-code discipline

--- a/packages/cli/src/queue.ts
+++ b/packages/cli/src/queue.ts
@@ -1,0 +1,272 @@
+/**
+ * protomaker queue
+ *
+ * Queue management commands — add, list, clear features in the execution queue.
+ *
+ * Usage:
+ *   protomaker queue add <featureId> [options]
+ *   protomaker queue list [options]
+ *   protomaker queue clear [options]
+ */
+
+import { Command } from 'commander';
+import { ApiClient } from './api-client.js';
+import { output, error, usageError, type GlobalFlags, getOutputMode } from './output.js';
+import { resolveApiConfig } from './config.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface QueueFeature {
+  id: string;
+  title?: string;
+  status?: string;
+  complexity?: string;
+  priority?: number;
+  [key: string]: unknown;
+}
+
+interface QueueAddResponse {
+  success: boolean;
+  feature?: QueueFeature;
+  error?: string;
+}
+
+interface QueueListResponse {
+  success: boolean;
+  features: QueueFeature[];
+  error?: string;
+}
+
+interface QueueClearResponse {
+  success: boolean;
+  clearedCount?: number;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getGlobalFlags(opts: Record<string, unknown>): GlobalFlags {
+  return {
+    json: opts.json === true,
+    quiet: opts.quiet === true,
+    project: (opts.project as string) ?? process.cwd(),
+  };
+}
+
+function createClient(flags: GlobalFlags): ApiClient {
+  const config = resolveApiConfig(flags.project);
+  return new ApiClient(config);
+}
+
+function statusBadge(status?: string): string {
+  const map: Record<string, string> = {
+    backlog: '📋 backlog',
+    in_progress: '▶️ in_progress',
+    review: '👀 review',
+    blocked: '🚫 blocked',
+    done: '✅ done',
+    interrupted: '⏸️ interrupted',
+  };
+  return status ? (map[status] ?? status) : '—';
+}
+
+function complexityLabel(complexity?: string): string {
+  const map: Record<string, string> = {
+    small: 'S',
+    medium: 'M',
+    large: 'L',
+    architectural: 'A',
+  };
+  return complexity ? (map[complexity] ?? complexity) : '—';
+}
+
+function renderQueueList(features: QueueFeature[]): string {
+  if (features.length === 0) {
+    return 'Queue is empty.';
+  }
+
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(`Queue (${features.length} feature${features.length === 1 ? '' : 's'}):`);
+  lines.push('');
+
+  for (const f of features) {
+    const title = f.title || f.id;
+    const complexity = complexityLabel(f.complexity);
+    const priority = f.priority !== undefined ? `p${f.priority}` : '';
+    const status = statusBadge(f.status);
+    const parts = [title];
+    if (complexity !== '—') parts.push(complexity);
+    if (priority) parts.push(priority);
+    lines.push(`  • ${f.id} — ${parts.join(' ')} ${status}`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+/**
+ * protomaker queue add <featureId>
+ *
+ * Add a feature to the execution queue (transition to backlog status).
+ */
+export function addCommand(parent: Command): void {
+  const cmd = new Command('add <featureId>');
+  cmd.description('Add a feature to the execution queue');
+
+  cmd.action(async (featureId: string, opts) => {
+    const flags = getGlobalFlags(opts);
+    const client = createClient(flags);
+
+    const result = await client.post<QueueAddResponse>('/features/update', {
+      projectPath: flags.project,
+      featureId,
+      updates: { status: 'backlog' },
+    });
+
+    if (!result.ok) {
+      error(result.error || `Failed to add feature "${featureId}" to queue`);
+      process.exit(1);
+      return;
+    }
+
+    if (getOutputMode(flags) === 'json') {
+      output({ success: true, featureId, status: 'backlog' }, flags);
+    } else {
+      output(`Added "${featureId}" to the queue`, flags);
+    }
+  });
+
+  parent.addCommand(cmd);
+}
+
+/**
+ * protomaker queue list
+ *
+ * List features in the execution queue (backlog status).
+ */
+export function listCommand(parent: Command): void {
+  const cmd = new Command('list');
+  cmd.description('List features in the execution queue');
+
+  cmd.action(async (opts) => {
+    const flags = getGlobalFlags(opts);
+    const client = createClient(flags);
+
+    const result = await client.post<QueueListResponse>('/features/list', {
+      projectPath: flags.project,
+      status: 'backlog',
+    });
+
+    if (!result.ok) {
+      error(result.error || 'Failed to list queue');
+      process.exit(1);
+      return;
+    }
+
+    const features = result.data?.features ?? [];
+
+    if (getOutputMode(flags) === 'json') {
+      output(features, flags);
+    } else {
+      output(renderQueueList(features), flags);
+    }
+  });
+
+  parent.addCommand(cmd);
+}
+
+/**
+ * protomaker queue clear
+ *
+ * Clear all features from the execution queue (delete backlog features).
+ */
+export function clearCommand(parent: Command): void {
+  const cmd = new Command('clear');
+  cmd.description('Clear all features from the execution queue');
+  cmd.option('--yes', 'Skip confirmation prompt');
+
+  cmd.action(async (opts) => {
+    const flags = getGlobalFlags(opts);
+
+    if (!opts.yes) {
+      // Read confirmation from stdin
+      const readline = await import('node:readline');
+      const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
+
+      const answer = await new Promise<string>((resolve) => {
+        rl.question('This will delete all backlog features. Are you sure? (y/N) ', (a) => {
+          rl.close();
+          resolve(a.trim().toLowerCase());
+        });
+      });
+
+      if (answer !== 'y' && answer !== 'yes') {
+        output('Cancelled.', flags);
+        return;
+      }
+    }
+
+    const client = createClient(flags);
+
+    // First, get all backlog features
+    const listResult = await client.post<QueueListResponse>('/features/list', {
+      projectPath: flags.project,
+      status: 'backlog',
+    });
+
+    if (!listResult.ok) {
+      error(listResult.error || 'Failed to list queue');
+      process.exit(1);
+      return;
+    }
+
+    const features = listResult.data?.features ?? [];
+
+    if (features.length === 0) {
+      if (getOutputMode(flags) === 'json') {
+        output({ success: true, clearedCount: 0 }, flags);
+      } else {
+        output('Queue is already empty.', flags);
+      }
+      return;
+    }
+
+    // Delete all backlog features
+    const featureIds = features.map((f) => f.id);
+    const deleteResult = await client.post<QueueClearResponse>('/features/bulk-delete', {
+      projectPath: flags.project,
+      featureIds,
+    });
+
+    if (!deleteResult.ok) {
+      error(deleteResult.error || 'Failed to clear queue');
+      process.exit(1);
+      return;
+    }
+
+    const clearedCount = (deleteResult.data as any)?.deletedCount ?? featureIds.length;
+
+    if (getOutputMode(flags) === 'json') {
+      output({ success: true, clearedCount }, flags);
+    } else {
+      output(
+        `Cleared ${clearedCount} feature${clearedCount === 1 ? '' : 's'} from the queue`,
+        flags
+      );
+    }
+  });
+
+  parent.addCommand(cmd);
+}


### PR DESCRIPTION
## Summary

**Milestone:** Core board commands

`protomaker queue add <id>|list|clear` and `protomaker auto-mode start|stop|status`.
**Acceptance Criteria:**
- [ ] queue add/list/clear work
- [ ] auto-mode start/stop/status reflect server state
- [ ] --json

**Complexity:** small

**Guardrails:** If this phase involves new or changed behavior, include tests that verify correctness. If this phase adds, removes, or changes a user-facing feature, API endpoint, configuration option, or service, update the relev...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=transient-eb064d0a team= created=2026-05-26T09:37:25.075Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `protomaker auto-mode` subcommands (`start`, `stop`, `status`) for controlling automatic mode with configurable options like branch and concurrency settings.
  * Added `protomaker queue` subcommands (`add`, `list`, `clear`) for queue management, including confirmation prompts for destructive operations.
  * All new commands support both JSON and human-readable output formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->