### PR TITLE
Emit feature lifecycle bus events (feature.completed / feature.failed)

### DIFF
--- a/apps/server/src/services/feature-lifecycle-bus-publisher.ts
+++ b/apps/server/src/services/feature-lifecycle-bus-publisher.ts
@@ -5,16 +5,19 @@
  *
  * Subscribes to the existing `feature:status-changed` event (emitted by
  * FeatureLoader.update) and, when a feature transitions into a terminal state,
- * publishes `protomaker.feature.completed` to protoWorkstacean's /publish
- * endpoint. The payload echoes the originating signal metadata so a consumer
- * (e.g. the Linear ↔ protoMaker bridge) can reconstruct lineage and post a
- * "feature done" comment on the source issue. See protoLabsAI/protoMaker#3549
- * and the downstream consumer protoLabsAI/protoWorkstacean#482.
+ * publishes `protomaker.feature.completed` (status -> done) or
+ * `protomaker.feature.failed` (status -> blocked / escalated) to
+ * protoWorkstacean's /publish endpoint. The payload echoes the originating
+ * signal metadata so a consumer (e.g. the Linear ↔ protoMaker bridge) can
+ * reconstruct lineage and post a "feature done" comment on the source issue.
+ * See protoLabsAI/protoMaker#3549 and the downstream consumer
+ * protoLabsAI/protoWorkstacean#482.
  *
  * Opt-in: only active when WORKSTACEAN_URL is explicitly set, so installs
  * without protoWorkstacean don't attempt (and log) a publish on every feature
  * completion. The canonical board has a single terminal state (`done`); the
- * TERMINAL_STATUSES set is the extension point if more are added later.
+ * TERMINAL_STATUSES and FAILURE_STATUSES sets are the extension point if more
+ * are added later.
  */
 
 import { createLogger } from '@protolabsai/utils';
@@ -24,8 +27,11 @@ import { publish as workstaceanPublish } from '../client/workstacean-api.client.
 
 const logger = createLogger('FeatureLifecycleBusPublisher');
 
-/** Board statuses treated as terminal for lifecycle-event purposes. */
+/** Board statuses treated as terminal (success) for lifecycle-event purposes. */
 const TERMINAL_STATUSES: ReadonlySet<string> = new Set(['done']);
