### PR TITLE
feat(projects): wire lifecycle status truth (scaffolded / active / researching)

### DIFF
--- a/apps/server/src/services/project-lifecycle-service.ts
+++ b/apps/server/src/services/project-lifecycle-service.ts
@@ -221,8 +221,11 @@ export class ProjectLifecycleService {
       }
     }
 
+    // Approval scaffolds features but does not launch — leave the project in
+    // 'scaffolded' until launch() flips it to 'active'. (orchestrateProjectFeatures
+    // also sets 'scaffolded'; this keeps the service cache + markdown in step.)
     await this.projectService.updateProject(projectPath, projectSlug, {
-      status: 'active',
+      status: 'scaffolded',
     });
 
     this.events.emit('project:lifecycle:prd-approved', {
@@ -297,6 +300,13 @@ export class ProjectLifecycleService {
       logger.warn('Failed to start auto-mode:', error);
     }
 
+    // Launch is the transition into execution: mark the project 'active'. This
+    // is the only place 'active' is set in the lifecycle — approval lands in
+    // 'scaffolded', so 'active' unambiguously means "auto-mode launched".
+    await this.projectService.updateProject(projectPath, projectSlug, {
+      status: 'active',
+    });
+
     this.events.emit('project:lifecycle:launched', {
       projectPath,
       projectSlug,
@@ -355,10 +365,23 @@ export class ProjectLifecycleService {
   ): Promise<void> {
     logger.info(`[ProjectLifecycle] Starting research for project: ${projectSlug}`);
 
-    // Step 1: Mark researchStatus as running
+    // Reflect research in the lifecycle status (not just the separate
+    // researchStatus field) so the flow is observable from `status` alone — but
+    // only when the project is still early. Never clobber a scaffolded/active/
+    // completed project if research is re-run against it.
+    const EARLY_STATUSES = ['ongoing', 'researching', 'drafting', 'reviewing'];
+    const previousStatus = project.status;
+    const trackLifecycleStatus = !previousStatus || EARLY_STATUSES.includes(previousStatus);
+    // After research, the natural next step is PRD drafting; revert there unless
+    // we came from a more advanced early state worth preserving.
+    const revertStatus =
+      previousStatus && previousStatus !== 'researching' ? previousStatus : 'drafting';
+
+    // Step 1: Mark researchStatus as running (and lifecycle status 'researching')
     try {
       await this.projectService.updateProject(projectPath, projectSlug, {
         researchStatus: 'running',
+        ...(trackLifecycleStatus && { status: 'researching' as const }),
       });
     } catch (err) {
       logger.warn(
@@ -440,6 +463,7 @@ Search the codebase for relevant patterns and integration points, then research 
       await this.projectService.updateProject(projectPath, projectSlug, {
         researchSummary,
         researchStatus: 'complete',
+        ...(trackLifecycleStatus && { status: revertStatus }),
       });
       logger.info(`[ProjectLifecycle] Updated researchSummary for ${projectSlug}`);
 
@@ -455,9 +479,12 @@ Search the codebase for relevant patterns and integration points, then research 
     } catch (error) {
       logger.error(`[ProjectLifecycle] Research failed for ${projectSlug}:`, error);
 
-      // Mark as failed
+      // Mark as failed and revert the lifecycle status we may have advanced.
       await this.projectService
-        .updateProject(projectPath, projectSlug, { researchStatus: 'failed' })
+        .updateProject(projectPath, projectSlug, {
+          researchStatus: 'failed',
+          ...(trackLifecycleStatus && { status: revertStatus }),
+        })
         .catch(() => {});
     }
   }

--- a/apps/server/src/services/project-orchestration-service.ts
+++ b/apps/server/src/services/project-orchestration-service.ts
@@ -457,7 +457,11 @@ export async function orchestrateProjectFeatures(
   });
 
   try {
-    project.status = 'active';
+    // Scaffolding produces features but does NOT launch auto-mode — that's the
+    // explicit `launch()` step, which sets status to 'active'. Marking the
+    // project 'scaffolded' here keeps the lifecycle observable: a project that
+    // has features but isn't running is distinguishable from one in execution.
+    project.status = 'scaffolded';
     project.updatedAt = new Date().toISOString();
 
     // Link phases to features

--- a/apps/server/tests/unit/services/project-lifecycle-service.test.ts
+++ b/apps/server/tests/unit/services/project-lifecycle-service.test.ts
@@ -16,6 +16,7 @@ import { exec } from 'node:child_process';
 import { ProjectLifecycleService } from '@/services/project-lifecycle-service.js';
 import { getEffectivePrBaseBranch } from '@/lib/settings-helpers.js';
 import { orchestrateProjectFeatures } from '@/services/project-orchestration-service.js';
+import { streamingQuery } from '@/providers/simple-query-service.js';
 import type { Project } from '@protolabsai/types';
 
 // ---------------------------------------------------------------------------
@@ -59,6 +60,11 @@ vi.mock('@/services/project-orchestration-service.js', () => ({
 // without touching git or settings on disk.
 vi.mock('@/lib/settings-helpers.js', () => ({
   getEffectivePrBaseBranch: vi.fn(),
+}));
+
+// Mock the research model call so runResearch tests don't hit the gateway.
+vi.mock('@/providers/simple-query-service.js', () => ({
+  streamingQuery: vi.fn(),
 }));
 
 // Override only `exec` (used for git fetch/push in approvePrd) while preserving the
@@ -570,5 +576,95 @@ describe('ProjectLifecycleService — approvePrd() epic branch base', () => {
       epicBranchesPushed: 1,
       epicBranchPushFailures: 0,
     });
+  });
+
+  it("leaves the project 'scaffolded' (not 'active') after approval", async () => {
+    vi.mocked(getEffectivePrBaseBranch).mockResolvedValue('main');
+    const { service, projectService } = makeService(makeProjectWithMilestone());
+
+    await service.approvePrd(PROJECT_PATH, PROJECT_SLUG);
+
+    const statusUpdates = projectService.updateProject.mock.calls
+      .map((c) => c[2]?.status)
+      .filter(Boolean);
+    expect(statusUpdates).toContain('scaffolded');
+    expect(statusUpdates).not.toContain('active');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle status truth (#84) — launch() and runResearch() transitions
+// ---------------------------------------------------------------------------
+
+describe('ProjectLifecycleService — lifecycle status transitions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("launch() flips the project to 'active'", async () => {
+    const project = makeProject({
+      status: 'scaffolded',
+      milestones: [
+        {
+          number: 1,
+          slug: 'm1',
+          title: 'M1',
+          description: 'm1',
+          status: 'planned',
+          phases: [{ number: 1, name: 'p1', title: 'P1', description: 'p1' }],
+        },
+      ],
+    });
+    const { service, projectService } = makeService(project, {}, 2);
+
+    await service.launch(PROJECT_PATH, PROJECT_SLUG);
+
+    const statusUpdates = projectService.updateProject.mock.calls
+      .map((c) => c[2]?.status)
+      .filter(Boolean);
+    expect(statusUpdates).toContain('active');
+  });
+
+  it("runResearch() sets 'researching' then reverts on completion", async () => {
+    vi.mocked(streamingQuery).mockResolvedValue({
+      text: '## Summary\nFound relevant patterns.\n\n## Codebase Findings\n...',
+    } as Awaited<ReturnType<typeof streamingQuery>>);
+
+    const project = makeProject({ status: 'drafting' });
+    const { service, projectService } = makeService(project);
+
+    // runResearch is private and normally fire-and-forget via research();
+    // call it directly so we can await the full transition.
+    await (
+      service as unknown as {
+        runResearch: (p: string, s: string, proj: typeof project) => Promise<void>;
+      }
+    ).runResearch(PROJECT_PATH, PROJECT_SLUG, project);
+
+    const statusUpdates = projectService.updateProject.mock.calls
+      .map((c) => c[2]?.status)
+      .filter(Boolean);
+    // First sets 'researching', then reverts to 'drafting' on completion.
+    expect(statusUpdates).toContain('researching');
+    expect(statusUpdates[statusUpdates.length - 1]).toBe('drafting');
+  });
+
+  it('runResearch() reverts the lifecycle status even when research fails', async () => {
+    vi.mocked(streamingQuery).mockRejectedValue(new Error('gateway boom'));
+
+    const project = makeProject({ status: 'drafting' });
+    const { service, projectService } = makeService(project);
+
+    await (
+      service as unknown as {
+        runResearch: (p: string, s: string, proj: typeof project) => Promise<void>;
+      }
+    ).runResearch(PROJECT_PATH, PROJECT_SLUG, project);
+
+    const failCall = projectService.updateProject.mock.calls.find(
+      (c) => c[2]?.researchStatus === 'failed'
+    );
+    expect(failCall).toBeDefined();
+    expect(failCall![2]?.status).toBe('drafting');
   });
 });

--- a/docs/internal/server/project-service.md
+++ b/docs/internal/server/project-service.md
@@ -109,6 +109,21 @@ interface ProjectStats {
 
 Stats are written to `.automaker/projects/stats.json` and used by the dashboard.
 
+## Lifecycle status model
+
+`project.status` (`ProjectStatus`) reflects the stage of the design flow and is set at distinct transitions so the lifecycle is observable from `status` alone — no need to cross-reference other fields:
+
+| Status        | Set by                                                     | Means                                        |
+| ------------- | ---------------------------------------------------------- | -------------------------------------------- |
+| `drafting`    | project creation / after research                          | Idea captured, PRD not yet under review      |
+| `researching` | `ProjectLifecycleService.runResearch()` (early-stage only) | Deep research running; reverts to `drafting` |
+| `reviewing`   | `generate-prd`                                             | PRD drafted, awaiting approval               |
+| `scaffolded`  | `approvePrd()` / `orchestrateProjectFeatures()`            | Features created, **not** yet launched       |
+| `active`      | `ProjectLifecycleService.launch()`                         | Auto-mode launched — execution in progress   |
+| `completed`   | completion detection                                       | All work done                                |
+
+Key invariant: **approval lands in `scaffolded`, and only `launch()` sets `active`** — so `active` unambiguously means "running," distinct from "has features but idle." `researching` is only applied when the project is still early (`ongoing`/`drafting`/`reviewing`); re-running research against a `scaffolded`/`active` project does not clobber its status. `approved` remains reserved for a future explicit human-approval gate (approval and scaffolding are currently a single operation).
+
 ## Calendar Integration
 
 When `CalendarService` is wired in via `setCalendarService()`, project milestone dates can be synced to calendar events. This is optional; the service functions normally without it.


### PR DESCRIPTION
Part of the project features design-flow improvements (audit follow-up). Closes the "dead status states" gap.

## Problem

`ProjectStatus` defines `researching`, `approved`, and `scaffolded`, but **none were ever assigned** — the flow jumped `drafting → reviewing → active`. You couldn't tell "features scaffolded but idle" from "running," and research state lived only in a parallel `researchStatus` field.

## Change — distinct, observable transitions

- `orchestrateProjectFeatures` + `approvePrd` now land in **`scaffolded`** (was `active`).
- **`launch()` is the sole setter of `active`** — so `active` unambiguously means auto-mode launched / executing.
- `runResearch()` sets **`researching`** on start and reverts on completion/failure, but only for early-stage projects (`ongoing`/`drafting`/`reviewing`) so it never clobbers a `scaffolded`/`active`/`completed` project.
- `approved` stays reserved for the future explicit review gate (#86) — approval and scaffolding are currently a single operation.

The UI wizard (`project-wizard-store.ts`) already derives `review`/`launch` completion from these statuses, so **no UI change is needed** — its step indicator just becomes accurate (a just-approved project no longer shows as "launched").

## Observability

`project.status` now reflects the full lifecycle on its own, no cross-referencing `researchStatus`. Documented as a table in `docs/internal/server/project-service.md`.

## Tests

4 new unit tests (16 total pass): scaffolded-after-approval, `launch()`→active, research `researching`+revert on success, and revert on failure. `tsc --noEmit` clean; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)