### PR TITLE
fix(projects): resolve epic branch base instead of hardcoding origin/dev (#3867)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -793,21 +793,28 @@ interface Feature {
 When features belong to an epic, the git workflow follows a hierarchical PR structure:
 
 ```
-main
+base branch (prBaseBranch, default: main)
   ↑
-epic/foundation ──────────── Epic PR (targets dev)
+epic/foundation ──────────── Epic PR (targets the base branch)
   ↑         ↑         ↑
 feat-a    feat-b    feat-c   Feature PRs (target epic branch)
 ```
 
+This repo uses a single integration branch (`feature/* → main`). The epic flow inserts an
+epic branch between feature branches and the base branch — it does **not** introduce a separate
+long-lived `dev` branch. Everywhere below, "base branch" means the project's configured
+`prBaseBranch` (`DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch`, default `main`), resolved via
+`getEffectivePrBaseBranch()`. Never hardcode a branch name in orchestration code.
+
 **Automatic Behavior:**
 
-- Feature PRs automatically target their epic's branch (not dev)
-- Epic PRs target dev (never main directly)
-- Features without an epic target dev directly
-- When the last child feature's PR merges to the epic branch, `CompletionDetectorService` automatically creates the epic-to-dev PR with `--merge` auto-merge enabled
-- When the epic-to-dev PR merges (detected by GitHub webhook), the epic is marked `done` and the epic branch is deleted
-- If the epic-to-dev PR has conflicts, the epic is marked `blocked` with a reason explaining manual intervention is needed
+- Epic branches are created from the resolved base branch HEAD (`origin/<base>`), not a literal.
+- Feature PRs automatically target their epic's branch (not the base branch directly).
+- Epic PRs target the base branch (never bypass it).
+- Features without an epic target the base branch directly.
+- When the last child feature's PR merges to the epic branch, `CompletionDetectorService` automatically creates the epic-to-base PR with `--merge` auto-merge enabled.
+- When the epic-to-base PR merges (detected by GitHub webhook), the epic is marked `done` and the epic branch is deleted.
+- If the epic-to-base PR has conflicts, the epic is marked `blocked` with a reason explaining manual intervention is needed.
 
 **Epic Lifecycle:**
 
@@ -818,9 +825,9 @@ children in_progress → children done → epic PR created (review) → epic PR 
 **Merge Order:**
 
 1. Merge all feature PRs into the epic branch (squash OK)
-2. Epic-to-dev PR is auto-created and auto-merged with `--merge` strategy (never squash)
+2. Epic-to-base PR is auto-created and auto-merged with `--merge` strategy (never squash)
 
-This keeps dev clean while allowing incremental feature development within epics.
+This keeps the base branch clean while allowing incremental feature development within epics.
 
 ### Creating a Project via MCP
 

--- a/apps/server/src/services/project-lifecycle-service.ts
+++ b/apps/server/src/services/project-lifecycle-service.ts
@@ -28,6 +28,7 @@ import type { AutoModeService } from './auto-mode-service.js';
 import { orchestrateProjectFeatures } from './project-orchestration-service.js';
 import type { EventEmitter } from '../lib/events.js';
 import { streamingQuery } from '../providers/simple-query-service.js';
+import { getEffectivePrBaseBranch } from '../lib/settings-helpers.js';
 
 const execAsync = promisify(exec);
 const logger = createLogger('ProjectLifecycle');
@@ -165,22 +166,58 @@ export class ProjectLifecycleService {
     );
 
     // Push epic branches to remote so child features can branch from them.
-    // Each epic branch is created from origin/dev HEAD. If the branch already
-    // exists on the remote, the push is a no-op (error is swallowed).
+    // Each epic branch is created from the project's effective PR base branch
+    // (resolved from settings / remote HEAD — never a hardcoded branch) so this
+    // works for any repo's integration flow, not just our internal one.
     const epicBranchNames =
       Object.values(result.milestoneEpicMap).length > 0
         ? await this.getEpicBranchNames(projectPath, result.milestoneEpicMap)
         : [];
 
-    for (const epicBranch of epicBranchNames) {
+    let baseBranch: string | undefined;
+    let epicBranchesPushed = 0;
+    let epicBranchPushFailures = 0;
+
+    if (epicBranchNames.length > 0) {
+      baseBranch = await getEffectivePrBaseBranch(
+        projectPath,
+        this.settingsService,
+        '[ProjectLifecycle]'
+      );
+
+      // Ensure the base ref is present locally before forking epic branches from it.
+      // Without this, `git push origin origin/<base>:...` fails with "src refspec ...
+      // does not match any" on a fresh clone or when the base was never fetched.
       try {
-        await execAsync(`git push origin origin/dev:refs/heads/${epicBranch}`, {
-          cwd: projectPath,
-        });
-        logger.info(`Pushed epic branch to remote: ${epicBranch}`);
+        await execAsync(`git fetch origin ${baseBranch}`, { cwd: projectPath });
       } catch (err) {
-        // Branch may already exist on the remote — this is expected and safe to ignore
-        logger.debug(`Epic branch push skipped (may already exist): ${epicBranch}`, err);
+        logger.warn(
+          `[ProjectLifecycle] Failed to fetch base branch origin/${baseBranch} before epic push for ${projectSlug}`,
+          err
+        );
+      }
+
+      for (const epicBranch of epicBranchNames) {
+        try {
+          await execAsync(`git push origin origin/${baseBranch}:refs/heads/${epicBranch}`, {
+            cwd: projectPath,
+          });
+          epicBranchesPushed++;
+          logger.info(`Pushed epic branch ${epicBranch} from origin/${baseBranch}`);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          // A "rejected" / non-fast-forward / "already exists" outcome means the branch
+          // is already on the remote — expected and safe. Anything else (e.g. a missing
+          // base ref) is a real failure worth surfacing rather than silently swallowing.
+          if (/already exists|\[rejected\]|non-fast-forward|fetch first/i.test(message)) {
+            logger.debug(`Epic branch ${epicBranch} already exists on remote; skipping`);
+          } else {
+            epicBranchPushFailures++;
+            logger.error(
+              `Failed to push epic branch ${epicBranch} from origin/${baseBranch}: ${message}`
+            );
+          }
+        }
       }
     }
 
@@ -193,6 +230,9 @@ export class ProjectLifecycleService {
       slug: projectSlug,
       featuresCreated: result.featuresCreated,
       epicsCreated: Object.keys(result.milestoneEpicMap).length,
+      baseBranch,
+      epicBranchesPushed,
+      epicBranchPushFailures,
     });
 
     logger.info(`Approved PRD for ${projectSlug}: ${result.featuresCreated} features`);

--- a/apps/server/tests/unit/services/project-lifecycle-service.test.ts
+++ b/apps/server/tests/unit/services/project-lifecycle-service.test.ts
@@ -12,7 +12,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { exec } from 'node:child_process';
 import { ProjectLifecycleService } from '@/services/project-lifecycle-service.js';
+import { getEffectivePrBaseBranch } from '@/lib/settings-helpers.js';
+import { orchestrateProjectFeatures } from '@/services/project-orchestration-service.js';
 import type { Project } from '@protolabsai/types';
 
 // ---------------------------------------------------------------------------
@@ -51,6 +54,31 @@ vi.mock('@/services/project-orchestration-service.js', () => ({
     milestoneEpicMap: { 'milestone-1': 'epic-1' },
   }),
 }));
