### PR TITLE
fix(auto-mode): auto-retry empty agent executions instead of parking (#3860)

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -1572,15 +1572,40 @@ Output the branch name only.`,
       } else if (!gitAlreadySetStatus) {
         if (feature.skipTests) {
           finalStatus = 'waiting_approval';
+          await this.callbacks.updateFeatureStatus(projectPath, featureId, finalStatus);
         } else if (hasPrEvidence) {
           finalStatus = 'verified';
+          await this.callbacks.updateFeatureStatus(projectPath, featureId, finalStatus);
         } else {
-          finalStatus = 'review';
-          logger.warn(
-            `[AutoVerify] No PR evidence for ${featureId} after git workflow — moving to review for manual inspection.`
-          );
+          // No PR evidence after the git workflow. With committed-work detection
+          // fixed (#3845), this now genuinely means the agent produced nothing —
+          // an "empty execution", typically the SDK terminating after the
+          // planning turn (protoCLI#307). It's intermittent and usually succeeds
+          // on retry, so auto-retry up to a cap before parking for a human (#3860)
+          // instead of silently dropping the feature into review.
+          const MAX_EMPTY_RETRIES = 3;
+          const fc = postGitFeature?.failureCount ?? 0;
+          if (fc < MAX_EMPTY_RETRIES) {
+            finalStatus = 'backlog';
+            await this.featureLoader.update(projectPath, featureId, {
+              status: 'backlog',
+              failureCount: fc + 1,
+              statusChangeReason: `Empty execution (no PR/commits) — auto-retry ${fc + 1}/${MAX_EMPTY_RETRIES} (agent terminated early; protoCLI#307)`,
+            });
+            logger.warn(
+              `[AutoVerify] No PR evidence for ${featureId} — auto-retrying (${fc + 1}/${MAX_EMPTY_RETRIES})`
+            );
+          } else {
+            finalStatus = 'blocked';
+            await this.featureLoader.update(projectPath, featureId, {
+              status: 'blocked',
+              statusChangeReason: `Empty execution after ${MAX_EMPTY_RETRIES} retries — agent produced no reviewable output (protoCLI#307). Needs intervention.`,
+            });
+            logger.warn(
+              `[AutoVerify] No PR evidence for ${featureId} after ${MAX_EMPTY_RETRIES} retries — blocking for manual inspection.`
+            );
+          }
         }
-        await this.callbacks.updateFeatureStatus(projectPath, featureId, finalStatus);
       }
 
       const gitInfo = gitWorkflowResult?.commitHash

--- a/apps/server/tests/integration/services/auto-mode-service.integration.test.ts
+++ b/apps/server/tests/integration/services/auto-mode-service.integration.test.ts
@@ -147,9 +147,10 @@ describe('auto-mode-service.ts (integration)', () => {
       await service.executeFeature(testRepo.path, 'test-feature-error', false, false);
 
       // With AUTOMAKER_MOCK_AGENT=true, the mock agent runs successfully (provider error is never
-      // thrown). No PR evidence after the git workflow → feature lands in 'review'.
+      // thrown). No PR evidence after the git workflow → empty execution → auto-retry returns
+      // the feature to 'backlog' (failureCount incremented) rather than parking in review (#3860).
       const feature = await featureLoader.get(testRepo.path, 'test-feature-error');
-      expect(feature?.status).toBe('review');
+      expect(feature?.status).toBe('backlog');
     }, 30000);
 
     it('should work without worktrees', async () => {
@@ -526,7 +527,8 @@ describe('auto-mode-service.ts (integration)', () => {
       await service.executeFeature(testRepo.path, 'error-feature', false, false);
 
       // With AUTOMAKER_MOCK_AGENT=true, the mock agent runs successfully (provider error is never
-      // thrown). No PR evidence after the git workflow → feature lands in 'review'.
+      // thrown). No PR evidence after the git workflow → empty execution → auto-retry returns the
+      // feature to 'backlog' (failureCount incremented) rather than parking in review (#3860).
       // Poll until status exits 'in_progress'.
       let feature = await featureLoader.get(testRepo.path, 'error-feature');
       const deadline = Date.now() + 5000;
@@ -534,7 +536,7 @@ describe('auto-mode-service.ts (integration)', () => {
         await new Promise((r) => setTimeout(r, 250));
         feature = await featureLoader.get(testRepo.path, 'error-feature');
       }
-      expect(feature?.status).toBe('review');
+      expect(feature?.status).toBe('backlog');
     }, 30000);
 
     it('should continue auto loop after feature error', async () => {


### PR DESCRIPTION
When the agent produces no PR + no commits (empty execution — typically the SDK terminating after the planning turn, protoCLI#307), AutoVerify parked the feature in `review` for manual inspection. It's intermittent and usually succeeds on retry (the bus-events smoke test recovered after a few re-dispatches), so manual re-dispatch was the biggest throughput drag.

**Fix:** on no-PR-evidence, increment `failureCount` and return to `backlog` (scheduler re-dispatches, blocking at `failureCount >= 3` as today) up to 3 attempts, then block with a clear reason. Self-healing for the transient case. Fixes #3860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feature execution workflow with automatic retry logic for incomplete runs. Features now retry up to 3 times when execution data is missing before being blocked, replacing the previous immediate blocking behavior.

* **Improvements**
  * Enhanced status management during the execution process for better workflow tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3862?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->