### PR TITLE
docs: CLI how-to guide and command reference (Diataxis docs)

### DIFF
--- a/.claude/skills/protomaker-cli.md
+++ b/.claude/skills/protomaker-cli.md
@@ -1,0 +1,200 @@
+---
+name: protomaker-cli
+description: Use the protomaker CLI as the primary board interface. Discover commands via --help, complete feature->PR loops via Bash. Prefer this over MCP tools for board operations.
+category: tooling
+argument-hint: [command or subcommand to look up]
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# protomaker CLI — Primary Board Interface
+
+The `protomaker` CLI is the primary interface for board operations, agent lifecycle,
+and PR management. Use it via Bash instead of MCP tools.
+
+## Discovery Pattern
+
+Always discover available commands and flags via `--help`:
+
+```bash
+# Top-level help — shows all command groups
+protomaker --help
+
+# Command group help — shows subcommands
+protomaker feature --help
+protomaker agent --help
+protomaker pr --help
+protomaker auto-mode --help
+protomaker queue --help
+protomaker context --help
+
+# Subcommand help — shows arguments and flags
+protomaker feature create --help
+protomaker agent start --help
+protomaker pr create --help
+```
+
+## Global Flags
+
+Every command supports:
+
+| Flag               | Description                               |
+| ------------------ | ----------------------------------------- |
+| `--json`           | Output structured JSON (machine-readable) |
+| `--quiet`          | Suppress all non-error output             |
+| `--project <path>` | Project path (defaults to cwd)            |
+
+## Command Surface
+
+### Feature Management
+
+```bash
+protomaker feature list                    # Board view — grouped by status
+protomaker feature list --status backlog   # Filter by status
+protomaker feature list --compact          # One-line per feature (text mode)
+protomaker feature get <featureId>         # Full feature details
+protomaker feature create --description "..." --title "..." --complexity small --priority 3
+protomaker feature update <featureId> --title "..." --description "..."
+protomaker feature move <featureId> <status>   # status: backlog, in_progress, review, blocked, done, interrupted
+```
+
+### Agent Lifecycle
+
+```bash
+protomaker agent list                      # Show running agents
+protomaker agent start <featureId>         # Dispatch agent for a feature
+protomaker agent start <featureId> --force # Skip dependency checks
+protomaker agent start <featureId> --worktree # Use git worktree isolation
+protomaker agent stop <featureId>          # Stop a running agent
+protomaker agent output <featureId>        # Print agent output (agent-output.md)
+protomaker agent message <featureId> "..." # Send follow-up message to running agent
+```
+
+### PR Lifecycle
+
+```bash
+protomaker pr create <featureId>           # Commit, push, and open PR from worktree
+protomaker pr status <prNumber>            # CI rollup (checks, ownership, staleness)
+protomaker pr merge <prNumber>             # Merge with configured strategy (default: squash)
+protomaker pr merge <prNumber> --strategy rebase
+protomaker pr merge <prNumber> --no-wait-for-ci
+```
+
+### Auto-Mode
+
+```bash
+protomaker auto-mode start                 # Start the auto-mode loop
+protomaker auto-mode start --max-concurrency 3
+protomaker auto-mode stop                  # Stop the auto-mode loop
+protomaker auto-mode status                # Show auto-mode state + active features
+```
+
+### Queue
+
+```bash
+protomaker queue add <featureId>           # Add feature to execution queue
+protomaker queue list                      # List queued features
+protomaker queue clear --yes               # Clear all queued features
+```
+
+### Board & Query
+
+```bash
+protomaker board                           # Per-status summary with WIP limits
+protomaker query --status backlog          # Query with compound filters
+protomaker query --status in_progress --assignee agent
+```
+
+### Context Files
+
+```bash
+protomaker context list                    # List all context files
+protomaker context get <filename.md>       # Read a context file
+protomaker context create <filename.md> --content "..."  # Create a context file
+protomaker context delete <filename.md>    # Delete a context file
+```
+
+### Operations
+
+```bash
+protomaker sitrep                          # Full operational status (board, agents, PRs, health)
+protomaker health                          # Server health check
+```
+
+## Feature -> PR Loop (Agent Workflow)
+
+Complete a full feature-to-PR cycle using only the CLI:
+
+```bash
+# 1. Check server is reachable
+protomaker health
+
+# 2. View current board state
+protomaker board
+
+# 3. Create a feature
+protomaker feature create \
+  --title "Add user auth" \
+  --description "Implement JWT-based authentication for API endpoints" \
+  --complexity medium \
+  --priority 2
+
+# 4. Get the feature ID from the output (or list to find it)
+FEATURE_ID=$(protomaker feature list --compact --json | jq -r '.[0].id')
+
+# 5. Dispatch an agent
+protomaker agent start $FEATURE_ID --worktree
+
+# 6. Monitor agent progress
+protomaker agent list
+protomaker agent output $FEATURE_ID
+
+# 7. Send follow-up if needed
+protomaker agent message $FEATURE_ID "Also add rate limiting to auth endpoints"
+
+# 8. Create PR when agent completes
+protomaker pr create $FEATURE_ID \
+  --commit-message "feat: add user auth" \
+  --pr-title "Add user authentication"
+
+# 9. Check CI status
+protomaker pr status 123
+
+# 10. Merge when checks pass
+protomaker pr merge 123
+
+# 11. Move feature to done
+protomaker feature move $FEATURE_ID done
+```
+
+## JSON Mode for Parsing
+
+Use `--json` when you need to parse output programmatically:
+
+```bash
+# Get feature details as JSON
+protomaker feature get $FEATURE_ID --json
+
+# List features in JSON format
+protomaker feature list --json
+
+# Sitrep as JSON for scripting
+protomaker sitrep --json
+```
+
+## Exit Codes
+
+| Code | Meaning                                       |
+| ---- | --------------------------------------------- |
+| 0    | Success                                       |
+| 1    | Runtime error (server error, network failure) |
+| 2    | Usage error (bad args, missing required flag) |
+
+## Best Practices for Agents
+
+1. **Discover via `--help`** — run `protomaker --help` before using unfamiliar commands
+2. **Use `--json` for parsing** — always use JSON mode when extracting IDs or values for scripting
+3. **Check health first** — run `protomaker health` before starting work
+4. **Use `sitrep` for overview** — get a full picture before making decisions
+5. **Prefer CLI over MCP** — the CLI is the canonical interface; MCP tools may lag behind

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && tar -xzf gh.tar.gz \
     && mv gh_${GH_VERSION}_linux_${GH_ARCH}/bin/gh /usr/local/bin/gh \
     && rm -rf gh.tar.gz gh_${GH_VERSION}_linux_${GH_ARCH} \