+
+// Mock the base-branch resolver so approvePrd tests control the resolved branch
+// without touching git or settings on disk.
+vi.mock('@/lib/settings-helpers.js', () => ({
+  getEffectivePrBaseBranch: vi.fn(),
+}));
+
+// Override only `exec` (used for git fetch/push in approvePrd) while preserving the
+// rest of node:child_process so transitively-imported modules keep working.
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    exec: vi.fn(
+      (
+        _cmd: string,
+        opts: unknown,
+        cb?: (err: unknown, result: { stdout: string; stderr: string }) => void
+      ) => {
+        const callback = typeof opts === 'function' ? (opts as typeof cb) : cb;
+        callback?.(null, { stdout: '', stderr: '' });
+      }
+    ),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -116,6 +144,7 @@ function makeFeatureLoader(backlogCount = 1) {
   }));
   return {
     getAll: vi.fn().mockResolvedValue(features),
+    get: vi.fn().mockResolvedValue({ id: 'epic-1', branchName: 'epic/foundation', isEpic: true }),
     create: vi.fn(),
     update: vi.fn(),
   };
@@ -451,6 +480,95 @@ describe('ProjectLifecycleService — generateQaDoc()', () => {
       await service.launch(PROJECT_PATH, PROJECT_SLUG);
 
       expect(projectService.createDoc).toHaveBeenCalledOnce();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// approvePrd() — epic branch base resolution (#3867)
+// ---------------------------------------------------------------------------
+
+describe('ProjectLifecycleService — approvePrd() epic branch base', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Re-establish the orchestration result (global mock reset clears the
+    // module-level mockResolvedValue between tests).
+    vi.mocked(orchestrateProjectFeatures).mockResolvedValue({
+      featuresCreated: 2,
+      milestoneEpicMap: { 'milestone-1': 'epic-1' },
+    } as Awaited<ReturnType<typeof orchestrateProjectFeatures>>);
+  });
+
+  function makeProjectWithMilestone(): Project {
+    return makeProject({
+      status: 'reviewing',
+      milestones: [
+        {
+          number: 1,
+          slug: 'milestone-1',
+          title: 'Foundation',
+          description: 'Foundation work',
+          status: 'planned',
+          phases: [
+            {
+              number: 1,
+              name: 'phase-one',
+              title: 'Phase One',
+              description: 'First phase',
+              acceptanceCriteria: ['Works'],
+            },
+          ],
+        },
+      ],
+    });
+  }
+
+  function gitCommands(): string[] {
+    return vi
+      .mocked(exec)
+      .mock.calls.map((c) => c[0] as string)
+      .filter((cmd) => cmd.startsWith('git '));
+  }
+
+  it('pushes epic branches from the resolved base branch, never a hardcoded origin/dev', async () => {
+    vi.mocked(getEffectivePrBaseBranch).mockResolvedValue('main');
+    const { service } = makeService(makeProjectWithMilestone());
+
+    await service.approvePrd(PROJECT_PATH, PROJECT_SLUG);
+
+    const pushCommands = gitCommands().filter((cmd) => cmd.includes('git push'));
+    expect(pushCommands.length).toBeGreaterThan(0);
+    for (const cmd of pushCommands) {
+      expect(cmd).toContain('origin/main:refs/heads/epic/foundation');
+      expect(cmd).not.toContain('origin/dev');
+    }
+  });
+
+  it('fetches the resolved base branch before pushing epic branches', async () => {
+    vi.mocked(getEffectivePrBaseBranch).mockResolvedValue('trunk');
+    const { service } = makeService(makeProjectWithMilestone());
+
+    await service.approvePrd(PROJECT_PATH, PROJECT_SLUG);
+
+    const commands = gitCommands();
+    expect(commands.some((cmd) => cmd === 'git fetch origin trunk')).toBe(true);
+    expect(commands.some((cmd) => cmd.includes('origin/trunk:refs/heads/'))).toBe(true);
+  });
+
+  it('emits prd-approved with baseBranch and push counts for observability', async () => {
+    vi.mocked(getEffectivePrBaseBranch).mockResolvedValue('main');
+    const { service, events } = makeService(makeProjectWithMilestone());
+
+    await service.approvePrd(PROJECT_PATH, PROJECT_SLUG);
+
+    const approvedCall = vi
+      .mocked(events.emit)
+      .mock.calls.find((c) => c[0] === 'project:lifecycle:prd-approved');
+    expect(approvedCall).toBeDefined();
+    expect(approvedCall![1]).toMatchObject({
+      baseBranch: 'main',
+      epicBranchesPushed: 1,
+      epicBranchPushFailures: 0,
     });
   });
 });


