### PR TITLE
fix(auto-mode): don't relaunch on max-turns retry after stop (#3789)

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -2086,14 +2086,32 @@ Output the branch name only.`,
     // Capture values for closure before setTimeout
     const currentRetryCount = tempRunningFeature.retryCount;
     const currentPreviousErrors = tempRunningFeature.previousErrors;
+    const wasAutoMode = tempRunningFeature.isAutoMode;
     const backoffMs = Math.min(1000 * Math.pow(2, Math.min(currentRetryCount, 10)), 30_000);
     const retryTimer = setTimeout(() => {
       this.retryTimers.delete(featureId);
+      // If auto-mode was stopped while this max-turns retry was pending, do NOT
+      // relaunch — a user stop must halt the feature, not escalate turns and
+      // re-launch it (the #3789 stop→escalating-retry loop). stopAutoMode clears
+      // retryTimers, but a timer scheduled in the race window around the stop
+      // would otherwise still fire. Reset to backlog so it resumes on next start.
+      if (wasAutoMode && !this.callbacks.getAutoLoopRunning()) {
+        logger.info(
+          `[MaxTurnsRetry] Auto-mode stopped — skipping relaunch of ${featureId}; resetting to backlog.`
+        );
+        this.featureLoader
+          .update(projectPath, featureId, {
+            status: 'backlog',
+            statusChangeReason: 'Auto-mode stopped during max-turns retry; halted (will resume on restart)',
+          })
+          .catch(() => {});
+        return;
+      }
       this.executeFeature(
         projectPath,
         featureId,
         useWorktrees,
-        tempRunningFeature.isAutoMode,
+        wasAutoMode,
         providedWorktreePath,
         {
           retryCount: currentRetryCount + 1,

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -2102,22 +2102,16 @@ Output the branch name only.`,
         this.featureLoader
           .update(projectPath, featureId, {
             status: 'backlog',
-            statusChangeReason: 'Auto-mode stopped during max-turns retry; halted (will resume on restart)',
+            statusChangeReason:
+              'Auto-mode stopped during max-turns retry; halted (will resume on restart)',
           })
           .catch(() => {});
         return;
       }
-      this.executeFeature(
-        projectPath,
-        featureId,
-        useWorktrees,
-        wasAutoMode,
-        providedWorktreePath,
-        {
-          retryCount: currentRetryCount + 1,
-          previousErrors: [...currentPreviousErrors, errorInfo.message],
-        }
-      ).catch((retryError) => {
+      this.executeFeature(projectPath, featureId, useWorktrees, wasAutoMode, providedWorktreePath, {
+        retryCount: currentRetryCount + 1,
+        previousErrors: [...currentPreviousErrors, errorInfo.message],
+      }).catch((retryError) => {
         logger.error(`Max-turns retry failed for feature ${featureId}:`, retryError);
       });
     }, backoffMs);


### PR DESCRIPTION
Stopping auto-mode mid-EXECUTE could relaunch the feature with escalating turns (500→750→1000): if it hit max_turns around the stop, `handleTurnEscalation` scheduled a backoff retry timer that fired *after* `stopAutoMode` cleared the timer map, re-calling `executeFeature`. So 'stop' escalated+relaunched instead of halting.

**Fix:** guard the retry timer — if the run was auto-mode and `getAutoLoopRunning()` is now false, skip the relaunch and reset to `backlog` (resumes on next start). Fixes #3789.

🤖 Generated with [Claude Code](https://claude.com/claude-code)