+    # beads_rust (`br`) — beads issue-tracker CLI. Single static-ish binary,
+    # glibc-linked, ~17 MB. Used by agents running inside this image to
+    # read/write the .beads/ store mounted from the host repo.
+    && BR_VERSION="0.2.11" \
+    && case "$ARCH" in \
+        x86_64) BR_ARCH="amd64"; BR_SHA="3907b968122c9982e39822c5f56964f786ccf2f3ecdfc3291e8653eca39de9cf" ;; \
+        aarch64|arm64) BR_ARCH="arm64"; BR_SHA="5e66be7a01295978eb5e73db024bd140f9fd914a08dad0682f3230bb4a145421" ;; \
+    esac \
+    && curl -fsSL "https://github.com/Dicklesworthstone/beads_rust/releases/download/v${BR_VERSION}/br-${BR_VERSION}-linux_${BR_ARCH}.tar.gz" -o br.tar.gz \
+    && echo "${BR_SHA}  br.tar.gz" | sha256sum -c - \
+    && tar -xzf br.tar.gz -C /usr/local/bin br \
+    && chmod +x /usr/local/bin/br \
+    && rm -f br.tar.gz \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Claude CLI globally (available to all users via npm global bin)

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # =============================================================================
 # BASE STAGE - Common setup for all builds (DRY: defined once, used by all)
 # =============================================================================
-FROM node:22-slim AS base
+FROM node:22-trixie-slim AS base
 
 # Install build dependencies for native modules (node-pty)
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -77,7 +77,7 @@ RUN cd apps/server && find src -name '*.md' -o -name '*.json' | while read f; do
 # =============================================================================
 # SERVER PRODUCTION STAGE
 # =============================================================================
-FROM node:22-slim AS server
+FROM node:22-trixie-slim AS server
 
 # Build argument for tracking which commit this image was built from
 ARG GIT_COMMIT_SHA=unknown

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,17 +24,18 @@
 
 ## How-To Guides
 
