### PR TITLE
docs: link the Proto SDK smoke test from the server docs index

### DIFF
--- a/docs/internal/server/index.md
+++ b/docs/internal/server/index.md
@@ -23,6 +23,7 @@ The server is an Express 5 application with WebSocket streaming, organized into 
 - **[Timer Registry](./timer-registry)** — How to add and manage recurring timers via the SchedulerService
 - **[Maintenance Checks](./maintenance-checks)** — How to create composable maintenance check modules
 - **[Ops Dashboard](./ops-dashboard)** — Reference for the Ops Dashboard tabs, API endpoints, and WebSocket events
+- **[Proto SDK Smoke Test](./proto-sdk-smoke-test)** — One-command smoke test for the SDK agentic loop — run after SDK bumps or when agent runs come back empty
 
 ## Key Technologies
 


### PR DESCRIPTION
## Summary

Add a short pointer to the Proto SDK smoke test from docs/internal/server/index.md so it is discoverable. Acceptance: docs/internal/server/index.md links to docs/internal/server/proto-sdk-smoke-test.md with a one-line description of when/why to run it; no other content changed. This is a pipeline-validation canary after the @protolabsai/sdk 0.3.4 bump (protoCLI#307 fix). Keep the change minimal.

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=transient-435e33f6 team= created=2026-05-26T20:24:29.660Z -->