### PR TITLE
feat(docker): install beads_rust `br` CLI in the server image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && tar -xzf gh.tar.gz \
     && mv gh_${GH_VERSION}_linux_${GH_ARCH}/bin/gh /usr/local/bin/gh \
     && rm -rf gh.tar.gz gh_${GH_VERSION}_linux_${GH_ARCH} \
+    # beads_rust (`br`) — beads issue-tracker CLI. Single static-ish binary,
+    # glibc-linked, ~17 MB. Used by agents running inside this image to
+    # read/write the .beads/ store mounted from the host repo.
+    && BR_VERSION="0.2.11" \
+    && case "$ARCH" in \
+        x86_64) BR_ARCH="amd64"; BR_SHA="3907b968122c9982e39822c5f56964f786ccf2f3ecdfc3291e8653eca39de9cf" ;; \
+        aarch64|arm64) BR_ARCH="arm64"; BR_SHA="5e66be7a01295978eb5e73db024bd140f9fd914a08dad0682f3230bb4a145421" ;; \
+    esac \
+    && curl -fsSL "https://github.com/Dicklesworthstone/beads_rust/releases/download/v${BR_VERSION}/br-${BR_VERSION}-linux_${BR_ARCH}.tar.gz" -o br.tar.gz \
+    && echo "${BR_SHA}  br.tar.gz" | sha256sum -c - \
+    && tar -xzf br.tar.gz -C /usr/local/bin br \
+    && chmod +x /usr/local/bin/br \
+    && rm -f br.tar.gz \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Claude CLI globally (available to all users via npm global bin)


### PR DESCRIPTION
## Summary

Adds the `br` binary ([Dicklesworthstone/beads_rust](https://github.com/Dicklesworthstone/beads_rust) v0.2.11) alongside the existing `gh` install in the server runtime stage. Multi-arch (amd64 + arm64), SHA256-pinned.

## Why

protoMaker agents operate on host-mounted repos that increasingly use `.beads/` as the issue-tracker store. Without `br` in the container, the agents can't read/write that store from inside their worktrees.

## Verify (after build)
```
docker run --rm protoMaker-server:latest br --version
# expect: 0.2.11
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `br` command-line tool is now included and available in the production environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->