### PR TITLE
chore(sdk): bump @protolabsai/sdk 0.3.1 → 0.3.4 (fixes protoCLI#307) + smoke test

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -55,7 +55,7 @@
     "@protolabsai/observability": "^0.108.0",
     "@protolabsai/platform": "^0.108.0",
     "@protolabsai/prompts": "^0.108.0",
-    "@protolabsai/sdk": "^0.3.1",
+    "@protolabsai/sdk": "^0.3.4",
     "@protolabsai/templates": "^0.56.0",
     "@protolabsai/tools": "^0.108.0",
     "@protolabsai/types": "^0.108.0",

--- a/docs/internal/index.md
+++ b/docs/internal/index.md
@@ -71,6 +71,7 @@ This directory is NOT included in the public VitePress build. Content here is fo
 - [Overview](./server/index.md)
 - [Route Organization](./server/route-organization.md)
 - [Providers](./server/providers.md)
+- [Proto SDK Smoke Test](./server/proto-sdk-smoke-test.md)
 - [Utilities](./server/utilities.md)
 - [Quarantine Pipeline](./server/quarantine-pipeline.md)
 - [RAG Techniques](./server/rag-techniques.md)

--- a/docs/internal/server/proto-sdk-smoke-test.md
+++ b/docs/internal/server/proto-sdk-smoke-test.md
@@ -1,0 +1,55 @@
+# Test the Proto SDK ↔ protoMaker path
+
+A one-command smoke test that confirms `@protolabsai/sdk`'s agentic loop actually executes tools against the live gateway — the path protoMaker's `ProtoProvider` drives for every feature execution. Use it after bumping the SDK, when agent runs come back empty, or to sanity-check gateway connectivity. You'll have a PASS/FAIL verdict in well under a minute.
+
+## When to run it
+
+- **After an SDK bump** (`@protolabsai/sdk` version change in `apps/server/package.json`) — verify the new version didn't regress the loop before merging.
+- **When feature executions come back empty** — agents that emit intent then stop without running tools are the signature of [protoCLI#307](https://github.com/protoLabsAI/protoCLI/issues/307). This test reproduces that scenario in isolation, so you can tell an SDK problem apart from a protoMaker pipeline problem.
+- **To check the gateway path** — confirms `OPENAI_API_KEY` / `OPENAI_BASE_URL` reach the SDK and `api.proto-labs.ai` answers.
+
+## Run it
+
+From the repo root:
+
+```bash
+node scripts/smoke/proto-sdk-smoke.mjs                  # protolabs/smart, 1 iteration
+node scripts/smoke/proto-sdk-smoke.mjs protolabs/fast   # choose a model tier
+node scripts/smoke/proto-sdk-smoke.mjs protolabs/smart 5 # 5 iterations (the bug was intermittent)
+```
+
+Credentials are read from `GATEWAY_API_KEY` / `GATEWAY_BASE_URL`. If they aren't already exported, the script auto-loads the repo-root `.env` — the same file the prod LaunchAgent sources. No secrets are printed.
+
+## What it does
+
+The script calls `query()` from `@protolabsai/sdk` with the **same option shape `ProtoProvider.executeQuery` uses** (`model`, `cwd`, `env`, `maxSessionTurns`, `permissionMode: 'yolo'`, `abortController`). It runs a two-step task that _cannot_ be completed by planning alone:
+
+> Create `result.txt` containing exactly `PROTO_OK`, then read it back to confirm.
+
+It streams the SDK messages, counts assistant turns and `tool_use` blocks, and then checks the filesystem. **PASS requires the file to actually exist with the right contents and at least one tool call** — proof the loop continued past the planning turn and executed tools.
+
+```
+[1/1] PASS — turns=8 toolUses=2 [write_file, read_file] result=success file=true content="PROTO_OK"
+
+=== 1/1 PASS ===
+```
+
+Exit code is `0` only if every iteration passed (`1` on any failure, `2` if misconfigured), so it drops straight into CI or a pre-merge check.
+
+## Interpreting a FAIL
+
+| Symptom                                 | Likely cause                                                                      |
+| --------------------------------------- | --------------------------------------------------------------------------------- |
+| `toolUses=0`, `file=false`, low `turns` | Loop stopped after planning — the protoCLI#307 regression. Check the SDK version. |
+| `error=...` mentioning 401 / auth       | Gateway key not reaching the SDK. Confirm `GATEWAY_API_KEY` in `.env`.            |
+| `error=...` 529 / overloaded            | Transient gateway load — re-run; intermittent, not an SDK regression.             |
+| `result=error_*` with tools fired       | Task-level failure, not a loop failure — inspect the run.                         |
+
+## How this maps to protoMaker
+
+`ProtoProvider` (`apps/server/src/providers/proto-provider.ts`) is the production driver: it builds the gateway env (`buildEnv()` sets `OPENAI_API_KEY`/`OPENAI_BASE_URL`), maps `ExecuteOptions` → `QueryOptions`, and yields the SDK's `AsyncIterable` straight through as `ProviderMessage`s. The smoke test mirrors that invocation deliberately, so a PASS here means the same path the Lead Engineer pipeline relies on is healthy. See [Provider Architecture](./providers.md) for the full abstraction.
+
+## Files
+
+- `scripts/smoke/proto-sdk-smoke.mjs` — the test
+- `apps/server/src/providers/proto-provider.ts` — the production invocation it mirrors

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "@protolabsai/observability": "^0.108.0",
         "@protolabsai/platform": "^0.108.0",
         "@protolabsai/prompts": "^0.108.0",
-        "@protolabsai/sdk": "^0.3.1",
+        "@protolabsai/sdk": "^0.3.4",
         "@protolabsai/templates": "^0.56.0",
         "@protolabsai/tools": "^0.108.0",
         "@protolabsai/types": "^0.108.0",
@@ -254,6 +254,22 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "apps/server/node_modules/@protolabsai/sdk": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@protolabsai/sdk/-/sdk-0.3.4.tgz",
+      "integrity": "sha512-jwfgBvyAUsDVhbzSXUY3LN9d2xEOou2z46wv4+CvxgAAP6YLtz8jRtqFn1gKteNxTrV7nTBhggevYKo9vhk/1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.1",
+        "zod": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
       }
     },
     "apps/server/node_modules/@typescript-eslint/eslint-plugin": {
@@ -9229,31 +9245,6 @@
     "node_modules/@protolabsai/prompts": {
       "resolved": "libs/prompts",
       "link": true
-    },
-    "node_modules/@protolabsai/sdk": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@protolabsai/sdk/-/sdk-0.3.1.tgz",
-      "integrity": "sha512-6y5rpWLWxak3dV5kcrgFPll5R98B1cDgNLIfsj92W574SYDUsRGzNVD6xL7SQpXVYg3xJ9Njw+2O6WakWMqlPw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.1",
-        "zod": "^3.25.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.0"
-      }
-    },
-    "node_modules/@protolabsai/sdk/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     },
     "node_modules/@protolabsai/server": {
       "resolved": "apps/server",

--- a/scripts/smoke/proto-sdk-smoke.mjs
+++ b/scripts/smoke/proto-sdk-smoke.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// =============================================================================
+// Proto SDK smoke test
+// =============================================================================
+// Exercises @protolabsai/sdk's `query()` exactly the way apps/server's
+// ProtoProvider does, against the live gateway, to confirm the agentic loop
+// actually executes tools after the planning turn.
+//
+// Why this exists: protoCLI#307 ("agentic loop terminates after the planning
+// turn") was an SDK-level bug where the agent emitted intent then stopped
+// without running tools — surfacing in protoMaker as empty feature executions.
+// This script is the fast, dependency-light way to verify the SDK <-> gateway
+// path is healthy after an SDK bump, without spinning up the full board.
+//
+// What it does: runs a 2-step task that REQUIRES tool use after planning
+// (write a file, then read it back) and verifies the file was really written.
+// PASS means the loop continued past planning and executed tools.
+//
+// Usage (from repo root):
+//   node scripts/smoke/proto-sdk-smoke.mjs                 # protolabs/smart x1
+//   node scripts/smoke/proto-sdk-smoke.mjs protolabs/fast  # pick a model tier
+//   node scripts/smoke/proto-sdk-smoke.mjs protolabs/smart 5   # run 5 iterations
+//
+// Credentials: reads GATEWAY_API_KEY / GATEWAY_BASE_URL. If they aren't already
+// in the environment, the repo-root .env is auto-loaded (same file the prod
+// LaunchAgent sources). No secrets are printed.
+//
+// Exit code: 0 if every iteration passed, 1 if any failed, 2 if misconfigured.
+// =============================================================================
+
+import { mkdtempSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// --- Load repo-root .env (only fills vars not already set) -------------------
+function loadDotEnv() {
+  const envPath = join(REPO_ROOT, '.env');
+  if (!existsSync(envPath)) return;
+  for (const raw of readFileSync(envPath, 'utf8').split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let val = line.slice(eq + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    if (!(key in process.env)) process.env[key] = val;
+  }
+}
+loadDotEnv();
+
+const gatewayKey = process.env.GATEWAY_API_KEY || process.env.OPENAI_API_KEY;
+const gatewayBaseUrl =
+  process.env.GATEWAY_BASE_URL || process.env.OPENAI_BASE_URL || 'https://api.proto-labs.ai/v1';
+if (!gatewayKey) {
+  console.error('No GATEWAY_API_KEY / OPENAI_API_KEY (and none in repo-root .env). Aborting.');
+  process.exit(2);
+}
+
+// --- Resolve the SDK the same way the server would (root or apps/server) -----
+const require = createRequire(join(REPO_ROOT, 'apps', 'server', 'package.json'));
+let sdkDir;
+try {
+  sdkDir = dirname(require.resolve('@protolabsai/sdk/package.json'));
+} catch (e) {
+  console.error('Could not resolve @protolabsai/sdk — run `npm install` first.', e?.message || e);
+  process.exit(2);
+}
+const sdkVersion = JSON.parse(readFileSync(join(sdkDir, 'package.json'), 'utf8')).version;
+const { query } = await import(pathToFileURL(join(sdkDir, 'dist', 'index.mjs')).href);
+
+const model = process.argv[2] || 'protolabs/smart';
+const iterations = Math.max(1, parseInt(process.argv[3] || '1', 10));
+const env = { ...process.env, OPENAI_API_KEY: gatewayKey, OPENAI_BASE_URL: gatewayBaseUrl };
+
+const PROMPT =
+  'Create a file named result.txt in the current working directory containing exactly the ' +
+  'text PROTO_OK and nothing else. Then read the file back to confirm its contents. ' +
+  'You must actually use your tools to perform these steps, not just describe them.';
+
+console.log(
+  `Proto SDK smoke | sdk=${sdkVersion} | model=${model} | baseURL=${gatewayBaseUrl} | iterations=${iterations}\n`
+);
+
+async function runOnce(i) {
+  const cwd = mkdtempSync(join(tmpdir(), 'proto-sdk-smoke-'));
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), 150000);
+
+  let assistantTurns = 0;
+  let toolUses = 0;
+  const toolNames = [];
+  let resultSubtype = null;
+  let streamError = null;
+
+  try {
+    const stream = query({
+      prompt: PROMPT,
+      options: {
+        model,
+        cwd,
+        env,
+        maxSessionTurns: 12,
+        permissionMode: 'yolo',
+        abortController: ac,
+      },
+    });
+    for await (const msg of stream) {
+      if (msg.type === 'assistant') {
+        assistantTurns++;
+        for (const block of msg.message?.content ?? []) {
+          if (block.type === 'tool_use') {
+            toolUses++;
+            toolNames.push(block.name);
+          }
+        }
+      } else if (msg.type === 'result') {
+        resultSubtype = msg.subtype;
+      }
+    }
+  } catch (e) {
+    streamError = e?.message || String(e);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const filePath = join(cwd, 'result.txt');
+  const fileExists = existsSync(filePath);
+  const content = fileExists ? readFileSync(filePath, 'utf8').trim() : null;
+  const pass = fileExists && content === 'PROTO_OK' && toolUses > 0;
+
+  console.log(
+    `[${i}/${iterations}] ${pass ? 'PASS' : 'FAIL'} — turns=${assistantTurns} toolUses=${toolUses}` +
+      ` [${toolNames.join(', ') || 'none'}] result=${resultSubtype} file=${fileExists} content=${JSON.stringify(content)}` +
+      (streamError ? ` error=${streamError}` : '')
+  );
+  return pass;
+}
+
+let passed = 0;
+for (let i = 1; i <= iterations; i++) {
+  if (await runOnce(i)) passed++;
+}
+
+console.log(`\n=== ${passed}/${iterations} PASS ===`);
+process.exit(passed === iterations ? 0 : 1);


### PR DESCRIPTION
Pulls in `@protolabsai/sdk` **0.3.4**, which fixes the agentic-loop early-termination bug ([protoCLI#307](https://github.com/protoLabsAI/protoCLI/issues/307), closed as completed) — the agent emitted intent after the planning turn then stopped without executing tools, surfacing in protoMaker as **empty feature executions**.

## Verification

New isolated smoke test (`scripts/smoke/proto-sdk-smoke.mjs`) mirrors `ProtoProvider.executeQuery`'s `query()` invocation against the live gateway: it runs a 2-step task that requires tool use after planning (write `result.txt`, read it back) and asserts the file actually landed.

```
Proto SDK smoke | sdk=0.3.4 | model=protolabs/smart | iterations=1
[1/1] PASS — turns=8 toolUses=2 [write_file, read_file] result=success file=true content="PROTO_OK"
```

**4/4 PASS on `protolabs/smart`** (the bug was intermittent on 0.3.1). `tsc --noEmit` clean — 0.3.4 is API-compatible with our `ProtoProvider`/`ClaudeProvider` usage (no source changes needed).

## Changes

- `apps/server/package.json`: `^0.3.1` → `^0.3.4` (+ `package-lock.json`)
- `scripts/smoke/proto-sdk-smoke.mjs`: durable one-command smoke test — auto-loads repo-root `.env`, resolves the installed SDK, takes `model` + `iterations` args, exit-coded for CI.
- `docs/internal/server/proto-sdk-smoke-test.md`: when/how to run + FAIL triage table + how it maps to `ProtoProvider`.

## Follow-up

Unblocks crew dispatch (protoMaker#81), which was gated on this SDK fix. Recommend a full end-to-end validation (restart the prod instance on this build, dispatch one real feature) before re-enabling auto-mode at scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated `@protolabsai/sdk` to v0.3.4

* **Documentation**
  * Added Proto SDK smoke test documentation with execution guide

* **Tests**
  * Added smoke test script for validating SDK functionality against live gateway

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3870?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->