### PR TITLE
fix(auto-mode): un-stale reused feature worktree branches (#3825)

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3060,6 +3060,48 @@ Format your response as a structured markdown document.`;
             cwd: projectPath,
             env: gitEnv,
           });
+
+          // Un-stale a reused branch. A re-run reuses the existing local branch
+          // as-is; if a prior empty/failed run left it BEHIND its base with no
+          // commits of its own, the pre-flight then has to merge a diverged base
+          // and conflicts on files siblings also edit (e.g. cli.ts). If the
+          // branch has zero unique commits, reset it to the fresh base. Branches
+          // WITH real work (commits ahead) are left untouched. See #3825.
+          try {
+            let unstaleBaseRef = await getEffectivePrBaseBranch(
+              projectPath,
+              this.settingsService,
+              '[createWorktreeForBranch]'
+            );
+            if (feature?.epicId && !feature.isEpic) {
+              const epic = await this.featureLoader.get(projectPath, feature.epicId);
+              if (epic?.branchName) unstaleBaseRef = epic.branchName;
+            }
+            const unstaleBase = `origin/${unstaleBaseRef}`;
+            await execFileAsync('git', ['fetch', 'origin', unstaleBaseRef], {
+              cwd: projectPath,
+              env: gitEnv,
+            }).catch(() => {});
+            const { stdout: aheadOut } = await execFileAsync(
+              'git',
+              ['rev-list', '--count', `${unstaleBase}..${branchName}`],
+              { cwd: worktreePath, env: gitEnv }
+            );
+            if (parseInt(aheadOut.trim(), 10) === 0) {
+              await execFileAsync('git', ['reset', '--hard', unstaleBase], {
+                cwd: worktreePath,
+                env: gitEnv,
+              });
+              logger.info(
+                `[createWorktreeForBranch] Reset stale reused branch ${branchName} to ${unstaleBase} (no unique commits)`
+              );
+            }
+          } catch (unstaleErr) {
+            logger.warn(
+              `[createWorktreeForBranch] Un-stale check failed for ${branchName} (continuing):`,
+              unstaleErr
+            );
+          }
         } else {
           // Determine base branch: use epic branch if feature belongs to an epic,
           // otherwise use the project's configured prBaseBranch as the canonical base

--- a/apps/server/tests/unit/services/worktree-creation-base-branch.test.ts
+++ b/apps/server/tests/unit/services/worktree-creation-base-branch.test.ts
@@ -261,10 +261,12 @@ describe('AutoModeService - createWorktreeForBranch base branch resolution', () 
     expect(worktreeAdd![1]).not.toContain('origin/dev');
   });
 
-  it('skips getEffectivePrBaseBranch when branch already exists (uses existing branch checkout)', async () => {
+  it('reuses an existing branch with `worktree add <path> <branch>` (no -B) and un-stales it against its base', async () => {
     mockGetEffectivePrBaseBranch.mockResolvedValue('main');
 
-    // git rev-parse --verify succeeds → branch exists → uses `git worktree add <path> <branch>` (no -B)
+    // git rev-parse --verify succeeds → branch exists → uses `git worktree add <path> <branch>` (no -B).
+    // rev-list --count returns a non-numeric value here (mock), so the un-stale
+    // reset is NOT triggered — we only assert the reuse + base-resolution path.
     mockExecFileAsync.mockResolvedValue({ stdout: 'abc123', stderr: '' });
 
     const svc = makeService();
@@ -278,8 +280,33 @@ describe('AutoModeService - createWorktreeForBranch base branch resolution', () 
     // The existing-branch form does not use -B or origin/
     expect(worktreeAdds[0][1]).not.toContain('-B');
     expect(worktreeAdds[0][1].join(' ')).not.toContain('origin/');
-    // getEffectivePrBaseBranch is only called in the new-branch path, so it should NOT be called here
-    expect(mockGetEffectivePrBaseBranch).not.toHaveBeenCalled();
+    // The reuse path now resolves the base (origin/<prBaseBranch>) to un-stale the
+    // branch when it has no commits of its own (see #3825).
+    expect(mockGetEffectivePrBaseBranch).toHaveBeenCalled();
+  });
+
+  it('resets a reused branch to its base when it has no commits of its own (#3825)', async () => {
+    mockGetEffectivePrBaseBranch.mockResolvedValue('main');
+    // Branch exists; rev-list --count returns 0 → no unique commits → reset to base.
+    mockExecFileAsync.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes('rev-list') && args.includes('--count')) {
+        return Promise.resolve({ stdout: '0\n', stderr: '' });
+      }
+      return Promise.resolve({ stdout: 'abc123', stderr: '' });
+    });
+
+    const svc = makeService();
+    await (svc as any).createWorktreeForBranch(PROJECT_PATH, BRANCH_NAME, makeFeature());
+
+    const calls = mockExecFileAsync.mock.calls as [string, string[]][];
+    const reset = calls.find(
+      ([bin, args]) =>
+        bin === 'git' &&
+        args.includes('reset') &&
+        args.includes('--hard') &&
+        args.includes('origin/main')
+    );
+    expect(reset).toBeDefined();
   });
 
   it('branches from origin/epic/<name> when feature belongs to an epic with a remote branch', async () => {


### PR DESCRIPTION
New worktrees already branch from a freshly-fetched `origin/<base>` (not the checkout HEAD). But a **re-run reuses the existing local branch as-is** (`git worktree add <path> <branch>`), so a prior empty/failed run leaves it behind `origin/<base>`; pre-flight then merges a diverged base and conflicts on files siblings also edit (`cli.ts`). This caused repeated escalations this session (board+query, context+sitrep), recoverable only by manually deleting the branch.

**Fix:** in the branch-exists path, if the reused branch has **zero commits of its own** beyond its base (epic branch for epic features, else `origin/<prBaseBranch>`), reset it `--hard` to the fresh base. Branches with real work (commits ahead) are untouched.

Fixes #3825. Server build typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced branch management to automatically detect and synchronize existing branches with the base when they contain no unique commits ahead, ensuring branches remain up-to-date.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->