+
+/** Board statuses treated as terminal (failure) — emit `feature.failed`. */
+const FAILURE_STATUSES: ReadonlySet<string> = new Set(['blocked', 'escalated']);
 
 /** Subset of the `feature:status-changed` payload this publisher needs. */
 interface StatusChangedPayload {
@@ -33,6 +39,7 @@ interface StatusChangedPayload {
   oldStatus?: string;
   newStatus?: string;
   projectPath?: string;
+  reason?: string;
 }
 
 type PublishFn = (payload: {
@@ -66,12 +73,20 @@ export class FeatureLifecycleBusPublisher {
 
   /**
    * Publish `protomaker.feature.completed` when a feature reaches a terminal
-   * state. Loads the feature fresh to echo its source signal metadata. Never
-   * throws — a publish failure must not affect the board transition.
+   * success state (done), or `protomaker.feature.failed` when it reaches a
+   * terminal failure state (blocked / escalated). Loads the feature fresh to
+   * echo its source signal metadata and PR tracking fields. Never throws — a
+   * publish failure must not affect the board transition.
    */
   async handleStatusChange(payload: StatusChangedPayload): Promise<void> {
     const { featureId, newStatus, oldStatus, projectPath } = payload ?? {};
-    if (!featureId || !projectPath || !newStatus || !TERMINAL_STATUSES.has(newStatus)) {
+    if (!featureId || !projectPath || !newStatus) {
+      return;
+    }
+
+    const isTerminal = TERMINAL_STATUSES.has(newStatus);
+    const isFailure = FAILURE_STATUSES.has(newStatus);
+    if (!isTerminal && !isFailure) {
       return;
     }
 
@@ -82,13 +97,16 @@ export class FeatureLifecycleBusPublisher {
       logger.warn(`Could not load feature ${featureId} for lifecycle event:`, err);
     }
 
-    const event = 'protomaker.feature.completed';
+    const event = isTerminal ? 'protomaker.feature.completed' : 'protomaker.feature.failed';
     try {
       const result = await this.publishFn({
         event,
         data: {
           featureId,
           projectPath,
+          status: newStatus,
+          prNumber: feature?.prNumber,
+          reason: feature?.statusChangeReason ?? payload?.reason,
           projectSlug: feature?.projectSlug,
           title: feature?.title,
           completedAt: Date.now(),

--- a/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
+++ b/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
@@ -97,4 +97,126 @@ describe('FeatureLifecycleBusPublisher', () => {
     pub.start();
     expect(onSpy).not.toHaveBeenCalled();
   });
+
+  it('publishes protomaker.feature.failed on transition to blocked', async () => {
+    const feature = {
+      id: 'f2',
+      title: 'Blocked feature',
+      projectSlug: 'proj',
+      prNumber: 42,
+      statusChangeReason: 'CI checks failed after 3 retries',
+    };
+    const { pub, publishFn } = makePublisher({ feature });
+
+    await pub.handleStatusChange({
+      featureId: 'f2',
+      projectPath: '/p',
+      oldStatus: 'in_progress',
+      newStatus: 'blocked',
+      reason: 'CI checks failed after 3 retries',
+    });
+
+    expect(publishFn).toHaveBeenCalledTimes(1);
+    const arg = publishFn.mock.calls[0][0];
+    expect(arg.event).toBe('protomaker.feature.failed');
+    expect(arg.data.featureId).toBe('f2');
+    expect(arg.data.status).toBe('blocked');
+    expect(arg.data.prNumber).toBe(42);
+    expect(arg.data.reason).toBe('CI checks failed after 3 retries');
+    expect(arg.data.previousStatus).toBe('in_progress');
+  });
+
+  it('publishes protomaker.feature.failed on transition to escalated', async () => {
+    const feature = {
+      id: 'f3',
+      title: 'Escalated feature',
+      projectSlug: 'proj',
+    };
+    const { pub, publishFn } = makePublisher({ feature });
+
+    await pub.handleStatusChange({
+      featureId: 'f3',
+      projectPath: '/p',
+      oldStatus: 'review',
+      newStatus: 'escalated',
+    });
+
+    expect(publishFn).toHaveBeenCalledTimes(1);
+    const arg = publishFn.mock.calls[0][0];
+    expect(arg.event).toBe('protomaker.feature.failed');
+    expect(arg.data.featureId).toBe('f3');
+    expect(arg.data.status).toBe('escalated');
+  });
+
+  it('includes prNumber and reason in completed event payload', async () => {
+    const feature = {
+      id: 'f4',
+      title: 'Completed with PR',
+      projectSlug: 'proj',
+      prNumber: 99,
+      statusChangeReason: 'Workflow completed',
+    };
+    const { pub, publishFn } = makePublisher({ feature });
+
+    await pub.handleStatusChange({
+      featureId: 'f4',
+      projectPath: '/p',
+      oldStatus: 'review',
+      newStatus: 'done',
+    });
+
+    expect(publishFn).toHaveBeenCalledTimes(1);
+    const arg = publishFn.mock.calls[0][0];
+    expect(arg.event).toBe('protomaker.feature.completed');
+    expect(arg.data.prNumber).toBe(99);
+    expect(arg.data.reason).toBe('Workflow completed');
+    expect(arg.data.status).toBe('done');
+  });
+
+  it('falls back to payload reason when feature has no statusChangeReason', async () => {
+    const feature = {
+      id: 'f5',
+      title: 'No reason on feature',
+      projectSlug: 'proj',
+    };
+    const { pub, publishFn } = makePublisher({ feature });
+
+    await pub.handleStatusChange({
+      featureId: 'f5',
+      projectPath: '/p',
+      oldStatus: 'in_progress',
+      newStatus: 'blocked',
+      reason: 'from payload',
+    });
+
+    expect(publishFn).toHaveBeenCalledTimes(1);
+    const arg = publishFn.mock.calls[0][0];
+    expect(arg.data.reason).toBe('from payload');
+  });
+
+  it('still publishes feature.failed when the feature cannot be loaded', async () => {
+    const featureLoader = { get: vi.fn().mockRejectedValue(new Error('gone')) };
+    const publishFn = vi.fn().mockResolvedValue({ ok: true });
+    const pub = new FeatureLifecycleBusPublisher(
+      { on: vi.fn() } as never,
+      featureLoader as never,
+      publishFn,
+      true
+    );
+
+    await pub.handleStatusChange({
+      featureId: 'f6',
+      projectPath: '/p',
+      oldStatus: 'in_progress',
+      newStatus: 'blocked',
+      reason: 'max retries exceeded',
+    });
+
+    expect(publishFn).toHaveBeenCalledTimes(1);
+    const arg = publishFn.mock.calls[0][0];
+    expect(arg.event).toBe('protomaker.feature.failed');
+    expect(arg.data.featureId).toBe('f6');
+    expect(arg.data.reason).toBe('max retries exceeded');
+    expect(arg.data.prNumber).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Implements GitHub issue #3810. Emit structured lifecycle events on the server event bus when a feature reaches a terminal state: feature.completed (status -> done) and feature.failed (status -> blocked / escalated), with payload { featureId, projectPath, status, prNumber?, reason? }. This unblocks the protoWorkstacean Linear bridge which subscribes to these. Wire emission where feature status transitions to done/blocked (FeatureLoader.update or the LeadEngineer state machine terminal transitions...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=transient-d849126d team= created=2026-05-26T19:08:55.199Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System now distinguishes between successful and failed feature completions with separate lifecycle events.
  * Event payloads now include optional reason fields for improved failure tracking and diagnostics.

* **Tests**
  * Added comprehensive test coverage for feature lifecycle event publishing, including success and failure scenarios, payload validation, and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->