### PR TITLE
fix(docs-detector): docs-followup features use 'standard' workflow so they deliver

### DIFF
--- a/apps/server/src/services/docs-update-detector.ts
+++ b/apps/server/src/services/docs-update-detector.ts
@@ -119,6 +119,12 @@ export class DocsUpdateDetector {
         status: 'backlog',
         category: 'Documentation',
         complexity: 'small',
+        // Run the full pipeline so the docs work is committed and opened as a
+        // PR. Without an explicit workflow the feature falls into a read-only
+        // default (executionMode: 'read-only') — the agent writes nothing,
+        // produces no PR, and the EXECUTE->REVIEW guard blocks it. 'standard'
+        // makes the per-epic docs flow actually deliver. See #3806.
+        workflow: 'standard',
       });
 
       this.events.emit('docs:update-needed', {

--- a/apps/server/tests/unit/services/docs-update-detector.test.ts
+++ b/apps/server/tests/unit/services/docs-update-detector.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for DocsUpdateDetector.
+ *
+ * Regression guard for #3806: the per-epic docs-followup feature must be
+ * created with workflow 'standard' so it runs the full pipeline and opens a
+ * docs PR — NOT a read-only default that writes nothing and blocks.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('child_process', () => ({ execSync: vi.fn() }));
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: () => ({ info() {}, debug() {}, warn() {}, error() {} }),
+}));
+
+import { execSync } from 'child_process';
+import { DocsUpdateDetector } from '../../../src/services/docs-update-detector.js';
+
+type SubscribeCb = (type: string, payload: unknown) => void;
+
+function makeHarness(changedFiles: string[]) {
+  (execSync as unknown as ReturnType<typeof vi.fn>).mockReturnValue(changedFiles.join('\n'));
+  const create = vi.fn(async (_p: string, f: Record<string, unknown>) => ({ id: 'feat-x', ...f }));
+  const getAll = vi.fn(async () => [] as unknown[]);
+  const featureLoader = { create, getAll } as unknown as ConstructorParameters<
+    typeof DocsUpdateDetector
+  >[1];
+  let cb: SubscribeCb = () => {};
+  const events = {
+    subscribe: (fn: SubscribeCb) => {
+      cb = fn;
+      return () => {};
+    },
+    emit: vi.fn(),
+  } as unknown as ConstructorParameters<typeof DocsUpdateDetector>[0];
+  return { create, events, featureLoader, trigger: () => cb };
+}
+
+describe('DocsUpdateDetector', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("creates the docs feature with workflow 'standard' (regression #3806)", async () => {
+    // 4 doc-relevant files — above DOC_THRESHOLD (3)
+    const { create, events, featureLoader, trigger } = makeHarness([
+      'apps/server/src/routes/a.ts',
+      'apps/server/src/services/b.ts',
+      'libs/types/src/c.ts',
+      'docs/d.md',
+    ]);
+    new DocsUpdateDetector(events, featureLoader, '/proj').start();
+    trigger()('milestone:completed', { projectPath: '/proj', milestoneTitle: 'Epic X' });
+
+    await vi.waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    const arg = create.mock.calls[0][1] as Record<string, unknown>;
+    expect(arg.workflow).toBe('standard');
+    expect(arg.executionMode).not.toBe('read-only');
+    expect(arg.category).toBe('Documentation');
+  });
+
+  it('does not create a docs feature below the doc-relevant threshold', async () => {
+    const { create, events, featureLoader, trigger } = makeHarness(['docs/only.md']); // 1 < 3
+    new DocsUpdateDetector(events, featureLoader, '/proj').start();
+    trigger()('milestone:completed', { projectPath: '/proj', milestoneTitle: 'Epic X' });
+
+    // Give the async handler a tick; it must not create anything.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(create).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem
The per-epic docs flow (`DocsUpdateDetector`, fires on `milestone:completed` / `project:completed`) is a deliberate, wanted flow — ensure each epic gets docs so they don't get missed. But the "Update docs after: <epic>" feature it created had **no `workflow`**, so it fell into a read-only default (`executionMode: 'read-only'`). The agent wrote nothing, produced no PR, and the EXECUTE→REVIEW guard blocked it — every epic's docs feature dead-ended (seen 3× this session, each closed manually).

## Fix
Create the docs feature with `workflow: 'standard'` so it runs the full pipeline (plan → execute → review → PR) and actually delivers the docs.

Keeps the flow, makes it work. Fixes #3806.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented docs update tasks from getting created in a non-executable mode that could block PRs and workflow progress; workflows for docs follow-ups now run as intended.
* **Tests**
  * Added unit tests to guard the docs follow-up creation behavior and threshold-based suppression to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->