### PR DESCRIPTION
Closes #3867.

## Problem

`ProjectLifecycleService.approvePrd()` pushed epic branches from a hardcoded `origin/dev`:

```ts
git push origin origin/dev:refs/heads/${epicBranch}
```

This (1) violates platform-first config (base branch must come from settings, not a literal) and (2) is stale under the single-`main` integration flow. On a repo with no `dev` branch the push fails, was swallowed as "may already exist," so epic branches silently never got created from the right base — child feature PRs then target a missing/empty epic branch.

## Fix

- Resolve the base branch via `getEffectivePrBaseBranch()` (project settings → global → remote HEAD → default `main`) and push `origin/<base>:refs/heads/<epic>`.
- `git fetch origin <base>` before pushing so the base ref exists locally on fresh clones (previously `git push origin/<base>:...` would fail with "src refspec does not match any").
- Distinguish "already exists" / non-fast-forward (expected, debug log) from real failures like a missing base ref (now error log + counted).
- Emit `baseBranch`, `epicBranchesPushed`, `epicBranchPushFailures` on the `project:lifecycle:prd-approved` event for observability.
- Reconcile the CLAUDE.md "Epic Git Workflow" section with the single-`main` flow (base branch / `prBaseBranch`, not `dev`).

## Tests

3 new unit tests in `project-lifecycle-service.test.ts`:
- pushes epic branches from the resolved base branch, never `origin/dev`
- fetches the resolved base branch before pushing
- emits `prd-approved` with `baseBranch` + push counts

All 12 tests pass; `tsc --noEmit` clean; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)