-| Document                                         | Description                              |
-| ------------------------------------------------ | ---------------------------------------- |
-| [Agent Manifests](./guides/agent-manifests.md)   | Define agent roles and capabilities      |
-| [Agent Memory](./guides/agent-memory.md)         | Configure persistent agent memory        |
-| [Context Files](./guides/context-files.md)       | Add project-specific rules for AI agents |
-| [Writing Prompts](./guides/writing-prompts.md)   | Author effective agent prompts           |
-| [Authoring Skills](./guides/authoring-skills.md) | Create reusable agent skills             |
-| [Feature Flags](./guides/feature-flags.md)       | Feature flag system and conventions      |
-| [Flow Control](./guides/flow-control.md)         | Control agent execution flow             |
-| [Deployment Modes](./guides/deployment-modes.md) | Run in web, desktop, or headless mode    |
-| [Gotchas](./guides/gotchas.md)                   | Known pitfalls and workarounds           |
+| Document                                                    | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| [Drive the Board from the CLI](./how-to/drive-the-board.md) | Manage features and agents via CLI       |
+| [Agent Manifests](./guides/agent-manifests.md)              | Define agent roles and capabilities      |
+| [Agent Memory](./guides/agent-memory.md)                    | Configure persistent agent memory        |
+| [Context Files](./guides/context-files.md)                  | Add project-specific rules for AI agents |
+| [Writing Prompts](./guides/writing-prompts.md)              | Author effective agent prompts           |
+| [Authoring Skills](./guides/authoring-skills.md)            | Create reusable agent skills             |
+| [Feature Flags](./guides/feature-flags.md)                  | Feature flag system and conventions      |
+| [Flow Control](./guides/flow-control.md)                    | Control agent execution flow             |
+| [Deployment Modes](./guides/deployment-modes.md)            | Run in web, desktop, or headless mode    |
+| [Gotchas](./guides/gotchas.md)                              | Known pitfalls and workarounds           |
 
 ## Starter Kits
 
@@ -55,6 +56,7 @@
 | [Knowledge Hive](./reference/knowledge-hive.md)       | Multi-source knowledge aggregation           |
 | [MCP Tools](./reference/mcp-tools.md)                 | Full MCP tool catalog (120+ tools)           |
 | [API Key Profiles](./reference/api-key-profiles.md)   | Unified API key and provider profile system  |
+| [CLI Commands](./reference/cli-commands.md)           | Complete protomaker CLI command reference    |
 
 ## Integrations
 

