### PR TITLE
fix(docker): bump base to Debian Trixie so the `br` binary loads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # =============================================================================
 # BASE STAGE - Common setup for all builds (DRY: defined once, used by all)
 # =============================================================================
-FROM node:22-slim AS base
+FROM node:22-trixie-slim AS base
 
 # Install build dependencies for native modules (node-pty)
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -77,7 +77,7 @@ RUN cd apps/server && find src -name '*.md' -o -name '*.json' | while read f; do
 # =============================================================================
 # SERVER PRODUCTION STAGE
 # =============================================================================
-FROM node:22-slim AS server
+FROM node:22-trixie-slim AS server
 
 # Build argument for tracking which commit this image was built from
 ARG GIT_COMMIT_SHA=unknown


### PR DESCRIPTION
## Summary

Follow-up to #3835. The `beads_rust` v0.2.11 amd64 binary is dynamically linked against GLIBC 2.38/2.39, but `node:22-slim` is Debian Bookworm (glibc 2.36). After #3835 merged, running `br --version` in the rebuilt server image fails with:

```
br: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
br: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

Bumping both `FROM` directives (base + server stages) to `node:22-trixie-slim` gets us glibc 2.41, which satisfies the binary.

## Risk

Trixie is Debian's current stable. All apt packages we install — gh, gosu, dumb-init, Playwright/Chromium deps — exist in Trixie. The risk is minor version drift in those packages, which CI will catch.

## Verify (after merge + local rebuild)
```
docker exec protomaker-server br --version
# expect: 0.2.11
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js container base image to the latest Debian-based distribution for improved compatibility and security maintenance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->