### PR TITLE
feat(feature-loader): smart branch names via the fast tier + training capture (#3794)

### DIFF
--- a/apps/server/src/server/services.ts
+++ b/apps/server/src/server/services.ts
@@ -9,6 +9,7 @@ import { TopicBus } from '../lib/topic-bus.js';
 
 import { AgentService } from '../services/agent-service.js';
 import { FeatureLoader } from '../services/feature-loader.js';
+import { createSmartBranchNameGenerator } from '../services/branch-name-generator.js';
 import { UserIdentityService } from '../services/user-identity-service.js';
 import { AutoModeService } from '../services/auto-mode-service.js';
 import { getTerminalService } from '../services/terminal-service.js';
@@ -335,6 +336,14 @@ export async function createServices(dataDir: string, repoRoot: string): Promise
   const featureLoader = new FeatureLoader();
   featureLoader.setEventEmitter(events);
   featureLoader.setTopicBus(topicBus);
+  // Smart branch names via the fast tier when enabled (#3794); falls back to the
+  // deterministic slug. Captures input→output training data (#3859).
+  featureLoader.setSmartBranchNameGenerator(
+    createSmartBranchNameGenerator(
+      settingsService,
+      featureLoader.branchPrefixForCategory.bind(featureLoader)
+    )
+  );
 
   // Wire featureLoader into gitWorkflowService so it can persist prNumber immediately
   // after PR creation, preventing duplicate PR attempts on retry.

--- a/apps/server/src/services/branch-name-generator.ts
+++ b/apps/server/src/services/branch-name-generator.ts
@@ -1,0 +1,125 @@
+/**
+ * Smart branch-name generator (#3794).
+ *
+ * Produces a concise, human-readable feature branch name using the fast model
+ * tier (protolabs/fast) instead of a plain deterministic slug — and captures
+ * every input→output pair as training data so a small purpose-built model can
+ * be distilled for this task later (#3859).
+ *
+ * Designed for dependency injection into FeatureLoader: returns `null` whenever
+ * it can't (or shouldn't) produce a smart name — disabled by setting, no title,
+ * model failure, or a degenerate result — so the caller falls back to the
+ * deterministic slug. It never throws.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { createLogger } from '@protolabsai/utils';
+import { simpleQuery } from '../providers/simple-query-service.js';
+import { getWorkflowSettings } from '../lib/settings-helpers.js';
+import type { SettingsService } from './settings-service.js';
+
+const logger = createLogger('SmartBranchName');
+
+/** Fast tier alias — gateway-routed, NOT a hardcoded anthropic model id. */
+const FAST_MODEL = 'protolabs/fast';
+
+export interface SmartBranchInput {
+  title?: string;
+  description?: string;
+  category?: string;
+  featureId?: string;
+}
+
+export type SmartBranchNameGenerator = (
+  input: SmartBranchInput,
+  projectPath: string
+) => Promise<string | null>;
+
+/**
+ * Build a smart-branch-name generator. `branchPrefixForCategory` is injected so
+ * the prefix convention stays in one place (FeatureLoader).
+ */
+export function createSmartBranchNameGenerator(
+  settingsService: SettingsService | null,
+  branchPrefixForCategory: (category?: string) => string
+): SmartBranchNameGenerator {
+  return async (input, projectPath) => {
+    try {
+      const ws = await getWorkflowSettings(projectPath, settingsService);
+      if (!ws.smartBranchNames) return null; // disabled → deterministic slug
+
+      const title = input.title?.trim();
+      if (!title) return null;
+
+      const prefix = branchPrefixForCategory(input.category);
+      const shortId = (input.featureId ?? Date.now().toString(36)).slice(-7);
+
+      let slug = '';
+      let usedFallback = true;
+      try {
+        const res = await simpleQuery({
+          prompt:
+            `Generate a concise git branch slug for this work. ` +
+            `Rules: 2-5 words, lowercase, hyphen-separated, no path prefix, no quotes, no trailing id. ` +
+            `Return ONLY the slug.\n\nTitle: ${title}\nDescription: ${(input.description ?? '').slice(0, 300)}`,
+          model: FAST_MODEL,
+          cwd: projectPath,
+          maxTurns: 1,
+        });
+        slug = (res.text ?? '')
+          .trim()
+          .toLowerCase()
+          .split('\n')[0]
+          .replace(/[^a-z0-9-]/g, '-')
+          .replace(/-+/g, '-')
+          .replace(/^-|-$/g, '')
+          .slice(0, 50);
+        if (slug.length >= 3) usedFallback = false;
+      } catch (err) {
+        logger.debug('fast-model branch-name generation failed; deterministic fallback', err);
+      }
+
+      const branchName = usedFallback ? null : `${prefix}/${slug}-${shortId}`;
+
+      // Capture the input→output pair as training data (non-blocking, fail-open).
+      void captureTrainingRow(projectPath, {
+        task: 'branch-name',
+        model: FAST_MODEL,
+        input: {
+          title,
+          description: (input.description ?? '').slice(0, 500),
+          category: input.category ?? '',
+        },
+        output: branchName ?? '<deterministic-fallback>',
+        usedFallback,
+      });
+
+      return branchName; // null → caller uses the deterministic slug
+    } catch (err) {
+      logger.debug('smart branch-name generator error; deterministic fallback', err);
+      return null;
+    }
+  };
+}
+
+/**
+ * Append a training row to `.automaker/training/branch-names/captures.jsonl`.
+ * Fail-open — capture must never break feature creation. See #3859.
+ */
+async function captureTrainingRow(
+  projectPath: string,
+  row: Record<string, unknown>
+): Promise<void> {
+  try {
+    const dir = path.join(projectPath, '.automaker', 'training', 'branch-names');
+    await fs.promises.mkdir(dir, { recursive: true });
+    await fs.promises.appendFile(
+      path.join(dir, 'captures.jsonl'),
+      JSON.stringify({ ...row, timestamp: new Date().toISOString() }) + '\n',
+      'utf-8'
+    );
+  } catch {
+    // non-blocking
+  }
+}

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -41,6 +41,7 @@ import { debugLog } from '../lib/debug-log.js';
 import { normalizeTitle, jaccardSimilarity, extractIssueRefs } from '../lib/title-match.js';
 import type { DataIntegrityWatchdogService } from './data-integrity-watchdog-service.js';
 import type { ProjectSlugResolver } from './project-slug-resolver.js';
+import type { SmartBranchNameGenerator } from './branch-name-generator.js';
 import { featuresByStatus } from '../lib/prometheus.js';
 
 const execAsync = promisify(exec);
@@ -113,9 +114,19 @@ export class FeatureLoader implements FeatureStore {
   private events: EventEmitter | null = null;
   private topicBus: TopicBus | null = null;
   private projectSlugResolver: ProjectSlugResolver | null = null;
+  private smartBranchNameGenerator: SmartBranchNameGenerator | null = null;
 
   setIntegrityWatchdog(watchdog: DataIntegrityWatchdogService): void {
     this.integrityWatchdog = watchdog;
+  }
+
+  /**
+   * Set the optional smart branch-name generator (#3794). When set and enabled
+   * via the smartBranchNames workflow setting, create() uses it to name new
+   * branches via the fast model tier, falling back to the deterministic slug.
+   */
+  setSmartBranchNameGenerator(generator: SmartBranchNameGenerator): void {
+    this.smartBranchNameGenerator = generator;
   }
 
   setEventEmitter(events: EventEmitter): void {
@@ -923,14 +934,42 @@ export class FeatureLoader implements FeatureStore {
     // LLM artifact branch names (e.g. "fix/the-user-wants-me-to-generate-a-git-branch-name-...")
     // are also discarded — they pass syntactic validation but are the agent completing its own
     // reasoning prompt rather than emitting a real slug.
-    const branchName =
-      featureData.executionMode === 'read-only'
-        ? undefined
-        : ((featureData.branchName &&
-          isValidBranchName(featureData.branchName) &&
-          !this.isLlmArtifactBranchName(featureData.branchName)
-            ? featureData.branchName
-            : null) ?? this.generateBranchName(featureData.title, featureId, featureData.category));
+    let branchName: string | undefined;
+    if (featureData.executionMode === 'read-only') {
+      branchName = undefined;
+    } else {
+      const providedValid =
+        featureData.branchName &&
+        isValidBranchName(featureData.branchName) &&
+        !this.isLlmArtifactBranchName(featureData.branchName)
+          ? featureData.branchName
+          : null;
+      if (providedValid) {
+        branchName = providedValid;
+      } else {
+        // Smart branch name via the fast tier when enabled (#3794); the generator
+        // returns null when disabled, on failure, or for a degenerate slug, so we
+        // always fall back to the deterministic slug. isValidBranchName guards the
+        // model output before it's accepted.
+        let smart: string | null = null;
+        if (this.smartBranchNameGenerator) {
+          smart = await this.smartBranchNameGenerator(
+            {
+              title: featureData.title,
+              description: featureData.description,
+              category: featureData.category,
+              featureId,
+            },
+            projectPath
+          ).catch(() => null);
+          if (smart && (!isValidBranchName(smart) || this.isLlmArtifactBranchName(smart))) {
+            smart = null;
+          }
+        }
+        branchName =
+          smart ?? this.generateBranchName(featureData.title, featureId, featureData.category);
+      }
+    }
 
     // Auto-assign projectSlug if not already provided
     let resolvedProjectSlug = featureData.projectSlug;

--- a/apps/server/tests/unit/services/branch-name-generator.test.ts
+++ b/apps/server/tests/unit/services/branch-name-generator.test.ts
@@ -8,7 +8,12 @@ vi.mock('@protolabsai/utils', () => ({
   createLogger: () => ({ info() {}, debug() {}, warn() {}, error() {} }),
 }));
 vi.mock('node:fs', () => ({
-  default: { promises: { mkdir: vi.fn().mockResolvedValue(undefined), appendFile: vi.fn().mockResolvedValue(undefined) } },
+  default: {
+    promises: {
+      mkdir: vi.fn().mockResolvedValue(undefined),
+      appendFile: vi.fn().mockResolvedValue(undefined),
+    },
+  },
 }));
 const simpleQuery = vi.fn();
 vi.mock('../../../src/providers/simple-query-service.js', () => ({

--- a/apps/server/tests/unit/services/branch-name-generator.test.ts
+++ b/apps/server/tests/unit/services/branch-name-generator.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for the smart branch-name generator (#3794).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: () => ({ info() {}, debug() {}, warn() {}, error() {} }),
+}));
+vi.mock('node:fs', () => ({
+  default: { promises: { mkdir: vi.fn().mockResolvedValue(undefined), appendFile: vi.fn().mockResolvedValue(undefined) } },
+}));
+const simpleQuery = vi.fn();
+vi.mock('../../../src/providers/simple-query-service.js', () => ({
+  simpleQuery: (...args: unknown[]) => simpleQuery(...args),
+}));
+const getWorkflowSettings = vi.fn();
+vi.mock('../../../src/lib/settings-helpers.js', () => ({
+  getWorkflowSettings: (...args: unknown[]) => getWorkflowSettings(...args),
+}));
+
+import { createSmartBranchNameGenerator } from '../../../src/services/branch-name-generator.js';
+import fs from 'node:fs';
+
+const prefixFor = (c?: string) => (c === 'fix' ? 'fix' : 'feature');
+const input = {
+  title: 'Add user authentication flow',
+  description: 'Login + sessions',
+  category: 'feature',
+  featureId: 'feature-1779000000000-abc1234',
+};
+
+describe('createSmartBranchNameGenerator', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns null when smartBranchNames is disabled (no model call)', async () => {
+    getWorkflowSettings.mockResolvedValue({ smartBranchNames: false });
+    const gen = createSmartBranchNameGenerator(null, prefixFor);
+    const result = await gen(input, '/proj');
+    expect(result).toBeNull();
+    expect(simpleQuery).not.toHaveBeenCalled();
+  });
+
+  it('generates prefix/slug-shortId from the fast model when enabled', async () => {
+    getWorkflowSettings.mockResolvedValue({ smartBranchNames: true });
+    simpleQuery.mockResolvedValue({ text: 'user-auth-flow' });
+    const gen = createSmartBranchNameGenerator(null, prefixFor);
+    const result = await gen(input, '/proj');
+    expect(result).toBe('feature/user-auth-flow-abc1234');
+    // routes through the fast tier
+    expect(simpleQuery).toHaveBeenCalledWith(expect.objectContaining({ model: 'protolabs/fast' }));
+    // captured a training row
+    expect(vi.mocked(fs.promises.appendFile)).toHaveBeenCalled();
+  });
+
+  it('sanitizes model output and respects the category prefix', async () => {
+    getWorkflowSettings.mockResolvedValue({ smartBranchNames: true });
+    simpleQuery.mockResolvedValue({ text: '  Fix Login Bug!! \n(extra)' });
+    const gen = createSmartBranchNameGenerator(null, prefixFor);
+    const result = await gen({ ...input, category: 'fix' }, '/proj');
+    expect(result).toMatch(/^fix\/[a-z0-9-]+-abc1234$/);
+    expect(result).not.toMatch(/[^a-z0-9/-]/);
+  });
+
+  it('falls back (null) when the model errors', async () => {
+    getWorkflowSettings.mockResolvedValue({ smartBranchNames: true });
+    simpleQuery.mockRejectedValue(new Error('gateway 529'));
+    const gen = createSmartBranchNameGenerator(null, prefixFor);
+    expect(await gen(input, '/proj')).toBeNull();
+  });
+
+  it('falls back (null) on a degenerate slug', async () => {
+    getWorkflowSettings.mockResolvedValue({ smartBranchNames: true });
+    simpleQuery.mockResolvedValue({ text: '!!' }); // sanitizes to '' (< 3 chars)
+    const gen = createSmartBranchNameGenerator(null, prefixFor);
+    expect(await gen(input, '/proj')).toBeNull();
+  });
+});

--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -226,6 +226,14 @@ export interface AgentConfig {
 export interface WorkflowSettings {
   /** Per-branch gate configuration for the unified pipeline phases */
   gates?: PipelineGateConfig;
+  /**
+   * Generate feature branch names with the fast model tier (protolabs/fast)
+   * instead of a plain deterministic slug. Runs lazily at execution time (not
+   * on the create hot path), captures input→output pairs as training data for a
+   * future distilled model (#3859), and falls back to the deterministic slug on
+   * any failure. (default: false)
+   */
+  smartBranchNames?: boolean;
   pipeline: {
     /** Enable goal gate validation on state transitions (default: true) */
     goalGatesEnabled: boolean;
@@ -553,6 +561,7 @@ export interface WorkflowSettings {
 
 /** Default workflow settings */
 export const DEFAULT_WORKFLOW_SETTINGS: WorkflowSettings = {
+  smartBranchNames: false,
   pipeline: {
     goalGatesEnabled: true,
     checkpointEnabled: true,


### PR DESCRIPTION
Optional smart branch-name generation, **off by default** (`smartBranchNames` workflow setting). When enabled, `FeatureLoader.create()` names new branches via the fast tier (`protolabs/fast`) through an injected generator, falling back to the deterministic slug on disable/failure/degenerate output. Wired only on the app's primary FeatureLoader, so the create hot path is unaffected unless enabled (no LLM cost per create).

Every generation captures the input→output pair to `.automaker/training/branch-names/captures.jsonl` (fail-open) — labeled data toward distilling a small purpose-built model (#3859).

- `libs/types`: `smartBranchNames` setting (default false)
- `branch-name-generator.ts`: fast tier + sanitization + deterministic fallback + training capture (5 unit tests)
- `FeatureLoader`: `setSmartBranchNameGenerator()` + guarded use in `create()`
- `services.ts`: wiring

Implements #3794; captures toward #3859. Server + types build clean; generator tests pass (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent branch name generation using AI, creating meaningful names derived from feature titles and descriptions.

* **Configuration**
  * New `smartBranchNames` workflow setting to enable smart naming (disabled by default); gracefully falls back to standard naming if generation fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->