--- a/docs/how-to/drive-the-board.md
+++ b/docs/how-to/drive-the-board.md
@@ -1,0 +1,179 @@
+# Drive the board from the CLI
+
+Use the `protomaker` CLI to manage features, dispatch agents, and drive the full development loop — all from the terminal. This guide walks through a complete workflow: creating a feature, dispatching an agent, and merging the result.
+
+## Prerequisites
+
+- The protoLabs server is running (`:3008`)
+- `protomaker` CLI is installed and in your `PATH`
+- Your project is initialized (`.automaker/settings.json` exists)
+
+Verify the connection:
+
+```bash
+protomaker health
+```
+
+Expected output:
+
+```
+Server: ✅ healthy
+Version: 0.1.0
+Checked: 2026-05-26T10:30:00.000Z
+```
+
+## View the current board
+
+Check what's already queued or in progress:
+
+```bash
+protomaker board
+```
+
+This shows a per-status summary table with counts for backlog, in progress, review, blocked, and done features. You can also see the full board grouped by status:
+
+```bash
+protomaker feature list
+```
+
+## Create a feature
+
+Add a new feature to the backlog:
+
+```bash
+protomaker feature create \
+  --title "Add user authentication" \
+  --description "Implement JWT-based auth with login, logout, and token refresh endpoints" \
+  --category feature \
+  --complexity medium \
+  --priority 2
+```
+
+The CLI returns the new feature ID. Save it for the next steps.
+
+### Create an epic container
+
+For larger initiatives, create an epic that groups child features:
+
+```bash
+protomaker feature create \
+  --title "Q3 Platform Redesign" \
+  --description "Redesign the core platform with new architecture" \
+  --is-epic
+```
+
+Child features reference the epic via `--epic-id`:
+
+```bash
+protomaker feature create \
+  --title "Migrate to micro-frontends" \
+  --description "Split the monolith into independent frontend modules" \
+  --epic-id feature-1779776805064-xxx
+```
+
+## Dispatch an agent
+
+Start an agent on a feature. The agent will work in an isolated git worktree by default:
+
+```bash
+protomaker agent start feature-1779776805064-xxx
+```
+
+Skip dependency checks with `--force`:
+
+```bash
+protomaker agent start feature-1779776805064-xxx --force
+```
+
+Monitor what's running:
+
+```bash
+protomaker agent list
+```
+
+Stream agent output for a feature:
+
+```bash
+protomaker agent output feature-1779776805064-xxx
+```
+
+Send a follow-up message to a running agent:
+
+```bash
+protomaker agent message feature-1779776805064-xxx "Also handle edge case when token expires during refresh"
+```
+
+## Open a PR
+
+When the agent completes its work, create a pull request:
+
+```bash
+protomaker pr create feature-1779776805064-xxx \
+  --commit-message "feat: add user authentication" \
+  --pr-title "Add user authentication" \
+  --pr-body "Implements JWT-based auth with login, logout, and token refresh."
+```
+
+Check CI status on the PR:
+
+```bash
+protomaker pr status 42
+```
+
+## Merge the PR
+
+Once CI passes, merge with the default squash strategy:
+
+```bash
+protomaker pr merge 42
+```
+
+Use a different merge strategy if needed:
+
+```bash
+protomaker pr merge 42 --strategy rebase
+```
+
+## Use auto-mode for hands-off execution
+
+Start the auto-mode loop to automatically process backlog features:
+
+```bash
+protomaker auto-mode start --max-concurrency 3
+```
+
+Check auto-mode status at any time:
+
+```bash
+protomaker auto-mode status
+```
+
+Stop the loop:
+
+```bash
+protomaker auto-mode stop
+```
+
+## Get a full situation report
+
+For a single-command overview of board state, running agents, open PRs, and server health:
+
+```bash
+protomaker sitrep
+```
+
+## Use JSON output for scripting
+
+Every command supports `--json` for machine-readable output, making the CLI suitable for automation and CI pipelines:
+
+```bash
+protomaker feature list --json
+protomaker board --json
+protomaker sitrep --json
+```
+
+## Next Steps
+
+- **[CLI Command Reference](../reference/cli-commands)** — Complete list of every command and flag
+- **[Auto Mode](../reference/auto-mode)** — Deep dive into the auto-mode service
+- **[Workflow Settings](../reference/workflow-settings)** — Configure per-project behavior

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1,0 +1,509 @@
+# CLI Command Reference
+
+Complete reference for the `protomaker` CLI. Every command supports the global flags `--json`, `--quiet`, and `--project <path>`.
+
+## Global Flags
+
+| Flag               | Description                              | Default         |
+| ------------------ | ---------------------------------------- | --------------- |
+| `--json`           | Output results as structured JSON        | `false`         |
+| `--quiet`          | Suppress all non-error output            | `false`         |
+| `--project <path>` | Project path (resolves config from here) | `process.cwd()` |
+
+## Exit Codes
+
+| Code | Meaning       | Example                                 |
+| ---- | ------------- | --------------------------------------- |
+| 0    | Success       | Command completed without errors        |
+| 1    | Runtime error | Server returned error, network failure  |
+| 2    | Usage error   | Missing required argument, invalid flag |
+
+---
+
+## `protomaker board`
+
+Print a per-status summary of the feature board.
+
+**Usage:**
+
+```bash
+protomaker board [global-flags]
+```
+
+**Output:** Text summary table (counts per status, WIP limits). Use `--json` for raw JSON.
+
+---
+
+## `protomaker query`
+
+Query features with compound filters.
+
+**Usage:**
+
+```bash
+protomaker query [options] [global-flags]
+```
+
+**Options:**
+
+| Flag                    | Description        | Default |
+| ----------------------- | ------------------ | ------- |
+| `--status <status>`     | Filter by status   | —       |
+| `--category <category>` | Filter by category | —       |
+| `--assignee <assignee>` | Filter by assignee | —       |
+
+**Valid statuses:** `backlog`, `in_progress`, `review`, `blocked`, `done`, `interrupted`
+
+---
+
+## `protomaker health`
+
+Check server health status via `GET /health`.
+
+**Usage:**
+
+```bash
+protomaker health [global-flags]
+```
+
+---
+
+## `protomaker sitrep`
+
+Show operational status report: board state, running agents, auto-mode status, open PRs, escalations, and server health.
+
+**Usage:**
+
+```bash
+protomaker sitrep [options] [global-flags]
+```
+
+**Options:**
+
+| Flag                    | Description            | Default |
+| ----------------------- | ---------------------- | ------- |
+| `--project-slug <slug>` | Filter by project slug | —       |
+
+---
+
+## `protomaker feature`
+
+Core board commands — manage features.
+
+### `feature list`
+
+List all features grouped by status (board view).
+
+**Usage:**
+
+```bash
+protomaker feature list [options] [global-flags]
+```
+
+**Options:**
+
+| Flag                | Description                              | Default |
+| ------------------- | ---------------------------------------- | ------- |
+| `--status <status>` | Filter by status                         | —       |
+| `--compact`         | Show compact one-line format (text mode) | —       |
+
+### `feature get <featureId>`
+
+Show full feature details.
+
+**Usage:**
+
+```bash
+protomaker feature get <featureId> [global-flags]
+```
+
+### `feature create`
+
+Create a new feature.
+
+**Usage:**
+
+```bash
+protomaker feature create [options] [global-flags]
+```
+
+**Options:**
+
+| Flag                   | Description                    | Default   |
+| ---------------------- | ------------------------------ | --------- |
+| `--description <text>` | Feature description (required) | —         |
+| `--title <text>`       | Feature title                  | —         |
+| `--category <text>`    | Feature category               | `feature` |
+| `--complexity <level>` | Complexity level               | —         |
+| `--priority <n>`       | Priority (1=urgent, 4=low)     | —         |
+| `--epic-id <id>`       | Parent epic ID                 | —         |
+| `--is-epic`            | Mark as epic container         | `false`   |
+
+**Valid complexities:** `small`, `medium`, `large`, `architectural`
+
+### `feature update <featureId>`
+
+Update a feature's fields. At least one update flag is required.
+
+**Usage:**
+
+```bash
+protomaker feature update <featureId> [options] [global-flags]
+```
+
+**Options:**
+
+| Flag                   | Description          | Default |
+| ---------------------- | -------------------- | ------- |
+| `--title <text>`       | New title            | —       |
+| `--description <text>` | New description      | —       |
+| `--category <text>`    | New category         | —       |
+| `--complexity <level>` | New complexity level | —       |
+| `--priority <n>`       | New priority (1-4)   | —       |
+
+### `feature move <featureId> <status>`
+
+Transition a feature to a new status.
+
+**Usage:**
+
+```bash
+protomaker feature move <featureId> <status> [options] [global-flags]
+```
+
+**Options:**
+
+| Flag              | Description                                       | Default |
+| ----------------- | ------------------------------------------------- | ------- |
+| `--reason <text>` | Reason for status change (required when blocking) | —       |
+
+**Valid statuses:** `backlog`, `in_progress`, `review`, `blocked`, `done`, `interrupted`
+
+---
+
+## `protomaker agent`
+
+Manage AI agents and workflows.
+
+### `agent start <featureId>`
+
+Dispatch an agent to work on a feature.
+
+**Usage:**
+
+```bash
+protomaker agent start <featureId> [options] [global-flags]
+```
+
+**Options:**
+
+| Flag         | Description                             | Default |
+| ------------ | --------------------------------------- | ------- |
+| `--force`    | Skip dependency checks and start anyway | `false` |
+| `--worktree` | Use git worktree isolation              | `false` |
+
+### `agent stop <featureId>`
+
+Stop a running agent for a specific feature.
+
+**Usage:**
+
+```bash
+protomaker agent stop <featureId> [options] [global-flags]
+```
+
+**Options:**
+
+| Flag                       | Description                       | Default |
+| -------------------------- | --------------------------------- | ------- |
+| `--target-status <status>` | Set feature status after stopping | —       |
+
+### `agent list`
+
+Show running agents.
+
+**Usage:**
+
+```bash
+protomaker agent list [options] [global-flags]
+```
+
+**Options:**
+
+| Flag              | Description           | Default |
+| ----------------- | --------------------- | ------- |
+| `--branch <name>` | Filter by branch name | —       |
+
+### `agent output <featureId>`
+
+Print the agent output (agent-output.md) for a feature.
+
+**Usage:**
+
+```bash
+protomaker agent output <featureId> [global-flags]
+```
+
+### `agent message <featureId> <prompt>`
+
+Send a follow-up message to a running agent.
+
+**Usage:**
+
+```bash
+protomaker agent message <featureId> <prompt> [options] [global-flags]
+```
+
+**Options:**
+
+| Flag             | Description                       | Default |
+| ---------------- | --------------------------------- | ------- |
+| `--image <path>` | Attach an image file (repeatable) | —       |
+
+---
+
+## `protomaker pr`
+
+Pull request commands — create, check status, and merge PRs.
+
+### `pr create <featureId>`
+
+Open a PR from a feature worktree. Commits unpushed changes, pushes the branch, and creates (or reuses) the PR on GitHub.
+
+**Usage:**
+
+```bash
+protomaker pr create <featureId> [options] [global-flags]
+```
+
+**Options:**
+
+| Flag                      | Description                         | Default |
+| ------------------------- | ----------------------------------- | ------- |
+| `--commit-message <text>` | Commit message for unpushed changes | —       |
+| `--pr-title <text>`       | Pull request title                  | —       |
+| `--pr-body <text>`        | Pull request body                   | —       |
+| `--base-branch <branch>`  | Target base branch                  | —       |
+| `--draft`                 | Create as draft PR                  | `false` |
+
+### `pr status <prNumber>`
+
+Show CI rollup for a pull request (check statuses, ownership, staleness).
+
+**Usage:**
+
+```bash
+protomaker pr status <prNumber> [global-flags]
+```
+
+### `pr merge <prNumber>`
+
+Merge a PR with the configured strategy.
+
+**Usage:**
+
+```bash
+protomaker pr merge <prNumber> [options] [global-flags]
+```
+
+**Options:**
+
+| Flag                    | Description                              | Default  |
+| ----------------------- | ---------------------------------------- | -------- |
+| `--strategy <strategy>` | Merge strategy (merge, squash, rebase)   | `squash` |
+| `--no-wait-for-ci`      | Do not wait for CI checks before merging | `false`  |
+
+---
+
+## `protomaker queue`
+
+Manage the feature execution queue.
+
+### `queue add <featureId>`
+
+Add a feature to the execution queue (transition to backlog status).
+
+**Usage:**
+
+```bash
+protomaker queue add <featureId> [global-flags]
+```
+
+### `queue list`
+
+List features in the execution queue (backlog status).
+
+**Usage:**
+
+```bash
+protomaker queue list [global-flags]
+```
+
+### `queue clear`
+
+Clear all features from the execution queue (deletes backlog features).
+
+**Usage:**
+
+```bash
+protomaker queue clear [options] [global-flags]
+```
+
+**Options:**
+
+| Flag    | Description              | Default |
+| ------- | ------------------------ | ------- |
+| `--yes` | Skip confirmation prompt | `false` |
+
+---
+
+## `protomaker auto-mode`
+
+Control the auto-mode loop.
+
+### `auto-mode start`
+
+Start the auto-mode loop for a project.
+
+**Usage:**
+
+```bash
+protomaker auto-mode start [options] [global-flags]
+```
+
+**Options:**
+
+| Flag                    | Description                        | Default |
+| ----------------------- | ---------------------------------- | ------- |
+| `--branch <name>`       | Branch name for worktree isolation | —       |
+| `--max-concurrency <n>` | Max concurrent features (1-20)     | —       |
+
+### `auto-mode stop`
+
+Stop the auto-mode loop.
+
+**Usage:**
+
+```bash
+protomaker auto-mode stop [options] [global-flags]
+```
+
+**Options:**
+
+| Flag              | Description                        | Default |
+| ----------------- | ---------------------------------- | ------- |
+| `--branch <name>` | Branch name for worktree isolation | —       |
+
+### `auto-mode status`
+
+Show the current auto-mode status for a project.
+
+**Usage:**
+
+```bash
+protomaker auto-mode status [options] [global-flags]
+```
+
+**Options:**
+
+| Flag              | Description                        | Default |
+| ----------------- | ---------------------------------- | ------- |
+| `--branch <name>` | Branch name for worktree isolation | —       |
+
+---
+
+## `protomaker context`
+
+Manage project context files.
+
+### `context list`
+
+List all context files in the project.
+
+**Usage:**
+
+```bash
+protomaker context list [global-flags]
+```
+
+### `context get <filename>`
+
+Read and display a context file.
+
+**Usage:**
+
+```bash
+protomaker context get <filename> [global-flags]
+```
+
+**Filename rules:** Must end in `.md` or `.txt`.
+
+### `context create <filename>`
+
+Create a new context file. Reads content from stdin or `--content` option.
+
+**Usage:**
+
+```bash
+protomaker context create <filename> [options] [global-flags]
+```
+
+**Options:**
+
+| Flag               | Description                                | Default |
+| ------------------ | ------------------------------------------ | ------- |
+| `--content <text>` | Content to write (omit to read from stdin) | —       |
+
+**Filename rules:** Must end in `.md` or `.txt`.
+
+### `context delete <filename>`
+
+Delete a context file.
+
+**Usage:**
+
+```bash
+protomaker context delete <filename> [options] [global-flags]
+```
+
+**Options:**
+
+| Flag    | Description              | Default |
+| ------- | ------------------------ | ------- |
+| `--yes` | Skip confirmation prompt | `false` |
+
+**Filename rules:** Must end in `.md` or `.txt`.
+
+---
+
+## Command Summary
+
+| Command                                      | Description                     |
+| -------------------------------------------- | ------------------------------- |
+| `board`                                      | Per-status board summary        |
+| `query [--status] [--category] [--assignee]` | Query features with filters     |
+| `health`                                     | Check server health             |
+| `sitrep [--project-slug]`                    | Full operational status report  |
+| `feature list [--status] [--compact]`        | List features grouped by status |
+| `feature get <id>`                           | Show feature details            |
+| `feature create --description ...`           | Create a new feature            |
+| `feature update <id> --title ...`            | Update feature fields           |
+| `feature move <id> <status>`                 | Transition feature status       |
+| `agent start <id> [--force] [--worktree]`    | Dispatch an agent               |
+| `agent stop <id> [--target-status]`          | Stop a running agent            |
+| `agent list [--branch]`                      | Show running agents             |
+| `agent output <id>`                          | Print agent output              |
+| `agent message <id> <prompt> [--image]`      | Send follow-up to agent         |
+| `pr create <id> [--commit-message] ...`      | Open a PR from a worktree       |
+| `pr status <number>`                         | Show CI rollup for a PR         |
+| `pr merge <number> [--strategy]`             | Merge a PR                      |
+| `queue add <id>`                             | Add feature to queue            |
+| `queue list`                                 | List queued features            |
+| `queue clear [--yes]`                        | Clear the queue                 |
+| `auto-mode start [--max-concurrency]`        | Start the auto-mode loop        |
+| `auto-mode stop`                             | Stop the auto-mode loop         |
+| `auto-mode status`                           | Show auto-mode status           |
+| `context list`                               | List context files              |
+| `context get <filename>`                     | Read a context file             |
+| `context create <filename> [--content]`      | Create a context file           |
+| `context delete <filename> [--yes]`          | Delete a context file           |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -21,3 +21,4 @@ Technical reference for protoLabs Studio APIs, configuration, and services. Look
 ## Tools
 
 - **[MCP Tools](./mcp-tools)** — Complete MCP tool reference
+- **[CLI Commands](./cli-commands)** — Complete protomaker CLI reference


### PR DESCRIPTION
Completes the **Diataxis docs** feature (Agent integration & docs epic). The agent had committed this work in its worktree but no PR was created (the git-workflow saw a clean tree after the agent self-committed — see note below), so recovering it manually.

## Adds
- `docs/how-to/drive-the-board.md` — step-by-step: health check → board view → create feature → dispatch → PR → merge → auto-mode → sitrep → JSON scripting
- `docs/reference/cli-commands.md` — complete reference for all 10 command groups (board, query, health, sitrep, feature, agent, pr, queue, auto-mode, context) with flags, defaults, enums
- index + README TOC links

## Pipeline note
This surfaced a bug: when the execution agent commits its own work, the local review's `git diff --cached` finds nothing staged ("no diff to review") and the git-workflow creates no PR ("no PR evidence"), stranding committed work in the worktree. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)